### PR TITLE
fix(new-session): Named Sessions own tab, save from the session menu, validate up front

### DIFF
--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -1766,6 +1766,24 @@ public partial class MainWindow : Window
             }
         };
 
+        // Save this live session as a reusable named session (issue #508): captures its repository,
+        // agent and current name so it can be relaunched in one click from the New Session dialog's
+        // Named Sessions tab. Saving from a running session means the repo and agent are real and
+        // verified - the preset is valid the moment it is created.
+        var saveNamed = new MenuItem { Header = "Save as named session" };
+        saveNamed.Click += async (_, _) =>
+        {
+            try
+            {
+                await SaveSessionAsNamedAsync(vm);
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[MainWindow] Save as named session FAILED: {ex.Message}");
+                ShowNotification("Could not save the named session");
+            }
+        };
+
         var separator1 = new Separator();
 
         var openJsonl = new MenuItem { Header = "Open .jsonl in Explorer" };
@@ -1808,6 +1826,7 @@ public partial class MainWindow : Window
         menu.Items.Add(rename);
         menu.Items.Add(relink);
         menu.Items.Add(copyId);
+        menu.Items.Add(saveNamed);
         menu.Items.Add(separator1);
         menu.Items.Add(openJsonl);
         menu.Items.Add(separator2);
@@ -1821,6 +1840,77 @@ public partial class MainWindow : Window
         menu.Items.Add(close);
 
         menu.Open(button);
+    }
+
+    /// <summary>
+    /// Save a live session as a named session (issue #508): name = the session's own name, plus its
+    /// repository, its agent (resolved from <see cref="Session.AgentKind"/> back to a registered
+    /// agent-entry id), and its colour. Confirms before overwriting an existing preset of the same
+    /// name. The preset then appears on the New Session dialog's Named Sessions tab for one-click
+    /// relaunch. Throws on failure; the caller (the menu Click handler) reports it.
+    /// </summary>
+    private async Task SaveSessionAsNamedAsync(SessionViewModel vm)
+    {
+        FileLog.Write($"[MainWindow] SaveSessionAsNamedAsync: session={vm.Session.Id}");
+
+        var name = (vm.DisplayName ?? "").Trim();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            ShowNotification("Rename the session first, then save it as a named session.");
+            return;
+        }
+
+        var repoPath = vm.Session.RepoPath;
+        if (string.IsNullOrWhiteSpace(repoPath))
+        {
+            ShowNotification("This session has no repository path to save.");
+            return;
+        }
+
+        var store = new NamedSessionStore();
+        var slug = NamedSessionStore.ToSlug(name);
+
+        // A preset with this name already exists - confirm before overwriting it.
+        if (store.Exists(slug))
+        {
+            var overwrite = await MessageBox.ShowConfirmAsync(this,
+                "Named session exists",
+                $"A named session called \"{name}\" already exists. Overwrite it?",
+                "Overwrite", "Cancel");
+            if (!overwrite)
+            {
+                FileLog.Write("[MainWindow] SaveSessionAsNamedAsync: user declined overwrite");
+                return;
+            }
+        }
+
+        // Resolve the session's agent kind back to a registered agent-entry id so the preset
+        // relaunches with the same agent. No matching entry -> empty id (the preset shows
+        // "Unavailable" until the agent is re-registered), which is the designed failure direction.
+        var agentId = AgentEntryStore.ReadCurrentEntries()
+            .FirstOrDefault(en => en.Enabled && en.Type == vm.Session.AgentKind)?.Id ?? "";
+
+        var now = DateTimeOffset.UtcNow;
+        var existing = store.Load(slug);
+        var definition = new NamedSessionDefinition
+        {
+            Name = name,
+            RepoPath = repoPath,
+            AgentId = agentId,
+            Color = vm.Session.CustomColor,
+            CreatedAt = existing?.CreatedAt ?? now,
+            UpdatedAt = now,
+        };
+
+        if (store.Save(definition))
+        {
+            FileLog.Write($"[MainWindow] SaveSessionAsNamedAsync: saved \"{name}\" slug={slug} repo={repoPath} agent={agentId}");
+            ShowNotification($"Saved \"{name}\" as a named session");
+        }
+        else
+        {
+            ShowNotification("Could not save the named session");
+        }
     }
 
     private void ToggleSessionHold(SessionViewModel vm)

--- a/src/CcDirector.Avalonia/NewSessionDialog.axaml
+++ b/src/CcDirector.Avalonia/NewSessionDialog.axaml
@@ -26,10 +26,25 @@
             <Setter Property="BorderBrush" Value="#007ACC" />
         </Style>
 
-        <!-- Tab header styling -->
+        <!-- Tab header styling: distinct, segmented headers. Unselected tabs sit on a mid-grey
+             chip with dimmed text; a small gap between each makes them read as separate tabs
+             instead of one run of words. The selected tab drops to the content colour (so it
+             "connects" to the panel below) with bright text, on top of the theme's accent
+             underline. -->
         <Style Selector="TabItem">
-            <Setter Property="Background" Value="#3C3C3C" />
-            <Setter Property="Foreground" Value="#CCCCCC" />
+            <Setter Property="Background" Value="#2D2D30" />
+            <Setter Property="Foreground" Value="#9A9A9A" />
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="Padding" Value="18,8" />
+            <Setter Property="Margin" Value="0,0,3,0" />
+            <Setter Property="MinHeight" Value="0" />
+        </Style>
+        <Style Selector="TabItem:selected">
+            <Setter Property="Background" Value="#1E1E1E" />
+            <Setter Property="Foreground" Value="#FFFFFF" />
+        </Style>
+        <Style Selector="TabItem:pointerover">
+            <Setter Property="Foreground" Value="#FFFFFF" />
         </Style>
     </Window.Styles>
 
@@ -45,7 +60,7 @@
                     SelectionChanged="MainTabs_SelectionChanged">
 
             <!-- New Session Tab (first) -->
-            <TabItem Header="New Session">
+            <TabItem x:Name="NewSessionTab" Header="New Session">
                 <Grid Margin="12">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -60,106 +75,6 @@
                     </Grid.RowDefinitions>
 
                     <StackPanel Grid.Row="0" Orientation="Vertical">
-                    <!-- Named sessions (issue #508): a reusable item = repository + agent + name
-                         (optionally a colour and extra arguments). The list shows saved items,
-                         each launchable in one click; the save row stores the current selection.
-                         An item whose saved agent is no longer registered is shown as unavailable
-                         and is not launchable. -->
-                    <Border x:Name="NamedSessionPanel" Background="#2D2D30"
-                            BorderBrush="#3C3C3C" BorderThickness="1" CornerRadius="6"
-                            Padding="12,10" Margin="0,0,0,12">
-                        <StackPanel Orientation="Vertical">
-                            <TextBlock Text="Named sessions" Foreground="#AAAAAA"
-                                       FontSize="11" FontWeight="SemiBold" Margin="0,0,0,8" />
-
-                            <!-- Empty-state hint when nothing is saved yet -->
-                            <TextBlock x:Name="NoNamedSessionsHint"
-                                       Text="No named sessions yet. Pick a repository and agent below, type a name, and click Save."
-                                       Foreground="#888888" FontSize="12" FontStyle="Italic"
-                                       TextWrapping="Wrap" Margin="0,0,0,8"
-                                       IsVisible="False" />
-
-                            <!-- Saved items: one row each, with Launch and Delete. -->
-                            <ItemsControl x:Name="NamedSessionList" Margin="0,0,0,8">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <Grid Margin="0,2">
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="Auto" />
-                                                <ColumnDefinition Width="*" />
-                                                <ColumnDefinition Width="Auto" />
-                                                <ColumnDefinition Width="Auto" />
-                                            </Grid.ColumnDefinitions>
-
-                                            <!-- Colour indicator bar -->
-                                            <Border Grid.Column="0" Width="4" Height="16"
-                                                    CornerRadius="2" Margin="0,0,8,0"
-                                                    VerticalAlignment="Center"
-                                                    Background="{Binding ColorBrush}"
-                                                    IsVisible="{Binding HasColor}" />
-
-                                            <!-- Name + repository/agent detail -->
-                                            <StackPanel Grid.Column="1" Orientation="Vertical"
-                                                        VerticalAlignment="Center">
-                                                <TextBlock Text="{Binding Name}" FontWeight="Medium"
-                                                           FontSize="13" Foreground="#CCCCCC"
-                                                           TextTrimming="CharacterEllipsis" />
-                                                <TextBlock Text="{Binding Detail}" FontSize="11"
-                                                           Foreground="#888888"
-                                                           TextTrimming="CharacterEllipsis" />
-                                            </StackPanel>
-
-                                            <!-- Launch (disabled + relabelled when the agent is gone) -->
-                                            <Button Grid.Column="2" Content="{Binding LaunchLabel}"
-                                                    Click="BtnLaunchNamedSession_Click"
-                                                    Tag="{Binding Slug}"
-                                                    IsEnabled="{Binding IsAvailable}"
-                                                    Height="26" Padding="12,0" Margin="8,0,0,0"
-                                                    Background="#007ACC" Foreground="White"
-                                                    BorderThickness="0" Cursor="Hand"
-                                                    ToolTip.Tip="{Binding LaunchTooltip}" />
-
-                                            <!-- Delete -->
-                                            <Button Grid.Column="3" Content="X"
-                                                    Click="BtnDeleteNamedSession_Click"
-                                                    Tag="{Binding Slug}"
-                                                    Width="24" Height="26" Margin="6,0,0,0"
-                                                    Background="Transparent" Foreground="#CC4444"
-                                                    BorderThickness="0" Cursor="Hand"
-                                                    FontWeight="Bold"
-                                                    ToolTip.Tip="Delete this named session" />
-                                        </Grid>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-
-                            <!-- Save the current selection (repo + agent + name) as a named session. -->
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Column="0" Text="Save as:" Foreground="#CCCCCC"
-                                           FontSize="13" VerticalAlignment="Center"
-                                           Margin="0,0,12,0" />
-                                <TextBox x:Name="NamedSessionNameBox" Grid.Column="1"
-                                         Background="#1E1E1E" Foreground="#CCCCCC"
-                                         BorderBrush="#3C3C3C" Padding="6,4"
-                                         VerticalContentAlignment="Center"
-                                         Watermark="Name for this repository + agent"
-                                         TextChanged="NamedSessionNameBox_TextChanged"
-                                         ToolTip.Tip="Saves the selected repository and agent under this name" />
-                                <Button x:Name="BtnSaveNamedSession" Grid.Column="2"
-                                        Content="Save" Width="80" Height="28" Margin="8,0,0,0"
-                                        Click="BtnSaveNamedSession_Click"
-                                        Background="#3C3C3C" Foreground="#CCCCCC"
-                                        BorderThickness="0" Cursor="Hand"
-                                        ToolTip.Tip="Save the current repository + agent as a named session" />
-                            </Grid>
-                        </StackPanel>
-                    </Border>
-
                     <!-- Create-mode toggle (issue #254): "Single session" (the Type dropdown
                          applies) vs "Group" (a preset that creates several tied, typed sessions
                          at once). Exactly one of the Type dropdown / Group panel is shown below,
@@ -541,8 +456,85 @@
                 </Grid>
             </TabItem>
 
-            <!-- Resume Session Tab (second) -->
-            <TabItem Header="Resume Session">
+            <!-- Named Sessions Tab (issue #508): saved repository+agent presets, each launchable in
+                 one click; the save row stores the current New Session selection. Lives in its own
+                 tab so it does not clutter the New Session create form. -->
+            <TabItem x:Name="NamedSessionsTab" Header="Named Sessions">
+                <ScrollViewer Padding="12">
+                    <Border x:Name="NamedSessionPanel" Background="#2D2D30"
+                            BorderBrush="#3C3C3C" BorderThickness="1" CornerRadius="6"
+                            Padding="12,10" Margin="0,0,0,12">
+                        <StackPanel Orientation="Vertical">
+                            <TextBlock Text="Named sessions" Foreground="#AAAAAA"
+                                       FontSize="11" FontWeight="SemiBold" Margin="0,0,0,8" />
+
+                            <!-- Empty-state hint when nothing is saved yet -->
+                            <TextBlock x:Name="NoNamedSessionsHint"
+                                       Text="No named sessions yet. On the New Session tab, configure a repository and agent and use &quot;Save as named session&quot; - saved presets appear here for one-click launch."
+                                       Foreground="#888888" FontSize="12" FontStyle="Italic"
+                                       TextWrapping="Wrap" Margin="0,0,0,8"
+                                       IsVisible="False" />
+
+                            <!-- Saved items: one row each, with Launch and Delete. -->
+                            <ItemsControl x:Name="NamedSessionList" Margin="0,0,0,8">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid Margin="0,2">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
+
+                                            <!-- Colour indicator bar -->
+                                            <Border Grid.Column="0" Width="4" Height="16"
+                                                    CornerRadius="2" Margin="0,0,8,0"
+                                                    VerticalAlignment="Center"
+                                                    Background="{Binding ColorBrush}"
+                                                    IsVisible="{Binding HasColor}" />
+
+                                            <!-- Name + repository/agent detail -->
+                                            <StackPanel Grid.Column="1" Orientation="Vertical"
+                                                        VerticalAlignment="Center">
+                                                <TextBlock Text="{Binding Name}" FontWeight="Medium"
+                                                           FontSize="13" Foreground="#CCCCCC"
+                                                           TextTrimming="CharacterEllipsis" />
+                                                <TextBlock Text="{Binding Detail}" FontSize="11"
+                                                           Foreground="#888888"
+                                                           TextTrimming="CharacterEllipsis" />
+                                            </StackPanel>
+
+                                            <!-- Launch (disabled + relabelled when the agent is gone) -->
+                                            <Button Grid.Column="2" Content="{Binding LaunchLabel}"
+                                                    Click="BtnLaunchNamedSession_Click"
+                                                    Tag="{Binding Slug}"
+                                                    IsEnabled="{Binding IsAvailable}"
+                                                    Height="26" Padding="12,0" Margin="8,0,0,0"
+                                                    Background="#007ACC" Foreground="White"
+                                                    BorderThickness="0" Cursor="Hand"
+                                                    ToolTip.Tip="{Binding LaunchTooltip}" />
+
+                                            <!-- Delete -->
+                                            <Button Grid.Column="3" Content="X"
+                                                    Click="BtnDeleteNamedSession_Click"
+                                                    Tag="{Binding Slug}"
+                                                    Width="24" Height="26" Margin="6,0,0,0"
+                                                    Background="Transparent" Foreground="#CC4444"
+                                                    BorderThickness="0" Cursor="Hand"
+                                                    FontWeight="Bold"
+                                                    ToolTip.Tip="Delete this named session" />
+                                        </Grid>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Border>
+                </ScrollViewer>
+            </TabItem>
+
+            <!-- Resume Session Tab -->
+            <TabItem x:Name="ResumeTab" Header="Resume Session">
                 <Grid Margin="12">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />

--- a/src/CcDirector.Avalonia/NewSessionDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/NewSessionDialog.axaml.cs
@@ -393,11 +393,11 @@ public sealed class AgentEntryOption
 }
 
 /// <summary>
-/// Display-ready row for one saved named session (issue #508) in the New Session dialog's
-/// "Named sessions" list. Wraps a <see cref="NamedSessionDefinition"/> and resolves, at build
-/// time, whether its saved agent id still maps to a registered agent entry - an unavailable item
-/// is shown greyed with a disabled, relabelled Launch button rather than silently launching a
-/// different agent.
+/// Display-ready row for one saved named session (issue #508) in the dialog's Named Sessions list.
+/// Wraps a <see cref="NamedSessionDefinition"/> and resolves, at build time, whether it can still
+/// launch: its saved agent must still map to a registered agent entry AND its saved repository
+/// folder must still exist. An unavailable item (missing agent or missing repository) is shown
+/// greyed with a disabled, relabelled "Unavailable" button rather than launching into an error.
 /// </summary>
 public sealed class NamedSessionViewModel
 {
@@ -419,8 +419,17 @@ public sealed class NamedSessionViewModel
     public string Name => _definition.Name;
     public string Slug => NamedSessionStore.ToSlug(_definition.Name);
 
-    /// <summary>True when the saved agent id still maps to a registered agent entry.</summary>
-    public bool IsAvailable => _agent is not null;
+    /// <summary>True when the saved repository folder still exists on disk.</summary>
+    public bool RepoExists =>
+        !string.IsNullOrWhiteSpace(_definition.RepoPath) && Directory.Exists(_definition.RepoPath);
+
+    /// <summary>
+    /// True only when the named session can actually launch: its saved agent is still registered
+    /// AND its saved repository folder still exists. A missing agent or a deleted/moved repository
+    /// is detected up front - the row is greyed and the Launch button reads "Unavailable" - instead
+    /// of failing with an error at launch time.
+    /// </summary>
+    public bool IsAvailable => _agent is not null && RepoExists;
 
     public bool HasColor => !string.IsNullOrWhiteSpace(_definition.Color);
 
@@ -437,17 +446,20 @@ public sealed class NamedSessionViewModel
         }
     }
 
-    /// <summary>Repository folder name + agent name (or an unavailable note) under the title.</summary>
+    /// <summary>Repository folder name + agent name, annotated when either is missing.</summary>
     public string Detail
     {
         get
         {
-            var repoName = string.IsNullOrEmpty(_definition.RepoPath)
-                ? "(no repository)"
-                : Path.GetFileName(_definition.RepoPath.TrimEnd('\\', '/'));
-            var agentName = _agent is not null
-                ? _agent.DisplayName
-                : "agent no longer available";
+            string repoName;
+            if (string.IsNullOrEmpty(_definition.RepoPath))
+                repoName = "(no repository)";
+            else
+            {
+                var name = Path.GetFileName(_definition.RepoPath.TrimEnd('\\', '/'));
+                repoName = RepoExists ? name : $"{name} (folder not found)";
+            }
+            var agentName = _agent is not null ? _agent.DisplayName : "agent no longer available";
             return $"{repoName} - {agentName}";
         }
     }
@@ -456,7 +468,20 @@ public sealed class NamedSessionViewModel
 
     public string LaunchTooltip => IsAvailable
         ? $"Start a session in {_definition.RepoPath} with {_agent?.DisplayName}"
-        : "The agent saved for this named session is no longer registered. Edit your agents in Settings or delete this item.";
+        : UnavailableReason;
+
+    /// <summary>Why this named session cannot launch, naming the missing repository and/or agent.</summary>
+    private string UnavailableReason
+    {
+        get
+        {
+            if (!RepoExists && _agent is null)
+                return $"Cannot launch: the repository folder is missing ({_definition.RepoPath}) and the saved agent is no longer registered. Recreate it from the New Session tab, or delete this item.";
+            if (!RepoExists)
+                return $"Cannot launch: the repository folder is missing ({_definition.RepoPath}). Recreate it from the New Session tab, or delete this item.";
+            return "Cannot launch: the saved agent is no longer registered. Recreate it from the New Session tab, or delete this item.";
+        }
+    }
 }
 
 public partial class NewSessionDialog : Window
@@ -512,7 +537,6 @@ public partial class NewSessionDialog : Window
     /// </summary>
     public RemoteSessionConfig? RemoteConfig { get; private set; }
 
-    private const int GitHubTabIndex = 3;
     public bool BypassPermissions => BypassPermissionsCheckBox.IsChecked == true;
     public bool EnableRemoteControl => false;
     public bool WingmanEnabled => WingmanCheckBox?.IsChecked == true;
@@ -793,93 +817,6 @@ public partial class NewSessionDialog : Window
         FileLog.Write($"[NewSessionDialog] RefreshNamedSessions: {rows.Count} named sessions, {rows.Count(r => !r.IsAvailable)} unavailable");
     }
 
-    private void NamedSessionNameBox_TextChanged(object? sender, TextChangedEventArgs e)
-    {
-        UpdateSaveNamedSessionButton();
-    }
-
-    /// <summary>
-    /// Enable the Save button only when there is both a name and a selected repository and agent -
-    /// a named session is meaningless without all three.
-    /// </summary>
-    private void UpdateSaveNamedSessionButton()
-    {
-        if (BtnSaveNamedSession is null)
-            return;
-
-        var hasName = !string.IsNullOrWhiteSpace(NamedSessionNameBox?.Text);
-        var hasPath = !string.IsNullOrWhiteSpace(PathInput?.Text);
-        var hasAgent = SelectedAgentEntry is not null;
-        BtnSaveNamedSession.IsEnabled = hasName && hasPath && hasAgent;
-    }
-
-    private async void BtnSaveNamedSession_Click(object? sender, RoutedEventArgs e)
-    {
-        try
-        {
-            var name = NamedSessionNameBox?.Text?.Trim() ?? string.Empty;
-            var repoPath = PathInput?.Text?.Trim() ?? string.Empty;
-            var agent = SelectedAgentEntry;
-
-            FileLog.Write($"[NewSessionDialog] BtnSaveNamedSession_Click: name={name}, repo={repoPath}, agent={(agent?.DisplayName ?? "(none)")}");
-
-            if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(repoPath) || agent is null)
-            {
-                FileLog.Write("[NewSessionDialog] BtnSaveNamedSession_Click: missing name, repository, or agent; aborting");
-                await MessageBox.ShowAsync(this,
-                    "Cannot save named session",
-                    "Pick a repository, choose an agent, and type a name before saving.");
-                return;
-            }
-
-            // Overwrite an existing name only after the user confirms (matches Save Workspace),
-            // so a saved name is never silently duplicated on disk.
-            var slug = NamedSessionStore.ToSlug(name);
-            if (_namedSessionStore.Exists(slug))
-            {
-                var overwrite = await MessageBox.ShowConfirmAsync(this,
-                    "Named session exists",
-                    $"A named session called \"{name}\" already exists. Overwrite it?",
-                    "Overwrite", "Cancel");
-                if (!overwrite)
-                {
-                    FileLog.Write("[NewSessionDialog] BtnSaveNamedSession_Click: user declined overwrite");
-                    return;
-                }
-            }
-
-            var now = DateTimeOffset.UtcNow;
-            var existing = _namedSessionStore.Load(slug);
-            var definition = new NamedSessionDefinition
-            {
-                Name = name,
-                RepoPath = repoPath,
-                AgentId = agent.Id,
-                CreatedAt = existing?.CreatedAt ?? now,
-                UpdatedAt = now,
-            };
-
-            if (!_namedSessionStore.Save(definition))
-            {
-                FileLog.Write("[NewSessionDialog] BtnSaveNamedSession_Click: store reported save failure");
-                await MessageBox.ShowAsync(this,
-                    "Could not save named session",
-                    "CC Director could not write the named session file. See the Director log for details.");
-                return;
-            }
-
-            NamedSessionNameBox!.Text = string.Empty;
-            RefreshNamedSessions();
-            UpdateSaveNamedSessionButton();
-            FileLog.Write($"[NewSessionDialog] BtnSaveNamedSession_Click: saved named session {slug}");
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[NewSessionDialog] BtnSaveNamedSession_Click FAILED: {ex.Message}");
-            await MessageBox.ShowAsync(this, "Error", "Could not save the named session. Please try again.");
-        }
-    }
-
     private async void BtnDeleteNamedSession_Click(object? sender, RoutedEventArgs e)
     {
         try
@@ -924,6 +861,20 @@ public partial class NewSessionDialog : Window
             if (definition is null)
             {
                 FileLog.Write($"[NewSessionDialog] BtnLaunchNamedSession_Click: no definition for slug={slug}");
+                return;
+            }
+
+            // Defence in depth (the row's Launch button is already disabled when unavailable):
+            // refuse a launch whose repository folder no longer exists, naming the missing path,
+            // instead of failing later with "Repository path not found".
+            if (string.IsNullOrWhiteSpace(definition.RepoPath) || !Directory.Exists(definition.RepoPath))
+            {
+                FileLog.Write($"[NewSessionDialog] BtnLaunchNamedSession_Click: repo missing ({definition.RepoPath}); refusing to launch");
+                await MessageBox.ShowAsync(this,
+                    "Repository not found",
+                    $"The repository folder saved for \"{definition.Name}\" no longer exists:\n\n"
+                    + $"{definition.RepoPath}\n\n"
+                    + "Recreate the named session from the New Session tab, or delete this item.");
                 return;
             }
 
@@ -1019,7 +970,7 @@ public partial class NewSessionDialog : Window
         if (e.Source != MainTabs)
             return;
 
-        if (MainTabs.SelectedIndex == 2 && !_handoversLoaded)
+        if (MainTabs.SelectedItem == HandoversTab && !_handoversLoaded)
             await LoadHandoversAsync();
 
         UpdateActionButton();
@@ -1032,13 +983,9 @@ public partial class NewSessionDialog : Window
         if (BtnAction is null || MainTabs is null || BtnCopyHandover is null)
             return;
 
-        // Keep the "Save as named session" button (issue #508) in step with the current
-        // repository/agent selection alongside the main action button.
-        UpdateSaveNamedSessionButton();
+        BtnCopyHandover.IsVisible = MainTabs.SelectedItem == HandoversTab && HandoverList.SelectedItem != null;
 
-        BtnCopyHandover.IsVisible = MainTabs.SelectedIndex == 2 && HandoverList.SelectedItem != null;
-
-        if (MainTabs.SelectedIndex == 0)
+        if (MainTabs.SelectedItem == NewSessionTab)
         {
             // In Group mode the button reflects how many sessions get created (issue #259).
             var group = SelectedGroupDefinition;
@@ -1054,7 +1001,7 @@ public partial class NewSessionDialog : Window
             BtnAction.Background = isEnabled ? NewSessionButtonBrush : DisabledButtonBrush;
             BtnAction.Foreground = isEnabled ? EnabledTextBrush : DisabledTextBrush;
         }
-        else if (MainTabs.SelectedIndex == 1)
+        else if (MainTabs.SelectedItem == ResumeTab)
         {
             BtnAction.Content = "Resume Selected";
             var isEnabled = SessionList.SelectedItem != null;
@@ -1062,13 +1009,22 @@ public partial class NewSessionDialog : Window
             BtnAction.Background = isEnabled ? ResumeButtonBrush : DisabledButtonBrush;
             BtnAction.Foreground = isEnabled ? EnabledTextBrush : DisabledTextBrush;
         }
-        else if (MainTabs.SelectedIndex == GitHubTabIndex)
+        else if (MainTabs.SelectedItem == GitHubTab)
         {
             BtnAction.Content = "Start Remote";
             var isEnabled = IsGitHubTabValid();
             BtnAction.IsEnabled = isEnabled;
             BtnAction.Background = isEnabled ? NewSessionButtonBrush : DisabledButtonBrush;
             BtnAction.Foreground = isEnabled ? EnabledTextBrush : DisabledTextBrush;
+        }
+        else if (MainTabs.SelectedItem == NamedSessionsTab)
+        {
+            // Named Sessions has its own per-row Launch buttons; the shared bottom action does not
+            // apply here, so it stays disabled while this tab is active (issue #508).
+            BtnAction.Content = "Start Session";
+            BtnAction.IsEnabled = false;
+            BtnAction.Background = DisabledButtonBrush;
+            BtnAction.Foreground = DisabledTextBrush;
         }
         else
         {
@@ -1356,7 +1312,7 @@ public partial class NewSessionDialog : Window
 
     private void BtnAction_Click(object? sender, RoutedEventArgs e)
     {
-        if (MainTabs.SelectedIndex == 0)
+        if (MainTabs.SelectedItem == NewSessionTab)
         {
             SelectedPath = PathInput.Text;
             SelectedResumeSessionId = null;
@@ -1387,7 +1343,7 @@ public partial class NewSessionDialog : Window
             FileLog.Write($"[NewSessionDialog] BtnAction_Click: Starting new session at {SelectedPath}, agent={SelectedAgentKind}, customCmd={SelectedCustomCommand ?? "(none)"}");
             Close(true);
         }
-        else if (MainTabs.SelectedIndex == 1)
+        else if (MainTabs.SelectedItem == ResumeTab)
         {
             if (SessionList.SelectedItem is not SessionHistoryViewModel vm)
             {
@@ -1401,7 +1357,7 @@ public partial class NewSessionDialog : Window
             FileLog.Write($"[NewSessionDialog] BtnAction_Click: Resuming session claude={vm.ClaudeSessionId}, path={vm.ProjectPath}");
             Close(true);
         }
-        else if (MainTabs.SelectedIndex == GitHubTabIndex)
+        else if (MainTabs.SelectedItem == GitHubTab)
         {
             var config = BuildRemoteConfig();
             if (config is null)


### PR DESCRIPTION
Follow-up UX cleanup for named sessions (#508), from feedback on the running app.

## Changes

- **Named Sessions is its own tab.** It was crammed in at the top of the New Session
  create form, pushing the Agent/repository pickers down. It's now the 2nd tab
  (`New Session | Named Sessions | Resume Session | Handovers`), and the create form
  is clean again. The dialog's tab logic was converted from **hardcoded indexes**
  (`SelectedIndex == 0/1/2/3`) to **name-based** checks (`SelectedItem == NewSessionTab`,
  etc.) so adding/reordering a tab can no longer silently break the action button or
  the per-tab behaviour.
- **Saving moved to the live session.** There's no "save" UI on the create form
  anymore. Instead a running session's **"..." menu** has **"Save as named session"**,
  which captures that session's repository, agent and its own name. A preset is thus
  born from a real, working session - so its repo and agent are valid at creation. The
  Named Sessions tab is now **list-only** (Launch / Delete).
- **Up-front availability.** A named session is greyed and marked **Unavailable** when
  *either* its agent is no longer registered *or* its repository folder no longer
  exists (`Directory.Exists`). The detail line and tooltip name exactly what's missing,
  so you never click Launch and hit "Repository path not found".
- **Tab restyle.** Gaps between tabs and a clear selected-vs-unselected look so they
  read as distinct tabs.

## Notes

- A `Session` only remembers its agent *kind*; on save we resolve that back to a
  registered agent-entry id (`AgentEntryStore`) to store with the preset.
- Verified in a running build (slot 5): tabs render distinct, create form is clean,
  saving from the session menu creates a preset under the session's name, and a preset
  whose repo/agent is gone shows Unavailable instead of failing at launch. Avalonia +
  Core build clean.