### PR TITLE
[Recorder] Always finalize interrupted recordings so they never stay stuck "In Progress"

### DIFF
--- a/phone/CcDirectorClient.Tests/CcDirectorClient.Tests.csproj
+++ b/phone/CcDirectorClient.Tests/CcDirectorClient.Tests.csproj
@@ -58,6 +58,11 @@
     <!-- The recording upload-gating rules (notes + audio always upload regardless of
          transcription). Dependency-free; the same file the Android recorder uses. -->
     <Compile Include="..\CcDirectorClient\Recording\RecordingUploadGate.cs" Link="Recording\RecordingUploadGate.cs" />
+    <!-- Crash-recovery: rebuild a manifest's segment list from the .m4a files on disk so an
+         interrupted recording (open segment never finalized) still uploads. Dependency-free;
+         the same files the Android recorder uses. -->
+    <Compile Include="..\CcDirectorClient\Recording\LocalManifest.cs" Link="Recording\LocalManifest.cs" />
+    <Compile Include="..\CcDirectorClient\Recording\RecordingRecovery.cs" Link="Recording\RecordingRecovery.cs" />
   </ItemGroup>
 
 </Project>

--- a/phone/CcDirectorClient.Tests/RecordingRecoveryTests.cs
+++ b/phone/CcDirectorClient.Tests/RecordingRecoveryTests.cs
@@ -1,0 +1,160 @@
+using System.Security.Cryptography;
+using CcDirectorClient.Recording;
+using Xunit;
+
+namespace CcDirectorClient.Tests;
+
+/// <summary>
+/// Tests for <see cref="RecordingRecovery.ReconstructChunksFromDisk"/> - the rebuild that rescues a
+/// recording the app died mid-capture for. The crux: the OPEN segment is on disk but, because the
+/// kill skipped FinalizeSegment, it is absent from the manifest's Chunks. A recording shorter than
+/// one segment roll therefore had audio on disk but an EMPTY Chunks list, so it could never upload
+/// and was stranded forever showing "In Progress". These tests pin down that the open segment is
+/// rebuilt from disk (so it uploads), that already-listed segments are never disturbed, and that an
+/// empty shell stays empty.
+/// </summary>
+public sealed class RecordingRecoveryTests : IDisposable
+{
+    private readonly string _dir;
+
+    public RecordingRecoveryTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "recrecov-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    private string WriteSegment(int index, byte[] bytes)
+    {
+        var name = $"{index:D4}.m4a";
+        File.WriteAllBytes(Path.Combine(_dir, name), bytes);
+        return name;
+    }
+
+    private static string Sha256Hex(byte[] bytes)
+        => Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+
+    [Fact]
+    public void Reconstruct_OpenSegmentMissingFromManifest_IsRebuiltSoItCanUpload()
+    {
+        // THE bug: the app was killed before the first roll, so the only segment (0000.m4a) is on
+        // disk but the manifest lists no chunks. Without rebuilding, the uploader (which walks
+        // Chunks) sees nothing and the recording is stranded forever showing "In Progress".
+        var audio = new byte[] { 1, 2, 3, 4, 5 };
+        WriteSegment(0, audio);
+        var m = new LocalManifest { EndedAt = null }; // interrupted: Chunks empty
+
+        var added = RecordingRecovery.ReconstructChunksFromDisk(m, _dir);
+
+        Assert.Equal(1, added);
+        var chunk = Assert.Single(m.Chunks);
+        Assert.Equal(0, chunk.Index);
+        Assert.Equal("0000.m4a", chunk.File);
+        Assert.Equal(audio.Length, chunk.Bytes);
+        Assert.Equal(Sha256Hex(audio), chunk.Sha256);
+        Assert.False(chunk.Uploaded); // not yet on the server
+    }
+
+    [Fact]
+    public void Reconstruct_AppendsOnlyTheOpenSegment_LeavingFinalizedOnesUntouched()
+    {
+        // A longer recording: segments 0 and 1 were rolled cleanly (in the manifest, segment 0
+        // already uploaded), then the app died mid-segment-2. Recovery must add ONLY segment 2 and
+        // must not disturb the resume state of the already-listed segments.
+        WriteSegment(0, new byte[] { 10 });
+        WriteSegment(1, new byte[] { 20, 21 });
+        var open = new byte[] { 30, 31, 32 };
+        WriteSegment(2, open);
+
+        var m = new LocalManifest { EndedAt = null };
+        m.Chunks.Add(new ChunkInfo { Index = 0, File = "0000.m4a", Bytes = 1, DurationMs = 1000, StartMs = 0, Uploaded = true });
+        m.Chunks.Add(new ChunkInfo { Index = 1, File = "0001.m4a", Bytes = 2, DurationMs = 1000, StartMs = 1000, Uploaded = false });
+
+        var added = RecordingRecovery.ReconstructChunksFromDisk(m, _dir);
+
+        Assert.Equal(1, added);
+        Assert.Equal(3, m.Chunks.Count);
+        // Existing segments are preserved exactly (resume state intact).
+        Assert.True(m.Chunks[0].Uploaded);
+        Assert.False(m.Chunks[1].Uploaded);
+        // The open segment is appended with exact bytes/hash and placed last on the timeline.
+        var rebuilt = m.Chunks[2];
+        Assert.Equal(2, rebuilt.Index);
+        Assert.Equal(open.Length, rebuilt.Bytes);
+        Assert.Equal(Sha256Hex(open), rebuilt.Sha256);
+        Assert.Equal(2000, rebuilt.StartMs); // after segment 1 ends (1000 + 1000)
+    }
+
+    [Fact]
+    public void Reconstruct_IsIdempotent_DoesNotDuplicateAlreadyListedSegments()
+    {
+        var audio = new byte[] { 7, 7, 7 };
+        WriteSegment(0, audio);
+        var m = new LocalManifest { EndedAt = null };
+
+        var firstPass = RecordingRecovery.ReconstructChunksFromDisk(m, _dir);
+        var secondPass = RecordingRecovery.ReconstructChunksFromDisk(m, _dir);
+
+        Assert.Equal(1, firstPass);
+        Assert.Equal(0, secondPass); // nothing new on the second pass
+        Assert.Single(m.Chunks);
+    }
+
+    [Fact]
+    public void Reconstruct_IgnoresZeroLengthOpenSegment_NoAudioToSave()
+    {
+        // The app died the instant recording started: the open file exists but captured no bytes.
+        // There is nothing to save, so no chunk is created (the caller then leaves it as an empty
+        // shell rather than recovering a zero-byte recording).
+        WriteSegment(0, Array.Empty<byte>());
+        var m = new LocalManifest { EndedAt = null };
+
+        var added = RecordingRecovery.ReconstructChunksFromDisk(m, _dir);
+
+        Assert.Equal(0, added);
+        Assert.Empty(m.Chunks);
+    }
+
+    [Fact]
+    public void Reconstruct_MissingFolder_ReturnsZero()
+    {
+        var m = new LocalManifest { EndedAt = null };
+        var added = RecordingRecovery.ReconstructChunksFromDisk(m, Path.Combine(_dir, "does-not-exist"));
+        Assert.Equal(0, added);
+        Assert.Empty(m.Chunks);
+    }
+
+    [Fact]
+    public void Reconstruct_IgnoresNonSegmentFiles()
+    {
+        // manifest.json and any other non NNNN.m4a file must never be mistaken for a segment.
+        File.WriteAllText(Path.Combine(_dir, "manifest.json"), "{}");
+        File.WriteAllText(Path.Combine(_dir, "notes.txt"), "hello");
+        var m = new LocalManifest { EndedAt = null };
+
+        var added = RecordingRecovery.ReconstructChunksFromDisk(m, _dir);
+
+        Assert.Equal(0, added);
+        Assert.Empty(m.Chunks);
+    }
+
+    [Fact]
+    public void Reconstruct_RebuildsAllSegments_WhenManifestLostEntirely()
+    {
+        // Belt and braces: even if the manifest's Chunks were lost completely, every segment on
+        // disk is rebuilt in index order so the whole recording uploads.
+        WriteSegment(2, new byte[] { 3 });
+        WriteSegment(0, new byte[] { 1 });
+        WriteSegment(1, new byte[] { 2 });
+        var m = new LocalManifest { EndedAt = null };
+
+        var added = RecordingRecovery.ReconstructChunksFromDisk(m, _dir);
+
+        Assert.Equal(3, added);
+        Assert.Equal(new[] { 0, 1, 2 }, m.Chunks.Select(c => c.Index).ToArray());
+    }
+}

--- a/phone/CcDirectorClient/Platforms/Android/AndroidAudioRecorder.cs
+++ b/phone/CcDirectorClient/Platforms/Android/AndroidAudioRecorder.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Android.Content;
 using Android.Media;
 using CcDirectorClient.Recording;
+using CcDirectorClient.Voice;
 using Microsoft.Maui.Networking;
 using Microsoft.Maui.Storage;
 using Application = Android.App.Application;
@@ -200,35 +201,42 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
 
     public async Task ProcessUploadQueueAsync()
     {
-        // Do NOT gate on NetworkAccess == Internet. The Gateway is reachable
-        // over Tailscale, which can ride a network that Android reports as
-        // "constrained"/"local" (or even on mobile data with no public
-        // internet). Only skip when there is no network radio at all; otherwise
-        // attempt and let failures fall back to Retry.
-        if (Connectivity.Current.NetworkAccess == NetworkAccess.None) return;
-
-        // A fresh install (or a reinstall that wiped preferences) has no saved
-        // URL. Seed the built-in default so the recording uploads instead of
-        // silently sitting in the queue. The UI keeps the field editable.
-        var server = Preferences.Get("gateway_url", "").Trim();
-        if (string.IsNullOrWhiteSpace(server))
-        {
-            server = RecorderDefaults.GatewayUrl;
-            Preferences.Set("gateway_url", server);
-        }
-        var token = Preferences.Get("gateway_token", "").Trim();
-
         if (!await _uploadGate.WaitAsync(0)) return; // a run is already in progress
         try
         {
-            // Recover any recording that was interrupted mid-capture (app killed,
-            // crashed, or swiped away before StopAsync). Such a manifest has
-            // EndedAt==null but real audio segments on disk; recovery finalizes it
-            // into the normal "Queued" path so it is never stranded and uploads
-            // like any cleanly-stopped recording. This runs on every pass (launch
-            // and the background WorkManager worker) so no interrupted recording is
-            // ever excluded from upload (issue #687).
+            // Recover any recording that was interrupted mid-capture (app killed, crashed, or
+            // swiped away before StopAsync). Such a manifest has EndedAt==null but real audio on
+            // disk; recovery finalizes it into the normal "Queued" path so it is never stranded.
+            //
+            // This runs FIRST and UNCONDITIONALLY - before any network check - because it is a
+            // purely LOCAL on-disk operation. Gating it behind network availability (as the
+            // original #687 pass did) meant an interrupted recording could stay stuck "In Progress"
+            // forever whenever the recovery pass happened to run with no network (e.g. a cold start
+            // before the Tailscale radio is up). Finalizing here means the recording always leaves
+            // the "In Progress" state and joins the queue even offline; its bytes upload as soon as
+            // connectivity returns.
             RecoverOrphanedRecordings();
+
+            // The network-dependent half: pushing bytes to the Gateway and the server->phone
+            // deletion sync. Do NOT gate on NetworkAccess == Internet - the Gateway is reachable
+            // over Tailscale, which Android may report as "constrained"/"local" (or even mobile
+            // data with no public internet). Only skip when there is no network radio at all;
+            // otherwise attempt and let failures fall back to Retry.
+            if (Connectivity.Current.NetworkAccess == NetworkAccess.None)
+            {
+                ClientLog.Write("[Recorder] ProcessUploadQueue: recovery done, no network radio - upload deferred");
+                return;
+            }
+
+            // A fresh install (or a reinstall that wiped preferences) has no saved URL. Seed the
+            // built-in default so the recording uploads instead of silently sitting in the queue.
+            var server = Preferences.Get("gateway_url", "").Trim();
+            if (string.IsNullOrWhiteSpace(server))
+            {
+                server = RecorderDefaults.GatewayUrl;
+                Preferences.Set("gateway_url", server);
+            }
+            var token = Preferences.Get("gateway_token", "").Trim();
 
             foreach (var summary in ListRecordings())
             {
@@ -248,12 +256,18 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
     /// <summary>
     /// Finalize any recording that was interrupted before a clean <see cref="StopAsync"/> -
     /// the app was killed, crashed, or swiped away mid-capture, leaving a manifest with
-    /// <c>EndedAt == null</c> but real audio segments on disk. <see cref="ListRecordings"/>
-    /// reports such a recording with state <c>"Recording"</c>, which the upload gate excludes,
-    /// so without this it would never queue, never upload, never recover - silent data loss.
-    /// Recovery sets <c>EndedAt</c> and <c>State = "Queued"</c> so it enters the normal upload
-    /// path. The currently in-progress recording (if any) is skipped so a live capture is never
-    /// torn out from under itself.
+    /// <c>EndedAt == null</c> but real audio on disk. <see cref="ListRecordings"/> reports such a
+    /// recording with state <c>"Recording"</c>, which the upload gate excludes, so without this it
+    /// would never queue, never upload, never recover - silent data loss.
+    ///
+    /// The interrupting kill also skipped <see cref="FinalizeSegment"/> for the OPEN segment, so its
+    /// .m4a is on disk but absent from the manifest's <c>Chunks</c>. We therefore rebuild Chunks from
+    /// the actual files on disk first (<see cref="RecordingRecovery.ReconstructChunksFromDisk"/>):
+    /// without it, a recording shorter than one segment roll - whose only segment is that open one,
+    /// leaving Chunks empty - would still be invisible to recovery and stranded forever showing
+    /// "In Progress". Recovery then sets <c>EndedAt</c> and <c>State = "Queued"</c> so it enters the
+    /// normal upload path. The currently in-progress recording (if any) is skipped so a live capture
+    /// is never torn out from under itself.
     /// </summary>
     private void RecoverOrphanedRecordings()
     {
@@ -262,19 +276,38 @@ public sealed class AndroidAudioRecorder : IAudioRecorder
         lock (_gate)
             activeId = IsRecording ? _manifest?.RecordingId : null;
 
+        int recovered = 0;
         foreach (var summary in ListRecordings())
         {
             if (summary.RecordingId == activeId) continue;
-            if (!RecordingUploadGate.NeedsRecovery(summary.State, summary.SegmentCount > 0)) continue;
+            // Only an interrupted recording is a candidate: state "Recording" means the manifest
+            // has EndedAt==null because no clean StopAsync ever ran.
+            if (summary.State != RecordingUploadGate.Recording) continue;
 
             var m = LoadManifest(summary.RecordingId);
-            if (m is null || m.Chunks.Count == 0) continue; // nothing to recover
-            if (m.EndedAt is not null) continue;             // already finalized
+            if (m is null) continue;
+            if (m.EndedAt is not null) continue; // already finalized (a clean stop raced us)
+
+            // The interrupting kill skipped FinalizeSegment for the OPEN segment, so that .m4a is on
+            // disk but absent from the manifest's Chunks. Rebuild Chunks from the actual files so the
+            // open segment uploads too - and so a recording shorter than one segment roll (whose ONLY
+            // segment is the open one, leaving Chunks empty) is recovered at all instead of being
+            // stranded forever showing "In Progress" and never uploading.
+            var added = RecordingRecovery.ReconstructChunksFromDisk(m, RecordingFolder(summary.RecordingId));
+
+            // Decide on the real audio-on-disk truth (rebuilt above), not on whatever the pre-kill
+            // manifest happened to list. An interrupted recording with no bytes at all is an empty
+            // shell with nothing to save.
+            if (!RecordingUploadGate.NeedsRecovery(summary.State, hasAudioSegments: m.Chunks.Count > 0)) continue;
 
             m.EndedAt = DateTime.UtcNow.ToString("o");
-            m.State = "Queued"; // queued for background upload; never deleted until delivered
+            m.State = RecordingUploadGate.Queued; // queued for background upload; never deleted until delivered
             WriteManifest(summary.RecordingId, m);
+            recovered++;
+            ClientLog.Write($"[Recorder] Recovered interrupted recording {summary.RecordingId}: rebuilt {added} orphan segment(s) from disk, {m.Chunks.Count} total, queued for upload");
         }
+        if (recovered > 0)
+            ClientLog.Write($"[Recorder] RecoverOrphanedRecordings: finalized {recovered} interrupted recording(s)");
         RaiseChanged();
     }
 

--- a/phone/CcDirectorClient/Recording/RecordingRecovery.cs
+++ b/phone/CcDirectorClient/Recording/RecordingRecovery.cs
@@ -1,0 +1,83 @@
+using System.Security.Cryptography;
+
+namespace CcDirectorClient.Recording;
+
+/// <summary>
+/// Pure (no MAUI/Android) recovery logic for a recording the app died mid-capture for.
+///
+/// A segment .m4a is written to disk by the recorder as it captures, but it only becomes a
+/// <see cref="ChunkInfo"/> in the manifest when <c>FinalizeSegment</c> runs - on a one-minute
+/// segment roll or on a clean stop. A process kill, crash, or swipe-away skips that step, so the
+/// OPEN segment is on disk yet absent from <see cref="LocalManifest.Chunks"/>. A recording shorter
+/// than one roll (or killed before its first roll) therefore has audio on disk but an EMPTY Chunks
+/// list. The uploader walks Chunks, so such a recording could never upload and was stranded forever
+/// showing "In Progress" - the gap left by the issue #687 recovery, which only looked at the
+/// manifest's own chunk count.
+///
+/// Kept dependency-free so it is unit-tested off-device (the real Android recorder cannot run headless).
+/// </summary>
+public static class RecordingRecovery
+{
+    /// <summary>
+    /// Rebuild <paramref name="manifest"/>'s <see cref="LocalManifest.Chunks"/> from the actual
+    /// segment files in <paramref name="recordingFolder"/>, appending any NNNN.m4a segment that is
+    /// present on disk but missing from the manifest. Segments already in the manifest are left
+    /// exactly as they are - their <see cref="ChunkInfo.Uploaded"/> flag and measured durations are
+    /// preserved, so a resume after a dropped connection still skips bytes already on the server.
+    /// Zero-length files are ignored (an open segment that captured no bytes has nothing to save).
+    /// Returns the number of segments added. After this runs, a non-empty Chunks list means there is
+    /// real audio to upload, regardless of what the pre-kill manifest happened to list.
+    /// </summary>
+    public static int ReconstructChunksFromDisk(LocalManifest manifest, string recordingFolder)
+    {
+        if (!Directory.Exists(recordingFolder)) return 0;
+
+        var known = new HashSet<int>(manifest.Chunks.Select(c => c.Index));
+        int added = 0;
+
+        foreach (var path in Directory.GetFiles(recordingFolder, "*.m4a"))
+        {
+            var name = Path.GetFileName(path);
+            if (!TryParseSegmentIndex(name, out var index)) continue;
+            if (known.Contains(index)) continue;
+
+            var bytes = File.ReadAllBytes(path);
+            if (bytes.Length == 0) continue; // an empty open segment has no audio to save
+
+            manifest.Chunks.Add(new ChunkInfo
+            {
+                Index = index,
+                File = name,
+                // The kill skipped FinalizeSegment, so this segment was never measured. Its
+                // duration is unknown (0); place it after the last measured segment so the timeline
+                // stays monotonic. The bytes and their hash are exact - all the upload and the
+                // server's per-segment completeness gate actually need.
+                StartMs = NextStartMs(manifest),
+                DurationMs = 0,
+                Bytes = bytes.Length,
+                Sha256 = Sha256Hex(bytes),
+            });
+            known.Add(index);
+            added++;
+        }
+
+        if (added > 0)
+            manifest.Chunks.Sort((a, b) => a.Index.CompareTo(b.Index));
+
+        return added;
+    }
+
+    /// <summary>
+    /// The end of the latest measured segment, used as the start offset for a reconstructed
+    /// (unmeasured) segment so the timeline stays monotonic.
+    /// </summary>
+    private static long NextStartMs(LocalManifest manifest)
+        => manifest.Chunks.Count == 0 ? 0 : manifest.Chunks.Max(c => c.StartMs + c.DurationMs);
+
+    /// <summary>Parse the NNNN.m4a segment file name into its integer index.</summary>
+    private static bool TryParseSegmentIndex(string fileName, out int index)
+        => int.TryParse(Path.GetFileNameWithoutExtension(fileName), out index);
+
+    private static string Sha256Hex(byte[] bytes)
+        => Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+}


### PR DESCRIPTION
## Problem

Two voice recordings on the phone were stranded showing **"In Progress - Tap to Open"** and never uploaded to the Gateway, even though the issue #687 recovery already shipped in version 1.1.

Confirmed on the device over ADB (read-only):

| Recording | Manifest's last segment | Files on disk | Orphan |
|---|---|---|---|
| `40133a46...` | index 119 (120 chunks) | up to `0120.m4a` | `0120.m4a`, 431 KB partial |
| `52f30adb...` | index 214 (215 chunks) | up to `0215.m4a` | `0215.m4a`, 277 KB partial |

Both had `EndedAt == null`, and each had exactly one `.m4a` on disk that the manifest never listed - the **open segment** the app was killed mid-capture during. `FinalizeSegment` (which records a segment into the manifest) only runs on the one-minute roll or a clean stop, so a kill leaves the open segment on disk but absent from the manifest, and `EndedAt` stays null so the row shows "In Progress" forever.

## Root causes fixed

1. **Open segment orphaned.** Recovery only consulted the manifest's own chunk list, so the open segment was dropped from upload, and a recording whose *only* segment was the open one (shorter than one roll) was excluded from recovery entirely - stranded forever. Recovery now rebuilds the segment list from the actual `.m4a` files on disk (`RecordingRecovery.ReconstructChunksFromDisk`).

2. **Recovery gated behind the network check.** `ProcessUploadQueueAsync` returned early when offline *before* ever calling recovery, even though recovery is a purely local on-disk operation. On a cold start before the network/Tailscale radio is up, recovery was skipped - the likely reason the shipped #687 recovery never finalized these. Recovery now runs first and unconditionally; only the byte-upload half is network-gated.

3. **No logging on the recovery/upload path**, which made this invisible in the field. Added log lines for each recovered recording and the no-network-defer case.

## Effect after deploy

On the next app launch (even offline), recovery reconstructs each orphan segment, sets `EndedAt`, queues both recordings, and they upload when connectivity returns. The open segment's audio container was never closed by the kill, so its bytes are preserved and uploaded but that final partial minute may need server-side handling to transcribe; everything before it is intact.

## Tests
- 7 new `RecordingRecovery` tests (orphan rebuild, append without disturbing resume state, idempotency, zero-length/empty-shell, non-segment files ignored, full rebuild).
- Recovery + upload-gate suite: 34 passed, 0 failed.
- Android app builds clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)