### PR TITLE
fix(history): bottom-anchored list, always-visible scrollbar, measurement-safe links (#744, #745)

### DIFF
--- a/src/CcDirector.Avalonia/Controls/HistoryView.axaml
+++ b/src/CcDirector.Avalonia/Controls/HistoryView.axaml
@@ -22,26 +22,31 @@
             </StackPanel>
         </Border>
 
-        <!-- thread -->
+        <!-- thread. Scrollbar is always visible (like the terminal). The list is anchored to the
+             bottom: the host Grid fills at least the viewport height and the ItemsControl bottom-
+             aligns inside it, so the newest bubble always sits at the bottom (just above the input)
+             and a height miscalculation can only ever affect the oldest content at the top. -->
         <ScrollViewer x:Name="Scroller" Grid.Row="1"
-                      VerticalScrollBarVisibility="Auto"
+                      VerticalScrollBarVisibility="Visible"
                       HorizontalScrollBarVisibility="Disabled"
-                      Padding="10">
-            <ItemsControl x:Name="Items">
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate DataType="controls:HistoryMessageVm">
-                        <Border Background="{Binding CardBrush}" BorderBrush="#3C3C3C" BorderThickness="1"
-                                CornerRadius="8" Padding="12,9" Margin="0,0,0,8">
-                            <StackPanel Spacing="4">
-                                <TextBlock Text="{Binding Speaker}" Foreground="{Binding HeaderBrush}"
-                                           FontSize="11" FontWeight="Bold" />
-                                <controls:MarkdownTextBlock Markdown="{Binding Body}" Plain="{Binding IsRawText}"
-                                                            LinkContext="{Binding LinkContext}" />
-                            </StackPanel>
-                        </Border>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
+                      Padding="10,0">
+            <Grid MinHeight="{Binding #Scroller.Viewport.Height}">
+                <ItemsControl x:Name="Items" VerticalAlignment="Bottom" Margin="0,8">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate DataType="controls:HistoryMessageVm">
+                            <Border Background="{Binding CardBrush}" BorderBrush="#3C3C3C" BorderThickness="1"
+                                    CornerRadius="8" Padding="12,9" Margin="0,0,0,8">
+                                <StackPanel Spacing="4">
+                                    <TextBlock Text="{Binding Speaker}" Foreground="{Binding HeaderBrush}"
+                                               FontSize="11" FontWeight="Bold" />
+                                    <controls:MarkdownTextBlock Markdown="{Binding Body}" Plain="{Binding IsRawText}"
+                                                                LinkContext="{Binding LinkContext}" />
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </Grid>
         </ScrollViewer>
 
         <!-- empty state -->

--- a/src/CcDirector.Avalonia/Controls/HistoryView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/HistoryView.axaml.cs
@@ -66,6 +66,10 @@ public partial class HistoryView : UserControl
     private Session? _session;
     private string _lastSignature = "";
 
+    // Whether the History tab is the visible tab (#744). MainWindow drives this via OnShown/OnHidden
+    // so the poll timer only runs while the tab is on screen.
+    private bool _isShown;
+
     // Shared per-session link context for clickable paths/URLs in bubbles (#735). Built on Attach
     // because its inputs (the repo path and the routing callbacks) are stable for a session.
     private MarkdownRenderContext? _linkContext;
@@ -100,17 +104,16 @@ public partial class HistoryView : UserControl
             OnBrowserError = message => BrowserLaunchFailed?.Invoke(message),
         };
         FileLog.Write($"[HistoryView] Attach: session={session.Id} agent={session.AgentKind} transcript={session.ClaudeTranscriptPath ?? "(null)"}");
-        _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(2.5) };
-        _timer.Tick += async (_, _) => await RefreshAsync();
-        _timer.Start();
-        _ = RefreshAsync();
+        // Poll only while the History tab is the visible tab (#744). If it is hidden now, polling
+        // starts when MainWindow calls OnShown().
+        if (_isShown)
+            StartPolling();
     }
 
     /// <summary>Stop polling and clear the view.</summary>
     public void Detach()
     {
-        _timer?.Stop();
-        _timer = null;
+        StopPolling();
         _session = null;
         _linkContext = null;
         _lastSignature = "";
@@ -121,6 +124,43 @@ public partial class HistoryView : UserControl
         EmptyText.IsVisible = true;
         EmptyText.Text = "No messages yet.";
         HistoryStatePill.IsVisible = false;
+    }
+
+    /// <summary>Start the 2.5s poll timer (idempotent) and refresh once immediately.</summary>
+    private void StartPolling()
+    {
+        if (_timer != null || _session is null)
+            return;
+        _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(2.5) };
+        _timer.Tick += async (_, _) => await RefreshAsync();
+        _timer.Start();
+        _ = RefreshAsync();
+    }
+
+    /// <summary>Stop the poll timer (the session binding is left intact).</summary>
+    private void StopPolling()
+    {
+        _timer?.Stop();
+        _timer = null;
+    }
+
+    /// <summary>
+    /// Called by MainWindow when the History tab becomes the visible tab (#744). Resume polling (an
+    /// immediate refresh runs) and snap to the latest message. Gating on visibility avoids parsing
+    /// and rendering off-screen and avoids computing scroll geometry against a zero-size viewport.
+    /// </summary>
+    public void OnShown()
+    {
+        _isShown = true;
+        StartPolling();
+        ScrollToEndDeferred();
+    }
+
+    /// <summary>Called by MainWindow when the History tab is hidden (#744): stop polling.</summary>
+    public void OnHidden()
+    {
+        _isShown = false;
+        StopPolling();
     }
 
     private async Task RefreshAsync()
@@ -170,16 +210,20 @@ public partial class HistoryView : UserControl
             var vms = Map(history, _linkContext);
             FileLog.Write($"[HistoryView] refresh: path={path} messages={history.Messages.Count} vms={vms.Count}");
 
+            // Was the user parked at the bottom before this update? (Decide before changing the list.)
             var atBottom = IsNearBottom();
-            _messages.Clear();
-            foreach (var vm in vms)
-                _messages.Add(vm);
+
+            // Incremental render (#745): keep the common leading bubbles, append only what is new -
+            // existing bubbles are not re-created, so a scrolled-up reader keeps their position.
+            Reconcile(vms);
 
             CountText.Text = vms.Count == 0 ? "" : $"{vms.Count} messages";
             EmptyText.IsVisible = vms.Count == 0;
             if (vms.Count == 0)
                 EmptyText.Text = "No messages yet.";
 
+            // Keep the newest message in view if the user was already at the bottom (#744). The list
+            // is bottom-anchored, so a short conversation is always pinned without any scrolling.
             if (atBottom)
                 ScrollToEndDeferred();
         }
@@ -289,23 +333,26 @@ public partial class HistoryView : UserControl
             : "... [earlier terminal output trimmed]\n" + fullBody.Substring(fullBody.Length - GeminiBodyMaxChars);
         FileLog.Write($"[HistoryView] gemini refresh: bytes={buffer.TotalBytesWritten} bodyLen={body.Length} (full={fullBody.Length})");
 
-        var atBottom = IsNearBottom();
-        _messages.Clear();
         if (body.Length == 0)
         {
+            _messages.Clear();
             CountText.Text = "";
             EmptyText.IsVisible = true;
             EmptyText.Text = "Waiting for the conversation to start...";
             return;
         }
 
-        _messages.Add(new HistoryMessageVm
+        var atBottom = IsNearBottom();
+        Reconcile(new List<HistoryMessageVm>
         {
-            Speaker = GeminiTerminalHistory.Label,
-            Body = body,
-            HeaderBrush = ToolHeader,
-            CardBrush = ToolCard,
-            IsRawText = true,
+            new HistoryMessageVm
+            {
+                Speaker = GeminiTerminalHistory.Label,
+                Body = body,
+                HeaderBrush = ToolHeader,
+                CardBrush = ToolCard,
+                IsRawText = true,
+            },
         });
         CountText.Text = "raw terminal text";
         EmptyText.IsVisible = false;
@@ -313,6 +360,31 @@ public partial class HistoryView : UserControl
         if (atBottom)
             ScrollToEndDeferred();
     }
+
+    /// <summary>
+    /// Incrementally reconcile the rendered list with the latest view-models (#745). Keeps the common
+    /// leading run untouched (so existing bubbles are not re-created and a scrolled-up reader's
+    /// position is preserved), removes any diverging tail, then appends the new messages. A handover
+    /// that replaces the conversation (e.g. Claude /clear, which repoints the transcript) shares no
+    /// prefix, so it naturally rebuilds from scratch.
+    /// </summary>
+    private void Reconcile(List<HistoryMessageVm> newVms)
+    {
+        int prefix = 0;
+        int min = Math.Min(_messages.Count, newVms.Count);
+        while (prefix < min && SameVm(_messages[prefix], newVms[prefix]))
+            prefix++;
+
+        for (int i = _messages.Count - 1; i >= prefix; i--)
+            _messages.RemoveAt(i);
+        for (int i = prefix; i < newVms.Count; i++)
+            _messages.Add(newVms[i]);
+    }
+
+    // Two rendered messages are the same bubble when their visible content matches; LinkContext is
+    // per-session (identical across bubbles) so it is intentionally not compared.
+    private static bool SameVm(HistoryMessageVm a, HistoryMessageVm b)
+        => a.Speaker == b.Speaker && a.IsRawText == b.IsRawText && a.Body == b.Body;
 
     private static List<HistoryMessageVm> Map(ConversationHistory history, MarkdownRenderContext? linkContext)
     {
@@ -402,16 +474,17 @@ public partial class HistoryView : UserControl
     private static string Truncate(string text, int max)
         => text.Length <= max ? text : text.Substring(0, max) + " ...";
 
+    /// <summary>True when the user is parked at (or within a line of) the bottom of the thread, or
+    /// the content is short enough that there is nothing to scroll.</summary>
     private bool IsNearBottom()
     {
         var max = Scroller.Extent.Height - Scroller.Viewport.Height;
         return max <= 0 || Scroller.Offset.Y >= max - 60;
     }
 
+    /// <summary>Scroll to the newest message after the pending layout pass. With the bottom-anchored
+    /// layout a short conversation is already pinned to the bottom; this handles the case where the
+    /// thread is taller than the viewport and a new message has been appended.</summary>
     private void ScrollToEndDeferred()
-    {
-        Dispatcher.UIThread.Post(
-            () => Scroller.Offset = new Vector(0, Scroller.Extent.Height),
-            DispatcherPriority.Background);
-    }
+        => Dispatcher.UIThread.Post(() => Scroller.ScrollToEnd(), DispatcherPriority.Background);
 }

--- a/src/CcDirector.Avalonia/Helpers/MarkdownRenderer.cs
+++ b/src/CcDirector.Avalonia/Helpers/MarkdownRenderer.cs
@@ -5,7 +5,6 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Documents;
 using Avalonia.Input;
-using Avalonia.Layout;
 using Avalonia.Media;
 using CcDirector.Core.Utilities;
 using CcDirector.Terminal.Avalonia;
@@ -19,8 +18,9 @@ namespace CcDirector.Avalonia.Helpers;
 /// <summary>
 /// Optional context that turns file paths and URLs inside rendered Markdown into clickable links
 /// (GitHub #735). When supplied, literal text is scanned with <see cref="LinkDetector"/> and each
-/// match becomes a clickable inline that opens the shared <see cref="LinkContextMenuBuilder"/> menu -
-/// the same actions the terminal offers. When null, text is rendered as plain runs (markdown only).
+/// match is drawn as styled (underlined) text whose clicks open the shared
+/// <see cref="LinkContextMenuBuilder"/> menu - the same actions the terminal offers. When null, text
+/// is rendered as plain runs (markdown only).
 /// </summary>
 public sealed class MarkdownRenderContext
 {
@@ -38,12 +38,19 @@ public sealed class MarkdownRenderContext
     public Action<string>? OnBrowserError { get; init; }
 }
 
+/// <summary>One clickable link inside a rendered text block, identified by its character range in
+/// the block's flattened text so a click can be resolved by hit-testing (GitHub #735).</summary>
+internal sealed record LinkSpan(int Start, int Length, string Link, LinkDetector.LinkType Type);
+
 /// <summary>
 /// Renders a Markdown string into a native Avalonia control tree (GitHub #734). Unlike
 /// <see cref="MarkdownHtmlRenderer"/> (which produces HTML for a WebView2), this builds plain
-/// Avalonia controls so it is cheap enough to use once per History bubble and so individual text
-/// runs can be made clickable (GitHub #735). It reuses the same Markdig parser the rest of the app
-/// already depends on - no second Markdown library is introduced.
+/// Avalonia controls so it is cheap enough to use once per History bubble. Links (GitHub #735) are
+/// drawn as ordinary styled text - never embedded controls - so the text measures its height
+/// correctly; clicks are resolved by hit-testing the pointer against the text layout (the same
+/// technique the terminal uses), which keeps the scroll container's content height accurate.
+/// It reuses the same Markdig parser the rest of the app already depends on - no second Markdown
+/// library is introduced.
 ///
 /// The supported subset matches what agent output actually uses: headings, paragraphs, bold /
 /// italic / inline code, fenced and indented code blocks, ordered and unordered lists, block
@@ -152,7 +159,7 @@ public static class MarkdownRenderer
             _ => BaseFontSize * 1.02,
         };
 
-        var tb = new TextBlock
+        var tb = new LinkTextBlock
         {
             TextWrapping = TextWrapping.Wrap,
             FontSize = size,
@@ -161,20 +168,20 @@ public static class MarkdownRenderer
             Margin = new Thickness(0, 2, 0, 0),
         };
         if (heading.Inline != null)
-            AppendInlines(heading.Inline, tb.Inlines!, BaseFontSize, ctx);
+            BuildInlines(heading.Inline, tb, BaseFontSize, ctx);
         return tb;
     }
 
     private static Control RenderParagraph(ParagraphBlock paragraph, double baseSize, MarkdownRenderContext? ctx)
     {
-        var tb = new TextBlock
+        var tb = new LinkTextBlock
         {
             TextWrapping = TextWrapping.Wrap,
             FontSize = baseSize,
             Foreground = BodyBrush,
         };
         if (paragraph.Inline != null)
-            AppendInlines(paragraph.Inline, tb.Inlines!, baseSize, ctx);
+            BuildInlines(paragraph.Inline, tb, baseSize, ctx);
         return tb;
     }
 
@@ -279,20 +286,24 @@ public static class MarkdownRenderer
 
     // ---- inline rendering ----
 
-    private static void AppendInlines(ContainerInline container, InlineCollection target, double baseSize,
+    /// <summary>Build the inline runs for a block into <paramref name="tb"/>, collecting clickable
+    /// link ranges, then wire the block for click/hover hit-testing if it has any links.</summary>
+    private static void BuildInlines(ContainerInline container, LinkTextBlock tb, double baseSize,
         MarkdownRenderContext? ctx)
     {
+        var build = new InlineBuild(tb.Inlines!, baseSize, ctx);
         foreach (var inline in container)
-            AppendInline(inline, target, baseSize, FontWeight.Normal, FontStyle.Normal, ctx);
+            AppendInline(inline, FontWeight.Normal, FontStyle.Normal, build);
+        if (ctx != null && build.Links.Count > 0)
+            tb.SetLinks(build.Links, ctx);
     }
 
-    private static void AppendInline(MdInline inline, InlineCollection target, double baseSize,
-        FontWeight weight, FontStyle style, MarkdownRenderContext? ctx)
+    private static void AppendInline(MdInline inline, FontWeight weight, FontStyle style, InlineBuild build)
     {
         switch (inline)
         {
             case LiteralInline literal:
-                AppendText(literal.Content.ToString(), target, baseSize, weight, style, ctx);
+                AppendText(literal.Content.ToString(), weight, style, build);
                 break;
 
             case EmphasisInline emphasis:
@@ -301,86 +312,81 @@ public static class MarkdownRenderer
                 var w = emphasis.DelimiterCount >= 2 ? FontWeight.Bold : weight;
                 var s = emphasis.DelimiterCount == 1 ? FontStyle.Italic : style;
                 foreach (var child in emphasis)
-                    AppendInline(child, target, baseSize, w, s, ctx);
+                    AppendInline(child, w, s, build);
                 break;
             }
 
             case CodeInline code:
-            {
-                var run = new Run(code.Content)
+                AddRun(build, new Run(code.Content)
                 {
                     FontFamily = Mono,
-                    FontSize = baseSize - 0.5,
+                    FontSize = build.BaseSize - 0.5,
                     Background = InlineCodeBg,
                     Foreground = BodyBrush,
-                };
-                target.Add(run);
+                }, code.Content.Length);
                 break;
-            }
 
             case LineBreakInline:
-                target.Add(new LineBreak());
+                build.Target.Add(new LineBreak());
+                build.CharPos += 1; // a hard line break counts as one character in the text layout
                 break;
 
             case LinkInline link when !link.IsImage:
             {
                 var label = LinkLabel(link);
                 var url = link.Url ?? string.Empty;
-                if (ctx != null && url.Length > 0)
+                if (build.Ctx != null && url.Length > 0)
                 {
                     var type = url.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
                             || url.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
                         ? LinkDetector.LinkType.Url
                         : LinkDetector.LinkType.Path;
-                    target.Add(ClickableLink(label, url, type, baseSize, weight, style, ctx));
+                    AppendLink(label, url, type, weight, style, build);
                 }
                 else
                 {
-                    target.Add(new Run(label) { Foreground = LinkBrush, FontWeight = weight, FontStyle = style });
+                    AddRun(build, new Run(label) { Foreground = LinkBrush, FontWeight = weight, FontStyle = style }, label.Length);
                 }
                 break;
             }
 
             case AutolinkInline auto:
-            {
-                if (ctx != null)
-                    target.Add(ClickableLink(auto.Url, auto.Url, LinkDetector.LinkType.Url, baseSize, weight, style, ctx));
+                if (build.Ctx != null)
+                    AppendLink(auto.Url, auto.Url, LinkDetector.LinkType.Url, weight, style, build);
                 else
-                    target.Add(new Run(auto.Url) { Foreground = LinkBrush });
+                    AddRun(build, new Run(auto.Url) { Foreground = LinkBrush }, auto.Url.Length);
                 break;
-            }
 
             case ContainerInline nested:
                 foreach (var child in nested)
-                    AppendInline(child, target, baseSize, weight, style, ctx);
+                    AppendInline(child, weight, style, build);
                 break;
 
             default:
                 // Unknown inline: emit its plain text if it has any.
                 var text = inline.ToString();
                 if (!string.IsNullOrEmpty(text))
-                    AppendText(text, target, baseSize, weight, style, ctx);
+                    AppendText(text, weight, style, build);
                 break;
         }
     }
 
     /// <summary>
-    /// Append a plain text run, OR - when a link context is present - scan the text for file paths
-    /// and URLs (via <see cref="LinkDetector"/>) and split it into plain runs plus clickable links.
+    /// Append plain text. When a link context is present, scan it for file paths and URLs (via
+    /// <see cref="LinkDetector"/>) and split it into plain runs plus styled clickable-link runs.
     /// </summary>
-    private static void AppendText(string text, InlineCollection target, double baseSize,
-        FontWeight weight, FontStyle style, MarkdownRenderContext? ctx)
+    private static void AppendText(string text, FontWeight weight, FontStyle style, InlineBuild build)
     {
-        if (ctx == null || string.IsNullOrEmpty(text))
+        if (build.Ctx == null || string.IsNullOrEmpty(text))
         {
-            target.Add(StyledRun(text, baseSize, weight, style));
+            AddRun(build, StyledRun(text, build.BaseSize, weight, style), text.Length);
             return;
         }
 
         List<LinkDetector.LinkMatch> matches;
         try
         {
-            matches = LinkDetector.FindAllLinkMatches(text, ctx.RepoPath, ctx.PathExists);
+            matches = LinkDetector.FindAllLinkMatches(text, build.Ctx.RepoPath, build.Ctx.PathExists);
         }
         catch
         {
@@ -389,7 +395,7 @@ public static class MarkdownRenderer
 
         if (matches.Count == 0)
         {
-            target.Add(StyledRun(text, baseSize, weight, style));
+            AddRun(build, StyledRun(text, build.BaseSize, weight, style), text.Length);
             return;
         }
 
@@ -401,58 +407,35 @@ public static class MarkdownRenderer
             if (m.StartCol < pos || m.EndCol > text.Length || m.EndCol <= m.StartCol)
                 continue; // overlap or out-of-range guard
             if (m.StartCol > pos)
-                target.Add(StyledRun(text.Substring(pos, m.StartCol - pos), baseSize, weight, style));
-            target.Add(ClickableLink(m.Text, m.Text, m.Type, baseSize, weight, style, ctx));
+                AddRun(build, StyledRun(text.Substring(pos, m.StartCol - pos), build.BaseSize, weight, style), m.StartCol - pos);
+            AppendLink(m.Text, m.Text, m.Type, weight, style, build);
             pos = m.EndCol;
         }
         if (pos < text.Length)
-            target.Add(StyledRun(text.Substring(pos), baseSize, weight, style));
+            AddRun(build, StyledRun(text.Substring(pos), build.BaseSize, weight, style), text.Length - pos);
     }
 
-    /// <summary>
-    /// Build a clickable link inline: underlined blue text with a hand cursor that, on left click,
-    /// opens the shared terminal-equivalent context menu for the link.
-    /// </summary>
-    private static MdInlineHost ClickableLink(string display, string link, LinkDetector.LinkType type,
-        double baseSize, FontWeight weight, FontStyle style, MarkdownRenderContext ctx)
+    /// <summary>Add a styled (underlined, blue) link run and record its character range so a click
+    /// over it can be resolved by hit-testing.</summary>
+    private static void AppendLink(string display, string link, LinkDetector.LinkType type,
+        FontWeight weight, FontStyle style, InlineBuild build)
     {
-        var tb = new TextBlock
+        build.Links.Add(new LinkSpan(build.CharPos, display.Length, link, type));
+        AddRun(build, new Run(display)
         {
-            Text = display,
             Foreground = LinkBrush,
-            TextDecorations = TextDecorations.Underline,
-            Cursor = new Cursor(StandardCursorType.Hand),
             FontWeight = weight,
             FontStyle = style,
-            FontSize = baseSize,
-            VerticalAlignment = VerticalAlignment.Center,
-        };
+            FontSize = build.BaseSize,
+            TextDecorations = TextDecorations.Underline,
+        }, display.Length);
+    }
 
-        void Open(Control owner)
-        {
-            var menu = LinkContextMenuBuilder.Build(new LinkMenuContext
-            {
-                Link = link,
-                Type = type,
-                RepoPath = ctx.RepoPath,
-                Owner = owner,
-                OnViewFile = ctx.OnViewFile,
-                OnBrowserError = ctx.OnBrowserError,
-            });
-            menu.Open(owner);
-        }
-
-        tb.PointerPressed += (_, e) =>
-        {
-            // Left click opens the menu (mirrors the terminal); also handle right click for parity.
-            var props = e.GetCurrentPoint(tb).Properties;
-            if (!props.IsLeftButtonPressed && !props.IsRightButtonPressed)
-                return;
-            e.Handled = true;
-            Open(tb);
-        };
-
-        return new MdInlineHost(tb);
+    /// <summary>Add a run to the block and advance the character cursor that link ranges index into.</summary>
+    private static void AddRun(InlineBuild build, Run run, int length)
+    {
+        build.Target.Add(run);
+        build.CharPos += length;
     }
 
     private static Run StyledRun(string text, double size, FontWeight weight, FontStyle style)
@@ -484,16 +467,97 @@ public static class MarkdownRenderer
         }
         return sb.ToString();
     }
+
+    /// <summary>Mutable state threaded through inline building: the target inline collection, the
+    /// running character offset (for link ranges), and the collected link spans.</summary>
+    private sealed class InlineBuild
+    {
+        public InlineBuild(InlineCollection target, double baseSize, MarkdownRenderContext? ctx)
+        {
+            Target = target;
+            BaseSize = baseSize;
+            Ctx = ctx;
+        }
+
+        public InlineCollection Target { get; }
+        public double BaseSize { get; }
+        public MarkdownRenderContext? Ctx { get; }
+        public int CharPos { get; set; }
+        public List<LinkSpan> Links { get; } = new();
+    }
 }
 
 /// <summary>
-/// An <see cref="InlineUIContainer"/> that hosts a clickable link control inside flowing text.
-/// A thin named subclass keeps the call sites readable and the baseline alignment in one place.
+/// A <see cref="TextBlock"/> whose links are ordinary styled text (so the block measures its height
+/// correctly) and become clickable by hit-testing the pointer against the text layout (GitHub #735).
+/// This is the measurement-safe alternative to embedding a control per link, and mirrors how the
+/// terminal resolves link clicks by position.
 /// </summary>
-internal sealed class MdInlineHost : InlineUIContainer
+internal sealed class LinkTextBlock : TextBlock
 {
-    public MdInlineHost(Control child) : base(child)
+    private static readonly Cursor HandCursor = new(StandardCursorType.Hand);
+
+    private List<LinkSpan>? _links;
+    private MarkdownRenderContext? _ctx;
+
+    public void SetLinks(List<LinkSpan> links, MarkdownRenderContext ctx)
     {
-        BaselineAlignment = BaselineAlignment.TextBottom;
+        _links = links;
+        _ctx = ctx;
+    }
+
+    private LinkSpan? HitTest(Point point)
+    {
+        if (_links is null)
+            return null;
+        var layout = TextLayout;
+        if (layout is null)
+            return null;
+
+        var hit = layout.HitTestPoint(point);
+        if (!hit.IsInside)
+            return null;
+
+        var pos = hit.TextPosition;
+        foreach (var span in _links)
+        {
+            if (pos >= span.Start && pos < span.Start + span.Length)
+                return span;
+        }
+        return null;
+    }
+
+    protected override void OnPointerMoved(PointerEventArgs e)
+    {
+        base.OnPointerMoved(e);
+        // Hand cursor over a link, default elsewhere - the same affordance the terminal gives.
+        Cursor = HitTest(e.GetPosition(this)) is not null ? HandCursor : null;
+    }
+
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
+    {
+        base.OnPointerPressed(e);
+        if (_ctx is null)
+            return;
+
+        var props = e.GetCurrentPoint(this).Properties;
+        if (!props.IsLeftButtonPressed && !props.IsRightButtonPressed)
+            return;
+
+        var span = HitTest(e.GetPosition(this));
+        if (span is null)
+            return;
+
+        e.Handled = true;
+        var menu = LinkContextMenuBuilder.Build(new LinkMenuContext
+        {
+            Link = span.Link,
+            Type = span.Type,
+            RepoPath = _ctx.RepoPath,
+            Owner = this,
+            OnViewFile = _ctx.OnViewFile,
+            OnBrowserError = _ctx.OnBrowserError,
+        });
+        menu.Open(this);
     }
 }

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -4252,6 +4252,7 @@ public partial class MainWindow : Window
     private void SwitchLeftTab(string tab)
     {
         if (_activeLeftTab == tab) return;
+        var previousTab = _activeLeftTab;
         _activeLeftTab = tab;
         FileLog.Write($"[MainWindow] SwitchLeftTab: {tab}");
 
@@ -4283,6 +4284,13 @@ public partial class MainWindow : Window
         WingmanPanel.IsVisible = tab == "Wingman";
         HistoryPanel.IsVisible = tab == "History";
         DocumentPanel.IsVisible = isDocTab;
+
+        // Gate the History tab's polling + auto-scroll on its visibility (#744): it only follows the
+        // conversation while it is the visible tab, and snaps to the latest message on activation.
+        if (tab == "History")
+            HistoryView.OnShown();
+        else if (previousTab == "History")
+            HistoryView.OnHidden();
 
         // The shared prompt bar belongs to the terminal-style tabs. The Voice and
         // Wingman tabs have their own input affordances (push-to-talk buttons / a


### PR DESCRIPTION
Fixes the History tab: the newest message was clipped at the bottom and the view did not stay scrolled to the latest turn.

## Root cause
Clickable links were embedded in the text flow as `InlineUIContainer` controls, which breaks Avalonia's text-height measurement. Each bubble under-reported its height, so the scroll container thought the conversation was shorter than it was, showed no scrollbar, and let the newest content overflow and clip. The scroll code was never the real problem.

## Fixes
- **Measurement-safe links:** links are now ordinary styled (underlined) text; clicks are resolved by hit-testing the pointer against the text layout (the technique the terminal uses), via a small `LinkTextBlock`. No controls embedded in the text flow, so bubbles measure correctly. The menu is still the shared `LinkContextMenuBuilder`, so actions match the terminal.
- **Bottom-anchored list:** the bubble area fills at least the viewport and bottom-aligns, so the newest bubble is always pinned at the bottom and a height miscalculation can only ever affect the oldest content at the top.
- **Scrollbar always visible**, matching the terminal.
- **Incremental rendering (#745):** reconcile keeps the common leading bubbles and appends only new ones, preserving a scrolled-up reader's position and avoiding full re-render of long threads.
- **Polling gated on tab visibility (#744):** the 2.5s poll runs only while the History tab is shown; the tab snaps to the latest on activation.
- Removed the earlier over-engineered sticky-follow logic; the only rule now is "if you were at the bottom, stay at the bottom."

Closes #744
Closes #745

## Verification
Live on a slot-5 test Director: a long markdown reply shows its final line fully (no cut-off), and a new turn that pushes the thread past one screen follows to the newest message with the final line fully visible. Markdown formatting and styled links render correctly; the live link-click was implemented but not auto-clicked in CI due to desktop foreground contention (resolve via the shared terminal menu code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
