### PR TITLE
feat(cli): cc-fleet-selftest - end-to-end fleet messaging smoke test (#722)

### DIFF
--- a/docs/cencon/proof/issue-722/qa-report.html
+++ b/docs/cencon/proof/issue-722/qa-report.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Issue #722 - QA</title>
+<style>body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;max-width:880px;margin:0 auto;padding:24px;color:#1f2933;line-height:1.55}h1{border-bottom:2px solid #15803d;padding-bottom:8px}pre{background:#0f172a;color:#e2e8f0;padding:14px 16px;border-radius:8px;overflow-x:auto;font-size:13px}table{border-collapse:collapse;width:100%;margin:14px 0;font-size:14px}th,td{border:1px solid #cbd5e1;padding:8px 10px;text-align:left}th{background:#1f2937;color:#fff}.pass{color:#15803d;font-weight:700}</style></head><body>
+<h1>Issue #722 - cc-fleet-selftest - QA Independent Verification</h1>
+<p><strong>Verdict: VERIFIED.</strong> Fresh detached checkout (da9444c), own build, own test Director.</p>
+<table>
+<tr><th>Criterion</th><th>Result</th></tr>
+<tr><td>Green run: spawn 2 -> list -> send -> ask -> teardown, PASS, exit 0</td><td class="pass">PASS - 5/5, exit 0</td></tr>
+<tr><td>cc-ask returns the responder's marker (deterministic)</td><td class="pass">PASS - "marker found" (FLEETPONG)</td></tr>
+<tr><td>Forced failure (Director down) -> FAIL + non-zero exit</td><td class="pass">PASS - FAIL, exit 1</td></tr>
+<tr><td>No throwaway sessions left behind</td><td class="pass">PASS - cleanup check passed</td></tr>
+<tr><td>Shipped + Core manifest + cli-reference + guard</td><td class="pass">PASS - guard green</td></tr>
+</table>
+<pre>$ cc-fleet-selftest  ->  PASS spawn/list/send/ask(marker found)/cleanup  5/5  (exit 0)
+$ CC_DIRECTOR_API=...:59999 cc-fleet-selftest  ->  FAIL 0/2  (exit 1)
+independent build 0/0; FleetToolsShipGuardTests 2/2.</pre>
+<p>Standalone QA does not merge by itself; merge performed per the human's authorization to run this chain merge-as-we-go.</p>
+</body></html>

--- a/docs/cencon/proof/issue-722/report.html
+++ b/docs/cencon/proof/issue-722/report.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Issue #722 - Developer Proof</title>
+<style>body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;max-width:900px;margin:0 auto;padding:24px;color:#1f2933;line-height:1.55}h1{border-bottom:2px solid #4f46e5;padding-bottom:8px}h2{margin-top:28px;border-bottom:1px solid #cbd5e1;padding-bottom:5px}pre{background:#0f172a;color:#e2e8f0;padding:14px 16px;border-radius:8px;overflow-x:auto;font-size:13px}table{border-collapse:collapse;width:100%;margin:14px 0;font-size:14px}th,td{border:1px solid #cbd5e1;padding:8px 10px;text-align:left}th{background:#1f2937;color:#fff}.pass{color:#15803d;font-weight:700}code{background:#e7ebf0;padding:1px 5px;border-radius:4px}</style></head><body>
+<h1>Issue #722 - cc-fleet-selftest - Developer Proof</h1>
+<p>An on-demand end-to-end smoke test of fleet session messaging: spawn two throwaway sessions, list, send, ask, tear down, PASS/FAIL.</p>
+<h2>What was implemented</h2>
+<ul>
+<li><code>tools/cc-fleet-selftest/</code> - spawns a deterministic "responder" (cmd with a custom prompt marker <code>FLEETPONG</code>) + a recipient via <code>POST /sessions</code>, then exercises <code>GET /fleet/sessions</code>, <code>POST /fleet/send</code>, <code>POST /fleet/ask</code> (the machinery the cc-* tools wrap), asserts each, tears the sessions down (<code>DELETE /sessions/{id}</code>), prints PASS/FAIL, exits 0/non-zero.</li>
+<li><code>cc_shared/director.py</code> - added <code>delete()</code>.</li>
+<li>Shipped + verified: <code>tools/registry.json</code> (ship:true), Core <code>tools-manifest.json</code>, <code>docs/cli-reference.md</code>, and the <code>FleetToolsShipGuardTests</code> guard array.</li>
+</ul>
+<h2>Build and tests</h2>
+<pre>dotnet build cc-director.sln           -> 0 Warning(s) 0 Error(s)
+FleetToolsShipGuardTests (incl selftest) -> Passed! 2/2
+ship-selection -> cc-fleet-selftest shipped: True; json valid; py_compile OK</pre>
+<h2>Acceptance criteria - live (port 7881)</h2>
+<table>
+<tr><th>Criterion</th><th>Result</th><th>Evidence</th></tr>
+<tr><td>Green run: spawn 2, list, send, ask, teardown, PASS, exit 0</td><td class="pass">PASS</td><td>5/5 checks, exit 0. Transcript A.</td></tr>
+<tr><td>cc-ask returns the responder's known marker (deterministic)</td><td class="pass">PASS</td><td>"cc-ask returns the answer - marker found" (FLEETPONG).</td></tr>
+<tr><td>Forced failure (Director down) -> clear FAIL + non-zero exit</td><td class="pass">PASS</td><td>Transcript B: clear connection error, exit 1.</td></tr>
+<tr><td>No throwaway sessions left behind</td><td class="pass">PASS</td><td>Self-test cleanup check passed; cc-sessions shows 0 selftest sessions afterward.</td></tr>
+<tr><td>Shipped + Core manifest + cli-reference + guard covers it</td><td class="pass">PASS</td><td>ship-selection True; guard green.</td></tr>
+</table>
+<h2>Transcript A - green run</h2>
+<pre>$ cc-fleet-selftest
+  PASS  spawn two sessions  - responder=a08e0cc5 recipient=15a168a3
+  PASS  cc-sessions lists both
+  PASS  cc-send delivers
+  PASS  cc-ask returns the answer  - marker found
+  PASS  throwaway sessions cleaned up
+PASS - fleet messaging self-test: 5/5 checks passed.   (exit 0)
+# cc-sessions afterward: 0 selftest sessions remain</pre>
+<h2>Transcript B - forced failure (Director down)</h2>
+<pre>$ CC_DIRECTOR_API=http://127.0.0.1:59999 cc-fleet-selftest --timeout-ms 4000
+  FAIL  fleet messaging reachable  - Cannot reach the Director at http://127.0.0.1:59999: [WinError 10061] ...
+FAIL - fleet messaging self-test: 0/2 checks passed.   (exit 1)</pre>
+<h2>CenCon impact</h2>
+<p>Additive: a new <code>cc-fleet-selftest</code> tool (+ a <code>delete</code> helper), shipped + doctor-verified, reusing existing <code>/sessions</code> and <code>/fleet/*</code> endpoints. No drift.</p>
+<h2>Statement</h2>
+<p><strong>I believe this issue is finished.</strong> The self-test verifies the whole intercommunication loop deterministically, fails clearly when the Director is down, leaves no sessions behind, and is shipped + guarded. Build clean; proven live. Per the issue's flagged assumption, the deterministic answer comes from a marker-prompt cmd responder (no LLM).</p>
+</body></html>

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -786,6 +786,23 @@ OPTIONS:
 Prints the new session's short id and full GUID; the session then appears in `cc-sessions`. A
 non-existent repository path exits non-zero with a clear error.
 
+### cc-fleet-selftest
+
+Prove fleet session messaging works end to end on this machine (issue #722). Spawns two throwaway
+sessions, lists them, sends to one, asks the other (a deterministic marker responder), tears them
+down, and prints PASS/FAIL.
+
+```
+USAGE: cc-fleet-selftest [OPTIONS]
+
+OPTIONS:
+  --timeout-ms INTEGER  How long the ask step waits for the responder (default 25000)
+  --version -v
+```
+
+Exits 0 when every check passes, non-zero (with the failing step named) otherwise. Leaves no
+throwaway sessions behind. Useful as a post-deploy health check for the intercommunication feature.
+
 ---
 
 ## cc-reddit

--- a/src/CcDirector.Core.Tests/FleetToolsShipGuardTests.cs
+++ b/src/CcDirector.Core.Tests/FleetToolsShipGuardTests.cs
@@ -14,7 +14,7 @@ namespace CcDirector.Core.Tests;
 /// </summary>
 public sealed class FleetToolsShipGuardTests
 {
-    private static readonly string[] FleetTools = { "cc-sessions", "cc-whoami", "cc-send", "cc-ask", "cc-spawn" };
+    private static readonly string[] FleetTools = { "cc-sessions", "cc-whoami", "cc-send", "cc-ask", "cc-spawn", "cc-fleet-selftest" };
 
     [Fact]
     public void FleetTools_AreShippablePythonInRegistry()

--- a/src/CcDirector.Core/Tools/tools-manifest.json
+++ b/src/CcDirector.Core/Tools/tools-manifest.json
@@ -98,6 +98,13 @@
       "description": "Open a session on the local Director from the command line.",
       "smoke": null,
       "note": "Requires a live session environment (CC_DIRECTOR_API). Presence + version only."
+    },
+    {
+      "name": "cc-fleet-selftest",
+      "category": "Fleet",
+      "description": "End-to-end smoke test of fleet session messaging.",
+      "smoke": null,
+      "note": "Requires a live session environment (CC_DIRECTOR_API). Presence + version only."
     }
   ]
 }

--- a/tools/cc-fleet-selftest/build.ps1
+++ b/tools/cc-fleet-selftest/build.ps1
@@ -1,0 +1,32 @@
+# Build cc-fleet-selftest executable
+# Usage: .\build.ps1
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "Building cc-fleet-selftest..." -ForegroundColor Cyan
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $scriptDir
+
+if (-not (Test-Path ".venv")) {
+    Write-Host "Creating virtual environment..."
+    python -m venv .venv
+}
+
+. .venv\Scripts\Activate.ps1
+
+Write-Host "Installing dependencies..."
+pip install --quiet --upgrade pip
+pip install --quiet -r requirements.txt
+
+Write-Host "Building executable..."
+pyinstaller --clean --noconfirm cc-fleet-selftest.spec
+
+if (Test-Path "dist\cc-fleet-selftest.exe") {
+    $size = (Get-Item "dist\cc-fleet-selftest.exe").Length / 1MB
+    Write-Host "[OK] Built dist\cc-fleet-selftest.exe ($([math]::Round($size, 1)) MB)" -ForegroundColor Green
+    exit 0
+} else {
+    Write-Host "[FAIL] Build failed - cc-fleet-selftest.exe not found" -ForegroundColor Red
+    exit 1
+}

--- a/tools/cc-fleet-selftest/cc-fleet-selftest.spec
+++ b/tools/cc-fleet-selftest/cc-fleet-selftest.spec
@@ -1,0 +1,48 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+a = Analysis(
+    ['main.py'],
+    pathex=['..'],
+    binaries=[],
+    datas=[],
+    hiddenimports=[
+        'typer',
+        'rich',
+        'rich.console',
+        'cc_shared',
+        'cc_shared.director',
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='cc-fleet-selftest',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/tools/cc-fleet-selftest/main.py
+++ b/tools/cc-fleet-selftest/main.py
@@ -1,0 +1,6 @@
+"""Entry point for cc-fleet-selftest."""
+
+from src.cli import app
+
+if __name__ == "__main__":
+    app()

--- a/tools/cc-fleet-selftest/pyproject.toml
+++ b/tools/cc-fleet-selftest/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "cc-fleet-selftest"
+version = "1.0.0"
+description = "End-to-end smoke test of cc-director fleet session messaging"
+requires-python = ">=3.11"
+dependencies = [
+    "typer>=0.9.0",
+    "rich>=13.0.0",
+    "cc-shared",
+]
+
+[project.scripts]
+cc-fleet-selftest = "cc_fleet_selftest.cli:app"
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+# src/ installs as the unique import package so all tools share one venv.
+packages = ["cc_fleet_selftest"]
+package-dir = {"cc_fleet_selftest" = "src"}

--- a/tools/cc-fleet-selftest/requirements.txt
+++ b/tools/cc-fleet-selftest/requirements.txt
@@ -1,0 +1,3 @@
+typer>=0.9.0
+rich>=13.0.0
+pyinstaller>=6.0.0

--- a/tools/cc-fleet-selftest/src/__init__.py
+++ b/tools/cc-fleet-selftest/src/__init__.py
@@ -1,0 +1,3 @@
+"""cc-fleet-selftest - end-to-end smoke test of fleet session messaging."""
+
+__version__ = "1.0.0"

--- a/tools/cc-fleet-selftest/src/cli.py
+++ b/tools/cc-fleet-selftest/src/cli.py
@@ -1,0 +1,143 @@
+"""CLI for cc-fleet-selftest - prove fleet session messaging works end to end.
+
+Spawns two throwaway sessions on the local Director, then exercises the fleet messaging
+machinery the cc-* tools wrap (GET /fleet/sessions, POST /fleet/send, POST /fleet/ask) and
+asserts each step, then tears the sessions down. Exits 0 when every step passes, non-zero
+otherwise. Deterministic: the "responder" session runs cmd with a custom prompt marker, so the
+ask step always has a known token to look for (a plain cmd target is not a natural answerer).
+"""
+
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import typer
+from rich.console import Console
+
+# Share the one tools venv: make cc_shared importable when run from source (issue #722).
+_tools_dir = str(Path(__file__).resolve().parent.parent.parent)
+if _tools_dir not in sys.path:
+    sys.path.insert(0, _tools_dir)
+
+from cc_shared import director  # noqa: E402
+
+from . import __version__  # noqa: E402
+
+console = Console()
+
+MARKER = "FLEETPONG"
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        console.print(f"cc-fleet-selftest v{__version__}")
+        raise typer.Exit()
+
+
+def _spawn(repo: str, command_args: str, name: str) -> str:
+    resp = director.post_json(
+        "sessions",
+        {"repoPath": repo, "agent": "RawCli", "command": "cmd", "commandArgs": command_args},
+    )
+    sid = director.field(resp, "sessionId", "SessionId")
+    if not sid:
+        raise director.DirectorError("the Director did not return a session id when spawning.")
+    # Name it so the run is legible in cc-sessions; a rename failure is not fatal to the test.
+    try:
+        director.patch_json(f"sessions/{sid}", {"name": name})
+    except director.DirectorError:
+        pass
+    return sid
+
+
+def _fleet_ids() -> List[str]:
+    sessions = director.get_json("fleet/sessions") or []
+    return [director.field(s, "sessionId", "SessionId") for s in sessions]
+
+
+def _run(
+    timeout_ms: int = typer.Option(
+        25000, "--timeout-ms", help="How long the ask step waits for the responder."
+    ),
+    version: bool = typer.Option(
+        False, "--version", "-v", callback=_version_callback, is_eager=True, help="Show version."
+    ),
+) -> None:
+    """Run the fleet messaging self-test against the local Director and report PASS/FAIL."""
+    repo = tempfile.gettempdir()
+    results: List[Tuple[str, bool, str]] = []
+    responder: Optional[str] = None
+    recipient: Optional[str] = None
+
+    def record(step: str, ok: bool, detail: str = "") -> None:
+        results.append((step, ok, detail))
+        mark = "[green]PASS[/green]" if ok else "[red]FAIL[/red]"
+        console.print(f"  {mark}  {step}{('  - ' + detail) if detail else ''}")
+
+    try:
+        # 1. Spawn the two throwaway sessions: a responder (cmd with a marker prompt) and a recipient.
+        responder = _spawn(repo, f"/k prompt {MARKER}$G", "selftest-responder")
+        recipient = _spawn(repo, "/k", "selftest-recipient")
+        record("spawn two sessions", True, f"responder={director.short_id(responder)} recipient={director.short_id(recipient)}")
+        time.sleep(2)
+
+        # 2. List the fleet and assert both appear.
+        ids = _fleet_ids()
+        listed = responder in ids and recipient in ids
+        record("cc-sessions lists both", listed)
+
+        # 3. Send a message to the recipient and assert it was accepted for delivery.
+        send = director.post_json(
+            "fleet/send",
+            {"toSessionId": recipient, "text": "fleet self-test message", "fromSessionId": responder},
+        )
+        accepted = bool(isinstance(send, dict) and send.get("accepted", send.get("Accepted", False)))
+        record("cc-send delivers", accepted, str(director.field(send, "error", "Error") or ""))
+
+        # 4. Ask the responder and assert its known marker comes back.
+        ask = director.post_json(
+            "fleet/ask",
+            {"toSessionId": responder, "question": "selftest ping", "fromSessionId": recipient, "timeoutMs": timeout_ms},
+            timeout=timeout_ms / 1000.0 + 15.0,
+        )
+        answer = director.field(ask, "answer", "Answer") if isinstance(ask, dict) else ""
+        got_marker = MARKER in answer
+        record("cc-ask returns the answer", got_marker, "marker found" if got_marker else f"status={director.field(ask, 'status', 'Status')}")
+
+    except director.DirectorError as err:
+        record("fleet messaging reachable", False, str(err))
+    finally:
+        # 5. Tear the throwaway sessions down (best effort), then verify none leaked.
+        for sid in (responder, recipient):
+            if sid:
+                try:
+                    director.delete(f"sessions/{sid}")
+                except director.DirectorError:
+                    pass
+        try:
+            time.sleep(1)
+            remaining = _fleet_ids()
+            leaked = [s for s in (responder, recipient) if s and s in remaining]
+            record("throwaway sessions cleaned up", not leaked,
+                   "" if not leaked else f"leaked {len(leaked)}")
+        except director.DirectorError as err:
+            record("throwaway sessions cleaned up", False, str(err))
+
+    passed = sum(1 for _, ok, _ in results if ok)
+    total = len(results)
+    if passed == total and total > 0:
+        console.print(f"[green]PASS[/green] - fleet messaging self-test: {passed}/{total} checks passed.")
+        raise typer.Exit(0)
+    console.print(f"[red]FAIL[/red] - fleet messaging self-test: {passed}/{total} checks passed.")
+    raise typer.Exit(1)
+
+
+def app() -> None:
+    """Console-script entry point."""
+    typer.run(_run)
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/cc_shared/director.py
+++ b/tools/cc_shared/director.py
@@ -103,6 +103,10 @@ def patch_json(path: str, body: dict, timeout: float = 30) -> Any:
     return _request("PATCH", path, body, timeout=timeout)
 
 
+def delete(path: str, timeout: float = 30) -> Any:
+    return _request("DELETE", path, None, timeout=timeout)
+
+
 def field(dto: Dict[str, Any], *keys: str, default: str = "") -> str:
     """Read the first present key from a session DTO, tolerating camelCase or PascalCase."""
     for key in keys:

--- a/tools/registry.json
+++ b/tools/registry.json
@@ -338,6 +338,15 @@
       "requirements": []
     },
     {
+      "name": "cc-fleet-selftest",
+      "category": "fleet",
+      "type": "python",
+      "description": "End-to-end smoke test of fleet session messaging",
+      "built": true,
+      "ship": true,
+      "requirements": []
+    },
+    {
       "name": "cc-posthog",
       "category": "data-utilities",
       "type": "python",


### PR DESCRIPTION
Implements #722. `cc-fleet-selftest` spawns two throwaway sessions, lists them, sends, asks a deterministic marker responder, tears them down, prints PASS/FAIL. Shipped (registry ship:true) + doctor-verified + guarded. Build 0/0; proven live (green 5/5 exit 0; forced-failure exit 1; no leaked sessions).

Proof: docs/cencon/proof/issue-722/report.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)