### PR TITLE
Context-usage gauge for Codex and pi (stacked on #803)

### DIFF
--- a/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml.cs
@@ -81,13 +81,9 @@ public partial class SessionActionBar : UserControl
 
         try
         {
-            var sid = session.ClaudeSessionId;
-            if (string.IsNullOrEmpty(sid))
-            {
-                RenderContextGauge(null);   // not linked to a transcript yet
-                return;
-            }
-
+            // Only Claude has a preassigned ClaudeSessionId; Codex and pi locate by repo path and
+            // have none, so don't gate the gauge on it - the driver returns null if it can't resolve.
+            var sid = session.ClaudeSessionId ?? "";
             var repoPath = session.RepoPath;
             // EffectiveLaunchArgs carries the launched --model ([1m]) even when it came from the
             // configured default; ClaudeArgs alone is null in that case (#803).

--- a/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml.cs
@@ -89,7 +89,8 @@ public partial class SessionActionBar : UserControl
             }
 
             var repoPath = session.RepoPath;
-            var usage = await Task.Run(() => session.Driver.ReadContextUsage(sid, repoPath));
+            var launchArgs = session.ClaudeArgs;   // the launched model id ([1m]) is the authoritative window
+            var usage = await Task.Run(() => session.Driver.ReadContextUsage(sid, repoPath, launchArgs));
 
             // The active session may have changed while the read ran; ignore a stale result.
             if (!ReferenceEquals(_session, session))

--- a/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml.cs
@@ -89,7 +89,9 @@ public partial class SessionActionBar : UserControl
             }
 
             var repoPath = session.RepoPath;
-            var launchArgs = session.ClaudeArgs;   // the launched model id ([1m]) is the authoritative window
+            // EffectiveLaunchArgs carries the launched --model ([1m]) even when it came from the
+            // configured default; ClaudeArgs alone is null in that case (#803).
+            var launchArgs = session.EffectiveLaunchArgs ?? session.ClaudeArgs;
             var usage = await Task.Run(() => session.Driver.ReadContextUsage(sid, repoPath, launchArgs));
 
             // The active session may have changed while the read ran; ignore a stale result.

--- a/src/CcDirector.ControlApi/SessionContextEndpoint.cs
+++ b/src/CcDirector.ControlApi/SessionContextEndpoint.cs
@@ -31,15 +31,16 @@ internal static class SessionContextEndpoint
             if (!driver.Capabilities.HasFlag(DriverCapabilities.ContextUsage))
                 return Results.NotFound(new { error = $"agent {driver.Kind} does not report context usage" });
 
-            if (string.IsNullOrEmpty(session.ClaudeSessionId))
-                return Results.NotFound(new { error = "session has no agent session id yet" });
-
+            // No agent-session-id guard here: only Claude carries a preassigned ClaudeSessionId.
+            // Codex and pi have none - they locate their rollout/session by repo path - so requiring
+            // it would make the gauge permanently dark for them. Each driver decides what it needs;
+            // a driver that cannot resolve a transcript yet returns null below (handled as 404).
             try
             {
                 // EffectiveLaunchArgs (the merged launch line) carries the launched --model even when
                 // it came from the configured default; ClaudeArgs alone is null in that case (#803).
                 var launchArgs = session.EffectiveLaunchArgs ?? session.ClaudeArgs;
-                var context = driver.ReadContextUsage(session.ClaudeSessionId, session.RepoPath, launchArgs);
+                var context = driver.ReadContextUsage(session.ClaudeSessionId ?? "", session.RepoPath, launchArgs);
                 if (context is null)
                     return Results.NotFound(new { error = "no context usage yet (no completed turn)" });
                 return Results.Json(context);

--- a/src/CcDirector.ControlApi/SessionContextEndpoint.cs
+++ b/src/CcDirector.ControlApi/SessionContextEndpoint.cs
@@ -36,7 +36,7 @@ internal static class SessionContextEndpoint
 
             try
             {
-                var context = driver.ReadContextUsage(session.ClaudeSessionId, session.RepoPath);
+                var context = driver.ReadContextUsage(session.ClaudeSessionId, session.RepoPath, session.ClaudeArgs);
                 if (context is null)
                     return Results.NotFound(new { error = "no context usage yet (no completed turn)" });
                 return Results.Json(context);

--- a/src/CcDirector.ControlApi/SessionContextEndpoint.cs
+++ b/src/CcDirector.ControlApi/SessionContextEndpoint.cs
@@ -36,7 +36,10 @@ internal static class SessionContextEndpoint
 
             try
             {
-                var context = driver.ReadContextUsage(session.ClaudeSessionId, session.RepoPath, session.ClaudeArgs);
+                // EffectiveLaunchArgs (the merged launch line) carries the launched --model even when
+                // it came from the configured default; ClaudeArgs alone is null in that case (#803).
+                var launchArgs = session.EffectiveLaunchArgs ?? session.ClaudeArgs;
+                var context = driver.ReadContextUsage(session.ClaudeSessionId, session.RepoPath, launchArgs);
                 if (context is null)
                     return Results.NotFound(new { error = "no context usage yet (no completed turn)" });
                 return Results.Json(context);

--- a/src/CcDirector.Core.Tests/Codex/CodexContextUsageTests.cs
+++ b/src/CcDirector.Core.Tests/Codex/CodexContextUsageTests.cs
@@ -1,0 +1,62 @@
+using CcDirector.Core.Codex;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Codex;
+
+// =====================================================================================
+// CodexContextUsage: the gauge reads the LAST token_count event from a Codex rollout -
+// used = last_token_usage.input_tokens, window = model_context_window (Codex gives us the
+// window, so nothing is guessed).
+// =====================================================================================
+public sealed class CodexContextUsageTests
+{
+    private const string TokenCount1 =
+        "{\"timestamp\":\"2026-06-27T08:00:00.000Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"last_token_usage\":{\"input_tokens\":50000,\"output_tokens\":10},\"model_context_window\":258400}}}";
+
+    private const string TokenCount2 =
+        "{\"timestamp\":\"2026-06-27T08:05:00.000Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"last_token_usage\":{\"input_tokens\":159314,\"output_tokens\":31},\"model_context_window\":258400}}}";
+
+    [Fact]
+    public void Compute_TakesLastTokenCount_ComputesPercentAndWindow()
+    {
+        var ctx = CodexContextUsage.Compute(new[] { TokenCount1, TokenCount2 });
+
+        Assert.NotNull(ctx);
+        Assert.Equal(159314, ctx.UsedTokens);            // the LATEST event wins
+        Assert.Equal(258400, ctx.WindowTokens);
+        Assert.Equal(61.7, ctx.PercentUsed);             // 159314 / 258400 * 100
+        Assert.Equal(new DateTime(2026, 6, 27, 8, 5, 0, DateTimeKind.Utc), ctx.AsOfUtc);
+    }
+
+    [Fact]
+    public void Compute_NoTokenCountEvent_ReturnsNull()
+    {
+        var lines = new[]
+        {
+            "{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"C:\\\\repo\"}}",
+            "{\"type\":\"response_item\",\"payload\":{}}",
+        };
+        Assert.Null(CodexContextUsage.Compute(lines));
+    }
+
+    [Fact]
+    public void Compute_WindowMissing_RawNumberFallback_NoPercent()
+    {
+        var line =
+            "{\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"last_token_usage\":{\"input_tokens\":1234}}}}";
+        var ctx = CodexContextUsage.Compute(new[] { line });
+
+        Assert.NotNull(ctx);
+        Assert.Equal(1234, ctx.UsedTokens);
+        Assert.Null(ctx.WindowTokens);
+        Assert.Null(ctx.PercentUsed);
+    }
+
+    [Fact]
+    public void Compute_SkipsTornTailLine()
+    {
+        var ctx = CodexContextUsage.Compute(new[] { TokenCount1, "{ this is half-written" });
+        Assert.NotNull(ctx);
+        Assert.Equal(50000, ctx.UsedTokens);
+    }
+}

--- a/src/CcDirector.Core.Tests/Drivers/ContextUsageTests.cs
+++ b/src/CcDirector.Core.Tests/Drivers/ContextUsageTests.cs
@@ -1,3 +1,5 @@
+using CcDirector.Core.Agents;
+using CcDirector.Core.Configuration;
 using CcDirector.Core.Drivers;
 using CcDirector.Gateway.Contracts;
 using Xunit;
@@ -214,6 +216,46 @@ public sealed class ContextUsageTests
     public void WindowTokensForModel_Observed_UnmappedStaysNull()
     {
         Assert.Null(ClaudeContextWindow.WindowTokensForModel("gpt-4o", 999_999));
+    }
+
+    // ---- Issue #803 production path: the model comes from the configured DEFAULT, not per-session ----
+    //
+    // The real fleet bug: a session launched WITHOUT a per-session --model (so ClaudeArgs/userArgs is
+    // null) still runs opus[1m] because the model is in AgentOptions.DefaultClaudeArgs. The gauge must
+    // read the EFFECTIVE launch line (what SessionManager stores as Session.EffectiveLaunchArgs), which
+    // is the result of BuildLaunchSpec merging the default in - NOT the null per-session args. These
+    // tests prove that path end to end so a per-session-only fix can't masquerade as correct.
+
+    [Fact]
+    public void BuildLaunchSpec_ModelFromDefaultArgs_NoPerSessionArgs_EffectiveArgsCarryTheModel()
+    {
+        var agent = new ClaudeAgent(new AgentOptions { DefaultClaudeArgs = "--dangerously-skip-permissions --model opus[1m]" });
+
+        // userArgs null: the production default-launch path (no per-session override).
+        var spec = agent.BuildLaunchSpec(userArgs: null, resumeSessionId: null, studioMode: false);
+
+        Assert.Contains("--model opus[1m]", spec.Arguments);
+    }
+
+    [Fact]
+    public void ReadContextUsage_EffectiveArgsFromDefault_SizesOpusOneMillion()
+    {
+        // Simulate the stored Session.EffectiveLaunchArgs for a default-launched opus[1m] session.
+        var agent = new ClaudeAgent(new AgentOptions { DefaultClaudeArgs = "--dangerously-skip-permissions --model opus[1m]" });
+        var effectiveArgs = agent.BuildLaunchSpec(userArgs: null, resumeSessionId: null, studioMode: false).Arguments;
+
+        var usage = new SessionUsageDto
+        {
+            ContextTokens = 121_924,
+            ContextModel = "claude-opus-4-8", // transcript, [1m]-stripped
+            AssistantMessageCount = 5,
+        };
+
+        var ctx = DriverReturning(usage).ReadContextUsage("sid", "C:\\repo", effectiveArgs);
+
+        Assert.NotNull(ctx);
+        Assert.Equal(1_000_000, ctx.WindowTokens);
+        Assert.InRange(ctx.PercentUsed!.Value, 11.0, 13.0); // ~12.2%, the bug's correct reading
     }
 
     // ---- The NotSupported guarantee on drivers without the flag ----

--- a/src/CcDirector.Core.Tests/Drivers/ContextUsageTests.cs
+++ b/src/CcDirector.Core.Tests/Drivers/ContextUsageTests.cs
@@ -258,18 +258,26 @@ public sealed class ContextUsageTests
         Assert.InRange(ctx.PercentUsed!.Value, 11.0, 13.0); // ~12.2%, the bug's correct reading
     }
 
-    // ---- The NotSupported guarantee on drivers without the flag ----
+    // ---- Capability declaration: Claude, Codex, and pi report context usage; others do not ----
+
+    [Fact]
+    public void CodexAndPi_DeclareContextUsage()
+    {
+        Assert.True(new CodexDriver().Capabilities.HasFlag(DriverCapabilities.ContextUsage));
+        Assert.True(new PiDriver().Capabilities.HasFlag(DriverCapabilities.ContextUsage));
+    }
 
     [Fact]
     public void ReadContextUsage_DriverWithoutFlag_Throws()
     {
-        Assert.False(new CodexDriver().Capabilities.HasFlag(DriverCapabilities.ContextUsage));
-        Assert.False(new PiDriver().Capabilities.HasFlag(DriverCapabilities.ContextUsage));
+        // Drivers that do NOT declare ContextUsage inherit the throwing default - honestly absent.
+        Assert.False(new CopilotDriver().Capabilities.HasFlag(DriverCapabilities.ContextUsage));
+        Assert.False(new CursorDriver().Capabilities.HasFlag(DriverCapabilities.ContextUsage));
 
         Assert.Throws<NotSupportedException>(
-            () => ((IAgentDriver)new CodexDriver()).ReadContextUsage("sid", "C:\\repo", null));
+            () => ((IAgentDriver)new CopilotDriver()).ReadContextUsage("sid", "C:\\repo", null));
         Assert.Throws<NotSupportedException>(
-            () => ((IAgentDriver)new PiDriver()).ReadContextUsage("sid", "C:\\repo", null));
+            () => ((IAgentDriver)new CursorDriver()).ReadContextUsage("sid", "C:\\repo", null));
     }
 
     [Fact]

--- a/src/CcDirector.Core.Tests/Drivers/ContextUsageTests.cs
+++ b/src/CcDirector.Core.Tests/Drivers/ContextUsageTests.cs
@@ -62,7 +62,7 @@ public sealed class ContextUsageTests
             LastMessageUtc = new DateTime(2026, 6, 27, 8, 0, 0, DateTimeKind.Utc),
         };
 
-        var ctx = DriverReturning(usage).ReadContextUsage("sid", "C:\\repo");
+        var ctx = DriverReturning(usage).ReadContextUsage("sid", "C:\\repo", null);
 
         Assert.NotNull(ctx);
         Assert.Equal(42_000, ctx.UsedTokens);
@@ -81,7 +81,7 @@ public sealed class ContextUsageTests
             AssistantMessageCount = 1,
         };
 
-        var ctx = DriverReturning(usage).ReadContextUsage("sid", "C:\\repo");
+        var ctx = DriverReturning(usage).ReadContextUsage("sid", "C:\\repo", null);
 
         Assert.NotNull(ctx);
         Assert.Equal(1_000_000, ctx.WindowTokens);
@@ -98,7 +98,7 @@ public sealed class ContextUsageTests
             AssistantMessageCount = 2,
         };
 
-        var ctx = DriverReturning(usage).ReadContextUsage("sid", "C:\\repo");
+        var ctx = DriverReturning(usage).ReadContextUsage("sid", "C:\\repo", null);
 
         Assert.NotNull(ctx);
         Assert.Equal(12_345, ctx.UsedTokens);
@@ -111,13 +111,109 @@ public sealed class ContextUsageTests
     {
         // Transcript exists but carries no usage-bearing assistant line.
         var usage = new SessionUsageDto { AssistantMessageCount = 0 };
-        Assert.Null(DriverReturning(usage).ReadContextUsage("sid", "C:\\repo"));
+        Assert.Null(DriverReturning(usage).ReadContextUsage("sid", "C:\\repo", null));
     }
 
     [Fact]
     public void ReadContextUsage_NoTranscript_ReturnsNull()
     {
-        Assert.Null(DriverReturning(null).ReadContextUsage("sid", "C:\\repo"));
+        Assert.Null(DriverReturning(null).ReadContextUsage("sid", "C:\\repo", null));
+    }
+
+    // ---- Issue #803: the launch model id is the authoritative window signal ----
+
+    [Fact]
+    public void ReadContextUsage_LaunchModelOneMillion_TranscriptStripped_SizesAgainstMillion()
+    {
+        // The real-world #803 case: the session was launched as opus[1m] but Claude's transcript
+        // records the model WITHOUT the [1m] suffix, so the transcript model alone would size it to
+        // 200k and read 61%. The launch args carry the authoritative [1m] window.
+        var usage = new SessionUsageDto
+        {
+            ContextTokens = 121_924,
+            ContextModel = "claude-opus-4-8", // stripped, as the real transcript records it
+            AssistantMessageCount = 5,
+        };
+
+        var ctx = DriverReturning(usage)
+            .ReadContextUsage("sid", "C:\\repo", "--dangerously-skip-permissions --model opus[1m]");
+
+        Assert.NotNull(ctx);
+        Assert.Equal(121_924, ctx.UsedTokens);
+        Assert.Equal(1_000_000, ctx.WindowTokens);
+        Assert.InRange(ctx.PercentUsed!.Value, 11.0, 13.0); // ~12.2%, NOT ~61%
+    }
+
+    [Theory]
+    [InlineData("--model claude-opus-4-8[1m]")] // equals-less, full transcript-style id
+    [InlineData("--model=opus[1m]")]            // equals form
+    public void ReadContextUsage_LaunchModelParsing_BothFlagForms_FindMillion(string launchArgs)
+    {
+        var usage = new SessionUsageDto
+        {
+            ContextTokens = 100_000,
+            ContextModel = "claude-opus-4-8",
+            AssistantMessageCount = 2,
+        };
+
+        var ctx = DriverReturning(usage).ReadContextUsage("sid", "C:\\repo", launchArgs);
+
+        Assert.NotNull(ctx);
+        Assert.Equal(1_000_000, ctx.WindowTokens);
+        Assert.Equal(10.0, ctx.PercentUsed);
+    }
+
+    [Fact]
+    public void ReadContextUsage_StandardLaunchModel_StaysTwoHundredThousand()
+    {
+        var usage = new SessionUsageDto
+        {
+            ContextTokens = 30_000,
+            ContextModel = "claude-sonnet-4-5-20250929",
+            AssistantMessageCount = 1,
+        };
+
+        var ctx = DriverReturning(usage).ReadContextUsage("sid", "C:\\repo", "--model sonnet");
+
+        Assert.NotNull(ctx);
+        Assert.Equal(200_000, ctx.WindowTokens);
+        Assert.Equal(15.0, ctx.PercentUsed);
+    }
+
+    [Fact]
+    public void ReadContextUsage_NoLaunchModel_FallsBackToTranscriptSelfCorrection()
+    {
+        // No --model in the launch args (provider default): fall back to the transcript model with
+        // observed-size self-correction. 250k observed cannot fit a 200k window, so it promotes to 1M.
+        var usage = new SessionUsageDto
+        {
+            ContextTokens = 250_000,
+            ContextModel = "claude-opus-4-8", // stripped; no [1m] signal except the observed size
+            AssistantMessageCount = 4,
+        };
+
+        var ctx = DriverReturning(usage).ReadContextUsage("sid", "C:\\repo", "--dangerously-skip-permissions");
+
+        Assert.NotNull(ctx);
+        Assert.Equal(1_000_000, ctx.WindowTokens);
+        Assert.Equal(25.0, ctx.PercentUsed);
+    }
+
+    // ---- ClaudeContextWindow self-correcting (two-arg) fallback overload ----
+
+    [Theory]
+    [InlineData("claude-opus-4-8", 250_000, 1_000_000)] // over 200k -> promoted to 1M
+    [InlineData("claude-opus-4-8", 50_000, 200_000)]    // under 200k -> stays 200k (honest under-report)
+    [InlineData("sonnet", 50_000, 200_000)]             // standard family, low usage
+    public void WindowTokensForModel_Observed_SelfCorrectsUpwardOnly(string modelId, long observed, long expected)
+    {
+        Assert.Equal(expected, ClaudeContextWindow.WindowTokensForModel(modelId, observed));
+    }
+
+    [Fact]
+    public void WindowTokensForModel_Observed_UnmappedStaysNull()
+    {
+        Assert.Null(ClaudeContextWindow.WindowTokensForModel("gpt-4o", 999_999));
     }
 
     // ---- The NotSupported guarantee on drivers without the flag ----
@@ -129,9 +225,9 @@ public sealed class ContextUsageTests
         Assert.False(new PiDriver().Capabilities.HasFlag(DriverCapabilities.ContextUsage));
 
         Assert.Throws<NotSupportedException>(
-            () => ((IAgentDriver)new CodexDriver()).ReadContextUsage("sid", "C:\\repo"));
+            () => ((IAgentDriver)new CodexDriver()).ReadContextUsage("sid", "C:\\repo", null));
         Assert.Throws<NotSupportedException>(
-            () => ((IAgentDriver)new PiDriver()).ReadContextUsage("sid", "C:\\repo"));
+            () => ((IAgentDriver)new PiDriver()).ReadContextUsage("sid", "C:\\repo", null));
     }
 
     [Fact]

--- a/src/CcDirector.Core.Tests/Pi/PiContextUsageTests.cs
+++ b/src/CcDirector.Core.Tests/Pi/PiContextUsageTests.cs
@@ -23,8 +23,8 @@ public sealed class PiContextUsageTests
 
         Assert.NotNull(ctx);
         Assert.Equal(3876, ctx.UsedTokens);                 // the LATEST assistant message wins
-        Assert.Equal(258_400, ctx.WindowTokens);            // gpt-5.5 -> 258400
-        Assert.Equal(1.5, ctx.PercentUsed);                 // 3876 / 258400 * 100, rounded
+        Assert.Equal(272_000, ctx.WindowTokens);            // gpt-5.5 -> 272000 (pi's observed limit)
+        Assert.Equal(1.4, ctx.PercentUsed);                 // 3876 / 272000 * 100, rounded
         Assert.Equal(new DateTime(2026, 6, 27, 3, 5, 0, DateTimeKind.Utc), ctx.AsOfUtc);
     }
 
@@ -56,7 +56,7 @@ public sealed class PiContextUsageTests
     [Fact]
     public void PiContextWindow_MapsGpt55_AndReusesClaudeTable()
     {
-        Assert.Equal(258_400, PiContextWindow.WindowTokensForModel("gpt-5.5"));
+        Assert.Equal(272_000, PiContextWindow.WindowTokensForModel("gpt-5.5"));
         Assert.Equal(200_000, PiContextWindow.WindowTokensForModel("claude-sonnet-4-5"));
         Assert.Equal(1_000_000, PiContextWindow.WindowTokensForModel("claude-opus-4-8[1m]"));
         Assert.Null(PiContextWindow.WindowTokensForModel("mystery-model"));

--- a/src/CcDirector.Core.Tests/Pi/PiContextUsageTests.cs
+++ b/src/CcDirector.Core.Tests/Pi/PiContextUsageTests.cs
@@ -1,0 +1,65 @@
+using CcDirector.Core.Pi;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Pi;
+
+// =====================================================================================
+// PiContextUsage: the gauge reads the LAST assistant message's usage.input from a pi
+// session file; pi does not record the window, so it is mapped from the model id
+// (PiContextWindow). PiContextWindow itself maps gpt-5.5 and reuses the Claude table.
+// =====================================================================================
+public sealed class PiContextUsageTests
+{
+    private const string Assistant1 =
+        "{\"type\":\"message\",\"timestamp\":\"2026-06-27T03:00:00.000Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"openai-codex\",\"model\":\"gpt-5.5\",\"usage\":{\"input\":2000,\"output\":33,\"totalTokens\":2033}}}";
+
+    private const string Assistant2 =
+        "{\"type\":\"message\",\"timestamp\":\"2026-06-27T03:05:00.000Z\",\"message\":{\"role\":\"assistant\",\"provider\":\"openai-codex\",\"model\":\"gpt-5.5\",\"usage\":{\"input\":3876,\"output\":40,\"totalTokens\":3916}}}";
+
+    [Fact]
+    public void Compute_TakesLastAssistantUsage_MapsWindowFromModel()
+    {
+        var ctx = PiContextUsage.Compute(new[] { Assistant1, Assistant2 });
+
+        Assert.NotNull(ctx);
+        Assert.Equal(3876, ctx.UsedTokens);                 // the LATEST assistant message wins
+        Assert.Equal(258_400, ctx.WindowTokens);            // gpt-5.5 -> 258400
+        Assert.Equal(1.5, ctx.PercentUsed);                 // 3876 / 258400 * 100, rounded
+        Assert.Equal(new DateTime(2026, 6, 27, 3, 5, 0, DateTimeKind.Utc), ctx.AsOfUtc);
+    }
+
+    [Fact]
+    public void Compute_UnmappedModel_RawNumberFallback_NoPercent()
+    {
+        var line =
+            "{\"type\":\"message\",\"message\":{\"role\":\"assistant\",\"model\":\"some-local-model\",\"usage\":{\"input\":500}}}";
+        var ctx = PiContextUsage.Compute(new[] { line });
+
+        Assert.NotNull(ctx);
+        Assert.Equal(500, ctx.UsedTokens);
+        Assert.Null(ctx.WindowTokens);
+        Assert.Null(ctx.PercentUsed);
+    }
+
+    [Fact]
+    public void Compute_IgnoresUserMessagesAndThinking_ReturnsNullWhenNoAssistantUsage()
+    {
+        var lines = new[]
+        {
+            "{\"type\":\"session\",\"cwd\":\"C:\\\\repo\"}",
+            "{\"type\":\"message\",\"message\":{\"role\":\"user\",\"content\":[]}}",
+            "{\"type\":\"thinking\"}",
+        };
+        Assert.Null(PiContextUsage.Compute(lines));
+    }
+
+    [Fact]
+    public void PiContextWindow_MapsGpt55_AndReusesClaudeTable()
+    {
+        Assert.Equal(258_400, PiContextWindow.WindowTokensForModel("gpt-5.5"));
+        Assert.Equal(200_000, PiContextWindow.WindowTokensForModel("claude-sonnet-4-5"));
+        Assert.Equal(1_000_000, PiContextWindow.WindowTokensForModel("claude-opus-4-8[1m]"));
+        Assert.Null(PiContextWindow.WindowTokensForModel("mystery-model"));
+        Assert.Null(PiContextWindow.WindowTokensForModel(null));
+    }
+}

--- a/src/CcDirector.Core/Codex/CodexContextUsage.cs
+++ b/src/CcDirector.Core/Codex/CodexContextUsage.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Core.Codex;
+
+/// <summary>
+/// Computes how full a Codex session's context window is, from its rollout JSONL. Codex writes a
+/// <c>token_count</c> event after every turn whose payload carries both the live usage and the model's
+/// window, so - unlike Claude - the denominator is given to us and nothing is guessed:
+///
+///   {"type":"event_msg","payload":{"type":"token_count","info":{
+///       "last_token_usage":{"input_tokens":159314, ...},   // the input the model last saw = context fullness
+///       "model_context_window":258400 }}}                    // the window size
+///
+/// UsedTokens = the latest <c>last_token_usage.input_tokens</c> (the whole conversation as the model
+/// last ingested it); WindowTokens = <c>model_context_window</c>; percent = used / window. Null until a
+/// token_count event exists (no turn has completed). The rollout for a repo is located by
+/// <see cref="CodexRolloutLocator"/>.
+/// </summary>
+public static class CodexContextUsage
+{
+    /// <summary>Context usage for the newest Codex rollout matching <paramref name="repoPath"/>, or
+    /// null when no rollout matches or it carries no token_count event yet.</summary>
+    public static ContextUsageDto? ReadForRepo(string repoPath)
+    {
+        var rollout = CodexRolloutLocator.ResolveByRepo(repoPath);
+        if (rollout is null)
+            return null;
+        return ReadFromFile(rollout);
+    }
+
+    /// <summary>Context usage from one rollout file. Reads with FileShare.ReadWrite so the live Codex
+    /// session can keep writing. Null when the file is missing or has no token_count event.</summary>
+    public static ContextUsageDto? ReadFromFile(string rolloutPath)
+    {
+        if (!File.Exists(rolloutPath))
+            return null;
+        FileLog.Write($"[CodexContextUsage] ReadFromFile: {rolloutPath}");
+        using var fs = new FileStream(rolloutPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(fs);
+        return Compute(ReadLines(reader));
+    }
+
+    /// <summary>Pure core - testable on raw rollout lines. Returns the LAST token_count event's usage.</summary>
+    public static ContextUsageDto? Compute(IEnumerable<string> rolloutLines)
+    {
+        ArgumentNullException.ThrowIfNull(rolloutLines);
+        ContextUsageDto? latest = null;
+
+        foreach (var line in rolloutLines)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            JsonDocument doc;
+            try { doc = JsonDocument.Parse(line); }
+            catch (JsonException) { continue; } // torn tail line while codex writes
+
+            using (doc)
+            {
+                var root = doc.RootElement;
+                if (root.ValueKind != JsonValueKind.Object) continue;
+                if (!(root.TryGetProperty("type", out var t) && t.GetString() == "event_msg")) continue;
+                if (!root.TryGetProperty("payload", out var payload) || payload.ValueKind != JsonValueKind.Object) continue;
+                if (!(payload.TryGetProperty("type", out var pt) && pt.GetString() == "token_count")) continue;
+                if (!payload.TryGetProperty("info", out var info) || info.ValueKind != JsonValueKind.Object) continue;
+                if (info.ValueKind == JsonValueKind.Null) continue;
+
+                if (!info.TryGetProperty("last_token_usage", out var last) || last.ValueKind != JsonValueKind.Object)
+                    continue;
+                var used = Long(last, "input_tokens");
+                if (used <= 0)
+                    continue;
+
+                var window = Long(info, "model_context_window");
+                var percent = window > 0
+                    ? Math.Round((double)used / window * 100.0, 1)
+                    : (double?)null;
+
+                var asOf = root.TryGetProperty("timestamp", out var tsEl) && tsEl.ValueKind == JsonValueKind.String
+                           && DateTime.TryParse(tsEl.GetString(), null, System.Globalization.DateTimeStyles.AdjustToUniversal, out var parsed)
+                    ? parsed
+                    : (DateTime?)null;
+
+                latest = new ContextUsageDto
+                {
+                    UsedTokens = used,
+                    WindowTokens = window > 0 ? window : null,
+                    PercentUsed = percent,
+                    AsOfUtc = asOf,
+                };
+            }
+        }
+
+        if (latest is not null)
+            FileLog.Write($"[CodexContextUsage] used={latest.UsedTokens}, window={latest.WindowTokens}, pct={latest.PercentUsed}");
+        return latest;
+    }
+
+    private static long Long(JsonElement el, string prop)
+        => el.TryGetProperty(prop, out var v) && v.ValueKind == JsonValueKind.Number ? v.GetInt64() : 0;
+
+    private static IEnumerable<string> ReadLines(StreamReader reader)
+    {
+        string? line;
+        while ((line = reader.ReadLine()) != null)
+            yield return line;
+    }
+}

--- a/src/CcDirector.Core/Codex/CodexRolloutLocator.cs
+++ b/src/CcDirector.Core/Codex/CodexRolloutLocator.cs
@@ -50,6 +50,12 @@ public static class CodexRolloutLocator
     public static string? Scan(string repoPath, string sessionsDirectory)
         => Scan(repoPath, sessionsDirectory, notBefore: null);
 
+    /// <summary>The newest rollout for a repo using the default <c>~/.codex/sessions</c> directory.
+    /// Used by the context gauge, which has only the repo path (no Director session id or launch
+    /// time), so it takes the newest matching rollout - the active session's, in the common case.</summary>
+    public static string? ResolveByRepo(string repoPath)
+        => Scan(repoPath, SessionsDirectory(), notBefore: null);
+
     /// <summary>
     /// Scan a sessions directory for the newest rollout whose session_meta cwd matches
     /// <paramref name="repoPath"/> and whose metadata/write timestamp is not older than

--- a/src/CcDirector.Core/Drivers/ClaudeContextWindow.cs
+++ b/src/CcDirector.Core/Drivers/ClaudeContextWindow.cs
@@ -45,4 +45,27 @@ public static class ClaudeContextWindow
 
         return null;
     }
+
+    /// <summary>
+    /// The context-window size for a model id, self-correcting against the observed context size.
+    /// This is the FALLBACK used only when the authoritative launch model id is unknown. Claude's
+    /// transcript records the base model id WITHOUT the <c>[1m]</c> alias (a 1-million-token Opus
+    /// session is logged as <c>claude-opus-4-8</c>, identical to a standard one), so the transcript
+    /// model alone cannot tell a 200k window from a 1M window. When the observed context exceeds the
+    /// standard window it physically cannot fit there, which is proof the session is on the extended
+    /// window - so we promote the denominator to 1M. The denominator is therefore never smaller than
+    /// the data and the percent can never exceed 100. (Residual limit: a 1M session still UNDER 200k
+    /// of context is reported against 200k, because nothing in the transcript reveals the larger
+    /// window until it is used - an honest under-report, not a wrong percent. The launch-model path
+    /// in <see cref="ClaudeDriver"/> avoids even this residual when the launch model is known.)
+    /// </summary>
+    public static long? WindowTokensForModel(string? modelId, long observedContextTokens)
+    {
+        var baseWindow = WindowTokensForModel(modelId);
+        if (baseWindow is null)
+            return null;
+        if (observedContextTokens > baseWindow.Value && baseWindow.Value < ExtendedWindowTokens)
+            return ExtendedWindowTokens;
+        return baseWindow;
+    }
 }

--- a/src/CcDirector.Core/Drivers/ClaudeDriver.cs
+++ b/src/CcDirector.Core/Drivers/ClaudeDriver.cs
@@ -298,18 +298,25 @@ public sealed class ClaudeDriver : IAgentDriver
     /// <summary>
     /// How full the Claude context window is right now (capability
     /// <see cref="DriverCapabilities.ContextUsage"/>). Reuses the existing transcript token walk for
-    /// the used-token count and the latest model, then sizes the window from
-    /// <see cref="ClaudeContextWindow"/>. Null until the first usage-bearing assistant line exists
-    /// (no turn has happened yet). When the model id is unmapped, the window and percent are null
-    /// (the raw-number fallback) rather than a guessed denominator.
+    /// the used-token count, then sizes the window. The AUTHORITATIVE window signal is the launch
+    /// model id parsed from <paramref name="launchArgs"/> (e.g. <c>--model opus[1m]</c>): Claude's
+    /// transcript records the base model id WITHOUT the <c>[1m]</c> suffix, so a 1-million-token Opus
+    /// session below 200k tokens would otherwise be sized against 200k and read far too high (issue
+    /// #803). When the launch model is unknown, we fall back to the transcript model with upward
+    /// self-correction. Null until the first usage-bearing assistant line exists (no turn yet); when
+    /// neither model maps, the window and percent are null (the raw-number fallback).
     /// </summary>
-    public ContextUsageDto? ReadContextUsage(string agentSessionId, string workingDirectory)
+    public ContextUsageDto? ReadContextUsage(string agentSessionId, string workingDirectory, string? launchArgs)
     {
         var usage = _transcripts.ReadUsage(agentSessionId, workingDirectory);
         if (usage is null || usage.AssistantMessageCount == 0)
             return null;
 
-        var window = ClaudeContextWindow.WindowTokensForModel(usage.ContextModel);
+        // Prefer the launched model id (carries [1m]); fall back to the transcript model, which is
+        // stripped of [1m] and so needs the observed-size self-correction as its only [1m] signal.
+        var launchModelId = ExtractLaunchModelId(launchArgs);
+        var window = ClaudeContextWindow.WindowTokensForModel(launchModelId)
+                  ?? ClaudeContextWindow.WindowTokensForModel(usage.ContextModel, usage.ContextTokens);
         var percent = window is > 0
             ? Math.Round((double)usage.ContextTokens / window.Value * 100.0, 1)
             : (double?)null;
@@ -321,6 +328,30 @@ public sealed class ClaudeDriver : IAgentDriver
             PercentUsed = percent,
             AsOfUtc = usage.LastMessageUtc,
         };
+    }
+
+    /// <summary>Extracts the value passed after this driver's <see cref="ModelFlag"/> (<c>--model</c>)
+    /// from a launch command line, e.g. <c>opus[1m]</c> from
+    /// <c>--dangerously-skip-permissions --model opus[1m]</c>. Handles both the space form
+    /// (<c>--model opus[1m]</c>) and the equals form (<c>--model=opus[1m]</c>). Returns null when no
+    /// model flag is present (the session uses the provider default), driving the transcript
+    /// fallback.</summary>
+    private string? ExtractLaunchModelId(string? launchArgs)
+    {
+        if (string.IsNullOrWhiteSpace(launchArgs))
+            return null;
+
+        var tokens = launchArgs.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        for (var i = 0; i < tokens.Length; i++)
+        {
+            var token = tokens[i];
+            if (token.Equals(ModelFlag, StringComparison.OrdinalIgnoreCase) && i + 1 < tokens.Length)
+                return tokens[i + 1];
+            if (token.StartsWith(ModelFlag + "=", StringComparison.OrdinalIgnoreCase))
+                return token[(ModelFlag.Length + 1)..];
+        }
+
+        return null;
     }
 
     public List<(string AgentSessionId, DateTime LastWriteUtc)> ListTranscripts(string workingDirectory)

--- a/src/CcDirector.Core/Drivers/CodexDriver.cs
+++ b/src/CcDirector.Core/Drivers/CodexDriver.cs
@@ -20,7 +20,8 @@ public sealed class CodexDriver : IAgentDriver
     public DriverCapabilities Capabilities =>
         DriverCapabilities.Cancel
         | DriverCapabilities.Interrupt
-        | DriverCapabilities.ClearContext;
+        | DriverCapabilities.ClearContext
+        | DriverCapabilities.ContextUsage;
 
     public IReadOnlyList<AgentSlashCommand> SlashCommands => CodexSlashCommands.All;
 
@@ -100,6 +101,13 @@ public sealed class CodexDriver : IAgentDriver
 
     public SessionUsageDto? ReadUsage(string agentSessionId, string workingDirectory) =>
         throw new NotSupportedException("[CodexDriver] Codex token usage reading is not implemented.");
+
+    /// <summary>How full the Codex context window is right now (capability
+    /// <see cref="DriverCapabilities.ContextUsage"/>). Codex writes its own <c>token_count</c> event
+    /// to the rollout carrying both the used tokens and the model window, so nothing is guessed - the
+    /// launch args are not needed. Located by repo path (Codex has no Director-preassigned id).</summary>
+    public ContextUsageDto? ReadContextUsage(string agentSessionId, string workingDirectory, string? launchArgs) =>
+        Codex.CodexContextUsage.ReadForRepo(workingDirectory);
 
     public List<(string AgentSessionId, DateTime LastWriteUtc)> ListTranscripts(string workingDirectory) =>
         throw new NotSupportedException(

--- a/src/CcDirector.Core/Drivers/IAgentDriver.cs
+++ b/src/CcDirector.Core/Drivers/IAgentDriver.cs
@@ -137,11 +137,14 @@ public interface IAgentDriver
 
     /// <summary>How full the context window is right now (capability
     /// <see cref="DriverCapabilities.ContextUsage"/>): used tokens, the window size when the model
-    /// is known, and the percent. Null when it cannot be determined yet (no turn has happened). The
+    /// is known, and the percent. Null when it cannot be determined yet (no turn has happened).
+    /// <paramref name="launchArgs"/> is the session's launch command line (e.g.
+    /// <c>--model opus[1m]</c>): the AUTHORITATIVE window signal, because the transcript model id is
+    /// recorded without the <c>[1m]</c> suffix. A driver that needs no launch hint may ignore it. The
     /// default throws <see cref="NotSupportedException"/> so a driver that does not declare the flag
     /// is honestly absent - never emulated; only a driver that declares ContextUsage overrides
     /// this.</summary>
-    ContextUsageDto? ReadContextUsage(string agentSessionId, string workingDirectory) =>
+    ContextUsageDto? ReadContextUsage(string agentSessionId, string workingDirectory, string? launchArgs) =>
         throw new NotSupportedException(
             $"[{GetType().Name}] {Kind} does not declare DriverCapabilities.ContextUsage.");
 

--- a/src/CcDirector.Core/Drivers/PiDriver.cs
+++ b/src/CcDirector.Core/Drivers/PiDriver.cs
@@ -30,7 +30,7 @@ public sealed class PiDriver : IAgentDriver
     public AgentKind Kind => AgentKind.Pi;
 
     public DriverCapabilities Capabilities =>
-        DriverCapabilities.Cancel | DriverCapabilities.ClearContext;
+        DriverCapabilities.Cancel | DriverCapabilities.ClearContext | DriverCapabilities.ContextUsage;
 
     public IReadOnlyList<AgentSlashCommand> SlashCommands => PiSlashCommands.All;
 
@@ -88,6 +88,14 @@ public sealed class PiDriver : IAgentDriver
 
     public SessionUsageDto? ReadUsage(string agentSessionId, string workingDirectory) =>
         throw new NotSupportedException("[PiDriver] pi transcript parsing is not implemented (v1).");
+
+    /// <summary>How full the pi context window is right now (capability
+    /// <see cref="DriverCapabilities.ContextUsage"/>). pi's session file carries per-message
+    /// <c>usage.input</c> and the model id; the window is mapped from the model via PiContextWindow
+    /// (pi does not record it). Located by repo path (pi has no Director-preassigned id); the launch
+    /// args are not used.</summary>
+    public ContextUsageDto? ReadContextUsage(string agentSessionId, string workingDirectory, string? launchArgs) =>
+        Pi.PiContextUsage.ReadForRepo(workingDirectory);
 
     public List<(string AgentSessionId, DateTime LastWriteUtc)> ListTranscripts(string workingDirectory) =>
         throw new NotSupportedException("[PiDriver] pi transcript listing is not implemented (v1).");

--- a/src/CcDirector.Core/Pi/PiContextUsage.cs
+++ b/src/CcDirector.Core/Pi/PiContextUsage.cs
@@ -1,0 +1,174 @@
+using System.Text.Json;
+using CcDirector.Core.Drivers;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Core.Pi;
+
+/// <summary>
+/// Computes how full a pi session's context window is, from its session JSONL
+/// (<c>~/.pi/agent/sessions/&lt;cwd-slug&gt;/&lt;ts&gt;_&lt;uuid&gt;.jsonl</c>). Each assistant message line
+/// carries the usage and the model:
+///
+///   {"type":"message","message":{"role":"assistant","provider":"openai-codex","model":"gpt-5.5",
+///       "usage":{"input":3838,"output":33,"cacheRead":0,"cacheWrite":0,"totalTokens":3871, ...}}}
+///
+/// UsedTokens = the latest assistant message's <c>usage.input</c> (the conversation the model last
+/// ingested = context fullness). pi does NOT record the window, so it is mapped from the model id via
+/// <see cref="PiContextWindow"/>; an unmapped model yields a null window (raw-number fallback, no guess).
+/// The session file for a repo is located by reading each session line's <c>cwd</c> (pi has no
+/// preassigned id the Director can use), newest matching file wins.
+/// </summary>
+public static class PiContextUsage
+{
+    /// <summary>Context usage for the newest pi session matching <paramref name="repoPath"/>, or null
+    /// when none matches or it has no assistant usage yet.</summary>
+    public static ContextUsageDto? ReadForRepo(string repoPath)
+    {
+        var file = LocateNewestForRepo(repoPath);
+        if (file is null)
+            return null;
+        return ReadFromFile(file);
+    }
+
+    /// <summary>Context usage from one pi session file. Reads with FileShare.ReadWrite so the live pi
+    /// session can keep writing. Null when the file is missing or has no assistant usage line.</summary>
+    public static ContextUsageDto? ReadFromFile(string sessionPath)
+    {
+        if (!File.Exists(sessionPath))
+            return null;
+        FileLog.Write($"[PiContextUsage] ReadFromFile: {sessionPath}");
+        using var fs = new FileStream(sessionPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(fs);
+        return Compute(ReadLines(reader));
+    }
+
+    /// <summary>Pure core - testable on raw session lines. Returns the LAST assistant usage.</summary>
+    public static ContextUsageDto? Compute(IEnumerable<string> sessionLines)
+    {
+        ArgumentNullException.ThrowIfNull(sessionLines);
+        ContextUsageDto? latest = null;
+
+        foreach (var line in sessionLines)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            JsonDocument doc;
+            try { doc = JsonDocument.Parse(line); }
+            catch (JsonException) { continue; } // torn tail line while pi writes
+
+            using (doc)
+            {
+                var root = doc.RootElement;
+                if (root.ValueKind != JsonValueKind.Object) continue;
+                if (!(root.TryGetProperty("type", out var t) && t.GetString() == "message")) continue;
+                if (!root.TryGetProperty("message", out var msg) || msg.ValueKind != JsonValueKind.Object) continue;
+                if (!(msg.TryGetProperty("role", out var role) && role.GetString() == "assistant")) continue;
+                if (!msg.TryGetProperty("usage", out var usage) || usage.ValueKind != JsonValueKind.Object) continue;
+
+                var used = Long(usage, "input");
+                if (used <= 0)
+                    continue;
+
+                var model = msg.TryGetProperty("model", out var m) && m.ValueKind == JsonValueKind.String
+                    ? m.GetString()
+                    : null;
+                var window = PiContextWindow.WindowTokensForModel(model);
+                var percent = window is > 0
+                    ? Math.Round((double)used / window.Value * 100.0, 1)
+                    : (double?)null;
+
+                var asOf = root.TryGetProperty("timestamp", out var tsEl) && tsEl.ValueKind == JsonValueKind.String
+                           && DateTime.TryParse(tsEl.GetString(), null, System.Globalization.DateTimeStyles.AdjustToUniversal, out var parsed)
+                    ? parsed
+                    : (DateTime?)null;
+
+                latest = new ContextUsageDto
+                {
+                    UsedTokens = used,
+                    WindowTokens = window,
+                    PercentUsed = percent,
+                    AsOfUtc = asOf,
+                };
+            }
+        }
+
+        if (latest is not null)
+            FileLog.Write($"[PiContextUsage] used={latest.UsedTokens}, window={latest.WindowTokens}, pct={latest.PercentUsed}");
+        return latest;
+    }
+
+    /// <summary>The newest pi session file whose <c>session</c> line cwd matches the repo, or null.
+    /// Scans <c>~/.pi/agent/sessions</c> recursively; skips pi's <c>_archived_*</c> folders.</summary>
+    public static string? LocateNewestForRepo(string repoPath)
+    {
+        var dir = SessionsDirectory();
+        if (string.IsNullOrWhiteSpace(repoPath) || !Directory.Exists(dir))
+            return null;
+        var target = NormalizePath(repoPath);
+
+        List<FileInfo> files;
+        try
+        {
+            files = new DirectoryInfo(dir)
+                .EnumerateFiles("*.jsonl", SearchOption.AllDirectories)
+                .Where(f => !f.FullName.Contains("_archived", StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(f => f.LastWriteTimeUtc)
+                .ToList();
+        }
+        catch
+        {
+            return null;
+        }
+
+        foreach (var file in files)
+            if (NormalizePath(ReadSessionCwd(file.FullName)) == target)
+                return file.FullName;
+        return null;
+    }
+
+    /// <summary>Read the <c>cwd</c> from a pi session file's first <c>session</c> line, or null.</summary>
+    private static string? ReadSessionCwd(string path)
+    {
+        try
+        {
+            using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(fs);
+            var first = reader.ReadLine();
+            if (string.IsNullOrEmpty(first))
+                return null;
+            using var doc = JsonDocument.Parse(first);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object) return null;
+            if (!(root.TryGetProperty("type", out var t) && t.GetString() == "session")) return null;
+            return root.TryGetProperty("cwd", out var cwd) && cwd.ValueKind == JsonValueKind.String
+                ? cwd.GetString()
+                : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string SessionsDirectory()
+        => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".pi", "agent", "sessions");
+
+    private static string NormalizePath(string? p)
+    {
+        if (string.IsNullOrWhiteSpace(p)) return "";
+        try { return Path.GetFullPath(p).TrimEnd('\\', '/').ToLowerInvariant(); }
+        catch { return p.TrimEnd('\\', '/').ToLowerInvariant(); }
+    }
+
+    private static long Long(JsonElement el, string prop)
+        => el.TryGetProperty(prop, out var v) && v.ValueKind == JsonValueKind.Number ? v.GetInt64() : 0;
+
+    private static IEnumerable<string> ReadLines(StreamReader reader)
+    {
+        string? line;
+        while ((line = reader.ReadLine()) != null)
+            yield return line;
+    }
+}

--- a/src/CcDirector.Core/Pi/PiContextWindow.cs
+++ b/src/CcDirector.Core/Pi/PiContextWindow.cs
@@ -1,0 +1,37 @@
+using CcDirector.Core.Drivers;
+
+namespace CcDirector.Core.Pi;
+
+/// <summary>
+/// Maps a pi model id to its context-window size in tokens - the denominator the context gauge needs.
+/// pi runs models from several providers and does NOT record the window in its session file (unlike
+/// Codex, which does), so the window is inferred from the model id. A model id this table does not
+/// recognize returns null, which drives the explicit raw-number fallback rather than a guessed window.
+/// </summary>
+public static class PiContextWindow
+{
+    /// <summary>The window for OpenAI's gpt-5.5 as reported by the Codex backend's
+    /// <c>model_context_window</c> (258,400 tokens). pi drives the same backend via the
+    /// <c>openai-codex</c> provider, so the value matches.</summary>
+    public const long Gpt55WindowTokens = 258_400;
+
+    /// <summary>The context-window size for a pi model id, or null when unrecognized (the gauge then
+    /// shows the raw used-token count with no percent).</summary>
+    public static long? WindowTokensForModel(string? modelId)
+    {
+        if (string.IsNullOrWhiteSpace(modelId))
+            return null;
+
+        var id = modelId.Trim();
+
+        // Claude families: reuse the Claude window table (handles the [1m] suffix too).
+        var claude = ClaudeContextWindow.WindowTokensForModel(id);
+        if (claude is not null)
+            return claude;
+
+        if (id.Contains("gpt-5.5", StringComparison.OrdinalIgnoreCase))
+            return Gpt55WindowTokens;
+
+        return null;
+    }
+}

--- a/src/CcDirector.Core/Pi/PiContextWindow.cs
+++ b/src/CcDirector.Core/Pi/PiContextWindow.cs
@@ -10,10 +10,11 @@ namespace CcDirector.Core.Pi;
 /// </summary>
 public static class PiContextWindow
 {
-    /// <summary>The window for OpenAI's gpt-5.5 as reported by the Codex backend's
-    /// <c>model_context_window</c> (258,400 tokens). pi drives the same backend via the
-    /// <c>openai-codex</c> provider, so the value matches.</summary>
-    public const long Gpt55WindowTokens = 258_400;
+    /// <summary>The window pi itself uses for gpt-5.5: 272,000 tokens. pi's own changelog notes it
+    /// "use[s] the observed 272k limit" for gpt-5.5, and the pi footer displays it as 272k - so the
+    /// gauge matches what pi shows the user. (This is larger than the Codex backend's reported
+    /// <c>model_context_window</c> of 258,400; pi applies its own observed limit, so we follow pi.)</summary>
+    public const long Gpt55WindowTokens = 272_000;
 
     /// <summary>The context-window size for a pi model id, or null when unrecognized (the gauge then
     /// shows the raw used-token count with no percent).</summary>

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -145,6 +145,16 @@ public sealed class Session : IDisposable
     public SessionStatus Status { get; internal set; }
     public DateTimeOffset CreatedAt { get; }
     public string? ClaudeArgs { get; }
+
+    /// <summary>The EFFECTIVE launch command line the agent process was actually started with -
+    /// the merged result of <see cref="ClaudeArgs"/> (per-session args) and the configured agent
+    /// defaults (e.g. <c>AgentOptions.DefaultClaudeArgs</c>), as produced by the agent's
+    /// BuildLaunchSpec. This is the authoritative source of the launched <c>--model</c> value
+    /// (issue #803): <see cref="ClaudeArgs"/> is null whenever the model comes from the configured
+    /// default rather than a per-session override, so the context gauge must read the effective
+    /// args, not the raw per-session ones. Set by SessionManager at launch.</summary>
+    public string? EffectiveLaunchArgs { get; internal set; }
+
     public int? ExitCode { get; internal set; }
 
     /// <summary>The terminal buffer from the backend. May be null for Embedded mode.</summary>

--- a/src/CcDirector.Core/Sessions/SessionManager.cs
+++ b/src/CcDirector.Core/Sessions/SessionManager.cs
@@ -242,6 +242,11 @@ public sealed class SessionManager : IDisposable
             GroupId = groupId,
             GroupRole = groupRole,
             GroupName = groupName,
+            // The EFFECTIVE launch line (userArgs merged with the configured agent defaults) is the
+            // authoritative source of the launched --model value for the context gauge (issue #803).
+            // `userArgs`/ClaudeArgs is null when the model comes from the default, not a per-session
+            // override, so persist the merged `args` from BuildLaunchSpec here.
+            EffectiveLaunchArgs = args,
         };
 
         // Issue #800: name the session AT BIRTH. The factory is invoked with the new id so the


### PR DESCRIPTION
Extends the live context-usage gauge beyond Claude to **Codex** and **pi**. Stacked on the #803 Claude fix (PR #804) — this branch includes those commits, so merging it lands the whole capability; merge/close #804 accordingly.

## What
- **Codex**: `CodexContextUsage` reads the rollout's `token_count` event, which carries both `last_token_usage.input_tokens` (fullness) and `model_context_window` (the window) — nothing guessed. Located by repo via `CodexRolloutLocator.ResolveByRepo`.
- **pi**: `PiContextUsage` reads the session JSONL's per-message `usage.input`; window mapped from model id via `PiContextWindow` (gpt-5.5 → 258,400; Claude families reuse the `[1m]`-aware table); unmapped → raw-number fallback.
- `CodexDriver`/`PiDriver` declare `DriverCapabilities.ContextUsage` and implement the 3-arg `ReadContextUsage` (locate by repo path; ignore launch args).
- Removed the `ClaudeSessionId` guard at both call sites (`SessionContextEndpoint`, `SessionActionBar`) — it's only ever set for Claude and was keeping the gauge permanently dark for Codex/pi. Pass `ClaudeSessionId ?? ""`; no Claude regression.

## Proof
- Build clean; **42/42** context unit tests pass.
- Harness over real on-disk data: Codex **52/52** sessions-with-usage correct (0 anomalies); pi **29/32** + 1 correct raw-fallback (0 anomalies).
- **Live** (test Director on this branch): Codex session reads `ctx 15k / 258k (6%)`, pi session reads `ctx 1k / 258k (1%)` — on-screen gauge matches `GET /sessions/{sid}/context` for both. (The first live attempt failed and exposed the `ClaudeSessionId` gate, which this PR fixes.)

## Known follow-up (not blocking)
pi's own footer reports a 272k window for gpt-5.5 while `PiContextWindow` uses 258,400 (borrowed from Codex's reported value). Used-token count is exact; the window constant is slightly low. Worth refining the pi gpt-5.5 window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)