### PR TITLE
[Gateway] Fix flaky telemetry tests: isolate FileLog per test (#862)

### DIFF
--- a/docs/cencon/proof/issue-862/report.html
+++ b/docs/cencon/proof/issue-862/report.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Issue #862 - Flaky telemetry tests - Developer Proof</title>
+<style>
+  :root { --bg:#0b1020; --panel:#131a2e; --panel2:#1a2236; --border:#2a3550; --text:#e7ecf5; --dim:#93a0bd; --accent:#4f8cff; }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--bg); color:var(--text); font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif; line-height:1.6; }
+  .wrap { max-width:1040px; margin:0 auto; padding:32px 24px 96px; }
+  h1 { font-size:26px; margin:0 0 4px; }
+  h2 { font-size:20px; margin:36px 0 12px; padding-bottom:8px; border-bottom:1px solid var(--border); }
+  p,li { color:#d7deef; }
+  .sub { color:var(--dim); margin:0 0 8px; }
+  code { background:#0f1626; padding:1px 6px; border-radius:5px; font-family:Consolas,Menlo,monospace; font-size:13px; color:#cfe0ff; }
+  pre { background:#0f1626; border:1px solid var(--border); border-radius:10px; padding:14px 16px; overflow-x:auto; font-family:Consolas,Menlo,monospace; font-size:12.5px; color:#cfe0ff; }
+  table { border-collapse:collapse; width:100%; margin:12px 0; font-size:14px; }
+  th,td { border:1px solid var(--border); padding:8px 10px; text-align:left; vertical-align:top; }
+  th { background:var(--panel2); color:#cdd8f0; }
+  .pill { display:inline-block; font-size:12px; font-weight:700; padding:2px 9px; border-radius:999px; background:#11331f; color:#5fd08a; border:1px solid #1f5c38; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Issue #862 - Flaky telemetry tests</h1>
+  <p class="sub">Developer Agent proof. Branch <code>issue-862-flaky-telemetry</code> (off <code>main</code>).</p>
+  <p><span class="pill">I believe this is finished.</span></p>
+
+  <h2>1. Corrected root cause</h2>
+  <p>The issue first guessed test parallelism. On reading the code that proved wrong: <code>CcDirector.Gateway.Tests</code>
+  already disables parallelization (<code>TestParallelization.cs</code> -> <code>[assembly: CollectionBehavior(DisableTestParallelization = true)]</code>),
+  so the tests run <strong>serially</strong>. The real cause is the single, process-wide <code>FileLog</code> background writer:</p>
+  <ul>
+    <li><strong>Carryover</strong> - the shared writer is never stopped between serial tests, so a previous test's still-queued
+      lines flush into the current test's file after it snapshots/clears the shared log directory; a "never writes the token"
+      scan can then see another test's line.</li>
+    <li><strong>Flush timing</strong> - <code>FileLog</code> flushes on a background thread (1-second interval / on queue-drain).
+      The tests waited with a fixed <code>Task.Delay</code> / a poll loop; under CI load the expected line had not landed in
+      time, so the "records locally" / "logging is wired" assertions failed.</li>
+  </ul>
+
+  <h2>2. The fix</h2>
+  <ul>
+    <li><strong>A test-only seam on <code>FileLog</code></strong> (<code>src/CcDirector.Core/Utilities/FileLog.cs</code>):
+      <code>RedirectForTests()</code> returns a scope that swaps the single static writer for a fresh one pointed at a private,
+      throwaway directory, and <code>DrainAndReadLines()</code> <em>synchronously</em> drains it (<code>Stop()</code> completes
+      the queue and joins the writer thread) and returns exactly the lines that scope produced. Restored + the temp dir deleted
+      on dispose. Internal (Core already grants <code>InternalsVisibleTo CcDirector.Gateway.Tests</code>); safe because the test
+      assembly is serial, so one test owns <code>FileLog</code> at a time. No production behavior change - the live logger is untouched.</li>
+    <li><strong>The three tests now use the seam</strong> instead of snapshotting/clearing the shared
+      <code>CcStorage.ToolLogs("director")</code> directory: no baseline bookkeeping, no <code>Task.Delay</code>, no poll loops.
+      Each reads a private, fully-flushed log - deterministic by construction. (Dead <code>ReadAllLinesShared</code> helpers removed.)</li>
+  </ul>
+
+  <h2>3. Acceptance criteria - met</h2>
+  <table>
+    <tr><th>Criterion</th><th>Evidence</th></tr>
+    <tr><td>The three tests pass consistently across repeated runs (10x)</td><td>Telemetry cluster (34 tests incl. all three) looped 10x - all green (below).</td></tr>
+    <tr><td>Full <code>CcDirector.Gateway.Tests</code> green across repeated runs</td><td>Two full-suite runs, 1009/1009 passed each (below). (Each serial run is ~3.5 min; two shown.)</td></tr>
+    <tr><td>The three tests no longer depend on the shared log directory</td><td>Each now reads a private per-test temp dir via the seam - no shared <code>CcStorage.ToolLogs("director")</code> access. See the diff.</td></tr>
+    <tr><td>No production behavior change</td><td><code>FileLog</code>'s production sink resolution is unchanged; only a test-only seam is added. The <code>FileLog</code> Core tests pass (4/4).</td></tr>
+  </table>
+
+  <h2>4. Test runs</h2>
+  <pre>dotnet build cc-director.sln  ->  Build succeeded. 0 Warning(s) 0 Error(s)
+
+# Telemetry cluster (incl. the 3 previously-flaky tests), 10 consecutive runs:
+run 1:  Passed!  - Failed: 0, Passed: 34, Total: 34
+run 2:  Passed!  - Failed: 0, Passed: 34, Total: 34
+run 3:  Passed!  - Failed: 0, Passed: 34, Total: 34
+run 4:  Passed!  - Failed: 0, Passed: 34, Total: 34
+run 5:  Passed!  - Failed: 0, Passed: 34, Total: 34
+run 6:  Passed!  - Failed: 0, Passed: 34, Total: 34
+run 7:  Passed!  - Failed: 0, Passed: 34, Total: 34
+run 8:  Passed!  - Failed: 0, Passed: 34, Total: 34
+run 9:  Passed!  - Failed: 0, Passed: 34, Total: 34
+run 10: Passed!  - Failed: 0, Passed: 34, Total: 34
+
+# Full CcDirector.Gateway.Tests project (serial, ~3.5 min/run):
+run 1:  Passed!  - Failed: 0, Passed: 1009, Total: 1009
+run 2:  Passed!  - Failed: 0, Passed: 1009, Total: 1009
+
+# FileLog Core tests (the type I changed):
+Passed!  - Failed: 0, Passed: 4, Total: 4</pre>
+
+  <h2>5. CenCon impact</h2>
+  <p>No drift. The change adds a test-only seam to <code>FileLog</code> (no change to its production sink) and rewrites three
+  tests; no new container, external system, security boundary, or behavior. The Wingman/telemetry features are untouched.</p>
+</div>
+</body>
+</html>

--- a/src/CcDirector.Core/Utilities/FileLog.cs
+++ b/src/CcDirector.Core/Utilities/FileLog.cs
@@ -14,7 +14,10 @@ public static class FileLog
 {
     private static readonly string LogDir = CcStorage.ToolLogs("director");
 
-    private static readonly FileLogWriter _writer =
+    // The active writer. Production never reassigns it; the test-only RedirectForTests seam (issue
+    // #862) swaps it for an isolated writer for the duration of one test, which is safe because the
+    // test assemblies disable parallelization (one test owns FileLog at a time).
+    private static FileLogWriter _writer =
         new(LogDir, Environment.ProcessId, () => DateTime.Now);
 
     private static int _started;
@@ -48,4 +51,80 @@ public static class FileLog
     /// <summary>Returns the current log file path (useful for display).</summary>
     public static string CurrentLogPath =>
         Path.Combine(LogDir, $"director-{DateTime.Now:yyyy-MM-dd}-{Environment.ProcessId}.log");
+
+    /// <summary>
+    /// TEST-ONLY seam (issue #862). Redirects FileLog to a private, throwaway directory for the life
+    /// of the returned scope, then lets a test read exactly the lines it produced by draining the
+    /// writer synchronously. This removes the two flakiness sources of asserting against the shared,
+    /// process-wide writer: (1) <em>carryover</em> - a previous test's still-queued lines flushing
+    /// into this test's file; and (2) <em>flush timing</em> - reading before the 1-second background
+    /// flush landed the lines. Swapping the single static writer is safe because the test assemblies
+    /// disable parallelization, so exactly one test owns FileLog at a time. Not for production use.
+    /// </summary>
+    internal static FileLogTestScope RedirectForTests() => new();
+
+    /// <summary>The scope returned by <see cref="RedirectForTests"/>; restores the previous writer
+    /// on dispose and deletes the throwaway directory. See that method for the rationale.</summary>
+    internal sealed class FileLogTestScope : IDisposable
+    {
+        private readonly string _dir;
+        private readonly FileLogWriter _previousWriter;
+        private readonly int _previousStarted;
+        private readonly FileLogWriter _testWriter;
+        private List<string>? _lines;
+
+        internal FileLogTestScope()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "cc-filelog-test-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+            _previousWriter = _writer;
+            _previousStarted = _started;
+            _testWriter = new FileLogWriter(_dir, Environment.ProcessId, () => DateTime.Now);
+            _writer = _testWriter;
+            _started = 1;
+            _testWriter.Start();
+        }
+
+        /// <summary>
+        /// Synchronously drain the writer to disk and return every line it wrote during this scope.
+        /// Stop() completes the queue and joins the writer thread, so all lines are flushed before
+        /// the read - no polling, no carryover. Idempotent: repeated calls return the same lines.
+        /// </summary>
+        internal IReadOnlyList<string> DrainAndReadLines()
+        {
+            if (_lines is not null) return _lines;
+            _testWriter.Stop();
+            var lines = new List<string>();
+            foreach (var file in Directory.EnumerateFiles(_dir, "*.log"))
+                lines.AddRange(ReadAllLinesShared(file));
+            _lines = lines;
+            return lines;
+        }
+
+        public void Dispose()
+        {
+            // Ensure the writer thread is stopped (and its file handle released) before restoring,
+            // even if the test never called DrainAndReadLines.
+            if (_lines is null) _testWriter.Stop();
+            _writer = _previousWriter;
+            _started = _previousStarted;
+            // Best-effort cleanup of the throwaway directory; a leftover temp dir is harmless.
+            try { Directory.Delete(_dir, recursive: true); }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+
+        /// <summary>Read a log file with FileShare.ReadWrite so a still-open writer handle never
+        /// blocks the read.</summary>
+        private static List<string> ReadAllLinesShared(string path)
+        {
+            var lines = new List<string>();
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(stream);
+            string? line;
+            while ((line = reader.ReadLine()) is not null)
+                lines.Add(line);
+            return lines;
+        }
+    }
 }

--- a/src/CcDirector.Gateway.Tests/DirectorStartupTelemetryEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorStartupTelemetryEndpointTests.cs
@@ -152,16 +152,11 @@ public sealed class DirectorStartupTelemetryEndpointTests
     [Fact]
     public async Task PostDirectorStartup_NoCloudUrl_RecordsLocallyAndDoesNotForward()
     {
-        // FileLog's sink directory is captured when the FileLog type first initializes. The live
-        // background writer holds the file open, so reads use a SHARED stream (FileShare.ReadWrite).
-        var logDir = CcStorage.ToolLogs("director");
+        // Issue #862: capture FileLog in a private, synchronously-drained sink so this assertion
+        // reads exactly this test's lines - no carryover from the shared process-wide writer and no
+        // background-flush timing race (which previously made this test flaky in CI).
+        using var log = FileLog.RedirectForTests();
 
-        var baseline = new Dictionary<string, int>();
-        if (Directory.Exists(logDir))
-            foreach (var f in Directory.EnumerateFiles(logDir, "*.log"))
-                baseline[f] = ReadAllLinesShared(f).Count;
-
-        FileLog.Start();
         var (client, captured, dispose) = await StartAsync(startStub: false);
         try
         {
@@ -173,31 +168,16 @@ public sealed class DirectorStartupTelemetryEndpointTests
             }));
             // AC4: still 202 with no cloud URL configured.
             Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
-
-            // Give the flusher time to (NOT) deliver: nothing should ever reach a stub because none
-            // exists and nothing was enqueued.
-            await Task.Delay(500);
         }
         finally
         {
             await dispose();
-            // Let the background writer flush our lines (it does NOT stop here - FileLog is a
-            // process-wide static other concurrent tests may still be using).
-            await Task.Delay(500);
         }
 
         // Nothing was forwarded (no stub was started; captured stays empty by construction).
         Assert.Empty(captured);
 
-        var newLines = new List<string>();
-        if (Directory.Exists(logDir))
-            foreach (var f in Directory.EnumerateFiles(logDir, "*.log"))
-            {
-                var lines = ReadAllLinesShared(f);
-                var start = baseline.TryGetValue(f, out var n) ? n : 0;
-                for (var i = start; i < lines.Count; i++)
-                    newLines.Add(lines[i]);
-            }
+        var newLines = log.DrainAndReadLines();
 
         // AC2: the event is recorded Gateway-side with director_id + app_version.
         Assert.Contains(newLines, l =>
@@ -244,21 +224,6 @@ public sealed class DirectorStartupTelemetryEndpointTests
             Assert.Equal("WORKSTATION-3", doc.RootElement.GetProperty("machine_name").GetString());
         }
         finally { await dispose(); }
-    }
-
-    /// <summary>
-    /// Reads all lines from a file another thread may hold open for writing (the live FileLog
-    /// background writer). Uses <see cref="FileShare.ReadWrite"/> so the open handle does not block.
-    /// </summary>
-    private static List<string> ReadAllLinesShared(string path)
-    {
-        var lines = new List<string>();
-        using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-        using var reader = new StreamReader(fs);
-        string? line;
-        while ((line = reader.ReadLine()) is not null)
-            lines.Add(line);
-        return lines;
     }
 
     // ----- ResolveTargetUrl -----

--- a/src/CcDirector.Gateway.Tests/Issue639GatewayTelemetryTokenTests.cs
+++ b/src/CcDirector.Gateway.Tests/Issue639GatewayTelemetryTokenTests.cs
@@ -192,13 +192,11 @@ public sealed class Issue639GatewayTelemetryTokenTests
     [Fact]
     public async Task Forward_NeverWritesTheGatewayTokenToTheLog()
     {
-        var logDir = CcStorage.ToolLogs("director");
-        var baseline = new Dictionary<string, int>();
-        if (Directory.Exists(logDir))
-            foreach (var f in Directory.EnumerateFiles(logDir, "*.log"))
-                baseline[f] = ReadAllLinesShared(f).Count;
+        // Issue #862: capture FileLog in a private, synchronously-drained sink so we read exactly
+        // this test's lines - no carryover from the shared process-wide writer and no background-
+        // flush timing race (the old poll-the-shared-dir version was flaky in CI).
+        using var log = FileLog.RedirectForTests();
 
-        FileLog.Start();
         var (queue, handler, source, path) = NewQueue();
         try
         {
@@ -217,38 +215,7 @@ public sealed class Issue639GatewayTelemetryTokenTests
             Cleanup(path);
         }
 
-        // The shared FileLog writer flushes on a background thread, so poll (up to a generous
-        // deadline) for our line to land on disk rather than sleeping a fixed interval. The old
-        // fixed Task.Delay(500) raced the writer under load and made this test flaky in CI (it
-        // passed at 507 ms in one run and failed in another).
-        List<string> CollectNewLines()
-        {
-            var collected = new List<string>();
-            if (Directory.Exists(logDir))
-                foreach (var f in Directory.EnumerateFiles(logDir, "*.log"))
-                {
-                    var lines = ReadAllLinesShared(f);
-                    var start = baseline.TryGetValue(f, out var n) ? n : 0;
-                    for (var i = start; i < lines.Count; i++)
-                        collected.Add(lines[i]);
-                }
-            return collected;
-        }
-
-        static bool HasQueueMarker(List<string> lines)
-        {
-            foreach (var l in lines)
-                if (l.Contains("[TelemetryRetryQueue]")) return true;
-            return false;
-        }
-
-        var newLines = CollectNewLines();
-        var deadline = DateTime.UtcNow.AddSeconds(5);
-        while (!HasQueueMarker(newLines) && DateTime.UtcNow < deadline)
-        {
-            await Task.Delay(25);
-            newLines = CollectNewLines();
-        }
+        var newLines = log.DrainAndReadLines();
 
         // The queue logged on this path (proves logging is wired)...
         Assert.Contains(newLines, l => l.Contains("[TelemetryRetryQueue]"));
@@ -451,16 +418,5 @@ public sealed class Issue639GatewayTelemetryTokenTests
         var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
         while (captured.Count < count && DateTime.UtcNow < deadline)
             await Task.Delay(25);
-    }
-
-    private static List<string> ReadAllLinesShared(string path)
-    {
-        var lines = new List<string>();
-        using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-        using var reader = new StreamReader(fs);
-        string? line;
-        while ((line = reader.ReadLine()) is not null)
-            lines.Add(line);
-        return lines;
     }
 }

--- a/src/CcDirector.Gateway.Tests/TelemetryRelayEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/TelemetryRelayEndpointTests.cs
@@ -230,19 +230,11 @@ public sealed class TelemetryRelayEndpointTests
     [Fact]
     public async Task PostLogin_NeverWritesAccessTokenToTheGatewayLog()
     {
-        // FileLog's sink directory is captured when the FileLog type first initializes, which may be
-        // before this test runs - so we read whatever real log directory it actually writes to. The
-        // live background writer holds the file open, so we read with a SHARED stream (FileShare.
-        // ReadWrite) instead of File.ReadAllLines, which would throw on the open handle.
-        var logDir = CcStorage.ToolLogs("director");
+        // Issue #862: capture FileLog in a private, synchronously-drained sink so we read exactly
+        // this test's lines - no carryover from the shared process-wide writer and no background-
+        // flush timing race (the old baseline + Task.Delay version was flaky in CI).
+        using var log = FileLog.RedirectForTests();
 
-        // Snapshot the line count per existing log file, so we only inspect the lines THIS test added.
-        var baseline = new Dictionary<string, int>();
-        if (Directory.Exists(logDir))
-            foreach (var f in Directory.EnumerateFiles(logDir, "*.log"))
-                baseline[f] = ReadAllLinesShared(f).Count;
-
-        FileLog.Start();
         var (relay, captured, dispose) = await StartAsync(startStub: true);
         try
         {
@@ -254,42 +246,14 @@ public sealed class TelemetryRelayEndpointTests
         finally
         {
             await dispose();
-            // Give the background writer a moment to flush our lines to disk (it does NOT stop here:
-            // FileLog is a process-wide static other concurrent tests may still be using).
-            await Task.Delay(500);
         }
 
-        // Gather only the NEW lines (added after the baseline) across every log file.
-        var newLines = new List<string>();
-        if (Directory.Exists(logDir))
-            foreach (var f in Directory.EnumerateFiles(logDir, "*.log"))
-            {
-                var lines = ReadAllLinesShared(f);
-                var start = baseline.TryGetValue(f, out var n) ? n : 0;
-                for (var i = start; i < lines.Count; i++)
-                    newLines.Add(lines[i]);
-            }
+        var newLines = log.DrainAndReadLines();
 
         // The relay must have logged SOMETHING on this path (proves logging is wired)...
         Assert.Contains(newLines, l => l.Contains("[TelemetryRelayEndpoint]"));
         // ...and the access token must appear in NONE of the log lines.
         Assert.DoesNotContain(newLines, l => l.Contains(AccessToken));
-    }
-
-    /// <summary>
-    /// Reads all lines from a file that another process/thread may have open for writing (the live
-    /// FileLog background writer). Uses <see cref="FileShare.ReadWrite"/> so the open handle does not
-    /// block the read.
-    /// </summary>
-    private static List<string> ReadAllLinesShared(string path)
-    {
-        var lines = new List<string>();
-        using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-        using var reader = new StreamReader(fs);
-        string? line;
-        while ((line = reader.ReadLine()) is not null)
-            lines.Add(line);
-        return lines;
     }
 
     // ----- ResolveTargetUrl -----


### PR DESCRIPTION
Closes #862.

## Corrected root cause
The issue first guessed parallelism; reading the code disproved that — `CcDirector.Gateway.Tests` **already** disables parallelization (`TestParallelization.cs`), so the tests run **serially**. The real cause is the single, process-wide `FileLog` background writer:
- **Carryover** — the shared writer is never stopped between serial tests, so a prior test's still-queued lines flush into the current test's file after it snapshots/clears the shared log dir; a "never writes the token" scan can then see another test's line.
- **Flush timing** — `FileLog` flushes on a background thread (1s interval); the tests' fixed `Task.Delay` / poll loops raced it under CI load, so the expected line hadn't landed when they read.

## Fix
- **A test-only seam on `FileLog`** (`RedirectForTests()`): swaps the single static writer for a fresh one over a private temp dir, and `DrainAndReadLines()` **synchronously** drains it (`Stop()` completes the queue + joins the writer thread) and returns exactly the lines that scope produced — restored + temp dir deleted on dispose. `internal` (Core already grants `InternalsVisibleTo CcDirector.Gateway.Tests`); safe because the assembly is serial. **No production behavior change** — the live logger's sink is untouched.
- **The three tests use the seam** instead of snapshotting/clearing the shared `CcStorage.ToolLogs("director")` directory: no baseline, no `Task.Delay`, no poll loops. Dead `ReadAllLinesShared` helpers removed (the tests got simpler).

## Verification
- `dotnet build cc-director.sln` — 0 warnings, 0 errors.
- Telemetry cluster (34 tests, incl. all three previously-flaky): **10/10 consecutive runs green**.
- Full `CcDirector.Gateway.Tests` project: **1009/1009** (two full serial runs).
- `FileLog` Core tests: 4/4.
- Proof: `docs/cencon/proof/issue-862/report.html`.

## CenCon
No drift — a test-only seam (no change to `FileLog`'s production sink) plus three test rewrites; no new container, security boundary, or behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
