### PR TITLE
feat(cockpit): show idle Directors (zero sessions) in the tree rail

### DIFF
--- a/src/CcDirector.Cockpit.Tests/SessionRailIdleDirectorTests.cs
+++ b/src/CcDirector.Cockpit.Tests/SessionRailIdleDirectorTests.cs
@@ -1,0 +1,113 @@
+using Bunit;
+using CcDirector.Cockpit.Components;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Cockpit.Tests;
+
+/// <summary>
+/// The tree view must show EVERY reachable Director in the registry - including ones with
+/// zero sessions - because the Director header's [+] is the only way to start the first
+/// session on it. These bUnit tests render the real SessionRail in "tree" mode and assert
+/// the idle Director surfaces with its [+] and a "no sessions" hint. Mirrors the
+/// SessionRailRepoViewTests / SessionRailPortLabelTests harness.
+/// </summary>
+public sealed class SessionRailIdleDirectorTests : TestContext
+{
+    private const string GuidBusy = "a3a971fa-1111-2222-3333-444455556666";
+    private const string GuidIdle = "b7c44ee0-aaaa-bbbb-cccc-ddddeeeeffff";
+
+    private static DirectorDto Director(string id, string controlEndpoint, string machine = "SOREN_NORTH") => new()
+    {
+        DirectorId = id,
+        MachineName = machine,
+        Version = "0.6.25",
+        StartedAt = DateTime.UtcNow.AddMinutes(-12),
+        ControlEndpoint = controlEndpoint,
+    };
+
+    private static SessionDto Session(string id, string name, string directorId, string machine = "SOREN_NORTH") => new()
+    {
+        SessionId = id,
+        DirectorId = directorId,
+        MachineName = machine,
+        Name = name,
+        RepoPath = @"D:\repos\thing",
+        SortOrder = 0,
+        StatusColor = "blue",
+        ActivityState = "Idle",
+        Type = "Implement",
+    };
+
+    [Fact]
+    public void Tree_IdleDirector_WithNoSessions_StillRenders_WithAddButton()
+    {
+        // One Director owns a session, a second Director (in the registry) has none. The idle
+        // one must still get a header and its [+].
+        var cut = RenderComponent<SessionRail>(p => p
+            .Add(c => c.ViewMode, "tree")
+            .Add(c => c.Directors, new List<DirectorDto>
+            {
+                Director(GuidBusy, "http://127.0.0.1:7878"),
+                Director(GuidIdle, "http://127.0.0.1:7879"),
+            })
+            .Add(c => c.Sessions, new List<SessionDto>
+            {
+                Session("s1", "busy-sess", GuidBusy),
+            }));
+
+        // Two Director headers (busy + idle), each carrying a [+].
+        var labels = cut.FindAll(".dir-head-label").Select(h => h.TextContent.Trim()).ToList();
+        Assert.Equal(new[] { "director :7878", "director :7879" }, labels);
+        Assert.Equal(2, cut.FindAll(".dir-add").Count);
+    }
+
+    [Fact]
+    public void Tree_IdleDirector_ShowsNoSessionsHint_AndFiresOnNewSession_WithItsId()
+    {
+        string? firedDirectorId = null;
+        var cut = RenderComponent<SessionRail>(p => p
+            .Add(c => c.ViewMode, "tree")
+            .Add(c => c.Directors, new List<DirectorDto> { Director(GuidIdle, "http://127.0.0.1:7879") })
+            .Add(c => c.Sessions, new List<SessionDto>())
+            .Add(c => c.OnNewSession, (string id) => firedDirectorId = id));
+
+        // The idle Director reads as "no sessions", and the empty-roster message is suppressed.
+        Assert.Equal("no sessions", cut.Find(".dir-idle").TextContent.Trim());
+        Assert.Empty(cut.FindAll(".rail-empty"));
+
+        // Its [+] starts a session on THAT Director.
+        cut.Find(".dir-add").Click();
+        Assert.Equal(GuidIdle, firedDirectorId);
+    }
+
+    [Fact]
+    public void Tree_UnreachableDirector_NotRenderedAsEmptyHeader()
+    {
+        // A Director surfaced as unreachable gets the dedicated error row, never a bare [+] header.
+        var cut = RenderComponent<SessionRail>(p => p
+            .Add(c => c.ViewMode, "tree")
+            .Add(c => c.Directors, new List<DirectorDto> { Director(GuidIdle, "http://127.0.0.1:7879") })
+            .Add(c => c.Sessions, new List<SessionDto>())
+            .Add(c => c.Errors, new List<MachineErrorDto>
+            {
+                new() { DirectorId = GuidIdle, MachineName = "SOREN_NORTH", Error = "timeout" },
+            }));
+
+        Assert.Empty(cut.FindAll(".dir-head"));
+        Assert.Single(cut.FindAll(".dir-error"));
+    }
+
+    [Fact]
+    public void Tree_MachineWithOnlyIdleDirectors_StillAppears()
+    {
+        // The machine has no sessions and no errors - only a registry Director. It must still show.
+        var cut = RenderComponent<SessionRail>(p => p
+            .Add(c => c.ViewMode, "tree")
+            .Add(c => c.Directors, new List<DirectorDto> { Director(GuidIdle, "http://127.0.0.1:7879", "REMOTE_BOX") })
+            .Add(c => c.Sessions, new List<SessionDto>()));
+
+        var machines = cut.FindAll(".machine-name").Select(m => m.TextContent.Trim()).ToList();
+        Assert.Contains("REMOTE_BOX", machines);
+    }
+}

--- a/src/CcDirector.Cockpit/Components/SessionRail.razor
+++ b/src/CcDirector.Cockpit/Components/SessionRail.razor
@@ -2,8 +2,10 @@
 
    "tree"   - Machine -> Director -> Sessions. Sessions keep their owning Director's
               desktop order (SortOrder), so they hold a stable slot and don't reshuffle.
-              Each Director carries a [+] to start a session on it. Unreachable Directors
-              are shown inline so a dead Director is never silently dropped.
+              Each Director carries a [+] to start a session on it. Every reachable Director
+              in the registry is shown - INCLUDING ones with zero sessions - because that
+              [+] is the only way to start the first session on a Director. Unreachable
+              Directors are shown inline so a dead Director is never silently dropped.
 
    "triage" - one flat priority list across every Director: sessions that NEED YOU
               (StatusColor "red") at the top, ON HOLD (user/agent parked) at the bottom,
@@ -19,7 +21,10 @@
    StatusColor and OnHold are rendered verbatim from the Director; never derived. *@
 
 <div class="rail @ViewMode">
-    @if (Sessions.Count == 0 && Errors.Count == 0)
+    @* Suppress the empty message in tree mode when idle Directors will still render (each
+       carries a [+] to start its first session). Other modes only group sessions, so an
+       empty roster there really is empty. *@
+    @if (Sessions.Count == 0 && Errors.Count == 0 && !(ViewMode == "tree" && Directors.Count > 0))
     {
         <div class="rail-empty">No sessions. The Gateway returned an empty roster.</div>
     }
@@ -229,28 +234,38 @@
                     }
                 </div>
 
-                @foreach (var dir in machineSessions.GroupBy(s => s.DirectorId).OrderBy(g => g.Key))
+                @* Every Director for this machine - those that own a session here UNION the
+                   registry's Directors that have none yet - so an idle Director still shows
+                   its [+] (the only way to start its first session). *@
+                @foreach (var dirId in DirectorIdsForMachine(machine, machineSessions, machineErrors))
                 {
+                    var dirSessions = machineSessions.Where(s => s.DirectorId == dirId).ToList();
                     <div class="dir-head">
                         @* Issue #237: label each Director by its port (short, restart-stable, maps
                            to the slot convention) not the meaningless per-process GUID prefix. The
                            full DirectorId stays in the tooltip; it remains the routing key below. *@
-                        <span class="dir-head-label" title="@dir.Key">director @PortLabelFor(dir.Key)</span>
+                        <span class="dir-head-label" title="@dirId">director @PortLabelFor(dirId)</span>
                         @* Version + uptime from the Gateway's Director registry: makes a
                            stale pre-fix Director stand out without leaving the rail. *@
-                        @if (DirectorFor(dir.Key) is { } meta)
+                        @if (DirectorFor(dirId) is { } meta)
                         {
                             <span class="dir-meta"
                                   title="@($"v{meta.Version}, started {meta.StartedAt.ToLocalTime():yyyy-MM-dd HH:mm}")">
                                 v@(ShortVersion(meta.Version)) up @Uptime(meta.StartedAt)
                             </span>
                         }
+                        @* An idle Director (registered, reachable, zero sessions) reads as empty
+                           without this hint - so a human knows the [+] is what it is for. *@
+                        @if (dirSessions.Count == 0)
+                        {
+                            <span class="dir-idle" title="This Director has no sessions yet">no sessions</span>
+                        }
                         <button type="button" class="dir-add"
                                 title="Start a new session on this Director"
-                                @onclick="() => OnNewSession.InvokeAsync(dir.Key)">+</button>
+                                @onclick="() => OnNewSession.InvokeAsync(dirId)">+</button>
                     </div>
 
-                    @foreach (var s in SessionOrdering.InDesktopOrder(dir))
+                    @foreach (var s in SessionOrdering.InDesktopOrder(dirSessions))
                     {
                         @SessionRow(s)
                     }
@@ -334,7 +349,29 @@
     {
         var fromSessions = Sessions.Select(s => MachineKey(s.MachineName));
         var fromErrors = Errors.Select(e => MachineKey(e.MachineName));
-        return fromSessions.Concat(fromErrors).Distinct().OrderBy(m => m);
+        // A machine whose only Directors are idle (registered, zero sessions, no error) has
+        // nothing in Sessions/Errors - include it so its Directors' [+] are still reachable.
+        var fromDirectors = Directors.Select(d => MachineKey(d.MachineName));
+        return fromSessions.Concat(fromErrors).Concat(fromDirectors).Distinct().OrderBy(m => m);
+    }
+
+    /// <summary>
+    /// The Director ids to render under a machine in tree mode: the Directors that own a
+    /// session here UNION the registry's Directors for this machine that have none yet, so an
+    /// idle Director still shows its [+] (the only way to start its first session). Directors
+    /// surfaced as unreachable (<paramref name="machineErrors"/>) are excluded - they get the
+    /// dedicated error row instead of an empty header. Ordered by the rail's port label so the
+    /// list is human-sorted and stable across refreshes.
+    /// </summary>
+    private IReadOnlyList<string> DirectorIdsForMachine(
+        string machine, List<SessionDto> machineSessions, List<MachineErrorDto> machineErrors)
+    {
+        var unreachable = machineErrors.Select(e => e.DirectorId).ToHashSet();
+        var ids = new HashSet<string>(machineSessions.Select(s => s.DirectorId));
+        foreach (var d in Directors.Where(d => MachineKey(d.MachineName) == machine))
+            ids.Add(d.DirectorId);
+        ids.ExceptWith(unreachable);
+        return ids.OrderBy(PortLabelFor, StringComparer.OrdinalIgnoreCase).ToList();
     }
 
     private static string ShortId(string id) =>

--- a/src/CcDirector.Cockpit/wwwroot/app.css
+++ b/src/CcDirector.Cockpit/wwwroot/app.css
@@ -248,6 +248,8 @@ body{background:var(--panel);color:var(--text);
 /* Version + uptime on the Director group header (from the Gateway registry). Never wraps;
    the label ellipsizes first so the meta stays readable on narrow rails. */
 .dir-meta{flex:none;color:var(--muted);white-space:nowrap}
+/* "no sessions" hint on an idle Director header - dim so it reads as a state, not a row. */
+.dir-idle{flex:none;color:var(--muted);font-style:italic;white-space:nowrap;opacity:.8}
 .dir-add{flex:none;width:18px;height:18px;line-height:1;font-size:14px;cursor:pointer;
   color:var(--text2);background:transparent;border:1px solid var(--border);border-radius:4px;
   display:flex;align-items:center;justify-content:center;padding:0}


### PR DESCRIPTION
## Problem

In the Cockpit tree view, a Director with **no sessions** never appeared — the rail grouped the session roster by `DirectorId`, so a Director that owned zero sessions was dropped entirely. Because the Director header's `[+]` is the only way to start a session, an idle Director was unreachable: there was no way to add the first session to it.

(Spotted live: the Gateway reported `directors:2` but the rail only showed the one with sessions.)

## Change

Tree mode now renders **every reachable Director in the registry** — the ones that own a session here UNION the registry's Directors for this machine with none yet — each carrying its `[+]`.

- Idle Directors show a dim italic `no sessions` hint so the header doesn't read as broken.
- Unreachable Directors still get the dedicated error row, not a bare empty header (excluded via the `Errors` list).
- Machines whose only Directors are idle now appear too (`Machines()` also draws from the registry).
- The empty-roster message is suppressed in tree mode when idle Directors will render.

Triage/Repo views are unchanged — they group purely by sessions/repos and have no per-Director `[+]`.

## Tests

Adds `SessionRailIdleDirectorTests` (4 bUnit tests): idle Director renders with `[+]`, `[+]` fires `OnNewSession` with the right id, unreachable Directors don't get an empty header, and a machine with only idle Directors still appears. Full `SessionRail` suite green (24/24).

## Verification

Deployed to the live Gateway Cockpit and confirmed the previously-hidden `SORENLAPTOP` Director (`:7879`, zero sessions) now appears with its `no sessions` hint and `[+]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)