### PR TITLE
feat: dictation capture-health instrumentation across all surfaces (#863)

### DIFF
--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -300,7 +300,21 @@ export async function killSession(sessionId: string, signal?: AbortSignal): Prom
 // The Director's own /voice/utterance flow is NOT proxied through the Gateway; this /wingman/
 // utterance flow is the Gateway-native equivalent and is reachable by the mobile app same-origin
 // with the Bearer, so no backend change is needed.
-export async function transcribeUtterance(wav: Blob, signal?: AbortSignal): Promise<string> {
+// The optional client-measured capture-health sent with the complete call (issue #863), so the
+// Gateway can persist the audio-loss deficit (recording wall-clock vs decoded audio duration) into
+// the same dictation session log every other surface writes. Diagnostics only - omitting it changes
+// nothing about the transcription.
+export interface UtteranceCaptureHealth {
+  recordedMs: number;
+  decodedSeconds: number;
+  sourceBytes: number;
+}
+
+export async function transcribeUtterance(
+  wav: Blob,
+  health?: UtteranceCaptureHealth,
+  signal?: AbortSignal,
+): Promise<string> {
   // 1. Register the upload (mints an id the chunk + complete calls address).
   const reg = await fetch(`/wingman/utterance/upload`, {
     method: "POST",
@@ -336,7 +350,14 @@ export async function transcribeUtterance(wav: Blob, signal?: AbortSignal): Prom
   const comp = await fetch(`/wingman/utterance/${id}/complete`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
-    body: JSON.stringify({ totalChunks: 1, mime: "audio/wav", ext: "wav" }),
+    body: JSON.stringify({
+      totalChunks: 1,
+      mime: "audio/wav",
+      ext: "wav",
+      clientRecordedMs: health?.recordedMs,
+      clientDecodedSeconds: health?.decodedSeconds,
+      clientSourceBytes: health?.sourceBytes,
+    }),
     signal,
   });
   const compBody = (await comp.json().catch(() => ({}))) as { transcript?: string; error?: string };

--- a/mobile/src/dictation/DictationDialog.tsx
+++ b/mobile/src/dictation/DictationDialog.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { transcribeUtterance } from "../api/client";
+import { logCaptureHealth } from "./captureHealth";
 import { MicRecorder } from "./recorder";
 import { blobToWav16kMono } from "./wav";
 
@@ -115,15 +116,26 @@ export function DictationDialog({ onInsert, onSend, onClose }: DictationDialogPr
   // consumed here, so a segment is never transcribed twice.
   const transcribeCurrentSegment = useCallback(async (): Promise<string | null> => {
     let wav: Blob;
+    let health;
     try {
       const captured = await recorderRef.current.stop();
-      wav = await blobToWav16kMono(captured);
+      const transcoded = await blobToWav16kMono(captured);
+      wav = transcoded.wav;
+      // Capture-health (issue #863): compare the recording wall-clock to the decoded audio
+      // duration to detect audio dropped before transcription. Logged locally AND sent to the
+      // Gateway so it persists into the same dictation session log every other surface writes.
+      health = {
+        recordedMs: recorderRef.current.lastRecordedMs,
+        decodedSeconds: transcoded.decodedSeconds,
+        sourceBytes: transcoded.sourceBytes,
+      };
+      logCaptureHealth("mobile", health);
     } catch (err) {
       setHint(err instanceof Error ? err.message : "Could not capture the recording.");
       return null;
     }
     try {
-      const text = await transcribeUtterance(wav);
+      const text = await transcribeUtterance(wav, health);
       return text;
     } catch (err) {
       setHint("Transcription failed: " + (err instanceof Error ? err.message : "unknown error"));

--- a/mobile/src/dictation/captureHealth.ts
+++ b/mobile/src/dictation/captureHealth.ts
@@ -1,0 +1,39 @@
+// Capture-health diagnostics for the browser dictation paths (issue #863).
+//
+// Audio loss is the same failure on every surface - some of what the user said never reaches the
+// transcription model - but it is MEASURED differently per capture technology. The desktop NAudio
+// path compares captured bytes to a fixed PCM rate; a browser MediaRecorder produces variable-
+// bitrate compressed audio, so bytes are not a yardstick. The honest browser measure is RECORDING
+// WALL-CLOCK versus DECODED AUDIO DURATION: record 52 seconds but decode only 38 and ~14 seconds
+// was dropped. This module computes that deficit and logs it; it changes no capture behaviour.
+
+export interface BrowserCaptureHealth {
+  /** Wall-clock the microphone was open for the segment. */
+  recordedMs: number;
+  /** Duration of the audio actually decoded from the captured blob. */
+  decodedSeconds: number;
+  /** Size of the captured (compressed) blob, for reference only. */
+  sourceBytes: number;
+}
+
+/** Fraction of the recording wall-clock that produced no decoded audio (0 = nothing lost). Clamped
+ *  at 0 so codec priming/padding never reads as a negative deficit. */
+export function deficitFraction(h: BrowserCaptureHealth): number {
+  if (h.recordedMs <= 0) return 0;
+  const decodedMs = h.decodedSeconds * 1000;
+  return Math.max(0, 1 - decodedMs / h.recordedMs);
+}
+
+/** Log one capture-health line for a finished segment, tagged by surface so the mobile and Blazor
+ *  paths read the same way as the desktop log. A material deficit is a warning, not an error - it is
+ *  a measurement, and the audio still ships. */
+export function logCaptureHealth(surface: string, h: BrowserCaptureHealth): void {
+  const deficit = deficitFraction(h);
+  const line =
+    `[capture-health] surface=${surface} recordedMs=${h.recordedMs.toFixed(0)} ` +
+    `decodedSec=${h.decodedSeconds.toFixed(2)} deficit=${(deficit * 100).toFixed(1)}% ` +
+    `sourceBytes=${h.sourceBytes}`;
+  // A deficit over ~10% is worth surfacing prominently; below that it is normal codec slack.
+  if (deficit > 0.1) console.warn(line + " (audio appears to have been dropped before transcription)");
+  else console.log(line);
+}

--- a/mobile/src/dictation/recorder.ts
+++ b/mobile/src/dictation/recorder.ts
@@ -27,9 +27,21 @@ export class MicRecorder {
   private analyser: AnalyserNode | null = null;
   private levelData: Uint8Array | null = null;
 
+  // Capture-health (issue #863): wall-clock of the segment the mic was actually open.
+  // Compared against the DECODED audio duration of the captured blob (in wav.ts) to detect
+  // dropped audio - the browser analog of the desktop expected-vs-captured byte check. A
+  // compressed MediaRecorder blob has no fixed bytes/sec, so duration, not bytes, is the yardstick.
+  private startedAt = 0;
+  private recordedMs = 0;
+
   /** True while a segment is actively capturing. */
   get isRecording(): boolean {
     return this.recorder !== null && this.recorder.state === "recording";
+  }
+
+  /** Wall-clock milliseconds the most recently stopped segment was capturing. 0 before the first stop. */
+  get lastRecordedMs(): number {
+    return this.recordedMs;
   }
 
   /**
@@ -63,6 +75,7 @@ export class MicRecorder {
       if (e.data && e.data.size > 0) this.chunks.push(e.data);
     };
     this.recorder.start();
+    this.startedAt = performance.now();
   }
 
   /** Current input level in 0..1, sampled live. Returns 0 when not recording. */
@@ -87,6 +100,9 @@ export class MicRecorder {
       rec.onstop = () => resolve(new Blob(this.chunks, { type: mime }));
       rec.stop();
     });
+    // Freeze the segment wall-clock at stop, before releasing the stream, so capture-health can
+    // compare it to the decoded audio duration of the captured blob.
+    this.recordedMs = this.startedAt > 0 ? performance.now() - this.startedAt : 0;
     this.releaseStream();
     return captured;
   }

--- a/mobile/src/dictation/wav.ts
+++ b/mobile/src/dictation/wav.ts
@@ -10,9 +10,19 @@
 
 const TARGET_SAMPLE_RATE = 16000;
 
-export async function blobToWav16kMono(blob: Blob): Promise<Blob> {
+/** The WAV plus the capture-health facts the decode already revealed (issue #863): the decoded
+ *  audio duration (the actual amount of sound captured) and the source blob size. The caller
+ *  compares decodedSeconds to the recording wall-clock to detect dropped audio. */
+export interface TranscodeResult {
+  wav: Blob;
+  decodedSeconds: number;
+  sourceBytes: number;
+}
+
+export async function blobToWav16kMono(blob: Blob): Promise<TranscodeResult> {
   const arrayBuffer = await blob.arrayBuffer();
   if (arrayBuffer.byteLength === 0) throw new Error("No audio was captured.");
+  const sourceBytes = arrayBuffer.byteLength;
 
   const AudioCtor = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
   const decodeCtx = new AudioCtor();
@@ -33,7 +43,11 @@ export async function blobToWav16kMono(blob: Blob): Promise<Blob> {
   source.start(0);
   const rendered = await offline.startRendering();
 
-  return encodeWav(rendered.getChannelData(0), TARGET_SAMPLE_RATE);
+  return {
+    wav: encodeWav(rendered.getChannelData(0), TARGET_SAMPLE_RATE),
+    decodedSeconds: decoded.duration,
+    sourceBytes,
+  };
 }
 
 // Build a canonical 16-bit PCM WAV (RIFF) blob from mono float samples in -1..1.

--- a/scripts/dictation-capture-health.py
+++ b/scripts/dictation-capture-health.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""
+Dictation capture-health analyzer (issue #863).
+
+Reads the dictation session log that every dictation surface now writes, and prints a
+per-surface audio-loss summary plus the worst recordings, so capture loss is readable
+without dev tools and the local-stall versus upstream-under-delivery signal is visible.
+
+Default log location (Windows):
+    %LOCALAPPDATA%\\cc-director\\dictation\\sessions\\<date>.jsonl
+
+How loss is measured, per surface (Source field):
+    desktop-speak / endpoint : raw PCM16 at 24 kHz mono = 48000 bytes/sec.
+                               deficit = 1 - AudioBytesReceived / ExpectedAudioBytes
+    mobile                   : compressed audio, no fixed byte rate.
+                               deficit = 1 - DecodedAudioSeconds*1000 / RecordedWallMs
+
+Mechanism hint (desktop / endpoint only):
+    large handler self-time  -> local capture-thread stall (a local fix helps)
+    large callback gap       -> buffers arrived late / not at all (points upstream,
+                                e.g. the Remote Desktop audio-redirection channel)
+
+Usage:
+    python scripts/dictation-capture-health.py
+    python scripts/dictation-capture-health.py --days 1 --worst 15
+    python scripts/dictation-capture-health.py --file C:/path/to/2026-06-30.jsonl
+"""
+
+import argparse
+import json
+import os
+import sys
+from glob import glob
+
+
+# A 24 kHz, 16-bit, mono PCM stream is 48000 bytes per second. Both raw-PCM surfaces
+# (desktop NAudio and the browser AudioWorklet overlay) capture at this rate.
+PCM_BYTES_PER_SEC = 48000
+
+# Thresholds for the mechanism hint. The default NAudio headroom is 3 buffers of 50 ms
+# (150 ms); a gap beyond that means the driver could have run dry. A handler body that
+# takes longer than one buffer interval (50 ms) for cheap work means the thread stalled.
+GAP_STALL_MS = 150.0
+HANDLER_STALL_MS = 50.0
+
+
+def default_sessions_dir():
+    local = os.environ.get("LOCALAPPDATA")
+    if not local:
+        return ""
+    return os.path.join(local, "cc-director", "dictation", "sessions")
+
+
+def deficit_for(rec):
+    """Return (deficit_fraction, detail_string) or (None, reason) when not computable."""
+    source = rec.get("Source") or "unknown"
+
+    if source == "mobile":
+        recorded_ms = float(rec.get("RecordedWallMs") or 0)
+        decoded_s = float(rec.get("DecodedAudioSeconds") or 0)
+        if recorded_ms <= 0:
+            return None, "no RecordedWallMs"
+        deficit = max(0.0, 1.0 - (decoded_s * 1000.0) / recorded_ms)
+        return deficit, "recorded=%.0fms decoded=%.2fs" % (recorded_ms, decoded_s)
+
+    # desktop-speak, endpoint, and any other raw-PCM source.
+    received = float(rec.get("AudioBytesReceived") or 0)
+    expected = float(rec.get("ExpectedAudioBytes") or 0)
+    if expected <= 0:
+        # Legacy record without the expected-bytes field: derive it from the recording
+        # duration at the known PCM rate (this is how the original loss was first found).
+        dur_ms = float(rec.get("RecordingDurationMs") or 0)
+        expected = PCM_BYTES_PER_SEC * dur_ms / 1000.0
+    if expected <= 0 or received <= 0:
+        return None, "no audio / no duration"
+    deficit = max(0.0, 1.0 - received / expected)
+    return deficit, "recv=%d exp=%d bytes" % (int(received), int(expected))
+
+
+def mechanism_hint(rec):
+    """A short A-vs-B hint for the raw-PCM surfaces; empty for mobile / when not informative."""
+    if (rec.get("Source") or "") == "mobile":
+        return ""
+    handler = float(rec.get("MaxCaptureHandlerMs") or 0)
+    gap = float(rec.get("MaxCaptureCallbackGapMs") or 0)
+    if handler >= HANDLER_STALL_MS:
+        return "local-stall(handler=%.0fms)" % handler
+    if gap >= GAP_STALL_MS:
+        return "upstream(gap=%.0fms)" % gap
+    return ""
+
+
+def percentile(sorted_vals, pct):
+    if not sorted_vals:
+        return 0.0
+    if len(sorted_vals) == 1:
+        return sorted_vals[0]
+    rank = (pct / 100.0) * (len(sorted_vals) - 1)
+    lo = int(rank)
+    hi = min(lo + 1, len(sorted_vals) - 1)
+    frac = rank - lo
+    return sorted_vals[lo] * (1 - frac) + sorted_vals[hi] * frac
+
+
+def load_records(files):
+    records = []
+    for path in files:
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        records.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+        except OSError as ex:
+            print("WARNING: could not read %s: %s" % (path, ex))
+    return records
+
+
+def resolve_files(args):
+    if args.file:
+        return [args.file]
+    directory = args.dir or default_sessions_dir()
+    if not directory or not os.path.isdir(directory):
+        print("ERROR: sessions directory not found: %s" % directory)
+        print("Pass --dir <path> or --file <path/to/file.jsonl>.")
+        sys.exit(2)
+    files = sorted(glob(os.path.join(directory, "*.jsonl")))
+    if args.days and args.days > 0:
+        files = files[-args.days:]
+    return files
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Per-surface dictation capture-health summary (issue #863).")
+    parser.add_argument("--dir", help="sessions directory (default: %%LOCALAPPDATA%%/cc-director/dictation/sessions)")
+    parser.add_argument("--file", help="analyze a single .jsonl file instead of the directory")
+    parser.add_argument("--days", type=int, default=0, help="only the most recent N day-files (0 = all)")
+    parser.add_argument("--worst", type=int, default=10, help="how many worst recordings to list (default 10)")
+    parser.add_argument("--threshold", type=float, default=0.10, help="deficit fraction counted as a loss (default 0.10)")
+    args = parser.parse_args()
+
+    files = resolve_files(args)
+    records = load_records(files)
+
+    print("=" * 78)
+    print("Dictation capture-health   files=%d   records=%d   loss-threshold=%.0f%%"
+          % (len(files), len(records), args.threshold * 100))
+    print("=" * 78)
+
+    by_source = {}
+    worst = []
+    for rec in records:
+        source = rec.get("Source") or "unknown"
+        deficit, detail = deficit_for(rec)
+        bucket = by_source.setdefault(source, {"total": 0, "measured": [], "over": 0})
+        bucket["total"] += 1
+        if deficit is None:
+            continue
+        bucket["measured"].append(deficit)
+        if deficit >= args.threshold:
+            bucket["over"] += 1
+        worst.append((deficit, rec, detail))
+
+    if not records:
+        print("No records found.")
+        return
+
+    print()
+    print("%-14s %7s %9s %9s %9s %9s %9s" % ("surface", "records", "measured", "mean", "median", "p90", ">thresh"))
+    print("-" * 78)
+    for source in sorted(by_source):
+        b = by_source[source]
+        vals = sorted(b["measured"])
+        if vals:
+            mean = sum(vals) / len(vals)
+            print("%-14s %7d %9d %8.1f%% %8.1f%% %8.1f%% %9d"
+                  % (source, b["total"], len(vals), mean * 100,
+                     percentile(vals, 50) * 100, percentile(vals, 90) * 100, b["over"]))
+        else:
+            print("%-14s %7d %9d %9s %9s %9s %9d"
+                  % (source, b["total"], 0, "-", "-", "-", 0))
+
+    worst.sort(key=lambda t: t[0], reverse=True)
+    print()
+    print("Worst %d recordings by deficit:" % min(args.worst, len(worst)))
+    print("-" * 78)
+    if not worst:
+        print("(nothing measurable)")
+    for deficit, rec, detail in worst[: args.worst]:
+        ts = (rec.get("TimestampUtc") or "")[:19]
+        source = rec.get("Source") or "unknown"
+        hint = mechanism_hint(rec)
+        raw = rec.get("RawTranscript") or rec.get("CleanedTranscript") or ""
+        tail = raw[-44:].replace("\n", " ")
+        print("%-19s %-13s deficit=%5.1f%%  %-24s %s"
+              % (ts, source, deficit * 100, detail, hint))
+        if tail:
+            print("    ...ends: %r" % tail)
+
+    print()
+    print("Hint: a deficit with a local-stall(handler=...) tag is fixable locally (decouple the")
+    print("capture-thread work / add buffers); an upstream(gap=...) tag with a low handler time")
+    print("means the audio was under-delivered before capture (e.g. Remote Desktop redirection).")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/CcDirector.Avalonia.Tests/MicAudioCaptureDiagnosticsTests.cs
+++ b/src/CcDirector.Avalonia.Tests/MicAudioCaptureDiagnosticsTests.cs
@@ -1,0 +1,57 @@
+using CcDirector.Avalonia.Voice;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// Unit coverage for the capture-health math (issue #863). The instrumentation that
+/// drives audio-loss diagnosis is behaviour-neutral, but its two pure pieces - the
+/// expected-bytes yardstick and the deficit fraction - are exact and must stay exact,
+/// because the whole "is this a local stall or upstream under-delivery" decision is
+/// read off them.
+/// </summary>
+public sealed class MicAudioCaptureDiagnosticsTests
+{
+    [Theory]
+    [InlineData(1000.0, 48000)]  // 1s @ 24 kHz, 16-bit, mono = 48000 bytes
+    [InlineData(500.0, 24000)]   // half a second
+    [InlineData(0.0, 0)]         // no elapsed time -> no expected bytes
+    public void ExpectedBytes_MatchesPcmRate(double elapsedMs, long expected)
+        => Assert.Equal(expected, MicAudioCapture.ExpectedBytes(elapsedMs));
+
+    [Fact]
+    public void DeficitFraction_ReportsMissingAudio()
+    {
+        // The real incident: 32002 captured against 48000 expected over one second.
+        var h = new CaptureHealth(
+            CapturedBytes: 32000, ExpectedBytes: 48000, CallbackCount: 0,
+            MaxCallbackGapMs: 0, LongGapCount: 0, MaxHandlerMs: 0, TotalHandlerMs: 0,
+            ElapsedMs: 1000, NumberOfBuffers: 3, BufferMilliseconds: 50);
+
+        Assert.Equal(1.0 - 32000.0 / 48000.0, h.DeficitFraction, 5);
+    }
+
+    [Fact]
+    public void DeficitFraction_NoLoss_ClampsTheDrainTailToZero()
+    {
+        // The drain tail can push captured slightly above the stopwatch-derived expected;
+        // that is not a negative deficit, it is zero loss.
+        var h = new CaptureHealth(
+            CapturedBytes: 48200, ExpectedBytes: 48000, CallbackCount: 0,
+            MaxCallbackGapMs: 0, LongGapCount: 0, MaxHandlerMs: 0, TotalHandlerMs: 0,
+            ElapsedMs: 1000, NumberOfBuffers: 3, BufferMilliseconds: 50);
+
+        Assert.Equal(0.0, h.DeficitFraction);
+    }
+
+    [Fact]
+    public void DeficitFraction_NoExpectedBytes_IsZeroNotDivideByZero()
+    {
+        var h = new CaptureHealth(
+            CapturedBytes: 0, ExpectedBytes: 0, CallbackCount: 0,
+            MaxCallbackGapMs: 0, LongGapCount: 0, MaxHandlerMs: 0, TotalHandlerMs: 0,
+            ElapsedMs: 0, NumberOfBuffers: 3, BufferMilliseconds: 50);
+
+        Assert.Equal(0.0, h.DeficitFraction);
+    }
+}

--- a/src/CcDirector.Avalonia/Voice/BatchDictationRecorder.cs
+++ b/src/CcDirector.Avalonia/Voice/BatchDictationRecorder.cs
@@ -209,9 +209,13 @@ public sealed class BatchDictationRecorder : IAsyncDisposable
         // and clipped the end of the user's speech. Only after the drain do we detach,
         // so no genuinely-late chunk can race the snapshot; the lock guards it anyway.
         var device = _mic?.Description ?? MicDevices.DescribeDevice(_micDeviceNumber);
+        CaptureHealth? captureHealth = null;
         if (_mic is not null)
         {
             await _mic.StopAsync(TimeSpan.FromMilliseconds(750));
+            // Read capture-health AFTER the drain (counters are final) and BEFORE detaching,
+            // so the audit record can carry the per-recording diagnostics (issue #863).
+            captureHealth = (_mic as IAudioCaptureDiagnostics)?.GetCaptureHealth();
             _mic.OnAudioChunk -= AppendChunk;
         }
         _recordingStopwatch?.Stop();
@@ -262,6 +266,17 @@ public sealed class BatchDictationRecorder : IAsyncDisposable
             + $"correctedLen={batch.CorrectedTranscript.Length}, dictionaryApplied={batch.DictionaryApplied}, "
             + $"changed={batch.ChangedWords.Count}, method={routing.Mode.ToConfigString()}, model={routing.Model}");
 
+        // Capture-health line (issue #863): a byte deficit paired with large callback GAPS
+        // (and small handler self-time) points upstream - the audio was under-delivered
+        // before we saw it (e.g. Remote Desktop audio redirection); a deficit paired with
+        // large handler self-time points at a local capture-thread stall. This is what tells
+        // the two apart so any future fix is aimed at the real cause.
+        if (captureHealth is { } ch)
+            FileLog.Write($"[BatchDictationRecorder] capture-health: capturedBytes={ch.CapturedBytes}, "
+                + $"expectedBytes={ch.ExpectedBytes}, deficit={ch.DeficitFraction:P1}, callbacks={ch.CallbackCount}, "
+                + $"maxGapMs={ch.MaxCallbackGapMs:F0}, longGaps={ch.LongGapCount}, maxHandlerMs={ch.MaxHandlerMs:F1}, "
+                + $"buffers={ch.NumberOfBuffers}x{ch.BufferMilliseconds}ms");
+
         // Same JSONL audit record the other dictation surfaces write so a desktop
         // dictation incident keeps its raw text for forensics. Fire-and-forget off
         // the UI-facing path; failures are logged inside TryAppend.
@@ -282,7 +297,14 @@ public sealed class BatchDictationRecorder : IAsyncDisposable
             CleanupModel: _options.DictationCleanupModel,
             RemoteIp: null,
             ClientError: null,
-            Source: "desktop-speak");
+            Source: "desktop-speak",
+            ExpectedAudioBytes: captureHealth?.ExpectedBytes ?? 0,
+            CaptureCallbackCount: captureHealth?.CallbackCount ?? 0,
+            MaxCaptureCallbackGapMs: captureHealth?.MaxCallbackGapMs ?? 0,
+            LongCaptureGapCount: captureHealth?.LongGapCount ?? 0,
+            MaxCaptureHandlerMs: captureHealth?.MaxHandlerMs ?? 0,
+            CaptureBufferCount: captureHealth?.NumberOfBuffers ?? 0,
+            CaptureBufferMs: captureHealth?.BufferMilliseconds ?? 0);
         _ = Task.Run(() => DictationSessionLog.TryAppend(record));
 
         return new DictationResult(

--- a/src/CcDirector.Avalonia/Voice/MicAudioCapture.cs
+++ b/src/CcDirector.Avalonia/Voice/MicAudioCapture.cs
@@ -23,6 +23,54 @@ public interface IAudioMeterSource : IAudioSource
 }
 
 /// <summary>
+/// Optional capture-diagnostics extension: a source that can report per-recording
+/// capture health (bytes captured vs the elapsed wall-clock implies, callback
+/// cadence, and per-callback handler self-time) so audio loss can be LOCALIZED.
+/// Deliberately off the core <see cref="IAudioSource"/> contract because it is
+/// desktop-NAudio-specific instrumentation, not part of the capture guarantee.
+/// <see cref="BatchDictationRecorder"/> reads it when the source provides it.
+/// </summary>
+public interface IAudioCaptureDiagnostics
+{
+    /// <summary>Snapshot of capture health for the recording just finished. Read AFTER StopAsync's drain.</summary>
+    CaptureHealth GetCaptureHealth();
+}
+
+/// <summary>
+/// Per-recording capture-health snapshot (instrumentation only - it changes no
+/// capture behaviour). It exists to tell two distinct audio-loss mechanisms apart:
+///
+///   - A DEFICIT with large <see cref="MaxCallbackGapMs"/> / <see cref="LongGapCount"/>
+///     but small <see cref="MaxHandlerMs"/> means the buffers arrived late or not at
+///     all while OUR processing was cheap - the audio was under-delivered upstream
+///     (the Remote Desktop audio-redirection channel dropping samples before they
+///     reach us). Local buffering cannot recover bytes that never arrived.
+///   - A DEFICIT with large <see cref="MaxHandlerMs"/> means the capture thread
+///     stalled INSIDE our callback (per-chunk DSP overrunning the buffer headroom
+///     under machine load), so the driver ran out of free buffers and dropped audio.
+///     THIS one a local fix (decouple DSP / more buffers) actually addresses.
+/// </summary>
+public readonly record struct CaptureHealth(
+    long CapturedBytes,
+    long ExpectedBytes,
+    int CallbackCount,
+    double MaxCallbackGapMs,
+    int LongGapCount,
+    double MaxHandlerMs,
+    double TotalHandlerMs,
+    double ElapsedMs,
+    int NumberOfBuffers,
+    int BufferMilliseconds)
+{
+    /// <summary>
+    /// Fraction of the expected audio that never made it into the clip (0 = nothing
+    /// lost). Clamped at 0 so the small positive tail NAudio delivers after the
+    /// stopwatch math (the drain tail) never reads as a negative "deficit".
+    /// </summary>
+    public double DeficitFraction => ExpectedBytes <= 0 ? 0 : Math.Max(0.0, 1.0 - (double)CapturedBytes / ExpectedBytes);
+}
+
+/// <summary>
 /// Mic capture wrapper around NAudio's WaveInEvent, configured for the
 /// format the OpenAI Realtime transcription API expects: 24 kHz, 16-bit,
 /// mono PCM. Fires <see cref="OnAudioChunk"/> for every buffer the
@@ -34,7 +82,7 @@ public interface IAudioMeterSource : IAudioSource
 /// move independently the way a real frequency analyzer does, rather than all
 /// rising and falling together off a single energy number.
 /// </summary>
-public sealed class MicAudioCapture : IAudioMeterSource, IDisposable
+public sealed class MicAudioCapture : IAudioMeterSource, IAudioCaptureDiagnostics, IDisposable
 {
     public const int SampleRate = 24_000;
     public const int BitsPerSample = 16;
@@ -73,6 +121,25 @@ public sealed class MicAudioCapture : IAudioMeterSource, IDisposable
     private readonly string _description;
     private bool _started;
     private bool _disposed;
+
+    // ---- Capture-health instrumentation (issue #863) ----------------------------
+    // Behaviour-neutral diagnostics recorded on the single capture thread: how much
+    // audio actually arrived versus how much the elapsed wall-clock implies, the
+    // arrival cadence of the driver callbacks, and how long each callback body took.
+    // Together these localize audio loss (see CaptureHealth). Counter updates are
+    // plain arithmetic - no allocation, cannot throw. The cross-thread read in
+    // GetCaptureHealth is safe because StopAsync's drain barrier happens-before it.
+    private readonly int _bufferMilliseconds;
+    private readonly int _numberOfBuffers;
+    private readonly double _dropRiskGapMs;          // a gap this long means the driver could have run dry and dropped audio
+    private readonly System.Diagnostics.Stopwatch _captureClock = new();
+    private long _capturedBytes;
+    private int _callbackCount;
+    private double _lastCallbackStartMs = -1.0;
+    private double _maxCallbackGapMs;
+    private int _longGapCount;
+    private double _maxHandlerMs;
+    private double _totalHandlerMs;
 
     // Completed by OnRecordingStopped so StopAsync can wait for NAudio to deliver
     // its final buffered audio before the caller snapshots the buffer. Null except
@@ -114,6 +181,14 @@ public sealed class MicAudioCapture : IAudioMeterSource, IDisposable
         };
         _waveIn.DataAvailable += OnDataAvailable;
         _waveIn.RecordingStopped += OnRecordingStopped;
+
+        // Snapshot the driver's buffer geometry now so the diagnostics can report the
+        // headroom the capture thread had: NumberOfBuffers x BufferMilliseconds is how
+        // long the thread may stall before the driver runs out of free buffers and the
+        // hardware/redirection layer starts dropping incoming audio.
+        _bufferMilliseconds = bufferMilliseconds;
+        _numberOfBuffers = _waveIn.NumberOfBuffers;
+        _dropRiskGapMs = (double)_numberOfBuffers * _bufferMilliseconds;
     }
 
     public void Start()
@@ -122,9 +197,11 @@ public sealed class MicAudioCapture : IAudioMeterSource, IDisposable
         if (_started) return;
         try
         {
+            _captureClock.Restart();
             _waveIn.StartRecording();
             _started = true;
-            FileLog.Write($"[MicAudioCapture] Start: device={_deviceNumber} ({Description}), {SampleRate}Hz {BitsPerSample}-bit mono");
+            FileLog.Write($"[MicAudioCapture] Start: device={_deviceNumber} ({Description}), {SampleRate}Hz {BitsPerSample}-bit mono, "
+                + $"buffers={_numberOfBuffers}x{_bufferMilliseconds}ms");
         }
         catch (Exception ex)
         {
@@ -186,6 +263,21 @@ public sealed class MicAudioCapture : IAudioMeterSource, IDisposable
     private void OnDataAvailable(object? sender, WaveInEventArgs e)
     {
         if (e.BytesRecorded <= 0) return;
+
+        // Capture-health instrumentation: record arrival timing (start-to-start gap
+        // between callbacks) and byte counts BEFORE doing any work, so a late callback
+        // is attributed to the gap, not to our handler. Pure arithmetic; cannot throw.
+        double startMs = _captureClock.Elapsed.TotalMilliseconds;
+        if (_lastCallbackStartMs >= 0.0)
+        {
+            double gap = startMs - _lastCallbackStartMs;
+            if (gap > _maxCallbackGapMs) _maxCallbackGapMs = gap;
+            if (gap > _dropRiskGapMs) _longGapCount++;
+        }
+        _lastCallbackStartMs = startMs;
+        _callbackCount++;
+        _capturedBytes += e.BytesRecorded;
+
         var chunk = new byte[e.BytesRecorded];
         Buffer.BlockCopy(e.Buffer, 0, chunk, 0, e.BytesRecorded);
 
@@ -199,14 +291,62 @@ public sealed class MicAudioCapture : IAudioMeterSource, IDisposable
         double rawRms = ComputeInt16Rms(chunk);
         try { OnInputRms?.Invoke(rawRms); }
         catch (Exception ex) { FileLog.Write($"[MicAudioCapture] OnInputRms handler threw: {ex.Message}"); }
+
+        // Handler self-time = the wall-clock the whole callback body took. Large values
+        // for cheap CPU work mean the thread was descheduled mid-callback (machine under
+        // load) - the local capture-thread-stall signature that risks dropping audio.
+        double handlerMs = _captureClock.Elapsed.TotalMilliseconds - startMs;
+        _totalHandlerMs += handlerMs;
+        if (handlerMs > _maxHandlerMs) _maxHandlerMs = handlerMs;
     }
+
+    /// <summary>
+    /// Snapshot the capture-health counters for the recording that just finished.
+    /// Safe to call after <see cref="StopAsync"/> returns (its drain barrier
+    /// happens-before this read), and harmless to call at any time otherwise.
+    /// </summary>
+    public CaptureHealth GetCaptureHealth()
+    {
+        double elapsedMs = _captureClock.Elapsed.TotalMilliseconds;
+        return new CaptureHealth(
+            CapturedBytes: _capturedBytes,
+            ExpectedBytes: ExpectedBytes(elapsedMs),
+            CallbackCount: _callbackCount,
+            MaxCallbackGapMs: _maxCallbackGapMs,
+            LongGapCount: _longGapCount,
+            MaxHandlerMs: _maxHandlerMs,
+            TotalHandlerMs: _totalHandlerMs,
+            ElapsedMs: elapsedMs,
+            NumberOfBuffers: _numberOfBuffers,
+            BufferMilliseconds: _bufferMilliseconds);
+    }
+
+    /// <summary>
+    /// Bytes of PCM the capture format produces over <paramref name="elapsedMs"/> of
+    /// wall-clock at the fixed 24 kHz / 16-bit / mono rate (48000 bytes/sec). The
+    /// yardstick the captured byte count is measured against to compute the deficit.
+    /// </summary>
+    internal static long ExpectedBytes(double elapsedMs)
+        => (long)(SampleRate * Channels * (BitsPerSample / 8) * (elapsedMs / 1000.0));
 
     private void OnRecordingStopped(object? sender, StoppedEventArgs e)
     {
+        // Freeze the capture clock at the true end of capture so the elapsed-vs-captured
+        // math reflects only the recording window, not any post-stop teardown time.
+        _captureClock.Stop();
         if (e.Exception is not null)
             FileLog.Write($"[MicAudioCapture] Recording stopped with error: {e.Exception.Message}");
+
         // RecordThread raises this in its finally AFTER the last DataAvailable has
-        // been delivered, so by here every captured chunk is already appended.
+        // been delivered, so by here every captured chunk is already appended and the
+        // counters are final. Emit the capture-health summary for offline analysis.
+        var h = GetCaptureHealth();
+        FileLog.Write($"[MicAudioCapture] capture-health: capturedBytes={h.CapturedBytes}, expectedBytes={h.ExpectedBytes}, "
+            + $"deficit={h.DeficitFraction:P1}, callbacks={h.CallbackCount}, maxGapMs={h.MaxCallbackGapMs:F0}, "
+            + $"longGaps(>{_dropRiskGapMs:F0}ms)={h.LongGapCount}, maxHandlerMs={h.MaxHandlerMs:F1}, "
+            + $"totalHandlerMs={h.TotalHandlerMs:F0}, elapsedMs={h.ElapsedMs:F0}, "
+            + $"buffers={h.NumberOfBuffers}x{h.BufferMilliseconds}ms, device=\"{Description}\"");
+
         _stoppedSignal?.TrySetResult(true);
     }
 

--- a/src/CcDirector.Cockpit/wwwroot/js/dictation-overlay.js
+++ b/src/CcDirector.Cockpit/wwwroot/js/dictation-overlay.js
@@ -206,6 +206,13 @@ window.dictationOverlay = (function () {
     let mediaStream = null, ws = null, audioCtx = null, sourceNode = null, workletNode = null;
     let levelCtx = null, analyser = null, levelData = null, rafId = null, capture = null;
 
+    // Capture-health (issue #863): the worklet emits raw 24 kHz mono PCM16 = 48000 bytes/sec, so
+    // captured bytes versus elapsed capture time is the SAME audio-loss check the desktop NAudio
+    // path uses. lastFrameAtMs/maxFrameGapMs add the arrival-cadence signal that tells a local
+    // stall (large gaps) apart from clean capture. Diagnostic only - it changes nothing.
+    const EXPECTED_BYTES_PER_SEC = 48000;
+    let lastFrameAtMs = 0, maxFrameGapMs = 0;
+
     // ---- persistent across segments ----
     let stage = 'starting';            // starting | recording | transcribing | paused | error
     let finalIntent = 'pause';         // what to do when 'final' arrives: pause | insert | send
@@ -340,6 +347,7 @@ window.dictationOverlay = (function () {
       capture = createCaptureBuffer();
       for (const f of frames) capture.push(f, sendFrame);
       finalizing = false;
+      lastFrameAtMs = 0; maxFrameGapMs = 0;
       setStage('starting');
       const ok = await bootCapture();
       if (!ok) return;
@@ -433,7 +441,10 @@ window.dictationOverlay = (function () {
         workletNode = new AudioWorkletNode(audioCtx, 'pcm16-writer');
         let first = false;
         workletNode.port.onmessage = (e) => {
-          if (!first) { first = true; t0 = performance.now(); setStage('recording'); startTimer(); }
+          const nowMs = performance.now();
+          if (!first) { first = true; t0 = nowMs; setStage('recording'); startTimer(); }
+          else { const gap = nowMs - lastFrameAtMs; if (gap > maxFrameGapMs) maxFrameGapMs = gap; }
+          lastFrameAtMs = nowMs;
           if (capture) capture.push(e.data, sendFrame);
         };
         sourceNode.connect(workletNode);
@@ -501,14 +512,52 @@ window.dictationOverlay = (function () {
     async function startSegment() {
       capture = createCaptureBuffer();
       finalizing = false;
+      lastFrameAtMs = 0; maxFrameGapMs = 0;
       setStage('starting');
       const ok = await bootCapture();   // mic up immediately (capture-first)...
       if (!ok) return;
       openSocket();                     // ...socket opens in parallel; early frames buffer
     }
 
+    // ---------- capture-health (issue #863) ----------
+    // Raw PCM16 at 24 kHz mono is 48000 bytes/sec, so captured bytes versus the elapsed capture
+    // window is the same expected-vs-actual audio-loss check the desktop path logs. A deficit with
+    // large maxFrameGapMs points at a local capture/scheduling stall; a deficit with steady frames
+    // points upstream (e.g. the getUserMedia source under-delivering). Computed once at stop, when
+    // the drained tail has arrived and before any teardown nulls 'capture'.
+    function captureHealth() {
+      if (!capture) return null;
+      const recordingMs = lastFrameAtMs > t0 ? (lastFrameAtMs - t0) : 0;
+      const capturedBytes = capture.capturedBytes;
+      const expectedBytes = Math.round(EXPECTED_BYTES_PER_SEC * recordingMs / 1000);
+      const deficit = expectedBytes > 0 ? Math.max(0, 1 - capturedBytes / expectedBytes) : 0;
+      return {
+        recordingMs: Math.round(recordingMs), capturedBytes: capturedBytes, expectedBytes: expectedBytes,
+        deficit: deficit, frames: capture.frames.length, maxFrameGapMs: Math.round(maxFrameGapMs),
+      };
+    }
+
+    function logCaptureHealth(h) {
+      if (!h) return;
+      const line = '[capture-health] surface=overlay capturedBytes=' + h.capturedBytes +
+        ' expectedBytes=' + h.expectedBytes + ' deficit=' + (h.deficit * 100).toFixed(1) + '%' +
+        ' recordingMs=' + h.recordingMs + ' frames=' + h.frames + ' maxFrameGapMs=' + h.maxFrameGapMs;
+      if (h.deficit > 0.1) console.warn(line + ' (audio appears to have been dropped before transcription)');
+      else console.log(line);
+    }
+
     // ---------- finalize / send-stop ----------
-    function sendStop() { if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: 'stop' })); setStage('transcribing'); }
+    // Send the client-measured capture-health WITH the stop frame so the server persists it next to
+    // the bytes it actually received (issue #863): server-received bytes versus client recording
+    // wall-clock is the end-to-end audio deficit (capture loss PLUS any network loss).
+    function sendStop() {
+      const h = captureHealth();
+      logCaptureHealth(h);
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify(h ? { type: 'stop', health: h } : { type: 'stop' }));
+      }
+      setStage('transcribing');
+    }
 
     // Recording -> drain the trailing audio -> stop -> wait for 'final', then dispatch by
     // finalIntent. We keep the mic graph live for DRAIN_MS so the last words actually reach the

--- a/src/CcDirector.ControlApi/DictationEndpoint.cs
+++ b/src/CcDirector.ControlApi/DictationEndpoint.cs
@@ -162,6 +162,15 @@ internal static class DictationEndpoint
         var recordingStart = System.Diagnostics.Stopwatch.StartNew();
         long audioBytesReceived = 0;
 
+        // Client-measured capture-health carried on the stop frame (issue #863): the recording
+        // wall-clock the browser mic was open, the frame count, and the worst inter-frame gap.
+        // Comparing the client recording wall-clock to the bytes the SERVER actually received is the
+        // end-to-end audio deficit (capture loss plus any network loss); the gap tells a local stall
+        // apart from clean capture. Zero until a stop frame supplies them.
+        double clientRecordingMs = 0;
+        int clientFrames = 0;
+        double clientMaxGapMs = 0;
+
         await SendJsonAsync(ws, new { type = "started" }, ct);
 
         FileLog.Write($"[DictationEndpoint] session started: sid={sessionId} profile={profile} "
@@ -209,7 +218,11 @@ internal static class DictationEndpoint
                 if (doc is null) continue;
                 if (TryReadString(doc.RootElement, "type", out var t))
                 {
-                    if (t == "stop") break;
+                    if (t == "stop")
+                    {
+                        ReadCaptureHealth(doc.RootElement, ref clientRecordingMs, ref clientFrames, ref clientMaxGapMs);
+                        break;
+                    }
                     if (t == "abort")
                     {
                         FileLog.Write($"[DictationEndpoint] sid={sessionId} client aborted");
@@ -298,7 +311,8 @@ internal static class DictationEndpoint
             stopWatch.ElapsedMilliseconds, stopWatch.ElapsedMilliseconds, audioBytesReceived,
             raw: transcript?.RawTranscript, cleaned: transcript?.CorrectedTranscript,
             applied: transcript?.DictionaryApplied ?? false, reason: transcript?.Reason,
-            options, remoteIp, clientError);
+            options, remoteIp, clientError,
+            clientRecordedMs: clientRecordingMs, clientFrames: clientFrames, clientMaxGapMs: clientMaxGapMs);
 
         await TryCloseAsync(ws, WebSocketCloseStatus.NormalClosure, "done");
     }
@@ -323,8 +337,15 @@ internal static class DictationEndpoint
         string? reason,
         AgentOptions options,
         string? remoteIp,
-        string? clientError)
+        string? clientError,
+        double clientRecordedMs = 0,
+        int clientFrames = 0,
+        double clientMaxGapMs = 0)
     {
+        // Expected bytes from the CLIENT recording wall-clock (24 kHz mono PCM16 = 48000 bytes/sec);
+        // comparing it to the bytes the server actually received is the end-to-end audio deficit.
+        var expectedBytes = (long)(48000.0 * clientRecordedMs / 1000.0);
+
         var record = new DictationSessionRecord(
             TimestampUtc: sessionStartUtc.ToString("o"),
             SessionId: sessionId,
@@ -342,10 +363,28 @@ internal static class DictationEndpoint
             CleanupModel: options.DictationCleanupModel,
             RemoteIp: remoteIp,
             ClientError: clientError,
-            Source: "endpoint");
+            Source: "endpoint",
+            ExpectedAudioBytes: expectedBytes,
+            CaptureCallbackCount: clientFrames,
+            MaxCaptureCallbackGapMs: clientMaxGapMs,
+            RecordedWallMs: clientRecordedMs);
 
         // Off the WebSocket hot path; never block the close-out on disk I/O.
         Task.Run(() => DictationSessionLog.TryAppend(record));
+    }
+
+    /// <summary>
+    /// Read the optional capture-health object the client attaches to its stop frame
+    /// (<c>{"type":"stop","health":{"recordingMs":..,"frames":..,"maxFrameGapMs":..}}</c>). Missing or
+    /// malformed fields leave the outputs untouched (they stay 0) - it is diagnostics, never required.
+    /// </summary>
+    private static void ReadCaptureHealth(JsonElement stop, ref double recordingMs, ref int frames, ref double maxGapMs)
+    {
+        if (stop.ValueKind != JsonValueKind.Object) return;
+        if (!stop.TryGetProperty("health", out var h) || h.ValueKind != JsonValueKind.Object) return;
+        if (h.TryGetProperty("recordingMs", out var r) && r.ValueKind == JsonValueKind.Number) recordingMs = r.GetDouble();
+        if (h.TryGetProperty("frames", out var f) && f.ValueKind == JsonValueKind.Number) frames = f.GetInt32();
+        if (h.TryGetProperty("maxFrameGapMs", out var g) && g.ValueKind == JsonValueKind.Number) maxGapMs = g.GetDouble();
     }
 
     // ===== helpers ===========================================================

--- a/src/CcDirector.Core/Dictation/DictationSessionLog.cs
+++ b/src/CcDirector.Core/Dictation/DictationSessionLog.cs
@@ -72,4 +72,23 @@ public sealed record DictationSessionRecord(
     string CleanupModel,
     string? RemoteIp,
     string? ClientError,
-    string? Source = null);
+    string? Source = null,
+    // Capture-health diagnostics (issue #863). Optional, default 0 so every existing
+    // reader and the non-NAudio record writers (Gateway, web dictate) keep working.
+    // ExpectedAudioBytes is rate x recording-duration; comparing it to AudioBytesReceived
+    // gives the audio-loss deficit. The gap/handler fields localize the loss: large gaps
+    // with small handler time = upstream under-delivery (e.g. Remote Desktop redirection);
+    // large handler time = local capture-thread stall.
+    long ExpectedAudioBytes = 0,
+    int CaptureCallbackCount = 0,
+    double MaxCaptureCallbackGapMs = 0,
+    int LongCaptureGapCount = 0,
+    double MaxCaptureHandlerMs = 0,
+    int CaptureBufferCount = 0,
+    int CaptureBufferMs = 0,
+    // Duration-based capture-health for the compressed browser path (mobile MediaRecorder), where a
+    // fixed bytes/sec yardstick does not apply: the recording wall-clock the mic was open versus the
+    // decoded audio duration of the captured clip. A gap between them is dropped audio. (The raw-PCM
+    // surfaces - desktop, overlay - measure loss in bytes above and leave these 0.)
+    double RecordedWallMs = 0,
+    double DecodedAudioSeconds = 0);

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using CcDirector.AgentBrain;
 using CcDirector.Core;
 using CcDirector.Core.Configuration;
+using CcDirector.Core.Dictation;
 using CcDirector.Core.Utilities;
 using CcDirector.Core.Voice.Services;
 using CcDirector.Gateway.Contracts;
@@ -162,6 +163,13 @@ internal static class GatewayWingmanVoiceEndpoint
             if (result.Outcome != Transcription.TranscriptionOutcome.Ok)
                 return Results.Json(new { error = result.Error }, statusCode: StatusCodes.Status502BadGateway);
             FileLog.Write($"[GatewayWingmanVoice] utterance complete {uploadId}: mode={result.Mode}, chars={result.Text?.Length ?? 0}");
+
+            // Capture-health persistence (issue #863): when the mobile dialog sent its measurements,
+            // record the audio-loss deficit (recording wall-clock vs decoded audio duration) into the
+            // same dictation session log the desktop and overlay write, tagged Source="mobile". The
+            // assembled WAV byte count is the audio the server actually transcribed. Fire-and-forget.
+            PersistMobileCaptureHealth(uploadId, req, assembledAudio.Length, result.Text);
+
             return Results.Json(new { transcript = result.Text });
         });
 
@@ -513,6 +521,45 @@ internal static class GatewayWingmanVoiceEndpoint
 
     private static string Escape(string? s) => (s ?? "").Replace("\r", "\\r").Replace("\n", "\\n");
 
+    /// <summary>
+    /// Persist a mobile dictation capture-health record (issue #863) into the shared dictation
+    /// session log, but only when the client actually supplied its measurements. The record exists to
+    /// carry the audio-loss deficit (recording wall-clock vs decoded audio duration), so the
+    /// transcription-context fields a desktop record carries (dictionary counts, cleanup model) are
+    /// left at their defaults here. Fire-and-forget; a logging failure never affects the response.
+    /// </summary>
+    private static void PersistMobileCaptureHealth(string uploadId, UtteranceCompleteRequest req, int wavBytes, string? cleaned)
+    {
+        if (req.ClientRecordedMs is not { } recordedMs) return; // client did not opt in - nothing to persist
+
+        var decodedSeconds = req.ClientDecodedSeconds ?? 0;
+        FileLog.Write($"[GatewayWingmanVoice] capture-health mobile {uploadId}: recordedMs={recordedMs:F0}, "
+            + $"decodedSec={decodedSeconds:F2}, wavBytes={wavBytes}, sourceBytes={req.ClientSourceBytes ?? 0}");
+
+        var record = new DictationSessionRecord(
+            TimestampUtc: DateTime.UtcNow.ToString("o"),
+            SessionId: uploadId,
+            Profile: "default",
+            VocabularyTermCount: 0,
+            MistranscriptionPatternCount: 0,
+            RecordingDurationMs: (long)recordedMs,
+            StopToTranscribedMs: 0,
+            StopToCleanedMs: 0,
+            AudioBytesReceived: (int)Math.Min(wavBytes, int.MaxValue),
+            RawTranscript: "",
+            CleanedTranscript: cleaned ?? "",
+            CleanupApplied: false,
+            CleanupReason: null,
+            CleanupModel: "",
+            RemoteIp: null,
+            ClientError: null,
+            Source: "mobile",
+            RecordedWallMs: recordedMs,
+            DecodedAudioSeconds: decodedSeconds);
+
+        Task.Run(() => DictationSessionLog.TryAppend(record));
+    }
+
     /// <summary>Shape a <see cref="WingmanMenu"/> for the JSON response (camelCase the phone reads).</summary>
     private static object MenuJson(WingmanMenu m) => new
     {
@@ -638,4 +685,12 @@ public sealed class UtteranceCompleteRequest
     public int TotalChunks { get; set; }
     public string? Mime { get; set; }
     public string? Ext { get; set; }
+
+    // Capture-health (issue #863), optional - present only for the mobile dictation dialog, which
+    // measures audio loss as recording wall-clock versus decoded audio duration (a compressed
+    // MediaRecorder clip has no fixed bytes/sec). When present the complete handler persists a
+    // dictation session record so mobile loss lands in the same log as the desktop and overlay.
+    public double? ClientRecordedMs { get; set; }
+    public double? ClientDecodedSeconds { get; set; }
+    public long? ClientSourceBytes { get; set; }
 }


### PR DESCRIPTION
Refs #863.

## What and why

Dictated prompts sometimes come back wrong or cut off. The first suspicion was the dictionary-correction model rewriting the user's words; the investigation shows that is **not** what happens. For the reported turn the raw transcript and the cleaned transcript are byte-identical (the cleanup did nothing), and the transcription-integrity tests already guarantee the only permitted change is a validated dictionary find-and-replace. The real problem is **audio lost during capture, before transcription runs** — measured at roughly a third of the audio missing on the worst turns.

This pull request adds **behavior-neutral** capture-health instrumentation to every dictation surface, plus persistence and an analysis helper, so the loss can be localized with certainty before any capture behavior is changed. The two candidate mechanisms (a local capture-thread stall versus Remote Desktop audio-redirection under-delivery) need different fixes, so we measure first.

## Changes

- **Desktop (NAudio)** — `MicAudioCapture` / `BatchDictationRecorder`: per-recording captured-versus-expected bytes, callback arrival-gap timing, and per-callback handler self-time; written to the director log and the session record.
- **Cockpit and the Director web session view (raw-PCM overlay)** — `dictation-overlay.js` / `DictationEndpoint`: the browser sends its measured recording wall-clock and frame timing on the stop frame; the server records the end-to-end deficit (client wall-clock versus the bytes the server actually received, which also catches network loss).
- **Mobile (compressed MediaRecorder)** — `recorder.ts` / `wav.ts` / `DictationDialog.tsx` / `client.ts` / `GatewayWingmanVoiceEndpoint`: recording wall-clock versus decoded audio duration, persisted by the Gateway on transcription complete.
- **Shared log** — two optional duration fields added to `DictationSessionRecord`; all surfaces write to `%LOCALAPPDATA%/cc-director/dictation/sessions/<date>.jsonl`.
- **Analysis helper** — `scripts/dictation-capture-health.py` prints per-surface deficit summaries and the worst recordings.

## How loss is read

- Raw-PCM surfaces (desktop, overlay): `1 - AudioBytesReceived / ExpectedAudioBytes`.
- Mobile: `1 - DecodedAudioSeconds*1000 / RecordedWallMs`.
- A deficit with a large handler self-time means a local stall (a local fix helps); a deficit with large callback gaps and a small handler time points upstream (e.g. Remote Desktop redirection).

## Verification

- `dotnet build` clean: Gateway, ControlApi (both compile Core with the new record fields).
- New unit tests for the capture-health math pass; the desktop tail-clipping regression tests still pass.
- Transcription-integrity guards pass (no transcript-rewrite path introduced).
- Mobile `npm run typecheck` clean; overlay `node --check` clean.
- The analysis helper, run against live logs, already shows about 38% of desktop recordings losing more than 10% of audio.

## Out of scope

The capture fix itself. Once the new instrumentation identifies the mechanism (run the desktop-over-Remote-Desktop versus mobile comparison), the targeted fix and its per-surface verification are a follow-up under #863.
