### PR TITLE
Fix Grok path-link underline flicker (#771)

### DIFF
--- a/src/CcDirector.Terminal.Avalonia.Tests/TerminalRenderTests.cs
+++ b/src/CcDirector.Terminal.Avalonia.Tests/TerminalRenderTests.cs
@@ -25,6 +25,41 @@ public sealed class TerminalRenderTests
     // A margin well above black, well below the real value, makes this robust to font fallback.
     private const double NotBlackThreshold = 0.02;
 
+    /// <summary>Walk up from the test binary to the repo root (the folder with cc-director.sln), so
+    /// relative path links in the fixture (docs/, phone/, ...) resolve to real on-disk directories.</summary>
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "cc-director.sln")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+
+    [AvaloniaFact]
+    public void Grok_path_link_does_not_flicker_on_footer_bytes()
+    {
+        // The flicker: path links render underlined only when an async disk-existence check has
+        // populated a cache; the per-byte handler used to wipe that cache, so on Grok's never-ending
+        // footer bytes existing path links (e.g. "docs/") vanished for a frame then reappeared,
+        // ~30x/s. Detect path links, simulate a footer byte, and assert the count is unchanged.
+        var fixture = LoadFixture();
+        var (terminal, window) = NewTerminal();
+        terminal.HarnessRepoPath = RepoRoot();
+        terminal.HarnessRebuild(fixture);
+
+        terminal.HarnessCountPathLinks();         // schedule the async existence checks
+        System.Threading.Thread.Sleep(250);       // let them resolve (cache warms)
+        int warm = terminal.HarnessCountPathLinks();
+        Assert.True(warm > 0, "fixture should contain existing path links (e.g. docs/) to test");
+
+        // A footer byte runs the per-byte handler. The link count must NOT drop.
+        terminal.HarnessFeed(System.Array.Empty<byte>());
+        int afterFooterByte = terminal.HarnessCountPathLinks();
+
+        Assert.Equal(warm, afterFooterByte);
+    }
+
     private static byte[] LoadFixture()
     {
         var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", "grok-alt-screen.bin");

--- a/src/CcDirector.Terminal.Avalonia/TerminalControl.cs
+++ b/src/CcDirector.Terminal.Avalonia/TerminalControl.cs
@@ -732,8 +732,14 @@ public class TerminalControl : Control
         // would otherwise stay frozen at the pre-alt content and the terminal renders black.
         SyncActiveGrid();
 
-        // Clear path cache so links re-evaluate with new terminal content
-        _pathExistsCache.Clear();
+        // Do NOT clear the path-existence cache here. A path's existence on disk does not change
+        // because the agent redrew its screen, and the cache is keyed by absolute path, so stale
+        // entries are harmless (a path no longer on screen is simply never looked up). Clearing it
+        // every byte made existing path links (e.g. "docs/") report as missing for one frame on the
+        // resulting cache miss, then reappear when the async check re-resolved - a per-byte underline
+        // flicker under Grok, whose footer never stops emitting bytes. The cache is still cleared on
+        // attach/detach/rebuild (a real content reset). Reset only the one-shot repaint guard so a
+        // newly-seen path can still schedule its repaint when its existence check resolves.
         Interlocked.Exchange(ref _pathCacheInvalidateNeeded, 0);
 
         // Let selection persist during output so users can
@@ -799,6 +805,29 @@ public class TerminalControl : Control
     /// <summary>Harness: the live parser, for reading the active (alt-aware) grid as ground truth.</summary>
     internal AnsiParser? HarnessParser => _parser;
 
+    // Harness: stand-in for the session's RepoPath so relative path links (e.g. "docs/") resolve
+    // to real on-disk directories and exercise the path-existence link rendering.
+    private string? _harnessRepoPath;
+    internal string? HarnessRepoPath { get => _harnessRepoPath; set => _harnessRepoPath = value; }
+
+    /// <summary>Harness: number of PATH link regions found in the most recent render. Drops to zero
+    /// the frame after the path-existence cache is cleared (the flicker), then recovers.</summary>
+    internal int HarnessPathLinkRegionCount =>
+        _linkRegions.Count(r => r.Type == LinkDetector.LinkType.Path);
+
+    /// <summary>Harness: run the renderer's exact path-link detection over the visible grid and count
+    /// PATH links right now. This calls <see cref="PathExistsCheckForRender"/>, so the FIRST call
+    /// after the path cache is cleared returns fewer links (existing paths report missing for that
+    /// frame) - that drop, repeated every Grok footer byte, is the flicker.</summary>
+    internal int HarnessCountPathLinks()
+    {
+        int n = 0;
+        for (int row = 0; row < _rows; row++)
+            foreach (var m in FindAllLinkMatches(GetLineText(row)))
+                if (m.Type == LinkDetector.LinkType.Path) n++;
+        return n;
+    }
+
     public override void Render(DrawingContext context)
     {
         // Always fill the full control area with the renderer background first.
@@ -856,7 +885,7 @@ public class TerminalControl : Control
             cursorVisible, curCol, curRow,
             renderLinkRegions,
             _dpiScale, _fontSize,
-            _session?.RepoPath);
+            _session?.RepoPath ?? _harnessRepoPath);
 
         try
         {
@@ -1385,7 +1414,7 @@ public class TerminalControl : Control
     /// </summary>
     private List<LinkDetector.LinkMatch> FindAllLinkMatches(string lineText)
     {
-        return LinkDetector.FindAllLinkMatches(lineText, _session?.RepoPath, PathExistsCheckForRender);
+        return LinkDetector.FindAllLinkMatches(lineText, _session?.RepoPath ?? _harnessRepoPath, PathExistsCheckForRender);
     }
 
     /// <summary>

--- a/src/CcDirector.Terminal.RenderHarness/Program.cs
+++ b/src/CcDirector.Terminal.RenderHarness/Program.cs
@@ -48,7 +48,12 @@ internal static class Program
         byte[] fixture = File.ReadAllBytes(fixturePath);
         Console.WriteLine($"[harness] fixture={fixturePath} ({fixture.Length} bytes) out={outDir}");
 
-        var terminal = new TerminalControl();
+        string repoPath = args.Length > 2 ? args[2] : "D:/ReposFred/devthrottle";
+        var terminal = new TerminalControl
+        {
+            // So relative path links like "docs/" resolve to a real on-disk dir and render as links.
+            HarnessRepoPath = repoPath,
+        };
         var window = new Window
         {
             Width = WindowWidth,
@@ -119,6 +124,31 @@ internal static class Program
         terminal.HarnessRebuild(fixture);
         Capture("reattach_after_tabswitch");
 
+        // ---- Phase 3: path-link flicker test ----
+        // Path links (e.g. "docs/") render underlined ONLY when an async disk-existence check has
+        // populated the cache. The per-byte handler clears that cache, and Grok's idle footer feeds
+        // bytes ~30x/s - so each frame the link reverts to plain (cache miss) then back to underlined
+        // (async resolves) = flicker. Reproduce deterministically: warm the cache (link underlined),
+        // then feed an EMPTY batch (no screen change, but the per-byte path-cache clear fires) and
+        // re-render. Any pixel difference is the link styling toggling = the flicker.
+        WriteableBitmap? CaptureBmp(string label)
+        {
+            Pump();
+            AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+            var f = window.CaptureRenderedFrame();
+            if (f is not null) f.Save(Path.Combine(outDir, label + ".png"));
+            return f;
+        }
+        terminal.HarnessCountPathLinks();     // first pass: schedules the async existence checks
+        System.Threading.Thread.Sleep(200);   // let the background checks resolve (cache warms)
+        int warmLinks = terminal.HarnessCountPathLinks();   // warm: existing paths now report as links
+        terminal.HarnessFeed(Array.Empty<byte>());          // no screen change, but clears the path cache
+        int clearedLinks = terminal.HarnessCountPathLinks();// first pass after clear: cache miss -> fewer links
+        CaptureBmp("link_warm");
+        CaptureBmp("link_after_clear");
+        log.Add($"LINK-FLICKER\tpathLinks warm={warmLinks} afterClear={clearedLinks}");
+        Console.WriteLine($"[harness] path-link flicker: pathLinks warm={warmLinks} -> immediately-after-cache-clear={clearedLinks}  (warm>cleared = flicker)");
+
         File.WriteAllLines(Path.Combine(outDir, "metrics.txt"), log);
         Console.WriteLine("[harness] DONE");
         Environment.Exit(0);
@@ -127,6 +157,22 @@ internal static class Program
     private static void Pump()
     {
         Dispatcher.UIThread.RunJobs();
+    }
+
+    /// <summary>Fraction of bytes that differ between two captured frames. 0 = identical.</summary>
+    private static double FrameDiffFraction(WriteableBitmap a, WriteableBitmap b)
+    {
+        using var fa = a.Lock();
+        using var fb = b.Lock();
+        int total = Math.Min(fa.RowBytes * fa.Size.Height, fb.RowBytes * fb.Size.Height);
+        var ba = new byte[fa.RowBytes * fa.Size.Height];
+        var bb = new byte[fb.RowBytes * fb.Size.Height];
+        Marshal.Copy(fa.Address, ba, 0, ba.Length);
+        Marshal.Copy(fb.Address, bb, 0, bb.Length);
+        long diff = 0;
+        for (int i = 0; i < total; i++)
+            if (ba[i] != bb[i]) diff++;
+        return total == 0 ? 0 : (double)diff / total;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes the file-path link underline flicker in Grok sessions: the path-existence cache was cleared on every byte, and Grok's footer never stops emitting, so existing path links lost their underline every frame then regained it. Fix stops the per-byte clear (existence doesn't change on redraw; cache still cleared on attach/detach/rebuild). Reproduced + guarded in the render harness and a new headless test.

Closes #771

Generated with [Claude Code](https://claude.com/claude-code)