### PR TITLE
Ignore mcps/ MCP tool-schema dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,8 @@ playground/headless-brain/state.json
 playground/hosted-agent-smoke/sandboxes/
 playground/hosted-agent-smoke/smoke-output.txt
 playground/alpha-test-root/
+
+# MCP server tool-definition schema dumps, written into the repo root at runtime by
+# connected MCP tooling (mindzie-dev-proto / mindzie-localhost-proto / pencil). Generated
+# local artifacts, never part of the codebase.
+mcps/


### PR DESCRIPTION
Connected MCP tooling writes per-tool definition JSON into a repo-root `mcps/` directory at runtime (255 generated local artifacts, never tracked) that inflated the working-tree change count to 256. They are not part of the codebase; this ignores the directory.

Generated with [Claude Code](https://claude.com/claude-code)