### PR TITLE
[Gateway] Proxy the account device list + revoke (GET/DELETE /account/devices) (#854)

### DIFF
--- a/docs/cencon/proof/issue-854/host-wiring-tests.txt
+++ b/docs/cencon/proof/issue-854/host-wiring-tests.txt
@@ -1,0 +1,14 @@
+Test run for D:\ReposFred\devthrottle-wt-854\src\CcDirector.Gateway.Tests\bin\Debug\net10.0\CcDirector.Gateway.Tests.dll (.NETCoreApp,Version=v10.0)
+A total of 1 test files matched the specified pattern.
+[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.8.2+699d445a1a (64-bit .NET 10.0.9)
+[xUnit.net 00:00:00.08]   Discovering: CcDirector.Gateway.Tests
+[xUnit.net 00:00:00.15]   Discovered:  CcDirector.Gateway.Tests
+[xUnit.net 00:00:00.15]   Starting:    CcDirector.Gateway.Tests
+[xUnit.net 00:00:01.01]   Finished:    CcDirector.Gateway.Tests
+  Passed CcDirector.Gateway.Tests.GatewayHostTests.AccountDevices_get_requires_auth [20 ms]
+  Passed CcDirector.Gateway.Tests.GatewayHostTests.AccountDevices_isWired_andSignedOutHostReturnsExplicitSignedInFalse [168 ms]
+
+Test Run Successful.
+Total tests: 2
+     Passed: 2
+ Total time: 1.4695 Seconds

--- a/docs/cencon/proof/issue-854/qa-report.html
+++ b/docs/cencon/proof/issue-854/qa-report.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Report - Issue #854 - Account device-list proxy (GET/DELETE /account/devices)</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; max-width: 980px; margin: 2rem auto; padding: 0 1rem; color: #1a1a1a; }
+  h1 { border-bottom: 3px solid #5319e7; padding-bottom: .4rem; }
+  h2 { margin-top: 2rem; color: #5319e7; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #ccc; padding: .5rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #f0ecff; }
+  .pass { color: #0a7a0a; font-weight: bold; }
+  .verdict { background: #e9f9e9; border: 2px solid #0a7a0a; padding: 1rem; font-size: 1.1rem; margin: 1.5rem 0; }
+  code { background: #f4f4f4; padding: .1rem .3rem; border-radius: 3px; font-size: .9em; }
+  .note { background: #fff8e1; border-left: 4px solid #d4a017; padding: .7rem 1rem; margin: 1rem 0; }
+</style>
+</head>
+<body>
+<h1>QA Report - Issue #854</h1>
+<p><strong>Title:</strong> [Gateway] Proxy the account device list + revoke (GET/DELETE /account/devices)<br>
+<strong>Pull request:</strong> #868 (branch <code>issue-854-account-devices-proxy</code>)<br>
+<strong>QA Agent:</strong> independent verifier (CenCon Implementation loop) - did not see the Developer's session<br>
+<strong>Date:</strong> 2026-06-30</p>
+
+<h2>How this was verified (independently)</h2>
+<ul>
+  <li>Checked out <code>origin/issue-854-account-devices-proxy</code> into a fresh isolated worktree (not the shared tree, not the Developer's binary).</li>
+  <li>Built the whole solution: <code>dotnet build cc-director.sln -c Debug</code> -&gt; <strong>Build succeeded. 0 Warning(s), 0 Error(s).</strong></li>
+  <li>Ran the feature test classes independently: <code>AccountDevicesEndpointTests</code> + <code>GatewayHostTests</code> -&gt; <strong>24 passed, 0 failed.</strong></li>
+  <li>Full code review of the endpoint, the cloud HTTP client, the DTO contract, the host wiring, and the auth middleware.</li>
+</ul>
+
+<div class="note">
+<strong>On a live real-cloud signed-in transcript:</strong> the acceptance criteria are HTTP/contract level on the Gateway and depend on the cloud contract devthrottle_internal#81/#82. A live signed-in end-to-end requires a real DevThrottle account access token and a reachable cloud device registry, neither of which can be staged from this automation session. Per the QA brief, the criteria are judged on the stub-cloud unit tests (which exercise the full proxy seam: Bearer forwarding, DTO mapping, revoke, signed-out, unreachable) plus code review. This is stated explicitly rather than rubber-stamped. There is no Cockpit UI in this issue (the page is a sibling issue), so there is no screen to capture - the proof surface is the HTTP/contract behaviour.
+</div>
+
+<h2>Acceptance criteria</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (independently verified)</th><th>Result</th></tr>
+
+<tr>
+<td>1</td>
+<td>GET /account/devices (signed-in) returns the account device list: name, last-seen, device id, this-device marker, mapped from cloud GET /api/v1/devices.</td>
+<td>200 with signedIn:true and a devices array carrying id, name, lastSeenAt, thisDevice.</td>
+<td><code>DeviceRegistryClient.ListDevicesAsync</code> GETs <code>/api/v1/devices</code> with the Bearer token; <code>AccountDevicesEndpoint</code> maps each masked record to <code>AccountDeviceDto</code> (id, name, lastSeenAt, createdAt, platform, deviceType, appVersion, key prefix/last4) and computes <code>thisDevice</code> by case-insensitive machine-name match. Test <code>Get_SignedIn_ForwardsBearer_MapsDtos_AndNoToken</code> asserts the Bearer was forwarded and the DTO fields (id, name, lastSeenAt, thisDevice) are correct. PASS.</td>
+<td class="pass">PASS</td>
+</tr>
+
+<tr>
+<td>2</td>
+<td>Cockpit-facing response contains NO account access/refresh token (DT-05).</td>
+<td>No token field anywhere in the response body.</td>
+<td>The DTOs (<code>AccountDeviceDto</code>, <code>AccountDevicesResponseDto</code>, <code>RevokeDeviceResponseDto</code>) have no token field by design. The access token is sent only as the <code>Authorization: Bearer</code> header to the cloud and is never logged. Test asserts the body does not contain the JWT, the refresh token, the substring "token", or "key_hash". PASS.</td>
+<td class="pass">PASS</td>
+</tr>
+
+<tr>
+<td>3</td>
+<td>DELETE /account/devices/{id} forwards the revoke; device no longer lists.</td>
+<td>Revoke succeeds; a subsequent GET omits the removed device.</td>
+<td><code>RevokeDeviceAsync</code> DELETEs <code>/api/v1/devices/{id}</code> with the Bearer token (200 -&gt; revoked:true, 404 -&gt; revoked:false). Test <code>Delete_Revokes_AndSubsequentGet_NoLongerListsDevice</code> revokes dev-2 then asserts the next GET lists only dev-1. The unknown-id 404 path is also covered. PASS.</td>
+<td class="pass">PASS</td>
+</tr>
+
+<tr>
+<td>4</td>
+<td>Signed-out Gateway returns an explicit signed-out status (never a silent empty 200 list).</td>
+<td>signedIn:false envelope with devices omitted (not an empty array), for both GET and DELETE.</td>
+<td>When <code>GetAccessTokenForForwarding()</code> is null/empty the endpoint returns <code>{signedIn:false}</code> with <code>Devices</code> omitted via <code>[JsonIgnore(WhenWritingNull)]</code>; the cloud is never called. Tests for GET and DELETE assert signedIn:false, the devices key is absent, and the stub recorded no Authorization. The real GatewayHost wiring is also proven by <code>GatewayHostTests.AccountDevices_isWired_andSignedOutHostReturnsExplicitSignedInFalse</code>. PASS.</td>
+<td class="pass">PASS</td>
+</tr>
+
+<tr>
+<td>5</td>
+<td>Cloud-unreachable returns a clear error (not a fabricated list) and logs it.</td>
+<td>A clear error status; no fabricated devices list; failure logged.</td>
+<td>On any cloud failure the endpoint catches at the boundary and returns <code>502 Bad Gateway</code> with an error message and writes a <code>FAILED</code> line via <code>FileLog</code>; the client throws on non-success (<code>EnsureSuccessStatusCode</code>) so it never fabricates a list. Tests <code>Get_CloudUnreachable_Returns502_NotFabricatedList</code> and <code>Delete_CloudUnreachable_Returns502</code> assert 502 and no devices key. PASS.</td>
+<td class="pass">PASS</td>
+</tr>
+</table>
+
+<h2>Regression / method checks</h2>
+<ul>
+  <li><strong>Local pairing #469 untouched:</strong> the PR diff touches no <code>DeviceEnrollmentEndpoint</code>, <code>DeviceRegistry.cs</code>, or pairing code. The account-scoped <code>/account/devices</code> is a distinct surface from the local <code>/devices</code>. PASS.</li>
+  <li><strong>Routes auth-gated:</strong> <code>/account/devices</code> is NOT in <code>AuthMiddleware.PublicPaths</code>, so it inherits the host-wide Gateway token gate exactly like the other <code>/account</code> routes. Tests <code>AuthEnabled_NoGatewayToken_Returns401</code>, <code>AuthEnabled_WithGatewayToken_Returns200</code>, and <code>GatewayHostTests.AccountDevices_get_requires_auth</code> confirm 401 without and 200 with the token. PASS.</li>
+  <li><strong>Coding standards:</strong> try-catch only at the endpoint delegates (entry points), enterprise logging on entry/exit/failure, injectable HttpClient seam, no fallback that hides failure (unreachable surfaces as 502, not a fake list). PASS.</li>
+  <li><strong>Build:</strong> clean, 0 warnings, 0 errors. PASS.</li>
+</ul>
+
+<div class="verdict">
+VERIFIED - all 5 acceptance criteria met. Build clean, 24/24 feature tests pass, code review confirms DT-05 (no token in the Cockpit-facing response), explicit signed-out and cloud-unreachable handling (no fabricated list), auth-gated routes, and the #469 local registry untouched. Live real-cloud signed-in transcript could not be staged from automation and was judged on stub tests + code review, as stated above.
+</div>
+
+</body>
+</html>

--- a/docs/cencon/proof/issue-854/report.html
+++ b/docs/cencon/proof/issue-854/report.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Issue #854 - Proof: Gateway account device-list proxy (GET/DELETE /account/devices)</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem; color: #1e1e1e; line-height: 1.5; }
+  h1 { border-bottom: 2px solid #007acc; padding-bottom: .3rem; }
+  h2 { color: #007acc; margin-top: 1.8rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #ccc; padding: .5rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #f0f6fc; }
+  code { background: #f3f3f3; padding: .1rem .3rem; border-radius: 3px; font-family: Consolas, monospace; }
+  pre { background: #1e1e1e; color: #d4d4d4; padding: 1rem; border-radius: 5px; overflow-x: auto; font-size: .85rem; }
+  .pass { color: #137333; font-weight: bold; }
+  .gate { color: #b06000; font-weight: bold; }
+  .files li { margin: .2rem 0; }
+</style>
+</head>
+<body>
+
+<h1>Issue #854 - Gateway account device-list proxy</h1>
+<p><strong>[Gateway] Proxy the account device list + revoke (GET/DELETE /account/devices)</strong></p>
+<p>A LOCAL Gateway proxy so the Cockpit never holds the account token or calls the cloud directly.
+The Gateway reads its own stored account token
+(<code>DevThrottleAccountService.GetAccessTokenForForwarding</code> - the same egress credential it
+already uses to forward telemetry/login), calls the cloud device registry
+(<code>GET /api/v1/devices</code> / <code>DELETE /api/v1/devices/:id</code>, contract
+devthrottle_internal#81/#82), and returns a token-free local DTO. Distinct from, and leaves untouched,
+the local pairing registry <code>GET /devices</code> (issue #469).</p>
+
+<h2>What was implemented</h2>
+<ul class="files">
+  <li><code>src/CcDirector.Core/Account/DeviceRegistryClient.cs</code> (new) - injectable-HttpClient cloud
+  egress client; base URL reuses <code>AccountTelemetryClient.ApiBaseUrlEnvVar</code> /
+  <code>DefaultApiBaseUrl</code> (<code>DEVTHROTTLE_API_URL</code>, default
+  <code>https://devthrottle.com</code>) - the same cloud base the Gateway already targets, no new
+  hard-coded URL. <code>ListDevicesAsync</code> + <code>RevokeDeviceAsync</code> attach the Bearer
+  token; the token is never logged.</li>
+  <li><code>src/CcDirector.Gateway.Contracts/AccountDevicesDto.cs</code> (new) -
+  <code>AccountDeviceDto</code>, <code>AccountDevicesResponseDto{signedIn,devices}</code>,
+  <code>RevokeDeviceResponseDto{signedIn,id,revoked}</code>. No token field exists on any of them
+  (security rule DT-05).</li>
+  <li><code>src/CcDirector.Gateway/Api/AccountDevicesEndpoint.cs</code> (new) - maps
+  <code>GET /account/devices</code> and <code>DELETE /account/devices/{id}</code>; signed-out yields an
+  explicit <code>signedIn:false</code> envelope; cloud-unreachable yields a clear 502 (logged);
+  this-device marker computed by matching the record name to the host machine name.</li>
+  <li><code>src/CcDirector.Gateway/GatewayHost.cs</code> - wired near the existing
+  <code>AccountStatusEndpoint</code> / <code>AccountLogoutEndpoint</code> mapping, under the same
+  host-wide Gateway auth middleware.</li>
+  <li><code>src/CcDirector.Gateway.Tests/Account/AccountDevicesEndpointTests.cs</code> (new) - 9
+  stub-cloud unit tests over a real Kestrel host + real credential service.</li>
+  <li><code>src/CcDirector.Gateway.Tests/GatewayHostTests.cs</code> - 2 wiring tests over the real
+  in-process <code>GatewayHost</code>.</li>
+</ul>
+
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+  <tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (proof)</th><th>Result</th></tr>
+  <tr>
+    <td>1</td>
+    <td>GET /account/devices returns the account's device list with name, last-seen, device id, and a
+    this-device marker.</td>
+    <td>200 with mapped DTOs; Bearer token forwarded to the cloud.</td>
+    <td><code>Get_SignedIn_ForwardsBearer_MapsDtos_AndNoToken</code>: stub captured
+    <code>Authorization: Bearer &lt;jwt&gt;</code>; body has 2 devices with id/name/lastSeenAt;
+    <code>thisDevice=true</code> for the matching machine name, false otherwise.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>2</td>
+    <td>The Cockpit-facing response never contains the account access or refresh token (DT-05).</td>
+    <td>Body carries no token of any kind.</td>
+    <td>Same test asserts the body does NOT contain the JWT, the refresh token, the substring "token",
+    or "key_hash". No <code>FileLog</code> line emits a token value (verified by code scan).</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>3</td>
+    <td>DELETE /account/devices/{id} forwards the revoke; a subsequent GET no longer lists it.</td>
+    <td>DELETE 200 {revoked:true}; next GET omits the device.</td>
+    <td><code>Delete_Revokes_AndSubsequentGet_NoLongerListsDevice</code>: DELETE returns
+    <code>{signedIn:true,id:dev-2,revoked:true}</code>; the follow-up GET lists only dev-1.
+    <code>Delete_UnknownId_Returns404_NotRevoked</code> covers the 404 path.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>4</td>
+    <td>Signed-out Gateway returns an explicit signed-out status, never a silent empty 200 list.</td>
+    <td>Explicit <code>signedIn:false</code> envelope with no devices array.</td>
+    <td><code>SignedOut_Get_...</code> and <code>SignedOut_Delete_...</code>: body is
+    <code>{signedIn:false}</code> with <code>devices</code> omitted; the cloud is never called (no
+    Authorization captured). Also proven through the REAL host:
+    <code>GatewayHostTests.AccountDevices_isWired_andSignedOutHostReturnsExplicitSignedInFalse</code>.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>5</td>
+    <td>When the cloud is unreachable, the endpoint returns a clear error (not a fabricated list) and
+    logs it.</td>
+    <td>502 with an error body; failure logged.</td>
+    <td><code>Get_CloudUnreachable_Returns502_NotFabricatedList</code> and
+    <code>Delete_CloudUnreachable_Returns502</code>: 502 Bad Gateway, body has an <code>error</code>
+    and no <code>devices</code>; the endpoint logs <code>... FAILED: {ex.Message}</code>.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>+</td>
+    <td>Gated under the Gateway auth middleware like other /account routes.</td>
+    <td>401 without the Gateway token; 200 with it.</td>
+    <td><code>AuthEnabled_NoGatewayToken_Returns401</code> /
+    <code>AuthEnabled_WithGatewayToken_Returns200</code>, and
+    <code>GatewayHostTests.AccountDevices_get_requires_auth</code> (real host, 401).</td>
+    <td class="pass">PASS</td>
+  </tr>
+</table>
+
+<h2>Build and test results</h2>
+<pre>
+dotnet build cc-director.sln  ->  Build succeeded. 0 Warning(s) 0 Error(s)
+
+Account namespace (includes the 9 new endpoint tests):
+  Total tests: 48   Passed: 48   Failed: 0
+
+Real-host wiring tests (GatewayHostTests.AccountDevices*):
+  Passed AccountDevices_get_requires_auth
+  Passed AccountDevices_isWired_andSignedOutHostReturnsExplicitSignedInFalse
+</pre>
+<p>Captured transcripts committed alongside this report:
+<code>unit-tests.txt</code> (Account namespace) and <code>host-wiring-tests.txt</code>.</p>
+
+<h2>CenCon impact</h2>
+<p>No drift. The new endpoint is consistent with the existing Gateway-as-single-egress architecture
+(it sits next to <code>/account/status</code> and <code>/account/logout</code>); there is no per-endpoint
+component registry in <code>architecture_manifest.yaml</code> to update. Security rule DT-05 is honored:
+no token field on any Cockpit-facing DTO and no token value in any log line. Security-profile drift and
+manifest staleness checks both PASS.</p>
+
+<h2>QA gate (live real-cloud end-to-end)</h2>
+<p class="gate">The signed-in, real-cloud path could not be staged from this automation session (no real
+signed-in DevThrottle account + live cloud device registry available here). It is proven against an
+in-process stub of the documented cloud contract (devthrottle_internal#81/#82), exercised through the
+real endpoint on a real Kestrel host and the real credential service. The live real-cloud
+end-to-end - a signed-in Gateway returning its actual account devices, a real revoke disappearing from a
+real subsequent list - is the QA verification gate. The list-envelope shape assumed here is a top-level
+JSON array of masked records; QA should confirm the cloud's actual envelope.</p>
+
+<h2>Conclusion</h2>
+<p class="pass">I believe this is finished. All five acceptance criteria plus the auth-gate requirement
+are met with proof; the build is clean with zero warnings; the change honors DT-05 and the no-fallback /
+try-catch-at-boundaries coding standards.</p>
+
+</body>
+</html>

--- a/docs/cencon/proof/issue-854/unit-tests.txt
+++ b/docs/cencon/proof/issue-854/unit-tests.txt
@@ -1,0 +1,60 @@
+Test run for D:\ReposFred\devthrottle-wt-854\src\CcDirector.Gateway.Tests\bin\Debug\net10.0\CcDirector.Gateway.Tests.dll (.NETCoreApp,Version=v10.0)
+A total of 1 test files matched the specified pattern.
+[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.8.2+699d445a1a (64-bit .NET 10.0.9)
+[xUnit.net 00:00:00.08]   Discovering: CcDirector.Gateway.Tests
+[xUnit.net 00:00:00.18]   Discovered:  CcDirector.Gateway.Tests
+[xUnit.net 00:00:00.19]   Starting:    CcDirector.Gateway.Tests
+  Passed CcDirector.Gateway.Tests.Account.GatewayTokenRefreshTests.RefreshIfNeeded_ExpiredTokenNoEndpoint_KeepsCachedCredential [160 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayTokenRefreshTests.GatewayHttpTokenRefresher_NoEndpoint_ReturnsNull [1 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayTokenRefreshTests.RefreshIfNeeded_ExpiredTokenWithStubEndpoint_StoresFreshValidPair [222 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayTokenRefreshTests.RefreshIfNeeded_ExpiredTokenUnreachableEndpoint_KeepsCachedCredential [46 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayTokenRefreshTests.RefreshIfNeeded_ValidToken_TriggersNoExchange [39 ms]
+  Passed CcDirector.Gateway.Tests.Account.AccountDevicesEndpointTests.AuthEnabled_WithGatewayToken_Returns200 [70 ms]
+  Passed CcDirector.Gateway.Tests.Account.AccountDevicesEndpointTests.Delete_UnknownId_Returns404_NotRevoked [30 ms]
+  Passed CcDirector.Gateway.Tests.Account.AccountDevicesEndpointTests.AuthEnabled_NoGatewayToken_Returns401 [11 ms]
+  Passed CcDirector.Gateway.Tests.Account.AccountDevicesEndpointTests.Delete_Revokes_AndSubsequentGet_NoLongerListsDevice [14 ms]
+  Passed CcDirector.Gateway.Tests.Account.AccountDevicesEndpointTests.Get_SignedIn_ForwardsBearer_MapsDtos_AndNoToken [14 ms]
+  Passed CcDirector.Gateway.Tests.Account.AccountDevicesEndpointTests.Delete_CloudUnreachable_Returns502 [14 ms]
+  Passed CcDirector.Gateway.Tests.Account.AccountDevicesEndpointTests.SignedOut_Delete_ReturnsExplicitSignedInFalse_NoRevoke [10 ms]
+  Passed CcDirector.Gateway.Tests.Account.AccountDevicesEndpointTests.SignedOut_Get_ReturnsExplicitSignedInFalse_NotEmptyList [13 ms]
+  Passed CcDirector.Gateway.Tests.Account.AccountDevicesEndpointTests.Get_CloudUnreachable_Returns502_NotFabricatedList [11 ms]
+  Passed CcDirector.Gateway.Tests.Account.AccountLogoutEndpointTests.Logout_WhenNotSignedIn_IsNoOp_ReportsSignedInFalse [18 ms]
+  Passed CcDirector.Gateway.Tests.Account.AccountLogoutEndpointTests.Logout_ClearsCredential_SignedInFlipsToFalse_AndNoToken [27 ms]
+  Passed CcDirector.Gateway.Tests.Account.AccountLogoutEndpointTests.Logout_AuthEnabled_WithToken_Returns200_AndClears [10 ms]
+  Passed CcDirector.Gateway.Tests.Account.AccountLogoutEndpointTests.Logout_NoCredentialService_Returns200_SignedInFalse [7 ms]
+  Passed CcDirector.Gateway.Tests.Account.AccountLogoutEndpointTests.Logout_AuthEnabled_NoToken_Returns401 [8 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayConsentSurfaceTests.FreshGateway_ShouldShowConsentOnLaunch_AndPreSelectsOn [12 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayConsentSurfaceTests.AfterAcknowledge_SubsequentLaunch_DoesNotReShow [20 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayConsentSurfaceTests.CurrentUsageSharingChoice_ReflectsPersistedCentralizedValue [10 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayConsentSurfaceTests.Acknowledge_ShareUsageTrue_RecordsAckAndSetsCentralizedConsentOn [4 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayConsentSurfaceTests.Acknowledge_ShareUsageFalse_SetsCentralizedConsentOff [12 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayConsentSurfaceTests.TogglingCentralizedConsentLater_DoesNotReShowTheScreen [7 ms]
+  Passed CcDirector.Gateway.Tests.Account.AccountStatusEndpointTests.SignedIn_Returns200_WithIdentity_AndNoToken [14 ms]
+  Passed CcDirector.Gateway.Tests.Account.AccountStatusEndpointTests.NotSignedIn_Returns200_SignedInFalse_NoIdentityFields [7 ms]
+  Passed CcDirector.Gateway.Tests.Account.AccountStatusEndpointTests.AuthEnabled_WithToken_Returns200 [17 ms]
+  Passed CcDirector.Gateway.Tests.Account.AccountStatusEndpointTests.AuthEnabled_NoToken_Returns401 [9 ms]
+  Passed CcDirector.Gateway.Tests.Account.AccountStatusEndpointTests.NoCredentialService_Returns200_SignedInFalse [9 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayAccountServiceTests.SeedTestCredentialIfRequested_SeedsThePairAndReportsSignedInWithIdentity [16 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayAccountServiceTests.StoreTokens_PersistsAnEncryptedBlobNotPlaintext [13 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayAccountServiceTests.GetIdentity_NoStoredCredential_ReturnsNull [1 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayAccountServiceTests.StoreThenLoad_RoundTripsTheTokenPair [13 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayAccountServiceTests.IsLoggedIn_NoStoredCredential_ReturnsFalse [1 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayAccountServiceTests.GetIdentity_StoredTokenWithIdentityClaims_ReturnsEmailAndProvider [13 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayAccountServiceTests.SeedTestCredentialIfRequested_NoSeedEnvVar_StoresNothing [1 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayAccountServiceTests.IsLoggedIn_ValidStoredToken_ReturnsTrue [13 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewaySignInServiceTests.TraySurface_SignedIn_DoesNotPromptOrShowActionAndShowsIdentity [17 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewaySignInServiceTests.TraySurface_NotSignedIn_PromptsAndShowsSignInActionAndNotSignedInRow [< 1 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewaySignInServiceTests.RunSignInAsync_AfterSignIn_GatewayReadsIdentity [53 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewaySignInServiceTests.RunSignInAsync_WhileOneIsRunning_SecondCallIsANoOp [9 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewaySignInServiceTests.IsSignedIn_WithStoredCredential_ReturnsTrue_SoNoPromptOnSubsequentLaunch [12 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewaySignInServiceTests.TraySurface_NoSignInFlow_PromptsNothingAndOmitsRow [1 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewaySignInServiceTests.RunSignInAsync_BrowserCannotOpen_ReturnsFailureAndStaysUnsignedIn [4 ms]
+[xUnit.net 00:00:01.31]   Finished:    CcDirector.Gateway.Tests
+  Passed CcDirector.Gateway.Tests.Account.GatewaySignInServiceTests.RunSignInAsync_OpensBrowserCapturesHandBackAndStores_GatewayThenReportsSignedIn [17 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewaySignInServiceTests.RunSignInAsync_Cancelled_LeavesGatewayUnsignedInAndRetryable [5 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewaySignInServiceTests.IsSignedIn_NoStoredCredential_ReturnsFalse_SoTheGatewayPrompts [1 ms]
+
+Test Run Successful.
+Total tests: 48
+     Passed: 48
+ Total time: 1.8416 Seconds

--- a/src/CcDirector.Core/Account/DeviceRegistryClient.cs
+++ b/src/CcDirector.Core/Account/DeviceRegistryClient.cs
@@ -1,0 +1,194 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json.Nodes;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Account;
+
+/// <summary>
+/// One MASKED device record as it lives on the DevThrottle account device registry (cloud contract
+/// devthrottle_internal#81/#82). Every field here is safe to surface to a caller: the registry never
+/// returns the device's key hash or any raw key, only the prefix/last4 of the key for display. This
+/// record carries NO account access or refresh token (security rule DT-05) - it describes a device,
+/// not a credential.
+/// </summary>
+/// <param name="Id">The device's stable identifier (used to revoke it).</param>
+/// <param name="Name">The human-readable device name (typically the machine name at registration).</param>
+/// <param name="Platform">The operating-system platform string, or null when the cloud omits it.</param>
+/// <param name="DeviceType">The device type (for example "gateway" or "phone"), or null when omitted.</param>
+/// <param name="AppVersion">The app version last reported by the device, or null when omitted.</param>
+/// <param name="KeyPrefix">The masked key prefix for display, or null when omitted.</param>
+/// <param name="KeyLast4">The masked key last-four for display, or null when omitted.</param>
+/// <param name="CreatedAt">When the device was registered, or null when omitted.</param>
+/// <param name="LastSeenAt">When the device was last seen, or null when omitted.</param>
+public sealed record CloudDeviceRecord(
+    string Id,
+    string Name,
+    string? Platform,
+    string? DeviceType,
+    string? AppVersion,
+    string? KeyPrefix,
+    string? KeyLast4,
+    string? CreatedAt,
+    string? LastSeenAt);
+
+/// <summary>
+/// A small HTTP client for the DevThrottle account device registry (cloud contract
+/// devthrottle_internal#81/#82). It lists the signed-in account's active devices with
+/// <c>GET /api/v1/devices</c> and revokes one with <c>DELETE /api/v1/devices/{id}</c>, both authenticated
+/// with the Bearer access token the Gateway already holds for cloud egress (the same credential
+/// <see cref="DevThrottleAccountService.GetAccessTokenForForwarding"/> returns for telemetry forwarding).
+///
+/// The endpoint base is resolved from <see cref="AccountTelemetryClient.ApiBaseUrlEnvVar"/> when set (so
+/// development and QA can point at a local stub), otherwise the documented production default
+/// <see cref="AccountTelemetryClient.DefaultApiBaseUrl"/> - the SAME cloud base the Gateway already
+/// targets for the rest of its account egress, so this client introduces no new hard-coded URL.
+///
+/// The access token is sent only as the Authorization header and is NEVER written to the log (security
+/// rule DT-05): this client logs only the request shape and the response outcome, never the token. The
+/// returned <see cref="CloudDeviceRecord"/> values are masked by the cloud and carry no token either.
+///
+/// The <see cref="HttpClient"/> is injectable so tests drive these calls against an in-process stub
+/// handler (the proof seam for issue #854).
+/// </summary>
+public sealed class DeviceRegistryClient
+{
+    /// <summary>The path that lists the signed-in account's active devices.</summary>
+    public const string DevicesPath = "/api/v1/devices";
+
+    private readonly HttpClient _client;
+    private readonly string _baseUrl;
+
+    /// <summary>
+    /// Creates the client. <paramref name="client"/> defaults to a short-timeout
+    /// <see cref="HttpClient"/>; tests inject one over a stub handler. <paramref name="baseUrl"/>
+    /// defaults to the <see cref="AccountTelemetryClient.ApiBaseUrlEnvVar"/> override when set, otherwise
+    /// the production default - the same resolution the rest of the account egress uses.
+    /// </summary>
+    public DeviceRegistryClient(HttpClient? client = null, string? baseUrl = null)
+    {
+        _client = client ?? new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        _baseUrl = ResolveBaseUrl(baseUrl);
+    }
+
+    /// <summary>
+    /// Resolves the API base URL: the explicit <paramref name="baseUrl"/> argument when given
+    /// (trimmed, non-empty), otherwise the <see cref="AccountTelemetryClient.ApiBaseUrlEnvVar"/>
+    /// environment override, otherwise the production default. The trailing slash is removed so the path
+    /// concatenation never double-slashes.
+    /// </summary>
+    private static string ResolveBaseUrl(string? baseUrl)
+    {
+        if (!string.IsNullOrWhiteSpace(baseUrl))
+            return baseUrl.Trim().TrimEnd('/');
+
+        var fromEnv = Environment.GetEnvironmentVariable(AccountTelemetryClient.ApiBaseUrlEnvVar);
+        if (!string.IsNullOrWhiteSpace(fromEnv))
+            return fromEnv.Trim().TrimEnd('/');
+
+        return AccountTelemetryClient.DefaultApiBaseUrl;
+    }
+
+    /// <summary>
+    /// Lists the signed-in account's active devices via <c>GET /api/v1/devices</c>. Throws on a
+    /// non-success response (so an unreachable or erroring cloud surfaces as a clear failure the caller
+    /// reports, never a fabricated empty list) or a malformed body. The returned records are the cloud's
+    /// masked shape; no token is ever returned or logged.
+    /// </summary>
+    /// <param name="accessToken">The Bearer access token the Gateway holds. Never logged.</param>
+    /// <param name="ct">Cancels the request.</param>
+    public async Task<IReadOnlyList<CloudDeviceRecord>> ListDevicesAsync(string accessToken, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(accessToken))
+            throw new ArgumentException("Access token is required", nameof(accessToken));
+
+        var endpoint = $"{_baseUrl}{DevicesPath}";
+        FileLog.Write($"[DeviceRegistryClient] ListDevicesAsync: GET {endpoint}");
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        using var response = await _client.SendAsync(request, ct).ConfigureAwait(false);
+        FileLog.Write($"[DeviceRegistryClient] ListDevicesAsync: response status={(int)response.StatusCode}");
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        var root = JsonNode.Parse(json) as JsonArray
+            ?? throw new InvalidOperationException("devices response was not a JSON array");
+
+        var devices = new List<CloudDeviceRecord>(root.Count);
+        foreach (var item in root)
+        {
+            if (item is not JsonObject obj)
+                throw new InvalidOperationException("devices response contained a non-object entry");
+            devices.Add(ParseRecord(obj));
+        }
+
+        FileLog.Write($"[DeviceRegistryClient] ListDevicesAsync: parsed {devices.Count} device(s)");
+        return devices;
+    }
+
+    /// <summary>
+    /// Revokes one device via <c>DELETE /api/v1/devices/{id}</c>. Returns true when the cloud revoked it
+    /// (200), false when the id is not the caller's device (404). Throws on any other non-success status
+    /// (so an unreachable or erroring cloud surfaces as a clear failure, never a silent success).
+    /// </summary>
+    /// <param name="accessToken">The Bearer access token the Gateway holds. Never logged.</param>
+    /// <param name="id">The device id to revoke.</param>
+    /// <param name="ct">Cancels the request.</param>
+    public async Task<bool> RevokeDeviceAsync(string accessToken, string id, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(accessToken))
+            throw new ArgumentException("Access token is required", nameof(accessToken));
+        if (string.IsNullOrWhiteSpace(id))
+            throw new ArgumentException("Device id is required", nameof(id));
+
+        var endpoint = $"{_baseUrl}{DevicesPath}/{Uri.EscapeDataString(id)}";
+        FileLog.Write($"[DeviceRegistryClient] RevokeDeviceAsync: DELETE {endpoint}");
+
+        using var request = new HttpRequestMessage(HttpMethod.Delete, endpoint);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        using var response = await _client.SendAsync(request, ct).ConfigureAwait(false);
+        FileLog.Write($"[DeviceRegistryClient] RevokeDeviceAsync: id={id}, response status={(int)response.StatusCode}");
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+            return false;
+
+        response.EnsureSuccessStatusCode();
+        return true;
+    }
+
+    /// <summary>
+    /// Parses one masked device record from the cloud response object. The id and name are required; the
+    /// remaining display fields are optional and read as null when absent. No token field exists in this
+    /// shape, so none can be parsed (security rule DT-05).
+    /// </summary>
+    private static CloudDeviceRecord ParseRecord(JsonObject obj)
+    {
+        var id = StringField(obj, "id")
+            ?? throw new InvalidOperationException("device record had no string 'id'");
+        var name = StringField(obj, "name")
+            ?? throw new InvalidOperationException($"device record '{id}' had no string 'name'");
+
+        return new CloudDeviceRecord(
+            id,
+            name,
+            StringField(obj, "platform"),
+            StringField(obj, "device_type"),
+            StringField(obj, "app_version"),
+            StringField(obj, "key_prefix"),
+            StringField(obj, "key_last4"),
+            StringField(obj, "created_at"),
+            StringField(obj, "last_seen_at"));
+    }
+
+    /// <summary>Reads a string field from the object, or null when absent or not a string value.</summary>
+    private static string? StringField(JsonObject obj, string name)
+    {
+        if (obj.TryGetPropertyValue(name, out var node) && node is JsonValue value && value.TryGetValue<string>(out var text))
+            return text;
+        return null;
+    }
+}

--- a/src/CcDirector.Gateway.Contracts/AccountDevicesDto.cs
+++ b/src/CcDirector.Gateway.Contracts/AccountDevicesDto.cs
@@ -1,0 +1,92 @@
+using System.Text.Json.Serialization;
+
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// One device in the Cockpit-facing account device list (issue #854). The Gateway maps each masked cloud
+/// record (cloud contract devthrottle_internal#81/#82) to this shape and serves it from
+/// <c>GET /account/devices</c>, so the Cockpit Account page can list the account's devices with a
+/// last-seen time and a per-device revoke - without ever holding the account token or calling the cloud.
+///
+/// Security (carries DT-05): this contract intentionally carries NO access- or refresh-token field. Every
+/// field is a display value already masked by the cloud (the key prefix/last-four, never a raw key), so
+/// the Cockpit can never receive or display a credential.
+/// </summary>
+public sealed class AccountDeviceDto
+{
+    /// <summary>The device's stable identifier, used as the path id for revoke.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>The human-readable device name (typically the machine name at registration).</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>The operating-system platform string, or null when the cloud omits it.</summary>
+    public string? Platform { get; set; }
+
+    /// <summary>The device type (for example "gateway" or "phone"), or null when omitted.</summary>
+    public string? DeviceType { get; set; }
+
+    /// <summary>The app version last reported by the device, or null when omitted.</summary>
+    public string? AppVersion { get; set; }
+
+    /// <summary>The masked key prefix for display, or null when omitted.</summary>
+    public string? KeyPrefix { get; set; }
+
+    /// <summary>The masked key last-four for display, or null when omitted.</summary>
+    public string? KeyLast4 { get; set; }
+
+    /// <summary>When the device was registered (cloud timestamp), or null when omitted.</summary>
+    public string? CreatedAt { get; set; }
+
+    /// <summary>When the device was last seen (cloud timestamp), or null when omitted.</summary>
+    public string? LastSeenAt { get; set; }
+
+    /// <summary>
+    /// True when this record is the Gateway's own machine, so the Cockpit can mark it "This device".
+    /// Computed locally by matching the record name to this host's machine name.
+    /// </summary>
+    public bool ThisDevice { get; set; }
+}
+
+/// <summary>
+/// The body of <c>GET /account/devices</c> (issue #854). When the Gateway holds a valid account
+/// credential, <see cref="SignedIn"/> is true and <see cref="Devices"/> carries the account's devices
+/// (possibly an empty list when the account has none). When the Gateway holds no credential,
+/// <see cref="SignedIn"/> is false and <see cref="Devices"/> is OMITTED (null) - an explicit signed-out
+/// envelope, never a fabricated empty 200 list.
+///
+/// Security (carries DT-05): this contract carries no token field, so the Cockpit-facing response can
+/// never include the account access or refresh token.
+/// </summary>
+public sealed class AccountDevicesResponseDto
+{
+    /// <summary>Whether the Gateway holds a valid DevThrottle account credential.</summary>
+    public bool SignedIn { get; set; }
+
+    /// <summary>
+    /// The account's devices when signed in (may be empty); omitted entirely when not signed in so the
+    /// signed-out response is unmistakably distinct from a signed-in account with zero devices.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<AccountDeviceDto>? Devices { get; set; }
+}
+
+/// <summary>
+/// The body of <c>DELETE /account/devices/{id}</c> (issue #854). When signed in, <see cref="Revoked"/>
+/// reports whether the cloud revoked the device (the id no longer appears in a subsequent list). When the
+/// Gateway holds no credential, <see cref="SignedIn"/> is false and <see cref="Revoked"/> is false - an
+/// explicit signed-out result, never a silent success.
+///
+/// Security (carries DT-05): this contract carries no token field.
+/// </summary>
+public sealed class RevokeDeviceResponseDto
+{
+    /// <summary>Whether the Gateway holds a valid DevThrottle account credential.</summary>
+    public bool SignedIn { get; set; }
+
+    /// <summary>The device id the revoke targeted.</summary>
+    public string? Id { get; set; }
+
+    /// <summary>Whether the device was revoked (false when signed out, or the id was not the account's).</summary>
+    public bool Revoked { get; set; }
+}

--- a/src/CcDirector.Gateway.Tests/Account/AccountDevicesEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/AccountDevicesEndpointTests.cs
@@ -1,0 +1,393 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core.Account;
+using CcDirector.Gateway.Account;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Util;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Account;
+
+/// <summary>
+/// HTTP wire tests for the account device-list proxy (issue #854): <c>GET /account/devices</c> and
+/// <c>DELETE /account/devices/{id}</c>. Boots only <see cref="AccountDevicesEndpoint"/> on an ephemeral
+/// port over a Gateway credential service built on an in-memory token store, and points its
+/// <see cref="DeviceRegistryClient"/> at an in-process STUB cloud handler (no real network). Proves the
+/// issue's five acceptance criteria:
+/// <list type="number">
+/// <item>(a) GET forwards the Bearer token and maps the cloud response to the DTO (with the this-device
+/// marker);</item>
+/// <item>(b) the Cockpit-facing response contains NO access/refresh token;</item>
+/// <item>(c) DELETE forwards the revoke and a subsequent GET no longer lists the device;</item>
+/// <item>(d) signed-out returns the explicit <c>signedIn:false</c> envelope, never an empty 200 list;</item>
+/// <item>(e) cloud-unreachable returns a clear error (502), not a fabricated list.</item>
+/// </list>
+/// The real signed-in cloud end-to-end is the QA gate; here the stub stands in for the cloud contract
+/// devthrottle_internal#81/#82.
+/// </summary>
+public sealed class AccountDevicesEndpointTests
+{
+    private const string GatewayToken = "test-gateway-token-for-issue-854";
+    private const string ThisMachine = "GATEWAY-HOST-854";
+
+    private sealed class InMemoryTokenStore : IProtectedTokenStore
+    {
+        private DevThrottleTokens? _tokens;
+        public bool HasTokens => _tokens is not null;
+        public void Save(DevThrottleTokens tokens) => _tokens = tokens;
+        public DevThrottleTokens? Load() => _tokens;
+        public void Clear() => _tokens = null;
+    }
+
+    /// <summary>
+    /// An in-process stub of the cloud device registry. It records the Authorization header it received
+    /// (so the test can assert the Bearer token was forwarded), serves a mutable device list for
+    /// <c>GET /api/v1/devices</c>, and removes a device on <c>DELETE /api/v1/devices/{id}</c>. When
+    /// <see cref="Unreachable"/> is set it throws like an unreachable host.
+    /// </summary>
+    private sealed class StubCloudHandler : HttpMessageHandler
+    {
+        private readonly List<(string Id, string Name)> _devices;
+
+        public StubCloudHandler(IEnumerable<(string Id, string Name)> devices) => _devices = devices.ToList();
+
+        public string? LastAuthorization { get; private set; }
+        public bool Unreachable { get; set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastAuthorization = request.Headers.Authorization?.ToString();
+
+            if (Unreachable)
+                throw new HttpRequestException("simulated cloud unreachable");
+
+            var path = request.RequestUri?.AbsolutePath ?? string.Empty;
+
+            if (request.Method == HttpMethod.Get && path == DeviceRegistryClient.DevicesPath)
+            {
+                var sb = new StringBuilder("[");
+                for (var i = 0; i < _devices.Count; i++)
+                {
+                    var d = _devices[i];
+                    if (i > 0) sb.Append(',');
+                    // Masked record shape from the cloud contract: id, name, platform, device_type,
+                    // app_version, key_prefix, key_last4, created_at, last_seen_at. No key_hash, no raw key.
+                    sb.Append($"{{\"id\":\"{d.Id}\",\"name\":\"{d.Name}\",\"platform\":\"windows\",\"device_type\":\"gateway\",\"app_version\":\"1.2.3\",\"key_prefix\":\"dtk_\",\"key_last4\":\"ab12\",\"created_at\":\"2026-06-01T00:00:00Z\",\"last_seen_at\":\"2026-06-30T12:00:00Z\"}}");
+                }
+                sb.Append(']');
+                return Task.FromResult(Json(HttpStatusCode.OK, sb.ToString()));
+            }
+
+            if (request.Method == HttpMethod.Delete && path.StartsWith(DeviceRegistryClient.DevicesPath + "/", StringComparison.Ordinal))
+            {
+                var id = Uri.UnescapeDataString(path[(DeviceRegistryClient.DevicesPath.Length + 1)..]);
+                var removed = _devices.RemoveAll(d => d.Id == id);
+                if (removed == 0)
+                    return Task.FromResult(Json(HttpStatusCode.NotFound, "{\"error\":\"not found\"}"));
+                return Task.FromResult(Json(HttpStatusCode.OK, $"{{\"id\":\"{id}\",\"revoked\":true}}"));
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+
+        private static HttpResponseMessage Json(HttpStatusCode status, string body) =>
+            new(status) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+    }
+
+    private static DevThrottleAccountService MakeAccount(DevThrottleTokens? seed)
+    {
+        var previous = Environment.GetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar);
+        Environment.SetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar, GatewayTestJwt.SigningSecret);
+        try
+        {
+            var authEventsLog = Path.Combine(Path.GetTempPath(), "cc-gw-acct-devices-" + Guid.NewGuid().ToString("N") + ".jsonl");
+            var service = GatewayAccountFactory.Build(new InMemoryTokenStore(), authEventsLog);
+            if (seed is not null)
+                service.StoreTokens(seed);
+            return service;
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar, previous);
+        }
+    }
+
+    private static async Task<(WebApplication app, HttpClient http)> StartAsync(
+        DevThrottleAccountService? account, DeviceRegistryClient devices, bool authEnabled)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        if (authEnabled)
+        {
+            var requireToken = new AuthMiddleware.RequireToken
+            {
+                Token = GatewayToken,
+                Devices = new DeviceRegistry(Path.Combine(Path.GetTempPath(), "cc-gw-acct-devices-dev-" + Guid.NewGuid().ToString("N") + ".json")),
+            };
+            app.Use(async (ctx, next) => await AuthMiddleware.Run(ctx, requireToken, next));
+        }
+
+        AccountDevicesEndpoint.Map(app, account, devices, ThisMachine);
+        await app.StartAsync();
+
+        var baseUrl = app.Urls.First();
+        var http = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        return (app, http);
+    }
+
+    private static DeviceRegistryClient ClientOver(StubCloudHandler stub) =>
+        new(new HttpClient(stub) { BaseAddress = new Uri("https://stub-cloud.invalid") }, baseUrl: "https://stub-cloud.invalid");
+
+    // Criterion (a) + (b): GET forwards the Bearer token, maps the cloud records to the DTO with the
+    // this-device marker, and the response body contains NO access or refresh token.
+    [Fact]
+    public async Task Get_SignedIn_ForwardsBearer_MapsDtos_AndNoToken()
+    {
+        var jwt = GatewayTestJwt.Create(DateTime.UtcNow.AddHours(1));
+        const string refreshToken = "REFRESH-TOKEN-PLAINTEXT-MARKER-854";
+        var account = MakeAccount(new DevThrottleTokens(jwt, refreshToken));
+        var stub = new StubCloudHandler(new[] { (Id: "dev-1", Name: ThisMachine), (Id: "dev-2", Name: "OTHER-LAPTOP") });
+
+        var (app, http) = await StartAsync(account, ClientOver(stub), authEnabled: false);
+        try
+        {
+            var resp = await http.GetAsync("/account/devices");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            var body = await resp.Content.ReadAsStringAsync();
+
+            // Criterion (a): the Bearer access token was forwarded to the cloud.
+            Assert.Equal($"Bearer {jwt}", stub.LastAuthorization);
+
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+            Assert.True(root.GetProperty("signedIn").GetBoolean());
+            var arr = root.GetProperty("devices");
+            Assert.Equal(2, arr.GetArrayLength());
+
+            var first = arr[0];
+            Assert.Equal("dev-1", first.GetProperty("id").GetString());
+            Assert.Equal(ThisMachine, first.GetProperty("name").GetString());
+            Assert.Equal("2026-06-30T12:00:00Z", first.GetProperty("lastSeenAt").GetString());
+            Assert.True(first.GetProperty("thisDevice").GetBoolean(), "matching machine name must mark thisDevice");
+            Assert.False(arr[1].GetProperty("thisDevice").GetBoolean());
+
+            // Criterion (b): the Cockpit-facing body never carries the access JWT or refresh token,
+            // nor any "token"/key_hash field.
+            Assert.DoesNotContain(jwt, body, StringComparison.Ordinal);
+            Assert.DoesNotContain(refreshToken, body, StringComparison.Ordinal);
+            Assert.DoesNotContain("token", body, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("key_hash", body, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    // Criterion (c): DELETE forwards the revoke and a subsequent GET no longer lists the removed device.
+    [Fact]
+    public async Task Delete_Revokes_AndSubsequentGet_NoLongerListsDevice()
+    {
+        var jwt = GatewayTestJwt.Create(DateTime.UtcNow.AddHours(1));
+        var account = MakeAccount(new DevThrottleTokens(jwt, "refresh-1"));
+        var stub = new StubCloudHandler(new[] { (Id: "dev-1", Name: ThisMachine), (Id: "dev-2", Name: "OTHER-LAPTOP") });
+        var client = ClientOver(stub);
+
+        var (app, http) = await StartAsync(account, client, authEnabled: false);
+        try
+        {
+            var del = await http.DeleteAsync("/account/devices/dev-2");
+            Assert.Equal(HttpStatusCode.OK, del.StatusCode);
+            using (var delDoc = JsonDocument.Parse(await del.Content.ReadAsStringAsync()))
+            {
+                Assert.True(delDoc.RootElement.GetProperty("signedIn").GetBoolean());
+                Assert.Equal("dev-2", delDoc.RootElement.GetProperty("id").GetString());
+                Assert.True(delDoc.RootElement.GetProperty("revoked").GetBoolean());
+            }
+
+            var after = await http.GetAsync("/account/devices");
+            using var doc = JsonDocument.Parse(await after.Content.ReadAsStringAsync());
+            var arr = doc.RootElement.GetProperty("devices");
+            Assert.Equal(1, arr.GetArrayLength());
+            Assert.Equal("dev-1", arr[0].GetProperty("id").GetString());
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    // Criterion (c, 404 path): revoking an id that is not the account's returns 404 with revoked:false.
+    [Fact]
+    public async Task Delete_UnknownId_Returns404_NotRevoked()
+    {
+        var jwt = GatewayTestJwt.Create(DateTime.UtcNow.AddHours(1));
+        var account = MakeAccount(new DevThrottleTokens(jwt, "refresh-1"));
+        var stub = new StubCloudHandler(new[] { (Id: "dev-1", Name: ThisMachine) });
+
+        var (app, http) = await StartAsync(account, ClientOver(stub), authEnabled: false);
+        try
+        {
+            var del = await http.DeleteAsync("/account/devices/does-not-exist");
+            Assert.Equal(HttpStatusCode.NotFound, del.StatusCode);
+            using var doc = JsonDocument.Parse(await del.Content.ReadAsStringAsync());
+            Assert.True(doc.RootElement.GetProperty("signedIn").GetBoolean());
+            Assert.False(doc.RootElement.GetProperty("revoked").GetBoolean());
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    // Criterion (d): a signed-out Gateway returns an explicit signedIn:false envelope with NO devices
+    // array - never a fabricated empty 200 list - for both GET and DELETE.
+    [Fact]
+    public async Task SignedOut_Get_ReturnsExplicitSignedInFalse_NotEmptyList()
+    {
+        var account = MakeAccount(seed: null);
+        var stub = new StubCloudHandler(Array.Empty<(string, string)>());
+
+        var (app, http) = await StartAsync(account, ClientOver(stub), authEnabled: false);
+        try
+        {
+            var resp = await http.GetAsync("/account/devices");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            Assert.False(doc.RootElement.GetProperty("signedIn").GetBoolean());
+            Assert.False(doc.RootElement.TryGetProperty("devices", out _), "devices must be omitted when signed out");
+            // The cloud was never called because there was no credential to forward.
+            Assert.Null(stub.LastAuthorization);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task SignedOut_Delete_ReturnsExplicitSignedInFalse_NoRevoke()
+    {
+        var account = MakeAccount(seed: null);
+        var stub = new StubCloudHandler(new[] { (Id: "dev-1", Name: ThisMachine) });
+
+        var (app, http) = await StartAsync(account, ClientOver(stub), authEnabled: false);
+        try
+        {
+            var del = await http.DeleteAsync("/account/devices/dev-1");
+            Assert.Equal(HttpStatusCode.OK, del.StatusCode);
+            using var doc = JsonDocument.Parse(await del.Content.ReadAsStringAsync());
+            Assert.False(doc.RootElement.GetProperty("signedIn").GetBoolean());
+            Assert.False(doc.RootElement.GetProperty("revoked").GetBoolean());
+            Assert.Null(stub.LastAuthorization);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    // Criterion (e): when the cloud is unreachable, GET returns a clear 502 error (not a fabricated list).
+    [Fact]
+    public async Task Get_CloudUnreachable_Returns502_NotFabricatedList()
+    {
+        var jwt = GatewayTestJwt.Create(DateTime.UtcNow.AddHours(1));
+        var account = MakeAccount(new DevThrottleTokens(jwt, "refresh-1"));
+        var stub = new StubCloudHandler(new[] { (Id: "dev-1", Name: ThisMachine) }) { Unreachable = true };
+
+        var (app, http) = await StartAsync(account, ClientOver(stub), authEnabled: false);
+        try
+        {
+            var resp = await http.GetAsync("/account/devices");
+            Assert.Equal(HttpStatusCode.BadGateway, resp.StatusCode);
+            var body = await resp.Content.ReadAsStringAsync();
+            Assert.DoesNotContain("\"devices\"", body, StringComparison.Ordinal);
+            Assert.Contains("error", body, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    // Criterion (e, revoke path): when the cloud is unreachable, DELETE returns a clear 502 error.
+    [Fact]
+    public async Task Delete_CloudUnreachable_Returns502()
+    {
+        var jwt = GatewayTestJwt.Create(DateTime.UtcNow.AddHours(1));
+        var account = MakeAccount(new DevThrottleTokens(jwt, "refresh-1"));
+        var stub = new StubCloudHandler(new[] { (Id: "dev-1", Name: ThisMachine) }) { Unreachable = true };
+
+        var (app, http) = await StartAsync(account, ClientOver(stub), authEnabled: false);
+        try
+        {
+            var del = await http.DeleteAsync("/account/devices/dev-1");
+            Assert.Equal(HttpStatusCode.BadGateway, del.StatusCode);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    // Gateway auth gate: with auth enabled a call carrying no Gateway token is 401 by the host-wide
+    // middleware (the same gate the other /account routes use), before the delegate runs.
+    [Fact]
+    public async Task AuthEnabled_NoGatewayToken_Returns401()
+    {
+        var jwt = GatewayTestJwt.Create(DateTime.UtcNow.AddHours(1));
+        var account = MakeAccount(new DevThrottleTokens(jwt, "refresh-1"));
+        var stub = new StubCloudHandler(new[] { (Id: "dev-1", Name: ThisMachine) });
+
+        var (app, http) = await StartAsync(account, ClientOver(stub), authEnabled: true);
+        try
+        {
+            var resp = await http.GetAsync("/account/devices");
+            Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    // Gateway auth gate (authorized path): with the Gateway token present the endpoint passes (200).
+    [Fact]
+    public async Task AuthEnabled_WithGatewayToken_Returns200()
+    {
+        var jwt = GatewayTestJwt.Create(DateTime.UtcNow.AddHours(1));
+        var account = MakeAccount(new DevThrottleTokens(jwt, "refresh-1"));
+        var stub = new StubCloudHandler(new[] { (Id: "dev-1", Name: ThisMachine) });
+
+        var (app, http) = await StartAsync(account, ClientOver(stub), authEnabled: true);
+        try
+        {
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", GatewayToken);
+            var resp = await http.GetAsync("/account/devices");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            Assert.True(doc.RootElement.GetProperty("signedIn").GetBoolean());
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/GatewayHostTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayHostTests.cs
@@ -182,6 +182,31 @@ public sealed class GatewayHostTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
     }
 
+    // Issue #854: the account device-list proxy is wired into the real GatewayHost (near the other
+    // /account routes) and gated by the host-wide auth middleware. This bare test host holds no account
+    // credential, so the route is reachable with the gateway token and answers the explicit signed-out
+    // envelope - proving the wiring line in GatewayHost.cs, not just the endpoint in isolation.
+    [Fact]
+    public async Task AccountDevices_isWired_andSignedOutHostReturnsExplicitSignedInFalse()
+    {
+        var resp = await _http.GetAsync("account/devices");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var obj = await resp.Content.ReadFromJsonAsync<JsonObject>();
+        Assert.NotNull(obj);
+        Assert.False((bool?)obj["signedIn"]);
+        // Signed out -> no fabricated device list.
+        Assert.False(obj.ContainsKey("devices"));
+    }
+
+    [Fact]
+    public async Task AccountDevices_get_requires_auth()
+    {
+        using var anonClient = new HttpClient { BaseAddress = _http.BaseAddress };
+        var resp = await anonClient.GetAsync("account/devices");
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
     private async Task WaitForDirectorCount(int target, TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;

--- a/src/CcDirector.Gateway/Api/AccountDevicesEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AccountDevicesEndpoint.cs
@@ -1,0 +1,147 @@
+using CcDirector.Core.Account;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The account device-list proxy (issue #854): <c>GET /account/devices</c> and
+/// <c>DELETE /account/devices/{id}</c>. The Cockpit Account page needs the account-wide device list with
+/// last-seen and a per-device revoke, but the Cockpit must NEVER hold the account token or call the cloud
+/// directly - the token lives on the Gateway. So the Gateway proxies: it reads its own stored account
+/// token (<see cref="DevThrottleAccountService.GetAccessTokenForForwarding"/>, the SAME egress credential
+/// it already uses to forward telemetry/login to the cloud), calls the cloud device registry
+/// (<see cref="DeviceRegistryClient"/>, cloud contract devthrottle_internal#81/#82), and returns a local,
+/// token-free DTO.
+///
+/// This is distinct from the LOCAL pairing registry <c>GET /devices</c> (issue #469): that lists the
+/// machines paired to THIS Gateway; this lists the devices registered to the DevThrottle ACCOUNT across
+/// the cloud. Both surfaces coexist.
+///
+/// Security (carries DT-05): the raw account token NEVER appears in the Cockpit-facing response (the DTOs
+/// have no token field) and is never written to the log on any path.
+///
+/// Behaviour at the edges (no fabricated data):
+/// <list type="bullet">
+/// <item>Signed out / no credential -> an explicit <c>signedIn:false</c> envelope, never a fabricated
+/// empty 200 device list.</item>
+/// <item>Cloud unreachable / erroring -> a clear 502 error (logged), never a fabricated list or a silent
+/// success.</item>
+/// </list>
+///
+/// When Gateway auth is enabled, both routes inherit the host-wide Gateway token middleware exactly like
+/// the other <c>/account</c> endpoints (they are not on the public-paths allow-list), so a call with no
+/// Gateway token is answered 401 by that middleware before these delegates run.
+/// </summary>
+internal static class AccountDevicesEndpoint
+{
+    /// <summary>
+    /// Maps <c>GET /account/devices</c> and <c>DELETE /account/devices/{id}</c>.
+    /// </summary>
+    /// <param name="app">The route builder.</param>
+    /// <param name="account">
+    /// The Gateway-hosted DevThrottle credential service (issue #636). Null on a host that has no
+    /// credential service (a non-Windows host); the endpoints then report an explicit signed-out result.
+    /// </param>
+    /// <param name="devices">The cloud device-registry client (the injectable cloud egress seam).</param>
+    /// <param name="thisDeviceName">
+    /// This host's machine name, used to mark the Gateway's own device in the list. Injected for tests.
+    /// </param>
+    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account, DeviceRegistryClient devices, string thisDeviceName)
+    {
+        if (devices is null) throw new ArgumentNullException(nameof(devices));
+        if (thisDeviceName is null) throw new ArgumentNullException(nameof(thisDeviceName));
+
+        app.MapGet("/account/devices", async (HttpContext ctx) =>
+        {
+            // Entry point: the delegate is the boundary, so the only try-catch lives here. A signed-out
+            // Gateway is an expected state answered explicitly (not an exception); a cloud failure is an
+            // unexpected failure caught here and reported as a clear error (never a fabricated list).
+            var token = account?.GetAccessTokenForForwarding();
+            if (string.IsNullOrEmpty(token))
+            {
+                FileLog.Write("[AccountDevicesEndpoint] GET /account/devices: no account credential -> signedIn=false (explicit, not an empty list)");
+                return Results.Json(new AccountDevicesResponseDto { SignedIn = false });
+            }
+
+            try
+            {
+                var records = await devices.ListDevicesAsync(token, ctx.RequestAborted).ConfigureAwait(false);
+                var list = new List<AccountDeviceDto>(records.Count);
+                foreach (var record in records)
+                    list.Add(ToDto(record, thisDeviceName));
+
+                FileLog.Write($"[AccountDevicesEndpoint] GET /account/devices: signedIn=true, returned {list.Count} device(s)");
+                return Results.Json(new AccountDevicesResponseDto { SignedIn = true, Devices = list });
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[AccountDevicesEndpoint] GET /account/devices FAILED: {ex.Message}");
+                return Results.Json(
+                    new { error = "Could not reach the DevThrottle account service to list devices. Try again shortly." },
+                    statusCode: StatusCodes.Status502BadGateway);
+            }
+        });
+
+        app.MapDelete("/account/devices/{id}", async (string id, HttpContext ctx) =>
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                return Results.BadRequest(new { error = "id is required" });
+
+            // Entry point: same boundary rule as the GET above.
+            var token = account?.GetAccessTokenForForwarding();
+            if (string.IsNullOrEmpty(token))
+            {
+                FileLog.Write($"[AccountDevicesEndpoint] DELETE /account/devices/{id}: no account credential -> signedIn=false (explicit, no revoke performed)");
+                return Results.Json(new RevokeDeviceResponseDto { SignedIn = false, Id = id, Revoked = false });
+            }
+
+            try
+            {
+                var revoked = await devices.RevokeDeviceAsync(token, id, ctx.RequestAborted).ConfigureAwait(false);
+                if (!revoked)
+                {
+                    FileLog.Write($"[AccountDevicesEndpoint] DELETE /account/devices/{id}: not found for this account -> 404");
+                    return Results.Json(
+                        new RevokeDeviceResponseDto { SignedIn = true, Id = id, Revoked = false },
+                        statusCode: StatusCodes.Status404NotFound);
+                }
+
+                FileLog.Write($"[AccountDevicesEndpoint] DELETE /account/devices/{id}: revoked");
+                return Results.Json(new RevokeDeviceResponseDto { SignedIn = true, Id = id, Revoked = true });
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[AccountDevicesEndpoint] DELETE /account/devices/{id} FAILED: {ex.Message}");
+                return Results.Json(
+                    new { error = "Could not reach the DevThrottle account service to revoke the device. Try again shortly." },
+                    statusCode: StatusCodes.Status502BadGateway);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Maps a masked cloud record to the Cockpit-facing DTO and computes the this-device marker by matching
+    /// the record name to this host's machine name (case-insensitive). The match on machine name is the
+    /// available signal until device self-registration (a sibling issue) stamps a stronger identity.
+    /// </summary>
+    private static AccountDeviceDto ToDto(CloudDeviceRecord record, string thisDeviceName)
+    {
+        return new AccountDeviceDto
+        {
+            Id = record.Id,
+            Name = record.Name,
+            Platform = record.Platform,
+            DeviceType = record.DeviceType,
+            AppVersion = record.AppVersion,
+            KeyPrefix = record.KeyPrefix,
+            KeyLast4 = record.KeyLast4,
+            CreatedAt = record.CreatedAt,
+            LastSeenAt = record.LastSeenAt,
+            ThisDevice = string.Equals(record.Name, thisDeviceName, StringComparison.OrdinalIgnoreCase),
+        };
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -744,6 +744,20 @@ public sealed class GatewayHost : IAsyncDisposable
         // nothing to clear and it reports not-signed-in.
         AccountLogoutEndpoint.Map(_app, Account);
 
+        // Account device list + revoke proxy (issue #854): GET /account/devices and
+        // DELETE /account/devices/{id}. The Cockpit Account page needs the account-wide device list with
+        // last-seen and a per-device revoke, but the Cockpit must never hold the account token or call the
+        // cloud directly - the token lives here on the Gateway. So the Gateway proxies: it reads its own
+        // stored account token (the SAME GetAccessTokenForForwarding credential it uses to forward
+        // telemetry/login to the cloud) and calls the cloud device registry through DeviceRegistryClient,
+        // returning a local token-free DTO (security rule DT-05). Signed-out yields an explicit
+        // signedIn:false envelope (never a fabricated empty list) and an unreachable cloud yields a clear
+        // 502 (logged). The injectable HttpClient is the test seam. This is distinct from the LOCAL pairing
+        // registry GET /devices (issue #469), which is left unchanged. Inherits the host-wide token
+        // middleware above, exactly like the other /account routes.
+        var accountDevicesClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        AccountDevicesEndpoint.Map(_app, Account, new Core.Account.DeviceRegistryClient(accountDevicesClient), Environment.MachineName);
+
         // Transcription routing (issue #506): the Gateway serves the WHOLE routing target
         // (mode + base URL + model + key) for its configured transcription mode, so a connected
         // Director stops hardcoding the URL/mode. Composes URL+key server-side from the one pure


### PR DESCRIPTION
Closes #854 (hand-off to QA).

## Release Notes
The Gateway now proxies the account-wide device list and per-device revoke so the Cockpit Account page can show the account's devices (with last-seen + a "this device" marker) and revoke one - WITHOUT the Cockpit ever holding the account token or calling the cloud directly. The token stays on the Gateway.

## Changes
- `DeviceRegistryClient` (Core): injectable-HttpClient cloud egress client for `GET /api/v1/devices` and `DELETE /api/v1/devices/:id`, authenticated with the Gateway's stored account token. Base URL reuses `AccountTelemetryClient.ApiBaseUrlEnvVar`/`DefaultApiBaseUrl` (the same cloud base the rest of the account egress targets). The token is attached as the Bearer header and never logged.
- `AccountDevicesDto` (Contracts): `AccountDeviceDto`, `AccountDevicesResponseDto`, `RevokeDeviceResponseDto` - none carry a token field (security rule DT-05).
- `AccountDevicesEndpoint` (Gateway): `GET /account/devices` and `DELETE /account/devices/{id}`. Signed-out returns an explicit `signedIn:false` envelope (never a fabricated empty list); cloud-unreachable returns a clear 502 and logs it; the this-device marker matches the record name to the host machine name.
- Wired into `GatewayHost` next to `AccountStatusEndpoint`/`AccountLogoutEndpoint`, under the same host-wide Gateway auth middleware.
- Leaves the local pairing registry `GET /devices` (#469) untouched.

## How to Test
`dotnet build cc-director.sln` (clean, 0 warnings), then `dotnet test src/CcDirector.Gateway.Tests` filtered to `AccountDevicesEndpointTests` (9 tests) and `GatewayHostTests.AccountDevices*` (2 real-host wiring tests).

## Expected Result
All five acceptance criteria pass against an in-process stub of the cloud contract (devthrottle_internal#81/#82): Bearer forwarded + DTOs mapped; no token in the response/logs; revoke then a list no longer shows it; signed-out is explicit; cloud-unreachable is a clear 502. The live real-cloud end-to-end is the QA gate (no real signed-in cloud account could be staged from the automation session).

## Proof
`docs/cencon/proof/issue-854/report.html` (Expected vs Actual per criterion), plus `unit-tests.txt` and `host-wiring-tests.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)