### PR TITLE
feat(installer): ship a fleet-comms skill to every machine (#723)

### DIFF
--- a/.claude/skills/fleet-comms/SKILL.md
+++ b/.claude/skills/fleet-comms/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: fleet-comms
+description: Talk to other CC Director sessions across the fleet. Use when you want to list running sessions, message another session, ask another session a question and get its answer, or open a new session - from inside a session. Triggers on "/fleet-comms", "message another session", "talk to another session", "ask another session", "list sessions", "what sessions are running", "open a session", "spawn a session", "cc-send", "cc-ask", "cc-spawn", "cc-sessions", "fleet messaging", "session intercommunication".
+---
+
+# Fleet communication between sessions
+
+CC Director lets a session talk to other sessions running anywhere in the fleet (any machine whose
+Director is attached to the same Gateway). You do this with a small set of `cc-*` command-line tools
+that are already on your PATH inside a session. You never need the Gateway URL or any token - your own
+Director relays for you.
+
+Every session is launched with two environment values these tools rely on: `CC_DIRECTOR_API` (your
+own Director's address) and `CC_SESSION_ID` (your own id). The tools read them automatically.
+
+## The tools
+
+### See who is running - `cc-sessions`
+Lists every session in the fleet: a short id, name, machine, repository, and status. Your own session
+is marked `(you)`. This is how you discover who exists and find the id or name to address.
+
+```
+cc-sessions
+```
+
+### Know yourself - `cc-whoami`
+Prints your own short id, name, machine, and repository, plus a reminder of how to message others.
+
+```
+cc-whoami
+```
+
+### Send a one-way message - `cc-send`
+Send a message to one session (by short id prefix or name), or to every other session with `all`.
+The recipient sees a framed message naming you and how to reply.
+
+```
+cc-send 4c810000 "I finished the API layer - you can start the frontend."
+cc-send docs "Please update the API page when you get a chance."
+cc-send all "Heads up: I am about to merge to main in 5 minutes."
+```
+
+An ambiguous id prefix or name is refused with the list of candidates (nothing is sent).
+
+### Ask a question and get the answer back - `cc-ask`
+Ask one session a question and wait for its answer (the round-trip `cc-send` cannot do). Use this to
+query another session's already-loaded context, for example "what is the database schema in your
+repo?". Single target only.
+
+```
+cc-ask 9b2f "What database schema is loaded in your repo?"
+cc-ask docs "What is the title of the API page?" --timeout-ms 60000
+```
+
+If the target does not answer within the timeout, `cc-ask` prints a clear timeout and exits non-zero;
+an unknown or unreachable target exits non-zero with a clear error.
+
+### Open a new session - `cc-spawn`
+Open a session on your own Director and print its id, so you can immediately message or ask it.
+
+```
+cc-spawn D:\path\to\repo
+cc-spawn D:\path\to\repo --agent ClaudeCode --prompt "Run the tests and report failures."
+cc-spawn D:\path\to\repo --name "frontend" --agent RawCli --command cmd
+```
+
+### Prove it works - `cc-fleet-selftest`
+A one-command health check: it spawns two throwaway sessions, lists/sends/asks between them, tears
+them down, and prints PASS/FAIL. Run it if you suspect fleet messaging is not working on a machine.
+
+```
+cc-fleet-selftest
+```
+
+## How addressing works
+- The stable handle is the session's id; you can use a short unique prefix of it (for example
+  `9b2f`). An ambiguous prefix is refused with the candidates.
+- You can also address by name (the session's display name), which is resolved to an id; an
+  ambiguous name is refused.
+- `cc-send all` is the only broadcast; `cc-ask` is always single-target.
+
+## A typical flow
+1. `cc-sessions` to see who is running and get a target id or name.
+2. `cc-send <id> "..."` to hand off or notify, or `cc-ask <id> "..."` to query and get an answer.
+3. `cc-spawn <repo>` if you need a fresh session to delegate work to, then `cc-send` / `cc-ask` it.
+
+## Notes
+- These tools only message sessions; they never expose the Gateway token to your session - the
+  Director relays on your behalf.
+- A message is delivered into the recipient as a prompt, framed with your identity, so the recipient
+  knows who sent it and how to reply.

--- a/docs/cencon/proof/issue-723/qa-report.html
+++ b/docs/cencon/proof/issue-723/qa-report.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Issue #723 - QA</title>
+<style>body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;max-width:880px;margin:0 auto;padding:24px;color:#1f2933;line-height:1.55}h1{border-bottom:2px solid #15803d;padding-bottom:8px}pre{background:#0f172a;color:#e2e8f0;padding:14px 16px;border-radius:8px;overflow-x:auto;font-size:13px}table{border-collapse:collapse;width:100%;margin:14px 0;font-size:14px}th,td{border:1px solid #cbd5e1;padding:8px 10px;text-align:left}th{background:#1f2937;color:#fff}.pass{color:#15803d;font-weight:700}</style></head><body>
+<h1>Issue #723 - fleet-comms skill - QA Independent Verification</h1>
+<p><strong>Verdict: VERIFIED.</strong> Fresh detached checkout (28b1826), independent build + tests.</p>
+<table>
+<tr><th>Criterion</th><th>Result</th></tr>
+<tr><td>SKILL.md exists documenting the tools</td><td class="pass">PASS - valid frontmatter (name/description/triggers), covers cc-sessions/whoami/send/ask/spawn/selftest</td></tr>
+<tr><td>SkillInstaller list includes fleet-comms; test asserts it</td><td class="pass">PASS - SkillNames = cc-director, fleet-comms; SkillNames_IncludesFleetComms green</td></tr>
+<tr><td>Install lands skill + manifest; uninstall removes (post-merge)</td><td class="pass">PASS by construction - flows the existing install/manifest path; live landing post-merge per flagged assumption</td></tr>
+<tr><td>Guard prevents half-wiring</td><td class="pass">PASS - negative check: hiding the SKILL.md turned the guard RED; reverted</td></tr>
+</table>
+<pre>independent build 0/0
+FleetCommsSkillShipTests -> 2/2 (positive); 1 FAIL when SKILL.md hidden (negative), reverted clean</pre>
+<p>Standalone QA; merge performed per the human's authorization to run this chain merge-as-we-go.</p>
+</body></html>

--- a/docs/cencon/proof/issue-723/report.html
+++ b/docs/cencon/proof/issue-723/report.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Issue #723 - Developer Proof</title>
+<style>body{font-family:-apple-system,"Segoe UI",Roboto,Arial,sans-serif;max-width:900px;margin:0 auto;padding:24px;color:#1f2933;line-height:1.55}h1{border-bottom:2px solid #4f46e5;padding-bottom:8px}h2{margin-top:28px;border-bottom:1px solid #cbd5e1;padding-bottom:5px}pre{background:#0f172a;color:#e2e8f0;padding:14px 16px;border-radius:8px;overflow-x:auto;font-size:13px}table{border-collapse:collapse;width:100%;margin:14px 0;font-size:14px}th,td{border:1px solid #cbd5e1;padding:8px 10px;text-align:left}th{background:#1f2937;color:#fff}.pass{color:#15803d;font-weight:700}.note{background:#fffbeb;border:1px solid #fde68a;border-radius:8px;padding:12px 16px}code{background:#e7ebf0;padding:1px 5px;border-radius:4px}</style></head><body>
+<h1>Issue #723 - Ship a fleet-comms skill to every machine - Developer Proof</h1>
+<h2>What was implemented</h2>
+<ul>
+<li><code>.claude/skills/fleet-comms/SKILL.md</code> - a new skill documenting cc-sessions / cc-whoami / cc-send / cc-ask / cc-spawn / cc-fleet-selftest: when to use each, the addressing model, and the framed-message convention.</li>
+<li><code>tools/cc-director-setup/Services/SkillInstaller.cs</code> - added <code>fleet-comms</code> to <code>SkillNames</code>, so the installer fetches and installs it into <code>%USERPROFILE%\.claude\skills\fleet-comms\</code> on every install/update (and records it in the SkillManifest for clean uninstall, existing behavior).</li>
+<li><code>tools/cc-director-setup.Tests/FleetCommsSkillShipTests.cs</code> - guards that fleet-comms is in the shipped list AND that every shipped skill name has a SKILL.md in the repo.</li>
+</ul>
+<h2>Build and tests</h2>
+<pre>dotnet build cc-director.sln                       -> 0 Warning(s) 0 Error(s)
+FleetCommsSkillShipTests                           -> Passed! 2/2
+  - SkillNames_IncludesFleetComms
+  - EverySkillName_HasASkillMdInTheRepo</pre>
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+<tr><th>Criterion</th><th>Result</th><th>Evidence</th></tr>
+<tr><td>SKILL.md exists documenting the five+ tools</td><td class="pass">PASS</td><td>.claude/skills/fleet-comms/SKILL.md (cc-sessions/cc-whoami/cc-send/cc-ask/cc-spawn/cc-fleet-selftest, addressing, framing).</td></tr>
+<tr><td>SkillInstaller shipped list includes fleet-comms; a test asserts it</td><td class="pass">PASS</td><td>SkillNames now ["cc-director","fleet-comms"]; SkillNames_IncludesFleetComms green.</td></tr>
+<tr><td>Install lands the skill + manifest records it; uninstall removes it</td><td class="pass">PASS (by construction + post-merge)</td><td>InstallSkillsAsync iterates SkillNames and records each via SkillManifest (existing path); the per-skill SKILL.md exists (test). The actual HTTP fetch resolves once on the default branch - see note.</td></tr>
+<tr><td>Skill fetchable from the default-branch raw URL</td><td class="pass">PASS (post-merge)</td><td>The installer fetches raw.githubusercontent/.../&lt;default branch&gt;/.claude/skills/fleet-comms/SKILL.md; available after this PR merges.</td></tr>
+</table>
+<div class="note"><strong>Note (flagged in the issue, Assumption #1).</strong> SkillInstaller fetches each SKILL.md by name from the repo's default branch raw URL, so the live install-landing of fleet-comms only works after this PR is merged to the default branch. Pre-merge the wiring is fully verified (list + SKILL.md present + tests), and the install/uninstall path is the same one the existing cc-director skill already flows through.</div>
+<h2>CenCon impact</h2>
+<p>Additive: a new skill + one entry in the installer's shipped list + a guard test. No architecture/security drift.</p>
+<h2>Statement</h2>
+<p><strong>I believe this issue is finished.</strong> fleet-comms is a real skill teaching the intercommunication verbs, wired into the installer's shipped list, and guarded by a test so it cannot be half-wired. Build clean, tests green. Live install-landing is post-merge per the issue's own flagged assumption.</p>
+</body></html>

--- a/tools/cc-director-setup.Tests/FleetCommsSkillShipTests.cs
+++ b/tools/cc-director-setup.Tests/FleetCommsSkillShipTests.cs
@@ -1,0 +1,44 @@
+using System.IO;
+using System.Linq;
+using CcDirectorSetup.Services;
+using Xunit;
+
+namespace CcDirectorSetup.Tests;
+
+/// <summary>
+/// Deployment guard (issue #723): the fleet-comms skill must be in the installer's shipped list so it
+/// reaches every machine, and its SKILL.md must exist in the repo (the installer fetches it by name
+/// from the default branch). Together these fail if the skill is half-wired (listed but missing, or
+/// present but not shipped).
+/// </summary>
+public sealed class FleetCommsSkillShipTests
+{
+    [Fact]
+    public void SkillNames_IncludesFleetComms()
+    {
+        Assert.Contains("fleet-comms", SkillInstaller.SkillNames);
+    }
+
+    [Fact]
+    public void EverySkillName_HasASkillMdInTheRepo()
+    {
+        var skillsDir = FindRepoDir(Path.Combine(".claude", "skills"));
+        foreach (var name in SkillInstaller.SkillNames)
+        {
+            var path = Path.Combine(skillsDir, name, "SKILL.md");
+            Assert.True(File.Exists(path), $"{name}: SKILL.md is missing at {path}; the installer fetches it by name.");
+        }
+    }
+
+    private static string FindRepoDir(string relativePath)
+    {
+        var dir = new DirectoryInfo(System.AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, relativePath);
+            if (Directory.Exists(candidate)) return candidate;
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException($"Could not locate {relativePath} walking up from {System.AppContext.BaseDirectory}");
+    }
+}

--- a/tools/cc-director-setup/Services/SkillInstaller.cs
+++ b/tools/cc-director-setup/Services/SkillInstaller.cs
@@ -19,6 +19,10 @@ public sealed class SkillInstaller
     public static readonly string[] SkillNames =
     [
         "cc-director",
+        // fleet-comms (issue #723): teaches an agent the session-to-session messaging verbs
+        // (cc-sessions / cc-whoami / cc-send / cc-ask / cc-spawn) so every machine's agents know
+        // the capability, not just the CC_FLEET_TOOLS env hint.
+        "fleet-comms",
     ];
 
     private static readonly HttpClient Http = CreateClient();


### PR DESCRIPTION
Implements #723. Adds a fleet-comms skill (documents cc-sessions/cc-whoami/cc-send/cc-ask/cc-spawn/cc-fleet-selftest) and wires it into SkillInstaller.SkillNames so it installs on every machine. FleetCommsSkillShipTests guards the list + that every shipped skill has a SKILL.md. Build 0/0; tests 2/2. Live install-landing is post-merge (installer fetches SKILL.md from the default branch - flagged assumption).

Proof: docs/cencon/proof/issue-723/report.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)