### PR TITLE
feat: show a subtle Transcribing status on the locked prompt bar

### DIFF
--- a/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml
+++ b/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml
@@ -47,6 +47,15 @@
                Foreground="#888888" FontSize="11"
                VerticalAlignment="Center" Margin="4,0,0,0" />
 
+    <!-- Subtle "Transcribing..." status, shown only while the compose surface is locked for a
+         background dictation send (see SetTranscribingLock). Orange to match the session roster's
+         transcribing color; italic and small so it reads as a quiet status, not a button. -->
+    <TextBlock x:Name="TranscribingLabel"
+               Text="Transcribing..."
+               IsVisible="False"
+               Foreground="#F97316" FontSize="11" FontStyle="Italic"
+               VerticalAlignment="Center" Margin="4,0,0,0" />
+
     <!-- Live context-usage gauge (issue #799), shown only when the session's driver declares
          DriverCapabilities.ContextUsage. A thin track with a colour-banded fill plus a compact
          "ctx <used> / <window> (<pct>%)" label, refreshed off-thread by a low-frequency poll. -->

--- a/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/SessionActionBar.axaml.cs
@@ -83,6 +83,7 @@ public partial class SessionActionBar : UserControl
     {
         BtnClearContext.IsEnabled = !locked;
         BtnHistory.IsEnabled = !locked;
+        TranscribingLabel.IsVisible = locked;
     }
 
     /// <summary>Timer-callback boundary (and the immediate kick from <see cref="Configure"/>):


### PR DESCRIPTION
## What

Follow-up to #912. Adds a subtle **`Transcribing...`** status label to the session action bar, shown only while the compose surface is locked for a background dictation send.

## Details
- Orange (`#F97316`, matching the session roster's transcribing color), small, italic — reads as a quiet status, not a control.
- Toggled by `SetTranscribingLock`, so it appears and clears exactly in step with the lock (alongside the disabling of Clear context / History).
- Lives in the action row, not over the input box, so it never overlaps typed text or shifts the input.

Verified live in a slot-5 test build (v1.0.1): the label appears next to the greyed Clear context / History the instant Send starts the background transcription, and disappears when it completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)