### PR TITLE
fix(terminal): mode-aware wheel forwarding (scroll Claude Code's view on the alternate screen)

### DIFF
--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -2612,6 +2612,16 @@ public partial class MainWindow : Window
         // scrollback list while the parser was growing it concurrently.
         var snap = TerminalHost.GetScrollSnapshot();
 
+        // On the alternate screen (e.g. Claude Code) there is no local scrollback
+        // -- the application owns scrolling and the wheel is forwarded to it. A
+        // visible-but-dead scrollbar reads as "scrolling is broken", so hide it.
+        if (TerminalHost.IsOnAlternateScreen)
+        {
+            TerminalScrollBar.IsVisible = false;
+            return;
+        }
+        TerminalScrollBar.IsVisible = true;
+
         // Avalonia's ScrollBar hides its thumb when Maximum == 0. When there
         // is no scrollback yet we still want a visible thumb filling the
         // entire track ("you're viewing everything"), so floor Maximum at 1.

--- a/src/CcDirector.Core.Tests/AnsiParserMouseModeTests.cs
+++ b/src/CcDirector.Core.Tests/AnsiParserMouseModeTests.cs
@@ -1,0 +1,150 @@
+using System.Text;
+using CcDirector.Terminal.Core;
+using Xunit;
+using static CcDirector.Core.Tests.TerminalTestHelper;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Mouse-reporting and alternate-screen mode tracking. A full-screen application
+/// such as Claude Code switches to the alternate screen (?1049) and requests
+/// mouse reporting (?1000/?1002/?1003, with ?1006 SGR coordinates). The terminal
+/// control reads this state to decide whether to forward the wheel to the
+/// application instead of scrolling the (empty) local scrollback. These tests
+/// pin the parser-side state machine that decision depends on, plus the
+/// mouse-report byte encoding the control sends.
+/// </summary>
+public class AnsiParserMouseModeTests
+{
+    [Fact]
+    public void FreshParser_HasNoMouseReportingOrAlternateScreen()
+    {
+        var (parser, _, _) = CreateParser();
+
+        Assert.False(parser.IsAlternateScreen);
+        Assert.False(parser.MouseReportingEnabled);
+        Assert.False(parser.MouseSgrCoordinates);
+    }
+
+    [Theory]
+    [InlineData("\x1b[?1000h")] // normal (click) tracking
+    [InlineData("\x1b[?1002h")] // button-event tracking
+    [InlineData("\x1b[?1003h")] // any-event tracking
+    public void EnablingAnyMouseTrackingMode_SetsMouseReporting(string sequence)
+    {
+        var (parser, _, _) = CreateParser();
+
+        Parse(parser, sequence);
+
+        Assert.True(parser.MouseReportingEnabled);
+    }
+
+    [Fact]
+    public void DisablingMouseTracking_ClearsMouseReporting()
+    {
+        var (parser, _, _) = CreateParser();
+
+        Parse(parser, "\x1b[?1003h");
+        Assert.True(parser.MouseReportingEnabled);
+
+        Parse(parser, "\x1b[?1003l");
+        Assert.False(parser.MouseReportingEnabled);
+    }
+
+    [Fact]
+    public void Sgr1006_TogglesSgrCoordinates()
+    {
+        var (parser, _, _) = CreateParser();
+
+        Parse(parser, "\x1b[?1006h");
+        Assert.True(parser.MouseSgrCoordinates);
+
+        Parse(parser, "\x1b[?1006l");
+        Assert.False(parser.MouseSgrCoordinates);
+    }
+
+    [Fact]
+    public void AlternateScreen_1049_TogglesIsAlternateScreen()
+    {
+        var (parser, _, _) = CreateParser();
+
+        Parse(parser, "\x1b[?1049h");
+        Assert.True(parser.IsAlternateScreen);
+
+        Parse(parser, "\x1b[?1049l");
+        Assert.False(parser.IsAlternateScreen);
+    }
+
+    [Fact]
+    public void ClaudeCodeStartupSequence_EntersAltScreenWithSgrMouseReporting()
+    {
+        // The exact private-mode burst Claude Code emits at startup: enter the
+        // alternate screen and request button-event + any-event mouse reporting
+        // with SGR extended coordinates. This is the state in which the wheel
+        // must be forwarded to the application rather than scrolling local history.
+        var (parser, _, _) = CreateParser();
+
+        Parse(parser, "\x1b[?1049h\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h");
+
+        Assert.True(parser.IsAlternateScreen);
+        Assert.True(parser.MouseReportingEnabled);
+        Assert.True(parser.MouseSgrCoordinates);
+    }
+
+    [Fact]
+    public void FullReset_ClearsMouseAndAlternateScreenState()
+    {
+        var (parser, _, _) = CreateParser();
+
+        Parse(parser, "\x1b[?1049h\x1b[?1003h\x1b[?1006h");
+        Assert.True(parser.IsAlternateScreen);
+        Assert.True(parser.MouseReportingEnabled);
+        Assert.True(parser.MouseSgrCoordinates);
+
+        // RIS (full reset). Written as a concatenation because the single literal
+        // "\x1bc" would parse as the one character U+01BC -- C#'s \x escape
+        // greedily consumes the 'c' as a hex digit. Splitting keeps ESC and 'c'
+        // as two characters.
+        Parse(parser, "\x1b" + "c");
+
+        Assert.False(parser.IsAlternateScreen);
+        Assert.False(parser.MouseReportingEnabled);
+        Assert.False(parser.MouseSgrCoordinates);
+    }
+
+    [Fact]
+    public void EncodeSgr_WheelUp_ProducesExpectedSequence()
+    {
+        // ESC [ < 64 ; col ; row M  (1-based coordinates, M = press).
+        byte[] bytes = MouseReportEncoder.EncodeSgr(MouseReportEncoder.WheelUp, col: 12, row: 5);
+
+        Assert.Equal("\x1b[<64;12;5M", Encoding.ASCII.GetString(bytes));
+    }
+
+    [Fact]
+    public void EncodeSgr_WheelDown_ProducesExpectedSequence()
+    {
+        byte[] bytes = MouseReportEncoder.EncodeSgr(MouseReportEncoder.WheelDown, col: 1, row: 1);
+
+        Assert.Equal("\x1b[<65;1;1M", Encoding.ASCII.GetString(bytes));
+    }
+
+    [Fact]
+    public void EncodeX10_WheelUp_OffsetsEachValueBy32()
+    {
+        // ESC [ M  Cb Cx Cy  where Cb = 32 + button, Cx = 32 + col, Cy = 32 + row.
+        byte[] bytes = MouseReportEncoder.EncodeX10(MouseReportEncoder.WheelUp, col: 1, row: 1);
+
+        Assert.Equal(new byte[] { 0x1b, (byte)'[', (byte)'M', 32 + 64, 32 + 1, 32 + 1 }, bytes);
+    }
+
+    [Fact]
+    public void EncodeX10_LargeCoordinates_AreClampedTo223()
+    {
+        byte[] bytes = MouseReportEncoder.EncodeX10(MouseReportEncoder.WheelDown, col: 5000, row: 5000);
+
+        // 32 + 223 = 255 is the largest single-byte coordinate the X10 form allows.
+        Assert.Equal(255, bytes[4]);
+        Assert.Equal(255, bytes[5]);
+    }
+}

--- a/src/CcDirector.Terminal.Avalonia/TerminalControl.cs
+++ b/src/CcDirector.Terminal.Avalonia/TerminalControl.cs
@@ -167,6 +167,13 @@ public class TerminalControl : Control
     /// <summary>Total number of lines in scrollback buffer.</summary>
     public int ScrollbackCount => _scrollback.Count;
 
+    /// <summary>
+    /// True while the running application is on the alternate screen buffer.
+    /// The alternate screen has no scrollback, so the host hides the local
+    /// scrollbar and the wheel is forwarded to the application instead.
+    /// </summary>
+    public bool IsOnAlternateScreen => _parser?.IsAlternateScreen ?? false;
+
     /// <summary>Number of visible rows in the viewport.</summary>
     public int ViewportRows => _rows;
 
@@ -1111,6 +1118,19 @@ public class TerminalControl : Control
     {
         try
         {
+            // When a full-screen application is on the alternate screen and has
+            // requested mouse reporting (e.g. Claude Code), the local scrollback
+            // is empty by design -- the application scrolls its own view. Forward
+            // the wheel to it as mouse-wheel reports instead of scrolling local
+            // history, which would do nothing and leave the user stuck.
+            if (_session != null && _parser != null
+                && _parser.IsAlternateScreen && _parser.MouseReportingEnabled)
+            {
+                ForwardWheelToApplication(e);
+                e.Handled = true;
+                return;
+            }
+
             int lines = e.Delta.Y > 0 ? 3 : -3;
             ScrollOffset = _scrollOffset + lines; // Uses property to trigger event
 
@@ -1124,6 +1144,39 @@ public class TerminalControl : Control
         {
             FileLog.Write($"[TerminalControl] OnPointerWheelChanged FAILED: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Forward a wheel event to the running application as mouse-wheel reports.
+    /// Used when the application is on the alternate screen with mouse reporting
+    /// enabled, so it scrolls its own view (the local scrollback is empty then).
+    /// </summary>
+    private void ForwardWheelToApplication(PointerWheelEventArgs e)
+    {
+        if (_session == null || _parser == null) return;
+
+        var pos = e.GetPosition(this);
+        int col = _cellWidth > 0 ? (int)(pos.X / _cellWidth) + 1 : 1;
+        int row = _cellHeight > 0 ? (int)(pos.Y / _cellHeight) + 1 : 1;
+        col = Math.Max(1, Math.Min(_cols, col));
+        row = Math.Max(1, Math.Min(_rows, row));
+
+        int button = e.Delta.Y > 0 ? MouseReportEncoder.WheelUp : MouseReportEncoder.WheelDown;
+
+        // Send one wheel report per notch. Delta.Y is ~1 per standard wheel
+        // notch; precise trackpads report fractional/larger values, so round up
+        // and cap to keep a single gesture from flooding the application.
+        int notches = (int)Math.Ceiling(Math.Abs(e.Delta.Y));
+        notches = Math.Max(1, Math.Min(notches, 10));
+
+        byte[] report = _parser.MouseSgrCoordinates
+            ? MouseReportEncoder.EncodeSgr(button, col, row)
+            : MouseReportEncoder.EncodeX10(button, col, row);
+
+        for (int i = 0; i < notches; i++)
+            _session.SendInput(report);
+
+        FileLog.Write($"[TerminalControl] ForwardWheelToApplication: button={button}, col={col}, row={row}, notches={notches}, sgr={_parser.MouseSgrCoordinates}");
     }
 
     private void RecalculateGridSize()

--- a/src/CcDirector.Terminal.Core/AnsiParser.cs
+++ b/src/CcDirector.Terminal.Core/AnsiParser.cs
@@ -75,6 +75,15 @@ public class AnsiParser
     // generation (not our concern here).
     private bool _bracketedPaste;
 
+    // --- Mouse reporting (?1000 / ?1002 / ?1003 tracking, ?1006 SGR coords) ---
+    // A full-screen application that switches to the alternate screen (e.g.
+    // Claude Code) typically also requests mouse reporting so it can scroll its
+    // own view in response to wheel events. The terminal control reads these so
+    // it can forward the wheel to the application instead of scrolling the
+    // (empty by design) local scrollback. See TerminalControl.OnPointerWheelChanged.
+    private bool _mouseReporting;
+    private bool _mouseSgrCoordinates;
+
     // --- Alternate screen buffer (?1049 / ?1047 / ?47) ---
     // Only scroll-region margins need to be saved across the swap; cursor
     // and attrs are handled by the caller via ?1049's implicit save-cursor.
@@ -222,6 +231,27 @@ public class AnsiParser
 
     /// <summary>Whether the cursor is currently visible per DECTCEM (?25).</summary>
     public bool IsCursorVisible => _cursorVisible;
+
+    /// <summary>
+    /// Whether the application is currently using the alternate screen buffer
+    /// (?1049 / ?1047 / ?47). The alternate screen has no scrollback by design,
+    /// so the terminal control suppresses its local scrollbar and forwards the
+    /// wheel to the application while this is true.
+    /// </summary>
+    public bool IsAlternateScreen => _altCells != null;
+
+    /// <summary>
+    /// Whether the application has requested mouse reporting (?1000 normal,
+    /// ?1002 button-event, or ?1003 any-event). When true, wheel events should
+    /// be forwarded to the application as mouse-wheel reports.
+    /// </summary>
+    public bool MouseReportingEnabled => _mouseReporting;
+
+    /// <summary>
+    /// Whether the application requested SGR extended mouse coordinates (?1006).
+    /// Determines the encoding used when forwarding mouse reports.
+    /// </summary>
+    public bool MouseSgrCoordinates => _mouseSgrCoordinates;
 
     /// <summary>
     /// Snapshot of internal parser state, for terminal-capture diagnostics.
@@ -858,7 +888,15 @@ public class AnsiParser
                 case 1048: if (set) SaveCursor(); else RestoreCursor(); break;
                 case 1049: SwitchAltScreen(set, saveCursor: true); break;
                 case 2004: _bracketedPaste = set; break;
-                // 1000-1006 (mouse), 2026 (synchronized update), etc. -- accepted without effect.
+                // Mouse reporting: ?1000 (normal/click), ?1002 (button-event),
+                // ?1003 (any-event) all enable reporting; ?1006 selects SGR
+                // extended coordinates. Tracked so the control can forward the
+                // wheel to the application. ?1005/?1015 (other encodings) and
+                // 2026 (synchronized update) are accepted without effect.
+                case 1000:
+                case 1002:
+                case 1003: _mouseReporting = set; break;
+                case 1006: _mouseSgrCoordinates = set; break;
             }
         }
     }
@@ -1509,6 +1547,9 @@ public class AnsiParser
         _cursorVisible = true;
         _hasSavedCursor = false;
         _altCells = null;
+        _bracketedPaste = false;
+        _mouseReporting = false;
+        _mouseSgrCoordinates = false;
         _committedFrame = null; // drop repaint-diff baseline on RIS (issue #240)
         _g0IsDecSpecial = false;
         _g1IsDecSpecial = false;

--- a/src/CcDirector.Terminal.Core/MouseReportEncoder.cs
+++ b/src/CcDirector.Terminal.Core/MouseReportEncoder.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Text;
+
+namespace CcDirector.Terminal.Core;
+
+/// <summary>
+/// Encodes mouse events into the byte sequences a terminal application expects on
+/// its input stream. Used to forward wheel events to applications that have
+/// switched to the alternate screen and requested mouse reporting (e.g. Claude
+/// Code), so they scroll their own view instead of the terminal's local
+/// scrollback (which is empty on the alternate screen).
+/// </summary>
+public static class MouseReportEncoder
+{
+    /// <summary>xterm mouse button code for a wheel-up notch.</summary>
+    public const int WheelUp = 64;
+
+    /// <summary>xterm mouse button code for a wheel-down notch.</summary>
+    public const int WheelDown = 65;
+
+    /// <summary>
+    /// SGR extended mouse report (DECSET ?1006):
+    /// <c>ESC [ &lt; button ; col ; row M</c>. Column and row are 1-based. The
+    /// trailing <c>M</c> marks a button press; wheel events have no release.
+    /// </summary>
+    public static byte[] EncodeSgr(int button, int col, int row)
+    {
+        int c = Math.Max(col, 1);
+        int r = Math.Max(row, 1);
+        return Encoding.ASCII.GetBytes($"\x1b[<{button};{c};{r}M");
+    }
+
+    /// <summary>
+    /// Legacy X10 mouse report: <c>ESC [ M Cb Cx Cy</c>, with each value offset
+    /// by 32. Column and row are 1-based. Coordinates above 223 cannot be encoded
+    /// in a single byte and are clamped; applications that need larger
+    /// coordinates request SGR encoding via ?1006.
+    /// </summary>
+    public static byte[] EncodeX10(int button, int col, int row)
+    {
+        int cb = 32 + button;
+        int cx = 32 + Math.Min(Math.Max(col, 1), 223);
+        int cy = 32 + Math.Min(Math.Max(row, 1), 223);
+        return new byte[] { 0x1b, (byte)'[', (byte)'M', (byte)cb, (byte)cx, (byte)cy };
+    }
+}


### PR DESCRIPTION
## Problem

The embedded terminal could not scroll when running Claude Code (and other full-screen TUIs). Claude Code runs on the **alternate screen** (`?1049h`) with **mouse reporting** enabled (`?1000/?1002/?1003` + `?1006` SGR), painting in place with absolute cursor positioning. The alternate screen has no local scrollback by design, but the wheel was always consumed for that (empty) local scrollback and never forwarded to the application — so the wheel did nothing and the user was stuck. The scrollbar also stayed visible as a dead, full-track thumb, reading as "scrolling is broken."

Root cause was confirmed by decoding a real session's raw pseudo-terminal recording: a single `ESC[?1049h` near startup with no exit, ~7,900 absolute cursor moves, zero scroll-region/index operations, and `?1000/?1002/?1003/?1006` all enabled. Director logs showed `scrollback=0` even after 77 KB of replayed output.

## Fix

Make wheel handling **mode-aware**, as standard terminal emulators do:

- **AnsiParser**: track `?1000/?1002/?1003` (mouse reporting) and `?1006` (SGR coordinates); expose `IsAlternateScreen`, `MouseReportingEnabled`, `MouseSgrCoordinates`; reset on RIS.
- **MouseReportEncoder** (new, in `Terminal.Core`): pure encoder for SGR (`ESC[<b;col;rowM`) and legacy X10 wheel reports — kept out of the UI project so it's unit-testable.
- **TerminalControl**: when on the alternate screen with mouse reporting on, forward wheel ticks to the pseudo-terminal as mouse-wheel reports so the application scrolls its own view; primary-screen behavior is unchanged. Exposes `IsOnAlternateScreen`.
- **MainWindow**: hide the terminal scrollbar on the alternate screen.

## Tests

- 13 new tests: parser mode tracking (including the exact Claude Code startup burst and RIS clearing) + SGR/X10 byte encoding with coordinate clamping.
- Full parser/scrollbar suite green (66 tests), zero build warnings.

## Verified live

In a real Claude Code session in a slot build:
- Wheel up forwarded as `button=64` SGR reports → Claude's view scrolled up (items 116–150 → 81–116, "Jump to bottom" affordance appeared).
- Wheel down (`button=65`) → returned to the bottom.
- Scrollbar hidden on the alternate screen.

## Note for reviewers

This branch was based on a local `main` that was behind `origin/main`; a rebase onto latest `main` (and a re-run of build/tests) is advisable before merge, since the terminal files have seen recent activity.