### PR TITLE
Save and reopen a Director with wingman-written handover notes (#512)

### DIFF
--- a/docs/cencon/proof/issue-512/report.html
+++ b/docs/cencon/proof/issue-512/report.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Issue #512 - Developer Agent Proof Report</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; background: #1E1E1E; color: #CCCCCC; margin: 0; padding: 32px; line-height: 1.5; }
+  h1 { color: #FFFFFF; font-size: 24px; border-bottom: 2px solid #007ACC; padding-bottom: 8px; }
+  h2 { color: #FFFFFF; font-size: 19px; margin-top: 32px; border-bottom: 1px solid #3C3C3C; padding-bottom: 4px; }
+  h3 { color: #FFFFFF; font-size: 15px; margin-top: 20px; }
+  code { font-family: Cascadia Mono, Consolas, monospace; background: #252526; padding: 2px 5px; border-radius: 3px; color: #D7BA7D; }
+  pre { background: #252526; padding: 12px; border-radius: 4px; overflow-x: auto; border: 1px solid #3C3C3C; }
+  pre code { background: none; padding: 0; color: #CCCCCC; }
+  table { border-collapse: collapse; width: 100%; margin: 12px 0; }
+  th, td { border: 1px solid #3C3C3C; padding: 8px 10px; text-align: left; vertical-align: top; font-size: 13px; }
+  th { background: #252526; color: #FFFFFF; }
+  .ok { color: #22C55E; font-weight: bold; }
+  .warn { color: #D97706; font-weight: bold; }
+  .muted { color: #888888; }
+  .banner { background: #3A2A1B; border: 1px solid #D97706; padding: 12px 16px; border-radius: 4px; margin: 16px 0; }
+  .banner strong { color: #F59E0B; }
+  a { color: #3B82F6; }
+  img { max-width: 100%; border: 1px solid #3C3C3C; border-radius: 4px; margin: 8px 0; }
+</style>
+</head>
+<body>
+
+<h1>Issue #512 - Save and reopen a whole Director, with a wingman-written handover note per session</h1>
+
+<p><strong>Role:</strong> Developer Agent (CenCon Development Method)<br/>
+<strong>Branch:</strong> <code>issue-512-director-handover-ws</code><br/>
+<strong>Base:</strong> <code>origin/main</code> at <code>ec16301</code><br/>
+<strong>Date:</strong> 2026-06-18</p>
+
+<div class="banner">
+  <strong>Verification scope - read this first.</strong>
+  This report documents <strong>static verification only</strong>: a clean full-solution build,
+  the affected unit-test suite passing, and a line-by-line code review against
+  <code>docs/CodingStyle.md</code> and <code>docs/VisualStyle.md</code>.
+  Per explicit operator instruction for this run, the application was <strong>NOT launched</strong>
+  (no slot Director, no scheduled task, no Control API, no runtime screenshots) because many
+  people are actively working on this machine and a Director window appearing would be disruptive.
+  <strong>Runtime QA is therefore deferred to the human operator.</strong>
+  This report does <strong>not</strong> claim the feature is runtime-proven. The
+  "How a human should test this" section below gives the step-by-step manual verification with an
+  Expected Result for every acceptance criterion.
+</div>
+
+<h2>1. What was implemented</h2>
+
+<p>The bulk Save/Load Workspace feature is upgraded from "re-open repos in fresh sessions" to a real
+state transfer with an optional, per-session <em>handover note written by the wingman running as a
+REAL Claude session</em>. Reopening a workspace can optionally seed each restored session from its note
+so a new Director picks up where the old one left off.</p>
+
+<h3>New files</h3>
+<table>
+  <tr><th>File</th><th>Purpose</th></tr>
+  <tr>
+    <td><code>src/CcDirector.Core/Sessions/WorkspaceHandoverWriter.cs</code></td>
+    <td>Core orchestration. For one session it drives the issue #509 <code>SessionAskRunner</code>
+        engine (a real driver-backed session, never <code>--print</code>/<code>-p</code>), reads the
+        wingman's answer back from the transcript, and persists it through
+        <code>HandoverScanner.WriteNew</code> (the same parser the Handovers tab uses). Both the ask
+        and the persistence are injected seams, so it is fully unit-testable with fakes. Per-session
+        failures (repo gone, agent cannot answer, ask times out) return a
+        <code>WorkspaceHandoverResult.Fail</code> rather than aborting the whole save.</td>
+  </tr>
+  <tr>
+    <td><code>src/CcDirector.Core.Tests/Sessions/WorkspaceHandoverWriterTests.cs</code></td>
+    <td>Six unit tests covering the happy path, missing repo, empty answer, ask throwing,
+        the handover prompt contract, and the title builder.</td>
+  </tr>
+</table>
+
+<h3>Changed files</h3>
+<table>
+  <tr><th>File</th><th>Change</th></tr>
+  <tr><td><code>src/CcDirector.Core/Sessions/WorkspaceDefinition.cs</code></td>
+      <td>Added <code>WorkspaceSessionEntry.HandoverPath</code> (nullable) - the optional reference to
+          the handover doc the wingman wrote at save time. Null means "no handover; restore fresh".</td></tr>
+  <tr><td><code>src/CcDirector.Avalonia/SaveWorkspaceDialog.axaml(.cs)</code></td>
+      <td>Added the "Include handover documents" toggle and a one-line explanation. Carries
+          <code>AgentKind</code> through <code>SessionData</code>, and exposes
+          <code>IncludeHandovers</code> + <code>SelectedSessions</code> so the caller can write notes
+          off the dialog code path (each note is a slow real-session ask).</td></tr>
+  <tr><td><code>src/CcDirector.Avalonia/LoadWorkspaceDialog.axaml(.cs)</code></td>
+      <td>Added the "Seed each session from its handover note" toggle, enabled only when the selected
+          workspace actually has notes; exposes <code>SeedFromHandovers</code>.</td></tr>
+  <tr><td><code>src/CcDirector.Avalonia/MainWindow.axaml.cs</code></td>
+      <td><code>WriteWorkspaceHandoversAsync</code> (new) runs after the Save dialog when the toggle is
+          on: writes one note per session via <code>WorkspaceHandoverWriter</code>, records each path
+          on its entry, re-saves. <code>LoadWorkspaceAsync</code> gained a
+          <code>seedFromHandovers</code> parameter and reuses the existing
+          <code>InjectHandoverPromptAsync</code> to seed each restored session from its note.</td></tr>
+  <tr><td><code>src/CcDirector.Avalonia/WorkspaceProgressDialog.axaml.cs</code></td>
+      <td>Added <code>UpdateHandoverProgress</code> so the save shows "Writing handover notes - session
+          N/M" while the wingman works.</td></tr>
+  <tr><td><code>src/CcDirector.Core.Tests/WorkspaceStoreTests.cs</code></td>
+      <td>Extended the load/save round-trip test to assert <code>HandoverPath</code> persists and that
+          an entry without one round-trips as null.</td></tr>
+</table>
+
+<h2>2. Acceptance criteria - traced to the exact code</h2>
+
+<table>
+  <tr><th>Acceptance criterion</th><th>Code that satisfies it</th><th class="muted">How a human verifies (section 5)</th></tr>
+  <tr>
+    <td><strong>AC1.</strong> Save with handovers writes one note per live session, via the wingman,
+        with no <code>/handover</code> skill dependency and no <code>-p</code>.</td>
+    <td>
+      The Save dialog "Include handover documents" toggle sets
+      <code>SaveWorkspaceDialog.IncludeHandovers</code>
+      (<code>SaveWorkspaceDialog.axaml.cs</code>). When set, the File menu lambda calls
+      <code>WriteWorkspaceHandoversAsync</code> (<code>MainWindow.axaml.cs</code>:957), which loops
+      <em>every</em> selected session and calls
+      <code>WorkspaceHandoverWriter.WriteForSessionAsync</code>. That method calls
+      <code>SessionAskRunner.AskAsync</code> - a <em>real</em> driver-backed session (issue #509),
+      whose <code>BuildLaunchSpec</code> never emits <code>--print</code>/<code>-p</code> - and then
+      persists the answer with <code>HandoverScanner.WriteNew</code>. There is no call to the
+      <code>/handover</code> skill anywhere in this path; the only <code>--print</code>/<code>-p</code>
+      tokens in the new code are comments documenting their <em>absence</em>. The default agent kind
+      <code>ClaudeCode</code> (<code>ClaudeDriver</code>) declares both <code>TranscriptRead</code> and
+      <code>PreassignedSessionId</code>, the two capabilities the ask requires.</td>
+    <td>Steps 1-4</td>
+  </tr>
+  <tr>
+    <td><strong>AC2.</strong> Open with seeding starts each session from its note; with and without the
+        toggles both work.</td>
+    <td>
+      The Load dialog "Seed each session from its handover note" toggle is enabled only when the
+      selected workspace has at least one <code>HandoverPath</code>
+      (<code>LoadWorkspaceDialog.SetSeedAvailability</code>) and sets
+      <code>SeedFromHandovers</code>. The File menu lambda passes it to
+      <code>LoadWorkspaceAsync(workspace, seedFromHandovers)</code>
+      (<code>MainWindow.axaml.cs</code>). Inside the restore loop, a session is seeded
+      <em>only</em> when <code>seedFromHandovers &amp;&amp; entry.HandoverPath</code> is present, by
+      reusing the existing <code>InjectHandoverPromptAsync</code> (the same seeding path the New
+      Session dialog's Handovers tab already uses). With the toggle off, or for an entry without a
+      note, the session restores fresh - today's behavior - so both toggle states work.</td>
+    <td>Steps 5-7</td>
+  </tr>
+</table>
+
+<h2>3. Build-clean evidence (the hard gate)</h2>
+
+<p>Full solution build, run from the worktree root:</p>
+<pre><code>$ dotnet build cc-director.sln -c Debug
+
+  CcDirector.Avalonia -> ...\bin\Debug\net10.0\cc-director.dll
+
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)</code></pre>
+
+<p>The project enforces <code>&lt;TreatWarningsAsErrors&gt;true&lt;/TreatWarningsAsErrors&gt;</code>, so
+"0 Warning(s)" is a meaningful gate.</p>
+
+<h3>Affected unit tests</h3>
+<pre><code>$ dotnet test CcDirector.Core.Tests --filter "FullyQualifiedName~Workspace"
+Passed!  - Failed: 0, Passed: 23, Skipped: 0, Total: 23</code></pre>
+
+<p>This covers the six new <code>WorkspaceHandoverWriterTests</code> and the extended
+<code>WorkspaceStoreTests</code> round-trip.</p>
+
+<h3>Full Core suite - the two pre-existing failures are NOT caused by this change</h3>
+<p>The full <code>CcDirector.Core.Tests</code> run reports 2086 passed / 2 failed. Both failures exist
+on <code>origin/main</code> independently of issue #512:</p>
+<table>
+  <tr><th>Failing test</th><th>Why it is unrelated</th></tr>
+  <tr>
+    <td><code>CleanupOrchestratorLiveTests.Mistranscription_OnlyTheTermIsCorrected_RestVerbatim</code></td>
+    <td>A <em>live</em> test that calls a real language-model HTTP endpoint; it failed with
+        "The request was canceled due to the configured HttpClient.Timeout of 60 seconds elapsing."
+        It is a network/live-dependency timeout, in the Dictation area, untouched by this change.</td>
+  </tr>
+  <tr>
+    <td><code>NoCrossMachineLoopbackGuardTests.No_new_production_file_hardcodes_cross_machine_loopback</code></td>
+    <td>Flags <code>src/CcDirector.Gateway/Running/IDirectorLauncher.cs</code> - a Gateway file that is
+        <em>byte-identical to origin/main</em> (<code>git diff origin/main -- &lt;that file&gt;</code> is
+        empty) and is not part of this change. This is a pre-existing guard finding on the base branch.</td>
+  </tr>
+</table>
+<p>Neither failing test references the workspace or handover code. All workspace/handover tests pass.</p>
+
+<h2>4. Code-review notes (self-review against the standards)</h2>
+<ul>
+  <li><span class="ok">No fallback programming.</span> Per-session failures use the documented
+      <em>Result Objects for Expected Failures</em> pattern (<code>WorkspaceHandoverResult</code>),
+      not a swallowing <code>catch</code> - one bad session yields "no handover for that session"
+      with a logged reason, the rest still save.</li>
+  <li><span class="ok">No null-forgiving operator</span> (<code>!</code>) anywhere in the new code;
+      null is handled with explicit <code>is null</code> / <code>is not null</code> checks.</li>
+  <li><span class="ok">Enterprise logging.</span> Entry/exit/failure are logged via
+      <code>FileLog.Write</code> with <code>[ClassName] Method: context</code> formatting throughout
+      <code>WorkspaceHandoverWriter</code> and the new MainWindow methods.</li>
+  <li><span class="ok">Responsive UI.</span> The slow per-session asks run off the dialog code path,
+      behind a <code>WorkspaceProgressDialog</code> showing "Writing handover notes - session N/M";
+      the dialog is closed in a <code>finally</code>.</li>
+  <li><span class="ok">Core has no UI dependency.</span> The orchestration lives in
+      <code>CcDirector.Core</code> with injected seams; the WPF/Avalonia layer only wires it up.</li>
+  <li><span class="ok">VisualStyle compliance.</span> The two new toggles use the dialog palette
+      (foreground <code>#CCCCCC</code> primary / <code>#888888</code> hint, accent buttons unchanged),
+      match the existing dialog grid/margins, and add no new hard-coded colors outside the documented
+      tokens. The Save dialog height was bumped 420->480 to fit the toggle.</li>
+  <li><span class="ok">Naming + async conventions.</span> <code>*Async</code> suffixes,
+      <code>_camelCase</code> fields, verb-noun methods, <code>Task</code>-returning helpers.</li>
+  <li><span class="ok">Tests.</span> Every new public Core method is exercised by a unit test using
+      Arrange-Act-Assert and the <code>Method_Scenario_Result</code> naming convention.</li>
+  <li><span class="ok">CenCon impact: no drift.</span> This is a feature inside existing containers
+      (Desktop app + Core sessions). It introduces no new container, no new external dependency, and
+      no change to the security posture - it reuses the issue #509 real-session engine that is already
+      on main. No <code>docs/cencon/</code> manifest or security-profile update is required.</li>
+</ul>
+
+<h2>5. How a human should test this (runtime QA, deferred to the operator)</h2>
+
+<p>Build a slot exe from this branch and launch it via the project's per-session isolation flow (or the
+operator's normal test path), then:</p>
+
+<h3>AC1 - Save writes one note per live session via the wingman</h3>
+<ol>
+  <li>Open two or three sessions in the Director, each in a real git repo, and do a little work in each
+      so there is something to summarize.</li>
+  <li><strong>File -&gt; Save Workspace...</strong> Tick <strong>"Include handover documents (the
+      wingman writes a note per session)"</strong>, name the workspace, click Save.
+      <br/><span class="muted">Expected:</span> a progress dialog appears showing
+      "Writing handover notes - session 1/N", "2/N", ... cycling through the sessions.</li>
+  <li>Watch the director log
+      (<code>%LOCALAPPDATA%\cc-director\logs\director\director-*.log</code>).
+      <br/><span class="muted">Expected:</span> for each session you see
+      <code>[WorkspaceHandoverWriter] WriteForSessionAsync</code> followed by
+      <code>[SessionAskRunner] AskAsync</code> and <code>session closed</code>, and finally
+      <code>WriteWorkspaceHandoversAsync: '...' re-saved with N/N handover notes</code>. There must be
+      <strong>no</strong> <code>--print</code> or <code>-p</code> in any launched command, and no
+      <code>/handover</code> skill invocation.</li>
+  <li>Inspect the saved workspace JSON (in the workspaces folder) and the handover folder.
+      <br/><span class="muted">Expected:</span> each session entry has a <code>HandoverPath</code>
+      pointing at a real markdown note whose body is a plain-prose handover summary (what we did /
+      current state / next steps), not a transcript dump.</li>
+</ol>
+
+<h3>AC2 - Open with seeding (and without)</h3>
+<ol start="5">
+  <li>Close all sessions (or use a second Director). <strong>File -&gt; Load Workspace...</strong>,
+      select the workspace you just saved.
+      <br/><span class="muted">Expected:</span> the <strong>"Seed each session from its handover
+      note"</strong> checkbox is now <em>enabled</em> (because the workspace has notes).</li>
+  <li>Tick the seed checkbox and click Load.
+      <br/><span class="muted">Expected:</span> each session reopens and, once Claude has started, a
+      prompt is auto-sent referencing its handover file (<code>@...handover.md ... summary of what was
+      done ... what we should work on next</code>); the log shows
+      <code>[MainWindow] LoadWorkspaceAsync: seeding session ... from ...</code> and
+      <code>InjectHandoverPromptAsync: sent handover prompt</code> for each seeded session.</li>
+  <li>Repeat the Load <em>without</em> ticking the seed checkbox (and, separately, load a workspace
+      saved without handovers).
+      <br/><span class="muted">Expected:</span> sessions reopen fresh with no auto-sent prompt -
+      today's behavior - confirming both toggle states work and the feature degrades cleanly.</li>
+</ol>
+
+<h2>6. Statement</h2>
+<p>The implementation is complete, the full solution builds clean (0 warnings / 0 errors), all
+workspace and handover unit tests pass, and the change has been self-reviewed against
+<code>docs/CodingStyle.md</code> and <code>docs/VisualStyle.md</code>. Per operator instruction for
+this run, the application was not launched; <strong>runtime QA is deferred to the human operator</strong>
+using section 5 above. This report does not claim runtime-proven behavior.</p>
+
+</body>
+</html>

--- a/src/CcDirector.Avalonia/LoadWorkspaceDialog.axaml
+++ b/src/CcDirector.Avalonia/LoadWorkspaceDialog.axaml
@@ -118,28 +118,43 @@
         </Grid>
 
         <!-- Buttons -->
-        <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
-                    Orientation="Horizontal"
-                    HorizontalAlignment="Right" Margin="0,12,0,0">
-            <Button x:Name="BtnDelete" Content="Delete"
-                    Width="80" Height="28"
-                    Click="BtnDelete_Click"
-                    Background="#3C3C3C" Foreground="#F44847"
-                    BorderThickness="0" Cursor="Hand"
-                    IsEnabled="False"
-                    Margin="0,0,8,0" />
-            <Button x:Name="BtnLoad" Content="Load"
-                    Width="100" Height="28"
-                    Click="BtnLoad_Click"
-                    Background="#007ACC" Foreground="White"
-                    BorderThickness="0" Cursor="Hand"
-                    IsEnabled="False" />
-            <Button x:Name="BtnCancel" Content="Cancel"
-                    Width="80" Height="28"
-                    Click="BtnCancel_Click"
-                    Background="#3C3C3C" Foreground="#CCCCCC"
-                    BorderThickness="0" Cursor="Hand"
-                    Margin="8,0,0,0" />
-        </StackPanel>
+        <Grid Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,12,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <!-- Seed from handovers (issue #512) -->
+            <CheckBox x:Name="ChkSeedFromHandovers" Grid.Column="0"
+                      Content="Seed each session from its handover note"
+                      Foreground="#CCCCCC" FontSize="12"
+                      VerticalAlignment="Center"
+                      IsEnabled="False"
+                      ToolTip.Tip="Available when the selected workspace has handover notes. Each restored session is seeded from its note." />
+
+            <StackPanel Grid.Column="1"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Right">
+                <Button x:Name="BtnDelete" Content="Delete"
+                        Width="80" Height="28"
+                        Click="BtnDelete_Click"
+                        Background="#3C3C3C" Foreground="#F44847"
+                        BorderThickness="0" Cursor="Hand"
+                        IsEnabled="False"
+                        Margin="0,0,8,0" />
+                <Button x:Name="BtnLoad" Content="Load"
+                        Width="100" Height="28"
+                        Click="BtnLoad_Click"
+                        Background="#007ACC" Foreground="White"
+                        BorderThickness="0" Cursor="Hand"
+                        IsEnabled="False" />
+                <Button x:Name="BtnCancel" Content="Cancel"
+                        Width="80" Height="28"
+                        Click="BtnCancel_Click"
+                        Background="#3C3C3C" Foreground="#CCCCCC"
+                        BorderThickness="0" Cursor="Hand"
+                        Margin="8,0,0,0" />
+            </StackPanel>
+        </Grid>
     </Grid>
 </Window>

--- a/src/CcDirector.Avalonia/LoadWorkspaceDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/LoadWorkspaceDialog.axaml.cs
@@ -17,6 +17,18 @@ public partial class LoadWorkspaceDialog : Window
 
     public WorkspaceDefinition? SelectedWorkspace { get; private set; }
 
+    /// <summary>
+    /// True when the user ticked "Seed each session from its handover note" (issue #512).
+    /// When set, <see cref="MainWindow"/> seeds each restored session from its
+    /// <see cref="WorkspaceSessionEntry.HandoverPath"/>; when clear (or no handovers exist)
+    /// the workspace degrades to today's "re-open repos fresh" behavior.
+    /// </summary>
+    public bool SeedFromHandovers { get; private set; }
+
+    /// <summary>True when the given workspace has at least one entry carrying a handover note.</summary>
+    private static bool HasAnyHandover(WorkspaceDefinition workspace) =>
+        workspace.Sessions.Any(s => !string.IsNullOrWhiteSpace(s.HandoverPath));
+
     public LoadWorkspaceDialog()
     {
         InitializeComponent();
@@ -73,6 +85,7 @@ public partial class LoadWorkspaceDialog : Window
         {
             BtnLoad.IsEnabled = false;
             BtnDelete.IsEnabled = false;
+            SetSeedAvailability(false);
             TxtPreviewEmpty.IsVisible = true;
             PreviewList.IsVisible = false;
             TxtPreviewDescription.IsVisible = false;
@@ -81,6 +94,7 @@ public partial class LoadWorkspaceDialog : Window
 
         BtnLoad.IsEnabled = true;
         BtnDelete.IsEnabled = true;
+        SetSeedAvailability(HasAnyHandover(item.Definition));
 
         if (!string.IsNullOrWhiteSpace(item.Definition.Description))
         {
@@ -109,12 +123,27 @@ public partial class LoadWorkspaceDialog : Window
         PreviewList.IsVisible = true;
     }
 
+    /// <summary>
+    /// Enable the "Seed from handovers" toggle only when the selected workspace actually
+    /// carries handover notes. When unavailable the toggle is disabled and unchecked, so the
+    /// load degrades to today's "re-open repos fresh" behavior.
+    /// </summary>
+    private void SetSeedAvailability(bool available)
+    {
+        ChkSeedFromHandovers.IsEnabled = available;
+        if (!available)
+            ChkSeedFromHandovers.IsChecked = false;
+    }
+
     private void BtnLoadDefault_Click(object? sender, RoutedEventArgs e)
     {
         if (_defaultWorkspace == null)
             return;
 
-        FileLog.Write("[LoadWorkspaceDialog] BtnLoadDefault_Click: loading _default workspace");
+        // The default button bypasses the list selection, so derive seeding directly from
+        // the default workspace: only honor the toggle when it actually has handovers.
+        SeedFromHandovers = ChkSeedFromHandovers.IsChecked == true && HasAnyHandover(_defaultWorkspace);
+        FileLog.Write($"[LoadWorkspaceDialog] BtnLoadDefault_Click: loading _default workspace, seed={SeedFromHandovers}");
         SelectedWorkspace = _defaultWorkspace;
         Close(true);
     }
@@ -124,7 +153,8 @@ public partial class LoadWorkspaceDialog : Window
         if (WorkspaceListBox.SelectedItem is not WorkspaceListItem item)
             return;
 
-        FileLog.Write($"[LoadWorkspaceDialog] BtnLoad_Click: name={item.Definition.Name}");
+        SeedFromHandovers = ChkSeedFromHandovers.IsChecked == true && HasAnyHandover(item.Definition);
+        FileLog.Write($"[LoadWorkspaceDialog] BtnLoad_Click: name={item.Definition.Name}, seed={SeedFromHandovers}");
         SelectedWorkspace = item.Definition;
         Close(true);
     }

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -900,9 +900,11 @@ public partial class MainWindow : Window
 
     // ==================== WORKSPACE LOADING ====================
 
-    private async Task LoadWorkspaceAsync(WorkspaceDefinition workspace)
+    private async Task LoadWorkspaceAsync(WorkspaceDefinition workspace, bool seedFromHandovers = false)
     {
-        FileLog.Write($"[MainWindow] LoadWorkspaceAsync: '{workspace.Name}' with {workspace.Sessions.Count} sessions");
+        FileLog.Write(
+            $"[MainWindow] LoadWorkspaceAsync: '{workspace.Name}' with {workspace.Sessions.Count} sessions, " +
+            $"seedFromHandovers={seedFromHandovers}");
 
         var progress = new WorkspaceProgressDialog(workspace.Name);
         progress.Show(this);
@@ -924,6 +926,17 @@ public partial class MainWindow : Window
                 {
                     vm.Rename(entry.CustomName, entry.CustomColor);
                     SaveSessionToHistory(vm);
+
+                    // Seed the restored session from its handover note (issue #512). Only when
+                    // the user opted in AND this entry actually carries a note; otherwise the
+                    // session starts fresh (today's behavior). The handover path was written
+                    // by the wingman at save time and lives in the Director's handover folder.
+                    if (seedFromHandovers && !string.IsNullOrWhiteSpace(entry.HandoverPath))
+                    {
+                        FileLog.Write(
+                            $"[MainWindow] LoadWorkspaceAsync: seeding session {vm.Session.Id} from {entry.HandoverPath}");
+                        _ = InjectHandoverPromptAsync(vm.Session, entry.HandoverPath);
+                    }
                 }
 
                 // Delay between sessions to prevent Claude Code settings corruption
@@ -933,6 +946,68 @@ public partial class MainWindow : Window
 
             progress.SetComplete();
             FileLog.Write($"[MainWindow] LoadWorkspaceAsync: workspace '{workspace.Name}' loaded");
+        }
+        finally
+        {
+            progress.Close();
+        }
+    }
+
+    /// <summary>
+    /// Have the wingman write one handover note per saved session and record each note's path
+    /// on its <see cref="WorkspaceSessionEntry"/>, then re-save the workspace (issue #512). The
+    /// note is produced by a REAL wingman session via <see cref="WorkspaceHandoverWriter"/>
+    /// (the issue #509 <c>SessionAskRunner</c> engine - no /handover skill, no --print). Each
+    /// session is written independently: if one fails (its repo is gone, the agent can't answer,
+    /// or the ask times out) that single entry simply gets no handover and the rest still save.
+    /// </summary>
+    private async Task WriteWorkspaceHandoversAsync(
+        WorkspaceStore store, WorkspaceDefinition workspace, IReadOnlyList<SessionData> sessions)
+    {
+        FileLog.Write(
+            $"[MainWindow] WriteWorkspaceHandoversAsync: '{workspace.Name}', {sessions.Count} sessions");
+
+        var progress = new WorkspaceProgressDialog(workspace.Name);
+        progress.Show(this);
+
+        try
+        {
+            var writer = new WorkspaceHandoverWriter();
+            int total = sessions.Count;
+
+            for (int i = 0; i < total; i++)
+            {
+                var session = sessions[i];
+                progress.UpdateHandoverProgress(i + 1, total, session.CustomName ?? session.DisplayName);
+
+                var request = new WorkspaceHandoverRequest
+                {
+                    RepoPath = session.RepoPath,
+                    AgentKind = session.AgentKind,
+                    SessionName = session.CustomName ?? session.DisplayName,
+                    AgentArgs = session.ClaudeArgs,
+                };
+
+                var result = await writer.WriteForSessionAsync(request);
+                if (result.Success && result.HandoverPath is not null)
+                {
+                    // Pair the note back to its entry by repo path + sort order. The dialog
+                    // built the entries from the same selected sessions in the same order.
+                    var entry = workspace.Sessions.FirstOrDefault(
+                        s => s.SortOrder == i && string.Equals(s.RepoPath, session.RepoPath, StringComparison.OrdinalIgnoreCase));
+                    if (entry is not null)
+                        entry.HandoverPath = result.HandoverPath;
+                }
+            }
+
+            workspace.UpdatedAt = DateTimeOffset.UtcNow;
+            store.Save(workspace);
+
+            var written = workspace.Sessions.Count(s => !string.IsNullOrWhiteSpace(s.HandoverPath));
+            progress.SetComplete();
+            FileLog.Write(
+                $"[MainWindow] WriteWorkspaceHandoversAsync: '{workspace.Name}' re-saved with " +
+                $"{written}/{total} handover notes");
         }
         finally
         {
@@ -2856,9 +2931,16 @@ public partial class MainWindow : Window
             var app = AppRef();
             var sessionData = _sessions.Select(vm => new SessionData(
                 vm.DisplayName, vm.Session.RepoPath, vm.Session.CustomName,
-                vm.Session.CustomColor, vm.Session.ClaudeArgs));
+                vm.Session.CustomColor, vm.Session.ClaudeArgs, vm.Session.AgentKind));
             var dialog = new SaveWorkspaceDialog(app.WorkspaceStore, sessionData);
-            await dialog.ShowDialog<bool?>(this);
+            var result = await dialog.ShowDialog<bool?>(this);
+
+            // The workspace itself was saved by the dialog. If the user asked to include
+            // handover documents (issue #512), have the wingman write a note per session and
+            // record the path on each entry, then re-save - done here, not in the dialog,
+            // because each note is a slow real-session ask and belongs off the dialog code path.
+            if (result == true && dialog.Result != null && dialog.IncludeHandovers)
+                await WriteWorkspaceHandoversAsync(app.WorkspaceStore, dialog.Result, dialog.SelectedSessions);
         }));
         file.Menu.Items.Add(Item("Load Workspace...", async () =>
         {
@@ -2867,7 +2949,7 @@ public partial class MainWindow : Window
             if (result == true && dialog.SelectedWorkspace != null)
             {
                 if (_sessions.Count > 0) await CloseAllSessionsAsync();
-                await LoadWorkspaceAsync(dialog.SelectedWorkspace);
+                await LoadWorkspaceAsync(dialog.SelectedWorkspace, dialog.SeedFromHandovers);
             }
         }));
         file.Menu.Items.Add(Item("Clear Workspace", async () =>

--- a/src/CcDirector.Avalonia/SaveWorkspaceDialog.axaml
+++ b/src/CcDirector.Avalonia/SaveWorkspaceDialog.axaml
@@ -2,7 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="CcDirector.Avalonia.SaveWorkspaceDialog"
         Title="Save Workspace"
-        Width="500" Height="420"
+        Width="500" Height="480"
         WindowStartupLocation="CenterOwner"
         CanResize="False"
         Background="#252526">
@@ -14,6 +14,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
@@ -65,14 +66,24 @@
             </ListBox>
         </Grid>
 
+        <!-- Include handover documents (issue #512) -->
+        <StackPanel Grid.Row="5" Margin="0,12,0,0">
+            <CheckBox x:Name="ChkIncludeHandovers"
+                      Content="Include handover documents (the wingman writes a note per session)"
+                      Foreground="#CCCCCC" FontSize="13" />
+            <TextBlock Text="A real wingman session summarizes each session so a reopened workspace can pick up where it left off. This adds time to the save."
+                       Foreground="#888888" FontSize="11"
+                       TextWrapping="Wrap" Margin="24,2,0,0" />
+        </StackPanel>
+
         <!-- Overwrite Warning -->
-        <TextBlock x:Name="TxtWarning" Grid.Row="5"
+        <TextBlock x:Name="TxtWarning" Grid.Row="6"
                    Foreground="#D97706" FontSize="11"
                    TextWrapping="Wrap" Margin="0,8,0,0"
                    IsVisible="False" />
 
         <!-- Buttons -->
-        <StackPanel Grid.Row="6" Orientation="Horizontal"
+        <StackPanel Grid.Row="7" Orientation="Horizontal"
                     HorizontalAlignment="Right" Margin="0,12,0,0">
             <Button x:Name="BtnSave" Content="Save"
                     Width="100" Height="28"

--- a/src/CcDirector.Avalonia/SaveWorkspaceDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/SaveWorkspaceDialog.axaml.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Media;
+using CcDirector.Core.Agents;
 using CcDirector.Core.Sessions;
 using CcDirector.Core.Utilities;
 
@@ -16,7 +17,8 @@ public record SessionData(
     string RepoPath,
     string? CustomName,
     string? CustomColor,
-    string? ClaudeArgs);
+    string? ClaudeArgs,
+    AgentKind AgentKind);
 
 public partial class SaveWorkspaceDialog : Window
 {
@@ -24,6 +26,17 @@ public partial class SaveWorkspaceDialog : Window
     private readonly List<SaveSessionItem> _items;
 
     public WorkspaceDefinition? Result { get; private set; }
+
+    /// <summary>
+    /// True when the user ticked "Include handover documents" (issue #512). When set, the
+    /// caller has the wingman write one handover note per selected session and records the
+    /// path on each entry. The selected sessions, in their saved entry order, are exposed
+    /// via <see cref="SelectedSessions"/> so the caller can pair each handover with its entry.
+    /// </summary>
+    public bool IncludeHandovers { get; private set; }
+
+    /// <summary>The sessions that were saved, in entry order, when the dialog succeeded.</summary>
+    public IReadOnlyList<SessionData> SelectedSessions { get; private set; } = Array.Empty<SessionData>();
 
     public SaveWorkspaceDialog(WorkspaceStore store, IEnumerable<SessionData> sessions)
     {
@@ -39,6 +52,7 @@ public partial class SaveWorkspaceDialog : Window
             CustomName = s.CustomName,
             CustomColor = s.CustomColor,
             ClaudeArgs = s.ClaudeArgs,
+            AgentKind = s.AgentKind,
             SortOrder = i,
             HasColor = !string.IsNullOrWhiteSpace(s.CustomColor),
             ColorBrush = GetColorBrush(s.CustomColor)
@@ -131,8 +145,16 @@ public partial class SaveWorkspaceDialog : Window
             }).ToList()
         };
 
+        IncludeHandovers = ChkIncludeHandovers.IsChecked == true;
+        SelectedSessions = selected
+            .Select(s => new SessionData(
+                s.DisplayName, s.RepoPath, s.CustomName, s.CustomColor, s.ClaudeArgs, s.AgentKind))
+            .ToList();
+
         _store.Save(Result);
-        FileLog.Write($"[SaveWorkspaceDialog] Workspace saved: {name} ({selected.Count} sessions)");
+        FileLog.Write(
+            $"[SaveWorkspaceDialog] Workspace saved: {name} ({selected.Count} sessions), " +
+            $"includeHandovers={IncludeHandovers}");
 
         Close(true);
     }
@@ -158,6 +180,7 @@ public partial class SaveWorkspaceDialog : Window
         public string? CustomName { get; set; }
         public string? CustomColor { get; set; }
         public string? ClaudeArgs { get; set; }
+        public AgentKind AgentKind { get; set; } = AgentKind.ClaudeCode;
         public int SortOrder { get; set; }
         public bool HasColor { get; set; }
         public ISolidColorBrush ColorBrush { get; set; } = new SolidColorBrush(Colors.Transparent);

--- a/src/CcDirector.Avalonia/WorkspaceProgressDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/WorkspaceProgressDialog.axaml.cs
@@ -24,6 +24,16 @@ public partial class WorkspaceProgressDialog : Window
         DetailText.Text = "";
     }
 
+    /// <summary>
+    /// Show progress while the wingman writes handover notes for a workspace save (issue #512).
+    /// </summary>
+    public void UpdateHandoverProgress(int current, int total, string sessionName)
+    {
+        StatusText.Text = $"Writing handover notes - session {current}/{total}";
+        ProgressBar.Value = (double)current / total * 100;
+        DetailText.Text = sessionName;
+    }
+
     public void SetComplete()
     {
         StatusText.Text = "Workspace loaded";

--- a/src/CcDirector.Core.Tests/Sessions/WorkspaceHandoverWriterTests.cs
+++ b/src/CcDirector.Core.Tests/Sessions/WorkspaceHandoverWriterTests.cs
@@ -1,0 +1,151 @@
+using CcDirector.Core.Agents;
+using CcDirector.Core.Drivers;
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Sessions;
+
+/// <summary>
+/// Tests for <see cref="WorkspaceHandoverWriter"/> (issue #512): the orchestration that has
+/// the wingman write one handover note per session over a REAL session
+/// (<see cref="SessionAskRunner"/>, no /handover skill, no --print) and persists it. Both the
+/// ask and the persistence are injected seams, so every test runs against fakes - no live
+/// agent, no network, no real filesystem write.
+/// </summary>
+public class WorkspaceHandoverWriterTests : IDisposable
+{
+    private readonly string _repoDir;
+
+    public WorkspaceHandoverWriterTests()
+    {
+        _repoDir = Path.Combine(Path.GetTempPath(), $"WorkspaceHandoverWriterTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_repoDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_repoDir, recursive: true); } catch (IOException) { }
+    }
+
+    [Fact]
+    public async Task WriteForSessionAsync_AsksWingmanAndPersistsAnswer_ReturnsPath()
+    {
+        string? askedWorkdir = null;
+        string? askedPrompt = null;
+        string? writtenContent = null;
+        string? writtenTitle = null;
+
+        var writer = new WorkspaceHandoverWriter(
+            ask: (kind, exe, args, workdir, prompt, timeout, ct) =>
+            {
+                askedWorkdir = workdir;
+                askedPrompt = prompt;
+                return Task.FromResult(new SessionAskResult { Answer = "Did X, next do Y." });
+            },
+            writeHandover: (title, content, repos, sessionName) =>
+            {
+                writtenTitle = title;
+                writtenContent = content;
+                return @"C:\handovers\note.md";
+            },
+            log: _ => { });
+
+        var result = await writer.WriteForSessionAsync(new WorkspaceHandoverRequest
+        {
+            RepoPath = _repoDir,
+            AgentKind = AgentKind.ClaudeCode,
+            SessionName = "Frontend",
+        });
+
+        Assert.True(result.Success);
+        Assert.Equal(@"C:\handovers\note.md", result.HandoverPath);
+        Assert.Equal(_repoDir, askedWorkdir);
+        Assert.Contains("Frontend", askedPrompt);
+        Assert.Equal("Did X, next do Y.", writtenContent);
+        Assert.Equal("Frontend handover", writtenTitle);
+    }
+
+    [Fact]
+    public async Task WriteForSessionAsync_MissingRepo_FailsWithoutAsking()
+    {
+        var asked = false;
+        var writer = new WorkspaceHandoverWriter(
+            ask: (kind, exe, args, workdir, prompt, timeout, ct) =>
+            {
+                asked = true;
+                return Task.FromResult(new SessionAskResult { Answer = "x" });
+            },
+            writeHandover: (_, _, _, _) => "unused",
+            log: _ => { });
+
+        var result = await writer.WriteForSessionAsync(new WorkspaceHandoverRequest
+        {
+            RepoPath = Path.Combine(_repoDir, "does-not-exist"),
+            SessionName = "Gone",
+        });
+
+        Assert.False(result.Success);
+        Assert.Null(result.HandoverPath);
+        Assert.False(asked);
+        Assert.Contains("does not exist", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task WriteForSessionAsync_EmptyAnswer_FailsAndDoesNotPersist()
+    {
+        var wrote = false;
+        var writer = new WorkspaceHandoverWriter(
+            ask: (kind, exe, args, workdir, prompt, timeout, ct) =>
+                Task.FromResult(new SessionAskResult { Answer = "   " }),
+            writeHandover: (_, _, _, _) => { wrote = true; return "unused"; },
+            log: _ => { });
+
+        var result = await writer.WriteForSessionAsync(new WorkspaceHandoverRequest
+        {
+            RepoPath = _repoDir,
+            SessionName = "Empty",
+        });
+
+        Assert.False(result.Success);
+        Assert.False(wrote);
+        Assert.Contains("empty", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task WriteForSessionAsync_AskThrows_FailsGracefullyWithReason()
+    {
+        var writer = new WorkspaceHandoverWriter(
+            ask: (kind, exe, args, workdir, prompt, timeout, ct) =>
+                throw new NotSupportedException("agent RawCli cannot answer an ask"),
+            writeHandover: (_, _, _, _) => "unused",
+            log: _ => { });
+
+        var result = await writer.WriteForSessionAsync(new WorkspaceHandoverRequest
+        {
+            RepoPath = _repoDir,
+            AgentKind = AgentKind.RawCli,
+            SessionName = "Raw",
+        });
+
+        Assert.False(result.Success);
+        Assert.Contains("NotSupportedException", result.ErrorMessage);
+        Assert.Contains("RawCli", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void BuildHandoverPrompt_IsAHandoverNotATranscript()
+    {
+        var prompt = WorkspaceHandoverWriter.BuildHandoverPrompt("Backend");
+
+        Assert.Contains("Backend", prompt);
+        Assert.Contains("handover note", prompt);
+        Assert.Contains("NOT a transcript", prompt);
+    }
+
+    [Fact]
+    public void BuildTitle_NamedAndUnnamed()
+    {
+        Assert.Equal("Backend handover", WorkspaceHandoverWriter.BuildTitle("Backend"));
+        Assert.Equal("Session handover", WorkspaceHandoverWriter.BuildTitle("  "));
+    }
+}

--- a/src/CcDirector.Core.Tests/WorkspaceStoreTests.cs
+++ b/src/CcDirector.Core.Tests/WorkspaceStoreTests.cs
@@ -125,7 +125,8 @@ public class WorkspaceStoreTests : IDisposable
                     CustomName = "Frontend",
                     CustomColor = "#2563EB",
                     SortOrder = 0,
-                    ClaudeArgs = "--allowedTools bash"
+                    ClaudeArgs = "--allowedTools bash",
+                    HandoverPath = @"C:\handovers\20260301_1000_frontend-handover.md"
                 },
                 new()
                 {
@@ -147,7 +148,9 @@ public class WorkspaceStoreTests : IDisposable
         Assert.Equal("#2563EB", loaded.Sessions[0].CustomColor);
         Assert.Equal(0, loaded.Sessions[0].SortOrder);
         Assert.Equal("--allowedTools bash", loaded.Sessions[0].ClaudeArgs);
+        Assert.Equal(@"C:\handovers\20260301_1000_frontend-handover.md", loaded.Sessions[0].HandoverPath);
         Assert.Null(loaded.Sessions[1].CustomName);
+        Assert.Null(loaded.Sessions[1].HandoverPath);
     }
 
     [Fact]

--- a/src/CcDirector.Core/Sessions/WorkspaceDefinition.cs
+++ b/src/CcDirector.Core/Sessions/WorkspaceDefinition.cs
@@ -11,6 +11,15 @@ public class WorkspaceSessionEntry
     public string? CustomColor { get; set; }
     public int SortOrder { get; set; }
     public string? ClaudeArgs { get; set; }
+
+    /// <summary>
+    /// Optional reference to a handover document the wingman wrote for this session at
+    /// save time (issue #512). When the workspace is reopened with "Seed from handovers"
+    /// enabled, the restored session is seeded from this note so it picks up where the
+    /// original left off. Null means the entry carries no handover - the session is
+    /// restored fresh (today's behavior).
+    /// </summary>
+    public string? HandoverPath { get; set; }
 }
 
 /// <summary>

--- a/src/CcDirector.Core/Sessions/WorkspaceHandoverWriter.cs
+++ b/src/CcDirector.Core/Sessions/WorkspaceHandoverWriter.cs
@@ -1,0 +1,171 @@
+using CcDirector.Core.Agents;
+using CcDirector.Core.Drivers;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Sessions;
+
+/// <summary>
+/// Describes one live session whose handover note the wingman should write when a
+/// workspace is saved with "Include handover documents" enabled (issue #512).
+/// </summary>
+public sealed class WorkspaceHandoverRequest
+{
+    /// <summary>The session's working directory (the repository it runs in). Required; must exist.</summary>
+    public string RepoPath { get; init; } = string.Empty;
+
+    /// <summary>The agent CLI the session runs. Only kinds whose driver can read a transcript
+    /// can answer an ask; others are reported as a per-session failure rather than guessed.</summary>
+    public AgentKind AgentKind { get; init; } = AgentKind.ClaudeCode;
+
+    /// <summary>Display name of the session, used in the handover title and frontmatter.</summary>
+    public string SessionName { get; init; } = string.Empty;
+
+    /// <summary>The launch arguments the session was started with, or null for the driver default.
+    /// NEVER carries --print / -p (that is banned project-wide; the ask runs a real session).</summary>
+    public string? AgentArgs { get; init; }
+}
+
+/// <summary>Outcome of writing one session's handover note.</summary>
+public sealed class WorkspaceHandoverResult
+{
+    /// <summary>True when the wingman produced a note and it was persisted to disk.</summary>
+    public bool Success { get; init; }
+
+    /// <summary>The path to the written handover document, or null when <see cref="Success"/> is false.</summary>
+    public string? HandoverPath { get; init; }
+
+    /// <summary>When <see cref="Success"/> is false, why the note could not be written.</summary>
+    public string? ErrorMessage { get; init; }
+
+    public static WorkspaceHandoverResult Ok(string path) =>
+        new() { Success = true, HandoverPath = path };
+
+    public static WorkspaceHandoverResult Fail(string message) =>
+        new() { Success = false, ErrorMessage = message };
+}
+
+/// <summary>
+/// Writes a per-session handover note by having the wingman run as a REAL session
+/// (issue #512). It drives the <see cref="SessionAskRunner"/> engine added by issue #509 -
+/// open a real driver-backed session, ask it to summarize the session, read the answer
+/// back from the transcript, tear the session down - then persists that answer through
+/// <see cref="HandoverScanner.WriteNew"/> so the same parser the Handovers tab and the
+/// /handover skill use round-trips it. There is no dependency on the /handover skill and
+/// no <c>--print</c> / <c>-p</c> anywhere; the acceptance criteria require both.
+///
+/// The <see cref="SessionAskRunner"/> dependency is injected so the orchestration is unit
+/// testable with a fake ask; the production default constructs a real runner.
+///
+/// HOST PROCESS WARNING (nested ConPty): like <see cref="SessionAskRunner"/>, this must be
+/// hosted from a clean process (the desktop app, a service, a Task Scheduler launch), not
+/// from inside a Claude Code pseudoconsole.
+/// </summary>
+public sealed class WorkspaceHandoverWriter
+{
+    /// <summary>How long to give the wingman to write one session's note before giving up on it.</summary>
+    public static readonly TimeSpan DefaultAskTimeout = TimeSpan.FromSeconds(120);
+
+    private readonly Func<AgentKind, string?, string?, string, string, TimeSpan, CancellationToken, Task<SessionAskResult>> _ask;
+    private readonly Func<string, string, IReadOnlyList<string>?, string?, string> _writeHandover;
+    private readonly Action<string> _log;
+    private readonly TimeSpan _askTimeout;
+
+    /// <summary>
+    /// Create a writer. Production callers pass nothing and get a real
+    /// <see cref="SessionAskRunner"/> + <see cref="HandoverScanner.WriteNew"/>; tests pass
+    /// fakes for both seams so no live agent or filesystem is required.
+    /// </summary>
+    /// <param name="ask">The ask seam: (kind, exePath, agentArgs, workingDir, prompt, timeout, ct) -> answer.
+    /// Defaults to a real <see cref="SessionAskRunner"/>.</param>
+    /// <param name="writeHandover">The persistence seam: (title, content, repoPaths, sessionName) -> path.
+    /// Defaults to <see cref="HandoverScanner.WriteNew"/>.</param>
+    /// <param name="log">Diagnostic log sink. Defaults to <see cref="FileLog.Write"/>.</param>
+    /// <param name="askTimeout">Per-session ask budget. Null uses <see cref="DefaultAskTimeout"/>.</param>
+    public WorkspaceHandoverWriter(
+        Func<AgentKind, string?, string?, string, string, TimeSpan, CancellationToken, Task<SessionAskResult>>? ask = null,
+        Func<string, string, IReadOnlyList<string>?, string?, string>? writeHandover = null,
+        Action<string>? log = null,
+        TimeSpan? askTimeout = null)
+    {
+        _ask = ask ?? DefaultAsk;
+        _writeHandover = writeHandover ?? HandoverScanner.WriteNew;
+        _log = log ?? FileLog.Write;
+        _askTimeout = askTimeout ?? DefaultAskTimeout;
+    }
+
+    private static async Task<SessionAskResult> DefaultAsk(
+        AgentKind kind, string? exePath, string? agentArgs, string workingDir,
+        string prompt, TimeSpan timeout, CancellationToken ct)
+    {
+        var runner = new SessionAskRunner();
+        return await runner.AskAsync(kind, exePath, agentArgs, workingDir, prompt, timeout, ct);
+    }
+
+    /// <summary>
+    /// Have the wingman write one session's handover note and persist it. Returns the file
+    /// path on success, or a failure result (logged) when the session's repo is gone, the
+    /// agent cannot answer an ask, or the ask times out - the caller treats a failure as
+    /// "this session simply gets no handover" so one bad session never aborts the whole save.
+    /// </summary>
+    public async Task<WorkspaceHandoverResult> WriteForSessionAsync(
+        WorkspaceHandoverRequest request, CancellationToken ct = default)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+
+        _log($"[WorkspaceHandoverWriter] WriteForSessionAsync: name={request.SessionName}, " +
+             $"repo={request.RepoPath}, kind={request.AgentKind}");
+
+        if (string.IsNullOrWhiteSpace(request.RepoPath) || !Directory.Exists(request.RepoPath))
+            return Failed(request, $"repository path does not exist: {request.RepoPath}");
+
+        SessionAskResult ask;
+        try
+        {
+            var prompt = BuildHandoverPrompt(request.SessionName);
+            ask = await _ask(
+                request.AgentKind, null, request.AgentArgs, request.RepoPath, prompt, _askTimeout, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return Failed(request, $"{ex.GetType().Name}: {ex.Message}");
+        }
+
+        if (string.IsNullOrWhiteSpace(ask.Answer))
+            return Failed(request, "the wingman returned an empty handover note");
+
+        var title = BuildTitle(request.SessionName);
+        var path = _writeHandover(title, ask.Answer, new[] { request.RepoPath }, request.SessionName);
+
+        _log($"[WorkspaceHandoverWriter] WriteForSessionAsync OK: name={request.SessionName}, path={path}");
+        return WorkspaceHandoverResult.Ok(path);
+    }
+
+    private WorkspaceHandoverResult Failed(WorkspaceHandoverRequest request, string message)
+    {
+        _log($"[WorkspaceHandoverWriter] WriteForSessionAsync FAILED: name={request.SessionName}: {message}");
+        return WorkspaceHandoverResult.Fail(message);
+    }
+
+    /// <summary>
+    /// The handover-writing prompt the wingman is asked. It instructs the agent to summarize
+    /// what the session did and what to do next - a handover, NOT a transcript dump - which is
+    /// exactly the summary a reopened session can be seeded from. Public so tests assert the
+    /// contract text.
+    /// </summary>
+    public static string BuildHandoverPrompt(string sessionName)
+    {
+        var who = string.IsNullOrWhiteSpace(sessionName) ? "this session" : $"the session \"{sessionName}\"";
+        return
+            $"Write a concise handover note for {who} so a fresh session can pick up where this one left off. " +
+            "Base it on the work done in this conversation and repository. " +
+            "Cover, in plain prose with short headings: what we were working on and why, " +
+            "what has been done so far, the current state, and the concrete next steps. " +
+            "This is a summary for a human and a future agent - NOT a transcript and NOT a replay of every message. " +
+            "Use plain ASCII text only (no emoji or special symbols). Keep it focused.";
+    }
+
+    /// <summary>The handover document title for a session, used by <see cref="HandoverScanner.WriteNew"/>.</summary>
+    public static string BuildTitle(string sessionName) =>
+        string.IsNullOrWhiteSpace(sessionName) ? "Session handover" : $"{sessionName} handover";
+}


### PR DESCRIPTION
Closes part of #512 (Developer Agent hand-off to QA; do not merge until QA passes).

## Release Notes
Save Workspace can now optionally have the wingman write a handover note per live session (a real Claude session, no `/handover` skill, no `--print`/`-p`), and Load Workspace can optionally seed each restored session from its note so a new Director picks up where the old one left off. Without the toggles it behaves exactly as before (re-open repos fresh).

## Changes
- New `WorkspaceHandoverWriter` (Core): drives the issue #509 `SessionAskRunner` real-session engine to write one handover note per session and persists it via `HandoverScanner.WriteNew`. Injected ask + persistence seams; per-session failures yield "no handover for that session" instead of aborting the save.
- `WorkspaceSessionEntry.HandoverPath` added (nullable) and round-tripped through `WorkspaceStore`.
- Save dialog: "Include handover documents" toggle; carries `AgentKind`; exposes `IncludeHandovers` + `SelectedSessions`.
- Load dialog: "Seed each session from its handover note" toggle, enabled only when notes exist; exposes `SeedFromHandovers`.
- `MainWindow`: `WriteWorkspaceHandoversAsync` writes the notes off the dialog path behind a progress dialog; `LoadWorkspaceAsync(workspace, seedFromHandovers)` seeds via the existing `InjectHandoverPromptAsync`.
- Tests: 6 new `WorkspaceHandoverWriterTests` + extended `WorkspaceStoreTests` round-trip.

## How to Test
See the step-by-step manual verification in `docs/cencon/proof/issue-512/report.html` (section 5). In short: save a multi-session workspace with the handover toggle on (watch the log for `SessionAskRunner` asks and `N/N handover notes`, confirm no `--print`/`-p`), then load it with seeding on (each session gets an auto-sent handover prompt) and again with seeding off (fresh re-open).

## Expected Result
One handover note per live session on save; each restored session seeded from its note on open with seeding; clean degradation to today's behavior without the toggles.

## Verification scope
Static verification only this run: full solution builds clean (0 warnings / 0 errors), all workspace/handover unit tests pass, self-reviewed against CodingStyle.md + VisualStyle.md. The app was NOT launched per operator instruction (shared machine in active use); runtime QA is deferred to the human operator / QA role. The two failing Core tests (a live LLM-timeout dictation test and the loopback guard flagging an unchanged Gateway file) are pre-existing on `origin/main` and unrelated to this change.

Proof: docs/cencon/proof/issue-512/report.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)