### PR TITLE
Fix terminal scrollback while a session is active (#761)

### DIFF
--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -3134,10 +3134,12 @@ public partial class MainWindow : Window
         // scrollback list while the parser was growing it concurrently.
         var snap = TerminalHost.GetScrollSnapshot();
 
-        // On the alternate screen (e.g. Claude Code) there is no local scrollback
-        // -- the application owns scrolling and the wheel is forwarded to it. A
-        // visible-but-dead scrollbar reads as "scrolling is broken", so hide it.
-        if (TerminalHost.IsOnAlternateScreen)
+        // On the alternate screen the snapshot reports the recovered alt-screen
+        // scrollback (issue #761). Until a full-screen agent has repainted any lines
+        // off the top there is nothing to scroll, so hide the bar -- a visible-but-dead
+        // scrollbar reads as "scrolling is broken". Once history exists, show it so the
+        // user can scroll back through the running agent's transcript.
+        if (TerminalHost.IsOnAlternateScreen && snap.ScrollbackCount == 0)
         {
             TerminalScrollBar.IsVisible = false;
             return;

--- a/src/CcDirector.Core.Tests/AnsiParserAltScrollbackTests.cs
+++ b/src/CcDirector.Core.Tests/AnsiParserAltScrollbackTests.cs
@@ -1,0 +1,147 @@
+using System.Text;
+using CcDirector.Terminal.Core;
+using Xunit;
+using static CcDirector.Core.Tests.TerminalTestHelper;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Alternate-screen local scrollback (issue #761). Full-screen agents (Claude Code,
+/// Codex, Grok, Copilot) run on the alternate screen, which traditionally has no
+/// scrollback -- so a user could not read back through a running session. The parser
+/// now recovers alternate-screen history the same way it does for the primary buffer
+/// (ScrollUp and the in-place repaint diff), but into a dedicated <see cref="AnsiParser.AltScrollback"/>
+/// that is cleared whenever the app enters or leaves the alternate screen.
+/// </summary>
+public class AnsiParserAltScrollbackTests
+{
+    private const string EnterAlt = "\x1b[?1049h";
+    private const string LeaveAlt = "\x1b[?1049l";
+
+    // One Claude-style repaint frame on the alternate screen: bare ESC[H frame marker
+    // then absolute-positioned line writes (CUP with params, not a frame marker). The
+    // content rows scroll up by one per frame; the bottom two rows are a fixed input box.
+    private static string Frame(int f, int rows)
+    {
+        int contentRows = rows - 2;
+        var sb = new StringBuilder();
+        sb.Append("\x1b[H");
+        for (int r = 0; r < rows; r++)
+        {
+            sb.Append($"\x1b[{r + 1};1H");
+            if (r < contentRows) sb.Append($"L{f + r}");
+            else if (r == rows - 2) sb.Append("--------");
+            else sb.Append(">box");
+            sb.Append("\x1b[K");
+        }
+        return sb.ToString();
+    }
+
+    private static string RowText(TerminalCell[] row)
+    {
+        var sb = new StringBuilder();
+        foreach (var cell in row) sb.Append(cell.Character == '\0' ? ' ' : cell.Character);
+        return sb.ToString().TrimEnd();
+    }
+
+    [Fact]
+    public void AlternateScreen_InPlaceRepaint_RecoversHistoryIntoAltScrollback()
+    {
+        var (parser, _, primary) = CreateParser(cols: 20, rows: 10);
+
+        Parse(parser, EnterAlt);
+        Assert.True(parser.IsAlternateScreen);
+
+        for (int f = 0; f < 12; f++)
+            Parse(parser, Frame(f, rows: 10));
+        Parse(parser, "\x1b[H"); // commit the final frame
+
+        // The bug was AltScrollbackCount == 0. Now the lines that scrolled off the
+        // top are recovered, in order, into the dedicated alt buffer.
+        Assert.True(parser.AltScrollbackCount >= 10,
+            $"expected recovered alt history, got {parser.AltScrollbackCount} lines");
+        Assert.Equal("L0", RowText(parser.AltScrollback[0]));
+        Assert.Equal("L1", RowText(parser.AltScrollback[1]));
+
+        // The primary buffer's scrollback must NOT be touched while on the alt screen.
+        Assert.Empty(primary);
+    }
+
+    [Fact]
+    public void AlternateScreen_PlainLineFeed_CapturesIntoAltScrollback()
+    {
+        var (parser, _, primary) = CreateParser(cols: 20, rows: 10);
+
+        Parse(parser, EnterAlt);
+        var sb = new StringBuilder();
+        for (int i = 0; i < 21; i++) sb.Append($"L{i}\r\n");
+        Parse(parser, sb.ToString());
+
+        Assert.True(parser.AltScrollbackCount >= 10,
+            $"expected ScrollUp alt history, got {parser.AltScrollbackCount}");
+        Assert.Equal("L0", RowText(parser.AltScrollback[0]));
+        Assert.Empty(primary);
+    }
+
+    [Fact]
+    public void LeavingAlternateScreen_ClearsAltScrollback()
+    {
+        var (parser, _, _) = CreateParser(cols: 20, rows: 10);
+
+        Parse(parser, EnterAlt);
+        for (int f = 0; f < 12; f++)
+            Parse(parser, Frame(f, rows: 10));
+        Parse(parser, "\x1b[H");
+        Assert.True(parser.AltScrollbackCount > 0);
+
+        Parse(parser, LeaveAlt);
+
+        Assert.False(parser.IsAlternateScreen);
+        Assert.Equal(0, parser.AltScrollbackCount);
+    }
+
+    [Fact]
+    public void EnteringAlternateScreen_LeavesPrimaryScrollbackIntact()
+    {
+        var (parser, _, primary) = CreateParser(cols: 20, rows: 10);
+
+        // Build real primary-buffer history first.
+        var sb = new StringBuilder();
+        for (int i = 0; i < 15; i++) sb.Append($"P{i}\r\n");
+        Parse(parser, sb.ToString());
+        int primaryBefore = primary.Count;
+        Assert.True(primaryBefore > 0);
+
+        // Enter the alt screen and repaint; the primary history is preserved untouched
+        // for when the app exits, and the alt history is kept separately.
+        Parse(parser, EnterAlt);
+        for (int f = 0; f < 12; f++)
+            Parse(parser, Frame(f, rows: 10));
+        Parse(parser, "\x1b[H");
+
+        Assert.Equal(primaryBefore, primary.Count);
+        Assert.True(parser.AltScrollbackCount > 0);
+    }
+
+    [Fact]
+    public void TotalLinesScrolled_CountsPrimaryAndAlternate()
+    {
+        var (parser, _, _) = CreateParser(cols: 20, rows: 10);
+
+        var sb = new StringBuilder();
+        for (int i = 0; i < 5; i++) sb.Append($"P{i}\r\n"); // no scroll yet (fits in 10 rows)
+        for (int i = 5; i < 21; i++) sb.Append($"P{i}\r\n"); // now scrolling
+        Parse(parser, sb.ToString());
+
+        long afterPrimary = parser.TotalLinesScrolled;
+        Assert.True(afterPrimary > 0, "counter should advance for primary scrollback");
+
+        Parse(parser, EnterAlt);
+        var sb2 = new StringBuilder();
+        for (int i = 0; i < 21; i++) sb2.Append($"A{i}\r\n");
+        Parse(parser, sb2.ToString());
+
+        Assert.True(parser.TotalLinesScrolled > afterPrimary,
+            "counter should keep advancing for alternate-screen scrollback");
+    }
+}

--- a/src/CcDirector.Terminal.Avalonia.Tests/TerminalScrollbackTests.cs
+++ b/src/CcDirector.Terminal.Avalonia.Tests/TerminalScrollbackTests.cs
@@ -1,0 +1,117 @@
+using System.Text;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Xunit;
+
+namespace CcDirector.Terminal.Avalonia.Tests;
+
+/// <summary>
+/// Scrollback behavior of the production <see cref="TerminalControl"/> (issue #761):
+///  - the normal buffer must PIN a scrolled-up viewport to the same content as new
+///    output arrives, instead of letting it drift upward; and
+///  - the alternate screen (full-screen agents) must expose local scrollback so the
+///    user can read back through a running session.
+/// These run headless and drive the control's real parse + scroll paths.
+/// </summary>
+public sealed class TerminalScrollbackTests
+{
+    private static byte[] Bytes(string s) => Encoding.UTF8.GetBytes(s);
+
+    private static string PlainLines(int from, int toExclusive)
+    {
+        var sb = new StringBuilder();
+        for (int i = from; i < toExclusive; i++) sb.Append($"L{i}\r\n");
+        return sb.ToString();
+    }
+
+    // A Claude-style alternate-screen repaint frame: bare ESC[H marker + absolute-positioned
+    // line writes, content scrolling up one line per frame, with a fixed 2-row input box.
+    private static string AltFrame(int f, int rows)
+    {
+        int contentRows = rows - 2;
+        var sb = new StringBuilder();
+        sb.Append("\x1b[H");
+        for (int r = 0; r < rows; r++)
+        {
+            sb.Append($"\x1b[{r + 1};1H");
+            if (r < contentRows) sb.Append($"L{f + r}");
+            else if (r == rows - 2) sb.Append("--------");
+            else sb.Append(">box");
+            sb.Append("\x1b[K");
+        }
+        return sb.ToString();
+    }
+
+    private static TerminalControl NewTerminal()
+    {
+        var terminal = new TerminalControl();
+        var window = new Window { Width = 800, Height = 400, Content = terminal };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        terminal.HarnessSetGrid(20, 10);
+        return terminal;
+    }
+
+    [AvaloniaFact]
+    public void NormalBuffer_ScrolledUpViewport_StaysPinnedAsOutputArrives()
+    {
+        var terminal = NewTerminal();
+
+        // Build history well beyond the 10-row viewport, then scroll up.
+        terminal.HarnessRebuild(Bytes(PlainLines(0, 40)));
+        terminal.HarnessScrollUp(5);
+
+        string topBefore = terminal.HarnessVisibleLine(0);
+        int offsetBefore = terminal.HarnessScrollOffset;
+        Assert.StartsWith("L", topBefore);
+
+        // More output arrives while the user is reading back.
+        terminal.HarnessFeed(Bytes(PlainLines(40, 60)));
+
+        // The pinned line must still be at the top of the viewport (no drift), and the
+        // offset must have grown to keep it there as scrollback advanced.
+        Assert.Equal(topBefore, terminal.HarnessVisibleLine(0));
+        Assert.True(terminal.HarnessScrollOffset > offsetBefore,
+            $"offset should advance to keep content pinned (before={offsetBefore}, after={terminal.HarnessScrollOffset})");
+    }
+
+    [AvaloniaFact]
+    public void NormalBuffer_AtBottom_KeepsFollowingLiveOutput()
+    {
+        var terminal = NewTerminal();
+        terminal.HarnessRebuild(Bytes(PlainLines(0, 40)));
+
+        // Not scrolled up: stays attached to the live bottom.
+        terminal.HarnessFeed(Bytes(PlainLines(40, 60)));
+
+        Assert.Equal(0, terminal.HarnessScrollOffset);
+        Assert.EndsWith("59", terminal.HarnessVisibleLine(terminal.HarnessRows - 2));
+    }
+
+    [AvaloniaFact]
+    public void AlternateScreen_ExposesLocalScrollbackAndRendersIt()
+    {
+        var terminal = NewTerminal();
+
+        var sb = new StringBuilder();
+        sb.Append("\x1b[?1049h");
+        for (int f = 0; f < 12; f++) sb.Append(AltFrame(f, rows: 10));
+        sb.Append("\x1b[H");
+        terminal.HarnessRebuild(Bytes(sb.ToString()));
+
+        var parser = terminal.HarnessParser;
+        Assert.NotNull(parser);
+        Assert.True(parser!.IsAlternateScreen, "fixture should leave the parser on the alternate screen");
+        Assert.True(parser.AltScrollbackCount > 0, "alternate-screen history should have been recovered");
+
+        // The host reads scroll extents from the snapshot; on the alt screen it must report
+        // the alternate-screen history (so the scrollbar becomes usable), not the empty primary.
+        Assert.Equal(parser.AltScrollbackCount, terminal.GetScrollSnapshot().ScrollbackCount);
+
+        // Scrolling up renders the recovered alternate-screen lines.
+        terminal.HarnessScrollUp(3);
+        Assert.True(terminal.HarnessScrollOffset > 0);
+        Assert.StartsWith("L", terminal.HarnessVisibleLine(0));
+    }
+}

--- a/src/CcDirector.Terminal.Avalonia/TerminalControl.cs
+++ b/src/CcDirector.Terminal.Avalonia/TerminalControl.cs
@@ -103,6 +103,23 @@ public class TerminalControl : Control
     private int _scrollOffset; // 0 = bottom (current view), >0 = scrolled up
     private bool _userScrolled; // True when user has manually scrolled up (prevents auto-scroll)
 
+    // Last observed value of the parser's monotonic line counter. The per-poll delta
+    // tells us how many lines were appended to scrollback so a scrolled-up viewport
+    // can be nudged to stay pinned to the same content (issue #761).
+    private long _lastScrollTotal;
+
+    /// <summary>
+    /// The scrollback the viewport is reading from right now: the parser's alternate-screen
+    /// history while a full-screen agent is on the alternate screen, otherwise the local
+    /// primary-buffer history (issue #761).
+    /// </summary>
+    private IReadOnlyList<TerminalCell[]> ActiveScrollback =>
+        _parser?.IsAlternateScreen == true ? _parser.AltScrollback : _scrollback;
+
+    /// <summary>Line count of the currently active scrollback (see <see cref="ActiveScrollback"/>).</summary>
+    private int ActiveScrollbackCount =>
+        _parser?.IsAlternateScreen == true ? _parser.AltScrollbackCount : _scrollback.Count;
+
     // Selection state
     private bool _isSelecting;
     private (int col, int row) _selectionStart;  // Anchor point (where mouse down occurred)
@@ -162,7 +179,7 @@ public class TerminalControl : Control
         get => _scrollOffset;
         set
         {
-            int clamped = Math.Max(0, Math.Min(_scrollback.Count, value));
+            int clamped = Math.Max(0, Math.Min(ActiveScrollbackCount, value));
             if (_scrollOffset != clamped)
             {
                 _scrollOffset = clamped;
@@ -193,7 +210,7 @@ public class TerminalControl : Control
     /// growing concurrently with a redraw.
     /// </summary>
     public ScrollSnapshot GetScrollSnapshot()
-        => new(_scrollback.Count, _rows, _scrollOffset);
+        => new(ActiveScrollbackCount, _rows, _scrollOffset);
 
     /// <summary>Total number of lines (scrollback + current screen) - includes empty rows.</summary>
     public int TotalLineCount => _scrollback.Count + _rows;
@@ -315,6 +332,7 @@ public class TerminalControl : Control
         _bufferPosition = 0;
         _scrollOffset = 0;
         _userScrolled = false;
+        _lastScrollTotal = 0;
         _scrollback.Clear();
         _pathExistsCache.Clear();
 
@@ -379,6 +397,7 @@ public class TerminalControl : Control
         _scrollback.Clear();
         _scrollOffset = 0;
         _userScrolled = false;
+        _lastScrollTotal = 0;
         _pathExistsCache.Clear();
 
         _parser = new AnsiParser(_cells, _cols, _rows, _scrollback, ScrollbackLines, FileLog.Write);
@@ -396,6 +415,10 @@ public class TerminalControl : Control
         // After replay the parser may be on the alternate screen, drawing into its own buffer;
         // render that, not the frozen array we constructed it with.
         SyncActiveGrid();
+
+        // The replay already advanced the parser's line counter; baseline our tracker to it so the
+        // first live poll computes a delta of zero, not the whole replayed history (issue #761).
+        _lastScrollTotal = _parser?.TotalLinesScrolled ?? 0;
 
         FileLog.Write($"[TerminalControl] RebuildFromBuffer: cols={_cols}, rows={_rows}, replayedBytes={replayedBytes}, scrollback={_scrollback.Count}");
     }
@@ -748,7 +771,23 @@ public class TerminalControl : Control
         // Only auto-scroll if user hasn't manually scrolled up
         // This lets users review history while output continues
         if (!_userScrolled && _scrollOffset > 0)
+        {
             _scrollOffset = 0;
+        }
+        else if (_userScrolled)
+        {
+            // The user is reading back. As the parser appends lines to scrollback,
+            // a fixed distance-from-bottom offset would let the pinned content drift
+            // upward out of view (and jump again when the oldest lines are trimmed).
+            // Advance the offset by however many lines were just appended so the text
+            // the user is reading stays put; clamp when their content ages off the top.
+            long total = _parser?.TotalLinesScrolled ?? _lastScrollTotal;
+            long delta = total - _lastScrollTotal;
+            if (delta > 0)
+                _scrollOffset = Math.Min(ActiveScrollbackCount, _scrollOffset + (int)delta);
+        }
+
+        _lastScrollTotal = _parser?.TotalLinesScrolled ?? 0;
 
         // Synchronized output (?2026): if the agent is mid-frame, hold the repaint
         // so we never paint a half-drawn frame (that mid-frame paint is what makes
@@ -780,11 +819,13 @@ public class TerminalControl : Control
         _scrollback.Clear();
         _scrollOffset = 0;
         _userScrolled = false;
+        _lastScrollTotal = 0;
         _pathExistsCache.Clear();
         _parser = new AnsiParser(_cells, _cols, _rows, _scrollback, ScrollbackLines, FileLog.Write);
         if (data.Length > 0)
             _parser.Parse(data);
         SyncActiveGrid();
+        _lastScrollTotal = _parser.TotalLinesScrolled;
         InvalidateVisual();
     }
 
@@ -804,6 +845,22 @@ public class TerminalControl : Control
 
     /// <summary>Harness: the live parser, for reading the active (alt-aware) grid as ground truth.</summary>
     internal AnsiParser? HarnessParser => _parser;
+
+    /// <summary>Harness: emulate a wheel scroll-up of <paramref name="lines"/> rows, exactly like the
+    /// pointer-wheel handler on the normal buffer, so a test can drive the scrolled-up pin behavior
+    /// (issue #761).</summary>
+    internal void HarnessScrollUp(int lines)
+    {
+        ScrollOffset = _scrollOffset + lines;
+        _userScrolled = _scrollOffset > 0;
+    }
+
+    /// <summary>Harness: the plain text of visible viewport row <paramref name="row"/> (0 = top),
+    /// read through the same scrollback-aware path the renderer uses.</summary>
+    internal string HarnessVisibleLine(int row) => GetLineText(row).TrimEnd();
+
+    /// <summary>Harness: current scroll offset (lines up from the live bottom).</summary>
+    internal int HarnessScrollOffset => _scrollOffset;
 
     // Harness: stand-in for the session's RepoPath so relative path links (e.g. "docs/") resolve
     // to real on-disk directories and exercise the path-existence link rendering.
@@ -880,7 +937,7 @@ public class TerminalControl : Control
         var (curCol, curRow) = _parser.GetCursorPosition();
 
         var ctx = new RenderContext(
-            _scrollback, _scrollOffset,
+            ActiveScrollback, _scrollOffset,
             _hasSelection, selStartCol, selStartRow, selEndCol, selEndRow,
             cursorVisible, curCol, curRow,
             renderLinkRegions,
@@ -1236,20 +1293,35 @@ public class TerminalControl : Control
     {
         try
         {
-            // When a full-screen application is on the alternate screen and has
-            // requested mouse reporting (e.g. Claude Code), the local scrollback
-            // is empty by design -- the application scrolls its own view. Forward
-            // the wheel to it as mouse-wheel reports instead of scrolling local
-            // history, which would do nothing and leave the user stuck.
-            if (_session != null && _parser != null
-                && _parser.IsAlternateScreen && _parser.MouseReportingEnabled)
+            int lines = e.Delta.Y > 0 ? 3 : -3;
+
+            // On the alternate screen, prefer our recovered local scrollback (issue #761)
+            // so a running full-screen agent (Claude Code, Codex, Grok, Copilot) can be
+            // scrolled back through. We only hand the wheel to the application when the
+            // user is already at the live bottom and scrolling further down, so an app
+            // that scrolls its own view still works but the user is never stuck.
+            if (_parser != null && _parser.IsAlternateScreen)
             {
-                ForwardWheelToApplication(e);
+                bool scrollingUp = e.Delta.Y > 0;
+                bool hasLocalHistory = _parser.AltScrollbackCount > 0;
+
+                if (hasLocalHistory && (scrollingUp || _scrollOffset > 0))
+                {
+                    ScrollOffset = _scrollOffset + lines; // Uses property to trigger event
+                    _userScrolled = _scrollOffset > 0;
+                    e.Handled = true;
+                    return;
+                }
+
+                // At the live bottom (or nothing captured yet): let the application scroll
+                // its own view if it asked for mouse reporting.
+                if (_session != null && _parser.MouseReportingEnabled)
+                    ForwardWheelToApplication(e);
+
                 e.Handled = true;
                 return;
             }
 
-            int lines = e.Delta.Y > 0 ? 3 : -3;
             ScrollOffset = _scrollOffset + lines; // Uses property to trigger event
 
             // Track if user is reviewing history (scrolled up)
@@ -1367,20 +1439,21 @@ public class TerminalControl : Control
     {
         if (_scrollOffset > 0)
         {
-            int virtualIndex = _scrollback.Count - _scrollOffset + row;
+            var scrollback = ActiveScrollback;
+            int virtualIndex = scrollback.Count - _scrollOffset + row;
 
             if (virtualIndex < 0)
             {
                 return default;
             }
-            else if (virtualIndex < _scrollback.Count)
+            else if (virtualIndex < scrollback.Count)
             {
-                var line = _scrollback[virtualIndex];
+                var line = scrollback[virtualIndex];
                 return col < line.Length ? line[col] : default;
             }
             else
             {
-                int screenRow = virtualIndex - _scrollback.Count;
+                int screenRow = virtualIndex - scrollback.Count;
                 return (screenRow >= 0 && screenRow < _rows)
                     ? _cells[col, screenRow]
                     : default;
@@ -1503,20 +1576,21 @@ public class TerminalControl : Control
                 if (_scrollOffset > 0)
                 {
                     // Same logic as Render for scrollback
-                    int virtualIndex = _scrollback.Count - _scrollOffset + row;
+                    var scrollback = ActiveScrollback;
+                    int virtualIndex = scrollback.Count - _scrollOffset + row;
 
                     if (virtualIndex < 0)
                     {
                         cell = default;
                     }
-                    else if (virtualIndex < _scrollback.Count)
+                    else if (virtualIndex < scrollback.Count)
                     {
-                        var line = _scrollback[virtualIndex];
+                        var line = scrollback[virtualIndex];
                         cell = col < line.Length ? line[col] : default;
                     }
                     else
                     {
-                        int screenRow = virtualIndex - _scrollback.Count;
+                        int screenRow = virtualIndex - scrollback.Count;
                         cell = (screenRow >= 0 && screenRow < _rows)
                             ? _cells[col, screenRow]
                             : default;

--- a/src/CcDirector.Terminal.Core/AnsiParser.cs
+++ b/src/CcDirector.Terminal.Core/AnsiParser.cs
@@ -38,7 +38,23 @@ public class AnsiParser
     // scrolling region. The grid is never modified here, so xterm parity is
     // unaffected; this only ever appends to _scrollback.
     private TerminalCell[][]? _committedFrame; // snapshot of the last completed frame
-    private int _scrollbackCountAtFrame;       // _scrollback.Count at last frame (ScrollUp reconciliation)
+    private int _scrollbackCountAtFrame;       // active-scrollback count at last frame (ScrollUp reconciliation)
+
+    // --- Alternate-screen scrollback (issue #761) ---
+    // Full-screen agents (Claude Code, Codex, Grok, Copilot) run on the alternate
+    // screen, which by tradition has no scrollback. But those agents repaint their
+    // transcript in place, so lines that scroll off the top are lost and the user
+    // cannot read back. We recover that history exactly as we do for the primary
+    // buffer -- ScrollUp and the repaint-diff both append displaced lines -- but into
+    // this dedicated list, which is cleared whenever the app enters or leaves the
+    // alternate screen so shell history and app history never bleed into each other.
+    private readonly List<TerminalCell[]> _altScrollback = new();
+
+    // Monotonic count of every line ever appended to a scrollback list (primary or
+    // alternate), counted BEFORE the max-scrollback trim so it is immune to trimming.
+    // The owning control reads the per-tick delta to keep a scrolled-up viewport pinned
+    // to the same content as new lines arrive (issue #761, the drift fix).
+    private long _totalLinesScrolled;
 
     // --- Cursor ---
     private int _cursorCol;
@@ -285,6 +301,32 @@ public class AnsiParser
     /// wheel to the application while this is true.
     /// </summary>
     public bool IsAlternateScreen => _altCells != null;
+
+    /// <summary>
+    /// The alternate screen's recovered scrollback (issue #761). Empty unless a
+    /// full-screen agent is on the alternate screen and has repainted lines off the
+    /// top. The owning control renders this instead of the primary scrollback while
+    /// <see cref="IsAlternateScreen"/> is true, so the user can scroll back through a
+    /// running Claude Code / Codex / Grok / Copilot session.
+    /// </summary>
+    public IReadOnlyList<TerminalCell[]> AltScrollback => _altScrollback;
+
+    /// <summary>Number of lines currently held in the alternate-screen scrollback.</summary>
+    public int AltScrollbackCount => _altScrollback.Count;
+
+    /// <summary>
+    /// Monotonic count of every line ever pushed into scrollback (primary or alternate),
+    /// counted before the max-scrollback trim. The owning control reads the delta between
+    /// polls to keep a scrolled-up viewport anchored to the same content as history grows
+    /// (issue #761). Resets to zero only when a fresh parser is constructed.
+    /// </summary>
+    public long TotalLinesScrolled => _totalLinesScrolled;
+
+    /// <summary>
+    /// The scrollback list history is appended to right now: the alternate-screen list
+    /// while an alternate screen is active, otherwise the caller-owned primary list.
+    /// </summary>
+    private List<TerminalCell[]> ActiveScrollback => _altCells != null ? _altScrollback : _scrollback;
 
     /// <summary>
     /// True while the application is inside a synchronized output frame (it has sent
@@ -1136,15 +1178,18 @@ public class AnsiParser
     {
         // Only save to scrollback when scrolling the full screen (top margin
         // at row 0); otherwise we're inside a DECSTBM region and the rows
-        // that leave are gone.
-        if (_scrollTop == 0 && _altCells == null)
+        // that leave are gone. On the alternate screen this feeds the dedicated
+        // alt scrollback so full-screen agents get local history too (issue #761).
+        if (_scrollTop == 0)
         {
+            var sb = ActiveScrollback;
             var savedRow = new TerminalCell[_cols];
             for (int c = 0; c < _cols; c++)
                 savedRow[c] = _cells[c, 0];
-            _scrollback.Add(savedRow);
-            while (_scrollback.Count > _maxScrollback)
-                _scrollback.RemoveAt(0);
+            sb.Add(savedRow);
+            _totalLinesScrolled++;
+            while (sb.Count > _maxScrollback)
+                sb.RemoveAt(0);
         }
 
         for (int r = _scrollTop; r < _scrollBottom; r++)
@@ -1177,7 +1222,10 @@ public class AnsiParser
     /// </summary>
     private void CommitRepaintFrame()
     {
-        if (_altCells != null) return; // never capture alt-screen frames
+        // Runs for both the primary buffer and the alternate screen. On the alternate
+        // screen the recovered lines go into the dedicated alt scrollback (issue #761);
+        // the diff logic below is identical either way and never mutates the grid.
+        var sb = ActiveScrollback;
 
         var current = SnapshotGrid();
 
@@ -1185,16 +1233,16 @@ public class AnsiParser
         if (_committedFrame == null || _committedFrame.Length != _rows)
         {
             _committedFrame = current;
-            _scrollbackCountAtFrame = _scrollback.Count;
+            _scrollbackCountAtFrame = sb.Count;
             return;
         }
 
         // If real scrolling (ScrollUp) already pushed lines since the last frame,
         // that path captured the history -- don't double-count it here.
-        if (_scrollback.Count != _scrollbackCountAtFrame)
+        if (sb.Count != _scrollbackCountAtFrame)
         {
             _committedFrame = current;
-            _scrollbackCountAtFrame = _scrollback.Count;
+            _scrollbackCountAtFrame = sb.Count;
             return;
         }
 
@@ -1239,17 +1287,18 @@ public class AnsiParser
                     // frame-boundary capture can re-emit a settled line once (e.g. a
                     // section header on both scroll-off and the final flush). Blank
                     // lines are preserved so paragraph spacing survives.
-                    if (_scrollback.Count > 0 && !RowIsBlank(row) && RowTextEquals(_scrollback[^1], row))
+                    if (sb.Count > 0 && !RowIsBlank(row) && RowTextEquals(sb[^1], row))
                         continue;
-                    _scrollback.Add(CopyRow(row));
-                    if (_scrollback.Count > _maxScrollback)
-                        _scrollback.RemoveAt(0);
+                    sb.Add(CopyRow(row));
+                    _totalLinesScrolled++;
+                    if (sb.Count > _maxScrollback)
+                        sb.RemoveAt(0);
                 }
             }
         }
 
         _committedFrame = current;
-        _scrollbackCountAtFrame = _scrollback.Count;
+        _scrollbackCountAtFrame = sb.Count;
     }
 
     private TerminalCell[][] SnapshotGrid()
@@ -1562,6 +1611,8 @@ public class AnsiParser
             _altSavedScrollTop = _scrollTop;
             _altSavedScrollBottom = _scrollBottom;
             _altCells = _cells;
+            // Start the alternate screen with empty local history (issue #761).
+            _altScrollback.Clear();
             var fresh = new TerminalCell[_cols, _rows];
             _cells = fresh;
             // Caller can't see _cells; but our public API hands the grid to
@@ -1584,6 +1635,8 @@ public class AnsiParser
             if (_altCells == null) return;
             _cells = _altCells;
             _altCells = null;
+            // Drop the alternate screen's recovered history; the shell owns the view now (issue #761).
+            _altScrollback.Clear();
             _scrollTop = _altSavedScrollTop;
             _scrollBottom = Math.Min(_altSavedScrollBottom, _rows - 1);
             if (saveCursor) RestoreCursor();
@@ -1626,5 +1679,6 @@ public class AnsiParser
             for (int c = 0; c < _cols; c++)
                 _cells[c, r] = new TerminalCell();
         _scrollback.Clear();
+        _altScrollback.Clear();
     }
 }

--- a/src/CcDirector.Terminal.Core/Rendering/RenderContext.cs
+++ b/src/CcDirector.Terminal.Core/Rendering/RenderContext.cs
@@ -6,7 +6,7 @@ namespace CcDirector.Terminal.Core.Rendering;
 /// </summary>
 public readonly struct RenderContext
 {
-    public readonly List<TerminalCell[]> Scrollback;
+    public readonly IReadOnlyList<TerminalCell[]> Scrollback;
     public readonly int ScrollOffset;
     public readonly bool HasSelection;
     public readonly int SelectionStartCol;
@@ -22,7 +22,7 @@ public readonly struct RenderContext
     public readonly string? RepoPath;
 
     public RenderContext(
-        List<TerminalCell[]> scrollback,
+        IReadOnlyList<TerminalCell[]> scrollback,
         int scrollOffset,
         bool hasSelection,
         int selectionStartCol, int selectionStartRow,


### PR DESCRIPTION
Fixes #761.

## Problem
The desktop session terminal could not be scrolled back while a session was active. Two distinct defects:

- **Normal buffer** (Pi, Gemini, OpenCode, plain shell): the scroll offset was measured as distance-from-bottom, so as the parser appended lines the pinned content drifted upward out of view, and jumped again when the oldest lines were trimmed at the 1000-line cap.
- **Alternate screen** (Claude Code, Codex, Grok, Copilot): had no local scrollback at all, so the most common agents could not be read back.

## Fix
**Part A - normal-buffer pin.** `AnsiParser` exposes a monotonic `TotalLinesScrolled` counter (incremented before the max-scrollback trim). `TerminalControl` advances the scroll offset by the per-poll delta while the user is scrolled up, so the content being read stays at the same viewport row. Scroll to the bottom to re-attach and resume following live output.

**Part B - alternate-screen scrollback.** `AnsiParser` recovers alternate-screen history into a dedicated `_altScrollback` via the same `ScrollUp` and repaint-diff paths already used for the primary buffer, cleared on alt-screen enter/exit so shell and app history never mix. `TerminalControl` renders whichever buffer is active, prefers local scrollback on the wheel (forwarding to the application only at the live bottom), and the host shows the scrollbar once alt-screen history exists.

## Files
- `src/CcDirector.Terminal.Core/AnsiParser.cs`
- `src/CcDirector.Terminal.Core/Rendering/RenderContext.cs`
- `src/CcDirector.Terminal.Avalonia/TerminalControl.cs`
- `src/CcDirector.Avalonia/MainWindow.axaml.cs`

## Tests
- 5 new parser tests (`AnsiParserAltScrollbackTests`): alt capture (repaint + linefeed), primary isolation, clear-on-exit, counter.
- 3 new headless control tests (`TerminalScrollbackTests`): scrolled-up viewport stays pinned, at-bottom keeps following, alt screen exposes and renders local scrollback.
- Full parser suite (225 tests) including the xterm snapshot parity gate, and the Avalonia control suite (7 tests), all pass. No regressions.

## Notes / trade-off
On the alternate screen, wheel-up now scrolls our captured history rather than being forwarded to the agent (the repainting agents ignore wheel anyway); an app that scrolls its own view still receives the wheel at the live bottom.

Not yet done: live in-app screenshot proof against a real Claude Code session (the issue's acceptance criteria) - the headless tests prove the mechanics.

Generated with Claude Code
