### PR TITLE
fix(installer): ship and self-verify the fleet-messaging tools (#719)

### DIFF
--- a/docs/cencon/proof/issue-719/qa-report.html
+++ b/docs/cencon/proof/issue-719/qa-report.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><title>Issue #719 - QA Verification</title>
+<style>
+  body { font-family: -apple-system, "Segoe UI", Roboto, Arial, sans-serif; max-width: 900px; margin: 0 auto; padding: 24px; color: #1f2933; line-height: 1.55; }
+  h1 { border-bottom: 2px solid #15803d; padding-bottom: 8px; } h2 { margin-top: 28px; border-bottom: 1px solid #cbd5e1; padding-bottom: 5px; }
+  pre { background: #0f172a; color: #e2e8f0; padding: 14px 16px; border-radius: 8px; overflow-x: auto; font-size: 13px; }
+  table { border-collapse: collapse; width: 100%; margin: 14px 0; font-size: 14px; } th,td { border: 1px solid #cbd5e1; padding: 8px 10px; text-align: left; } th { background: #1f2937; color: #fff; }
+  .pass { color: #15803d; font-weight: 700; } code { background: #e7ebf0; padding: 1px 5px; border-radius: 4px; }
+</style></head><body>
+<h1>Issue #719 - QA Agent Independent Verification</h1>
+<p><strong>Verdict: VERIFIED - all acceptance criteria met.</strong> Verified from a fresh detached
+checkout of the PR branch (commit <code>6d64800</code>), independent build and test runs.</p>
+
+<h2>Criteria - Expected vs Actual (my run)</h2>
+<table>
+<tr><th>Criterion</th><th>Result</th><th>Evidence</th></tr>
+<tr><td>Four tools ship:true python in registry.json</td><td class="pass">PASS</td><td>Independent ship-selection (the build's exact filter) returned: cc-sessions, cc-whoami, cc-send, cc-ask.</td></tr>
+<tr><td>Build ship-selection includes all four</td><td class="pass">PASS</td><td>Same transcript.</td></tr>
+<tr><td>Four tools in the Core health-check manifest</td><td class="pass">PASS</td><td>FleetTools_ArePresentInCoreHealthCheckManifest passes.</td></tr>
+<tr><td>Guard fails if any of the four is missing from either manifest</td><td class="pass">PASS</td><td>NEGATIVE CHECK: I removed cc-ask from the Core manifest and the guard went RED (1 failed); reverted. The guard genuinely guards.</td></tr>
+<tr><td>Clean build + existing tool-catalog tests pass</td><td class="pass">PASS</td><td>Independent build 0/0; guard + catalog + inventory tests green.</td></tr>
+</table>
+
+<h2>Transcripts (my run)</h2>
+<pre>ship-selection (independent)  -> cc-sessions, cc-whoami, cc-send, cc-ask
+guard test (positive)         -> Passed! Failed: 0, Passed: 2
+guard test (cc-ask removed)   -> Failed! Failed: 1, Passed: 1  (FleetTools_ArePresentInCoreHealthCheckManifest FAIL)
+revert                        -> working tree clean</pre>
+
+<h2>Method / regression</h2>
+<p>Additive deployment-config + a test. No CenCon drift; no security impact (it makes an existing
+feature reachable and adds a regression guard). No running-app surface for this change, so terminal
+transcripts are the proof.</p>
+
+<h2>Standalone QA note</h2>
+<p>Standalone QA does not merge. PR #720 is left open with developer + QA proof committed; the human merges.</p>
+</body></html>

--- a/docs/cencon/proof/issue-719/report.html
+++ b/docs/cencon/proof/issue-719/report.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Issue #719 - Developer Agent Proof</title>
+<style>
+  body { font-family: -apple-system, "Segoe UI", Roboto, Arial, sans-serif; max-width: 900px; margin: 0 auto; padding: 24px; color: #1f2933; line-height: 1.55; }
+  h1 { border-bottom: 2px solid #4f46e5; padding-bottom: 8px; }
+  h2 { margin-top: 30px; border-bottom: 1px solid #cbd5e1; padding-bottom: 5px; }
+  pre { background: #0f172a; color: #e2e8f0; padding: 14px 16px; border-radius: 8px; overflow-x: auto; font-size: 13px; }
+  table { border-collapse: collapse; width: 100%; margin: 16px 0; font-size: 14px; }
+  th, td { border: 1px solid #cbd5e1; padding: 8px 10px; text-align: left; vertical-align: top; }
+  th { background: #1f2937; color: #fff; }
+  .pass { color: #15803d; font-weight: 700; }
+  code { background: #e7ebf0; padding: 1px 5px; border-radius: 4px; }
+</style>
+</head>
+<body>
+
+<h1>Issue #719 - Ship and self-verify the fleet-messaging tools - Developer Agent Proof</h1>
+<p><strong>Branch:</strong> <code>issue-719-ship-fleet-tools</code>. Deployment-config change: makes
+<code>cc-sessions</code>, <code>cc-whoami</code>, <code>cc-send</code>, <code>cc-ask</code> actually
+ship to every machine and be self-verified by the in-app doctor. No runtime UI - proof is the
+manifests, the build selection, and the guard test.</p>
+
+<h2>What was changed</h2>
+<ul>
+  <li><code>tools/registry.json</code> - added the four tools as <code>"type":"python","ship":true</code>
+      so the Python bundle builds them and the installer puts them on PATH.</li>
+  <li><code>src/CcDirector.Core/Tools/tools-manifest.json</code> - added the four (category Fleet,
+      presence + <code>--version</code>, <code>smoke:null</code> with a note that they require a
+      session env), so the in-app doctor verifies them.</li>
+  <li><code>src/CcDirector.Core.Tests/FleetToolsShipGuardTests.cs</code> - a guard that fails if any
+      of the four is missing from EITHER manifest, so they cannot silently half-ship again.</li>
+</ul>
+
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+<tr><th>Criterion</th><th>Result</th><th>Evidence</th></tr>
+<tr><td>Four tools are ship:true python in registry.json</td><td class="pass">PASS</td><td>Entries added; guard test asserts it.</td></tr>
+<tr><td>Build ship-selection includes all four</td><td class="pass">PASS</td><td>The exact filter from build-python-bundle.ps1 selected: cc-sessions, cc-whoami, cc-send, cc-ask (14 shipped python tools total). Transcript below.</td></tr>
+<tr><td>Four tools in the Core health-check manifest (presence + --version, smoke null + note)</td><td class="pass">PASS</td><td>Entries added; guard test asserts it via ToolCatalogService.</td></tr>
+<tr><td>A unit test fails if any of the four is missing from either manifest</td><td class="pass">PASS</td><td>FleetToolsShipGuardTests (2 facts) - both green. Each uses Assert.True(contains, ...) so a missing entry fails by construction.</td></tr>
+<tr><td>Clean solution build + existing tool-catalog tests still pass</td><td class="pass">PASS</td><td>dotnet build: 0/0. 27 tests pass (guard + ToolCatalogService + ToolInventory).</td></tr>
+</table>
+
+<h2>Transcript - build ship-selection (the exact build filter)</h2>
+<pre>$r = Get-Content tools/registry.json -Raw | ConvertFrom-Json
+$py = @($r.tools | Where-Object { $_.type -eq "python" -and $_.ship -eq $true -and $_.name -ne "cc-director-setup" })
+shipped python tool count: 14
+fleet tools selected: cc-sessions, cc-whoami, cc-send, cc-ask</pre>
+
+<h2>Transcript - build + tests</h2>
+<pre>python -c "json.load(registry); json.load(core-manifest)"   -> both valid
+dotnet test (FleetToolsShipGuard + ToolCatalog + ToolInventory) -> Passed! Failed: 0, Passed: 27
+dotnet build cc-director.sln                                 -> Build succeeded. 0 Warning(s) 0 Error(s)</pre>
+
+<h2>CenCon impact</h2>
+<p>Touches <code>core_services</code> (the embedded health-check manifest + a new test) and the
+build/deploy config <code>tools/registry.json</code>. No architecture/security drift - it makes an
+already-built feature reachable in the installed product and adds a regression guard. No installer
+code change was needed (the registry flows automatically into the bundle and installer, confirmed by
+the ship-selection transcript).</p>
+
+<h2>Statement</h2>
+<p><strong>I believe this issue is finished.</strong> The four fleet tools are now ship:true in the
+registry (so they build into the bundle and land on PATH on every install/update), present in the
+Core doctor manifest (so they are self-verified), and guarded by a test so the two hand-synced lists
+cannot drift for these tools. Build is clean and all 27 tool tests pass. Note for QA: this is
+deployment config; the conclusive checks are the ship-selection transcript, the guard test, and the
+manifest contents - there is no running-app surface for this change.</p>
+
+</body>
+</html>

--- a/src/CcDirector.Core.Tests/FleetToolsShipGuardTests.cs
+++ b/src/CcDirector.Core.Tests/FleetToolsShipGuardTests.cs
@@ -1,0 +1,73 @@
+using System.Text.Json;
+using CcDirector.Core.Tools;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Deployment guard (issue #719): the fleet-messaging tools must be both SHIPPED (ship:true python
+/// in tools/registry.json, so the Python bundle builds them and the installer puts them on PATH)
+/// AND SELF-VERIFIED (present in the embedded Core tools-manifest.json the in-app doctor reads).
+/// Those two lists are hand-synced today; this guard fails if either drifts for the fleet tools, so
+/// they cannot silently half-ship again - the exact gap that left #705/#717 dead on arrival in the
+/// installed product.
+/// </summary>
+public sealed class FleetToolsShipGuardTests
+{
+    private static readonly string[] FleetTools = { "cc-sessions", "cc-whoami", "cc-send", "cc-ask" };
+
+    [Fact]
+    public void FleetTools_AreShippablePythonInRegistry()
+    {
+        var shipped = ShipTruePythonToolsFromRegistry();
+        foreach (var tool in FleetTools)
+            Assert.True(shipped.Contains(tool),
+                $"{tool} must be ship:true python in tools/registry.json so it builds into the bundle and deploys to PATH.");
+    }
+
+    [Fact]
+    public void FleetTools_ArePresentInCoreHealthCheckManifest()
+    {
+        var binDir = Path.Combine(Path.GetTempPath(), "FleetToolsGuard_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(binDir);
+        try
+        {
+            var catalog = new ToolCatalogService(binDir).GetCatalog().Select(d => d.Name).ToHashSet(StringComparer.Ordinal);
+            foreach (var tool in FleetTools)
+                Assert.True(catalog.Contains(tool),
+                    $"{tool} must be in src/CcDirector.Core/Tools/tools-manifest.json so the in-app doctor verifies it.");
+        }
+        finally
+        {
+            try { Directory.Delete(binDir, recursive: true); } catch (IOException) { }
+        }
+    }
+
+    private static HashSet<string> ShipTruePythonToolsFromRegistry()
+    {
+        var registryPath = FindRepoFile(Path.Combine("tools", "registry.json"));
+        using var doc = JsonDocument.Parse(File.ReadAllText(registryPath));
+        var result = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var tool in doc.RootElement.GetProperty("tools").EnumerateArray())
+        {
+            var type = tool.TryGetProperty("type", out var ty) ? ty.GetString() : null;
+            var ship = tool.TryGetProperty("ship", out var sh) && sh.ValueKind == JsonValueKind.True;
+            var name = tool.TryGetProperty("name", out var nm) ? nm.GetString() : null;
+            if (type == "python" && ship && name is not null)
+                result.Add(name);
+        }
+        return result;
+    }
+
+    private static string FindRepoFile(string relativePath)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, relativePath);
+            if (File.Exists(candidate)) return candidate;
+            dir = dir.Parent;
+        }
+        throw new FileNotFoundException($"Could not locate {relativePath} walking up from {AppContext.BaseDirectory}");
+    }
+}

--- a/src/CcDirector.Core/Tools/tools-manifest.json
+++ b/src/CcDirector.Core/Tools/tools-manifest.json
@@ -63,6 +63,34 @@
       "description": "Trusted-event browser automation via Playwright CDP with named, isolated connections.",
       "smoke": { "args": ["list"], "expectContains": null },
       "note": null
+    },
+    {
+      "name": "cc-sessions",
+      "category": "Fleet",
+      "description": "List every session running across the fleet.",
+      "smoke": null,
+      "note": "Requires a live session environment (CC_DIRECTOR_API). Presence + version only."
+    },
+    {
+      "name": "cc-whoami",
+      "category": "Fleet",
+      "description": "Show this session's own fleet identity.",
+      "smoke": null,
+      "note": "Requires a live session environment (CC_DIRECTOR_API). Presence + version only."
+    },
+    {
+      "name": "cc-send",
+      "category": "Fleet",
+      "description": "Send a message to another session in the fleet (or all of them).",
+      "smoke": null,
+      "note": "Requires a live session environment (CC_DIRECTOR_API). Presence + version only."
+    },
+    {
+      "name": "cc-ask",
+      "category": "Fleet",
+      "description": "Ask another session a question and get its answer back.",
+      "smoke": null,
+      "note": "Requires a live session environment (CC_DIRECTOR_API). Presence + version only."
     }
   ]
 }

--- a/tools/registry.json
+++ b/tools/registry.json
@@ -293,6 +293,42 @@
       "requirements": []
     },
     {
+      "name": "cc-sessions",
+      "category": "fleet",
+      "type": "python",
+      "description": "List every session running across the fleet",
+      "built": true,
+      "ship": true,
+      "requirements": []
+    },
+    {
+      "name": "cc-whoami",
+      "category": "fleet",
+      "type": "python",
+      "description": "Show this session's own fleet identity",
+      "built": true,
+      "ship": true,
+      "requirements": []
+    },
+    {
+      "name": "cc-send",
+      "category": "fleet",
+      "type": "python",
+      "description": "Send a message to another session in the fleet (or all of them)",
+      "built": true,
+      "ship": true,
+      "requirements": []
+    },
+    {
+      "name": "cc-ask",
+      "category": "fleet",
+      "type": "python",
+      "description": "Ask another session a question and get its answer back",
+      "built": true,
+      "ship": true,
+      "requirements": []
+    },
+    {
       "name": "cc-posthog",
       "category": "data-utilities",
       "type": "python",


### PR DESCRIPTION
Implements #719. Makes cc-sessions/cc-whoami/cc-send/cc-ask actually ship (registry.json ship:true -> Python bundle -> PATH on install+update) and be self-verified (Core tools-manifest.json doctor), with a guard test so they cannot silently half-ship again. Build 0/0; 27 tool tests pass. Deployment-config change, no runtime UI - proof is the ship-selection transcript + guard test + manifests.

Proof: docs/cencon/proof/issue-719/report.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)