### PR TITLE
Bump CcDirectorClient version to 1.2 (version code 3)

### DIFF
--- a/phone/CcDirectorClient/CcDirectorClient.csproj
+++ b/phone/CcDirectorClient/CcDirectorClient.csproj
@@ -34,8 +34,8 @@
 		<ApplicationId>com.ccdirector.client</ApplicationId>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>1.1</ApplicationDisplayVersion>
-		<ApplicationVersion>2</ApplicationVersion>
+		<ApplicationDisplayVersion>1.2</ApplicationDisplayVersion>
+		<ApplicationVersion>3</ApplicationVersion>
 
 		<!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
 		<WindowsPackageType>None</WindowsPackageType>


### PR DESCRIPTION
Ships the recorder recovery fix from #690 to the phone.

Increments the phone client version so the new build is visually verifiable on the device and installs as an **in-place update** over the currently-installed 1.1 (code 2) without uninstalling (which would wipe the local recordings we are recovering):

- `ApplicationDisplayVersion`: 1.1 -> 1.2
- `ApplicationVersion` (versionCode): 2 -> 3

Distribution is the established sideload model (debug-signed APK built on the dev machine, installed over ADB) - there is no CI/Play Store path for the phone app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)