### PR TITLE
Phase 4 (#924): website device-revoke locks the device out (revoke down-propagation)

### DIFF
--- a/docs/architecture/mobile/DEVICE_AUTH_SECURITY_MODEL.md
+++ b/docs/architecture/mobile/DEVICE_AUTH_SECURITY_MODEL.md
@@ -100,6 +100,23 @@ cookie carrying (C); `AuthMiddleware` accepts (C) on both the Bearer header and 
 
 Revocation is per-device: removing one phone never affects any other device or the master token.
 
+**Guaranteed revocation-latency bound (issue #924).** Revocation is PULL-based, not push: there is no
+inbound cloud-to-Gateway channel (sub-second/instant revoke is a Non-goal of epic #916 - it would need a
+persistent relay). A website revoke reaches the Gateway only on its next OUTBOUND reconcile sweep, so the
+bound is exactly **one sweep interval - `GatewayHost.CronSweepInterval`, ~1 minute**. A revoked device may
+keep working up to that one interval and is refused on the first request after the sweep that drops its
+key; it is never refused sooner (nothing pushes the revoke) and never later than one sweep (the sweep is
+periodic). Under host-wide enforcement (issue #917) that refusal is a hard `401`.
+
+**Revoke-propagation failures are visible (issue #924).** The reconcile sweep no longer swallows a broken
+revoke path into an indistinguishable retry line. `ChildDeviceMirrorService` counts consecutive reconcile
+failures and exposes `HasPersistentReconcileFailure` (plus `ConsecutiveReconcileFailures` /
+`LastReconcileError`) for the Cockpit/tray to read, and logs a distinct escalated signal once the path is
+persistently stuck. That status is also set when the Gateway's account-token refresh is persistently
+failing (the issue #911 signal) - the case where reconcile has no usable token and would otherwise skip in
+silence. So a "website revokes are not reaching this Gateway" condition surfaces instead of retrying
+forever unseen.
+
 ---
 
 ## 4. What each control defends against
@@ -117,6 +134,13 @@ Revocation is per-device: removing one phone never affects any other device or t
 ---
 
 ## 5. Known gaps (open audit items)
+
+> Update (issue #924): epic #916 has since landed its enforcement and refresh phases. Gap 1 is closed by
+> Phase 1 (#917 - the host-wide auth gate is now ON by default) and gap 2 by Phase 3 (#911 - the refresh
+> exchange now sends the `apikey`). Phase 4 (#924) additionally makes revoke-propagation failures visible
+> (see the Revoke section above). The gaps are retained below as the original audit record; gap 3 (a live,
+> end-to-end enforced audit across the whole fleet, including the owner's real-phone revoke round-trip)
+> remains the epic's real done-check and is owner-run.
 
 1. **Host-wide enforcement is OFF by default.** The device-key check only *enforces* when the Gateway
    runs with `CC_GATEWAY_AUTH=1`. With it off (the shipped default; the tailnet is the boundary today),

--- a/docs/cencon/proof/issue-924/qa-enforced-transcript.txt
+++ b/docs/cencon/proof/issue-924/qa-enforced-transcript.txt
@@ -1,0 +1,11 @@
+  Passed CcDirector.Gateway.Tests.Account.RevokeDownEnforcedGatewayProofTests.Website_revoke_locks_the_device_out_of_the_enforced_gateway_within_one_reconcile [230 ms]
+ === Issue #924 revoke-down proof: running ENFORCING Gateway + test/fake roster ===
+ Gateway: real GatewayHost, authEnabled=true (issue #917), loopback port 60267
+ Fake cloud roster: in-process stub, GET /api/v1/devices returns an EMPTY roster (device revoked)
+ STEP 1  key present  -> GET /sessions with the device key -> HTTP 200 OK
+ STEP 2  website revoke -> the cloud roster no longer lists this device
+ STEP 3  ONE ReconcileAsync sweep ran against the fake roster
+ STEP 4  key gone      -> DeviceRegistry no longer holds the device key
+ STEP 5  revoked      -> GET /sessions with the same key -> HTTP 401 Unauthorized; body={"error":"missing or invalid token"}
+ RESULT: a website revoke locked the device out of the enforced Gateway within one reconcile sweep.
+ NOTE: this automated proof uses a TEST/FAKE roster; the live-hardware phone revoke round-trip is the owner-run human follow-up.

--- a/docs/cencon/proof/issue-924/qa-report.html
+++ b/docs/cencon/proof/issue-924/qa-report.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>QA Proof Report - Issue #924 (Phase 4: website device-revoke lock-out)</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; max-width: 960px; margin: 2rem auto; padding: 0 1rem; color: #1b1b1b; line-height: 1.5; }
+  h1 { border-bottom: 3px solid #5319e7; padding-bottom: .4rem; }
+  h2 { margin-top: 2rem; color: #5319e7; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #ccc; padding: .5rem .6rem; text-align: left; vertical-align: top; }
+  th { background: #f2eefc; }
+  .pass { color: #0a7d28; font-weight: bold; }
+  .verdict { background: #e7f8ec; border: 2px solid #0a7d28; padding: 1rem; margin-top: 2rem; font-size: 1.1rem; }
+  pre { background: #1b1b1b; color: #e6e6e6; padding: 1rem; overflow-x: auto; border-radius: 5px; font-size: .85rem; }
+  code { background: #f0f0f0; padding: .1rem .3rem; border-radius: 3px; }
+</style>
+</head>
+<body>
+<h1>QA Proof Report - Issue #924 (Phase 4)</h1>
+<p><strong>Title:</strong> Make website device-revoke lock the device out (revoke down-propagation)<br>
+<strong>Pull request:</strong> #926 (branch <code>issue-924-revoke-down</code>, HEAD 6cfd9380)<br>
+<strong>Epic:</strong> #916, security. Phases 1 (#917), 2 (#920), 3 (#911) merged.<br>
+<strong>QA identity:</strong> independent verifier - separate context from the Developer Agent; did not reuse the developer's binary, tests output, or report.<br>
+<strong>Verified:</strong> 2026-07-04</p>
+
+<h2>Method</h2>
+<p>Fresh git worktree of the PR branch. Full solution built from source
+(<code>dotnet build cc-director.sln</code>: <strong>Build succeeded, 0 Warning(s), 0 Error(s)</strong>).
+Full Gateway test suite run from my own build. Criterion-specific tests re-run individually with a detailed
+transcript. This is a headless Gateway/backend change; every acceptance criterion is test-, code-, or
+docs-based, and the issue's own "Proof required" section names the automated tests plus a transcript against
+a running enforcing Gateway as the proof - which I reproduced independently below.</p>
+
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (my run)</th><th>Verdict</th></tr>
+<tr>
+  <td>1</td>
+  <td>End to end under enforcement: one <code>ReconcileAsync</code> removes a roster-absent key; next request 401s.</td>
+  <td>enroll -&gt; key present -&gt; roster drops it -&gt; one reconcile -&gt; key gone -&gt; enforced request 401.</td>
+  <td><code>MobileEnrollRevokeRoundTripTests.Enroll_then_website_revoke_under_enforcement_makes_the_next_request_401</code> PASS (drives the real <code>AuthMiddleware.Run</code> gate). <code>RevokeDownEnforcedGatewayProofTests</code> boots a REAL enforcing <code>GatewayHost</code> over loopback HTTP: STEP 1 key present -&gt; HTTP 200 OK; STEP 5 after one reconcile -&gt; HTTP 401 Unauthorized, body <code>{"error":"missing or invalid token"}</code>.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>2</td>
+  <td>A device still on the roster is NOT removed (no false eviction).</td>
+  <td>Two reconciles with the device still on the roster keep its key; enforced access continues (200).</td>
+  <td><code>Enroll_then_reconcile_with_device_still_on_roster_keeps_enforced_access</code> PASS (key valid, count=1, enforced GET still 200, no persistent-failure flag). <code>ChildDeviceMirrorTests.Reconcile_ChildStillOnRoster_IsKept</code> PASS. The persistent-failure test also asserts a failing sweep evicts nothing.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>3</td>
+  <td>A persistent reconcile/auth failure is surfaced (status + log), not silently swallowed; a test covers it.</td>
+  <td>After N consecutive roster-pull failures, <code>HasPersistentReconcileFailure</code> is true, <code>ConsecutiveReconcileFailures</code>/<code>LastReconcileError</code> set, a distinct escalated log line fires, no child evicted, and a clean sweep clears it. The Phase 3 refresh-failure signal is reused.</td>
+  <td><code>Reconcile_CloudRosterPullPersistentlyFails_SurfacesPersistentReconcileFailure</code> PASS (asserts the status fields, the greppable "PERSISTENT reconcile failure" log line, no false eviction, and recovery-clears). <code>HasPersistentReconcileFailure_WhenAccountRefreshPersistentlyFailing_IsTrue</code> PASS (reused #911 signal). Source confirms failures are recorded, not swallowed (no fallback).</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>4</td>
+  <td>The guaranteed revocation-latency bound (one sweep, ~1 min) is documented.</td>
+  <td>A code comment and a line in the security-model doc state the one-sweep bound.</td>
+  <td><code>DEVICE_AUTH_SECURITY_MODEL.md</code> documents the one-sweep bound (<code>GatewayHost.CronSweepInterval</code>, ~1 min) and the failure-visibility signal. <code>ReconcileAsync</code> remarks document the same. I confirmed <code>CronSweepInterval = TimeSpan.FromMinutes(1)</code> in <code>GatewayHost.cs</code>, so the documented ~1 min bound is accurate.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>5</td>
+  <td>Full Gateway test suite green.</td>
+  <td>All Gateway tests pass.</td>
+  <td>My run: <strong>Passed: 1205, Failed: 0, Skipped: 0, Total: 1205</strong> (Duration 2 m 55 s).</td>
+  <td class="pass">PASS</td>
+</tr>
+</table>
+
+<h2>Independent enforced-Gateway transcript (my run)</h2>
+<pre>=== Issue #924 revoke-down proof: running ENFORCING Gateway + test/fake roster ===
+Gateway: real GatewayHost, authEnabled=true (issue #917), loopback port 60267
+Fake cloud roster: in-process stub, GET /api/v1/devices returns an EMPTY roster (device revoked)
+STEP 1  key present  -> GET /sessions with the device key -> HTTP 200 OK
+STEP 2  website revoke -> the cloud roster no longer lists this device
+STEP 3  ONE ReconcileAsync sweep ran against the fake roster
+STEP 4  key gone      -> DeviceRegistry no longer holds the device key
+STEP 5  revoked      -> GET /sessions with the same key -> HTTP 401 Unauthorized; body={"error":"missing or invalid token"}
+RESULT: a website revoke locked the device out of the enforced Gateway within one reconcile sweep.
+NOTE: this automated proof uses a TEST/FAKE roster; the live-hardware phone revoke round-trip is the owner-run human follow-up.</pre>
+
+<h2>Regression and method checks</h2>
+<ul>
+  <li>Build clean: 0 warnings, 0 errors across the whole solution.</li>
+  <li>Full Gateway suite green (1205/1205) - nothing adjacent broke.</li>
+  <li>No fallback programming: cloud failures are recorded and surfaced (status + distinct log), not swallowed into a silent forever-retry.</li>
+  <li>Security rule DT-05 respected: <code>ChildDeviceMirrorTests.MirrorChildUp_NeverStoresOrLogsCloudKey_NorToken</code> asserts the cloud key and the account token never reach disk or the log.</li>
+  <li>Scope respected: no push/inbound channel added (Non-goal); no Phase 5 tray work.</li>
+  <li>Documentation updated for the architecture/security change (<code>DEVICE_AUTH_SECURITY_MODEL.md</code>).</li>
+</ul>
+
+<h2>Scope note</h2>
+<p>The automated proof uses a TEST/FAKE cloud roster, exactly as the issue specifies. The real-hardware phone
+revoke round-trip (enroll the owner's actual phone against the live Gateway, revoke on devthrottle.com, watch
+it lock out within a sweep) is an owner-run HUMAN follow-up and is explicitly NOT a merge blocker for this issue.</p>
+
+<div class="verdict">
+VERIFIED - all 5 acceptance criteria met, independently reproduced. Build clean, full Gateway suite green
+(1205/1205), enforced-Gateway 200-then-401 transcript reproduced against a real in-process GatewayHost.
+</div>
+</body>
+</html>

--- a/docs/cencon/proof/issue-924/reconcile-transcript.txt
+++ b/docs/cencon/proof/issue-924/reconcile-transcript.txt
@@ -1,0 +1,37 @@
+Issue #924 - Phase 4 - Revoke down-propagation
+Running-enforcing-Gateway transcript (test/fake roster)
+=======================================================
+
+Source: test CcDirector.Gateway.Tests.Account.RevokeDownEnforcedGatewayProofTests
+        .Website_revoke_locks_the_device_out_of_the_enforced_gateway_within_one_reconcile
+
+This transcript is produced by a REAL, ENFORCING GatewayHost booted in-process over a loopback
+port (authEnabled=true, the issue #917 default), driven over real HTTP. The cloud roster is an
+in-process STUB (a real DeviceRegistryClient over one HttpMessageHandler, no network) whose
+GET /api/v1/devices returns an EMPTY roster - modelling a device that was revoked on the website.
+
+Sequence proven (key present -> roster drop -> ONE reconcile -> key gone -> 401):
+
+=== Issue #924 revoke-down proof: running ENFORCING Gateway + test/fake roster ===
+Gateway: real GatewayHost, authEnabled=true (issue #917), loopback port <ephemeral>
+Fake cloud roster: in-process stub, GET /api/v1/devices returns an EMPTY roster (device revoked)
+
+STEP 1  key present  -> GET /sessions with the device key -> HTTP 200 OK
+STEP 2  website revoke -> the cloud roster no longer lists this device
+STEP 3  ONE ReconcileAsync sweep ran against the fake roster
+STEP 4  key gone      -> DeviceRegistry no longer holds the device key
+STEP 5  revoked      -> GET /sessions with the same key -> HTTP 401 Unauthorized; body={"error":"missing or invalid token"}
+
+RESULT: a website revoke locked the device out of the enforced Gateway within one reconcile sweep.
+NOTE: this automated proof uses a TEST/FAKE roster; the live-hardware phone revoke round-trip
+      (enroll the owner's real phone, revoke on devthrottle.com, watch it lock out within a sweep)
+      is the OWNER-RUN human follow-up, not a merge blocker.
+
+Guaranteed revocation-latency bound
+-----------------------------------
+Revocation is PULL-based (no inbound cloud->Gateway push - a Non-goal of epic #916). A website
+revoke reaches the Gateway only on its next OUTBOUND reconcile sweep, so the bound is exactly ONE
+sweep interval (GatewayHost.CronSweepInterval, ~1 minute): a revoked device may keep working up to
+one interval and is refused on the first request after the sweep that drops its key - never sooner,
+never later than one sweep. Documented in code (ChildDeviceMirrorService.ReconcileAsync remarks)
+and in docs/architecture/mobile/DEVICE_AUTH_SECURITY_MODEL.md.

--- a/docs/cencon/proof/issue-924/report.html
+++ b/docs/cencon/proof/issue-924/report.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Issue #924 - Revoke down-propagation - Developer Proof</title>
+<style>
+  body { font-family: -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; max-width: 900px;
+         margin: 2rem auto; padding: 0 1rem; color: #1b1b1b; line-height: 1.55; }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid #007ACC; padding-bottom: .4rem; }
+  h2 { font-size: 1.2rem; margin-top: 2rem; color: #005a9e; }
+  code, pre { font-family: Consolas, Menlo, monospace; }
+  pre { background: #f4f6f8; border: 1px solid #dfe3e6; border-radius: 6px; padding: .8rem 1rem;
+        overflow-x: auto; font-size: .86rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; font-size: .93rem; }
+  th, td { border: 1px solid #d0d7de; padding: .5rem .6rem; text-align: left; vertical-align: top; }
+  th { background: #eef3f7; }
+  .ok { color: #157347; font-weight: 600; }
+  .tag { display: inline-block; background: #eef3f7; border: 1px solid #cdd7e0; border-radius: 4px;
+         padding: .05rem .4rem; font-size: .8rem; }
+  .note { background: #fff8e6; border: 1px solid #f0d98a; border-radius: 6px; padding: .7rem 1rem; }
+</style>
+</head>
+<body>
+
+<h1>Issue #924 - Phase 4 - Make a website device-revoke lock the device out</h1>
+<p>
+  <span class="tag">Epic #916</span>
+  <span class="tag">Phase 4 - revoke down-propagation</span>
+  <span class="tag">Developer Agent proof</span>
+</p>
+
+<h2>What was implemented</h2>
+<p>
+  Phase 4 confirms and hardens the pull-based revoke-down path so a website device-revoke reliably and
+  promptly locks the device out of the now-enforced Gateway (issue #917). The core removal path already
+  worked and <code>/m/enroll</code>-enrolled devices are already recorded with a cloud roster id, so they
+  are already subject to the same reconcile removal as a paired child. The genuine new work:
+</p>
+<ul>
+  <li><b>Failure visibility.</b> <code>ChildDeviceMirrorService</code> no longer swallows a persistently
+      broken revoke path into an indistinguishable retry line. It counts consecutive reconcile failures and
+      exposes <code>HasPersistentReconcileFailure</code> (plus <code>ConsecutiveReconcileFailures</code> and
+      <code>LastReconcileError</code>) for the Cockpit/tray to read, and logs a distinct escalated signal
+      once the path is persistently stuck. The status also reflects the Phase 3 (#911)
+      <code>HasPersistentRefreshFailure</code> signal - the case where reconcile has no usable token and
+      would otherwise skip in silence.</li>
+  <li><b>Guaranteed revocation-latency bound documented.</b> One sweep interval
+      (<code>GatewayHost.CronSweepInterval</code>, ~1 min) - in code (the <code>ReconcileAsync</code>
+      remarks) and in <code>docs/architecture/mobile/DEVICE_AUTH_SECURITY_MODEL.md</code>.</li>
+</ul>
+<p>
+  Non-goal honored: no push / inbound cloud-to-Gateway channel was added. Revocation stays pull-based on
+  the ~1-minute reconcile sweep.
+</p>
+
+<h2>Files changed</h2>
+<table>
+  <tr><th>File</th><th>Change</th></tr>
+  <tr><td><code>src/CcDirector.Gateway/Account/ChildDeviceMirrorService.cs</code></td>
+      <td>Consecutive-failure counter, <code>HasPersistentReconcileFailure</code> /
+          <code>ConsecutiveReconcileFailures</code> / <code>LastReconcileError</code>, distinct escalated
+          log signal, latency-bound remarks. Reuses the Phase 3 persistent-refresh-failure signal.</td></tr>
+  <tr><td><code>docs/architecture/mobile/DEVICE_AUTH_SECURITY_MODEL.md</code></td>
+      <td>Documents the guaranteed one-sweep revocation-latency bound and the failure-visibility signal.</td></tr>
+  <tr><td><code>src/CcDirector.Gateway.Tests/Account/MobileEnrollRevokeRoundTripTests.cs</code></td>
+      <td>Extended to the ENFORCED path (real <code>AuthMiddleware</code> -> 401) + a no-false-eviction test.</td></tr>
+  <tr><td><code>src/CcDirector.Gateway.Tests/Account/ChildDeviceMirrorTests.cs</code></td>
+      <td>Failure-surfaced tests (persistent cloud failure + reused Phase 3 signal); list-failure stub hook.</td></tr>
+  <tr><td><code>src/CcDirector.Gateway.Tests/Account/RevokeDownEnforcedGatewayProofTests.cs</code></td>
+      <td>New end-to-end proof against a real, enforcing, in-process <code>GatewayHost</code> over HTTP.</td></tr>
+</table>
+
+<h2>Acceptance criteria - each met</h2>
+<table>
+  <tr><th>Criterion</th><th>How it is met</th><th>Proof</th></tr>
+  <tr><td>End to end under enforcement: key present + absent from roster is removed by one
+          <code>ReconcileAsync</code>, and the next request 401s.</td>
+      <td>Extended <code>MobileEnrollRevokeRoundTripTests</code> drives the real enforced gate; the live
+          Gateway proof shows the full chain over real HTTP.</td>
+      <td class="ok">PASS</td></tr>
+  <tr><td>A device still on the roster is NOT removed (no false eviction).</td>
+      <td><code>Enroll_then_reconcile_with_device_still_on_roster_keeps_enforced_access</code> +
+          <code>Reconcile_ChildStillOnRoster_IsKept</code>.</td>
+      <td class="ok">PASS</td></tr>
+  <tr><td>A persistent reconcile/auth failure is surfaced (status + log), with a test.</td>
+      <td><code>Reconcile_CloudRosterPullPersistentlyFails_SurfacesPersistentReconcileFailure</code> and
+          <code>HasPersistentReconcileFailure_WhenAccountRefreshPersistentlyFailing_IsTrue</code>.</td>
+      <td class="ok">PASS</td></tr>
+  <tr><td>Guaranteed revocation-latency bound documented.</td>
+      <td>Code remarks + security-model doc: one sweep interval (~1 min).</td>
+      <td class="ok">PASS</td></tr>
+  <tr><td>Full Gateway test suite green.</td>
+      <td>1205 passed, 0 failed.</td>
+      <td class="ok">PASS</td></tr>
+</table>
+
+<h2>Running-enforcing-Gateway transcript (test/fake roster)</h2>
+<pre>=== Issue #924 revoke-down proof: running ENFORCING Gateway + test/fake roster ===
+Gateway: real GatewayHost, authEnabled=true (issue #917), loopback port &lt;ephemeral&gt;
+Fake cloud roster: in-process stub, GET /api/v1/devices returns an EMPTY roster (device revoked)
+
+STEP 1  key present  -> GET /sessions with the device key -> HTTP 200 OK
+STEP 2  website revoke -> the cloud roster no longer lists this device
+STEP 3  ONE ReconcileAsync sweep ran against the fake roster
+STEP 4  key gone      -> DeviceRegistry no longer holds the device key
+STEP 5  revoked      -> GET /sessions with the same key -> HTTP 401 Unauthorized; body={"error":"missing or invalid token"}
+
+RESULT: a website revoke locked the device out of the enforced Gateway within one reconcile sweep.</pre>
+<p>See <code>reconcile-transcript.txt</code> and <code>test-output.txt</code> in this folder.</p>
+
+<div class="note">
+  <b>Scope note.</b> This automated proof uses a TEST/FAKE roster. The real-hardware acceptance test
+  (enroll the owner's actual phone against the live Gateway, revoke it on devthrottle.com, and watch it get
+  locked out within a sweep and returned to Sign in) is the OWNER-RUN human follow-up, not a merge blocker,
+  exactly as the issue states.
+</div>
+
+<h2>CenCon impact</h2>
+<p>
+  No architecture or security-posture drift: the change is an additive visibility status plus documentation
+  and tests; the revoke removal path itself is unchanged. The mobile security-model doc is updated per the
+  issue's explicit request.
+</p>
+
+<h2>Verdict</h2>
+<p class="ok">I believe this is finished. Build clean (0 warnings, 0 errors); full Gateway suite green
+   (1205 passed); every acceptance criterion proven.</p>
+
+</body>
+</html>

--- a/docs/cencon/proof/issue-924/test-output.txt
+++ b/docs/cencon/proof/issue-924/test-output.txt
@@ -1,0 +1,27 @@
+Passed CcDirector.Gateway.Tests.Account.RevokeDownEnforcedGatewayProofTests.Website_revoke_locks_the_device_out_of_the_enforced_gateway_within_one_reconcile [227 ms]
+=== Issue #924 revoke-down proof: running ENFORCING Gateway + test/fake roster ===
+Gateway: real GatewayHost, authEnabled=true (issue #917), loopback port 62008
+Fake cloud roster: in-process stub, GET /api/v1/devices returns an EMPTY roster (device revoked)
+STEP 1  key present  -> GET /sessions with the device key -> HTTP 200 OK
+STEP 2  website revoke -> the cloud roster no longer lists this device
+STEP 3  ONE ReconcileAsync sweep ran against the fake roster
+STEP 4  key gone      -> DeviceRegistry no longer holds the device key
+STEP 5  revoked      -> GET /sessions with the same key -> HTTP 401 Unauthorized; body={"error":"missing or invalid token"}
+RESULT: a website revoke locked the device out of the enforced Gateway within one reconcile sweep.
+NOTE: this automated proof uses a TEST/FAKE roster; the live-hardware phone revoke round-trip is the owner-run human follow-up.
+Passed CcDirector.Gateway.Tests.Account.MobileEnrollRevokeRoundTripTests.Enroll_then_website_revoke_drops_the_local_key [10 ms]
+Passed CcDirector.Gateway.Tests.Account.MobileEnrollRevokeRoundTripTests.Enroll_then_website_revoke_under_enforcement_makes_the_next_request_401 [6 ms]
+Passed CcDirector.Gateway.Tests.Account.MobileEnrollRevokeRoundTripTests.Enroll_then_reconcile_with_device_still_on_roster_keeps_enforced_access [2 ms]
+Passed CcDirector.Gateway.Tests.Account.ChildDeviceMirrorTests.MirrorChildUp_NeverStoresOrLogsCloudKey_NorToken [16 ms]
+Passed CcDirector.Gateway.Tests.Account.ChildDeviceMirrorTests.Reconcile_UnmirroredChild_IsNeverHeartbeatedAndNeverDropped [3 ms]
+Passed CcDirector.Gateway.Tests.Account.ChildDeviceMirrorTests.MirrorChildUp_CloudRejects_DoesNotThrow_AndChildStaysEnrolled [1 ms]
+Passed CcDirector.Gateway.Tests.Account.ChildDeviceMirrorTests.NotSignedIn_MirrorAndReconcile_AreNoOps [< 1 ms]
+Passed CcDirector.Gateway.Tests.Account.ChildDeviceMirrorTests.Reconcile_SendsHeartbeatForMirroredChild [2 ms]
+Passed CcDirector.Gateway.Tests.Account.ChildDeviceMirrorTests.Reconcile_CloudRosterPullPersistentlyFails_SurfacesPersistentReconcileFailure [13 ms]
+Passed CcDirector.Gateway.Tests.Account.ChildDeviceMirrorTests.Reconcile_HeartbeatReturns404ForMirroredChild_DropsLocalKey [5 ms]
+Passed CcDirector.Gateway.Tests.Account.ChildDeviceMirrorTests.Reconcile_ChildRevokedInCloud_DropsLocalPairingKey [5 ms]
+Passed CcDirector.Gateway.Tests.Account.ChildDeviceMirrorTests.HasPersistentReconcileFailure_WhenAccountRefreshPersistentlyFailing_IsTrue [3 ms]
+Passed CcDirector.Gateway.Tests.Account.ChildDeviceMirrorTests.Reconcile_ChildStillOnRoster_IsKept [1 ms]
+Passed CcDirector.Gateway.Tests.Account.ChildDeviceMirrorTests.Reconcile_AfterRestart_DoesNotReMirrorAnAlreadyMirroredChild [10 ms]
+Passed CcDirector.Gateway.Tests.Account.ChildDeviceMirrorTests.MirrorChildUp_RegistersChildWithCorrectBody_AndRecordsCloudId [1 ms]
+Total tests: 16

--- a/src/CcDirector.Gateway.Tests/Account/ChildDeviceMirrorTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/ChildDeviceMirrorTests.cs
@@ -68,6 +68,13 @@ public sealed class ChildDeviceMirrorTests
         public string? LastRegisterName { get; private set; }
         public readonly List<string> HeartbeatInstallIds = new();
 
+        /// <summary>
+        /// When non-zero, GET /devices (the revoke-down roster pull) answers this HTTP status instead of the
+        /// roster - modelling a cloud/auth outage on the reconcile's source-of-truth call (issue #924). A 500
+        /// makes <c>ListDevicesAsync</c> throw, which the reconcile records as a failure.
+        /// </summary>
+        public int ListStatusOverride { get; set; }
+
         public string CloudIdFor(string installId) => _byInstall[installId].Id;
         public void Revoke(string installId) => _revoked.Add(installId);
         public void HeartbeatNotFound(string installId) => _heartbeat404.Add(installId);
@@ -82,6 +89,8 @@ public sealed class ChildDeviceMirrorTests
             if (method == HttpMethod.Get && path == DeviceRegistryClient.DevicesPath)
             {
                 ListCallCount++;
+                if (ListStatusOverride != 0)
+                    return Json((HttpStatusCode)ListStatusOverride, "{\"error\":\"roster unavailable\"}");
                 var rows = _byInstall
                     .Where(kv => !_revoked.Contains(kv.Key))
                     .Select(kv => RecordJson(kv.Value))
@@ -376,5 +385,78 @@ public sealed class ChildDeviceMirrorTests
         Assert.Equal(0, stub.ListCallCount);
         Assert.Null(stub.LastAuthorization);
         Assert.True(devices.IsValidDeviceKey(childKey), "a not-signed-in Gateway must never drop a child");
+    }
+
+    // Issue #924 (failure-surfaced): when the revoke-down roster pull PERSISTENTLY fails, the reconcile
+    // surfaces a visible status (HasPersistentReconcileFailure / ConsecutiveReconcileFailures /
+    // LastReconcileError) AND emits a distinct escalated log signal - it is not swallowed into an
+    // indistinguishable forever-retry. A failing sweep must never look like a revoke (no child is evicted),
+    // and a later clean sweep clears the status.
+    [Fact]
+    public async Task Reconcile_CloudRosterPullPersistentlyFails_SurfacesPersistentReconcileFailure()
+    {
+        var account = MakeAccount(signedIn: true);
+        var stub = new StubCloudDeviceRegistry();
+        var devices = TempRegistry();
+        var childKey = EnrollChild(devices);
+        var mirror = new ChildDeviceMirrorService(account, ClientOver(stub), devices);
+
+        stub.ListStatusOverride = 500; // the revoke-down roster pull fails on every sweep (cloud/auth outage)
+
+        IReadOnlyList<string> lines;
+        using (var scope = FileLog.RedirectForTests())
+        {
+            for (var i = 0; i < ChildDeviceMirrorService.PersistentReconcileFailureThreshold; i++)
+                await mirror.ReconcileAsync();
+            lines = scope.DrainAndReadLines();
+        }
+
+        Assert.Equal(ChildDeviceMirrorService.PersistentReconcileFailureThreshold, mirror.ConsecutiveReconcileFailures);
+        Assert.True(mirror.HasPersistentReconcileFailure, "a persistently-failing roster pull must surface as a persistent reconcile failure");
+        Assert.NotNull(mirror.LastReconcileError);
+        Assert.Contains(lines, l => l.Contains("PERSISTENT reconcile failure", StringComparison.Ordinal));
+        Assert.True(devices.IsValidDeviceKey(childKey), "a reconcile failure must not evict a child (no false revoke)");
+
+        // Recovery: once the cloud answers again, the next clean sweep clears the persistent status and logs it.
+        stub.ListStatusOverride = 0;
+        await mirror.ReconcileAsync();
+        Assert.Equal(0, mirror.ConsecutiveReconcileFailures);
+        Assert.False(mirror.HasPersistentReconcileFailure, "a clean sweep must clear the persistent-failure status");
+        Assert.Null(mirror.LastReconcileError);
+    }
+
+    // Issue #924 (failure-surfaced, reusing the Phase 3 signal): when the Gateway's account-token refresh is
+    // persistently failing (issue #911), reconcile has no usable token to pull the roster and would silently
+    // skip forever - so HasPersistentReconcileFailure reports the stuck condition via that reused signal.
+    [Fact]
+    public async Task HasPersistentReconcileFailure_WhenAccountRefreshPersistentlyFailing_IsTrue()
+    {
+        var account = MakePersistentRefreshFailingAccount();
+        await account.RefreshIfNeededAsync();
+        Assert.True(account.HasPersistentRefreshFailure, "precondition: the account is in the Phase 3 persistent-refresh-failure state");
+
+        var mirror = new ChildDeviceMirrorService(account, ClientOver(new StubCloudDeviceRegistry()), TempRegistry());
+
+        Assert.True(mirror.HasPersistentReconcileFailure, "a persistent account-refresh failure must surface as a persistent reconcile failure");
+    }
+
+    /// <summary>
+    /// Builds a signed-in account whose token refresh is PERSISTENTLY misconfigured (issue #911): an expired
+    /// access token plus a refresher with no anonymous key, which short-circuits to a persistent
+    /// misconfiguration WITHOUT a network call. After <c>RefreshIfNeededAsync</c> the account reports
+    /// <see cref="DevThrottleAccountService.HasPersistentRefreshFailure"/>. Cross-platform (in-memory store).
+    /// </summary>
+    private static DevThrottleAccountService MakePersistentRefreshFailingAccount()
+    {
+        var authEventsLog = Path.Combine(Path.GetTempPath(), "cc-gw-child-mirror-refreshfail-" + Guid.NewGuid().ToString("N") + ".jsonl");
+        var store = new InMemoryTokenStore();
+        var validator = new JwtAccessTokenValidator(GatewayTestJwt.SigningSecret);
+        var eventLog = new AuthEventLog(authEventsLog);
+        // A resolvable endpoint but a null anon key -> the exchange is persistently misconfigured (issue #911)
+        // and short-circuits before sending any request.
+        var refresher = new GatewayHttpTokenRefresher(new HttpClient(), () => "http://127.0.0.1:9/refresh", () => null);
+        var service = new DevThrottleAccountService(store, validator, eventLog, refresher);
+        service.StoreTokens(new DevThrottleTokens(GatewayTestJwt.Create(DateTime.UtcNow.AddHours(-1)), "seed-refresh"));
+        return service;
     }
 }

--- a/src/CcDirector.Gateway.Tests/Account/MobileEnrollRevokeRoundTripTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/MobileEnrollRevokeRoundTripTests.cs
@@ -5,6 +5,8 @@ using System.Text.Json.Nodes;
 using CcDirector.Core.Account;
 using CcDirector.Gateway.Account;
 using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Util;
+using Microsoft.AspNetCore.Http;
 using Xunit;
 
 namespace CcDirector.Gateway.Tests.Account;
@@ -102,6 +104,98 @@ public sealed class MobileEnrollRevokeRoundTripTests
 
     private static DeviceRegistry TempRegistry() =>
         new(Path.Combine(Path.GetTempPath(), "cc-gw-revoke-" + Guid.NewGuid().ToString("N") + ".json"));
+
+    // The per-machine shared Gateway token, distinct from any issued per-device key, so a request bearing
+    // the phone's local key authenticates ONLY via the device registry (the path this test exercises).
+    private const string GatewayToken = "shared-machine-token-924";
+
+    /// <summary>
+    /// Drives the real host-wide auth gate (<see cref="AuthMiddleware.Run"/>, enforced by default since
+    /// issue #917) for a data endpoint request carrying the given Bearer, and reports what the gate did:
+    /// whether the request was allowed through (the downstream ran) and the HTTP status it left behind. This
+    /// is the enforced path a revoked phone hits - after its local key is dropped the same request must 401.
+    /// </summary>
+    private static async Task<(bool Allowed, int StatusCode, string Body)> RunEnforcedGateAsync(DeviceRegistry devices, string bearer)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Method = HttpMethods.Get;
+        ctx.Request.Path = "/sessions";                 // a gated data endpoint (not public, not /m)
+        ctx.Request.Headers["Authorization"] = $"Bearer {bearer}";
+        ctx.Request.Headers["Accept"] = "application/json"; // non-browser -> a 401 (not a login redirect)
+        ctx.Response.Body = new MemoryStream();
+
+        var allowed = false;
+        var cfg = new AuthMiddleware.RequireToken { Token = GatewayToken, Devices = devices };
+        await AuthMiddleware.Run(ctx, cfg, () => { allowed = true; return Task.CompletedTask; });
+
+        ctx.Response.Body.Position = 0;
+        var body = await new StreamReader(ctx.Response.Body).ReadToEndAsync();
+        return (allowed, ctx.Response.StatusCode, body);
+    }
+
+    // Acceptance criterion (issue #924): end to end under enforcement. An enrolled phone's local key is
+    // accepted by the enforced gate; after a website revoke drops it from the roster and ONE reconcile runs,
+    // the SAME request to the enforced Gateway returns 401. This extends the round trip past "the key stops
+    // validating" to the real enforced-gate outcome the phone actually sees.
+    [Fact]
+    public async Task Enroll_then_website_revoke_under_enforcement_makes_the_next_request_401()
+    {
+        var account = MakeAccount();
+        var stub = new StubCloud();
+        var devices = TempRegistry();
+
+        // Enroll (the /m/enroll path): the phone gets a local key AND is recorded with its cloud roster id,
+        // so it is subject to the same revoke-down removal as a paired child.
+        var enroll = new MobileDeviceEnrollmentService(account, ClientOver(stub), devices);
+        var outcome = await enroll.EnrollAsync(CloudKey, InstallId, "Pixel", "android");
+        Assert.Equal(MobileEnrollmentOutcome.ResultKind.Ok, outcome.Kind);
+        var localKey = outcome.LocalDeviceKey;
+        Assert.NotNull(localKey);
+
+        // Before the revoke: the enforced gate ALLOWS the phone's request (200-class, downstream ran).
+        var before = await RunEnforcedGateAsync(devices, localKey);
+        Assert.True(before.Allowed, "an enrolled phone's local key must pass the enforced gate");
+        Assert.Equal(StatusCodes.Status200OK, before.StatusCode);
+
+        // Website revoke, then ONE reconcile sweep drops the local key.
+        stub.Revoked = true;
+        await new ChildDeviceMirrorService(account, ClientOver(stub), devices).ReconcileAsync();
+        Assert.False(devices.IsValidDeviceKey(localKey), "one reconcile after the revoke must drop the local key");
+
+        // After the revoke + reconcile: the SAME request is now REFUSED by the enforced gate with a hard 401.
+        var after = await RunEnforcedGateAsync(devices, localKey);
+        Assert.False(after.Allowed, "a revoked phone's request must not reach the downstream");
+        Assert.Equal(StatusCodes.Status401Unauthorized, after.StatusCode);
+        Assert.Contains("missing or invalid token", after.Body, StringComparison.Ordinal);
+    }
+
+    // Acceptance criterion (issue #924): no false eviction. A device STILL on the roster is not removed by
+    // reconcile, and its request keeps passing the enforced gate.
+    [Fact]
+    public async Task Enroll_then_reconcile_with_device_still_on_roster_keeps_enforced_access()
+    {
+        var account = MakeAccount();
+        var stub = new StubCloud();
+        var devices = TempRegistry();
+
+        var enroll = new MobileDeviceEnrollmentService(account, ClientOver(stub), devices);
+        var outcome = await enroll.EnrollAsync(CloudKey, InstallId, "Pixel", "android");
+        Assert.Equal(MobileEnrollmentOutcome.ResultKind.Ok, outcome.Kind);
+        var localKey = outcome.LocalDeviceKey;
+        Assert.NotNull(localKey);
+
+        // The phone is NOT revoked (stub.Revoked stays false), so it stays on the roster across reconciles.
+        var mirror = new ChildDeviceMirrorService(account, ClientOver(stub), devices);
+        await mirror.ReconcileAsync();
+        await mirror.ReconcileAsync();
+
+        Assert.True(devices.IsValidDeviceKey(localKey), "a device still on the roster must keep its local key");
+        Assert.Equal(1, devices.Count);
+        var stillAllowed = await RunEnforcedGateAsync(devices, localKey);
+        Assert.True(stillAllowed.Allowed, "a non-revoked phone must keep passing the enforced gate");
+        Assert.Equal(StatusCodes.Status200OK, stillAllowed.StatusCode);
+        Assert.False(mirror.HasPersistentReconcileFailure, "healthy reconciles must not report a reconcile failure");
+    }
 
     [Fact]
     public async Task Enroll_then_website_revoke_drops_the_local_key()

--- a/src/CcDirector.Gateway.Tests/Account/RevokeDownEnforcedGatewayProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/RevokeDownEnforcedGatewayProofTests.cs
@@ -1,0 +1,177 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using CcDirector.Core.Account;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Account;
+using CcDirector.Gateway.Pairing;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CcDirector.Gateway.Tests.Account;
+
+/// <summary>
+/// Issue #924 (Phase 4) end-to-end proof against a REAL, ENFORCING, in-process Gateway over loopback HTTP,
+/// using a test/fake cloud roster. It proves the headline promise of security epic #916 - "revoking a
+/// device on the website locks it out" - along the ENFORCED path:
+///
+/// <list type="number">
+/// <item>a device key present in the Gateway's <see cref="DeviceRegistry"/> is ACCEPTED by the enforced
+/// host-wide auth gate (issue #917) - the request is NOT 401;</item>
+/// <item>the (fake) cloud roster drops that device (a website revoke);</item>
+/// <item>ONE <see cref="ChildDeviceMirrorService.ReconcileAsync"/> sweep removes the local key;</item>
+/// <item>the SAME request to the same running enforcing Gateway now returns a hard 401.</item>
+/// </list>
+///
+/// The roster is an in-process STUB (a real <see cref="DeviceRegistryClient"/> over one handler, no
+/// network), so this is the automated proof the issue asks for; the live-hardware phone revoke round-trip
+/// (enroll the owner's real phone, revoke it on devthrottle.com, watch it lock out within a sweep) is the
+/// OWNER-RUN human follow-up, not a merge blocker. The transcript is emitted through
+/// <see cref="ITestOutputHelper"/> so a detailed test run captures the step-by-step evidence.
+/// </summary>
+public sealed class RevokeDownEnforcedGatewayProofTests : IAsyncLifetime
+{
+    private const string PhoneDeviceId = "phone-install-924-proof";
+    private const string PhoneMachine = "Pixel-924";
+    private const string CloudId = "cloud-dev-924-proof";
+
+    private readonly ITestOutputHelper _out;
+    private readonly string _tempDir;
+    private GatewayHost _gateway = null!; // set in InitializeAsync
+    private string _phoneKey = "";
+
+    public RevokeDownEnforcedGatewayProofTests(ITestOutputHelper output)
+    {
+        _out = output;
+        _tempDir = Path.Combine(Path.GetTempPath(), "cc-gw-revoke-proof-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    private sealed class InMemoryTokenStore : IProtectedTokenStore
+    {
+        private DevThrottleTokens? _tokens;
+        public bool HasTokens => _tokens is not null;
+        public void Save(DevThrottleTokens tokens) => _tokens = tokens;
+        public DevThrottleTokens? Load() => _tokens;
+        public void Clear() => _tokens = null;
+    }
+
+    /// <summary>
+    /// A minimal stub of the cloud device roster: GET /devices returns an EMPTY roster, modelling a device
+    /// that has been revoked on the website ("Your devices" -> Remove). That is the single signal the
+    /// revoke-down reconcile needs to drop the local key.
+    /// </summary>
+    private sealed class RevokedRosterStub : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri?.AbsolutePath ?? string.Empty;
+            if (request.Method == HttpMethod.Get && path == DeviceRegistryClient.DevicesPath)
+                return Task.FromResult(Json("{\"data\":[]}"));
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+
+        private static HttpResponseMessage Json(string body) =>
+            new(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+    }
+
+    private DevThrottleAccountService MakeSignedInAccount()
+    {
+        var previous = Environment.GetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar);
+        Environment.SetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar, GatewayTestJwt.SigningSecret);
+        try
+        {
+            var service = GatewayAccountFactory.Build(new InMemoryTokenStore(), Path.Combine(_tempDir, "auth-events.jsonl"));
+            service.StoreTokens(new DevThrottleTokens(GatewayTestJwt.Create(DateTime.UtcNow.AddHours(1)), "refresh-924"));
+            return service;
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(GatewayAccountFactory.SigningSecretEnvVar, previous);
+        }
+    }
+
+    public async Task InitializeAsync()
+    {
+        // Boot a REAL Gateway with the host-wide auth gate ENFORCED (issue #917) on an ephemeral loopback
+        // port, isolated to this test's temp dir so it never touches the developer's live registry.
+        _gateway = new GatewayHost(
+            port: AllocateFreePort(),
+            token: "shared-machine-token-924-proof",
+            authEnabled: true,
+            instancesDirectory: Path.Combine(_tempDir, "instances"),
+            devicesPath: Path.Combine(_tempDir, "devices.json"),
+            account: MakeSignedInAccount());
+        await _gateway.StartAsync();
+
+        // Post-enrollment state: the phone holds a local per-device key issued by THIS Gateway, recorded
+        // with its cloud roster id (exactly what /m/enroll records), so the revoke-down sweep can match it.
+        _phoneKey = _gateway.Devices.Register(PhoneDeviceId, PhoneMachine, "android", "phone").DeviceKey;
+        _gateway.Devices.SetCloudDeviceId(PhoneDeviceId, CloudId);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _gateway.StopAsync();
+        try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, true); }
+        catch { /* best-effort temp cleanup */ }
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+
+    private HttpClient NewClientWithKey() => new()
+    {
+        BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/"),
+        DefaultRequestHeaders = { Authorization = new AuthenticationHeaderValue("Bearer", _phoneKey) },
+    };
+
+    [Fact]
+    public async Task Website_revoke_locks_the_device_out_of_the_enforced_gateway_within_one_reconcile()
+    {
+        _out.WriteLine("=== Issue #924 revoke-down proof: running ENFORCING Gateway + test/fake roster ===");
+        _out.WriteLine($"Gateway: real GatewayHost, authEnabled=true (issue #917), loopback port {_gateway.Port}");
+        _out.WriteLine($"Fake cloud roster: in-process stub, GET {DeviceRegistryClient.DevicesPath} returns an EMPTY roster (device revoked)");
+        _out.WriteLine("");
+
+        // STEP 1: the enrolled key is PRESENT in the registry and ACCEPTED by the enforced gate over HTTP.
+        Assert.True(_gateway.Devices.IsValidDeviceKey(_phoneKey), "precondition: the local key is present");
+        using (var client = NewClientWithKey())
+        {
+            var before = await client.GetAsync("sessions");
+            _out.WriteLine($"STEP 1  key present  -> GET /sessions with the device key -> HTTP {(int)before.StatusCode} {before.StatusCode}");
+            Assert.NotEqual(HttpStatusCode.Unauthorized, before.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, before.StatusCode);
+        }
+
+        // STEP 2: the website revoke - the cloud roster drops the device (modelled by the empty-roster stub).
+        _out.WriteLine("STEP 2  website revoke -> the cloud roster no longer lists this device");
+
+        // STEP 3: ONE reconcile sweep over the SAME registry the enforced gate reads removes the local key.
+        var stub = new RevokedRosterStub();
+        var client2 = new DeviceRegistryClient(new HttpClient(stub) { BaseAddress = new Uri("https://stub-cloud.invalid") }, baseUrl: "https://stub-cloud.invalid");
+        await new ChildDeviceMirrorService(MakeSignedInAccount(), client2, _gateway.Devices).ReconcileAsync();
+        _out.WriteLine("STEP 3  ONE ReconcileAsync sweep ran against the fake roster");
+        Assert.False(_gateway.Devices.IsValidDeviceKey(_phoneKey), "after one reconcile the local key is gone");
+        _out.WriteLine("STEP 4  key gone      -> DeviceRegistry no longer holds the device key");
+
+        // STEP 5: the SAME request to the same running enforcing Gateway now returns a hard 401.
+        using (var client = NewClientWithKey())
+        {
+            var after = await client.GetAsync("sessions");
+            var body = await after.Content.ReadAsStringAsync();
+            _out.WriteLine($"STEP 5  revoked      -> GET /sessions with the same key -> HTTP {(int)after.StatusCode} {after.StatusCode}; body={body}");
+            Assert.Equal(HttpStatusCode.Unauthorized, after.StatusCode);
+        }
+
+        _out.WriteLine("");
+        _out.WriteLine("RESULT: a website revoke locked the device out of the enforced Gateway within one reconcile sweep.");
+        _out.WriteLine("NOTE: this automated proof uses a TEST/FAKE roster; the live-hardware phone revoke round-trip is the owner-run human follow-up.");
+    }
+}

--- a/src/CcDirector.Gateway/Account/ChildDeviceMirrorService.cs
+++ b/src/CcDirector.Gateway/Account/ChildDeviceMirrorService.cs
@@ -27,6 +27,9 @@ namespace CcDirector.Gateway.Account;
 /// mirrors up any child not yet mirrored, pulls the cloud roster (GET /devices returns only non-revoked
 /// devices), drops the local pairing key of any child this Gateway mirrored that is now absent from the
 /// roster (revoked on the account page), and advances each surviving child's last-seen with a heartbeat.
+/// A device enrolled via <c>/m/enroll</c> is recorded with its cloud roster id exactly like a paired child,
+/// so it is subject to the same revoke-down removal. Persistent reconcile failures are surfaced via
+/// <see cref="HasPersistentReconcileFailure"/> (issue #924) rather than being retried forever in silence.
 /// </item>
 /// </list>
 ///
@@ -41,10 +44,28 @@ namespace CcDirector.Gateway.Account;
 /// </summary>
 public sealed class ChildDeviceMirrorService
 {
+    /// <summary>
+    /// How many consecutive reconcile sweeps must fail on a real cloud error before the condition is
+    /// treated as PERSISTENT and surfaced (issue #924). At the ~1-minute sweep this is ~3 minutes of the
+    /// revoke-down path being unable to reach the cloud - long enough to rule out a single transient blip,
+    /// short enough that a genuinely-stuck "revokes are not propagating" condition becomes visible quickly
+    /// rather than being retried forever in silence.
+    /// </summary>
+    public const int PersistentReconcileFailureThreshold = 3;
+
     private readonly DevThrottleAccountService _account;
     private readonly DeviceRegistryClient _client;
     private readonly DeviceRegistry _devices;
     private readonly string? _appVersion;
+
+    // Reconcile-failure visibility (issue #924): the revoke-down sweep used to swallow every cloud error
+    // into a per-sweep log line and retry forever, so a persistently-broken sweep ("website revokes are
+    // not reaching this Gateway") was invisible. These fields count consecutive real reconcile failures so
+    // the Cockpit/tray can read a status and a distinct escalated log signal fires once it is persistent.
+    // Written on the sweep (timer) thread and read by status callers, so guarded by _statusGate.
+    private readonly object _statusGate = new();
+    private int _consecutiveReconcileFailures;
+    private string? _lastReconcileError;
 
     /// <summary>
     /// Creates the child-mirror coordinator.
@@ -63,6 +84,53 @@ public sealed class ChildDeviceMirrorService
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _devices = devices ?? throw new ArgumentNullException(nameof(devices));
         _appVersion = appVersion;
+    }
+
+    /// <summary>
+    /// The number of consecutive reconcile sweeps that have failed on a real cloud error (issue #924),
+    /// reset to zero by the next clean sweep. A read-only status the Cockpit/tray can poll. No network call.
+    /// </summary>
+    public int ConsecutiveReconcileFailures
+    {
+        get { lock (_statusGate) { return _consecutiveReconcileFailures; } }
+    }
+
+    /// <summary>
+    /// The message of the most recent reconcile failure (issue #924), or null when the last sweep was clean.
+    /// A user-safe reason (never a token or key - those are never in the exception messages we record here).
+    /// </summary>
+    public string? LastReconcileError
+    {
+        get { lock (_statusGate) { return _lastReconcileError; } }
+    }
+
+    /// <summary>
+    /// True when the revoke-down path is PERSISTENTLY unable to propagate account-page revokes to this
+    /// Gateway (issue #924) - so a stuck "website revokes are not reaching this device" condition is a
+    /// visible status the Cockpit/tray can show, not a silent forever-retry. It is set by EITHER of the two
+    /// ways the sweep can be persistently stuck:
+    /// <list type="bullet">
+    /// <item>the reconcile cloud call itself has failed on
+    /// <see cref="PersistentReconcileFailureThreshold"/> or more consecutive sweeps; or</item>
+    /// <item>the Gateway's account-token refresh is persistently failing
+    /// (<see cref="DevThrottleAccountService.HasPersistentRefreshFailure"/>, the Phase 3 / issue #911
+    /// signal) - the reconcile then has no usable token to pull the roster with and silently skips, which is
+    /// exactly the invisible-forever case this surfaces.</item>
+    /// </list>
+    /// Cleared by the next clean sweep (and, for the refresh half, by the next successful token refresh). No
+    /// network call.
+    /// </summary>
+    public bool HasPersistentReconcileFailure
+    {
+        get
+        {
+            if (_account.HasPersistentRefreshFailure)
+                return true;
+            lock (_statusGate)
+            {
+                return _consecutiveReconcileFailures >= PersistentReconcileFailureThreshold;
+            }
+        }
     }
 
     /// <summary>
@@ -119,6 +187,13 @@ public sealed class ChildDeviceMirrorService
     /// boundary try/catch so a cloud failure only logs and the next sweep retries - it never throws to the
     /// timer. Per-child steps are individually guarded so one bad child never stops the sweep.
     /// </summary>
+    /// <remarks>
+    /// Guaranteed revocation-latency bound (issue #924): because this is PULL-based on the periodic sweep
+    /// (no inbound cloud-to-Gateway push - a Non-goal of epic #916), a device revoked on the account page
+    /// keeps working until the NEXT sweep runs. The bound is therefore ONE sweep interval (the Gateway's
+    /// cron sweep, ~1 minute); a revoked device is refused within that window and not before. This bound is
+    /// also documented in docs/architecture/mobile/DEVICE_AUTH_SECURITY_MODEL.md.
+    /// </remarks>
     /// <param name="ct">Cancels the cloud calls.</param>
     public async Task ReconcileAsync(CancellationToken ct = default)
     {
@@ -127,6 +202,10 @@ public sealed class ChildDeviceMirrorService
             var token = _account.GetAccessTokenForForwarding();
             if (string.IsNullOrEmpty(token))
             {
+                // A genuinely signed-out Gateway has no reconcile failure of its own (the dead-token case is
+                // surfaced separately by the account's persistent-refresh-failure signal, issue #911/#924),
+                // so a clean sign-out clears any prior cloud-call failure streak.
+                ClearReconcileFailure();
                 FileLog.Write("[ChildDeviceMirrorService] ReconcileAsync: Gateway not signed in -> skipping child reconcile");
                 return;
             }
@@ -134,6 +213,7 @@ public sealed class ChildDeviceMirrorService
             var children = _devices.MirrorSnapshot();
             if (children.Count == 0)
             {
+                ClearReconcileFailure();
                 FileLog.Write("[ChildDeviceMirrorService] ReconcileAsync: no local children -> nothing to reconcile");
                 return;
             }
@@ -192,13 +272,60 @@ public sealed class ChildDeviceMirrorService
                     FileLog.Write($"[ChildDeviceMirrorService] ReconcileAsync: heartbeat failed for child id={child.DeviceId} (retry next sweep): {ex.Message}");
                 }
             }
+
+            // Reaching here means the roster pull (the revoke-down source of truth) succeeded, so the
+            // revoke-down path is healthy this sweep - clear any prior cloud-call failure streak (issue #924).
+            ClearReconcileFailure();
         }
         catch (Exception ex)
         {
             // Graceful degradation (#857): a cloud failure must not crash, block, or gate the Gateway. Log
-            // and let the next sweep retry - the Gateway stays signed in and running.
-            FileLog.Write($"[ChildDeviceMirrorService] ReconcileAsync: cloud reconcile failed (Gateway stays signed in and running; retry next sweep): {ex.Message}");
+            // and let the next sweep retry - the Gateway stays signed in and running. Issue #924: record the
+            // failure so a PERSISTENTLY-broken revoke-down path becomes a visible status + a distinct log
+            // signal instead of an invisible forever-retry.
+            RecordReconcileFailure(ex);
         }
+    }
+
+    /// <summary>
+    /// Clears the consecutive-reconcile-failure streak after a clean sweep (issue #924). Logs a one-time
+    /// recovery line when a previously-persistent failure has just cleared so the recovery is as visible as
+    /// the escalation was.
+    /// </summary>
+    private void ClearReconcileFailure()
+    {
+        bool wasPersistent;
+        lock (_statusGate)
+        {
+            wasPersistent = _consecutiveReconcileFailures >= PersistentReconcileFailureThreshold;
+            _consecutiveReconcileFailures = 0;
+            _lastReconcileError = null;
+        }
+        if (wasPersistent)
+            FileLog.Write("[ChildDeviceMirrorService] ReconcileAsync: revoke-down path RECOVERED - the reconcile sweep reached the cloud roster again after a persistent failure");
+    }
+
+    /// <summary>
+    /// Records one failed reconcile sweep (issue #924): advances the consecutive-failure counter, stores the
+    /// message, and logs. The message never carries a token or key (those are not in the exception messages
+    /// the reconcile can throw). Emits a DISTINCT escalated log signal on the sweep that first crosses
+    /// <see cref="PersistentReconcileFailureThreshold"/>, so a stuck "revokes are not propagating" condition
+    /// is a greppable, visible event rather than one indistinguishable retry line among many.
+    /// </summary>
+    private void RecordReconcileFailure(Exception ex)
+    {
+        int failures;
+        bool justBecamePersistent;
+        lock (_statusGate)
+        {
+            failures = ++_consecutiveReconcileFailures;
+            _lastReconcileError = ex.Message;
+            justBecamePersistent = failures == PersistentReconcileFailureThreshold;
+        }
+
+        FileLog.Write($"[ChildDeviceMirrorService] ReconcileAsync: cloud reconcile failed (Gateway stays signed in and running; retry next sweep); consecutiveFailures={failures}: {ex.Message}");
+        if (justBecamePersistent)
+            FileLog.Write($"[ChildDeviceMirrorService] ReconcileAsync: PERSISTENT reconcile failure - the revoke-down sweep has failed {failures} times in a row and website device revokes are NOT reaching this Gateway; sign-in/connectivity needs attention (HasPersistentReconcileFailure is now true)");
     }
 
     /// <summary>


### PR DESCRIPTION
## Release Notes
Phase 4 of security epic thefrederiksen/devthrottle_internal#660. Confirms and hardens the pull-based revoke-down path so a website device-revoke reliably and promptly locks the device out of the now-enforced Gateway (#917), and makes a persistently-broken revoke path visible instead of a silent forever-retry.

Closes thefrederiksen/devthrottle#924.

## Changes
- **`ChildDeviceMirrorService`**: consecutive-failure counter + `HasPersistentReconcileFailure` / `ConsecutiveReconcileFailures` / `LastReconcileError` (Cockpit/tray-readable), a distinct escalated log signal once persistent, and reuse of the Phase 3 (#911) `HasPersistentRefreshFailure` signal for the no-usable-token case. Records the guaranteed one-sweep revocation-latency bound in code remarks. `/m/enroll` devices are already recorded with a cloud roster id, so they were already subject to the same reconcile removal (now proven).
- **`docs/architecture/mobile/DEVICE_AUTH_SECURITY_MODEL.md`**: documents the guaranteed ~1-minute (one sweep) revocation-latency bound and the new failure-visibility signal.
- **Tests**: `MobileEnrollRevokeRoundTripTests` extended to the enforced path (real `AuthMiddleware` -> 401) + a no-false-eviction test; failure-surfaced tests in `ChildDeviceMirrorTests`; new `RevokeDownEnforcedGatewayProofTests` (real, enforcing, in-process `GatewayHost` over HTTP with a test/fake roster).

No push/inbound channel added (Non-goal of thefrederiksen/devthrottle_internal#660). Out of scope not touched: Phase 5 tray; no re-verification of Phase 1/2/3.

## How to Test
```
dotnet build cc-director.sln
dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj
```

## Expected Result
Build clean (0 warnings, 0 errors); full Gateway suite green (1205 passed, 0 failed).

## Before / After
- **Before**: a persistently-failing revoke-down sweep logged one indistinguishable retry line per sweep and retried forever, invisibly; the enforced-path 401 outcome and the latency bound were unproven/undocumented.
- **After**: a stuck revoke path surfaces `HasPersistentReconcileFailure` + a distinct escalated log; the enforced end-to-end chain (key present -> 200; roster drop; one reconcile; key gone; 401) is proven against a real enforcing Gateway; the one-sweep latency bound is documented.

## Proof
`docs/cencon/proof/issue-924/report.html` (plus `reconcile-transcript.txt`, `test-output.txt`).

The automated proof uses a **test/fake roster**. The real-hardware phone revoke round-trip (revoke the owner's actual phone on devthrottle.com and watch it lock out within a sweep) is the **owner-run human follow-up**, not a merge blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)