### PR TITLE
[Tools] Add ToolReconciler - manifest-driven automatic drift reconcile (engine + tests) (#826)

### DIFF
--- a/docs/cencon/proof/issue-826/build-and-test.txt
+++ b/docs/cencon/proof/issue-826/build-and-test.txt
@@ -1,0 +1,12 @@
+=== Full solution build ===
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+
+Time Elapsed 00:00:02.29
+
+=== Engine test suite (incl. 8 new ToolReconciler tests) ===
+Test run for D:\ReposFred\devthrottle-wt-826\tools\cc-director-setup-engine.Tests\bin\Debug\net10.0\CcDirector.Setup.Engine.Tests.dll (.NETCoreApp,Version=v10.0)
+A total of 1 test files matched the specified pattern.
+
+Passed!  - Failed:     0, Passed:   201, Skipped:     0, Total:   201, Duration: 3 s - CcDirector.Setup.Engine.Tests.dll (net10.0)

--- a/docs/cencon/proof/issue-826/qa-report.html
+++ b/docs/cencon/proof/issue-826/qa-report.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Proof Report - Issue #826 ToolReconciler</title>
+<style>
+ body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem; color: #1a1a1a; }
+ h1 { border-bottom: 2px solid #333; padding-bottom: .3rem; }
+ table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
+ th, td { border: 1px solid #bbb; padding: .5rem .6rem; text-align: left; vertical-align: top; }
+ th { background: #f0f0f0; }
+ .pass { color: #0a7d28; font-weight: bold; }
+ code { background: #f4f4f4; padding: 0 .2rem; }
+ .verdict { margin-top: 1.5rem; padding: 1rem; background: #e8f6ec; border: 1px solid #0a7d28; font-weight: bold; }
+</style>
+</head>
+<body>
+<h1>QA Proof Report - Issue #826</h1>
+<p><strong>Title:</strong> [Tools] Add ToolReconciler - manifest-driven automatic drift reconcile (engine + tests)</p>
+<p><strong>PR:</strong> #831 (branch <code>issue-826-tool-reconciler</code>)</p>
+<p><strong>QA method:</strong> Independent verification in a separate QA worktree. Branch checked out fresh,
+solution built from scratch (<code>dotnet build cc-director.sln</code>), and the engine test project executed
+by the QA agent (not reusing the developer's binary or report). Scope is engine + tests only (no UI / lifecycle /
+config), so there is no app surface to drive - verification is the build gate plus the offline test suite.</p>
+
+<h2>Build gate</h2>
+<p><code>dotnet build cc-director.sln</code> -> <span class="pass">Build succeeded. 0 Warning(s), 0 Error(s).</span></p>
+
+<h2>Test gate</h2>
+<p><code>dotnet test CcDirector.Setup.Engine.Tests.csproj</code> -> <span class="pass">Passed! Failed: 0, Passed: 201,
+Skipped: 0</span> (8 new ToolReconciler tests + 193 existing engine tests). All tests use a temp/fake install
+layout and an injected heavy-repair delegate; no network or real machine-install dependence
+(grep for http/HttpClient/github in the reconciler and its tests returns NONE).</p>
+
+<h2>Acceptance criteria</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (verified)</th><th>Result</th></tr>
+<tr><td>1</td><td>New public ToolReconciler.ReconcileAsync with XML-doc as automatic Fix-Tools equivalent</td>
+<td>Public operation with descriptive XML doc</td>
+<td>ToolReconciler.cs: public sealed class, ReconcileAsync(CancellationToken), XML doc explicitly names it the
+"automatic, idempotent equivalent of the manual Fix Tools repair"</td><td class="pass">PASS</td></tr>
+<tr><td>2</td><td>Reuses existing detection (catalog + GetUnmanagedBinaries + legacy-shim presence); covers (a) missing shims, (b) orphaned legacy, (c) broken venv; no duplicated legacy list</td>
+<td>No parallel comparison; reuses RemoveLegacyAliasShims/LegacyAliasShimNames</td>
+<td>Uses ToolCatalogService.GetCatalog + GetUnmanagedBinaries + PythonToolsInstaller.FindOrphanedLegacyAliasShims +
+VenvHasAllTools. RemoveLegacyAliasShims refactored to share one path-set; legacy name list not duplicated.</td>
+<td class="pass">PASS</td></tr>
+<tr><td>3</td><td>Structured result (InSync / Reconciled / Failed) + human-readable actions list</td>
+<td>Richer than a bool</td>
+<td>record ReconcileResult(ReconcileOutcome Outcome, IReadOnlyList&lt;string&gt; Actions, string? Error); enum has
+InSync/Reconciled/Failed</td><td class="pass">PASS</td></tr>
+<tr><td>4</td><td>Idempotent and cheap: no-drift -> zero FS mutation, no network, InSync; second call no-op</td>
+<td>Happy path mutates nothing</td>
+<td>Test ReconcileAsync_NoDrift_ReturnsInSync_NoMutation asserts bin snapshot unchanged + heavy.Calls==0.
+Test ..._CalledTwice_SecondCallIsInSyncNoOp asserts second call InSync, empty actions, no mutation. Both PASS.</td>
+<td class="pass">PASS</td></tr>
+<tr><td>5</td><td>Scales action to drift; heavy RepairPythonToolsAsync only on broken venv</td>
+<td>Shim drift never rebuilds venv</td>
+<td>WriteShims/RemoveLegacyAliasShims called directly; heavy path gated on venvBroken only. Test
+..._ShimOnlyDrift_DoesNotEnterHeavyPath asserts heavy.Calls==0. PASS.</td><td class="pass">PASS</td></tr>
+<tr><td>6</td><td>Heavy path guarded by machine-wide named mutex; if held, returns without forcing; light path may proceed without it (documented)</td>
+<td>No concurrent venv rebuild</td>
+<td>Global\cc-director-tool-reconcile mutex via WaitOne(Zero); on contention logs "reconcile skipped - another
+Director is reconciling" and returns. Light shim path documented as taking no lock. Test
+..._AnotherDirectorHoldsMutex_SkipsHeavyRepair asserts heavy.Calls==0 + "skipped" action. PASS.</td>
+<td class="pass">PASS</td></tr>
+<tr><td>7</td><td>FileLog.Write("[ToolReconciler] ...") at entry/decision/action/exit/error</td>
+<td>Project logging standard</td>
+<td>Logs present at entry, drift decision, each corrective action, exit, and catch block.</td>
+<td class="pass">PASS</td></tr>
+<tr><td>8</td><td>Tests cover a-e; offline, fake layout, no network/real install</td>
+<td>5 required cases + escalation coverage</td>
+<td>8 tests: no-drift, missing-shim, orphaned-legacy, idempotency, shim-only-no-heavy, broken-venv-escalates,
+heavy-fails, mutex-skip. Temp dir layout + injected delegate; no network refs. All PASS.</td>
+<td class="pass">PASS</td></tr>
+<tr><td>9</td><td>Clean solution build (0 warnings introduced); all tests pass</td>
+<td>0 warnings / 0 errors; green suite</td>
+<td>Build succeeded, 0 Warning(s), 0 Error(s); 201/201 tests pass.</td><td class="pass">PASS</td></tr>
+</table>
+
+<h2>Regression sweep</h2>
+<p>Change is confined to <code>tools/cc-director-setup-engine/</code> (ToolReconciler.cs new; PythonToolsInstaller.cs
+refactor that makes WriteShims/RemoveLegacyAliasShims public and extracts a shared legacy path-set) plus the test
+project and proof docs. No UI/lifecycle/config touched, matching the issue scope. Full 201-test engine suite green -
+the PythonToolsInstaller refactor broke no existing behavior.</p>
+
+<div class="verdict">VERIFIED - all 9 acceptance criteria met. PASS.</div>
+</body>
+</html>

--- a/docs/cencon/proof/issue-826/report.html
+++ b/docs/cencon/proof/issue-826/report.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Issue #826 - ToolReconciler proof</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; max-width: 980px; margin: 2rem auto; padding: 0 1rem; color: #222; }
+  h1 { border-bottom: 2px solid #444; padding-bottom: .3rem; }
+  h2 { margin-top: 1.8rem; border-bottom: 1px solid #ccc; padding-bottom: .2rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #bbb; padding: .45rem .6rem; text-align: left; vertical-align: top; }
+  th { background: #f0f0f0; }
+  code { background: #f4f4f4; padding: .1rem .3rem; border-radius: 3px; }
+  pre { background: #f4f4f4; padding: .8rem; overflow-x: auto; border-radius: 4px; }
+  .pass { color: #157f3b; font-weight: bold; }
+  .files li { margin: .2rem 0; }
+</style>
+</head>
+<body>
+<h1>Issue #826 - ToolReconciler: manifest-driven automatic drift reconcile (engine + tests)</h1>
+
+<p><strong>Branch:</strong> <code>issue-826-tool-reconciler</code> &nbsp; | &nbsp;
+   <strong>Scope:</strong> setup engine + tests only (no UI, no <code>App.axaml.cs</code> lifecycle, no settings/config key - those are follow-ups #827/#828/#829).</p>
+
+<h2>What was implemented</h2>
+<ul class="files">
+  <li><strong>New:</strong> <code>tools/cc-director-setup-engine/ToolReconciler.cs</code> - the <code>ToolReconciler.ReconcileAsync(...)</code> operation, the <code>ReconcileResult</code> record, and the <code>ReconcileOutcome</code> enum (<code>InSync</code> / <code>Reconciled</code> / <code>Failed</code>). It is the automatic, idempotent, lightweight equivalent of the manual "Fix Tools" repair.</li>
+  <li><strong>Edited:</strong> <code>tools/cc-director-setup-engine/PythonToolsInstaller.cs</code> - exposed existing reuse points without duplicating logic: made <code>RemoveLegacyAliasShims()</code> and <code>WriteShims(...)</code> public, and added <code>FindOrphanedLegacyAliasShims()</code> (pure detection) sharing one private path-set helper with the purge.</li>
+  <li><strong>New:</strong> <code>tools/cc-director-setup-engine.Tests/ToolReconcilerTests.cs</code> - 8 offline tests (temp/fake layout, injected fake heavy-repair, no network).</li>
+</ul>
+
+<h2>How it works (reusing existing detection, not a parallel comparison)</h2>
+<ul>
+  <li><strong>(a) Missing shim:</strong> enumerates the embedded manifest via <code>ToolCatalogService.GetCatalog()</code>; for a tool whose venv console-script exe exists (<code>PythonToolsInstaller.ConsoleScriptPath</code>) but whose <code>bin\&lt;name&gt;.cmd</code> shim is absent, it creates the shim directly via <code>PythonToolsInstaller.WriteShims</code>.</li>
+  <li><strong>(b) Orphaned legacy shims:</strong> detected with <code>PythonToolsInstaller.FindOrphanedLegacyAliasShims()</code> (reusing <code>LegacyAliasShimNames</code>) and purged with <code>RemoveLegacyAliasShims()</code> - the legacy list is never duplicated.</li>
+  <li><strong>(c) Broken/absent venv:</strong> detected with <code>PythonToolsState.LoadScripts</code> + <code>PythonToolsInstaller.VenvHasAllTools</code>; only this escalates to the heavy release-backed <code>ToolUpdater.RepairPythonToolsAsync</code>.</li>
+  <li><strong>Cheap happy path:</strong> drift is fully computed from reads first; with no drift the method performs zero filesystem mutation, never calls the heavy repair, and returns <code>InSync</code>.</li>
+  <li><strong>Mutex:</strong> the heavy escalation is guarded by the machine-wide named mutex <code>Global\cc-director-tool-reconcile</code> (same convention as <code>TailscaleCli.ServeMutexName</code> / <code>agent-session-isolation.ps1</code>). If another Director holds it, the call logs "reconcile skipped - another Director is reconciling" and returns without forcing. The light shim path does not take the heavy lock.</li>
+</ul>
+
+<h2>Acceptance criteria - how each is met and verified</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>How met</th><th>Proof</th></tr>
+<tr><td>1</td><td>New public op with XML doc</td><td><code>ToolReconciler.ReconcileAsync</code> with summary calling it the automatic equivalent of Fix-Tools</td><td>Build; code</td></tr>
+<tr><td>2</td><td>Reuse existing detection</td><td>catalog + <code>GetUnmanagedBinaries()</code> + legacy-shim presence + <code>VenvHasAllTools</code>; no duplicated legacy list / comparison</td><td>Code review; tests b/c</td></tr>
+<tr><td>3</td><td>Structured result</td><td><code>ReconcileResult(Outcome, Actions, Error)</code>, enum InSync/Reconciled/Failed + action list</td><td>All 8 tests</td></tr>
+<tr><td>4</td><td>Idempotent &amp; cheap</td><td>No-drift =&gt; no FS mutation, no heavy call, InSync; second call is a no-op</td><td><code>...NoDrift_ReturnsInSync_NoMutation</code>, <code>...CalledTwice_SecondCallIsInSyncNoOp</code></td></tr>
+<tr><td>5</td><td>Scale action to drift</td><td>shim create/purge direct; heavy only on broken venv</td><td><code>...ShimOnlyDrift_DoesNotEnterHeavyPath</code>, <code>...BrokenVenv_EscalatesToHeavyRepair...</code></td></tr>
+<tr><td>6</td><td>Machine-wide mutex on heavy path</td><td><code>Global\cc-director-tool-reconcile</code>; held =&gt; skip without forcing; light path unlocked</td><td><code>...AnotherDirectorHoldsMutex_SkipsHeavyRepair</code></td></tr>
+<tr><td>7</td><td>Logging standard</td><td><code>FileLog.Write($"[ToolReconciler] ...")</code> at entry, drift decision, each action, exit, error</td><td>Code review</td></tr>
+<tr><td>8</td><td>Unit tests a-e</td><td>no-drift; missing shim; orphaned legacy; idempotency; heavy-not-entered for shim-only - plus broken-venv escalation, failure, and mutex-skip</td><td>8/8 pass (below)</td></tr>
+<tr><td>9</td><td>Clean build, all tests pass</td><td><code>dotnet build cc-director.sln</code> 0 warnings / 0 errors; 201 engine tests pass</td><td>Build &amp; test log</td></tr>
+</table>
+
+<h2>Proof: build and tests</h2>
+<p class="pass">Full solution build: Build succeeded. 0 Warning(s), 0 Error(s).</p>
+<p class="pass">Engine test suite: Passed! Failed: 0, Passed: 201, Skipped: 0 (includes the 8 new ToolReconciler tests).</p>
+
+<p>The 8 new tests (all <span class="pass">Passed</span>):</p>
+<pre>
+ReconcileAsync_NoDrift_ReturnsInSync_NoMutation                 (criterion 8a, 4)
+ReconcileAsync_MissingShim_CreatesShim_ReturnsReconciled       (criterion 8b)
+ReconcileAsync_OrphanedLegacyShim_Purged_ReturnsReconciled     (criterion 8c)
+ReconcileAsync_CalledTwice_SecondCallIsInSyncNoOp              (criterion 8d, 4)
+ReconcileAsync_ShimOnlyDrift_DoesNotEnterHeavyPath            (criterion 8e, 5)
+ReconcileAsync_BrokenVenv_EscalatesToHeavyRepair_ReturnsReconciled  (criterion 5)
+ReconcileAsync_BrokenVenv_HeavyRepairFails_ReturnsFailed            (criterion 3)
+ReconcileAsync_BrokenVenv_AnotherDirectorHoldsMutex_SkipsHeavyRepair (criterion 6)
+</pre>
+
+<p>Raw captured evidence: <code>docs/cencon/proof/issue-826/build-and-test.txt</code></p>
+
+<h2>CenCon impact</h2>
+<p>No drift. A new internal engine class within the existing <code>cc-director-setup-engine</code> container; no architecture or security-posture change. The three <code>PythonToolsInstaller</code> member visibility changes are additive (private -&gt; public) with no behavior change - all pre-existing installer tests still pass.</p>
+
+<h2>Conclusion</h2>
+<p class="pass">I believe this is finished. The engine operation and its tests are complete, the full solution builds clean with zero warnings, and all 201 engine tests (including the 8 new ones covering every acceptance criterion) pass. No UI, lifecycle, or config changes were made, per the issue scope.</p>
+</body>
+</html>

--- a/tools/cc-director-setup-engine.Tests/ToolReconcilerTests.cs
+++ b/tools/cc-director-setup-engine.Tests/ToolReconcilerTests.cs
@@ -1,0 +1,235 @@
+using System.Runtime.Versioning;
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+/// <summary>
+/// Offline tests for the manifest-driven <see cref="ToolReconciler"/> (issue #826). They drive a temp/fake
+/// install layout - never the real machine install or the network. The heavy release-backed repair is
+/// injected as a delegate so the venv-broken escalation can be exercised (and asserted NOT to fire for a
+/// shim-only drift) without a real release.
+///
+/// All cases use real manifest tool names (e.g. cc-pdf) because the reconciler enumerates the embedded
+/// tools manifest via <see cref="CcDirector.Core.Tools.ToolCatalogService"/>; the venv console-script exe is
+/// faked on disk so detection sees a "built" tool.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class ToolReconcilerTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly InstallLayout _layout;
+
+    public ToolReconcilerTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cc-reconcile-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+        _layout = new InstallLayout(Path.Combine(_dir, "local"));
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    /// <summary>Place a fake venv console-script exe for each given tool name (so it looks "built").</summary>
+    private void PlaceVenvScripts(params string[] names)
+    {
+        Directory.CreateDirectory(_layout.PyenvScriptsDir);
+        foreach (var n in names)
+            File.WriteAllText(PythonToolsInstaller.ConsoleScriptPath(_layout, n), "fake-exe");
+    }
+
+    /// <summary>Record the bundle's expected console-script names so the venv-health probe has an expectation.</summary>
+    private void RecordExpectedScripts(params string[] names)
+        => PythonToolsState.SaveScripts(_layout, names);
+
+    private string ShimPath(string name) => Path.Combine(_layout.BinDir, name + ".cmd");
+
+    /// <summary>A heavy-repair delegate that records whether it was called and returns a fixed result.</summary>
+    private sealed class FakeHeavyRepair
+    {
+        public int Calls { get; private set; }
+        private readonly bool _success;
+        public FakeHeavyRepair(bool success) => _success = success;
+
+        public Task<PythonToolsResult> InvokeAsync(CancellationToken ct)
+        {
+            Calls++;
+            return Task.FromResult(new PythonToolsResult(
+                _success, _success ? "rebuilt" : "rebuild failed", Array.Empty<string>(), 0, _success ? "1.0.0" : null));
+        }
+    }
+
+    // (a) no-drift -> InSync, zero mutations -------------------------------------------------------------
+
+    [Fact]
+    public async Task ReconcileAsync_NoDrift_ReturnsInSync_NoMutation()
+    {
+        // Every recorded tool is built (console script present) AND has its shim - no orphans, no broken venv.
+        PlaceVenvScripts("cc-pdf");
+        RecordExpectedScripts("cc-pdf");
+        new PythonToolsInstaller(_layout).WriteShims(new[] { "cc-pdf" });
+        Assert.True(File.Exists(ShimPath("cc-pdf")));
+
+        // Snapshot bin so we can prove nothing changed.
+        var before = Directory.GetFileSystemEntries(_layout.BinDir).OrderBy(p => p).ToArray();
+        var heavy = new FakeHeavyRepair(success: true);
+
+        var result = await new ToolReconciler(_layout, heavy.InvokeAsync).ReconcileAsync();
+
+        Assert.Equal(ReconcileOutcome.InSync, result.Outcome);
+        Assert.Empty(result.Actions);
+        Assert.Equal(0, heavy.Calls); // no network/release fetch on the happy path
+        var after = Directory.GetFileSystemEntries(_layout.BinDir).OrderBy(p => p).ToArray();
+        Assert.Equal(before, after); // zero filesystem mutation
+    }
+
+    // (b) missing shim -> shim created, Reconciled ------------------------------------------------------
+
+    [Fact]
+    public async Task ReconcileAsync_MissingShim_CreatesShim_ReturnsReconciled()
+    {
+        // cc-pdf's venv exe exists but its bin shim is absent -> the reconciler must create it.
+        PlaceVenvScripts("cc-pdf");
+        RecordExpectedScripts("cc-pdf");
+        Assert.False(File.Exists(ShimPath("cc-pdf")));
+        var heavy = new FakeHeavyRepair(success: true);
+
+        var result = await new ToolReconciler(_layout, heavy.InvokeAsync).ReconcileAsync();
+
+        Assert.Equal(ReconcileOutcome.Reconciled, result.Outcome);
+        Assert.True(File.Exists(ShimPath("cc-pdf")), "the missing shim was not created");
+        Assert.Contains(result.Actions, a => a.Contains("cc-pdf"));
+        Assert.Equal(0, heavy.Calls); // a missing shim must NOT trigger the heavy rebuild
+    }
+
+    // (c) orphaned legacy shim present -> purged, Reconciled --------------------------------------------
+
+    [Fact]
+    public async Task ReconcileAsync_OrphanedLegacyShim_Purged_ReturnsReconciled()
+    {
+        // A retired alias shim left by an older install; no other drift.
+        Directory.CreateDirectory(_layout.BinDir);
+        var legacy = Path.Combine(_layout.BinDir, "cc-send.cmd");
+        File.WriteAllText(legacy, "@echo off\r\n");
+        var heavy = new FakeHeavyRepair(success: true);
+
+        var result = await new ToolReconciler(_layout, heavy.InvokeAsync).ReconcileAsync();
+
+        Assert.Equal(ReconcileOutcome.Reconciled, result.Outcome);
+        Assert.False(File.Exists(legacy), "the orphaned legacy alias shim was not purged");
+        Assert.Contains(result.Actions, a => a.Contains("legacy", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(0, heavy.Calls); // a legacy shim purge must NOT trigger the heavy rebuild
+    }
+
+    // (d) idempotency: second call is InSync ------------------------------------------------------------
+
+    [Fact]
+    public async Task ReconcileAsync_CalledTwice_SecondCallIsInSyncNoOp()
+    {
+        PlaceVenvScripts("cc-pdf");
+        RecordExpectedScripts("cc-pdf");
+        var heavy = new FakeHeavyRepair(success: true);
+        var reconciler = new ToolReconciler(_layout, heavy.InvokeAsync);
+
+        var first = await reconciler.ReconcileAsync();
+        Assert.Equal(ReconcileOutcome.Reconciled, first.Outcome); // first call fixed the missing shim
+
+        var before = Directory.GetFileSystemEntries(_layout.BinDir).OrderBy(p => p).ToArray();
+        var second = await reconciler.ReconcileAsync();
+
+        Assert.Equal(ReconcileOutcome.InSync, second.Outcome); // nothing left to fix
+        Assert.Empty(second.Actions);
+        var after = Directory.GetFileSystemEntries(_layout.BinDir).OrderBy(p => p).ToArray();
+        Assert.Equal(before, after); // the second call mutated nothing
+    }
+
+    // (e) the heavy path is NOT entered for a shim-only drift -------------------------------------------
+
+    [Fact]
+    public async Task ReconcileAsync_ShimOnlyDrift_DoesNotEnterHeavyPath()
+    {
+        // Missing shim AND an orphaned legacy shim, but the venv is healthy (every recorded script on disk).
+        // Both are light fixes - the heavy release-backed rebuild must NOT be invoked.
+        PlaceVenvScripts("cc-pdf", "cc-html");
+        RecordExpectedScripts("cc-pdf", "cc-html"); // both present -> venv healthy
+        Directory.CreateDirectory(_layout.BinDir);
+        File.WriteAllText(Path.Combine(_layout.BinDir, "cc-spawn.cmd"), "@echo off\r\n"); // retired alias
+        var heavy = new FakeHeavyRepair(success: true);
+
+        var result = await new ToolReconciler(_layout, heavy.InvokeAsync).ReconcileAsync();
+
+        Assert.Equal(ReconcileOutcome.Reconciled, result.Outcome);
+        Assert.Equal(0, heavy.Calls); // shim-only drift never escalates to the heavy rebuild
+    }
+
+    // venv-broken -> heavy path IS entered (proves the escalation is wired) ------------------------------
+
+    [Fact]
+    public async Task ReconcileAsync_BrokenVenv_EscalatesToHeavyRepair_ReturnsReconciled()
+    {
+        // A recorded script is missing from the venv -> broken -> escalate to the heavy repair delegate.
+        RecordExpectedScripts("cc-pdf", "cc-html");
+        PlaceVenvScripts("cc-pdf"); // cc-html missing -> venv unhealthy
+        var heavy = new FakeHeavyRepair(success: true);
+
+        var result = await new ToolReconciler(_layout, heavy.InvokeAsync).ReconcileAsync();
+
+        Assert.Equal(ReconcileOutcome.Reconciled, result.Outcome);
+        Assert.Equal(1, heavy.Calls); // the broken venv escalated to the heavy rebuild
+        Assert.Contains(result.Actions, a => a.Contains("venv", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_BrokenVenv_HeavyRepairFails_ReturnsFailed()
+    {
+        RecordExpectedScripts("cc-pdf", "cc-html");
+        PlaceVenvScripts("cc-pdf"); // cc-html missing -> venv unhealthy
+        var heavy = new FakeHeavyRepair(success: false);
+
+        var result = await new ToolReconciler(_layout, heavy.InvokeAsync).ReconcileAsync();
+
+        Assert.Equal(ReconcileOutcome.Failed, result.Outcome);
+        Assert.Equal(1, heavy.Calls);
+        Assert.False(string.IsNullOrEmpty(result.Error));
+    }
+
+    // mutex skip: when another holder owns the heavy mutex, the heavy repair is not forced ---------------
+
+    [Fact]
+    public async Task ReconcileAsync_BrokenVenv_AnotherDirectorHoldsMutex_SkipsHeavyRepair()
+    {
+        RecordExpectedScripts("cc-pdf", "cc-html");
+        PlaceVenvScripts("cc-pdf"); // cc-html missing -> venv unhealthy
+        var heavy = new FakeHeavyRepair(success: true);
+
+        // Simulate ANOTHER Director (another process/thread) holding the machine-wide heavy-repair mutex.
+        // A Windows Mutex is owned per-thread, so the holder MUST run on its own thread - acquiring it on the
+        // test thread would let the reconciler's same-thread WaitOne re-acquire it recursively.
+        using var acquired = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+        var holderThread = new Thread(() =>
+        {
+            using var holder = new Mutex(initiallyOwned: false, ToolReconciler.HeavyRepairMutexName, out _);
+            holder.WaitOne();
+            acquired.Set();
+            release.Wait();
+            holder.ReleaseMutex();
+        });
+        holderThread.Start();
+        Assert.True(acquired.Wait(TimeSpan.FromSeconds(5)), "holder thread did not acquire the mutex");
+        try
+        {
+            var result = await new ToolReconciler(_layout, heavy.InvokeAsync).ReconcileAsync();
+
+            Assert.Equal(0, heavy.Calls); // did not force the rebuild while another holder owns the lock
+            Assert.Contains(result.Actions, a => a.Contains("skipped", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            release.Set();
+            holderThread.Join();
+        }
+    }
+}

--- a/tools/cc-director-setup-engine/PythonToolsInstaller.cs
+++ b/tools/cc-director-setup-engine/PythonToolsInstaller.cs
@@ -349,39 +349,52 @@ public sealed class PythonToolsInstaller
     };
 
     /// <summary>
+    /// All possible on-disk shim file paths for one legacy alias name: on Windows a bin\&lt;name&gt;.cmd,
+    /// a bin\&lt;name&gt;.exe (from an even older PyInstaller install), and a bare-name bash shim; on macOS
+    /// a ~/.local/bin/&lt;name&gt; symlink. This is the single definition of WHERE a legacy alias shim can
+    /// live, shared by the detection (<see cref="FindOrphanedLegacyAliasShims"/>) and the purge
+    /// (<see cref="RemoveLegacyAliasShims"/>) so neither duplicates the path set.
+    /// </summary>
+    private IEnumerable<string> LegacyAliasShimPaths(string name) =>
+        OperatingSystem.IsWindows()
+            ? new[]
+              {
+                  Path.Combine(_layout.BinDir, $"{name}.cmd"),
+                  Path.Combine(_layout.BinDir, $"{name}.exe"),
+                  Path.Combine(_layout.BinDir, name), // bare-name bash shim
+              }
+            : new[] { Path.Combine(_layout.MacUserBinDir, name) };
+
+    /// <summary>
+    /// The orphaned legacy alias shim files that currently exist on disk (issue #823) - pure detection, no
+    /// mutation. Exposed so the reconciler (<see cref="ToolReconciler"/>) can decide whether a purge is even
+    /// needed BEFORE touching the filesystem (its happy path performs no mutation), reusing the same legacy
+    /// name list and path set the purge uses instead of re-deriving them.
+    /// </summary>
+    internal IReadOnlyList<string> FindOrphanedLegacyAliasShims() =>
+        LegacyAliasShimNames.SelectMany(LegacyAliasShimPaths).Where(File.Exists).ToList();
+
+    /// <summary>
     /// Delete any orphaned legacy alias shims from the install (issue #823). Each retired alias may have left
     /// a bin\&lt;name&gt;.cmd, a bare-name bash shim, and (from an even older PyInstaller install) a
     /// bin\&lt;name&gt;.exe on Windows, or a ~/.local/bin/&lt;name&gt; symlink on macOS - all pointing at a
     /// venv exe that no longer exists. Removing them is what satisfies "no shim points at a missing exe":
     /// the command becomes absent and the fleet banner directs the agent to the cc-devthrottle subcommand
-    /// instead. Best-effort: a shim we cannot delete is logged, never thrown.
+    /// instead. Best-effort: a shim we cannot delete is logged, never thrown. Public so the reconciler can
+    /// reuse it as the corrective action for orphaned-shim drift.
     /// </summary>
-    private void RemoveLegacyAliasShims()
+    public void RemoveLegacyAliasShims()
     {
-        foreach (var name in LegacyAliasShimNames)
+        foreach (var path in FindOrphanedLegacyAliasShims())
         {
-            var paths = OperatingSystem.IsWindows()
-                ? new[]
-                  {
-                      Path.Combine(_layout.BinDir, $"{name}.cmd"),
-                      Path.Combine(_layout.BinDir, $"{name}.exe"),
-                      Path.Combine(_layout.BinDir, name), // bare-name bash shim
-                  }
-                : new[] { Path.Combine(_layout.MacUserBinDir, name) };
-            foreach (var path in paths)
+            try
             {
-                try
-                {
-                    if (File.Exists(path))
-                    {
-                        File.Delete(path);
-                        EngineLog.Write($"[PythonToolsInstaller] removed orphaned legacy alias shim {path}");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    EngineLog.Write($"[PythonToolsInstaller] could not remove legacy alias shim {path}: {ex.Message}");
-                }
+                File.Delete(path);
+                EngineLog.Write($"[PythonToolsInstaller] removed orphaned legacy alias shim {path}");
+            }
+            catch (Exception ex)
+            {
+                EngineLog.Write($"[PythonToolsInstaller] could not remove legacy alias shim {path}: {ex.Message}");
             }
         }
     }
@@ -411,8 +424,13 @@ public sealed class PythonToolsInstaller
         }
     }
 
-    /// <summary>Create the tool shims: bin\&lt;script&gt;.cmd on Windows, ~/.local/bin symlinks on macOS.</summary>
-    private void WriteShims(IReadOnlyList<string> scripts)
+    /// <summary>
+    /// Create the tool shims: bin\&lt;script&gt;.cmd (plus a bare-name bash shim) on Windows, ~/.local/bin
+    /// symlinks on macOS. Public so the reconciler can reuse it to (re)create a single tool's missing shim
+    /// whose venv console-script target already exists - the lightweight corrective action for shim-only
+    /// drift, which must never duplicate the shim-body or path conventions defined here.
+    /// </summary>
+    public void WriteShims(IReadOnlyList<string> scripts)
     {
         if (OperatingSystem.IsWindows()) WriteWindowsShims(scripts);
         else WriteUnixShims(scripts);

--- a/tools/cc-director-setup-engine/ToolReconciler.cs
+++ b/tools/cc-director-setup-engine/ToolReconciler.cs
@@ -1,0 +1,216 @@
+using CcDirector.Core.Tools;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Setup.Engine;
+
+/// <summary>The state a <see cref="ReconcileResult"/> reports after a reconcile pass.</summary>
+public enum ReconcileOutcome
+{
+    /// <summary>No drift was found; nothing was changed (the cheap, idempotent happy path).</summary>
+    InSync,
+
+    /// <summary>Drift was found and corrected; <see cref="ReconcileResult.Actions"/> lists what was done.</summary>
+    Reconciled,
+
+    /// <summary>A corrective action failed; <see cref="ReconcileResult.Error"/> carries the reason.</summary>
+    Failed,
+}
+
+/// <summary>
+/// The structured outcome of <see cref="ToolReconciler.ReconcileAsync"/>: the overall
+/// <see cref="Outcome"/>, the human-readable list of corrective actions performed (empty when
+/// <see cref="ReconcileOutcome.InSync"/>), and an optional <see cref="Error"/> when
+/// <see cref="ReconcileOutcome.Failed"/>. The supervisor / UI reads this; it is intentionally richer
+/// than a bool so the later indicator work can show exactly what happened.
+/// </summary>
+public sealed record ReconcileResult(ReconcileOutcome Outcome, IReadOnlyList<string> Actions, string? Error = null);
+
+/// <summary>
+/// The automatic, idempotent equivalent of the manual "Fix Tools" repair (the Settings dialog's
+/// Fix-Tools button -> <see cref="ToolUpdater.RepairPythonToolsAsync"/>). Where the manual repair always
+/// runs the heavy release-backed rebuild (fetch the latest release, rebuild the shared venv, reinstall
+/// everything), this reconcile is the lightweight sibling meant to run frequently and unattended: it
+/// detects drift between the embedded tools manifest and the installed tool layout and corrects ONLY the
+/// drift it finds, scaling the corrective action to the problem.
+///
+/// Drift it considers, reusing the existing detection rather than a parallel comparison:
+///   (a) a manifest tool whose venv console-script exe exists but whose bin shim is missing -> create
+///       the shim (<see cref="PythonToolsInstaller.WriteShims"/>);
+///   (b) orphaned legacy/retired alias shims left by older installs -> purge them
+///       (<see cref="PythonToolsInstaller.RemoveLegacyAliasShims"/> / <c>LegacyAliasShimNames</c>, issue #823);
+///   (c) a broken/absent shared venv (a recorded console script is missing) -> escalate to the heavy
+///       release-backed <see cref="ToolUpdater.RepairPythonToolsAsync"/>.
+///
+/// It is cheap and idempotent on the happy path: when there is no drift it performs NO filesystem mutation
+/// and NO network/release fetch and returns <see cref="ReconcileOutcome.InSync"/> quickly; a second call in
+/// a row is a pure no-op. The heavy escalation (c) is guarded by a machine-wide named mutex so two Directors
+/// sharing one venv + bin dir never rebuild concurrently - if another process already holds it, this call
+/// returns without forcing. The light shim-only fixes (a)/(b) proceed without the heavy lock: they are
+/// per-file create/delete operations that are safe to repeat and never rebuild the venv.
+/// </summary>
+public sealed class ToolReconciler
+{
+    /// <summary>
+    /// Machine-wide named mutex serializing the heavy venv rebuild across Directors that share one install
+    /// (same convention as scripts/agent-session-isolation.ps1's launch mutex). The light shim path does not
+    /// take it - only the release-backed rebuild does, so concurrent reconciles never rebuild the venv twice.
+    /// </summary>
+    public const string HeavyRepairMutexName = @"Global\cc-director-tool-reconcile";
+
+    private readonly InstallLayout _layout;
+    private readonly Func<CancellationToken, Task<PythonToolsResult>> _heavyRepairAsync;
+
+    /// <summary>
+    /// Construct against an install layout (defaults to the production layout) and the heavy-repair
+    /// escalation (defaults to <see cref="ToolUpdater.RepairPythonToolsAsync"/>). The heavy-repair delegate is
+    /// injectable so tests can drive the reconcile logic without a real release or network access.
+    /// </summary>
+    public ToolReconciler(
+        InstallLayout? layout = null,
+        Func<CancellationToken, Task<PythonToolsResult>>? heavyRepairAsync = null)
+    {
+        _layout = layout ?? InstallLayout.Default();
+        _heavyRepairAsync = heavyRepairAsync ?? (ct => new ToolUpdater(_layout).RepairPythonToolsAsync(ct: ct));
+    }
+
+    /// <summary>
+    /// Detect drift between the embedded manifest and the installed tool layout and correct it. Returns a
+    /// structured <see cref="ReconcileResult"/> (never throws for the supervisor's benefit): InSync when there
+    /// was no drift, Reconciled when drift was found and fixed, Failed when a corrective action failed.
+    /// </summary>
+    public async Task<ReconcileResult> ReconcileAsync(CancellationToken ct = default)
+    {
+        FileLog.Write("[ToolReconciler] ReconcileAsync: detecting tool drift");
+        try
+        {
+            // --- DETECT (pure reads, no mutation) -----------------------------------------------------
+            var installer = new PythonToolsInstaller(_layout);
+            var catalog = new ToolCatalogService(_layout.BinDir);
+            var descriptors = catalog.GetCatalog();
+
+            // (a) manifest tools whose venv console-script exe exists but whose managed bin shim is absent.
+            var missingShims = descriptors
+                .Where(d => File.Exists(PythonToolsInstaller.ConsoleScriptPath(_layout, d.Name))
+                            && !File.Exists(ManagedShimPath(d.Name)))
+                .Select(d => d.Name)
+                .ToList();
+
+            // (b) orphaned legacy/retired alias shims (reuse the installer's name list + path set).
+            var orphanedLegacy = installer.FindOrphanedLegacyAliasShims();
+
+            // (c) a broken/absent shared venv: a recorded console script is missing. We only judge this when
+            //     we have a recorded expectation (the sidecar). With no expectation we cannot tell a healthy
+            //     install from an empty one, so we never escalate the heavy rebuild on a guess.
+            var expectedScripts = PythonToolsState.LoadScripts(_layout);
+            var venvBroken = expectedScripts.Count > 0
+                && !PythonToolsInstaller.VenvHasAllTools(_layout, expectedScripts);
+
+            // Built binaries not in the manifest. We surface these for visibility but do NOT remove them - the
+            // only shims we purge are the known retired aliases; a user's own cc-* binary is left untouched.
+            var unmanaged = catalog.GetUnmanagedBinaries();
+            if (unmanaged.Count > 0)
+                FileLog.Write($"[ToolReconciler] observed {unmanaged.Count} unmanaged binaries (not acted on): {string.Join(", ", unmanaged)}");
+
+            if (missingShims.Count == 0 && orphanedLegacy.Count == 0 && !venvBroken)
+            {
+                FileLog.Write("[ToolReconciler] no drift; tools are in sync (no action taken)");
+                return new ReconcileResult(ReconcileOutcome.InSync, Array.Empty<string>());
+            }
+
+            FileLog.Write($"[ToolReconciler] drift found: missingShims={missingShims.Count}, orphanedLegacyShims={orphanedLegacy.Count}, venvBroken={venvBroken}");
+
+            // --- CORRECT --------------------------------------------------------------------------------
+            var actions = new List<string>();
+            var mutated = false;
+
+            // (a) Create missing shims directly - their venv targets already exist, so this is a cheap,
+            //     per-file write that never rebuilds the venv.
+            if (missingShims.Count > 0)
+            {
+                installer.WriteShims(missingShims);
+                foreach (var name in missingShims)
+                    FileLog.Write($"[ToolReconciler] created missing shim for {name}");
+                actions.Add($"created {missingShims.Count} missing tool shim(s): {string.Join(", ", missingShims)}");
+                mutated = true;
+            }
+
+            // (b) Purge orphaned legacy alias shims directly (reuse the installer's purge).
+            if (orphanedLegacy.Count > 0)
+            {
+                installer.RemoveLegacyAliasShims();
+                FileLog.Write($"[ToolReconciler] purged {orphanedLegacy.Count} orphaned legacy alias shim(s)");
+                actions.Add($"purged {orphanedLegacy.Count} orphaned legacy alias shim(s)");
+                mutated = true;
+            }
+
+            // (c) Only a genuinely broken venv escalates to the heavy release-backed rebuild, and only under
+            //     the machine-wide mutex so two Directors never rebuild the shared venv at once.
+            if (venvBroken)
+            {
+                var heavy = await EscalateHeavyRepairAsync(actions, ct);
+                if (heavy is { } failure)
+                    return failure; // heavy repair failed -> Failed (light actions already recorded)
+                if (actions.Count > 0)
+                    mutated = true;
+            }
+
+            var outcome = mutated ? ReconcileOutcome.Reconciled : ReconcileOutcome.InSync;
+            FileLog.Write($"[ToolReconciler] ReconcileAsync done: outcome={outcome}, actions={actions.Count}");
+            return new ReconcileResult(outcome, actions);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[ToolReconciler] ReconcileAsync FAILED: {ex.Message}");
+            return new ReconcileResult(ReconcileOutcome.Failed, Array.Empty<string>(), ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Run the heavy release-backed venv repair under the machine-wide mutex. Returns null on success (the
+    /// action is appended to <paramref name="actions"/>) or a skip-note; returns a Failed result when the
+    /// repair itself failed. If another Director already holds the mutex, we do NOT force - we log the skip
+    /// and leave the rebuild to the holder.
+    /// </summary>
+    private async Task<ReconcileResult?> EscalateHeavyRepairAsync(List<string> actions, CancellationToken ct)
+    {
+        using var mutex = new Mutex(initiallyOwned: false, HeavyRepairMutexName, out _);
+        var held = false;
+        try
+        {
+            try { held = mutex.WaitOne(TimeSpan.Zero); }
+            catch (AbandonedMutexException) { held = true; } // a prior holder died; we now own it
+
+            if (!held)
+            {
+                FileLog.Write("[ToolReconciler] reconcile skipped - another Director is reconciling");
+                actions.Add("heavy venv repair skipped - another Director is reconciling");
+                return null;
+            }
+
+            FileLog.Write("[ToolReconciler] venv is broken; escalating to the release-backed repair");
+            var repair = await _heavyRepairAsync(ct);
+            if (!repair.Success)
+            {
+                FileLog.Write($"[ToolReconciler] heavy venv repair FAILED: {repair.Message}");
+                return new ReconcileResult(ReconcileOutcome.Failed, actions, repair.Message);
+            }
+
+            FileLog.Write($"[ToolReconciler] heavy venv repair succeeded: {repair.Message}");
+            actions.Add($"rebuilt the shared Python tools venv ({repair.Message})");
+            return null;
+        }
+        finally
+        {
+            if (held) mutex.ReleaseMutex();
+        }
+    }
+
+    /// <summary>
+    /// The managed shim path the installer writes for a tool: bin\&lt;name&gt;.cmd on Windows, the
+    /// ~/.local/bin/&lt;name&gt; symlink on macOS - matching <see cref="PythonToolsInstaller.WriteShims"/>.
+    /// </summary>
+    private string ManagedShimPath(string name) =>
+        OperatingSystem.IsWindows()
+            ? Path.Combine(_layout.BinDir, name + ".cmd")
+            : Path.Combine(_layout.MacUserBinDir, name);
+}


### PR DESCRIPTION
## Release Notes
Adds `ToolReconciler` to the setup engine: the lightweight, idempotent, automatic equivalent of the manual "Fix Tools" repair. It detects drift between the embedded tools manifest and the installed tool layout and corrects only the drift it finds. This is the building block the later lifecycle/indicator work (#827/#828/#829) will call. Engine + tests only - no UI, no `App.axaml.cs` lifecycle, no settings/config key.

## Changes
- New `tools/cc-director-setup-engine/ToolReconciler.cs`: `ReconcileAsync(...)`, `ReconcileResult` record, `ReconcileOutcome` enum (`InSync`/`Reconciled`/`Failed`).
  - (a) missing shim (venv console-script present, `bin\<name>.cmd` absent) -> create directly via `PythonToolsInstaller.WriteShims`.
  - (b) orphaned legacy/retired alias shims -> purge via `RemoveLegacyAliasShims` (reusing `LegacyAliasShimNames`; not duplicated).
  - (c) broken/absent shared venv -> escalate to heavy `ToolUpdater.RepairPythonToolsAsync`, guarded by machine-wide mutex `Global\cc-director-tool-reconcile`; if another Director holds it, skip without forcing. Light shim path is unlocked.
  - Detection reuses `ToolCatalogService` (+`GetUnmanagedBinaries`), `VenvHasAllTools`, `PythonToolsState` - not a parallel comparison. Happy path does zero FS mutation and no network fetch, returns `InSync`; second call is a no-op.
- Edited `PythonToolsInstaller.cs`: `RemoveLegacyAliasShims` and `WriteShims` made public for reuse; new `FindOrphanedLegacyAliasShims` (pure detection) shares one path-set helper with the purge.
- New `ToolReconcilerTests.cs`: 8 offline tests (temp/fake layout, injected fake heavy-repair, no network).

## How to Test
- `dotnet build cc-director.sln`
- `dotnet test tools/cc-director-setup-engine.Tests/CcDirector.Setup.Engine.Tests.csproj --filter "FullyQualifiedName~ToolReconcilerTests"`

## Expected Result
Build succeeds with 0 warnings / 0 errors. All 8 ToolReconciler tests pass; the full engine suite (201 tests) passes.

## Before / After
- Before: the only drift correction was a human clicking Settings "Fix Tools" -> heavy release-backed rebuild.
- After: a cheap, idempotent, manifest-driven reconcile exists in the engine that fixes shim drift directly and only escalates the heavy rebuild when the venv itself is broken.

Proof: docs/cencon/proof/issue-826/report.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)