### PR TITLE
Fix dictation Send: include typed text and insert at the cursor

### DIFF
--- a/mobile/src/components/SessionControls.tsx
+++ b/mobile/src/components/SessionControls.tsx
@@ -2,6 +2,7 @@ import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import { sendEscape, sendInterrupt, sendPrompt } from "../api/client";
 import { backgroundTranscribeAndSend, type CapturedUtterance } from "../dictation/backgroundSend";
 import { DictationDialog } from "../dictation/DictationDialog";
+import { insertAt, joinText } from "../dictation/transcript";
 import {
   KEY_ARROW_DOWN,
   KEY_ARROW_LEFT,
@@ -39,6 +40,13 @@ export function SessionControls({ sessionId, onFlash, onError, showKeyRows }: Se
   const [input, setInput] = useState("");
   const [dictating, setDictating] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  // The caret position in the composer, snapshotted when Speak is pressed (the dialog is modal, so the
+  // box cannot change while it is open). Dictation is inserted here, exactly like the desktop Insert
+  // button, instead of being appended at the end.
+  const caretRef = useRef(0);
+  // Where to move the caret after an Insert drops text mid-box; applied post-render below. Null except
+  // in the render right after an Insert.
+  const pendingCaretRef = useRef<number | null>(null);
 
   // Auto-grow the textarea to fit its content (up to a cap, after which it scrolls). Re-run on every
   // input change so it grows as you type AND shrinks back when the box is cleared (Send) or replaced
@@ -49,6 +57,16 @@ export function SessionControls({ sessionId, onFlash, onError, showKeyRows }: Se
     if (!el) return;
     el.style.height = "auto";
     el.style.height = `${Math.min(el.scrollHeight, MAX_INPUT_HEIGHT_PX)}px`;
+  }, [input]);
+
+  // After an Insert drops dictation mid-box, put the caret right after the inserted words so the user
+  // can keep editing there. Does not force focus (that would pop the mobile keyboard unbidden).
+  useLayoutEffect(() => {
+    const pos = pendingCaretRef.current;
+    if (pos === null) return;
+    pendingCaretRef.current = null;
+    const el = inputRef.current;
+    if (el) el.selectionStart = el.selectionEnd = pos;
   }, [input]);
 
   const sendKey = useCallback(
@@ -97,13 +115,20 @@ export function SessionControls({ sessionId, onFlash, onError, showKeyRows }: Se
     }
   }, [sessionId, onFlash, onError]);
 
-  // Speak opens the dictation dialog. Insert drops the transcript into the input (no submit, joined
-  // onto any existing text); Send submits it via the same POST /prompt path the Send button uses.
+  // Speak opens the dictation dialog. Insert drops the transcript into the input at the caret (no
+  // submit); Send inserts it at the caret and submits via the same POST /prompt path the Send button
+  // uses. Both use the caret snapshotted when Speak was pressed, exactly like the desktop Insert.
   const onDictateInsert = useCallback(
     (text: string) => {
       setDictating(false);
       if (text.trim().length === 0) return;
-      setInput((cur) => (cur.trim().length === 0 ? text : `${cur.trimEnd()} ${text}`));
+      const caret = caretRef.current;
+      setInput((cur) => {
+        const composed = insertAt(cur, caret, text);
+        const clamped = caret < 0 || caret > cur.length ? cur.length : caret;
+        pendingCaretRef.current = composed.length - (cur.length - clamped);
+        return composed;
+      });
       onFlash("Inserted");
     },
     [onFlash],
@@ -112,29 +137,54 @@ export function SessionControls({ sessionId, onFlash, onError, showKeyRows }: Se
   const onDictateSend = useCallback(
     async (text: string) => {
       setDictating(false);
-      if (!sessionId || text.trim().length === 0) return;
+      if (!sessionId) return;
+      // Send behaves like Insert-then-Enter: the dictation is inserted at the caret inside any typed
+      // text (like the Insert button), then submitted. Clear the box, exactly like the normal Send
+      // path, so the user does not re-send what just went out.
+      const combined = insertAt(input, caretRef.current, text).trim();
+      if (combined.length === 0) return;
+      setInput("");
       try {
-        await sendPrompt(sessionId, text, true);
+        await sendPrompt(sessionId, combined, true);
         onFlash("Sent");
       } catch (err) {
+        setInput(combined); // restore so a failed send never loses the typed + dictated text
         onError(err instanceof Error ? err.message : "Send failed");
       }
     },
-    [sessionId, onFlash, onError],
+    [sessionId, input, onFlash, onError],
   );
 
-  // Fire-and-forget Send from the Speak dialog: the dialog already captured the audio buffer and
-  // closed itself, releasing the screen. We now transcode + upload + transcribe + submit in the
+  // Immediate (fire-and-forget) Send from the Speak dialog: the dialog already captured the audio
+  // buffer and closed itself, releasing the screen. We transcode + upload + transcribe + submit in the
   // background while the roster shows the session orange ("Transcribing..."), so the user can move on
   // immediately. The flash is a brief acknowledgement; the persistent signal is the orange roster row.
   const onDictateSendAudio = useCallback(
     (captured: CapturedUtterance) => {
       setDictating(false);
       if (!sessionId) return;
+      // Send behaves like Insert-then-Enter: the dictation is inserted at the caret inside the typed
+      // text via the compose hook (like the Insert button). Clear the box now (at dialog-close time) -
+      // the background transcribe-and-submit sends the combined text. On a transcription failure the
+      // typed text is put back so Send never loses it.
+      const composerText = input;
+      const caret = caretRef.current;
+      setInput("");
       onFlash("Transcribing...");
-      void backgroundTranscribeAndSend(sessionId, captured, { onError });
+      void backgroundTranscribeAndSend(sessionId, captured, {
+        onError,
+        // Insert the dictated words at the snapshotted caret inside the typed text, then submit.
+        compose: (dictation) => insertAt(composerText, caret, dictation),
+        // On a genuine transcription failure the audio is unrecoverable, but the typed text is not:
+        // put it back (ahead of anything typed since) so Send never silently loses it. If the user has
+        // navigated away this component is unmounted and setInput is a harmless no-op; the onError
+        // notification is then the signal.
+        onFailed: () => {
+          if (composerText.trim().length > 0) setInput((cur) => joinText(composerText, cur));
+        },
+      });
     },
-    [sessionId, onFlash, onError],
+    [sessionId, input, onFlash, onError],
   );
 
   return (
@@ -162,7 +212,11 @@ export function SessionControls({ sessionId, onFlash, onError, showKeyRows }: Se
         <button
           type="button"
           className="term-btn term-speak"
-          onClick={() => setDictating(true)}
+          onClick={() => {
+            // Snapshot the caret so the dictation lands where the cursor was, not at the end.
+            caretRef.current = inputRef.current?.selectionStart ?? input.length;
+            setDictating(true);
+          }}
           disabled={dictating}
         >
           Speak

--- a/mobile/src/dictation/DictationDialog.tsx
+++ b/mobile/src/dictation/DictationDialog.tsx
@@ -31,12 +31,12 @@ export interface DictationDialogProps {
   /** Commit the transcript AND submit it (the view's Send path). Used for the instant PAUSED-stage
    *  Send (the text is already transcribed) and as the fallback Send when onSendAudio is not wired. */
   onSend: (text: string) => void;
-  /** Fire-and-forget Send: when provided, hitting Send while still RECORDING captures the audio
-   *  buffer, hands it here, and closes the dialog IMMEDIATELY - the host then transcodes, uploads,
-   *  transcribes, and submits in the background (marking the session "Transcribing..."). This is what
-   *  releases the screen the instant Send is pressed, since the result cannot be viewed here anyway.
-   *  When omitted (e.g. the Voice-mode reply panel) Send falls back to the blocking transcribe-then-
-   *  submit path via onSend. */
+  /** Immediate (fire-and-forget) Send: when provided, hitting Send while still RECORDING captures the
+   *  audio buffer, hands it here, and closes the dialog IMMEDIATELY - the host then transcodes,
+   *  uploads, transcribes, and submits in the background (marking the session "Transcribing..."). This
+   *  is what releases the screen the instant Send is pressed, since the result cannot be viewed here
+   *  anyway. When omitted (e.g. the Voice-mode reply panel) Send falls back to the blocking
+   *  transcribe-then-submit path via onSend. */
   onSendAudio?: (captured: CapturedUtterance) => void;
   /** Close the dialog (Cancel, or after a commit). Nothing is sent on Cancel. */
   onClose: () => void;
@@ -210,11 +210,11 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
     [stage, transcript, transcribeCurrentSegment, onClose],
   );
 
-  // Send. The whole point of this handler (issue: mobile Speak should not hold the screen): when we
-  // are still RECORDING and the host wired the fire-and-forget path (onSendAudio), grab the captured
-  // audio buffer and hand it up, then close IMMEDIATELY - the host transcribes + submits in the
-  // background and marks the session "Transcribing...". The user cannot see the transcript here
-  // anyway (Send submits straight into the session), so waiting for it is pure dead time.
+  // Send. The whole point of this handler (mobile Speak should not hold the screen): when we are
+  // still RECORDING and the host wired the fire-and-forget path (onSendAudio), grab the captured audio
+  // buffer and hand it up, then close IMMEDIATELY - the host transcribes + submits in the background
+  // and marks the session "Transcribing...". The user cannot see the transcript here anyway (Send
+  // submits straight into the session), so waiting for it is pure dead time.
   //   * PAUSED: the text is already transcribed - submit it instantly, no audio round trip.
   //   * RECORDING without onSendAudio (Voice-mode reply panel): fall back to the blocking
   //     transcribe-then-submit commit so that surface is unchanged.

--- a/mobile/src/dictation/backgroundSend.ts
+++ b/mobile/src/dictation/backgroundSend.ts
@@ -21,8 +21,8 @@ export interface CapturedUtterance {
   blob: Blob;
   /** Wall-clock milliseconds the segment was capturing (capture-health, issue #863). */
   recordedMs: number;
-  /** Already-transcribed text from earlier Pause/Resume segments to prepend to this final segment.
-   *  Empty in the common "just talk and Send" case (no pause). */
+  /** Earlier Pause/Resume dictation segments, joined ahead of this final segment's transcript to form
+   *  the full dictation. Empty in the common "just talk and Send" case (no pause). */
   prefixText: string;
 }
 
@@ -30,6 +30,14 @@ export interface CapturedUtterance {
  *  and the roster's orange flag clearing is the visible completion signal. */
 export interface BackgroundSendHooks {
   onError?: (message: string) => void;
+  /** Called when the transcribe/submit chain throws, so the host can restore anything (e.g. the typed
+   *  compose text) it cleared at dialog-close time for a send that never went. */
+  onFailed?: () => void;
+  /** Place the dictated words into the final message. The host uses this to insert them at the caret
+   *  inside any typed compose text (like the Insert button), then this result is submitted. Defaults
+   *  to submitting the dictation alone. Called even for an empty dictation, so a Send pressed with
+   *  typed text present still submits that text; a fully-empty message submits nothing. */
+  compose?: (dictation: string) => string;
 }
 
 // Mark the session transcribing (roster -> orange), transcode + upload + transcribe the captured
@@ -57,14 +65,17 @@ export async function backgroundTranscribeAndSend(
     };
     logCaptureHealth("mobile", health);
     const segment = await transcribeUtterance(transcoded.wav, health);
-    const text = joinText(captured.prefixText, segment).trim();
-    // A silent clip (no speech captured) transcribes to nothing - submit nothing rather than an
-    // empty line, so a mis-tapped Send does not fire a blank turn into the session.
-    if (text.length > 0) {
-      await sendPrompt(sessionId, text, true);
+    const dictation = joinText(captured.prefixText, segment).trim();
+    // Let the host place the dictation (it inserts at the caret inside any typed text); default to the
+    // dictation alone. The typed text survives an empty/silent clip because compose still returns it,
+    // and a fully-empty message submits nothing so a mis-tapped Send does not fire a blank turn.
+    const message = (hooks.compose ? hooks.compose(dictation) : dictation).trim();
+    if (message.length > 0) {
+      await sendPrompt(sessionId, message, true);
     }
   } catch (err) {
     hooks.onError?.(err instanceof Error ? err.message : "Transcription failed");
+    hooks.onFailed?.();
   } finally {
     // Authoritative clear - releases the orange roster state whether the transcript submitted or the
     // attempt failed. Best-effort; the Gateway also expires an abandoned mark as a backstop.

--- a/mobile/src/dictation/transcript.ts
+++ b/mobile/src/dictation/transcript.ts
@@ -10,3 +10,18 @@ export function joinText(left: string, right: string): string {
   const boundary = /\s$/.test(left) || /^\s/.test(right);
   return boundary ? left + right : left + " " + right;
 }
+
+// Insert `insert` into `existing` at index `caret`, adding exactly one separating space on a side
+// only when the adjacent character is not already whitespace - so the inserted words never smush
+// against the surrounding text. An out-of-range caret is clamped to the end; an empty insert returns
+// `existing` unchanged. Mirrors the desktop DictationText.InsertAt so the Speak dialog drops dictation
+// at the caret identically to the desktop Insert button.
+export function insertAt(existing: string, caret: number, insert: string): string {
+  if (!insert) return existing;
+  if (caret < 0 || caret > existing.length) caret = existing.length;
+  const prefix = existing.slice(0, caret);
+  const suffix = existing.slice(caret);
+  const needsSpaceBefore = prefix.length > 0 && !/\s$/.test(prefix);
+  const needsSpaceAfter = suffix.length > 0 && !/^\s/.test(suffix);
+  return prefix + (needsSpaceBefore ? " " : "") + insert + (needsSpaceAfter ? " " : "") + suffix;
+}

--- a/src/CcDirector.Avalonia.Tests/DictationTextTests.cs
+++ b/src/CcDirector.Avalonia.Tests/DictationTextTests.cs
@@ -69,4 +69,52 @@ public class DictationTextTests
         Assert.EndsWith(newSpeech, result);
         Assert.Equal(edited + " " + newSpeech, result);
     }
+
+    // InsertAt underpins "Send drops the dictation at the caret, exactly like the Insert button".
+
+    [Fact]
+    public void InsertAt_EmptyExisting_ReturnsInsertUnchanged()
+    {
+        Assert.Equal("hello", DictationText.InsertAt("", 0, "hello"));
+    }
+
+    [Fact]
+    public void InsertAt_EmptyInsert_ReturnsExistingUnchanged()
+    {
+        Assert.Equal("fix the bug", DictationText.InsertAt("fix the bug", 4, ""));
+    }
+
+    [Fact]
+    public void InsertAt_AtEnd_AppendsWithSingleSpace()
+    {
+        Assert.Equal("fix the login bug and add a test",
+            DictationText.InsertAt("fix the login bug", 17, "and add a test"));
+    }
+
+    [Fact]
+    public void InsertAt_InMiddleOnWordBoundary_SpacesOnlyTheOpenSide()
+    {
+        // Caret sits just after "fix the " (index 8), before "bug". The left side already ends in a
+        // space so no space is added there; the right side starts with a letter so one space is added.
+        Assert.Equal("fix the and bug", DictationText.InsertAt("fix the bug", 8, "and"));
+    }
+
+    [Fact]
+    public void InsertAt_InMiddleMidWord_SpacesBothSides()
+    {
+        // Caret between two non-space characters: a separating space is added on both sides.
+        Assert.Equal("foo bar baz", DictationText.InsertAt("foobaz", 3, "bar"));
+    }
+
+    [Fact]
+    public void InsertAt_CaretOutOfRange_ClampsToEnd()
+    {
+        Assert.Equal("hello world", DictationText.InsertAt("hello", 999, "world"));
+    }
+
+    [Fact]
+    public void InsertAt_CaretAtStart_PrependsWithSingleSpace()
+    {
+        Assert.Equal("hello world", DictationText.InsertAt("world", 0, "hello"));
+    }
 }

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -2977,27 +2977,44 @@ public partial class MainWindow : Window
             var target = _activeSession?.Session;
             var dlg = new global::CcDirector.Avalonia.Voice.SpeakDialog(options)
             {
-                // Fire-and-forget Send (spec section 10) needs a target session to submit into and to
-                // mark orange; only enable it when we have one.
+                // Immediate (fire-and-forget) Send needs a target session to submit into; enable it
+                // whenever we have one so pressing Send releases the screen at once.
                 EnableBackgroundSend = target is not null,
             };
             await dlg.ShowDialog(this);
 
-            // Fire-and-forget Send: the dialog handed us the still-capturing recorder and closed. The
-            // screen is already released; transcribe + submit in the background while the session
-            // shows orange "Transcribing...". Not awaited - that is the whole point.
+            // Immediate Send: the dialog handed us the still-capturing recorder and closed at once. The
+            // screen is already released; transcribe + submit in the background while the session shows
+            // orange "Transcribing...". Send behaves exactly like the Insert button followed by Enter:
+            // the dictation is dropped at the caret we snapshotted, inside any typed text (via the same
+            // DictationText.InsertAt the Insert button uses), then submitted. The dialog was modal, so
+            // the box could not change since we snapshotted it; clear it now so the user does not see -
+            // or re-send - already-committed text. On a transcription FAILURE the typed text is put back
+            // (RestoreDictatedComposerText) so it is never lost.
             if (dlg.IsBackgroundSend && dlg.BackgroundRecorder is not null && target is not null)
             {
                 var recorder = dlg.BackgroundRecorder;
-                var prefix = dlg.BackgroundPrefix;
-                FileLog.Write($"[MainWindow] BtnSpeak_Click: background dictation send to session {target.Id}");
+                var composerText = existingTextBefore;
+                var caret = caretBefore;
+                PromptInput.Text = "";
+                FileLog.Write($"[MainWindow] BtnSpeak_Click: background dictation send to session {target.Id}, composer chars={composerText.Length}, caret={caret}");
                 _ = global::CcDirector.Avalonia.Voice.BackgroundDictationSend.RunAsync(
-                    recorder, prefix, target,
-                    text => global::Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
-                        () => SubmitDictatedTextAsync(target, text)));
+                    recorder, dlg.BackgroundPrefix, target,
+                    dictation => global::Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+                        () => SubmitDictatedTextAsync(
+                            target,
+                            global::CcDirector.Avalonia.Voice.DictationText.InsertAt(composerText, caret, dictation))),
+                    onFailed: () => global::Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
+                    {
+                        RestoreDictatedComposerText(target, composerText);
+                        return Task.CompletedTask;
+                    }));
                 return;
             }
 
+            // Insert, or a blocking Send when there was no target session: the dialog already
+            // transcribed and returned the text. Insert it at the caret we snapshotted (joining with
+            // anything already typed) and submit only if the user chose Send.
             var transcript = dlg.ResultText;
             if (string.IsNullOrWhiteSpace(transcript))
             {
@@ -3029,13 +3046,12 @@ public partial class MainWindow : Window
     {
         var existing = PromptInput.Text ?? "";
         if (caret < 0 || caret > existing.Length) caret = existing.Length;
-        var prefix = existing[..caret];
-        var suffix = existing[caret..];
-        var needsSpaceBefore = prefix.Length > 0 && !char.IsWhiteSpace(prefix[^1]);
-        var needsSpaceAfter = suffix.Length > 0 && !char.IsWhiteSpace(suffix[0]);
-        var insert = (needsSpaceBefore ? " " : "") + text + (needsSpaceAfter ? " " : "");
-        PromptInput.Text = prefix + insert + suffix;
-        PromptInput.CaretIndex = prefix.Length + insert.Length;
+        var suffixLen = existing.Length - caret;
+        var composed = global::CcDirector.Avalonia.Voice.DictationText.InsertAt(existing, caret, text);
+        PromptInput.Text = composed;
+        // Caret lands right after the inserted content: the untouched suffix is still at the tail, so
+        // the insertion ends at composed.Length - suffixLen.
+        PromptInput.CaretIndex = composed.Length - suffixLen;
         PromptInput.Focus();
     }
 
@@ -3066,6 +3082,23 @@ public partial class MainWindow : Window
 
         await target.SendTextAsync(text);
         ScheduleEnterRetry(target);
+    }
+
+    /// <summary>
+    /// Restore typed compose text after a fire-and-forget dictation Send failed to transcribe (the
+    /// send it was folded into never happened, and the box was cleared when the dialog closed). If the
+    /// target session is still on screen, put the words back at the front of the box; otherwise stash
+    /// them in that session's saved compose text so they reappear when the user returns. Never silent:
+    /// a notification tells the user the dictation failed but their typed text was kept.
+    /// </summary>
+    private void RestoreDictatedComposerText(Session target, string composerText)
+    {
+        if (string.IsNullOrEmpty(composerText)) return;
+        if (_activeSession?.Session == target)
+            InsertIntoPromptInputAt(composerText, 0);
+        else
+            target.PendingPromptText = global::CcDirector.Avalonia.Voice.DictationText.Join(composerText, target.PendingPromptText ?? "");
+        ShowNotification("Dictation failed to transcribe - your typed text was kept.");
     }
 
     private void BtnOpenInBrowser_Click(object? sender, RoutedEventArgs e)

--- a/src/CcDirector.Avalonia/Voice/BackgroundDictationSend.cs
+++ b/src/CcDirector.Avalonia/Voice/BackgroundDictationSend.cs
@@ -7,8 +7,8 @@ namespace CcDirector.Avalonia.Voice;
 /// The fire-and-forget desktop dictation send (docs/architecture/dictation/DICTATION_UX_SPEC.md
 /// section 10), the desktop twin of the mobile PWA's background send. The Speak dialog handed us the
 /// still-capturing recorder the instant Send was pressed and closed itself, releasing the screen;
-/// this runs the rest - transcribe the clip, join it onto any earlier paused text, and submit it into
-/// the session - OFF the UI thread, while the session shows orange "Transcribing..." so nobody else
+/// this runs the rest - transcribe the clip, join it onto the leading text, and submit it into the
+/// session - OFF the UI thread, while the session shows orange "Transcribing..." so nobody else
 /// starts typing into it mid-dictation.
 ///
 /// It marks <see cref="Session.IsTranscribing"/> for the duration (the SessionStatusWingman paints
@@ -18,16 +18,21 @@ namespace CcDirector.Avalonia.Voice;
 public static class BackgroundDictationSend
 {
     /// <summary>
-    /// Transcribe <paramref name="recorder"/>'s clip, prepend <paramref name="prefix"/> (earlier
-    /// paused segments), and hand the joined text to <paramref name="submit"/> - which the caller
-    /// wires to its normal per-session submit path (it is responsible for marshaling to the UI thread
-    /// if its submit touches UI). The session shows orange until this returns.
+    /// Transcribe <paramref name="recorder"/>'s clip, prepend <paramref name="prefix"/>, and hand the
+    /// joined text to <paramref name="submit"/> - which the caller wires to its normal per-session
+    /// submit path (it is responsible for marshaling to the UI thread if its submit touches UI). The
+    /// session shows orange until this returns.
     /// </summary>
     /// <param name="recorder">The detached, still-capturing recorder. Owned and disposed here.</param>
-    /// <param name="prefix">Already-transcribed text from earlier Pause/Resume segments; may be empty.</param>
+    /// <param name="prefix">Already-transcribed text from earlier Pause/Resume segments, joined ahead
+    /// of this segment's transcript to form the full dictation; may be empty.</param>
     /// <param name="target">The session the message is being dictated into (marked orange meanwhile).</param>
-    /// <param name="submit">Submits the finished text into the session. Not called for an empty clip.</param>
-    public static async Task RunAsync(BatchDictationRecorder recorder, string prefix, Session target, Func<string, Task> submit)
+    /// <param name="submit">Places the dictated words (the caller inserts them at the caret inside any
+    /// typed text) and submits the result. Called even for an empty dictation, because the caller may
+    /// still have typed text to submit; the caller guards a fully-empty message itself.</param>
+    /// <param name="onFailed">Invoked when transcription throws, so the caller can restore any typed
+    /// text it cleared at dialog-close time (the send it was folded into never happened).</param>
+    public static async Task RunAsync(BatchDictationRecorder recorder, string prefix, Session target, Func<string, Task> submit, Func<Task>? onFailed = null)
     {
         // This is the root of a detached background task (the dialog is already gone), so it is an
         // entry point: catch here so a transcription/submit failure is logged and the orange mark is
@@ -37,20 +42,22 @@ public static class BackgroundDictationSend
         try
         {
             var result = await recorder.TranscribeAsync();
-            var text = DictationText.Join(prefix, result.CleanedTranscript).Trim();
-            if (!string.IsNullOrEmpty(text))
-            {
-                await submit(text);
-                FileLog.Write($"[BackgroundDictationSend] submitted {text.Length} chars to session {target.Id}");
-            }
-            else
-            {
-                FileLog.Write($"[BackgroundDictationSend] empty transcript for session {target.Id} - nothing submitted");
-            }
+            var dictation = DictationText.Join(prefix, result.CleanedTranscript).Trim();
+            // Hand the dictated words to the caller to place at the caret and submit. Always call it -
+            // even for an empty dictation - because the caller may still have typed text to send; it
+            // guards a fully-empty message itself, so a mis-tapped silent Send with an empty box sends
+            // nothing.
+            FileLog.Write($"[BackgroundDictationSend] transcribed {dictation.Length} chars for session {target.Id}");
+            await submit(dictation);
         }
         catch (Exception ex)
         {
             FileLog.Write($"[BackgroundDictationSend] FAILED for session {target.Id}: {ex.Message}");
+            if (onFailed is not null)
+            {
+                try { await onFailed(); }
+                catch (Exception restoreEx) { FileLog.Write($"[BackgroundDictationSend] onFailed restore error: {restoreEx.Message}"); }
+            }
         }
         finally
         {

--- a/src/CcDirector.Avalonia/Voice/DictationText.cs
+++ b/src/CcDirector.Avalonia/Voice/DictationText.cs
@@ -24,4 +24,25 @@ public static class DictationText
         if (leftEndsWithSpace || rightStartsWithSpace) return left + right;
         return left + " " + right;
     }
+
+    /// <summary>
+    /// Insert <paramref name="insert"/> into <paramref name="existing"/> at index
+    /// <paramref name="caret"/>, adding exactly one separating space on a side only when the adjacent
+    /// character is not already whitespace - so the inserted words never smush against the surrounding
+    /// text. An out-of-range caret is clamped to the end; an empty insert returns
+    /// <paramref name="existing"/> unchanged. This is the pure, box-free core shared by the desktop
+    /// Insert button and the fire-and-forget Send, so both drop dictation at the caret identically.
+    /// </summary>
+    public static string InsertAt(string existing, int caret, string insert)
+    {
+        existing ??= "";
+        if (string.IsNullOrEmpty(insert)) return existing;
+        if (caret < 0 || caret > existing.Length) caret = existing.Length;
+        var prefix = existing[..caret];
+        var suffix = existing[caret..];
+        var needsSpaceBefore = prefix.Length > 0 && !char.IsWhiteSpace(prefix[^1]);
+        var needsSpaceAfter = suffix.Length > 0 && !char.IsWhiteSpace(suffix[0]);
+        var mid = (needsSpaceBefore ? " " : "") + insert + (needsSpaceAfter ? " " : "");
+        return prefix + mid + suffix;
+    }
 }

--- a/src/CcDirector.Avalonia/Voice/SpeakDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/Voice/SpeakDialog.axaml.cs
@@ -96,8 +96,8 @@ public partial class SpeakDialog : Window
     /// Opt in to fire-and-forget Send (spec section 10). When true, pressing Send while RECORDING
     /// hands the still-capturing recorder to the caller and closes the dialog IMMEDIATELY instead of
     /// blocking on transcription - the caller then transcribes + submits in the background while the
-    /// session shows orange "Transcribing...". Default false keeps the original blocking behavior for
-    /// callers that cannot run a background send (they read <see cref="ResultText"/> as before).
+    /// session shows orange "Transcribing...". Default false keeps the blocking behavior for callers
+    /// that cannot run a background send (e.g. the Wingman surface; they read <see cref="ResultText"/>).
     /// </summary>
     public bool EnableBackgroundSend { get; set; }
 
@@ -408,7 +408,8 @@ public partial class SpeakDialog : Window
     private async void PrimaryButton_Click(object? sender, RoutedEventArgs e)
     {
         // Send. From RECORDING with fire-and-forget enabled (spec section 10), hand the recorder to
-        // the caller and close NOW; otherwise transcribe-then-close (the original blocking Send).
+        // the caller and close NOW so the screen is released immediately; the caller transcribes and
+        // submits in the background. Without it (the Wingman surface), transcribe-then-close (blocking).
         // From PAUSED the text already exists, so it commits instantly either way.
         if (_stage == Stage.Recording)
         {

--- a/src/CcDirector.Cockpit/Components/Pages/Cockpit.razor
+++ b/src/CcDirector.Cockpit/Components/Pages/Cockpit.razor
@@ -357,9 +357,9 @@
                                           placeholder="Type a message... (Ctrl+Enter to send, Ctrl+Shift+Enter to queue)"></textarea>
                                 <InputFile OnChange="OnDropImages" multiple accept="image/*" class="composer-drop-input" />
                                 <div class="composer-btns">
-                                    <button class="btn send" @onclick="SendNow" disabled="@(_acting || string.IsNullOrWhiteSpace(_compose))">Send</button>
+                                    <button class="btn send" @onclick="SendNow" disabled="@(_acting || _sendLockedForDictation || string.IsNullOrWhiteSpace(_compose))">Send</button>
                                     <button class="btn speak @(_dictating ? "on" : "")" @onclick="OpenDictate" title="Dictate" disabled="@_dictating">Speak</button>
-                                    <button class="btn queue" @onclick="QueueIt" disabled="@(_acting || string.IsNullOrWhiteSpace(_compose))">Queue</button>
+                                    <button class="btn queue" @onclick="QueueIt" disabled="@(_acting || _sendLockedForDictation || string.IsNullOrWhiteSpace(_compose))">Queue</button>
                                 </div>
                             </div>
                             @if (!string.IsNullOrEmpty(_shotStatus))
@@ -1201,6 +1201,9 @@
     {
         var sel = Selected;
         if (sel is null || string.IsNullOrWhiteSpace(_compose)) return;
+        // Locked while a dictated turn is transcribing in the background for this session, so a typed
+        // Send (button or Ctrl+Enter) cannot race the incoming dictated prompt and double-send.
+        if (_sendLockedForDictation) return;
         Log.LogInformation("Cockpit action=send sid={Sid} chars={Chars}", sel.SessionId, _compose.Length);
         await Act(async () =>
         {
@@ -1451,8 +1454,19 @@
     // fire-and-forget background send marks/clears the RIGHT session's orange "Transcribing" state
     // even if the user selects a different session while the transcription runs in the background.
     private string? _dictatingSessionId;
+    // The composer caret position snapshotted when Speak opened, so Insert/Send drop the dictation
+    // where the cursor was rather than at the end (the overlay is modal, so it cannot move meanwhile).
+    private int _dictateCaret;
     private DotNetObjectReference<Cockpit>? _dictateRef;
     private IJSObjectReference? _composerDropModule;
+
+    // True between a fire-and-forget Send closing the Speak dialog and the background transcribe-and-
+    // submit landing (spec section 10). The composer keeps the typed text through this window, and
+    // OnDictateSend appends the dictation to it when the transcript lands (Send = Insert-then-Enter),
+    // so Send and Queue are locked meanwhile to stop a manual Send racing the incoming dictated turn
+    // and firing the typed text twice. Scoped to the dictating session so other sessions stay usable.
+    private bool _backgroundDictating;
+    private bool _sendLockedForDictation => _backgroundDictating && Selected?.SessionId == _dictatingSessionId;
 
     // ---- Voice tab (issue #531) ----
     // When true, the dictation result routes to the wingman voice-turn flow instead of the
@@ -1541,6 +1555,14 @@
             _dictating = true;
             _dictatingSessionId = Selected.SessionId;
             _actError = null;
+            // Snapshot where the cursor is in the composer so the dictation lands there, not at the end
+            // (like the desktop Insert button). Best-effort - default to the end if we cannot read it.
+            _dictateCaret = _compose?.Length ?? 0;
+            if (_composerDropModule is not null)
+            {
+                try { _dictateCaret = await _composerDropModule.InvokeAsync<int>("caretOf", _composerEl); }
+                catch (Exception ex) { Log.LogDebug(ex, "caretOf failed; defaulting to end of composer"); }
+            }
             _dictateRef ??= DotNetObjectReference.Create(this);
             // Issue #268: dictate over a same-origin WS to the GATEWAY (never the Director's own
             // address); the Gateway resolves the owning Director and reverse-proxies /dictate.
@@ -1561,8 +1583,8 @@
         }
     }
 
-    // Insert: the dialog finished and the user chose Insert - append the cleaned text to the
-    // composer for review (no auto-submit), mirroring the desktop dialog's Insert button.
+    // Insert: the dialog finished and the user chose Insert - drop the cleaned text into the composer
+    // at the caret we snapshotted when Speak opened (no auto-submit), mirroring the desktop Insert.
     [JSInvokable]
     public async Task OnDictateInsert(string text)
     {
@@ -1577,12 +1599,20 @@
             return;
         }
         if (!string.IsNullOrWhiteSpace(text))
-            _compose = string.IsNullOrEmpty(_compose) ? text : _compose + " " + text;
+        {
+            var existing = _compose ?? "";
+            var suffixLen = existing.Length - Math.Clamp(_dictateCaret, 0, existing.Length);
+            _compose = InsertAt(existing, _dictateCaret, text);
+            await InvokeAsync(StateHasChanged);
+            // Put the caret right after the inserted words so the user can keep editing there.
+            await SetComposerCaretAsync(_compose.Length - suffixLen);
+            return;
+        }
         await InvokeAsync(StateHasChanged);
     }
 
-    // Send: the dialog finished and the user chose Send - append the cleaned text and submit
-    // immediately via the normal composer send path.
+    // Send: the dialog finished and the user chose Send - insert the cleaned text at the snapshotted
+    // caret and submit immediately via the normal composer send path.
     [JSInvokable]
     public async Task OnDictateSend(string text)
     {
@@ -1597,9 +1627,32 @@
             return;
         }
         if (!string.IsNullOrWhiteSpace(text))
-            _compose = string.IsNullOrEmpty(_compose) ? text : _compose + " " + text;
+            _compose = InsertAt(_compose ?? "", _dictateCaret, text);
         await InvokeAsync(StateHasChanged);
         await SendNow();
+    }
+
+    // Insert `insert` into `existing` at `caret`, adding one separating space on a side only when the
+    // adjacent character is not already whitespace. Clamps an out-of-range caret to the end; an empty
+    // insert returns `existing` unchanged. Mirrors the desktop DictationText.InsertAt so the Cockpit
+    // drops dictation at the caret identically to the desktop Insert button.
+    private static string InsertAt(string existing, int caret, string insert)
+    {
+        existing ??= "";
+        if (string.IsNullOrEmpty(insert)) return existing;
+        if (caret < 0 || caret > existing.Length) caret = existing.Length;
+        var prefix = existing[..caret];
+        var suffix = existing[caret..];
+        var needsSpaceBefore = prefix.Length > 0 && !char.IsWhiteSpace(prefix[^1]);
+        var needsSpaceAfter = suffix.Length > 0 && !char.IsWhiteSpace(suffix[0]);
+        return prefix + (needsSpaceBefore ? " " : "") + insert + (needsSpaceAfter ? " " : "") + suffix;
+    }
+
+    private async Task SetComposerCaretAsync(int pos)
+    {
+        if (_composerDropModule is null) return;
+        try { await _composerDropModule.InvokeVoidAsync("setCaret", _composerEl, pos); }
+        catch (Exception ex) { Log.LogDebug(ex, "setCaret failed"); }
     }
 
     // Cancel / closed with no text.
@@ -1614,13 +1667,16 @@
 
     // Fire-and-forget Send (spec section 10): the overlay closed the instant Send was pressed and
     // the transcribe-and-submit is now running in the background. Release the dialog guard so the
-    // user can act immediately, and mark the session orange ("Transcribing...") on the roster so
-    // nobody else starts using it. The matching OnDictateSend still fires later with the text.
+    // user can act immediately, mark the session orange ("Transcribing...") on the roster, and lock
+    // the composer Send/Queue so the typed text sitting there cannot be sent twice while the dictated
+    // transcript is on its way. The matching OnDictateSend fires later and appends the transcript to
+    // that typed text. Skip the composer lock for the Voice tab, which does not touch the composer.
     [JSInvokable]
     public async Task OnDictateTranscribingStart()
     {
         _dictating = false;
         var sid = _dictatingSessionId;
+        if (!_voiceDictation) _backgroundDictating = true;
         ActionInfo("speak-transcribing", "state=start");
         await InvokeAsync(StateHasChanged);
         if (!string.IsNullOrEmpty(sid))
@@ -1630,21 +1686,27 @@
         }
     }
 
-    // The background transcription finished (or failed) - clear the orange "Transcribing" mark.
+    // The background transcription finished (or failed) - clear the orange "Transcribing" mark and
+    // release the composer lock. This fires AFTER the matching OnDictateSend on the success path, so
+    // the dictated turn is already submitted by now; on the empty/failed path the composer still holds
+    // the typed text, which the user can now Send themselves.
     [JSInvokable]
     public async Task OnDictateTranscribingEnd()
     {
         var sid = _dictatingSessionId;
         ActionInfo("speak-transcribing", "state=end");
+        _backgroundDictating = false;
         if (!string.IsNullOrEmpty(sid))
         {
             try { await Director.SetTranscribingAsync(sid, false); }
             catch (Exception ex) { Log.LogDebug(ex, "SetTranscribing(false) failed for {Sid}", sid); }
         }
+        await InvokeAsync(StateHasChanged);
     }
 
-    // The background send failed after the overlay closed - surface the cause (the orange mark is
-    // already cleared by OnDictateTranscribingEnd, which fires first).
+    // The background send failed after the overlay closed - surface the cause. The composer still
+    // holds the user's typed text (it was never cleared), so nothing is lost; the orange mark is
+    // already cleared by OnDictateTranscribingEnd, which fires first.
     [JSInvokable]
     public Task OnDictateError(string message)
     {

--- a/src/CcDirector.Cockpit/wwwroot/js/cockpit-composer-drop.js
+++ b/src/CcDirector.Cockpit/wwwroot/js/cockpit-composer-drop.js
@@ -16,6 +16,28 @@ export function resizeTextarea(el) {
   el.style.height = Math.min(el.scrollHeight, 160) + 'px';
 }
 
+// Read the caret position of a composer textarea, so a dictation Insert/Send can drop the words where
+// the cursor was rather than at the end. Falls back to the end of the text when unavailable.
+export function caretOf(el) {
+  if (!el) return 0;
+  try {
+    const pos = el.selectionStart;
+    return (typeof pos === 'number') ? pos : (el.value ? el.value.length : 0);
+  } catch (_) {
+    return el.value ? el.value.length : 0;
+  }
+}
+
+// Move the caret to a position and focus the textarea, so after an Insert the user can keep editing
+// right after the words that were dropped in.
+export function setCaret(el, pos) {
+  if (!el) return;
+  try {
+    el.focus();
+    el.selectionStart = el.selectionEnd = pos;
+  } catch (_) {}
+}
+
 export function init() {
   if (window.__cockpitComposerDropInit) return;
   window.__cockpitComposerDropInit = true;

--- a/src/CcDirector.Cockpit/wwwroot/js/dictation-overlay.js
+++ b/src/CcDirector.Cockpit/wwwroot/js/dictation-overlay.js
@@ -148,7 +148,7 @@ window.dictationOverlay = (function () {
     return overlay;
   }
 
-  // Resolve the three outcome callbacks from the options object. A Blazor host passes a
+  // Resolve the outcome callbacks from the options object. A Blazor host passes a
   // DotNetObjectReference (dotNetRef) and we invoke its OnDictate* methods; a plain-JS host
   // passes onInsert/onSend/onCancel directly. onSend falls back to onInsert when omitted.
   //


### PR DESCRIPTION
## What and why

Pressing **Send** in the Speak (dictation) dialog used to submit only the dictated words and drop whatever was already typed in the compose box. This fixes that and makes Send a true convenience for "Insert, then Enter".

Send now:
- Inserts the dictation **at the cursor position** inside any existing typed text (not appended at the end), using the same caret-aware `InsertAt` logic the Insert button uses.
- Keeps the **immediate (fire-and-forget)** behavior: the screen is released the instant Send is pressed and transcription runs in the background.
- **Restores the typed text on a transcription failure**, so nothing is lost.

## Per surface

- **Desktop (Avalonia):** shared `DictationText.InsertAt`; the Insert button and the background Send both call it. Fire-and-forget Send snapshots the caret, clears the box, submits typed+dictation to the captured session, and restores the typed text if transcription fails.
- **Mobile (React `/m`):** `insertAt` in `transcript.ts`; caret snapshotted on Speak-press; Insert and both Send paths (paused + fire-and-forget) insert at the caret via a new `compose` hook on the background sender.
- **Cockpit (Blazor):** C# `InsertAt` plus `caretOf`/`setCaret` JS helpers; Insert and Send drop dictation at the snapshotted caret. Send/Queue are locked while a dictated turn transcribes in the background so a manual Send cannot race it and double-send.

## Testing

- Added `InsertAt` unit tests (caret at end, mid-word, on a word boundary, at the start, out-of-range clamp, empty insert). All 15 `DictationText` tests pass.
- Avalonia and Cockpit build clean (0 warnings / 0 errors); mobile `tsc --noEmit` passes.
- Verified live in a slot-5 desktop build: typed text, placed the cursor mid-string, dictated, hit Send, and the words landed at the cursor and were submitted.

## Notes

- Mobile does not force focus after Insert (that would raise the on-screen keyboard), so the visible cursor only lands after the inserted words when the box is already focused.
- On the Cockpit fire-and-forget path, if the user types into the composer during the brief background window, the snapshotted caret can be stale; the insert still happens (clamped, nothing lost), just possibly not at the exact expected spot. Desktop and mobile clear the box at Send, so they do not have this case.

Generated with Claude Code (https://claude.com/claude-code)
