### PR TITLE
feat: lock the desktop compose surface while a session is transcribing

### DIFF
--- a/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml.cs
@@ -56,6 +56,9 @@ public partial class SessionActionBar : UserControl
         BtnInterrupt.IsVisible = caps.HasFlag(DriverCapabilities.Interrupt);
         BtnClearContext.IsVisible = caps.HasFlag(DriverCapabilities.ClearContext);
         BtnHistory.IsVisible = caps.HasFlag(DriverCapabilities.History);
+        // A session switch clears any transcribing lock left over from the outgoing session; the
+        // caller re-applies the incoming session's state right after Configure.
+        SetTranscribingLock(false);
         ActionStatus.Text = "";
 
         // Context gauge: capability-gated, polled while this session is the active one.
@@ -68,6 +71,18 @@ public partial class SessionActionBar : UserControl
             RefreshContextGauge();      // immediate first read so the gauge is not blank for ~4s
             _contextTimer.Start();
         }
+    }
+
+    /// <summary>
+    /// Lock the non-safety actions while the active session is transcribing a dictated utterance in
+    /// the background (the Speak-Send fire-and-forget window). Clear context and History are disabled
+    /// so the operator cannot mutate a session that is about to receive its dictated prompt. Stop and
+    /// Interrupt stay live on purpose - the brakes are never taken away, even mid-transcription.
+    /// </summary>
+    public void SetTranscribingLock(bool locked)
+    {
+        BtnClearContext.IsEnabled = !locked;
+        BtnHistory.IsEnabled = !locked;
     }
 
     /// <summary>Timer-callback boundary (and the immediate kick from <see cref="Configure"/>):

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -1754,6 +1754,7 @@ public partial class MainWindow : Window
             _activeSession.Session.OnActivityStateChanged -= OnActiveSessionActivityChanged;
             _activeSession.Session.OnPendingPromptTextChanged -= OnActiveSessionPendingPromptTextChanged;
             _activeSession.Session.OnCachedExplainChanged -= OnActiveSessionCachedExplainChanged;
+            _activeSession.Session.OnIsTranscribingChanged -= OnActiveSessionTranscribingChanged;
             TerminalHost.Detach();
             GitChangesView.Detach();
             CleanView.Detach();
@@ -1794,6 +1795,9 @@ public partial class MainWindow : Window
         // Re-render the Wingman tab whenever ProactiveExplainService stores a fresh
         // briefing on this session. The tab is a passive viewer of CachedExplainText.
         vm.Session.OnCachedExplainChanged += OnActiveSessionCachedExplainChanged;
+        // Lock the compose surface while this session is transcribing a dictated utterance in the
+        // background, so a second Speak/Send/Queue cannot fire into a session mid-transcribe.
+        vm.Session.OnIsTranscribingChanged += OnActiveSessionTranscribingChanged;
 
         // Update header
         SetSessionHeaderVisible(true);
@@ -1860,6 +1864,10 @@ public partial class MainWindow : Window
         // Refresh right panel for new session
         RefreshQueuePanel();
 
+        // Apply the incoming session's transcribing lock (usually unlocked; locked if you switch to a
+        // session that is still transcribing a dictated utterance in the background).
+        ApplyComposeLock(vm.Session.IsTranscribing);
+
         // Persist session state (debounced)
         PersistSessionState();
 
@@ -1875,6 +1883,39 @@ public partial class MainWindow : Window
     private void OnActiveSessionMetadataChanged(ClaudeSessionMetadata? metadata)
     {
         Dispatcher.UIThread.Post(UpdateSessionHeader);
+    }
+
+    /// <summary>True while the on-screen session is transcribing a dictated utterance in the
+    /// background (the Speak-Send fire-and-forget window). The compose actions and their keyboard
+    /// shortcuts no-op during this brief window so a second action cannot race the dictated prompt.</summary>
+    private bool IsActiveSessionTranscribing() => _activeSession?.Session.IsTranscribing == true;
+
+    /// <summary>Fires (possibly off the UI thread) when the active session's transcribing flag flips.
+    /// Marshals to the UI thread and locks or unlocks the compose surface.</summary>
+    private void OnActiveSessionTranscribingChanged(bool isTranscribing)
+    {
+        Dispatcher.UIThread.Post(() => ApplyComposeLock(isTranscribing));
+    }
+
+    /// <summary>
+    /// Lock (or unlock) the prompt-bar compose surface for the active session. While a dictated
+    /// utterance transcribes and submits in the background, the input box, Send, Speak, Queue,
+    /// Explain and Handover are disabled, and the action bar's Clear context / History are disabled
+    /// via <see cref="Controls.SessionActionBar.SetTranscribingLock"/> - Stop and Interrupt stay live.
+    /// The keyboard shortcuts (Ctrl+H / Ctrl+Enter / Ctrl+Shift+Enter) are guarded separately by
+    /// <see cref="IsActiveSessionTranscribing"/> so they no-op too. Unlocks automatically when the
+    /// background send clears the flag.
+    /// </summary>
+    private void ApplyComposeLock(bool locked)
+    {
+        PromptInput.IsEnabled = !locked;
+        BtnSend.IsEnabled = !locked;
+        BtnSpeak.IsEnabled = !locked;
+        BtnQueuePrompt.IsEnabled = !locked;
+        BtnExplain.IsEnabled = !locked;
+        BtnHandover.IsEnabled = !locked;
+        ActionBar.SetTranscribingLock(locked);
+        FileLog.Write($"[MainWindow] ApplyComposeLock: locked={locked}");
     }
 
     private void OnActiveSessionActivityChanged(ActivityState oldState, ActivityState newState)
@@ -2843,6 +2884,14 @@ public partial class MainWindow : Window
                 FileLog.Write("[MainWindow] Ctrl+H ignored: prompt bar not visible");
                 return;
             }
+            // Locked while the session transcribes a dictated utterance in the background: swallow the
+            // keystroke so Ctrl+H cannot open a second Speak dialog mid-transcribe.
+            if (IsActiveSessionTranscribing())
+            {
+                FileLog.Write("[MainWindow] Ctrl+H ignored: session transcribing");
+                e.Handled = true;
+                return;
+            }
             FileLog.Write("[MainWindow] Ctrl+H -> BtnSpeak_Click");
             e.Handled = true;
             BtnSpeak_Click(this, new RoutedEventArgs());
@@ -2885,6 +2934,13 @@ public partial class MainWindow : Window
 
     private async void BtnSpeak_Click(object? sender, RoutedEventArgs e)
     {
+        // Locked out while the active session is still transcribing a previous dictation in the
+        // background: no second Speak into a session mid-transcribe (guards the click AND Ctrl+H).
+        if (IsActiveSessionTranscribing())
+        {
+            FileLog.Write("[MainWindow] BtnSpeak_Click ignored: session transcribing");
+            return;
+        }
         // In-process dictation. Opens SpeakDialog which captures audio via
         // NAudio (BatchDictationRecorder), runs it through the shared
         // BatchTranscriptionPipeline (one batch transcription, then the validated
@@ -4942,6 +4998,13 @@ public partial class MainWindow : Window
     private async void SendPrompt()
     {
         if (_activeSession == null || string.IsNullOrWhiteSpace(PromptInput.Text)) return;
+        // Locked out while the session transcribes a dictated utterance in the background, so a
+        // typed Send cannot race the incoming dictated prompt (guards the button AND Ctrl+Enter).
+        if (IsActiveSessionTranscribing())
+        {
+            FileLog.Write("[MainWindow] SendPrompt ignored: session transcribing");
+            return;
+        }
 
         // Strip newlines -- Claude Code prompt expects single-line input
         var text = PromptInput.Text.ReplaceLineEndings(" ").Trim();
@@ -5188,6 +5251,13 @@ public partial class MainWindow : Window
     {
         if (_activeSession == null || string.IsNullOrWhiteSpace(PromptInput.Text))
             return;
+        // Locked out while the session transcribes a dictated utterance in the background (guards the
+        // Queue button AND Ctrl+Shift+Enter).
+        if (IsActiveSessionTranscribing())
+        {
+            FileLog.Write("[MainWindow] QueueCurrentPrompt ignored: session transcribing");
+            return;
+        }
 
         var text = PromptInput.Text.Trim();
         FileLog.Write($"[MainWindow] QueueCurrentPrompt: session={_activeSession.Session.Id}, text=\"{(text.Length > 60 ? text[..60] + "..." : text)}\"");


### PR DESCRIPTION
## What

While a dictated utterance is being transcribed and submitted in the background (the fire-and-forget Speak Send flow), the desktop session's compose surface now locks so a second action cannot race the dictated prompt.

## Locked while transcribing
- Prompt input box, **Send**, **Speak**, **Queue**, **Explain**, **Handover**
- Action bar: **Clear context** and **History**
- Shortcuts guarded: **Ctrl+H** (Speak), **Ctrl+Enter** (Send), **Ctrl+Shift+Enter** (Queue). The send/queue/speak methods also early-return, so the remote and phone paths are covered too.

## Stays live (the brakes)
- **Stop** and **Interrupt** are never disabled.

## Behaviour
- The lock is keyed on the active session's `IsTranscribing`, wired through `Session.OnIsTranscribingChanged`. It follows the active session (switch to a different session and its bar is fully usable) and clears automatically when the background transcription finishes.

Verified live in a slot-5 test build (v1.0.1): dialog closes instantly on Send, the surface locks orange, Stop/Interrupt remain clickable, and everything re-enables when transcription completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)