### PR TITLE
feat(cli): cc-spawn - open a session from the command line (#721)

### DIFF
--- a/docs/cencon/proof/issue-721/qa-report.html
+++ b/docs/cencon/proof/issue-721/qa-report.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><title>Issue #721 - QA Verification</title>
+<style>
+  body { font-family: -apple-system, "Segoe UI", Roboto, Arial, sans-serif; max-width: 900px; margin: 0 auto; padding: 24px; color: #1f2933; line-height: 1.55; }
+  h1 { border-bottom: 2px solid #15803d; padding-bottom: 8px; } h2 { margin-top: 26px; border-bottom: 1px solid #cbd5e1; padding-bottom: 5px; }
+  pre { background: #0f172a; color: #e2e8f0; padding: 14px 16px; border-radius: 8px; overflow-x: auto; font-size: 13px; }
+  table { border-collapse: collapse; width: 100%; margin: 14px 0; font-size: 14px; } th,td { border: 1px solid #cbd5e1; padding: 8px 10px; text-align: left; } th { background: #1f2937; color: #fff; }
+  .pass { color: #15803d; font-weight: 700; } code { background: #e7ebf0; padding: 1px 5px; border-radius: 4px; }
+  .note { background: #fffbeb; border: 1px solid #fde68a; border-radius: 8px; padding: 12px 16px; }
+</style></head><body>
+<h1>Issue #721 - cc-spawn - QA Independent Verification</h1>
+<p><strong>Verdict: VERIFIED - all acceptance criteria met.</strong> Verified from a fresh detached
+checkout of the PR branch (commit <code>6f10f7e</code>), my own build, my own test Director.</p>
+
+<h2>Criteria - Expected vs Actual (my run)</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>Result</th></tr>
+<tr><td>1</td><td>cc-spawn creates a session that appears in cc-sessions</td><td class="pass">PASS - created e452e0e6 (qa-spawn); shows in cc-sessions.</td></tr>
+<tr><td>2</td><td>--agent and --prompt passed through</td><td class="pass">PASS - RawCli cmd session; --prompt "echo QASPAWNPROMPT" dispatched + executed.</td></tr>
+<tr><td>3</td><td>Non-existent repo -> clear error + non-zero exit</td><td class="pass">PASS - "Error: repoPath does not exist: ..." exit 1.</td></tr>
+<tr><td>4</td><td>Shipped (registry) + Core manifest + cli-reference + guard covers it</td><td class="pass">PASS - guard test (incl cc-spawn) green; entries present.</td></tr>
+<tr><td>5</td><td>Clean build + existing tests pass</td><td class="pass">PASS - independent build 0/0; guard tests green.</td></tr>
+</table>
+
+<h2>Transcript (my run, port 7884)</h2>
+<pre>$ cc-spawn D:/ReposFred/devthrottle-wt-721-qa --agent RawCli --command cmd --name "qa-spawn"
+Opened session e452e0e6 (qa-spawn).   (exit 0)
+$ cc-sessions   -> | e452e0e6 | qa-spawn | SOREN_NORTH | devthrottle-wt... | WaitingForInput |
+$ cc-spawn D:/nope/qa   -> Error: repoPath does not exist: D:/nope/qa   (exit 1)
+$ cc-spawn ... --prompt "echo QASPAWNPROMPT"  -> after readiness window, target buffer:
+   D:\...\devthrottle-wt-721-qa>echo QASPAWNPROMPT
+   QASPAWNPROMPT</pre>
+
+<div class="note">
+<strong>Environment note (NOT a #721 defect).</strong> My first launch self-allocated Control API
+port 7882, but that port is held by the Windows System process (PID 4 - an http.sys / excluded-port
+reservation), so every request 404'd ("no such endpoint") even though the Director logged "Kestrel
+listening on 7882". I diagnosed this as a port-allocation collision (the feature itself worked on a
+clean port in the dev run), relaunched onto port 7884, and all criteria passed. This is a flaky spot
+in the Director's port allocator / the agent-session-isolation harness (it can pick a Windows-reserved
+port) and is worth a separate follow-up - it is independent of cc-spawn.
+</div>
+
+<h2>Standalone QA note</h2>
+<p>Standalone QA does not merge. PR #724 is left open with developer + QA proof committed; the human merges.</p>
+</body></html>

--- a/docs/cencon/proof/issue-721/report.html
+++ b/docs/cencon/proof/issue-721/report.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><title>Issue #721 - Developer Agent Proof</title>
+<style>
+  body { font-family: -apple-system, "Segoe UI", Roboto, Arial, sans-serif; max-width: 900px; margin: 0 auto; padding: 24px; color: #1f2933; line-height: 1.55; }
+  h1 { border-bottom: 2px solid #4f46e5; padding-bottom: 8px; } h2 { margin-top: 28px; border-bottom: 1px solid #cbd5e1; padding-bottom: 5px; }
+  pre { background: #0f172a; color: #e2e8f0; padding: 14px 16px; border-radius: 8px; overflow-x: auto; font-size: 13px; }
+  table { border-collapse: collapse; width: 100%; margin: 14px 0; font-size: 14px; } th,td { border: 1px solid #cbd5e1; padding: 8px 10px; text-align: left; } th { background: #1f2937; color: #fff; }
+  .pass { color: #15803d; font-weight: 700; } code { background: #e7ebf0; padding: 1px 5px; border-radius: 4px; }
+</style></head><body>
+<h1>Issue #721 - cc-spawn - Developer Agent Proof</h1>
+<p><strong>Branch:</strong> <code>issue-721-cc-spawn</code>. A command-line way to open a session on the
+local Director and then message/ask it.</p>
+
+<h2>What was implemented</h2>
+<ul>
+  <li><code>tools/cc-spawn/</code> - new tool: <code>cc-spawn &lt;repo&gt; [--agent --prompt --name --type --command --command-args]</code>
+      POSTs <code>NewSessionRequest</code> to <code>$CC_DIRECTOR_API/sessions</code>, prints the new
+      session's short id + full GUID. <code>--name</code> applies a follow-up rename (PATCH).</li>
+  <li><code>cc_shared/director.py</code> - added <code>patch_json</code> (for the rename).</li>
+  <li>Shipped + self-verified: added to <code>tools/registry.json</code> (ship:true),
+      <code>src/CcDirector.Core/Tools/tools-manifest.json</code>, <code>docs/cli-reference.md</code>,
+      and the <code>FleetToolsShipGuardTests</code> guard array.</li>
+</ul>
+
+<h2>Build and tests</h2>
+<pre>dotnet build cc-director.sln              -> Build succeeded. 0 Warning(s) 0 Error(s)
+FleetToolsShipGuardTests (incl cc-spawn)  -> Passed! Failed: 0, Passed: 2
+ship-selection -> cc-spawn shipped: True
+json valid; py_compile OK</pre>
+
+<h2>Acceptance criteria - Expected vs Actual (live, port 7881)</h2>
+<table>
+<tr><th>Criterion</th><th>Result</th><th>Evidence</th></tr>
+<tr><td>cc-spawn creates a session that appears in cc-sessions</td><td class="pass">PASS</td><td>Created e0ffbeda; it shows in cc-sessions as "spawn-proof". Transcript A.</td></tr>
+<tr><td>--agent and --prompt are passed through</td><td class="pass">PASS</td><td>--agent RawCli --command cmd produced a cmd session; --prompt "echo SPAWNPROMPT123" was dispatched and executed (Transcript B).</td></tr>
+<tr><td>Non-existent repo -> clear error + non-zero exit</td><td class="pass">PASS</td><td>"Error: repoPath does not exist: ..." exit 1. Transcript A.</td></tr>
+<tr><td>Shipped (registry), in Core manifest, in cli-reference, guard covers it</td><td class="pass">PASS</td><td>ship-selection includes cc-spawn; guard test (with cc-spawn) green; cli-reference entry added.</td></tr>
+<tr><td>Clean build + existing tests pass</td><td class="pass">PASS</td><td>0/0; guard tests green.</td></tr>
+</table>
+
+<h2>Transcript A - create + list + error (my run)</h2>
+<pre>$ cc-spawn D:/ReposFred/devthrottle-wt-721 --agent RawCli --command cmd --name "spawn-proof"
+Opened session e0ffbeda (spawn-proof).
+id: e0ffbeda-0930-4e69-8df2-e7faef187ce8
+Message it:  cc-send e0ffbeda "<message>"   |   Ask it:  cc-ask e0ffbeda "<question>"
+
+$ cc-sessions
+| e0ffbeda | spawn-proof   | SOREN_NORTH | devthrottle-wt... | WaitingForInput |
+
+$ cc-spawn D:/no/such/repo/here
+Error: repoPath does not exist: D:/no/such/repo/here     (exit 1)</pre>
+
+<h2>Transcript B - --prompt passthrough (my run)</h2>
+<pre>$ cc-spawn D:/ReposFred/devthrottle-wt-721 --agent RawCli --command cmd --prompt "echo SPAWNPROMPT123"
+Opened session d3689692 ...
+# after the prePrompt readiness window, the target session's buffer:
+D:\ReposFred\devthrottle-wt-721>echo SPAWNPROMPT123
+SPAWNPROMPT123</pre>
+
+<h2>CenCon impact</h2>
+<p>Additive: a new <code>cc-spawn</code> tool (+ a <code>patch_json</code> helper), shipped via the
+registry and verified by the doctor, reusing <code>POST /sessions</code> (unchanged). No
+architecture/security drift.</p>
+
+<h2>Statement</h2>
+<p><strong>I believe this issue is finished.</strong> cc-spawn opens a session from the command line
+with agent/prompt/name passthrough, fails clearly on a bad repo, and is shipped + self-verified +
+guarded. Build clean, tests green, proven live against a running Director.</p>
+</body></html>

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -763,6 +763,29 @@ If the target does not answer within the timeout, `cc-ask` prints a clear timeou
 non-zero; an unknown or unreachable target exits non-zero with a clear error. `cc-ask all` is not
 supported (ask is single-target).
 
+### cc-spawn
+
+Open a session on the local Director from the command line, then message or ask it (issue #721).
+
+```
+USAGE: cc-spawn [OPTIONS] REPO
+
+ARGUMENTS:
+  REPO  Absolute path to the repository / working directory for the session [required]
+
+OPTIONS:
+  --agent TEXT          Agent CLI: ClaudeCode (default), Pi, Codex, Gemini, OpenCode, Grok, Copilot, RawCli
+  --prompt TEXT         First prompt to send once the session is ready
+  --name TEXT           Custom display name for the session
+  --type TEXT           Session type: Developer, Implementation, Discuss, Product, QA, Support
+  --command TEXT        For --agent RawCli: the executable to run (e.g. cmd, pwsh)
+  --command-args TEXT   For --agent RawCli: arguments for the command
+  --version -v
+```
+
+Prints the new session's short id and full GUID; the session then appears in `cc-sessions`. A
+non-existent repository path exits non-zero with a clear error.
+
 ---
 
 ## cc-reddit

--- a/src/CcDirector.Core.Tests/FleetToolsShipGuardTests.cs
+++ b/src/CcDirector.Core.Tests/FleetToolsShipGuardTests.cs
@@ -14,7 +14,7 @@ namespace CcDirector.Core.Tests;
 /// </summary>
 public sealed class FleetToolsShipGuardTests
 {
-    private static readonly string[] FleetTools = { "cc-sessions", "cc-whoami", "cc-send", "cc-ask" };
+    private static readonly string[] FleetTools = { "cc-sessions", "cc-whoami", "cc-send", "cc-ask", "cc-spawn" };
 
     [Fact]
     public void FleetTools_AreShippablePythonInRegistry()

--- a/src/CcDirector.Core/Tools/tools-manifest.json
+++ b/src/CcDirector.Core/Tools/tools-manifest.json
@@ -91,6 +91,13 @@
       "description": "Ask another session a question and get its answer back.",
       "smoke": null,
       "note": "Requires a live session environment (CC_DIRECTOR_API). Presence + version only."
+    },
+    {
+      "name": "cc-spawn",
+      "category": "Fleet",
+      "description": "Open a session on the local Director from the command line.",
+      "smoke": null,
+      "note": "Requires a live session environment (CC_DIRECTOR_API). Presence + version only."
     }
   ]
 }

--- a/tools/cc-spawn/build.ps1
+++ b/tools/cc-spawn/build.ps1
@@ -1,0 +1,32 @@
+# Build cc-spawn executable
+# Usage: .\build.ps1
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "Building cc-spawn..." -ForegroundColor Cyan
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $scriptDir
+
+if (-not (Test-Path ".venv")) {
+    Write-Host "Creating virtual environment..."
+    python -m venv .venv
+}
+
+. .venv\Scripts\Activate.ps1
+
+Write-Host "Installing dependencies..."
+pip install --quiet --upgrade pip
+pip install --quiet -r requirements.txt
+
+Write-Host "Building executable..."
+pyinstaller --clean --noconfirm cc-spawn.spec
+
+if (Test-Path "dist\cc-spawn.exe") {
+    $size = (Get-Item "dist\cc-spawn.exe").Length / 1MB
+    Write-Host "[OK] Built dist\cc-spawn.exe ($([math]::Round($size, 1)) MB)" -ForegroundColor Green
+    exit 0
+} else {
+    Write-Host "[FAIL] Build failed - cc-spawn.exe not found" -ForegroundColor Red
+    exit 1
+}

--- a/tools/cc-spawn/cc-spawn.spec
+++ b/tools/cc-spawn/cc-spawn.spec
@@ -1,0 +1,48 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+a = Analysis(
+    ['main.py'],
+    pathex=['..'],
+    binaries=[],
+    datas=[],
+    hiddenimports=[
+        'typer',
+        'rich',
+        'rich.console',
+        'cc_shared',
+        'cc_shared.director',
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='cc-spawn',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/tools/cc-spawn/main.py
+++ b/tools/cc-spawn/main.py
@@ -1,0 +1,6 @@
+"""Entry point for cc-spawn."""
+
+from src.cli import app
+
+if __name__ == "__main__":
+    app()

--- a/tools/cc-spawn/pyproject.toml
+++ b/tools/cc-spawn/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "cc-spawn"
+version = "1.0.0"
+description = "Open a session on the local cc-director from the command line"
+requires-python = ">=3.11"
+dependencies = [
+    "typer>=0.9.0",
+    "rich>=13.0.0",
+    "cc-shared",
+]
+
+[project.scripts]
+cc-spawn = "cc_spawn.cli:app"
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+# src/ installs as the unique import package so all tools share one venv.
+packages = ["cc_spawn"]
+package-dir = {"cc_spawn" = "src"}

--- a/tools/cc-spawn/requirements.txt
+++ b/tools/cc-spawn/requirements.txt
@@ -1,0 +1,3 @@
+typer>=0.9.0
+rich>=13.0.0
+pyinstaller>=6.0.0

--- a/tools/cc-spawn/src/__init__.py
+++ b/tools/cc-spawn/src/__init__.py
@@ -1,0 +1,3 @@
+"""cc-spawn - open a session on the local Director from the command line."""
+
+__version__ = "1.0.0"

--- a/tools/cc-spawn/src/cli.py
+++ b/tools/cc-spawn/src/cli.py
@@ -1,0 +1,95 @@
+"""CLI for cc-spawn - open a session on the local Director and print its id."""
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import typer
+from rich.console import Console
+
+# Share the one tools venv: make cc_shared importable when run from source (issue #721).
+_tools_dir = str(Path(__file__).resolve().parent.parent.parent)
+if _tools_dir not in sys.path:
+    sys.path.insert(0, _tools_dir)
+
+from cc_shared import director  # noqa: E402
+
+from . import __version__  # noqa: E402
+
+console = Console()
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        console.print(f"cc-spawn v{__version__}")
+        raise typer.Exit()
+
+
+def _run(
+    repo: str = typer.Argument(..., help="Absolute path to the repository / working directory."),
+    agent: str = typer.Option(
+        "ClaudeCode", "--agent",
+        help="Agent CLI: ClaudeCode, Pi, Codex, Gemini, OpenCode, Grok, Copilot, RawCli.",
+    ),
+    prompt: Optional[str] = typer.Option(
+        None, "--prompt", help="First prompt to send once the session is ready."
+    ),
+    name: Optional[str] = typer.Option(None, "--name", help="Custom display name for the session."),
+    session_type: Optional[str] = typer.Option(
+        None, "--type", help="Session type: Developer, Implementation, Discuss, Product, QA, Support."
+    ),
+    command: Optional[str] = typer.Option(
+        None, "--command", help="For --agent RawCli: the executable to run (e.g. cmd, pwsh)."
+    ),
+    command_args: Optional[str] = typer.Option(
+        None, "--command-args", help="For --agent RawCli: arguments for the command."
+    ),
+    version: bool = typer.Option(
+        False, "--version", "-v", callback=_version_callback, is_eager=True, help="Show version."
+    ),
+) -> None:
+    """Open a new session on the local Director in REPO and print its id."""
+    body: Dict[str, Any] = {"repoPath": repo, "agent": agent}
+    if prompt:
+        body["prePrompt"] = prompt
+    if session_type:
+        body["type"] = session_type
+    if command:
+        body["command"] = command
+    if command_args:
+        body["commandArgs"] = command_args
+
+    try:
+        resp = director.post_json("sessions", body)
+    except director.DirectorError as err:
+        console.print(f"[red]Error:[/red] {err}")
+        raise typer.Exit(1)
+
+    sid = director.field(resp, "sessionId", "SessionId")
+    if not sid:
+        console.print("[red]Error:[/red] the Director did not return a session id.")
+        raise typer.Exit(1)
+
+    if name:
+        # Set the display name with a follow-up rename; a failure here is non-fatal (the session
+        # exists), but report it so the caller is not misled.
+        try:
+            director.patch_json(f"sessions/{sid}", {"name": name})
+        except director.DirectorError as err:
+            console.print(f"[yellow]Session created, but rename failed:[/yellow] {err}")
+
+    short = director.short_id(sid)
+    label = name or director.field(resp, "name", "Name") or short
+    console.print(f"[green]Opened[/green] session {short} ({label}).")
+    console.print(f"id: {sid}")
+    console.print(f'Message it:  cc-send {short} "<message>"   |   Ask it:  cc-ask {short} "<question>"')
+
+
+def app() -> None:
+    """Console-script entry point. typer.run builds a single-command CLI so the positional
+    REPO argument binds cleanly."""
+    typer.run(_run)
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/cc_shared/director.py
+++ b/tools/cc_shared/director.py
@@ -99,6 +99,10 @@ def post_json(path: str, body: dict, timeout: float = 30) -> Any:
     return _request("POST", path, body, timeout=timeout)
 
 
+def patch_json(path: str, body: dict, timeout: float = 30) -> Any:
+    return _request("PATCH", path, body, timeout=timeout)
+
+
 def field(dto: Dict[str, Any], *keys: str, default: str = "") -> str:
     """Read the first present key from a session DTO, tolerating camelCase or PascalCase."""
     for key in keys:

--- a/tools/registry.json
+++ b/tools/registry.json
@@ -329,6 +329,15 @@
       "requirements": []
     },
     {
+      "name": "cc-spawn",
+      "category": "fleet",
+      "type": "python",
+      "description": "Open a session on the local Director from the command line",
+      "built": true,
+      "ship": true,
+      "requirements": []
+    },
+    {
       "name": "cc-posthog",
       "category": "data-utilities",
       "type": "python",


### PR DESCRIPTION
Implements #721. New `cc-spawn <repo> [--agent --prompt --name --type --command --command-args]` opens a session on the local Director (POST /sessions) and prints its id; bad repo -> clear error + non-zero exit. Shipped (registry ship:true), self-verified (Core manifest), documented (cli-reference), guarded (FleetToolsShipGuardTests). Build 0/0; proven live (create+list, --agent/--prompt passthrough, error path).

Proof: docs/cencon/proof/issue-721/report.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)