### PR TITLE
fix: [Dictation] compress desktop dictation to Opus before upload (#896)

### DIFF
--- a/src/CcDirector.Avalonia/Voice/BatchDictationRecorder.cs
+++ b/src/CcDirector.Avalonia/Voice/BatchDictationRecorder.cs
@@ -252,14 +252,21 @@ public sealed class BatchDictationRecorder : IAsyncDisposable
         // local cache as a side effect, #253); falls back to the local cache offline.
         var dictionary = await _dictionaryResolver.ResolveAsync(ct);
 
-        // Wrap the whole captured PCM in one WAV blob and transcribe ONCE through the
-        // shared batch pipeline. The dictionary corrector is the only text transform.
-        var wav = WavWriter.WrapPcm16(
-            pcm, MicAudioCapture.SampleRate, MicAudioCapture.Channels, MicAudioCapture.BitsPerSample);
+        // Compress the whole captured PCM to Opus (in an Ogg container) for the ONE batch upload, so a
+        // long dictation stays well under the transcription endpoint's request-body limit (issue #896:
+        // the hosted DevThrottle endpoint caps bodies at 4.5 MB, and the mic's uncompressed 24 kHz WAV
+        // at ~48 KB/s exceeded it past ~90 seconds - a hard platform 413). BOTH transcription modes are
+        // remote HTTP endpoints that decode Ogg Opus (the hosted Whisper backend and OpenAI both do),
+        // and the in-process local mode was removed in issue #887, so there is no uncompressed path to
+        // preserve. The dictionary corrector downstream is the only text transform.
+        var oggOpus = OggOpusEncoder.EncodePcm16(
+            pcm, MicAudioCapture.SampleRate, MicAudioCapture.Channels);
+        FileLog.Write($"[BatchDictationRecorder] upload packaged: file=dictation.ogg, "
+            + $"bytes={oggOpus.Length} (pcm={pcm.Length}), mode={routing.Mode.ToConfigString()}");
 
         var stopWatch = System.Diagnostics.Stopwatch.StartNew();
         using var pipeline = new BatchTranscriptionPipeline(cleanupModel: _options.DictationCleanupModel);
-        var batch = await pipeline.TranscribeAsync(wav, "dictation.wav", routing, dictionary, _profile, ct);
+        var batch = await pipeline.TranscribeAsync(oggOpus, "dictation.ogg", routing, dictionary, _profile, ct);
         stopWatch.Stop();
 
         FileLog.Write($"[BatchDictationRecorder] transcribed: rawLen={batch.RawTranscript.Length}, "

--- a/src/CcDirector.Core.Tests/Audio/OggOpusEncoderTests.cs
+++ b/src/CcDirector.Core.Tests/Audio/OggOpusEncoderTests.cs
@@ -1,0 +1,72 @@
+using System.Text;
+using CcDirector.Core.Audio;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Audio;
+
+/// <summary>
+/// Tests for <see cref="OggOpusEncoder"/> (issue #896): the desktop dictation compressor that keeps a
+/// long remote-mode upload under the hosted endpoint's four and a half megabyte body limit.
+/// </summary>
+public sealed class OggOpusEncoderTests
+{
+    private const int SampleRate = 24_000; // MicAudioCapture.SampleRate - an Opus-native rate
+    private const int Channels = 1;
+    private const int BitsPerSample = 16;
+
+    // A synthetic mono PCM16 sine, `seconds` long, so the tests exercise real audio without a mic.
+    private static byte[] SinePcm16(double seconds, double freqHz = 220.0)
+    {
+        int totalSamples = (int)(SampleRate * seconds);
+        var pcm = new byte[totalSamples * 2];
+        for (int i = 0; i < totalSamples; i++)
+        {
+            double t = (double)i / SampleRate;
+            short s = (short)(Math.Sin(2 * Math.PI * freqHz * t) * 12000);
+            pcm[i * 2] = (byte)(s & 0xFF);
+            pcm[i * 2 + 1] = (byte)((s >> 8) & 0xFF);
+        }
+        return pcm;
+    }
+
+    [Fact]
+    public void EncodePcm16_ProducesOggOpusContainer()
+    {
+        var pcm = SinePcm16(1.0);
+
+        var ogg = OggOpusEncoder.EncodePcm16(pcm, SampleRate, Channels);
+
+        Assert.True(ogg.Length > 0);
+        // The Ogg capture pattern begins the first page.
+        Assert.Equal("OggS", Encoding.ASCII.GetString(ogg, 0, 4));
+        // The Opus identification header magic ("OpusHead") sits in that first page's payload; its
+        // presence proves this is a well-formed Ogg Opus stream, not just any Ogg.
+        Assert.Contains("OpusHead", Encoding.ASCII.GetString(ogg));
+    }
+
+    [Fact]
+    public void EncodePcm16_IsFarSmallerThanWav_GivingHeadroomUnderTheFourAndAHalfMegabyteCap()
+    {
+        // Three minutes of 24 kHz mono PCM16 is about 8.6 megabytes as WAV - well over the hosted
+        // endpoint's 4.5 megabyte body limit, which is exactly the #896 failure. Opus must bring the
+        // same clip comfortably under it.
+        var pcm = SinePcm16(180.0);
+        var wav = PcmWav.Wrap(pcm, SampleRate, Channels, BitsPerSample);
+
+        var ogg = OggOpusEncoder.EncodePcm16(pcm, SampleRate, Channels);
+
+        const int cap = 4_500_000;
+        Assert.True(wav.Length > cap, $"WAV should exceed the cap to reproduce #896 (was {wav.Length})");
+        Assert.True(ogg.Length < cap, $"Ogg Opus must be under the cap (was {ogg.Length})");
+        // Voice Opus should be at least ten times smaller than WAV for this clip.
+        Assert.True(ogg.Length * 10 < wav.Length, $"Opus not compressing as expected: ogg={ogg.Length}, wav={wav.Length}");
+    }
+
+    [Fact]
+    public void EncodePcm16_OddLength_Throws()
+        => Assert.Throws<ArgumentException>(() => OggOpusEncoder.EncodePcm16(new byte[3], SampleRate, Channels));
+
+    [Fact]
+    public void EncodePcm16_Null_Throws()
+        => Assert.Throws<ArgumentNullException>(() => OggOpusEncoder.EncodePcm16(null!, SampleRate, Channels));
+}

--- a/src/CcDirector.Core.Tests/Audio/OggOpusEncoderTests.cs
+++ b/src/CcDirector.Core.Tests/Audio/OggOpusEncoderTests.cs
@@ -1,5 +1,7 @@
 using System.Text;
 using CcDirector.Core.Audio;
+using Concentus;
+using Concentus.Oggfile;
 using Xunit;
 
 namespace CcDirector.Core.Tests.Audio;
@@ -60,6 +62,46 @@ public sealed class OggOpusEncoderTests
         Assert.True(ogg.Length < cap, $"Ogg Opus must be under the cap (was {ogg.Length})");
         // Voice Opus should be at least ten times smaller than WAV for this clip.
         Assert.True(ogg.Length * 10 < wav.Length, $"Opus not compressing as expected: ogg={ogg.Length}, wav={wav.Length}");
+    }
+
+    [Fact]
+    public void EncodePcm16_RoundTripsThroughAnOpusDecoder_ProvingTheOggIsValid()
+    {
+        var pcm = SinePcm16(2.0);
+        long inputSamples = pcm.Length / 2;
+
+        var ogg = OggOpusEncoder.EncodePcm16(pcm, SampleRate, Channels);
+
+        // Decode the produced .ogg back to PCM with an independent Opus decoder. That it decodes at
+        // all, to roughly the original duration, proves the encoder emits a genuinely valid Ogg Opus
+        // stream - stronger than a magic-byte check. (Opus adds a small pre-skip and pads the final
+        // frame with silence, so the decoded length is close to, not exactly, the input.)
+        var decoder = OpusCodecFactory.CreateDecoder(SampleRate, Channels);
+        using var ms = new MemoryStream(ogg);
+        var reader = new OpusOggReadStream(decoder, ms);
+        long decodedSamples = 0;
+        while (reader.HasNextPacket)
+        {
+            short[]? packet = reader.DecodeNextPacket();
+            if (packet != null) decodedSamples += packet.Length;
+        }
+
+        Assert.True(decodedSamples >= inputSamples * 0.9, $"decoded too short: {decodedSamples} vs input {inputSamples}");
+        Assert.True(decodedSamples <= inputSamples * 1.2, $"decoded too long: {decodedSamples} vs input {inputSamples}");
+    }
+
+    [Fact]
+    public void EncodePcm16_WhiteNoiseThreeMinutes_StillUnderTheCap()
+    {
+        // White noise is the incompressible worst case (a stricter proxy than a sine). Opus targets a
+        // bitrate rather than a compression ratio, so even here three minutes must stay under the cap.
+        var rng = new Random(20260702);
+        var pcm = new byte[SampleRate * 180 * 2];
+        rng.NextBytes(pcm);
+
+        var ogg = OggOpusEncoder.EncodePcm16(pcm, SampleRate, Channels);
+
+        Assert.True(ogg.Length < 4_500_000, $"white-noise Opus must be under the cap (was {ogg.Length})");
     }
 
     [Fact]

--- a/src/CcDirector.Core/Audio/OggOpusEncoder.cs
+++ b/src/CcDirector.Core/Audio/OggOpusEncoder.cs
@@ -1,0 +1,73 @@
+using Concentus;
+using Concentus.Enums;
+using Concentus.Oggfile;
+
+namespace CcDirector.Core.Audio;
+
+/// <summary>
+/// Encodes raw little-endian PCM16 into a complete Ogg-framed Opus file (issue #896).
+///
+/// Why this exists: desktop dictation captured uncompressed PCM and, until #896, wrapped the whole
+/// clip in a WAV before its single upload. That is about 48 kilobytes per second at 24 kilohertz, so
+/// any remote-mode dictation past roughly ninety seconds exceeded the hosted transcription service's
+/// fixed four and a half megabyte request-body limit (the platform edge returns
+/// FUNCTION_PAYLOAD_TOO_LARGE before our own service code runs). Opus at a voice bitrate turns the
+/// same two minutes into a few hundred kilobytes, well under the limit, so long dictations transcribe
+/// instead of failing with 413.
+///
+/// This is the ENCODE direction only. The Gateway's local Whisper branch will need the DECODE
+/// direction (Opus back to PCM) when the mobile and Gateway path stops transcoding on the phone (a
+/// separate follow-up); that is deliberately NOT built here because this change has no caller for it.
+/// The class is named for the codec, not the direction, so the decoder can join it without a rename.
+///
+/// Container note: this writes Ogg-framed Opus (a .ogg file). Browser MediaRecorder emits Opus inside
+/// a WebM container instead, so a future decode path that must accept phone audio needs a WebM
+/// demultiplexer, not just Ogg page parsing - the audio boundary is intentionally container-aware,
+/// never "Opus means Ogg".
+///
+/// Uses Concentus (pure managed, no native library) so it needs no extra platform binary.
+/// </summary>
+public static class OggOpusEncoder
+{
+    /// <summary>
+    /// The Opus target bitrate for dictation speech. Twenty-four thousand bits per second is
+    /// transparent for a single mono voice and gives large headroom under the four and a half
+    /// megabyte cap (over twenty minutes of speech), while keeping transcription accuracy
+    /// indistinguishable from the raw capture.
+    /// </summary>
+    public const int VoiceBitrateBitsPerSecond = 24_000;
+
+    /// <summary>
+    /// Encode raw PCM16 samples into a complete Ogg Opus file the transcription endpoints decode
+    /// directly. The sample rate must be an Opus-native rate (8000, 12000, 16000, 24000, or 48000
+    /// hertz); the desktop microphone's 24000 hertz is one, so no resampling happens.
+    /// </summary>
+    /// <param name="pcm">Raw little-endian signed 16-bit PCM sample bytes (no header). Length must be even.</param>
+    /// <param name="sampleRate">Samples per second - an Opus-native rate.</param>
+    /// <param name="channels">Channel count (1 for the dictation microphone).</param>
+    /// <param name="bitrateBitsPerSecond">Opus target bitrate; defaults to <see cref="VoiceBitrateBitsPerSecond"/>.</param>
+    public static byte[] EncodePcm16(byte[] pcm, int sampleRate, int channels, int bitrateBitsPerSecond = VoiceBitrateBitsPerSecond)
+    {
+        if (pcm is null) throw new ArgumentNullException(nameof(pcm));
+        if ((pcm.Length & 1) != 0)
+            throw new ArgumentException("PCM16 byte length must be even (two bytes per sample).", nameof(pcm));
+
+        // Bytes to short samples. The desktop mic delivers little-endian PCM16, which is the native
+        // memory layout on win-x64, so a straight block copy is the correct reinterpretation.
+        var samples = new short[pcm.Length / 2];
+        Buffer.BlockCopy(pcm, 0, samples, 0, pcm.Length);
+
+        var encoder = OpusCodecFactory.CreateEncoder(sampleRate, channels, OpusApplication.OPUS_APPLICATION_VOIP);
+        encoder.Bitrate = bitrateBitsPerSecond;
+
+        using var ms = new MemoryStream();
+        // inputSampleRate equals the encoder sample rate: the capture is already an Opus-native rate,
+        // so the writer's resampler is a no-op. OpusOggWriteStream owns all Opus framing and Ogg
+        // paging; Finish() pads and flushes the final partial frame so the tail of speech is never
+        // clipped. leaveOpen keeps the MemoryStream ours to read via ToArray after Finish.
+        var ogg = new OpusOggWriteStream(encoder, ms, fileTags: null, inputSampleRate: sampleRate, leaveOpen: true);
+        ogg.WriteSamples(samples, 0, samples.Length);
+        ogg.Finish();
+        return ms.ToArray();
+    }
+}

--- a/src/CcDirector.Core/CcDirector.Core.csproj
+++ b/src/CcDirector.Core/CcDirector.Core.csproj
@@ -21,6 +21,13 @@
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="SQLitePCLRaw.core" Version="3.0.3" />
     <PackageReference Include="YamlDotNet" Version="16.2.1" />
+    <!-- Opus encoding for dictation uploads (issue #896): compress the whole-clip capture before the
+         single remote transcription POST so a long dictation stays under the hosted endpoint's fixed
+         4.5 MB request-body limit. Concentus is pure-managed (no native library, so it stays win-x64
+         and cross-platform safe with no extra DLL to ship); Concentus.OggFile wraps the encoder output
+         as an Ogg Opus (.ogg) file the transcription providers decode directly. -->
+    <PackageReference Include="Concentus" Version="2.2.2" />
+    <PackageReference Include="Concentus.OggFile" Version="1.0.7" />
     <!-- Windows Data Protection (DPAPI) for the DevThrottle account credential store - encrypts
          the account token pair at rest so the raw token is never written to disk in plain text. -->
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.0" />


### PR DESCRIPTION
Fixes #896.

## Problem

Desktop dictation (the Dictate window) failed with a `413 Request Entity Too Large` for any recording longer than about ninety seconds. The recorder POSTed the whole clip as uncompressed 24 kHz mono WAV (about 48 kilobytes per second), so a longer recording deterministically exceeded the hosted DevThrottle transcription endpoint's fixed 4.5 MB request-body limit. The `FUNCTION_PAYLOAD_TOO_LARGE` error is generated at the platform edge before our own service code runs, so it cannot be fixed by a server change alone. A one minute fifty-one second field recording (about 5 MB) is what triggered the report.

## Fix

Encode the capture to **Ogg Opus** before the single upload, using Concentus (pure-managed, no native library). A voice-bitrate Opus stream turns two minutes of speech into a few hundred kilobytes, giving more than twenty minutes of headroom under the cap.

Both transcription modes are remote HTTP endpoints that decode Ogg Opus (OpenAI directly, and the hosted Whisper backend). The in-process **Local** mode was removed in thefrederiksen/devthrottle_internal#656, so there is no uncompressed path left to preserve and the recorder always compresses. (The original issue assumed a Local mode still existed; see the issue comment for the corrected two-mode framing.)

## Changes

- **New `CcDirector.Core/Audio/OggOpusEncoder.cs`** — encodes raw PCM16 to a complete Ogg Opus file. Encode direction only; named for the codec, not the direction, so the Gateway decode path can join it in the mobile follow-up without a rename. Documents the WebM-versus-Ogg container caveat for that follow-up.
- **`CcDirector.Avalonia/Voice/BatchDictationRecorder.cs`** — sends `dictation.ogg` instead of `dictation.wav` through the unchanged shared batch pipeline.
- **`CcDirector.Core.csproj`** — adds Concentus 2.2.2 and Concentus.OggFile 1.0.7.
- **Tests** — Ogg Opus container shape, argument guards, and a three-minute clip proven to land under the 4.5 MB cap (more than ten times smaller than the equivalent WAV, which itself exceeds the cap and reproduces the bug).

## Verification

- `CcDirector.Core` and `CcDirector.Avalonia` build clean (zero warnings, warnings-as-errors on).
- Four new `OggOpusEncoder` unit tests pass.
- All twenty-two existing desktop dictation proof tests still pass (no regression; the `WavWriter` path they exercise is unchanged).

## Remaining acceptance gate (follow-up)

Size headroom is proven by unit test. The one unverified risk is **decode correctness at the configured hosted provider** (whisper-large-v3): that it returns a correct transcript from Ogg Opus, not merely that the bytes get through. Both OpenAI and Groq accept ogg/opus, so this is expected to pass, but it needs a live round-trip with a `dt_` key to confirm. If the hosted provider were to reject ogg/opus, the safe fallbacks are FLAC (lossless) or MP3, both of which the server's container sniffer already accepts.

## Out of scope (tracked separately)

- The mobile and Gateway upload path. The phone uploads to the Gateway, which owns the mode, so any container change there is a Gateway-side follow-up.
- A presigned direct-to-storage upload flow for arbitrarily long single recordings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
