### PR TITLE
feat(settings): first-run tool wizard appends to agent.entries

### DIFF
--- a/src/CcDirector.Avalonia/SettingsDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/SettingsDialog.axaml.cs
@@ -639,7 +639,7 @@ public partial class SettingsDialog : Window
             if (accepted == true)
             {
                 LoadAgentEntries();
-                ShowAgentToolsStatus("Detection wizard finished. The tools it added are shown above.", error: false);
+                ShowAgentToolsStatus(BuildWizardResultMessage(dialog.LastResult), error: false);
                 FileLog.Write("[SettingsDialog] BtnRunWizard_Click: wizard accepted; reloaded agent list");
             }
         }
@@ -652,6 +652,32 @@ public partial class SettingsDialog : Window
         {
             RunWizardButton.IsEnabled = true;
         }
+    }
+
+    /// <summary>
+    /// Build the honest after-wizard status: name the agents that were actually added to the list
+    /// and how many selected ones were skipped because they were already present. Avoids the old
+    /// "the tools it added are shown above" message that lied when nothing new was added.
+    /// </summary>
+    private static string BuildWizardResultMessage(WizardAcceptResult? result)
+    {
+        if (result is null)
+            return "Detection wizard finished.";
+
+        var addedNames = result.AddedTools.Select(t => AgentToolCatalog.GetEntry(t).DisplayName).ToList();
+        var addedPart = addedNames.Count switch
+        {
+            0 => "No new agents added",
+            1 => $"Added 1 new agent: {addedNames[0]}",
+            _ => $"Added {addedNames.Count} new agents: {string.Join(", ", addedNames)}",
+        };
+
+        var skippedCount = result.SkippedTools.Count;
+        var skippedPart = skippedCount == 0
+            ? ""
+            : $" {skippedCount} selected {(skippedCount == 1 ? "tool was" : "tools were")} already in your list and left unchanged.";
+
+        return addedPart + "." + skippedPart;
     }
 
     private void ShowAgentToolsStatus(string text, bool error)

--- a/src/CcDirector.Avalonia/ToolDetectionWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/ToolDetectionWizardDialog.axaml.cs
@@ -33,7 +33,13 @@ public partial class ToolDetectionWizardDialog : Window
     // and the resolved path the scan found for it.
     private readonly List<ToolRow> _rows = new();
 
-    private sealed record ToolRow(AgentKind Tool, CheckBox Check, string ResolvedPath, bool Found);
+    private sealed record ToolRow(AgentKind Tool, string DisplayName, CheckBox Check, string ResolvedPath, bool Found, bool AlreadyAdded);
+
+    /// <summary>
+    /// The outcome of the last accept (added vs skipped tools), so the caller can report honestly
+    /// after the dialog closes. Null until the user accepts at least once.
+    /// </summary>
+    public WizardAcceptResult? LastResult { get; private set; }
 
     public ToolDetectionWizardDialog() : this(new AgentOptions()) { }
 
@@ -56,16 +62,33 @@ public partial class ToolDetectionWizardDialog : Window
         FileLog.Write("[ToolDetectionWizardDialog] ScanAsync");
         try
         {
-            var suggestions = await Task.Run(() => _model.ScanSuggestions(_options));
-            BuildRows(suggestions);
+            // Scan the catalog AND read the user's current agent.entries (without seeding) on the
+            // background thread, so we can mark tools already in the list and pre-check only the
+            // genuinely new ones.
+            var (suggestions, existingTypes) = await Task.Run(() =>
+            {
+                var scanned = _model.ScanSuggestions(_options);
+                var present = new HashSet<AgentKind>(AgentEntryStore.ReadCurrentEntries().Select(e => e.Type));
+                return (scanned, present);
+            });
+            BuildRows(suggestions, existingTypes);
 
             var foundCount = suggestions.Count(s => s.Found);
-            ScanStatusText.Text = foundCount > 0
-                ? $"Found {foundCount} of {suggestions.Count} known tools. Review the selection and click Add selected tools."
-                : $"No known agent tools were found on this machine. Install one, or close this and configure a path on the Agents tab in Settings.";
+            var addableCount = suggestions.Count(s => s.Found && !existingTypes.Contains(s.Tool));
+            var alreadyCount = suggestions.Count(s => s.Found && existingTypes.Contains(s.Tool));
+
+            if (foundCount == 0)
+                ScanStatusText.Text = "No known agent tools were found on this machine. Install one, or close this and configure a path on the Agents tab in Settings.";
+            else if (addableCount == 0)
+                ScanStatusText.Text = $"Found {foundCount} of {suggestions.Count} known tools, but all are already in your Agents list. Nothing new to add.";
+            else
+                ScanStatusText.Text = alreadyCount > 0
+                    ? $"Found {foundCount} of {suggestions.Count} known tools ({addableCount} new, {alreadyCount} already in your list). Review the selection and click Add selected tools."
+                    : $"Found {foundCount} of {suggestions.Count} known tools. Review the selection and click Add selected tools.";
+
             ScanStatusText.FontStyle = FontStyle.Normal;
-            AcceptButton.IsEnabled = foundCount > 0;
-            FileLog.Write($"[ToolDetectionWizardDialog] ScanAsync: found={foundCount}, total={suggestions.Count}");
+            AcceptButton.IsEnabled = addableCount > 0;
+            FileLog.Write($"[ToolDetectionWizardDialog] ScanAsync: found={foundCount}, addable={addableCount}, alreadyAdded={alreadyCount}, total={suggestions.Count}");
         }
         catch (Exception ex)
         {
@@ -75,17 +98,23 @@ public partial class ToolDetectionWizardDialog : Window
         }
     }
 
-    private void BuildRows(IReadOnlyList<ToolDetectionSuggestion> suggestions)
+    private void BuildRows(IReadOnlyList<ToolDetectionSuggestion> suggestions, ISet<AgentKind> existingTypes)
     {
         _rows.Clear();
         ToolListPanel.Children.Clear();
 
         foreach (var s in suggestions)
         {
+            // A tool already in agent.entries is shown disabled and unchecked with an "ALREADY
+            // ADDED" badge, so the checkboxes represent exactly what Accept will add. Only a found
+            // tool that is NOT already present is checkable/pre-checked.
+            var alreadyAdded = existingTypes.Contains(s.Tool);
+            var addable = s.Found && !alreadyAdded;
+
             var check = new CheckBox
             {
-                IsChecked = s.Found,
-                IsEnabled = s.Found,
+                IsChecked = addable,
+                IsEnabled = addable,
                 VerticalAlignment = VerticalAlignment.Center,
             };
             check.IsCheckedChanged += (_, _) => UpdateAcceptEnabled();
@@ -99,16 +128,19 @@ public partial class ToolDetectionWizardDialog : Window
                 VerticalAlignment = VerticalAlignment.Center,
             };
 
+            var badgeText = alreadyAdded ? "ALREADY ADDED" : s.Found ? "FOUND" : "NOT FOUND";
+            var badgeBg = alreadyAdded ? "#1B2A3A" : s.Found ? "#1B3A2A" : "#3A2A1B";
+            var badgeFg = alreadyAdded ? "#60A5FA" : s.Found ? "#22C55E" : "#F59E0B";
             var statusBadge = new Border
             {
-                Background = Brush(s.Found ? "#1B3A2A" : "#3A2A1B"),
+                Background = Brush(badgeBg),
                 CornerRadius = new global::Avalonia.CornerRadius(3),
                 Padding = new global::Avalonia.Thickness(6, 1),
                 VerticalAlignment = VerticalAlignment.Center,
                 Child = new TextBlock
                 {
-                    Text = s.Found ? "FOUND" : "NOT FOUND",
-                    Foreground = Brush(s.Found ? "#22C55E" : "#F59E0B"),
+                    Text = badgeText,
+                    Foreground = Brush(badgeFg),
                     FontSize = 10,
                     FontWeight = FontWeight.SemiBold,
                 },
@@ -124,7 +156,13 @@ public partial class ToolDetectionWizardDialog : Window
             headerRow.Children.Add(statusBadge);
 
             var details = new StackPanel { Spacing = 2, Margin = new global::Avalonia.Thickness(28, 4, 0, 0) };
-            if (s.Found)
+            if (alreadyAdded)
+            {
+                details.Children.Add(DetailLine("Already in your Agents list - it will not be added again."));
+                if (s.Found)
+                    details.Children.Add(DetailLine($"Path: {s.ResolvedPath}"));
+            }
+            else if (s.Found)
             {
                 details.Children.Add(DetailLine($"Path: {s.ResolvedPath}"));
                 details.Children.Add(DetailLine($"Command line: {s.RecommendedPresetName}"));
@@ -147,7 +185,7 @@ public partial class ToolDetectionWizardDialog : Window
             };
 
             ToolListPanel.Children.Add(card);
-            _rows.Add(new ToolRow(s.Tool, check, s.ResolvedPath, s.Found));
+            _rows.Add(new ToolRow(s.Tool, s.DisplayName, check, s.ResolvedPath, s.Found, alreadyAdded));
         }
     }
 
@@ -184,13 +222,10 @@ public partial class ToolDetectionWizardDialog : Window
                 return;
             }
 
-            var written = await Task.Run(() => ToolDetectionWizardModel.AcceptSelected(selections));
+            var result = await Task.Run(() => ToolDetectionWizardModel.AcceptSelected(selections));
+            LastResult = result;
 
-            // Apply the accepted Claude command line + paths to the running options so the next
-            // session launched without a restart uses them (mirrors the Settings dialog wiring).
-            ApplyAcceptedToRunningOptions(selections);
-
-            FileLog.Write($"[ToolDetectionWizardDialog] BtnAccept_Click: wrote {written} tool(s)");
+            FileLog.Write($"[ToolDetectionWizardDialog] BtnAccept_Click: added={result.AddedTools.Count}, skipped={result.SkippedTools.Count}");
             Close(true);
         }
         catch (Exception ex)
@@ -199,35 +234,6 @@ public partial class ToolDetectionWizardDialog : Window
             ShowResult($"Could not save the selected tools: {ex.Message}", error: true);
             AcceptButton.IsEnabled = true;
         }
-    }
-
-    /// <summary>
-    /// Push the just-saved per-tool config onto the running AgentOptions so a session launched
-    /// without restarting picks up the accepted tool paths and the Claude default command line.
-    /// </summary>
-    private void ApplyAcceptedToRunningOptions(IReadOnlyList<AcceptedToolSelection> selections)
-    {
-        var options = (global::Avalonia.Application.Current as App)?.SessionManager?.Options
-            ?? (global::Avalonia.Application.Current as App)?.Options;
-        if (options is null)
-        {
-            FileLog.Write("[ToolDetectionWizardDialog] ApplyAcceptedToRunningOptions: no running options; skipped");
-            return;
-        }
-
-        foreach (var selection in selections)
-        {
-            if (!string.IsNullOrWhiteSpace(selection.ResolvedPath))
-                ToolDetectionService.SetConfiguredPath(selection.Tool, options, selection.ResolvedPath);
-        }
-
-        var claudeConfig = AgentToolConfig.Load(AgentKind.ClaudeCode);
-        var args = claudeConfig.ResolveEffectiveArguments().Trim();
-        var model = claudeConfig.DefaultModel?.Trim() ?? "";
-        if (model.Length > 0 && !args.Contains("--model", StringComparison.OrdinalIgnoreCase))
-            args = string.IsNullOrEmpty(args) ? $"--model {model}" : $"{args} --model {model}";
-        options.DefaultClaudeArgs = args;
-        FileLog.Write($"[ToolDetectionWizardDialog] ApplyAcceptedToRunningOptions: claudeArgs='{args}'");
     }
 
     private void BtnCancel_Click(object? sender, RoutedEventArgs e)

--- a/src/CcDirector.Core.Tests/Agents/ToolDetectionWizardModelTests.cs
+++ b/src/CcDirector.Core.Tests/Agents/ToolDetectionWizardModelTests.cs
@@ -1,4 +1,3 @@
-using System.Text.Json.Nodes;
 using Xunit;
 using CcDirector.Core.Agents;
 using CcDirector.Core.Configuration;
@@ -12,13 +11,8 @@ public class ToolDetectionWizardModelTests
     private static string NewRoot() =>
         Path.Combine(Path.GetTempPath(), "cc-director-wizard-tests", Guid.NewGuid().ToString("N"));
 
-    private static JsonObject ReadConfig()
-    {
-        return CcDirectorConfigService.ReadRaw();
-    }
-
     [Fact]
-    public void IsFirstRun_NoAgentToolsSection_ReturnsTrue()
+    public void IsFirstRun_NoAgentEntries_ReturnsTrue()
     {
         var old = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
         var root = NewRoot();
@@ -82,28 +76,29 @@ public class ToolDetectionWizardModelTests
     }
 
     [Fact]
-    public void AcceptSelected_WritesOnlySelectedTools()
+    public void AcceptSelected_AddsOnlySelectedToolsToEntries()
     {
         var old = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
         var root = NewRoot();
         Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", root);
         try
         {
-            var written = ToolDetectionWizardModel.AcceptSelected(new[]
+            var result = ToolDetectionWizardModel.AcceptSelected(new[]
             {
                 new AcceptedToolSelection(AgentKind.ClaudeCode, "claude"),
                 new AcceptedToolSelection(AgentKind.Pi, "pi"),
             });
 
-            Assert.Equal(2, written);
+            Assert.Equal(2, result.AddedTools.Count);
+            Assert.Empty(result.SkippedTools);
 
-            var config = ReadConfig();
-            var tools = (config["agent"] as JsonObject)?["tools"] as JsonObject;
-            Assert.NotNull(tools);
-            Assert.True(tools!.ContainsKey("claude"));
-            Assert.True(tools.ContainsKey("pi"));
-            // A deselected tool (Codex was never passed) is NOT written.
-            Assert.False(tools.ContainsKey("codex"));
+            // The accepted tools land in the live agent.entries list (what the New Session picker
+            // launches from) - the regression this fix is about.
+            var entries = AgentEntryStore.ReadCurrentEntries();
+            Assert.Contains(entries, e => e.Type == AgentKind.ClaudeCode);
+            Assert.Contains(entries, e => e.Type == AgentKind.Pi);
+            // A deselected tool (Codex was never passed) is NOT added.
+            Assert.DoesNotContain(entries, e => e.Type == AgentKind.Codex);
         }
         finally
         {
@@ -113,7 +108,7 @@ public class ToolDetectionWizardModelTests
     }
 
     [Fact]
-    public void AcceptSelected_Claude_WritesAutomaticDefaultPreset()
+    public void AcceptSelected_Claude_WritesAutomaticDefaultPresetOnEntry()
     {
         var old = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
         var root = NewRoot();
@@ -125,12 +120,12 @@ public class ToolDetectionWizardModelTests
                 new AcceptedToolSelection(AgentKind.ClaudeCode, "claude"),
             });
 
-            // Issue #436: accepting Claude from the wizard now writes the Automatic (skip
-            // permissions) catalog default, so a freshly configured Claude skips permissions.
-            var loaded = AgentToolConfig.Load(AgentKind.ClaudeCode);
-            Assert.Equal(AgentToolCatalog.ClaudeAutomaticPresetName, loaded.PresetName);
-            Assert.Equal(AgentToolCatalog.ClaudeSkipPermissionsArg, loaded.ResolveEffectiveArguments());
-            Assert.True(loaded.Enabled);
+            // Issue #436: accepting Claude from the wizard seeds the Automatic (skip permissions)
+            // catalog default on the new entry, so a freshly configured Claude skips permissions.
+            var entry = AgentEntryStore.ReadCurrentEntries().Single(e => e.Type == AgentKind.ClaudeCode);
+            Assert.Equal(AgentToolCatalog.ClaudeAutomaticPresetName, entry.PresetId);
+            Assert.Equal(AgentToolCatalog.ClaudeSkipPermissionsArg, entry.ToToolConfig().ResolveEffectiveArguments());
+            Assert.True(entry.Enabled);
         }
         finally
         {
@@ -140,7 +135,7 @@ public class ToolDetectionWizardModelTests
     }
 
     [Fact]
-    public void AcceptSelected_RecordsResolvedPathUnderAgentSection()
+    public void AcceptSelected_RecordsResolvedPathOnEntry()
     {
         var old = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
         var root = NewRoot();
@@ -152,10 +147,53 @@ public class ToolDetectionWizardModelTests
                 new AcceptedToolSelection(AgentKind.ClaudeCode, @"C:\tools\claude.cmd"),
             });
 
-            var config = ReadConfig();
-            var agent = config["agent"] as JsonObject;
-            Assert.NotNull(agent);
-            Assert.Equal(@"C:\tools\claude.cmd", (agent!["claude_path"] as JsonValue)?.GetValue<string>());
+            var entry = AgentEntryStore.ReadCurrentEntries().Single(e => e.Type == AgentKind.ClaudeCode);
+            Assert.Equal(@"C:\tools\claude.cmd", entry.ExecutablePath);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", old);
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void AcceptSelected_WhenTypeAlreadyInEntries_SkipsItAndAddsTheRest()
+    {
+        var old = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        var root = NewRoot();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", root);
+        try
+        {
+            // Pre-existing list already has a (customized) Codex entry, like the user's real
+            // machine in the bug report. Re-running the wizard and selecting Codex + Gemini must
+            // add only Gemini and leave the existing Codex entry untouched.
+            AgentEntryStore.SaveEntries(new[]
+            {
+                new AgentEntry
+                {
+                    DisplayName = "My Codex",
+                    Type = AgentKind.Codex,
+                    ExecutablePath = @"C:\custom\codex.exe",
+                },
+            });
+
+            var result = ToolDetectionWizardModel.AcceptSelected(new[]
+            {
+                new AcceptedToolSelection(AgentKind.Codex, @"C:\detected\codex.exe"),
+                new AcceptedToolSelection(AgentKind.Gemini, @"C:\detected\gemini.cmd"),
+            });
+
+            Assert.Equal(new[] { AgentKind.Gemini }, result.AddedTools);
+            Assert.Equal(new[] { AgentKind.Codex }, result.SkippedTools);
+
+            var entries = AgentEntryStore.ReadCurrentEntries();
+            // Exactly one Codex, still the original customized one (not overwritten).
+            var codex = Assert.Single(entries, e => e.Type == AgentKind.Codex);
+            Assert.Equal("My Codex", codex.DisplayName);
+            Assert.Equal(@"C:\custom\codex.exe", codex.ExecutablePath);
+            // Gemini was genuinely added.
+            Assert.Contains(entries, e => e.Type == AgentKind.Gemini);
         }
         finally
         {

--- a/src/CcDirector.Core/Agents/ToolDetectionWizardModel.cs
+++ b/src/CcDirector.Core/Agents/ToolDetectionWizardModel.cs
@@ -36,8 +36,20 @@ public sealed record ToolDetectionSuggestion(
 /// user left checked.
 /// </summary>
 /// <param name="Tool">Which agent CLI to write.</param>
-/// <param name="ResolvedPath">The detected executable path to record under agent.&lt;key&gt;_path.</param>
+/// <param name="ResolvedPath">The detected executable path to record on the new agent entry.</param>
 public sealed record AcceptedToolSelection(AgentKind Tool, string ResolvedPath);
+
+/// <summary>
+/// Outcome of accepting tools in the wizard: which tools became NEW entries in
+/// <c>agent.entries</c> and which were skipped because an entry of that type already existed.
+/// Lets the UI report honestly ("Added 2, skipped 3 already in your list") instead of a bare
+/// count that hides the skip.
+/// </summary>
+/// <param name="AddedTools">Tools that were appended to <c>agent.entries</c> as new entries.</param>
+/// <param name="SkippedTools">Selected tools left untouched because their type was already present.</param>
+public sealed record WizardAcceptResult(
+    IReadOnlyList<AgentKind> AddedTools,
+    IReadOnlyList<AgentKind> SkippedTools);
 
 /// <summary>
 /// UI-free engine for the first-run tool-detection wizard (issue #392): decides whether this is
@@ -57,18 +69,19 @@ public sealed class ToolDetectionWizardModel
     }
 
     /// <summary>
-    /// True when no agent tools have been configured yet - the first-run trigger (issue #392):
-    /// the <c>agent.tools</c> section is absent or empty in <c>config.json</c>. Accepting the
-    /// wizard writes at least one tool under <c>agent.tools.&lt;key&gt;</c>, after which this
-    /// returns false and the wizard never auto-opens again.
+    /// True when no agent has been configured yet - the first-run trigger: the
+    /// <c>agent.entries</c> list is absent or empty in <c>config.json</c>. Accepting the wizard
+    /// appends at least one entry under <c>agent.entries</c>, after which this returns false and
+    /// the wizard never auto-opens again. (Checks <c>agent.entries</c> - the live source of truth
+    /// the New Session picker launches from - not the retired <c>agent.tools</c> section.)
     /// </summary>
     public static bool IsFirstRun()
     {
         FileLog.Write("[ToolDetectionWizardModel] IsFirstRun");
         var root = CcDirectorConfigService.ReadRaw();
         var agent = root["agent"] as JsonObject ?? root["Agent"] as JsonObject;
-        var tools = agent?["tools"] as JsonObject;
-        var firstRun = tools is null || tools.Count == 0;
+        var entries = agent?["entries"] as JsonArray;
+        var firstRun = entries is null || entries.Count == 0;
         FileLog.Write($"[ToolDetectionWizardModel] IsFirstRun: result={firstRun}");
         return firstRun;
     }
@@ -104,59 +117,58 @@ public sealed class ToolDetectionWizardModel
     }
 
     /// <summary>
-    /// Write the user-accepted tools to the machine-level <c>config.json</c>: each selected tool
-    /// is saved with the catalog's recommended default preset and model (enabled), and its
-    /// detected executable path is recorded under <c>agent.&lt;key&gt;_path</c>. Tools the user
-    /// deselected are NOT written. No tool is ever written with
-    /// <c>--dangerously-skip-permissions</c> - the catalog default preset is the Standard one.
-    /// Returns the number of tools written.
+    /// Append the user-accepted tools to the live <c>agent.entries</c> list in the machine-level
+    /// <c>config.json</c> - the same list the Settings Agents tab and the New Session picker read,
+    /// so an accepted tool actually shows up and is launchable. Each new entry is seeded from the
+    /// catalog's recommended default preset and model (enabled) and carries the detector's resolved
+    /// executable path. A selected tool whose <em>type</em> already has an entry is SKIPPED (not
+    /// duplicated and not overwritten), so the wizard is safely re-runnable and never clobbers a
+    /// user's customized entry. Reads the current list WITHOUT seeding (see
+    /// <see cref="AgentEntryStore.ReadCurrentEntries"/>) and only writes when something new was
+    /// added. Returns which tools were added versus skipped.
     /// </summary>
-    public static int AcceptSelected(IReadOnlyList<AcceptedToolSelection> selections)
+    public static WizardAcceptResult AcceptSelected(IReadOnlyList<AcceptedToolSelection> selections)
     {
         FileLog.Write($"[ToolDetectionWizardModel] AcceptSelected: count={selections?.Count ?? 0}");
         if (selections is null) throw new ArgumentNullException(nameof(selections));
 
+        var entries = AgentEntryStore.ReadCurrentEntries();
+        var existingTypes = new HashSet<AgentKind>(entries.Select(e => e.Type));
+
+        var added = new List<AgentKind>();
+        var skipped = new List<AgentKind>();
+
         foreach (var selection in selections)
         {
-            // Seed from the catalog defaults so a freshly accepted tool gets the recommended
-            // Standard command line (never skip-permissions) and recommended model, enabled.
-            var config = AgentToolConfig.FromCatalogDefaults(selection.Tool);
-            config.Save();
+            if (existingTypes.Contains(selection.Tool))
+            {
+                skipped.Add(selection.Tool);
+                FileLog.Write($"[ToolDetectionWizardModel] AcceptSelected: skipped tool={selection.Tool} (type already in agent.entries)");
+                continue;
+            }
 
-            if (!string.IsNullOrWhiteSpace(selection.ResolvedPath))
-                SavePath(selection.Tool, selection.ResolvedPath);
-
-            FileLog.Write($"[ToolDetectionWizardModel] AcceptSelected: wrote tool={selection.Tool}, preset={config.PresetName}");
+            // Seed the new entry from the catalog defaults so it gets the recommended command line
+            // and model, enabled, plus the detected executable path.
+            var defaults = AgentToolConfig.FromCatalogDefaults(selection.Tool);
+            entries.Add(new AgentEntry
+            {
+                DisplayName = AgentToolCatalog.GetEntry(selection.Tool).DisplayName,
+                Type = selection.Tool,
+                Enabled = true,
+                ExecutablePath = selection.ResolvedPath ?? "",
+                PresetId = defaults.PresetName,
+                DefaultModel = defaults.DefaultModel,
+                ArgsOverride = defaults.ArgsOverride,
+            });
+            existingTypes.Add(selection.Tool);
+            added.Add(selection.Tool);
+            FileLog.Write($"[ToolDetectionWizardModel] AcceptSelected: added tool={selection.Tool}, preset={defaults.PresetName}");
         }
 
-        return selections.Count;
-    }
+        if (added.Count > 0)
+            AgentEntryStore.SaveEntries(entries);
 
-    /// <summary>
-    /// Persist a tool's detected executable path under <c>agent.&lt;key&gt;_path</c> in
-    /// config.json (machine-level), so the path the detector resolved is the path Director
-    /// launches with. Untouched sections are preserved by the merge writer.
-    /// </summary>
-    private static void SavePath(AgentKind tool, string resolvedPath)
-    {
-        var patch = new JsonObject
-        {
-            ["agent"] = new JsonObject
-            {
-                [PathKeyFor(tool)] = resolvedPath,
-            }
-        };
-        CcDirectorConfigService.MergePatch(patch);
+        FileLog.Write($"[ToolDetectionWizardModel] AcceptSelected: added={added.Count}, skipped={skipped.Count}");
+        return new WizardAcceptResult(added, skipped);
     }
-
-    /// <summary>The config.json key for a tool's executable path, e.g. <c>claude_path</c>.</summary>
-    private static string PathKeyFor(AgentKind tool) => tool switch
-    {
-        AgentKind.ClaudeCode => "claude_path",
-        AgentKind.Pi => "pi_path",
-        AgentKind.Codex => "codex_path",
-        AgentKind.Gemini => "gemini_path",
-        AgentKind.OpenCode => "opencode_path",
-        _ => throw new NotSupportedException($"[ToolDetectionWizardModel] Tool {tool} has no path config key.")
-    };
 }

--- a/src/CcDirector.Core/Configuration/AgentEntry.cs
+++ b/src/CcDirector.Core/Configuration/AgentEntry.cs
@@ -114,6 +114,29 @@ public static class AgentEntryStore
     }
 
     /// <summary>
+    /// Read the persisted <c>agent.entries</c> WITHOUT triggering the first-run legacy seed:
+    /// returns the current entries in array order, or an empty list when <c>agent.entries</c> is
+    /// absent. The tool-detection wizard uses this (not <see cref="LoadEntries"/>) so it sees the
+    /// user's REAL current list - if it seeded, every tool would look already-present and the
+    /// wizard could never add anything.
+    /// </summary>
+    public static List<AgentEntry> ReadCurrentEntries()
+    {
+        FileLog.Write("[AgentEntryStore] ReadCurrentEntries");
+        var root = CcDirectorConfigService.ReadRaw();
+        var agent = root["agent"] as JsonObject ?? root["Agent"] as JsonObject;
+        if (agent?["entries"] is JsonArray array)
+        {
+            var loaded = ReadEntries(array);
+            FileLog.Write($"[AgentEntryStore] ReadCurrentEntries: read {loaded.Count} entries");
+            return loaded;
+        }
+
+        FileLog.Write("[AgentEntryStore] ReadCurrentEntries: no agent.entries; returning empty (no seed)");
+        return new List<AgentEntry>();
+    }
+
+    /// <summary>
     /// Persist the ordered entries to <c>config.json</c> under <c>agent.entries</c>. The array is
     /// REPLACED wholesale (MergePatch replaces arrays), so removing/reordering takes effect; all
     /// other config sections are left exactly as they were.


### PR DESCRIPTION
## What
The first-run tool-detection wizard used to write the retired `agent.tools` / `*_path` config keys. It now appends accepted tools to the live `agent.entries` list - the same list the Settings Agents tab and the New Session picker read - so an accepted tool actually shows up and is launchable.

## Behaviour
- A selected tool whose type already has an entry is **skipped** (not duplicated, not overwritten), so the wizard is safely re-runnable.
- Settings reports honestly: "Added N new agents: ..." plus how many selected tools were skipped because they were already present.
- Adds `AgentEntryStore.ReadCurrentEntries` which reads `agent.entries` without triggering the legacy first-run seed (so the wizard sees the real current list).

## Files
- `src/CcDirector.Core/Agents/ToolDetectionWizardModel.cs`
- `src/CcDirector.Core/Configuration/AgentEntry.cs`
- `src/CcDirector.Avalonia/ToolDetectionWizardDialog.axaml.cs`
- `src/CcDirector.Avalonia/SettingsDialog.axaml.cs`
- `src/CcDirector.Core.Tests/Agents/ToolDetectionWizardModelTests.cs`

## Verification
`dotnet build` of CcDirector.Avalonia and CcDirector.Core.Tests both succeed with 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)