### PR TITLE
Fix Gateway test suite: pin BYO transcription mode; de-flake telemetry log test

### DIFF
--- a/src/CcDirector.Gateway.Tests/Issue639GatewayTelemetryTokenTests.cs
+++ b/src/CcDirector.Gateway.Tests/Issue639GatewayTelemetryTokenTests.cs
@@ -215,18 +215,40 @@ public sealed class Issue639GatewayTelemetryTokenTests
         {
             await queue.DisposeAsync();
             Cleanup(path);
-            await Task.Delay(500); // let the background writer flush our lines
         }
 
-        var newLines = new List<string>();
-        if (Directory.Exists(logDir))
-            foreach (var f in Directory.EnumerateFiles(logDir, "*.log"))
-            {
-                var lines = ReadAllLinesShared(f);
-                var start = baseline.TryGetValue(f, out var n) ? n : 0;
-                for (var i = start; i < lines.Count; i++)
-                    newLines.Add(lines[i]);
-            }
+        // The shared FileLog writer flushes on a background thread, so poll (up to a generous
+        // deadline) for our line to land on disk rather than sleeping a fixed interval. The old
+        // fixed Task.Delay(500) raced the writer under load and made this test flaky in CI (it
+        // passed at 507 ms in one run and failed in another).
+        List<string> CollectNewLines()
+        {
+            var collected = new List<string>();
+            if (Directory.Exists(logDir))
+                foreach (var f in Directory.EnumerateFiles(logDir, "*.log"))
+                {
+                    var lines = ReadAllLinesShared(f);
+                    var start = baseline.TryGetValue(f, out var n) ? n : 0;
+                    for (var i = start; i < lines.Count; i++)
+                        collected.Add(lines[i]);
+                }
+            return collected;
+        }
+
+        static bool HasQueueMarker(List<string> lines)
+        {
+            foreach (var l in lines)
+                if (l.Contains("[TelemetryRetryQueue]")) return true;
+            return false;
+        }
+
+        var newLines = CollectNewLines();
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (!HasQueueMarker(newLines) && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(25);
+            newLines = CollectNewLines();
+        }
 
         // The queue logged on this path (proves logging is wired)...
         Assert.Contains(newLines, l => l.Contains("[TelemetryRetryQueue]"));

--- a/src/CcDirector.Gateway.Tests/VaultGatewayIntegrationTests.cs
+++ b/src/CcDirector.Gateway.Tests/VaultGatewayIntegrationTests.cs
@@ -69,10 +69,13 @@ public sealed class VaultGatewayIntegrationTests : IAsyncLifetime
         Assert.Contains("OPENAI_API_KEY", listBody);
         Assert.DoesNotContain("sk-integration-123", listBody);
 
-        // The real resolver a gateway-attached Director uses pulls it over HTTP.
+        // The real resolver a gateway-attached Director uses pulls it over HTTP. Pin BYO transcription
+        // mode: since issue #541 the default mode is Local (in-process, no key), so an unpinned
+        // resolver would short-circuit ResolveAsync to null; this test covers the OpenAI key path.
         var resolver = new OpenAiKeyResolver(
             new AgentOptions(),
-            new GatewayConfig { Url = _gatewayBase, Token = Token });
+            () => new GatewayConfig { Url = _gatewayBase, Token = Token },
+            () => TranscriptionMode.Byo);
         Assert.True(resolver.UsesGateway);
         Assert.Equal("sk-integration-123", await resolver.ResolveAsync());
     }
@@ -84,9 +87,12 @@ public sealed class VaultGatewayIntegrationTests : IAsyncLifetime
         var del = await _http.DeleteAsync("vault/keys/OPENAI_API_KEY");
         del.EnsureSuccessStatusCode();
 
+        // Pin BYO mode (default is Local since #541, which has no key) so the deleted-key path is
+        // what makes ResolveAsync return null - not the mode having no key in the first place.
         var resolver = new OpenAiKeyResolver(
             new AgentOptions(),
-            new GatewayConfig { Url = _gatewayBase, Token = Token });
+            () => new GatewayConfig { Url = _gatewayBase, Token = Token },
+            () => TranscriptionMode.Byo);
         Assert.Null(await resolver.ResolveAsync());
         Assert.Contains("Cockpit", resolver.UnavailableMessage);
     }
@@ -94,15 +100,20 @@ public sealed class VaultGatewayIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task Standalone_resolver_uses_local_key_no_gateway()
     {
-        // No gateway configured: the resolver uses the local Settings > Voice key.
+        // No gateway configured: the resolver uses the local Settings > Voice key. Pin BYO mode
+        // (default is Local since #541, which has no key) so the local OpenAI key path is exercised.
         var withKey = new OpenAiKeyResolver(
             new AgentOptions { OpenAiKey = "sk-local-standalone" },
-            new GatewayConfig());
+            () => new GatewayConfig(),
+            () => TranscriptionMode.Byo);
         Assert.False(withKey.UsesGateway);
         Assert.Equal("sk-local-standalone", await withKey.ResolveAsync());
 
         // No local key either: unavailable, pointed at Settings > Transcription (not the Cockpit).
-        var noKey = new OpenAiKeyResolver(new AgentOptions(), new GatewayConfig());
+        var noKey = new OpenAiKeyResolver(
+            new AgentOptions(),
+            () => new GatewayConfig(),
+            () => TranscriptionMode.Byo);
         Assert.Null(await noKey.ResolveAsync());
         Assert.Contains("Settings > Transcription", noKey.UnavailableMessage);
     }
@@ -117,7 +128,9 @@ public sealed class VaultGatewayIntegrationTests : IAsyncLifetime
         await _http.PutAsJsonAsync("vault/keys/OPENAI_API_KEY", new { value = "sk-late-gateway" });
 
         var mode = new GatewayConfig();                 // standalone at boot
-        var resolver = new OpenAiKeyResolver(new AgentOptions(), () => mode);
+        // Pin BYO transcription mode (default is Local since #541, which has no key); this test is
+        // about the gateway-config live re-read (standalone -> attached), not the transcription mode.
+        var resolver = new OpenAiKeyResolver(new AgentOptions(), () => mode, () => TranscriptionMode.Byo);
         Assert.False(resolver.UsesGateway);
         Assert.Null(await resolver.ResolveAsync());
         Assert.Contains("Settings > Transcription", resolver.UnavailableMessage);


### PR DESCRIPTION
## Why

Two pre-existing test failures were keeping continuous integration red on `main`, both in `CcDirector.Gateway.Tests`. Neither is a product defect.

### 1. `VaultGatewayIntegrationTests` — 3 deterministic failures

Issue #541 changed the default transcription mode from **Byo** (bring-your-own OpenAI key) to **Local** (in-process Whisper, no key). These tests construct `OpenAiKeyResolver` **without pinning the mode**, so they read the machine/default mode via `TranscriptionModeConfig.Get`. Under the new `Local` default, `ResolveAsync` short-circuits to `null` (Local mode has no key name), so the assertions on a resolved key value failed:

```
Expected: "sk-local-standalone"
Actual:   null
```

These tests are about the OpenAI **Byo** key path, so the fix pins the transcription mode to `Byo` in the four resolver-using tests. **No product change** — returning `null` in Local mode is intentional.

### 2. `Issue639...Forward_NeverWritesTheGatewayTokenToTheLog` — flaky

The test waited a fixed `Task.Delay(500)` for the shared, background `FileLog` writer to flush before reading the log directory. Under continuous-integration load the flush sometimes took longer (it passed at **507 ms** in one run and failed in another). The fix replaces the fixed sleep with a deadline-based poll that re-reads the log until the `[TelemetryRetryQueue]` line lands (up to 5 seconds), so the test waits exactly as long as needed and no longer races.

## Verification

Full `CcDirector.Gateway.Tests` suite, run locally in parallel (the same way continuous integration runs it):

- Before: **952 passed, 3 failed, 1 skipped**
- After: **955 passed, 0 failed, 1 skipped**

The three previously-failing Vault tests now pass, and the telemetry log test was run repeatedly without a failure.

## Scope

Test-only changes, two files. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)