### PR TITLE
[Gateway] #881 refinement: revoke the auto-minted inference key on sign-out

### DIFF
--- a/docs/cencon/proof/issue-887/live-transcription/REVOKE-PROOF.md
+++ b/docs/cencon/proof/issue-887/live-transcription/REVOKE-PROOF.md
@@ -1,0 +1,28 @@
+# #881 refinement: revoke-on-sign-out live proof (2026-07-02)
+
+Signing out revokes the auto-minted inference key so a signed-out install leaves no live key behind.
+
+## Live cycle (production)
+1. **Mint** `POST /api/v1/keys` (account JWT) -> **201**; the key id is at `data.record.id` (exactly what
+   `AccountInferenceKeyProvisioner.ExtractKeyId` reads).
+2. **Revoke** `DELETE /api/v1/keys/{data.record.id}` -> **200**.
+3. **Confirm dead** transcribe with the revoked key -> **401** (the key no longer authenticates inference).
+
+No leftover keys (the cleanup delete of the prior run's id returned 404 = already gone).
+
+## Code
+- `IInferenceKeyMinter.MintAsync` now returns `MintedInferenceKey { Key, Id }`; new `RevokeAsync(jwt, id)`.
+- `TranscriptionKeyAutoProvisioner` records the id in the vault entry `DEVTHROTTLE_API_KEY_ID` when it
+  mints, and `RevokeMintedKeyAsync` revokes THAT key on sign-out and clears both vault entries. A
+  MANUALLY-pasted key has no id and is left untouched (never revoked - it is the user's key).
+- `POST /account/logout` runs the revoke as a best-effort pre-clear hook (the revoke needs the still-present JWT).
+
+## Tests
+22 unit tests (id extraction incl. the real `data.record.id` shape, mint returns key+id, revoke clears
+both entries, and a manual key is left untouched).
+
+## Deferred (still fast-follow)
+Capturing the `dtd_` device key into the DPAPI blob and moving the minted key/id into the blob (vs the
+vault, which already holds the manual key in plaintext) - both ripple into the `DevThrottleTokens` record
+and its token-refresh preservation path; kept out of this increment to avoid risking the working
+auto-wiring on token renewal. The id is stored in the vault alongside the key it revokes instead.

--- a/src/CcDirector.Gateway.Tests/TranscriptionKeyAutoProvisionerTests.cs
+++ b/src/CcDirector.Gateway.Tests/TranscriptionKeyAutoProvisionerTests.cs
@@ -65,15 +65,27 @@ public sealed class TranscriptionKeyAutoProvisionerTests : IDisposable
         }
     }
 
+    [Theory]
+    [InlineData("{\"data\":{\"key\":\"dt_live_full_KEY\",\"record\":{\"id\":\"key-uuid-123\"}}}", "key-uuid-123")]
+    [InlineData("{\"data\":{\"key\":\"dt_live_full_KEY\",\"id\":\"data-id-9\"}}", "data-id-9")]
+    [InlineData("{\"id\":\"root-id-7\",\"key\":\"dt_live_full_KEY\"}", "root-id-7")]
+    [InlineData("{\"data\":{\"key\":\"dt_live_full_KEY\"}}", null)]
+    public void ExtractKeyId_FindsRecordId(string body, string? expected)
+        => Assert.Equal(expected, AccountInferenceKeyProvisioner.ExtractKeyId(body));
+
     [Fact]
-    public async Task MintAsync_201_ReturnsKey_AndBearsTheJwt()
+    public async Task MintAsync_201_ReturnsKeyAndId_AndBearsTheJwt()
     {
-        var handler = new StatusHandler(HttpStatusCode.Created, "{\"key\":\"dt_live_minted01\"}");
+        // The real live shape: full key at data.key, id at data.record.id.
+        var body = "{\"data\":{\"key\":\"dt_live_minted01\",\"record\":{\"id\":\"the-key-id\"}}}";
+        var handler = new StatusHandler(HttpStatusCode.Created, body);
         var minter = new AccountInferenceKeyProvisioner(new HttpClient(handler));
 
-        var key = await minter.MintAsync("the.jwt.token", "cc-director TESTBOX");
+        var minted = await minter.MintAsync("the.jwt.token", "cc-director TESTBOX");
 
-        Assert.Equal("dt_live_minted01", key);
+        Assert.NotNull(minted);
+        Assert.Equal("dt_live_minted01", minted!.Key);
+        Assert.Equal("the-key-id", minted.Id);
         Assert.Equal("Bearer the.jwt.token", handler.SeenAuth);
     }
 
@@ -87,7 +99,7 @@ public sealed class TranscriptionKeyAutoProvisionerTests : IDisposable
     [Fact]
     public async Task MintAsync_NoAccessToken_ReturnsNull_WithoutCalling()
     {
-        var minter = new AccountInferenceKeyProvisioner(new HttpClient(new StatusHandler(HttpStatusCode.Created, "{\"key\":\"dt_live_x\"}")));
+        var minter = new AccountInferenceKeyProvisioner(new HttpClient(new StatusHandler(HttpStatusCode.Created, "{\"data\":{\"key\":\"dt_live_x\"}}")));
         Assert.Null(await minter.MintAsync("", "label"));
     }
 
@@ -95,13 +107,21 @@ public sealed class TranscriptionKeyAutoProvisionerTests : IDisposable
 
     private sealed class FakeMinter : IInferenceKeyMinter
     {
-        private readonly string? _key;
+        private readonly MintedInferenceKey? _minted;
         public int Calls { get; private set; }
-        public FakeMinter(string? key) { _key = key; }
-        public Task<string?> MintAsync(string accessToken, string label, CancellationToken ct = default)
+        public int RevokeCalls { get; private set; }
+        public string? RevokedId { get; private set; }
+        public FakeMinter(string? key, string? id = "key-id") { _minted = key is null ? null : new MintedInferenceKey(key, id); }
+        public Task<MintedInferenceKey?> MintAsync(string accessToken, string label, CancellationToken ct = default)
         {
             Calls++;
-            return Task.FromResult(_key);
+            return Task.FromResult(_minted);
+        }
+        public Task<bool> RevokeAsync(string accessToken, string keyId, CancellationToken ct = default)
+        {
+            RevokeCalls++;
+            RevokedId = keyId;
+            return Task.FromResult(true);
         }
     }
 
@@ -134,17 +154,56 @@ public sealed class TranscriptionKeyAutoProvisionerTests : IDisposable
     }
 
     [Fact]
-    public async Task EnsureAsync_SignedIn_EmptyVault_MintsAndStores()
+    public async Task EnsureAsync_SignedIn_EmptyVault_MintsAndStoresKeyAndId()
     {
         var vault = new KeyVault(_vaultPath);
-        var minter = new FakeMinter("dt_live_freshly_minted");
+        var minter = new FakeMinter("dt_live_freshly_minted", id: "minted-key-id");
         var sut = new TranscriptionKeyAutoProvisioner(vault, () => "the.jwt", minter);
 
         var minted = await sut.EnsureAsync();
 
         Assert.True(minted);
         Assert.Equal(1, minter.Calls);
-        Assert.Equal("dt_live_freshly_minted", new KeyVault(_vaultPath).Get(TranscriptionEndpointResolver.DevThrottleKeyName));
+        var reread = new KeyVault(_vaultPath);
+        Assert.Equal("dt_live_freshly_minted", reread.Get(TranscriptionEndpointResolver.DevThrottleKeyName));
+        // The id is recorded so sign-out can revoke THIS auto-minted key.
+        Assert.Equal("minted-key-id", reread.Get(TranscriptionKeyAutoProvisioner.InferenceKeyIdVaultName));
+    }
+
+    // ----- Revoke-on-sign-out (issue #881) -----
+
+    [Fact]
+    public async Task RevokeMintedKeyAsync_AutoMintedKey_RevokesAndClearsBoth()
+    {
+        var vault = new KeyVault(_vaultPath);
+        var minter = new FakeMinter("dt_live_x", id: "the-id");
+        var sut = new TranscriptionKeyAutoProvisioner(vault, () => "the.jwt", minter);
+        await sut.EnsureAsync(); // mints + records the id
+
+        var revoked = await sut.RevokeMintedKeyAsync();
+
+        Assert.True(revoked);
+        Assert.Equal(1, minter.RevokeCalls);
+        Assert.Equal("the-id", minter.RevokedId);
+        var reread = new KeyVault(_vaultPath);
+        Assert.Null(reread.Get(TranscriptionEndpointResolver.DevThrottleKeyName));
+        Assert.Null(reread.Get(TranscriptionKeyAutoProvisioner.InferenceKeyIdVaultName));
+    }
+
+    [Fact]
+    public async Task RevokeMintedKeyAsync_ManualKey_LeavesItUntouched()
+    {
+        // A manual key has no recorded id; sign-out must NOT revoke or clear it (it is the user's key).
+        var vault = new KeyVault(_vaultPath);
+        vault.Set(TranscriptionEndpointResolver.DevThrottleKeyName, "dt_live_manual");
+        var minter = new FakeMinter("dt_live_unused");
+        var sut = new TranscriptionKeyAutoProvisioner(vault, () => "the.jwt", minter);
+
+        var revoked = await sut.RevokeMintedKeyAsync();
+
+        Assert.False(revoked);
+        Assert.Equal(0, minter.RevokeCalls);
+        Assert.Equal("dt_live_manual", new KeyVault(_vaultPath).Get(TranscriptionEndpointResolver.DevThrottleKeyName));
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/Account/AccountInferenceKeyProvisioner.cs
+++ b/src/CcDirector.Gateway/Account/AccountInferenceKeyProvisioner.cs
@@ -39,7 +39,7 @@ public sealed class AccountInferenceKeyProvisioner : IInferenceKeyMinter
         _baseUrl = string.IsNullOrWhiteSpace(baseUrl) ? TranscriptionEndpointResolver.DevThrottleBaseUrl : baseUrl!;
     }
 
-    public async Task<string?> MintAsync(string accessToken, string label, CancellationToken ct = default)
+    public async Task<MintedInferenceKey?> MintAsync(string accessToken, string label, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(accessToken))
         {
@@ -64,8 +64,14 @@ public sealed class AccountInferenceKeyProvisioner : IInferenceKeyMinter
             }
 
             var key = ExtractKey(text);
-            FileLog.Write($"[AccountInferenceKeyProvisioner] MintAsync POST /keys -> {(int)resp.StatusCode}, key minted={(key is not null)}");
-            return key;
+            if (key is null)
+            {
+                FileLog.Write($"[AccountInferenceKeyProvisioner] MintAsync POST /keys -> {(int)resp.StatusCode} but no key in the body");
+                return null;
+            }
+            var id = ExtractKeyId(text);
+            FileLog.Write($"[AccountInferenceKeyProvisioner] MintAsync POST /keys -> {(int)resp.StatusCode}, key minted, id present={(id is not null)}");
+            return new MintedInferenceKey(key, id);
         }
         catch (Exception ex)
         {
@@ -73,6 +79,32 @@ public sealed class AccountInferenceKeyProvisioner : IInferenceKeyMinter
             // add-credits / manual-key state and the user can still paste a key.
             FileLog.Write($"[AccountInferenceKeyProvisioner] MintAsync failed (ignored, best-effort): {ex.Message}");
             return null;
+        }
+    }
+
+    public async Task<bool> RevokeAsync(string accessToken, string keyId, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(accessToken) || string.IsNullOrWhiteSpace(keyId))
+        {
+            FileLog.Write("[AccountInferenceKeyProvisioner] RevokeAsync: missing token or key id -> not revoking");
+            return false;
+        }
+
+        var url = _baseUrl.TrimEnd('/') + "/keys/" + Uri.EscapeDataString(keyId);
+        try
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Delete, url);
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+            using var resp = await _http.SendAsync(req, ct);
+            // A 404 means it is already gone - treat that as revoked (idempotent).
+            var ok = resp.IsSuccessStatusCode || resp.StatusCode == System.Net.HttpStatusCode.NotFound;
+            FileLog.Write($"[AccountInferenceKeyProvisioner] RevokeAsync DELETE /keys/{{id}} -> {(int)resp.StatusCode}, revoked={ok}");
+            return ok;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[AccountInferenceKeyProvisioner] RevokeAsync failed (ignored, best-effort): {ex.Message}");
+            return false;
         }
     }
 
@@ -109,6 +141,35 @@ public sealed class AccountInferenceKeyProvisioner : IInferenceKeyMinter
 
         var m = DtKeyPattern.Match(body);
         return m.Success ? m.Value : null;
+    }
+
+    /// <summary>
+    /// Pulls the key's stable id from the mint response (needed to revoke it later). The live shape puts
+    /// it at <c>data.record.id</c>; falls back to <c>data.id</c> / root <c>id</c>. Returns null when absent.
+    /// </summary>
+    internal static string? ExtractKeyId(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body)) return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+            if (root.ValueKind == JsonValueKind.Object && root.TryGetProperty("data", out var data) && data.ValueKind == JsonValueKind.Object)
+            {
+                if (data.TryGetProperty("record", out var rec) && rec.ValueKind == JsonValueKind.Object
+                    && rec.TryGetProperty("id", out var recId) && recId.ValueKind == JsonValueKind.String)
+                    return recId.GetString();
+                if (data.TryGetProperty("id", out var dataId) && dataId.ValueKind == JsonValueKind.String)
+                    return dataId.GetString();
+            }
+            if (root.ValueKind == JsonValueKind.Object && root.TryGetProperty("id", out var rootId) && rootId.ValueKind == JsonValueKind.String)
+                return rootId.GetString();
+        }
+        catch (JsonException)
+        {
+            // No parseable id: revoke-on-sign-out simply won't have one to use.
+        }
+        return null;
     }
 
     /// <summary>Reads the first full-key-shaped string from the common field names on one JSON object.</summary>

--- a/src/CcDirector.Gateway/Account/IInferenceKeyMinter.cs
+++ b/src/CcDirector.Gateway/Account/IInferenceKeyMinter.cs
@@ -1,21 +1,34 @@
 namespace CcDirector.Gateway.Account;
 
+/// <summary>A minted inference key: the <c>dt_</c> value (returned once at mint) plus the key's stable
+/// id, which is what revokes it later (issue #881 revoke-on-sign-out).</summary>
+/// <param name="Key">The plain <c>dt_</c> inference key. Persisted, never logged.</param>
+/// <param name="Id">The key's stable id used to revoke it, or null when the cloud omits it.</param>
+public sealed record MintedInferenceKey(string Key, string? Id);
+
 /// <summary>
-/// Mints a DevThrottle inference API key for the signed-in account (issue #881). The account JWT
-/// authenticates the account endpoints; the inference endpoints (transcription, text-to-speech, chat)
+/// Mints and revokes a DevThrottle inference API key for the signed-in account (issue #881). The account
+/// JWT authenticates the account endpoints; the inference endpoints (transcription, text-to-speech, chat)
 /// want a <c>dt_live_</c> API key, so after sign-in the Gateway mints one and uses it as the hosted-AI
-/// credential. The key value is returned by the cloud ONLY at mint time, so the caller must persist
-/// what this returns. Abstracted so <see cref="TranscriptionKeyAutoProvisioner"/> is unit-testable
-/// without a live cloud call.
+/// credential, and revokes it on sign-out. The key value is returned by the cloud ONLY at mint time, so
+/// the caller must persist what this returns. Abstracted so <see cref="TranscriptionKeyAutoProvisioner"/>
+/// is unit-testable without a live cloud call.
 /// </summary>
 public interface IInferenceKeyMinter
 {
     /// <summary>
     /// Mints a new inference key for the account the <paramref name="accessToken"/> (a Supabase JWT)
     /// authenticates. <paramref name="label"/> names the key (e.g. the machine name) so it is
-    /// recognisable in the account's key list. Returns the <c>dt_</c> key on success, or null on any
+    /// recognisable in the account's key list. Returns the key (value + id) on success, or null on any
     /// expected failure (the caller treats a null as "no key minted" and stays graceful - never throws
     /// through the best-effort sign-in hook).
     /// </summary>
-    Task<string?> MintAsync(string accessToken, string label, CancellationToken ct = default);
+    Task<MintedInferenceKey?> MintAsync(string accessToken, string label, CancellationToken ct = default);
+
+    /// <summary>
+    /// Revokes the inference key with <paramref name="keyId"/> (DELETE the account key), authenticated by
+    /// the account <paramref name="accessToken"/>. Returns true when revoked (or already gone), false on
+    /// an expected failure. Best-effort: never throws through the sign-out path.
+    /// </summary>
+    Task<bool> RevokeAsync(string accessToken, string keyId, CancellationToken ct = default);
 }

--- a/src/CcDirector.Gateway/Account/TranscriptionKeyAutoProvisioner.cs
+++ b/src/CcDirector.Gateway/Account/TranscriptionKeyAutoProvisioner.cs
@@ -23,6 +23,13 @@ namespace CcDirector.Gateway.Account;
 /// </summary>
 public sealed class TranscriptionKeyAutoProvisioner
 {
+    /// <summary>
+    /// The vault entry that records the stable id of an AUTO-MINTED inference key. Its presence marks the
+    /// stored <c>DEVTHROTTLE_API_KEY</c> as one this Gateway minted (not a manual key), so sign-out can
+    /// revoke it; a manually-pasted key has no id entry and is never revoked on sign-out.
+    /// </summary>
+    public const string InferenceKeyIdVaultName = "DEVTHROTTLE_API_KEY_ID";
+
     private readonly KeyVault _vault;
     private readonly Func<string?> _accessTokenProvider;
     private readonly IInferenceKeyMinter _minter;
@@ -64,8 +71,8 @@ public sealed class TranscriptionKeyAutoProvisioner
         }
 
         FileLog.Write("[TranscriptionKeyAutoProvisioner] EnsureAsync: no DevThrottle key stored and signed in -> minting an inference key");
-        var key = await _minter.MintAsync(accessToken, _label, ct);
-        if (string.IsNullOrWhiteSpace(key))
+        var minted = await _minter.MintAsync(accessToken, _label, ct);
+        if (minted is null || string.IsNullOrWhiteSpace(minted.Key))
         {
             FileLog.Write("[TranscriptionKeyAutoProvisioner] EnsureAsync: mint returned no key -> leaving unset (user sees the add-credits/manual state)");
             return false;
@@ -73,8 +80,47 @@ public sealed class TranscriptionKeyAutoProvisioner
 
         // SetIfAbsent (not Set) guards a race with a concurrent manual save or a second provisioning
         // pass - the first writer wins and we never clobber a key that appeared meanwhile.
-        var stored = _vault.SetIfAbsent(TranscriptionEndpointResolver.DevThrottleKeyName, key);
-        FileLog.Write($"[TranscriptionKeyAutoProvisioner] EnsureAsync: minted inference key {(stored ? "stored" : "not stored - a key appeared first")}");
+        var stored = _vault.SetIfAbsent(TranscriptionEndpointResolver.DevThrottleKeyName, minted.Key);
+        if (stored && !string.IsNullOrWhiteSpace(minted.Id))
+            // Record the id so sign-out can revoke THIS auto-minted key (a manual key has no id and is
+            // never revoked). Set (not SetIfAbsent) because the id belongs to the key we just stored.
+            _vault.Set(InferenceKeyIdVaultName, minted.Id!);
+        FileLog.Write($"[TranscriptionKeyAutoProvisioner] EnsureAsync: minted inference key {(stored ? "stored" : "not stored - a key appeared first")}, id recorded={stored && !string.IsNullOrWhiteSpace(minted.Id)}");
         return stored;
+    }
+
+    /// <summary>
+    /// On sign-out, revokes the AUTO-MINTED inference key (if any) and clears it from the vault, so a
+    /// signed-out install leaves no live key behind. A MANUALLY-pasted key (no recorded id) is left
+    /// untouched - it is the user's own key, not ours to revoke. Best-effort: any failure is logged and
+    /// swallowed so sign-out never fails; call it BEFORE the credential is cleared (it needs the JWT).
+    /// Returns true when an auto-minted key was revoked and cleared.
+    /// </summary>
+    public async Task<bool> RevokeMintedKeyAsync(CancellationToken ct = default)
+    {
+        var keyId = _vault.Get(InferenceKeyIdVaultName);
+        if (string.IsNullOrWhiteSpace(keyId))
+        {
+            FileLog.Write("[TranscriptionKeyAutoProvisioner] RevokeMintedKeyAsync: no auto-minted key id -> nothing to revoke (manual key left untouched)");
+            return false;
+        }
+
+        var accessToken = _accessTokenProvider();
+        if (!string.IsNullOrWhiteSpace(accessToken))
+        {
+            var revoked = await _minter.RevokeAsync(accessToken, keyId!, ct);
+            FileLog.Write($"[TranscriptionKeyAutoProvisioner] RevokeMintedKeyAsync: cloud revoke result={revoked}");
+        }
+        else
+        {
+            FileLog.Write("[TranscriptionKeyAutoProvisioner] RevokeMintedKeyAsync: no access token to revoke with (clearing locally anyway)");
+        }
+
+        // Clear the local copies regardless of the cloud outcome: the key is being signed out, so it must
+        // not remain as this machine's transcription credential. The cloud key, if the revoke failed, can
+        // still be revoked from the website.
+        _vault.Delete(TranscriptionEndpointResolver.DevThrottleKeyName);
+        _vault.Delete(InferenceKeyIdVaultName);
+        return true;
     }
 }

--- a/src/CcDirector.Gateway/Api/AccountLogoutEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AccountLogoutEndpoint.cs
@@ -36,9 +36,14 @@ internal static class AccountLogoutEndpoint
     /// credential service (a non-Windows host, where the operating-system credential store is not yet
     /// implemented); the endpoint then reports not-signed-in (there was nothing to clear).
     /// </param>
-    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account)
+    /// <param name="onBeforeLogout">
+    /// An optional best-effort hook run BEFORE the credential is cleared (issue #881: revoke the
+    /// auto-minted inference key while the account token is still available to authenticate the revoke).
+    /// It has its own boundary try/catch here, so a slow or failed revoke never blocks or fails logout.
+    /// </param>
+    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account, Func<CancellationToken, Task>? onBeforeLogout = null)
     {
-        app.MapPost("/account/logout", () =>
+        app.MapPost("/account/logout", async (HttpContext ctx) =>
         {
             // No credential service on this host (a non-Windows host where the operating-system
             // credential store is not yet implemented): there is no credential to clear, so the truthful
@@ -47,6 +52,14 @@ internal static class AccountLogoutEndpoint
             {
                 FileLog.Write("[AccountLogoutEndpoint] POST /account/logout: no credential service on this host -> already signedIn=false");
                 return Results.Json(new AccountStatusDto { SignedIn = false });
+            }
+
+            // Revoke the auto-minted inference key BEFORE clearing the credential (the revoke needs the
+            // still-present account token). Best-effort: a failure here must never block sign-out.
+            if (onBeforeLogout is not null)
+            {
+                try { await onBeforeLogout(ctx.RequestAborted); }
+                catch (Exception ex) { FileLog.Write($"[AccountLogoutEndpoint] onBeforeLogout failed (ignored, best-effort): {ex.Message}"); }
             }
 
             // Clear the cached credential locally (no network call). Logout is idempotent: clearing when

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -836,7 +836,11 @@ public sealed class GatewayHost : IAsyncDisposable
         // post-logout boolean, never the access/refresh token (security rule DT-05). Inherits the
         // host-wide token middleware above. On a host with no credential service (Account null) there is
         // nothing to clear and it reports not-signed-in.
-        AccountLogoutEndpoint.Map(_app, Account);
+        // Issue #881: revoke the auto-minted inference key on sign-out (before the credential is cleared),
+        // so a signed-out install leaves no live key behind. A manually-pasted key has no recorded id and
+        // is left untouched. Best-effort - never blocks logout.
+        AccountLogoutEndpoint.Map(_app, Account,
+            onBeforeLogout: _transcriptionKeyProvisioner is null ? null : ct => _transcriptionKeyProvisioner.RevokeMintedKeyAsync(ct));
 
         // Account device list + revoke proxy (issue #854): GET /account/devices and
         // DELETE /account/devices/{id}. The Cockpit Account page needs the account-wide device list with


### PR DESCRIPTION
Signing out revokes the DevThrottle inference key this Gateway auto-minted (issue thefrederiksen/devthrottle_internal#650 follow-up), so a signed-out install leaves no live key behind. A manually-pasted key is untouched.

- `IInferenceKeyMinter.MintAsync` → `MintedInferenceKey { Key, Id }` (id from `data.record.id`); new `RevokeAsync(jwt, id)` → `DELETE /keys/{id}` (404 = already gone).
- `TranscriptionKeyAutoProvisioner` records the id in `DEVTHROTTLE_API_KEY_ID` on mint; `RevokeMintedKeyAsync` revokes that key + clears both entries. No id (manual key) → nothing revoked.
- `POST /account/logout` runs the revoke as a best-effort pre-clear hook (before the JWT is cleared); never blocks sign-out.

### Verification
- **22 provisioner unit tests** (id extraction incl. the real `data.record.id` shape; revoke clears both entries; manual key untouched) + logout tests green.
- **Live:** mint **201** → revoke by `data.record.id` **200** → transcribe with the revoked key **401** (dead). No leftover keys. `docs/cencon/proof/issue-887/live-transcription/REVOKE-PROOF.md`.

### Deferred (fast-follow)
Capturing `dtd_` and moving the minted key/id into the DPAPI blob both ripple into `DevThrottleTokens` + its token-refresh preservation; kept out to avoid risking the working auto-wiring on token renewal. The id lives in the vault alongside the key it revokes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)