### PR TITLE
feat(voice): read-only live terminal view on the phone voice page

### DIFF
--- a/src/CcDirector.Cockpit/wwwroot/pages/voice/index.html
+++ b/src/CcDirector.Cockpit/wwwroot/pages/voice/index.html
@@ -49,6 +49,7 @@
     </div>
 
     <div class="controls-row">
+      <button id="terminal-btn" class="secondary">Watch terminal</button>
       <button id="wingman-btn" class="secondary">Talk to Wingman</button>
     </div>
 
@@ -117,6 +118,33 @@
         <button id="wm-escape-btn" class="danger">Escape</button>
       </div>
     </div>
+  </section>
+
+  <!-- Terminal view: a live, auto-refreshing, read-only look at the session's terminal so
+       you can see what the agent is doing from a phone. It ONLY polls
+       GET /sessions/{id}/buffer (ANSI-stripped text) and NEVER sends anything to the
+       session - to act on the session, use the Wingman screen's explicit actions. -->
+  <section id="terminal-view" class="view hidden">
+    <header class="bar">
+      <button id="tm-back-btn" class="ghost">&larr; Back</button>
+      <h1 id="tm-title" class="session-name">Terminal</h1>
+    </header>
+
+    <div class="tm-toolbar">
+      <button id="tm-live-btn" class="secondary tm-live">Live</button>
+      <button id="tm-refresh-btn" class="secondary">Refresh</button>
+      <label class="tm-ctl">Lines
+        <select id="tm-lines" class="tm-select">
+          <option value="80">80</option>
+          <option value="200" selected>200</option>
+          <option value="500">500</option>
+        </select>
+      </label>
+      <button id="tm-wrap-btn" class="secondary tm-toggle">Wrap</button>
+    </div>
+
+    <p id="tm-status" class="status-line">Connecting...</p>
+    <pre id="tm-screen" class="tm-screen" aria-live="polite"></pre>
   </section>
 
   <!-- The Gateway token is injected server-side by the /voice route (same box reads

--- a/src/CcDirector.Cockpit/wwwroot/pages/voice/voice.css
+++ b/src/CcDirector.Cockpit/wwwroot/pages/voice/voice.css
@@ -16,6 +16,9 @@
   --badge-pending-line:#5a4a1f; --badge-uploading-line:#2a4170;
   --badge-uploaded-line:#1f5a37; --badge-failed-line:#5a2a2d;
   --badge-stale-line:#7a5a1f; --badge-stale-bg:#3a2f12;
+  /* Terminal view: kept dark in both themes so the read-only screen reads like a terminal
+     and its light text never collides with the page's theme ink. */
+  --term-bg:#05080f; --term-ink:#D6DEEC;
 }
 *{box-sizing:border-box}
 html,body{margin:0;height:100%}
@@ -185,5 +188,24 @@ button:disabled{opacity:.45;cursor:default}
     --badge-pending-line:#E2C98A; --badge-uploading-line:#A9C2F6;
     --badge-uploaded-line:#A6D7BB; --badge-failed-line:#E4B6B8;
     --badge-stale-line:#D9BE7F; --badge-stale-bg:#FBF1D6;
+    /* Terminal stays dark even in light mode (a dark terminal panel is the convention and
+       keeps the monospace screen high-contrast). */
+    --term-bg:#0E1424; --term-ink:#D6DEEC;
   }
 }
+
+/* Terminal view: a live, read-only look at the session's terminal, sized for a phone. The
+   <pre> is the scroll container (so "follow the bottom" can detect the user's scroll), and a
+   Wrap toggle switches between horizontal scroll (true terminal layout) and soft-wrapping. */
+.tm-toolbar{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin:0 2px 12px}
+.tm-toolbar .secondary{padding:10px 14px;font-size:14px}
+.tm-live.on{color:var(--green);border-color:var(--badge-uploaded-line)}
+.tm-toggle.on{color:var(--blue);border-color:var(--badge-uploading-line)}
+.tm-ctl{display:flex;align-items:center;gap:8px;color:var(--muted);font-size:14px}
+.tm-select{font:inherit;color:var(--ink);background:var(--panel);border:1px solid var(--line);
+  border-radius:10px;padding:9px 10px}
+.tm-screen{margin:0;background:var(--term-bg);border:1px solid var(--line);border-radius:14px;
+  padding:14px;color:var(--term-ink);font-family:ui-monospace,Menlo,Consolas,monospace;
+  font-size:12px;line-height:1.4;white-space:pre;overflow:auto;
+  max-height:calc(100vh - 230px);-webkit-overflow-scrolling:touch}
+.tm-screen.wrap{white-space:pre-wrap;word-break:break-word}

--- a/src/CcDirector.Cockpit/wwwroot/pages/voice/voice.js
+++ b/src/CcDirector.Cockpit/wwwroot/pages/voice/voice.js
@@ -47,6 +47,7 @@
     $("session-view").classList.toggle("hidden", view !== "session");
     $("newsession-view").classList.toggle("hidden", view !== "newsession");
     $("wingman-view").classList.toggle("hidden", view !== "wingman");
+    $("terminal-view").classList.toggle("hidden", view !== "terminal");
   }
 
   async function api(path, opts) {
@@ -1148,6 +1149,85 @@
     wmAppend("wingman", "Escape sent to the session.", "explicit action");
   }
 
+  // ===== Terminal view (live, read-only screen) =====
+  // A phone-sized, auto-refreshing look at the session's terminal so you can see what the
+  // agent is doing without the desktop. READ-ONLY: it only polls GET /sessions/{id}/buffer
+  // (ANSI-stripped text) and never sends anything to the session. Polling stops the moment
+  // the view is left (or the tab is hidden) so a backgrounded screen does not keep hitting
+  // the Gateway.
+  var tmSession = null;     // the session the terminal is bound to (null when the view is closed)
+  var tmTimer = null;       // the auto-refresh interval handle
+  var tmLive = true;        // whether auto-refresh is on (the Live/Paused toggle)
+  var tmInFlight = false;   // guard so a slow fetch does not stack another on top of it
+  var TM_POLL_MS = 2000;
+
+  function openTerminal(s) {
+    tmSession = s;
+    $("tm-title").textContent = sessionTitle(s);
+    $("tm-screen").textContent = "";
+    $("tm-status").textContent = "Connecting...";
+    setTmLive(true);
+    show("terminal");
+    refreshTerminal();          // immediate first paint, do not wait for the first tick
+    startTerminalPolling();
+  }
+
+  function startTerminalPolling() {
+    stopTerminalPolling();
+    tmTimer = setInterval(function () {
+      // Skip while paused or while the tab is hidden (no point polling a screen nobody sees).
+      if (tmLive && !document.hidden) refreshTerminal();
+    }, TM_POLL_MS);
+  }
+
+  function stopTerminalPolling() {
+    if (tmTimer) { clearInterval(tmTimer); tmTimer = null; }
+  }
+
+  // Leaving the terminal view: stop polling and unbind the session so a late fetch is ignored.
+  function closeTerminal() {
+    stopTerminalPolling();
+    tmSession = null;
+  }
+
+  function setTmLive(on) {
+    tmLive = on;
+    var btn = $("tm-live-btn");
+    btn.textContent = on ? "Live" : "Paused";
+    btn.classList.toggle("on", on);
+  }
+
+  function tmLines() {
+    var v = parseInt($("tm-lines").value, 10);
+    return (isFinite(v) && v > 0) ? v : 200;
+  }
+
+  // Fetch the latest buffer and render it. Preserves the user's scroll position unless they
+  // are already pinned to the bottom (then it auto-follows new output), so scrolling back
+  // through scrollback to read is not yanked away on every 2-second refresh.
+  async function refreshTerminal() {
+    if (!tmSession || tmInFlight) return;
+    tmInFlight = true;
+    var sid = tmSession.sessionId;
+    try {
+      var r = await api("/sessions/" + sid + "/buffer?lines=" + tmLines());
+      if (!tmSession || tmSession.sessionId !== sid) return; // user switched away mid-flight
+      if (!r.ok || !r.data) {
+        $("tm-status").textContent = r.status === 401
+          ? "Not connected. Pair this phone with the Gateway first."
+          : "Could not read the terminal (" + r.status + ").";
+        return;
+      }
+      var pre = $("tm-screen");
+      var nearBottom = (pre.scrollHeight - pre.scrollTop - pre.clientHeight) < 40;
+      pre.textContent = (r.data.text || "").replace(/\s+$/, "") || "(terminal is empty)";
+      if (nearBottom) pre.scrollTop = pre.scrollHeight;
+      $("tm-status").textContent = tmLive ? "Live - updates every 2s" : "Paused";
+    } finally {
+      tmInFlight = false;
+    }
+  }
+
   // ===== util =====
   function sleep(ms) { return new Promise(function (r) { setTimeout(r, ms); }); }
 
@@ -1174,6 +1254,18 @@
   $("back-btn").addEventListener("click", function () { show("list"); loadSessions(); });
   $("speak-btn").addEventListener("click", function () { toggleSpeak(); });
   $("play-btn").addEventListener("click", playReply);
+
+  // Terminal view (live read-only screen). Opening it binds to the open session; Back returns
+  // to that session view and stops the polling.
+  $("terminal-btn").addEventListener("click", function () { if (current) openTerminal(current); });
+  $("tm-back-btn").addEventListener("click", function () { closeTerminal(); show("session"); });
+  $("tm-live-btn").addEventListener("click", function () { setTmLive(!tmLive); if (tmLive) refreshTerminal(); });
+  $("tm-refresh-btn").addEventListener("click", function () { refreshTerminal(); });
+  $("tm-lines").addEventListener("change", function () { refreshTerminal(); });
+  $("tm-wrap-btn").addEventListener("click", function () {
+    var wrapped = $("tm-screen").classList.toggle("wrap");
+    $("tm-wrap-btn").classList.toggle("on", wrapped);
+  });
 
   // Wingman Chat (issue #424)
   $("wingman-btn").addEventListener("click", function () { if (current) openWingman(current); });


### PR DESCRIPTION
## What
Adds a **Watch terminal** view to the Cockpit voice page - a phone-sized, auto-refreshing, read-only look at a session's terminal, so you can see what an agent is doing without the desktop.

## Behaviour
- **Read-only:** polls `GET /sessions/{id}/buffer` (ANSI-stripped text) and never sends anything to the session. To act on a session, use the Wingman screen's explicit actions.
- Controls: Live / Refresh, a Lines selector (80 / 200 / 500), and a Wrap toggle.
- Polling stops the moment the view is left or the browser tab is hidden, so a backgrounded screen does not keep hitting the Gateway.
- The terminal panel stays dark in both light and dark themes (terminal convention, high contrast).

## Files
- `src/CcDirector.Cockpit/wwwroot/pages/voice/index.html`
- `src/CcDirector.Cockpit/wwwroot/pages/voice/voice.css`
- `src/CcDirector.Cockpit/wwwroot/pages/voice/voice.js`

## Verification
Static front-end assets (HTML / CSS / JavaScript); no build step. The Cockpit serves them as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)