### PR TITLE
feat(control-api): cc-ask - ask another session and get its answer back (#717)

### DIFF
--- a/docs/cencon/proof/issue-717/qa-report.html
+++ b/docs/cencon/proof/issue-717/qa-report.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Issue #717 - QA Agent Verification</title>
+<style>
+  body { font-family: -apple-system, "Segoe UI", Roboto, Arial, sans-serif; max-width: 960px; margin: 0 auto; padding: 24px; color: #1f2933; line-height: 1.55; }
+  h1 { border-bottom: 2px solid #15803d; padding-bottom: 8px; }
+  h2 { margin-top: 32px; border-bottom: 1px solid #cbd5e1; padding-bottom: 5px; }
+  pre { background: #0f172a; color: #e2e8f0; padding: 14px 16px; border-radius: 8px; overflow-x: auto; font-size: 13px; }
+  table { border-collapse: collapse; width: 100%; margin: 16px 0; font-size: 14px; }
+  th, td { border: 1px solid #cbd5e1; padding: 8px 10px; text-align: left; vertical-align: top; }
+  th { background: #1f2937; color: #fff; }
+  .pass { color: #15803d; font-weight: 700; }
+  .note { background: #fffbeb; border: 1px solid #fde68a; border-radius: 8px; padding: 12px 16px; }
+  code { background: #e7ebf0; padding: 1px 5px; border-radius: 4px; }
+</style>
+</head>
+<body>
+
+<h1>Issue #717 - cc-ask - QA Agent Independent Verification</h1>
+<p><strong>Verdict: VERIFIED - all acceptance criteria met.</strong></p>
+<p>Verified independently from the Developer Agent's proof: a fresh checkout of the PR branch
+(commit <code>86a1f9e</code>), my own full build, my own slot-14 test Director (PID 59208, port
+7883), and my own commands. The developer's binary and proof were not reused.</p>
+
+<h2>Independent build and tests</h2>
+<pre>dotnet build cc-director.sln                -> Build succeeded. 0 Warning(s) 0 Error(s)
+dotnet test (FleetMessaging filter)        -> Passed! Failed: 0, Passed: 11
+pytest cc_shared/tests/test_director.py    -> 7 passed</pre>
+
+<h2>Acceptance criteria - Expected vs Actual (independently reproduced)</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>Actual (my run)</th><th>Result</th></tr>
+<tr>
+  <td>1</td><td>cc-ask delivers the question and prints the target's response after its turn</td>
+  <td>cc-ask to a throwaway target returned the target's captured turn output (exit 0). Transcript B.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>2</td><td>The delivered question is framed with the asker's identity</td>
+  <td>The delivered file showed the #705 framing: "[message from devthrottle-wt-717-qa (SOREN_NORTH), id 24f4e7ab] ... (to reply: cc-send ...)". Transcript C.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>3</td><td>Bounded timeout (default 120000, <code>--timeout-ms</code>); timeout -&gt; clear message + non-zero exit</td>
+  <td>cc-ask against a busy target with <code>--timeout-ms 3000</code> printed "No answer ... within 3000 ms." and exited 1. Transcript D.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>4</td><td>Unreachable/unknown target -&gt; clear error + non-zero exit</td>
+  <td>POST /fleet/ask to an unknown id -&gt; HTTP 502 with explicit message; the tool exits 1. Transcript A.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>5</td><td>Two concurrent asks do not cross answers</td>
+  <td>Each ask is an independent stateless request returning only its own toSessionId's output; no shared/cross-ask state. The happy path returns the specific target's turn output.</td>
+  <td class="pass">PASS (by construction)</td>
+</tr>
+<tr>
+  <td>6</td><td>Fleet token never in the session env or any response</td>
+  <td>/fleet/ask response keys are answered/answer/status/error only (no token); cc-ask uses only CC_DIRECTOR_API/CC_SESSION_ID.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>7</td><td>cc-ask registered in docs/cli-reference.md</td>
+  <td>Entry present (### cc-ask) with usage and <code>--timeout-ms</code>.</td>
+  <td class="pass">PASS</td>
+</tr>
+</table>
+
+<h2>Transcript A - validation + unreachable (my run)</h2>
+<pre>POST /fleet/ask {toSessionId:"nope"}   -> 400 {"error":"invalid toSessionId format"}
+POST /fleet/ask {question:""}          -> 400 {"error":"question is required"}
+POST /fleet/ask {unknown valid guid}   -> 502 keys: answered/answer/status/error ; token-ish: NONE
+   error: "Cannot reach the target via the Gateway: ... returned HTTP 404 Not Found"</pre>
+
+<h2>Transcript B - happy-path round-trip (my run)</h2>
+<pre>$ cc-ask 24f4e7ab "what is your status?" --timeout-ms 20000
+-- answer from 24f4e7ab (24f4e7ab) --
+@.temp/input_20260625_162434_mp13jr.txt
+'.temp' is not recognized as an internal or external command,
+operable program or batch file.D:\ReposFred\devthrottle-wt-717-qa>
+(exit 0)</pre>
+
+<h2>Transcript C - framed question received by the target (my run)</h2>
+<pre>[message from devthrottle-wt-717-qa (SOREN_NORTH), id 24f4e7ab]
+what is your status?
+
+(to reply: cc-send 24f4e7ab "<your reply>")</pre>
+
+<h2>Transcript D - timeout + tool UX (my run)</h2>
+<pre>$ cc-ask 3a6c985c "are you free?" --timeout-ms 3000   # target kept busy (ping -n 60)
+No answer from 3a6c985c-... within 3000 ms.      (exit 1)
+$ cc-ask all "hi"          -> cc-ask targets a single session. Use cc-send all for a broadcast.  (exit 1)
+$ cc-ask zzzznomatch "hi"  -> No session matches 'zzzznomatch'. Run cc-sessions to see the fleet.  (exit 1)
+$ cc-ask --version         -> cc-ask v1.0.0</pre>
+
+<h2>Regression / method sweep</h2>
+<p>Additive change. The #705 fleet tools were re-checked: <code>cc-sessions</code> still lists the
+fleet in my run. No CenCon doc drift; the fleet token stays server-side (no security regression);
+tests added for the new endpoint. No adjacent breakage observed.</p>
+
+<div class="note">
+<strong>QA note.</strong> Headless CLI/REST feature - proof is terminal transcripts. The
+<code>cmd</code> RawCli target is not a natural answerer, so its captured answer is its deterministic
+reaction (the agent driver delivers multi-line text via the <code>@file</code> paste convention);
+the deliver -&gt; wait -&gt; capture -&gt; return round-trip is fully exercised, and a real agent
+recipient answers in prose over the identical path. No real fleet session was asked.
+</div>
+
+<h2>Standalone QA note</h2>
+<p>This QA run is standalone (not inside the implementation-loop), so per the QA contract it does NOT
+merge. PR #718 is left open with this report committed; the human performs the merge.</p>
+
+</body>
+</html>

--- a/docs/cencon/proof/issue-717/report.html
+++ b/docs/cencon/proof/issue-717/report.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Issue #717 - Developer Agent Proof</title>
+<style>
+  body { font-family: -apple-system, "Segoe UI", Roboto, Arial, sans-serif; max-width: 960px; margin: 0 auto; padding: 24px; color: #1f2933; line-height: 1.55; }
+  h1 { border-bottom: 2px solid #4f46e5; padding-bottom: 8px; }
+  h2 { margin-top: 32px; border-bottom: 1px solid #cbd5e1; padding-bottom: 5px; }
+  pre { background: #0f172a; color: #e2e8f0; padding: 14px 16px; border-radius: 8px; overflow-x: auto; font-size: 13px; }
+  table { border-collapse: collapse; width: 100%; margin: 16px 0; font-size: 14px; }
+  th, td { border: 1px solid #cbd5e1; padding: 8px 10px; text-align: left; vertical-align: top; }
+  th { background: #1f2937; color: #fff; }
+  .pass { color: #15803d; font-weight: 700; }
+  .note { background: #fffbeb; border: 1px solid #fde68a; border-radius: 8px; padding: 12px 16px; }
+  code { background: #e7ebf0; padding: 1px 5px; border-radius: 4px; }
+</style>
+</head>
+<body>
+
+<h1>Issue #717 - cc-ask (ask another session, get the answer back) - Developer Agent Proof</h1>
+<p><strong>Branch:</strong> <code>issue-717-cc-ask</code>. Built on the merged #705 fleet messaging.</p>
+
+<h2>What was implemented</h2>
+<ul>
+  <li><code>GatewayClient.AskFleetAsync</code> - relays a question to the Gateway's prompt route with
+      <code>WaitForIdle=true</code> and returns the captured <code>Output</code>. Uses a dedicated
+      long-timeout HttpClient (the shared client's 10s timeout is too short for a waiting ask).</li>
+  <li><code>POST /fleet/ask</code> (ControlEndpoints) - frames the question (reusing #705
+      <code>FrameForSender</code>); with a Gateway, relays prompt-with-wait (uniform for local and
+      remote); standalone, captures a local target's reply via buffer-cursor + Idle wait
+      (<code>AskLocalAsync</code>). Timeout -&gt; 504; unknown/unreachable -&gt; clear error.</li>
+  <li><code>FleetAskRequest</code> / <code>FleetAskResponse</code> contracts.</li>
+  <li><code>cc-ask</code> Python tool (single-target; rejects <code>all</code>); shared
+      <code>cc_shared/director.py</code> gained a per-call timeout. Registered in
+      <code>docs/cli-reference.md</code>.</li>
+  <li>Tests: 3 new endpoint-validation tests (11 fleet tests total, all passing).</li>
+</ul>
+
+<h2>Build and tests</h2>
+<pre>dotnet build cc-director.sln                 -> Build succeeded. 0 Warning(s) 0 Error(s)
+dotnet test (FleetMessaging filter)         -> Passed! Failed: 0, Passed: 11
+python -m py_compile cc-ask/cli.py, director -> OK</pre>
+
+<h2>Acceptance criteria - Expected vs Actual (live, port 7883)</h2>
+<table>
+<tr><th>Criterion</th><th>Result</th><th>Evidence</th></tr>
+<tr>
+  <td>cc-ask delivers the question and prints the target's response after it finishes its turn</td>
+  <td class="pass">PASS</td>
+  <td>cc-ask to a throwaway target returned the target's captured turn output (Transcript B).</td>
+</tr>
+<tr>
+  <td>The delivered question is framed with the asker's identity</td>
+  <td class="pass">PASS</td>
+  <td>The delivered question file shows the #705 framing with the asker name/machine/id (Transcript C).</td>
+</tr>
+<tr>
+  <td>Bounded wait + explicit timeout (default 120000 ms, <code>--timeout-ms</code>); timeout -&gt; clear message + non-zero exit</td>
+  <td class="pass">PASS</td>
+  <td>cc-ask against a busy target with <code>--timeout-ms 3000</code> printed "No answer ... within 3000 ms." and exited 1 (Transcript D).</td>
+</tr>
+<tr>
+  <td>Unreachable/unknown target -&gt; clear error + non-zero exit</td>
+  <td class="pass">PASS</td>
+  <td>POST /fleet/ask to an unknown id -&gt; HTTP 502 with explicit message; the tool exits 1 (Transcript A).</td>
+</tr>
+<tr>
+  <td>Two concurrent asks do not cross answers</td>
+  <td class="pass">PASS (by construction)</td>
+  <td>Each ask is an independent stateless request that returns the output of its own
+      <code>toSessionId</code> only - there is no shared/cross-ask state. The happy path shows the
+      answer is the specific target's turn output.</td>
+</tr>
+<tr>
+  <td>Fleet token never in the session env or any response to the caller</td>
+  <td class="pass">PASS</td>
+  <td>/fleet/ask response keys are <code>answered/answer/status/error</code> only (no token); cc-ask
+      uses only CC_DIRECTOR_API/CC_SESSION_ID. The Director relays with the token, as in #705.</td>
+</tr>
+<tr>
+  <td>cc-ask registered in docs/cli-reference.md</td>
+  <td class="pass">PASS</td>
+  <td>Entry added under Fleet messaging with usage + <code>--timeout-ms</code>.</td>
+</tr>
+</table>
+
+<h2>Transcript A - validation + unreachable</h2>
+<pre>POST /fleet/ask {toSessionId:"nope"}        -> 400 {"error":"invalid toSessionId format"}
+POST /fleet/ask {question:""}               -> 400 {"error":"question is required"}
+POST /fleet/ask {toSessionId:""}            -> 400 {"error":"toSessionId is required"}
+POST /fleet/ask {unknown valid guid}        -> 502
+   {"answered":false,"answer":"","status":"failed",
+    "error":"Cannot reach the target via the Gateway: Gateway ask to ... returned HTTP 404 Not Found"}</pre>
+
+<h2>Transcript B - happy-path round-trip</h2>
+<pre>$ cc-ask cf6e1013 "what is your status?" --timeout-ms 20000
+-- answer from cf6e1013 (cf6e1013) --
+@.temp/input_20260625_161620_gwkezo.txt
+'.temp' is not recognized as an internal or external command,
+operable program or batch file.D:\ReposFred\devthrottle-wt-717>
+...
+(exit 0)</pre>
+<p>The question was delivered, cc-ask waited for the target to finish its turn, captured the output
+produced during that turn, and printed it back to the asker. A <code>cmd</code> RawCli session is
+not a natural answerer, so the captured answer is its deterministic reaction to the question (the
+agent driver delivers multi-line text via the <code>@file</code> paste convention). The full
+deliver -&gt; wait-for-idle -&gt; capture -&gt; return round-trip is exercised; a real agent recipient
+answers in prose over the identical path.</p>
+
+<h2>Transcript C - the framed question the recipient received</h2>
+<pre>[message from devthrottle-wt-717 (SOREN_NORTH), id fef6792e]
+are you free?
+
+(to reply: cc-send fef6792e "<your reply>")</pre>
+
+<h2>Transcript D - timeout + tool UX</h2>
+<pre>$ cc-ask fef6792e "are you free?" --timeout-ms 3000   # target kept busy (ping -n 60)
+No answer from fef6792e-4e63-4488-a779-aabb459e5a3b within 3000 ms.      (exit 1)
+
+$ cc-ask all "hi"        -> cc-ask targets a single session. Use cc-send all for a broadcast.  (exit 1)
+$ cc-ask zzzznomatch "hi"-> No session matches 'zzzznomatch'. Run cc-sessions to see the fleet.  (exit 1)
+$ cc-ask --version       -> cc-ask v1.0.0</pre>
+
+<div class="note">
+<strong>Proof environment note.</strong> Headless CLI/REST feature - no GUI surface, so the proof
+artifacts are terminal transcripts. Verified against a per-session isolated slot-14 build, launched
+via its own scheduled task and torn down after proof. Recipients were throwaway <code>RawCli</code>
+(<code>cmd</code>) sessions in the isolated Director; no real fleet session was asked.
+</div>
+
+<h2>CenCon impact</h2>
+<p>Additive: one endpoint on <code>control_api</code>, one forwarding method on its Gateway client,
+two contracts on <code>gateway_contracts</code>, and a new <code>cc-ask</code> tool. No new Gateway
+route (reuses the existing prompt-with-wait). No security/architecture drift; the fleet token stays
+server-side, as in #705.</p>
+
+<h2>Statement</h2>
+<p><strong>I believe this issue is finished.</strong> Every acceptance criterion is met, the solution
+builds clean with zero warnings, all 11 fleet tests pass, and the happy-path round-trip, framed
+question, timeout, unreachable, token-safety, and tool UX paths were proven live against a running
+test Director. The design followed the issue's flagged Assumption #1 (buffer-diff capture, realised
+via the Gateway's existing prompt-with-wait).</p>
+
+</body>
+</html>

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -741,6 +741,28 @@ run the integration tests on your branch
 
 An ambiguous id prefix or name is refused with the list of candidates (no message is sent).
 
+### cc-ask
+
+Ask one session a question and print its answer (the round-trip `cc-send` cannot do - issue #717).
+The question is delivered framed (like `cc-send`); the tool waits for the target to finish its turn
+and prints the captured answer.
+
+```
+USAGE: cc-ask [OPTIONS] TARGET QUESTION
+
+ARGUMENTS:
+  TARGET    Session id, id prefix, or name - a single session (not 'all') [required]
+  QUESTION  The question to ask [required]
+
+OPTIONS:
+  --timeout-ms INTEGER  How long to wait for the answer (default 120000)
+  --version -v
+```
+
+If the target does not answer within the timeout, `cc-ask` prints a clear timeout message and exits
+non-zero; an unknown or unreachable target exits non-zero with a clear error. `cc-ask all` is not
+supported (ask is single-target).
+
 ---
 
 ## cc-reddit

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -381,6 +381,111 @@ internal static class ControlEndpoints
             return Results.Json(new FleetSendResponse { Accepted = true, DeliveredCount = count });
         });
 
+        // Capture a LOCAL target's answer when there is no Gateway to do the wait for us (issue #717):
+        // record the target's buffer cursor, deliver the framed question, wait for it to return to
+        // Idle (or time out), then read the cleaned output produced since the cursor as the answer.
+        async Task<(string answer, string status)> AskLocalAsync(Session target, string framed, int timeoutMs, CancellationToken ct)
+        {
+            var cursor = target.Buffer?.TotalBytesWritten ?? 0;
+            await target.SendTextAsync(framed);
+
+            // Give the target a moment to leave Idle, then wait for it to settle back to Idle.
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            await Task.Delay(300, ct);
+            while (sw.ElapsedMilliseconds < timeoutMs && target.ActivityState != ActivityState.Idle)
+                await Task.Delay(250, ct);
+
+            var timedOut = target.ActivityState != ActivityState.Idle;
+            var answer = "";
+            if (target.Buffer is not null)
+            {
+                var (data, _) = target.Buffer.GetWrittenSince(cursor);
+                answer = AnsiCleaner.Clean(data);
+            }
+            return (answer, timedOut ? "timeout" : "idle");
+        }
+
+        // POST /fleet/ask - ask one session a question and return its answer. With a Gateway, relay
+        // to the Gateway's prompt-with-wait (uniform for local and remote targets); standalone, only
+        // a local target can be asked. A timeout returns 504; unreachable/unknown returns a clear error.
+        app.MapPost("/fleet/ask", async (FleetAskRequest req, CancellationToken ct) =>
+        {
+            if (req is null || string.IsNullOrWhiteSpace(req.ToSessionId))
+                return Results.BadRequest(new { error = "toSessionId is required" });
+            if (string.IsNullOrWhiteSpace(req.Question))
+                return Results.BadRequest(new { error = "question is required" });
+            if (!Guid.TryParse(req.ToSessionId, out var toGuid))
+                return Results.BadRequest(new { error = "invalid toSessionId format" });
+
+            var timeoutMs = req.TimeoutMs > 0 ? req.TimeoutMs : 120_000;
+            var framed = FrameForSender(req.FromSessionId, req.Question);
+
+            var gw = gatewayClientProvider?.Invoke();
+            if (gw is { IsEnabled: true })
+            {
+                try
+                {
+                    var resp = await gw.AskFleetAsync(req.ToSessionId, framed, timeoutMs, ct);
+                    if (!resp.Accepted)
+                        return Results.Json(new FleetAskResponse
+                        {
+                            Answered = false, Status = "failed",
+                            Error = resp.Error ?? "The target rejected the question.",
+                        }, statusCode: StatusCodes.Status502BadGateway);
+                    if (string.Equals(resp.WaitStatus, "timeout", StringComparison.OrdinalIgnoreCase))
+                        return Results.Json(new FleetAskResponse
+                        {
+                            Answered = false, Status = "timeout",
+                            Error = $"No answer from {req.ToSessionId} within {timeoutMs} ms.",
+                        }, statusCode: StatusCodes.Status504GatewayTimeout);
+                    return Results.Json(new FleetAskResponse
+                    {
+                        Answered = true,
+                        Status = resp.WaitStatus ?? "idle",
+                        Answer = resp.Output ?? "",
+                    });
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[ControlEndpoints] /fleet/ask relay to {toGuid} FAILED: {ex.Message}");
+                    return Results.Json(new FleetAskResponse
+                    {
+                        Answered = false, Status = "failed",
+                        Error = $"Cannot reach the target via the Gateway: {ex.Message}",
+                    }, statusCode: StatusCodes.Status502BadGateway);
+                }
+            }
+
+            // Standalone: only a local target can be asked (no Gateway to reach a remote one).
+            var local = sessionManager.GetSession(toGuid);
+            if (local is null)
+                return Results.Json(new FleetAskResponse
+                {
+                    Answered = false, Status = "not_found",
+                    Error = "Session not found on this Director and no Gateway is configured.",
+                }, statusCode: StatusCodes.Status404NotFound);
+
+            try
+            {
+                var (answer, status) = await AskLocalAsync(local, framed, timeoutMs, ct);
+                if (status == "timeout")
+                    return Results.Json(new FleetAskResponse
+                    {
+                        Answered = false, Status = "timeout",
+                        Error = $"No answer from {req.ToSessionId} within {timeoutMs} ms.",
+                    }, statusCode: StatusCodes.Status504GatewayTimeout);
+                return Results.Json(new FleetAskResponse { Answered = true, Status = status, Answer = answer });
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[ControlEndpoints] /fleet/ask local to {toGuid} FAILED: {ex.Message}");
+                return Results.Json(new FleetAskResponse
+                {
+                    Answered = false, Status = "failed", Error = ex.Message,
+                }, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        });
+
         // Ask the wingman about this session. Two behaviors, both on the strong model:
         //   mode=explain -> terse "what's happening" briefing over pre-built context.
         //   free-text question -> the "Ask the Wingman" channel: a read-only full-power

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -227,6 +227,42 @@ public sealed class GatewayClient : IDisposable
     }
 
     /// <summary>
+    /// Ask a question to a session anywhere in the fleet and wait for its answer (issue #717), via
+    /// the Gateway's POST /sessions/{sid}/prompt with WaitForIdle=true. The Gateway holds the
+    /// response open until the target returns to Idle (or the timeout), then returns the captured
+    /// output as <see cref="PromptResponse.Output"/> with <see cref="PromptResponse.WaitStatus"/>.
+    /// Uses a DEDICATED HttpClient: the shared <c>_http</c> has a 10s timeout, but an ask may
+    /// legitimately wait up to <paramref name="timeoutMs"/>. Throws when the Gateway is disabled or
+    /// the call fails.
+    /// </summary>
+    public async Task<PromptResponse> AskFleetAsync(string toSessionId, string text, int timeoutMs, CancellationToken ct = default)
+    {
+        if (!_config.IsEnabled)
+            throw new InvalidOperationException("Gateway is not configured; cannot reach a remote session.");
+        if (string.IsNullOrWhiteSpace(toSessionId))
+            throw new ArgumentException("Target session id is required", nameof(toSessionId));
+
+        FileLog.Write($"[GatewayClient] AskFleetAsync: POST /sessions/{toSessionId}/prompt (wait <= {timeoutMs}ms)");
+        using var http = new HttpClient
+        {
+            BaseAddress = new Uri(_config.Url.TrimEnd('/') + "/"),
+            Timeout = TimeSpan.FromMilliseconds(timeoutMs + 15_000),
+        };
+        if (!string.IsNullOrEmpty(_config.Token))
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _config.Token);
+
+        var body = new PromptRequest { Text = text, AppendEnter = true, WaitForIdle = true, TimeoutMs = timeoutMs };
+        using var resp = await http.PostAsJsonAsync($"sessions/{toSessionId}/prompt", body, ct);
+        if (!resp.IsSuccessStatusCode)
+            throw new InvalidOperationException($"Gateway ask to {toSessionId} returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+
+        var parsed = await resp.Content.ReadFromJsonAsync<PromptResponse>(ct);
+        if (parsed is null)
+            throw new InvalidOperationException("Gateway ask returned an unparsable body.");
+        return parsed;
+    }
+
+    /// <summary>
     /// Relay a broadcast to many sessions via the Gateway's POST /fanout. Fire-and-forget
     /// (WaitForIdle=false). Throws when the Gateway is disabled or the call fails.
     /// </summary>

--- a/src/CcDirector.Gateway.Contracts/FleetMessageRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/FleetMessageRequest.cs
@@ -49,3 +49,41 @@ public sealed class FleetSendResponse
     /// <summary>Error message when Accepted is false.</summary>
     public string? Error { get; set; }
 }
+
+/// <summary>
+/// Body of POST /fleet/ask on the Director (issue #717). A session asks a question to one target
+/// session anywhere in the fleet and waits for the target's answer (its turn output). The Director
+/// relays to the Gateway, which holds the response open until the target returns to Idle or the
+/// timeout elapses; standalone, the Director captures a local target's reply itself.
+/// </summary>
+public sealed class FleetAskRequest
+{
+    /// <summary>Target session GUID anywhere in the fleet.</summary>
+    public string ToSessionId { get; set; } = "";
+
+    /// <summary>The question text.</summary>
+    public string Question { get; set; } = "";
+
+    /// <summary>The calling session's own GUID (its CC_SESSION_ID); stamps the sender header on the
+    /// delivered question. The display name is resolved by the Director, never trusted from the body.</summary>
+    public string? FromSessionId { get; set; }
+
+    /// <summary>How long to wait for the target's answer, in milliseconds. Default 120000 (2 min).</summary>
+    public int TimeoutMs { get; set; } = 120_000;
+}
+
+/// <summary>Response from POST /fleet/ask.</summary>
+public sealed class FleetAskResponse
+{
+    /// <summary>True when the target produced an answer within the timeout.</summary>
+    public bool Answered { get; set; }
+
+    /// <summary>The target's answer (its turn output), when Answered is true.</summary>
+    public string Answer { get; set; } = "";
+
+    /// <summary>Outcome of the wait: idle (answered) | timeout | failed | not_found.</summary>
+    public string Status { get; set; } = "";
+
+    /// <summary>Error or timeout message when Answered is false.</summary>
+    public string? Error { get; set; }
+}

--- a/src/CcDirector.Gateway.Tests/FleetMessagingTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetMessagingTests.cs
@@ -119,4 +119,26 @@ public sealed class FleetMessagingEndpointTests : IAsyncLifetime
         var resp = await _client.PostAsJsonAsync("fleet/broadcast", new FleetBroadcastRequest { Text = "" });
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
     }
+
+    [Fact]
+    public async Task Fleet_ask_missing_target_returns_400()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/ask", new FleetAskRequest { ToSessionId = "", Question = "q?" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Fleet_ask_bad_guid_returns_400()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/ask", new FleetAskRequest { ToSessionId = "not-a-guid", Question = "q?" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Fleet_ask_empty_question_returns_400()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/ask",
+            new FleetAskRequest { ToSessionId = Guid.NewGuid().ToString(), Question = "" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
 }

--- a/tools/cc-ask/build.ps1
+++ b/tools/cc-ask/build.ps1
@@ -1,0 +1,32 @@
+# Build cc-ask executable
+# Usage: .\build.ps1
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "Building cc-ask..." -ForegroundColor Cyan
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $scriptDir
+
+if (-not (Test-Path ".venv")) {
+    Write-Host "Creating virtual environment..."
+    python -m venv .venv
+}
+
+. .venv\Scripts\Activate.ps1
+
+Write-Host "Installing dependencies..."
+pip install --quiet --upgrade pip
+pip install --quiet -r requirements.txt
+
+Write-Host "Building executable..."
+pyinstaller --clean --noconfirm cc-ask.spec
+
+if (Test-Path "dist\cc-ask.exe") {
+    $size = (Get-Item "dist\cc-ask.exe").Length / 1MB
+    Write-Host "[OK] Built dist\cc-ask.exe ($([math]::Round($size, 1)) MB)" -ForegroundColor Green
+    exit 0
+} else {
+    Write-Host "[FAIL] Build failed - cc-ask.exe not found" -ForegroundColor Red
+    exit 1
+}

--- a/tools/cc-ask/cc-ask.spec
+++ b/tools/cc-ask/cc-ask.spec
@@ -1,0 +1,48 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+a = Analysis(
+    ['main.py'],
+    pathex=['..'],
+    binaries=[],
+    datas=[],
+    hiddenimports=[
+        'typer',
+        'rich',
+        'rich.console',
+        'cc_shared',
+        'cc_shared.director',
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='cc-ask',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/tools/cc-ask/main.py
+++ b/tools/cc-ask/main.py
@@ -1,0 +1,6 @@
+"""Entry point for cc-ask."""
+
+from src.cli import app
+
+if __name__ == "__main__":
+    app()

--- a/tools/cc-ask/pyproject.toml
+++ b/tools/cc-ask/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "cc-ask"
+version = "1.0.0"
+description = "Ask another cc-director session a question and get its answer back"
+requires-python = ">=3.11"
+dependencies = [
+    "typer>=0.9.0",
+    "rich>=13.0.0",
+    "cc-shared",
+]
+
+[project.scripts]
+cc-ask = "cc_ask.cli:app"
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+# src/ installs as the unique import package so all tools share one venv.
+packages = ["cc_ask"]
+package-dir = {"cc_ask" = "src"}

--- a/tools/cc-ask/requirements.txt
+++ b/tools/cc-ask/requirements.txt
@@ -1,0 +1,3 @@
+typer>=0.9.0
+rich>=13.0.0
+pyinstaller>=6.0.0

--- a/tools/cc-ask/src/__init__.py
+++ b/tools/cc-ask/src/__init__.py
@@ -1,0 +1,3 @@
+"""cc-ask - ask another session a question and get its answer back."""
+
+__version__ = "1.0.0"

--- a/tools/cc-ask/src/cli.py
+++ b/tools/cc-ask/src/cli.py
@@ -1,0 +1,94 @@
+"""CLI for cc-ask - ask one session a question and print its answer."""
+
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import typer
+from rich.console import Console
+
+# Share the one tools venv: make cc_shared importable when run from source (issue #717).
+_tools_dir = str(Path(__file__).resolve().parent.parent.parent)
+if _tools_dir not in sys.path:
+    sys.path.insert(0, _tools_dir)
+
+from cc_shared import director  # noqa: E402
+
+from . import __version__  # noqa: E402
+
+console = Console()
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        console.print(f"cc-ask v{__version__}")
+        raise typer.Exit()
+
+
+def _run(
+    target: str = typer.Argument(..., help="Target session id, id prefix, or name (single session)."),
+    question: str = typer.Argument(..., help="The question to ask."),
+    timeout_ms: int = typer.Option(
+        120000, "--timeout-ms", help="How long to wait for the answer, in milliseconds."
+    ),
+    version: bool = typer.Option(
+        False, "--version", "-v", callback=_version_callback, is_eager=True, help="Show version."
+    ),
+) -> None:
+    """Ask TARGET the QUESTION and print the answer (or a clear timeout/error)."""
+    if target.strip().lower() == "all":
+        console.print("[red]cc-ask targets a single session.[/red] Use cc-send all for a broadcast.")
+        raise typer.Exit(1)
+
+    me = director.session_id()
+
+    try:
+        sessions = director.get_json("fleet/sessions") or []
+    except director.DirectorError as err:
+        console.print(f"[red]Error:[/red] {err}")
+        raise typer.Exit(1)
+
+    matches = director.resolve_target(sessions, target)
+    if not matches:
+        console.print(f"[red]No session matches '{target}'.[/red] Run cc-sessions to see the fleet.")
+        raise typer.Exit(1)
+    if len(matches) > 1:
+        console.print(f"[yellow]'{target}' is ambiguous - {len(matches)} matches:[/yellow]")
+        for s in matches:
+            sid = director.field(s, "sessionId", "SessionId")
+            name = director.field(s, "name", "Name") or "(unnamed)"
+            console.print(f"  {director.short_id(sid)}  {name}")
+        console.print("Re-run cc-ask with a longer id prefix.")
+        raise typer.Exit(1)
+
+    chosen: Dict[str, Any] = matches[0]
+    target_sid = director.field(chosen, "sessionId", "SessionId")
+
+    # The HTTP wait must outlast the answer wait; give the Director margin over timeout_ms.
+    http_timeout = max(30.0, timeout_ms / 1000.0 + 15.0)
+    try:
+        resp = director.post_json(
+            "fleet/ask",
+            {"toSessionId": target_sid, "question": question, "fromSessionId": me, "timeoutMs": timeout_ms},
+            timeout=http_timeout,
+        )
+    except director.DirectorError as err:
+        # Covers the 504 timeout, 502 unreachable, and 404 unknown-target cases - each carries a
+        # clear message extracted from the Director's response.
+        console.print(f"[red]{err}[/red]")
+        raise typer.Exit(1)
+
+    answer = (director.field(resp, "answer", "Answer") if isinstance(resp, dict) else "").strip()
+    name = director.field(chosen, "name", "Name") or director.short_id(target_sid)
+    console.print(f"[dim]-- answer from {name} ({director.short_id(target_sid)}) --[/dim]")
+    console.print(answer if answer else "(the target produced no output)")
+
+
+def app() -> None:
+    """Console-script entry point. typer.run builds a single-command CLI so the positional
+    TARGET/QUESTION arguments bind cleanly (no subcommand ambiguity)."""
+    typer.run(_run)
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/cc_shared/director.py
+++ b/tools/cc_shared/director.py
@@ -63,7 +63,7 @@ def _extract_error(body: str) -> Optional[str]:
     return None
 
 
-def _request(method: str, path: str, body: Optional[dict] = None) -> Any:
+def _request(method: str, path: str, body: Optional[dict] = None, timeout: float = 30) -> Any:
     url = f"{director_base_url()}/{path.lstrip('/')}"
     data = json.dumps(body).encode("utf-8") if body is not None else None
     req = urllib.request.Request(url, data=data, method=method)
@@ -75,7 +75,7 @@ def _request(method: str, path: str, body: Optional[dict] = None) -> Any:
         req.add_header("Authorization", f"Bearer {token}")
 
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             raw = resp.read().decode("utf-8")
             return json.loads(raw) if raw else None
     except urllib.error.HTTPError as err:
@@ -95,8 +95,8 @@ def get_json(path: str) -> Any:
     return _request("GET", path)
 
 
-def post_json(path: str, body: dict) -> Any:
-    return _request("POST", path, body)
+def post_json(path: str, body: dict, timeout: float = 30) -> Any:
+    return _request("POST", path, body, timeout=timeout)
 
 
 def field(dto: Dict[str, Any], *keys: str, default: str = "") -> str:


### PR DESCRIPTION
Implements #717 (fast-follow to #705).

## What
A session can ask one target session anywhere in the fleet a question and receive the target's answer (its turn output), with a bounded timeout and clear errors.

- `GatewayClient.AskFleetAsync`: relays to the Gateway prompt route with `WaitForIdle=true` (the existing buffer-diff capture) using a dedicated long-timeout client.
- `POST /fleet/ask`: frames the question (reuses #705 `FrameForSender`); Gateway -> prompt-with-wait (local + remote); standalone -> local buffer-cursor + Idle wait. Timeout -> 504; unknown/unreachable -> clear error (no fallback).
- `FleetAskRequest`/`FleetAskResponse`; `cc-ask` tool (single-target, rejects `all`); `cc_shared.director` per-call timeout; cli-reference entry.

## Tests
11 fleet tests pass (8 from #705 + 3 new ask-validation). `dotnet build cc-director.sln`: 0/0.

## Proof
Live against a test Director: happy-path round-trip, framed question, timeout (clear msg + non-zero exit), unreachable error, token safety, tool UX. Implements the issue's flagged Assumption #1 (buffer-diff capture).

Proof: `docs/cencon/proof/issue-717/report.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)