### PR TITLE
Add Control-API regression test for session name-at-birth (#807)

### DIFF
--- a/src/CcDirector.Gateway.Tests/ControlApiHostTests.cs
+++ b/src/CcDirector.Gateway.Tests/ControlApiHostTests.cs
@@ -147,6 +147,61 @@ public sealed class ControlApiHostTests : IAsyncLifetime
         Assert.True(_host.IsListening);
         Assert.Null(_host.StartupError);
     }
+
+    // OS shell used as a harmless RawCli agent so these tests exercise the real create
+    // path without depending on an installed coding-agent CLI.
+    private static string TestShellPath =>
+        System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+            System.Runtime.InteropServices.OSPlatform.Windows) ? "cmd.exe" : "/bin/sh";
+
+    [Fact]
+    public async Task Post_sessions_applies_explicit_name_at_birth()
+    {
+        // Issue #807 regression: a session created via POST /sessions with a meaningful Name
+        // must come back with THAT name immediately (name-at-birth, issue #800) - the create
+        // response AND a subsequent GET must both show it, with no PATCH. The reported failure
+        // was the session born unnamed, then displaying as the bare repo folder name.
+        var repo = Path.GetTempPath();
+        const string name = "mobile PWA - impl loop #806";
+
+        var resp = await _client.PostAsJsonAsync("sessions", new NewSessionRequest
+        {
+            RepoPath = repo,
+            Agent = "RawCli",
+            Command = TestShellPath,
+            Name = name,
+        });
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var created = await resp.Content.ReadFromJsonAsync<SessionDto>();
+        Assert.NotNull(created);
+        Assert.Equal(name, created!.Name);
+
+        // GET by id returns the same name with no PATCH in between.
+        var fetched = await _client.GetFromJsonAsync<SessionDto>($"sessions/{created.SessionId}");
+        Assert.NotNull(fetched);
+        Assert.Equal(name, fetched!.Name);
+        Assert.NotEqual(Path.GetFileName(repo.TrimEnd('\\', '/')), fetched.Name);
+    }
+
+    [Fact]
+    public async Task Post_sessions_rejects_weak_explicit_name()
+    {
+        // The other half of issue #800: an explicit name equal to the bare repository folder
+        // name is refused with 400, so a caller that bothers to pass a name passes a useful one.
+        var repo = Path.GetTempPath();
+        var folder = Path.GetFileName(repo.TrimEnd('\\', '/'));
+
+        var resp = await _client.PostAsJsonAsync("sessions", new NewSessionRequest
+        {
+            RepoPath = repo,
+            Agent = "RawCli",
+            Command = TestShellPath,
+            Name = folder,
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
Closes #807.

## Finding: version skew, not a live bug
POST /sessions was reported returning an unnamed session (displaying as the bare repo folder name) even though a meaningful `Name` was supplied, forcing a follow-up PATCH.

I traced the current create path end to end:
- `ControlEndpoints` POST /sessions composes the name and passes a `nameFactory` to `SessionManager.CreateSession`.
- `CreateSession` sets `session.CustomName = nameFactory(id)` **before** the session is added to the roster and **before** `OnSessionCreated` fires.
- The DTO maps `Name = s.CustomName`.

So the name is applied at birth in the current source. The reported failure (observed 2026-06-28, session e888ea4e) was a Director binary that predated the issue #800 name-at-birth wiring. The fix on any affected machine is a redeploy of a build that includes it.

## What this PR adds
The regression coverage called for by the issue's acceptance criterion #3 - exercised through the real Control API surface (real `SessionManager` over HTTP, `RawCli` + the OS shell as a harmless stand-in agent so no coding-agent CLI is required):

- `Post_sessions_applies_explicit_name_at_birth` - a supplied `Name` is returned by both the create response **and** a subsequent GET, with no PATCH, and is not the bare folder name.
- `Post_sessions_rejects_weak_explicit_name` - an explicit name equal to the bare folder name is rejected with HTTP 400.

Both pass against current source. No product code changed.

## Files
- `src/CcDirector.Gateway.Tests/ControlApiHostTests.cs`

Generated with Claude Code
