### PR TITLE
Named sessions: save repo+agent+model preset, launch from New Session dialog (#508)

### DIFF
--- a/docs/cencon/proof/issue-508/HUMAN_QA_PLAN.html
+++ b/docs/cencon/proof/issue-508/HUMAN_QA_PLAN.html
@@ -1,0 +1,562 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>Human QA Test Plan - Issue #508: Named Sessions</title>
+<style>
+        /* Boardroom Theme - Corporate, executive style with serif fonts */
+        
+        :root {
+            /* Colors */
+            --primary: #1A365D;
+            --primary-light: #2A4A7F;
+            --accent: #D69E2E;
+            --text: #2D3748;
+            --heading: #1A365D;
+            --background: #FFFFFF;
+            --code-bg: #EDF2F7;
+            --code-text: #1A365D;
+            --border: #CBD5E0;
+            --link: #2B6CB0;
+            --blockquote-text: #4A5568;
+            --blockquote-border: #D69E2E;
+            --blockquote-bg: #FFFFFF;
+            --table-header-bg: #1A365D;
+            --table-header-text: #FFFFFF;
+            --alt-row-bg: #F7FAFC;
+            --shadow-color: rgba(26, 54, 93, 0.08);
+        
+            /* Fonts */
+            --font-heading: "Palatino Linotype", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            --font-body: "Georgia", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            --font-code: "Courier New", "JetBrains Mono", "Fira Code", Consolas, monospace;
+        
+            /* Style */
+            --heading-letter-spacing: -0.02em;
+            --line-height: 1.7;
+            --radius: 4px;
+            --code-radius: 6px;
+            --shadow-sm: 0 1px 3px rgba(26, 54, 93, 0.08);
+            --shadow-md: 0 4px 12px rgba(26, 54, 93, 0.1);
+        }
+        
+        /* Base styles for all themes */
+        
+        *,
+        *::before,
+        *::after {
+            box-sizing: border-box;
+        }
+        
+        html {
+            font-size: 16px;
+            line-height: var(--line-height);
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            text-rendering: optimizeLegibility;
+        }
+        
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: var(--font-body);
+            color: var(--text);
+            background: var(--background);
+        }
+        
+        .markdown-body {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 3rem 2.5rem;
+        }
+        
+        /* Typography */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            color: var(--heading);
+            margin-top: 1.8em;
+            margin-bottom: 0.6em;
+            font-weight: 600;
+            line-height: 1.25;
+            letter-spacing: var(--heading-letter-spacing);
+            orphans: 3;
+            widows: 3;
+        }
+        
+        h1 {
+            font-size: 2.25em;
+            margin-top: 0;
+        }
+        
+        h2 { font-size: 1.65em; }
+        h3 { font-size: 1.35em; }
+        h4 { font-size: 1.1em; }
+        h5 { font-size: 0.95em; }
+        h6 { font-size: 0.85em; color: var(--blockquote-text); }
+        
+        p {
+            margin: 1em 0;
+            orphans: 3;
+            widows: 3;
+        }
+        
+        /* Links */
+        a {
+            color: var(--link);
+            text-decoration: none;
+            border-bottom: 1px solid transparent;
+            transition: border-color 0.2s ease;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--link);
+        }
+        
+        /* Lists */
+        ul, ol {
+            margin: 1em 0;
+            padding-left: 2em;
+            line-height: var(--line-height);
+        }
+        
+        li {
+            margin: 0.35em 0;
+        }
+        
+        li > ul,
+        li > ol {
+            margin: 0.2em 0;
+        }
+        
+        /* Inline code */
+        code {
+            font-family: var(--font-code);
+            font-size: 0.875em;
+            padding: 0.15em 0.4em;
+            border-radius: var(--radius);
+            background: var(--code-bg);
+            color: var(--code-text);
+        }
+        
+        /* Code blocks */
+        pre {
+            margin: 1.5em 0;
+            padding: 1.25em 1.5em;
+            overflow-x: auto;
+            border-radius: var(--code-radius);
+            background: var(--code-bg);
+            border: 1px solid var(--border);
+            box-shadow: var(--shadow-sm);
+            position: relative;
+        }
+        
+        pre code {
+            padding: 0;
+            background: transparent;
+            border-radius: 0;
+            font-size: 0.875em;
+            line-height: 1.55;
+        }
+        
+        /* Blockquotes */
+        blockquote {
+            margin: 1.5em 0;
+            padding: 0.75em 1.25em;
+            border-left: 4px solid var(--blockquote-border);
+            background: var(--blockquote-bg);
+            color: var(--blockquote-text);
+            border-radius: 0 var(--radius) var(--radius) 0;
+        }
+        
+        blockquote p {
+            margin: 0.4em 0;
+        }
+        
+        blockquote p:first-child {
+            margin-top: 0;
+        }
+        
+        blockquote p:last-child {
+            margin-bottom: 0;
+        }
+        
+        /* Tables */
+        table {
+            width: 100%;
+            border-collapse: separate;
+            border-spacing: 0;
+            margin: 1.5em 0;
+            border-radius: var(--radius);
+            overflow: hidden;
+            box-shadow: var(--shadow-sm);
+            border: 1px solid var(--border);
+        }
+        
+        th, td {
+            padding: 0.75em 1em;
+            text-align: left;
+            border-bottom: 1px solid var(--border);
+        }
+        
+        th {
+            font-weight: 600;
+            background: var(--table-header-bg);
+            color: var(--table-header-text);
+        }
+        
+        tr:last-child td {
+            border-bottom: none;
+        }
+        
+        /* Horizontal rule */
+        hr {
+            border: none;
+            height: 2px;
+            max-width: 200px;
+            margin: 2.5em auto;
+            background: var(--border);
+            border-radius: 1px;
+        }
+        
+        /* Images */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: var(--radius);
+            box-shadow: var(--shadow-sm);
+        }
+        
+        /* Task lists */
+        .task-list-item {
+            list-style-type: none;
+        }
+        
+        .task-list-item input[type="checkbox"] {
+            margin-right: 0.5em;
+        }
+        
+        /* Strong and emphasis */
+        strong {
+            font-weight: 700;
+        }
+        
+        /* Definition lists (if supported by parser) */
+        dt {
+            font-weight: 600;
+            margin-top: 1em;
+        }
+        
+        dd {
+            margin-left: 1.5em;
+            margin-bottom: 0.5em;
+        }
+        
+        
+        /* Boardroom: corporate authority with accent borders */
+        h1 {
+            border-bottom: 3px solid var(--accent);
+            padding-bottom: 0.5em;
+        }
+        
+        h2 {
+            border-bottom: 1px solid var(--border);
+            padding-bottom: 0.3em;
+        }
+        
+        pre {
+            border-left: 4px solid var(--primary);
+            border-radius: 0 var(--code-radius) var(--code-radius) 0;
+        }
+        
+        pre::before {
+            content: "";
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 4px;
+            height: 100%;
+            background: var(--accent);
+            border-radius: 0;
+        }
+        
+        blockquote {
+            font-style: italic;
+        }
+        
+        hr {
+            background: var(--accent);
+            max-width: none;
+            height: 2px;
+        }
+        
+        tr:nth-child(even) td {
+            background: var(--alt-row-bg);
+        }
+        
+    </style>
+</head>
+<body>
+<article class="markdown-body">
+<h1>Human QA Test Plan - Issue #508: Named Sessions</h1>
+<p>This plan lets a human tester verify every acceptance criterion in issue #508 by clicking through
+        the running application. No knowledge of the code is required - follow the steps in order.</p>
+<p>The feature: a "named session" is a saved launch preset that ties together a repository, an agent,
+        and a model under a fixed name. You save the combination once and launch it again in one click from
+        the New Session dialog.</p>
+<hr/>
+<h2>What was built (so you know what to look for)</h2>
+<ul>
+<li>A new per-file store, <code>NamedSessionStore</code>, saves each preset as
+        <code>config/director/named-sessions/{slug}.named-session.json</code>.</li>
+<li>The New Session tab gained ONE compact row at the top: a "Named session" dropdown (placeholder
+        "(none)") and a small "Manage..." button.</li>
+<li>A compact "Model:" row sits with the Agent picker. It defaults to the selected agent's default
+        model; a preset fills it with its saved model.</li>
+<li>A "Save as named session..." button sits to the LEFT of the Start button, enabled only when a
+        repository, an agent, and a model are all set.</li>
+<li>A dedicated "Manage Named Sessions" dialog (opened by "Manage...") lists presets and supports
+        rename and delete. Orphaned presets (missing repository folder or removed agent) appear only here,
+        greyed and labelled, never in the start flow.</li>
+</ul>
+<hr/>
+<h2>Preconditions</h2>
+<ol>
+<li>CC Director is running (a normal build; this feature needs no special mode).</li>
+<li>At least one agent is configured (Settings &gt; Agents). For the model checks, an agent whose
+        "Default model" is set is convenient but not required.</li>
+<li>Have at least two real repository folders on disk that you can pick.</li>
+<li>Storage location to inspect saved files (optional, for the file-write check):
+        <code>%LOCALAPPDATA%\cc-director\config\director\named-sessions\</code></li>
+</ol>
+<p>If you want to start from a clean slate, you may delete any existing <code>*.named-session.json</code> files in
+        that folder before you begin.</p>
+<hr/>
+<h2>Test 1 - The compact row exists and the primary flow keeps its place</h2>
+<p>Verifies: "The New Session tab shows a single compact 'Named session' row (dropdown + Manage); the
+        Agent picker, repository list, and Start button keep their position."</p>
+<p>Steps:</p>
+<ol>
+<li>Open the New Session dialog (the "+ New Session" entry point).</li>
+<li>Confirm the "New Session" tab is selected.</li>
+</ol>
+<p>Expected result:</p>
+<ul>
+<li>At the very top there is a single row reading "Named session:" with a dropdown showing "(none)"
+        and a small "Manage..." button to its right. That is the only named-session control in the dialog
+        body.</li>
+<li>Below it, the Agent picker, the "Model:" row, the "Select a repository:" search and list, and the
+        "Start Session" button are all present and in their normal positions. Named sessions did NOT push
+        them down behind a large panel.</li>
+</ul>
+<p>PASS if the compact row is present and the primary controls are unchanged in position. FAIL
+        otherwise.</p>
+<hr/>
+<h2>Test 2 - "Save as named session..." is disabled until repository + agent + model are all set</h2>
+<p>Verifies: "'Save as named session...' is disabled until a repository, an agent, and a model are all
+        selected; saving writes one preset file capturing repository + agent id + model + name."</p>
+<p>Steps:</p>
+<ol>
+<li>In the New Session dialog, look at the bottom button row. There is a "Save as named session..."
+        button to the LEFT of "Start Session".</li>
+<li>Clear the "Model:" box if it has text. Do not select a repository yet.</li>
+<li>Observe the "Save as named session..." button state.</li>
+<li>Select a repository from the list (or Browse to one).</li>
+<li>Make sure an agent radio is selected (the first is selected by default).</li>
+<li>Type a model into the "Model:" box (for example <code>claude-opus-4</code> - any non-empty value).</li>
+<li>Observe the "Save as named session..." button state again.</li>
+<li>Click "Save as named session...". In the small "Save named session" prompt, type a name such as
+        <code>QA Director Opus</code> and confirm.</li>
+</ol>
+<p>Expected result:</p>
+<ul>
+<li>At step 3 (no repository and/or empty model), "Save as named session..." is DISABLED (dimmed).</li>
+<li>At step 7 (repository + agent + model all set), the button is ENABLED.</li>
+<li>After step 8 a preset file appears at
+        <code>%LOCALAPPDATA%\cc-director\config\director\named-sessions\qa-director-opus.named-session.json</code>.
+        Open it and confirm it contains the repository path you chose, an <code>AgentId</code> value, the model text
+        you typed, and the name.</li>
+</ul>
+<p>PASS if the enable/disable behaviour matches and the file is written with all four values. FAIL
+        otherwise.</p>
+<hr/>
+<h2>Test 3 - Selecting a preset fills the repository, agent, and model fields</h2>
+<p>Verifies: "Selecting a saved preset from the dropdown fills the repository, agent, and model fields
+        with the saved values (the user can see them before starting)."</p>
+<p>Steps:</p>
+<ol>
+<li>Still in the New Session dialog (with the <code>QA Director Opus</code> preset saved from Test 2), change
+        the fields away from the saved values: pick a DIFFERENT repository, select a different agent if
+        you have one, and change the "Model:" box text.</li>
+<li>Open the "Named session:" dropdown and pick <code>QA Director Opus</code>.</li>
+</ol>
+<p>Expected result:</p>
+<ul>
+<li>The repository path returns to the one saved in the preset (and the matching repository row
+        becomes selected if it is in the list).</li>
+<li>The agent radio returns to the agent saved in the preset.</li>
+<li>The "Model:" box returns to the model saved in the preset.</li>
+<li>No session starts - the dialog stays open. The user can see the filled values before pressing
+        Start.</li>
+</ul>
+<p>PASS if all three fields fill with the saved values and nothing launches. FAIL otherwise.</p>
+<hr/>
+<h2>Test 4 - Start launches the saved repository, agent, and model</h2>
+<p>Verifies: "Pressing Start after selecting a preset launches a session in the saved repository, with
+        the saved agent and model (verified by the launch log line and the running session)."</p>
+<p>Steps:</p>
+<ol>
+<li>With <code>QA Director Opus</code> selected in the dropdown (fields filled as in Test 3), press
+        "Start Session".</li>
+<li>Watch the new session appear and open the Director log at
+        <code>%LOCALAPPDATA%\cc-director\logs\director\</code> (the newest <code>director-*.log</code>).</li>
+</ol>
+<p>Expected result:</p>
+<ul>
+<li>A new session starts in the repository saved in the preset.</li>
+<li>In the log, the line <code>[MainWindow] ShowNewSessionDialog: path=...</code> shows the saved repository path
+        and the saved agent. The resolved command line for the agent includes the saved model (look for
+        the model string you saved, passed as the agent's <code>--model</code> argument).</li>
+<li>The running session is working in the saved repository (its title/path matches).</li>
+</ul>
+<p>PASS if the launched session uses the saved repository, agent, and model. FAIL otherwise.</p>
+<hr/>
+<h2>Test 5 - Manage dialog lists presets and supports rename and delete; no delete in the start flow</h2>
+<p>Verifies: "The Manage dialog lists presets and supports rename and delete; deleting removes the
+        preset file. There is NO delete control in the New Session start flow itself."</p>
+<p>Steps:</p>
+<ol>
+<li>In the New Session dialog, confirm there is NO delete (trash / X) control on the "Named session:"
+        row or anywhere in the start flow for named sessions.</li>
+<li>Click "Manage...". The "Manage Named Sessions" dialog opens.</li>
+<li>Confirm <code>QA Director Opus</code> is listed with its agent, model, and repository on the detail line.</li>
+<li>Select it and click "Rename...". Enter <code>QA Director Renamed</code> and confirm.</li>
+<li>Confirm the list now shows <code>QA Director Renamed</code>.</li>
+<li>Select it and click "Delete". Confirm the deletion in the prompt.</li>
+<li>Confirm the row disappears from the list. Close the Manage dialog.</li>
+<li>(Optional) Confirm the matching <code>*.named-session.json</code> file is gone from the named-sessions
+        folder.</li>
+</ol>
+<p>Expected result:</p>
+<ul>
+<li>There is no delete control in the New Session start flow; deletion is only inside the Manage
+        dialog, away from the launch buttons.</li>
+<li>Rename updates the displayed name (and the underlying file slug).</li>
+<li>Delete removes the preset from the list and removes its file from disk.</li>
+</ul>
+<p>PASS if rename and delete work in the Manage dialog and no delete control exists in the start flow.
+        FAIL otherwise.</p>
+<hr/>
+<h2>Test 6 - Orphans appear only in Manage, greyed and labelled, launch disabled</h2>
+<p>Verifies: "A preset whose repository folder or agent id no longer exists appears only in the Manage
+        dialog, greyed, labelled with the reason, with launch disabled - it does not appear as a row in the
+        New Session start flow."</p>
+<p>Set up an orphan (choose ONE of the two cases, or do both):</p>
+<p>Case A - missing repository:</p>
+<ol>
+<li>Save a new preset (Test 2 steps) pointing at a repository folder you can delete or rename.</li>
+<li>Close CC Director.</li>
+<li>On disk, rename or delete that repository folder so the saved path no longer exists.</li>
+<li>Reopen CC Director and open the New Session dialog.</li>
+</ol>
+<p>Case B - removed agent:</p>
+<ol>
+<li>Save a new preset using a specific agent.</li>
+<li>Go to Settings &gt; Agents and delete (or disable then remove) that agent.</li>
+<li>Reopen the New Session dialog.</li>
+</ol>
+<p>Steps (after either case):</p>
+<ol>
+<li>Open the "Named session:" dropdown in the New Session tab.</li>
+<li>Click "Manage..." and look at the orphaned preset's row.</li>
+</ol>
+<p>Expected result:</p>
+<ul>
+<li>The orphaned preset does NOT appear in the "Named session:" dropdown in the start flow.</li>
+<li>In the Manage dialog the orphaned preset IS listed, shown greyed/dimmed, with a small label
+        reading "repository missing" (Case A) or "agent removed" (Case B).</li>
+<li>The orphan cannot be launched from the start flow (it is simply not offered there).</li>
+</ul>
+<p>PASS if the orphan is hidden from the start dropdown but visible, greyed, and labelled in Manage.
+        FAIL otherwise.</p>
+<hr/>
+<h2>Test 7 - Logging format (spot check)</h2>
+<p>Verifies: "Entry, exit, and failure are logged in the [ClassName] Method: context format."</p>
+<p>Steps:</p>
+<ol>
+<li>After running Tests 2-5, open the newest Director log under
+        <code>%LOCALAPPDATA%\cc-director\logs\director\</code>.</li>
+<li>Search for <code>[NamedSessionStore]</code>, <code>[NewSessionDialog]</code>, and <code>[ManageNamedSessionsDialog]</code>.</li>
+</ol>
+<p>Expected result:</p>
+<ul>
+<li>You see lines such as <code>[NamedSessionStore] Save: ...</code>, <code>[NewSessionDialog] LoadNamedSessions</code>,
+        <code>[NewSessionDialog] NamedSessionCombo_SelectionChanged: applying preset ...</code>,
+        <code>[ManageNamedSessionsDialog] BtnDelete_Click: ...</code>, all in the <code>[ClassName] Method: context</code>
+        format.</li>
+</ul>
+<p>PASS if the log lines are present in that format. FAIL otherwise.</p>
+<hr/>
+<h2>Test 8 - Store unit tests (automated, no app)</h2>
+<p>Verifies: "The store has unit tests covering create, list, delete, and the orphan (missing repo /
+        missing agent) cases."</p>
+<p>Steps:</p>
+<ol>
+<li>From the repository root run:
+        <code>dotnet test src/CcDirector.Core.Tests/CcDirector.Core.Tests.csproj --filter "FullyQualifiedName~NamedSessionStoreTests"</code></li>
+</ol>
+<p>Expected result:</p>
+<ul>
+<li>All <code>NamedSessionStoreTests</code> pass, including the create/list/delete cases and the orphan cases
+        (<code>LoadAllWithStatus_MissingRepository_IsRepositoryMissingOrphan</code>,
+        <code>LoadAllWithStatus_RemovedAgent_IsAgentRemovedOrphan</code>, and the doubly-broken case).</li>
+</ul>
+<p>PASS if all tests pass. FAIL otherwise.</p>
+<hr/>
+<h2>Acceptance criteria coverage map</h2>
+<table>
+<thead>
+<tr>
+<th>Acceptance criterion (issue #508)</th>
+<th>Test</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Single compact "Named session" row; primary flow keeps position</td>
+<td>Test 1</td>
+</tr>
+<tr>
+<td>Save disabled until repository + agent + model; writes one preset file</td>
+<td>Test 2</td>
+</tr>
+<tr>
+<td>Selecting a preset fills repository + agent + model</td>
+<td>Test 3</td>
+</tr>
+<tr>
+<td>Start launches the saved repository + agent + model</td>
+<td>Test 4</td>
+</tr>
+<tr>
+<td>Manage dialog lists, renames, deletes; no delete in start flow</td>
+<td>Test 5</td>
+</tr>
+<tr>
+<td>Orphans only in Manage, greyed, labelled, launch disabled</td>
+<td>Test 6</td>
+</tr>
+<tr>
+<td>Logging in <code>[ClassName] Method: context</code> format</td>
+<td>Test 7</td>
+</tr>
+<tr>
+<td>Store unit tests: create / list / delete / orphan cases</td>
+<td>Test 8</td>
+</tr>
+</tbody>
+</table>
+</article>
+</body>
+</html>

--- a/docs/cencon/proof/issue-508/HUMAN_QA_PLAN.md
+++ b/docs/cencon/proof/issue-508/HUMAN_QA_PLAN.md
@@ -1,0 +1,249 @@
+# Human QA Test Plan - Issue #508: Named Sessions
+
+This plan lets a human tester verify every acceptance criterion in issue #508 by clicking through
+the running application. No knowledge of the code is required - follow the steps in order.
+
+The feature: a "named session" is a saved launch preset that ties together a repository, an agent,
+and a model under a fixed name. You save the combination once and launch it again in one click from
+the New Session dialog.
+
+---
+
+## What was built (so you know what to look for)
+
+- A new per-file store, `NamedSessionStore`, saves each preset as
+  `config/director/named-sessions/{slug}.named-session.json`.
+- The New Session tab gained ONE compact row at the top: a "Named session" dropdown (placeholder
+  "(none)") and a small "Manage..." button.
+- A compact "Model:" row sits with the Agent picker. It defaults to the selected agent's default
+  model; a preset fills it with its saved model.
+- A "Save as named session..." button sits to the LEFT of the Start button, enabled only when a
+  repository, an agent, and a model are all set.
+- A dedicated "Manage Named Sessions" dialog (opened by "Manage...") lists presets and supports
+  rename and delete. Orphaned presets (missing repository folder or removed agent) appear only here,
+  greyed and labelled, never in the start flow.
+
+---
+
+## Preconditions
+
+1. CC Director is running (a normal build; this feature needs no special mode).
+2. At least one agent is configured (Settings > Agents). For the model checks, an agent whose
+   "Default model" is set is convenient but not required.
+3. Have at least two real repository folders on disk that you can pick.
+4. Storage location to inspect saved files (optional, for the file-write check):
+   `%LOCALAPPDATA%\cc-director\config\director\named-sessions\`
+
+If you want to start from a clean slate, you may delete any existing `*.named-session.json` files in
+that folder before you begin.
+
+---
+
+## Test 1 - The compact row exists and the primary flow keeps its place
+
+Verifies: "The New Session tab shows a single compact 'Named session' row (dropdown + Manage); the
+Agent picker, repository list, and Start button keep their position."
+
+Steps:
+1. Open the New Session dialog (the "+ New Session" entry point).
+2. Confirm the "New Session" tab is selected.
+
+Expected result:
+- At the very top there is a single row reading "Named session:" with a dropdown showing "(none)"
+  and a small "Manage..." button to its right. That is the only named-session control in the dialog
+  body.
+- Below it, the Agent picker, the "Model:" row, the "Select a repository:" search and list, and the
+  "Start Session" button are all present and in their normal positions. Named sessions did NOT push
+  them down behind a large panel.
+
+PASS if the compact row is present and the primary controls are unchanged in position. FAIL
+otherwise.
+
+---
+
+## Test 2 - "Save as named session..." is disabled until repository + agent + model are all set
+
+Verifies: "'Save as named session...' is disabled until a repository, an agent, and a model are all
+selected; saving writes one preset file capturing repository + agent id + model + name."
+
+Steps:
+1. In the New Session dialog, look at the bottom button row. There is a "Save as named session..."
+   button to the LEFT of "Start Session".
+2. Clear the "Model:" box if it has text. Do not select a repository yet.
+3. Observe the "Save as named session..." button state.
+4. Select a repository from the list (or Browse to one).
+5. Make sure an agent radio is selected (the first is selected by default).
+6. Type a model into the "Model:" box (for example `claude-opus-4` - any non-empty value).
+7. Observe the "Save as named session..." button state again.
+8. Click "Save as named session...". In the small "Save named session" prompt, type a name such as
+   `QA Director Opus` and confirm.
+
+Expected result:
+- At step 3 (no repository and/or empty model), "Save as named session..." is DISABLED (dimmed).
+- At step 7 (repository + agent + model all set), the button is ENABLED.
+- After step 8 a preset file appears at
+  `%LOCALAPPDATA%\cc-director\config\director\named-sessions\qa-director-opus.named-session.json`.
+  Open it and confirm it contains the repository path you chose, an `AgentId` value, the model text
+  you typed, and the name.
+
+PASS if the enable/disable behaviour matches and the file is written with all four values. FAIL
+otherwise.
+
+---
+
+## Test 3 - Selecting a preset fills the repository, agent, and model fields
+
+Verifies: "Selecting a saved preset from the dropdown fills the repository, agent, and model fields
+with the saved values (the user can see them before starting)."
+
+Steps:
+1. Still in the New Session dialog (with the `QA Director Opus` preset saved from Test 2), change
+   the fields away from the saved values: pick a DIFFERENT repository, select a different agent if
+   you have one, and change the "Model:" box text.
+2. Open the "Named session:" dropdown and pick `QA Director Opus`.
+
+Expected result:
+- The repository path returns to the one saved in the preset (and the matching repository row
+  becomes selected if it is in the list).
+- The agent radio returns to the agent saved in the preset.
+- The "Model:" box returns to the model saved in the preset.
+- No session starts - the dialog stays open. The user can see the filled values before pressing
+  Start.
+
+PASS if all three fields fill with the saved values and nothing launches. FAIL otherwise.
+
+---
+
+## Test 4 - Start launches the saved repository, agent, and model
+
+Verifies: "Pressing Start after selecting a preset launches a session in the saved repository, with
+the saved agent and model (verified by the launch log line and the running session)."
+
+Steps:
+1. With `QA Director Opus` selected in the dropdown (fields filled as in Test 3), press
+   "Start Session".
+2. Watch the new session appear and open the Director log at
+   `%LOCALAPPDATA%\cc-director\logs\director\` (the newest `director-*.log`).
+
+Expected result:
+- A new session starts in the repository saved in the preset.
+- In the log, the line `[MainWindow] ShowNewSessionDialog: path=...` shows the saved repository path
+  and the saved agent. The resolved command line for the agent includes the saved model (look for
+  the model string you saved, passed as the agent's `--model` argument).
+- The running session is working in the saved repository (its title/path matches).
+
+PASS if the launched session uses the saved repository, agent, and model. FAIL otherwise.
+
+---
+
+## Test 5 - Manage dialog lists presets and supports rename and delete; no delete in the start flow
+
+Verifies: "The Manage dialog lists presets and supports rename and delete; deleting removes the
+preset file. There is NO delete control in the New Session start flow itself."
+
+Steps:
+1. In the New Session dialog, confirm there is NO delete (trash / X) control on the "Named session:"
+   row or anywhere in the start flow for named sessions.
+2. Click "Manage...". The "Manage Named Sessions" dialog opens.
+3. Confirm `QA Director Opus` is listed with its agent, model, and repository on the detail line.
+4. Select it and click "Rename...". Enter `QA Director Renamed` and confirm.
+5. Confirm the list now shows `QA Director Renamed`.
+6. Select it and click "Delete". Confirm the deletion in the prompt.
+7. Confirm the row disappears from the list. Close the Manage dialog.
+8. (Optional) Confirm the matching `*.named-session.json` file is gone from the named-sessions
+   folder.
+
+Expected result:
+- There is no delete control in the New Session start flow; deletion is only inside the Manage
+  dialog, away from the launch buttons.
+- Rename updates the displayed name (and the underlying file slug).
+- Delete removes the preset from the list and removes its file from disk.
+
+PASS if rename and delete work in the Manage dialog and no delete control exists in the start flow.
+FAIL otherwise.
+
+---
+
+## Test 6 - Orphans appear only in Manage, greyed and labelled, launch disabled
+
+Verifies: "A preset whose repository folder or agent id no longer exists appears only in the Manage
+dialog, greyed, labelled with the reason, with launch disabled - it does not appear as a row in the
+New Session start flow."
+
+Set up an orphan (choose ONE of the two cases, or do both):
+
+Case A - missing repository:
+1. Save a new preset (Test 2 steps) pointing at a repository folder you can delete or rename.
+2. Close CC Director.
+3. On disk, rename or delete that repository folder so the saved path no longer exists.
+4. Reopen CC Director and open the New Session dialog.
+
+Case B - removed agent:
+1. Save a new preset using a specific agent.
+2. Go to Settings > Agents and delete (or disable then remove) that agent.
+3. Reopen the New Session dialog.
+
+Steps (after either case):
+1. Open the "Named session:" dropdown in the New Session tab.
+2. Click "Manage..." and look at the orphaned preset's row.
+
+Expected result:
+- The orphaned preset does NOT appear in the "Named session:" dropdown in the start flow.
+- In the Manage dialog the orphaned preset IS listed, shown greyed/dimmed, with a small label
+  reading "repository missing" (Case A) or "agent removed" (Case B).
+- The orphan cannot be launched from the start flow (it is simply not offered there).
+
+PASS if the orphan is hidden from the start dropdown but visible, greyed, and labelled in Manage.
+FAIL otherwise.
+
+---
+
+## Test 7 - Logging format (spot check)
+
+Verifies: "Entry, exit, and failure are logged in the [ClassName] Method: context format."
+
+Steps:
+1. After running Tests 2-5, open the newest Director log under
+   `%LOCALAPPDATA%\cc-director\logs\director\`.
+2. Search for `[NamedSessionStore]`, `[NewSessionDialog]`, and `[ManageNamedSessionsDialog]`.
+
+Expected result:
+- You see lines such as `[NamedSessionStore] Save: ...`, `[NewSessionDialog] LoadNamedSessions`,
+  `[NewSessionDialog] NamedSessionCombo_SelectionChanged: applying preset ...`,
+  `[ManageNamedSessionsDialog] BtnDelete_Click: ...`, all in the `[ClassName] Method: context`
+  format.
+
+PASS if the log lines are present in that format. FAIL otherwise.
+
+---
+
+## Test 8 - Store unit tests (automated, no app)
+
+Verifies: "The store has unit tests covering create, list, delete, and the orphan (missing repo /
+missing agent) cases."
+
+Steps:
+1. From the repository root run:
+   `dotnet test src/CcDirector.Core.Tests/CcDirector.Core.Tests.csproj --filter "FullyQualifiedName~NamedSessionStoreTests"`
+
+Expected result:
+- All `NamedSessionStoreTests` pass, including the create/list/delete cases and the orphan cases
+  (`LoadAllWithStatus_MissingRepository_IsRepositoryMissingOrphan`,
+  `LoadAllWithStatus_RemovedAgent_IsAgentRemovedOrphan`, and the doubly-broken case).
+
+PASS if all tests pass. FAIL otherwise.
+
+---
+
+## Acceptance criteria coverage map
+
+| Acceptance criterion (issue #508) | Test |
+|-----------------------------------|------|
+| Single compact "Named session" row; primary flow keeps position | Test 1 |
+| Save disabled until repository + agent + model; writes one preset file | Test 2 |
+| Selecting a preset fills repository + agent + model | Test 3 |
+| Start launches the saved repository + agent + model | Test 4 |
+| Manage dialog lists, renames, deletes; no delete in start flow | Test 5 |
+| Orphans only in Manage, greyed, labelled, launch disabled | Test 6 |
+| Logging in `[ClassName] Method: context` format | Test 7 |
+| Store unit tests: create / list / delete / orphan cases | Test 8 |

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -2665,7 +2665,12 @@ public partial class MainWindow : Window
         // Per-entry preset/model/args resolve to the same effective command line the Tools/Agents
         // page previews (issue #436's shared resolver). For Claude the dialog's Bypass-permissions
         // checkbox still applies on top, because it is a per-session choice, not a stored preset.
-        var entryArgs = selectedEntry.ToToolConfig().ResolveEffectiveCommandLineArguments().Trim();
+        // The dialog's Model box (issue #508) is a per-launch override of the entry's default model;
+        // when set, it replaces DefaultModel in the resolved command line.
+        var toolConfig = selectedEntry.ToToolConfig();
+        if (!string.IsNullOrWhiteSpace(dialog.SelectedModel))
+            toolConfig.DefaultModel = dialog.SelectedModel;
+        var entryArgs = toolConfig.ResolveEffectiveCommandLineArguments().Trim();
         string? agentArgs;
         if (agentKind == AgentKind.ClaudeCode)
         {

--- a/src/CcDirector.Avalonia/ManageNamedSessionsDialog.axaml
+++ b/src/CcDirector.Avalonia/ManageNamedSessionsDialog.axaml
@@ -1,0 +1,99 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="CcDirector.Avalonia.ManageNamedSessionsDialog"
+        Title="Manage Named Sessions"
+        Width="640" Height="480"
+        MinWidth="560" MinHeight="360"
+        WindowStartupLocation="CenterOwner"
+        CanResize="True"
+        Background="#252526">
+
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="Saved named sessions:"
+                   Foreground="#CCCCCC" FontSize="14" Margin="0,0,0,8" />
+
+        <!-- Empty state -->
+        <TextBlock x:Name="EmptyText" Grid.Row="1"
+                   Text="No named sessions saved yet. Save one from the New Session tab using 'Save as named session...'."
+                   Foreground="#888888" FontStyle="Italic" TextWrapping="Wrap"
+                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                   Margin="24" IsVisible="False" />
+
+        <!-- Preset list. Orphans (repository missing / agent removed) are greyed, labelled with the
+             reason, and their Launch-from-start eligibility is off; rename/delete still work here. -->
+        <ListBox x:Name="PresetList" Grid.Row="1"
+                 Background="#1E1E1E" Foreground="#CCCCCC"
+                 BorderBrush="#3C3C3C" BorderThickness="1"
+                 SelectionChanged="PresetList_SelectionChanged">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <Grid Margin="6,6" Opacity="{Binding RowOpacity}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <!-- Name + orphan badge -->
+                        <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal">
+                            <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="13"
+                                       Foreground="#CCCCCC" VerticalAlignment="Center" />
+                            <Border IsVisible="{Binding IsOrphan}"
+                                    Background="#3A2A1B" CornerRadius="3" Padding="6,1"
+                                    Margin="8,0,0,0" VerticalAlignment="Center">
+                                <TextBlock Text="{Binding OrphanLabel}" Foreground="#F59E0B"
+                                           FontSize="10" FontWeight="SemiBold" />
+                            </Border>
+                        </StackPanel>
+
+                        <!-- Detail line: agent + model + repository -->
+                        <TextBlock Grid.Row="1" Grid.Column="0"
+                                   Text="{Binding Detail}" Foreground="#888888"
+                                   FontSize="11" Margin="0,2,0,0"
+                                   TextTrimming="CharacterEllipsis" />
+                    </Grid>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+
+        <!-- Buttons: management lives here, away from the launch flow. Delete is here, not in the
+             New Session start row, so it cannot be mis-clicked while starting a session. -->
+        <Grid Grid.Row="2" Margin="0,12,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0" Orientation="Horizontal">
+                <Button x:Name="BtnRename" Content="Rename..."
+                        Width="100" Height="28"
+                        Click="BtnRename_Click"
+                        Background="#3C3C3C" Foreground="#CCCCCC"
+                        BorderThickness="0" Cursor="Hand"
+                        IsEnabled="False" />
+                <Button x:Name="BtnDelete" Content="Delete"
+                        Width="90" Height="28" Margin="8,0,0,0"
+                        Click="BtnDelete_Click"
+                        Background="#3C3C3C" Foreground="#CC4444"
+                        BorderThickness="0" Cursor="Hand"
+                        IsEnabled="False" />
+            </StackPanel>
+
+            <Button Grid.Column="2" Content="Close"
+                    Width="80" Height="28"
+                    Click="BtnClose_Click"
+                    Background="#3C3C3C" Foreground="#CCCCCC"
+                    BorderThickness="0" Cursor="Hand" />
+        </Grid>
+    </Grid>
+</Window>

--- a/src/CcDirector.Avalonia/ManageNamedSessionsDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/ManageNamedSessionsDialog.axaml.cs
@@ -98,14 +98,20 @@ public partial class ManageNamedSessionsDialog : Window
             var oldSlug = NamedSessionStore.ToSlug(row.Name);
 
             // Renaming to an existing different preset's slug would overwrite it; confirm first.
-            if (!string.Equals(newSlug, oldSlug, StringComparison.Ordinal) && _store.Exists(newSlug))
+            // Show the colliding preset's actual stored name, not the name just typed, because two
+            // different display names can collapse to the same slug.
+            if (!string.Equals(newSlug, oldSlug, StringComparison.Ordinal))
             {
-                var overwrite = new ConfirmDialog(
-                    "Name in use",
-                    $"A named session called \"{newName}\" already exists. Overwrite it?",
-                    "Overwrite");
-                if (await overwrite.ShowDialog<bool?>(this) != true)
-                    return;
+                var colliding = _store.Load(newSlug);
+                if (colliding is not null)
+                {
+                    var overwrite = new ConfirmDialog(
+                        "Name in use",
+                        $"A named session called \"{colliding.Name}\" already exists. Overwrite it?",
+                        "Overwrite");
+                    if (await overwrite.ShowDialog<bool?>(this) != true)
+                        return;
+                }
             }
 
             var preset = _store.Load(oldSlug);

--- a/src/CcDirector.Avalonia/ManageNamedSessionsDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/ManageNamedSessionsDialog.axaml.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using CcDirector.Avalonia.Controls;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia;
+
+/// <summary>
+/// The dedicated Manage dialog for named-session presets (issue #508). All management - listing,
+/// renaming, deleting, and showing orphaned presets greyed/labelled - lives here, never inline in
+/// the New Session start flow, so destructive actions cannot be mis-clicked while launching.
+/// </summary>
+public partial class ManageNamedSessionsDialog : Window
+{
+    private readonly NamedSessionStore _store;
+
+    // Agent id -> display name, so the detail line and orphan check can resolve the agent. Ids not
+    // in this map are "agent removed" orphans.
+    private readonly IReadOnlyDictionary<string, string> _agentNames;
+
+    /// <summary>True when the user changed anything (rename/delete), so the caller refreshes its
+    /// dropdown on close.</summary>
+    public bool Changed { get; private set; }
+
+    public ManageNamedSessionsDialog(NamedSessionStore store, IReadOnlyDictionary<string, string> agentNames)
+    {
+        FileLog.Write("[ManageNamedSessionsDialog] Constructor");
+        InitializeComponent();
+
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _agentNames = agentNames ?? throw new ArgumentNullException(nameof(agentNames));
+
+        Reload();
+    }
+
+    // Parameterless constructor for the XAML designer.
+    public ManageNamedSessionsDialog()
+        : this(new NamedSessionStore(), new Dictionary<string, string>()) { }
+
+    /// <summary>Rebuild the list from disk and reset selection-dependent button state.</summary>
+    private void Reload()
+    {
+        FileLog.Write("[ManageNamedSessionsDialog] Reload");
+        try
+        {
+            var statuses = _store.LoadAllWithStatus(_agentNames.Keys);
+            var rows = statuses.Select(s => new PresetRow(s, ResolveAgentName(s.Preset.AgentId))).ToList();
+
+            PresetList.ItemsSource = rows;
+            EmptyText.IsVisible = rows.Count == 0;
+            PresetList.IsVisible = rows.Count > 0;
+
+            UpdateButtons();
+            FileLog.Write($"[ManageNamedSessionsDialog] Reload: {rows.Count} presets");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[ManageNamedSessionsDialog] Reload FAILED: {ex.Message}");
+            throw;
+        }
+    }
+
+    private string ResolveAgentName(string agentId) =>
+        _agentNames.TryGetValue(agentId, out var name) ? name : "(removed agent)";
+
+    private void PresetList_SelectionChanged(object? sender, SelectionChangedEventArgs e) => UpdateButtons();
+
+    private void UpdateButtons()
+    {
+        var hasSelection = PresetList.SelectedItem is PresetRow;
+        BtnRename.IsEnabled = hasSelection;
+        BtnDelete.IsEnabled = hasSelection;
+    }
+
+    private async void BtnRename_Click(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            if (PresetList.SelectedItem is not PresetRow row)
+                return;
+
+            FileLog.Write($"[ManageNamedSessionsDialog] BtnRename_Click: {row.Name}");
+
+            var input = new Controls.InputDialog("Rename named session", "New name:", row.Name);
+            var ok = await input.ShowDialog<bool?>(this);
+            if (ok != true)
+                return;
+
+            var newName = input.InputText.Trim();
+            if (string.IsNullOrWhiteSpace(newName) || string.Equals(newName, row.Name, StringComparison.Ordinal))
+                return;
+
+            var newSlug = NamedSessionStore.ToSlug(newName);
+            var oldSlug = NamedSessionStore.ToSlug(row.Name);
+
+            // Renaming to an existing different preset's slug would overwrite it; confirm first.
+            if (!string.Equals(newSlug, oldSlug, StringComparison.Ordinal) && _store.Exists(newSlug))
+            {
+                var overwrite = new ConfirmDialog(
+                    "Name in use",
+                    $"A named session called \"{newName}\" already exists. Overwrite it?",
+                    "Overwrite");
+                if (await overwrite.ShowDialog<bool?>(this) != true)
+                    return;
+            }
+
+            var preset = _store.Load(oldSlug);
+            if (preset is null)
+            {
+                FileLog.Write($"[ManageNamedSessionsDialog] BtnRename_Click: source preset gone, slug={oldSlug}");
+                return;
+            }
+
+            preset.Name = newName;
+            preset.UpdatedAt = DateTimeOffset.UtcNow;
+
+            // Save under the new slug, then delete the old file when the slug actually changed.
+            if (!_store.Save(preset))
+                return;
+            if (!string.Equals(newSlug, oldSlug, StringComparison.Ordinal))
+                _store.Delete(oldSlug);
+
+            Changed = true;
+            Reload();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[ManageNamedSessionsDialog] BtnRename_Click FAILED: {ex.Message}");
+        }
+    }
+
+    private async void BtnDelete_Click(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            if (PresetList.SelectedItem is not PresetRow row)
+                return;
+
+            FileLog.Write($"[ManageNamedSessionsDialog] BtnDelete_Click: {row.Name}");
+
+            var confirm = new ConfirmDialog(
+                "Delete named session",
+                $"Delete the named session \"{row.Name}\"? This removes the saved preset; it does not affect any running session.",
+                "Delete");
+            if (await confirm.ShowDialog<bool?>(this) != true)
+                return;
+
+            if (_store.Delete(NamedSessionStore.ToSlug(row.Name)))
+            {
+                Changed = true;
+                Reload();
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[ManageNamedSessionsDialog] BtnDelete_Click FAILED: {ex.Message}");
+        }
+    }
+
+    private void BtnClose_Click(object? sender, RoutedEventArgs e)
+    {
+        FileLog.Write($"[ManageNamedSessionsDialog] BtnClose_Click: changed={Changed}");
+        Close(Changed);
+    }
+
+    /// <summary>One row in the Manage list: the preset, its launch status, and the display strings.</summary>
+    internal sealed class PresetRow
+    {
+        public PresetRow(NamedSessionStatus status, string agentName)
+        {
+            var preset = status.Preset;
+            Name = preset.Name;
+            IsOrphan = !status.IsLaunchable;
+            RowOpacity = status.IsLaunchable ? 1.0 : 0.5;
+
+            OrphanLabel = status.OrphanReason switch
+            {
+                NamedSessionOrphanReason.RepositoryMissing => "repository missing",
+                NamedSessionOrphanReason.AgentRemoved => "agent removed",
+                _ => string.Empty
+            };
+
+            var model = string.IsNullOrWhiteSpace(preset.Model) ? "(agent default)" : preset.Model;
+            Detail = $"{agentName} - {model} - {preset.RepositoryPath}";
+        }
+
+        public string Name { get; }
+        public bool IsOrphan { get; }
+        public double RowOpacity { get; }
+        public string OrphanLabel { get; }
+        public string Detail { get; }
+    }
+}

--- a/src/CcDirector.Avalonia/NewSessionDialog.axaml
+++ b/src/CcDirector.Avalonia/NewSessionDialog.axaml
@@ -60,6 +60,35 @@
                     </Grid.RowDefinitions>
 
                     <StackPanel Grid.Row="0" Orientation="Vertical">
+                    <!-- Named session row (issue #508): ONE compact row - a "Named session"
+                         dropdown (placeholder "(none)") plus a small "Manage..." button. This is
+                         the entire in-dialog footprint for named sessions; it does NOT crowd out
+                         the primary Agent/Model/repository/Start flow below. Selecting a preset
+                         fills the repository, agent, and model fields; it does NOT auto-launch. -->
+                    <StackPanel x:Name="NamedSessionRow" Orientation="Horizontal" Margin="0,0,0,12">
+                        <TextBlock Text="Named session:"
+                                   Foreground="#CCCCCC" FontSize="14"
+                                   VerticalAlignment="Center" Margin="0,0,16,0" />
+                        <ComboBox x:Name="NamedSessionCombo" Width="320"
+                                  Background="#1E1E1E" Foreground="#CCCCCC"
+                                  BorderBrush="#3C3C3C"
+                                  VerticalAlignment="Center"
+                                  SelectionChanged="NamedSessionCombo_SelectionChanged"
+                                  ToolTip.Tip="Pick a saved preset to fill the repository, agent, and model below">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Label}" Foreground="#CCCCCC" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                        <Button x:Name="BtnManageNamedSessions" Content="Manage..."
+                                Width="90" Height="28" Margin="8,0,0,0"
+                                Click="BtnManageNamedSessions_Click"
+                                Background="#3C3C3C" Foreground="#CCCCCC"
+                                BorderThickness="0" Cursor="Hand"
+                                ToolTip.Tip="Rename, delete, or fix saved named sessions" />
+                    </StackPanel>
+
                     <!-- Create-mode toggle (issue #254): "Single session" (the Type dropdown
                          applies) vs "Group" (a preset that creates several tied, typed sessions
                          at once). Exactly one of the Type dropdown / Group panel is shown below,
@@ -116,6 +145,23 @@
                                    Foreground="#888888" FontSize="13" FontStyle="Italic"
                                    VerticalAlignment="Center"
                                    IsVisible="False" />
+                    </StackPanel>
+
+                    <!-- Model row (issue #508): a compact per-launch model field. Defaults to the
+                         selected agent's configured default model; a named-session preset fills it
+                         with its saved model. Empty means "use the agent's own default model". It
+                         is one of the three fields a named-session preset captures. -->
+                    <StackPanel x:Name="ModelRow" Orientation="Horizontal" Margin="0,0,0,12">
+                        <TextBlock Text="Model:"
+                                   Foreground="#CCCCCC" FontSize="14"
+                                   VerticalAlignment="Center" Margin="0,0,16,0" />
+                        <TextBox x:Name="ModelBox" Width="320"
+                                 Background="#1E1E1E" Foreground="#CCCCCC"
+                                 BorderBrush="#3C3C3C" Padding="6,4"
+                                 VerticalContentAlignment="Center"
+                                 TextChanged="ModelBox_TextChanged"
+                                 Watermark="Agent default model"
+                                 ToolTip.Tip="Model passed to the agent; leave blank for the agent's own default" />
                     </StackPanel>
 
                     <!-- Custom CLI panel (issue #333): shown only when "Custom CLI" agent is selected.
@@ -694,8 +740,18 @@
                     IsVisible="False"
                     ToolTip.Tip="Copy handover content to clipboard" />
 
-            <!-- Right: Action + Cancel -->
+            <!-- Right: Save preset + Action + Cancel -->
             <StackPanel Grid.Column="2" Orientation="Horizontal">
+                <!-- Save as named session (issue #508): one small action next to Start. Enabled only
+                     when a repository + agent + model are all selected, so it always saves a valid,
+                     complete preset. Shown only on the New Session tab. -->
+                <Button x:Name="BtnSaveNamedSession" Content="Save as named session..." Width="190"
+                        Click="BtnSaveNamedSession_Click"
+                        BorderThickness="0" Margin="0,0,8,0"
+                        IsEnabled="False"
+                        Background="#3C3C3C" Foreground="#CCCCCC"
+                        Cursor="Hand"
+                        ToolTip.Tip="Save the current repository, agent, and model as a reusable named session" />
                 <Button x:Name="BtnAction" Content="Resume Selected" Width="120"
                         Click="BtnAction_Click"
                         BorderThickness="0" Margin="0,0,8,0"

--- a/src/CcDirector.Avalonia/NewSessionDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/NewSessionDialog.axaml.cs
@@ -392,6 +392,26 @@ public sealed class AgentEntryOption
     public bool IsSelected { get; set; }
 }
 
+/// <summary>
+/// One entry in the compact "Named session" dropdown (issue #508). The leading placeholder carries
+/// a null <see cref="Preset"/> and the label "(none)"; every other entry carries a launchable
+/// preset. Orphaned presets are never added here - they live only in the Manage dialog.
+/// </summary>
+public sealed class NamedSessionComboItem
+{
+    public NamedSessionComboItem(NamedSessionDefinition? preset, string label)
+    {
+        Preset = preset;
+        Label = label;
+    }
+
+    /// <summary>The saved preset this entry applies, or null for the "(none)" placeholder.</summary>
+    public NamedSessionDefinition? Preset { get; }
+
+    /// <summary>The text shown in the dropdown.</summary>
+    public string Label { get; }
+}
+
 public partial class NewSessionDialog : Window
 {
     private static readonly ISolidColorBrush ResumeButtonBrush = new SolidColorBrush(Color.Parse("#22C55E"));
@@ -413,6 +433,34 @@ public partial class NewSessionDialog : Window
     public string? SelectedPath { get; private set; }
     public string? SelectedResumeSessionId { get; private set; }
     public string? SelectedHandoverPath { get; private set; }
+
+    /// <summary>
+    /// The named-session preset store (issue #508). The compact dropdown lists its launchable
+    /// presets; the Save button writes to it; the Manage dialog edits it.
+    /// </summary>
+    private readonly NamedSessionStore _namedSessionStore = new();
+
+    /// <summary>The dropdown options - a leading "(none)" placeholder plus one per launchable
+    /// preset (orphans are excluded from the start flow by design, issue #508).</summary>
+    private readonly List<NamedSessionComboItem> _namedSessionItems = new();
+
+    /// <summary>Guards the fill-the-fields logic so programmatic updates (when a preset is applied)
+    /// do not re-enter selection handlers and clear the dropdown.</summary>
+    private bool _applyingNamedSession;
+
+    /// <summary>
+    /// The model selected for this launch (issue #508). Read from the compact Model box; empty
+    /// means "use the selected agent's own default model". MainWindow passes this as the agent's
+    /// model when non-empty.
+    /// </summary>
+    public string? SelectedModel
+    {
+        get
+        {
+            var text = ModelBox?.Text?.Trim();
+            return string.IsNullOrWhiteSpace(text) ? null : text;
+        }
+    }
 
     /// <summary>
     /// When <see cref="SelectedAgentKind"/> is <see cref="AgentKind.RawCli"/>, the
@@ -572,6 +620,9 @@ public partial class NewSessionDialog : Window
             GroupCombo.SelectedIndex = 0;
         FileLog.Write($"[NewSessionDialog] Loaded {SessionGroupDefinition.BuiltIn.Count} group definitions");
 
+        // Named sessions (issue #508): load the launchable presets into the compact dropdown.
+        LoadNamedSessions();
+
         Loaded += async (_, _) =>
         {
             Dispatcher.UIThread.Post(() => RepoSearchBox.Focus());
@@ -667,6 +718,12 @@ public partial class NewSessionDialog : Window
                 CustomArgsBox.Text = entry.ArgsOverride;
         }
 
+        // Seed the Model box from the newly selected agent's default model (issue #508), so the
+        // user sees what model will launch. Skipped while a named-session preset is being applied,
+        // because the preset's own saved model wins in that case.
+        if (!_applyingNamedSession && ModelBox is not null)
+            ModelBox.Text = entry?.DefaultModel ?? string.Empty;
+
         // Refresh the Start button - it is disabled when Custom CLI is chosen but
         // the Command box is empty (validated inside UpdateActionButton).
         UpdateActionButton();
@@ -677,6 +734,193 @@ public partial class NewSessionDialog : Window
     private void CustomCommandBox_TextChanged(object? sender, TextChangedEventArgs e)
     {
         UpdateActionButton();
+    }
+
+    private void ModelBox_TextChanged(object? sender, TextChangedEventArgs e)
+    {
+        UpdateActionButton();
+    }
+
+    /// <summary>
+    /// Rebuild the compact "Named session" dropdown (issue #508): a leading "(none)" placeholder
+    /// plus one entry per LAUNCHABLE preset, in saved (name) order. Orphaned presets are
+    /// deliberately excluded - they appear only in the Manage dialog. The placeholder is selected,
+    /// so opening the dialog never auto-fills a preset.
+    /// </summary>
+    private void LoadNamedSessions()
+    {
+        FileLog.Write("[NewSessionDialog] LoadNamedSessions");
+
+        var knownAgentIds = AgentEntryStore.LoadEntries(CurrentOptions()).Select(en => en.Id);
+        var launchable = _namedSessionStore.LoadAllWithStatus(knownAgentIds)
+            .Where(s => s.IsLaunchable)
+            .Select(s => s.Preset)
+            .ToList();
+
+        _namedSessionItems.Clear();
+        _namedSessionItems.Add(new NamedSessionComboItem(null, "(none)"));
+        foreach (var preset in launchable)
+            _namedSessionItems.Add(new NamedSessionComboItem(preset, preset.Name));
+
+        _applyingNamedSession = true;
+        NamedSessionCombo.ItemsSource = _namedSessionItems;
+        NamedSessionCombo.SelectedIndex = 0;
+        _applyingNamedSession = false;
+
+        FileLog.Write($"[NewSessionDialog] LoadNamedSessions: {launchable.Count} launchable presets");
+    }
+
+    /// <summary>
+    /// Apply a chosen named-session preset to the existing fields (issue #508): set the repository,
+    /// select the matching agent radio, and set the model box. This fills the normal controls so
+    /// the user sees exactly what will launch; it does NOT start a session.
+    /// </summary>
+    private void NamedSessionCombo_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (_applyingNamedSession)
+            return;
+
+        if (NamedSessionCombo.SelectedItem is not NamedSessionComboItem item || item.Preset is null)
+            return;
+
+        var preset = item.Preset;
+        FileLog.Write($"[NewSessionDialog] NamedSessionCombo_SelectionChanged: applying preset {preset.Name}");
+
+        _applyingNamedSession = true;
+        try
+        {
+            // Repository: set the path box and select the matching repo-list row when present.
+            PathInput.Text = preset.RepositoryPath;
+            SelectedPath = preset.RepositoryPath;
+            SelectedResumeSessionId = null;
+            RepoList.SelectedItem = _allRepos?.FirstOrDefault(
+                r => string.Equals(r.Path, preset.RepositoryPath, StringComparison.OrdinalIgnoreCase));
+
+            // Agent: select the radio whose entry id matches the saved preset.
+            SelectAgentById(preset.AgentId);
+
+            // Model: the preset's saved model wins over the agent default seeded above.
+            if (ModelBox is not null)
+                ModelBox.Text = preset.Model;
+        }
+        finally
+        {
+            _applyingNamedSession = false;
+        }
+
+        UpdateActionButton();
+    }
+
+    /// <summary>Select the agent radio whose entry id matches <paramref name="agentId"/> (issue #508).</summary>
+    private void SelectAgentById(string agentId)
+    {
+        var match = _agentOptions.FirstOrDefault(o => string.Equals(o.Entry.Id, agentId, StringComparison.Ordinal));
+        if (match is null)
+            return;
+
+        foreach (var option in _agentOptions)
+            option.IsSelected = ReferenceEquals(option, match);
+
+        // Rebind so the radio visuals reflect the new selection.
+        AgentEntryList.ItemsSource = null;
+        AgentEntryList.ItemsSource = _agentOptions;
+
+        ApplyAgentSelection();
+    }
+
+    /// <summary>The configured agents' id -> display name map, for the Manage dialog (issue #508).</summary>
+    private static IReadOnlyDictionary<string, string> AgentNameMap()
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var entry in AgentEntryStore.LoadEntries(CurrentOptions()))
+            map[entry.Id] = entry.DisplayName;
+        return map;
+    }
+
+    private async void BtnManageNamedSessions_Click(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            FileLog.Write("[NewSessionDialog] BtnManageNamedSessions_Click");
+            var dialog = new ManageNamedSessionsDialog(_namedSessionStore, AgentNameMap());
+            var changed = await dialog.ShowDialog<bool?>(this);
+            if (changed == true)
+                LoadNamedSessions();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[NewSessionDialog] BtnManageNamedSessions_Click FAILED: {ex.Message}");
+        }
+    }
+
+    private async void BtnSaveNamedSession_Click(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var repoPath = PathInput.Text?.Trim();
+            var entry = SelectedAgentEntry;
+            var model = ModelBox?.Text?.Trim() ?? string.Empty;
+
+            // The button is only enabled when all three are present, but re-validate before writing.
+            if (string.IsNullOrWhiteSpace(repoPath) || entry is null || string.IsNullOrWhiteSpace(model))
+            {
+                FileLog.Write("[NewSessionDialog] BtnSaveNamedSession_Click: incomplete selection; aborting");
+                return;
+            }
+
+            FileLog.Write($"[NewSessionDialog] BtnSaveNamedSession_Click: repo={repoPath}, agent={entry.Id}, model={model}");
+
+            var input = new Controls.InputDialog("Save named session", "Name this preset:", string.Empty);
+            if (await input.ShowDialog<bool?>(this) != true)
+                return;
+
+            var name = input.InputText.Trim();
+            if (string.IsNullOrWhiteSpace(name))
+                return;
+
+            // Duplicate-name handling: overwrite after a confirm (issue #508 assumption).
+            var slug = NamedSessionStore.ToSlug(name);
+            if (_namedSessionStore.Exists(slug))
+            {
+                var overwrite = new ConfirmDialog(
+                    "Name in use",
+                    $"A named session called \"{name}\" already exists. Overwrite it?",
+                    "Overwrite");
+                if (await overwrite.ShowDialog<bool?>(this) != true)
+                    return;
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            var existing = _namedSessionStore.Load(slug);
+            var preset = new NamedSessionDefinition
+            {
+                Version = 1,
+                Name = name,
+                RepositoryPath = repoPath,
+                AgentId = entry.Id,
+                Model = model,
+                CreatedAt = existing?.CreatedAt ?? now,
+                UpdatedAt = now
+            };
+
+            if (_namedSessionStore.Save(preset))
+            {
+                LoadNamedSessions();
+                // Reflect the just-saved preset as the current dropdown selection.
+                var saved = _namedSessionItems.FirstOrDefault(
+                    i => i.Preset is not null && NamedSessionStore.ToSlug(i.Preset.Name) == slug);
+                if (saved is not null)
+                {
+                    _applyingNamedSession = true;
+                    NamedSessionCombo.SelectedItem = saved;
+                    _applyingNamedSession = false;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[NewSessionDialog] BtnSaveNamedSession_Click FAILED: {ex.Message}");
+        }
     }
 
     private async Task LoadSessionHistoryAsync()
@@ -753,6 +997,10 @@ public partial class NewSessionDialog : Window
 
         BtnCopyHandover.IsVisible = MainTabs.SelectedIndex == 2 && HandoverList.SelectedItem != null;
 
+        // The "Save as named session..." button belongs only to the New Session tab (issue #508).
+        if (BtnSaveNamedSession is not null)
+            BtnSaveNamedSession.IsVisible = MainTabs.SelectedIndex == 0;
+
         if (MainTabs.SelectedIndex == 0)
         {
             // In Group mode the button reflects how many sessions get created (issue #259).
@@ -768,6 +1016,14 @@ public partial class NewSessionDialog : Window
             BtnAction.IsEnabled = isEnabled;
             BtnAction.Background = isEnabled ? NewSessionButtonBrush : DisabledButtonBrush;
             BtnAction.Foreground = isEnabled ? EnabledTextBrush : DisabledTextBrush;
+
+            // Save-as-named-session (issue #508) is enabled only when a repository + agent + model
+            // are all selected, so it always writes a valid, complete preset.
+            if (BtnSaveNamedSession is not null)
+            {
+                var hasModel = !string.IsNullOrWhiteSpace(ModelBox?.Text);
+                BtnSaveNamedSession.IsEnabled = hasPath && hasAgent && hasModel;
+            }
         }
         else if (MainTabs.SelectedIndex == 1)
         {

--- a/src/CcDirector.Avalonia/NewSessionDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/NewSessionDialog.axaml.cs
@@ -843,8 +843,13 @@ public partial class NewSessionDialog : Window
         {
             FileLog.Write("[NewSessionDialog] BtnManageNamedSessions_Click");
             var dialog = new ManageNamedSessionsDialog(_namedSessionStore, AgentNameMap());
-            var changed = await dialog.ShowDialog<bool?>(this);
-            if (changed == true)
+            await dialog.ShowDialog<bool?>(this);
+
+            // Read the Changed flag off the dialog instance rather than the dialog result. Closing
+            // via the title-bar window X returns a null result, which would skip the refresh and
+            // leave the dropdown showing stale presets after a rename or delete. The flag is set
+            // however the change was made and survives any close path.
+            if (dialog.Changed)
                 LoadNamedSessions();
         }
         catch (Exception ex)
@@ -880,18 +885,21 @@ public partial class NewSessionDialog : Window
 
             // Duplicate-name handling: overwrite after a confirm (issue #508 assumption).
             var slug = NamedSessionStore.ToSlug(name);
-            if (_namedSessionStore.Exists(slug))
+            var existing = _namedSessionStore.Load(slug);
+            if (existing is not null)
             {
+                // Show the colliding preset's actual stored name, not the name just typed. Two
+                // different display names can collapse to the same slug, so the preset about to be
+                // overwritten may carry a different name than what the user typed.
                 var overwrite = new ConfirmDialog(
                     "Name in use",
-                    $"A named session called \"{name}\" already exists. Overwrite it?",
+                    $"A named session called \"{existing.Name}\" already exists. Overwrite it?",
                     "Overwrite");
                 if (await overwrite.ShowDialog<bool?>(this) != true)
                     return;
             }
 
             var now = DateTimeOffset.UtcNow;
-            var existing = _namedSessionStore.Load(slug);
             var preset = new NamedSessionDefinition
             {
                 Version = 1,

--- a/src/CcDirector.Core.Tests/NamedSessionStoreTests.cs
+++ b/src/CcDirector.Core.Tests/NamedSessionStoreTests.cs
@@ -1,0 +1,258 @@
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+public class NamedSessionStoreTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _existingRepo;
+
+    public NamedSessionStoreTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"NamedSessionStoreTests_{Guid.NewGuid():N}");
+        // A real directory used as the "repository folder" for launchable-preset cases.
+        _existingRepo = Path.Combine(_tempDir, "repo");
+        Directory.CreateDirectory(_existingRepo);
+    }
+
+    [Fact]
+    public void Save_ValidPreset_WritesJsonFile()
+    {
+        var store = new NamedSessionStore(_tempDir);
+        var preset = MakePreset("Director on Opus");
+
+        var result = store.Save(preset);
+
+        Assert.True(result);
+        var filePath = Path.Combine(_tempDir, "director-on-opus.named-session.json");
+        Assert.True(File.Exists(filePath));
+    }
+
+    [Fact]
+    public void LoadAll_MultiplePresets_ReturnsSorted()
+    {
+        var store = new NamedSessionStore(_tempDir);
+        store.Save(MakePreset("Zebra"));
+        store.Save(MakePreset("Alpha"));
+        store.Save(MakePreset("Mango"));
+
+        var all = store.LoadAll();
+
+        Assert.Equal(3, all.Count);
+        Assert.Equal("Alpha", all[0].Name);
+        Assert.Equal("Mango", all[1].Name);
+        Assert.Equal("Zebra", all[2].Name);
+    }
+
+    [Fact]
+    public void LoadAll_EmptyFolder_ReturnsEmptyList()
+    {
+        var store = new NamedSessionStore(_tempDir);
+
+        var all = store.LoadAll();
+
+        Assert.Empty(all);
+    }
+
+    [Fact]
+    public void Load_NonExistent_ReturnsNull()
+    {
+        var store = new NamedSessionStore(_tempDir);
+
+        var result = store.Load("does-not-exist");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Delete_ExistingPreset_RemovesFile()
+    {
+        var store = new NamedSessionStore(_tempDir);
+        store.Save(MakePreset("To Delete"));
+
+        var deleted = store.Delete("to-delete");
+
+        Assert.True(deleted);
+        Assert.Null(store.Load("to-delete"));
+    }
+
+    [Fact]
+    public void Delete_NonExistent_ReturnsFalse()
+    {
+        var store = new NamedSessionStore(_tempDir);
+
+        var result = store.Delete("ghost");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Save_AndLoad_RoundTripsAllFields()
+    {
+        var store = new NamedSessionStore(_tempDir);
+        var preset = new NamedSessionDefinition
+        {
+            Version = 1,
+            Name = "Full Test",
+            RepositoryPath = _existingRepo,
+            AgentId = "agent-123",
+            Model = "claude-opus-4",
+            CreatedAt = new DateTimeOffset(2026, 3, 1, 10, 0, 0, TimeSpan.Zero),
+            UpdatedAt = new DateTimeOffset(2026, 3, 4, 15, 30, 0, TimeSpan.Zero)
+        };
+
+        store.Save(preset);
+        var loaded = store.Load("full-test");
+
+        Assert.NotNull(loaded);
+        Assert.Equal(1, loaded.Version);
+        Assert.Equal("Full Test", loaded.Name);
+        Assert.Equal(_existingRepo, loaded.RepositoryPath);
+        Assert.Equal("agent-123", loaded.AgentId);
+        Assert.Equal("claude-opus-4", loaded.Model);
+    }
+
+    [Fact]
+    public void Save_OverwriteExisting_UpdatesFile()
+    {
+        var store = new NamedSessionStore(_tempDir);
+        var original = MakePreset("Overwrite Me");
+        original.Model = "claude-sonnet-4";
+        store.Save(original);
+
+        var updated = MakePreset("Overwrite Me");
+        updated.Model = "claude-opus-4";
+        store.Save(updated);
+
+        var loaded = store.Load("overwrite-me");
+        Assert.NotNull(loaded);
+        Assert.Equal("claude-opus-4", loaded.Model);
+        Assert.Single(store.LoadAll());
+    }
+
+    [Fact]
+    public void Exists_ExistingPreset_ReturnsTrue()
+    {
+        var store = new NamedSessionStore(_tempDir);
+        store.Save(MakePreset("Exists Test"));
+
+        Assert.True(store.Exists("exists-test"));
+    }
+
+    [Fact]
+    public void Exists_NonExistent_ReturnsFalse()
+    {
+        var store = new NamedSessionStore(_tempDir);
+
+        Assert.False(store.Exists("nope"));
+    }
+
+    [Theory]
+    [InlineData("Director on Opus", "director-on-opus")]
+    [InlineData("Hello   World", "hello-world")]
+    [InlineData("  spaces  ", "spaces")]
+    [InlineData("Special!@#Chars$%^", "specialchars")]
+    [InlineData("UPPERCASE", "uppercase")]
+    [InlineData("   ", "named-session")]
+    [InlineData("", "named-session")]
+    public void ToSlug_SpecialCharacters_ProducesValidFilename(string name, string expected)
+    {
+        var slug = NamedSessionStore.ToSlug(name);
+
+        Assert.Equal(expected, slug);
+    }
+
+    [Fact]
+    public void LoadAllWithStatus_RepositoryAndAgentPresent_IsLaunchable()
+    {
+        var store = new NamedSessionStore(_tempDir);
+        var preset = MakePreset("Healthy");
+        preset.AgentId = "agent-A";
+        store.Save(preset);
+
+        var statuses = store.LoadAllWithStatus(new[] { "agent-A" });
+
+        var single = Assert.Single(statuses);
+        Assert.True(single.IsLaunchable);
+        Assert.Equal(NamedSessionOrphanReason.None, single.OrphanReason);
+    }
+
+    [Fact]
+    public void LoadAllWithStatus_MissingRepository_IsRepositoryMissingOrphan()
+    {
+        var store = new NamedSessionStore(_tempDir);
+        var preset = MakePreset("Broken Repo");
+        preset.RepositoryPath = Path.Combine(_tempDir, "no-such-repo");
+        preset.AgentId = "agent-A";
+        store.Save(preset);
+
+        var statuses = store.LoadAllWithStatus(new[] { "agent-A" });
+
+        var single = Assert.Single(statuses);
+        Assert.False(single.IsLaunchable);
+        Assert.Equal(NamedSessionOrphanReason.RepositoryMissing, single.OrphanReason);
+    }
+
+    [Fact]
+    public void LoadAllWithStatus_RemovedAgent_IsAgentRemovedOrphan()
+    {
+        var store = new NamedSessionStore(_tempDir);
+        var preset = MakePreset("Broken Agent");
+        preset.AgentId = "gone-agent";
+        store.Save(preset);
+
+        var statuses = store.LoadAllWithStatus(new[] { "agent-A", "agent-B" });
+
+        var single = Assert.Single(statuses);
+        Assert.False(single.IsLaunchable);
+        Assert.Equal(NamedSessionOrphanReason.AgentRemoved, single.OrphanReason);
+    }
+
+    [Fact]
+    public void LoadAllWithStatus_MissingRepositoryAndAgent_ReportsRepositoryFirst()
+    {
+        var store = new NamedSessionStore(_tempDir);
+        var preset = MakePreset("Doubly Broken");
+        preset.RepositoryPath = Path.Combine(_tempDir, "no-such-repo");
+        preset.AgentId = "gone-agent";
+        store.Save(preset);
+
+        var statuses = store.LoadAllWithStatus(Array.Empty<string>());
+
+        var single = Assert.Single(statuses);
+        Assert.Equal(NamedSessionOrphanReason.RepositoryMissing, single.OrphanReason);
+    }
+
+    [Fact]
+    public void ResolveOrphanReason_EmptyRepositoryPath_IsRepositoryMissing()
+    {
+        var preset = new NamedSessionDefinition { Name = "x", RepositoryPath = "", AgentId = "a" };
+
+        var reason = NamedSessionStore.ResolveOrphanReason(preset, new HashSet<string>(new[] { "a" }));
+
+        Assert.Equal(NamedSessionOrphanReason.RepositoryMissing, reason);
+    }
+
+    private NamedSessionDefinition MakePreset(string name)
+    {
+        return new NamedSessionDefinition
+        {
+            Name = name,
+            RepositoryPath = _existingRepo,
+            AgentId = "agent-default",
+            Model = "claude-opus-4",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            try { Directory.Delete(_tempDir, true); }
+            catch { /* cleanup best effort */ }
+        }
+    }
+}

--- a/src/CcDirector.Core/Sessions/NamedSessionDefinition.cs
+++ b/src/CcDirector.Core/Sessions/NamedSessionDefinition.cs
@@ -1,0 +1,39 @@
+namespace CcDirector.Core.Sessions;
+
+/// <summary>
+/// A named session preset (issue #508): a saved launch combination of a repository, an agent
+/// (referenced by <see cref="AgentId"/>, an <c>AgentEntry.Id</c>), and a model, under a fixed
+/// <see cref="Name"/>. The user saves the combination once and launches it in one click from the
+/// New Session dialog. Stored as an individual JSON file in the named-sessions directory, mirroring
+/// <see cref="WorkspaceDefinition"/>.
+/// </summary>
+public class NamedSessionDefinition
+{
+    /// <summary>Schema version of this preset file. Bumped only on a breaking shape change.</summary>
+    public int Version { get; set; } = 1;
+
+    /// <summary>The fixed display name shown in the New Session dropdown and the Manage dialog.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>The repository folder this preset launches in.</summary>
+    public string RepositoryPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The stable identity of the configured agent this preset launches (an
+    /// <c>AgentEntry.Id</c>). When the matching agent entry no longer exists, the preset is an
+    /// orphan and is shown only in the Manage dialog with launch disabled.
+    /// </summary>
+    public string AgentId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The model string passed to the agent for this preset (the same model field the New Session
+    /// dialog uses). Empty means the agent's own configured default model.
+    /// </summary>
+    public string Model { get; set; } = string.Empty;
+
+    /// <summary>When the preset was first created (UTC).</summary>
+    public DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>When the preset was last written (UTC).</summary>
+    public DateTimeOffset UpdatedAt { get; set; }
+}

--- a/src/CcDirector.Core/Sessions/NamedSessionStore.cs
+++ b/src/CcDirector.Core/Sessions/NamedSessionStore.cs
@@ -1,0 +1,256 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Sessions;
+
+/// <summary>
+/// The reason a named-session preset cannot be launched (issue #508). <see cref="None"/> means the
+/// preset is launchable; the other values are the two orphan cases the Manage dialog labels.
+/// </summary>
+public enum NamedSessionOrphanReason
+{
+    /// <summary>The preset is launchable - its repository folder exists and its agent is present.</summary>
+    None,
+
+    /// <summary>The preset's repository folder no longer exists on disk.</summary>
+    RepositoryMissing,
+
+    /// <summary>The preset's agent id no longer matches any configured agent entry.</summary>
+    AgentRemoved,
+}
+
+/// <summary>
+/// A named-session preset paired with whether it is launchable or an orphan (issue #508). The
+/// Manage dialog renders the orphan ones greyed and launch-disabled; the New Session start flow
+/// only ever shows the launchable ones.
+/// </summary>
+public sealed class NamedSessionStatus
+{
+    public NamedSessionStatus(NamedSessionDefinition preset, NamedSessionOrphanReason reason)
+    {
+        Preset = preset ?? throw new ArgumentNullException(nameof(preset));
+        OrphanReason = reason;
+    }
+
+    /// <summary>The underlying saved preset.</summary>
+    public NamedSessionDefinition Preset { get; }
+
+    /// <summary>Why the preset cannot launch, or <see cref="NamedSessionOrphanReason.None"/>.</summary>
+    public NamedSessionOrphanReason OrphanReason { get; }
+
+    /// <summary>True when the preset is launchable (repository present and agent present).</summary>
+    public bool IsLaunchable => OrphanReason == NamedSessionOrphanReason.None;
+}
+
+/// <summary>
+/// Manages named-session preset files as individual JSON files in the named-sessions directory
+/// (issue #508). Each preset is stored as {slug}.named-session.json. Mirrors
+/// <see cref="WorkspaceStore"/> (create / list / delete / slug / exists) and adds orphan resolution
+/// so the UI can grey out presets whose repository folder or agent id no longer exists.
+/// </summary>
+public class NamedSessionStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public string FolderPath { get; }
+
+    public NamedSessionStore(string? folderPath = null)
+    {
+        FolderPath = folderPath ?? CcStorage.NamedSessions();
+    }
+
+    /// <summary>
+    /// Save a named-session preset. Overwrites if a file with the same slug exists.
+    /// </summary>
+    public bool Save(NamedSessionDefinition preset)
+    {
+        if (preset is null) throw new ArgumentNullException(nameof(preset));
+
+        var slug = ToSlug(preset.Name);
+        FileLog.Write($"[NamedSessionStore] Save: name={preset.Name}, slug={slug}, agentId={preset.AgentId}");
+
+        try
+        {
+            EnsureDirectory();
+
+            var filePath = GetFilePath(slug);
+            var json = JsonSerializer.Serialize(preset, JsonOptions);
+            File.WriteAllText(filePath, json);
+
+            FileLog.Write($"[NamedSessionStore] Save: written to {filePath}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[NamedSessionStore] Save FAILED: {ex.GetType().Name}: {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Load all named-session presets, sorted by name. Skips corrupt files with a warning log.
+    /// </summary>
+    public List<NamedSessionDefinition> LoadAll()
+    {
+        FileLog.Write($"[NamedSessionStore] LoadAll: scanning {FolderPath}");
+
+        if (!Directory.Exists(FolderPath))
+        {
+            FileLog.Write("[NamedSessionStore] LoadAll: folder does not exist, returning empty list");
+            return new List<NamedSessionDefinition>();
+        }
+
+        var presets = new List<NamedSessionDefinition>();
+        var files = Directory.GetFiles(FolderPath, "*.named-session.json");
+
+        foreach (var file in files)
+        {
+            try
+            {
+                var json = File.ReadAllText(file);
+                var preset = JsonSerializer.Deserialize<NamedSessionDefinition>(json, JsonOptions);
+                if (preset != null)
+                    presets.Add(preset);
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[NamedSessionStore] LoadAll: skipping corrupt file {Path.GetFileName(file)}: {ex.Message}");
+            }
+        }
+
+        presets.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+
+        FileLog.Write($"[NamedSessionStore] LoadAll: loaded {presets.Count} presets");
+        return presets;
+    }
+
+    /// <summary>
+    /// Load all presets and classify each as launchable or orphaned (issue #508), given the set of
+    /// configured agent ids. A preset is an orphan when its repository folder is missing or its
+    /// agent id is not in <paramref name="knownAgentIds"/>. Repository is checked first, so a preset
+    /// that is broken both ways reports the repository as the reason.
+    /// </summary>
+    public List<NamedSessionStatus> LoadAllWithStatus(IEnumerable<string> knownAgentIds)
+    {
+        if (knownAgentIds is null) throw new ArgumentNullException(nameof(knownAgentIds));
+
+        var agentIds = new HashSet<string>(knownAgentIds, StringComparer.Ordinal);
+        var statuses = LoadAll().Select(p => new NamedSessionStatus(p, ResolveOrphanReason(p, agentIds))).ToList();
+
+        FileLog.Write($"[NamedSessionStore] LoadAllWithStatus: {statuses.Count} presets, {statuses.Count(s => !s.IsLaunchable)} orphaned");
+        return statuses;
+    }
+
+    /// <summary>
+    /// Classify one preset as launchable or orphaned. Repository-missing is checked before
+    /// agent-removed so a doubly-broken preset reports the repository reason.
+    /// </summary>
+    public static NamedSessionOrphanReason ResolveOrphanReason(NamedSessionDefinition preset, ISet<string> knownAgentIds)
+    {
+        if (preset is null) throw new ArgumentNullException(nameof(preset));
+        if (knownAgentIds is null) throw new ArgumentNullException(nameof(knownAgentIds));
+
+        if (string.IsNullOrWhiteSpace(preset.RepositoryPath) || !Directory.Exists(preset.RepositoryPath))
+            return NamedSessionOrphanReason.RepositoryMissing;
+
+        if (!knownAgentIds.Contains(preset.AgentId))
+            return NamedSessionOrphanReason.AgentRemoved;
+
+        return NamedSessionOrphanReason.None;
+    }
+
+    /// <summary>
+    /// Load a single preset by slug. Returns null if not found or corrupt.
+    /// </summary>
+    public NamedSessionDefinition? Load(string slug)
+    {
+        FileLog.Write($"[NamedSessionStore] Load: slug={slug}");
+
+        var filePath = GetFilePath(slug);
+        if (!File.Exists(filePath))
+        {
+            FileLog.Write($"[NamedSessionStore] Load: file not found for slug={slug}");
+            return null;
+        }
+
+        try
+        {
+            var json = File.ReadAllText(filePath);
+            return JsonSerializer.Deserialize<NamedSessionDefinition>(json, JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[NamedSessionStore] Load FAILED for {slug}: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Delete a preset by slug. Returns true if the file was deleted.
+    /// </summary>
+    public bool Delete(string slug)
+    {
+        FileLog.Write($"[NamedSessionStore] Delete: slug={slug}");
+
+        var filePath = GetFilePath(slug);
+        if (!File.Exists(filePath))
+        {
+            FileLog.Write($"[NamedSessionStore] Delete: file not found for slug={slug}");
+            return false;
+        }
+
+        try
+        {
+            File.Delete(filePath);
+            FileLog.Write($"[NamedSessionStore] Delete: deleted {filePath}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[NamedSessionStore] Delete FAILED: {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>Check if a preset with the given slug exists.</summary>
+    public bool Exists(string slug)
+    {
+        return File.Exists(GetFilePath(slug));
+    }
+
+    /// <summary>
+    /// Convert a preset name to a filesystem-safe slug (lowercase, hyphens). Same rules as
+    /// <see cref="WorkspaceStore.ToSlug"/> for consistency, falling back to "named-session" when the
+    /// name has no slug-able characters.
+    /// </summary>
+    public static string ToSlug(string name)
+    {
+        var slug = (name ?? string.Empty).Trim().ToLowerInvariant();
+        slug = Regex.Replace(slug, @"[^a-z0-9\s-]", "");
+        slug = Regex.Replace(slug, @"[\s]+", "-");
+        slug = Regex.Replace(slug, @"-+", "-");
+        slug = slug.Trim('-');
+
+        if (string.IsNullOrEmpty(slug))
+            slug = "named-session";
+
+        return slug;
+    }
+
+    private string GetFilePath(string slug) => Path.Combine(FolderPath, $"{slug}.named-session.json");
+
+    private void EnsureDirectory()
+    {
+        if (!Directory.Exists(FolderPath))
+        {
+            Directory.CreateDirectory(FolderPath);
+            FileLog.Write($"[NamedSessionStore] Created directory {FolderPath}");
+        }
+    }
+}

--- a/src/CcDirector.Core/Storage/CcStorage.cs
+++ b/src/CcDirector.Core/Storage/CcStorage.cs
@@ -211,6 +211,9 @@ public static class CcStorage
     /// <summary>Workspace definitions directory: config/director/workspaces/</summary>
     public static string Workspaces() => Path.Combine(ToolConfig("director"), "workspaces");
 
+    /// <summary>Named-session preset directory (issue #508): config/director/named-sessions/</summary>
+    public static string NamedSessions() => Path.Combine(ToolConfig("director"), "named-sessions");
+
     // -- Browser Connections --
 
     /// <summary>Browser connections directory: base/connections/</summary>


### PR DESCRIPTION
## Release Notes
Named sessions: save a repository + agent + model under a fixed name and launch it in one click from the New Session dialog. Closes #508.

## Changes
- **Core:** new `NamedSessionDefinition` model and `NamedSessionStore` per-file store mirroring `WorkspaceStore` (create/list/delete/exists/slug), with orphan resolution for missing repository / removed agent. `CcStorage.NamedSessions()` directory helper.
- **NewSessionDialog:** ONE compact "Named session" row (dropdown + small "Manage..." button) at the top; a compact "Model:" row; a "Save as named session..." button next to Start, enabled only when repository + agent + model are all set. Selecting a preset fills the existing fields and does not auto-launch.
- **ManageNamedSessionsDialog:** dedicated list / rename / delete dialog; orphans are greyed, labelled ("repository missing" / "agent removed"), launch-disabled, and never shown in the start flow.
- **MainWindow:** applies the dialog Model box as a per-launch model override.
- **Tests:** `NamedSessionStoreTests` (22) covering create / list / delete / round-trip / slug and the orphan cases.

## How to Test
This was a deferred-QA round (no agent launched the app). A full click-by-click human QA plan covering every acceptance criterion is committed at `docs/cencon/proof/issue-508/HUMAN_QA_PLAN.md` (and `.html`).

Automated: `dotnet test src/CcDirector.Core.Tests/CcDirector.Core.Tests.csproj --filter "FullyQualifiedName~NamedSessionStoreTests"`

## Expected Result
- `dotnet build cc-director.sln`: 0 warnings, 0 errors.
- `NamedSessionStoreTests`: 22 passed.

## Before / After
Before: the New Session dialog had no way to save or recall a repo+agent+model combination. After: a compact named-session row recalls saved presets, a Save button captures the current selection, and a dedicated Manage dialog handles rename/delete and orphan presets.

Proof: docs/cencon/proof/issue-508/HUMAN_QA_PLAN.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)