### PR TITLE
fix(dictation): compress long dictation audio to Opus so it fits the upload cap (#898)

### DIFF
--- a/src/CcDirector.Core.Tests/Audio/OggOpusEncoderTests.cs
+++ b/src/CcDirector.Core.Tests/Audio/OggOpusEncoderTests.cs
@@ -1,0 +1,76 @@
+using System.Text;
+using CcDirector.Core.Audio;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Audio;
+
+/// <summary>
+/// Proves the OGG-Opus transcode that keeps long dictations under the hosted proxy's 4.5 MB
+/// request-body cap (issue #898): a whole-turn PCM16 WAV that would exceed the cap encodes to an OGG
+/// blob an order of magnitude smaller, and the WAV reader round-trips the format it was written with.
+/// </summary>
+public sealed class OggOpusEncoderTests
+{
+    private const int SampleRate = 24_000;   // dictation capture format
+    private const int Channels = 1;
+    private const int BitsPerSample = 16;
+
+    // Vercel serverless request-body cap. A whole-turn WAV crosses this at ~90 s; the Opus output
+    // must sit far below it. (proxy: docs/architecture/transcription-request-path.md s7)
+    private const int PlatformBodyCapBytes = 4_500_000;
+
+    /// <summary>Raw PCM16 for a low-amplitude sine tone of the given duration - non-degenerate audio.</summary>
+    private static byte[] MakePcm16(int seconds)
+    {
+        int samples = SampleRate * seconds;
+        var pcm = new byte[samples * 2];
+        for (int i = 0; i < samples; i++)
+        {
+            double t = (double)i / SampleRate;
+            short v = (short)(Math.Sin(2 * Math.PI * 220.0 * t) * 8000);
+            pcm[i * 2] = (byte)(v & 0xFF);
+            pcm[i * 2 + 1] = (byte)((v >> 8) & 0xFF);
+        }
+        return pcm;
+    }
+
+    [Fact]
+    public void EncodePcm16_LongClipThatWouldExceedTheCap_ProducesOggFarUnderIt()
+    {
+        // 100 seconds of raw PCM16/24k/mono = 4.8 MB WAV - over the ~90 s / 4.5 MB failure point.
+        var pcm = MakePcm16(seconds: 100);
+        var wav = PcmWav.Wrap(pcm, SampleRate, Channels, BitsPerSample);
+        Assert.True(wav.Length > PlatformBodyCapBytes,
+            $"precondition: the WAV ({wav.Length}) must exceed the cap to model the failure");
+
+        var ogg = OggOpusEncoder.EncodePcm16(pcm, SampleRate, Channels);
+
+        // The whole point: the compressed upload is comfortably under the platform cap.
+        Assert.True(ogg.Length < PlatformBodyCapBytes,
+            $"OGG-Opus ({ogg.Length}) must be under the {PlatformBodyCapBytes}-byte cap");
+        // Sanity: a real OGG stream starts with the "OggS" capture pattern.
+        Assert.Equal("OggS", Encoding.ASCII.GetString(ogg, 0, 4));
+        // And it is a genuine reduction, not a no-op.
+        Assert.True(ogg.Length < wav.Length / 4, $"expected >4x reduction; got {wav.Length} -> {ogg.Length}");
+    }
+
+    [Fact]
+    public void TryReadPcm16_RoundTripsWhatWrapWrote()
+    {
+        var pcm = MakePcm16(seconds: 1);
+        var wav = PcmWav.Wrap(pcm, SampleRate, Channels, BitsPerSample);
+
+        Assert.True(PcmWav.TryReadPcm16(wav, out var readPcm, out var rate, out var channels));
+        Assert.Equal(SampleRate, rate);
+        Assert.Equal(Channels, channels);
+        Assert.Equal(pcm, readPcm);
+    }
+
+    [Fact]
+    public void TryReadPcm16_RejectsNonWavBytes()
+    {
+        // An already-compressed container (fake OGG header) is not PCM16 WAV and must be left alone.
+        var notWav = Encoding.ASCII.GetBytes("OggS").Concat(new byte[64]).ToArray();
+        Assert.False(PcmWav.TryReadPcm16(notWav, out _, out _, out _));
+    }
+}

--- a/src/CcDirector.Core.Tests/Transcription/BatchTranscriptionPipelineCompressionTests.cs
+++ b/src/CcDirector.Core.Tests/Transcription/BatchTranscriptionPipelineCompressionTests.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using System.Text;
+using CcDirector.Core.Audio;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Dictation.Models;
+using CcDirector.Core.Transcription;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Transcription;
+
+/// <summary>
+/// Proves the shared pipeline shrinks an oversize dictation upload under the hosted proxy's request
+/// cap (issue #898): a whole-turn WAV that would trip Vercel's 4.5 MB <c>FUNCTION_PAYLOAD_TOO_LARGE</c>
+/// is transcoded to OGG-Opus before the POST, while a short clip is still sent byte-for-byte as WAV.
+/// </summary>
+public sealed class BatchTranscriptionPipelineCompressionTests
+{
+    private const int SampleRate = 24_000;
+    private const int PlatformBodyCapBytes = 4_500_000;
+
+    // Captures the raw bytes of the multipart POST to /audio/transcriptions so the test can assert
+    // exactly what would go over the wire (size + container), then returns a canned transcript.
+    private sealed class RawBodyHandler : HttpMessageHandler
+    {
+        public byte[] Body { get; private set; } = Array.Empty<byte>();
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var url = request.RequestUri?.ToString() ?? "";
+            if (url.EndsWith("/audio/transcriptions", StringComparison.Ordinal))
+            {
+                Body = request.Content is null ? Array.Empty<byte>() : await request.Content.ReadAsByteArrayAsync(ct);
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"text\":\"ok\"}", Encoding.UTF8, "application/json"),
+                };
+            }
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }
+    }
+
+    private static ResolvedTranscription DevThrottle() => new()
+    {
+        BaseUrl = TranscriptionEndpointResolver.DevThrottleBaseUrl,
+        ApiKey = "dt_live_key",
+        Transport = TranscriptionTransport.Batch,
+        Model = TranscriptionEndpointResolver.DevThrottleModel,
+        Mode = TranscriptionMode.DevThrottle,
+    };
+
+    private static byte[] SineWav(int seconds)
+    {
+        int samples = SampleRate * seconds;
+        var pcm = new byte[samples * 2];
+        for (int i = 0; i < samples; i++)
+        {
+            short v = (short)(Math.Sin(2 * Math.PI * 220.0 * i / SampleRate) * 8000);
+            pcm[i * 2] = (byte)(v & 0xFF);
+            pcm[i * 2 + 1] = (byte)((v >> 8) & 0xFF);
+        }
+        return PcmWav.Wrap(pcm, SampleRate, 1, 16);
+    }
+
+    private static bool Contains(byte[] haystack, string ascii)
+    {
+        var needle = Encoding.ASCII.GetBytes(ascii);
+        for (int i = 0; i + needle.Length <= haystack.Length; i++)
+        {
+            bool hit = true;
+            for (int j = 0; j < needle.Length; j++)
+                if (haystack[i + j] != needle[j]) { hit = false; break; }
+            if (hit) return true;
+        }
+        return false;
+    }
+
+    [Fact]
+    public async Task LargeWav_IsTranscodedToOggUnderTheCap_BeforePosting()
+    {
+        var wav = SineWav(seconds: 100);   // 4.8 MB WAV - over the ~90 s failure point
+        Assert.True(wav.Length > PlatformBodyCapBytes, "precondition: the WAV must exceed the cap");
+
+        var handler = new RawBodyHandler();
+        using var pipeline = new BatchTranscriptionPipeline(new HttpClient(handler));
+        await pipeline.TranscribeAsync(wav, "dictation.wav", DevThrottle(), DictationDictionary.Empty);
+
+        // The whole multipart body - what Vercel measures against 4.5 MB - is now well under the cap.
+        Assert.True(handler.Body.Length < PlatformBodyCapBytes,
+            $"posted body ({handler.Body.Length}) must be under the {PlatformBodyCapBytes}-byte cap");
+        // It went out as OGG-Opus named .ogg, and the raw WAV ("RIFF") is gone.
+        Assert.True(Contains(handler.Body, "OggS"), "body should carry an OGG-Opus stream");
+        Assert.True(Contains(handler.Body, "dictation.ogg"), "the upload should be named .ogg");
+        Assert.False(Contains(handler.Body, "RIFF"), "the raw WAV should have been replaced");
+    }
+
+    [Fact]
+    public async Task ShortWav_IsSentUnchanged_AsWav()
+    {
+        var wav = SineWav(seconds: 2);     // ~96 KB WAV - well under the threshold
+        Assert.True(wav.Length < PlatformBodyCapBytes);
+
+        var handler = new RawBodyHandler();
+        using var pipeline = new BatchTranscriptionPipeline(new HttpClient(handler));
+        await pipeline.TranscribeAsync(wav, "dictation.wav", DevThrottle(), DictationDictionary.Empty);
+
+        // No regression for the common short-clip case: still a WAV, still named .wav, no transcode.
+        Assert.True(Contains(handler.Body, "RIFF"), "a short clip should be sent as-is (WAV)");
+        Assert.True(Contains(handler.Body, "dictation.wav"), "a short clip keeps its .wav name");
+        Assert.False(Contains(handler.Body, "OggS"), "a short clip should not be transcoded");
+    }
+}

--- a/src/CcDirector.Core/Audio/OggOpusEncoder.cs
+++ b/src/CcDirector.Core/Audio/OggOpusEncoder.cs
@@ -1,0 +1,59 @@
+using Concentus.Enums;
+using Concentus.Oggfile;
+using Concentus.Structs;
+
+namespace CcDirector.Core.Audio;
+
+/// <summary>
+/// Encodes raw PCM16 into an OGG-Opus container so long dictation clips fit under the
+/// hosted proxy's request-body limit (issue #898).
+///
+/// Uncompressed PCM16 at 24 kHz mono is 48 KB/s, so a whole-turn WAV crosses the
+/// platform's 4.5 MB serverless request-body cap at ~90 seconds and the upload is
+/// rejected (Vercel <c>FUNCTION_PAYLOAD_TOO_LARGE</c>) before the proxy code runs.
+/// Opus at ~24 kbps is ~10x smaller and speech-transparent, turning that ~90 s ceiling
+/// into ~25 minutes while the OpenAI-compatible endpoints (OpenAI and the DevThrottle
+/// proxy) decode <c>audio/ogg</c> natively. This is applied only to the remote batch
+/// POST (see <see cref="Transcription.BatchTranscriptionPipeline"/>); on-device Whisper
+/// keeps raw WAV because it decodes PCM directly and has no network body limit.
+/// </summary>
+public static class OggOpusEncoder
+{
+    /// <summary>
+    /// Target Opus bitrate for mono speech. 24 kbps is well above telephone quality and
+    /// transparent for speech recognition, while keeping the ~25-minute headroom that makes
+    /// the 4.5 MB cap a non-issue for any realistic dictation turn.
+    /// </summary>
+    public const int BitrateBitsPerSecond = 24_000;
+
+    /// <summary>
+    /// Encode little-endian PCM16 samples to an OGG-Opus file. The sample rate must be one
+    /// Opus supports natively (8/12/16/24/48 kHz); dictation is 24 kHz mono.
+    /// </summary>
+    /// <param name="pcm">Raw little-endian PCM16 sample bytes (no container header).</param>
+    /// <param name="sampleRate">Samples per second (e.g. 24000).</param>
+    /// <param name="channels">Channel count (1 = mono, 2 = stereo).</param>
+    /// <returns>A complete <c>.ogg</c> (OGG-Opus) file the transcription endpoint can decode.</returns>
+    public static byte[] EncodePcm16(byte[] pcm, int sampleRate, int channels)
+    {
+        if (pcm is null) throw new ArgumentNullException(nameof(pcm));
+        if (channels is not (1 or 2))
+            throw new ArgumentOutOfRangeException(nameof(channels), channels, "Opus supports 1 or 2 channels.");
+
+        // PCM16 is 2 bytes per sample; drop a dangling odd byte rather than read past the buffer.
+        var samples = new short[pcm.Length / 2];
+        Buffer.BlockCopy(pcm, 0, samples, 0, samples.Length * 2);
+
+        var encoder = OpusEncoder.Create(sampleRate, channels, OpusApplication.OPUS_APPLICATION_VOIP);
+        encoder.Bitrate = BitrateBitsPerSecond;
+
+        using var ogg = new MemoryStream();
+        // OpusOggWriteStream packages the samples into Opus frames and writes the OGG pages;
+        // WriteSamples accepts an arbitrary sample count and buffers internally. Finish flushes
+        // the trailing partial frame and finalizes the stream.
+        var oggStream = new OpusOggWriteStream(encoder, ogg, null, sampleRate);
+        oggStream.WriteSamples(samples, 0, samples.Length);
+        oggStream.Finish();
+        return ogg.ToArray();
+    }
+}

--- a/src/CcDirector.Core/Audio/PcmWav.cs
+++ b/src/CcDirector.Core/Audio/PcmWav.cs
@@ -46,4 +46,64 @@ public static class PcmWav
         bw.Flush();
         return ms.ToArray();
     }
+
+    /// <summary>
+    /// Read a RIFF/WAV blob back into its raw PCM16 samples plus format, for callers that need to
+    /// re-encode the audio (issue #898: transcode a large dictation WAV to OGG-Opus before the
+    /// remote upload). Returns false for anything that is not linear PCM16 (audioFormat 1, 16
+    /// bits/sample) - e.g. an already-compressed container - so the caller can pass those through
+    /// untouched. Walks the chunk list rather than assuming a fixed 44-byte layout, so a WAV with
+    /// extra chunks (LIST/fact) still reads correctly.
+    /// </summary>
+    /// <param name="wav">The complete RIFF/WAV bytes.</param>
+    /// <param name="pcm">On success, the raw little-endian PCM16 sample bytes (the data chunk).</param>
+    /// <param name="sampleRate">On success, samples per second from the fmt chunk.</param>
+    /// <param name="channels">On success, the channel count from the fmt chunk.</param>
+    public static bool TryReadPcm16(byte[] wav, out byte[] pcm, out int sampleRate, out int channels)
+    {
+        pcm = Array.Empty<byte>();
+        sampleRate = 0;
+        channels = 0;
+        if (wav is null || wav.Length < 44) return false;
+        if (!Matches(wav, 0, "RIFF") || !Matches(wav, 8, "WAVE")) return false;
+
+        int bitsPerSample = 0;
+        bool haveFmt = false;
+        int pos = 12; // first chunk starts after "RIFF"<size>"WAVE"
+        while (pos + 8 <= wav.Length)
+        {
+            string id = Encoding.ASCII.GetString(wav, pos, 4);
+            long size = BitConverter.ToUInt32(wav, pos + 4);
+            int body = pos + 8;
+            if (body + size > wav.Length) size = wav.Length - body; // tolerate a truncated final chunk
+
+            if (id == "fmt " && size >= 16)
+            {
+                int audioFormat = BitConverter.ToUInt16(wav, body);
+                channels = BitConverter.ToUInt16(wav, body + 2);
+                sampleRate = (int)BitConverter.ToUInt32(wav, body + 4);
+                bitsPerSample = BitConverter.ToUInt16(wav, body + 14);
+                if (audioFormat != 1 || bitsPerSample != 16) return false; // not linear PCM16
+                haveFmt = true;
+            }
+            else if (id == "data")
+            {
+                if (!haveFmt) return false; // data before fmt: malformed
+                pcm = new byte[size];
+                Buffer.BlockCopy(wav, body, pcm, 0, (int)size);
+                return channels is 1 or 2 && sampleRate > 0;
+            }
+
+            // Chunks are word-aligned: an odd size is followed by one pad byte.
+            pos = body + (int)size + ((size & 1) == 1 ? 1 : 0);
+        }
+        return false;
+    }
+
+    private static bool Matches(byte[] buf, int offset, string ascii)
+    {
+        for (int i = 0; i < ascii.Length; i++)
+            if (buf[offset + i] != (byte)ascii[i]) return false;
+        return true;
+    }
 }

--- a/src/CcDirector.Core/CcDirector.Core.csproj
+++ b/src/CcDirector.Core/CcDirector.Core.csproj
@@ -14,6 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Pure-managed Opus codec (no native DLL) + its OGG container writer. Used to transcode a
+         large dictation WAV to OGG-Opus before the remote upload so long clips fit under the hosted
+         proxy's 4.5 MB request-body cap (issue #898). Concentus.OggFile 1.0.4 targets Concentus 1.x. -->
+    <PackageReference Include="Concentus" Version="1.1.7" />
+    <PackageReference Include="Concentus.OggFile" Version="1.0.4" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.2" />
     <!-- Pin the patched native SQLite library (3.0.x) to resolve advisory GHSA-2m69-gcr7-jv3q
          (NU1903 high-severity). All of SQLitePCLRaw <= 2.1.11 is vulnerable and Microsoft.Data.Sqlite

--- a/src/CcDirector.Core/Transcription/BatchTranscriptionPipeline.cs
+++ b/src/CcDirector.Core/Transcription/BatchTranscriptionPipeline.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Headers;
 using System.Text.Json;
+using CcDirector.Core.Audio;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Dictation;
 using CcDirector.Core.Dictation.Models;
@@ -146,6 +147,14 @@ public sealed class BatchTranscriptionPipeline : IDisposable
     {
         var endpoint = routing.BaseUrl.TrimEnd('/') + "/audio/transcriptions";
 
+        // Issue #898: a whole-turn dictation WAV (raw PCM16) crosses the hosted proxy's 4.5 MB
+        // request-body cap at ~90 seconds and the upload is rejected before the proxy runs. When the
+        // upload is a large WAV, transcode it to OGG-Opus (~10x smaller, speech-transparent, decoded
+        // natively by both OpenAI and the DevThrottle proxy) so long clips fit. Short clips and
+        // already-compressed uploads are sent byte-for-byte as before. This runs only on the remote
+        // POST path; on-device Whisper takes a different route and keeps its raw WAV.
+        (audio, fileName) = CompressLargeWavToOpus(audio, fileName);
+
         using var request = new HttpRequestMessage(HttpMethod.Post, endpoint);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", routing.ApiKey);
 
@@ -191,6 +200,35 @@ public sealed class BatchTranscriptionPipeline : IDisposable
         using var cleanup = new CleanupOrchestrator(
             apiKey: routing.ApiKey, model: _cleanupModel, httpClient: _http, baseUrl: routing.BaseUrl);
         return await cleanup.CleanAsync(raw, dictionary, profileName, ct);
+    }
+
+    /// <summary>
+    /// The WAV size at or above which the upload is transcoded to OGG-Opus (issue #898). Uncompressed
+    /// PCM16 at 24 kHz mono is 48 KB/s, so this ~4 MB threshold (~83 s of audio) trips well before the
+    /// platform's 4.5 MB request-body cap, leaving margin for multipart overhead while keeping every
+    /// shorter clip byte-for-byte unchanged.
+    /// </summary>
+    private const int WavCompressionThresholdBytes = 4_000_000;
+
+    /// <summary>
+    /// If the upload is a linear-PCM16 WAV at or above <see cref="WavCompressionThresholdBytes"/>,
+    /// transcode it to OGG-Opus and return the compressed bytes with a <c>.ogg</c> filename; otherwise
+    /// return the input unchanged. Only PCM16 WAV is transcoded - anything else (an already-compressed
+    /// container, or non-PCM WAV) legitimately needs no compression and is passed through. A genuine
+    /// encode failure is NOT swallowed: it throws, because sending the oversize WAV would only be
+    /// rejected downstream with a misleading error (no-fallback rule - surface the real cause).
+    /// </summary>
+    private static (byte[] audio, string fileName) CompressLargeWavToOpus(byte[] audio, string fileName)
+    {
+        if (audio.Length < WavCompressionThresholdBytes) return (audio, fileName);
+        if (!PcmWav.TryReadPcm16(audio, out var pcm, out var sampleRate, out var channels))
+            return (audio, fileName);
+
+        var ogg = OggOpusEncoder.EncodePcm16(pcm, sampleRate, channels);
+        var name = Path.ChangeExtension(string.IsNullOrEmpty(fileName) ? "dictation" : fileName, ".ogg");
+        FileLog.Write($"[BatchTranscriptionPipeline] compressed WAV {audio.Length} -> OGG-Opus {ogg.Length} bytes "
+            + $"({sampleRate}Hz {channels}ch) to fit the upload cap");
+        return (ogg, name);
     }
 
     private static string GuessAudioContentType(string fileName)


### PR DESCRIPTION
Fixes #898.

## Problem

Whole-turn dictation captures raw PCM16 (24 kHz mono) and posts it as one WAV. PCM16 at 24 kHz is 48 KB/s, so the clip crosses Vercel's **4.5 MB serverless request-body cap at ~90 seconds** and the upload is rejected with `FUNCTION_PAYLOAD_TOO_LARGE` before the proxy code even runs (the 1:51 failure seen in the field).

## Fix

Transcode to **OGG-Opus** at the one shared remote-POST chokepoint, `BatchTranscriptionPipeline.TranscribeBatchAsync`: when the upload is a linear-PCM16 WAV at/above ~4 MB, encode it to Opus (~24 kbps, pure-managed **Concentus**, no native DLL) before the multipart POST. Opus is ~10x smaller and speech-transparent, turning the ~90 s ceiling into **~25 minutes**; both OpenAI and the DevThrottle proxy decode `audio/ogg` natively.

- **Desktop** (`BatchDictationRecorder`) and **web** (`DictationEndpoint`) both funnel through this method -> both fixed with **no call-site change**.
- **On-device Whisper** takes a different path and keeps raw WAV (it decodes PCM directly and has no network cap) -> untouched by construction.
- **Short clips / already-compressed uploads** are sent byte-for-byte as before (size-gated, zero regression for the common case).
- A genuine encode failure **throws** rather than silently shipping the oversize WAV (repo no-fallback rule).

## Changes

- `src/CcDirector.Core/Audio/OggOpusEncoder.cs` (new) - PCM16 -> OGG-Opus.
- `src/CcDirector.Core/Audio/PcmWav.cs` - `TryReadPcm16` reader (chunk-walking, PCM16-only).
- `src/CcDirector.Core/Transcription/BatchTranscriptionPipeline.cs` - size-gated transcode before the POST.
- `CcDirector.Core.csproj` - `Concentus 1.1.7` + `Concentus.OggFile 1.0.4`.
- Tests: `OggOpusEncoderTests`, `BatchTranscriptionPipelineCompressionTests`.

## Verification

- New tests (5) pass: a 100 s clip (4.8 MB WAV, over the old cap) encodes to OGG well under 4.5 MB; the actual multipart POST goes out as `dictation.ogg` with no `RIFF`; a short clip is still sent byte-identical as `.wav`.
- Full `CcDirector.Core.Tests` suite: **2634 passed, 0 failed**.
- `CcDirector.Avalonia` and `CcDirector.ControlApi` build clean (0 warnings, `TreatWarningsAsErrors`).

## Acceptance run (needs a mic + real dt_ key - reviewer to confirm)

A continuous **>2-minute** dictation returns a transcript with no 413 on BOTH the desktop Dictate dialog and the web Cockpit; local (on-device) mode still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
