### PR TITLE
feat: surface the Ctrl+H dictation shortcut in the prompt bar

### DIFF
--- a/src/CcDirector.Avalonia/MainWindow.axaml
+++ b/src/CcDirector.Avalonia/MainWindow.axaml
@@ -1195,7 +1195,7 @@
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBox x:Name="PromptInput"
                                      Grid.Column="0"
-                                     Watermark="Type a message here, then press Ctrl+Enter to send it into the terminal (Ctrl+Shift+Enter to queue it).&#10;&#10;This box lives outside the terminal, so you can write slowly or dictate - and it can be driven remotely from your phone or the web."
+                                     Watermark="Type a message here, then press Ctrl+Enter to send it into the terminal (Ctrl+Shift+Enter to queue it).&#10;&#10;This box lives outside the terminal, so you can write slowly, or dictate with Speak (Ctrl+H) - and it can be driven remotely from your phone or the web."
                                      AcceptsReturn="True"
                                      TextWrapping="Wrap"
                                      MinHeight="98"
@@ -1274,7 +1274,7 @@
                                         HorizontalContentAlignment="Center"
                                         FontSize="13"
                                         Click="BtnSpeak_Click"
-                                        ToolTip.Tip="Dictate (Ctrl+H from anywhere on the Terminal tab)" />
+                                        ToolTip.Tip="Dictate a message - press Ctrl+H from anywhere on the Terminal tab to open this" />
                                 <Button x:Name="BtnQueuePrompt"
                                         Content="Queue"
                                         Width="80" Height="30"


### PR DESCRIPTION
## What

Makes the **Ctrl+H** dictation shortcut discoverable from the prompt bar.

- **Prompt box watermark:** "or dictate" becomes "or dictate with **Speak (Ctrl+H)**".
- **Speak button tooltip:** now spells out that pressing **Ctrl+H** from anywhere on the Terminal tab opens the dictation box (previously terse).

Follows #912 / #913. Verified in a slot-5 test build (v1.0.1): the empty prompt box shows the updated watermark, and hovering Speak shows the fuller tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)