### PR TITLE
Add launch-time fleet preamble (Claude + Codex) and the agent-expert reference skill

### DIFF
--- a/.claude/skills/agent-expert/SKILL.md
+++ b/.claude/skills/agent-expert/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: agent-expert
+description: INTERNAL reference, NOT shipped with the installer. The in-repo expert on every coding-agent CLI CC Director can run (Claude Code, Codex, Gemini, OpenCode, Grok, Copilot, Cursor, Pi). Knows each agent's command line, config files, context-injection points, lifecycle hooks and events, SDK/API/server mode, transcript format, session semantics, and how CC Director drives it. Triggers on "agent-expert", "agent expert", "how does <agent> inject context", "<agent> hooks", "<agent> events", "<agent> CLI reference", "which agents support X", "agent capability matrix".
+---
+
+# Agent Expert (internal super-agent-manager)
+
+This skill is the single place that knows everything we need to build drivers and plugins
+for the coding-agent CLIs CC Director supervises, and to make sessions talk to each other.
+It exists ONLY in this repository, for our own use. It is NOT deployed to customers and must
+be excluded from the installer skill bundle (see "Do not ship" below).
+
+## What it is for
+
+When you need to know, for any agent, how to:
+- launch it (command line, headless mode, session id, model flag, output format),
+- configure it (config files and their precedence),
+- inject context at launch (instruction files, system-prompt flags, hook additionalContext),
+- get a signal when it clears or compacts its context (lifecycle hooks / event bus),
+- read its transcript, or drive it through an SDK / server / RPC channel,
+- and exactly how CC Director integrates it today plus the gaps -
+
+read the per-agent reference file. Do not re-derive this from the web each time; that is the
+delay this skill removes. If a fact is missing or stale, research it, then update the file.
+
+## How to use
+
+1. Open `agents/README.md` for the at-a-glance cross-agent matrix.
+2. Open `agents/<agent>.md` for the deep reference on one agent. These files are authoritative;
+   the matrix is only the summary.
+3. Each file marks every fact [VERIFIED from docs] or [INFERRED/UNCERTAIN] and links the source.
+
+## The agents
+
+| Agent | AgentKind | File |
+|-------|-----------|------|
+| Claude Code | ClaudeCode | [agents/claude-code.md](agents/claude-code.md) |
+| OpenAI Codex | Codex | [agents/codex.md](agents/codex.md) |
+| Google Gemini | Gemini | [agents/gemini.md](agents/gemini.md) |
+| opencode | OpenCode | [agents/opencode.md](agents/opencode.md) |
+| xAI Grok ("Grok Build") | Grok | [agents/grok.md](agents/grok.md) |
+| GitHub Copilot | Copilot | [agents/copilot.md](agents/copilot.md) |
+| Cursor (cursor-agent) | Cursor | [agents/cursor.md](agents/cursor.md) |
+| pi | Pi | [agents/pi.md](agents/pi.md) |
+
+To add an agent, copy [agents/_template.md](agents/_template.md) and fill every section.
+
+## The one thing this skill is really about: context injection and reset detection
+
+Every agent reaches the fleet through its own Director (CC_DIRECTOR_API) and gets a launch
+preamble (its identity plus the cc-* fleet commands). The hard part is keeping that preamble
+present after the agent clears or compacts its context. The CLIs fall into four mechanism
+families - see `agents/README.md` for which agent is in which:
+
+- Family A - shell-command hook that injects context. A config file registers a command we
+  own; the command prints the preamble as additionalContext. This is what is already wired
+  for Claude (`ClaudeHookInstaller` plus the `GET /sessions/{sid}/fleet-preamble` endpoint).
+- Family B - out-of-process event bus. We subscribe to the agent's event stream and push the
+  preamble when we see a new/cleared/compacted session.
+- Family C - in-process extension or plugin we author and load into the agent.
+- Family D - instruction file the agent re-reads every prompt (passive, self-healing, no event).
+
+The shared piece across all families is the Director endpoint `GET /sessions/{sid}/fleet-preamble`,
+which already exists and is agent-agnostic.
+
+## Do not ship
+
+This skill is internal. Before any installer/skill-bundle change, confirm `agent-expert` is
+excluded from the shipped skill set. It documents competitor tooling and our internal
+integration plans and has no place on a customer machine.

--- a/.claude/skills/agent-expert/agents/README.md
+++ b/.claude/skills/agent-expert/agents/README.md
@@ -1,0 +1,63 @@
+# Agent capability matrix (at a glance)
+
+This is the summary. The per-agent files are authoritative; open them for detail, exact field
+names, source links, and verification status. Ratings: Strong / Partial / None / Unknown.
+
+## Context injection and reset detection
+
+| Agent | Inject at launch | Signal/hook on /clear | Signal/hook on compact | Mechanism family | Our driver |
+|-------|------------------|-----------------------|------------------------|------------------|------------|
+| [Claude Code](claude-code.md) | Strong (SessionStart additionalContext) | Strong (hook, source=clear) | Strong (hook, source=compact) | A shell-hook | ClaudeDriver |
+| [Codex](codex.md) | Strong (SessionStart additionalContext) | Strong (hook, source=clear) | Strong (hook, source=compact) | A shell-hook | CodexDriver |
+| [Gemini](gemini.md) | Strong (SessionStart additionalContext, or GEMINI.md) | Strong (hook, source=clear) | Detect via PreCompress; GEMINI.md persists | A shell-hook + D file | GenericDriver |
+| [Grok](grok.md) | Strong (instruction files CLAUDE.local.md / .grok/rules) - hook stdout is IGNORED, NO additionalContext (verified vs binary 0.2.67) | Detect via hook; re-inject via file | Detect via PreCompact/PostCompact; re-inject via file | D instruction-file (A hooks exist but cannot inject) | GenericDriver |
+| [opencode](opencode.md) | Strong (AGENTS.md) | Detect (session.created over SSE bus) | Detect (session.compacted over SSE bus) | B event-bus / C plugin | GenericDriver |
+| [Cursor](cursor.md) | Strong (sessionStart additional_context; rules) | Unknown (sessionStart re-fire undocumented) | Detect via preCompact (observe only) | A shell-hook | CursorDriver |
+| [Copilot](copilot.md) | Partial (instruction files; CLI hook output ignored) | None documented | Detect via preCompact | D instruction-file | CopilotDriver |
+| [pi](pi.md) | Strong (flags, AGENTS.md, before_agent_start) | Strong (extension, session_start reason=new) | Strong (extension, session_before_compact) | C in-process extension | PiDriver |
+
+## The four mechanism families
+
+- A - shell-command hook that injects context. A config file registers a command we own; it
+  prints the preamble as additionalContext. Agents: Claude (wired), Codex, Gemini, Cursor.
+- B - out-of-process event bus. We subscribe to the agent's event stream and push the preamble
+  on a new/cleared/compacted session. Agents: opencode (opencode serve, GET /event SSE).
+- C - in-process extension or plugin we author and load. Agents: pi (TypeScript extension),
+  opencode (plugin), Copilot (only via its SDK, not the stock CLI).
+- D - instruction file the agent re-reads every prompt (passive, self-healing, no event).
+  Agents: Copilot (primary), Grok (its hook output is ignored, so file is the only injector),
+  and a universal fallback for everyone (AGENTS.md / CLAUDE.md).
+
+## Notes that bite
+
+- "Only Claude can do this" was WRONG: it described what we had WIRED, not what the CLIs
+  support. Most CLIs have converged on the Claude hook model; the work is wiring each plugin.
+- These hook systems are recent and churning (Gemini, Codex, Grok, Cursor, Copilot all have
+  open issues). Every field name needs a live check against the installed binary before we
+  depend on it. See each file's "Caveats and verification needed".
+- cc-ask (ask another session and read its reply) needs the TranscriptRead capability, which
+  today only ClaudeDriver declares. So cross-agent "ask" only works Claude -> Claude so far.
+- The shared piece for all families is the Director endpoint GET /sessions/{sid}/fleet-preamble,
+  which already exists and is agent-agnostic.
+- CORRECTION (verified against binaries): Grok was previously listed as a Family A hook-injector
+  by analogy to Claude. That is wrong - Grok 0.2.67's shipped hooks guide says passive-event hook
+  stdout is ignored, and a binary scan found no `additionalContext`/`hookSpecificOutput`. Grok is
+  Family D. Treat all "by analogy to Claude" claims as suspect until checked against the binary.
+
+## Live-verification status on this dev machine (SOREN_NORTH)
+
+What was actually checked against an installed binary versus researched from docs only:
+
+| Agent | Installed here | Notes |
+|-------|----------------|-------|
+| Claude Code | Yes | Fleet preamble wired AND proven live (startup + clear). Reference impl. |
+| Grok | Yes (0.2.67) | Ships its full user guide at ~/.grok/docs/user-guide/. Hook injection NOT available - use instruction files. |
+| Gemini | Yes (0.1.11) | Binary PREDATES the hooks system, --output-format, --resume. Family A cannot be wired until upgraded and re-probed. Also: current docs say Gemini DOES persist transcripts (our code assumes it does not - re-check). |
+| Codex | Yes (0.141.0) | WIRED + proven live: hook auto-installs into ~/.codex/hooks.json, preamble injects (fires at first turn). Also fixed a programmatic-submit bug (echo-verified submit). |
+| opencode | Not confirmed here | Docs only. Family B needs the TUI to expose a reachable server (it may not by default). |
+| Copilot | Not confirmed here | Docs only. Docs contradict each other on whether the CLI sessionStart can inject - verify live. |
+| Cursor | NO (cursor-agent absent) | Spawn fails with CreateProcess failed. All Cursor facts are docs-only and unverifiable here. |
+| pi | Not confirmed here | Docs only (read from the repo raw markdown). Richest event system; Family C extension. |
+
+Every per-agent file ends with a "Caveats and verification needed" section listing the exact
+fields and behaviors to confirm against the installed binary before code depends on them.

--- a/.claude/skills/agent-expert/agents/_template.md
+++ b/.claude/skills/agent-expert/agents/_template.md
@@ -1,0 +1,57 @@
+<!--
+Per-agent reference template. Copy this to agents/<agent>.md and fill EVERY section.
+Rules:
+- ASCII only. No Unicode, no emoji, no em-dashes (use " - "). This repo forbids non-ASCII.
+- Mark every non-trivial fact [VERIFIED from docs] or [INFERRED/UNCERTAIN].
+- Link the source inline AND collect all links in the Sources section.
+- Prefer official docs and source repos over blog posts.
+-->
+
+# <Agent Display Name> (<AgentKind>)
+
+> One-line summary. Our integration status: <driver class> / <plugin class>.
+
+## 1. Identity and install
+- Binary name, npm package or install command, source repository, official documentation home.
+- Windows install location of the launchable shim, and the version-probe command.
+
+## 2. Command-line interface
+- Interactive vs headless/print/non-interactive mode.
+- Flag table: model flag, session-id / resume, output format (json / stream-json), auto-approve,
+  system-prompt flags, anything we pass or could pass at launch.
+
+## 3. Configuration
+- Config files, their locations, and precedence (global / user / project / session).
+
+## 4. Context injection (how to inject a preamble)
+- Instruction / context files (AGENTS.md, CLAUDE.md, tool-specific), system-prompt flags,
+  and hook-based additionalContext.
+- For each: does it survive /clear? does it survive /compact?
+
+## 5. Lifecycle events and hooks
+- Full event list. Config file format and location. The stdin/stdout JSON contract.
+- Which events fire on: startup, resume, clear / new, compact.
+- Can a hook's output inject model context (additionalContext or equivalent)? Field name.
+
+## 6. SDK / programmatic API / server mode
+- Libraries, RPC / server / event-stream, endpoints or methods, auth.
+
+## 7. MCP / extensions / plugins / skills
+
+## 8. Transcript / history
+- Location, file format, whether parseable, token-usage availability.
+
+## 9. Session semantics
+- clear vs compact vs new vs resume. What each does. Session-id behavior across them.
+
+## 10. How CC Director integrates it
+- Our classes: driver, agent, plugin. Declared driver capabilities. History provider kind.
+- Fleet-preamble strategy family (A shell-hook / B event-bus / C extension / D instruction-file).
+- Concrete plan to inject the fleet preamble at launch and re-inject on clear/compact.
+- Current gaps.
+
+## 11. Caveats and verification needed
+- Recency / churn, unverified field names, behaviors to confirm live against the installed binary.
+
+## Sources
+- Every documentation URL used, bulleted.

--- a/.claude/skills/agent-expert/agents/claude-code.md
+++ b/.claude/skills/agent-expert/agents/claude-code.md
@@ -1,0 +1,221 @@
+<!--
+Per-agent reference: Claude Code (Anthropic's `claude` CLI).
+Rules:
+- ASCII only. No Unicode, no emoji, no em-dashes (use " - ").
+- Every non-trivial fact is marked [VERIFIED from docs] or [INFERRED/UNCERTAIN].
+- Sources linked inline and collected in the Sources section.
+- Doc churn is high. Re-check anything before depending on it. See section 11.
+-->
+
+# Claude Code (ClaudeCode)
+
+> Anthropic's official coding-agent CLI (binary: claude). Our integration: ClaudeDriver / ClaudeAgent / ClaudeAgentPlugin, history provider kind TranscriptFile. This is the reference implementation for fleet-preamble injection (mechanism Family A, shell-command hook): it is ALREADY WIRED and proven live. All other agents mirror it.
+
+## 1. Identity and install
+
+- Binary name: claude. [VERIFIED from docs - https://code.claude.com/docs/en/cli-reference]
+- TypeScript/npm Agent SDK package: @anthropic-ai/claude-agent-sdk (bundles a native Claude Code binary per platform as an optional dependency, so installing the SDK does not require installing Claude Code separately). Python package: claude-agent-sdk (import name claude_agent_sdk, requires Python 3.10 or later). [VERIFIED from docs - https://code.claude.com/docs/en/agent-sdk/overview]
+- Self-install / update commands: `claude install [version|stable|latest]`, `claude update`. The native binary can be pinned to a version like 2.1.118. [VERIFIED from docs - https://code.claude.com/docs/en/cli-reference]
+- Official documentation home: https://code.claude.com/docs (docs.anthropic.com and docs.claude.com URLs now redirect into code.claude.com and platform.claude.com). [VERIFIED - observed live redirects during this research, see Sources]
+- Source repositories: TypeScript SDK https://github.com/anthropics/claude-agent-sdk-typescript ; Python SDK https://github.com/anthropics/claude-agent-sdk-python . The Claude Code CLI itself is distributed as a native binary, not as open source. [VERIFIED from docs - https://code.claude.com/docs/en/agent-sdk/overview]
+- Windows launchable shim: we resolve `claude.exe` from an explicitly configured path, otherwise the first `claude.exe` found on PATH. [VERIFIED from our code - src/CcDirector.Core/Drivers/ClaudeDriver.cs ResolveExecutable]
+- Version-probe command: `claude --version` (alias `claude -v`). [VERIFIED from docs - https://code.claude.com/docs/en/cli-reference]
+- Auth: `claude auth login` (subscription) or `claude auth status` (JSON, exit 0 if logged in). Headless/SDK auth uses ANTHROPIC_API_KEY or `claude setup-token` for a long-lived OAuth token; bare mode skips OAuth and keychain reads entirely. [VERIFIED from docs - https://code.claude.com/docs/en/cli-reference and https://code.claude.com/docs/en/headless]
+
+## 2. Command-line interface
+
+Two modes:
+- Interactive TUI: `claude` or `claude "initial prompt"`. This is what CC Director drives in a terminal. [VERIFIED from docs - https://code.claude.com/docs/en/cli-reference]
+- Headless / print / non-interactive: `claude -p "query"` (alias `--print`). Runs the agent loop, prints, exits. All CLI flags work with -p. This is the Agent-SDK-via-CLI surface. [VERIFIED from docs - https://code.claude.com/docs/en/headless]
+
+Flag table (the ones we pass or could pass at launch). [VERIFIED from docs - https://code.claude.com/docs/en/cli-reference unless noted]
+
+| Flag | Meaning / accepted values |
+| --- | --- |
+| `--print`, `-p` | Headless print mode; run and exit, no interactive TUI. |
+| `--session-id <uuid>` | Use a specific session id (must be a valid UUID). We preassign this so the transcript path is known from birth. |
+| `--resume`, `-r <id-or-name>` | Resume a specific session by id or name; bare `--resume` opens the picker. |
+| `--continue`, `-c` | Resume the most recent session in the current directory. |
+| `--fork-session` | When resuming, mint a NEW session id instead of reusing the original (use with --resume or --continue). |
+| `--model <alias-or-id>` | sonnet, opus, haiku, fable, or a full model id (e.g. claude-sonnet-4-6). Overrides the `model` setting and ANTHROPIC_MODEL. |
+| `--settings <file-or-json>` | Path to a settings JSON file OR an inline JSON string. Values override the same keys in settings.json files for this session; omitted keys keep file values. This is how we inject our SessionStart hook (it MERGES with the user's hooks). |
+| `--setting-sources <list>` | Comma-separated sources to load: user, project, local. |
+| `--output-format <fmt>` | Print mode only: text (default), json, stream-json. |
+| `--input-format <fmt>` | Print mode only: text, stream-json. |
+| `--include-partial-messages` | Emit partial streaming events. Requires --print and --output-format stream-json. |
+| `--include-hook-events` | Include hook lifecycle events in the stream. Requires --output-format stream-json. |
+| `--verbose` | Full turn-by-turn output (required for stream-json streaming examples). |
+| `--append-system-prompt <text>` | Append text to the end of the default system prompt. Per-invocation only. |
+| `--append-system-prompt-file <path>` | Same, from a file. |
+| `--system-prompt <text>` | REPLACE the entire default system prompt. |
+| `--system-prompt-file <path>` | Replace from a file. (--system-prompt and --system-prompt-file are mutually exclusive; append flags combine with either.) |
+| `--mcp-config <files-or-json>` | Load MCP servers from JSON files or strings (space-separated). |
+| `--strict-mcp-config` | Use only --mcp-config servers, ignore all other MCP config. |
+| `--permission-mode <mode>` | default, acceptEdits, plan, auto, dontAsk, bypassPermissions. Overrides defaultMode from settings. |
+| `--dangerously-skip-permissions` | Equivalent to --permission-mode bypassPermissions. This is our DefaultArgs. |
+| `--allowedTools` / `--allowed-tools <list>` | Tools that run without a prompt. |
+| `--disallowedTools` / `--disallowed-tools <list>` | Deny rules; a bare name removes the tool from context. |
+| `--tools <list>` | Restrict which built-in tools are available. |
+| `--add-dir <paths>` | Add working directories (grants file access; does NOT load their .claude config or CLAUDE.md unless CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1). |
+| `--agents <json>` | Define custom subagents inline as JSON (frontmatter fields plus a `prompt` field). |
+| `--agent <name>` | Select a named agent for the session. |
+| `--bare` | Skip auto-discovery of hooks, skills, plugins, MCP servers, auto memory, and CLAUDE.md (fast scripted start). NOTE: this would suppress our hook - do not use it for fleet sessions. |
+| `--init-only` | Run Setup and SessionStart hooks, then exit without a conversation. Useful to test our hook fires. |
+| `--no-session-persistence` | Print mode only; do not write the transcript / cannot resume. |
+| `--json-schema <schema>` | Print mode only; structured output into a `structured_output` field. |
+| `--name`, `-n <name>` | Set a session display name (resumable with --resume <name>). |
+
+Relevant subcommands: `claude mcp ...` (configure MCP servers), `claude agents` (agent view; `--json` lists active background sessions for scripting), `claude remote-control` (server mode, see section 6), `claude setup-token`, `claude auth ...`. [VERIFIED from docs - https://code.claude.com/docs/en/cli-reference]
+
+What CC Director passes today: new session -> `--dangerously-skip-permissions --session-id <guid>` plus our `--settings <hooks-settings.json>`; resume -> `--dangerously-skip-permissions --resume <id>`; Studio mode prepends `-p --output-format stream-json --verbose`. [VERIFIED from our code - ClaudeDriver.BuildLaunchSpec, ClaudeAgent.BuildLaunchSpec; --settings wiring in ClaudeHookInstaller / SessionManager]
+
+## 3. Configuration
+
+settings.json scopes and precedence (highest wins). [VERIFIED from docs - https://code.claude.com/docs/en/settings]
+
+| Scope | Path |
+| --- | --- |
+| Managed (enterprise) | Windows: C:\Program Files\ClaudeCode\managed-settings.json (also a managed-settings.d/*.json drop-in dir); macOS: /Library/Application Support/ClaudeCode/managed-settings.json; Linux/WSL: /etc/claude-code/managed-settings.json. Also OS policy: Windows registry HKLM\SOFTWARE\Policies\ClaudeCode. |
+| Command-line args | e.g. --settings, --model, --permission-mode (session overrides). |
+| Local (per project, gitignored) | .claude/settings.local.json |
+| Project (committed) | .claude/settings.json |
+| User | ~/.claude/settings.json (Windows: %USERPROFILE%\.claude\settings.json) |
+
+Precedence order high to low: Managed > command-line args > Local > Project > User. Managed settings cannot be overridden. [VERIFIED from docs - https://code.claude.com/docs/en/settings]
+
+Key settings.json fields: `model`, `permissions` (allow/deny arrays), `env`, `hooks` (lives at root level), `outputStyle`, `effortLevel`, `autoMemoryEnabled`, `autoMemoryDirectory`, `cleanupPeriodDays`, `claudeMdExcludes`, and (managed only) `claudeMd`, `forceLoginMethod`, `forceLoginOrgUUID`, `sandbox.enabled`. The hooks key is reloaded when settings files change; `model` is not (use /model mid-session). [VERIFIED from docs - https://code.claude.com/docs/en/settings and https://code.claude.com/docs/en/memory]
+
+ClaudeDriver reads ~/.claude/settings.json's `model` key as a display hint for the model picker (never writes it). [VERIFIED from our code - ClaudeDriver.ReadConfiguredDefaultModel]
+
+Other config locations: MCP servers in project .mcp.json; skills in .claude/skills/*/SKILL.md; legacy commands in .claude/commands/*.md; path-scoped rules in .claude/rules/*.md; user rules in ~/.claude/rules/. Transcript/config storage root can be moved with CLAUDE_CONFIG_DIR. [VERIFIED from docs - https://code.claude.com/docs/en/agent-sdk/overview, https://code.claude.com/docs/en/memory, https://code.claude.com/docs/en/sessions]
+
+## 4. Context injection (how to inject a preamble)
+
+Mechanisms, each with whether it survives /clear and /compact:
+
+1. SessionStart hook additionalContext (OUR mechanism, Family A). A hook prints `hookSpecificOutput.additionalContext`; Claude wraps it in a system reminder and inserts it at the point the hook fired, before the first prompt. [VERIFIED from docs - https://code.claude.com/docs/en/hooks]
+   - Survives /clear: YES, the hook RE-FIRES on /clear (SessionStart matcher `clear`), so the preamble is re-injected into the new context. [VERIFIED from docs - hooks matcher table]
+   - Survives /compact: YES, the hook RE-FIRES on compaction (SessionStart matcher `compact`). [VERIFIED from docs - hooks matcher table]
+   - This is the only listed mechanism that self-heals on BOTH boundaries via an event we control, which is why it is our reference implementation.
+
+2. CLAUDE.md memory files (Family D, passive). Loaded into context at the start of every session as a user message after the system prompt. [VERIFIED from docs - https://code.claude.com/docs/en/memory]
+   - Survives /clear: YES (re-loaded at the fresh context start; /clear starts an empty context but CLAUDE.md re-loads). [INFERRED/UNCERTAIN - docs say CLAUDE.md loads "at the start of every session"; the precise reload-on-clear behavior is not stated as explicitly as the compaction case.]
+   - Survives /compact: YES for project-root CLAUDE.md - docs explicitly state it is re-read from disk and re-injected after /compact. Nested subdirectory CLAUDE.md files are NOT re-injected automatically; they reload only when Claude next reads a file in that subdirectory. [VERIFIED from docs - https://code.claude.com/docs/en/memory "Instructions seem lost after /compact"]
+
+3. --append-system-prompt / --system-prompt (and -file variants). System-prompt-level text. [VERIFIED from docs - https://code.claude.com/docs/en/cli-reference system prompt flags]
+   - Survives /clear and /compact: applies to the running process for the whole invocation, so it persists across in-session /clear and /compact within that process. But it is per-invocation only: a NEW process (e.g. a resume we relaunch) must pass it again. [INFERRED/UNCERTAIN - docs say "apply only to the current invocation"; persistence across in-process /clear is inferred, not stated.]
+
+4. Auto memory MEMORY.md at ~/.claude/projects/<project>/memory/MEMORY.md (first 200 lines or 25KB loaded each session). Written by Claude, not a clean injection point for us. [VERIFIED from docs - https://code.claude.com/docs/en/memory]
+
+CLAUDE.md locations and load order (broadest to most specific, all concatenated, root-to-cwd within the tree; CLAUDE.local.md appended after CLAUDE.md at each level): managed policy CLAUDE.md (Windows C:\Program Files\ClaudeCode\CLAUDE.md) > user ~/.claude/CLAUDE.md > project ./CLAUDE.md or ./.claude/CLAUDE.md > local ./CLAUDE.local.md. Imports via `@path/to/file` (relative to the importing file; max depth 4). Claude Code reads CLAUDE.md, not AGENTS.md (you import AGENTS.md from CLAUDE.md to share). [VERIFIED from docs - https://code.claude.com/docs/en/memory]
+
+## 5. Lifecycle events and hooks
+
+Config format and location: hooks live under the `hooks` key in any settings.json (user/project/local/managed) OR in a file/JSON passed via `--settings`. A hook entry is an array of matcher groups; each group has a `matcher` and a `hooks` array of `{ "type": "command", "command": "...", "timeout": <sec> }` (an `http` type with a URL also exists). Passing hooks via --settings MERGES with the user's own hooks rather than replacing them. [VERIFIED from docs - https://code.claude.com/docs/en/settings, https://code.claude.com/docs/en/hooks; merge behavior also relied on in our code - ClaudeHookInstaller]
+
+Full hook event list (Claude Code has the largest event set of any agent we drive). [VERIFIED from docs - https://code.claude.com/docs/en/hooks]:
+SessionStart, Setup, UserPromptSubmit, UserPromptExpansion, PreToolUse, PermissionRequest, PermissionDenied, PostToolUse, PostToolUseFailure, PostToolBatch, Notification, MessageDisplay, SubagentStart, SubagentStop, TaskCreated, TaskCompleted, Stop, StopFailure, TeammateIdle, InstructionsLoaded, ConfigChange, CwdChanged, FileChanged, WorktreeCreate, WorktreeRemove, PreCompact, PostCompact, Elicitation, ElicitationResult, SessionEnd.
+
+stdin/stdout JSON contract:
+- Common stdin fields a hook receives: `session_id`, `transcript_path`, `cwd`, `hook_event_name`, and event-specific fields. [VERIFIED from docs - https://code.claude.com/docs/en/hooks]
+- SessionStart stdin: `session_id`, `transcript_path`, `cwd`, `hook_event_name` = "SessionStart", `source` (one of startup/resume/clear/compact), optional `model`, optional `agent_type`, optional `session_title`. [VERIFIED from docs - https://code.claude.com/docs/en/hooks]
+- SessionStart stdout: JSON with `hookSpecificOutput` containing `hookEventName` = "SessionStart" and `additionalContext` (string added to context, wrapped in a system reminder). Other fields: `sessionTitle`, `watchPaths`, `reloadSkills`, `initialUserMessage`. Plain stdout (no JSON) is also accepted as additionalContext for SessionStart. Values over 10,000 chars are written to a file and Claude gets the path plus a preview. [VERIFIED from docs - https://code.claude.com/docs/en/hooks]
+
+Which events fire on each boundary:
+- startup (new session): SessionStart with source `startup`. [VERIFIED from docs]
+- resume (--resume / --continue / /resume): SessionStart with source `resume` (re-runs on resume to refresh context). [VERIFIED from docs]
+- clear (/clear): SessionStart with source `clear`. Also SessionEnd with matcher `clear`. [VERIFIED from docs]
+- compact (auto or manual): SessionStart with source `compact`; PreCompact (matchers `manual`/`auto`, can block by returning {"decision":"block"} or exit 2) before, PostCompact after. [VERIFIED from docs]
+
+additionalContext field name: `hookSpecificOutput.additionalContext` (SessionStart). This is exactly what our hook emits. [VERIFIED from docs and from our code - ClaudeHookInstaller.ScriptContent]
+
+## 6. SDK / programmatic API / server mode
+
+- Agent SDK (library form). TypeScript: `import { query } from "@anthropic-ai/claude-agent-sdk"` - `query({ prompt, options })` returns an async iterator of messages. Python: `from claude_agent_sdk import query, ClaudeAgentOptions` - `async for message in query(prompt=..., options=ClaudeAgentOptions(...))`. Python also exposes ClaudeAgentOptions, AgentDefinition, HookMatcher, SystemMessage, ResultMessage. [VERIFIED from docs - https://code.claude.com/docs/en/agent-sdk/overview]
+   - Note on the streaming/persistent-client class: the docs we read showed `query()` for both languages and the options object; an interactive `ClaudeSDKClient` Python class exists in the broader SDK reference but was not confirmed on the overview page. [INFERRED/UNCERTAIN - verify against https://code.claude.com/docs/en/agent-sdk/python]
+   - Options (camelCase TS / snake_case Python): model, systemPrompt/system_prompt, allowedTools/allowed_tools, mcpServers/mcp_servers, permissionMode/permission_mode, hooks (callback functions keyed by event, with matcher groups), agents, resume (session id), forkSession/fork_session, settingSources/setting_sources, plugins. [VERIFIED from docs - https://code.claude.com/docs/en/agent-sdk/overview]
+   - The SDK is the same agent loop as the CLI; the TS package bundles the native binary. Sessions are captured from the `system`/`init` message's `session_id` and resumed via the `resume` option. [VERIFIED from docs - https://code.claude.com/docs/en/agent-sdk/overview]
+- Agent SDK via CLI: `claude -p` with --output-format json or stream-json is the scriptable surface (no library). [VERIFIED from docs - https://code.claude.com/docs/en/headless]
+- Headless JSON shapes. With --output-format json the result payload includes (at least) `result` (text), `session_id`, `usage`, `total_cost_usd` (plus a per-model cost breakdown), and run metadata; with --json-schema the structured data is in `structured_output`. [VERIFIED from docs - https://code.claude.com/docs/en/headless]
+- stream-json event types (newline-delimited JSON, one event per line): a leading `system` event with `subtype` "init" (reports model, tools, MCP servers, loaded `plugins`/`plugin_errors`), `system` with subtype "api_retry" on retryable errors (fields attempt, max_retries, retry_delay_ms, error_status, error, uuid, session_id), `system` with subtype "plugin_install" when CLAUDE_CODE_SYNC_PLUGIN_INSTALL is set, assistant/user messages, partial `stream_event` deltas (with --include-partial-messages), and a final result. [VERIFIED from docs - https://code.claude.com/docs/en/headless]
+- Server mode: `claude remote-control` starts a Remote Control server (control from claude.ai or the Claude app); `claude --remote-control`/`--rc` adds it to an interactive session. This is Anthropic's own remote channel, not a local control API we would build against. [VERIFIED from docs - https://code.claude.com/docs/en/cli-reference, https://code.claude.com/docs/en/remote-control]
+- Background-session supervisor: `claude agents` / `--bg` / attach/respawn/stop, with a daemon (`claude daemon status|stop`). [VERIFIED from docs - https://code.claude.com/docs/en/cli-reference]
+
+## 7. MCP / extensions / plugins / skills
+
+- MCP: configured via `claude mcp ...`, project .mcp.json, or --mcp-config (JSON files/strings); --strict-mcp-config restricts to only those. MCP login/logout: `claude mcp login|logout <name>` (v2.1.186+). [VERIFIED from docs - https://code.claude.com/docs/en/cli-reference, https://code.claude.com/docs/en/mcp]
+- Skills: .claude/skills/<name>/SKILL.md, auto-loaded or invoked as /<name>. User-invoked skills work in -p mode (include /skill-name in the prompt). [VERIFIED from docs - https://code.claude.com/docs/en/agent-sdk/overview, https://code.claude.com/docs/en/headless]
+- Plugins: `claude plugin install ...`; per-session loads via --plugin-dir <path-or-zip> and --plugin-url <url>. Plugins bundle skills, agents, hooks, and MCP servers. [VERIFIED from docs - https://code.claude.com/docs/en/cli-reference, https://code.claude.com/docs/en/agent-sdk/overview]
+- Subagents: .claude agents or inline via --agents JSON / SDK `agents` option; invoked through the Agent tool. [VERIFIED from docs - https://code.claude.com/docs/en/cli-reference, https://code.claude.com/docs/en/agent-sdk/overview]
+- Rules: .claude/rules/*.md (optionally path-scoped via `paths` frontmatter); user rules ~/.claude/rules/. [VERIFIED from docs - https://code.claude.com/docs/en/memory]
+
+## 8. Transcript / history
+
+- Location: ~/.claude/projects/<project>/<session-id>.jsonl . [VERIFIED from docs - https://code.claude.com/docs/en/sessions]
+- Project slug derivation: the working directory path with non-alphanumeric characters replaced by `-`. [VERIFIED from docs - https://code.claude.com/docs/en/sessions]
+- Format: JSONL, one JSON object per line (a message, tool use, or metadata entry). [VERIFIED from docs - https://code.claude.com/docs/en/sessions]
+- Parseable: yes, but the docs explicitly warn the entry format is INTERNAL and changes between versions; they recommend /export or the script interfaces (-p --output-format json, the hook `transcript_path`, or the SDK) instead of parsing JSONL directly. We DO parse it (ClaudeTranscriptReader); this is a known coupling to monitor on each Claude Code release. [VERIFIED from docs - https://code.claude.com/docs/en/sessions; coupling noted from our code - ClaudeDriver / ClaudeTranscriptReader]
+- Token usage: available. Headless json/stream-json carries `usage` and `total_cost_usd`; our ClaudeDriver.ReadUsage reads usage from the transcript. [VERIFIED from docs - https://code.claude.com/docs/en/headless; and our code - ClaudeDriver.ReadUsage]
+- Retention/relocation: 30-day default (cleanupPeriodDays); move with CLAUDE_CONFIG_DIR; suppress with CLAUDE_CODE_SKIP_PROMPT_HISTORY or --no-session-persistence. [VERIFIED from docs - https://code.claude.com/docs/en/sessions]
+
+## 9. Session semantics
+
+- A session = a saved conversation tied to a project directory, persisted continuously to the JSONL transcript. [VERIFIED from docs - https://code.claude.com/docs/en/sessions]
+- /clear: starts a fresh, empty context; the previous conversation is saved and resumable. It fires SessionStart source `clear` (and SessionEnd matcher `clear`). [VERIFIED from docs - https://code.claude.com/docs/en/sessions, https://code.claude.com/docs/en/hooks] That a NEW session id and NEW transcript file are minted on /clear is asserted by our integration (it is why our pointer goes stale and the hook must report the new id) and is consistent with the SessionStart `clear` event carrying a fresh session_id, but the public docs do not state the new-id-on-clear behavior in those exact words. [INFERRED/UNCERTAIN - our code ClaudeDriver / ClaudeHookInstaller assert it; treat as our operating assumption, re-verify on version bumps.]
+- /compact and auto-compact: replace history with a summary in place; fire PreCompact, then SessionStart source `compact`, then PostCompact. Project-root CLAUDE.md is re-injected after compaction. Our integration treats compaction the same as clear for pointer purposes (the hook reports the current id). [VERIFIED from docs for the events - https://code.claude.com/docs/en/hooks, https://code.claude.com/docs/en/memory; the new-id assumption is INFERRED/UNCERTAIN as above.]
+- resume vs continue vs fork: --continue resumes the most recent session in the cwd; --resume <id|name> resumes a specific one (lookup scoped to the current project dir and its git worktrees); --fork-session (with --resume/--continue) copies the conversation into a NEW session id, leaving the original intact (also /branch and /rewind). [VERIFIED from docs - https://code.claude.com/docs/en/sessions, https://code.claude.com/docs/en/cli-reference]
+- Sessions started with -p or the SDK do not appear in the picker but are resumable by id from the same directory. [VERIFIED from docs - https://code.claude.com/docs/en/sessions]
+
+## 10. How CC Director integrates it (our current integration)
+
+Classes:
+- Driver: ClaudeDriver (src/CcDirector.Core/Drivers/ClaudeDriver.cs). Declares capabilities ClearContext, Cancel, Interrupt, History, TranscriptRead, PreassignedSessionId, ModelSelection. ModelFlag = --model. [VERIFIED from our code]
+- Agent launch: ClaudeAgent (src/CcDirector.Core/Agents/ClaudeAgent.cs). [VERIFIED from our code]
+- Plugin: ClaudeAgentPlugin (src/CcDirector.Core/AgentPlugins/ClaudeAgentPlugin.cs). [VERIFIED from our code]
+- History provider kind: TranscriptFile (we read the ~/.claude/projects JSONL directly via ClaudeTranscriptReader). [VERIFIED - stated by the task; consistent with ClaudeDriver using ITranscriptReader]
+
+Launch line we build:
+- New session: `--dangerously-skip-permissions --session-id <new-guid>` (preassigned id => transcript path known from birth) plus our `--settings <hooks-settings.json>`. [VERIFIED from our code - ClaudeDriver.BuildLaunchSpec / ClaudeAgent.BuildLaunchSpec; --settings from ClaudeHookInstaller]
+- Resume: `--dangerously-skip-permissions --resume <id>`. [VERIFIED from our code]
+- Studio mode prepends `-p --output-format stream-json --verbose`. [VERIFIED from our code - ClaudeAgent.BuildLaunchSpec]
+- Keystroke conventions: Cancel = single Esc byte (0x1B); Interrupt = Ctrl+C (0x03); ShowHistory = double-Esc with a 350ms gap (opens the Rewind picker); ClearContext = submit "/clear"; submit is echo-verified to dodge a TUI input race that can drop Enter or prepend a stray "/". [VERIFIED from our code - ClaudeDriver]
+
+Fleet-preamble injection (ALREADY WIRED and proven live - mechanism Family A, the reference implementation):
+- ClaudeHookInstaller (src/CcDirector.Core/Claude/ClaudeHookInstaller.cs) writes two STATIC files under %LOCALAPPDATA%\cc-director\claude-hooks: a PowerShell script report-session.ps1 and a hooks-settings.json that registers a SessionStart hook for matchers startup, resume, clear, compact. We pass that settings file via `--settings`, which MERGES with the user's own hooks (relied upon; see Claude Code issue #11392). [VERIFIED from our code]
+- The hook command is `powershell -NoProfile -ExecutionPolicy Bypass -File "<script>"` with timeout 10. The script reads the hook event JSON from stdin and the per-session CC_SESSION_ID and CC_DIRECTOR_API from the environment the Director already injects (so nothing per-session is baked into the files). [VERIFIED from our code]
+- The script does two things, both swallowing all errors and exiting 0:
+  1. POSTs the current claude `session_id`, `transcript_path`, `hook_event_name`, and `source` to `POST {CC_DIRECTOR_API}/sessions/{CC_SESSION_ID}/claude-hook`, so the Director re-discovers the new session id / transcript after /clear or compaction. [VERIFIED from our code - endpoint at ControlEndpoints.cs line ~2107]
+  2. GETs `{CC_DIRECTOR_API}/sessions/{CC_SESSION_ID}/fleet-preamble` and, if non-empty, writes `{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"<preamble>"}}` to stdout, so Claude injects the fleet identity + cc-* command preamble at startup/resume/clear/compact with zero turn cost. [VERIFIED from our code - endpoint GET at ControlEndpoints.cs line 222]
+- The GET /sessions/{sid}/fleet-preamble endpoint is agent-agnostic and shared by all mechanism families. [VERIFIED from our code - FleetPreamble.cs, ControlEndpoints.cs]
+
+Why this is the reference: SessionStart's four matchers cover every moment Claude's memory of the fleet would otherwise be empty (startup, resume, clear, compact), the additionalContext contract is officially documented, and the re-fire-on-clear/compact behavior is verified in the docs - so the preamble self-heals on both reset boundaries through an event we own. Other agents mirror this shape where their hook systems allow.
+
+Current gaps:
+- We parse the JSONL transcript directly, which the docs flag as internal/unstable. A Claude Code release can change the entry format and break ClaudeTranscriptReader. [VERIFIED concern - https://code.claude.com/docs/en/sessions]
+- The new-session-id-on-/clear and on-compact behavior is our operating assumption, not a documented guarantee; the hook's claude-hook POST is what actually keeps us correct, so we are covered as long as the hook fires. [INFERRED/UNCERTAIN]
+- cc-ask (ask another session and read its reply) needs TranscriptRead, which today only ClaudeDriver declares, so cross-agent ask is Claude -> Claude only. [VERIFIED from README matrix - agents/README.md]
+
+## 11. Caveats and verification needed
+
+- Doc churn is high and version-gated. Many flags carry min-version/max-version notes (e.g. --enable-auto-mode removed in 2.1.111, mcp login added 2.1.186, --bare slated to become the -p default). Probe `claude --version` and re-check before depending on a flag. [VERIFIED from docs - https://code.claude.com/docs/en/cli-reference]
+- `claude --help` does NOT list every flag; absence from --help does not mean unavailable. [VERIFIED from docs - https://code.claude.com/docs/en/cli-reference]
+- The --settings-merges-with-user-hooks behavior is what our pointer/preamble tracking depends on. Confirm it still merges (not replaces) on each major Claude Code bump; our code cites issue #11392 as the basis. [INFERRED/UNCERTAIN - verify live with --init-only]
+- ClaudeSDKClient (persistent/streaming Python client) was not confirmed on the overview page; check the Python SDK reference before using it. [INFERRED/UNCERTAIN - https://code.claude.com/docs/en/agent-sdk/python]
+- new-session-id on /clear and /compact: not stated verbatim in public docs; verify live (watch the session_id the claude-hook POST reports before/after a /clear). [INFERRED/UNCERTAIN]
+- Quickest live check that our hook fires and injects: `claude --init-only` with our --settings, then confirm the claude-hook POST arrives and the SessionStart additionalContext appears. [INFERRED - based on documented --init-only semantics]
+- --bare and --safe-mode disable hooks/CLAUDE.md/skills/MCP; never use them for fleet sessions or the preamble will not inject. [VERIFIED from docs - https://code.claude.com/docs/en/cli-reference, https://code.claude.com/docs/en/headless]
+
+## Sources
+
+- CLI reference: https://code.claude.com/docs/en/cli-reference
+- Hooks reference: https://code.claude.com/docs/en/hooks
+- Memory / CLAUDE.md: https://code.claude.com/docs/en/memory
+- Settings: https://code.claude.com/docs/en/settings
+- Headless / print mode: https://code.claude.com/docs/en/headless
+- Manage sessions / transcripts: https://code.claude.com/docs/en/sessions
+- Agent SDK overview: https://code.claude.com/docs/en/agent-sdk/overview
+- Agent SDK Python reference: https://code.claude.com/docs/en/agent-sdk/python
+- TypeScript SDK source: https://github.com/anthropics/claude-agent-sdk-typescript
+- Python SDK source: https://github.com/anthropics/claude-agent-sdk-python
+- Remote Control: https://code.claude.com/docs/en/remote-control
+- Our code: src/CcDirector.Core/Drivers/ClaudeDriver.cs, src/CcDirector.Core/Agents/ClaudeAgent.cs, src/CcDirector.Core/AgentPlugins/ClaudeAgentPlugin.cs, src/CcDirector.Core/Claude/ClaudeHookInstaller.cs, src/CcDirector.Core/Sessions/FleetPreamble.cs, src/CcDirector.ControlApi/ControlEndpoints.cs (GET /sessions/{sid}/fleet-preamble line 222, POST /sessions/{sid}/claude-hook line ~2107)

--- a/.claude/skills/agent-expert/agents/codex.md
+++ b/.claude/skills/agent-expert/agents/codex.md
@@ -1,0 +1,644 @@
+<!--
+Per-agent reference for the agent-expert skill. Internal, not shipped.
+ASCII only. No Unicode, no emoji, no em-dashes (use " - ").
+Every non-trivial fact is marked [VERIFIED from docs] or [INFERRED/UNCERTAIN] with an inline source.
+All source links are collected in the Sources section.
+-->
+
+# OpenAI Codex CLI (AgentKind.Codex)
+
+> OpenAI's terminal coding agent. npm package `@openai/codex`, binary `codex`.
+> Our integration status: CodexDriver / CodexAgent / CodexAgentPlugin, with a
+> CodexTranscriptReader that exists but is NOT yet wired as a declared driver capability.
+> Mechanism family A (shell-command hook). Closest twin to the wired Claude Code path.
+
+This file describes how Codex behaves and how CC Director drives it. Codex hooks and the
+App Server are recent and churning; every field name below should be re-checked live against
+the installed binary before we depend on it (see section 11).
+
+---
+
+## 1. Identity and install
+
+- Binary name: `codex`. [VERIFIED from docs] https://developers.openai.com/codex/cli/reference
+- npm package: `@openai/codex` (also a standalone native installer). [VERIFIED from docs] https://github.com/openai/codex
+- Source repository: https://github.com/openai/codex (the CLI engine is Rust under `codex-rs/`).
+  [VERIFIED from docs] https://github.com/openai/codex/blob/main/codex-rs/core/src/config/mod.rs
+- Official documentation home: https://developers.openai.com/codex [VERIFIED from docs]
+- Codex home directory: `~/.codex` by default, overridable with the `CODEX_HOME` environment
+  variable. [VERIFIED from docs] https://developers.openai.com/codex/guides/agents-md
+- Windows install location of the launchable shim (npm global install): our plugin probes
+  `%APPDATA%\npm\codex.cmd` first, then bare `codex` on PATH.
+  [VERIFIED from source] src/CcDirector.Core/AgentPlugins/CodexAgentPlugin.cs (DefaultNpmCliPath)
+- Version-probe command: `codex --version`. Our validation metadata uses `--version` with an
+  8-second timeout. [VERIFIED from source] CodexAgentPlugin.ValidationMetadata
+
+---
+
+## 2. Command-line interface
+
+Codex has an interactive terminal UI and a non-interactive `exec` mode, plus `resume` and an
+`app-server` subcommand.
+
+### Modes
+
+- `codex` - interactive terminal UI (the default). Accepts global flags and an optional initial
+  prompt / image attachments. This is the mode CC Director launches into a ConPTY.
+  [VERIFIED from docs] https://developers.openai.com/codex/cli/reference
+- `codex exec` (alias `codex e`) - non-interactive / scripted. Runs a task without human
+  interaction and streams results to stdout or JSONL. This is the headless equivalent of Claude's
+  `--print`. CC Director does NOT use exec mode today. [VERIFIED from docs] (same)
+- `codex resume` - continue a previous interactive session by id, or resume the most recent.
+  [VERIFIED from docs] (same)
+- `codex app-server` - JSON-RPC server mode (see section 6). [VERIFIED from docs]
+  https://developers.openai.com/codex/app-server
+
+### Flag table (global unless noted)
+
+| Flag | Values | Purpose | Notes |
+|------|--------|---------|-------|
+| `--model`, `-m` | string | Override configured model | [VERIFIED from docs] cli/reference |
+| `--profile`, `-p` | profile name | Layer a named profile from config.toml | [VERIFIED from docs] |
+| `--config`, `-c` | key=value | Override any config value, repeatable | [VERIFIED from docs] |
+| `--cd`, `-C` | path | Set working directory before processing | [VERIFIED from docs] |
+| `--sandbox`, `-s` | read-only / workspace-write / danger-full-access | Sandbox policy for shell commands | [VERIFIED from docs] |
+| `--ask-for-approval`, `-a` | untrusted / on-request / never | Approval timing | [VERIFIED from docs] |
+| `--json` | (boolean) | Emit newline-delimited JSON events | [VERIFIED from docs] |
+| `--output-last-message`, `-o` | path | Write the final assistant message to a file | [VERIFIED from docs] |
+| `--output-schema` | path | JSON Schema to validate the response shape | [VERIFIED from docs] |
+| `--ephemeral` | (exec) | Run without persisting session files | [VERIFIED from docs] |
+| `--ignore-rules` | (exec) | Skip execpolicy rule files | [VERIFIED from docs] |
+| `--image`, `-i` | path | Attach images to the initial message | [VERIFIED from docs] |
+| `--last` | (resume) | Skip the picker, continue the most recent session | [VERIFIED from docs] |
+| `--all` | (resume) | Include sessions outside the current directory | [VERIFIED from docs] |
+
+### Session id / resume
+
+- There is a documented `codex resume <SESSION_ID>` and `codex resume --last`.
+  [VERIFIED from docs] https://developers.openai.com/codex/cli/reference
+- A top-level `--session-id` flag for the interactive `codex` command is NOT confirmed in the
+  public CLI reference. Resume is done by the `resume` subcommand (by id or `--last`), and the
+  App Server resumes by thread id via `thread/resume`. [INFERRED/UNCERTAIN] - we do not pass a
+  preassigned session id; CodexDriver.BuildLaunchSpec explicitly ignores any resume id and
+  returns PreassignedSessionId=null. [VERIFIED from source] CodexDriver.BuildLaunchSpec
+- Implication for CC Director: Codex owns its own session id; we cannot pre-mint one the way
+  Claude allows `--session-id`. This is why CodexAgent.SupportsPreassignedSessionId == false.
+  [VERIFIED from source] CodexAgent
+
+### Output formats
+
+- `--json` produces newline-delimited JSON events, one per state change (the structured stream
+  for exec and json mode). [VERIFIED from docs] cli/reference and the AGENTS.md guide search.
+- `--output-last-message` writes just the final assistant text to a file; `--output-schema`
+  enforces a JSON Schema on the structured result. [VERIFIED from docs] cli/reference
+
+---
+
+## 3. Configuration
+
+- Primary config file: `~/.codex/config.toml` (under `CODEX_HOME`). [VERIFIED from docs]
+  https://developers.openai.com/codex/config-reference
+- Project override: `.codex/config.toml` inside a repo, loaded only for trusted projects.
+  [VERIFIED from docs] (same)
+- Profiles: `[profiles.NAME]` tables in config.toml, or separate `$CODEX_HOME/NAME.config.toml`
+  files; selected with `--profile NAME`. [VERIFIED from docs] config-reference
+- System config (Unix): `/etc/codex/config.toml`. [INFERRED/UNCERTAIN] - reported by the
+  developer docs summary but Windows path not stated. https://developers.openai.com/codex/config-reference
+
+### Precedence (highest to lowest) [VERIFIED from docs] config-reference
+
+1. CLI flags and `--config` overrides
+2. Project config files (`.codex/config.toml`, closest directory wins)
+3. Profile files (`~/.codex/NAME.config.toml` or `[profiles.NAME]`)
+4. User config (`~/.codex/config.toml`)
+5. System config (`/etc/codex/config.toml` on Unix)
+6. Built-in defaults
+
+Project-scoped config CANNOT override provider, auth, notification, profile selection, or
+telemetry settings. [VERIFIED from docs] config-reference
+
+### Relevant keys [VERIFIED from docs] config-reference unless noted
+
+- `model` - model id, e.g. `model = "gpt-5.5"`.
+- `model_reasoning_effort` - `minimal | low | medium | high | xhigh`.
+- `approval_policy` - `untrusted | on-request | never`.
+- `sandbox_mode` - `read-only | workspace-write | danger-full-access`.
+- `web_search` - `cached | live | disabled`. [VERIFIED from docs] config-reference (local-config page)
+- `[features]` table - enable experimental capabilities (e.g. `shell_snapshot`, `memories`,
+  `codex_git_commit`, `hooks`). [VERIFIED from docs] local-config and hooks pages.
+- `model_instructions_file` - path to a custom instructions file that REPLACES the built-in
+  default instructions. [VERIFIED from docs] config-reference, agents-md guide.
+- `project_doc_fallback_filenames` - extra filenames searched when `AGENTS.md` is missing.
+  [VERIFIED from docs] config-reference, agents-md guide.
+- `project_doc_max_bytes` - max bytes read from the instruction chain; default 32 KiB. Codex
+  stops adding files once the limit is reached. [VERIFIED from docs] agents-md guide.
+- `notify` - argv array of an external notification program (see section 5, post-turn only).
+  [VERIFIED from docs] config-advanced.
+- `[hooks]` - inline hook configuration (see section 5). [VERIFIED from docs] config-reference, hooks.
+- `[mcp_servers.<id>]` - MCP server definitions with `command`, `args`, env, `enabled_tools` /
+  `disabled_tools`, `startup_timeout_sec`, `tool_timeout_sec`. [VERIFIED from docs] config-reference.
+- `allow_managed_hooks_only` - top-level key set in `requirements.toml` (the managed/enterprise
+  layer) to ignore user, project, and session hook configs while still allowing managed hooks.
+  [VERIFIED from docs] https://github.com/openai/codex/blob/main/docs/config.md and hooks page.
+
+---
+
+## 4. Context injection (how to inject a preamble)
+
+For each mechanism: does the injected text survive `/clear`, and does it survive `/compact`?
+
+### a. AGENTS.md hierarchy (instruction files) - mechanism family D, passive
+
+- Discovery order [VERIFIED from docs] https://developers.openai.com/codex/guides/agents-md :
+  1. Global: `~/.codex/AGENTS.override.md` if present, else `~/.codex/AGENTS.md` (first non-empty
+     file at this level only).
+  2. Project: walk from the Git root down to the current working directory; in EACH directory
+     check `AGENTS.override.md`, then `AGENTS.md`, then any name in `project_doc_fallback_filenames`.
+- Concatenation: files are joined root-to-current with blank lines; files CLOSER to the current
+  directory appear later and therefore override earlier guidance. [VERIFIED from docs] agents-md.
+- `AGENTS.override.md` is for a temporary override without deleting the base `AGENTS.md`.
+  [VERIFIED from docs] agents-md.
+- Size cap: `project_doc_max_bytes` (default 32 KiB); empty files skipped. [VERIFIED from docs] agents-md.
+- The instruction chain is built "once per run; in the TUI this usually means once per launched
+  session." [VERIFIED from docs] agents-md.
+- Survives /clear? [INFERRED/UNCERTAIN] - because AGENTS.md is part of the persistent base
+  instruction chain (not turn conversation), it should remain in effect after `/clear`, but the
+  docs do not state /clear behavior explicitly. Note open issue #21675 asks for a per-session
+  cache of additionalContext for "InstructionsLoaded parity," implying current re-load behavior
+  is in flux. https://github.com/openai/codex/issues/21675
+- Survives /compact? [INFERRED/UNCERTAIN] - same reasoning; the base instructions are not the
+  conversation that gets compacted, so they should persist, but this is not documented. Verify live.
+
+### b. model_instructions_file - mechanism family D, passive
+
+- Replaces the built-in default instructions entirely. [VERIFIED from docs] config-reference, agents-md.
+- Survives /clear and /compact? [INFERRED/UNCERTAIN] - it is base instruction text, so the same
+  caveat as AGENTS.md applies. Verify live.
+
+### c. SessionStart hook additionalContext - mechanism family A, active (PREFERRED)
+
+- A SessionStart command hook can print `hookSpecificOutput.additionalContext`, which Codex adds
+  as extra developer context. [VERIFIED from docs] https://developers.openai.com/codex/hooks
+- The SessionStart `source` matcher fires with `startup`, `resume`, `clear`, and `compact`
+  (see section 5). [VERIFIED from docs] hooks.
+- Survives /clear? Yes by re-firing: SessionStart fires again with `source = "clear"`, so the hook
+  re-emits additionalContext after a clear. [VERIFIED from docs] hooks.
+- Survives /compact? Yes by re-firing: SessionStart fires again with `source = "compact"`. There
+  are ALSO dedicated PreCompact / PostCompact events. [VERIFIED from docs] hooks.
+- This is the family A path and the one we should wire (section 10). It is the direct analogue of
+  Claude Code's SessionStart additionalContext.
+
+Summary: AGENTS.md / model_instructions_file are passive and probably persist but are
+undocumented for /clear and /compact; the SessionStart hook is the active, event-driven injector
+that demonstrably re-fires on clear and compact.
+
+---
+
+## 5. Lifecycle events and hooks
+
+Codex has a Claude-Code-style hook framework. This is the heart of the integration plan.
+
+### Event list [VERIFIED from docs] https://developers.openai.com/codex/hooks
+
+1. `SessionStart` - session initialization (thread scope).
+2. `SubagentStart` - a subagent begins (subagent-start scope).
+3. `PreToolUse` - before a tool call executes (turn scope).
+4. `PermissionRequest` - when approval is needed (turn scope).
+5. `PostToolUse` - after a tool completes (turn scope).
+6. `PreCompact` - before conversation compaction (turn scope).
+7. `PostCompact` - after conversation compaction (turn scope).
+8. `UserPromptSubmit` - when the user sends a prompt (turn scope).
+9. `SubagentStop` - when a subagent concludes (turn scope).
+10. `Stop` - when a conversation turn stops (turn scope).
+
+### SessionStart `source` matcher values [VERIFIED from docs] hooks
+
+The `source` field on SessionStart is one of: `"startup"`, `"resume"`, `"clear"`, `"compact"`.
+This is the same set Claude Code uses, which is what makes Codex the closest twin. A `matcher`
+like `"startup|resume"` selects which sources trigger the hook.
+
+### Which events fire when
+
+- On startup (fresh launch): `SessionStart` with `source = "startup"`. [VERIFIED from docs] hooks
+- On resume (`codex resume`): `SessionStart` with `source = "resume"`. [VERIFIED from docs] hooks
+- On `/clear` (new conversation in place): `SessionStart` with `source = "clear"`. [VERIFIED from docs] hooks
+- On `/compact`: `SessionStart` with `source = "compact"`, plus the dedicated `PreCompact` and
+  `PostCompact` events. [VERIFIED from docs] hooks
+
+### Config format and location [VERIFIED from docs] hooks
+
+Discovery order (precedence high to low):
+1. `~/.codex/hooks.json` (user)
+2. `~/.codex/config.toml` with a `[hooks]` table (user)
+3. `<repo>/.codex/hooks.json` (project)
+4. `<repo>/.codex/config.toml` with `[hooks]` (project)
+5. Plugin-bundled `hooks/hooks.json`
+
+Merge behavior: higher-precedence layers do NOT replace lower-precedence hooks; ALL matching
+hooks from all layers run concurrently. If a single layer has both `hooks.json` and inline
+`[hooks]`, Codex merges them and warns at startup ("prefer one representation per layer").
+[VERIFIED from docs] hooks
+
+Trust: non-managed command hooks require review before they execute. Use the `/hooks` command to
+inspect, review, and trust them. Managed hooks from `requirements.toml` / MDM bypass this flow.
+[VERIFIED from docs] hooks. NOTE open issue #17532 reports hooks not firing in interactive
+sessions when configured via repo-local `.codex/config.toml` - so prefer `~/.codex/hooks.json`
+(user layer) for reliability. https://github.com/openai/codex/issues/17532
+
+`allow_managed_hooks_only = true` in `requirements.toml` makes ONLY managed hooks execute; user,
+project, session, and plugin hooks are skipped. [VERIFIED from docs]
+https://github.com/openai/codex/blob/main/docs/config.md
+
+### stdin JSON (what a hook receives) [VERIFIED from docs] hooks
+
+Common input fields across events:
+```json
+{
+  "session_id": "string",
+  "transcript_path": "string|null",
+  "cwd": "string",
+  "hook_event_name": "string",
+  "model": "string",
+  "turn_id": "string",
+  "permission_mode": "default|acceptEdits|plan|dontAsk|bypassPermissions"
+}
+```
+For SessionStart the payload also carries the `source` value (startup/resume/clear/compact).
+[VERIFIED from docs] hooks
+
+### stdout JSON (what a hook returns) [VERIFIED from docs] hooks
+
+Common output fields (supported by SessionStart, PreCompact, PostCompact, UserPromptSubmit,
+SubagentStop, Stop):
+```json
+{
+  "continue": true,
+  "stopReason": "optional reason",
+  "systemMessage": "optional warning",
+  "suppressOutput": false,
+  "hookSpecificOutput": {}
+}
+```
+
+### additionalContext field and which events support it [VERIFIED from docs] hooks
+
+`hookSpecificOutput.additionalContext` is supported by:
+- `SessionStart` - added as extra developer context. (This is the one we use.)
+- `SubagentStart` - surfaces as extra subagent context.
+- `PreToolUse` - model-visible context without blocking (not the primary use case).
+- `PostToolUse` - added as developer context.
+- `UserPromptSubmit` - surfaces as extra context.
+
+Plain text on stdout is also accepted for SessionStart and added as developer context; JSON with
+the `hookSpecificOutput` shape is the structured form. [VERIFIED from docs] hooks.
+
+Note: `PreToolUse` and `PermissionRequest` support `systemMessage` but NOT `continue`,
+`stopReason`, or `suppressOutput`. [VERIFIED from docs] hooks. Open issue #19385 tracks parity
+gaps in PreToolUse additionalContext handling. https://github.com/openai/codex/issues/19385
+
+### Example hooks.json with a SessionStart command hook [VERIFIED from docs] hooks
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.codex/hooks/session_start.py",
+            "statusMessage": "Loading fleet preamble",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Inline TOML equivalent of a hook (for the `[hooks]` form) [VERIFIED from docs] config-advanced:
+```toml
+[[hooks.PreToolUse]]
+matcher = "^Bash$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = '/usr/bin/python3 "$(git rev-parse --show-toplevel)/.codex/hooks/pre_tool_use_policy.py"'
+timeout = 30
+statusMessage = "Checking Bash command"
+```
+
+### Benchmark against Claude Code [VERIFIED from docs] hooks
+
+Claude Code's SessionStart hook uses matchers `startup | resume | clear | compact` and emits
+`hookSpecificOutput.additionalContext` that Claude injects. Codex is functionally IDENTICAL:
+same four `source` values on SessionStart, same `hookSpecificOutput.additionalContext` field
+name, same re-fire on clear and compact. The only differences are file location
+(`~/.codex/hooks.json` vs `~/.claude/settings.json` hooks block) and the field-name casing in the
+stdin payload (Codex uses snake_case `session_id`, `hook_event_name`, `turn_id`). The hook output
+contract is the camelCase Claude shape (`hookSpecificOutput.additionalContext`).
+
+### The older `notify` program - why it is NOT the answer
+
+`notify` is an argv array in config.toml (e.g. `notify = ["notify-send", "Codex"]`). Codex
+appends one JSON argument describing the event. It currently fires for ONLY ONE event,
+`agent-turn-complete`, i.e. AFTER a turn finishes. [VERIFIED from docs] config-advanced.
+Payload example:
+```json
+{
+  "type": "agent-turn-complete",
+  "turn-id": "12345",
+  "input-messages": ["Rename foo to bar and update the callsites."],
+  "last-assistant-message": "Rename complete and cargo build succeeds."
+}
+```
+Why `notify` is NOT how we inject a preamble:
+- It is post-turn only - it cannot run at SessionStart, resume, clear, or compact.
+- It is notification-only - it cannot return `additionalContext` or modify the model's context;
+  its stdout/return value is ignored. [VERIFIED from docs] config-advanced.
+- It is one-directional alerting (toasts, webhooks). The hook framework superseded it for
+  context injection. Use SessionStart hooks, not `notify`.
+
+---
+
+## 6. SDK / programmatic API / server mode (App Server)
+
+- `codex app-server` exposes JSON-RPC 2.0. Transports: `stdio://` (default, newline-delimited
+  JSON), `ws://IP:PORT` (experimental WebSocket), `unix://`, or `off`. Selected with `--listen`.
+  [VERIFIED from docs] https://developers.openai.com/codex/app-server
+- Handshake: send an `initialize` request first (with `clientInfo`), then emit an `initialized`
+  notification. Requests before `initialize` are rejected with "Not initialized".
+  [VERIFIED from docs] app-server
+- Thread lifecycle methods: `thread/start`, `thread/resume`, `thread/fork`, `thread/read`,
+  `thread/list`, `thread/archive`, `thread/unarchive`, `thread/delete`, `thread/unsubscribe`.
+  [VERIFIED from docs] app-server
+- Turn control: `turn/start` (input array of text/images/skills, plus `model`, `effort`,
+  `personality`, `sandboxPolicy`, `approvalPolicy`, `outputSchema`), `turn/steer`,
+  `turn/interrupt`. [VERIFIED from docs] app-server
+- Notifications streamed by the server: `thread/started`, `turn/started`, `turn/completed`
+  (status completed/interrupted/failed), `item/started`, `item/completed`,
+  `item/agentMessage/delta`, `thread/status/changed`. [VERIFIED from docs] app-server
+- Approvals: server requests `item/commandExecution/requestApproval` and
+  `item/fileChange/requestApproval`; client replies accept / decline / cancel / acceptForSession.
+  [VERIFIED from docs] app-server
+- Also: `config/read`, `config/value/write`, `config/batchWrite`, `model/list`, `fs/watch`,
+  `command/exec`, experimental `process/spawn` / `process/writeStdin` / `process/kill`.
+  [VERIFIED from docs] app-server
+- WebSocket auth: capability tokens or signed bearer tokens (`--ws-auth capability-token
+  --ws-token-file PATH`). [VERIFIED from docs] app-server
+- CC Director does NOT use the App Server today; we drive the interactive TUI through a ConPTY.
+  The App Server is a future option for higher-fidelity drive + structured event subscription
+  (it would move Codex toward a family B event-bus integration). [INFERRED] - based on our
+  current driver, which is terminal-only.
+
+---
+
+## 7. MCP / extensions / skills
+
+- MCP: configure servers under `[mcp_servers.<id>]` in config.toml (command, args, env,
+  `enabled_tools`/`disabled_tools`, timeouts). Codex can also act as an MCP server / client.
+  [VERIFIED from docs] config-reference. Manage at runtime via the `/mcp` slash command.
+  [VERIFIED from source] CodexSlashCommands.cs
+- Agent Skills: invoked in App Server input via `$skill-name` text plus an optional `skill` input
+  item. [VERIFIED from docs] app-server. Skills are also referenced in `turn/start` input arrays.
+- Apps: mentioned with `$app-slug` and a `mention` input item (`app://id`). [VERIFIED from docs] app-server
+- Plugins: can bundle lifecycle config via a manifest or a default `hooks/hooks.json` (the
+  lowest-precedence hook layer). [VERIFIED from docs] hooks
+- Subagents: `SubagentStart` / `SubagentStop` hook events exist; subagents get their own
+  additionalContext via `SubagentStart`. [VERIFIED from docs] hooks, subagents guide.
+
+---
+
+## 8. Transcript / history
+
+- Location: `~/.codex/sessions/<yyyy>/<mm>/<dd>/rollout-<timestamp>-<id>.jsonl`. Example:
+  `~/.codex/sessions/2025/01/22/rollout-2025-01-22T10-30-00-abc123.jsonl`. [VERIFIED from docs]
+  agents-md search result, and confirmed by our reader.
+  [VERIFIED from source] CodexRolloutLocator.cs, CodexTranscriptReader.cs
+- Format: JSON Lines (one JSON object per line). Each line has a `type` and a `payload`:
+  - `session_meta` - first line; carries `cwd` and a `timestamp` (we key on `cwd` to match a
+    rollout to a Director session). [VERIFIED from source] CodexRolloutLocator.cs
+  - `turn_context` - per-turn settings. Skipped by our reader.
+  - `event_msg` - a parallel pre-cleaned event stream. Skipped by our reader.
+  - `response_item` - the actual conversation. Its `payload.type` is one of `message`
+    (role user/assistant/developer/system, content array of text items), `function_call`
+    (name, call_id, arguments), `custom_tool_call` (name, call_id, input),
+    `function_call_output` / `custom_tool_call_output` (call_id, output), `reasoning`
+    (summary text; `encrypted_content` has no plaintext and is skipped).
+    [VERIFIED from source] CodexTranscriptReader.cs (this is our live, tested mapping)
+- Codex appends to the rollout live; reads must use shared read access and tolerate a truncated
+  final line. [VERIFIED from source] CodexTranscriptReader.cs
+- `--ephemeral` (exec) runs without persisting a rollout file. [VERIFIED from docs] cli/reference
+- Token usage: the rollout has `turn_context` and usage data, but our reader does NOT extract it;
+  CodexDriver.ReadUsage throws NotSupported. [VERIFIED from source] CodexDriver.cs
+- Parseable: yes. We do not yet expose it as a declared driver capability (see section 10).
+
+---
+
+## 9. Session semantics
+
+- new / `/new` - start a fresh conversation. [VERIFIED from source] CodexSlashCommands.cs
+- `/clear` - clear the current conversation in place. Fires SessionStart with `source = "clear"`.
+  [VERIFIED from docs] hooks. This is what CC Director submits for ClearContext.
+- `/compact [instructions]` - summarize and shrink the conversation. Fires PreCompact, then
+  SessionStart `source = "compact"`, then PostCompact. [VERIFIED from docs] hooks
+- `/resume` and `/fork` - resume or branch a saved session (interactive). `codex resume <id>` /
+  `--last` from the CLI; `thread/resume` / `thread/fork` in the App Server. [VERIFIED from docs]
+  cli/reference, app-server. [VERIFIED from source] CodexSlashCommands.cs
+- Session id behavior: Codex mints and owns the session/thread id; the rollout filename embeds it.
+  CC Director cannot pre-assign one, so we resolve the rollout AFTER launch by scanning
+  `~/.codex/sessions` for the newest `rollout-*.jsonl` whose `session_meta.cwd` matches the repo,
+  scoped to a launch-time window so a new terminal does not bind to an older rollout.
+  [VERIFIED from source] CodexRolloutLocator.cs
+- Across clear/compact the rollout file generally continues (same session), so our cwd-newest
+  heuristic stays valid. [INFERRED/UNCERTAIN] - confirm that `/clear` does not start a NEW rollout
+  file; if it does, the locator's newest-for-cwd logic still finds it, but session-id continuity
+  should be verified live.
+
+---
+
+## 10. How CC Director integrates it
+
+### Current classes
+
+- Driver: `CodexDriver` (src/CcDirector.Core/Drivers/CodexDriver.cs). Declared capabilities:
+  `Cancel | Interrupt | ClearContext`. Cancel = send Esc (0x1B); Interrupt = send Ctrl+C (0x03);
+  ClearContext = submit the literal `/clear`. ShowHistory, ReadWidgets, ReadUsage, and
+  ListTranscripts all throw NotSupported. ModelFlag is empty and KnownModels is empty (we do not
+  drive `--model`). [VERIFIED from source] CodexDriver.cs
+- Agent: `CodexAgent` (src/CcDirector.Core/Agents/CodexAgent.cs). SupportsPreassignedSessionId =
+  false, SupportsStudioMode = false. BuildLaunchSpec passes through user args; ignores resume id
+  and studio mode. [VERIFIED from source] CodexAgent.cs
+- Plugin: `CodexAgentPlugin` (src/CcDirector.Core/AgentPlugins/CodexAgentPlugin.cs). Id "codex",
+  built-in. History provider kind = `TranscriptFile`, SupportsConversationHistory = true. Detection
+  probes `%APPDATA%\npm\codex.cmd` then `codex`. Validation `--version`. Command presets: Standard
+  (empty) and a Codex full-access preset. [VERIFIED from source] CodexAgentPlugin.cs
+- Slash commands: `CodexSlashCommands` (captured 2026-06-18) - /help, /status, /model, /approvals,
+  /permissions, /sandbox, /new, /clear, /compact, /init, /diff, /review, /mention, /mcp, /resume,
+  /fork, /quit. [VERIFIED from source] CodexSlashCommands.cs
+- Transcript: `CodexTranscriptReader` + `CodexRolloutLocator` exist and are tested, surfaced
+  through the Director History tab / SessionHistoryReader. [VERIFIED from source]
+
+### Gap: TranscriptRead not declared on the driver
+
+`CodexTranscriptReader` is fully functional, but `CodexDriver.Capabilities` does NOT include a
+TranscriptRead flag, and the driver's transcript methods throw NotSupported (history is read via
+the separate SessionHistoryReader path, not the driver). Consequence: cross-agent "ask another
+session and read its reply" (cc-ask, which needs TranscriptRead on the driver) does not work for
+Codex yet, even though the reader exists. Wiring the existing reader into a declared
+TranscriptRead capability is a low-risk follow-up. [VERIFIED from source] CodexDriver.cs + README.md
+
+### Mechanism family and fleet-preamble plan
+
+Codex is family A (shell-command hook) and is the closest twin to the already-wired Claude
+implementation. The shared, agent-agnostic Director endpoint already exists:
+`GET /sessions/{sid}/fleet-preamble`. [VERIFIED from source] README.md (agents folder).
+
+Concrete plan to register a SessionStart hook that injects the fleet preamble:
+
+1. On Codex session launch, write (or ensure) a SessionStart hook in the USER layer
+   `~/.codex/hooks.json` (user layer, not repo-local, to dodge issue #17532 where repo-local
+   `.codex/config.toml` hooks do not fire in interactive sessions). Use matcher
+   `"startup|resume|clear|compact"` so it re-fires on every reset that matters.
+2. The hook command is a small Director-owned helper (a script or a `cc-*` shim) that:
+   - reads the Director session id. The hook stdin gives Codex's `session_id`, `cwd`, and
+     `source`; we map cwd + launch window to OUR Director session id (the same mapping
+     CodexRolloutLocator already does), OR we stamp the Director session id into an env var at
+     launch and the helper reads it.
+   - calls `GET http://127.0.0.1:<controlPort>/sessions/{sid}/fleet-preamble`.
+   - prints JSON to stdout:
+     ```json
+     {"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"<preamble>"}}
+     ```
+3. Codex injects that `additionalContext` as developer context at startup AND re-injects it on
+   `/clear` (source=clear) and `/compact` (source=compact) automatically, because SessionStart
+   re-fires on those sources. No extra wiring is needed for reset re-injection - this is the same
+   property we rely on for Claude. [VERIFIED from docs] hooks.
+4. Trust: the hook must be trusted once (Codex's `/hooks` review flow) unless deployed as a managed
+   hook. For an installed-fleet scenario, consider the managed-hooks path (`requirements.toml`,
+   `allow_managed_hooks_only` if we want to lock it down) so the Director hook is trusted without
+   per-user prompts. [VERIFIED from docs] hooks, config.md.
+
+Field-name parity to exploit: the hook OUTPUT contract is byte-for-byte the Claude shape
+(`hookSpecificOutput.additionalContext`), so the preamble emitter we already have for Claude can
+be reused almost verbatim; only the hook REGISTRATION location and the stdin field casing
+(snake_case) differ. [VERIFIED from docs] hooks.
+
+### Current gaps
+
+- DONE: the SessionStart fleet-preamble hook is wired (CodexHookInstaller + SessionManager flag) and
+  the programmatic submit bug is fixed (CodexDriver echo-verified submit). See section 11.
+- TranscriptRead capability is not declared, so cc-ask does not reach Codex.
+- We do not drive `--model` (ModelFlag empty), so model selection is whatever config.toml / the
+  user picks via `/model`.
+- We do not preassign or resume session ids from the Director side.
+
+---
+
+## 11. Caveats and verification needed
+
+### LIVE FINDING 2026-06-26 (codex 0.141.0 on SOREN_NORTH) - Family A CONFIRMED WORKING
+
+Verified the SessionStart fleet-preamble hook end to end against the installed binary. Family A is
+viable for Codex; the earlier "interactive TUI does not fire" observation was a symptom of a
+separate, now-fixed submit bug.
+
+- `hooks` is a STABLE feature, enabled by default (`codex features list` -> `hooks stable true`).
+- A user-layer `~/.codex/hooks.json` SessionStart hook (matcher `startup|resume|clear|compact`)
+  running our PowerShell preamble emitter, launched with `--dangerously-bypass-hook-trust`,
+  FIRES and INJECTS in both `codex exec` AND the interactive TUI that CC Director drives. PROOF:
+  the Codex rollout (`~/.codex/sessions/.../rollout-*.jsonl`) contains a `response_item` with
+  `role: "developer"` carrying the full preamble ("[CC Director fleet] You are session ... cc-sessions
+  ... cc-send ..."), and the assistant then answered the test prompt. So additionalContext from the
+  hook genuinely lands in Codex's model context.
+- TIMING: in the interactive TUI, SessionStart fires at the FIRST TURN, not at idle process startup
+  (the preamble developer message is timestamped ~4 s after launch, when the first prompt ran).
+  Contrast Claude, which fires SessionStart at startup before any turn. Practical effect: the Codex
+  preamble is present from the first turn onward, which is what matters; a session that never takes
+  a turn simply never needed it.
+- The env-var mapping is identical to Claude: the hook reads the Director-injected CC_DIRECTOR_API +
+  CC_SESSION_ID and fetches `GET /sessions/{sid}/fleet-preamble`. No cwd/rollout mapping needed.
+
+THE BLOCKER WAS A SUBMIT BUG (now fixed). The Director's REST prompt path drove Codex with the
+backend's blind submit (type text, wait 50 ms, one Enter). Codex's composer repaints a cycling
+placeholder, so that single Enter landed mid-repaint and was swallowed - the prompt parked
+unsubmitted, no turn ran, so SessionStart never fired. Fix: `CodexDriver.SubmitAsync` now does an
+ECHO-VERIFIED submit (type the text, wait until the composer echoes it, then a SEPARATE Enter), the
+same pattern ClaudeDriver uses. Covered by CodexDriverTests
+(`SubmitAsync_EchoVerified_TypesTextThenPressesEnterSeparately`,
+`SubmitAsync_NoBufferBackend_FallsBackToBlindSendText`). The desktop UI never had this bug because
+there Enter is a separate, later human keystroke.
+
+WIRED 2026-06-26 (verified end to end). `CodexHookInstaller` (src/CcDirector.Core/Codex/) merges the
+SessionStart hook into `~/.codex/hooks.json` on Codex launch (preserving the user's own hooks,
+idempotent, atomic write, never clobbers a malformed file), and SessionManager appends
+`CodexHookInstaller.BypassTrustFlag` (`--dangerously-bypass-hook-trust`) to the Codex command - the
+analog of how Claude passes `--settings`. Proven: spawning a Codex session with NO manual args
+auto-created hooks.json, the Director logged the install, a turn ran (thanks to the submit fix), and
+the rollout carried the preamble as a `role:"developer"` context item. Tests: CodexHookInstallerTests
+(4) + CodexDriverTests submit cases (2).
+
+Open design point (NOT a blocker): the hooks.json is GLOBAL to the user's Codex (no `--settings`-style
+scoping). It no-ops outside Director sessions (no CC_SESSION_ID) and only runs un-prompted because the
+Director passes the bypass flag; the user's own non-Director Codex sessions would see an un-trusted
+hook. For a shipped product, consider the managed-hooks path (`requirements.toml`) instead of writing
+the user's personal config.
+
+CLEAR / COMPACT RE-FIRE: VERIFIED LIVE 2026-06-26 (codex 0.141.0, interactive TUI). One session,
+counting preamble injections (each carries "You are session <shortid>"): turn 1 = 1 injection;
+after `/clear` a NEW rollout appeared with a 2nd injection; after `/compact` a 3rd injection landed
+in the post-clear rollout. So SessionStart re-fires on both `source=clear` and `source=compact` and
+the preamble re-injects automatically after every context reset, exactly like Claude. Nothing left to
+verify on the Codex preamble path.
+
+### Other items to confirm live
+
+- Codex hooks are recent and churning. Confirm live against the installed binary:
+  - That SessionStart actually re-fires with `source = "clear"` and `source = "compact"` in the
+    interactive TUI (docs say so; verify). [VERIFIED from docs] but unverified on our binary.
+  - That a USER-layer `~/.codex/hooks.json` SessionStart hook fires in an interactive session
+    (issue #17532 reports repo-local config hooks NOT firing). https://github.com/openai/codex/issues/17532
+  - The exact stdin field casing (`session_id`, `hook_event_name`, `turn_id`, `permission_mode`)
+    and whether `source` is top-level on the SessionStart payload. [VERIFIED from docs] hooks; verify live.
+  - Whether plain-text stdout vs the JSON `hookSpecificOutput` form is honored for additionalContext
+    on our version. [VERIFIED from docs] hooks; verify live.
+- `--session-id` as a top-level interactive flag is NOT confirmed; treat resume as
+  `codex resume <id>`/`--last` and App Server `thread/resume` only. [INFERRED/UNCERTAIN]
+- Whether AGENTS.md / model_instructions_file survive `/clear` and `/compact` is undocumented;
+  open issue #21675 (per-session cache for additionalContext) suggests instruction reload behavior
+  is in flux. Verify live. https://github.com/openai/codex/issues/21675
+- PreToolUse additionalContext parity is an open question (issue #19385). Do not depend on
+  PreToolUse for context injection; use SessionStart. https://github.com/openai/codex/issues/19385
+- Model names in examples (`gpt-5.5`) are doc placeholders; the actual default model on the
+  installed binary should be read from `codex --version` / `/status`, not assumed.
+- The App Server method names (`thread/start`, `turn/start`, etc.) are from the docs; confirm
+  against the installed `codex app-server` before building on them - it is marked experimental in
+  places (WebSocket transport, `process/*`).
+- Our rollout-locator heuristic (newest `rollout-*.jsonl` for the matching cwd within a launch
+  window) is a heuristic; confirm `/clear` continuity (same rollout file vs new file) live.
+
+---
+
+## Sources
+
+- Codex documentation home: https://developers.openai.com/codex
+- CLI command-line reference: https://developers.openai.com/codex/cli/reference
+- Hooks: https://developers.openai.com/codex/hooks
+- Configuration reference: https://developers.openai.com/codex/config-reference
+- Advanced configuration (notify, inline hooks): https://developers.openai.com/codex/config-advanced
+- Local config / basics: https://developers.openai.com/codex/config-basic and /codex/local-config
+- AGENTS.md custom instructions guide: https://developers.openai.com/codex/guides/agents-md
+- App Server (JSON-RPC): https://developers.openai.com/codex/app-server
+- Subagents: https://developers.openai.com/codex/subagents
+- Source repo: https://github.com/openai/codex
+- Config source of truth: https://github.com/openai/codex/blob/main/docs/config.md
+- Config Rust implementation: https://github.com/openai/codex/blob/main/codex-rs/core/src/config/mod.rs
+- Issue #17532 (repo-local config hooks do not fire interactively): https://github.com/openai/codex/issues/17532
+- Issue #19385 (PreToolUse additionalContext parity): https://github.com/openai/codex/issues/19385
+- Issue #21675 (per-session additionalContext cache / InstructionsLoaded parity): https://github.com/openai/codex/issues/21675
+- Issue #4005 (notify payload should include cwd): https://github.com/openai/codex/issues/4005
+- Our integration source: src/CcDirector.Core/Drivers/CodexDriver.cs, Agents/CodexAgent.cs,
+  AgentPlugins/CodexAgentPlugin.cs, Drivers/CodexSlashCommands.cs, Codex/CodexTranscriptReader.cs,
+  Codex/CodexRolloutLocator.cs

--- a/.claude/skills/agent-expert/agents/copilot.md
+++ b/.claude/skills/agent-expert/agents/copilot.md
@@ -1,0 +1,439 @@
+<!--
+Per-agent reference for the GitHub Copilot CLI (the agentic `copilot` binary).
+ASCII only. No Unicode, no emoji, no em-dashes (use " - ").
+Every non-trivial fact is marked [VERIFIED from docs] or [INFERRED/UNCERTAIN] with an inline source.
+All links are collected in the Sources section.
+
+CRITICAL SCOPE NOTE: This file is about the COPILOT CLI (npm @github/copilot, binary `copilot`,
+source repo github/copilot-cli) - the newer agentic terminal agent. It is NOT about:
+  - the old `gh copilot` gh-extension (suggest/explain), which is a different product, and
+  - the @github/copilot-sdk TypeScript library (source repo github/copilot-sdk), which is for
+    building your OWN agent.
+Many GitHub doc pages blur the CLI and the SDK. When they disagree, the CLI-specific page wins for
+us, because CC Director supervises the CLI, not the SDK. The single most important divergence:
+the CLI's sessionStart hook output is IGNORED, while the SDK's onSessionStart additionalContext
+IS injected. See sections 4, 5, and 6.
+-->
+
+# GitHub Copilot CLI (Copilot)
+
+> The agentic `copilot` terminal agent from `@github/copilot`. Our integration: CopilotDriver /
+> CopilotAgent / CopilotAgentPlugin. Mechanism family D (instruction file re-read per prompt); the
+> CLI hook system canNOT inject context, unlike Claude Code.
+
+## 1. Identity and install
+
+- Binary name: `copilot`. On Windows the launchable shim is `copilot.cmd`. [VERIFIED from docs - CLI command reference, and our CopilotDriver/CopilotAgentPlugin resolve it as `copilot.cmd`]
+  (https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference)
+- npm package: `@github/copilot`, install global: `npm install -g @github/copilot`. Also installable via the `gh.io/copilot-install` script, Homebrew, or WinGet. [VERIFIED from docs - install page; mirrored in our CopilotDriver.ResolveExecutable error text]
+  (https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli)
+- Source repository: `github/copilot-cli` (issues live here). [VERIFIED - issues referenced throughout]
+  (https://github.com/github/copilot-cli)
+- SDK (separate product, section 6): `@github/copilot-sdk`, repo `github/copilot-sdk`. [VERIFIED from docs]
+  (https://www.npmjs.com/package/@github/copilot-sdk)
+- Documentation home: docs.github.com/en/copilot, with a dedicated CLI section. [VERIFIED from docs]
+  (https://docs.github.com/en/copilot/how-tos/copilot-cli/use-copilot-cli)
+- Windows install location of the shim: the npm global bin directory, typically
+  `%APPDATA%\npm\copilot.cmd`. Our CopilotAgentPlugin detection probes exactly that path
+  (`Environment.SpecialFolder.ApplicationData` + `npm\copilot.cmd`) and falls back to `copilot` on PATH. [VERIFIED - CopilotAgentPlugin.DefaultNpmCliPath in this repo]
+- Version-probe command: `copilot --version` (alias `-v`). Our CopilotAgentPlugin uses `--version`
+  with an 8-second timeout for validation. [VERIFIED from docs and CopilotAgentPlugin.ValidationMetadata]
+  (https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference)
+- Version context: behavior cited here spans roughly v1.0.x. Our CopilotAgent comment records live
+  verification against Copilot CLI v1.0.63. The CLI churns fast; re-verify hook/flag details against
+  the installed build. [INFERRED/UNCERTAIN - versions move; see section 11]
+
+## 2. Command-line interface
+
+Two modes:
+- Interactive: bare `copilot` starts a back-and-forth terminal session. Shift+Tab cycles modes
+  (including a plan mode). [VERIFIED from docs]
+  (https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli)
+- Non-interactive / programmatic: `-p` / `--prompt` runs one prompt and exits after completion. [VERIFIED from docs]
+  (https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference)
+
+Flag table (exact spellings from the CLI command reference). [VERIFIED from docs unless noted]
+(https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference)
+
+| Flag | Meaning |
+|------|---------|
+| `-p PROMPT`, `--prompt=PROMPT` | Execute a prompt programmatically, then exit (non-interactive). |
+| `--model=MODEL` | Set the model to use. |
+| `-r`, `--resume[=VALUE]` | Resume a previous interactive session (picker, or a specific id/prefix/name when VALUE is given). |
+| `--continue` | Resume the most recent session in the current working directory. |
+| `--session-id=UUID` | Start a new session with a caller-chosen UUID. [VERIFIED - we pass this and it echoes in the json stream; see section 10] |
+| `--allow-tool=TOOL` | Pre-allow a tool (no permission prompt). Example: `--allow-tool='shell(git)'`. |
+| `--deny-tool=TOOL` | Deny a tool. |
+| `--allow-all-tools` | Allow all tools without confirmation (the "yolo" path). |
+| `--add-dir=PATH` | Add a directory to the allowed file-access list. |
+| `--cloud` | Run the task in an isolated cloud-hosted sandbox instead of locally. |
+| `--log-level=LEVEL` | none, error, warning, info, debug, all, default. |
+| `--banner` / `--no-banner` | Show or hide the startup banner. |
+| `--no-color` | Disable color output. |
+| `--screen-reader` | Screen-reader optimizations. |
+| `-v`, `--version` | Print version. |
+
+Note on the "yolo" preset: our CopilotAgentPlugin contributes an "Automatic (yolo)" preset whose
+arg is carried in `AgentToolCatalog.CopilotAllowAllArg`. [VERIFIED - CopilotAgentPlugin.Presets in this repo]
+(The exact allow-all flag string lives in AgentToolCatalog; treat the doc's `--allow-all-tools` as
+the canonical spelling and verify the preset matches it.) [INFERRED/UNCERTAIN - cross-check the constant]
+
+Slash commands (interactive only). [VERIFIED from docs - CLI command reference + slash-command cheat sheet]
+(https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference)
+(https://github.blog/ai-and-ml/github-copilot/a-cheat-sheet-to-slash-commands-in-github-copilot-cli/)
+
+- `/clear` (aliases `/new`, `/reset`) - start a new conversation / delete the current session's
+  conversation history. [VERIFIED]
+- `/compact` - summarize conversation history to reduce context-window usage. [VERIFIED]
+- `/context` - show context-window token usage and a visualization. [VERIFIED]
+- `/model`, `/models` - select the model. [VERIFIED]
+- `/session` - show session information and manage sessions. [VERIFIED]
+- `/resume`, `/continue` - switch to a different session from a picker. [VERIFIED]
+- `/mcp` - manage MCP server configuration (subcommands: show, add, edit, delete, disable, enable). [VERIFIED]
+  (https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli)
+- `/agent` - browse and select custom agents. [VERIFIED]
+- `/settings` - open the settings dialog, or set a setting inline. [VERIFIED]
+- `/every INTERVAL PROMPT` - schedule a recurring prompt or slash command. Interval suffixes s/m/h/d;
+  a bare number means minutes; minimum 10 seconds, maximum 1 day. Built-in commands like `/clear`
+  cannot be scheduled. [VERIFIED from docs / blog]
+  (https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli)
+- `/after DELAY PROMPT` - schedule a one-shot prompt/command after a delay. [VERIFIED]
+- `/login`, `/logout`, `/user` - authentication / account. [VERIFIED]
+- `/usage` - session usage metrics. [VERIFIED]
+- `/sandbox` (e.g. `/sandbox enable`) - configure shell-command sandboxing. [VERIFIED]
+- `/add-dir`, `/list-dirs`, `/cwd` - directory access management. [VERIFIED - slash cheat sheet]
+- `/delegate` - create an AI-generated pull request (cloud). [VERIFIED]
+- `/share` - export the session. [VERIFIED]
+- `/theme`, `/terminal-setup`, `/reset-allowed-tools`, `/feedback`, `/help` - misc. [VERIFIED]
+- `/chronicle` - generate insights from local session history (subcommands). [VERIFIED - see section 8]
+  (https://docs.github.com/en/copilot/how-tos/copilot-cli/chronicle)
+
+Scheduling caveat for automation: `/every` and `/after` run only while the interactive session is
+open and cannot schedule built-in commands like `/clear`. For real loops, wrap `copilot -p` in a
+script. [VERIFIED from docs]
+(https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli)
+
+## 3. Configuration
+
+- Config / state directory: `~/.copilot/` (Windows `%USERPROFILE%\.copilot\`). Holds auth tokens,
+  settings, hooks, custom instructions, and session state. [VERIFIED from docs]
+  (https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference)
+- Override with `COPILOT_HOME` (Windows `%COPILOT_HOME%`). When set, all of the above move under it
+  (e.g. `$COPILOT_HOME/hooks/`). [VERIFIED from docs]
+  (https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks)
+- Settings files (inline `hooks` blocks also live here):
+  - User settings: `~/.copilot/settings.json`. [VERIFIED from docs - hooks reference]
+  - Repository settings: `.github/copilot/settings.json` and `.github/copilot/settings.local.json`. [VERIFIED from docs - hooks reference]
+  (https://docs.github.com/en/copilot/reference/hooks-reference)
+- Auth env vars, checked in order: `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`. [VERIFIED from docs]
+- Custom-provider env vars: `COPILOT_PROVIDER_BASE_URL`, `COPILOT_PROVIDER_TYPE`,
+  `COPILOT_PROVIDER_API_KEY`, `COPILOT_MODEL`. [VERIFIED from docs - CLI overview]
+  (https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli)
+- Custom-instruction dirs env var: `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` (comma-separated). [VERIFIED from docs - section 4]
+- Precedence for hooks (lowest-to-highest effect order is policy, then user/project, then plugins):
+  policy directory -> `.github/hooks/*.json` (repo) -> `~/.copilot/hooks/` (user) ->
+  inline `hooks` in repo settings -> inline `hooks` in user settings -> plugin-contributed hooks. [VERIFIED from docs - hooks reference]
+  (https://docs.github.com/en/copilot/reference/hooks-reference)
+
+## 4. Context injection (how to inject a preamble)
+
+The decisive fact for CC Director: with the CLI, you inject context through INSTRUCTION FILES, not
+through hook output. The CLI hook system canNOT add model context at session start (section 5).
+
+Instruction files the CLI reads (and re-reads). On every request the CLI collects all applicable
+instruction files, evaluates any `applyTo` globs, and merges matching layers in priority order. [VERIFIED from docs - add-custom-instructions]
+(https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-custom-instructions)
+
+1. `AGENTS.md` - repo root, the current working directory, or any directory listed in
+   `COPILOT_CUSTOM_INSTRUCTIONS_DIRS`. The root AGENTS.md is treated as primary instructions. [VERIFIED from docs]
+   - Survives `/clear`? [INFERRED/UNCERTAIN - very likely yes: it is a file re-read per prompt, not part of the cleared conversation. Not explicitly documented for the CLI's /clear; verify live.]
+   - Survives `/compact`? [INFERRED/UNCERTAIN - very likely yes for the same reason; compaction summarizes the transcript, but instruction files are re-collected per request. Verify live.]
+2. `.github/copilot-instructions.md` - repo root `.github/` directory; repository-wide instructions. [VERIFIED from docs]
+   - Survives /clear and /compact? Same reasoning as AGENTS.md: re-read per prompt, so it should
+     self-heal after any reset. [INFERRED/UNCERTAIN - not explicitly documented for the CLI's reset path]
+3. Path-scoped: `.github/instructions/**/*.instructions.md` with an `applyTo` glob in frontmatter -
+   merged only for matching files, at repo root or under the working directory. [VERIFIED from docs]
+   - Survives /clear and /compact? Re-evaluated per request; self-healing. [INFERRED/UNCERTAIN]
+4. Personal / user-global: `$HOME/.copilot/copilot-instructions.md` - a user-level instructions
+   file applied across repos. [INFERRED/UNCERTAIN - listed by the task and consistent with the
+   `~/.copilot` config root, but I could not open a docs page that names this exact path; verify
+   live by creating the file and confirming it is honored.]
+   - Survives /clear and /compact? If it is re-read per prompt like the others, yes. [INFERRED/UNCERTAIN]
+
+Key property for us: because instruction files are re-read on every prompt, they are SELF-HEALING.
+Any context placed in them comes back automatically after `/clear` or `/compact` without an event
+firing - no re-injection mechanism is needed. This is the foundation of our Mechanism Family D plan
+(section 10). [VERIFIED that files are re-read per request from docs; the "survives reset" conclusion
+is INFERRED/UNCERTAIN until verified live.]
+(https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-custom-instructions)
+
+Known gap to be aware of: issue #1433 reports `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` not reliably
+auto-loading AGENTS.md from the listed dirs - documented behavior vs actual behavior diverge. Prefer
+a path the CLI definitely scans (repo-root AGENTS.md, or the user-global file) over relying solely on
+the env var. [VERIFIED - issue #1433]
+(https://github.com/github/copilot-cli/issues/1433)
+
+Contrast with Claude Code (the benchmark): Claude Code's SessionStart hook emits `additionalContext`
+that IS injected into the model. The Copilot CLI has no equivalent working hook path - its
+sessionStart hook output is discarded (section 5). So for Copilot, injection MUST go through
+instruction files, not hooks.
+
+## 5. Lifecycle events and hooks
+
+The CLI has a real hooks system, registered as JSON, fired around the session and tool lifecycle.
+But it is primarily a POLICY / OBSERVABILITY system (allow/deny tools, log, notify), NOT a
+context-injection system at session start.
+
+Registration locations (also section 3 precedence). [VERIFIED from docs - hooks reference / use-hooks]
+(https://docs.github.com/en/copilot/reference/hooks-reference)
+(https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks)
+- Repository: `.github/hooks/*.json`
+- User: `~/.copilot/hooks/` (or `$COPILOT_HOME/hooks/`); Windows `%USERPROFILE%\.copilot\hooks\`
+- Inline `hooks` block inside `.github/copilot/settings.json` (and `.local.json`) or `~/.copilot/settings.json`
+- Policy directory (Linux/macOS `/etc/github-copilot/policy.d/`, Windows
+  `C:\ProgramData\GitHub\Copilot\policy.d\`); always runs, cannot be disabled by `disableAllHooks`.
+- The cloud agent only loads `.github/hooks/*.json` from the cloned repo.
+
+Config schema: top-level `{"version": 1, "hooks": { <event>: [ <entry>, ... ] }}`. Set
+`"disableAllHooks": true` to skip non-policy hooks. Hook entry types: `command` (with `bash`,
+`powershell`, or cross-platform `command`, plus `cwd`, `env`, `timeoutSec` default 30), `http`
+(POST JSON to `url`), and `prompt` (CLI-only; submits text as if the user typed it; fires on
+sessionStart for new interactive sessions only). [VERIFIED from docs - hooks reference]
+
+Event names use two parallel conventions: native camelCase (`sessionStart`) and Claude-compatible
+PascalCase (`SessionStart`, `PreToolUse`, ...). PascalCase matchers use Claude semantic tool-name
+mapping. [VERIFIED from docs - hooks reference]
+
+stdin payload: each hook receives a JSON object on stdin. Common fields: `sessionId`, `timestamp`,
+`cwd`. Per event it adds more (below). [VERIFIED from docs - hooks reference]
+
+Event list and - critically - what each hook's OUTPUT can do. [VERIFIED from docs - hooks reference]
+(https://docs.github.com/en/copilot/reference/hooks-reference)
+
+| Event (camel / Pascal) | Extra input fields | Output effect |
+|------------------------|--------------------|---------------|
+| `sessionStart` / `SessionStart` | `source` ("startup"\|"resume"\|"new"), optional `initialPrompt` | See the KEY FINDING below - effectively informational for the CLI. |
+| `sessionEnd` / `SessionEnd` | `reason` ("complete"\|"error"\|"abort"\|"timeout"\|"user_exit") | None (informational). |
+| `userPromptSubmitted` / `UserPromptSubmit` | `prompt` | None - output disregarded by the CLI. |
+| `preToolUse` / `PreToolUse` | `toolName`, `toolArgs` | Allow / deny / modify: `permissionDecision` (allow\|deny\|ask), `permissionDecisionReason`, `modifiedArgs`. Command hooks are FAIL-CLOSED (crash or non-zero exit denies). Matcher: regex on toolName. |
+| `postToolUse` / `PostToolUse` | `toolName`, `toolArgs`, `toolResult` | Can modify result (`modifiedResult`) or inject `additionalContext` appended to tool output. |
+| `postToolUseFailure` / `PostToolUseFailure` | `toolName`, `toolArgs`, `error` | Recovery guidance via `additionalContext` (exit code 2 treated as context). |
+| `preCompact` / `PreCompact` | `transcriptPath`, `trigger` ("manual"\|"auto"), `customInstructions` | None - notification only. Matcher: regex on trigger. |
+| `agentStop` / `Stop` | `transcriptPath`, `stopReason` | Can block and force continuation (`decision` block\|allow, `reason`). |
+| `subagentStart` | `transcriptPath`, `agentName`, ... | Cannot block; `additionalContext` is prepended to the subagent's prompt. |
+| `subagentStop` / `SubagentStop` | `transcriptPath`, `agentName`, `stopReason` | Can block / force continuation. |
+| `errorOccurred` / `ErrorOccurred` | `error`, `errorContext`, `recoverable` | None - informational. |
+| `notification` (CLI-only) | `message`, `title`, `notification_type` | Optional `additionalContext` injected as a prepended user message; fire-and-forget, never blocks. Matcher: regex on notification_type. |
+| `permissionRequest` (CLI-only) | `toolName` etc. | Allow/deny programmatically (`behavior`, `message`, `interrupt`). |
+
+KEY FINDING - state it plainly: for the CLI, the `sessionStart` hook OUTPUT IS IGNORED. The
+conceptual/tutorial docs say it directly: "Any output from this hook is ignored by Copilot CLI,
+which makes it suitable for informational messages." So a sessionStart hook can print a banner but
+CANNOT inject `additionalContext` into the model. This is confirmed by issue #2142 (the
+`additionalContext` return value is silently ignored - fire-and-forget in the bundled source). [VERIFIED from docs - copilot-cli-hooks tutorial; VERIFIED - issue #2142]
+(https://docs.github.com/en/copilot/tutorials/copilot-cli-hooks)
+(https://github.com/github/copilot-cli/issues/2142)
+
+Doc contradiction to flag: the newer hooks-reference TABLE lists sessionStart output as "Optional -
+can inject additionalContext into the session." This conflicts with the tutorial/concept prose and
+with issue #2142. This is exactly the kind of CLI-vs-SDK / version churn the task warns about; the
+SDK fixed sessionStart injection in v1.0.11 (section 6), and the reference table may be describing
+the SDK contract or an aspirational/just-landed CLI fix. DO NOT depend on CLI sessionStart injection
+until verified live against the installed binary. [INFERRED/UNCERTAIN - reconcile reference table vs
+tutorial vs #2142 live]
+(https://docs.github.com/en/copilot/reference/hooks-reference)
+
+Other injection-capable hooks exist but are the wrong tool for a startup preamble: `postToolUse`,
+`postToolUseFailure`, `subagentStart`, and `notification` can carry `additionalContext`, but they
+fire on tool calls / subagents / notifications, not at "session start". Reports #2585 (preToolUse)
+and #2980 (postToolUse) note additionalContext not reaching the model in some builds, so even these
+are shaky. [VERIFIED - issues exist] (https://github.com/github/copilot-cli/issues/2980)
+
+Which events fire on each transition:
+- Startup: `sessionStart` with `source: "startup"`. [VERIFIED from docs]
+- Resume: `sessionStart` with `source: "resume"`. [VERIFIED from docs]
+- Clear / new: not clearly documented. There is no documented hook event specifically for `/clear`.
+  Because `/clear` starts a new conversation, a fresh `sessionStart` (source "new") MAY fire, but
+  this is unconfirmed and tangled with bug #2491. [INFERRED/UNCERTAIN]
+- Compact: `preCompact` fires before compaction with `trigger` "manual" or "auto" (auto at ~95%
+  capacity). It is notification-only - it cannot re-inject context, but it IS observable. [VERIFIED from docs]
+
+BUG to track - #2491: `sessionStart` fires on EVERY user message, not once per session (closed as a
+duplicate of #991). The observed pattern is per-turn: sessionStart -> response -> sessionEnd ->
+next sessionStart. Consequences: (a) you cannot treat sessionStart as a once-per-session signal,
+and (b) expensive setup in a sessionStart hook runs every turn. This further undermines any plan to
+key off sessionStart. [VERIFIED - issue #2491]
+(https://github.com/github/copilot-cli/issues/2491)
+
+## 6. SDK / programmatic API (@github/copilot-sdk)
+
+This is a SEPARATE product from the CLI: a TypeScript/Node library (repo github/copilot-sdk) for
+building your own agent. CC Director supervises the CLI, not the SDK, so the SDK is documented here
+only to keep the CLI-vs-SDK distinction clear. [VERIFIED from docs / npm]
+(https://www.npmjs.com/package/@github/copilot-sdk)
+(https://github.com/github/copilot-sdk/blob/main/docs/features/hooks.md)
+
+- Session lifecycle hooks are registered programmatically, e.g.:
+  ```
+  const session = await client.createSession({
+    hooks: {
+      onSessionStart: async (input, invocation) => { ... },
+      onSessionEnd:   async (input, invocation) => { ... },
+    },
+  });
+  ```
+  [VERIFIED from docs - SDK session-lifecycle]
+  (https://docs.github.com/en/copilot/how-tos/copilot-sdk/use-hooks/session-lifecycle)
+- CRITICAL difference from the CLI: the SDK's `onSessionStart` returns `additionalContext` (string,
+  "Context to add at session start") and `modifiedConfig` (object), and these ARE injected. The
+  `input` includes `timestamp`, `cwd`, `source`, and (as of v1.0.44) `initialPrompt`. [VERIFIED from docs]
+- Version note: in CLI builds before v1.0.11 the additionalContext from onSessionStart was
+  fire-and-forget; the SDK path was fixed in v1.0.11. This is the version line where the SDK and CLI
+  behaviors split in the docs, and the likely source of the reference-table contradiction in
+  section 5. [VERIFIED from SDK docs commentary] [INFERRED/UNCERTAIN whether the CLI was also fixed]
+- SDK hooks also include `onSessionEnd` and (in examples) `onUserPromptSubmitted` / `onPreToolUse`.
+  Returning null means "continue with default behavior". [VERIFIED from docs]
+- Net: if we ever needed reliable session-start injection for Copilot, the SDK provides it - but
+  that means embedding the SDK and running our own agent loop, which is a different integration than
+  supervising the stock `copilot` binary in a terminal. Out of scope for the current driver.
+
+## 7. MCP / custom agents / instructions
+
+- MCP: managed via `/mcp` (show, add, edit, delete, disable, enable) and stored in Copilot config.
+  Standard Model Context Protocol servers. [VERIFIED from docs]
+  (https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli)
+- Custom agents: defined as files and selected with `/agent` or the `--agent`-style picker; the
+  hooks `subagentStart` / `subagentStop` fire around them. [VERIFIED from docs - create-custom-agents-for-cli]
+  (https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/create-custom-agents-for-cli)
+- Custom instructions: see section 4 (AGENTS.md, .github/copilot-instructions.md, path-scoped
+  .instructions.md, user-global, COPILOT_CUSTOM_INSTRUCTIONS_DIRS). These are the supported
+  context-injection surface for the CLI. [VERIFIED from docs]
+- Plugins can contribute hooks (lowest precedence layer). [VERIFIED from docs - hooks reference]
+
+## 8. Transcript / history
+
+- Every CLI session is persisted under `~/.copilot/session-state/` (honoring `COPILOT_HOME`). Each
+  session is a subdirectory containing an `events.jsonl` event log and a `workspace.yaml` metadata
+  file; a top-level `session-store.db` holds an FTS5 full-text index across all sessions. By default
+  sessions also sync to your GitHub account. [VERIFIED from docs / DeepWiki]
+  (https://docs.github.com/en/copilot/how-tos/copilot-cli/chronicle)
+  (https://deepwiki.com/github/copilot-cli/3.3-session-management-and-history)
+- The `/chronicle` slash command generates insights from this local history. [VERIFIED from docs]
+- Parseability: `events.jsonl` is line-delimited JSON, parseable; `session-store.db` is SQLite with
+  FTS5. Token usage is surfaced live via `/usage` and `/context`. [VERIFIED from docs]
+- IMPORTANT for our driver: this on-disk transcript location/format is NOT yet live-verified by us,
+  so CopilotDriver deliberately does NOT declare `TranscriptRead` and throws on the on-disk verbs
+  (ReadWidgets/ReadUsage/ListTranscripts). What the driver DOES parse live is Copilot's
+  `--output-format json` JSONL stream (one event per line), not the on-disk file. Note the tension:
+  CopilotAgentPlugin.History already advertises `AgentHistoryProviderKind.SqliteStore`
+  (SupportsConversationHistory true, "GitHub Copilot SQLite session store") pointing at
+  session-store.db, while the driver has not wired reading it. Resolve before relying on history. [VERIFIED - this repo: CopilotDriver and CopilotAgentPlugin]
+
+## 9. Session semantics
+
+- new (`copilot` fresh, or `/clear` / `/new` / `/reset`): starts a new conversation, dropping prior
+  turns. `/clear` "deletes the current session's conversation history". [VERIFIED from docs]
+- `/compact`: summarizes the conversation to shrink context; same session continues. Auto-compaction
+  fires near 95% capacity. `preCompact` hook observes it. [VERIFIED from docs]
+- resume: `copilot --resume [id]` or `--continue` (most recent in cwd); interactively `/resume`.
+  Resume replays a stored session by id/prefix/name. [VERIFIED from docs]
+- session id: caller may preassign via `--session-id <uuid>` at launch; the id is echoed in the
+  `--output-format json` stream. Resume passes the existing id. [VERIFIED - this repo + docs]
+- Across transitions: a `/clear`/new conversation is a context reset within the SAME running
+  process; whether it mints a new session id or keeps the launch id is not documented and not
+  verified by us. `/compact` keeps the same session id. [INFERRED/UNCERTAIN for /clear id behavior]
+
+## 10. How CC Director integrates it
+
+Classes in this repo:
+- Driver: `CopilotDriver` (src/CcDirector.Core/Drivers/CopilotDriver.cs).
+- Agent: `CopilotAgent` (src/CcDirector.Core/Agents/CopilotAgent.cs).
+- Plugin: `CopilotAgentPlugin` (src/CcDirector.Core/AgentPlugins/CopilotAgentPlugin.cs).
+
+Declared driver capabilities (intentionally minimal - capability honesty): `Interrupt`
+(Ctrl+C, byte 0x03) and `PreassignedSessionId` (`--session-id <uuid>`). The driver THROWS on
+`ClearContextAsync` (NotSupportedException: "no verified in-place context-clear command"),
+`CancelAsync` (soft-cancel keystroke unverified - use Ctrl+C), `ShowHistoryAsync` (no verified
+in-terminal picker), and the on-disk transcript verbs (location/format unverified). It does NOT
+declare `Cancel`, `History`, or `TranscriptRead`. [VERIFIED - CopilotDriver in this repo]
+
+Launch: new session mints a fresh UUID and passes `--session-id <uuid>`; resume passes
+`--resume <id>`. The "Automatic (yolo)" preset carries the allow-all arg via the preset args.
+Studio (stream-json card UI) is NOT wired for Copilot; the driver parses Copilot's own
+`--output-format json` JSONL via ParseStreamLine/TryCaptureSessionId. [VERIFIED - CopilotAgent / CopilotAgentPlugin]
+
+Fleet-preamble strategy: Mechanism Family D (instruction file), because the CLI's hook system
+cannot inject context at session start (sections 4, 5). Concrete plan:
+1. Write the fleet preamble into a custom-instruction file the CLI re-reads every prompt. Two
+   candidate sinks:
+   a. A directory we control, exported via `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` at launch, containing
+      an `AGENTS.md` (and/or `.github/instructions/*.instructions.md`). Risk: issue #1433 reports
+      this env var does not reliably load AGENTS.md - verify before committing to it.
+   b. The user-global `$HOME/.copilot/copilot-instructions.md` (or `$COPILOT_HOME/...`). Risk: this
+      exact path is not doc-confirmed (section 4); verify it is honored.
+   Recommended primary: write the preamble where the CLI is GUARANTEED to scan - the working
+   directory's `AGENTS.md` or `.github/copilot-instructions.md` for the session's repo - falling
+   back to the global file only once verified. [INFERRED/UNCERTAIN - pick after live test]
+2. Re-injection on reset is NOT needed for content: because instruction files are re-read per
+   prompt, the preamble self-heals automatically after `/clear` and `/compact` (no event required).
+   This is the whole point of family D. [Re-read-per-prompt VERIFIED; survives-reset INFERRED/UNCERTAIN]
+3. Detect compaction via a `preCompact` hook (notification-only, but observable) registered at
+   `~/.copilot/hooks/` or `$COPILOT_HOME/hooks/`, posting the event to the Director. Use it for
+   telemetry / UI, not for re-injection. [VERIFIED preCompact exists and is notification-only]
+4. `/clear` is NOT observable from outside: there is no documented `/clear` hook event, and any
+   sessionStart re-fire is confounded by bug #2491 (fires every turn). So the Director should treat
+   `/clear` as undetectable and rely on the self-healing instruction file rather than a clear signal. [VERIFIED no clear hook; #2491 confounds sessionStart]
+
+What to verify live (gates before we depend on the plan):
+- Confirm an instruction file's content actually reappears in the model's behavior after `/clear`
+  and after `/compact` (the self-heal assumption).
+- Confirm which sink the installed build honors: COPILOT_CUSTOM_INSTRUCTIONS_DIRS (re-check #1433),
+  the user-global `~/.copilot/copilot-instructions.md`, or per-repo AGENTS.md.
+- Confirm a `preCompact` hook fires and reaches our endpoint on both manual and auto compaction.
+- Confirm the on-disk session-store.db / events.jsonl format before flipping the plugin's
+  SqliteStore history claim into real reads (today the driver throws on transcript verbs).
+- Confirm whether `/clear` changes the session id (affects resume and id tracking).
+
+## 11. Caveats and verification needed
+
+- Recency / churn: the CLI is on a fast v1.0.x cadence; flags, hook output contracts, and the
+  reference table change between builds. Re-verify against the installed binary (our CopilotAgent
+  notes v1.0.63; the broader hook discussion spans v1.0.8-v1.0.44+). [INFERRED/UNCERTAIN]
+- The sessionStart-output contradiction (section 5): tutorial/concept docs and issue #2142 say the
+  CLI ignores it; the hooks-reference table says it can inject. Treat CLI sessionStart injection as
+  NON-WORKING until proven live. The SDK (different product) does inject. [needs live check]
+- Bug #2491: sessionStart fires every user message - do not use it as a once-per-session signal.
+- Issue #1433: COPILOT_CUSTOM_INSTRUCTIONS_DIRS may not auto-load AGENTS.md - verify the sink.
+- additionalContext on preToolUse/postToolUse reportedly not always injected (#2585, #2980) - even
+  the injection-capable hooks are shaky on some builds.
+- Our driver's unverified-but-plausible spots: the exact allow-all flag string in AgentToolCatalog
+  vs the doc's `--allow-all-tools`; whether session-store.db is the right history source; the
+  soft-cancel keystroke; the in-terminal history picker. All deliberately left unsupported / throwing.
+- `--cloud` and `/delegate` run work off the local machine; supervising those is out of the local
+  terminal model and not handled by the current driver.
+
+## Sources
+
+- About GitHub Copilot CLI (concept / overview): https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli
+- Install GitHub Copilot CLI: https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli
+- Using GitHub Copilot CLI (how-to, slash commands incl. /every, /after, /mcp): https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli
+- Use Copilot CLI (how-to index): https://docs.github.com/en/copilot/how-tos/copilot-cli/use-copilot-cli
+- CLI command reference (flags + slash commands): https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference
+- Slash-command cheat sheet (blog): https://github.blog/ai-and-ml/github-copilot/a-cheat-sheet-to-slash-commands-in-github-copilot-cli/
+- Hooks reference (events, payloads, output contracts): https://docs.github.com/en/copilot/reference/hooks-reference
+- Using hooks with Copilot CLI (how-to, config locations + example): https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks
+- Copilot CLI hooks tutorial (the "output is ignored / informational messages" statement): https://docs.github.com/en/copilot/tutorials/copilot-cli-hooks
+- Adding custom instructions for Copilot CLI (AGENTS.md, copilot-instructions.md, .instructions.md, COPILOT_CUSTOM_INSTRUCTIONS_DIRS, re-read per request): https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-custom-instructions
+- Creating and using custom agents for Copilot CLI: https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/create-custom-agents-for-cli
+- Copilot CLI session data (chronicle, session-state): https://docs.github.com/en/copilot/how-tos/copilot-cli/chronicle
+- Session management and history (DeepWiki): https://deepwiki.com/github/copilot-cli/3.3-session-management-and-history
+- Copilot SDK session lifecycle hooks (onSessionStart additionalContext IS injected): https://docs.github.com/en/copilot/how-tos/copilot-sdk/use-hooks/session-lifecycle
+- Copilot SDK hooks feature doc: https://github.com/github/copilot-sdk/blob/main/docs/features/hooks.md
+- @github/copilot-sdk on npm: https://www.npmjs.com/package/@github/copilot-sdk
+- copilot-cli source repo: https://github.com/github/copilot-cli
+- Issue #2142 - onSessionStart additionalContext silently ignored (CLI): https://github.com/github/copilot-cli/issues/2142
+- Issue #2491 - sessionStart fires on every user message: https://github.com/github/copilot-cli/issues/2491
+- Issue #1433 - COPILOT_CUSTOM_INSTRUCTIONS_DIRS not loading AGENTS.md: https://github.com/github/copilot-cli/issues/1433
+- Issue #2980 - postToolUse additionalContext not injected: https://github.com/github/copilot-cli/issues/2980
+- Issue #2585 - preToolUse additionalContext not passed to agent: https://github.com/github/copilot-cli/issues/2585
+- CC Director integration classes (this repo): src/CcDirector.Core/Drivers/CopilotDriver.cs, src/CcDirector.Core/Agents/CopilotAgent.cs, src/CcDirector.Core/AgentPlugins/CopilotAgentPlugin.cs

--- a/.claude/skills/agent-expert/agents/cursor.md
+++ b/.claude/skills/agent-expert/agents/cursor.md
@@ -1,0 +1,356 @@
+<!--
+Per-agent reference for the agent-expert skill. ASCII only. No Unicode, no emoji, no em-dashes.
+Every non-trivial fact is marked [VERIFIED from docs] or [INFERRED/UNCERTAIN] with inline source links.
+All links are collected in the Sources section.
+-->
+
+# Cursor Agent (Cursor)
+
+> The Cursor command line agent, binary `cursor-agent` from cursor.com, marketed as "Cursor Agent" / "Agent".
+> Our integration status: driver class `CursorDriver` / agent class `CursorAgent` / plugin class `CursorAgentPlugin`.
+> IMPORTANT: the `cursor-agent` binary is NOT installed on our Windows dev machine and there is no
+> native Windows build - spawn attempts fail with "CreateProcess failed". Everything in section 10
+> that is marked "needs live verification" cannot be checked here yet.
+
+---
+
+## 1. Identity and install
+
+- Binary name: `cursor-agent`. [VERIFIED from docs](https://cursor.com/docs/cli/overview)
+- Vendor / docs home: cursor.com, docs at https://cursor.com/docs/cli/overview. [VERIFIED from docs](https://cursor.com/docs/cli/overview)
+- Install (Unix): `curl https://cursor.com/install -fsS | bash`. [VERIFIED from docs](https://cursor.com/docs/cli/headless)
+- NO native Windows build. The official installer (`https://cursor.com/install`) is a bash
+  script that accepts only `uname -s` of `Linux*` or `Darwin*`; `https://cursor.com/install.ps1`
+  is not a real installer (returns the marketing homepage). On Windows it runs only under WSL or
+  Linux/macOS. [VERIFIED from our prior survey](D:\ReposFred\devthrottle\docs\design\agent-history-capture\drivers\cursor.md)
+- Install location (Unix): symlink at `~/.local/bin/cursor-agent`; versioned binary under
+  `~/.local/share/cursor-agent/versions/<version>/`. [VERIFIED from our prior survey](D:\ReposFred\devthrottle\docs\design\agent-history-capture\drivers\cursor.md)
+- Version probe: `cursor-agent --version` (also `-v`). [VERIFIED from docs](https://cursor.com/docs/cli/reference/parameters)
+  Our plugin probes with `--version`, timeout 8 seconds. Observed version in WSL: `2026.06.24-00-45-58-9f61de7`.
+- Update in place: `cursor-agent update`. [VERIFIED from docs](https://cursor.com/docs/cli/reference/parameters)
+- Auth: `cursor-agent login` (device flow) / `logout` / `status` (alias `whoami`); or headless via
+  `--api-key <key>` or the `CURSOR_API_KEY` environment variable. [VERIFIED from docs](https://cursor.com/docs/cli/reference/parameters)
+
+## 2. Command-line interface
+
+Interactive (default): `cursor-agent` opens a terminal UI (TUI). Headless / non-interactive:
+add `-p`/`--print`. [VERIFIED from docs](https://cursor.com/docs/cli/headless)
+
+Flag table (all [VERIFIED from docs](https://cursor.com/docs/cli/reference/parameters) unless noted):
+
+| Flag | Meaning |
+| --- | --- |
+| `-p`, `--print` | Print responses to console; non-interactive scripting mode. |
+| `--output-format <fmt>` | `text`, `json`, or `stream-json`. Only works with `--print`. |
+| `--stream-partial-output` | Stream partial output as individual text deltas (adds `timestamp_ms`/`model_call_id` to assistant events). [VERIFIED from docs](https://cursor.com/docs/cli/reference/output-format) |
+| `--resume [chatId]` | Resume a chat session by id (load prior context). |
+| `--continue` | Continue the previous session; alias for `--resume=-1`. |
+| `--model <model>` | Model to use. (We currently pass no model flag - see section 3.) |
+| `--list-models` / `models` | List available models. |
+| `--mode <mode>` | Set agent mode: `plan` or `ask`. |
+| `--plan` | Start in plan mode (shorthand for `--mode=plan`). |
+| `-f`, `--force` | Force allow commands unless explicitly denied. |
+| `--yolo` | Alias for `--force`. |
+| `--sandbox <mode>` | `enabled` or `disabled`. |
+| `--approve-mcps` | Automatically approve all MCP servers. |
+| `--trust` | Trust the workspace without prompting (headless mode only). |
+| `--workspace <path>` | Workspace / repository root to use. |
+| `--plugin-dir <path>` | Load a local plugin directory (repeatable). |
+| `-w`, `--worktree [name]` | Run in a new Git worktree under `~/.cursor/worktrees/<reponame>/<name>`. |
+| `--worktree-base <branch>` | Branch/ref to base the new worktree on. |
+| `--api-key <key>` | API key (or `CURSOR_API_KEY`). |
+| `-H`, `--header <hdr>` | Add a custom header (`Name: Value`) to agent requests. |
+| `-v`, `--version` | Print version. |
+| `-h`, `--help` | Help. |
+
+Subcommands: `agent [prompt...]`, `login`, `logout`, `status`/`whoami`, `models`, `mcp`
+(`login`/`list`/`list-tools`/`enable`/`disable`), `ls` (resume picker), `resume` (resume latest),
+`sandbox` (`enable`/`disable`/`reset`/`run`), `update`. [VERIFIED from docs](https://cursor.com/docs/cli/reference/parameters)
+
+Model selection at runtime is also done with the `/model` slash command (`/model auto`,
+`/model gpt-5`, `/model sonnet-4-thinking`). [VERIFIED from docs](https://cursor.com/docs/cli/reference/configuration)
+
+What we pass at launch (`CursorAgent.BuildLaunchSpec`): user/preset args, plus `--resume="<chat-id>"`
+when resuming, plus `-p --output-format stream-json` when in Studio (stream-json) mode. The
+"Automatic" preset adds the force/auto-approve arg (`AgentToolCatalog.CursorForceArg`).
+
+## 3. Configuration
+
+- Global config: `~/.cursor/cli-config.json` (Windows: `%USERPROFILE%\.cursor\cli-config.json`).
+  [VERIFIED from docs](https://cursor.com/docs/cli/reference/configuration)
+- Project config: `<project>/.cursor/cli.json` (permissions only). [VERIFIED from docs](https://cursor.com/docs/cli/reference/configuration)
+- Environment overrides: `CURSOR_CONFIG_DIR` (custom dir), `XDG_CONFIG_HOME` on Linux/BSD
+  (`$XDG_CONFIG_HOME/cursor/cli-config.json`). [VERIFIED from docs](https://cursor.com/docs/cli/reference/configuration)
+- Config keys: `version` (=1), `editor.vimMode`, `permissions.allow` / `permissions.deny`,
+  `model` (object), `notifications`, `display.showThinkingBlocks`, `approvalMode`
+  (`allowlist` or `unrestricted`), `network.useHttp1ForAgent`,
+  `attribution.attributeCommitsToAgent`. [VERIFIED from docs](https://cursor.com/docs/cli/reference/configuration)
+- Precedence (config): enterprise/system > project `.cursor/cli.json` > global `~/.cursor/cli-config.json`.
+  [INFERRED/UNCERTAIN] - the docs describe the files but do not give an explicit ordered precedence
+  list for `cli-config.json` vs `cli.json` beyond "project = permissions only".
+- Auth env var: `CURSOR_API_KEY`. [VERIFIED from docs](https://cursor.com/docs/cli/headless)
+- Our config: `AgentOptions.CursorPath` holds the executable path; we set no model
+  (`DefaultModel = ""`, `ModelFlag = ""`, no known-models list).
+
+## 4. Context injection (how to inject a preamble)
+
+Cursor reads rules / instruction files at the start of context (highest-leverage injection point):
+
+- `.cursor/rules` (project rules directory), `AGENTS.md`, and `CLAUDE.md` are read and inserted at
+  the start of the conversation context. [VERIFIED from docs](https://cursor.com/docs/cli/using)
+  - Survives `/clear` (new conversation): [INFERRED/UNCERTAIN] - rules files are re-read when a new
+    conversation context is built, so they should re-apply, but this is not explicitly documented for
+    the CLI. Needs live verification.
+  - Survives `/compact` (summarize/compress): [INFERRED/UNCERTAIN] - compaction summarizes the
+    conversation; rules are part of system context rather than the conversation turns, so they are
+    expected to persist, but not documented. Needs live verification.
+- Hook-based injection: the `sessionStart` hook can return `additional_context` (a string) on stdout,
+  which is "injected into the conversation's initial system context", and an `env` object that
+  persists for the session. [VERIFIED from docs](https://cursor.com/docs/hooks) This is the near-exact
+  analog of Claude Code's SessionStart `additionalContext`, but only for LAUNCH (see the benchmark in
+  section 5).
+  - Survives `/clear`: [INFERRED/UNCERTAIN] - depends entirely on whether `sessionStart` re-fires when
+    a new conversation begins. UNDOCUMENTED. Needs live verification.
+  - Survives `/compact`: NO re-injection path. There is only the observational `preCompact` hook,
+    which cannot return `additional_context` to re-inject context after a compaction. [VERIFIED from docs](https://cursor.com/docs/hooks)
+- `postToolUse` can also return `additional_context`, but that is per-tool, not a launch preamble.
+  [VERIFIED from docs](https://cursor.com/docs/hooks)
+
+## 5. Lifecycle events and hooks
+
+Hooks config file `hooks.json`, version 1. Locations, highest-to-lowest priority: enterprise/system
+(`C:\ProgramData\Cursor\hooks.json` on Windows; `/etc/cursor/hooks.json` Linux/WSL;
+`/Library/Application Support/Cursor/hooks.json` macOS) > team (cloud, Enterprise) > project
+`<project-root>/.cursor/hooks.json` > user `~/.cursor/hooks.json`. [VERIFIED from docs](https://cursor.com/docs/hooks)
+
+Config shape per hook entry: `command`, `type` (`command` or `prompt`), `timeout`, `matcher`,
+`loop_limit`, `failClosed`. Project hooks run from the project root. [VERIFIED from docs](https://cursor.com/docs/hooks)
+
+Stdin/stdout contract: every command hook receives a JSON object on stdin and returns JSON on stdout.
+Base input fields on all hooks: `conversation_id`, `generation_id`, `model`, `model_id`,
+`model_params`, `hook_event_name`, `cursor_version`, `workspace_roots`, `user_email`,
+`transcript_path`. Exit codes: `0` = success (use JSON output), `2` = block/deny, anything else =
+failure and proceed (fail-open, unless `failClosed`). Hooks also receive env vars:
+`CURSOR_PROJECT_DIR`, `CURSOR_VERSION`, `CURSOR_USER_EMAIL`, `CURSOR_TRANSCRIPT_PATH`,
+`CURSOR_CODE_REMOTE`, and `CLAUDE_PROJECT_DIR` (alias). [VERIFIED from docs](https://cursor.com/docs/hooks)
+
+Full event list [VERIFIED from docs](https://cursor.com/docs/hooks):
+- Lifecycle: `sessionStart`, `sessionEnd`, `workspaceOpen` (output `pluginPaths`).
+- Prompt: `beforeSubmitPrompt`.
+- Tools (generic): `preToolUse`, `postToolUse`, `postToolUseFailure`.
+- Subagents (Task tool): `subagentStart`, `subagentStop`.
+- Shell: `beforeShellExecution`, `afterShellExecution`.
+- MCP: `beforeMCPExecution`, `afterMCPExecution`.
+- Files: `beforeReadFile`, `afterFileEdit`.
+- Tab (autocomplete): `beforeTabFileRead`, `afterTabFileEdit`.
+- Compaction: `preCompact` (observe only).
+- Responses: `afterAgentResponse`, `afterAgentThought`.
+- Completion: `stop`.
+
+Key schemas [VERIFIED from docs](https://cursor.com/docs/hooks):
+- `sessionStart` input: `session_id`, `is_background_agent`, `composer_mode`
+  (`agent`|`ask`|`edit`); output: `{ "env": {...}, "additional_context": "string" }`.
+- `stop` input: `status` (`completed`|`aborted`|`error`), `loop_count`; output:
+  `{ "followup_message": "string" }` - when non-empty, Cursor auto-submits it as the next user
+  message (respecting `loop_limit`).
+- `preToolUse` output: `permission` (`allow`|`deny`), `user_message`, `agent_message`,
+  `updated_input`. `postToolUse` output: `updated_mcp_tool_output`, `additional_context`.
+- `beforeShellExecution` / `beforeMCPExecution` output: `permission` (`allow`|`deny`|`ask`),
+  `user_message`, `agent_message`.
+- `beforeReadFile` output: `permission`, `user_message`. `afterFileEdit` input includes
+  `file_path` and `edits` (array of `old_string`/`new_string`).
+- `subagentStart` output: `permission`, `user_message`. `subagentStop` output: `followup_message`
+  (consumed only when `status == "completed"`).
+
+Which events fire when:
+- Startup: `sessionStart` (and `workspaceOpen` on workspace open). [VERIFIED from docs](https://cursor.com/docs/hooks)
+- Resume: [INFERRED/UNCERTAIN] - presumably `sessionStart` fires for a resumed session too, but not
+  documented. Needs live verification.
+- Clear / new conversation: [INFERRED/UNCERTAIN] - whether `sessionStart` re-fires on `/clear` or a
+  new conversation is UNDOCUMENTED. Needs live verification.
+- Compact: `preCompact` fires (observational only; cannot re-inject context). [VERIFIED from docs](https://cursor.com/docs/hooks)
+
+Can a hook inject model context? YES, via `sessionStart.additional_context` (launch) and
+`postToolUse.additional_context` (per tool). [VERIFIED from docs](https://cursor.com/docs/hooks)
+
+IMPORTANT HEADLESS CAVEAT: in `cursor-agent --print` (headless) mode, community reports indicate
+that ONLY `sessionStart` fires - the response hooks (`afterAgentResponse`, `afterAgentThought`) and
+the other in-loop hooks do NOT fire; the full hook set fires only in the interactive TUI.
+[INFERRED/UNCERTAIN - forum-reported, not vendor-confirmed](https://forum.cursor.com/t/hooks-afteragentresponse-afteragentthought-not-firing-in-headless-cli/156220)
+This matters: any preamble we depend on landing via hooks in headless mode can only rely on
+`sessionStart`.
+
+BENCHMARK vs Claude Code: Claude Code's SessionStart hook fires on startup AND on resume/clear/compact
+and can emit `additionalContext` each time, giving a re-injection path on every reset. Cursor's
+`sessionStart` + `additional_context` is the near-exact analog for LAUNCH only. The gap is RESET:
+whether `sessionStart` re-fires on `/clear` or a new conversation is undocumented, and compaction
+exposes only the observational `preCompact` with no re-inject hook. So Cursor matches Claude Code at
+launch but has no documented equivalent of Claude's clear/compact re-injection.
+
+## 6. SDK / programmatic API / server mode
+
+No separate SDK package. The programmatic surface is the headless CLI plus its stream-json output.
+[VERIFIED from docs](https://cursor.com/docs/cli/headless) The CLI also speaks MCP and ACP (Agent
+Client Protocol). [VERIFIED from docs](https://cursor.com/docs/cli/using)
+
+`--output-format` modes (with `--print`) [VERIFIED from docs](https://cursor.com/docs/cli/reference/output-format):
+- `text` (default): final assistant message only.
+- `json`: a single aggregated JSON object on completion (no intermediate events).
+- `stream-json`: newline-delimited JSON (NDJSON), one event per execution step.
+
+stream-json event types and shapes (all [VERIFIED from docs](https://cursor.com/docs/cli/reference/output-format)):
+- `{ "type": "system", "subtype": "init", "apiKeySource": "env|flag|login", "cwd": "<abs>",
+  "session_id": "<uuid>", "model": "<display name>", "permissionMode": "default" }` - this is where
+  the session id, model, cwd, and permission mode arrive.
+- `{ "type": "user", "message": { "role": "user", "content": [{"type":"text","text":"<prompt>"}] },
+  "session_id": "<uuid>" }`.
+- `{ "type": "assistant", "message": { "role": "assistant",
+  "content": [{"type":"text","text":"<text>"}] }, "session_id": "<uuid>",
+  "timestamp_ms": <n>, "model_call_id": "<id>" }` (last two fields only with `--stream-partial-output`).
+- `{ "type": "tool_call", "subtype": "started", "call_id": "<id>",
+  "tool_call": { "readToolCall": { "args": {...} } }, "session_id": "<uuid>" }`.
+- `{ "type": "tool_call", "subtype": "completed", "call_id": "<id>",
+  "tool_call": { "readToolCall": { "args": {...}, "result": { "success": {...} } } }, ... }`.
+- `{ "type": "result", "subtype": "success", "duration_ms": <n>, "duration_api_ms": <n>,
+  "is_error": false, "result": "<full text>", "session_id": "<uuid>", "request_id": "<opt>" }`.
+
+NOTE: there is NO `clear` / `new` / `compact` event in the stream. The stream only describes a single
+run's init -> user -> assistant/tool_call(s) -> result. Context-reset is not represented in
+stream-json. [VERIFIED from docs - by absence](https://cursor.com/docs/cli/reference/output-format)
+
+Known headless gotcha: `cursor-agent -p` has been reported to hang indefinitely and never return in
+some setups. [INFERRED/UNCERTAIN - forum-reported](https://forum.cursor.com/t/cursor-agent-p-print-headless-mode-hangs-indefinitely-and-never-returns/150246)
+
+## 7. MCP / rules / hooks / plugins
+
+- MCP: managed via the `mcp` subcommand (`login`/`list`/`list-tools`/`enable`/`disable`) and
+  auto-detected MCP server config (project `.cursor/mcp.json` and the global `~/.cursor/mcp.json`,
+  consistent with the Cursor editor). [VERIFIED from docs](https://cursor.com/docs/cli/reference/parameters)
+  Headless: `--approve-mcps` auto-approves all MCP servers; `beforeMCPExecution`/`afterMCPExecution`
+  hooks gate MCP calls. [VERIFIED from docs](https://cursor.com/docs/hooks)
+  - [INFERRED/UNCERTAIN] the exact `mcp.json` filename/path for the CLI was not explicitly stated on
+    the configuration page (it lists `cli-config.json` and `cli.json`); the editor's `.cursor/mcp.json`
+    convention is assumed. Needs verification.
+- Rules: `.cursor/rules`, `AGENTS.md`, `CLAUDE.md` (section 4). [VERIFIED from docs](https://cursor.com/docs/cli/using)
+- Hooks: `hooks.json` (section 5). [VERIFIED from docs](https://cursor.com/docs/hooks)
+- Plugins: `--plugin-dir <path>` (repeatable) loads a local plugin directory; the `workspaceOpen` hook
+  can return `pluginPaths`. [VERIFIED from docs](https://cursor.com/docs/cli/reference/parameters)
+
+## 8. Transcript / history
+
+- Chats are persisted and addressable by id (`--resume [chatId]`, `--continue`, `ls`, `resume`).
+  [VERIFIED from docs](https://cursor.com/docs/cli/reference/parameters)
+- On-disk transcript LOCATION and FORMAT are NOT verified. On our prior WSL survey the chat store was
+  never created (the agent was "Not logged in"), and on Windows there is no native install to inspect.
+  [VERIFIED from our prior survey](D:\ReposFred\devthrottle\docs\design\agent-history-capture\drivers\cursor.md)
+- Hooks expose a `transcript_path` (and `CURSOR_TRANSCRIPT_PATH` env var) when transcript recording is
+  enabled - a likely future pointer to the on-disk transcript, but its format is unverified.
+  [VERIFIED from docs](https://cursor.com/docs/hooks)
+- Token usage: not exposed as a clean per-session counter in the docs surveyed; `result` events carry
+  `duration_ms`/`duration_api_ms` but not token counts. [INFERRED/UNCERTAIN]
+- Consequence for us: `CursorAgentPlugin.History` is `AgentHistoryProviderKind.None`,
+  `SupportsConversationHistory = false`. We read the LIVE stream-json stdout instead of any on-disk file.
+
+## 9. Session semantics
+
+- new / resume: each run mints a session id, surfaced in the `system`/`init` event's `session_id`.
+  Cursor cannot be told an id in advance - there is no `--session-id` preassign flag; we capture the
+  id from the init event (`CursorAgent.SupportsPreassignedSessionId = false`,
+  `CursorDriver.TryCaptureSessionId`). [VERIFIED from docs](https://cursor.com/docs/cli/reference/output-format)
+- `--resume [chatId]` reloads a prior chat (its context); `--continue` is the alias for
+  `--resume=-1` (the previous session). [VERIFIED from docs](https://cursor.com/docs/cli/reference/parameters)
+- clear vs compact (interactive): `/summarize` (alias `/compress`) frees context-window space by
+  summarizing; there is a `preCompact` hook for compaction. A distinct "clear to an empty new
+  conversation" command for the CLI was not explicitly named in the docs surveyed (the editor uses a
+  new-chat action). [INFERRED/UNCERTAIN] whether `/clear` exists as a CLI slash command and whether it
+  re-fires `sessionStart` is undocumented and needs live verification.
+  [VERIFIED for /summarize from docs](https://cursor.com/docs/cli/using)
+- The stream-json output carries no clear/new/compact event (section 6), so a reset is invisible to a
+  stream consumer; it would have to be inferred from a new `init` event. [VERIFIED by absence](https://cursor.com/docs/cli/reference/output-format)
+
+## 10. How CC Director integrates it
+
+Classes and declared capabilities (current state in this repo):
+- Driver `CursorDriver` (`src/CcDirector.Core/Drivers/CursorDriver.cs`): `Kind = AgentKind.Cursor`;
+  `Capabilities = DriverCapabilities.Interrupt` ONLY. Interrupt sends Ctrl+C (`0x03`).
+  - `ClearContext` is NOT declared - `ClearContextAsync` throws `NotSupportedException` ("no verified
+    in-place context-clear command").
+  - `CancelAsync` (soft-cancel) throws - keystroke not live-verified (assumption A4).
+  - `ShowHistoryAsync` throws - no verified in-terminal history picker.
+  - `TranscriptRead` is NOT declared - `ReadWidgets`/`ReadUsage`/`ListTranscripts` all throw. Instead
+    the Director parses `cursor-agent` stdout stream-json LIVE: `TryCaptureSessionId` reads the
+    `system`/`init` (or bare `init`) `session_id`; `ParseStreamLine` maps `assistant` / `tool_call` /
+    `result` events into `TurnWidgetDto` cards.
+  - `ResolveExecutable` and `BuildLaunchSpec` on the driver throw - launch is owned by the
+    Director's `CursorAgent` path, not the driver.
+- Agent `CursorAgent` (`src/CcDirector.Core/Agents/CursorAgent.cs`): `ExecutablePath = options.CursorPath`;
+  `SupportsPreassignedSessionId = false`; `SupportsStudioMode = true`. Studio mode prepends
+  `-p --output-format stream-json`; resume adds `--resume="<chat-id>"`.
+- Plugin `CursorAgentPlugin` (`src/CcDirector.Core/AgentPlugins/CursorAgentPlugin.cs`):
+  built-in; detection candidate `cursor-agent` on PATH; validation `--version` (8s);
+  `History = AgentHistoryProviderKind.None`, `SupportsConversationHistory = false`;
+  `Launch = (SupportsPreassignedSessionId: false, SupportsStudioMode: true)`; presets Standard ("")
+  and Automatic (`CursorForceArg`, i.e. `--force`/auto-approve).
+
+Hosting reality: the `cursor-agent` binary is NOT installed on our dev machine and there is no native
+Windows build, so spawn attempts fail with "CreateProcess failed". The Cursor history driver is
+formally DEFERRED in `docs/design/agent-history-capture/drivers/cursor.md` - not for lack of a
+transcript, but because there is nothing native to host on Windows (it would require launching through
+`wsl.exe` and reading across `\\wsl$`, a platform decision, not a per-driver one).
+
+Fleet-preamble strategy family: A (shell-hook). Concrete plan to inject the fleet preamble:
+- Write a `hooks.json` with a `sessionStart` hook (project `.cursor/hooks.json` or user
+  `~/.cursor/hooks.json`) whose command returns `{ "additional_context": "<fleet preamble>" }` on
+  stdout. This lands the preamble in the conversation's initial system context at LAUNCH - the
+  near-exact analog of Claude Code's SessionStart `additionalContext`.
+- Re-injection on reset is the open problem and MUST be live-verified on an installed build:
+  1. Does `sessionStart` re-fire on `/clear` or a new conversation? UNDOCUMENTED. If yes, the same
+     hook re-injects for free; if no, there is no documented re-inject path on clear.
+  2. Compaction has only the observational `preCompact` (no `additional_context` return), so there is
+     no documented re-inject after compaction; rely on rules files (`AGENTS.md` / `CLAUDE.md` /
+     `.cursor/rules`) persisting through compaction as the durable fallback - which itself needs
+     verification (section 4).
+  3. The headless caveat: in `--print` mode only `sessionStart` is reported to fire, so in headless
+     mode the hook-based preamble can only count on `sessionStart`; the full hook set firing on the
+     interactive TUI also needs live verification.
+- As a belt-and-suspenders durable channel, also place the fleet preamble in a rules file
+  (`AGENTS.md` / `CLAUDE.md` / `.cursor/rules`) so it is read at the start of context regardless of
+  hooks.
+
+Current gaps: no installed binary to verify against; clear/compact re-fire behavior unknown;
+headless-vs-TUI hook-set difference unconfirmed; on-disk transcript location/format unknown (we rely
+on live stream-json only).
+
+## 11. Caveats and verification needed
+
+- HIGH CHURN: the CLI is dated 2026 and changing fast (changelog Jan 2026 added "CLI Agent Modes and
+  Cloud Handoff"); flag names and hook schemas may drift. Re-check before relying on any specific field.
+- NOT installed here / no native Windows build - nothing in sections 4, 5, 8, 9 marked
+  [INFERRED/UNCERTAIN] has been live-confirmed on our platform.
+- Needs live verification on an installed build:
+  1. Does `sessionStart` re-fire on `/clear` / new conversation and on `--resume`? (the reset gap)
+  2. Headless `--print`: confirm only `sessionStart` fires and the rest do not (forum-reported only).
+  3. Whether a CLI `/clear` slash command exists at all, and what it does to the session id.
+  4. On-disk transcript path/format (and whether `transcript_path` points to a parseable file).
+  5. Exact CLI `mcp.json` path (assumed `.cursor/mcp.json` from the editor).
+  6. Rules files (`AGENTS.md`/`CLAUDE.md`/`.cursor/rules`) surviving `/clear` and `/compact`.
+  7. `cursor-agent -p` hang reports - confirm a reliable non-hanging invocation in our harness.
+- Field-name notes: our `CursorDriver.ParseStreamLine` defensively accepts several alternative
+  property names for `tool_call` (`tool`/`name`, `tool_call_id`/`id`, `command`/`input`,
+  `result`/`output`) that the docs' canonical shape (`tool_call.readToolCall`/`writeToolCall`) does
+  NOT use - this is hedging against build-to-build drift and should be reconciled against a real
+  stream once installed.
+
+## Sources
+
+- Cursor CLI overview: https://cursor.com/docs/cli/overview
+- Using Agent in CLI: https://cursor.com/docs/cli/using
+- Using Headless CLI: https://cursor.com/docs/cli/headless
+- Output format reference (stream-json): https://cursor.com/docs/cli/reference/output-format
+- Parameters reference (flags/subcommands): https://cursor.com/docs/cli/reference/parameters
+- Configuration reference: https://cursor.com/docs/cli/reference/configuration
+- Hooks: https://cursor.com/docs/hooks
+- Forum (headless hooks caveat): https://forum.cursor.com/t/hooks-afteragentresponse-afteragentthought-not-firing-in-headless-cli/156220
+- Forum (-p hang report): https://forum.cursor.com/t/cursor-agent-p-print-headless-mode-hangs-indefinitely-and-never-returns/150246
+- Changelog (CLI Agent Modes and Cloud Handoff, Jan 16 2026): https://cursor.com/changelog/cli-jan-16-2026
+- Our prior survey: D:\ReposFred\devthrottle\docs\design\agent-history-capture\drivers\cursor.md

--- a/.claude/skills/agent-expert/agents/gemini.md
+++ b/.claude/skills/agent-expert/agents/gemini.md
@@ -1,0 +1,413 @@
+<!--
+Per-agent reference for the Google Gemini CLI.
+Rules: ASCII only. No Unicode, no emoji, no em-dashes (use " - ").
+Every non-trivial fact is marked [VERIFIED from docs] or [INFERRED/UNCERTAIN] with an inline source.
+All links are collected in the Sources section.
+-->
+
+# Google Gemini CLI (Gemini)
+
+> Google's open-source terminal coding agent. npm `@google/gemini-cli`, binary `gemini`.
+> Our integration status: GenericDriver (no bespoke driver yet) / GeminiAgentPlugin / history provider kind TerminalBuffer.
+
+IMPORTANT recency note up front: the Gemini CLI moves fast and the locally installed
+binary on this machine is version 0.1.11 (probed live: `gemini --version` -> `0.1.11`,
+installed at `C:\Users\soren\AppData\Roaming\npm\gemini.cmd`). That 0.1.11 build PREDATES
+the hooks system, `--output-format`, `--resume`, `--approval-mode`, and `--include-directories`.
+Most of this document describes the CURRENT documented CLI (geminicli.com/docs and the
+main branch of the source repo), which is well ahead of 0.1.11. Treat every "newer feature"
+as not present until the installed binary is upgraded and re-probed. See section 11.
+
+---
+
+## 1. Identity and install
+
+- Binary: `gemini`. [VERIFIED from docs - https://geminicli.com/docs/]
+- npm package: `@google/gemini-cli` (install: `npm install -g @google/gemini-cli`, or run via
+  `npx https://github.com/google-gemini/gemini-cli`). [VERIFIED from docs - https://github.com/google-gemini/gemini-cli]
+- Source repository: https://github.com/google-gemini/gemini-cli (Apache-2.0, Google).
+  [VERIFIED from repo - https://github.com/google-gemini/gemini-cli]
+- Official documentation home: https://geminicli.com/docs/ (mirrors the in-repo `docs/`
+  tree at https://github.com/google-gemini/gemini-cli/tree/main/docs). [VERIFIED]
+- Core engine package: `@google/gemini-cli-core` (the reusable backend the CLI is built on).
+  [INFERRED/UNCERTAIN - package exists in the monorepo; not independently re-verified here]
+
+Windows install location of the launchable shim (probed live on this machine):
+- `C:\Users\soren\AppData\Roaming\npm\gemini` (Unix-style shim) and
+  `C:\Users\soren\AppData\Roaming\npm\gemini.cmd` (the Windows launcher CC Director should spawn).
+  [VERIFIED live - `where gemini`]
+- Version-probe command: `gemini --version` (alias `-v`). Probed: `0.1.11`. [VERIFIED live]
+
+---
+
+## 2. Command-line interface
+
+Default invocation `gemini` with no prompt opens the INTERACTIVE terminal UI (a React/Ink TUI).
+[VERIFIED live - `gemini --help` first line: "Launch an interactive CLI, use -p/--prompt for non-interactive mode"]
+
+Non-interactive (headless) mode is triggered by ANY of: passing `-p`/`--prompt`, piping data
+on stdin (for example `echo "query" | gemini`), or running in a non-TTY environment.
+[VERIFIED from docs - https://geminicli.com/docs/cli/headless/]
+Note: `--prompt` text is APPENDED to whatever arrives on stdin, so `cat file | gemini -p "..."`
+sends both. [VERIFIED live - help text: "Prompt. Appended to input on stdin (if any)."]
+
+Flag table. Flags marked (0.1.11) are present in the installed build; flags marked (current)
+are documented on main but NOT in 0.1.11 help output.
+
+| Flag | Purpose | Status |
+|------|---------|--------|
+| `-m, --model <id>` | Model id (0.1.11 default `gemini-2.5-pro`) | (0.1.11) [VERIFIED live] |
+| `-p, --prompt <text>` | One-shot non-interactive prompt; appended to stdin | (0.1.11) [VERIFIED live] |
+| `-i, --prompt-interactive <text>` | Run a prompt, then stay in the interactive UI | (current) [VERIFIED from docs - https://geminicli.com/docs/cli/headless/] |
+| `--output-format <text\|json>` | `json` returns one object `{response, stats, error}`; streaming is JSONL (`init`,`message`,`tool_use`,`tool_result`,`error`,`result`) | (current) [VERIFIED from docs - https://geminicli.com/docs/cli/headless/] |
+| `-r, --resume [index\|uuid]` | Resume a saved session: no arg = most recent, integer = by index, UUID = by session id | (current) [VERIFIED from docs - https://geminicli.com/docs/cli/session-management/] |
+| `-y, --yolo` | Auto-accept all actions (YOLO) | (0.1.11) [VERIFIED live] |
+| `--approval-mode <text>` | Finer-grained approval policy (default / auto-edit / yolo) | (current) [INFERRED/UNCERTAIN - referenced in headless docs, not in 0.1.11 help] |
+| `-s, --sandbox` / `--sandbox-image <uri>` | Run tools in a sandbox | (0.1.11) [VERIFIED live] |
+| `-a, --all-files` | Include ALL files in context | (0.1.11) [VERIFIED live] |
+| `--include-directories <dirs>` | Add extra workspace directories | (current) [INFERRED/UNCERTAIN - not in 0.1.11 help] |
+| `-c, --checkpointing` | Snapshot project state before file edits | (0.1.11) [VERIFIED live] |
+| `-e, --extensions <list>` | Restrict to named extensions | (0.1.11) [VERIFIED live] |
+| `-l, --list-extensions` | List extensions and exit | (0.1.11) [VERIFIED live] |
+| `--allowed-mcp-server-names <list>` | Allowlist MCP servers | (0.1.11) [VERIFIED live] |
+| `-d, --debug` | Debug mode | (0.1.11) [VERIFIED live] |
+| `--show-memory-usage` | Show memory usage in status bar | (0.1.11) [VERIFIED live] |
+| `--telemetry*` | Telemetry target / endpoint / log-prompts | (0.1.11) [VERIFIED live] |
+| `-v, --version`, `-h, --help` | Version / help | (0.1.11) [VERIFIED live] |
+
+Headless exit codes: `0` success, `1` general error / API failure, `42` input error
+(bad prompt/args), `53` turn limit exceeded. [VERIFIED from docs - https://geminicli.com/docs/cli/headless/]
+
+In-session slash commands relevant to context and sessions:
+- `/memory show` | `/memory add <text>` | `/memory refresh` (also documented as `/memory reload`).
+  [VERIFIED from docs - https://geminicli.com/docs/cli/gemini-md/ and https://geminicli.com/docs/cli/tutorials/memory-management/]
+- `/clear` (clear the conversation/screen), `/compress` (replace history with a summary),
+  `/chat save <tag>` / `/chat resume <tag>` / `/chat list` / `/chat share <file.md|file.json>`,
+  `/resume` (Session Browser), `/quit`. [VERIFIED from docs - https://geminicli.com/docs/reference/commands/ and https://geminicli.com/docs/cli/session-management/]
+- `@path` references include a file/dir in the next prompt; `!` runs a shell command. [VERIFIED from docs - https://geminicli.com/docs/reference/commands/]
+
+---
+
+## 3. Configuration
+
+Primary config is `settings.json` (JSON). Three file scopes, plus env vars and CLI args.
+[VERIFIED from docs - https://geminicli.com/docs/reference/configuration/]
+
+| Scope | Path |
+|-------|------|
+| System | Windows `C:\ProgramData\gemini-cli\settings.json`; Linux `/etc/gemini-cli/settings.json`; macOS `/Library/Application Support/GeminiCli/settings.json` |
+| User | `~/.gemini/settings.json` (Windows `%USERPROFILE%\.gemini\settings.json`) |
+| Project | `.gemini/settings.json` in the project root |
+
+[VERIFIED from docs - https://geminicli.com/docs/reference/configuration/]
+
+Precedence, lowest to highest: hardcoded defaults -> system defaults file -> USER settings ->
+PROJECT settings -> SYSTEM settings (overrides all files) -> environment variables ->
+command-line arguments. NOTE the unusual rule: the SYSTEM settings file overrides user and
+project, the opposite of the GEMINI.md context hierarchy (where more-specific wins). [VERIFIED from docs - https://geminicli.com/docs/reference/configuration/]
+
+Keys that matter to us:
+- `context.fileName` - string or array of strings; the context filename(s) to load instead of /
+  in addition to `GEMINI.md`. Example: `{"context": {"fileName": ["AGENTS.md","GEMINI.md"]}}`.
+  [VERIFIED from docs - https://geminicli.com/docs/cli/gemini-md/]
+- `hooks` - object keyed by event name; each value is an array of hook entries. [VERIFIED from docs - https://geminicli.com/docs/hooks/reference/]
+- `hooksConfig.enabled` - master on/off toggle for the entire hooks system. [VERIFIED from docs - https://geminicli.com/docs/reference/configuration/]
+- `mcpServers` - MCP server definitions (see section 7). [VERIFIED from docs]
+
+---
+
+## 4. Context injection (how to inject a preamble)
+
+For each mechanism: "survives /clear?" = is the content still present in the model context
+immediately after `/clear`; "survives /compact?" = is it still present after `/compress`
+summarization.
+
+1. GEMINI.md hierarchical context files. The CLI discovers context files and CONCATENATES
+   them and sends the combined block to the model WITH EVERY PROMPT. Hierarchy: global
+   `~/.gemini/GEMINI.md` -> project root and ancestor `GEMINI.md` -> subdirectory `GEMINI.md`
+   (just-in-time, scanned as tools touch files). Supports `@path.md` imports to modularize.
+   [VERIFIED from docs - https://geminicli.com/docs/cli/gemini-md/]
+   - Survives /clear: YES. Because the file is re-read and re-sent on every prompt, a `/clear`
+     that wipes conversation does not remove GEMINI.md content - it returns on the next turn.
+     [INFERRED/UNCERTAIN - follows directly from "sent with every prompt"; verify live]
+   - Survives /compact: YES, for the same reason - GEMINI.md is re-injected each prompt
+     regardless of history compression. This is why CC Director uses GEMINI.md for the
+     compaction-survival path (Family D). [INFERRED/UNCERTAIN - verify live]
+   - Filename configurable via `context.fileName`. [VERIFIED from docs - https://geminicli.com/docs/cli/gemini-md/]
+
+2. `/memory add <text>` / `/memory show` / `/memory refresh`(`reload`). `/memory add` appends
+   to memory at runtime; `/memory refresh` forces a re-scan and reload of all GEMINI.md files
+   and updates the model with the latest content; `/memory show` prints the concatenated memory.
+   [VERIFIED from docs - https://geminicli.com/docs/cli/gemini-md/ and https://geminicli.com/docs/cli/tutorials/memory-management/]
+   - Caveat: there is a known bug class where `/memory refresh` did not always update the live
+     system instruction in an existing chat (issue #10702, PR #12136). [VERIFIED - https://github.com/google-gemini/gemini-cli/issues/10702]
+
+3. SessionStart hook `hookSpecificOutput.additionalContext` (newer builds). A SessionStart
+   hook command can print JSON whose `hookSpecificOutput.additionalContext` string is injected
+   into the model context. In INTERACTIVE mode it is "injected as the first turn in history";
+   in NON-INTERACTIVE mode it is "prepended to the user's prompt". [VERIFIED from docs - https://geminicli.com/docs/hooks/reference/]
+   - Survives /clear: YES by re-fire - SessionStart fires again with `source: "clear"` after a
+     `/clear`, so the hook re-injects. [VERIFIED from docs - SessionStart fires "after a /clear command" - https://geminicli.com/docs/hooks/reference/]
+   - Survives /compact: NO directly - there is NO SessionStart `compact` source and no
+     re-fire of SessionStart on `/compress`. Because `additionalContext` is injected as a
+     history turn (not re-sent each prompt), compaction can summarize it away. The supported
+     compaction signal is the separate PreCompress hook (see section 5). This is the key gap;
+     see the benchmark note below. [VERIFIED from docs - source list is startup/resume/clear only]
+
+Benchmark vs Claude Code: Claude Code's SessionStart hook emits
+`hookSpecificOutput.additionalContext` and fires with four sources - startup, resume, clear,
+AND compact - so a single hook re-injects after compaction. Gemini's SessionStart emits the
+SAME field name (`hookSpecificOutput.additionalContext`) but its source set is ONLY
+startup/resume/clear - there is NO `compact` source. Gemini handles compaction differently:
+the PreCompress hook fires before summarization (trigger `auto`/`manual`), and GEMINI.md
+persistence (re-sent every prompt) is what actually keeps a preamble alive across a compaction.
+So Gemini matches Claude on launch and clear, but NOT on compact-via-hook-reinjection; you
+must lean on GEMINI.md (Family D) for compaction durability. [VERIFIED from docs - https://geminicli.com/docs/hooks/reference/]
+
+---
+
+## 5. Lifecycle events and hooks
+
+Hooks are shell commands registered in the `hooks` block of `settings.json` (and bundled by
+extensions via `hooks/hooks.json`). Master toggle `hooksConfig.enabled`. All hooks read a JSON
+object on stdin and may write a JSON object on stdout; stderr is for logs / rejection reasons.
+[VERIFIED from docs - https://geminicli.com/docs/hooks/reference/ and https://geminicli.com/docs/hooks/writing-hooks/]
+
+Full event list (11): [VERIFIED from docs - https://geminicli.com/docs/hooks/reference/]
+- SessionStart - application startup, session resume, or after `/clear`.
+- SessionEnd - CLI exits or a session is cleared.
+- BeforeAgent - after the user submits a prompt, before the agent begins planning.
+- AfterAgent - once per turn after the model generates its final response.
+- BeforeModel - before sending a request to the LLM.
+- AfterModel - immediately after an LLM response chunk is received.
+- BeforeToolSelection - before the LLM decides which tools to call.
+- BeforeTool - before a tool is invoked.
+- AfterTool - after a tool executes.
+- Notification - when the CLI emits a system alert.
+- PreCompress - before the CLI summarizes history to save tokens.
+
+Settings shape (two documented forms appear in the docs; the matcher form is the general one):
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      { "type": "command", "command": "my-preamble-hook" }
+    ],
+    "PreCompress": [
+      { "matcher": "", "hooks": [ { "type": "command", "command": "my-precompress-hook" } ] }
+    ]
+  }
+}
+```
+[VERIFIED from docs - https://geminicli.com/docs/hooks/reference/]
+
+stdin JSON contract. Base fields common to all hooks:
+```json
+{
+  "session_id": "string",
+  "transcript_path": "string",
+  "cwd": "string",
+  "hook_event_name": "string",
+  "timestamp": "string"
+}
+```
+[VERIFIED from docs - https://geminicli.com/docs/hooks/reference/]
+- SessionStart ADDS `"source"` with exactly one of `"startup"`, `"resume"`, `"clear"`.
+  There is NO `"compact"` source. [VERIFIED from docs - https://geminicli.com/docs/hooks/reference/]
+- PreCompress ADDS `"trigger"` with one of `"auto"` (CLI hit the token threshold) or
+  `"manual"` (user ran `/compress`). [VERIFIED from docs - https://geminicli.com/docs/hooks/reference/]
+
+stdout JSON contract (the bit we use):
+- SessionStart can return `{"hookSpecificOutput": {"additionalContext": "..."}}`. Interactive:
+  injected as the first turn in history. Non-interactive: prepended to the user's prompt.
+  A `systemMessage` field is also accepted. [VERIFIED from docs - https://geminicli.com/docs/hooks/reference/]
+- PreCompress supports `systemMessage` only; flow-control fields are ignored, and it does NOT
+  inject additionalContext. So PreCompress is a SIGNAL ("compaction is about to happen"), not
+  an injection point. [VERIFIED from docs - https://geminicli.com/docs/hooks/reference/]
+
+Which events fire on each transition:
+- Startup (new session): SessionStart `source=startup`. [VERIFIED from docs]
+- Resume (`--resume`): SessionStart `source=resume`. [VERIFIED from docs]
+- Clear (`/clear`): SessionEnd then SessionStart `source=clear` (re-fire). [VERIFIED from docs]
+- Compact (`/compress` or auto threshold): PreCompress `trigger=manual|auto`. NO SessionStart.
+  [VERIFIED from docs]
+
+Hooks history note: the comprehensive hooking system was tracked in issue #9070 and landed
+across recent PRs (for example PR #14151 added session-lifecycle and compression integration).
+This is new and churning. [VERIFIED - https://github.com/google-gemini/gemini-cli/issues/9070]
+
+---
+
+## 6. SDK / programmatic API / server mode
+
+- The supported programmatic surface for the stock CLI is HEADLESS mode with
+  `--output-format json` (single object `{response, stats, error}`) or streaming JSONL
+  (`init`/`message`/`tool_use`/`tool_result`/`error`/`result` events). This is the clean
+  machine-readable channel; it is what an integrator scripts against. [VERIFIED from docs - https://geminicli.com/docs/cli/headless/]
+- There is NO documented long-running local HTTP/RPC server mode in the stock CLI comparable
+  to `opencode serve`. The CLI is launched per task; for streaming you read its stdout JSONL.
+  [INFERRED/UNCERTAIN - absence of a server doc; an experimental Agent-to-Agent / A2A server
+  has appeared in the repo at times but is not a stable integration surface - verify before use]
+- The reusable backend is the `@google/gemini-cli-core` package; embedding it is a Node/TypeScript
+  path, not a cross-process API. CC Director drives the CLI as a terminal child process, not via
+  this library. [INFERRED/UNCERTAIN - verify package name/exports if we ever embed it]
+- Auth: Google account OAuth (free tier), Gemini API key (`GEMINI_API_KEY`), or Vertex AI.
+  [INFERRED/UNCERTAIN - standard Gemini CLI auth; not re-verified in this pass]
+
+---
+
+## 7. MCP / extensions / commands
+
+- MCP servers: declared under `mcpServers` in `settings.json` (and bundled by extensions).
+  The CLI is an MCP client; `--allowed-mcp-server-names` / `--allowed-mcp-server-names`
+  allowlists, `/mcp` inspects. [VERIFIED from docs - https://geminicli.com/docs/reference/configuration/ and live help `--allowed-mcp-server-names`]
+- Custom slash commands: TOML files placed in a `commands/` directory - user-level
+  `~/.gemini/commands/` and project-level `.gemini/commands/`, or bundled in an extension's
+  `commands/` directory. [VERIFIED from docs - https://geminicli.com/docs/extensions/reference/]
+- Extensions: installed under `~/.gemini/extensions/<name>/`, each described by a
+  `gemini-extension.json` manifest with fields `name`, `version`, `mcpServers`,
+  `contextFileName` (defaults to `GEMINI.md` in the extension dir if omitted), and
+  `excludeTools`. An extension can bundle MCP servers, custom commands (TOML in `commands/`),
+  a context file (GEMINI.md), HOOKS (`hooks/hooks.json`), sub-agents, and skills. This makes an
+  extension a single-package way to ship a hook + a context file + commands together.
+  [VERIFIED from docs - https://geminicli.com/docs/extensions/ and https://geminicli.com/docs/extensions/reference/]
+- NOTE a naming inconsistency to watch: the extension manifest field is `contextFileName`
+  (camelCase, no dot), while the settings.json key is `context.fileName` (dotted). Do not mix
+  them up. [VERIFIED from docs - compare the two pages above]
+
+---
+
+## 8. Transcript / history
+
+Current docs: sessions ARE persisted to disk automatically. Location
+`~/.gemini/tmp/<project_hash>/chats/`, where `<project_hash>` derives from the project root.
+What is recorded: "Your prompts and the model's responses. All tool executions (inputs and
+outputs). Token usage statistics (input, output, cached, etc.). Assistant thoughts and
+reasoning summaries (when available)." [VERIFIED from docs - https://geminicli.com/docs/cli/session-management/]
+- Each hook also receives a `transcript_path` pointing at the session transcript. [VERIFIED from docs - https://geminicli.com/docs/hooks/reference/]
+- File format (JSON vs other) is not pinned down by the docs; needs a live read. [INFERRED/UNCERTAIN]
+- Token usage is available both in the persisted `stats` and in the headless `--output-format json`
+  `stats` block. [VERIFIED from docs - https://geminicli.com/docs/cli/headless/]
+
+CONFLICT to resolve: CC Director's current history provider for Gemini is TerminalBuffer, on the
+assumption "Gemini does not persist assistant responses - terminal capture only". The CURRENT docs
+contradict that - newer Gemini CLI persists full transcripts including assistant responses to
+`~/.gemini/tmp/<project_hash>/chats/`. The assumption likely dates from an older build (the
+installed 0.1.11 may predate on-disk chat persistence). Action: verify what 0.1.11 (and whatever
+we ship against) actually writes before relying on a file-based history provider. See section 11.
+[VERIFIED docs vs INFERRED legacy assumption - https://geminicli.com/docs/cli/session-management/]
+
+---
+
+## 9. Session semantics
+
+- New / startup: `gemini` boots a fresh session with a new `session_id`; SessionStart
+  `source=startup`. [VERIFIED from docs]
+- Clear (`/clear`): wipes the visible conversation/history for the SAME session; SessionEnd
+  fires, then SessionStart re-fires with `source=clear`. The `session_id` is understood to
+  persist across `/clear` (same session, cleared history). [VERIFIED for hook behavior; session_id
+  continuity is INFERRED/UNCERTAIN - verify live]
+- Compact (`/compress`, or automatic at the token threshold): replaces history with a summary
+  to save tokens; PreCompress fires (`trigger=manual|auto`). No new session, no SessionStart.
+  [VERIFIED from docs]
+- Resume (`--resume`/`-r`, or `/resume` Session Browser, or `/chat resume <tag>`): reloads a
+  prior persisted session; SessionStart `source=resume`. `--resume` with no arg = most recent,
+  integer = by index, UUID = by id. [VERIFIED from docs - https://geminicli.com/docs/cli/session-management/]
+- Checkpointing (`-c`/`/checkpointing`) is a SEPARATE feature: it snapshots PROJECT FILE STATE
+  before tool edits so you can revert file changes; it is not conversation history. [VERIFIED from docs]
+
+---
+
+## 10. How CC Director integrates it
+
+Current wiring:
+- Driver class: GenericDriver (Gemini has no bespoke driver). GenericDriver declares ONLY the
+  Cancel and Interrupt capabilities and THROWS on ClearContext - so today CC Director cannot
+  programmatically clear a Gemini session, and has no driver-level clear/compact detection.
+- Agent class: GeminiAgent. Plugin: GeminiAgentPlugin.
+- History provider kind: TerminalBuffer (we scrape the terminal, we do not read a transcript file).
+
+Mechanism families for the fleet preamble:
+- Family A (settings.json SessionStart hook emitting `additionalContext`) for LAUNCH and CLEAR.
+- Family D (GEMINI.md persistence) for COMPACTION survival.
+
+Concrete plan:
+1. Family A - install a SessionStart hook in USER-level `~/.gemini/settings.json`:
+   ```json
+   {
+     "hooks": {
+       "SessionStart": [
+         { "type": "command",
+           "command": "<helper that does: GET http://127.0.0.1:<port>/sessions/{sid}/fleet-preamble and prints {\"hookSpecificOutput\":{\"additionalContext\":\"<preamble>\"}}>" }
+       ]
+     }
+   }
+   ```
+   The hook receives `session_id` and `source` on stdin; map `session_id` to our `{sid}` and
+   call the existing agent-agnostic Director endpoint `GET /sessions/{sid}/fleet-preamble`.
+   Emit the body as `hookSpecificOutput.additionalContext`. This covers `source=startup`,
+   `source=resume`, and `source=clear` in one hook (clear re-fires SessionStart). [PLAN; field
+   names VERIFIED from docs]
+2. Family D - write the preamble into a USER-level `~/.gemini/GEMINI.md` (or an extension-bundled
+   context file). Because GEMINI.md is concatenated and re-sent with EVERY prompt, the preamble
+   survives `/compress` (where the SessionStart hook does NOT re-fire). This is the compaction
+   backstop the hook cannot provide. [PLAN; persistence VERIFIED from docs]
+3. Optional consolidation - ship both the hook and the context file as a single Gemini EXTENSION
+   under `~/.gemini/extensions/cc-director/` (manifest `gemini-extension.json` + `hooks/hooks.json`
+   + `GEMINI.md`), so install/uninstall is one unit. [PLAN]
+
+Gaps in the current integration:
+- No bespoke GeminiDriver: ClearContext throws, so we cannot drive `/clear` or detect
+  clear/compact from the driver. Detection currently depends on TerminalBuffer scraping.
+- The Family A hook is NOT YET wired (only Claude's `ClaudeHookInstaller` exists). We need a
+  GeminiHookInstaller writing to `~/.gemini/settings.json`.
+- TerminalBuffer may be the wrong history provider now that the CLI persists transcripts (section 8).
+
+---
+
+## 11. Caveats and verification needed
+
+- VERSION SKEW is the headline risk. Installed binary is 0.1.11; its `--help` shows NONE of:
+  hooks, `--output-format`, `--resume`/`-r`, `--prompt-interactive`/`-i`, `--approval-mode`,
+  `--include-directories`. Everything in sections 4-9 that depends on those is CURRENT-docs
+  behavior, not 0.1.11 behavior. Before wiring Family A, upgrade and re-probe
+  (`gemini --version`, `gemini --help`, and a live hooks smoke test). [VERIFIED live - 0.1.11 help]
+- Hooks are new and churning (issue #9070; PR #14151). The `hooks` settings shape appears in two
+  forms in the docs (flat `[{type,command}]` and matcher `[{matcher,hooks:[...]}]`); confirm which
+  the target binary accepts for SessionStart. [VERIFIED issues exist]
+- `/memory refresh` has a known bug where it did not always update the live system instruction
+  (#10702). If we rely on `/memory` for re-injection, test it; prefer GEMINI.md file persistence.
+  [VERIFIED - #10702]
+- Confirm `session_id` continuity across `/clear` (same id vs new id) live - it drives how the
+  hook maps to our `{sid}`. [INFERRED/UNCERTAIN]
+- Confirm transcript on-disk format and whether the shipped build writes
+  `~/.gemini/tmp/<project_hash>/chats/` before swapping TerminalBuffer for a file reader.
+  [INFERRED/UNCERTAIN]
+- Watch the `context.fileName` (settings) vs `contextFileName` (extension manifest) naming split.
+  [VERIFIED from docs]
+- System `settings.json` overrides user/project (unusual). If a customer machine has a managed
+  system settings file, it could override our user-level hook. [VERIFIED from docs]
+
+## Sources
+
+- https://geminicli.com/docs/ (documentation home)
+- https://github.com/google-gemini/gemini-cli (source repository)
+- https://github.com/google-gemini/gemini-cli/tree/main/docs (in-repo docs)
+- https://geminicli.com/docs/cli/headless/ (non-interactive mode, output-format, exit codes)
+- https://geminicli.com/docs/reference/commands/ (slash commands, @ and ! syntax)
+- https://geminicli.com/docs/reference/configuration/ (settings.json locations, precedence, hooksConfig.enabled)
+- https://geminicli.com/docs/cli/gemini-md/ (GEMINI.md hierarchy, context.fileName, @imports, /memory)
+- https://geminicli.com/docs/cli/tutorials/memory-management/ (/memory show|add|refresh)
+- https://geminicli.com/docs/hooks/ (hooks overview)
+- https://geminicli.com/docs/hooks/reference/ (event list, stdin/stdout JSON, SessionStart sources, additionalContext, PreCompress trigger)
+- https://geminicli.com/docs/hooks/writing-hooks/ (hook authoring; stdin/stdout/stderr contract)
+- https://github.com/google-gemini/gemini-cli/blob/main/docs/hooks/writing-hooks.md (hook authoring, source)
+- https://geminicli.com/docs/cli/session-management/ (session persistence path, what is recorded, --resume)
+- https://geminicli.com/docs/extensions/ (extension capabilities: MCP, commands, hooks, context, sub-agents, skills)
+- https://geminicli.com/docs/extensions/reference/ (gemini-extension.json fields, install path, contextFileName)
+- https://github.com/google-gemini/gemini-cli/issues/9070 (comprehensive hooking system tracking issue)
+- https://github.com/google-gemini/gemini-cli/pull/14151 (hook session-lifecycle and compression integration)
+- https://github.com/google-gemini/gemini-cli/issues/10702 (/memory refresh system-instruction bug)
+- https://github.com/google-gemini/gemini-cli/pull/12136 (fix: update system instruction on GEMINI.md load/refresh)
+- Live probe on this machine: `gemini --version` -> 0.1.11; `gemini --help`; `where gemini` ->
+  C:\Users\soren\AppData\Roaming\npm\gemini(.cmd)

--- a/.claude/skills/agent-expert/agents/grok.md
+++ b/.claude/skills/agent-expert/agents/grok.md
@@ -1,0 +1,488 @@
+<!--
+Per-agent reference for the xAI "Grok Build" CLI (binary: grok).
+ASCII only. No Unicode, no emoji, no em-dashes (use " - ").
+Every non-trivial fact is marked [VERIFIED from docs] or [INFERRED/UNCERTAIN].
+"Shipped user-guide" = the markdown docs xAI ships inside the installed binary at
+~/.grok/docs/user-guide/*.md. These were read directly from grok 0.2.67 on this machine
+and are the most authoritative source available (more complete than the public web pages).
+-->
+
+# Grok Build (Grok)
+
+> xAI's official "Grok Build" terminal coding agent. A deliberate Claude Code clone: reads
+> CLAUDE.md, Anthropic-format skills, and Claude-style hook JSON. Our integration:
+> GenericDriver / GrokAgent / GrokAgentPlugin. Mechanism family A was assumed, but see the
+> headline finding in section 5 - Grok's SessionStart hook stdout is IGNORED, so context
+> injection must use family D (instruction files), NOT a hook.
+
+IMPORTANT - which Grok this is: this documents xAI's OFFICIAL "Grok Build" CLI, installed
+from x.ai/cli, binary `grok`, config under `~/.grok/`. It is NOT the community
+`@vibe-kit/grok-cli` / `superagent-ai/grok-cli` npm package (a separate, unaffiliated
+open-source project with a different config format `~/.grok/user-settings.json`, different
+flags, and no hooks/ACP). Several web "cheat sheets" conflate the two and report `config.json`
+/ `hooks.json` / `XAI_API_KEY`-only auth - those are wrong for Grok Build. Trust the shipped
+user-guide over third-party blogs.
+
+Version this was verified against: `grok 0.2.67 (03e13f9928) [stable]`.
+
+---
+
+## 1. Identity and install
+
+- Binary name: `grok` [VERIFIED from docs - overview]. On Windows it installs to
+  `%USERPROFILE%\.grok\bin\grok.exe` [VERIFIED locally - `where grok` returned
+  `C:\Users\soren\.grok\bin\grok.exe`].
+- Install (Windows PowerShell): `irm https://x.ai/cli/install.ps1 | iex` [VERIFIED from docs].
+  Install (macOS/Linux): `curl -fsSL https://x.ai/cli/install.sh | bash` [VERIFIED from docs].
+- Config / data home: `~/.grok/` (Windows `%USERPROFILE%\.grok`), overridable with the
+  `GROK_HOME` env var [VERIFIED from docs - 14-headless-mode.md, 05-configuration.md].
+- Default model: `grok-build` (the doc model id; marketing calls the weights `grok-build-0.1`,
+  256K-token context, text + image input) [VERIFIED from docs/news; the config key is
+  `grok-build`].
+- Documentation home: https://docs.x.ai/build . The authoritative copy is shipped inside the
+  binary at `~/.grok/docs/user-guide/01..22-*.md` [VERIFIED locally].
+- Version-probe command: `grok --version` [VERIFIED locally]. Our plugin uses `--version`
+  with an 8s timeout (GrokAgentPlugin ValidationMetadata).
+- Eligibility: early beta gated to SuperGrok / X Premium Plus, or an `XAI_API_KEY` from
+  console.x.ai for headless/CI [VERIFIED from docs - 14-headless-mode.md].
+
+---
+
+## 2. Command-line interface
+
+Three run shapes [VERIFIED from docs - 15-agent-mode.md, 14-headless-mode.md]:
+1. Interactive TUI: bare `grok` (alternate-screen pager by default).
+2. Headless / non-interactive: `grok -p "<prompt>"` (also triggered by `--prompt-json` /
+   `--prompt-file`). Prints one result and exits.
+3. Agent/server (ACP): `grok agent stdio` (see section 6).
+
+### Headless flag table [VERIFIED from docs - 14-headless-mode.md unless noted]
+
+| Flag | Meaning |
+|------|---------|
+| `-p, --single <PROMPT>` | Send one prompt (enters headless mode). Aliases for input: `--prompt-json <JSON>` (content blocks), `--prompt-file <PATH>`. |
+| `-m, --model <MODEL>` | Model id, e.g. `grok-build`. |
+| `-s, --session-id <ID>` | Set/choose session id - INTERACTIVE TUI ONLY. Ignored in headless mode (documented explicitly). |
+| `-r, --resume <ID>` | Resume an existing session by id; errors if it does not exist. |
+| `-c, --continue` | Continue the most recent session in the current directory. |
+| `--cwd <PATH>` | Working directory (project root is then discovered by walking up to `.git`). |
+| `--output-format <FMT>` | `plain` (default), `json`, or `streaming-json`. See section 6. |
+| `--yolo` | Auto-approve all tool executions. This is the real flag name. `--always-approve` is the documented alias on the `grok agent` subcommand; in headless the spelled flag is `--yolo`. |
+| `--rules <TEXT>` | Append text to the system prompt (alias `--append-system-prompt`); wrapped in a `<human_rules>` block. |
+| `--system-prompt-override <TEXT>` | Replace the system prompt verbatim (alias `--system-prompt`); skips default prompt and `--rules`. |
+| `--tools <CSV>` | Allowlist of built-in tool ids (headless only). Names are internal ids (e.g. `run_terminal_cmd`, `read_file`), not `Bash`. |
+| `--disallowed-tools <CSV>` | Denylist; supports `Agent`, `Agent(explore)`, `Agent(explore, plan)` to block subagents (headless only). |
+| `--allow <RULE>` / `--deny <RULE>` | Permission rules, `ToolPrefix(glob)` syntax e.g. `Bash(npm*)`, `WebFetch(domain:host)`; repeatable; deny wins. Work in TUI + headless. |
+| `--permission-mode <MODE>` | Parsed in both modes; only `bypassPermissions` currently takes effect via this flag. |
+| `--max-turns <N>` | Cap agentic turns (headless only). |
+| `--effort <LEVEL>` / `--reasoning-effort <EFFORT>` | `low|medium|high|xhigh|max` (headless only). |
+| `--agent <NAME>` / `--agents <JSON>` | Named agent / inline subagent defs (headless only). |
+| `--check` / `--self-verify`, `--best-of-n <N>` | Verification loop / run N ways pick best (headless only). |
+| `--no-plan`, `--no-subagents`, `--no-memory`, `--disable-web-search` | Feature toggles. |
+| `--worktree [NAME]`, `--ref <REF>` / `--worktree-ref <REF>` | Run session in a fresh git worktree. |
+| `--sandbox <PROFILE>` | Sandbox profile (off, workspace, devbox, read-only, strict, or custom). |
+| `--trust` | Trust the current folder for project hooks/MCP/LSP at launch (= `/hooks-trust`). |
+| `--no-alt-screen` | Run inline, no alternate-screen takeover. RELEVANT TO US (see section 10). |
+| `--no-auto-update` | Skip background update checks for this session. |
+| `--verbatim` | Send the prompt exactly as given. |
+
+Subcommands: `grok login [--device-auth|--device-code]`, `grok logout`, `grok inspect [--json]`
+(see section 7/8), `grok sessions list|search`, `grok agent stdio|serve|headless` (section 6)
+[VERIFIED from docs].
+
+Exit codes (headless) [VERIFIED from docs - 14-headless-mode.md]: `0` success, `1` error
+(auth/network/runtime), `130` SIGINT (Ctrl+C), `143` SIGTERM. On interrupt, session state is
+saved up to the last completed tool call but file edits are NOT rolled back.
+
+---
+
+## 3. Configuration
+
+Format is TOML, not JSON (blogs claiming `config.json`/`user-settings.json` are describing the
+community fork) [VERIFIED locally - read `~/.grok/config.toml`; and 05-configuration.md].
+
+Precedence (highest first) [VERIFIED from docs - 05-configuration.md]:
+1. CLI flags
+2. Environment variables (`XAI_API_KEY`, `GROK_MEMORY`, `GROK_HOME`, the `[compat]` toggles, etc.)
+3. `~/.grok/config.toml` (user / global)
+4. Remote/managed settings (enterprise GrowthBook)
+5. Built-in defaults
+
+Files [VERIFIED from docs - 05-configuration.md, 17-sessions.md]:
+- `~/.grok/config.toml` - main config. Notable sections: `[cli] auto_update`, `[models] default`,
+  `[ui] permission_mode|simple_mode|vim_mode`, `[session] auto_compact_threshold_percent` (default
+  85), `[skills] paths/ignore/disabled`, `[plugins] paths/disabled`, `[mcp_servers.<name>]`,
+  `[model.<id>]` (custom OpenAI-compatible endpoints), `[compat.claude]` / `[compat.cursor]`
+  (scan `.claude/`/`.cursor/` for skills/rules/agents/mcps/hooks - all default `true`),
+  `[memory]`, `[subagents]`, `[telemetry]`, `[ui.notifications]`, `[hints]`.
+- `~/.grok/pager.toml` - TUI appearance, including `[terminal] alt_screen = "auto"|"always"|"never"`.
+- Project-scoped `.grok/config.toml` - ONLY contributes `[mcp_servers]`, `[plugins]`, and
+  `[permission]` rules; all other sections load only from `~/.grok/config.toml`. Priority for
+  those sections: `./.grok/config.toml` > `<repo-root>/.grok/config.toml` > `~/.grok/config.toml`.
+- Enterprise layering: system `requirements.toml` / `managed_config.toml` can pin values above
+  the user config.
+
+Headless update-suppression matrix [VERIFIED from docs]: `--no-auto-update` (session) /
+`GROK_DISABLE_AUTOUPDATER=1` (process) / `[cli] auto_update = false` (persistent) / non-TTY
+stderr (auto). Update text goes to stderr so `--output-format json` stdout stays clean.
+
+`grok inspect` prints the resolved view of a directory: config sources, instruction files (with
+token counts), skills, plugins, hooks, MCP servers, and harness-compat state. `grok inspect
+--json` is machine-readable [VERIFIED from docs - 05/08/12].
+
+---
+
+## 4. Context injection (how to inject a preamble)
+
+For each mechanism: "survives /clear?" - remember `/clear` is an ALIAS for `/new`, i.e. it
+starts a brand-new session (section 9). "survives /compact?" - compaction summarizes the
+transcript but keeps the system prompt.
+
+| Mechanism | How | Survives /clear (=/new) | Survives /compact |
+|-----------|-----|-------------------------|-------------------|
+| Instruction files: `AGENTS.md`, `AGENT.md`, `Agents.md`, `CLAUDE.md`, `Claude.md`, `CLAUDE.local.md` | Auto-loaded from repo root down to cwd at session start; deeper files win on conflict; accumulate into context [VERIFIED from docs - 12-project-rules.md]. | YES - re-read when the new session starts [INFERRED/UNCERTAIN - reload on /new not stated verbatim but follows from "loaded at session start"; verify live]. | YES - they are project rules folded into the system prompt; compaction preserves the system prompt [INFERRED/UNCERTAIN]. |
+| Rules directories: `.grok/rules/*.md` (and `.claude/rules/`, `.cursor/rules/` when compat on) | Every `*.md` loaded at each dir level root->cwd [VERIFIED from docs - 12]. | YES (same as above) [INFERRED]. | YES [INFERRED]. |
+| `--rules <TEXT>` / `--append-system-prompt` | Appended to system prompt at launch, wrapped in `<human_rules>` [VERIFIED from docs - 12]. | UNCERTAIN - it is a launch-time flag; whether `/new` within the same TUI process re-applies it is undocumented. Verify live. | YES (in system prompt) [INFERRED]. |
+| `--system-prompt-override` | Replaces the system prompt verbatim [VERIFIED from docs - 12]. | UNCERTAIN (same as `--rules`). | YES [INFERRED]. |
+| ACP `session/new` `_meta.rules` / `_meta.systemPromptOverride` | Per-session injection over the protocol [VERIFIED from docs - 15-agent-mode.md]. | N/A - injected per session by the client. | YES [INFERRED]. |
+| SessionStart HOOK stdout (the Claude Code `additionalContext` pattern) | NOT SUPPORTED. See section 5. | n/a | n/a |
+| Cross-session memory (`[memory]`, `--experimental-memory`/`GROK_MEMORY=1`) | Auto-injects relevant memories on the first turn [VERIFIED from docs - 05/04]. | Depends on retrieval, not a deterministic preamble - not suitable for our fleet preamble. | n/a |
+
+Notes:
+- `AGENTS.override.md` is NOT a recognized filename in this version. The shipped list is exactly
+  `Agents.md`, `Claude.md`, `CLAUDE.md`, `CLAUDE.local.md`, `AGENT.md`, `AGENTS.md` [VERIFIED from
+  docs - 12-project-rules.md; binary scan found no `AGENTS.override` string]. Custom names such as
+  `AGENTS.local.md` are NOT discovered as top-level instruction files. Treat the "AGENTS.override.md"
+  in the task brief as not-present until proven otherwise on a newer build.
+- Files ignored by `.gitignore` are skipped during instruction discovery (use `CLAUDE.local.md`
+  gitignored for personal overrides). No size cap; whole file is loaded [VERIFIED from docs - 12].
+- The robust, self-healing injection for a supervised TUI session is the instruction-file path
+  (family D): it is re-read on every new session and lives in the system prompt across compaction.
+
+---
+
+## 5. Lifecycle events and hooks
+
+Grok's hook system is a near-clone of Claude Code's: nested JSON, `matcher`, `{decision}` for
+blocking. [VERIFIED from docs - 10-hooks.md.]
+
+### Events [VERIFIED from docs - 10-hooks.md]
+
+| Event | Fires when | Blocking? |
+|-------|-----------|-----------|
+| `SessionStart` | A session starts | No |
+| `UserPromptSubmit` | You submit a prompt | No |
+| `PreToolUse` | A tool is about to run | YES - can `deny` |
+| `PostToolUse` | A tool completed successfully | No |
+| `PostToolUseFailure` | A tool failed | No |
+| `PermissionDenied` | Permission system denied a tool call | No |
+| `Stop` | An agent turn ends (completed/cancelled/error) | No |
+| `StopFailure` | A turn ended due to an API error | No |
+| `Notification` | The agent sends a notification | No |
+| `SubagentStart` / `SubagentStop` (`SubagentEnd` alias) | A subagent starts / finishes | No |
+| `PreCompact` / `PostCompact` | Conversation compaction about to run / completed | No |
+| `SessionEnd` | The session ends | No |
+
+Only `PreToolUse` can block. Cursor camelCase event names and per-operation hooks
+(`beforeShellExecution`, `afterFileEdit`, ...) are accepted and mapped onto these generic events
+[VERIFIED from docs - 10].
+
+### Locations and trust [VERIFIED from docs - 10-hooks.md]
+
+- Global (always trusted): `~/.grok/hooks/*.json`. Also `~/.claude/settings.json`(+`.local`) and
+  `~/.cursor/hooks.json` when compat is on.
+- Project (require trust): `<repo>/.grok/hooks/*.json` (+ `.claude/settings.json`,
+  `.cursor/hooks.json`). Trust a folder with `/hooks-trust` or launch flag `--trust`; recorded in
+  `~/.grok/trusted_folders.toml`. The same gate covers project MCP/LSP. `GROK_FOLDER_TRUST=0` or
+  `[folder_trust] enabled = false` ungates everything. All `*.json` files in a hooks dir are merged.
+- Plugin-bundled hooks: trusted per-plugin.
+
+### JSON format [VERIFIED from docs - 10-hooks.md]
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash",
+        "hooks": [ { "type": "command", "command": "bin/safety-check.sh", "timeout": 10 } ] }
+    ],
+    "SessionStart": [
+      { "hooks": [ { "type": "command", "command": "bin/setup.sh" } ] }
+    ]
+  }
+}
+```
+
+- `type`: `"command"` (script/one-liner) or `"http"` (POST the event envelope to a `url`).
+- `matcher`: regex; applies to tool events (tests tool name) and `Notification` (tests type);
+  lifecycle events reject a matcher. Claude tool names are aliased (e.g. `Bash` ->
+  `run_terminal_command`, `Read` -> `read_file`, `Edit`/`Write`/`MultiEdit` -> `search_replace`).
+- `timeout`: seconds, default 5. `env`: per-hook extra vars (cannot override reserved vars below).
+- `${VAR}`/`$VAR` expansion is supported in `command` and `url`.
+
+### stdin / stdout / exit-code contract [VERIFIED from docs - 10-hooks.md]
+
+- stdin: the event JSON, e.g. `{"hookEventName":"pre_tool_use","sessionId":"...","cwd":"...",
+  "workspaceRoot":"...","toolName":"run_terminal_command","toolInput":{...},"timestamp":"..."}`
+  (PreToolUse also includes `toolUseId`, `toolInputTruncated`).
+- stdout (blocking PreToolUse only): `{"decision":"allow"}` or
+  `{"decision":"deny","reason":"..."}`.
+- Exit codes: `0` = success/allow; `2` = explicit deny (blocking hooks only); any other =
+  FAIL-OPEN (failure logged for the UI, tool call NOT blocked). A `deny` decision in stdout JSON
+  is honored regardless of exit code. All hook failures (timeout, crash, malformed output, missing
+  required env var) fail open.
+
+### Env vars injected into every hook process [VERIFIED from docs - 10-hooks.md]
+
+`GROK_HOOK_EVENT` (snake_case event, e.g. `session_start`, `pre_tool_use`), `GROK_HOOK_NAME`
+(configured hook name, with plugin prefix), `GROK_SESSION_ID`, `GROK_WORKSPACE_ROOT`, and
+`CLAUDE_PROJECT_DIR` (Claude-compatible alias for the workspace root). Plugin hooks also get
+`GROK_PLUGIN_ROOT` and `GROK_PLUGIN_DATA`. These are reserved - values set via the hook `env`
+map are stripped at load time.
+
+### HEADLINE FINDING - the benchmark question (verify live, but strongly indicated)
+
+Claude Code's SessionStart hook can emit `hookSpecificOutput.additionalContext` and that text
+becomes model context. THE OPEN QUESTION for Grok is whether its SessionStart hook stdout does the
+same. Per the shipped hooks guide it does NOT:
+
+> "Passive Hooks: For events like SessionStart or PostToolUse, stdout is ignored. Just exit 0 on
+> success." [VERIFIED from docs - 10-hooks.md].
+
+Corroborating: a full-text scan of the `grok.exe 0.2.67` binary and of every shipped doc found
+ZERO occurrences of `additionalContext`, `hookSpecificOutput`, or `additional_context` [VERIFIED
+locally via grep]. (One community write-up claimed SessionStart supports
+`hookSpecificOutput.additionalContext`; that claim is NOT supported by the shipped binary and
+appears to be Claude-Code carryover. Treat it as wrong unless a newer build proves otherwise.)
+
+Consequence: the "mechanism family A shell-hook that injects additionalContext" pattern - which
+works for Claude Code and Codex - DOES NOT WORK for Grok in this version. Grok hooks are for
+side effects (block a tool, log, notify, run setup, export env in the hook's own process) only.
+There is no documented stdout-to-context channel on any Grok event. This contradicts the current
+agent-expert capability matrix row for Grok ("Strong (SessionStart hook)") - that row should be
+downgraded. The verification to do live: write a SessionStart hook that prints
+`{"hookSpecificOutput":{"additionalContext":"PROBE-TOKEN"}}` and also a plain-text variant, start
+a session, and ask the model whether it can see PROBE-TOKEN. Expectation per docs: it cannot.
+
+---
+
+## 6. SDK / programmatic API / server mode
+
+### Headless output formats [VERIFIED from docs - 14-headless-mode.md]
+
+- `plain` (default): human text on stdout.
+- `json`: one object after completion:
+  `{"text":"...","stopReason":"EndTurn","sessionId":"abc123","requestId":"xyz789"}` (plus a
+  `thought` field when reasoning present). On failure instead: `{"type":"error","message":"..."}`
+  - check `type` before reading `text`. The `sessionId` here is what you pass to `-r/--resume`.
+- `streaming-json`: newline-delimited events, each a self-contained object with a `type`:
+  `{"type":"text","data":"..."}`, `{"type":"thought","data":"..."}`,
+  `{"type":"end","stopReason":"EndTurn","sessionId":"...","requestId":"..."}`,
+  `{"type":"error","message":"..."}`. May also emit `max_turns_reached`, `auto_compact_*`;
+  switch on `type` and treat the list as non-exhaustive. Stdin is NOT read into the prompt; pass
+  context via command substitution or `--prompt-file`.
+
+### ACP (Agent Communication / Agent Client Protocol) [VERIFIED from docs - 15-agent-mode.md]
+
+- `grok agent stdio` - JSON-RPC 2.0 over stdin/stdout. Primary integration mode (Zed, Neovim,
+  Emacs, marimo; JetBrains "coming soon").
+- `grok agent serve --bind 127.0.0.1:2419 --secret <token>` - WebSocket server (token via flag,
+  printed if omitted, or `GROK_AGENT_SECRET`). Persists across reconnects.
+- `grok agent headless --grok-ws-url wss://relay/ws` - dials out to a relay for web clients.
+- `grok agent` options (before the mode): `-m/--model`, `--always-approve` (alias `--yolo`),
+  `--reauth`, `--agent-profile <PATH>`.
+- Lifecycle: `initialize` -> `session/new` (params `cwd`, `mcpServers`; optional `_meta.rules`,
+  `_meta.systemPromptOverride`, `_meta.agentProfile`) -> `session/prompt`
+  (`prompt:[{type:"text",text}]`) -> `session/update` notifications.
+- `session/update.sessionUpdate` values: `agent_message_chunk`, `agent_thought_chunk`,
+  `tool_call`, `tool_call_update`, `plan`. `session/load` resumes by id.
+- xAI extension methods under `x.ai/*`: `x.ai/fs/*`, `x.ai/git/*`, `x.ai/git/worktree/*`,
+  `x.ai/search/*`, `x.ai/terminal/*`, `x.ai/session/*`, plus `prompt_history`, `rewind/*`,
+  `compact_conversation`. Discover the live set from the `initialize` response.
+- Official ACP SDKs: TypeScript `@agentclientprotocol/sdk`, Rust `agent-client-protocol`, Python,
+  Go, Kotlin. Spec at agentclientprotocol.com.
+
+Auth for programmatic/headless: `XAI_API_KEY` (console.x.ai), or `grok login --device-auth`, or
+browser `grok login` [VERIFIED from docs - 14/02].
+
+---
+
+## 7. MCP / extensions / skills / plugins
+
+- MCP [VERIFIED from docs - 05/07]: `[mcp_servers.<name>]` in `~/.grok/config.toml` (command/args/
+  env, or `url`+`headers` for HTTP/SSE; `{{session_id}}` templating). Per-project in
+  `.grok/config.toml` (override by name = full replacement). Manage in TUI via `/mcps`. Logs under
+  `~/.grok/logs/mcp/`.
+- Skills [VERIFIED from docs - 08-skills.md]: ANTHROPIC FORMAT - a directory with `SKILL.md`
+  (YAML frontmatter: `name`, `description`, optional `when-to-use`, `allowed-tools`,
+  `argument-hint`, `user-invocable`, `disable-model-invocation`, `model`, `effort`, ...) plus
+  markdown body. Discovered (priority high->low) from `./.grok/skills/`,
+  `<repo>/.grok/skills/`, `~/.grok/skills/`, and (compat) `~/.claude/skills/`, `~/.cursor/skills/`;
+  also `.agents/skills/` at each tier and additional `[skills] paths`. NOTE: the task mentioned
+  `~/.agents/skills` - the shipped doc says user-level Claude/Cursor dirs plus `.agents/skills` at
+  each tier; `~/.agents/skills` specifically is plausible but state as [INFERRED/UNCERTAIN].
+  User-invocable skills appear as `/skill-name` (qualified `/local:`, `/repo:`, `/user:`,
+  `/plugin:` on collision). Bundled skills (e.g. `/create-skill`, `/help`, `/docx`) are extracted
+  to `~/.grok/skills/`.
+- Plugins + marketplaces [VERIFIED from docs - 05/09]: a plugin bundles skills, agents, hooks, MCP
+  and LSP servers. Discovered from `~/.grok/plugins/`, `./.grok/plugins/`,
+  `~/.grok/plugins/marketplaces/`, `[plugins] paths`, or `--plugin-dir`. Marketplaces from
+  `[[marketplace.sources]]` (the xAI Official one auto-installs:
+  `github.com/xai-org/plugin-marketplace.git`) [VERIFIED locally in config.toml]. Manage via
+  `/plugins`, `/marketplace`, `/hooks`, `/skills`, `/mcps` (one extensions modal).
+- LSP: `~/.grok/lsp.json` / `.grok/lsp.json` / plugin-provided; the optional `lsp` tool is behind
+  `[features] lsp_tools` [VERIFIED from docs - 05].
+- Claude/Cursor harness compatibility is on by default and is the reason CLAUDE.md, `.claude/`
+  skills/rules/hooks/MCP all "just work" [VERIFIED from docs - 05]. `/import-claude` migrates
+  `~/.claude` settings.
+
+---
+
+## 8. Transcript / history
+
+Per session, under `~/.grok/sessions/<url-encoded-cwd>/<session-id>/` [VERIFIED from docs -
+17-sessions.md, locally confirmed the encoded-cwd directory layout]:
+
+| File | Contents |
+|------|----------|
+| `summary.json` | Index/metadata: `info` (id+cwd), `session_summary`, `generated_title`, `created_at`/`updated_at`, `num_messages`/`num_chat_messages`, `current_model_id`, `parent_session_id` (fork/restore), `agent_name`. |
+| `updates.jsonl` | AUTHORITATIVE conversation log - one ACP `session/update` event per line; drives `/resume` and restore. |
+| `chat_history.jsonl` | Raw chat messages sent to the model. (This is what our plugin reads.) |
+| `plan.json` | TODO/task list state. |
+| `rewind_points.jsonl` | File snapshots for `/rewind`. |
+| `signals.json` | Token usage + tool/turn counters. |
+| `feedback.jsonl` | Ratings/feedback. |
+| `compaction_checkpoints/`, `subagents/` | Compaction state; per-subagent meta. |
+
+- Format is JSONL (append-only, streamable, each line valid JSON) [VERIFIED from docs - 17].
+- Token usage IS available (`signals.json`; also `/context`, `/session-info`) [VERIFIED from docs].
+- Session ids are UUIDv7 when Grok generates them; a client may supply its own with `-s`
+  (interactive only) [VERIFIED from docs - 17].
+- A SQLite FTS5 index (`~/.grok/sessions/session_search.sqlite`) backs `grok sessions search`
+  [VERIFIED from docs - 17; file present locally]. `grok sessions list [--limit N]` lists by cwd.
+
+---
+
+## 9. Session semantics
+
+- `/new` (alias `/clear`): clears context and starts a NEW session (new id). It is NOT an in-place
+  context wipe of the same session id - it is a fresh session. [VERIFIED from docs - 17/04.]
+- `/compact [context]`: compress history within the SAME session; optional text says what to
+  preserve. Auto-compacts at `[session] auto_compact_threshold_percent` (default 85%). `PreCompact`
+  and `PostCompact` hooks fire around it. [VERIFIED from docs - 17/04/10.]
+- `/fork`: branch into a peer session that copies history up to now (`parent_session_id` set);
+  optional worktree. `/rewind`: restore files + truncate history to an earlier prompt (touches
+  disk). `/resume`: load a prior session from disk. [VERIFIED from docs - 17.]
+- New TUI launch = new session each time. Resume: `grok -r <id>` (errors if missing) or `grok -c`
+  (most recent in cwd). Headless ignores `-s`; use `-r`/`-c` to carry context. [VERIFIED from docs.]
+- So for reset detection: a `/clear` becomes observable as a `SessionEnd` + `SessionStart` (new id)
+  pair, and a compaction as `PreCompact`/`PostCompact` (same id). Both event pairs exist; what they
+  CANNOT do is inject context (section 5).
+
+---
+
+## 10. How CC Director integrates it
+
+Our current classes (verified in repo):
+- Agent: `src/CcDirector.Core/Agents/GrokAgent.cs` - `AgentKind.Grok`,
+  `SupportsPreassignedSessionId=false`, `SupportsStudioMode=false`. Launch builds args from user
+  text only; Director-initiated resume and Studio stream-json wrapper are explicitly ignored in
+  v1 (each launch = fresh ephemeral session).
+- Plugin: `src/CcDirector.Core/AgentPlugins/GrokAgentPlugin.cs` - built-in; detects
+  `~/.grok/bin/grok.exe` or `grok` on PATH; validates with `--version` (8s); history provider
+  `AgentHistoryProviderKind.TranscriptFile`, `SupportsConversationHistory=true`, source
+  "Grok chat_history.jsonl under ~/.grok/sessions"; `DefaultModel=""`.
+- Driver: `GenericDriver` via `AgentDrivers.For(AgentKind.Grok)`
+  (`src/CcDirector.Core/Drivers/GenericDriver.cs`). For Grok it sets
+  `EmitsContinuousIdleOutput=true` (Grok repaints an animated idle footer / pager animation, so the
+  byte-level idle detector must tolerate continuous repaint). It declares only `Cancel` and
+  `Interrupt` and THROWS on `ClearContext` (we do not drive `/clear` programmatically).
+- Mechanism family currently labelled: A (shell hook in `~/.grok/hooks`).
+
+REVISED plan in light of section 5. The original plan - "register a SessionStart (and PostCompact)
+hook that fetches `GET /sessions/{sid}/fleet-preamble` and emits it as additionalContext" - WILL
+NOT inject context on Grok 0.2.67, because SessionStart/PostCompact stdout is ignored and there is
+no `additionalContext` channel. Concrete options, best first:
+
+1. PRIMARY - family D, instruction file (self-healing, survives /clear and /compact). Write the
+   fleet preamble into a Grok-discovered instruction file in the session's cwd before launch -
+   e.g. a gitignored `CLAUDE.local.md` or a `.grok/rules/zz-fleet-preamble.md` (rules dirs load
+   every `*.md`). Grok re-reads instruction files when a new session starts (so it covers
+   `/clear`=`/new`) and keeps them in the system prompt across `/compact`. This is the same
+   universal-fallback family the matrix lists for everyone, and for Grok it is the ONLY reliable
+   in-band channel today. Refresh the file when the preamble changes; Grok picks it up on the next
+   session/turn.
+2. LAUNCH-TIME - pass `--rules "<preamble>"` (or `--append-system-prompt`) at spawn. Simple, but
+   it is launch-scoped; whether `/new` inside the running TUI re-applies it is unverified (section
+   4). Good for headless one-shots, weaker for long-lived supervised TUI sessions.
+3. ACP path (future) - if/when we drive Grok over `grok agent stdio`, inject via `session/new`
+   `_meta.rules` / `_meta.systemPromptOverride` on every new session. This is the cleanest
+   deterministic per-session injection but requires moving Grok off the raw-TUI driver.
+4. Hooks remain useful for SIDE EFFECTS only: a `SessionStart`/`SessionEnd`/`PreCompact`/
+   `PostCompact` hook can still PING the Director (so we observe new/cleared/compacted sessions via
+   `GROK_SESSION_ID`/`GROK_WORKSPACE_ROOT`), and a `PreToolUse` hook can enforce policy. They just
+   cannot carry the preamble into the model.
+
+The shared Director endpoint `GET /sessions/{sid}/fleet-preamble` stays the source of the preamble
+text for whichever channel we use.
+
+Current gaps:
+- TranscriptRead capability is not declared for GenericDriver, so cross-agent `cc-ask` (Claude ->
+  Grok) still will not work even though `chat_history.jsonl`/`updates.jsonl` are parseable. A
+  TranscriptFile history reader for Grok is a clear future win.
+- We do not preassign session ids or resume; Grok owns session state. Fine for v1.
+
+---
+
+## 11. Caveats and verification needed
+
+1. THE BIG ONE: confirm live that no Grok event injects model context (the section-5 PROBE-TOKEN
+   test). Everything in section 10 hinges on this. If a newer build adds `additionalContext`, we
+   can switch Grok back to family A.
+2. The agent-expert capability matrix (`README.md`) currently rates Grok "Strong (SessionStart
+   hook)". Per this version that is wrong - downgrade to "instruction-file (family D); hooks are
+   side-effect only; no stdout-to-context channel". Update when confirmed live.
+3. Fast churn: this is beta (0.2.67). Flag/section names move between releases. The shipped
+   `~/.grok/docs/user-guide/*.md` is the per-build source of truth - re-read it after upgrades.
+4. `--yolo` vs `--always-approve`: `--yolo` is the headless flag; `--always-approve` is documented
+   as the alias on `grok agent`. Confirm which the installed build accepts in headless before
+   wiring auto-approve.
+5. `-s/--session-id` is interactive-only and ignored headless - do not rely on preassignment.
+6. `AGENTS.override.md` and `~/.agents/skills` (both named in the task brief) are NOT confirmed in
+   0.2.67 (override filename absent from the supported list; `.agents/skills` is supported per-tier
+   but the exact `~/.agents/skills` home path is inferred). Verify before depending on them.
+7. Many third-party "Grok Build cheat sheets" describe the community `grok-cli` fork (config.json,
+   user-settings.json, different flags). Do not import their facts into our integration.
+8. EmitsContinuousIdleOutput is essential: without it the idle detector would never see Grok as
+   idle because of the animated footer. Keep it set; re-check if Grok adds `--no-alt-screen`-style
+   static output we could prefer for capture.
+
+## Sources
+
+Shipped in-binary user-guide (authoritative for grok 0.2.67, read locally at
+`C:\Users\soren\.grok\docs\user-guide\`):
+- 01-getting-started.md, 04-slash-commands.md, 05-configuration.md, 08-skills.md, 09-plugins.md,
+  10-hooks.md, 12-project-rules.md, 14-headless-mode.md, 15-agent-mode.md, 17-sessions.md.
+- Local binary string scan of `C:\Users\soren\.grok\bin\grok.exe` (no `additionalContext` /
+  `hookSpecificOutput` / `AGENTS.override`).
+- Local `C:\Users\soren\.grok\config.toml` (marketplace source, permission_mode).
+
+Public xAI docs and announcement:
+- https://docs.x.ai/build/overview
+- https://docs.x.ai/build/cli/headless-scripting
+- https://docs.x.ai/build/modes-and-commands
+- https://docs.x.ai/build/features/skills-plugins-marketplaces
+- https://docs.x.ai/build/enterprise
+- https://x.ai/news/grok-build-cli
+- https://x.ai/cli
+
+Community/secondary (corroboration only; lower trust - some conflate the community fork):
+- https://mer.vin/2026/05/grok-build-cli-xai-terminal-coding-agent-with-plan-mode-subagents-and-headless-ci/
+- https://www.aimadetools.com/blog/grok-build-cheat-sheet/
+- https://github.com/manaflow-ai/cmux/issues/4220 (reverse-engineered hook events)
+- ACP spec: https://agentclientprotocol.com
+
+Repo (our integration):
+- src/CcDirector.Core/Agents/GrokAgent.cs
+- src/CcDirector.Core/AgentPlugins/GrokAgentPlugin.cs
+- src/CcDirector.Core/Drivers/GenericDriver.cs

--- a/.claude/skills/agent-expert/agents/opencode.md
+++ b/.claude/skills/agent-expert/agents/opencode.md
@@ -1,0 +1,394 @@
+<!--
+Per-agent reference for CC Director's agent-expert skill. INTERNAL, not shipped.
+ASCII only. No Unicode, no emoji, no em-dashes (use " - ").
+Every non-trivial fact is marked [VERIFIED from docs] or [INFERRED/UNCERTAIN] with an inline source.
+All links collected in Sources.
+-->
+
+# opencode (OpenCode)
+
+> Open-source terminal coding agent with a true client/server split: the TUI is just one
+> client of a local HTTP server that exposes an OpenAPI surface, a server-sent-events bus,
+> and a TypeScript plugin system. Our integration status: GenericDriver (no bespoke driver) /
+> OpenCodeAgent / OpenCodeAgentPlugin.
+
+The headline contrast with Claude Code: Claude injects context with an in-process SessionStart
+shell hook that prints `additionalContext` to stdout. opencode does NOT have a shell-hook
+equivalent. It favors an OUT-OF-PROCESS model: stand up `opencode serve`, subscribe to its SSE
+bus over HTTP, and push context back through the same HTTP API; or load an in-process TypeScript
+plugin. There is no "run my shell command and read its stdout as extra context" mechanism. This
+shapes our whole strategy (Section 10).
+
+---
+
+## 1. Identity and install
+
+- Binary: `opencode`. Project site `opencode.ai`, source `github.com/sst/opencode` (the SST team).
+  [VERIFIED - https://opencode.ai/docs/]
+- Install: npm `npm i -g opencode-ai`, or `curl -fsSL https://opencode.ai/install | bash`, or
+  Homebrew/Scoop/paru per platform. [VERIFIED - https://opencode.ai/docs/]
+- SDK / plugin npm packages: `@opencode-ai/sdk` (client) and `@opencode-ai/plugin` (plugin types).
+  [VERIFIED - https://opencode.ai/docs/sdk/, https://opencode.ai/docs/plugins/]
+- Windows shim: our detection looks for `%APPDATA%\npm\opencode.cmd` first, then bare `opencode`
+  on PATH. [VERIFIED - src/CcDirector.Core/AgentPlugins/OpenCodeAgentPlugin.cs DefaultNpmCliPath]
+- Version probe: `opencode --version`. We run it with an 8 second timeout.
+  [VERIFIED - OpenCodeAgentPlugin.cs ValidationMetadata = new("--version", 8s)]
+
+## 2. Command-line interface
+
+opencode is primarily an interactive full-screen TUI; a bare `opencode` launch opens the TUI in
+the current working directory. It also has subcommands and a non-interactive run path.
+[VERIFIED - https://opencode.ai/docs/cli/]
+
+Selected commands and flags (the ones that matter to a supervisor):
+
+| Command / flag | Purpose |
+|----------------|---------|
+| `opencode` | Launch interactive TUI in cwd. [VERIFIED - docs/cli] |
+| `opencode run "<msg>"` | Non-interactive: run one message and print the result (headless). [VERIFIED - docs/cli] |
+| `opencode run --continue` / `-c` | Continue the most recent session in run mode. [VERIFIED - docs/cli] |
+| `opencode run --session <id>` / `-s` | Target a specific session id. [VERIFIED - docs/cli] |
+| `opencode serve` | Start the headless HTTP server (no TUI). [VERIFIED - https://opencode.ai/docs/server/] |
+| `opencode serve --port <n>` | Server port, default 4096. [VERIFIED - docs/server] |
+| `opencode serve --hostname <h>` | Bind host, default 127.0.0.1. [VERIFIED - docs/server] |
+| `opencode serve --cors <origin>` | Allow a CORS origin (repeatable). [VERIFIED - docs/server] |
+| `opencode serve --mdns` / `--mdns-domain` | Optional mDNS discovery. [VERIFIED - docs/server] |
+| `--model <provider/model>` / `-m` | Model selection (run/tui). [INFERRED/UNCERTAIN - docs/cli, confirm exact flag] |
+| `--agent <name>` | Start with a named agent. [INFERRED/UNCERTAIN - docs/cli] |
+| `opencode auth login` | Provider credential setup. [VERIFIED - docs/cli] |
+
+Our `OpenCodeAgent.BuildLaunchSpec` passes user args through verbatim and does nothing else: no
+session-id preassignment, no Director-initiated resume, no Studio stream-json wrapper. A resume id
+or studioMode flag is logged and ignored. [VERIFIED - src/CcDirector.Core/Agents/OpenCodeAgent.cs]
+
+## 3. Configuration
+
+- File: `opencode.json` (JSON or JSONC). Schema marker `"$schema": "https://opencode.ai/config.json"`.
+  [VERIFIED - https://opencode.ai/docs/config/]
+- Locations and precedence (later overrides earlier, merged per-key, not wholesale):
+  1. Global `~/.config/opencode/opencode.json`.
+  2. Project `opencode.json` in the project root (also `.opencode/opencode.json`).
+  3. `OPENCODE_CONFIG` env var points at a custom file.
+  Project config has the highest precedence among the standard files; non-conflicting keys from
+  all sources are preserved. [VERIFIED - docs/config]
+- Top-level keys: `model`, `small_model`, `provider`, `agent`, `command`, `mcp`, `instructions`,
+  `plugin`, `permission`, `theme` (deprecated, moved to `tui.json`). [VERIFIED - docs/config]
+- Separate `tui.json` holds terminal-UI config (themes, keybinds). [VERIFIED - docs/config]
+
+## 4. Context injection (how to inject a preamble)
+
+Each row notes whether the injected text survives `/clear`-equivalent and `/compact`. Note opencode
+has no `/clear`; its reset-to-empty is `/new` (a brand-new session). See Section 9.
+
+| Mechanism | Survives /new (fresh session)? | Survives /compact? | Notes |
+|-----------|-------------------------------|--------------------|-------|
+| `AGENTS.md` (project root, walks up) | Yes - re-read for every session and prompt | Yes - re-read | Primary instruction file. Created/updated by `/init`. [VERIFIED - https://opencode.ai/docs/rules/] |
+| Global `~/.config/opencode/AGENTS.md` | Yes | Yes | Personal rules across all sessions. [VERIFIED - docs/rules] |
+| `CLAUDE.md` (legacy fallback) | Yes (only if no AGENTS.md) | Yes | opencode falls back to `CLAUDE.md`, and global `~/.claude/CLAUDE.md`, when no native file exists. Disable with `OPENCODE_DISABLE_CLAUDE_CODE`. [VERIFIED - docs/rules] |
+| `instructions` array in opencode.json | Yes | Yes | Accepts file paths, glob patterns (e.g. `.cursor/rules/*.md`), and remote URLs (5 second fetch timeout). [VERIFIED - docs/rules] |
+| Per-agent `prompt` file (`"{file:./path}"`) | Yes (for that agent) | Yes | Replaces/sets the agent system prompt. [VERIFIED - https://opencode.ai/docs/agents/] |
+| Injected message via HTTP/SDK (`session.prompt` with `noReply`/`noReply:true`) | N/A - per call | N/A | Pushes context into the live session without triggering a reply. This is the dynamic path. [VERIFIED - https://opencode.ai/docs/sdk/] |
+| Plugin `experimental.chat.system.transform` hook | Yes (runs every chat) | Yes | EXPERIMENTAL. Mutates the system prompt array in-process. [VERIFIED - https://opencode.ai/docs/plugins/] |
+
+Key point: the file-based mechanisms (AGENTS.md, instructions array, agent prompt) are passive and
+self-healing - re-read every prompt - so they inherently survive both reset and compaction. They
+are the equivalent of family D. The dynamic mechanisms (HTTP message inject, plugin hooks) are how
+you respond to a live event. There is NO SessionStart-style shell hook that prints additionalContext.
+[VERIFIED - docs/rules, docs/plugins; absence confirmed by docs/plugins hook list]
+
+## 5. Lifecycle events and hooks (and the event bus)
+
+opencode does not use a stdin/stdout JSON shell-hook contract. Two distinct extension surfaces exist:
+(A) the HTTP server-sent-events bus, consumed out-of-process; and (B) the in-process TypeScript
+plugin hooks. Both observe the SAME underlying event types.
+
+### 5a. The event bus (out-of-process, over HTTP)
+
+- `GET /event` - server-sent-events stream. The FIRST event is always `server.connected`, then bus
+  events follow. [VERIFIED - https://opencode.ai/docs/server/]
+- `GET /global/event` - a global (cross-project) SSE stream. [VERIFIED - docs/server]
+- The SDK exposes the same stream via `client.event.subscribe()`. [VERIFIED - https://opencode.ai/docs/sdk/]
+
+Event types carried on the bus (the `event` property `type` field). [VERIFIED - https://opencode.ai/docs/plugins/ event list]:
+
+- Server: `server.connected`.
+- Session: `session.created`, `session.updated`, `session.compacted`, `session.idle`,
+  `session.deleted`, `session.error`, `session.status`, `session.diff`.
+- Message: `message.updated`, `message.removed`, `message.part.updated`, `message.part.removed`.
+- Permission: `permission.asked`, `permission.replied`.
+- Tool/command/file/LSP/todo/installation: `command.executed`, `file.edited`,
+  `file.watcher.updated`, `lsp.client.diagnostics`, `lsp.updated`, `todo.updated`,
+  `installation.updated`, `shell.env`.
+
+Which event fires when (the load-bearing ones for us):
+- New session (`/new`, or first launch, or an API `session.create`): `session.created`.
+  [VERIFIED - docs naming; live-confirm pending]
+- Compaction (`/compact`, or auto-compact at context limit): `session.compacted`. [VERIFIED - naming]
+- Idle / turn finished: `session.idle`. [VERIFIED - naming]
+- IMPORTANT: there is NO `session.cleared` event. opencode has no in-place clear; a "clear" is a
+  new session and therefore surfaces as `session.created`. [VERIFIED - event list has no cleared type;
+  see Section 9]
+
+### 5b. Plugin hooks (in-process TypeScript)
+
+A plugin function returns a hooks object. Exact hook names from the `@opencode-ai/plugin` Hooks
+interface [VERIFIED - https://opencode.ai/docs/plugins/ and packages/plugin/src/index.ts]:
+
+- `event` - catch-all: `(input: { event: Event }) => Promise<void>`. Receives EVERY bus event in
+  process. This is the in-process analogue of subscribing to `GET /event`.
+- `config` - `(input: Config) => Promise<void>`. Observe/adjust resolved config at load.
+- `chat.message` - fires when a new message is received.
+- `chat.params` - modify the parameters sent to the model (temperature, etc.).
+- `chat.headers` - mutate outgoing provider HTTP headers.
+- `permission.ask` - `(input: Permission, output: { status: "ask" | "deny" | "allow" })` - approve
+  or deny tool/permission requests programmatically.
+- `tool.execute.before` - `(input: { tool, sessionID, callID }, output: { args })` - inspect/mutate
+  tool args before a tool runs.
+- `tool.execute.after` - receives the tool result (title, output, metadata).
+- `tool.definition` - `(input: { toolID }, output: { description, parameters })` - rewrite a tool's
+  schema.
+- `experimental.chat.system.transform` - EXPERIMENTAL. Modify the system prompt array. This is the
+  in-process re-injection hook we care about.
+- `experimental.session.compacting` - EXPERIMENTAL. "Called before session compaction starts. Allows
+  plugins to customize the compaction prompt." Our re-inject-on-compact hook.
+- `experimental.compaction.autocontinue` - EXPERIMENTAL. Controls the synthetic continue message
+  after compaction.
+- `experimental.chat.messages.transform` - EXPERIMENTAL. Transform the message array.
+- `experimental.provider.small_model`, `experimental.text.complete` - EXPERIMENTAL, not relevant here.
+
+All `experimental.*` hooks are unstable and may be renamed or removed; pin the opencode version and
+re-verify before depending on them. [VERIFIED - they carry the experimental prefix in the type]
+
+## 6. SDK / programmatic API / server mode (the key section)
+
+This is opencode's defining capability and the basis of our integration. The TUI is one client of
+a local HTTP server; you can run that server yourself and drive it.
+
+### 6a. Server mode
+
+- Start: `opencode serve --port 4096 --hostname 127.0.0.1` (those are the defaults).
+  [VERIFIED - https://opencode.ai/docs/server/]
+- Auth: set `OPENCODE_SERVER_PASSWORD` (required to enable auth) and optionally
+  `OPENCODE_SERVER_USERNAME` (default `opencode`). HTTP basic auth. Without the password var, the
+  loopback server is unauthenticated. [VERIFIED - docs/server]
+- OpenAPI 3.1 spec is served at `GET /doc` - the authoritative, machine-readable contract; generate
+  a client from it if needed. [VERIFIED - docs/server]
+
+Selected endpoints (full list is in `/doc`) [VERIFIED - docs/server]:
+
+- Events: `GET /event` (per-instance SSE, first event `server.connected`), `GET /global/event`.
+- Sessions: `GET /session`, `POST /session` (create), `GET /session/status`, `GET /session/:id`,
+  `DELETE /session/:id`, `PATCH /session/:id`, `GET /session/:id/children`,
+  `POST /session/:id/init`, `POST /session/:id/fork`, `POST /session/:id/abort`,
+  `POST /session/:id/summarize` (this is the compact/summarize trigger),
+  `POST /session/:id/revert`, `POST /session/:id/unrevert`, `GET /session/:id/diff`,
+  `GET /session/:id/todo`, share endpoints.
+- Messages: `GET /session/:id/message` (list), `POST /session/:id/message` (send),
+  `GET /session/:id/message/:messageID`, `POST /session/:id/prompt_async` (async prompt),
+  `POST /session/:id/command`, `POST /session/:id/shell`,
+  `POST /session/:id/permissions/:permissionID` (answer a permission ask).
+- Config / project / providers: `GET|PATCH /config`, `GET /config/providers`, `GET /provider`,
+  `GET /project`, `GET /project/current`, `GET /path`, `GET /agent`, `GET /command`, `GET|POST /mcp`.
+- TUI control surface (drive a running TUI from outside): `POST /tui/append-prompt`,
+  `POST /tui/submit-prompt`, `POST /tui/clear-prompt`, `POST /tui/execute-command`,
+  `POST /tui/open-sessions`, `POST /tui/open-models`, `POST /tui/show-toast`,
+  `GET /tui/control/next`, `POST /tui/control/response`. These map to the plugin `tui.prompt.append`
+  / `tui.command.execute` / `tui.toast.show` surface. They let an external process type into and
+  drive the user's live TUI. [VERIFIED - docs/server]
+
+### 6b. SDK (@opencode-ai/sdk)
+
+- Client only (attach to an existing server):
+  `import { createOpencodeClient } from "@opencode-ai/sdk"` then
+  `const client = createOpencodeClient({ baseUrl: "http://localhost:4096" })`. Default base URL is
+  `http://localhost:4096`. [VERIFIED - https://opencode.ai/docs/sdk/]
+- Full setup (spawn a server and get a client):
+  `import { createOpencode } from "@opencode-ai/sdk"; const { client } = await createOpencode()`.
+  [VERIFIED - docs/sdk]
+- Core methods: `client.session.create({ body })`, `client.session.prompt({ path, body })`,
+  `client.session.messages({ path })`, `client.event.subscribe()` (async-iterable SSE stream),
+  `client.auth.set({ path, body })`. [VERIFIED - docs/sdk]
+- Context-without-reply: `session.prompt` with `body.noReply: true` injects content into the session
+  WITHOUT triggering a model response. This is exactly the primitive for pushing a fleet preamble.
+  [VERIFIED - docs/sdk]
+
+Contrast with Claude Code: Claude's programmatic surface is the Agent SDK plus a SessionStart shell
+hook on the local process. opencode's is a long-lived HTTP server with an OpenAPI contract and an
+SSE bus - you talk to it over a socket, not through a child process's stdio. This is why CC Director
+treats opencode with mechanism family B (subscribe over HTTP) rather than family A (shell hook).
+
+## 7. MCP / extensions / plugins / commands
+
+- MCP: configured under the `mcp` key in opencode.json; also `GET|POST /mcp` and the `/mcp` slash
+  command manage servers at runtime. [VERIFIED - docs/config, OpenCodeSlashCommands.cs]
+- Plugins: TypeScript/JavaScript modules in `.opencode/plugin/` (project) and
+  `~/.config/opencode/plugin/` (global), auto-loaded at startup. npm plugins install via Bun and
+  cache under `~/.cache/opencode/node_modules/`. Load order: global config, project config, global
+  plugins, project plugins. A plugin is `async ({ project, client, $, directory, worktree }) => ({ ...hooks })`
+  where `client` is an SDK client bound to the running server, `$` is Bun's shell. [VERIFIED -
+  https://opencode.ai/docs/plugins/]
+  NOTE: docs prose has used both `plugin/` and `plugins/` for the directory name - confirm the exact
+  folder against the installed binary before relying on it. [INFERRED/UNCERTAIN - docs/plugins]
+- Agents: primary agents (Build, Plan; Tab to cycle) and subagents (General, Explore, Scout;
+  `@name` to invoke). Defined as markdown in `.opencode/agent/` and `~/.config/opencode/agent/`, or
+  under the `agent` key. Per-agent fields: `description` (required), `prompt` (`"{file:./path}"`),
+  `model`, `temperature`, `mode` (`primary`/`subagent`/`all`), `permission`. [VERIFIED -
+  https://opencode.ai/docs/agents/]
+- Custom slash commands: markdown in `.opencode/command/` and `~/.config/opencode/command/`, or
+  under the `command` key. Frontmatter: `description`, `agent`, `model`, `subtask` (bool, forces a
+  subagent to avoid context pollution). Body supports `$ARGUMENTS` / `$1`,`$2`,...,
+  shell injection `` !`command` ``, and file embedding `@filename`. Built-ins include `/init`,
+  `/undo`, `/redo`, `/share`, `/help`. [VERIFIED - https://opencode.ai/docs/commands/]
+  Our maintained TUI command catalog (OpenCodeSlashCommands.cs, captured 2026-06-18) also lists
+  `/model`, `/models`, `/provider`, `/agent`, `/sessions`, `/session`, `/new`, `/continue`, `/fork`,
+  `/compact`, `/theme`, `/stats`, `/export`, `/import`, `/mcp`, `/plugin`, `/quit`.
+  [VERIFIED - src/CcDirector.Core/Drivers/OpenCodeSlashCommands.cs]
+
+## 8. Transcript / history
+
+- opencode persists conversations in a local SQLite store, not per-session JSON files. Our reader
+  uses `~/.local/share/opencode/opencode.db` (same path on Windows under the user profile).
+  [VERIFIED - src/CcDirector.Core/OpenCode/OpenCodeHistoryReader.cs DefaultDatabasePath]
+- Schema we rely on: a `session` row per session (with a `directory` column = the repo path and
+  `time_updated`); a `message` row per turn (`data` JSON blob carries `role` = user/assistant); and
+  ordered `part` rows per message (`data` JSON blob with `type`: `text`, `reasoning`, `tool`, plus
+  turn markers `step-start`/`step-finish`). A `tool` part carries both call and result via
+  `state.input` / `state.output` / `state.error`. [VERIFIED - OpenCodeHistoryReader.cs class doc]
+- The DB is written by a live process (a `-wal` file is present), so we snapshot-copy before opening
+  to avoid locking the writer (SqliteSnapshotReader). The TUI runs full-screen, so terminal
+  scrollback is empty - the SQLite store is the only conversation source. [VERIFIED -
+  OpenCodeHistoryReader.cs]
+- There is no per-session file to locate: we resolve the active session as the newest `session` row
+  whose normalized `directory` equals the Director session's repo path. [VERIFIED -
+  OpenCodeHistoryReader.cs ResolveSessionId]
+- Token usage / cost: available via `/stats` in the TUI and surfaced in message metadata over the
+  API; not currently parsed by our reader. [INFERRED/UNCERTAIN - OpenCodeSlashCommands `/stats`]
+- Our plugin declares history provider kind `SqliteStore`, SupportsConversationHistory = true.
+  [VERIFIED - OpenCodeAgentPlugin.cs HistoryMetadata]
+
+## 9. Session semantics
+
+- `/new` - starts a brand-new session. New session id. Emits `session.created`. This is opencode's
+  closest thing to a "clear": there is no in-place context clear that keeps the same session id.
+  [VERIFIED - OpenCodeSlashCommands.cs `/new`; docs event naming]
+- `/compact` (a.k.a. summarize, `POST /session/:id/summarize`) - compacts/summarizes the current
+  conversation in place, KEEPING the session id. Emits `session.compacted`. [VERIFIED - docs/server
+  summarize endpoint; event naming]
+- `/continue` - resume the most recent session. [VERIFIED - OpenCodeSlashCommands.cs]
+- `/fork` (`POST /session/:id/fork`) - branch the current session into a new one. [VERIFIED -
+  docs/server, OpenCodeSlashCommands.cs]
+- `/sessions` - browse/switch sessions. [VERIFIED - OpenCodeSlashCommands.cs]
+- CRITICAL for reset detection: there is NO `session.cleared` event and no clear-in-place command.
+  A user "clearing" really means `/new`, which we see as `session.created`. So our reset trigger is
+  `session.created` (new session in this repo) and our compaction trigger is `session.compacted`.
+  [VERIFIED - event list absence; OpenCodeSlashCommands.cs has /new, /compact, no /clear]
+
+## 10. How CC Director integrates it
+
+Current wiring [VERIFIED from source]:
+- Driver: GenericDriver, constructed for AgentKind.OpenCode (no bespoke OpenCodeDriver). It declares
+  only `DriverCapabilities.Cancel | Interrupt`. Cancel sends Esc (0x1B); Interrupt sends Ctrl+C
+  (0x03). `ClearContextAsync`, `ShowHistoryAsync`, `ReadWidgets`, `ReadUsage`, `ListTranscripts`,
+  `BuildLaunchSpec`, `ResolveExecutable` all throw NotSupported - the conservative "these two
+  keystrokes are all we have verified" contract. (GenericDriver.cs)
+- Agent: OpenCodeAgent - passes user args through, no preassigned session id, no resume, no Studio
+  mode. (OpenCodeAgent.cs)
+- Plugin: OpenCodeAgentPlugin - detection (`%APPDATA%\npm\opencode.cmd` then `opencode`), validation
+  (`--version`, 8s), history provider `SqliteStore`, single Standard command preset, no default
+  model. (OpenCodeAgentPlugin.cs)
+- History: OpenCodeHistoryReader over the SQLite store (Section 8).
+- Shared endpoint: the Director exposes `GET /sessions/{sid}/fleet-preamble` (FleetPreamble.cs,
+  ControlEndpoints.cs) - agent-agnostic, returns the preamble text for a session. Every mechanism
+  family pulls from here. [VERIFIED - src/CcDirector.Core/Sessions/FleetPreamble.cs]
+
+Fleet-preamble strategy. opencode is the canonical family B agent, with family C as a robust
+alternative. Both target the same trigger pair: inject at session start, re-inject on
+`session.created` (the reset) and `session.compacted` (the compaction).
+
+Plan B - out-of-process event bus (preferred, matches opencode's architecture):
+1. For an opencode session, launch via `opencode serve` (or attach to the TUI's own server) so a
+   local HTTP server with an SSE bus exists. Capture the chosen port.
+2. From the Director, open `GET /event` and read the SSE stream. Discard the leading
+   `server.connected`, then watch for `session.created` and `session.compacted` scoped to this
+   session/repo.
+3. On either event, fetch the preamble from `GET /sessions/{sid}/fleet-preamble`, then push it into
+   the opencode session with `POST /session/:id/message` (or SDK `session.prompt` with
+   `noReply: true`) so context lands WITHOUT generating a model reply.
+4. If auth is enabled, supply `OPENCODE_SERVER_USERNAME`/`OPENCODE_SERVER_PASSWORD` basic auth.
+
+Tradeoffs of B: cleanest fit for opencode (it is built to be driven over HTTP); fully out of
+process, so no code runs inside the agent; handles auto-compaction we did not trigger. Costs: we
+must own a server lifecycle and a port, manage the SSE connection (reconnect on drop), and the
+`session.created`/`session.compacted` scoping to the right session must be verified live. It only
+works when a server is reachable - a plain TUI launch may need `--server`/serve coordination.
+
+Plan C - in-process opencode plugin (alternative / belt-and-suspenders):
+1. Ship a small first-party plugin into `~/.config/opencode/plugin/` (or per-project
+   `.opencode/plugin/`).
+2. In its `experimental.chat.system.transform` hook, fetch the Director preamble (the plugin's
+   `client`/`$`/`fetch` can call `GET /sessions/{sid}/fleet-preamble`) and append it to the system
+   prompt - this self-heals on every chat, covering both fresh sessions and post-compaction turns.
+3. Optionally also implement `experimental.session.compacting` to fold the preamble into the
+   compaction prompt so it survives summarization explicitly, and the `event` catch-all to react to
+   `session.created`/`session.compacted`.
+
+Tradeoffs of C: passive and self-healing (no event plumbing, no reconnects); naturally survives
+compaction. Costs: relies on EXPERIMENTAL hooks that can be renamed/removed (pin the version);
+requires installing a TypeScript plugin on the user's machine (Bun/node_modules footprint); runs
+in-process, which is a higher trust surface than B.
+
+Recommended: B as the primary (subscribe to `GET /event`, inject on `session.created` /
+`session.compacted` via `noReply` message), with the file-based AGENTS.md / `instructions` array as
+the always-on passive backstop (family D) so even a server-less plain TUI launch still carries the
+preamble. C is the upgrade if/when we want survival across auto-compaction without owning a server.
+
+Why not family A (the Claude path): opencode has no SessionStart shell hook that reads our command's
+stdout as additionalContext. Attempting to emulate Claude's model here would be inventing a
+mechanism opencode does not expose. Use the bus or a plugin.
+
+Current gaps in our wiring:
+- No bespoke OpenCodeDriver: ClearContext/history-picker/transcript-via-driver all throw; history
+  comes only through OpenCodeHistoryReader, not the driver.
+- No event-bus subscriber implemented yet: we do not start `opencode serve`, do not read `/event`,
+  and do not push the preamble. The plan above is design, not code.
+- No opencode plugin shipped.
+- We do not parse token usage from the SQLite store.
+
+## 11. Caveats and verification needed
+
+- High churn: opencode ships fast and the SST team renames things. Treat every event name, endpoint,
+  and config key as version-pinned; re-check against the installed binary and against `GET /doc`
+  (the live OpenAPI) before depending on it. [INFERRED/UNCERTAIN]
+- Plugin directory name: docs prose has used both `plugin/` and `plugins/` (and `agent/` vs
+  `agents/`, `command/` vs `commands/`). Confirm the exact singular/plural folder on disk before
+  shipping a plugin. [INFERRED/UNCERTAIN - docs/plugins, docs/agents, docs/commands]
+- The `noReply` field name on `session.prompt` (context-inject-without-response) must be confirmed
+  against the installed SDK/OpenAPI - exact casing/spelling is load-bearing for Plan B. [VERIFIED in
+  docs as `noReply`; confirm against installed `/doc`]
+- All `experimental.*` plugin hooks are unstable by name. Pin and re-verify. [VERIFIED experimental]
+- `session.created`/`session.compacted` payload shape (does it carry sessionID and directory so we
+  can scope to the right Director session?) needs a live capture off `GET /event`. [INFERRED/UNCERTAIN]
+- Whether the TUI launched by a bare `opencode` exposes a reachable `/event` server (and on which
+  port) versus needing `opencode serve` separately must be verified live; our OpenCodeAgent launch
+  does not currently start a server. [INFERRED/UNCERTAIN]
+- SQLite path on Windows: code uses `~/.local/share/opencode/opencode.db`; confirm opencode writes
+  there on Windows rather than under `%LOCALAPPDATA%`/`%APPDATA%`. [INFERRED/UNCERTAIN -
+  OpenCodeHistoryReader.cs assumes the Unix-style path under the user profile]
+
+## Sources
+- https://opencode.ai/docs/ (overview, install)
+- https://opencode.ai/docs/cli/ (commands and flags)
+- https://opencode.ai/docs/config/ (opencode.json, precedence, keys)
+- https://opencode.ai/docs/rules/ (AGENTS.md, CLAUDE.md fallback, instructions array, /init)
+- https://opencode.ai/docs/agents/ (primary vs subagents, per-agent prompt/model/mode fields)
+- https://opencode.ai/docs/commands/ (custom slash commands, frontmatter, argument/shell/file syntax)
+- https://opencode.ai/docs/server/ (opencode serve, flags, auth env vars, /doc, /event, /global/event, endpoint list, /tui control surface)
+- https://opencode.ai/docs/plugins/ (plugin locations, signature, hook list including experimental.*, event catch-all, bus event types)
+- https://opencode.ai/docs/sdk/ (@opencode-ai/sdk, createOpencodeClient/createOpencode, session.create/prompt/messages, event.subscribe, noReply)
+- https://github.com/sst/opencode , packages/plugin/src/index.ts (Hooks interface)
+- src/CcDirector.Core/Agents/OpenCodeAgent.cs (our agent)
+- src/CcDirector.Core/AgentPlugins/OpenCodeAgentPlugin.cs (our plugin metadata)
+- src/CcDirector.Core/Drivers/GenericDriver.cs (our driver)
+- src/CcDirector.Core/Drivers/OpenCodeSlashCommands.cs (TUI command catalog)
+- src/CcDirector.Core/OpenCode/OpenCodeHistoryReader.cs (SQLite history reader)
+- src/CcDirector.Core/Sessions/FleetPreamble.cs , src/CcDirector.ControlApi/ControlEndpoints.cs (shared fleet-preamble endpoint)

--- a/.claude/skills/agent-expert/agents/pi.md
+++ b/.claude/skills/agent-expert/agents/pi.md
@@ -1,0 +1,409 @@
+<!--
+Per-agent reference. ASCII only. No Unicode, no emoji, no em-dashes (use " - ").
+Every non-trivial fact is marked [VERIFIED from docs] or [INFERRED/UNCERTAIN] with an inline
+source link; all links collected in Sources.
+-->
+
+# Pi Coding Agent (Pi)
+
+> The "pi" terminal coding harness from earendil-works. Standout feature: the richest
+> extension and event system of any agent CC Director runs - hooks are TypeScript handlers
+> loaded INTO pi, not external shell commands. Our integration status: PiDriver / PiAgent /
+> PiAgentPlugin.
+
+## 1. Identity and install
+
+- Binary name: `pi`. [VERIFIED from docs] (README, [pi README](https://raw.githubusercontent.com/earendil-works/pi/main/packages/coding-agent/README.md))
+- npm package: `@earendil-works/pi-coding-agent`. [VERIFIED from docs] (same README; [sdk.md](https://raw.githubusercontent.com/earendil-works/pi/main/packages/coding-agent/docs/sdk.md))
+- Source repository: github.com/earendil-works/pi, coding agent under `packages/coding-agent`. [VERIFIED from docs]
+- Official documentation: pi.dev/docs and the repo `packages/coding-agent/docs/` markdown files. [INFERRED/UNCERTAIN] (pi.dev/docs referenced by task; docs read here were the raw repo files)
+- Self-description: "Pi is a minimal terminal coding harness" extensible with TypeScript extensions, skills, prompt templates, and themes without forking the core. [VERIFIED from docs] (README)
+- Default tools given to the model: `read`, `write`, `edit`, `bash`. [VERIFIED from docs] (README)
+- Install (global, recommended): `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`. Alternative installer: `curl -fsSL https://pi.dev/install.sh | sh`. [VERIFIED from docs] (README)
+- Config directory: `~/.pi/agent/` holds settings, sessions, extensions, skills, prompts, themes. [VERIFIED from docs] (README)
+- Windows launchable shim: installed by npm global as `pi.cmd` on PATH. Our PiAgent resolves it via `AgentOptions.PiPath`. [INFERRED/UNCERTAIN] (standard npm-on-Windows behavior; PiAgent.cs comment says "pi.cmd from @earendil-works/pi-coding-agent")
+- Version probe: `pi --version`. [VERIFIED from docs] (README; exact version string not stated in docs)
+
+## 2. Command-line interface (the four modes)
+
+Pi has four operational modes. [VERIFIED from docs] ([usage.md](https://raw.githubusercontent.com/earendil-works/pi/main/packages/coding-agent/docs/usage.md))
+
+1. Interactive (default): full terminal UI - startup header (loaded context files, prompt
+   templates, skills, extensions), messages, editor (border color = thinking level), footer
+   (cwd, session name, token/cache usage, cost, context usage, model). [VERIFIED from docs]
+2. Print mode (`-p`, `--print`): "Print response and exit." Also merges piped stdin into the
+   initial prompt. [VERIFIED from docs]
+3. JSON mode (`--mode json`): "Output all events as JSON lines" for programmatic integration.
+   [VERIFIED from docs]
+4. RPC mode (`--mode rpc`): "RPC mode over stdin/stdout" for embedding pi in external
+   applications. Bidirectional - the host sends command objects and receives an event stream
+   (see Section 6). [VERIFIED from docs]
+5. Embeddable SDK: not a CLI mode but a fifth integration path - import the npm package and
+   construct an agent session in-process (see Section 6). [VERIFIED from docs] (sdk.md)
+
+Flag table [VERIFIED from docs] (usage.md):
+
+| Flag | Meaning |
+|------|---------|
+| `-p`, `--print` | Print response and exit (headless single-shot) |
+| `--mode json` | Emit all events as JSON lines |
+| `--mode rpc` | RPC over stdin/stdout |
+| `--system-prompt <text>` | "Replace default prompt; context files and skills are still appended" |
+| `--append-system-prompt <text>` | Append to the default system prompt |
+| `-c`, `--continue` | "Continue the most recent session" |
+| `-r`, `--resume` | "Browse and select a session" |
+| `--no-session` | "Ephemeral mode; do not save" |
+| `--name <name>` | "Set session display name at startup" |
+| `-e`, `--extension <source>` | "Load an extension from path, npm, or git; repeatable" |
+| `--provider <name>` | Provider: `anthropic`, `openai`, `google`, etc. |
+| `--model <pattern>` | Model pattern or ID; supports `provider/id` and `:<thinking>` |
+| `--thinking <level>` | `off`, `minimal`, `low`, `medium`, `high`, `xhigh` |
+| `--no-context-files`, `-nc` | Disable AGENTS.md/CLAUDE.md context discovery |
+| `--approve`, `-a` | Override per-command project trust |
+
+Key distinction from `--system-prompt`: it REPLACES the default prompt, but context files and
+skills are STILL appended afterward. [VERIFIED from docs] (usage.md)
+
+## 3. Configuration
+
+Two-tier settings, project overrides global, nested objects are merged (not replaced).
+[VERIFIED from docs] ([settings.md](https://raw.githubusercontent.com/earendil-works/pi/main/packages/coding-agent/docs/settings.md))
+
+- Global settings: `~/.pi/agent/settings.json` (all projects). [VERIFIED from docs]
+- Project settings: `.pi/settings.json` (current directory). [VERIFIED from docs]
+- Trust decisions: `~/.pi/agent/trust.json`. Pi prompts before trusting folders containing
+  project settings or `.agents/skills`. `defaultProjectTrust` = `"ask"` (default) | `"always"`
+  | `"never"`; `--approve`/`-a` overrides per command. [VERIFIED from docs]
+
+Notable settings keys [VERIFIED from docs] (settings.md):
+- Model/thinking: `defaultProvider`, `defaultModel`, `defaultThinkingLevel`, `hideThinkingBlock`,
+  `thinkingBudgets`.
+- UI: `theme`, `quietStartup`, `defaultProjectTrust`, `collapseChangelog`, `doubleEscapeAction`,
+  `treeFilterMode`, autocomplete/editor padding, telemetry toggles.
+- Network: `httpProxy` (global only).
+- Retry: agent-level and provider-level retry with exponential backoff.
+- Delivery: `steeringMode`, `followUpMode`, `transport`, timeout settings.
+- Resources: `packages`, `extensions`, `skills`, `prompts`, `themes` arrays (glob patterns and
+  exclusions supported) - this is how settings.json adds extra extension/skill/prompt/theme paths.
+- Sessions: custom `sessionDir` location.
+
+## 4. Context injection (how to inject a preamble)
+
+Per item: does it survive `/new` (pi's clear-equivalent)? does it survive `/compact`?
+
+a. Context files AGENTS.md / CLAUDE.md - discovered at startup from: global
+   `~/.pi/agent/AGENTS.md`; every parent directory walking up from cwd; the current directory.
+   Disable with `--no-context-files` / `-nc`. [VERIFIED from docs] (usage.md, README)
+   - Survives `/new`: YES (re-discovered at every session_start, including reason=new).
+     [INFERRED/UNCERTAIN] (context-file discovery runs on session start per usage.md; re-read on
+     /new not explicitly stated but `resources_discover` fires after every session_start)
+   - Survives `/compact`: YES - it is part of the system prompt assembly, not conversation
+     content, so compaction does not remove it. [INFERRED/UNCERTAIN]
+
+b. System-prompt files - `.pi/SYSTEM.md` "Replace the default system prompt" (project);
+   `~/.pi/agent/SYSTEM.md` global override; `APPEND_SYSTEM.md` "Append to the default prompt
+   without replacing it". [VERIFIED from docs] (usage.md)
+   - Survives `/new` and `/compact`: YES (system-prompt layer, reassembled each session/turn).
+     [INFERRED/UNCERTAIN]
+
+c. `--system-prompt` / `--append-system-prompt` flags - set at launch; `--system-prompt`
+   replaces but still appends context files and skills. [VERIFIED from docs] (usage.md)
+   - Survives `/new`: process-level flag, so it persists for the life of the pi process across
+     `/new`. [INFERRED/UNCERTAIN] (flag is bound to the process, /new replaces the session not
+     the process)
+   - Survives `/compact`: YES (system-prompt layer). [INFERRED/UNCERTAIN]
+
+d. Extension `before_agent_start` injection - a loaded extension can append to / replace the
+   system prompt AND inject a persistent message into the session on each prompt (see Section 5).
+   This is the active, programmatic injection path and the one CC Director will use.
+   [VERIFIED from docs] ([extensions.md](https://raw.githubusercontent.com/earendil-works/pi/main/packages/coding-agent/docs/extensions.md))
+   - Survives `/new`: the extension stays loaded across `/new`; it re-fires on the next
+     prompt, so injection self-heals. [VERIFIED from docs] (extension lifecycle: session_start
+     reason=new keeps the extension runtime; before_agent_start fires per prompt)
+   - Survives `/compact`: the injected persistent message may be summarized away by compaction,
+     but the extension re-injects on the next prompt and can also supply a custom compaction
+     summary. [INFERRED/UNCERTAIN]
+
+Contrast with Claude Code: Claude injects context via a SessionStart SHELL-COMMAND hook - a
+settings entry that runs an EXTERNAL program whose stdout (additionalContext) is fed to the
+model. Pi has NO equivalent external-command hook. Pi's hooks are TypeScript extension handlers
+loaded into the pi process; injection happens by an extension returning `{ systemPrompt, message }`
+from `before_agent_start` or calling `pi.sendMessage`. The matcher mapping is nearly 1:1
+(startup->startup, clear->new, resume->resume, compact->session_compact) but the handler must be
+authored as a pi extension, not configured as a command line. [VERIFIED from docs] (extensions.md)
+
+## 5. Lifecycle events and hooks (the centerpiece)
+
+Extensions are TypeScript files auto-discovered from trusted locations and run with full system
+permissions. [VERIFIED from docs] (extensions.md)
+
+Loading locations [VERIFIED from docs] (extensions.md):
+- Global: `~/.pi/agent/extensions/*.ts` and subdirectories with `index.ts`.
+- Project-local: `.pi/extensions/*.ts` (loaded only after project trust confirmed).
+- CLI: `-e ./path.ts` (path, npm, or git; repeatable).
+- Settings: `settings.json` `"extensions"` array (additional paths, globs).
+- Hot reload: `/reload` command reloads keybindings, extensions, skills, prompts, context files.
+  [VERIFIED from docs] (usage.md, extensions.md)
+
+Registration: `pi.on(event, handler)` subscribes; handler receives `(event, ctx)` and may return
+values per event type. Also `pi.registerTool`, `pi.registerCommand`, `pi.registerShortcut`,
+`pi.registerFlag` / `pi.getFlag`. [VERIFIED from docs] (extensions.md)
+
+Startup sequence: `pi starts -> project_trust -> session_start {reason:"startup"} ->
+resources_discover {reason:"startup"}`. [VERIFIED from docs]
+
+Session replacement (`/new` or `/resume`): `session_before_switch (can cancel) -> session_shutdown
+-> session_start {reason:"new"|"resume", previousSessionFile?} -> resources_discover`. [VERIFIED from docs]
+
+Per-prompt flow: `input -> before_agent_start -> agent_start -> [message_* cycle] ->
+[turn_start / context / tool_call / tool_result / turn_end] -> agent_end`. [VERIFIED from docs]
+
+Full event list (handler `(event, ctx)`) [VERIFIED from docs] (extensions.md):
+
+- `project_trust` - before trusting a project dir. Returns `{ trusted: "yes"|"no"|"undecided",
+  remember? }`. Only user/global and CLI `-e` extensions participate; first yes/no wins.
+- `session_start` - `event.reason` is `"startup" | "reload" | "new" | "resume" | "fork"`;
+  `event.previousSessionFile` present for new/resume/fork. Use for init / state reconstruction.
+  THIS IS THE CLEAR-EQUIVALENT SIGNAL: reason "new" == Claude's clear matcher.
+- `session_shutdown` - `event.reason` is `"quit"|"reload"|"new"|"resume"|"fork"`;
+  `event.targetSessionFile` for replacement flows. Cleanup/save.
+- `session_before_switch` - before `/new` or `/resume`. `event.reason` `"new"|"resume"`,
+  `event.targetSessionFile` (resume only). Return `{ cancel: true }` to block.
+- `session_before_fork` - before `/fork` or `/clone`. `event.entryId`, `event.position`
+  ("before" for /fork, "at" for /clone). Return `{ cancel: true }`.
+- `session_before_compact` - before `/compact` (and automatic compaction). `event.reason` is
+  `"manual" | "threshold" | "overflow"`; `event.willRetry`; `event.preparation`
+  (`firstKeptEntryId`, `tokensBefore`). Return `{ cancel: true }` OR provide a custom summary:
+  `{ compaction: { summary, firstKeptEntryId, tokensBefore } }`.
+- `session_compact` - AFTER compaction. `event.compactionEntry`, `event.fromExtension`,
+  `event.reason`, `event.willRetry`. This is the post-compact signal (Claude's compact matcher).
+- `session_before_tree` / `session_tree` - before/after `/tree` navigation; can cancel or supply
+  a custom summary; `session_tree` gives `newLeafId`, `oldLeafId`, `summaryEntry`, `fromExtension`.
+- `resources_discover` - after session_start. `event.cwd`, `event.reason` `"startup"|"reload"`.
+  Returns `{ skillPaths, promptPaths, themePaths }` to contribute resource directories.
+- `before_agent_start` - after the user submits, before the agent loop. `event.prompt`,
+  `event.images`, `event.systemPrompt` (current chained prompt), `event.systemPromptOptions`
+  (`customPrompt`, `selectedTools`, `toolSnippets`, `promptGuidelines`, `appendSystemPrompt`,
+  `cwd`, `contextFiles`, `skills`). Returns `{ message: { customType, content, display },
+  systemPrompt: "..." }`. The `message` is PERSISTENT (stored in the session). Handlers chain;
+  later handlers see prior modifications. THIS IS THE INJECTION HOOK.
+- `agent_start` / `agent_end` - once per prompt; agent_end has `event.messages`.
+- `turn_start` / `turn_end` - per LLM-response + tool-exec cycle; `turnIndex`, `message`,
+  `toolResults`.
+- `message_start` / `message_update` / `message_end` - message lifecycle; message_update carries
+  the streaming `assistantMessageEvent`; message_end can return `{ message }` to replace it.
+- `context` - before each LLM call; `event.messages` is a deep copy, return `{ messages }` to
+  filter/transform non-destructively.
+- `before_provider_request` / `after_provider_response` - raw provider payload / HTTP status +
+  headers; can replace payload.
+- `tool_execution_start` / `tool_execution_update` / `tool_execution_end` - tool exec lifecycle
+  (`toolCallId`, `toolName`, `args`, `partialResult` / `result`, `isError`).
+- `tool_call` - after tool_execution_start, before the tool runs. `event.input` is MUTABLE;
+  return `{ block: true, reason }` to block.
+- `tool_result` - after exec, before final message events; return `{ content, details, isError }`
+  to modify (middleware chain).
+- `model_select` / `thinking_level_select` - model/thinking changes (notification).
+- `user_bash` - user `!`/`!!` commands; can intercept and return custom result.
+- `input` - user input after extension-command check, before skill/template expansion.
+  `event.text`, `event.images`, `event.source` (`"interactive"|"rpc"|"extension"`),
+  `event.streamingBehavior`. Return `{ action: "continue"|"transform"|"handled", text? }`.
+
+ExtensionContext (`ctx`) highlights: `ctx.ui` (select/confirm/input/editor/notify), `ctx.mode`
+(`"tui"|"rpc"|"json"|"print"`), `ctx.hasUI`, `ctx.cwd`, `ctx.sessionManager` (read-only:
+getEntries/getBranch/getLeafId), `ctx.getSystemPrompt()`, `ctx.compact()`, `ctx.getContextUsage()`,
+`ctx.shutdown()`, `ctx.signal`. Command-only contexts add `newSession()`, `fork()`,
+`switchSession()`, `navigateTree()`, `reload()`, `waitForIdle()`. [VERIFIED from docs] (extensions.md)
+
+State/message APIs: `pi.sendMessage(message, { deliverAs: "steer"|"followUp"|"nextTurn",
+triggerTurn })`, `pi.sendUserMessage`, `pi.appendEntry(customType, data)` (persist extension state,
+NOT in LLM context), `pi.setSessionName`/`getSessionName`, `pi.setLabel`. [VERIFIED from docs]
+
+Mapping to Claude Code matchers [VERIFIED from docs, derived from extensions.md]:
+- startup  -> `session_start { reason: "startup" }`
+- clear    -> `session_start { reason: "new" }` (pi has NO /clear; /new is the clear-equivalent)
+- resume   -> `session_start { reason: "resume" }`
+- compact  -> `session_before_compact` (pre) and `session_compact` (post)
+The difference: Claude runs an external command; pi runs an in-process TypeScript handler.
+
+## 6. SDK / programmatic API / RPC mode
+
+RPC mode (`--mode rpc`) - the supervisor-facing protocol. JSONL framing, LF (`\n`) only; strip
+optional trailing `\r`. [VERIFIED from docs] ([rpc.md](https://raw.githubusercontent.com/earendil-works/pi/main/packages/coding-agent/docs/rpc.md))
+
+RPC event stream (agent -> host, JSON lines on stdout) [VERIFIED from docs] (rpc.md):
+`agent_start`, `agent_end` (all messages from the run), `turn_start`, `turn_end`,
+`message_start`, `message_update` (text/thinking/toolcall deltas), `message_end`,
+`tool_execution_start`, `tool_execution_update` (accumulated output), `tool_execution_end`,
+`queue_update`, `compaction_start` (reason manual/threshold/overflow), `compaction_end`,
+`auto_retry_start`, `auto_retry_end`, `extension_error`, `extension_ui_request`.
+
+RPC commands (host -> agent) [VERIFIED from docs] (rpc.md):
+- Session: `{"type":"new_session"}`, `{"type":"new_session","parentSession":"/path.jsonl"}`,
+  `{"type":"switch_session","sessionPath":"/path.jsonl"}`, `{"type":"fork","entryId":"abc"}`,
+  `{"type":"clone"}`.
+- Interaction: `{"type":"prompt","message":"...","images":[...]}`,
+  `{"type":"prompt","message":"...","streamingBehavior":"steer"}`,
+  `{"type":"bash","command":"ls -la"}`.
+- Steering/follow-up: `steer`, `follow_up`, `abort`, `abort_bash`.
+- State/config: `get_state`, `get_messages`, `set_model` (`provider`, `modelId`),
+  `set_thinking_level` (`level`), `set_steering_mode`, `set_follow_up_mode`,
+  `compact` (`customInstructions`), `set_auto_compaction`, `set_auto_retry`.
+- Extension UI replies: `{"type":"extension_ui_response","id":"uuid","value"|"confirmed"|"cancelled"}`.
+
+This means a supervisor in RPC mode can drive clear (`new_session`), compact (`compact`), fork,
+resume (`switch_session`), and prompt entirely over stdin/stdout - no terminal keystrokes. CC
+Director does NOT use RPC mode today (it drives the interactive TUI), but RPC is the cleaner
+long-term path for pi specifically. [VERIFIED from docs for the protocol; INFERRED for our non-use]
+
+Embeddable SDK (in-process, TypeScript) [VERIFIED from docs] (sdk.md):
+```typescript
+import { createAgentSession, SessionManager, AuthStorage, ModelRegistry,
+         getModel } from "@earendil-works/pi-coding-agent";
+const authStorage = AuthStorage.create();
+const modelRegistry = ModelRegistry.create(authStorage);
+const { session } = await createAgentSession({
+  model: getModel("anthropic", "claude-opus-4-5"),
+  sessionManager: SessionManager.inMemory(),
+  authStorage, modelRegistry,
+});
+session.subscribe((event) => { /* message_update, tool_execution_*, agent_*, turn_* ... */ });
+await session.prompt("What files are here?", { streamingBehavior: "steer" });
+```
+Key exports: `createAgentSession`, `AuthStorage`, `ModelRegistry`, `SessionManager`,
+`SettingsManager`, `DefaultResourceLoader`, `defineTool`. API-key resolution order: runtime
+overrides -> stored credentials -> environment variables -> fallback resolver. [VERIFIED from docs]
+
+## 7. Skills / prompt templates / themes / MCP
+
+- Skills, prompt templates, and themes are first-class extensible resources, discovered from
+  `~/.pi/agent/` and project `.pi/`, contributable by extensions via `resources_discover`
+  returning `{ skillPaths, promptPaths, themePaths }`, and configurable in settings
+  (`skills`, `prompts`, `themes` arrays). [VERIFIED from docs] (extensions.md, settings.md, README)
+- Input expansion order: extension commands (`/cmd`) -> `input` event -> skill commands
+  (`/skill:name`) -> prompt templates (`/template`) -> agent. [VERIFIED from docs] (extensions.md)
+- Project skills directory `.agents/skills` triggers the trust prompt. [VERIFIED from docs] (settings.md)
+- Pi Packages: third-party bundles installable via the `packages` setting. [VERIFIED from docs] (README, settings.md)
+- MCP: not described in the docs read here. Pi's tool model centers on built-in tools (read/
+  write/edit/bash) plus extension-registered tools (`pi.registerTool` / `defineTool`). MCP
+  support status is UNVERIFIED. [INFERRED/UNCERTAIN]
+
+## 8. Transcript / history
+
+- Location: `~/.pi/agent/sessions/`, organized by working directory (a cwd slug subdirectory),
+  one `<uuid>.jsonl` per session. [VERIFIED from docs] (usage.md); our PiDriver comment records
+  the concrete shape `~/.pi/agent/sessions/<cwd-slug>/<uuid>.jsonl` [VERIFIED from code]
+  (PiDriver.cs).
+- Format: JSONL, one entry per line, branching/tree-structured (entries have IDs;
+  `/tree`, `/fork`, `/clone` navigate and branch). [VERIFIED from docs] (usage.md)
+- Parseable: yes in principle, but CC Director does NOT parse it in v1 - the exact entry schema
+  is not yet reverse-engineered, so PiDriver does not declare TranscriptRead. [VERIFIED from code]
+  (PiDriver.cs: ReadWidgets/ReadUsage/ListTranscripts throw NotSupportedException).
+- Token usage: available live in the interactive footer and via RPC `get_state` /
+  `ctx.getContextUsage()`; not extracted from the jsonl by us. [VERIFIED from docs/code]
+
+## 9. Session semantics
+
+Pi has NO `/clear`. The clear-equivalent is `/new`. [VERIFIED from docs] (usage.md) [VERIFIED from
+code] (PiDriver.cs ClearContextAsync submits "/new").
+
+Command semantics [VERIFIED from docs] (usage.md):
+- `/new` - start a fresh session in place (drops context; new session file). Clear-equivalent.
+- `/resume` - pick and switch to a previous session.
+- `/compact [prompt]` - compact context now, optional custom instructions. Keeps the session.
+- `/fork` - new session starting from a chosen earlier user message.
+- `/clone` - duplicate the current active branch into a new session.
+- `/tree` - jump to any point in the session and continue (branching navigation).
+- `/reload` - reload keybindings, extensions, skills, prompts, context files.
+
+Keyboard map (live-verified in Director QA) - critical, differs from Claude [VERIFIED from code]
+(PiDriver.cs):
+- Escape = cancel/abort current turn.
+- Ctrl+C = CLEAR THE EDITOR (not an interrupt).
+- Ctrl+C twice = QUIT pi.
+- Esc twice = open `/tree` session navigator (not a history rewind).
+
+Session-id behavior: pi generates and owns its own session UUID; there is no Director-preassigned
+session id and no Director-initiated resume in v1 (resume only via pi's own `/resume` in the TUI).
+[VERIFIED from code] (PiAgent.cs: SupportsPreassignedSessionId=false; resume args ignored).
+
+## 10. How CC Director integrates it
+
+Classes:
+- Driver: `PiDriver` (`src/CcDirector.Core/Drivers/PiDriver.cs`). Declared capabilities:
+  `Cancel | ClearContext`. Cancel = send Esc byte (0x1B). ClearContext = submit `/new`.
+  Interrupt is NOT declared (Ctrl+C clears the editor / quits - unsafe). History is NOT declared
+  (double-Esc opens /tree, not a rewind). TranscriptRead is NOT declared (jsonl unparsed in v1).
+  No model flag (pi selects model internally in v1). [VERIFIED from code]
+- Agent: `PiAgent` (`src/CcDirector.Core/Agents/PiAgent.cs`). Executable = `AgentOptions.PiPath`
+  (pi.cmd). `SupportsPreassignedSessionId=false`, `SupportsStudioMode=false`. Passes user args
+  through verbatim; ignores resume/studio. [VERIFIED from code]
+- Plugin: `PiAgentPlugin` (`src/CcDirector.Core/AgentPlugins/PiAgentPlugin.cs`). Built-in plugin;
+  verified controls are cancel and clear-context; no preassigned session id, no Studio wrapper.
+  [VERIFIED from code]
+- Slash commands: `PiSlashCommands` (`src/CcDirector.Core/Drivers/PiSlashCommands.cs`). [VERIFIED from code]
+
+Mechanism family: C (in-process extension we author and load), the closest analog to Claude's
+SessionStart matchers and the right choice because pi has no external-command hook.
+
+Concrete fleet-preamble plan (Family C):
+1. Author a small pi extension (e.g. `~/.pi/agent/extensions/cc-director-fleet/index.ts`),
+   placed in the GLOBAL extensions dir so it loads for every pi process the Director launches,
+   no per-project trust needed. [INFERRED/UNCERTAIN] (global extensions load without project
+   trust per extensions.md)
+2. The extension handles `session_start`. On reason `"startup"` and reason `"new"` (the
+   clear-equivalent), it marks "preamble needed". This single handler covers both first launch
+   and clear, matching Claude's startup + clear matchers. [VERIFIED from docs for the events]
+3. The extension injects on `before_agent_start`: it fetches
+   `GET /sessions/{sid}/fleet-preamble` from `CC_DIRECTOR_API` (base URL + session id passed in
+   as environment variables at launch), then returns
+   `{ message: { customType: "cc-director-fleet-preamble", content: <preamble>, display: true },
+   systemPrompt: event.systemPrompt + "\n\n" + <preamble> }`. Injecting on before_agent_start
+   (not session_start) guarantees the preamble lands in-context for the very first prompt and
+   re-lands after `/new` because before_agent_start fires per prompt and the extension stays
+   loaded. [VERIFIED from docs for the hook contract]
+4. The extension handles `session_before_compact` and/or `session_compact` to detect compaction.
+   It can either let the next before_agent_start re-inject (self-healing) or supply a custom
+   compaction summary that preserves the preamble via `{ compaction: { summary, ... } }`.
+   [VERIFIED from docs]
+5. Identifying the session id: the Director must give the extension the session id and API base.
+   Options: pass as environment variables to the pi process, or have the extension read them
+   from a Director-written file. Exact wiring is TBD. [INFERRED/UNCERTAIN]
+
+History provider kind: none (TranscriptRead undeclared). cc-ask cross-agent reply does not work
+to/from pi until the jsonl reader and TranscriptRead are added. [VERIFIED from code]
+
+Current gaps in our integration: no preassigned session id, no Director-initiated resume, no
+Studio/stream-json mode, no transcript parsing, no model selection, the fleet-preamble extension
+is NOT yet built (Family C is planned, not wired), and pi's composer echo layout is unverified so
+SubmitAsync is a blind send (no echo gate). [VERIFIED from code]
+
+## 11. Caveats and verification needed
+
+- The docs read are the raw repo markdown at `main`; field names and event shapes can churn.
+  Verify the live event payloads against the installed pi version before depending on them.
+  [INFERRED/UNCERTAIN]
+- `session_start` re-firing on `/new` with reason `"new"` is documented; confirm live that the
+  extension runtime survives `/new` (it should, since shutdown reason "new" precedes a
+  session_start, not a process exit). [INFERRED/UNCERTAIN]
+- Whether context files / system-prompt files are re-read on `/new` vs only at process start is
+  not explicitly stated; verify by changing AGENTS.md mid-process and running `/new`. [INFERRED/UNCERTAIN]
+- Whether a `before_agent_start`-injected persistent message survives `/compact` (vs being
+  summarized away) needs a live check; if it can be lost, rely on per-prompt re-injection or a
+  custom compaction summary. [INFERRED/UNCERTAIN]
+- MCP support is undocumented here - verify separately if needed. [INFERRED/UNCERTAIN]
+- Exact installed version and the global extensions dir auto-load behavior without project trust
+  should be confirmed on the target machine. [INFERRED/UNCERTAIN]
+- The transcript jsonl entry schema is unparsed; reverse-engineer it before declaring
+  TranscriptRead. [VERIFIED from code that it is unparsed]
+
+## Sources
+
+- pi README (raw): https://raw.githubusercontent.com/earendil-works/pi/main/packages/coding-agent/README.md
+- usage.md (raw): https://raw.githubusercontent.com/earendil-works/pi/main/packages/coding-agent/docs/usage.md
+- extensions.md (raw): https://raw.githubusercontent.com/earendil-works/pi/main/packages/coding-agent/docs/extensions.md
+- rpc.md (raw): https://raw.githubusercontent.com/earendil-works/pi/main/packages/coding-agent/docs/rpc.md
+- sdk.md (raw): https://raw.githubusercontent.com/earendil-works/pi/main/packages/coding-agent/docs/sdk.md
+- settings.md (raw): https://raw.githubusercontent.com/earendil-works/pi/main/packages/coding-agent/docs/settings.md
+- npm: https://www.npmjs.com/package/@earendil-works/pi-coding-agent
+- pi.dev docs: https://pi.dev/docs
+- CC Director code: src/CcDirector.Core/Drivers/PiDriver.cs, src/CcDirector.Core/Agents/PiAgent.cs, src/CcDirector.Core/AgentPlugins/PiAgentPlugin.cs, src/CcDirector.Core/Drivers/PiSlashCommands.cs

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -215,6 +215,29 @@ internal static class ControlEndpoints
             return Results.Json(MapWithIdentity(session, turnSummaryCache));
         });
 
+        // The launch-time "fleet awareness" preamble for a session: its own identity plus the
+        // cc-* commands to reach the rest of the fleet. The Claude SessionStart hook fetches this
+        // and injects it as additionalContext so the agent knows the fleet instantly, with no
+        // skill lookup. Plain text (not JSON) so a hook can drop it straight into a context field.
+        app.MapGet("/sessions/{sid}/fleet-preamble", (string sid) =>
+        {
+            if (!Guid.TryParse(sid, out var guid))
+                return Results.BadRequest(new { error = "invalid session id format" });
+
+            var session = sessionManager.GetSession(guid);
+            if (session is null)
+                return Results.NotFound(new { error = "session not found" });
+
+            var name = string.IsNullOrWhiteSpace(session.CustomName)
+                ? Path.GetFileName(session.RepoPath.TrimEnd('\\', '/'))
+                : session.CustomName;
+
+            // A session only ever calls its OWN Director, so this Director's machine name is the
+            // session's machine.
+            var text = FleetPreamble.Build(session.Id.ToString(), name, Environment.MachineName, session.RepoPath);
+            return Results.Text(text, "text/plain");
+        });
+
         // ===== REST: Fleet messaging (issue #705) =====
         // A session can only reach its OWN Director (CC_DIRECTOR_API); it never holds the Gateway
         // URL or the fleet token. These endpoints let a session list and message other sessions

--- a/src/CcDirector.Core.Tests/Claude/ClaudeHookInstallerTests.cs
+++ b/src/CcDirector.Core.Tests/Claude/ClaudeHookInstallerTests.cs
@@ -26,6 +26,12 @@ public class ClaudeHookInstallerTests
             Assert.Contains("CC_SESSION_ID", script);
             Assert.Contains("CC_DIRECTOR_API", script);
 
+            // It also fetches the fleet preamble and surfaces it into the session via the
+            // SessionStart additionalContext field, so the agent knows the fleet instantly.
+            Assert.Contains("fleet-preamble", script);
+            Assert.Contains("additionalContext", script);
+            Assert.Contains("hookSpecificOutput", script);
+
             // The settings register a SessionStart hook for each boundary source, in order.
             using var doc = JsonDocument.Parse(File.ReadAllText(settingsPath!));
             var sessionStart = doc.RootElement.GetProperty("hooks").GetProperty("SessionStart");

--- a/src/CcDirector.Core.Tests/Codex/CodexHookInstallerTests.cs
+++ b/src/CcDirector.Core.Tests/Codex/CodexHookInstallerTests.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+using CcDirector.Core.Codex;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Codex;
+
+public class CodexHookInstallerTests
+{
+    private static (string ScriptDir, string HooksPath) TempPaths()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "cc-codex-hook-test-" + Guid.NewGuid().ToString("N"));
+        return (Path.Combine(root, "scripts"), Path.Combine(root, ".codex", "hooks.json"));
+    }
+
+    [Fact]
+    public void EnsureInstalled_WritesScript_AndAddsSessionStartHook()
+    {
+        var (scriptDir, hooksPath) = TempPaths();
+        try
+        {
+            var ok = CodexHookInstaller.EnsureInstalled(scriptDir, hooksPath);
+
+            Assert.True(ok);
+            var scriptPath = Path.Combine(scriptDir, "report-preamble.ps1");
+            Assert.True(File.Exists(scriptPath));
+            var script = File.ReadAllText(scriptPath);
+            Assert.Contains("fleet-preamble", script);
+            Assert.Contains("additionalContext", script);
+            Assert.Contains("CC_SESSION_ID", script);
+
+            using var doc = JsonDocument.Parse(File.ReadAllText(hooksPath));
+            var sessionStart = doc.RootElement.GetProperty("hooks").GetProperty("SessionStart");
+            var entry = Assert.Single(sessionStart.EnumerateArray());
+            Assert.Equal("startup|resume|clear|compact", entry.GetProperty("matcher").GetString());
+            var command = entry.GetProperty("hooks")[0].GetProperty("command").GetString();
+            Assert.Contains("report-preamble.ps1", command);
+        }
+        finally { TryDeleteRoot(scriptDir); }
+    }
+
+    [Fact]
+    public void EnsureInstalled_IsIdempotent_NoDuplicateEntry()
+    {
+        var (scriptDir, hooksPath) = TempPaths();
+        try
+        {
+            CodexHookInstaller.EnsureInstalled(scriptDir, hooksPath);
+            CodexHookInstaller.EnsureInstalled(scriptDir, hooksPath);
+
+            using var doc = JsonDocument.Parse(File.ReadAllText(hooksPath));
+            var sessionStart = doc.RootElement.GetProperty("hooks").GetProperty("SessionStart");
+            Assert.Single(sessionStart.EnumerateArray());
+        }
+        finally { TryDeleteRoot(scriptDir); }
+    }
+
+    [Fact]
+    public void EnsureInstalled_PreservesExistingUserHooks()
+    {
+        var (scriptDir, hooksPath) = TempPaths();
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(hooksPath)!);
+            // A user who already has a PreToolUse hook AND their own SessionStart hook.
+            File.WriteAllText(hooksPath, """
+            {
+              "hooks": {
+                "PreToolUse": [ { "matcher": "Bash", "hooks": [ { "type": "command", "command": "my-policy.py" } ] } ],
+                "SessionStart": [ { "matcher": "startup", "hooks": [ { "type": "command", "command": "my-greeting.py" } ] } ]
+              }
+            }
+            """);
+
+            var ok = CodexHookInstaller.EnsureInstalled(scriptDir, hooksPath);
+
+            Assert.True(ok);
+            using var doc = JsonDocument.Parse(File.ReadAllText(hooksPath));
+            var hooks = doc.RootElement.GetProperty("hooks");
+            // The user's PreToolUse hook survives untouched.
+            Assert.Equal("my-policy.py",
+                hooks.GetProperty("PreToolUse")[0].GetProperty("hooks")[0].GetProperty("command").GetString());
+            // SessionStart now has BOTH the user's entry and ours.
+            var sessionStart = hooks.GetProperty("SessionStart").EnumerateArray().ToList();
+            Assert.Equal(2, sessionStart.Count);
+            var commands = sessionStart
+                .Select(e => e.GetProperty("hooks")[0].GetProperty("command").GetString() ?? "")
+                .ToList();
+            Assert.Contains(commands, c => c.Contains("my-greeting.py"));
+            Assert.Contains(commands, c => c.Contains("report-preamble.ps1"));
+        }
+        finally { TryDeleteRoot(scriptDir); }
+    }
+
+    [Fact]
+    public void EnsureInstalled_MalformedHooksJson_ReturnsFalse_AndDoesNotClobber()
+    {
+        var (scriptDir, hooksPath) = TempPaths();
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(hooksPath)!);
+            const string garbage = "this is not json {{{";
+            File.WriteAllText(hooksPath, garbage);
+
+            var ok = CodexHookInstaller.EnsureInstalled(scriptDir, hooksPath);
+
+            Assert.False(ok);
+            // The user's file is left exactly as it was - never overwritten.
+            Assert.Equal(garbage, File.ReadAllText(hooksPath));
+        }
+        finally { TryDeleteRoot(scriptDir); }
+    }
+
+    private static void TryDeleteRoot(string scriptDir)
+    {
+        try
+        {
+            var root = Directory.GetParent(scriptDir)?.FullName;
+            if (root is not null && Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+        catch { /* best effort */ }
+    }
+}

--- a/src/CcDirector.Core.Tests/Drivers/CodexDriverTests.cs
+++ b/src/CcDirector.Core.Tests/Drivers/CodexDriverTests.cs
@@ -1,5 +1,7 @@
+using System.Text;
 using CcDirector.Core.Agents;
 using CcDirector.Core.Drivers;
+using CcDirector.Core.Memory;
 using Xunit;
 
 namespace CcDirector.Core.Tests.Drivers;
@@ -44,6 +46,33 @@ public sealed class CodexDriverTests
 
         var bytes = Assert.Single(backend.WrittenBytes);
         Assert.Equal([0x03], bytes);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_EchoVerified_TypesTextThenPressesEnterSeparately()
+    {
+        // A buffering backend that echoes typed bytes back, like the repainting Codex composer.
+        var backend = new RecordingSessionBackend { Buffer = new CircularTerminalBuffer() };
+
+        await new CodexDriver().SubmitAsync(backend, "hello codex");
+
+        // The fix: type the text, wait for the echo, THEN a SEPARATE Enter (0x0D). A blind
+        // text+Enter (the old behavior) is dropped by the repainting composer.
+        Assert.Equal(2, backend.WrittenBytes.Count);
+        Assert.Equal(Encoding.UTF8.GetBytes("hello codex"), backend.WrittenBytes[0]);
+        Assert.Equal(new byte[] { 0x0D }, backend.WrittenBytes[1]);
+        Assert.Empty(backend.SentTexts); // did not take the blind SendTextAsync path
+    }
+
+    [Fact]
+    public async Task SubmitAsync_NoBufferBackend_FallsBackToBlindSendText()
+    {
+        // No buffer (non-PTY transport): nothing to echo-verify against, so use SendTextAsync.
+        var backend = new RecordingSessionBackend();
+
+        await new CodexDriver().SubmitAsync(backend, "hello");
+
+        Assert.Equal("hello", Assert.Single(backend.SentTexts));
     }
 
     [Fact]

--- a/src/CcDirector.Core.Tests/Drivers/RecordingSessionBackend.cs
+++ b/src/CcDirector.Core.Tests/Drivers/RecordingSessionBackend.cs
@@ -30,6 +30,9 @@ internal sealed class RecordingSessionBackend : ISessionBackend
     public void Write(byte[] data)
     {
         WrittenBytes.Add(data.ToArray());
+        // Echo typed bytes into the terminal buffer when one is attached, like a real TUI
+        // composer - lets echo-verified driver submits (CodexDriver, ClaudeDriver) be tested.
+        Buffer?.Write(data);
     }
 
     public Task SendTextAsync(string text)

--- a/src/CcDirector.Core.Tests/Sessions/FleetPreambleTests.cs
+++ b/src/CcDirector.Core.Tests/Sessions/FleetPreambleTests.cs
@@ -1,0 +1,57 @@
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Sessions;
+
+public class FleetPreambleTests
+{
+    [Fact]
+    public void Build_NamedSession_IncludesIdentityAndFleetCommands()
+    {
+        var text = FleetPreamble.Build(
+            "a3dfb85e-49dd-442a-9e36-40fc44838783",
+            "devthrottle",
+            "SOREN_NORTH",
+            @"D:\ReposFred\devthrottle");
+
+        // Identity: short id, name, machine, repo, and the full id are all present.
+        Assert.Contains("a3dfb85e", text);
+        Assert.Contains("devthrottle", text);
+        Assert.Contains("SOREN_NORTH", text);
+        Assert.Contains(@"D:\ReposFred\devthrottle", text);
+        Assert.Contains("a3dfb85e-49dd-442a-9e36-40fc44838783", text);
+
+        // The five fleet commands are spelled out so the agent needs no skill lookup.
+        Assert.Contains("cc-sessions", text);
+        Assert.Contains("cc-whoami", text);
+        Assert.Contains("cc-send", text);
+        Assert.Contains("cc-ask", text);
+        Assert.Contains("cc-spawn", text);
+    }
+
+    [Fact]
+    public void Build_UnnamedSession_RendersUnnamedPlaceholder()
+    {
+        var text = FleetPreamble.Build(
+            "603b2066-d587-40f2-a37c-a308cebb8038",
+            name: null,
+            "SOREN_NORTH",
+            @"D:\ReposFred\devthrottle");
+
+        Assert.Contains("(unnamed)", text);
+        Assert.Contains("603b2066", text);
+    }
+
+    [Fact]
+    public void Build_IsAsciiOnly()
+    {
+        var text = FleetPreamble.Build(
+            "603b2066-d587-40f2-a37c-a308cebb8038",
+            "frontend",
+            "SOREN_NORTH",
+            @"D:\ReposFred\devthrottle");
+
+        // No Unicode: every character must be plain ASCII so it renders on every terminal.
+        Assert.All(text, ch => Assert.True(ch < 128, $"non-ASCII character U+{(int)ch:X4} in preamble"));
+    }
+}

--- a/src/CcDirector.Core/Claude/ClaudeHookInstaller.cs
+++ b/src/CcDirector.Core/Claude/ClaudeHookInstaller.cs
@@ -30,10 +30,10 @@ public static class ClaudeHookInstaller
         "$ErrorActionPreference = 'SilentlyContinue'\r\n" +
         "try {\r\n" +
         "    $raw = [Console]::In.ReadToEnd()\r\n" +
+        "    $api = $env:CC_DIRECTOR_API\r\n" +
+        "    $sid = $env:CC_SESSION_ID\r\n" +
         "    if ($raw) {\r\n" +
         "        $evt = $raw | ConvertFrom-Json\r\n" +
-        "        $api = $env:CC_DIRECTOR_API\r\n" +
-        "        $sid = $env:CC_SESSION_ID\r\n" +
         "        if ($api -and $sid -and $evt.session_id) {\r\n" +
         "            $body = @{\r\n" +
         "                claudeSessionId = $evt.session_id\r\n" +
@@ -42,6 +42,18 @@ public static class ClaudeHookInstaller
         "                source          = $evt.source\r\n" +
         "            } | ConvertTo-Json -Compress\r\n" +
         "            Invoke-RestMethod -Uri \"$api/sessions/$sid/claude-hook\" -Method Post -Body $body -ContentType 'application/json' -TimeoutSec 3 | Out-Null\r\n" +
+        "        }\r\n" +
+        "    }\r\n" +
+        // Surface the launch-time fleet preamble into the session's context. SessionStart's
+        // additionalContext is injected by Claude at startup/resume/clear/compact - exactly the
+        // moments the agent's memory of the fleet is otherwise empty - so it learns its identity
+        // and the cc-* commands instantly, with no skill lookup and zero turn cost. The text is
+        // owned by the Director (GET /fleet-preamble); the script just relays it.
+        "    if ($api -and $sid) {\r\n" +
+        "        $preamble = Invoke-RestMethod -Uri \"$api/sessions/$sid/fleet-preamble\" -TimeoutSec 3\r\n" +
+        "        if ($preamble) {\r\n" +
+        "            $out = @{ hookSpecificOutput = @{ hookEventName = 'SessionStart'; additionalContext = [string]$preamble } } | ConvertTo-Json -Compress\r\n" +
+        "            [Console]::Out.Write($out)\r\n" +
         "        }\r\n" +
         "    }\r\n" +
         "} catch { }\r\n" +

--- a/src/CcDirector.Core/Codex/CodexHookInstaller.cs
+++ b/src/CcDirector.Core/Codex/CodexHookInstaller.cs
@@ -1,0 +1,161 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Codex;
+
+/// <summary>
+/// Installs the Codex SessionStart hook that surfaces the fleet preamble into a Codex session's
+/// context, the Codex analogue of <see cref="Claude.ClaudeHookInstaller"/>.
+///
+/// Codex fires a <c>SessionStart</c> hook with a <c>source</c> matcher (startup/resume/clear/compact)
+/// whose command may print <c>hookSpecificOutput.additionalContext</c> - the same shape Claude uses.
+/// Unlike Claude (which takes a private settings file via <c>--settings</c>), Codex reads hooks only
+/// from fixed locations, so this MERGES our SessionStart entry into the user-layer
+/// <c>~/.codex/hooks.json</c> (honoring <c>CODEX_HOME</c>) without disturbing the user's own hooks.
+/// The hook script is static and shared: it reads the per-session <c>CC_SESSION_ID</c> /
+/// <c>CC_DIRECTOR_API</c> the Director injects, so it no-ops in the user's own (non-Director) Codex
+/// sessions. The Director appends <c>--dangerously-bypass-hook-trust</c> at launch so the hook runs
+/// without a per-user trust prompt (verified live on codex 0.141.0).
+/// </summary>
+public static class CodexHookInstaller
+{
+    // PowerShell: read (and discard) the hook event JSON on stdin, fetch the preamble the Director
+    // owns, and print it as additionalContext. Must never block or fail the session - swallows all
+    // errors and exits 0. Codex re-fires SessionStart on /clear and /compact, so the preamble is
+    // re-injected automatically with no extra wiring.
+    private const string ScriptContent =
+        "$ErrorActionPreference = 'SilentlyContinue'\r\n" +
+        "try {\r\n" +
+        "    $null = [Console]::In.ReadToEnd()\r\n" +
+        "    $api = $env:CC_DIRECTOR_API\r\n" +
+        "    $sid = $env:CC_SESSION_ID\r\n" +
+        "    if ($api -and $sid) {\r\n" +
+        "        $preamble = Invoke-RestMethod -Uri \"$api/sessions/$sid/fleet-preamble\" -TimeoutSec 5\r\n" +
+        "        if ($preamble) {\r\n" +
+        "            $out = @{ hookSpecificOutput = @{ hookEventName = 'SessionStart'; additionalContext = [string]$preamble } } | ConvertTo-Json -Compress\r\n" +
+        "            [Console]::Out.Write($out)\r\n" +
+        "        }\r\n" +
+        "    }\r\n" +
+        "} catch { }\r\n" +
+        "exit 0\r\n";
+
+    /// <summary>The SessionStart sources Codex can switch context on - the moments we want the
+    /// preamble (re-)injected. Same set Claude uses.</summary>
+    private const string Matcher = "startup|resume|clear|compact";
+
+    /// <summary>The launch flag the Director appends so the hook runs without a per-user trust
+    /// prompt. Exposed so SessionManager and tests share one source of truth.</summary>
+    public const string BypassTrustFlag = "--dangerously-bypass-hook-trust";
+
+    /// <summary>
+    /// Ensure the hook script exists and our SessionStart entry is present in the user's Codex
+    /// hooks.json. Returns true on success (the Director should then append
+    /// <see cref="BypassTrustFlag"/> to the Codex command); false if anything failed, in which case
+    /// the session still launches, just without the preamble hook.
+    /// </summary>
+    public static bool EnsureInstalled() => EnsureInstalled(DefaultScriptDirectory(), DefaultCodexHooksPath());
+
+    /// <summary>Testable overload that writes under explicit paths.</summary>
+    public static bool EnsureInstalled(string scriptDirectory, string hooksJsonPath)
+    {
+        try
+        {
+            Directory.CreateDirectory(scriptDirectory);
+            var scriptPath = Path.Combine(scriptDirectory, "report-preamble.ps1");
+            File.WriteAllText(scriptPath, ScriptContent);
+
+            var command = $"powershell -NoProfile -ExecutionPolicy Bypass -File \"{scriptPath}\"";
+            MergeSessionStartHook(hooksJsonPath, command);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[CodexHookInstaller] EnsureInstalled failed: {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Add our SessionStart command hook to <paramref name="hooksJsonPath"/>, preserving any hooks
+    /// the user already has. Idempotent: a re-run with the same script command is a no-op. Writes
+    /// atomically (temp file then replace) so a crash mid-write cannot corrupt the user's hooks.
+    /// </summary>
+    private static void MergeSessionStartHook(string hooksJsonPath, string command)
+    {
+        var root = LoadRoot(hooksJsonPath);
+
+        if (root["hooks"] is not JsonObject hooks)
+        {
+            hooks = new JsonObject();
+            root["hooks"] = hooks;
+        }
+
+        if (hooks["SessionStart"] is not JsonArray sessionStart)
+        {
+            sessionStart = new JsonArray();
+            hooks["SessionStart"] = sessionStart;
+        }
+
+        // Idempotent: if any existing entry already runs our command, leave the file untouched.
+        foreach (var entry in sessionStart)
+        {
+            if (entry is JsonObject obj && obj["hooks"] is JsonArray inner)
+            {
+                foreach (var h in inner)
+                {
+                    if (h is JsonObject ho && ho["command"]?.GetValue<string>() == command)
+                        return;
+                }
+            }
+        }
+
+        sessionStart.Add(new JsonObject
+        {
+            ["matcher"] = Matcher,
+            ["hooks"] = new JsonArray(new JsonObject
+            {
+                ["type"] = "command",
+                ["command"] = command,
+                ["timeout"] = 10,
+            }),
+        });
+
+        var json = root.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+        var dir = Path.GetDirectoryName(hooksJsonPath);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+        var tmp = hooksJsonPath + ".tmp";
+        File.WriteAllText(tmp, json);
+        File.Move(tmp, hooksJsonPath, overwrite: true);
+    }
+
+    private static JsonObject LoadRoot(string hooksJsonPath)
+    {
+        if (!File.Exists(hooksJsonPath))
+            return new JsonObject();
+
+        var existing = File.ReadAllText(hooksJsonPath);
+        if (string.IsNullOrWhiteSpace(existing))
+            return new JsonObject();
+
+        // A malformed user hooks.json must not be clobbered: surface the error so EnsureInstalled
+        // returns false and the session launches without the hook, rather than overwriting it.
+        return JsonNode.Parse(existing) as JsonObject
+            ?? throw new InvalidOperationException($"hooks.json is not a JSON object: {hooksJsonPath}");
+    }
+
+    private static string DefaultScriptDirectory()
+        => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "cc-director", "codex-hooks");
+
+    private static string DefaultCodexHooksPath()
+    {
+        var codexHome = Environment.GetEnvironmentVariable("CODEX_HOME");
+        if (string.IsNullOrWhiteSpace(codexHome))
+            codexHome = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".codex");
+        return Path.Combine(codexHome, "hooks.json");
+    }
+}

--- a/src/CcDirector.Core/Drivers/CodexDriver.cs
+++ b/src/CcDirector.Core/Drivers/CodexDriver.cs
@@ -1,5 +1,7 @@
+using System.Text;
 using CcDirector.Core.Agents;
 using CcDirector.Core.Backends;
+using CcDirector.Core.Input;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -13,7 +15,14 @@ namespace CcDirector.Core.Drivers;
 public sealed class CodexDriver : IAgentDriver
 {
     private static readonly byte[] EscapeByte = [0x1B];
+    private static readonly byte[] EnterByte = [0x0D];
     private static readonly byte[] CtrlC = [0x03];
+
+    // Echo-verified submit timing (see SubmitAsync). The composer repaints a cycling
+    // placeholder, so we wait for the typed text to appear before pressing Enter.
+    private static readonly TimeSpan EchoTimeout = TimeSpan.FromSeconds(4);
+    private static readonly TimeSpan EchoPollInterval = TimeSpan.FromMilliseconds(50);
+    private static readonly TimeSpan EnterSettleDelay = TimeSpan.FromMilliseconds(40);
 
     public AgentKind Kind => AgentKind.Codex;
 
@@ -56,10 +65,76 @@ public sealed class CodexDriver : IAgentDriver
         return new AgentLaunchSpec(args, PreassignedSessionId: null);
     }
 
-    public Task SubmitAsync(ISessionBackend backend, string text)
+    /// <summary>
+    /// ECHO-VERIFIED submit. Codex's TUI repaints a cycling placeholder in its composer, so the
+    /// backend's blind submit (type text, wait 50 ms, send one Enter) drops the Enter when driven
+    /// programmatically: the Enter lands mid-repaint and is swallowed, leaving the prompt parked
+    /// in the composer unsubmitted (confirmed live on codex 0.141.0 via the REST prompt path).
+    /// The desktop UI is unaffected because there the Enter is a separate, later human keystroke.
+    /// Mirror the Claude fix: type the text WITHOUT Enter, wait until the composer echoes it back
+    /// in the terminal byte stream, then press Enter. One Esc-and-retype recovery; a second miss
+    /// throws rather than silently parking the prompt.
+    ///
+    /// Large / multi-line prompts delegate to the backend's @-temp-file submit path unchanged.
+    /// </summary>
+    public async Task SubmitAsync(ISessionBackend backend, string text)
     {
         ArgumentNullException.ThrowIfNull(backend);
-        return backend.SendTextAsync(text);
+
+        if (LargeInputHandler.IsLargeInput(text.TrimEnd('\r', '\n')))
+        {
+            await backend.SendTextAsync(text);
+            return;
+        }
+
+        var buffer = backend.Buffer;
+        if (buffer is null)
+        {
+            // No buffering backend (non-PTY transport): nothing to echo-verify against.
+            await backend.SendTextAsync(text);
+            return;
+        }
+
+        // Letters/digits/slash alphabet, ANSI stripped - survives the composer's wrapping/styling.
+        var needle = ClaudeDriver.NormalizeForEcho(text);
+
+        for (var attempt = 1; attempt <= 2; attempt++)
+        {
+            var cursor = buffer.TotalBytesWritten;
+            backend.Write(Encoding.UTF8.GetBytes(text));
+
+            if (needle.Length == 0 || await WaitForComposerEchoAsync(buffer, cursor, needle))
+            {
+                await Task.Delay(EnterSettleDelay);   // let the repaint settle before Enter
+                backend.Write(EnterByte);
+                return;
+            }
+
+            FileLog.Write($"[CodexDriver] SubmitAsync: composer echo not seen on attempt {attempt} " +
+                          $"(len={text.Length}) - clearing the composer and retyping");
+            backend.Write(EscapeByte);
+            await Task.Delay(TimeSpan.FromMilliseconds(300));
+        }
+
+        throw new InvalidOperationException(
+            "[CodexDriver] SubmitAsync: the Codex composer never echoed the typed text after 2 attempts - " +
+            "the TUI is not accepting input (a modal, a picker, or a composer still initializing).");
+    }
+
+    /// <summary>Poll the terminal byte stream until the typed text echoes back in the composer.</summary>
+    private static async Task<bool> WaitForComposerEchoAsync(
+        Memory.CircularTerminalBuffer buffer, long cursor, string needle)
+    {
+        var deadline = DateTime.UtcNow + EchoTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            var (bytes, _) = buffer.GetWrittenSince(cursor);
+            var hay = ClaudeDriver.NormalizeForEcho(ClaudeDriver.StripAnsi(Encoding.UTF8.GetString(bytes)));
+            if (hay.Contains(needle, StringComparison.Ordinal))
+                return true;
+            await Task.Delay(EchoPollInterval);
+        }
+        return false;
     }
 
     public Task CancelAsync(ISessionBackend backend)

--- a/src/CcDirector.Core/Sessions/FleetPreamble.cs
+++ b/src/CcDirector.Core/Sessions/FleetPreamble.cs
@@ -1,0 +1,43 @@
+namespace CcDirector.Core.Sessions;
+
+/// <summary>
+/// Builds the one-screen "fleet awareness" preamble that a session receives at launch so the
+/// agent knows its own identity and how to reach the rest of the fleet WITHOUT first having to
+/// discover and read a skill. This removes the discovery delay: every session already carries
+/// CC_SESSION_ID and CC_DIRECTOR_API in its environment, but an agent never reads environment
+/// variables unless something surfaces them - this is that something.
+///
+/// Surfaced into Claude sessions through the SessionStart hook's additionalContext (zero turn
+/// cost; see <see cref="Claude.ClaudeHookInstaller"/>) and reusable by other agent integrations
+/// through the GET /sessions/{sid}/fleet-preamble Control API endpoint.
+///
+/// ASCII only (no Unicode) so it renders cleanly in every agent's terminal on Windows.
+/// </summary>
+public static class FleetPreamble
+{
+    /// <summary>
+    /// Render the preamble for one session. <paramref name="name"/> may be null/empty
+    /// (an unnamed session); the other values are always present on a live session.
+    /// </summary>
+    public static string Build(string sessionId, string? name, string machine, string repoPath)
+    {
+        var shortId = sessionId.Length >= 8 ? sessionId.Substring(0, 8) : sessionId;
+        var displayName = string.IsNullOrWhiteSpace(name) ? "(unnamed)" : name;
+
+        var lines = new[]
+        {
+            $"[CC Director fleet] You are session {shortId} \"{displayName}\" on machine {machine}, repo {repoPath}.",
+            $"Your full session id is {sessionId}.",
+            "You can talk to other sessions across the fleet. These commands are already on your PATH:",
+            "  cc-sessions             list every session in the fleet (id, name, machine, repo, status)",
+            "  cc-whoami               print your own id, name, machine, and repo",
+            "  cc-send <id|all> \"msg\"  send a one-way message to one session, or to every session with 'all'",
+            "  cc-ask <id> \"question\"  ask one session a question and wait for its answer",
+            "  cc-spawn <repo>         open a new session on this Director",
+            "Address a session by a short prefix of its id or by its name. You reach the fleet through your",
+            "own Director (CC_DIRECTOR_API); no Gateway address or token is needed.",
+        };
+
+        return string.Join("\n", lines);
+    }
+}

--- a/src/CcDirector.Core/Sessions/SessionManager.cs
+++ b/src/CcDirector.Core/Sessions/SessionManager.cs
@@ -300,6 +300,19 @@ public sealed class SessionManager : IDisposable
                 }
             }
 
+            // For Codex, merge the fleet-preamble SessionStart hook into ~/.codex/hooks.json and
+            // append --dangerously-bypass-hook-trust so it runs without a per-user trust prompt.
+            // Codex re-fires SessionStart on /clear and /compact, so the preamble re-injects itself;
+            // the hook reads CC_SESSION_ID / CC_DIRECTOR_API from the environment injected above.
+            if (agent.Kind == AgentKind.Codex)
+            {
+                if (CcDirector.Core.Codex.CodexHookInstaller.EnsureInstalled())
+                {
+                    args = $"{args} {CcDirector.Core.Codex.CodexHookInstaller.BypassTrustFlag}".Trim();
+                    _log?.Invoke("Installed Codex fleet-preamble SessionStart hook (--dangerously-bypass-hook-trust).");
+                }
+            }
+
             // Resolve the agent command to a concrete executable path before spawning.
             // CreateProcess only appends ".exe" to a bare command name, so a CLI installed
             // as a ".cmd" shim (e.g. npm-installed "opencode.cmd") would never be found from


### PR DESCRIPTION
## Summary

Makes a session know the rest of the fleet the instant it starts, with no skill lookup, and extends that to Codex - which also turned up and fixed a real Codex prompt-submission bug.

### Launch-time fleet preamble (Claude)
- `FleetPreamble` builds the one-screen identity-plus-commands text (a single source of truth, plain ASCII).
- New Control API endpoint `GET /sessions/{id}/fleet-preamble` serves it from the session's own identity.
- The Claude SessionStart hook fetches it and emits it as additionalContext, injected at startup and re-injected after a context clear and auto-compaction. Zero turn cost.

### Codex wiring + submit fix
- `CodexHookInstaller` merges a SessionStart hook into the user's `~/.codex/hooks.json` (preserves the user's own hooks, idempotent, atomic write, never clobbers a malformed file). `SessionManager` appends `--dangerously-bypass-hook-trust` so the hook runs without a per-user trust prompt - the Codex analog of how Claude passes `--settings`.
- Wiring Codex surfaced a bug: the Director's programmatic prompt path used a blind submit that Codex's repainting composer dropped, parking every programmatic prompt unsubmitted. `CodexDriver` now does an echo-verified submit (type, wait for the composer echo, then a separate Enter). This repairs cc-send, cc-ask, the prompt queue, and phone-driven prompts to Codex generally, not just this feature.

### Internal agent-expert reference skill
- A repository-local skill (deliberately not shipped with the installer) documenting every coding-agent command-line tool the Director can run: command line, configuration, context-injection points, lifecycle hooks and events, software development kits, transcript formats, and how the Director integrates each. One file per agent plus a cross-agent matrix.

## Verification (all live, codex 0.141.0 and Claude)
- Claude: a fresh session reports its identity and the five fleet commands from context alone, no tool calls.
- Codex: auto-installs the hook, the preamble injects (fires at first turn), and it re-injects on both a context clear and compaction (counted three injections across the lifecycle).
- Tests: FleetPreamble, ClaudeHookInstaller, CodexHookInstaller (4), and CodexDriver submit cases (2) - all passing; full Director builds clean.

## Follow-ups (not in this change)
- Exclude the agent-expert skill from the shipped installer bundle.
- For a shipped product, prefer Codex managed-hooks (requirements.toml) over writing the user's personal hooks.json.
- Declare TranscriptRead on the Codex driver so cc-ask can reach Codex.

Generated with [Claude Code](https://claude.com/claude-code)