### PR TITLE
fix(dictation): compress web/Cockpit dictation to Opus too (#898)

### DIFF
--- a/src/CcDirector.ControlApi/DictationEndpoint.cs
+++ b/src/CcDirector.ControlApi/DictationEndpoint.cs
@@ -60,11 +60,20 @@ internal static class DictationEndpoint
 {
     // The browser captures at this fixed format (see dictation-overlay.js: the
     // AudioContext is opened at 24 kHz and the pcm16-writer worklet emits mono
-    // 16-bit PCM). The server wraps the accumulated PCM in a WAV header using
-    // exactly this format before the single batch transcription.
+    // 16-bit PCM). The server Opus-encodes the accumulated PCM at this format
+    // before the single batch upload (see PackageUpload).
     private const int CaptureSampleRate = 24000;
     private const int CaptureChannels = 1;
-    private const int CaptureBitsPerSample = 16;
+
+    /// <summary>
+    /// Package the captured PCM16 for the single batch upload. Mirrors the desktop recorder (#897):
+    /// the whole clip is Opus-encoded in an Ogg container so a long dictation stays well under the
+    /// transcription endpoint's 4.5 MB request-body cap (issue #898) - the endpoints decode Ogg Opus
+    /// natively and the in-process local mode was removed in #887, so there is no uncompressed path to
+    /// preserve. Internal so the packaging (format + name) is unit-testable without the WebSocket loop.
+    /// </summary>
+    internal static (byte[] audio, string fileName) PackageUpload(byte[] pcm, int sampleRate, int channels)
+        => (OggOpusEncoder.EncodePcm16(pcm, sampleRate, channels), "dictation.ogg");
 
     public static void Map(IEndpointRouteBuilder app, AgentOptions options, OpenAiKeyResolver keyResolver, DictionaryResolver dictionaryResolver)
     {
@@ -270,9 +279,14 @@ internal static class DictationEndpoint
             return;
         }
 
-        // Wrap the whole captured PCM in one WAV blob and transcribe ONCE through the shared batch
-        // pipeline (the same one the desktop uses). The dictionary corrector is the only text transform.
-        var wav = PcmWav.Wrap(pcmBytes, CaptureSampleRate, CaptureChannels, CaptureBitsPerSample);
+        // Package the whole captured PCM for ONE batch upload through the shared pipeline (the same
+        // one the desktop uses). PackageUpload Opus-encodes it so a long dictation stays under the
+        // transcription endpoint's request-body cap - the web path was still shipping raw WAV and hit
+        // the same platform 413 past ~90 s that the desktop path fixed in #897 (issue #898). The
+        // dictionary corrector downstream is the only text transform.
+        var (upload, uploadName) = PackageUpload(pcmBytes, CaptureSampleRate, CaptureChannels);
+        FileLog.Write($"[DictationEndpoint] sid={sessionId} upload packaged: file={uploadName}, "
+            + $"bytes={upload.Length} (pcm={pcmBytes.Length})");
 
         var stopWatch = System.Diagnostics.Stopwatch.StartNew();
         BatchTranscriptionResult? transcript = null;
@@ -280,7 +294,7 @@ internal static class DictationEndpoint
         try
         {
             using var pipeline = new BatchTranscriptionPipeline(cleanupModel: options.DictationCleanupModel);
-            transcript = await pipeline.TranscribeAsync(wav, "dictation.wav", routing, dictionary, profile, ct);
+            transcript = await pipeline.TranscribeAsync(upload, uploadName, routing, dictionary, profile, ct);
         }
         catch (Exception ex)
         {

--- a/src/CcDirector.Gateway.Tests/DictationEndpointPackagingTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationEndpointPackagingTests.cs
@@ -1,0 +1,51 @@
+using System.Text;
+using CcDirector.ControlApi;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Proves the web/Cockpit dictation path packages its upload as Ogg Opus (issue #898). The desktop
+/// path was fixed in #897, but the WebSocket endpoint still shipped raw WAV and hit the same platform
+/// 413 past ~90 s. This tests the packaging decision (<see cref="DictationEndpoint.PackageUpload"/>)
+/// directly, without standing up the WebSocket loop, so it needs no network or real key.
+/// </summary>
+public sealed class DictationEndpointPackagingTests
+{
+    private const int SampleRate = 24_000;   // the browser capture format
+    private const int Channels = 1;
+    private const int PlatformBodyCapBytes = 4_500_000;
+
+    /// <summary>Raw PCM16 for a low-amplitude sine tone of the given duration - non-degenerate audio.</summary>
+    private static byte[] Pcm16(int seconds)
+    {
+        int samples = SampleRate * seconds;
+        var pcm = new byte[samples * 2];
+        for (int i = 0; i < samples; i++)
+        {
+            short v = (short)(Math.Sin(2 * Math.PI * 220.0 * i / SampleRate) * 8000);
+            pcm[i * 2] = (byte)(v & 0xFF);
+            pcm[i * 2 + 1] = (byte)((v >> 8) & 0xFF);
+        }
+        return pcm;
+    }
+
+    [Fact]
+    public void PackageUpload_LongClip_IsOggOpusFarUnderTheCap()
+    {
+        // 100 seconds of raw PCM16/24k/mono is a 4.8 MB WAV - past the ~90 s point where the old
+        // uncompressed web upload failed with FUNCTION_PAYLOAD_TOO_LARGE.
+        var pcm = Pcm16(seconds: 100);
+        long equivalentWavBytes = pcm.Length + 44;
+        Assert.True(equivalentWavBytes > PlatformBodyCapBytes, "precondition: the raw WAV would exceed the cap");
+
+        var (audio, fileName) = DictationEndpoint.PackageUpload(pcm, SampleRate, Channels);
+
+        Assert.Equal("dictation.ogg", fileName);
+        Assert.Equal("OggS", Encoding.ASCII.GetString(audio, 0, 4));    // real Ogg capture pattern
+        Assert.True(audio.Length < PlatformBodyCapBytes,
+            $"packaged upload ({audio.Length}) must be under the {PlatformBodyCapBytes}-byte cap");
+        Assert.True(audio.Length < equivalentWavBytes / 4,
+            $"expected >4x reduction vs WAV; got {equivalentWavBytes} -> {audio.Length}");
+    }
+}


### PR DESCRIPTION
Follow-up to thefrederiksen/devthrottle#897 / fixes the remaining half of #898.

## Problem

thefrederiksen/devthrottle#897 fixed **desktop** dictation (`BatchDictationRecorder`) by compressing to Opus before upload. But the **web/Cockpit** path - the `/dictate` WebSocket handled by `DictationEndpoint` - still wrapped the accumulated PCM in a raw WAV and POSTed it. So an un-paused dictation segment past ~90 s hit the exact same platform `413 FUNCTION_PAYLOAD_TOO_LARGE` at Vercel's 4.5 MB request-body cap. (Pause/Resume masked it - each segment is a fresh upload - but a single long segment still failed.)

## Fix

Package the web upload the same way the desktop path does: Opus-encode the whole clip (Ogg container) via the `OggOpusEncoder` thefrederiksen/devthrottle#897 already merged, and send `dictation.ogg`. Factored into an internal `PackageUpload` helper so the format + name choice is unit-testable without standing up the WebSocket loop. Local mode was removed in thefrederiksen/devthrottle_internal#656, so there is no uncompressed path to preserve.

## Changes

- `src/CcDirector.ControlApi/DictationEndpoint.cs` - `PackageUpload` (Opus/Ogg) replaces the raw `PcmWav.Wrap` + `dictation.wav`; drops the now-unused `CaptureBitsPerSample` const.
- `src/CcDirector.Gateway.Tests/DictationEndpointPackagingTests.cs` - a 100 s clip packages to an Ogg-Opus blob far under the 4.5 MB cap (>4x smaller than the equivalent WAV), named `dictation.ogg`.

## Verification

- New test passes; the dictation test group is green (7 passed, 0 failed).
- `CcDirector.ControlApi` + `CcDirector.Gateway.Tests` build clean (0 warnings, `TreatWarningsAsErrors`).
- Reuses the encoder + bitrate (24 kbps) from thefrederiksen/devthrottle#897 - no new dependency.

## Acceptance run (reviewer)

A continuous **>2-minute** dictation in the **web Cockpit** returns a transcript with no 413 (desktop already covered by thefrederiksen/devthrottle#897).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
