### PR TITLE
Pin .NET SDK to 10.0.301+ via global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.301",
+    "rollForward": "latestMinor",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
## Why

On a clean build, the C# compiler shipped in **.NET SDK 10.0.102** stack-overflows while compiling `src/CcDirector.Core/Wingman/TurnBriefContract.cs` (a very large single method). The way it surfaces depends on the build mode:

- **Multi-node (default):** the crashed compiler worker wedges the parent process on its named pipe, so it looks like a multi-minute build hang (observed as a ~440-second "hang" on a Windows 10 machine).
- **Single-node:** it surfaces as an explicit `Stack overflow.`

The compiler in **SDK 10.0.301** compiles the exact same committed source in ~2 seconds with no error. Same source, same commit, same operating system family — the only variable is the SDK / Roslyn version. (Confirmed by building the identical checkout on a second machine that had 10.0.301.)

This normally stays hidden because the local build script only cleans the Avalonia project, never Core, so the compiler rarely re-runs on that file.

## What this does

Adds a repository-root `global.json` pinning SDK **10.0.301** as a floor, with `rollForward: latestMinor` (so any newer 10.x is also accepted) and `allowPrerelease: false`.

A machine or runner that has only an older SDK (such as 10.0.102) now fails fast with a clear "compatible SDK not found" message instead of silently using the compiler that overflows.

## Continuous integration impact

None. The workflows use `actions/setup-dotnet` with `10.0.x`, which installs the latest patch (10.0.301 or newer) and honors `global.json`.

## Verification

- `dotnet --version` from the repository root now resolves to `10.0.301`.
- Clean compile of `CcDirector.Core` (`-t:Rebuild`) succeeds in ~4 seconds, 0 errors.
- Full local slot build (`scripts/local-build-avalonia.ps1`) completes end to end and produces the executable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)