### PR TITLE
Enforce transcription integrity: dictionary correction only, never model rewrite

### DIFF
--- a/docs/CodingStyle.md
+++ b/docs/CodingStyle.md
@@ -812,6 +812,40 @@ await Task.Delay(500);
 | Regex | Always set timeout | `TimeSpan.FromMilliseconds(50)` |
 | Brushes | Freeze for cross-thread | `brush.Freeze()` |
 | Collections | Snapshot before iterating across threads | `.ToList()` |
+| Transcription | Model may only LOCATE words; only `TranscriptEditEngine` may change them | Never round-trip a transcript through a model that returns free text |
+
+---
+
+## 16. Transcription integrity - CRITICAL
+
+**When a user dictates by voice, the speech-to-text result is the user's words and is the source of truth. It must never be rewritten by a language model.**
+
+This is an absolute, load-bearing rule (it traces to a real corruption incident, issue #190). It has regressed before, so it is written here, enforced by an architecture test, and called out in the one engine allowed to touch the words.
+
+### The rule
+
+1. The raw speech-to-text transcript is the user's words. The ONLY permitted change to it is replacing a misheard term with the correct **dictionary** spelling of a term the user actually said (a single word, or a tightly-joined multi-word term like `cc-director`).
+
+2. A language model may be used ONLY to **locate** which spans are misheard dictionary terms, and it must return that judgment as a **JSON list of find/replace proposals** - never the transcript text itself.
+
+3. Only deterministic code - `CcDirector.Core.Dictation.TranscriptEditEngine`, driven by `CleanupOrchestrator` - may change the words, and only by applying a validated proposal (the `find` must occur verbatim in the raw transcript, the `replace` must be an exact dictionary term, and it must be a plausible mishearing). Everything else fails open to the raw transcript.
+
+4. A transcript with no dictionary hit must come back **byte-identical**.
+
+### Forbidden
+
+- Sending the user's transcript to a chat/completions (or any text-generating) model and using the returned text as the user's words. No rephrasing, reordering, summarizing, grammar-fixing, "cleanup", expansion, or answering.
+- Adding a second, divergent cleanup path. `TranscriptEditEngine` is the single chokepoint; route every surface through `BatchTranscriptionPipeline` / `CleanupOrchestrator`.
+- Mutating transcript content in front-end JavaScript beyond pure display (trivial whitespace trimming and single-space segment joining are the only allowed touches).
+
+### Allowed (different feature, do not confuse)
+
+In voice-**conversation** mode, summarizing the **agent's reply** for text-to-speech playback is fine. The rule protects the **user's** spoken words on their way IN; it does not constrain how the agent's response is spoken back OUT.
+
+### Enforcement
+
+- The invariant is restated at the top of `TranscriptEditEngine`.
+- An architecture test fails the build if any transcription path sends the user's transcript into a text-returning model, and byte-identical regression tests guard every surface.
 
 ---
 

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -2481,10 +2481,11 @@ public partial class MainWindow : Window
     private async void BtnSpeak_Click(object? sender, RoutedEventArgs e)
     {
         // In-process dictation. Opens SpeakDialog which captures audio via
-        // NAudio, runs it through the dictation library (OpenAiRealtimeProvider
-        // + CleanupOrchestrator) all in this same process, then returns the
-        // cleaned transcript which we insert into PromptInput. No browser, no
-        // localhost roundtrip.
+        // NAudio (BatchDictationRecorder), runs it through the shared
+        // BatchTranscriptionPipeline (one batch transcription, then the validated
+        // dictionary find/replace in CleanupOrchestrator/TranscriptEditEngine -
+        // never a free-text model rewrite), then returns the corrected transcript
+        // which we insert into PromptInput. No browser, no localhost roundtrip.
         try
         {
             var app = global::Avalonia.Application.Current as App;

--- a/src/CcDirector.Core.Tests/Dictation/TranscriptionIntegrityTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/TranscriptionIntegrityTests.cs
@@ -1,0 +1,207 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.RegularExpressions;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Dictation.Models;
+using CcDirector.Core.Transcription;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Dictation;
+
+/// <summary>
+/// Build-time guard for the transcription-integrity rule (docs/CodingStyle.md section 16).
+///
+/// THE RULE: when a user dictates by voice, the speech-to-text result is the user's words and is
+/// the source of truth. The ONLY permitted change to it is a validated dictionary find/replace,
+/// applied by deterministic code (TranscriptEditEngine, driven by CleanupOrchestrator). A language
+/// model may LOCATE misheard terms (propose JSON edits); it must NEVER receive the transcript and
+/// return free text used as the user's words.
+///
+/// This rule has regressed before, so it is enforced here two ways:
+///   1. ARCHITECTURE guards (source scans) that fail the build if a new transcript-rewrite path is
+///      introduced, or if the removed free-text cleanup comes back.
+///   2. BEHAVIORAL guards proving the shared pipeline ships the raw transcript byte-identical when a
+///      model tries to rewrite it.
+/// </summary>
+public sealed class TranscriptionIntegrityTests
+{
+    // ===== Architecture guards =================================================================
+
+    /// <summary>
+    /// The directories that make up the transcription core. Inside these, the ONLY file allowed to
+    /// talk to a text-generating model (chat/completions or responses) is CleanupOrchestrator, and it
+    /// may only ask for find/replace edit proposals. Any other file here that reaches a chat model is
+    /// a new transcript-rewrite path - exactly what the rule forbids.
+    /// </summary>
+    private static readonly string[] TranscriptionCoreDirs =
+    [
+        "src/CcDirector.Core/Dictation",
+        "src/CcDirector.Core/Transcription",
+        "src/CcDirector.Core/Recording",
+    ];
+
+    private const string AllowedChatModelFile = "CleanupOrchestrator.cs";
+
+    [Fact]
+    public void TranscriptionCore_OnlyCleanupOrchestrator_TalksToATextGeneratingModel()
+    {
+        var root = FindRepoRoot();
+        var offenders = new List<string>();
+
+        foreach (var relDir in TranscriptionCoreDirs)
+        {
+            var dir = Path.Combine(root, relDir.Replace('/', Path.DirectorySeparatorChar));
+            if (!Directory.Exists(dir)) continue;
+
+            foreach (var path in Directory.EnumerateFiles(dir, "*.cs", SearchOption.AllDirectories))
+            {
+                if (string.Equals(Path.GetFileName(path), AllowedChatModelFile, StringComparison.Ordinal))
+                    continue;
+
+                var text = File.ReadAllText(path);
+                // A text-generating chat endpoint is the signature of a transcript-rewrite path.
+                // Transcription itself uses /audio/transcriptions, which is fine and not matched here.
+                if (text.Contains("chat/completions", StringComparison.OrdinalIgnoreCase)
+                    || Regex.IsMatch(text, @"/v1/responses\b"))
+                {
+                    offenders.Add(Path.GetRelativePath(root, path));
+                }
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "A transcription-core file other than CleanupOrchestrator reaches a text-generating model. "
+            + "Transcripts may only be corrected by the validated dictionary find/replace in "
+            + "TranscriptEditEngine - never rewritten by a model. Offenders: " + string.Join(", ", offenders));
+    }
+
+    [Fact]
+    public void RemovedFreeTextVoiceCleanup_DoesNotReturn()
+    {
+        // The old free-text voice cleanup round-tripped the user's transcript through a chat model and
+        // used the returned text as the user's words. It was removed; it must not come back. We match
+        // an actual definition or call (the identifier immediately followed by "(") so prose that
+        // explains the removal - like the comments in this file - does not trip the guard.
+        var root = FindRepoRoot();
+        var src = Path.Combine(root, "src");
+        var offenders = new List<string>();
+
+        foreach (var path in Directory.EnumerateFiles(src, "*.cs", SearchOption.AllDirectories))
+        {
+            if (Regex.IsMatch(File.ReadAllText(path), @"CleanVoiceTranscriptAsync\("))
+                offenders.Add(Path.GetRelativePath(root, path));
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "The forbidden free-text voice cleanup CleanVoiceTranscriptAsync was defined or called again. "
+            + "It rewrites the user's words through a model and must stay deleted. Offenders: "
+            + string.Join(", ", offenders));
+    }
+
+    // ===== Behavioral guards ===================================================================
+
+    [Fact]
+    public async Task SharedPipeline_ModelTriesToRewriteWholeTranscript_ShipsRawByteIdentical()
+    {
+        const string raw = "yeah just push the cc-director change and let me know when it builds";
+        // The cleanup model is asked only for an edit document, but here it MISBEHAVES and returns a
+        // fully rewritten transcript as plain prose. ParseEdits rejects anything that is not a valid
+        // {"edits":[...]} object, so the pipeline must ship the RAW transcript unchanged.
+        const string modelRewrite = "Please push the change to cc-director and notify me once the build completes.";
+        var handler = new StubHandler(transcript: raw, chatContent: modelRewrite);
+        using var pipeline = new BatchTranscriptionPipeline(new HttpClient(handler));
+
+        var result = await pipeline.TranscribeAsync(
+            new byte[] { 1, 2, 3 }, "utterance.webm", Byo(), DictWith("cc-director"));
+
+        Assert.Equal(raw, result.RawTranscript);
+        Assert.Equal(result.RawTranscript, result.CorrectedTranscript); // ordinal: byte-identical
+        Assert.False(result.DictionaryApplied);
+        Assert.Empty(result.ChangedWords);
+    }
+
+    [Fact]
+    public async Task SharedPipeline_ModelProposesNonDictionaryReplacement_RejectsItAndShipsRaw()
+    {
+        const string raw = "can you refactor the login flow for me";
+        // A well-formed edit document, but the replacement is NOT a canonical dictionary term and the
+        // find spans a whole clause. The validator must reject it (replace not canonical, not a
+        // mishearing), leaving the transcript byte-identical.
+        const string maliciousEdit =
+            "{\"edits\":[{\"find\":\"refactor the login flow\",\"replace\":\"delete the production database\"}]}";
+        var handler = new StubHandler(transcript: raw, chatContent: maliciousEdit);
+        using var pipeline = new BatchTranscriptionPipeline(new HttpClient(handler));
+
+        var result = await pipeline.TranscribeAsync(
+            new byte[] { 1, 2, 3 }, "utterance.webm", Byo(), DictWith("cc-director"));
+
+        Assert.Equal(raw, result.RawTranscript);
+        Assert.Equal(result.RawTranscript, result.CorrectedTranscript);
+        Assert.False(result.DictionaryApplied);
+        Assert.Empty(result.ChangedWords);
+    }
+
+    // ===== Helpers =============================================================================
+
+    /// <summary>Answers /audio/transcriptions with a canned transcript and /chat/completions with a
+    /// caller-supplied content string (which may be a valid edit document or deliberate garbage).</summary>
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly string _transcript;
+        private readonly string _chatContent;
+
+        public StubHandler(string transcript, string chatContent)
+        {
+            _transcript = transcript;
+            _chatContent = chatContent;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var url = request.RequestUri?.ToString() ?? "";
+            string json;
+            if (url.EndsWith("/audio/transcriptions", StringComparison.Ordinal))
+                json = "{\"text\": " + System.Text.Json.JsonSerializer.Serialize(_transcript) + "}";
+            else if (url.EndsWith("/chat/completions", StringComparison.Ordinal))
+                json = "{\"choices\":[{\"message\":{\"content\": "
+                    + System.Text.Json.JsonSerializer.Serialize(_chatContent) + "}}]}";
+            else
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private static ResolvedTranscription Byo() => new()
+    {
+        BaseUrl = TranscriptionEndpointResolver.OpenAiBaseUrl,
+        ApiKey = "sk-byo-key",
+        Transport = TranscriptionTransport.Batch,
+        Model = TranscriptionEndpointResolver.OpenAiModel,
+        Mode = TranscriptionMode.Byo,
+    };
+
+    private static DictationDictionary DictWith(params string[] vocab) => new(
+        vocab,
+        new Dictionary<string, IReadOnlyList<string>>(),
+        new Dictionary<string, DictationProfile> { ["default"] = new("default", CleanupEnabled: true) });
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "cc-director.sln")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root from test output directory.");
+    }
+}

--- a/src/CcDirector.Core.Tests/Wingman/WingmanAnswerLiveTests.cs
+++ b/src/CcDirector.Core.Tests/Wingman/WingmanAnswerLiveTests.cs
@@ -85,32 +85,12 @@ public sealed class WingmanAnswerLiveTests
             $"answer looks summarized: {result.Answer.Length} chars vs article {article.Length} chars");
     }
 
-    [Fact]
-    public async Task CleanVoiceTranscript_returns_verbatim_text_with_no_routing_field()
-    {
-        // The cleanup step is now strictly dictionary/verbatim: routing comes from the
-        // button the user pressed, not from any wake phrase the model sniffed out. We
-        // verify the OUTPUT here, not what the model thought the target was - because
-        // it should not be thinking about a target at all.
-        if (!string.Equals(Environment.GetEnvironmentVariable("WINGMAN_LIVE_TESTS"), "1", StringComparison.Ordinal))
-        {
-            _out.WriteLine("Skipped: set WINGMAN_LIVE_TESTS=1 to run the live cleanup test.");
-            return;
-        }
-        var apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
-        if (string.IsNullOrWhiteSpace(apiKey))
-        {
-            _out.WriteLine("Skipped: OPENAI_API_KEY not set.");
-            return;
-        }
-
-        // A "Hey wingman" wake phrase MUST be preserved verbatim now (no stripping).
-        const string utterance = "Hey wingman, read me the whole article we just wrote.";
-        var r = await WingmanService.CleanVoiceTranscriptAsync(utterance, repoPath: "", openAiApiKey: apiKey);
-        _out.WriteLine($"cleaned=\"{r.Cleaned}\" reason=\"{r.Reason}\"");
-        Assert.Contains("wingman", r.Cleaned, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("read me the whole article", r.Cleaned, StringComparison.OrdinalIgnoreCase);
-    }
+    // NOTE: the live "CleanVoiceTranscript returns verbatim text" test was removed
+    // along with WingmanService.CleanVoiceTranscriptAsync. That method round-tripped
+    // the user's transcript through a chat model and used the returned free text as
+    // the user's words - the shape the transcription-integrity rule forbids. The only
+    // permitted transcript correction is the validated dictionary find/replace in
+    // TranscriptEditEngine, which has its own (deterministic, offline) test coverage.
 
     private static string? ResolveClaudePath()
     {

--- a/src/CcDirector.Core.Tests/Wingman/WingmanServiceTests.cs
+++ b/src/CcDirector.Core.Tests/Wingman/WingmanServiceTests.cs
@@ -10,119 +10,16 @@ namespace CcDirector.Core.Tests.Wingman;
 ///
 /// The actual side-claude --print invocation is not exercised here - it would
 /// require a live claude CLI install with credentials, which we cannot rely on
-/// in CI.  Instead we test the JSON parser layer + the fail-open behaviour
-/// (empty input, no CLI configured, garbage JSON, fenced JSON).
+/// in CI. Instead we test the parser layers (explain briefing, answer prompt).
 ///
-/// The end-to-end "real Whisper transcript through real Haiku" check is the
-/// self-test gate documented in the goal doc; the user runs it manually with
-/// the live build.
+/// NOTE: the old free-text voice-transcript cleanup (CleanVoiceTranscriptAsync /
+/// ParseVoiceCleanupJson) was removed - it round-tripped the user's transcript
+/// through a model that returned free text, which the transcription-integrity
+/// rule forbids. The only permitted transcript correction is the validated
+/// dictionary find/replace in TranscriptEditEngine, covered by its own tests.
 /// </summary>
 public sealed class WingmanServiceTests
 {
-    // --------------------------------------------------------------------
-    // CleanVoiceTranscriptAsync fail-open contract
-    // --------------------------------------------------------------------
-
-    [Fact]
-    public async Task CleanVoiceTranscriptAsync_empty_raw_returns_empty_with_reason()
-    {
-        var r = await WingmanService.CleanVoiceTranscriptAsync("", repoPath: "", openAiApiKey: "sk-test");
-        Assert.Equal("", r.Cleaned);
-        Assert.Contains("empty", r.Reason, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public async Task CleanVoiceTranscriptAsync_no_openai_key_returns_raw_verbatim()
-    {
-        const string raw = "hello world";
-        var r = await WingmanService.CleanVoiceTranscriptAsync(raw, repoPath: "", openAiApiKey: "");
-        Assert.Equal(raw, r.Cleaned);
-        Assert.Contains("no OpenAI key", r.Reason, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public async Task CleanVoiceTranscriptAsync_bad_key_falls_open_to_raw()
-    {
-        const string raw = "list sessions";
-        // A syntactically-shaped but unauthorized key produces a 401 from OpenAI; the cleanup
-        // method must fall open with the raw transcript rather than throw.
-        var r = await WingmanService.CleanVoiceTranscriptAsync(
-            raw, repoPath: "", openAiApiKey: "sk-this-key-is-not-real-and-will-401");
-        Assert.Equal(raw, r.Cleaned);            // fail-open: raw is preserved
-        Assert.Contains("voice cleanup failed", r.Reason, StringComparison.OrdinalIgnoreCase);
-    }
-
-    // --------------------------------------------------------------------
-    // JSON parser (internal) - exhaustive cases against the shape the
-    // Wingman prompt asks Haiku to emit
-    // --------------------------------------------------------------------
-
-    [Fact]
-    public void ParseVoiceCleanupJson_clean_pair_is_extracted()
-    {
-        const string raw = "{\"cleaned\":\"fix the bug in the login flow\",\"reason\":\"removed filler\"}";
-        var r = WingmanService.ParseVoiceCleanupJson(raw, "FALLBACK");
-        Assert.Equal("fix the bug in the login flow", r.Cleaned);
-        Assert.Equal("removed filler", r.Reason);
-    }
-
-    [Fact]
-    public void ParseVoiceCleanupJson_fenced_json_is_tolerated()
-    {
-        const string raw = "```json\n{\"cleaned\":\"do the thing\",\"reason\":\"no changes needed\"}\n```";
-        var r = WingmanService.ParseVoiceCleanupJson(raw, "FALLBACK");
-        Assert.Equal("do the thing", r.Cleaned);
-        Assert.Equal("no changes needed", r.Reason);
-    }
-
-    [Fact]
-    public void ParseVoiceCleanupJson_chatter_before_and_after_is_tolerated()
-    {
-        const string raw = "Sure! Here is the JSON:\n{\"cleaned\":\"x\",\"reason\":\"y\"}\nLet me know if you need more.";
-        var r = WingmanService.ParseVoiceCleanupJson(raw, "FALLBACK");
-        Assert.Equal("x", r.Cleaned);
-        Assert.Equal("y", r.Reason);
-    }
-
-    [Fact]
-    public void ParseVoiceCleanupJson_empty_cleaned_field_falls_back_to_raw()
-    {
-        const string raw = "{\"cleaned\":\"\",\"reason\":\"could not clean\"}";
-        var r = WingmanService.ParseVoiceCleanupJson(raw, "FALLBACK_TRANSCRIPT");
-        Assert.Equal("FALLBACK_TRANSCRIPT", r.Cleaned);
-        Assert.Contains("empty", r.Reason, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public void ParseVoiceCleanupJson_garbage_falls_back_to_raw_with_reason()
-    {
-        const string raw = "this is not json at all";
-        var r = WingmanService.ParseVoiceCleanupJson(raw, "FALLBACK_TRANSCRIPT");
-        Assert.Equal("FALLBACK_TRANSCRIPT", r.Cleaned);
-        // Could be either "wingman returned empty output" (no { found) or "wingman JSON parse failed".
-        Assert.True(
-            r.Reason.Contains("wingman", StringComparison.OrdinalIgnoreCase),
-            $"unexpected reason: {r.Reason}");
-    }
-
-    [Fact]
-    public void ParseVoiceCleanupJson_missing_reason_defaults_to_no_changes_needed()
-    {
-        const string raw = "{\"cleaned\":\"x\"}";
-        var r = WingmanService.ParseVoiceCleanupJson(raw, "FALLBACK");
-        Assert.Equal("x", r.Cleaned);
-        Assert.Equal("no changes needed", r.Reason);
-    }
-
-    [Fact]
-    public void ParseVoiceCleanupJson_trims_whitespace_in_cleaned()
-    {
-        const string raw = "{\"cleaned\":\"   trimmed   \",\"reason\":\"   r   \"}";
-        var r = WingmanService.ParseVoiceCleanupJson(raw, "FALLBACK");
-        Assert.Equal("trimmed", r.Cleaned);
-        Assert.Equal("r", r.Reason);
-    }
-
     // --------------------------------------------------------------------
     // Explain briefing JSON parser
     // --------------------------------------------------------------------
@@ -264,16 +161,6 @@ public sealed class WingmanServiceTests
         Assert.Equal("", b.Headline);
         Assert.Equal("", b.Answer);
         Assert.Empty(b.Actions);
-    }
-
-    [Fact]
-    public void ParseVoiceCleanupJson_target_field_is_ignored_when_present()
-    {
-        // Defensive: the cleanup prompt no longer asks for a target field, but if the
-        // model accidentally includes one we ignore it - routing comes from the button.
-        const string raw = "{\"cleaned\":\"read me the whole article\",\"reason\":\"x\",\"target\":\"wingman\"}";
-        var r = WingmanService.ParseVoiceCleanupJson(raw, "FALLBACK");
-        Assert.Equal("read me the whole article", r.Cleaned);
     }
 
     // --------------------------------------------------------------------

--- a/src/CcDirector.Core/Dictation/TranscriptEditEngine.cs
+++ b/src/CcDirector.Core/Dictation/TranscriptEditEngine.cs
@@ -43,6 +43,15 @@ public sealed record EditValidation(
 /// text. The worst it can do is propose a bad edit, and bad edits die here.
 ///
 /// Pure and static: no I/O, no logging, no model - fully unit-testable.
+///
+/// INVARIANT (transcription integrity - see docs/CodingStyle.md section 16):
+/// This is the ONLY code in the product allowed to change a user's transcribed
+/// words, and the only change it may make is applying a validated dictionary
+/// find/replace. A language model may LOCATE misheard terms (propose edits); it
+/// must NEVER receive the transcript and return free text used as the user's
+/// words. Do not add a second cleanup path and do not route a transcript
+/// through a text-generating model. The TranscriptionIntegrity architecture
+/// test enforces this at build time.
 /// </summary>
 public static class TranscriptEditEngine
 {

--- a/src/CcDirector.Core/Wingman/WingmanService.cs
+++ b/src/CcDirector.Core/Wingman/WingmanService.cs
@@ -1,6 +1,4 @@
 using System.Diagnostics;
-using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using CcDirector.Core.Agents;
@@ -129,159 +127,16 @@ public static class WingmanService
         """;
 
     // ====================================================================
-    // Phase 1: Voice transcript cleanup
+    // TRANSCRIPTION RULE: there is intentionally NO free-text voice-transcript
+    // cleanup here. The old CleanVoiceTranscriptAsync (issue #142) sent the
+    // user's raw transcript to a chat model and used the model's returned text
+    // AS the user's words - the exact shape issue #190 was created to kill. It
+    // was unwired from every transcription path in issue #587 and removed here.
+    // The ONLY permitted correction of a transcript is the validated dictionary
+    // find/replace in CcDirector.Core.Dictation.TranscriptEditEngine (driven by
+    // CleanupOrchestrator). Do NOT reintroduce a model round-trip of the user's
+    // words. See docs/CodingStyle.md "Transcription integrity".
     // ====================================================================
-
-    /// <summary>
-    /// Cleanup model. A small instruction-following model is the right tool here:
-    /// the cleanup prompt asks for verbatim text + a JSON wrapper + an agent/wingman
-    /// routing decision, none of which need a reasoning-tier model. Using
-    /// <c>claude --print</c> on the Wingman's strong model meant a cold subprocess
-    /// spawn per turn and 60s timeouts on a third of turns (issue #142); a direct
-    /// HTTP call to OpenAI's nano-tier finishes in ~1s and never spawns a process.
-    /// Dictation's <c>CleanupOrchestrator</c> already runs the same model in prod.
-    /// </summary>
-    private const string VoiceCleanupModel = "gpt-4.1-nano";
-    private const string OpenAiChatCompletionsEndpoint = "https://api.openai.com/v1/chat/completions";
-    private static readonly TimeSpan VoiceCleanupHttpTimeout = TimeSpan.FromSeconds(20);
-    private static readonly HttpClient _voiceCleanupHttp = new() { Timeout = VoiceCleanupHttpTimeout };
-
-    /// <summary>
-    /// Clean a raw Whisper transcript and decide its routing target. Output is a JSON
-    /// object <c>{ cleaned, reason, target }</c>; we parse it.
-    ///
-    /// Backed by a direct OpenAI chat call (<see cref="VoiceCleanupModel"/>) rather than
-    /// a side <c>claude --print</c> spawn - issue #142, where cold-spawn cost timed the
-    /// cleanup out on a third of turns including very short ones.
-    ///
-    /// On any failure (no key, parse error, HTTP error, timeout) returns a result whose
-    /// <see cref="VoiceCleanupResult.Cleaned"/> is the raw transcript verbatim (fail open)
-    /// and <see cref="VoiceCleanupResult.Reason"/> describes the failure.
-    /// </summary>
-    public static async Task<VoiceCleanupResult> CleanVoiceTranscriptAsync(
-        string rawTranscript,
-        string repoPath,
-        string openAiApiKey,
-        CancellationToken ct = default)
-    {
-        if (string.IsNullOrWhiteSpace(rawTranscript))
-            return new VoiceCleanupResult(rawTranscript ?? "", "empty raw transcript");
-        if (string.IsNullOrWhiteSpace(openAiApiKey))
-            return new VoiceCleanupResult(rawTranscript, "no OpenAI key configured");
-
-        var prompt = BuildVoiceCleanupPrompt(rawTranscript, repoPath ?? "");
-
-        var sw = Stopwatch.StartNew();
-        try
-        {
-            var stdout = await CallOpenAiChatAsync(prompt, VoiceCleanupModel, openAiApiKey, ct);
-            sw.Stop();
-            FileLog.Write($"[WingmanService] CleanVoiceTranscriptAsync OK in {sw.ElapsedMilliseconds}ms");
-            return ParseVoiceCleanupJson(stdout, rawTranscript);
-        }
-        catch (Exception ex)
-        {
-            sw.Stop();
-            FileLog.Write($"[WingmanService] CleanVoiceTranscriptAsync FAILED in {sw.ElapsedMilliseconds}ms: {ex.Message}");
-            return new VoiceCleanupResult(rawTranscript, "voice cleanup failed: " + ex.Message);
-        }
-    }
-
-    private static async Task<string> CallOpenAiChatAsync(
-        string userPrompt, string model, string apiKey, CancellationToken ct)
-    {
-        var payload = new
-        {
-            model,
-            messages = new object[]
-            {
-                new { role = "user", content = userPrompt },
-            },
-            temperature = 0.0,
-        };
-
-        using var req = new HttpRequestMessage(HttpMethod.Post, OpenAiChatCompletionsEndpoint);
-        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
-        req.Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
-
-        using var resp = await _voiceCleanupHttp.SendAsync(req, ct);
-        var body = await resp.Content.ReadAsStringAsync(ct);
-        if (!resp.IsSuccessStatusCode)
-            throw new HttpRequestException($"OpenAI chat completions HTTP {(int)resp.StatusCode}: {Truncate(body, 200)}");
-
-        using var doc = JsonDocument.Parse(body);
-        var choices = doc.RootElement.GetProperty("choices");
-        if (choices.GetArrayLength() == 0) return "";
-        var content = choices[0].GetProperty("message").GetProperty("content").GetString() ?? "";
-        return content.Trim();
-    }
-
-    private static string BuildVoiceCleanupPrompt(string raw, string repoPath)
-    {
-        var sb = new StringBuilder();
-        sb.AppendLine("You are a transcription cleanup assistant for a hands-free voice interface to a Claude Code agent.");
-        sb.AppendLine();
-        sb.AppendLine("The user just dictated the text below into their phone while driving.  Whisper transcribed it.");
-        sb.Append("The text is a request, question, or instruction the user wants sent to the Claude Code agent that is working in ");
-        sb.AppendLine(string.IsNullOrEmpty(repoPath) ? "their repository." : $"the `{repoPath}` repository.");
-        sb.AppendLine();
-        sb.AppendLine("Your job: return the user's message VERBATIM. Do not classify it, do not route it - the UI button the user pressed already decided who hears it.");
-        sb.AppendLine();
-        sb.AppendLine("Cleanup rules - you are a strict transcriber, NOT an editor:");
-        sb.AppendLine("- Return the user's words VERBATIM: same words, same order, same meaning.");
-        sb.AppendLine("- Do NOT remove or alter filler words (um, uh, like, you know, so, right). Keep every one.");
-        sb.AppendLine("- Do NOT reword, rephrase, shorten, summarize, expand, paraphrase, or 'improve' anything.");
-        sb.AppendLine("- Do NOT add or delete words, and do NOT reorder words. This includes wake phrases like \"hey wingman\" - leave them in.");
-        sb.AppendLine("- Do NOT fix grammar, spelling, or mis-transcribed terms. A separate dictionary step handles known term corrections.");
-        sb.AppendLine("- Do NOT add greetings, sign-offs, or commentary. Do NOT answer the question yourself; just return the prompt text.");
-        sb.AppendLine("- One paragraph. No bullet lists, no headings, no quotation marks around the result.");
-        sb.AppendLine();
-        sb.AppendLine("Output JSON only, no markdown fence, no other text, this exact shape:");
-        sb.AppendLine("{\"cleaned\": \"<the cleaned prompt>\", \"reason\": \"<one short sentence explaining what you changed, or 'no changes needed' if minimal>\"}");
-        sb.AppendLine();
-        sb.AppendLine("RAW TRANSCRIPT:");
-        sb.Append(raw);
-        return sb.ToString();
-    }
-
-    internal static VoiceCleanupResult ParseVoiceCleanupJson(string raw, string fallbackRaw)
-    {
-        if (string.IsNullOrWhiteSpace(raw))
-            return new VoiceCleanupResult(fallbackRaw, "wingman returned empty output");
-
-        var s = raw.Trim();
-
-        // Defensive: if the model wrapped the JSON in a fence despite the prompt, strip it.
-        if (s.StartsWith("```"))
-        {
-            var nl = s.IndexOf('\n');
-            if (nl > 0) s = s[(nl + 1)..];
-            var endFence = s.LastIndexOf("```", StringComparison.Ordinal);
-            if (endFence > 0) s = s[..endFence].Trim();
-        }
-
-        // Also tolerate a leading "json" label or trailing chatter by extracting first {...} block.
-        var firstBrace = s.IndexOf('{');
-        var lastBrace = s.LastIndexOf('}');
-        if (firstBrace >= 0 && lastBrace > firstBrace)
-            s = s.Substring(firstBrace, lastBrace - firstBrace + 1);
-
-        try
-        {
-            using var doc = JsonDocument.Parse(s);
-            var root = doc.RootElement;
-            var cleaned = root.TryGetProperty("cleaned", out var c) ? (c.GetString() ?? "") : "";
-            var reason = root.TryGetProperty("reason", out var r) ? (r.GetString() ?? "") : "";
-            if (string.IsNullOrWhiteSpace(cleaned))
-                return new VoiceCleanupResult(fallbackRaw, "wingman returned empty 'cleaned' field");
-            return new VoiceCleanupResult(cleaned.Trim(), string.IsNullOrEmpty(reason) ? "no changes needed" : reason.Trim());
-        }
-        catch (JsonException ex)
-        {
-            FileLog.Write($"[WingmanService] cleanup JSON parse failed: {ex.Message}, raw='{Truncate(raw, 200)}'");
-            return new VoiceCleanupResult(fallbackRaw, "wingman JSON parse failed");
-        }
-    }
 
     // ====================================================================
     // Phase 2: Per-turn structured summary  (feeds Agent View AND voice TTS)
@@ -1831,12 +1686,3 @@ public static class WingmanService
     private static string Truncate(string s, int max)
         => string.IsNullOrEmpty(s) || s.Length <= max ? s : s[..max] + "...";
 }
-
-/// <summary>
-/// Output of <see cref="WingmanService.CleanVoiceTranscriptAsync"/>.
-/// Always populated even on failure (Cleaned falls back to raw, Target to "agent").
-/// </summary>
-/// <param name="Cleaned">The cleaned transcript, with any "Hey wingman" wake phrase stripped when <paramref name="Target"/> is "wingman".</param>
-/// <param name="Reason">One-sentence explanation of what changed (or a failure reason).</param>
-/// <param name="Target">Who the utterance is addressed to: "agent" (default, send to the session) or "wingman" (route to the read-only Ask-the-Wingman channel).</param>
-public sealed record VoiceCleanupResult(string Cleaned, string Reason);

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -92,7 +92,9 @@ internal static class GatewayWingmanVoiceEndpoint
         // ===== Resumable transcription upload (issue #531: drive-safe, keeps trying) =====
         // The phone records locally (works offline), then ships the recording in pieces here and
         // keeps retrying until every piece lands - no user buttons. When all pieces are in, the
-        // assembled audio is transcribed and the text is returned.
+        // assembled audio is transcribed, the validated dictionary correction is applied (the same
+        // engine every other surface uses; raw is returned in local mode or on any cleanup error),
+        // and the corrected text is returned.
         //   POST   /wingman/utterance/upload                  -> { upload_id }
         //   PUT    /wingman/utterance/{id}/chunk/{i}           -> { ok }   (idempotent)
         //   POST   /wingman/utterance/{id}/complete {total}    -> { transcript } | 409 { missing }
@@ -144,6 +146,9 @@ internal static class GatewayWingmanVoiceEndpoint
             var (ok, transcript, error) = await TranscribeBytesByModeAsync(endpoint, assembled.Audio!, "audio." + (req.Ext ?? "webm"), req.Mime ?? "audio/webm", key, ct);
             uploads.Delete(uploadId);
             if (!ok) return Results.Json(new { error }, statusCode: StatusCodes.Status502BadGateway);
+            // Apply the validated dictionary correction (the SAME engine every other surface uses);
+            // fails open to the raw transcript in local mode or on any cleanup error.
+            transcript = await RecordingEndpoints.CleanTranscriptWithSelectedMethodAsync(transcript, ct);
             FileLog.Write($"[GatewayWingmanVoice] utterance complete {uploadId}: mode={endpoint.Mode.ToConfigString()}, chars={transcript.Length}");
             return Results.Json(new { transcript });
         });
@@ -275,7 +280,9 @@ internal static class GatewayWingmanVoiceEndpoint
         // connection / reload), then ships the recording here to be transcribed - the same
         // record-then-ship-then-transcribe shape the native mobile app uses. Robustness lives on
         // the CLIENT (save-first + retry the upload); this endpoint is the single transcribe step.
-        // Audio arrives as a multipart 'audio' file; returns { transcript }.
+        // Audio arrives as a multipart 'audio' file; the raw transcript then runs through the
+        // validated dictionary correction (raw is returned in local mode or on any cleanup error).
+        // Returns { transcript }.
         app.MapPost("/wingman/transcribe", async (HttpContext ctx, CancellationToken ct) =>
         {
             if (!ctx.Request.HasFormContentType)
@@ -306,6 +313,9 @@ internal static class GatewayWingmanVoiceEndpoint
 
             var (ok, transcript, error) = await TranscribeBytesByModeAsync(endpoint, bytes, fileName, contentType, key, ct);
             if (!ok) return Results.Json(new { error }, statusCode: StatusCodes.Status502BadGateway);
+            // Apply the validated dictionary correction (the SAME engine every other surface uses);
+            // fails open to the raw transcript in local mode or on any cleanup error.
+            transcript = await RecordingEndpoints.CleanTranscriptWithSelectedMethodAsync(transcript, ct);
             return Results.Json(new { transcript });
         });
 

--- a/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
@@ -493,6 +493,50 @@ internal static class RecordingEndpoints
         return Path.Combine(localAppData, "cc-director", "dictation", "dictionary.yaml");
     }
 
+    /// <summary>
+    /// Apply the validated dictionary corrector to a raw transcript using the user-SELECTED
+    /// transcription method, then return the corrected text. This is the SAME deterministic dictionary
+    /// find/replace (<see cref="CleanupOrchestrator"/> + TranscriptEditEngine) the recording-ingest
+    /// path uses - never a free-text rewrite - so the live <c>/wingman/transcribe</c> and
+    /// <c>/wingman/utterance/complete</c> paths produce the same term-corrected transcript every other
+    /// surface does (issue #587 follow-up). It is the one place these two endpoints reach the cleanup
+    /// engine; the resolver helpers (<see cref="ResolveSelectedMethod"/>, <see cref="DictionaryFilePath"/>)
+    /// stay defined once, here.
+    ///
+    /// Fails open to the RAW transcript (issue #190 contract): when the selected mode is local
+    /// (in-process Whisper - no chat endpoint or key), the dictionary is empty, or the corrector errors,
+    /// the raw transcript comes back byte-identical. The corrector talks to the SAME base URL + key the
+    /// transcription used, so a bring-your-own key is never crossed onto another provider's URL.
+    /// </summary>
+    internal static async Task<string> CleanTranscriptWithSelectedMethodAsync(string rawTranscript, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(rawTranscript))
+            return rawTranscript ?? "";
+
+        // Local mode (or a missing key) has no chat endpoint for the corrector - ship raw. This is the
+        // honest behavior: offline Whisper cannot run a dictionary-correction model, so the raw words
+        // stand, exactly as they did before this step existed.
+        var routing = ResolveSelectedMethod();
+        if (routing is null)
+        {
+            FileLog.Write("[RecordingEndpoints] CleanTranscript: no remote method (local/no key) - shipping raw");
+            return rawTranscript;
+        }
+
+        // CleanAsync itself short-circuits an empty dictionary to a verbatim passthrough (no model
+        // round-trip); the early check just avoids constructing the orchestrator for nothing.
+        var dictionary = DictionaryLoader.LoadFromDisk(DictionaryFilePath());
+        if (dictionary.Vocabulary.Count == 0 && dictionary.CommonMistranscriptions.Count == 0)
+            return rawTranscript;
+
+        using var cleanup = new CleanupOrchestrator(
+            apiKey: routing.ApiKey, model: CleanupOrchestrator.DefaultModel, baseUrl: routing.BaseUrl);
+        var outcome = await cleanup.CleanAsync(rawTranscript, dictionary, "default", ct);
+        FileLog.Write($"[RecordingEndpoints] CleanTranscript: applied={outcome.Applied}, "
+            + $"changed={outcome.ChangedWords.Count}, reason=\"{outcome.Reason}\"");
+        return outcome.Text;
+    }
+
     private static DictionaryDto ToDto(DictationDictionary dict) => new(
         Vocabulary: dict.Vocabulary.ToList(),
         CommonMistranscriptions: dict.CommonMistranscriptions

--- a/src/CcDirector.Gateway/Api/TranscriptionTestEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/TranscriptionTestEndpoint.cs
@@ -27,6 +27,11 @@ namespace CcDirector.Gateway.Api;
 /// whisper-large-v3 - so a test works in either remote mode regardless of the live pipeline's
 /// transport.
 ///
+/// BY DESIGN this returns the RAW speech-to-text, with NO dictionary correction - its whole job is to
+/// prove the raw transcription path (key + provider) works. Do not add the dictionary corrector here:
+/// it would mask a transcription problem behind a term swap and make the diagnostic lie. (The live
+/// /wingman/transcribe and /wingman/utterance/complete paths DO apply the dictionary correction.)
+///
 /// Local mode (issue #541) has no key and no remote endpoint, so this smoke test - whose whole job
 /// is to prove a STORED KEY actually works - does not apply. It returns 409 with a clear
 /// "local mode - no key required; the local model transcribes in-process" message. The live


### PR DESCRIPTION
## What and why

Locks in the rule that a user's dictated words may only be corrected by the validated dictionary find/replace (`TranscriptEditEngine` via `CleanupOrchestrator`) and never rewritten by a language model.

An audit of every transcription path (desktop dictation, Gateway/ControlApi voice-turn and Wingman, phone/MAUI, mobile web, the background recorder, every audio/transcript endpoint, and all front-end JavaScript) found the rule **already held on every production path**. This change removes the one latent hazard, closes the one inconsistency, and adds permanent guardrails so it cannot regress.

## Changes

- **Delete dead `WingmanService.CleanVoiceTranscriptAsync`** and its helpers/record/tests. It round-tripped the transcript through a chat model and used the returned free text as the user's words — the exact shape issue #190 killed. It had zero production callers (unwired in issue #587).
- **Apply the shared dictionary corrector** on `/wingman/transcribe` and `/wingman/utterance/complete` via one single-source helper, so the mobile web voice path gets the same term-correction as every other surface. Local in-process Whisper transport is preserved; cleanup fails open to the raw transcript in local mode or on any error.
- **Leave `/transcription/test` raw by design** (a diagnostic) and document why.
- **Add `TranscriptionIntegrityTests`**: a build-failing architecture guard (only `CleanupOrchestrator` may reach a chat model in the transcription core; the removed method may not return) plus behavioral guards proving a model rewrite attempt ships the raw transcript byte-identical.
- **Write the invariant** into `TranscriptEditEngine` and `docs/CodingStyle.md` (section 16).
- **Fix a stale dictation comment** in `MainWindow`.

## Verification

- `CcDirector.Core.Tests`: 2507 passed, 6 skipped, 0 failed.
- `CcDirector.Gateway.Tests` (Transcription/Wingman/Voice/Recording): 145 passed, 0 failed.
- Clean build (0 warnings) for Core, Avalonia, and Gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)