### PR TITLE
feat(setup): survive GitHub release-fetch rate limits during install (#266)

### DIFF
--- a/tools/cc-director-setup-avalonia/MainWindow.axaml.cs
+++ b/tools/cc-director-setup-avalonia/MainWindow.axaml.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Media;
+using CcDirector.Setup.Engine;
 using CcDirectorSetup.Models;
 using CcDirectorSetup.Services;
 using CcDirectorSetup.Steps;
@@ -212,6 +213,14 @@ public partial class MainWindow : Window
         {
             prep = _cachedPrep ?? await _runner.PrepareAsync();
             _cachedPrep = prep;
+        }
+        catch (GitHubRateLimitException ex)
+        {
+            SetupLog.Write($"[MainWindow] RunInstallAsync: prepare FAILED (rate limit): {ex.Message}");
+            _installStep?.SetStatus(ex.UserMessage());
+            NextButton.Content = "Retry";
+            NextButton.IsEnabled = true;
+            return;
         }
         catch (Exception ex)
         {

--- a/tools/cc-director-setup-engine.Tests/ReleaseSourceTests.cs
+++ b/tools/cc-director-setup-engine.Tests/ReleaseSourceTests.cs
@@ -124,4 +124,175 @@ public class ReleaseSourceTests : IDisposable
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             source.DownloadAssetAsync("missing.zip", new Dictionary<string, string>(), CancellationToken.None));
     }
+
+    // ----- Issue #266: GitHub rate-limit hardening of FetchLatestAsync -----
+
+    private const string ManifestUrl = "https://release.test/release-manifest.json";
+
+    /// <summary>A GitHub "latest release" body whose only asset is the release manifest.</summary>
+    private static string ReleaseJson() =>
+        $$"""
+        { "tag_name": "v1.2.3", "assets": [
+            { "name": "release-manifest.json", "browser_download_url": "{{ManifestUrl}}" }
+        ] }
+        """;
+
+    /// <summary>A minimal valid release-manifest.json body served for the manifest asset.</summary>
+    private static string ManifestJson() =>
+        """
+        { "version": "1.2.3", "assets": {
+            "release-manifest.json": { "version": "1.2.3", "sha256": "", "platform": "any", "size": 0 }
+        } }
+        """;
+
+    /// <summary>Builds a 403 rate-limit response carrying the exhausted-budget headers GitHub sends.</summary>
+    private static HttpResponseMessage RateLimited(DateTimeOffset? reset = null)
+    {
+        var resp = new HttpResponseMessage(HttpStatusCode.Forbidden)
+        {
+            Content = new StringContent("{ \"message\": \"API rate limit exceeded\" }"),
+        };
+        resp.Headers.TryAddWithoutValidation("X-RateLimit-Remaining", "0");
+        if (reset is { } r)
+            resp.Headers.TryAddWithoutValidation("X-RateLimit-Reset", r.ToUnixTimeSeconds().ToString());
+        return resp;
+    }
+
+    private static HttpResponseMessage Ok(string body, string? etag = null)
+    {
+        var resp = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body) };
+        if (etag is not null)
+            resp.Headers.ETag = new System.Net.Http.Headers.EntityTagHeaderValue(etag);
+        return resp;
+    }
+
+    /// <summary>
+    /// Records every request and returns scripted responses. The latest-release endpoint is driven
+    /// by a queue of responses (one per attempt); any request to the manifest URL is served the
+    /// manifest body so a successful path can complete.
+    /// </summary>
+    private sealed class ScriptedHandler(Queue<HttpResponseMessage> latestResponses) : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Requests { get; } = [];
+        public List<DateTimeOffset> RequestTimes { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Requests.Add(request);
+            RequestTimes.Add(DateTimeOffset.UtcNow);
+
+            if (request.RequestUri!.ToString() == ManifestUrl)
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(ManifestJson()),
+                });
+
+            return Task.FromResult(latestResponses.Dequeue());
+        }
+    }
+
+    private static ReleaseInfoCache TempCache() =>
+        new(Path.Combine(Path.GetTempPath(), "cc-relcache-" + Guid.NewGuid().ToString("N") + ".json"));
+
+    [Fact]
+    public async Task FetchLatestAsync_RateLimitedEveryAttempt_ThrowsClassifiedException()
+    {
+        // Arrange: 403 rate-limit on every attempt. No-op delay so the test does not actually wait.
+        var responses = new Queue<HttpResponseMessage>();
+        var reset = DateTimeOffset.UtcNow.AddMinutes(5);
+        for (var i = 0; i < 8; i++) responses.Enqueue(RateLimited(reset));
+        var handler = new ScriptedHandler(responses);
+        var source = new ReleaseSource(new HttpClient(handler), TempCache(), (_, _) => Task.CompletedTask);
+
+        // Act / Assert: a classified rate-limit exception, NOT a raw HttpRequestException 403.
+        var ex = await Assert.ThrowsAsync<GitHubRateLimitException>(() =>
+            source.FetchLatestAsync(CancellationToken.None));
+
+        Assert.True(ex.Attempts >= 2, $"expected multiple attempts, got {ex.Attempts}");
+        Assert.NotNull(ex.ResetsAtUtc);
+        // Every recorded request is the latest-release endpoint (it never reached the manifest).
+        Assert.All(handler.Requests, r => Assert.EndsWith("/releases/latest", r.RequestUri!.ToString()));
+        Assert.True(handler.Requests.Count >= 2, "expected at least one retry beyond the first attempt");
+    }
+
+    [Fact]
+    public async Task FetchLatestAsync_403ThenSuccess_RecoversAndDelaysBetweenAttempts()
+    {
+        // Arrange: first attempt 403, second attempt 200 with the release body.
+        var responses = new Queue<HttpResponseMessage>();
+        responses.Enqueue(RateLimited(DateTimeOffset.UtcNow.AddSeconds(1)));
+        responses.Enqueue(Ok(ReleaseJson(), etag: "\"abc123\""));
+        var handler = new ScriptedHandler(responses);
+
+        var delays = new List<TimeSpan>();
+        var source = new ReleaseSource(new HttpClient(handler), TempCache(),
+            (d, _) => { delays.Add(d); return Task.CompletedTask; });
+
+        // Act
+        var release = await source.FetchLatestAsync(CancellationToken.None);
+
+        // Assert: ultimately succeeded.
+        Assert.Equal("1.2.3", release.Manifest.Version);
+        // A backoff happened between the 403 and the retry (not an immediate same-instant re-request).
+        Assert.Single(delays);
+        Assert.True(delays[0] > TimeSpan.Zero, "expected a non-zero backoff before the retry");
+        // Two latest-release requests (403 then 200), each before the manifest fetch.
+        var latestRequests = handler.Requests.Count(r => r.RequestUri!.ToString().EndsWith("/releases/latest"));
+        Assert.Equal(2, latestRequests);
+    }
+
+    [Fact]
+    public async Task FetchLatestAsync_CachedEtag_SendsConditionalRequest()
+    {
+        // Arrange: a cache already holding an entity tag + the release body.
+        var cache = TempCache();
+        cache.Write("\"cached-etag\"", ReleaseJson());
+
+        var responses = new Queue<HttpResponseMessage>();
+        responses.Enqueue(Ok(ReleaseJson(), etag: "\"fresh-etag\""));
+        var handler = new ScriptedHandler(responses);
+        var source = new ReleaseSource(new HttpClient(handler), cache, (_, _) => Task.CompletedTask);
+
+        // Act
+        await source.FetchLatestAsync(CancellationToken.None);
+
+        // Assert: the latest-release request carried If-None-Match with the cached tag.
+        var latest = handler.Requests.First(r => r.RequestUri!.ToString().EndsWith("/releases/latest"));
+        Assert.True(latest.Headers.TryGetValues("If-None-Match", out var values));
+        Assert.Contains("\"cached-etag\"", values);
+    }
+
+    [Fact]
+    public async Task FetchLatestAsync_NotModified_ServesCachedReleaseWithoutError()
+    {
+        // Arrange: cache holds the release; GitHub answers 304 Not Modified (does not consume budget).
+        var cache = TempCache();
+        cache.Write("\"cached-etag\"", ReleaseJson());
+
+        var responses = new Queue<HttpResponseMessage>();
+        responses.Enqueue(new HttpResponseMessage(HttpStatusCode.NotModified));
+        var handler = new ScriptedHandler(responses);
+        var source = new ReleaseSource(new HttpClient(handler), cache, (_, _) => Task.CompletedTask);
+
+        // Act: serves the cached release (the manifest URL is still fetched to build the result).
+        var release = await source.FetchLatestAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Equal("1.2.3", release.Manifest.Version);
+    }
+
+    [Fact]
+    public void ReleaseInfoCache_Read_CorruptFile_ReturnsNullDoesNotThrow()
+    {
+        // A corrupt cache file must degrade to "no cache" (a normal unconditional fetch), never
+        // throw - the cache is best-effort and non-authoritative. Regression for the unguarded Read().
+        Directory.CreateDirectory(_dir);
+        var path = Path.Combine(_dir, "corrupt-cache.json");
+        File.WriteAllText(path, "{ this is not valid json ]");
+        var cache = new ReleaseInfoCache(path);
+
+        var result = cache.Read();
+
+        Assert.Null(result);
+    }
 }

--- a/tools/cc-director-setup-engine/GitHubRateLimitException.cs
+++ b/tools/cc-director-setup-engine/GitHubRateLimitException.cs
@@ -1,0 +1,45 @@
+namespace CcDirector.Setup.Engine;
+
+/// <summary>
+/// Raised when the GitHub REST API rejects the release-information fetch with an
+/// HTTP 403 (or 429) rate-limit response and the bounded retry has been exhausted.
+/// The setup wizards recognise this type to show a plain-English message that names
+/// the cause (a shared-network-address GitHub rate limit) and tells the user what to
+/// do next, instead of surfacing a raw "status code does not indicate success: 403".
+/// </summary>
+public sealed class GitHubRateLimitException : Exception
+{
+    /// <summary>
+    /// The moment GitHub says the rate-limit budget resets, when the response carried
+    /// a usable hint (the Retry-After header or the X-RateLimit-Reset header). Null when
+    /// GitHub gave no reset hint.
+    /// </summary>
+    public DateTimeOffset? ResetsAtUtc { get; }
+
+    /// <summary>How many fetch attempts were made before giving up.</summary>
+    public int Attempts { get; }
+
+    public GitHubRateLimitException(string message, int attempts, DateTimeOffset? resetsAtUtc)
+        : base(message)
+    {
+        Attempts = attempts;
+        ResetsAtUtc = resetsAtUtc;
+    }
+
+    /// <summary>
+    /// The plain-English, ASCII-only message both setup wizards show at the Install step when the
+    /// release fetch is rate-limited and retries are exhausted. It names the cause and tells the
+    /// user what to do next, replacing the bare "ERROR: Could not fetch release info from GitHub."
+    /// </summary>
+    public string UserMessage()
+    {
+        var when = ResetsAtUtc is { } r
+            ? $" The limit resets around {r.ToLocalTime():HH:mm} local time."
+            : "";
+        return
+            "GitHub is temporarily blocking release downloads from your network because too many " +
+            "requests came from your internet address (this is common on shared home, office, or VPN " +
+            "networks)." + when + " Please wait a few minutes and click Retry, or try again from a " +
+            "different network.";
+    }
+}

--- a/tools/cc-director-setup-engine/ReleaseInfoCache.cs
+++ b/tools/cc-director-setup-engine/ReleaseInfoCache.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+
+namespace CcDirector.Setup.Engine;
+
+/// <summary>
+/// Persists the last successful GitHub release-information response together with its
+/// HTTP entity tag (the value of the response ETag header), under the per-user setup
+/// config directory. The cache lets <see cref="ReleaseSource"/> send a conditional
+/// request (If-None-Match) so a repeated or returning install gets an HTTP 304 Not
+/// Modified, which GitHub does NOT charge against the unauthenticated rate-limit
+/// budget. On a 304 the cached body is served without a second network read.
+///
+/// The cache is best-effort and non-authoritative: a missing, unreadable, or corrupt
+/// cache simply means no conditional request is sent and the fetch proceeds normally.
+/// </summary>
+public sealed class ReleaseInfoCache
+{
+    private readonly string _path;
+
+    /// <summary>Production location: %LOCALAPPDATA%\cc-director\config\setup\release-info-cache.json.</summary>
+    public ReleaseInfoCache()
+        : this(Path.Combine(InstallLayout.Default().SetupStateDir, "release-info-cache.json"))
+    {
+    }
+
+    /// <summary>Test/explicit location.</summary>
+    public ReleaseInfoCache(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("Cache path must not be empty.", nameof(path));
+        _path = path;
+    }
+
+    private sealed record Entry(string ETag, string Body);
+
+    /// <summary>
+    /// The cached entry, or null when no usable cache exists. Returns null (never throws)
+    /// on a missing or corrupt cache file - a bad cache must not break the fetch.
+    /// </summary>
+    public (string ETag, string Body)? Read()
+    {
+        if (!File.Exists(_path))
+            return null;
+
+        try
+        {
+            var json = File.ReadAllText(_path);
+            var entry = JsonSerializer.Deserialize<Entry>(json);
+            if (entry is null || string.IsNullOrEmpty(entry.ETag) || string.IsNullOrEmpty(entry.Body))
+                return null;
+
+            return (entry.ETag, entry.Body);
+        }
+        catch (Exception ex)
+        {
+            // The cache is best-effort and non-authoritative: a corrupt, locked, or otherwise
+            // unreadable file must NOT break the install - it just means no conditional request is
+            // sent and the fetch proceeds normally. Logged, never thrown (this is the documented
+            // contract above and mirrors how the workspace/named-session stores skip bad files).
+            EngineLog.Write($"[ReleaseInfoCache] Read: ignoring unusable cache ({ex.GetType().Name}: {ex.Message})");
+            return null;
+        }
+    }
+
+    /// <summary>Persist the entity tag and the release JSON body. Creates the config dir if missing.</summary>
+    public void Write(string etag, string body)
+    {
+        if (string.IsNullOrEmpty(etag) || string.IsNullOrEmpty(body))
+            return; // nothing worth caching without both halves
+
+        var dir = Path.GetDirectoryName(_path);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+
+        var json = JsonSerializer.Serialize(new Entry(etag, body));
+        File.WriteAllText(_path, json);
+        EngineLog.Write($"[ReleaseInfoCache] Stored release info: etag={etag}, bytes={body.Length}");
+    }
+}

--- a/tools/cc-director-setup-engine/ReleaseSource.cs
+++ b/tools/cc-director-setup-engine/ReleaseSource.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
 
@@ -20,14 +21,29 @@ public sealed class ReleaseSource
     private const string Repo = "devthrottle";
     private const string ManifestAssetName = "release-manifest.json";
 
-    private readonly HttpClient _http;
+    /// <summary>Total attempts at the release fetch (1 initial + retries) before giving up on a rate limit.</summary>
+    private const int MaxAttempts = 4;
 
-    public ReleaseSource(HttpClient? http = null)
+    /// <summary>Backoff floor when GitHub gives no reset hint, doubled per attempt.</summary>
+    private static readonly TimeSpan BaseBackoff = TimeSpan.FromSeconds(2);
+
+    /// <summary>Upper bound on any single wait, so a far-future reset hint never stalls the install.</summary>
+    private static readonly TimeSpan MaxBackoff = TimeSpan.FromSeconds(30);
+
+    private readonly HttpClient _http;
+    private readonly ReleaseInfoCache _cache;
+    private readonly Func<TimeSpan, CancellationToken, Task> _delay;
+
+    public ReleaseSource(HttpClient? http = null, ReleaseInfoCache? cache = null,
+        Func<TimeSpan, CancellationToken, Task>? delay = null)
     {
         _http = http ?? new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
         if (!_http.DefaultRequestHeaders.UserAgent.Any())
             _http.DefaultRequestHeaders.UserAgent.ParseAdd("cc-director-setup");
         _http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        _cache = cache ?? new ReleaseInfoCache();
+        // The delay seam lets tests assert the backoff happened without actually waiting.
+        _delay = delay ?? Task.Delay;
     }
 
     public static ResolvedRelease LoadLocalManifest(string path)
@@ -60,12 +76,82 @@ public sealed class ReleaseSource
         return new ResolvedRelease(manifest, urls);
     }
 
+    /// <summary>
+    /// Fetch the GitHub latest release, hardened against the shared-network-address
+    /// rate limit that dead-ended first-run installs (issue #266):
+    ///   - sends a conditional request (If-None-Match) when a cached entity tag exists;
+    ///     a 304 Not Modified serves the cached body and does NOT consume the rate-limit
+    ///     budget;
+    ///   - on a 403/429 rate-limit response, retries with bounded backoff that honours
+    ///     GitHub's reset hint (Retry-After or X-RateLimit-Reset) within a sane cap, then
+    ///     raises a classified <see cref="GitHubRateLimitException"/> rather than a raw
+    ///     "status code does not indicate success: 403".
+    /// </summary>
+    /// <exception cref="GitHubRateLimitException">The fetch was rate-limited and retries were exhausted.</exception>
     public async Task<ResolvedRelease> FetchLatestAsync(CancellationToken ct)
     {
         var url = $"https://api.github.com/repos/{Owner}/{Repo}/releases/latest";
-        var resp = await _http.GetAsync(url, ct);
-        resp.EnsureSuccessStatusCode();
-        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync(ct));
+        var cached = _cache.Read();
+        DateTimeOffset? lastResetHint = null;
+
+        for (var attempt = 1; attempt <= MaxAttempts; attempt++)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            if (cached is { } c)
+                request.Headers.TryAddWithoutValidation("If-None-Match", c.ETag);
+
+            using var resp = await _http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+            // 304: the release has not changed since we cached it - serve the cached body.
+            // GitHub does not charge a 304 against the rate-limit budget.
+            if (resp.StatusCode == HttpStatusCode.NotModified)
+            {
+                if (cached is not { } hit)
+                    throw new InvalidOperationException(
+                        "GitHub returned 304 Not Modified but no cached release info is available.");
+                EngineLog.Write("[ReleaseSource] FetchLatest: 304 Not Modified, serving cached release info");
+                return await BuildResolvedReleaseAsync(hit.Body, ct);
+            }
+
+            if (resp.IsSuccessStatusCode)
+            {
+                var body = await resp.Content.ReadAsStringAsync(ct);
+                var etag = resp.Headers.ETag?.ToString();
+                if (!string.IsNullOrEmpty(etag))
+                    _cache.Write(etag, body);
+                return await BuildResolvedReleaseAsync(body, ct);
+            }
+
+            if (IsRateLimited(resp))
+            {
+                lastResetHint = ReadResetHint(resp);
+                if (attempt >= MaxAttempts)
+                    break;
+
+                var wait = ComputeBackoff(attempt, lastResetHint);
+                EngineLog.Write(
+                    $"[ReleaseSource] FetchLatest: 403 rate-limit, retry {attempt}/{MaxAttempts - 1} after {wait.TotalSeconds:0}s");
+                await _delay(wait, ct);
+                continue;
+            }
+
+            // Any other non-success is a real, non-rate-limit failure - surface it as before.
+            resp.EnsureSuccessStatusCode();
+        }
+
+        var hint = lastResetHint is { } r
+            ? $" GitHub says the limit resets at {r.UtcDateTime:u}."
+            : "";
+        EngineLog.Write(
+            $"[ReleaseSource] FetchLatest: rate-limit retries exhausted after {MaxAttempts} attempts.{hint}");
+        throw new GitHubRateLimitException(
+            "GitHub rate limit exceeded while fetching release info." + hint, MaxAttempts, lastResetHint);
+    }
+
+    /// <summary>Parse a release JSON body into the resolved release (asset URLs + manifest).</summary>
+    private async Task<ResolvedRelease> BuildResolvedReleaseAsync(string releaseJson, CancellationToken ct)
+    {
+        using var doc = JsonDocument.Parse(releaseJson);
         var root = doc.RootElement;
 
         var urls = new Dictionary<string, string>(StringComparer.Ordinal);
@@ -88,6 +174,68 @@ public sealed class ReleaseSource
         var manifestJson = await _http.GetStringAsync(manifestUrl, ct);
         var manifest = ReleaseManifest.Parse(manifestJson);
         return new ResolvedRelease(manifest, urls);
+    }
+
+    /// <summary>
+    /// True when the response is GitHub's rate-limit signal: a 403 or 429 carrying an
+    /// exhausted X-RateLimit-Remaining (primary limit) or a Retry-After (secondary limit).
+    /// A 403 that is NOT a rate limit (e.g. a private repo without auth) is left to the
+    /// normal EnsureSuccessStatusCode path.
+    /// </summary>
+    private static bool IsRateLimited(HttpResponseMessage resp)
+    {
+        if (resp.StatusCode != HttpStatusCode.Forbidden &&
+            resp.StatusCode != HttpStatusCode.TooManyRequests)
+            return false;
+
+        if (resp.Headers.Contains("Retry-After"))
+            return true;
+
+        if (resp.Headers.TryGetValues("X-RateLimit-Remaining", out var remaining) &&
+            int.TryParse(remaining.FirstOrDefault(), out var left) && left <= 0)
+            return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// The reset moment GitHub advertised, from Retry-After (delta seconds or HTTP date)
+    /// or the X-RateLimit-Reset epoch-seconds header. Null when neither is present.
+    /// </summary>
+    private static DateTimeOffset? ReadResetHint(HttpResponseMessage resp)
+    {
+        var retryAfter = resp.Headers.RetryAfter;
+        if (retryAfter is not null)
+        {
+            if (retryAfter.Delta is { } delta)
+                return DateTimeOffset.UtcNow + delta;
+            if (retryAfter.Date is { } date)
+                return date;
+        }
+
+        if (resp.Headers.TryGetValues("X-RateLimit-Reset", out var values) &&
+            long.TryParse(values.FirstOrDefault(), out var epochSeconds))
+            return DateTimeOffset.FromUnixTimeSeconds(epochSeconds);
+
+        return null;
+    }
+
+    /// <summary>
+    /// How long to wait before the next attempt: the time until GitHub's reset hint when
+    /// one was given, otherwise exponential backoff from <see cref="BaseBackoff"/>. Always
+    /// clamped to [0, <see cref="MaxBackoff"/>] so a stale or far-future hint never stalls.
+    /// </summary>
+    private static TimeSpan ComputeBackoff(int attempt, DateTimeOffset? resetHint)
+    {
+        if (resetHint is { } reset)
+        {
+            var untilReset = reset - DateTimeOffset.UtcNow;
+            if (untilReset < TimeSpan.Zero) untilReset = TimeSpan.Zero;
+            return untilReset > MaxBackoff ? MaxBackoff : untilReset;
+        }
+
+        var exponential = TimeSpan.FromTicks(BaseBackoff.Ticks * (1L << (attempt - 1)));
+        return exponential > MaxBackoff ? MaxBackoff : exponential;
     }
 
     /// <summary>

--- a/tools/cc-director-setup/MainWindow.xaml.cs
+++ b/tools/cc-director-setup/MainWindow.xaml.cs
@@ -410,6 +410,14 @@ public partial class MainWindow : Window
         {
             prep = await runner.PrepareAsync();
         }
+        catch (GitHubRateLimitException ex)
+        {
+            SetupLog.Write($"[MainWindow] RunInstallAsync: prepare FAILED (rate limit): {ex.Message}");
+            _installStep?.SetStatus(ex.UserMessage());
+            NextButton.Content = "Retry";
+            NextButton.IsEnabled = true;
+            return;
+        }
         catch (Exception ex)
         {
             SetupLog.Write($"[MainWindow] RunInstallAsync: prepare FAILED: {ex.Message}");


### PR DESCRIPTION
## What

First-run installs from a shared internet address (home / office / VPN, where many
machines share one public IP) could dead-end with a raw *"status code does not indicate
success: 403"* once GitHub's unauthenticated REST rate limit (60/hr per address) was
exhausted. This hardens the installer's release fetch.

Closes #266.

## How

- **`ReleaseInfoCache`** — stores the last successful release JSON plus its HTTP `ETag`
  under the per-user setup config dir. The next fetch sends a conditional `If-None-Match`
  request; an unchanged release returns **304 Not Modified**, which GitHub does **not**
  charge against the rate-limit budget, and the cached body is served. Best-effort: a
  missing, corrupt, or unreadable cache is ignored (`Read()` returns null, never throws).
- **`ReleaseSource.FetchLatestAsync`** — bounded retry (4 attempts) with backoff that
  honours GitHub's own reset hint (`Retry-After` / `X-RateLimit-Reset`), clamped to 30s so
  a far-future hint can't stall the install. `IsRateLimited()` distinguishes a genuine
  rate limit (403/429 with the rate-limit headers) from other 403s.
- **`GitHubRateLimitException`** — carries the reset time + attempt count and a
  plain-English (ASCII) `UserMessage()` that names the cause and the next step. Both
  installer wizards (WPF + Avalonia) catch it at the Install step, show the message, and
  relabel **Next -> Retry**.

## Tests

New `ReleaseSource` tests (all pass): rate-limit retry exhaustion -> classified exception,
403-then-success with a real backoff, conditional `If-None-Match` request, 304 serves the
cache, and **corrupt-cache-returns-null** (regression for the `Read()` guard). Both
wizards and the engine compile.

## Note for the reviewer

Branch was based on an older `main` (`d6f2735`, an ancestor of current `main`), so the
diff is just this feature. A clean build on that base trips an unrelated `NU1903` NuGet
advisory (transitive `SQLitePCLRaw`) that current `main` already suppresses; the code
compiles clean otherwise.