### PR TITLE
[Tests] Fix flaky TerminalThroughputTests: median + jitter tolerance (#870)

### DIFF
--- a/docs/cencon/proof/issue-870/report.html
+++ b/docs/cencon/proof/issue-870/report.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Issue #870 - Flaky throughput test - Developer Proof</title>
+<style>
+ :root{--bg:#0b1020;--border:#2a3550;--text:#e7ecf5;--dim:#93a0bd;--accent:#4f8cff;}
+ *{box-sizing:border-box;} body{margin:0;background:var(--bg);color:var(--text);font-family:-apple-system,Segoe UI,Roboto,Arial,sans-serif;line-height:1.6;}
+ .wrap{max-width:1000px;margin:0 auto;padding:32px 24px 96px;} h1{font-size:25px;margin:0 0 4px;} h2{font-size:19px;margin:34px 0 12px;padding-bottom:8px;border-bottom:1px solid var(--border);}
+ p,li{color:#d7deef;} code{background:#0f1626;padding:1px 6px;border-radius:5px;font-family:Consolas,monospace;font-size:13px;color:#cfe0ff;}
+ pre{background:#0f1626;border:1px solid var(--border);border-radius:10px;padding:14px 16px;overflow-x:auto;font-family:Consolas,monospace;font-size:12.5px;color:#cfe0ff;}
+ .pill{display:inline-block;font-size:12px;font-weight:700;padding:2px 9px;border-radius:999px;background:#11331f;color:#5fd08a;border:1px solid #1f5c38;}
+</style></head><body><div class="wrap">
+<h1>Issue #870 - Flaky throughput test</h1>
+<p style="color:var(--dim)">Branch <code>issue-870-flaky-throughput</code> (off <code>main</code>).</p>
+<p><span class="pill">I believe this is finished.</span></p>
+
+<h2>1. Root cause (measured)</h2>
+<p><code>TerminalThroughputTests.Parse10MbInChunks_EachChunkCompletesWithin100Ms</code> parsed 10 MB in 160 x 64 KB
+chunks and failed if <strong>any single chunk</strong> exceeded a 100 ms wall-clock budget. Measured distribution
+across runs: the <strong>typical (median) chunk is ~25 ms</strong>, max usually 67-85 ms, but it
+<strong>occasionally spikes to ~128 ms</strong> from GC / OS-scheduler jitter (one run: max 128 ms, 2 offenders ->
+FAIL). The parser is fine; a single jitter spike at the 100 ms line flaked the gate.</p>
+
+<h2>2. Fix</h2>
+<p>Assert the signals that separate a responsive parser from a real regression, instead of an absolute per-chunk
+deadline (the approach the issue's criteria endorse):</p>
+<ul>
+ <li><strong>Median chunk &lt;= 100 ms</strong> - the typical chunk stays within the UI budget (jitter-robust: a
+   few outliers do not move the median; a real slowdown does).</li>
+ <li><strong>&lt;= 5% of chunks may exceed 100 ms</strong> - tolerates rare GC/scheduler jitter; a systemic
+   slowdown pushes far more over.</li>
+ <li><strong>No chunk &gt; 1000 ms</strong> - a true catastrophic per-chunk UI block still fails.</li>
+</ul>
+<p>Test-only change in <code>src/CcDirector.Core.Tests/TerminalThroughputTests.cs</code> (renamed to
+<code>Parse10MbInChunks_TypicalChunkStaysWithinUiBudget</code> to match the assertion). No production code change.</p>
+
+<h2>3. Verification</h2>
+<pre>dotnet build cc-director.sln  ->  Build succeeded. 0 Warning(s) 0 Error(s)
+
+# TerminalThroughputTests x10 consecutive (under load):
+run 1..10: Passed!  - Failed: 0, Passed: 4, Total: 4   (every run)
+
+# Full CcDirector.Core.Tests (in-suite + regression):
+Passed!  - Failed: 0, Passed: 2646, Skipped: 6, Total: 2652</pre>
+<p>The previously-flaky test passed 10/10 isolated runs and within the full suite, with no regression. (Before the
+fix, the same test failed intermittently - e.g. 1 of 3 isolated runs.)</p>
+
+<h2>4. CenCon impact</h2>
+<p>No drift. A test-only fix (test isolation/robustness); no new container, security boundary, or production
+behavior change.</p>
+</div></body></html>

--- a/src/CcDirector.Core.Tests/TerminalThroughputTests.cs
+++ b/src/CcDirector.Core.Tests/TerminalThroughputTests.cs
@@ -155,22 +155,33 @@ public class TerminalThroughputTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void Parse10MbInChunks_EachChunkCompletesWithin100Ms()
+    public void Parse10MbInChunks_TypicalChunkStaysWithinUiBudget()
     {
         const int TargetBytes = 10 * 1024 * 1024; // 10 MB
         const int ChunkSize = 64 * 1024;           // 64 KB per chunk -- matches typical read buffer
         const double MaxChunkMs = 100.0;           // responsive-UI mandate (CLAUDE.md)
 
+        // Issue #870: this is a WALL-CLOCK measurement, so a chunk occasionally spikes past the budget
+        // from GC / OS-scheduler jitter (especially on a loaded CI runner) even though the parser keeps
+        // up - the median chunk is a small fraction of the budget. Asserting that EVERY chunk stays
+        // under 100 ms made the test flaky (a single jitter spike failed the run). Instead we assert the
+        // signals that actually separate a responsive parser from a regression: the TYPICAL (median)
+        // chunk is within the UI budget, only a small fraction of chunks may exceed it (jitter), and no
+        // single chunk catastrophically blocks the UI thread. A real slowdown moves the median and/or
+        // pushes far more than the jitter budget of chunks over the limit.
+        const double MaxOverBudgetFraction = 0.05;  // <= 5% of chunks may blow the budget (jitter)
+        const double CatastropheMs = 1000.0;        // no single chunk may block the UI this long
+
         byte[] stream = BuildSyntheticStream(TargetBytes);
         var (parser, _, _) = CreateParser(cols: 120, rows: 30, maxScrollback: 5000);
 
-        double maxObserved = 0.0;
+        var perChunkMs = new List<double>();
         double totalSec = 0.0;
-        int chunks = 0;
         var offenders = new List<string>();
 
         var sw = new Stopwatch();
         int pos = 0;
+        int chunks = 0;
         while (pos < stream.Length)
         {
             int n = Math.Min(ChunkSize, stream.Length - pos);
@@ -182,7 +193,7 @@ public class TerminalThroughputTests
 
             double ms = sw.Elapsed.TotalMilliseconds;
             totalSec += sw.Elapsed.TotalSeconds;
-            if (ms > maxObserved) maxObserved = ms;
+            perChunkMs.Add(ms);
             if (ms > MaxChunkMs)
                 offenders.Add($"chunk {chunks}: {ms:F1} ms ({n} bytes at offset {pos})");
 
@@ -190,15 +201,34 @@ public class TerminalThroughputTests
             chunks++;
         }
 
-        _output.WriteLine($"Chunks     : {chunks} x {ChunkSize / 1024} KB");
-        _output.WriteLine($"Total time : {totalSec:F3} s");
-        _output.WriteLine($"Max chunk  : {maxObserved:F2} ms (limit = {MaxChunkMs} ms)");
-        _output.WriteLine($"Offenders  : {offenders.Count}");
+        perChunkMs.Sort();
+        double median = perChunkMs[perChunkMs.Count / 2];
+        double maxObserved = perChunkMs[^1];
+        int overBudget = offenders.Count;
+        double overBudgetFraction = (double)overBudget / chunks;
 
+        _output.WriteLine($"Chunks      : {chunks} x {ChunkSize / 1024} KB");
+        _output.WriteLine($"Total time  : {totalSec:F3} s");
+        _output.WriteLine($"Median chunk: {median:F2} ms (budget = {MaxChunkMs} ms)");
+        _output.WriteLine($"Max chunk   : {maxObserved:F2} ms (catastrophe = {CatastropheMs} ms)");
+        _output.WriteLine($"Over budget : {overBudget}/{chunks} ({overBudgetFraction:P1}, allowed <= {MaxOverBudgetFraction:P0})");
+
+        // The typical chunk must keep the UI responsive (the real regression signal; jitter-robust).
         Assert.True(
-            offenders.Count == 0,
-            $"{offenders.Count} chunk(s) exceeded {MaxChunkMs} ms UI-block budget:\n"
-            + string.Join("\n", offenders.Take(10)));
+            median <= MaxChunkMs,
+            $"median chunk {median:F1} ms exceeded the {MaxChunkMs} ms UI budget - parser regression");
+
+        // Only a small fraction may exceed the budget (rare GC/scheduler jitter); a systemic slowdown
+        // pushes far more chunks over.
+        Assert.True(
+            overBudgetFraction <= MaxOverBudgetFraction,
+            $"{overBudget}/{chunks} chunks ({overBudgetFraction:P1}) exceeded {MaxChunkMs} ms, over the "
+            + $"{MaxOverBudgetFraction:P0} jitter budget:\n" + string.Join("\n", offenders.Take(10)));
+
+        // And no single chunk may catastrophically block the UI thread (a true per-chunk regression).
+        Assert.True(
+            maxObserved <= CatastropheMs,
+            $"a chunk took {maxObserved:F1} ms (> {CatastropheMs} ms) - catastrophic UI block");
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Closes #870.

## Root cause (measured)
`Parse10MbInChunks_EachChunkCompletesWithin100Ms` failed if **any** of the 160 × 64 KB chunks exceeded a 100 ms wall-clock budget. Measured: the typical (median) chunk is **~25 ms**, max usually 67–85 ms, but it **occasionally spikes to ~128 ms** from GC / scheduler jitter (one run: max 128 ms, 2 offenders → FAIL). The parser is fine; a single jitter spike flaked the gate.

## Fix
Assert the signals that separate a responsive parser from a real regression (per the issue's endorsed approach), instead of an absolute per-chunk deadline:
- **median chunk ≤ 100 ms** — typical chunk within the UI budget (jitter-robust),
- **≤ 5% of chunks may exceed 100 ms** — tolerates rare jitter; a systemic slowdown pushes far more over,
- **no chunk > 1000 ms** — a true catastrophic per-chunk UI block still fails.

Renamed to `Parse10MbInChunks_TypicalChunkStaysWithinUiBudget`. **Test-only** — no production change.

## Verification
- `dotnet build cc-director.sln` — 0 warnings, 0 errors.
- `TerminalThroughputTests` — **10/10 consecutive runs green** under load (was failing ~1 in 3 isolated runs before).
- Full `CcDirector.Core.Tests` — **2646 passed, 0 failed** (in-suite + regression).
- Proof: `docs/cencon/proof/issue-870/report.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
