### PR TITLE
Fix Grok terminal: render flicker (#764) and never-idle session state (#766)

### DIFF
--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -3084,8 +3084,22 @@ internal static class ControlEndpoints
         // and live on the Session itself. Map() reads them directly - no derivation, no
         // recomputation from TurnSummaryCache, no fallback. The `cache` argument is kept for
         // other endpoints that surface raw summaries; it is not consulted for color.
-        var lastWrite = s.Buffer?.LastWriteAtUtc ?? DateTime.MinValue;
-        var lastActivity = lastWrite == DateTime.MinValue ? s.CreatedAt.UtcDateTime : lastWrite;
+        // Idle clock source. Most agents go byte-silent when idle, so the raw last-write time is
+        // the honest "how long since output" measure. Agents with an animated idle footer (Grok)
+        // never go byte-silent - their footer repaints forever - so the raw clock would read ~0
+        // even when the agent is done and waiting. For those, measure idle from the last screen-
+        // BODY change instead (Session.LastBodyActivityAtUtc), matching the detector's content rule
+        // so the idle seconds and the WaitingForInput badge agree.
+        DateTime lastActivity;
+        if (s.Driver.EmitsContinuousIdleOutput)
+        {
+            lastActivity = s.LastBodyActivityAtUtc;
+        }
+        else
+        {
+            var lastWrite = s.Buffer?.LastWriteAtUtc ?? DateTime.MinValue;
+            lastActivity = lastWrite == DateTime.MinValue ? s.CreatedAt.UtcDateTime : lastWrite;
+        }
         var idleSeconds = Math.Max(0, (DateTime.UtcNow - lastActivity).TotalSeconds);
 
         // Issue #335: build the viewUrl from the resolved tailnetEndpoint and the configured

--- a/src/CcDirector.Core.Tests/AnsiParserSynchronizedOutputTests.cs
+++ b/src/CcDirector.Core.Tests/AnsiParserSynchronizedOutputTests.cs
@@ -1,0 +1,102 @@
+using CcDirector.Terminal.Core;
+using Xunit;
+using static CcDirector.Core.Tests.TerminalTestHelper;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Synchronized output (DEC private mode ?2026, the Begin/End Synchronized Update
+/// protocol). Modern TUIs - including the xAI Grok CLI - bracket every frame in
+/// ?2026h ... ?2026l so the terminal can render the whole frame at once. The owning
+/// terminal control reads <see cref="AnsiParser.InSynchronizedUpdate"/> to hold its
+/// repaint while a frame is open and paint once it closes; without that, Grok's
+/// mid-frame clear-and-redraw paints a half-built frame and flickers on screen.
+/// These tests pin the parser-side flag that decision depends on.
+/// </summary>
+public class AnsiParserSynchronizedOutputTests
+{
+    [Fact]
+    public void FreshParser_IsNotInSynchronizedUpdate()
+    {
+        var (parser, _, _) = CreateParser();
+
+        Assert.False(parser.InSynchronizedUpdate);
+    }
+
+    [Fact]
+    public void BeginSynchronizedUpdate_2026h_SetsFlag()
+    {
+        var (parser, _, _) = CreateParser();
+
+        Parse(parser, "\x1b[?2026h");
+
+        Assert.True(parser.InSynchronizedUpdate);
+    }
+
+    [Fact]
+    public void EndSynchronizedUpdate_2026l_ClearsFlag()
+    {
+        var (parser, _, _) = CreateParser();
+
+        Parse(parser, "\x1b[?2026h");
+        Assert.True(parser.InSynchronizedUpdate);
+
+        Parse(parser, "\x1b[?2026l");
+        Assert.False(parser.InSynchronizedUpdate);
+    }
+
+    [Fact]
+    public void CompleteFrame_LeavesParserNotInSynchronizedUpdate()
+    {
+        // A whole frame in one chunk: begin, draw, end. After it the control is free
+        // to paint, so the flag must be clear.
+        var (parser, cells, _) = CreateParser();
+
+        Parse(parser, "\x1b[?2026hHELLO\x1b[?2026l");
+
+        Assert.False(parser.InSynchronizedUpdate);
+        // Content drawn inside the frame is still written to the grid (we do not buffer
+        // cell writes; we only defer the repaint).
+        Assert.Equal('H', cells[0, 0].Character);
+        Assert.Equal('O', cells[4, 0].Character);
+    }
+
+    [Fact]
+    public void OpenFrameWithoutEnd_RemainsInSynchronizedUpdate()
+    {
+        // Begin and partial draw with no matching end (a frame split across feeds). The
+        // control should still be holding its repaint until the end arrives.
+        var (parser, _, _) = CreateParser();
+
+        Parse(parser, "\x1b[?2026hPARTIAL");
+
+        Assert.True(parser.InSynchronizedUpdate);
+    }
+
+    [Fact]
+    public void GrokIdleHeartbeat_EmptyBeginEndPairs_LeaveFrameClosed()
+    {
+        // The exact idle stream observed from the Grok CLI: empty begin/end pairs
+        // repeated forever. Each pair opens and immediately closes a frame, so the
+        // parser must end not-in-frame - otherwise the control would stop repainting.
+        var (parser, _, _) = CreateParser();
+
+        Parse(parser, string.Concat(System.Linq.Enumerable.Repeat("\x1b[?2026h\x1b[?2026l", 50)));
+
+        Assert.False(parser.InSynchronizedUpdate);
+    }
+
+    [Fact]
+    public void FullReset_ClearsSynchronizedUpdate()
+    {
+        var (parser, _, _) = CreateParser();
+
+        Parse(parser, "\x1b[?2026h");
+        Assert.True(parser.InSynchronizedUpdate);
+
+        // RIS (full reset). Split so C#'s \x escape does not consume the 'c'.
+        Parse(parser, "\x1b" + "c");
+
+        Assert.False(parser.InSynchronizedUpdate);
+    }
+}

--- a/src/CcDirector.Core.Tests/Wingman/ContinuousIdleStateTests.cs
+++ b/src/CcDirector.Core.Tests/Wingman/ContinuousIdleStateTests.cs
@@ -1,0 +1,134 @@
+using CcDirector.Core.Agents;
+using CcDirector.Core.Drivers;
+using CcDirector.Core.Wingman;
+using CcDirector.Terminal.Core;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Wingman;
+
+/// <summary>
+/// Covers the fix for issue 766: agents whose idle terminal never goes byte-silent (Grok)
+/// must not be pinned to Working forever. Two deterministic pieces are tested here - the
+/// per-agent capability flag (approach C) and the screen-body extraction that the detector
+/// uses instead of raw bytes (approach A). The detector's timer machinery itself is exercised
+/// live in the slot build, not in this pure unit test.
+/// </summary>
+public sealed class ContinuousIdleStateTests
+{
+    // ---- Approach C: the per-agent capability flag ----
+
+    [Fact]
+    public void Grok_declares_continuous_idle_output()
+    {
+        // Grok's TUI repaints an animated footer forever, so it is the one built-in agent that
+        // opts into the screen-body idle rule.
+        Assert.True(AgentDrivers.For(AgentKind.Grok).EmitsContinuousIdleOutput);
+    }
+
+    [Theory]
+    [InlineData(AgentKind.ClaudeCode)]
+    [InlineData(AgentKind.Codex)]
+    [InlineData(AgentKind.Gemini)]
+    [InlineData(AgentKind.OpenCode)]
+    [InlineData(AgentKind.Pi)]
+    [InlineData(AgentKind.Copilot)]
+    public void Other_agents_keep_the_byte_only_rule(AgentKind kind)
+    {
+        // Everyone else goes byte-silent when idle, so they stay on the cheap byte rule and must
+        // NOT opt into the screen-body path.
+        Assert.False(AgentDrivers.For(kind).EmitsContinuousIdleOutput);
+    }
+
+    // ---- Approach A: screen-body extraction (rows above the cursor) ----
+
+    [Fact]
+    public void Body_is_rows_above_the_cursor()
+    {
+        var rows = new[] { "answer line 1", "answer line 2", "> composer", "shortcuts -" };
+        Assert.True(TerminalStateDetector.TryExtractBody(rows, cursorRow: 2, out var body));
+        Assert.Equal("answer line 1\nanswer line 2", body);
+    }
+
+    [Fact]
+    public void Footer_only_change_does_not_change_the_body()
+    {
+        // The spinner glyph cycles in the footer (at/below the cursor) while the answer body is
+        // unchanged. Both frames must extract the SAME body, so the detector sees no activity.
+        var frameA = new[] { "the answer", "> composer", "shortcuts -" };
+        var frameB = new[] { "the answer", "> composer", "shortcuts \\" };
+        Assert.True(TerminalStateDetector.TryExtractBody(frameA, 1, out var bodyA));
+        Assert.True(TerminalStateDetector.TryExtractBody(frameB, 1, out var bodyB));
+        Assert.Equal(bodyA, bodyB);
+    }
+
+    [Fact]
+    public void Body_change_above_the_cursor_is_detected()
+    {
+        // A new answer token lands above the composer: the bodies must differ, so the detector
+        // re-arms Working.
+        var before = new[] { "partial ans", "> composer", "shortcuts -" };
+        var after = new[] { "partial answer", "> composer", "shortcuts -" };
+        Assert.True(TerminalStateDetector.TryExtractBody(before, 1, out var b1));
+        Assert.True(TerminalStateDetector.TryExtractBody(after, 1, out var b2));
+        Assert.NotEqual(b1, b2);
+    }
+
+    [Fact]
+    public void No_body_when_cursor_at_top()
+    {
+        // Cursor at row 0 (or -1 when there is no grid): the body cannot be isolated, so extraction
+        // fails and the caller treats the frame as activity rather than risk a false idle.
+        var rows = new[] { "> composer", "shortcuts -" };
+        Assert.False(TerminalStateDetector.TryExtractBody(rows, cursorRow: 0, out _));
+        Assert.False(TerminalStateDetector.TryExtractBody(rows, cursorRow: -1, out _));
+        Assert.False(TerminalStateDetector.TryExtractBody(System.Array.Empty<string>(), cursorRow: 5, out _));
+    }
+
+    // ---- AnsiParser.SnapshotActiveRows: the alternate-screen correctness fix ----
+
+    [Fact]
+    public void SnapshotActiveRows_reads_the_primary_grid()
+    {
+        var parser = MakeParser(out _);
+        parser.Parse(System.Text.Encoding.UTF8.GetBytes("hello world"));
+        var (rows, _, _) = parser.SnapshotActiveRows();
+        Assert.Equal("hello world", rows[0]);
+    }
+
+    [Fact]
+    public void SnapshotActiveRows_reflects_alternate_screen_content()
+    {
+        // This is the core of the bug: on the alternate screen the parser swaps its internal grid,
+        // so a caller iterating the array it was handed at construction sees the FROZEN primary
+        // grid. SnapshotActiveRows reads the live grid, so it must show the alt-screen text.
+        var parser = MakeParser(out _);
+        parser.Parse(System.Text.Encoding.UTF8.GetBytes("primary content"));
+
+        // Enter the alternate screen (ESC[?1049h) and draw different content.
+        parser.Parse(System.Text.Encoding.UTF8.GetBytes("\x1b[?1049h\x1b[H\x1b[2Jalt screen body"));
+
+        Assert.True(parser.IsAlternateScreen);
+        var (rows, _, _) = parser.SnapshotActiveRows();
+        var joined = string.Join("\n", rows);
+        Assert.Contains("alt screen body", joined);
+        Assert.DoesNotContain("primary content", joined);
+    }
+
+    [Fact]
+    public void SnapshotActiveRows_returns_cursor_position()
+    {
+        var parser = MakeParser(out _);
+        parser.Parse(System.Text.Encoding.UTF8.GetBytes("\x1b[3;5H")); // row 3, col 5 (1-based)
+        var (_, cursorRow, cursorCol) = parser.SnapshotActiveRows();
+        Assert.Equal(2, cursorRow); // 0-based
+        Assert.Equal(4, cursorCol);
+    }
+
+    private static AnsiParser MakeParser(out TerminalCell[,] cells)
+    {
+        const int cols = 80, rows = 24;
+        cells = new TerminalCell[cols, rows];
+        var scrollback = new System.Collections.Generic.List<TerminalCell[]>();
+        return new AnsiParser(cells, cols, rows, scrollback, 1000);
+    }
+}

--- a/src/CcDirector.Core.Tests/Wingman/TerminalStateDetectorTests.cs
+++ b/src/CcDirector.Core.Tests/Wingman/TerminalStateDetectorTests.cs
@@ -70,6 +70,18 @@ public sealed class TerminalStateDetectorTests : System.IDisposable
     }
 
     [Fact]
+    public void StampBodyActivity_advances_the_body_activity_clock()
+    {
+        // The idle clock for continuous-idle agents (Grok) reads off LastBodyActivityAtUtc, which
+        // the detector advances only on a real screen-body change (not the never-quiet footer).
+        var session = CreateTestSession();
+        var before = session.LastBodyActivityAtUtc;
+        System.Threading.Thread.Sleep(5);
+        session.StampBodyActivity();
+        Assert.True(session.LastBodyActivityAtUtc > before);
+    }
+
+    [Fact]
     public void SuppressActivityFor_only_extends_never_shortens()
     {
         // Overlapping resizes (e.g. attach then an immediate layout change) must not cut a

--- a/src/CcDirector.Core/Drivers/AgentDrivers.cs
+++ b/src/CcDirector.Core/Drivers/AgentDrivers.cs
@@ -23,7 +23,7 @@ public static class AgentDrivers
         AgentKind.Codex => new CodexDriver(),
         AgentKind.Gemini => new GenericDriver(k, GeminiSlashCommands.All),
         AgentKind.OpenCode => new GenericDriver(k, OpenCodeSlashCommands.All),
-        AgentKind.Grok => new GenericDriver(k, GrokSlashCommands.All),
+        AgentKind.Grok => new GenericDriver(k, GrokSlashCommands.All, emitsContinuousIdleOutput: true),
         _ => new GenericDriver(k),
     });
 }

--- a/src/CcDirector.Core/Drivers/GenericDriver.cs
+++ b/src/CcDirector.Core/Drivers/GenericDriver.cs
@@ -23,16 +23,27 @@ public sealed class GenericDriver : IAgentDriver
 
     private readonly IReadOnlyList<AgentSlashCommand> _slashCommands;
 
-    public GenericDriver(AgentKind kind, IReadOnlyList<AgentSlashCommand>? slashCommands = null)
+    public GenericDriver(
+        AgentKind kind,
+        IReadOnlyList<AgentSlashCommand>? slashCommands = null,
+        bool emitsContinuousIdleOutput = false)
     {
         Kind = kind;
         _slashCommands = slashCommands ?? [];
+        EmitsContinuousIdleOutput = emitsContinuousIdleOutput;
     }
 
     public AgentKind Kind { get; }
 
     public DriverCapabilities Capabilities =>
         DriverCapabilities.Cancel | DriverCapabilities.Interrupt;
+
+    /// <summary>
+    /// Set true for Grok: its idle terminal keeps repainting an animated footer (spinner +
+    /// shortcuts + synchronized-output heartbeat), so the byte-only idle rule never fires.
+    /// See <see cref="IAgentDriver.EmitsContinuousIdleOutput"/>.
+    /// </summary>
+    public bool EmitsContinuousIdleOutput { get; }
 
     public IReadOnlyList<AgentSlashCommand> SlashCommands => _slashCommands;
 

--- a/src/CcDirector.Core/Drivers/IAgentDriver.cs
+++ b/src/CcDirector.Core/Drivers/IAgentDriver.cs
@@ -59,6 +59,19 @@ public interface IAgentDriver
 
     DriverCapabilities Capabilities { get; }
 
+    /// <summary>
+    /// True when this CLI's idle terminal never goes byte-silent: it continuously repaints
+    /// an animated footer (a spinner, a shortcuts hint, a clock, the synchronized-output
+    /// heartbeat) even after the turn is finished and it is waiting for input. The byte-only
+    /// idle rule in <c>TerminalStateDetector</c> would pin such a session to Working forever,
+    /// so for these agents the detector switches to a screen-content rule: it only treats the
+    /// session as active while the screen body (above the cursor) is changing. Default false -
+    /// a well-behaved CLI stops emitting bytes when idle, which the cheap byte rule handles.
+    /// This is a terminal-behavior trait, deliberately separate from <see cref="Capabilities"/>
+    /// (which drives the Director action buttons).
+    /// </summary>
+    bool EmitsContinuousIdleOutput => false;
+
     /// <summary>Slash command metadata for the agent's own composer model. This is
     /// separate from <see cref="Capabilities"/>, which controls Director action buttons.</summary>
     IReadOnlyList<AgentSlashCommand> SlashCommands { get; }

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -730,6 +730,23 @@ public sealed class Session : IDisposable
     private long _lastOutputTicks = DateTime.UtcNow.Ticks;
 
     /// <summary>
+    /// UTC time the screen BODY last changed, as judged by the <c>TerminalStateDetector</c>'s
+    /// content rule. For agents whose idle terminal never goes byte-silent (Grok), this is the
+    /// honest idle clock: <see cref="LastOutputAtUtc"/> keeps moving forever as the animated
+    /// footer repaints, but this only advances when the conversation body actually changes, so
+    /// "time since the last body change" is a true measure of how long the agent has been idle.
+    /// The Control API surfaces idle seconds off this for continuous-idle agents. Defaults to the
+    /// creation time; only the detector advances it, via <see cref="StampBodyActivity"/>.
+    /// </summary>
+    public DateTime LastBodyActivityAtUtc => new(Volatile.Read(ref _lastBodyActivityTicks), DateTimeKind.Utc);
+    private long _lastBodyActivityTicks = DateTime.UtcNow.Ticks;
+
+    /// <summary>Record that the screen body changed now. Called by the detector's content rule;
+    /// independent of whether the detector is driving state, so the idle clock is correct even in
+    /// observe-only mode.</summary>
+    internal void StampBodyActivity() => Volatile.Write(ref _lastBodyActivityTicks, DateTime.UtcNow.Ticks);
+
+    /// <summary>
     /// UTC instant until which terminal byte activity must NOT be counted as agent work by
     /// the <c>TerminalStateDetector</c>. Set whenever the Director itself issues a PTY resize
     /// (on attaching/switching to a session, force-refresh, or a layout change): a resize is a
@@ -1164,23 +1181,12 @@ public sealed class Session : IDisposable
     {
         if (_htmlCells is null || _htmlParser is null)
             return (System.Array.Empty<string>(), -1, -1);
+        // Read the parser's ACTIVE grid, not our held _htmlCells array. On the alternate
+        // screen (Grok, and now Claude Code) the parser draws into an internal buffer that
+        // _htmlCells no longer points at, so iterating _htmlCells here would return the
+        // frozen pre-alternate-screen content. SnapshotActiveRows reflects what is on screen.
         lock (_htmlParserLock)
-        {
-            var rows = new string[HtmlGridRows];
-            var sb = new System.Text.StringBuilder(HtmlGridCols);
-            for (int r = 0; r < HtmlGridRows; r++)
-            {
-                sb.Clear();
-                for (int c = 0; c < HtmlGridCols; c++)
-                {
-                    var ch = _htmlCells[c, r].Character;
-                    sb.Append(ch == '\0' ? ' ' : ch);
-                }
-                rows[r] = sb.ToString().TrimEnd();
-            }
-            var (col, row) = _htmlParser.GetCursorPosition();
-            return (rows, row, col);
-        }
+            return _htmlParser.SnapshotActiveRows();
     }
 
     /// <summary>

--- a/src/CcDirector.Core/Wingman/TerminalStateDetector.cs
+++ b/src/CcDirector.Core/Wingman/TerminalStateDetector.cs
@@ -29,6 +29,25 @@ public sealed class TerminalStateDetector : IDisposable
     /// </summary>
     public static readonly TimeSpan QuietThreshold = TimeSpan.FromSeconds(10);
 
+    /// <summary>
+    /// Extract the screen BODY used by the continuous-idle rule: the visible rows strictly ABOVE
+    /// the cursor row, joined with newlines. For an agent with an animated idle footer (Grok) the
+    /// input composer and the never-quiet footer (spinner / shortcuts / clock) sit at and below
+    /// the cursor, so excluding them leaves only the conversation body - which is static once the
+    /// turn is done. Returns false when there is no grid or the cursor is at the top (row 0 or
+    /// unknown), so the body cannot be isolated; the caller then treats the frame as activity
+    /// rather than risk a false idle. Pure and side-effect free so it can be unit tested directly.
+    /// </summary>
+    internal static bool TryExtractBody(string[] rows, int cursorRow, out string body)
+    {
+        body = "";
+        if (rows is null || rows.Length == 0 || cursorRow <= 0)
+            return false;
+        int bodyRows = Math.Min(cursorRow, rows.Length);
+        body = string.Join("\n", rows, 0, bodyRows);
+        return true;
+    }
+
     private readonly SessionManager _sessionManager;
     private readonly bool _driveState;
     private readonly ConcurrentDictionary<Guid, Watcher> _watchers = new();
@@ -99,20 +118,38 @@ public sealed class TerminalStateDetector : IDisposable
     /// <summary>Per-session: byte -> working, plus the idle countdown.</summary>
     private sealed class Watcher : IDisposable
     {
+        // How often, at most, the continuous-idle path takes the (locked) screen snapshot to
+        // diff the body. Between checks it does nothing - it never re-arms the idle timer on a
+        // footer-only repaint. 500ms is far inside the 10s QuietThreshold, so a changing body is
+        // still caught ~20 times before the idle flip, while keeping the per-byte cost trivial.
+        private static readonly long BodyCheckIntervalTicks = TimeSpan.FromMilliseconds(500).Ticks;
+
         private readonly Session _session;
         private readonly CircularTerminalBuffer _buffer;
         private readonly bool _driveState;
         private readonly Action<byte[]> _onBytes;
         private readonly System.Threading.Timer _quietTimer;
 
+        // True for agents whose idle terminal never goes byte-silent (Grok): an animated footer
+        // keeps repainting forever. For these the byte rule is replaced by a screen-body rule.
+        private readonly bool _continuousIdle;
+
         private bool _active;
         private int _disposed;
+
+        // Continuous-idle state. _lastBody (the screen body above the cursor at the last check) is
+        // touched only on the PTY producer thread. The body-change TIMESTAMP lives on the Session
+        // (Session.LastBodyActivityAtUtc) so the idle clock can read it too; the detector stamps it
+        // via Session.StampBodyActivity. _lastBodyCheckTicks throttles the locked snapshot.
+        private string? _lastBody;
+        private long _lastBodyCheckTicks;
 
         public Watcher(Session session, bool driveState)
         {
             _session = session;
             _buffer = session.Buffer!;
             _driveState = driveState;
+            _continuousIdle = session.Driver.EmitsContinuousIdleOutput;
             _onBytes = OnBytes;
             _quietTimer = new System.Threading.Timer(OnQuiet, null, Timeout.Infinite, Timeout.Infinite);
         }
@@ -163,6 +200,15 @@ public sealed class TerminalStateDetector : IDisposable
             if (_session.IsBrandNew)
                 return;
 
+            // Agents with an animated idle footer (Grok) never go byte-silent, so "a byte =
+            // working" would pin them to Working forever. For those, activity is a change to the
+            // screen BODY (above the cursor), not a raw byte. See OnBytesContinuousIdle.
+            if (_continuousIdle)
+            {
+                OnBytesContinuousIdle();
+                return;
+            }
+
             // THE ONLY RULE: a byte out of the ConPTY means the agent is producing output, so
             // it is working. We do not inspect what the byte is, diff the grid, read the footer,
             // or ask a judge. A byte is activity. Period. Full stop. The buffer already stamps
@@ -175,6 +221,61 @@ public sealed class TerminalStateDetector : IDisposable
                 if (_driveState) _session.ApplyTerminalActivityState(ActivityState.Working);
             }
             ArmQuietTimer(); // restart the idle countdown on every byte
+        }
+
+        /// <summary>
+        /// Activity rule for agents whose idle terminal never goes byte-silent. We cannot trust
+        /// raw bytes (the footer animates forever), so the agent is "working" only while the
+        /// screen BODY changes. Body = the visible rows ABOVE the cursor; the input composer and
+        /// the animated footer (spinner / shortcuts / clock) sit at and below the cursor, so the
+        /// churn that never stops is excluded. The screen snapshot is taken under a lock, so it is
+        /// throttled to BodyCheckIntervalTicks; between checks we deliberately do nothing, which is
+        /// what lets the idle timer actually fire. When the body cannot be isolated (cursor at the
+        /// very top, or no grid yet) we treat the frame as activity - never go idle on an ambiguous
+        /// frame, the same conservative outcome the byte rule would give.
+        /// </summary>
+        private void OnBytesContinuousIdle()
+        {
+            var nowTicks = DateTime.UtcNow.Ticks;
+            if (nowTicks - Volatile.Read(ref _lastBodyCheckTicks) < BodyCheckIntervalTicks)
+                return;
+            Volatile.Write(ref _lastBodyCheckTicks, nowTicks);
+
+            if (!TryReadScreenBody(out var body))
+            {
+                MarkContinuousActive();
+                return;
+            }
+
+            if (!string.Equals(body, _lastBody, StringComparison.Ordinal))
+            {
+                _lastBody = body;
+                MarkContinuousActive();
+            }
+            // else: body unchanged (footer-only repaint) - do nothing. The quiet timer keeps
+            // running from the last real change and will flip the session to WaitingForInput.
+        }
+
+        /// <summary>Read the screen body (rows strictly above the cursor) as one string. Returns
+        /// false when there is no grid or the cursor is at the top so no body can be isolated.</summary>
+        private bool TryReadScreenBody(out string body)
+        {
+            var (rows, cursorRow, _) = _session.SnapshotScreenRowsWithCursor();
+            return TryExtractBody(rows, cursorRow, out body);
+        }
+
+        /// <summary>Body changed (or an ambiguous frame): flag Working and re-arm the idle timer
+        /// from now. The quiet confirmation in OnQuietCore measures silence from this moment.</summary>
+        private void MarkContinuousActive()
+        {
+            _session.StampBodyActivity();
+            if (!_active)
+            {
+                _active = true;
+                FileLog.Write($"[TerminalStateDetector] {_session.Id} terminal=ACTIVE (body) | hook={_session.ActivityState}");
+                if (_driveState) _session.ApplyTerminalActivityState(ActivityState.Working);
+            }
+            ArmQuietTimer();
         }
 
         private void OnQuiet(object? state)
@@ -194,8 +295,14 @@ public sealed class TerminalStateDetector : IDisposable
         {
             if (!_active) return;
 
-            // Confirm the silence is real (guard a raced timer fire).
-            var idle = DateTime.UtcNow - _buffer.LastWriteAtUtc;
+            // Confirm the silence is real (guard a raced timer fire). For a byte-silent agent,
+            // "silent" means no bytes (LastWriteAtUtc). For a continuous-idle agent the bytes
+            // never stop, so "silent" means no BODY change since the last one - measure against
+            // _lastBodyChangeTicks instead, or the footer heartbeat would re-arm us forever.
+            var lastChange = _continuousIdle
+                ? _session.LastBodyActivityAtUtc
+                : _buffer.LastWriteAtUtc;
+            var idle = DateTime.UtcNow - lastChange;
             if (idle + TimeSpan.FromMilliseconds(250) < QuietThreshold)
             {
                 ArmQuietTimer();

--- a/src/CcDirector.Terminal.Avalonia/TerminalControl.cs
+++ b/src/CcDirector.Terminal.Avalonia/TerminalControl.cs
@@ -30,6 +30,19 @@ public class TerminalControl : Control
     private const double PollIntervalMs = 50;
 
     /// <summary>
+    /// Safety bound on synchronized-output (?2026) repaint holding. While an agent has an
+    /// open frame we defer the repaint so it renders atomically (no flicker). A well-behaved
+    /// agent closes the frame within a tick or two; if one opens a frame and never closes it,
+    /// this many consecutive deferred ticks forces a repaint anyway so the view cannot freeze.
+    /// At a 50ms poll that is ~300ms - imperceptible for real frames, safe against a stuck frame.
+    /// </summary>
+    private const int MaxDeferredSyncTicks = 6;
+
+    // Consecutive PollTimer ticks whose repaint was deferred because a synchronized
+    // output frame was still open. Reset to zero whenever a repaint actually happens.
+    private int _deferredSyncTicks;
+
+    /// <summary>
     /// How long after a Director-issued PTY resize the terminal-state detector should ignore
     /// byte activity. A resize makes Claude Code repaint its whole screen; that burst is our
     /// doing, not the agent working, so we tell the session to suppress it. Kept well under the
@@ -695,8 +708,21 @@ public class TerminalControl : Control
                 if (!_userScrolled && _scrollOffset > 0)
                     _scrollOffset = 0;
 
-                InvalidateVisual();
-                ScrollChanged?.Invoke(this, EventArgs.Empty);
+                // Synchronized output (?2026): if the agent is mid-frame, hold the repaint
+                // so we never paint a half-drawn frame (that mid-frame paint is what makes
+                // Grok flicker). Paint once the frame closes - or after a bounded number of
+                // deferred ticks, so a frame that never closes cannot freeze the view.
+                bool frameOpen = _parser?.InSynchronizedUpdate == true;
+                if (frameOpen && _deferredSyncTicks < MaxDeferredSyncTicks)
+                {
+                    _deferredSyncTicks++;
+                }
+                else
+                {
+                    _deferredSyncTicks = 0;
+                    InvalidateVisual();
+                    ScrollChanged?.Invoke(this, EventArgs.Empty);
+                }
             }
         }
         catch (Exception ex)

--- a/src/CcDirector.Terminal.Avalonia/TerminalView.cs
+++ b/src/CcDirector.Terminal.Avalonia/TerminalView.cs
@@ -142,7 +142,11 @@ public class TerminalView : Control
         if (!_userScrolled && _scrollOffset > 0)
             _scrollOffset = 0;
 
-        InvalidateVisual();
+        // Synchronized output (?2026): hold the repaint while a frame is still open so
+        // partially-drawn frames are never shown; the next Feed that closes the frame
+        // paints it atomically. Prevents the Grok mid-frame redraw flicker.
+        if (_parser?.InSynchronizedUpdate != true)
+            InvalidateVisual();
     }
 
     /// <summary>

--- a/src/CcDirector.Terminal.Core/AnsiParser.cs
+++ b/src/CcDirector.Terminal.Core/AnsiParser.cs
@@ -70,6 +70,14 @@ public class AnsiParser
     private bool _autoWrap = true;     // DECAWM (?7)
     private bool _originMode;          // DECOM (?6)
     private bool _cursorVisible = true; // DECTCEM (?25)
+    // Synchronized output (DEC private mode ?2026, the BSU/ESU protocol used by
+    // modern TUIs - kitty, wezterm, ghostty, and the xAI Grok CLI). The app
+    // brackets each frame in ?2026h ... ?2026l so the terminal can render the
+    // whole frame atomically. We do not buffer cell writes; instead the owning
+    // control reads InSynchronizedUpdate after Parse and holds its repaint while
+    // a frame is open, painting once when the frame closes. That is what stops
+    // Grok's mid-frame clear+redraw from flickering on screen (issue: Grok flicker).
+    private bool _inSynchronizedUpdate;
     // Bracketed paste / mouse modes are tracked so that mode changes don't
     // corrupt our state; the actual enabling is only reflected in input
     // generation (not our concern here).
@@ -229,6 +237,34 @@ public class AnsiParser
     /// <summary>Current cursor position (0-based col, row). Diagnostic accessor.</summary>
     public (int Col, int Row) GetCursorPosition() => (_cursorCol, _cursorRow);
 
+    /// <summary>
+    /// Snapshot the CURRENTLY ACTIVE visible grid as trailing-trimmed plain-text rows
+    /// (top to bottom) plus the cursor cell. "Active" means the alternate screen when one
+    /// is in use, otherwise the primary grid: this reads the live <see cref="_cells"/>
+    /// pointer, which the parser swaps to an internal buffer on entering the alternate
+    /// screen. A caller that iterates the grid array it was handed at construction sees a
+    /// FROZEN pre-alternate-screen grid once an app like Grok or Claude Code switches to
+    /// the alternate screen (<c>ESC[?1049h</c>); this method is the only way to read what is
+    /// actually on screen now. Not internally synchronized - the owner serializes Parse and
+    /// this call under its own lock.
+    /// </summary>
+    public (string[] Rows, int CursorRow, int CursorCol) SnapshotActiveRows()
+    {
+        var rows = new string[_rows];
+        var sb = new System.Text.StringBuilder(_cols);
+        for (int r = 0; r < _rows; r++)
+        {
+            sb.Clear();
+            for (int c = 0; c < _cols; c++)
+            {
+                var ch = _cells[c, r].Character;
+                sb.Append(ch == '\0' ? ' ' : ch);
+            }
+            rows[r] = sb.ToString().TrimEnd();
+        }
+        return (rows, _cursorRow, _cursorCol);
+    }
+
     /// <summary>Whether the cursor is currently visible per DECTCEM (?25).</summary>
     public bool IsCursorVisible => _cursorVisible;
 
@@ -239,6 +275,15 @@ public class AnsiParser
     /// wheel to the application while this is true.
     /// </summary>
     public bool IsAlternateScreen => _altCells != null;
+
+    /// <summary>
+    /// True while the application is inside a synchronized output frame (it has sent
+    /// DEC private mode ?2026h - Begin Synchronized Update - and not yet the matching
+    /// ?2026l - End Synchronized Update). The owning terminal control should defer its
+    /// repaint while this is true so partially-drawn frames are never shown, then paint
+    /// once when it returns false. Resets on RIS/full reset.
+    /// </summary>
+    public bool InSynchronizedUpdate => _inSynchronizedUpdate;
 
     /// <summary>
     /// Whether the application has requested mouse reporting (?1000 normal,
@@ -891,12 +936,16 @@ public class AnsiParser
                 // Mouse reporting: ?1000 (normal/click), ?1002 (button-event),
                 // ?1003 (any-event) all enable reporting; ?1006 selects SGR
                 // extended coordinates. Tracked so the control can forward the
-                // wheel to the application. ?1005/?1015 (other encodings) and
-                // 2026 (synchronized update) are accepted without effect.
+                // wheel to the application. ?1005/?1015 (other encodings) are
+                // accepted without effect.
                 case 1000:
                 case 1002:
                 case 1003: _mouseReporting = set; break;
                 case 1006: _mouseSgrCoordinates = set; break;
+                // Synchronized output: ?2026h begins a frame, ?2026l ends it. The
+                // owning control reads InSynchronizedUpdate to hold its repaint until
+                // the frame is complete, rendering each frame atomically.
+                case 2026: _inSynchronizedUpdate = set; break;
             }
         }
     }
@@ -1550,6 +1599,7 @@ public class AnsiParser
         _bracketedPaste = false;
         _mouseReporting = false;
         _mouseSgrCoordinates = false;
+        _inSynchronizedUpdate = false; // a full reset closes any open synchronized frame
         _committedFrame = null; // drop repaint-diff baseline on RIS (issue #240)
         _g0IsDecSpecial = false;
         _g1IsDecSpecial = false;


### PR DESCRIPTION
## What this fixes

Two related defects in the Grok command-line interface terminal. Grok drives its
terminal with the alternate screen, synchronized output, and an animated idle
footer that never goes quiet, and both issues come from that.

### Render flicker (closes #764)

The terminal emulator repainted mid-frame, so Grok's clear-and-redraw frames were
shown half-built and the model's answer was not reliably visible. `AnsiParser` now
tracks DEC private mode 2026 (begin and end synchronized update); `TerminalControl`
and `TerminalView` hold the repaint while a frame is open and paint once it closes,
bounded so a frame that never closes cannot freeze the view.

### Session pinned to Working forever (closes #766)

The terminal state detector treated any byte as activity and only flagged "needs
you" after ten seconds of complete byte silence. Grok's idle footer repaints
forever, so the session was pinned to Working and the idle clock never advanced.

- New per-agent capability `IAgentDriver.EmitsContinuousIdleOutput`, set true for
  Grok. For these agents the detector switches from the byte rule to a screen rule:
  activity is a change to the screen body above the cursor, so the animated footer
  at and below the cursor is ignored. The quiet timer measures silence from the last
  body change.
- The server-side screen snapshot was blind to the alternate screen: on entering it
  the parser swaps its grid, so the array the session held froze at the
  pre-alternate-screen content. `AnsiParser.SnapshotActiveRows` reads the live grid,
  and `Session.SnapshotScreenRowsWithCursor` uses it. The idle clock for
  continuous-idle agents now reads from the last body change, so the idle seconds and
  the WaitingForInput badge agree.

## Verification

Verified live in a slot build. A Grok session goes Working during its answer and
flips to WaitingForInput within the quiet threshold after it finishes, with the idle
clock climbing past one hundred seconds while the footer keeps emitting bytes. Before
the fix the session stayed Working forever and the idle clock stayed near zero.

Tests: new `ContinuousIdleStateTests` (capability flag, body extraction,
alternate-screen snapshot) and `AnsiParserSynchronizedOutputTests`, plus a
`Session` idle-clock test. Detector and parser suites green.

## Known limitation

If Grok thinks silently for longer than the quiet threshold with no body output, it
may briefly show WaitingForInput; the next body update flips it straight back to
Working. The fully robust long-term option is to anchor state to Grok's transcript
turn boundaries, tracked on #766.

Closes #764
Closes #766

Generated with [Claude Code](https://claude.com/claude-code)
