### PR TITLE
[Mobile] Sign in + per-device authentication (retire the master token) (#908)

### DIFF
--- a/docs/architecture/mobile/MOBILE_DEVICE_AUTH.md
+++ b/docs/architecture/mobile/MOBILE_DEVICE_AUTH.md
@@ -1,0 +1,296 @@
+# Mobile App Device Authentication - Specification (Version 1)
+
+Status: DRAFT for review (2026-07-03)
+Area: Gateway + mobile Progressive Web App
+Tracker: `thefrederiksen/devthrottle` issue #908
+Related shipped work: the account-as-device-fabric issue set (#852-#858) and local device
+enrollment (#469).
+
+This document specifies how the mobile Progressive Web App (served at `/m`) authenticates a person
+and registers the phone as its own revocable device, replacing the current model in which the app is
+handed the master Gateway token from a public page.
+
+---
+
+## 1. The problem (today's model)
+
+The mobile app has no app-level security. Reaching it equals full control of the fleet:
+
+1. The `/m` shell is deliberately public. `AuthMiddleware` lets `/m` and `/m/*` through with no
+   token check at all (`src/CcDirector.Gateway/Util/AuthMiddleware.cs`, issue #806).
+2. The Gateway injects the per-machine master token into the served `index.html` in place of the
+   `__GATEWAY_TOKEN__` placeholder (`src/CcDirector.Gateway/Mobile/MobileApp.cs`). The app reads it
+   as `window.__GW_TOKEN__` and sends it as the Bearer on every call (`mobile/src/api/client.ts`).
+3. That token is the master credential: a 32-byte value in `gateway-token.txt`, generated once,
+   plain text, no expiry, the same credential the desktop uses (`GatewayAuth.cs`). Anyone who loads
+   `https://<tailnet>/m`, or simply views page source, walks away with permanent, unrevocable
+   control of the whole fleet.
+
+The only barrier is Tailscale network membership. Once a device is on the tailnet - or once a phone
+has ever loaded the page - it is root forever, and nothing times out.
+
+---
+
+## 2. Target model (two independent layers)
+
+Security is split into two layers, and the cloud only ever touches the first of them for a moment,
+never the traffic:
+
+- **Network reachability.** The phone must have a direct network path to the Gateway. This is the
+  owner's to provide: Tailscale today, any other virtual private network, or a local network.
+  DevThrottle is not a relay or proxy - no session traffic ever routes through the cloud. This layer
+  does not change.
+- **Identity and authorization (new).** The person signs in against the central DevThrottle account.
+  On success the phone obtains its own **per-device token**. From then on the phone presents that
+  token as the Bearer on every direct-to-Gateway call. Being on the network is no longer enough;
+  the token is what turns "I can reach the Gateway" into "I am allowed to use it."
+
+Locked decisions from the conversation that produced this spec:
+
+- **A token is required.** Network presence alone must not grant access.
+- **The token is minted only after account sign-in against the central server.**
+- **No timeout.** The device stays signed in until it is revoked (consistent with the shipped
+  "revoke-only, no auto-expiry" device model).
+- **No PC presence needed.** Registration is done from the phone via the cloud, never by reading a
+  code off the Gateway host window.
+- **Per-device, not master.** Losing one phone never compromises anything else; it is revoked in one
+  action, and every other device keeps working.
+- **The cloud is never in the request path.** After enrollment the Gateway validates the token
+  itself, offline, so it stays fast and keeps working if the cloud is briefly unreachable.
+- **All sign-in and device registration happen on devthrottle.com** (one fixed address the project
+  owns), so email, Google, and GitHub all work the same way. The brief redirect out to a provider's
+  own sign-in page (Google / GitHub) at first enrollment is accepted.
+
+---
+
+## 3. The enrollment flow
+
+Sign-in and device registration happen on **devthrottle.com** - one fixed address - so every
+provider (email, Google, GitHub) works the same way (see section 5 for why the fixed address is what
+makes this possible). The phone is the courier: it is the only thing that can reach both the public
+site and the owner's private Gateway.
+
+One time, per phone:
+
+1. The phone opens `/m`. The app finds no stored device token, so it shows a **Sign in** screen
+   instead of silently receiving the master token. (The master token is no longer injected - see
+   section 6.) The app passes its own `/m` origin along so the site knows where to return the phone.
+2. Tapping Sign in sends the phone to **devthrottle.com**. The person signs in with email, Google,
+   or GitHub. For Google / GitHub the browser briefly visits the provider's own sign-in page and
+   returns to devthrottle.com; that redirect is registered once against the site's fixed address, so
+   it works for every owner.
+3. devthrottle.com registers this phone as a device on the account and issues its per-device token,
+   then returns the phone to its `/m` origin carrying that token. (This return hop is the site's own
+   redirect, not the provider's, so it is free to target any owner's `/m` address - see section 5.)
+4. `/m` hands the token to a new, deliberately public enrollment endpoint on the Gateway (public the
+   same way `/devices/register` is, because it carries its own authorization).
+5. The Gateway verifies the token identifies **the same account the Gateway itself is signed into**
+   (it already knows its own account identity locally, `GatewaySignInService.GetIdentity()`). On a
+   match it issues the phone a **local** device key it can validate offline and mirrors the phone to
+   the account's cloud roster (so it appears under "Your devices" and is revocable there). See
+   section 4 for why the working credential is a local key.
+6. The phone stores its key and uses it as the Bearer from then on. No further sign-in, no expiry,
+   until it is revoked.
+
+Every real request after enrollment - roster, prompts, the terminal stream - is validated by the
+Gateway locally and goes straight phone-to-Gateway over the network.
+
+---
+
+## 4. The bridge (the one genuinely new mechanism)
+
+The hard part is step 4-5: how a **local** Gateway comes to trust a phone that authenticated against
+the **cloud**. Two shipped facts constrain the design:
+
+- The existing Gateway sign-in uses a **local loopback browser callback**
+  (`GatewaySignInService` + Core `FirstRunLoginCoordinator` + `LoopbackLoginListener`). That only
+  works when the browser is on the same machine as the Gateway. A phone browser is remote, so it
+  **cannot reuse** this flow. The phone must authenticate to the cloud directly.
+- The cloud device **list** returns only masked keys (`KeyPrefix` + `KeyLast4`), never raw keys
+  (`AccountDevicesEndpoint.cs`). So the Gateway cannot validate an arbitrary cloud-issued key by
+  syncing the roster and comparing - there is nothing to compare against locally.
+
+### Recommended design: local per-device key, mirrored to the cloud
+
+The phone's working credential is a **local device key** that the Gateway can validate offline,
+while the cloud copy exists only for visibility and revocation:
+
+- **Verify identity at enrollment (cloud touched once).** The phone signs into the account and
+  presents its account access token to the Gateway's enrollment endpoint. The Gateway confirms the
+  token belongs to its own account (verify the token's signature and subject against the account
+  service, or call the account "who am I" endpoint once). This is the only cloud interaction on the
+  enrollment path and it never repeats per request.
+- **Issue a local key the Gateway already accepts.** On a verified match, the Gateway registers the
+  phone in the local device registry (`DeviceRegistry.Register`, issue #469) and returns that
+  per-device key. `AuthMiddleware.HasValidToken` **already accepts a valid local device key as a
+  Bearer** (`AuthMiddleware.cs`, the `IsValidDeviceKey` branch), so no new hot-path validation code
+  is needed and the cloud is never called to authorize a request.
+- **Mirror up for website visibility and revoke.** The Gateway mirrors the enrolled phone to the
+  account's cloud roster using the existing Path B mirror (`ChildDeviceMirrorService`), so the phone
+  shows under "Your devices" and can be revoked from the website or the Cockpit. A revoke propagates
+  back down through the existing mirror/reconcile sweep, after which the Gateway rejects that key.
+
+Why this over having the phone hold a cloud `dtd_` key directly: a cloud key cannot be validated by
+the Gateway offline (the list is masked), so it would force a cloud call on every request - which
+violates the "cloud is never in the request path" decision. The local-key-plus-mirror design keeps
+authorization entirely local while still giving cloud-side visibility and one-click revoke.
+
+### What already exists, and the one security fork (findings 2026-07-04)
+
+Most of this is already built and can be reused:
+
+- devthrottle.com already ships `/activate` (issue #106): a device-approval page that signs the
+  person in with **any** provider (Google / GitHub / email / magic link), registers the device via
+  `POST /api/v1/devices/register` (mints the per-device `dtd_` key), and hands the credential back to
+  the app. `/signin` (issue #46) is the same hand-back contract without the approval metadata.
+- The hand-back helper `buildCallbackUrl` (website `src/lib/loopback.js`) already supports returning a
+  `device_key` alongside (or instead of) the session tokens.
+- On the Gateway, `DeviceRegistry.Register` / `IsValidDeviceKey` issue and offline-validate a local
+  key, and `DevThrottleAccountService` verifies a JWT signature and reads its identity locally.
+
+The one genuinely new decision: `validateRedirectUri` (website `src/lib/loopback.js`) is
+**deliberately loopback-only** (`http://127.0.0.1` / `localhost`, the one callback path) as the
+anti-token-exfiltration control - handing a Supabase session to an arbitrary URL is account theft.
+The phone's callback is `https://<tailnet>/m/...`, not loopback, so the phone flow cannot use the
+existing hand-back unchanged.
+
+**Chosen resolution (2026-07-04, owner to veto):** hand back to the phone's tailnet callback **only
+the revocable per-device key, never the Supabase session tokens.** Worst-case interception then costs
+one revocable device, not the account. The phone presents that key once to the new Gateway enrollment
+endpoint, which confirms the key belongs to the Gateway's OWN signed-in account (matching it against
+the account device roster it can already read via `DeviceRegistryClient`), then issues the phone a
+**local** `DeviceRegistry` key for day-to-day use. A phone variant of the redirect validation accepts
+the Gateway's own tailnet `/m` callback for a **device-key-only** hand-back (never a session
+hand-back), keeping the strict loopback rule for the token path intact.
+
+Alternative considered: hand back the full session, but only to a redirect origin pre-registered
+under the same account (the Gateway publishes its tailnet URL to the cloud). Also secure; rejected for
+V1 as more cloud plumbing with no better outcome than the device-key-only path.
+
+### Alternative (documented, not recommended)
+
+Have the cloud mint the phone's key and add a new cloud endpoint that lets the Gateway validate a
+presented key by hash (so it can sync hashes and check locally). This is more cloud surface, more
+sensitive data to sync, and no better an outcome than the recommended design. Recorded only so the
+trade-off is on the record.
+
+---
+
+## 5. Why registering on devthrottle.com makes every provider work the same (DECIDED)
+
+Signing a **phone browser** in directly against the app would hit one wall: the app is served from a
+per-owner tailnet origin (for example `https://<tailnet-name>/m`), and social sign-in
+(Google / GitHub) requires the exact **return address** to be registered in advance with the
+provider. A different tailnet origin per owner cannot be pre-registered for everyone.
+
+The decision (owner, 2026-07-03) is to sidestep this entirely by doing **all sign-in and device
+registration on devthrottle.com**, one fixed address the project owns. This works because:
+
+- The provider's return-address rule only governs the leg **from the provider back to us**. We
+  register devthrottle.com's fixed callback with Google / GitHub **once**, and it is satisfied for
+  every owner forever.
+- Once the person is back on **our own** site, the hop from devthrottle.com back to the phone's `/m`
+  address is **our** redirect, not the provider's - so it is not subject to the provider's
+  registered-address list and can target any owner's tailnet `/m` origin.
+
+So email, Google, and GitHub all become "sign in on devthrottle.com," i.e. identical. The owner has
+accepted the brief redirect out to a provider's own page for Google / GitHub (it is inherent to those
+sign-ins - the app never sees the provider password). This is a **one-time** step per phone, because
+there is no timeout (section 7).
+
+Cost of this decision (recorded honestly): it adds a device-registration surface on devthrottle.com
+and a token hand-back to the phone, so it **does** require cloud/site work - this reverses the
+earlier "probably no cloud change" assumption. It also means the phone needs internet reachability at
+enrollment time (it needs the account to sign in regardless); after enrollment it is local-only.
+
+---
+
+## 6. Change to the `/m` shell (stop handing out the master token)
+
+`MobileApp.cs` must stop injecting the master token into `index.html`. The shell still loads
+publicly (it must, so the Sign in screen can render), but it no longer carries any credential. The
+app authorizes its own calls with the per-device token it obtained at enrollment.
+
+Backwards-compatibility note for the Developer Agent: confirm whether any surface other than the
+Progressive Web App relies on `window.__GW_TOKEN__` injection before removing it. The native phone
+application authenticates separately and is not in scope here.
+
+---
+
+## 7. Revocation and "keep logged in" semantics
+
+- **Keep logged in:** the per-device token never expires. The account session on the phone
+  auto-refreshes, so the person signs in once and is not asked again.
+- **Revoke one device:** removing the device from the website or the Cockpit ("Your devices" ->
+  Remove) drops it from the account roster; the mirror/reconcile sweep removes the local key and the
+  Gateway then rejects that token on its next request. Every other device is unaffected.
+- **Lost phone:** the person revokes that one device. The phone's own lock screen is the near-term
+  protection; revoke is the durable one. No fleet-wide credential rotation is ever required.
+
+---
+
+## 8. Reused shipped components
+
+| Concern | Existing component | Reused how |
+|---|---|---|
+| Local per-device key issue + validate | `DeviceRegistry` (#469), `AuthMiddleware.HasValidToken` | Phone gets a local key; the Bearer check already accepts it |
+| Account identity on the Gateway | `GatewaySignInService`, `DevThrottleAccountService` | Read the Gateway's own account to verify the phone's token matches |
+| Cloud device roster (list / revoke) | `AccountDevicesEndpoint`, `DeviceRegistryClient` | The phone appears under "Your devices"; revoke from the website |
+| Mirror a device up / revoke down | `ChildDeviceMirrorService` (Path B) | Mirror the enrolled phone to the cloud; propagate a revoke back down |
+| Serve `/m` | `MobileApp.cs` | Same serving; remove token injection only |
+
+---
+
+## 9. New work
+
+- **devthrottle.com (site / cloud):** a device-registration surface reached from the phone that
+  signs the person in (email, Google, GitHub - the provider callbacks registered once against the
+  site's fixed address), registers the phone as a device on the account, issues its per-device
+  token, and returns the phone to its `/m` origin carrying that token.
+- **Gateway:** a public enrollment endpoint under `/m` that verifies the presented account token
+  against the Gateway's own account and, on a match, issues a local device key and mirrors the phone
+  up. Stop injecting the master token in `MobileApp.cs`.
+- **Mobile:** a Sign in screen that hands off to devthrottle.com (passing its own `/m` origin) and
+  receives the token back; store the returned per-device token; send it as the Bearer (replacing the
+  injected-token path in `mobile/src/api/client.ts`); a signed-out state that routes to Sign in on a
+  401.
+
+---
+
+## 10. Out of scope (Version 1)
+
+- The native phone application's authentication - unchanged; it is a separate surface.
+- Any change to the network layer (Tailscale, virtual private network, local network) - unchanged.
+- Multi-person accounts / roles - the model is one account owning many devices.
+
+---
+
+## 11. Proposed issue breakdown (to confirm during build)
+
+Small, independently testable steps, each proven on a real phone before the next:
+
+1. **devthrottle.com device-registration surface.** Sign in (email, Google, GitHub via the site's
+   fixed callback), register the phone as a device, mint its per-device token, and return it to a
+   given `/m` origin. Provable on the site before any Gateway change.
+2. **Gateway enrollment endpoint + stop injecting the master token.** Verify a presented account
+   token against the Gateway's own account; issue a local device key; mirror the phone up. `/m` shell
+   loads with no credential. Provable with a token round-trip and the Bearer check.
+3. **Mobile Sign in screen + token storage + authorized calls.** Hand off to devthrottle.com and
+   receive the token back; store the per-device token; every existing call sends it; a 401 routes
+   back to Sign in.
+4. **Revoke round-trip.** Removing the phone from "Your devices" causes the Gateway to reject its
+   token; the app returns to Sign in. Proven end to end.
+
+---
+
+## 12. Assumptions (flagged for the human, per the Definition of Ready)
+
+- Version 1 includes email, Google, and GitHub, all via devthrottle.com (section 5, DECIDED).
+- Cloud/site work **is** required: a device-registration surface on devthrottle.com plus the token
+  hand-back to the phone. (This reverses the initial "probably no cloud change" guess.) The exact
+  split between reusing shipped account/register endpoints and new site pages is a design task.
+- The recommended bridge (local key plus cloud mirror) is accepted over the cloud-key alternative
+  (section 4).
+- The native phone application does not depend on the `/m` master-token injection being removed.
+</content>
+</invoke>

--- a/mobile/index.html
+++ b/mobile/index.html
@@ -6,13 +6,10 @@
     <meta name="theme-color" content="#0B1020" />
     <title>DevThrottle Mobile</title>
     <!--
-      The per-machine Gateway token is injected here server-side (the Gateway replaces the
-      __GATEWAY_TOKEN__ placeholder before serving this page, the same pattern the /voice page
-      uses). The app reads window.__GW_TOKEN__ and sends it as a Bearer header on API calls.
-      A value still starting with "__" means the page was served without injection (treated as
-      absent by the client).
+      Issue #908: the shell carries NO credential. The master token is no longer injected here. The
+      app authenticates with a per-device key it obtains by signing in on devthrottle.com and enrolling
+      (POST /m/enroll); that key lives in the app's own device-key store, never in the page.
     -->
-    <script>window.__GW_TOKEN__ = "__GATEWAY_TOKEN__";</script>
   </head>
   <body>
     <div id="root"></div>

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -8,6 +8,7 @@
 import type { components } from "./schema";
 import type { SessionHistoryDto } from "../history/types";
 import { planUploadChunks } from "./chunking";
+import { getDeviceKey, clearDeviceKey } from "../auth/deviceKey";
 
 export type SessionDto = components["schemas"]["SessionDto"];
 
@@ -43,32 +44,46 @@ export interface RepoInfo {
   lastUsed: string;
 }
 
-// The injected token. A value still starting with "__" means the page was served without
-// injection (e.g. opened directly from the raw build) - treat that as absent.
+// The app's credential is the per-device key it obtained at enrollment (issue #908), read from the
+// device-key store - NOT a token injected into the page (the shell no longer carries one). Empty until
+// the phone has enrolled, in which case the caller (the auth gate) routes to the Sign in screen.
 function gatewayToken(): string {
-  const raw =
-    (typeof window !== "undefined" && (window as unknown as { __GW_TOKEN__?: string }).__GW_TOKEN__) || "";
-  return raw.indexOf("__") === 0 ? "" : raw;
+  return getDeviceKey();
 }
 
 // Exported so the dictation transcription calls (which post raw audio bytes and read a transcript)
-// attach the same Bearer the rest of the client uses - the app works with Gateway auth on or off.
+// attach the same Bearer the rest of the client uses. Empty headers before enrollment; the app gates
+// on the device key so no data call runs without one.
 export function authHeaders(): HeadersInit {
   const token = gatewayToken();
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
-// Mirror the per-machine Gateway token into the cc-gateway-token cookie (issue #817). A browser
-// WebSocket cannot set an Authorization header, so the live terminal stream
-// (GET /sessions/{sid}/stream) authenticates via this cookie, which the same-origin handshake
-// carries and the Gateway's AuthMiddleware accepts (HasValidToken checks Bearer OR this cookie).
-// The token is already in the page (window.__GW_TOKEN__), so the cookie exposes nothing new; it is
-// scoped to this origin. A no-op when the page was served without an injected token (auth is then
-// off and the stream needs no credential anyway).
+// Mirror the per-device key into the cc-gateway-token cookie (issue #817/#908). A browser WebSocket
+// cannot set an Authorization header, so the live terminal stream (GET /sessions/{sid}/stream)
+// authenticates via this cookie, which the same-origin handshake carries and the Gateway's
+// AuthMiddleware accepts (HasValidToken checks the cookie against the shared token OR an active
+// per-device key). The key is already in this origin's storage, so the cookie exposes nothing new; it
+// is scoped to this origin. A no-op before enrollment (no key yet - the stream is never opened then).
 export function ensureGatewayCookie(): void {
   const token = gatewayToken();
   if (!token) return;
   document.cookie = `cc-gateway-token=${encodeURIComponent(token)}; path=/; SameSite=Lax`;
+}
+
+// The path the app navigates to when its credential is missing or rejected. Absolute under the /m
+// basename so it works from any in-app route.
+const SIGN_IN_PATH = "/m/signin";
+
+// Called when the Gateway answers 401 to a credentialed call: the device key was revoked (from the
+// website's "Your devices") or is otherwise no longer valid. Forget it and send the user back to Sign
+// in, so a revoke on the account promptly ends the phone's access (the revoke round-trip, issue #908).
+// A hard navigation (not the router) guarantees the whole app re-gates from a clean state.
+function onUnauthorized(): void {
+  clearDeviceKey();
+  if (typeof window !== "undefined" && window.location.pathname !== SIGN_IN_PATH) {
+    window.location.assign(SIGN_IN_PATH);
+  }
 }
 
 export class GatewayError extends Error {
@@ -89,6 +104,12 @@ export async function listSessions(signal?: AbortSignal): Promise<SessionDto[]> 
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
   });
+  if (res.status === 401) {
+    // The device key was revoked (or is otherwise invalid): forget it and re-gate to Sign in. The
+    // roster is the first credentialed call the app makes, so this is where a revoke surfaces.
+    onUnauthorized();
+    throw new GatewayError(res.status, "This device is no longer authorized. Please sign in again.");
+  }
   if (!res.ok) {
     throw new GatewayError(res.status, `GET /sessions failed: ${res.status}`);
   }

--- a/mobile/src/api/enroll.ts
+++ b/mobile/src/api/enroll.ts
@@ -1,0 +1,43 @@
+// The enrollment call (issue #908): hand the Gateway the per-device key the phone received from
+// devthrottle.com, and receive back the LOCAL device key the Gateway issues and validates offline.
+// This is the only place the cloud-issued key is used; from then on the app authenticates with the
+// local key returned here. POST /m/enroll is under /m/, so it is reachable before the phone holds any
+// credential (it carries its own authorization: the account-scoped device key in the body).
+import { GatewayError } from "./client";
+
+/**
+ * Exchange the cloud device key for a local Gateway device key.
+ * @returns the local per-device key the app must store and send as its Bearer.
+ * @throws GatewayError on any non-2xx, carrying the server's reason (403 = not on this Gateway's
+ *   account; 409 = the Gateway is not signed in; 502 = the cloud could not be reached).
+ */
+export async function enrollDevice(
+  cloudDeviceKey: string,
+  deviceId: string,
+  name: string,
+  platform: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  const res = await fetch("/m/enroll", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify({ deviceKey: cloudDeviceKey, deviceId, name, platform }),
+    signal,
+  });
+  if (!res.ok) {
+    let detail = `${res.status}`;
+    try {
+      const err = (await res.json()) as { error?: string };
+      detail = err.error ?? detail;
+    } catch {
+      /* non-JSON error body - keep the status code */
+    }
+    throw new GatewayError(res.status, detail);
+  }
+  const body = (await res.json()) as { deviceKey?: string };
+  const localKey = (body.deviceKey ?? "").trim();
+  if (!localKey) {
+    throw new GatewayError(res.status, "Enrollment succeeded but returned no device key.");
+  }
+  return localKey;
+}

--- a/mobile/src/auth/DeviceCallback.tsx
+++ b/mobile/src/auth/DeviceCallback.tsx
@@ -1,0 +1,92 @@
+// The device-enrollment callback (issue #908), served at /m/device-callback. devthrottle.com redirects
+// the phone here after sign-in with the per-device key in the URL FRAGMENT (never the query, so it is
+// not sent to any server). This screen reads that key, exchanges it at the Gateway (POST /m/enroll) for
+// a LOCAL device key, stores the local key, and enters the app. The account session never reaches here.
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { getInstallId, setDeviceKey } from "./deviceKey";
+import { takeEnrollState, detectPlatform, deviceName } from "./enrollRequest";
+import { enrollDevice } from "../api/enroll";
+
+type Phase = "working" | "denied" | "error";
+
+export function DeviceCallback() {
+  const navigate = useNavigate();
+  const [phase, setPhase] = useState<Phase>("working");
+  const [message, setMessage] = useState("");
+  // Guards the enroll to exactly once (survives React StrictMode's dev double-mount).
+  const started = useRef(false);
+
+  useEffect(() => {
+    if (started.current) return;
+    started.current = true;
+
+    let cancelled = false;
+    (async () => {
+      const rawHash = window.location.hash.startsWith("#") ? window.location.hash.slice(1) : window.location.hash;
+      const params = new URLSearchParams(rawHash);
+      const error = params.get("error");
+      const deviceKey = params.get("device_key");
+      const state = params.get("state");
+      const expected = takeEnrollState();
+
+      if (error) {
+        setPhase("denied");
+        setMessage("Sign-in was declined. Nothing was connected.");
+        return;
+      }
+      // Verify the round trip when we have a saved state; a null expected-state (storage cleared) is not
+      // treated as a failure, so a legitimate sign-in is never blocked by missing session storage.
+      if (expected && state !== expected) {
+        setPhase("error");
+        setMessage("This sign-in could not be verified. Please try again.");
+        return;
+      }
+      if (!deviceKey) {
+        setPhase("error");
+        setMessage("Sign-in did not return a device key. Please try again.");
+        return;
+      }
+
+      try {
+        const localKey = await enrollDevice(deviceKey, getInstallId(), deviceName(), detectPlatform());
+        if (cancelled) return;
+        setDeviceKey(localKey);
+        // Strip the key from the URL before entering the app, then go to the roster.
+        window.history.replaceState(null, "", "/m/");
+        navigate("/", { replace: true });
+      } catch (err) {
+        if (cancelled) return;
+        setPhase("error");
+        setMessage(err instanceof Error ? err.message : "Could not connect this device. Please try again.");
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [navigate]);
+
+  const container = { maxWidth: 420, margin: "0 auto", padding: "2.5rem 1.25rem", textAlign: "center" as const };
+
+  if (phase === "working") {
+    return (
+      <div style={container}>
+        <h1>Connecting…</h1>
+        <p style={{ opacity: 0.8 }}>Finishing sign-in and connecting this phone to your account.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={container}>
+      <h1>{phase === "denied" ? "Sign-in declined" : "Something went wrong"}</h1>
+      <p style={{ opacity: 0.8, marginBottom: "1.5rem" }}>{message}</p>
+      <button
+        type="button"
+        onClick={() => navigate("/signin", { replace: true })}
+        style={{ padding: "0.8rem 1.25rem", fontSize: "1rem", fontWeight: 600, borderRadius: 10, border: "none", cursor: "pointer" }}
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/mobile/src/auth/SignIn.tsx
+++ b/mobile/src/auth/SignIn.tsx
@@ -1,0 +1,54 @@
+// The mobile Sign in screen (issue #908). Shown by the auth gate whenever the phone has no device
+// key. Tapping "Sign in" sends the phone to devthrottle.com's /m-activate page, where the person signs
+// in with any provider (Google / GitHub / email) and approves this phone; the site hands the phone's
+// per-device key back to /m/device-callback, which enrolls it with the Gateway.
+import { getInstallId } from "./deviceKey";
+import { SITE_BASE, DEVICE_CALLBACK_PATH, detectPlatform, deviceName, newEnrollState } from "./enrollRequest";
+
+export function SignIn() {
+  function start() {
+    const installId = getInstallId();
+    const state = newEnrollState();
+    // The site returns here, to this Gateway's own origin. buildMobileCallbackUrl on the site only ever
+    // attaches the device key (never the account session), so this callback carries no account secret.
+    const redirectUri = window.location.origin + DEVICE_CALLBACK_PATH;
+
+    const url = new URL("/m-activate", SITE_BASE);
+    url.searchParams.set("redirect_uri", redirectUri);
+    url.searchParams.set("name", deviceName());
+    url.searchParams.set("install_id", installId);
+    url.searchParams.set("platform", detectPlatform());
+    url.searchParams.set("state", state);
+
+    window.location.assign(url.toString());
+  }
+
+  return (
+    <div className="signin-screen" style={{ maxWidth: 420, margin: "0 auto", padding: "2rem 1.25rem", textAlign: "center" }}>
+      <h1 style={{ marginBottom: "0.5rem" }}>DevThrottle</h1>
+      <p style={{ opacity: 0.8, marginBottom: "1.5rem" }}>
+        Sign in to connect this phone to your account. You will sign in on devthrottle.com and approve
+        this device; it stays signed in until you remove it from your account.
+      </p>
+      <button
+        type="button"
+        onClick={start}
+        style={{
+          display: "block",
+          width: "100%",
+          padding: "0.9rem 1rem",
+          fontSize: "1rem",
+          fontWeight: 600,
+          borderRadius: 10,
+          border: "none",
+          cursor: "pointer",
+        }}
+      >
+        Sign in
+      </button>
+      <p style={{ opacity: 0.6, fontSize: "0.85rem", marginTop: "1.25rem" }}>
+        You will be taken to devthrottle.com to sign in, then returned here.
+      </p>
+    </div>
+  );
+}

--- a/mobile/src/auth/deviceKey.ts
+++ b/mobile/src/auth/deviceKey.ts
@@ -1,0 +1,62 @@
+// The mobile app's own credential store (issue #908). The app no longer receives the master token
+// from the page (the shell carries no secret). Instead it holds a per-device key it obtained by
+// signing in on devthrottle.com and enrolling with the Gateway (POST /m/enroll). That key lives here,
+// in localStorage, scoped to this origin (the Gateway), and is sent as the Bearer on every API call.
+//
+// A stable install id is generated once and persisted. It is the SAME value the app sends to
+// devthrottle.com (install_id, when it registers the phone) and to the Gateway (deviceId, at enroll),
+// so the Gateway's local device record maps to the same cloud roster row - which is what lets a revoke
+// on the website propagate down and drop the local key.
+
+const DEVICE_KEY = "cc.deviceKey";
+const INSTALL_ID = "cc.installId";
+
+/** The stored per-device key, or "" when the phone has not enrolled yet. */
+export function getDeviceKey(): string {
+  try {
+    return localStorage.getItem(DEVICE_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+/** Store the per-device key issued by the Gateway at enrollment. */
+export function setDeviceKey(key: string): void {
+  try {
+    localStorage.setItem(DEVICE_KEY, key);
+  } catch {
+    /* storage unavailable (private mode) - the app will simply prompt to sign in again */
+  }
+}
+
+/** Forget the per-device key (sign out, or the key was revoked and the Gateway now rejects it). */
+export function clearDeviceKey(): void {
+  try {
+    localStorage.removeItem(DEVICE_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+/** True once the phone has enrolled and holds a per-device key. */
+export function hasDeviceKey(): boolean {
+  return getDeviceKey().length > 0;
+}
+
+/**
+ * The phone's stable, self-generated install id, created once and persisted. Used as install_id at
+ * devthrottle.com and as deviceId at /m/enroll so both sides map to one device. Falls back to a
+ * non-persisted id only if storage is unavailable (the flow still works for this session).
+ */
+export function getInstallId(): string {
+  try {
+    let id = localStorage.getItem(INSTALL_ID);
+    if (!id) {
+      id = crypto.randomUUID();
+      localStorage.setItem(INSTALL_ID, id);
+    }
+    return id;
+  } catch {
+    return crypto.randomUUID();
+  }
+}

--- a/mobile/src/auth/enrollRequest.ts
+++ b/mobile/src/auth/enrollRequest.ts
@@ -1,0 +1,52 @@
+// Shared helpers for building the device-enrollment request the app sends to devthrottle.com and for
+// verifying the round trip when it returns (issue #908).
+//
+// The base is devthrottle.com in production; a dev build can point at a local site with
+// VITE_DT_SITE_BASE (for example http://localhost:5173) so the flow can be exercised end to end
+// without the production site.
+
+export const SITE_BASE: string =
+  (import.meta.env.VITE_DT_SITE_BASE as string | undefined) || "https://devthrottle.com";
+
+// The path the site hands the device key back to. Must match the mobile router route and the site's
+// MOBILE_CALLBACK_PATH (website/src/lib/loopback.js).
+export const DEVICE_CALLBACK_PATH = "/m/device-callback";
+
+const STATE_KEY = "cc.enrollState";
+
+/** The phone platform, as the site's MobileActivate expects it ("android" | "ios"). */
+export function detectPlatform(): "android" | "ios" {
+  const ua = typeof navigator === "undefined" ? "" : navigator.userAgent || "";
+  return /iPhone|iPad|iPod/i.test(ua) ? "ios" : "android";
+}
+
+/** A short, non-identifying device label shown in the account's Devices list. */
+export function deviceName(): string {
+  return detectPlatform() === "ios" ? "iPhone" : "Android phone";
+}
+
+/** Mint a fresh anti-forgery state, persist it for the return leg, and return it. */
+export function newEnrollState(): string {
+  const state = crypto.randomUUID();
+  try {
+    sessionStorage.setItem(STATE_KEY, state);
+  } catch {
+    /* sessionStorage unavailable - the callback then skips the match (best-effort) */
+  }
+  return state;
+}
+
+/**
+ * Read and clear the state saved before the round trip. Returns null when none was saved (private
+ * mode, or storage cleared); the callback treats a null expected-state as "cannot verify, proceed"
+ * rather than blocking a legitimate sign-in.
+ */
+export function takeEnrollState(): string | null {
+  try {
+    const state = sessionStorage.getItem(STATE_KEY);
+    sessionStorage.removeItem(STATE_KEY);
+    return state;
+  } catch {
+    return null;
+  }
+}

--- a/mobile/src/main.tsx
+++ b/mobile/src/main.tsx
@@ -1,15 +1,26 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { createBrowserRouter, RouterProvider, Navigate, Outlet } from "react-router-dom";
 import { Home } from "./pages/Home";
 import { NewSession } from "./pages/NewSession";
 import { Terminal } from "./pages/Terminal";
 import { Chat } from "./pages/Chat";
 import { VoiceMode } from "./pages/VoiceMode";
 import { AiSettings } from "./pages/AiSettings";
+import { SignIn } from "./auth/SignIn";
+import { DeviceCallback } from "./auth/DeviceCallback";
+import { hasDeviceKey } from "./auth/deviceKey";
 import { ensureGatewayCookie } from "./api/client";
 import { ensurePushSubscribed } from "./push/register";
 import "./styles.css";
+
+// The auth gate (issue #908): every real screen requires an enrolled device key. Without one, the
+// phone is sent to Sign in. /signin and /device-callback sit OUTSIDE the gate so an unenrolled phone
+// can reach them. hasDeviceKey() is read at navigation time, so enrolling (or a 401-triggered
+// clear) re-gates on the next route.
+function RequireDeviceKey() {
+  return hasDeviceKey() ? <Outlet /> : <Navigate to="/signin" replace />;
+}
 
 // Mirror the injected per-machine token into the cc-gateway-token cookie at startup so the live
 // terminal WebSocket (which cannot carry an Authorization header) authenticates same-origin to the
@@ -26,13 +37,22 @@ void ensurePushSubscribed();
 // resolves it client-side.
 const router = createBrowserRouter(
   [
-    { path: "/", element: <Home /> },
-    { path: "/settings", element: <AiSettings /> },
-    { path: "/new", element: <NewSession /> },
-    { path: "/session/:sessionId", element: <Chat /> },
-    { path: "/session/:sessionId/chat", element: <Chat /> },
-    { path: "/session/:sessionId/terminal", element: <Terminal /> },
-    { path: "/session/:sessionId/voice", element: <VoiceMode /> },
+    // Ungated: reachable before the phone has enrolled.
+    { path: "/signin", element: <SignIn /> },
+    { path: "/device-callback", element: <DeviceCallback /> },
+    // Gated: everything real requires an enrolled device key.
+    {
+      element: <RequireDeviceKey />,
+      children: [
+        { path: "/", element: <Home /> },
+        { path: "/settings", element: <AiSettings /> },
+        { path: "/new", element: <NewSession /> },
+        { path: "/session/:sessionId", element: <Chat /> },
+        { path: "/session/:sessionId/chat", element: <Chat /> },
+        { path: "/session/:sessionId/terminal", element: <Terminal /> },
+        { path: "/session/:sessionId/voice", element: <VoiceMode /> },
+      ],
+    },
   ],
   { basename: "/m" }
 );

--- a/src/CcDirector.Core/Account/DeviceRegistryClient.cs
+++ b/src/CcDirector.Core/Account/DeviceRegistryClient.cs
@@ -98,6 +98,13 @@ public sealed class DeviceRegistryClient
     /// <summary>The path that advances this device's last-seen timestamp.</summary>
     public const string HeartbeatPath = "/api/v1/devices/heartbeat";
 
+    /// <summary>
+    /// The path that confirms a presented per-device key belongs to the caller's own account
+    /// (issue #908). Account-scoped: the cloud matches the key's hash against a non-revoked device
+    /// under the caller's member, so it never confirms another account's key.
+    /// </summary>
+    public const string VerifyPath = "/api/v1/devices/verify";
+
     private readonly HttpClient _client;
     private readonly string _baseUrl;
 
@@ -305,6 +312,61 @@ public sealed class DeviceRegistryClient
 
         response.EnsureSuccessStatusCode();
         return true;
+    }
+
+    /// <summary>
+    /// Confirms a presented per-device key belongs to the signed-in account via
+    /// <c>POST /api/v1/devices/verify</c>, returning the cloud device id when it does and null when it
+    /// does not (issue #908). This is how a Gateway admits a phone that enrolled on devthrottle.com and
+    /// received its per-device key, WITHOUT ever handling the account session: the phone hands the
+    /// Gateway only its device key, and the Gateway confirms - account-scoped, by key hash - that the key
+    /// is a live device on the Gateway's OWN account before issuing a local key. The verify is
+    /// account-scoped by the caller's Bearer, so a key belonging to a different account returns null (not
+    /// a match), and a masked-roster prefix/last-four compare is deliberately NOT used (too few bits to
+    /// resist a guess). Throws on a non-success response or a malformed body (an unreachable or erroring
+    /// cloud surfaces as a clear failure the caller handles, never a fabricated match). The device key is
+    /// sent only in the request body and is NEVER written to the log (security rule DT-05).
+    /// </summary>
+    /// <param name="accessToken">The Bearer access token the Gateway holds. Never logged.</param>
+    /// <param name="deviceKey">The presented per-device key to confirm. Never logged.</param>
+    /// <param name="ct">Cancels the request.</param>
+    public async Task<string?> VerifyDeviceKeyAsync(string accessToken, string deviceKey, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(accessToken))
+            throw new ArgumentException("Access token is required", nameof(accessToken));
+        if (string.IsNullOrWhiteSpace(deviceKey))
+            throw new ArgumentException("Device key is required", nameof(deviceKey));
+
+        var endpoint = $"{_baseUrl}{VerifyPath}";
+        FileLog.Write($"[DeviceRegistryClient] VerifyDeviceKeyAsync: POST {endpoint} (device key not logged)");
+
+        var body = new JsonObject { ["device_key"] = deviceKey };
+        using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+        {
+            Content = new StringContent(body.ToJsonString(), Encoding.UTF8, "application/json"),
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        using var response = await _client.SendAsync(request, ct).ConfigureAwait(false);
+        FileLog.Write($"[DeviceRegistryClient] VerifyDeviceKeyAsync: response status={(int)response.StatusCode}");
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        var data = DataObject(json, "device verify");
+
+        var valid = data.TryGetPropertyValue("valid", out var validNode)
+            && validNode is JsonValue validValue
+            && validValue.TryGetValue<bool>(out var b) && b;
+        if (!valid)
+        {
+            FileLog.Write("[DeviceRegistryClient] VerifyDeviceKeyAsync: key is not a live device on this account -> null");
+            return null;
+        }
+
+        var id = StringField(data, "id")
+            ?? throw new InvalidOperationException("device verify response had valid=true but no string 'data.id'");
+        FileLog.Write($"[DeviceRegistryClient] VerifyDeviceKeyAsync: verified device id={id}");
+        return id;
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway.Contracts/MobileEnrollmentRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/MobileEnrollmentRequest.cs
@@ -1,0 +1,43 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// The mobile app's request to enroll this phone with the Gateway (issue #908). The phone signed in
+/// on devthrottle.com, which registered it as a device on the account and returned its per-device key;
+/// the phone POSTs that key here to <c>/m/enroll</c>. The Gateway confirms (account-scoped) that the
+/// key belongs to its OWN signed-in account and, on a match, issues the phone a LOCAL device key it can
+/// validate offline. The account session is NEVER sent here - only the per-device key - so a worst-case
+/// leak costs one revocable device, not the account (the device-key-only hand-back decision).
+/// </summary>
+public sealed class MobileEnrollmentRequest
+{
+    /// <summary>
+    /// The per-device key the phone received from devthrottle.com (a <c>dtd_</c> account device key).
+    /// Verified against the Gateway's own account; never logged (security rule DT-05).
+    /// </summary>
+    public string DeviceKey { get; set; } = "";
+
+    /// <summary>
+    /// The phone's stable, self-generated device id. It MUST be the same value the phone used as its
+    /// install id when it registered on devthrottle.com, so the Gateway's local record maps to the same
+    /// cloud roster row (revoke-down and last-seen match on it).
+    /// </summary>
+    public string DeviceId { get; set; } = "";
+
+    /// <summary>A human-readable device name shown in the roster (for example the phone model). Optional.</summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>The phone's platform string ("android" / "ios"). Optional; a roster attribute only.</summary>
+    public string Platform { get; set; } = "";
+}
+
+/// <summary>
+/// The Gateway's response to a successful <see cref="MobileEnrollmentRequest"/> (issue #908): the LOCAL
+/// per-device key the phone stores and sends as its Bearer from then on. This is a
+/// Gateway-issued key (not the cloud <c>dtd_</c> key and not the master token), so the Gateway validates
+/// it offline and it is individually revocable.
+/// </summary>
+public sealed class MobileEnrollmentResponse
+{
+    /// <summary>The local, individually-revocable per-device key the phone uses as its Bearer.</summary>
+    public string DeviceKey { get; set; } = "";
+}

--- a/src/CcDirector.Gateway.Tests/Account/MobileDeviceEnrollmentTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/MobileDeviceEnrollmentTests.cs
@@ -1,0 +1,237 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json.Nodes;
+using CcDirector.Core.Account;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Account;
+using CcDirector.Gateway.Pairing;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Account;
+
+/// <summary>
+/// Proves the mobile device-enrollment bridge (issue #908) - the phone hands the Gateway ONLY its
+/// per-device key (never the account session), the Gateway confirms account-scoped that the key is a
+/// live device on its OWN account, and issues the phone a LOCAL device key it validates offline - end to
+/// end against an in-process STUB cloud (a real <see cref="DeviceRegistryClient"/> over a handler, no
+/// network). Covers: a valid on-account key issues a local key the Bearer check accepts and records the
+/// cloud id (so revoke-down can drop it); a not-signed-in Gateway cannot enroll; a key that is not on the
+/// account is rejected with no key issued; missing inputs are rejected; and the presented device key is
+/// never written to the log (DT-05). The Google/GitHub/email live sign-in that mints the key on
+/// devthrottle.com is the owner's QA gate; the stub stands in for the cloud verify.
+/// </summary>
+public sealed class MobileDeviceEnrollmentTests
+{
+    private const string PhoneId = "phone-guid-908";
+    private const string PhoneName = "Pixel 8";
+    private const string OnAccountKey = "dtd_live_ON_ACCOUNT_KEY_908";
+    private const string CloudId = "cloud-dev-908";
+
+    private sealed class InMemoryTokenStore : IProtectedTokenStore
+    {
+        private DevThrottleTokens? _tokens;
+        public bool HasTokens => _tokens is not null;
+        public void Save(DevThrottleTokens tokens) => _tokens = tokens;
+        public DevThrottleTokens? Load() => _tokens;
+        public void Clear() => _tokens = null;
+    }
+
+    /// <summary>
+    /// An in-process stub of the cloud device-verify endpoint. It answers POST /devices/verify with
+    /// valid=true + a cloud id for exactly the keys registered as "on this account", and valid=false for
+    /// anything else - the account-scoped hash match, modelled. Records the last Authorization header and
+    /// the verify call count so the tests can assert the Bearer was sent and the cloud was consulted.
+    /// </summary>
+    private sealed class StubCloudVerify : HttpMessageHandler
+    {
+        private readonly Dictionary<string, string> _onAccount; // device_key -> cloud id
+
+        public StubCloudVerify(Dictionary<string, string> onAccount) => _onAccount = onAccount;
+
+        public int VerifyCallCount { get; private set; }
+        public string? LastAuthorization { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastAuthorization = request.Headers.Authorization?.ToString();
+            var path = request.RequestUri?.AbsolutePath ?? string.Empty;
+
+            if (request.Method == HttpMethod.Post && path == DeviceRegistryClient.VerifyPath)
+            {
+                VerifyCallCount++;
+                var bodyText = request.Content is null ? "{}" : await request.Content.ReadAsStringAsync(cancellationToken);
+                var deviceKey = (string?)JsonNode.Parse(bodyText)?["device_key"] ?? "";
+                if (_onAccount.TryGetValue(deviceKey, out var cloudId))
+                    return Json(HttpStatusCode.OK, $"{{\"data\":{{\"valid\":true,\"id\":\"{cloudId}\"}}}}");
+                return Json(HttpStatusCode.OK, "{\"data\":{\"valid\":false}}");
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }
+
+        private static HttpResponseMessage Json(HttpStatusCode status, string body) =>
+            new(status) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+    }
+
+    private static DevThrottleAccountService MakeAccount(bool signedIn)
+    {
+        var previous = Environment.GetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar);
+        Environment.SetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar, GatewayTestJwt.SigningSecret);
+        try
+        {
+            var authEventsLog = Path.Combine(Path.GetTempPath(), "cc-gw-mobile-enroll-" + Guid.NewGuid().ToString("N") + ".jsonl");
+            var service = GatewayAccountFactory.Build(new InMemoryTokenStore(), authEventsLog);
+            if (signedIn)
+                service.StoreTokens(new DevThrottleTokens(GatewayTestJwt.Create(DateTime.UtcNow.AddHours(1)), "refresh-908"));
+            return service;
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar, previous);
+        }
+    }
+
+    private static DeviceRegistryClient ClientOver(StubCloudVerify stub) =>
+        new(new HttpClient(stub) { BaseAddress = new Uri("https://stub-cloud.invalid") }, baseUrl: "https://stub-cloud.invalid");
+
+    private static DeviceRegistry TempRegistry() =>
+        new(Path.Combine(Path.GetTempPath(), "cc-gw-mobile-enroll-" + Guid.NewGuid().ToString("N") + ".json"));
+
+    private static MobileDeviceEnrollmentService Service(DevThrottleAccountService? account, StubCloudVerify stub, DeviceRegistry devices) =>
+        new(account, ClientOver(stub), devices);
+
+    private static StubCloudVerify OnAccountStub() =>
+        new(new Dictionary<string, string>(StringComparer.Ordinal) { [OnAccountKey] = CloudId });
+
+    // A valid on-account key issues a local key the Bearer check accepts, records the cloud roster id (so
+    // the existing revoke-down sweep can drop it), and records the device as a phone.
+    [Fact]
+    public async Task Enroll_ValidOnAccountKey_IssuesLocalKey_AcceptedAsBearer_AndRecordsCloudId()
+    {
+        var account = MakeAccount(signedIn: true);
+        var stub = OnAccountStub();
+        var devices = TempRegistry();
+
+        var outcome = await Service(account, stub, devices).EnrollAsync(OnAccountKey, PhoneId, PhoneName, "android");
+
+        Assert.Equal(MobileEnrollmentOutcome.ResultKind.Ok, outcome.Kind);
+        Assert.False(string.IsNullOrEmpty(outcome.LocalDeviceKey));
+        Assert.Equal(1, stub.VerifyCallCount);
+        Assert.Contains("Bearer", stub.LastAuthorization ?? "", StringComparison.Ordinal);
+
+        // The issued key is a LOCAL key the AuthMiddleware Bearer check accepts...
+        Assert.True(devices.IsValidDeviceKey(outcome.LocalDeviceKey), "the issued local key must validate as a device key");
+        // ...and it is NOT the cloud key the phone presented (device-key-only: the Gateway swaps it).
+        Assert.NotEqual(OnAccountKey, outcome.LocalDeviceKey);
+        // ...and a random string does not validate.
+        Assert.False(devices.IsValidDeviceKey("not-a-real-key"));
+
+        var mapped = devices.MirrorSnapshot().Single(c => c.DeviceId == PhoneId);
+        Assert.Equal(CloudId, mapped.CloudDeviceId);
+        Assert.Equal(MobileDeviceEnrollmentService.PhoneDeviceType, mapped.DeviceType);
+        Assert.Equal("android", mapped.Platform);
+    }
+
+    // Not signed in: the Gateway has no account token to verify against, so it cannot enroll and it never
+    // touches the cloud or registers a device.
+    [Fact]
+    public async Task Enroll_GatewayNotSignedIn_NotSignedIn_NoCloudCall_NoDevice()
+    {
+        var account = MakeAccount(signedIn: false);
+        var stub = OnAccountStub();
+        var devices = TempRegistry();
+
+        var outcome = await Service(account, stub, devices).EnrollAsync(OnAccountKey, PhoneId, PhoneName, "android");
+
+        Assert.Equal(MobileEnrollmentOutcome.ResultKind.NotSignedIn, outcome.Kind);
+        Assert.Equal(0, stub.VerifyCallCount);
+        Assert.Equal(0, devices.Count);
+    }
+
+    // A null account service (a host with no credential service) is the same "cannot verify" outcome.
+    [Fact]
+    public async Task Enroll_NoAccountService_NotSignedIn()
+    {
+        var stub = OnAccountStub();
+        var devices = TempRegistry();
+
+        var outcome = await Service(null, stub, devices).EnrollAsync(OnAccountKey, PhoneId, PhoneName, "android");
+
+        Assert.Equal(MobileEnrollmentOutcome.ResultKind.NotSignedIn, outcome.Kind);
+        Assert.Equal(0, stub.VerifyCallCount);
+        Assert.Equal(0, devices.Count);
+    }
+
+    // A key that is not a live device on THIS account is rejected, and no local key is issued.
+    [Fact]
+    public async Task Enroll_KeyNotOnAccount_Rejected_NoDevice()
+    {
+        var account = MakeAccount(signedIn: true);
+        var stub = OnAccountStub();
+        var devices = TempRegistry();
+
+        var outcome = await Service(account, stub, devices).EnrollAsync("dtd_live_SOMEONE_ELSES_KEY", PhoneId, PhoneName, "android");
+
+        Assert.Equal(MobileEnrollmentOutcome.ResultKind.Rejected, outcome.Kind);
+        Assert.Equal(1, stub.VerifyCallCount);
+        Assert.Equal(0, devices.Count);
+    }
+
+    [Theory]
+    [InlineData(null, PhoneId)]
+    [InlineData("", PhoneId)]
+    [InlineData("   ", PhoneId)]
+    [InlineData(OnAccountKey, null)]
+    [InlineData(OnAccountKey, "")]
+    public async Task Enroll_MissingInputs_BadRequest_NoCloudCall(string? deviceKey, string? deviceId)
+    {
+        var account = MakeAccount(signedIn: true);
+        var stub = OnAccountStub();
+        var devices = TempRegistry();
+
+        var outcome = await Service(account, stub, devices).EnrollAsync(deviceKey, deviceId, PhoneName, "android");
+
+        Assert.Equal(MobileEnrollmentOutcome.ResultKind.BadRequest, outcome.Kind);
+        Assert.Equal(0, stub.VerifyCallCount);
+        Assert.Equal(0, devices.Count);
+    }
+
+    // DT-05: the presented device key and the issued local key never appear in the log.
+    [Fact]
+    public async Task Enroll_NeverLogsAnyDeviceKey()
+    {
+        var account = MakeAccount(signedIn: true);
+        var stub = OnAccountStub();
+        var devices = TempRegistry();
+        var service = Service(account, stub, devices);
+
+        MobileEnrollmentOutcome outcome;
+        IReadOnlyList<string> lines;
+        using (var scope = FileLog.RedirectForTests())
+        {
+            outcome = await service.EnrollAsync(OnAccountKey, PhoneId, PhoneName, "android");
+            lines = scope.DrainAndReadLines();
+        }
+
+        Assert.Equal(MobileEnrollmentOutcome.ResultKind.Ok, outcome.Kind);
+        Assert.DoesNotContain(lines, line => line.Contains(OnAccountKey, StringComparison.Ordinal));
+        Assert.DoesNotContain(lines, line => line.Contains(outcome.LocalDeviceKey!, StringComparison.Ordinal));
+    }
+
+    // The client-level verify contract: it sends the account Bearer, posts the device key, and maps
+    // valid=true -> the cloud id, valid=false -> null.
+    [Fact]
+    public async Task VerifyDeviceKeyAsync_ReturnsCloudId_WhenOnAccount_AndNull_WhenNot()
+    {
+        var stub = OnAccountStub();
+        var client = ClientOver(stub);
+
+        var hit = await client.VerifyDeviceKeyAsync("account-bearer-token", OnAccountKey);
+        var miss = await client.VerifyDeviceKeyAsync("account-bearer-token", "dtd_live_NOPE");
+
+        Assert.Equal(CloudId, hit);
+        Assert.Null(miss);
+        Assert.Contains("Bearer account-bearer-token", stub.LastAuthorization ?? "", StringComparison.Ordinal);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/Account/MobileEnrollRevokeRoundTripTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/MobileEnrollRevokeRoundTripTests.cs
@@ -1,0 +1,129 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json.Nodes;
+using CcDirector.Core.Account;
+using CcDirector.Gateway.Account;
+using CcDirector.Gateway.Pairing;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Account;
+
+/// <summary>
+/// Proves the mobile revoke round trip end to end at the Gateway (issue #908, slice 4): a phone that
+/// enrolled with a local device key loses that key when the device is revoked on the account's Devices
+/// page. Enrollment issues a LOCAL key that validates; after the cloud roster drops the device (a
+/// website revoke) and the Gateway's periodic reconcile sweep runs, the same local key no longer
+/// validates - so the next credentialed request 401s and the phone re-gates to Sign in. Runs against an
+/// in-process STUB cloud (a real <see cref="DeviceRegistryClient"/> over one handler serving verify +
+/// list + heartbeat, no network). The live website revoke is the owner's QA gate.
+/// </summary>
+public sealed class MobileEnrollRevokeRoundTripTests
+{
+    private const string CloudKey = "dtd_live_PHONE_KEY_908";
+    private const string CloudId = "cloud-dev-908";
+    private const string InstallId = "phone-install-908";
+
+    private sealed class InMemoryTokenStore : IProtectedTokenStore
+    {
+        private DevThrottleTokens? _tokens;
+        public bool HasTokens => _tokens is not null;
+        public void Save(DevThrottleTokens tokens) => _tokens = tokens;
+        public DevThrottleTokens? Load() => _tokens;
+        public void Clear() => _tokens = null;
+    }
+
+    /// <summary>
+    /// A stateful stub of the cloud device registry serving the three endpoints this round trip needs.
+    /// Flipping <see cref="Revoked"/> models a website revoke: verify stops matching, the device leaves
+    /// the GET /devices roster, and its heartbeat becomes 404 - the three signals the reconcile uses.
+    /// </summary>
+    private sealed class StubCloud : HttpMessageHandler
+    {
+        public bool Revoked { get; set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri?.AbsolutePath ?? string.Empty;
+            var method = request.Method;
+
+            if (method == HttpMethod.Post && path == DeviceRegistryClient.VerifyPath)
+            {
+                var body = request.Content is null ? "{}" : await request.Content.ReadAsStringAsync(cancellationToken);
+                var key = (string?)JsonNode.Parse(body)?["device_key"] ?? "";
+                if (!Revoked && key == CloudKey)
+                    return Json(HttpStatusCode.OK, $"{{\"data\":{{\"valid\":true,\"id\":\"{CloudId}\"}}}}");
+                return Json(HttpStatusCode.OK, "{\"data\":{\"valid\":false}}");
+            }
+
+            if (method == HttpMethod.Get && path == DeviceRegistryClient.DevicesPath)
+            {
+                var row = Revoked
+                    ? ""
+                    : $"{{\"id\":\"{CloudId}\",\"name\":\"Pixel\",\"platform\":\"android\",\"device_type\":\"phone\",\"key_prefix\":\"dtd_live\",\"key_last4\":\"ab12\"}}";
+                return Json(HttpStatusCode.OK, $"{{\"data\":[{row}]}}");
+            }
+
+            if (method == HttpMethod.Post && path == DeviceRegistryClient.HeartbeatPath)
+            {
+                var body = request.Content is null ? "{}" : await request.Content.ReadAsStringAsync(cancellationToken);
+                var installId = (string?)JsonNode.Parse(body)?["install_id"] ?? "";
+                if (!Revoked && installId == InstallId)
+                    return Json(HttpStatusCode.OK, "{\"data\":{\"recorded\":true}}");
+                return Json(HttpStatusCode.NotFound, "{\"error\":\"unknown install\"}");
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }
+
+        private static HttpResponseMessage Json(HttpStatusCode status, string body) =>
+            new(status) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+    }
+
+    private static DevThrottleAccountService MakeAccount()
+    {
+        var previous = Environment.GetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar);
+        Environment.SetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar, GatewayTestJwt.SigningSecret);
+        try
+        {
+            var authEventsLog = Path.Combine(Path.GetTempPath(), "cc-gw-revoke-" + Guid.NewGuid().ToString("N") + ".jsonl");
+            var service = GatewayAccountFactory.Build(new InMemoryTokenStore(), authEventsLog);
+            service.StoreTokens(new DevThrottleTokens(GatewayTestJwt.Create(DateTime.UtcNow.AddHours(1)), "refresh-908"));
+            return service;
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar, previous);
+        }
+    }
+
+    private static DeviceRegistryClient ClientOver(StubCloud stub) =>
+        new(new HttpClient(stub) { BaseAddress = new Uri("https://stub-cloud.invalid") }, baseUrl: "https://stub-cloud.invalid");
+
+    private static DeviceRegistry TempRegistry() =>
+        new(Path.Combine(Path.GetTempPath(), "cc-gw-revoke-" + Guid.NewGuid().ToString("N") + ".json"));
+
+    [Fact]
+    public async Task Enroll_then_website_revoke_drops_the_local_key()
+    {
+        var account = MakeAccount();
+        var stub = new StubCloud();
+        var devices = TempRegistry();
+
+        // Enroll: the phone hands over its cloud key and gets a local key that validates.
+        var enroll = new MobileDeviceEnrollmentService(account, ClientOver(stub), devices);
+        var outcome = await enroll.EnrollAsync(CloudKey, InstallId, "Pixel", "android");
+        Assert.Equal(MobileEnrollmentOutcome.ResultKind.Ok, outcome.Kind);
+        var localKey = outcome.LocalDeviceKey!;
+        Assert.True(devices.IsValidDeviceKey(localKey), "the issued local key validates right after enrollment");
+
+        // Revoke on the account's Devices page, then run the Gateway's periodic reconcile sweep.
+        stub.Revoked = true;
+        await new ChildDeviceMirrorService(account, ClientOver(stub), devices).ReconcileAsync();
+
+        // The local key no longer validates: a website revoke has ended this phone's access. The next
+        // /sessions call 401s, and the app clears the key and returns to Sign in (client.ts onUnauthorized).
+        Assert.False(devices.IsValidDeviceKey(localKey), "after the account revoke + reconcile, the local key is dropped");
+        Assert.Equal(0, devices.Count);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/AuthMiddlewareTests.cs
+++ b/src/CcDirector.Gateway.Tests/AuthMiddlewareTests.cs
@@ -1,0 +1,73 @@
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Util;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Proves the AuthMiddleware credential check accepts a per-device key on BOTH the Bearer header and
+/// the cookie (issue #908). The cookie path matters because a browser WebSocket - the live terminal
+/// stream - cannot set an Authorization header, so a phone authenticated by its own device key must be
+/// able to open the stream via the cookie exactly as it calls the Bearer-authenticated endpoints.
+/// </summary>
+public sealed class AuthMiddlewareTests
+{
+    private const string SharedToken = "shared-machine-token";
+
+    private static DeviceRegistry TempRegistry() =>
+        new(Path.Combine(Path.GetTempPath(), "cc-authmw-" + Guid.NewGuid().ToString("N") + ".json"));
+
+    private static HttpContext WithCookie(string value)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Headers["Cookie"] = $"{AuthMiddleware.CookieName}={value}";
+        return ctx;
+    }
+
+    private static HttpContext WithBearer(string value)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Headers["Authorization"] = $"Bearer {value}";
+        return ctx;
+    }
+
+    [Fact]
+    public void Cookie_with_a_valid_device_key_is_accepted()
+    {
+        var devices = TempRegistry();
+        var key = devices.Register("phone-1", "PHONE").DeviceKey;
+        Assert.True(AuthMiddleware.HasValidToken(WithCookie(key), SharedToken, devices));
+    }
+
+    [Fact]
+    public void Cookie_with_the_shared_token_is_still_accepted()
+    {
+        var devices = TempRegistry();
+        Assert.True(AuthMiddleware.HasValidToken(WithCookie(SharedToken), SharedToken, devices));
+    }
+
+    [Fact]
+    public void Cookie_with_an_unknown_value_is_rejected()
+    {
+        var devices = TempRegistry();
+        Assert.False(AuthMiddleware.HasValidToken(WithCookie("not-a-real-key"), SharedToken, devices));
+    }
+
+    [Fact]
+    public void Cookie_device_key_is_rejected_when_no_device_registry_is_configured()
+    {
+        var devices = TempRegistry();
+        var key = devices.Register("phone-2", "PHONE").DeviceKey;
+        // A null registry disables per-device-key auth, so the same cookie no longer validates.
+        Assert.False(AuthMiddleware.HasValidToken(WithCookie(key), SharedToken, null));
+    }
+
+    [Fact]
+    public void Bearer_with_a_valid_device_key_is_accepted()
+    {
+        var devices = TempRegistry();
+        var key = devices.Register("phone-3", "PHONE").DeviceKey;
+        Assert.True(AuthMiddleware.HasValidToken(WithBearer(key), SharedToken, devices));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/GatewayAuthToggleTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayAuthToggleTests.cs
@@ -1,0 +1,64 @@
+using CcDirector.Gateway;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Proves the host-wide auth gate can be turned on without a code change via the CC_GATEWAY_AUTH
+/// environment opt-in (issue #908), while the shipped default stays off (the tailnet is the boundary
+/// until an operator opts in). The actual enforcement it unlocks - /sessions answering 401 without a
+/// credential when auth is on - is proven separately by MobileAuthServingTests.
+/// </summary>
+public sealed class GatewayAuthToggleTests
+{
+    [Fact]
+    public void Explicit_flag_enables_regardless_of_env()
+    {
+        Assert.True(GatewayHost.ResolveAuthEnabled(true));
+    }
+
+    [Fact]
+    public void Env_opt_in_enables_when_the_flag_is_off()
+    {
+        var previous = Environment.GetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar, "1");
+            Assert.True(GatewayHost.ResolveAuthEnabled(false));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar, previous);
+        }
+    }
+
+    [Fact]
+    public void Default_is_off_without_the_flag_or_env()
+    {
+        var previous = Environment.GetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar, null);
+            Assert.False(GatewayHost.ResolveAuthEnabled(false));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar, previous);
+        }
+    }
+
+    [Fact]
+    public void Env_value_other_than_1_does_not_enable()
+    {
+        var previous = Environment.GetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar, "true");
+            Assert.False(GatewayHost.ResolveAuthEnabled(false));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar, previous);
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Account/MobileDeviceEnrollmentService.cs
+++ b/src/CcDirector.Gateway/Account/MobileDeviceEnrollmentService.cs
@@ -1,0 +1,152 @@
+using CcDirector.Core.Account;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Pairing;
+
+namespace CcDirector.Gateway.Account;
+
+/// <summary>
+/// Enrolls a phone with this Gateway from a per-device key the phone obtained by signing in on
+/// devthrottle.com (issue #908). This is the bridge that lets the mobile app authenticate to the local
+/// Gateway WITHOUT the Gateway ever handing the browser the master token, and WITHOUT the cloud sitting
+/// in the request path:
+///
+/// <list type="number">
+/// <item>The phone signs in on devthrottle.com, which registers it as a device on the account and
+/// returns its per-device (<c>dtd_</c>) key. Only that key is handed back to the phone - never the
+/// account session (the device-key-only decision), so a worst-case leak costs one revocable device.</item>
+/// <item>The phone POSTs the key here. This service confirms, ACCOUNT-SCOPED, that the key is a live
+/// device on the Gateway's OWN signed-in account (<see cref="DeviceRegistryClient.VerifyDeviceKeyAsync"/>,
+/// a hash match under the Gateway's member - not a masked prefix/last-four compare, which has too few
+/// bits to resist a guess).</item>
+/// <item>On a match it issues the phone a LOCAL device key (<see cref="DeviceRegistry"/>) the Gateway
+/// validates offline on every later request, and records the cloud roster id against it so the existing
+/// Path B revoke-down sweep (<see cref="ChildDeviceMirrorService"/>) drops the local key when the device
+/// is revoked from "Your devices".</item>
+/// </list>
+///
+/// The verify is the ONLY cloud touch on the enrollment path; every request the phone makes afterward is
+/// validated locally. The device key and the account token are never written to the log (security rule
+/// DT-05). This type holds no try/catch: a cloud failure from the verify propagates to the endpoint
+/// boundary, which is the single place that translates it to an error response.
+/// </summary>
+public sealed class MobileDeviceEnrollmentService
+{
+    /// <summary>The device type recorded for an enrolled phone (a roster attribute, never a credential).</summary>
+    public const string PhoneDeviceType = "phone";
+
+    private readonly DevThrottleAccountService? _account;
+    private readonly DeviceRegistryClient _cloud;
+    private readonly DeviceRegistry _devices;
+
+    /// <summary>
+    /// Creates the enrollment service.
+    /// </summary>
+    /// <param name="account">
+    /// The Gateway-hosted account credential service, whose access token authorizes the account-scoped
+    /// verify. Null on a host with no credential service (a non-Windows host); enrollment then reports an
+    /// explicit "not signed in" outcome rather than proceeding.
+    /// </param>
+    /// <param name="cloud">The cloud device-registry client (the injectable egress seam). Required.</param>
+    /// <param name="devices">The Gateway's local device registry that issues and validates the local key. Required.</param>
+    public MobileDeviceEnrollmentService(DevThrottleAccountService? account, DeviceRegistryClient cloud, DeviceRegistry devices)
+    {
+        _account = account;
+        _cloud = cloud ?? throw new ArgumentNullException(nameof(cloud));
+        _devices = devices ?? throw new ArgumentNullException(nameof(devices));
+    }
+
+    /// <summary>
+    /// Enrolls the phone from its per-device key. Returns a <see cref="MobileEnrollmentOutcome"/> the
+    /// endpoint maps to an HTTP status: <c>BadRequest</c> for missing inputs, <c>NotSignedIn</c> when the
+    /// Gateway holds no account credential to verify against, <c>Rejected</c> when the key is not a live
+    /// device on this Gateway's account, and <c>Ok</c> (carrying the issued local key) on success. A cloud
+    /// failure during verify is NOT caught here - it propagates to the endpoint boundary.
+    /// </summary>
+    public async Task<MobileEnrollmentOutcome> EnrollAsync(
+        string? deviceKey, string? deviceId, string? name, string? platform, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(deviceKey))
+            return MobileEnrollmentOutcome.BadRequest("deviceKey is required");
+        if (string.IsNullOrWhiteSpace(deviceId))
+            return MobileEnrollmentOutcome.BadRequest("deviceId is required");
+
+        var token = _account?.GetAccessTokenForForwarding();
+        if (string.IsNullOrEmpty(token))
+        {
+            FileLog.Write($"[MobileDeviceEnrollmentService] EnrollAsync: Gateway not signed in -> cannot verify device key for deviceId={deviceId}");
+            return MobileEnrollmentOutcome.NotSignedIn();
+        }
+
+        var cloudDeviceId = await _cloud.VerifyDeviceKeyAsync(token, deviceKey, ct).ConfigureAwait(false);
+        if (cloudDeviceId is null)
+        {
+            FileLog.Write($"[MobileDeviceEnrollmentService] EnrollAsync: device key is not a live device on this Gateway's account -> rejected (deviceId={deviceId})");
+            return MobileEnrollmentOutcome.Rejected();
+        }
+
+        var displayName = string.IsNullOrWhiteSpace(name) ? deviceId!.Trim() : name!.Trim();
+        var registration = _devices.Register(deviceId!.Trim(), displayName, platform, PhoneDeviceType);
+        // Map the local device to its cloud roster row so the existing Path B revoke-down sweep drops the
+        // local key when the phone is revoked from "Your devices" (the cloud row is the source of the revoke).
+        _devices.SetCloudDeviceId(deviceId!.Trim(), cloudDeviceId);
+
+        FileLog.Write($"[MobileDeviceEnrollmentService] EnrollAsync: enrolled phone deviceId={deviceId}, cloud id={cloudDeviceId} -> issued a local device key (key not logged)");
+        return MobileEnrollmentOutcome.Ok(registration.DeviceKey);
+    }
+}
+
+/// <summary>
+/// The result of <see cref="MobileDeviceEnrollmentService.EnrollAsync"/>: a small tagged outcome the
+/// endpoint boundary maps to an HTTP status. The issued local key is present only on <see cref="Kind"/>
+/// == <see cref="ResultKind.Ok"/>; the message is a user-safe reason on the failure kinds.
+/// </summary>
+public sealed class MobileEnrollmentOutcome
+{
+    /// <summary>The kind of outcome, mapped by the endpoint to an HTTP status.</summary>
+    public enum ResultKind
+    {
+        /// <summary>Enrolled; <see cref="LocalDeviceKey"/> carries the issued local key.</summary>
+        Ok,
+
+        /// <summary>A required input was missing or blank (maps to 400).</summary>
+        BadRequest,
+
+        /// <summary>The Gateway holds no account credential to verify against (maps to 409).</summary>
+        NotSignedIn,
+
+        /// <summary>The key is not a live device on this Gateway's account (maps to 403).</summary>
+        Rejected,
+    }
+
+    private MobileEnrollmentOutcome(ResultKind kind, string? localDeviceKey, string? message)
+    {
+        Kind = kind;
+        LocalDeviceKey = localDeviceKey;
+        Message = message;
+    }
+
+    /// <summary>The outcome kind.</summary>
+    public ResultKind Kind { get; }
+
+    /// <summary>The issued local per-device key, present only when <see cref="Kind"/> is <see cref="ResultKind.Ok"/>.</summary>
+    public string? LocalDeviceKey { get; }
+
+    /// <summary>A user-safe reason on a failure kind, or null on success.</summary>
+    public string? Message { get; }
+
+    /// <summary>Enrolled: carries the issued local per-device key.</summary>
+    public static MobileEnrollmentOutcome Ok(string localDeviceKey) => new(ResultKind.Ok, localDeviceKey, null);
+
+    /// <summary>A required input was missing or blank.</summary>
+    public static MobileEnrollmentOutcome BadRequest(string message) => new(ResultKind.BadRequest, null, message);
+
+    /// <summary>The Gateway is not signed in, so it cannot verify the device key.</summary>
+    public static MobileEnrollmentOutcome NotSignedIn() => new(
+        ResultKind.NotSignedIn, null,
+        "This Gateway is not signed in to a DevThrottle account, so it cannot enroll a device. Sign the Gateway in and try again.");
+
+    /// <summary>The device key is not a live device on this Gateway's account.</summary>
+    public static MobileEnrollmentOutcome Rejected() => new(
+        ResultKind.Rejected, null,
+        "This device is not registered to this Gateway's account. Sign in on devthrottle.com with the same account this Gateway uses, then try again.");
+}

--- a/src/CcDirector.Gateway/Api/MobileEnrollmentEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/MobileEnrollmentEndpoint.cs
@@ -1,0 +1,64 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Account;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// Mobile device enrollment (issue #908): <c>POST /m/enroll</c>. This is how the mobile app stops
+/// receiving the master token. The phone signs in on devthrottle.com, is registered as a device on the
+/// account, and receives its per-device key; it POSTs that key here, and the Gateway confirms
+/// (account-scoped) the key belongs to its OWN signed-in account and issues the phone a LOCAL device key
+/// it validates offline. The account session is never sent here - only the per-device key.
+///
+/// The route lives under <c>/m/</c>, which the auth middleware lets through without the host-wide token
+/// (the mobile shell must load before the phone has any credential). Like <c>/devices/register</c>, it
+/// carries its OWN authorization - the account-scoped device key - so opening the route does not weaken
+/// the trust model: a call with no valid device key on this account is answered 403 with no key issued.
+///
+/// The device key is never written to the log (security rule DT-05); only the device id and platform are.
+/// This endpoint delegate is the boundary, so it owns the single try/catch: a cloud failure during the
+/// verify becomes a clear 502, never a fabricated success.
+/// </summary>
+internal static class MobileEnrollmentEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app, MobileDeviceEnrollmentService service)
+    {
+        if (service is null) throw new ArgumentNullException(nameof(service));
+
+        app.MapPost("/m/enroll", async (MobileEnrollmentRequest? req, HttpContext ctx) =>
+        {
+            try
+            {
+                FileLog.Write($"[MobileEnrollment] POST /m/enroll: deviceId={req?.DeviceId}, platform={req?.Platform} (device key not logged)");
+
+                var outcome = await service
+                    .EnrollAsync(req?.DeviceKey, req?.DeviceId, req?.Name, req?.Platform, ctx.RequestAborted)
+                    .ConfigureAwait(false);
+
+                return outcome.Kind switch
+                {
+                    MobileEnrollmentOutcome.ResultKind.Ok =>
+                        Results.Json(new MobileEnrollmentResponse { DeviceKey = outcome.LocalDeviceKey ?? "" }),
+                    MobileEnrollmentOutcome.ResultKind.BadRequest =>
+                        Results.BadRequest(new { error = outcome.Message }),
+                    MobileEnrollmentOutcome.ResultKind.NotSignedIn =>
+                        Results.Json(new { error = outcome.Message }, statusCode: StatusCodes.Status409Conflict),
+                    MobileEnrollmentOutcome.ResultKind.Rejected =>
+                        Results.Json(new { error = outcome.Message }, statusCode: StatusCodes.Status403Forbidden),
+                    _ => Results.StatusCode(StatusCodes.Status500InternalServerError),
+                };
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[MobileEnrollment] POST /m/enroll FAILED: {ex.Message}");
+                return Results.Json(
+                    new { error = "Could not reach the DevThrottle account service to enroll this device. Try again shortly." },
+                    statusCode: StatusCodes.Status502BadGateway);
+            }
+        });
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -35,6 +35,24 @@ public sealed class GatewayHost : IAsyncDisposable
     public bool AuthEnabled { get; }
 
     /// <summary>
+    /// Environment opt-in that turns the host-wide auth gate ON for a Gateway that would otherwise
+    /// default to off (issue #908). Set <c>CC_GATEWAY_AUTH=1</c> so reaching the Gateway on the tailnet
+    /// is no longer sufficient - a request must present the shared token or a per-device key. This
+    /// mirrors the <c>CC_GATEWAY_NO_TAILSCALE</c> env-toggle precedent and keeps the shipped default
+    /// unchanged (off) so no install starts requiring credentials without an explicit opt-in.
+    /// </summary>
+    public const string AuthEnabledEnvVar = "CC_GATEWAY_AUTH";
+
+    /// <summary>
+    /// Resolves whether the host-wide auth gate runs: the explicit constructor flag OR the
+    /// <see cref="AuthEnabledEnvVar"/> environment opt-in. Pure and side-effect free so it is unit-tested
+    /// directly.
+    /// </summary>
+    internal static bool ResolveAuthEnabled(bool explicitlyEnabled) =>
+        explicitlyEnabled
+        || string.Equals(Environment.GetEnvironmentVariable(AuthEnabledEnvVar), "1", StringComparison.Ordinal);
+
+    /// <summary>
     /// Issue #469: mints and verifies the short-lived 4-digit pairing code that authorizes a new
     /// device to enroll. The GatewayApp host window drives this in-process (it mints the code,
     /// shows it locally, and polls the device registry for the join); the /devices/register
@@ -257,7 +275,9 @@ public sealed class GatewayHost : IAsyncDisposable
         Token = token ?? GatewayAuth.LoadOrCreate();
         Registry = new DirectorRegistry(instancesDirectory);
         Devices = new Pairing.DeviceRegistry(devicesPath);
-        AuthEnabled = authEnabled;
+        AuthEnabled = ResolveAuthEnabled(authEnabled);
+        if (AuthEnabled && !authEnabled)
+            FileLog.Write($"[GatewayHost] {AuthEnabledEnvVar}=1 -> host-wide auth gate ENABLED (a per-device key or the shared token is now required, even on the tailnet)");
         _client = new DirectorEndpointClient(Token);
         _cockpitProxyPort = cockpitProxyPort ?? Cockpit.CockpitSupervisor.ResolvePort();
         _serveProvisioner = new TailscaleServeProvisioner(Registry, Port, Cockpit.CockpitSupervisor.ResolvePort());
@@ -1011,6 +1031,16 @@ public sealed class GatewayHost : IAsyncDisposable
         // Cockpit catch-all so these explicit routes win.
         Api.WebPushEndpoints.Map(_app, _vapidStore.PublicKey, _pushSubscriptions,
             onSubscribed: () => _pushNotifier?.ResetDedupe());
+
+        // Mobile device enrollment (issue #908): POST /m/enroll. A phone that signed in on
+        // devthrottle.com and received its per-device key hands that key here; the Gateway confirms
+        // (account-scoped, by key hash) that the key belongs to its OWN signed-in account and issues the
+        // phone a LOCAL device key it validates offline - so the master token is no longer injected into
+        // the mobile shell. Under /m/ so it is reachable before the phone holds any credential; it carries
+        // its own authorization (the account-scoped device key), exactly like /devices/register. Mapped
+        // before the mobile shell so the explicit POST route wins over the shell's GET catch-all.
+        var mobileEnrollmentClient = new Core.Account.DeviceRegistryClient(new HttpClient { Timeout = TimeSpan.FromSeconds(10) });
+        Api.MobileEnrollmentEndpoint.Map(_app, new Account.MobileDeviceEnrollmentService(Account, mobileEnrollmentClient, Devices));
 
         Mobile.MobileApp.Map(_app, Token);
 

--- a/src/CcDirector.Gateway/Mobile/MobileApp.cs
+++ b/src/CcDirector.Gateway/Mobile/MobileApp.cs
@@ -112,9 +112,17 @@ public static class MobileApp
             return;
         }
 
+        // Issue #908: the shell is served AS-IS - the per-machine master token is NO LONGER injected.
+        // The app has no credential until the phone signs in on devthrottle.com and enrolls (POST
+        // /m/enroll), which returns a per-device key the app stores and sends itself. So reaching /m
+        // hands out nothing; the gatewayToken parameter is retained only for backward compatibility with
+        // the Map() signature and is deliberately unused. A defensive replace still strips the old
+        // placeholder to an empty string in case a stale index.html (from a prior build) still carries it,
+        // so a literal "__GATEWAY_TOKEN__" never reaches the browser.
+        _ = gatewayToken;
         var template = await File.ReadAllTextAsync(indexPath);
-        var html = template.Replace(TokenPlaceholder, gatewayToken);
-        // The shell carries the per-machine token, so it must never be cached by a shared cache.
+        var html = template.Replace(TokenPlaceholder, string.Empty);
+        // The shell no longer carries a secret, but it still must revalidate so an updated app is picked up.
         ctx.Response.Headers.CacheControl = "no-cache";
         ctx.Response.ContentType = "text/html; charset=utf-8";
         await ctx.Response.WriteAsync(html);

--- a/src/CcDirector.Gateway/Util/AuthMiddleware.cs
+++ b/src/CcDirector.Gateway/Util/AuthMiddleware.cs
@@ -36,11 +36,13 @@ internal static class AuthMiddleware
 
         if (PublicPaths.Contains(path)) { await next(); return; }
 
-        // Issue #806: the mobile app shell (/m and its built assets) carries no secret - the
-        // per-machine token is injected into its index.html and the app then authenticates its
-        // OWN API calls (e.g. /sessions) with that Bearer. Letting the shell load without the
-        // global gate is what makes the page render whether global Gateway auth is on or off,
-        // while the data endpoints stay token-gated.
+        // Issue #806 / #908: the mobile app shell (/m and its built assets) carries no secret. It must
+        // load without the global gate so the Sign in screen can render before the phone has any
+        // credential; the phone then enrolls (POST /m/enroll, itself under /m/ and carrying its own
+        // authorization - an account-scoped device key) and authenticates its OWN API calls (e.g.
+        // /sessions) with the per-device key it receives. The master token is no longer injected into
+        // the shell (issue #908), so reaching /m grants no access on its own - the data endpoints stay
+        // Bearer/cookie-gated on that per-device key.
         if (string.Equals(path, "/m", StringComparison.OrdinalIgnoreCase)
             || path.StartsWith("/m/", StringComparison.OrdinalIgnoreCase))
         {
@@ -98,9 +100,19 @@ internal static class AuthMiddleware
             }
         }
 
-        // Cookie
-        return ctx.Request.Cookies.TryGetValue(CookieName, out var cookieValue) &&
-               string.Equals(cookieValue, token, StringComparison.Ordinal);
+        // Cookie. A browser WebSocket cannot set an Authorization header, so the live terminal stream
+        // authenticates via this cookie. It accepts the shared machine token OR, per issue #908, an
+        // active per-device key - so a phone that enrolled with its own device key (and mirrors that key
+        // into the cookie) can open the stream, exactly as it can call the Bearer-authenticated endpoints.
+        if (ctx.Request.Cookies.TryGetValue(CookieName, out var cookieValue))
+        {
+            if (string.Equals(cookieValue, token, StringComparison.Ordinal))
+                return true;
+            if (devices is not null && devices.IsValidDeviceKey(cookieValue))
+                return true;
+        }
+
+        return false;
     }
 
     public sealed class RequireToken


### PR DESCRIPTION
## What this does

Closes the mobile app's biggest security gap (issue thefrederiksen/devthrottle_internal#658): the Progressive Web App at `/m` was served
the **master Gateway token** injected into a public page, so reaching the URL (or viewing page source)
meant permanent, unrevocable control of the whole fleet.

Now the phone signs in on devthrottle.com, is registered as a device on the account, and receives a
**per-device key**. The Gateway confirms that key belongs to its **own** account (account-scoped) and
exchanges it for a **local** device key it validates offline. The account session never touches the
Gateway, and reaching `/m` grants nothing on its own.

Design: `docs/architecture/mobile/MOBILE_DEVICE_AUTH.md`. The devthrottle.com side is a companion PR on
`devthrottle_internal`.

## Changes

**Gateway**
- `POST /m/enroll` + `MobileDeviceEnrollmentService`: verify the presented device key against this
  Gateway's account, issue a local key, and record the cloud id so the existing revoke-down sweep drops
  it when the device is removed from "Your devices".
- `DeviceRegistryClient.VerifyDeviceKeyAsync` -> account-scoped `POST /api/v1/devices/verify` (full-key
  hash match, not a masked prefix/last-four compare).
- `MobileApp` no longer injects the master token into the shell; the placeholder is gone.
- `AuthMiddleware` cookie path now accepts an active per-device key, so the terminal WebSocket (which
  cannot set an Authorization header) works under device-key auth.
- `CC_GATEWAY_AUTH=1` env opt-in turns the host-wide auth gate on without a code change; the shipped
  default stays off.

**Mobile app**
- Sign in screen, `/m/device-callback` handler (reads the key from the URL fragment), a device-key
  store, and a client that authenticates with the per-device key and returns to Sign in on a 401.

## Verification

- Full Gateway test suite passes (1188/1188), including new tests for enrollment, the revoke round
  trip, the auth-middleware cookie/Bearer device key, and the auth toggle.
- Mobile `tsc --noEmit` clean + `vite build` succeeds.

## Live QA gates (not self-certifiable here)

- Deploy the `devthrottle_internal` companion (`/m-activate`, `/api/v1/devices/verify`).
- Add `https://devthrottle.com/m-activate` to the Supabase Auth redirect allow-list (unless a
  `devthrottle.com/**` wildcard already covers it).
- Sign in on a phone with all three providers (Google / GitHub / email) end to end.
- If enabling `CC_GATEWAY_AUTH=1`: restart the Gateway and smoke-test the Cockpit login, the cc-* tools,
  the native app, and Director connectivity - the Gateway has never run auth-on in production.

## Migration note

Existing `/m` users will see the Sign in screen once and re-enroll (the master token is gone) - intended.

Generated with Claude Code (https://claude.com/claude-code)
