### PR TITLE
[Security][Phase 1] Enforce Gateway auth by default (#917)

### DIFF
--- a/docs/cencon/proof/issue-917/gateway-transcript.txt
+++ b/docs/cencon/proof/issue-917/gateway-transcript.txt
@@ -1,0 +1,19 @@
+=== Issue #917 running-Gateway proof ===
+Log file: %LOCALAPPDATA%\cc-director\logs\director\director-2026-07-04-<pid>.log
+
+PART A - no override (production default)
+  GatewayHost.AuthEnabled = True   (expected: True)
+  GET /sessions            (no credential)  -> 401 Unauthorized   (expected: 401 Unauthorized)
+  GET /sessions            (Bearer token)   -> 200 OK   (expected: 200 OK)
+  GET /healthz             (public)         -> 200 OK   (expected: 200 OK)
+  GET /m                   (public shell)   -> 404 NotFound   (expected: NOT 401 / NOT redirect; 200 or 404)
+  POST /m/enroll           (public, no cred)-> 400 BadRequest   (expected: NOT 401 / NOT redirect; its own auth => 400/409/etc)
+  GET /login               (public)         -> 200 OK   (expected: 200 OK)
+
+PART B - CC_GATEWAY_NO_AUTH=1 (disable override for debugging)
+  GatewayHost.AuthEnabled = False   (expected: False)
+  GET /sessions            (no credential)  -> 200 OK   (expected: 200 OK - gate is off)
+
+Startup log lines (from the Gateway's own FileLog):
+  2026-07-04 07:42:09.560 [GatewayHost] auth gate booted ON (enforced by default, issue #917 - a per-device key or the shared token is required, even on the tailnet; set CC_GATEWAY_NO_AUTH=1 to disable for debugging)
+  2026-07-04 07:42:09.978 [GatewayHost] auth gate booted OFF (disabled via override - requests are accepted without a credential; this is a debugging mode, not the shipped default)

--- a/docs/cencon/proof/issue-917/qa/qa-live-transcript.txt
+++ b/docs/cencon/proof/issue-917/qa/qa-live-transcript.txt
@@ -1,0 +1,22 @@
+=== Issue #917 INDEPENDENT QA harness (booting real GatewayHost via default path) ===
+Log file: C:\Users\soren\AppData\Local\cc-director\logs\director\director-2026-07-04-20064.log
+
+PART A - no override (production default)
+  GatewayHost.AuthEnabled = True   (expected: True)
+  GET  /sessions          (no credential)  -> 401   (expected: 401)
+  GET  /sessions          (valid Bearer)   -> 200   (expected: 200)
+  GET  /healthz           (public)         -> 200   (expected: 200)
+  GET  /login             (public)         -> 200 loc=''   (expected: reachable, not 401/redirect)
+  GET  /logout            (public)         -> 302 loc='/login'   (expected: reachable, not 401/redirect)
+  POST /devices/register  (public)         -> 400 loc=''   (expected: reachable, not 401/redirect)
+  GET  /favicon.ico       (public)         -> 503 loc=''   (expected: reachable, not 401/redirect)
+  GET  /m                 (public shell)   -> 404 loc=''   (expected: not 401/redirect; 200 or 404)
+  POST /m/enroll          (public, no cred)-> 400 loc=''   (expected: not 401/redirect; own auth => 400/409/etc)
+
+PART B - CC_GATEWAY_NO_AUTH=1 (disable override for debugging)
+  GatewayHost.AuthEnabled = False   (expected: False)
+  GET  /sessions          (no credential)  -> 200   (expected: 200 - gate off)
+
+Startup log lines (from the Gateway's own FileLog):
+  2026-07-04 07:51:44.384 [GatewayHost] auth gate booted ON (enforced by default, issue #917 - a per-device key or the shared token is required, even on the tailnet; set CC_GATEWAY_NO_AUTH=1 to disable for debugging)
+  2026-07-04 07:51:46.942 [GatewayHost] auth gate booted OFF (disabled via override - requests are accepted without a credential; this is a debugging mode, not the shipped default)

--- a/docs/cencon/proof/issue-917/qa/qa-report.html
+++ b/docs/cencon/proof/issue-917/qa/qa-report.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>QA Proof - Issue #917 Enforce Gateway auth by default</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 0; padding: 2rem; line-height: 1.5;
+         background: #ffffff; color: #1b1b1b; }
+  @media (prefers-color-scheme: dark) { body { background: #14171a; color: #e6e6e6; } }
+  h1 { font-size: 1.5rem; }
+  h2 { font-size: 1.15rem; margin-top: 2rem; border-bottom: 1px solid #8884; padding-bottom: 0.3rem; }
+  code, pre { font-family: Consolas, monospace; }
+  pre { background: #0000000d; padding: 0.8rem; overflow-x: auto; border-radius: 4px; }
+  @media (prefers-color-scheme: dark) { pre { background: #ffffff12; } }
+  table { border-collapse: collapse; width: 100%; margin-top: 0.5rem; }
+  th, td { border: 1px solid #8886; padding: 0.5rem 0.6rem; text-align: left; vertical-align: top; }
+  th { background: #8882; }
+  .pass { color: #1a7f37; font-weight: bold; }
+  @media (prefers-color-scheme: dark) { .pass { color: #4ac26b; } }
+  .path { font-family: Consolas, monospace; font-size: 0.9em; }
+</style>
+</head>
+<body>
+<h1>QA Proof - Issue #917</h1>
+<p><strong>Title:</strong> [Security][Phase 1] Enforce Gateway auth by default (gate on unless
+explicitly disabled).</p>
+<p><strong>Branch under test:</strong> <span class="path">issue-917-enforce-gateway-auth</span>
+(HEAD <span class="path">ff6969de</span>). <strong>PR:</strong> #919. <strong>Parent epic:</strong> #916,
+Phase 1 only.</p>
+<p><strong>Verification identity:</strong> QA Agent, independent context - did not reuse the Developer's
+binary, tests, or transcript. Built the solution clean from an isolated worktree, ran the full Gateway
+test suite, and booted a real <code>GatewayHost</code> via the <em>production default constructor path</em>
+(the <code>authEnabled</code> argument OMITTED) to capture a fresh live HTTP transcript.</p>
+
+<h2>How this was verified</h2>
+<ul>
+  <li>Own git worktree on the PR branch; <code>dotnet build cc-director.sln</code> -> Build succeeded,
+    0 Warning(s), 0 Error(s).</li>
+  <li>Independent live boot: a standalone harness references the built
+    <span class="path">CcDirector.Gateway</span> assembly and constructs
+    <code>new GatewayHost(port, token, instancesDirectory, ...)</code> with NO <code>authEnabled</code>
+    argument - exactly the shipped production path that <code>GatewayWorker</code> and
+    <code>GatewayTrayController</code> use - then issues real HTTP requests on loopback. Full transcript:
+    <span class="path">docs/cencon/proof/issue-917/qa/qa-live-transcript.txt</span>.</li>
+  <li>Full Gateway test suite re-run from this checkout (not the Developer's numbers).</li>
+</ul>
+
+<h2>Acceptance criteria - independent proof</h2>
+<table>
+  <tr><th>Criterion (issue #917)</th><th>Expected</th><th>Actual (my live boot / my test run)</th><th>Result</th></tr>
+  <tr>
+    <td>No override: <code>GET /sessions</code> without a credential</td>
+    <td>401</td>
+    <td>401 (GatewayHost.AuthEnabled = <strong>True</strong> by default, no override, no explicit arg)</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>No override: <code>GET /sessions</code> with a valid Bearer credential</td>
+    <td>200</td>
+    <td>200</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td><code>/m</code> shell reachable without a prior credential</td>
+    <td>not 401 / not redirect (200 or 404)</td>
+    <td>404 (passed the gate; no <code>/m</code> asset staged in a bare build - not auth-blocked)</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td><code>POST /m/enroll</code> reachable without a prior credential</td>
+    <td>not 401 / not redirect (its own auth)</td>
+    <td>400 (reached the enroll handler, rejected an empty body - not gate-blocked)</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>Other public paths reachable: <code>/healthz</code>, <code>/login</code>, <code>/logout</code>,
+        <code>/devices/register</code>, <code>/favicon.ico</code></td>
+    <td>reachable, not auth-gated (not 401, not redirect-to-login by the gate)</td>
+    <td><code>/healthz</code> 200; <code>/login</code> 200; <code>/logout</code> 302 -&gt; /login
+        (the logout handler's OWN <code>Results.Redirect("/login")</code> after clearing the cookie, NOT
+        the auth gate); <code>/devices/register</code> 400 (reached handler, empty body); <code>/favicon.ico</code>
+        503 (passed the gate; downstream favicon serving unavailable under the harness's stub cockpit port -
+        NOT an auth block). None returned a gate 401 or a gate redirect.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td><code>CC_GATEWAY_NO_AUTH=1</code> turns the gate off; the choice is logged at startup</td>
+    <td>AuthEnabled False; <code>GET /sessions</code> -&gt; 200; startup log line</td>
+    <td>AuthEnabled = <strong>False</strong>; <code>GET /sessions</code> -&gt; 200; log line "auth gate
+        booted OFF (disabled via override...)"</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>Booted mode logged (gate ON by default)</td>
+    <td>startup log line</td>
+    <td>"[GatewayHost] auth gate booted ON (enforced by default, issue #917 ...)"</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td><code>GatewayAuthToggleTests</code> updated to the new default; full Gateway suite green</td>
+    <td>all green</td>
+    <td>Full suite: <strong>Passed! Failed: 0, Passed: 1190</strong>. Focused
+        <code>GatewayAuthToggleTests</code>: 6/6 pass (Default_is_on_without_any_override,
+        Explicit_false_forces_off_regardless_of_env, Explicit_true_forces_on_regardless_of_disable_override,
+        Disable_override_no_auth_turns_the_default_off, Disable_override_auth_zero_turns_the_default_off,
+        Disable_override_value_other_than_1_does_not_disable)</td>
+    <td class="pass">PASS</td>
+  </tr>
+</table>
+
+<h2>My live-boot transcript</h2>
+<pre>
+PART A - no override (production default)
+  GatewayHost.AuthEnabled = True   (expected: True)
+  GET  /sessions          (no credential)  -> 401   (expected: 401)
+  GET  /sessions          (valid Bearer)   -> 200   (expected: 200)
+  GET  /healthz           (public)         -> 200   (expected: 200)
+  GET  /login             (public)         -> 200   (reachable)
+  GET  /logout            (public)         -> 302 -> /login   (logout handler's own redirect, not the gate)
+  POST /devices/register  (public)         -> 400   (reached handler; not gate-blocked)
+  GET  /favicon.ico       (public)         -> 503   (passed gate; downstream serving unavailable, not gate-blocked)
+  GET  /m                 (public shell)   -> 404   (not 401/redirect)
+  POST /m/enroll          (public, no cred)-> 400   (own auth; not gate-blocked)
+
+PART B - CC_GATEWAY_NO_AUTH=1 (disable override for debugging)
+  GatewayHost.AuthEnabled = False   (expected: False)
+  GET  /sessions          (no credential)  -> 200   (gate off)
+
+Startup log lines (from the Gateway's own FileLog):
+  [GatewayHost] auth gate booted ON (enforced by default, issue #917 - a per-device key or the shared token is required, even on the tailnet; set CC_GATEWAY_NO_AUTH=1 to disable for debugging)
+  [GatewayHost] auth gate booted OFF (disabled via override - requests are accepted without a credential; this is a debugging mode, not the shipped default)
+</pre>
+
+<h2>Regression and method check</h2>
+<ul>
+  <li>Diff scope is confined to the auth toggle: <span class="path">GatewayHost.cs</span> (default
+    inverted, <code>authEnabled</code> now <code>bool?</code>, both booted modes logged),
+    <span class="path">AuthMiddleware.cs</span> (documentation only - the <code>PublicPaths</code> set and
+    the <code>/m</code> bypass are unchanged in code), and the rewritten
+    <span class="path">GatewayAuthToggleTests.cs</span>. No out-of-scope Phase 2-5 surface (Cockpit,
+    cc-* tools, Directors, token refresh, revoke, tray) was touched.</li>
+  <li>Full Gateway suite green (1190/1190), so no adjacent Gateway behavior regressed.</li>
+  <li>No CenCon architecture/security document exists to drift (<span class="path">docs/cencon/</span>
+    holds only <span class="path">proof/</span>).</li>
+</ul>
+
+<h2>Conclusion</h2>
+<p class="pass">VERIFIED - all acceptance criteria met. The Gateway auth gate enforces by default
+(<code>GET /sessions</code> -&gt; 401 without / 200 with a credential), the deliberately-public paths
+remain reachable through the gate, the <code>CC_GATEWAY_NO_AUTH=1</code> disable override turns the gate
+off and the booted mode is logged both ways, the build is clean, and the full Gateway test suite is green.</p>
+</body>
+</html>

--- a/docs/cencon/proof/issue-917/report.html
+++ b/docs/cencon/proof/issue-917/report.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Proof - Issue #917 Enforce Gateway auth by default</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 0; padding: 2rem; line-height: 1.5;
+         background: #ffffff; color: #1b1b1b; }
+  @media (prefers-color-scheme: dark) { body { background: #14171a; color: #e6e6e6; } }
+  h1 { font-size: 1.5rem; }
+  h2 { font-size: 1.15rem; margin-top: 2rem; border-bottom: 1px solid #8884; padding-bottom: 0.3rem; }
+  code, pre { font-family: Consolas, monospace; }
+  pre { background: #0000000d; padding: 0.8rem; overflow-x: auto; border-radius: 4px; }
+  @media (prefers-color-scheme: dark) { pre { background: #ffffff12; } }
+  table { border-collapse: collapse; width: 100%; margin-top: 0.5rem; }
+  th, td { border: 1px solid #8886; padding: 0.5rem 0.6rem; text-align: left; vertical-align: top; }
+  th { background: #8882; }
+  .pass { color: #1a7f37; font-weight: bold; }
+  @media (prefers-color-scheme: dark) { .pass { color: #4ac26b; } }
+  .path { font-family: Consolas, monospace; font-size: 0.9em; }
+</style>
+</head>
+<body>
+<h1>Proof - Issue #917</h1>
+<p><strong>Title:</strong> [Security][Phase 1] Enforce Gateway auth by default (gate on unless
+explicitly disabled).</p>
+<p><strong>Branch:</strong> <span class="path">issue-917-enforce-gateway-auth</span></p>
+<p><strong>Parent epic:</strong> #916. <strong>Scope:</strong> Phase 1 only.</p>
+
+<h2>What was implemented</h2>
+<p>The host-wide Gateway auth gate now enforces <strong>by default</strong>. Previously the effective
+default was off (only <code>CC_GATEWAY_AUTH=1</code> turned it on), so any request reaching the Gateway
+on the tailnet was accepted with no credential. The default is inverted: the gate is ON unless a
+deliberate disable override is set, so a request must present the shared token or a per-device key.</p>
+
+<h3>Changes</h3>
+<ul>
+  <li><span class="path">src/CcDirector.Gateway/GatewayHost.cs</span> - the constructor's
+    <code>authEnabled</code> parameter is now <code>bool?</code> (default <code>null</code> = "no
+    explicit choice"). <code>ResolveAuthEnabled(bool?)</code> is inverted: an explicit choice wins;
+    with no explicit choice the gate is ON unless <code>CC_GATEWAY_NO_AUTH=1</code> or
+    <code>CC_GATEWAY_AUTH=0</code> disables it. A startup line is always logged stating which mode the
+    gate booted in. The two production call sites (<code>GatewayWorker</code>,
+    <code>GatewayTrayController</code>) pass nothing, so they now enforce.</li>
+  <li><span class="path">src/CcDirector.Gateway/Util/AuthMiddleware.cs</span> - reviewed and confirmed
+    the deliberately-public set under mandatory auth (<code>/healthz</code>, <code>/cockpit</code>,
+    <code>/login</code>, <code>/logout</code>, <code>/favicon.ico</code>, <code>/devices/register</code>,
+    and <code>/m</code> + everything under <code>/m/</code> which includes <code>POST /m/enroll</code>).
+    Behavior unchanged; the header documentation was made accurate. <code>/m/enroll</code> stays public
+    via the existing <code>/m/</code> prefix bypass and carries its own account-scoped authorization.</li>
+  <li><span class="path">src/CcDirector.Gateway.Tests/GatewayAuthToggleTests.cs</span> - rewritten to
+    the inverted semantics (default ON, disable overrides turn it off, an explicit choice wins).</li>
+</ul>
+
+<h2>Acceptance criteria - proof</h2>
+<table>
+  <tr><th>Criterion</th><th>Expected</th><th>Actual (running Gateway)</th><th>Result</th></tr>
+  <tr>
+    <td><code>GET /sessions</code> with no override, no credential</td>
+    <td>401</td>
+    <td>401 Unauthorized (AuthEnabled = True by default)</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td><code>GET /sessions</code> with a valid Bearer credential</td>
+    <td>200</td>
+    <td>200 OK</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td><code>/m</code> shell reachable without a prior credential</td>
+    <td>not 401 / not redirect</td>
+    <td>404 NotFound (served, not auth-gated - a bare test build stages no <code>/m</code> asset)</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td><code>POST /m/enroll</code> reachable without a prior credential</td>
+    <td>not 401 / not redirect (its own auth)</td>
+    <td>400 BadRequest (reached the enroll handler, rejected an empty body - not gate-blocked)</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>Other public paths (<code>/healthz</code>, <code>/login</code>) reachable</td>
+    <td>200</td>
+    <td>200 OK / 200 OK</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td><code>CC_GATEWAY_NO_AUTH=1</code> turns the gate off; the choice is logged at startup</td>
+    <td>AuthEnabled False; <code>GET /sessions</code> -> 200; startup log line</td>
+    <td>AuthEnabled = False; 200 OK; "auth gate booted OFF (disabled via override...)"</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>Gate booted ON by default is logged at startup</td>
+    <td>startup log line</td>
+    <td>"auth gate booted ON (enforced by default, issue #917 ...)"</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td><code>GatewayAuthToggleTests</code> updated; full Gateway suite green</td>
+    <td>all green</td>
+    <td>Full suite 1190 passed, 0 failed; focused auth run 9 passed</td>
+    <td class="pass">PASS</td>
+  </tr>
+</table>
+
+<h2>Running-Gateway transcript</h2>
+<p>Captured by booting the real <code>GatewayHost</code> on a free loopback port (never port 7878, so it
+does not collide with a running Gateway) using the production default path (the <code>authEnabled</code>
+argument is omitted). Full file: <span class="path">docs/cencon/proof/issue-917/gateway-transcript.txt</span>.</p>
+<pre>
+PART A - no override (production default)
+  GatewayHost.AuthEnabled = True   (expected: True)
+  GET /sessions            (no credential)  -> 401 Unauthorized   (expected: 401 Unauthorized)
+  GET /sessions            (Bearer token)   -> 200 OK   (expected: 200 OK)
+  GET /healthz             (public)         -> 200 OK   (expected: 200 OK)
+  GET /m                   (public shell)   -> 404 NotFound   (expected: NOT 401 / NOT redirect; 200 or 404)
+  POST /m/enroll           (public, no cred)-> 400 BadRequest   (expected: NOT 401 / NOT redirect; its own auth => 400/409/etc)
+  GET /login               (public)         -> 200 OK   (expected: 200 OK)
+
+PART B - CC_GATEWAY_NO_AUTH=1 (disable override for debugging)
+  GatewayHost.AuthEnabled = False   (expected: False)
+  GET /sessions            (no credential)  -> 200 OK   (expected: 200 OK - gate is off)
+
+Startup log lines (from the Gateway's own FileLog):
+  [GatewayHost] auth gate booted ON (enforced by default, issue #917 - a per-device key or the shared token is required, even on the tailnet; set CC_GATEWAY_NO_AUTH=1 to disable for debugging)
+  [GatewayHost] auth gate booted OFF (disabled via override - requests are accepted without a credential; this is a debugging mode, not the shipped default)
+</pre>
+
+<h2>Test suite</h2>
+<pre>
+dotnet build cc-director.sln            -> Build succeeded. 0 Warning(s) 0 Error(s)
+dotnet test CcDirector.Gateway.Tests    -> Passed! Failed: 0, Passed: 1190, Skipped: 0, Total: 1190
+  focused auth filter                   -> Passed! Failed: 0, Passed: 9,    Skipped: 0, Total: 9
+</pre>
+
+<h2>CenCon impact</h2>
+<p>No architecture or security CenCon documents exist in this repo yet
+(<span class="path">docs/cencon/</span> holds only <span class="path">proof/</span>), so there is no
+manifest or security profile to drift. This change is the intended security-posture flip of epic #916
+Phase 1; no out-of-scope surface (Cockpit clients, cc-* tools, token refresh, revoke, tray) was touched.</p>
+
+<h2>Conclusion</h2>
+<p class="pass">I believe this is finished. The Gateway auth gate enforces by default, the
+deliberately-public paths still work, the disable override turns it off and is logged, the build is
+clean, and the full Gateway test suite is green.</p>
+</body>
+</html>

--- a/docs/cencon/proof/issue-917/test-output.txt
+++ b/docs/cencon/proof/issue-917/test-output.txt
@@ -1,0 +1,30 @@
+Issue #917 - Gateway test suite results
+=======================================
+
+Command (full Gateway suite):
+  dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj --no-build
+
+Result:
+  Passed!  - Failed:     0, Passed:  1190, Skipped:     0, Total:  1190, Duration: 3 m 1 s
+
+Focused run (the updated auth tests):
+  dotnet test ... --filter "FullyQualifiedName~GatewayAuthToggleTests|FullyQualifiedName~MobileAuthServingTests"
+
+Result:
+  Passed!  - Failed:     0, Passed:     9, Skipped:     0, Total:     9, Duration: 386 ms
+
+  GatewayAuthToggleTests (rewritten for the inverted default, issue #917):
+    - Default_is_on_without_any_override
+    - Explicit_false_forces_off_regardless_of_env
+    - Explicit_true_forces_on_regardless_of_disable_override
+    - Disable_override_no_auth_turns_the_default_off
+    - Disable_override_auth_zero_turns_the_default_off
+    - Disable_override_value_other_than_1_does_not_disable
+
+  MobileAuthServingTests (unchanged - proves 401-without / 200-with and /m public):
+    - Sessions_requires_bearer_when_auth_is_on
+    - Sessions_returns_200_with_the_injected_bearer
+    - Mobile_shell_is_public_and_not_login_gated_when_auth_is_on
+
+Build:
+  dotnet build cc-director.sln  ->  Build succeeded. 0 Warning(s) 0 Error(s)

--- a/src/CcDirector.Gateway.Tests/GatewayAuthToggleTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayAuthToggleTests.cs
@@ -4,61 +4,116 @@ using Xunit;
 namespace CcDirector.Gateway.Tests;
 
 /// <summary>
-/// Proves the host-wide auth gate can be turned on without a code change via the CC_GATEWAY_AUTH
-/// environment opt-in (issue #908), while the shipped default stays off (the tailnet is the boundary
-/// until an operator opts in). The actual enforcement it unlocks - /sessions answering 401 without a
-/// credential when auth is on - is proven separately by MobileAuthServingTests.
+/// Proves the host-wide auth gate now enforces BY DEFAULT (issue #917, Phase 1 of the security epic
+/// #916): with no explicit constructor choice and no disable override, the gate is ON. A disable
+/// override (CC_GATEWAY_NO_AUTH=1 or CC_GATEWAY_AUTH=0) turns it off for debugging, and an explicit
+/// constructor choice always wins so tests can force the gate on or off deterministically. The actual
+/// enforcement it unlocks - /sessions answering 401 without a credential when auth is on - is proven
+/// separately by MobileAuthServingTests.
 /// </summary>
 public sealed class GatewayAuthToggleTests
 {
     [Fact]
-    public void Explicit_flag_enables_regardless_of_env()
+    public void Default_is_on_without_any_override()
     {
-        Assert.True(GatewayHost.ResolveAuthEnabled(true));
-    }
-
-    [Fact]
-    public void Env_opt_in_enables_when_the_flag_is_off()
-    {
-        var previous = Environment.GetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar);
+        var previousDisabled = Environment.GetEnvironmentVariable(GatewayHost.AuthDisabledEnvVar);
+        var previousEnabled = Environment.GetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar);
         try
         {
-            Environment.SetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar, "1");
-            Assert.True(GatewayHost.ResolveAuthEnabled(false));
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar, previous);
-        }
-    }
-
-    [Fact]
-    public void Default_is_off_without_the_flag_or_env()
-    {
-        var previous = Environment.GetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar);
-        try
-        {
+            Environment.SetEnvironmentVariable(GatewayHost.AuthDisabledEnvVar, null);
             Environment.SetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar, null);
-            Assert.False(GatewayHost.ResolveAuthEnabled(false));
+            Assert.True(GatewayHost.ResolveAuthEnabled(null));
         }
         finally
         {
-            Environment.SetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar, previous);
+            Environment.SetEnvironmentVariable(GatewayHost.AuthDisabledEnvVar, previousDisabled);
+            Environment.SetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar, previousEnabled);
         }
     }
 
     [Fact]
-    public void Env_value_other_than_1_does_not_enable()
+    public void Explicit_false_forces_off_regardless_of_env()
     {
-        var previous = Environment.GetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar);
+        var previousDisabled = Environment.GetEnvironmentVariable(GatewayHost.AuthDisabledEnvVar);
         try
         {
-            Environment.SetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar, "true");
+            // Even with no disable override, an explicit false wins - this is how a test boots a Gateway
+            // with the gate deliberately off.
+            Environment.SetEnvironmentVariable(GatewayHost.AuthDisabledEnvVar, null);
             Assert.False(GatewayHost.ResolveAuthEnabled(false));
         }
         finally
         {
-            Environment.SetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar, previous);
+            Environment.SetEnvironmentVariable(GatewayHost.AuthDisabledEnvVar, previousDisabled);
+        }
+    }
+
+    [Fact]
+    public void Explicit_true_forces_on_regardless_of_disable_override()
+    {
+        var previousDisabled = Environment.GetEnvironmentVariable(GatewayHost.AuthDisabledEnvVar);
+        try
+        {
+            // An explicit true wins even when the disable override is set - the constructor choice is
+            // authoritative so tests are not perturbed by a stray env var on the build machine.
+            Environment.SetEnvironmentVariable(GatewayHost.AuthDisabledEnvVar, "1");
+            Assert.True(GatewayHost.ResolveAuthEnabled(true));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(GatewayHost.AuthDisabledEnvVar, previousDisabled);
+        }
+    }
+
+    [Fact]
+    public void Disable_override_no_auth_turns_the_default_off()
+    {
+        var previousDisabled = Environment.GetEnvironmentVariable(GatewayHost.AuthDisabledEnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(GatewayHost.AuthDisabledEnvVar, "1");
+            Assert.False(GatewayHost.ResolveAuthEnabled(null));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(GatewayHost.AuthDisabledEnvVar, previousDisabled);
+        }
+    }
+
+    [Fact]
+    public void Disable_override_auth_zero_turns_the_default_off()
+    {
+        var previousDisabled = Environment.GetEnvironmentVariable(GatewayHost.AuthDisabledEnvVar);
+        var previousEnabled = Environment.GetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(GatewayHost.AuthDisabledEnvVar, null);
+            Environment.SetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar, "0");
+            Assert.False(GatewayHost.ResolveAuthEnabled(null));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(GatewayHost.AuthDisabledEnvVar, previousDisabled);
+            Environment.SetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar, previousEnabled);
+        }
+    }
+
+    [Fact]
+    public void Disable_override_value_other_than_1_does_not_disable()
+    {
+        var previousDisabled = Environment.GetEnvironmentVariable(GatewayHost.AuthDisabledEnvVar);
+        var previousEnabled = Environment.GetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar);
+        try
+        {
+            // Only the exact disable tokens turn the gate off; anything else leaves the default (ON).
+            Environment.SetEnvironmentVariable(GatewayHost.AuthDisabledEnvVar, "true");
+            Environment.SetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar, "1");
+            Assert.True(GatewayHost.ResolveAuthEnabled(null));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(GatewayHost.AuthDisabledEnvVar, previousDisabled);
+            Environment.SetEnvironmentVariable(GatewayHost.AuthEnabledEnvVar, previousEnabled);
         }
     }
 }

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -35,22 +35,43 @@ public sealed class GatewayHost : IAsyncDisposable
     public bool AuthEnabled { get; }
 
     /// <summary>
-    /// Environment opt-in that turns the host-wide auth gate ON for a Gateway that would otherwise
-    /// default to off (issue #908). Set <c>CC_GATEWAY_AUTH=1</c> so reaching the Gateway on the tailnet
-    /// is no longer sufficient - a request must present the shared token or a per-device key. This
-    /// mirrors the <c>CC_GATEWAY_NO_TAILSCALE</c> env-toggle precedent and keeps the shipped default
-    /// unchanged (off) so no install starts requiring credentials without an explicit opt-in.
+    /// Environment override for the host-wide auth gate (issue #917). As of Phase 1 the gate is ON by
+    /// default, so this variable is now a DISABLE override for debugging: set <c>CC_GATEWAY_AUTH=0</c> to
+    /// turn the gate off. (Setting it to <c>1</c> is a harmless no-op since enforcement is already the
+    /// default.) A request that reaches the Gateway on the tailnet must present the shared token or a
+    /// per-device key unless the gate is explicitly disabled.
     /// </summary>
     public const string AuthEnabledEnvVar = "CC_GATEWAY_AUTH";
 
     /// <summary>
-    /// Resolves whether the host-wide auth gate runs: the explicit constructor flag OR the
-    /// <see cref="AuthEnabledEnvVar"/> environment opt-in. Pure and side-effect free so it is unit-tested
-    /// directly.
+    /// Environment override that turns the host-wide auth gate OFF for debugging (issue #917). Set
+    /// <c>CC_GATEWAY_NO_AUTH=1</c> to disable enforcement on a Gateway that would otherwise enforce by
+    /// default. This mirrors the <c>CC_GATEWAY_NO_TAILSCALE</c> env-toggle precedent.
     /// </summary>
-    internal static bool ResolveAuthEnabled(bool explicitlyEnabled) =>
-        explicitlyEnabled
-        || string.Equals(Environment.GetEnvironmentVariable(AuthEnabledEnvVar), "1", StringComparison.Ordinal);
+    public const string AuthDisabledEnvVar = "CC_GATEWAY_NO_AUTH";
+
+    /// <summary>
+    /// Resolves whether the host-wide auth gate runs. As of issue #917 enforcement is ON by default:
+    /// <list type="bullet">
+    /// <item>An explicit constructor choice (<paramref name="explicitChoice"/> non-null) always wins - a
+    /// test forces the gate on or off deterministically regardless of the environment.</item>
+    /// <item>With no explicit choice (production), the gate is ON unless a disable override is set:
+    /// <c>CC_GATEWAY_NO_AUTH=1</c> or <c>CC_GATEWAY_AUTH=0</c> turns it off for debugging.</item>
+    /// </list>
+    /// Pure and side-effect free so it is unit-tested directly.
+    /// </summary>
+    internal static bool ResolveAuthEnabled(bool? explicitChoice)
+    {
+        if (explicitChoice.HasValue)
+            return explicitChoice.Value;
+
+        if (string.Equals(Environment.GetEnvironmentVariable(AuthDisabledEnvVar), "1", StringComparison.Ordinal))
+            return false;
+        if (string.Equals(Environment.GetEnvironmentVariable(AuthEnabledEnvVar), "0", StringComparison.Ordinal))
+            return false;
+
+        return true;
+    }
 
     /// <summary>
     /// Issue #469: mints and verifies the short-lived 4-digit pairing code that authorizes a new
@@ -269,15 +290,17 @@ public sealed class GatewayHost : IAsyncDisposable
     /// <see cref="Account"/> null on a non-Windows host, where the operating-system credential store is
     /// not yet implemented).
     /// </param>
-    public GatewayHost(int port = DefaultPort, string? token = null, bool authEnabled = false, string? instancesDirectory = null, int? cockpitProxyPort = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null)
+    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, int? cockpitProxyPort = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null)
     {
         Port = port;
         Token = token ?? GatewayAuth.LoadOrCreate();
         Registry = new DirectorRegistry(instancesDirectory);
         Devices = new Pairing.DeviceRegistry(devicesPath);
         AuthEnabled = ResolveAuthEnabled(authEnabled);
-        if (AuthEnabled && !authEnabled)
-            FileLog.Write($"[GatewayHost] {AuthEnabledEnvVar}=1 -> host-wide auth gate ENABLED (a per-device key or the shared token is now required, even on the tailnet)");
+        if (AuthEnabled)
+            FileLog.Write($"[GatewayHost] auth gate booted ON (enforced by default, issue #917 - a per-device key or the shared token is required, even on the tailnet; set {AuthDisabledEnvVar}=1 to disable for debugging)");
+        else
+            FileLog.Write($"[GatewayHost] auth gate booted OFF (disabled via override - requests are accepted without a credential; this is a debugging mode, not the shipped default)");
         _client = new DirectorEndpointClient(Token);
         _cockpitProxyPort = cockpitProxyPort ?? Cockpit.CockpitSupervisor.ResolvePort();
         _serveProvisioner = new TailscaleServeProvisioner(Registry, Port, Cockpit.CockpitSupervisor.ResolvePort());

--- a/src/CcDirector.Gateway/Util/AuthMiddleware.cs
+++ b/src/CcDirector.Gateway/Util/AuthMiddleware.cs
@@ -6,9 +6,15 @@ namespace CcDirector.Gateway.Util;
 /// <summary>
 /// Bearer-or-cookie auth for the Gateway.
 ///
-/// Public, no auth:    /healthz, /login, /logout, /devices/register
+/// Public, no auth:    /healthz, /cockpit, /login, /logout, /favicon.ico, /devices/register, and the
+///                     mobile app shell /m + everything under /m/ (which includes the mobile enroll
+///                     path POST /m/enroll - it carries its own account-scoped authorization).
 /// Authenticated:      every other route (Bearer header OR cc-gateway-token cookie OR, per
 ///                     issue #469, a per-device key issued at enrollment).
+///
+/// This public set is deliberately the ONLY way in without a credential once the host-wide gate is on
+/// by default (issue #917): the enroll/pairing entry points carry their own authorization and the login
+/// surface must be reachable to obtain one, while every data endpoint stays credential-gated.
 ///
 /// Browser requests (Accept: text/html) get a 302 redirect to /login.
 /// Non-browser requests get a 401 with JSON body.


### PR DESCRIPTION
Closes thefrederiksen/devthrottle#917 (Phase 1 of security epic thefrederiksen/devthrottle_internal#660).

## Release Notes
The Gateway now enforces host-wide authentication by default. Any request must present the shared token or a per-device key, even on the tailnet, unless a deliberate disable override is set. The deliberately-public paths (login, enroll, health, mobile shell) still work.

## Changes
- `src/CcDirector.Gateway/GatewayHost.cs` - the `authEnabled` constructor parameter is now `bool?` (default `null` = no explicit choice). `ResolveAuthEnabled` is inverted: an explicit choice wins; with no explicit choice the gate is ON unless `CC_GATEWAY_NO_AUTH=1` or `CC_GATEWAY_AUTH=0` disables it for debugging. The booted mode is always logged at startup. The two production call sites (`GatewayWorker`, `GatewayTrayController`) pass nothing, so they now enforce.
- `src/CcDirector.Gateway/Util/AuthMiddleware.cs` - reviewed and confirmed the deliberately-public set under mandatory auth (`/healthz`, `/cockpit`, `/login`, `/logout`, `/favicon.ico`, `/devices/register`, and `/m` + everything under `/m/`, which includes `POST /m/enroll`). Behavior unchanged; the header documentation was made accurate.
- `src/CcDirector.Gateway.Tests/GatewayAuthToggleTests.cs` - rewritten for the inverted default.

## How to Test
Boot a Gateway with no override and call `GET /sessions` with and without a credential; set `CC_GATEWAY_NO_AUTH=1` to boot with the gate off. See the committed running-Gateway transcript.

## Expected Result
- No override: `GET /sessions` -> 401 without a credential, 200 with a valid Bearer/shared token.
- `/m`, `POST /m/enroll`, `/healthz`, `/login` reachable without a prior credential.
- `CC_GATEWAY_NO_AUTH=1`: `GET /sessions` -> 200 (gate off), logged at startup.
- Full Gateway test suite green (1190 passed, 0 failed).

## Before / After
- Before: `bool authEnabled = false` - gate off by default, any tailnet request accepted with no credential.
- After: gate ON by default; a credential is required unless explicitly disabled.

## Out of scope (per thefrederiksen/devthrottle#917)
No client surface fix-forward (Cockpit, cc-* tools, Directors, phone app, PWA), no token-refresh/revoke/tray work - those are Phases 2-5 under thefrederiksen/devthrottle_internal#660.

Proof: `docs/cencon/proof/issue-917/report.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)