### PR TITLE
fix(gateway-tests): BrainConfigEndpointTests independent of host-installed tools (un-red main)

### DIFF
--- a/src/CcDirector.Gateway.Tests/BrainConfigEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/BrainConfigEndpointTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json.Nodes;
+using CcDirector.Core.Agents;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Storage;
 using CcDirector.Gateway;
@@ -43,6 +44,25 @@ public sealed class BrainConfigEndpointTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        // Seed a deterministic registered agent into the isolated config so the brain block's agent
+        // list does not depend on whether Claude (or any tool) is actually installed on this host or
+        // the CI runner. First-run seeding only adds DETECTED tools (fix(agents): seed only detected
+        // tools on first run), so on a tool-less runner the list would otherwise be empty and these
+        // tests - which exercise the brain endpoint's agent surfacing and round-trip, not tool
+        // detection - would fail. Writing agent.entries up front makes LoadEntries read it rather than
+        // probe the host. This is also why the failure only showed on CI: a developer machine with
+        // Claude installed seeds a Claude entry and the tests pass, masking the host dependency.
+        AgentEntryStore.SaveEntries(new[]
+        {
+            new AgentEntry
+            {
+                DisplayName = "Claude Code",
+                Type = AgentKind.ClaudeCode,
+                Enabled = true,
+                ExecutablePath = "claude",
+            },
+        });
+
         _gateway = new GatewayHost(port: AllocateFreePort(), token: "test-token-12345", authEnabled: true,
             instancesDirectory: _instancesDir,
             workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));


### PR DESCRIPTION
## Fix: BrainConfigEndpointTests fail on CI (main has been red)

`main` has been red for many commits on three Gateway tests, all unrelated to any recent
feature:
- `BrainConfigEndpointTests.GatewaySettings_brain_block_carries_tool_agents_and_model_defaults`
- `BrainConfigEndpointTests.Put_brain_config_by_agent_id_persists_and_round_trips`
- `BrainConfigEndpointTests.Put_brain_config_preserves_unrelated_config_sections`

### Root cause
Commit `6a26716` (`fix(agents): seed only detected tools on first run`) made first-run agent
seeding skip any tool that is not actually installed. The brain endpoint's agent list comes from
that seed, so on a runner with no agent tool installed the list is empty. These tests assumed a
Claude Code entry is always seeded, so they passed on developer machines (Claude installed) and
failed on continuous integration runners (no Claude) - which is why the breakage only showed in CI.

### Fix
Seed a deterministic Claude Code agent entry into the isolated config during test setup, so the
tests exercise the brain endpoint's agent surfacing and round-trip without depending on the host's
installed tools. No production change - the seed-only-detected behaviour is intended; the tests
were simply relying on the old always-seed behaviour. The full `BrainConfigEndpointTests` class
passes locally.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
