### PR TITLE
Hide the mobile voice play-triangle once a session starts working again

### DIFF
--- a/mobile/src/pages/Home.tsx
+++ b/mobile/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { listSessions, type SessionDto } from "../api/client";
-import { classify, contextLine, dotColor, effectiveColor, inBucket, inDesktopOrder, repoLeaf } from "../sessions/ordering";
+import { classify, contextLine, dotColor, effectiveColor, inBucket, inDesktopOrder, isWorking, repoLeaf } from "../sessions/ordering";
 import { useNow, waitingLabel } from "../sessions/waiting";
 import { getClipState, playClip, playingSid, stopPlayback, syncVoiceSessions, useVoiceClips } from "../voice/clips";
 import { NavDrawer } from "../components/NavDrawer";
@@ -191,9 +191,22 @@ function SessionRow({ session }: { session: SessionDto }) {
 // Gateway or the phone is still downloading, a yellow spinner shows instead. Non-voice sessions
 // render nothing here. Tapping the triangle plays the locally-stored clip with no download wait;
 // preventDefault/stopPropagation keep the tap from also following the row's link.
+//
+// The finished-turn narration is retired the instant the session starts working again: while
+// isWorking(session) is true the whole indicator renders nothing (no triangle, no spinner), because
+// that verbal cue is now stale. If this session's clip is playing at that moment it is stopped, so a
+// stale clip cannot keep talking after the agent has resumed.
 function VoiceIndicator({ session }: { session: SessionDto }) {
-  if (!session.voiceMode) return null;
   const sid = session.sessionId ?? "";
+  const working = isWorking(session);
+
+  useEffect(() => {
+    if (working && playingSid() === sid) stopPlayback();
+  }, [working, sid]);
+
+  if (!session.voiceMode) return null;
+  if (working) return null;
+
   const clip = getClipState(sid);
 
   if (clip.phase === "ready") {

--- a/mobile/src/pages/VoiceMode.tsx
+++ b/mobile/src/pages/VoiceMode.tsx
@@ -18,6 +18,7 @@ import { DictationDialog } from "../dictation/DictationDialog";
 import { SessionManageBar } from "../components/SessionManageBar";
 import { ViewTabs } from "../components/ViewTabs";
 import { ensureClip, getClipState, stopPlayback, useVoiceClips } from "../voice/clips";
+import { isWorking } from "../sessions/ordering";
 
 // Session Voice mode (issue #850): the hands-free Wingman narration screen, the third session view
 // alongside Terminal (#817) and Chat (#811). A read-only Wingman narrates every completed turn as
@@ -168,9 +169,30 @@ export function VoiceMode() {
   const phoneReady =
     generatedAt.length > 0 && clip.phase === "ready" && clip.generatedAt === generatedAt && clip.url !== null;
 
-  // Auto-play a freshly downloaded clip exactly once, and only while the voice screen is foreground
-  // (decision 4: never auto-play from the list, never while the app is hidden).
+  // Whether the agent has resumed working (blue) - the instant it does, the finished-turn narration is
+  // stale and must not be spoken or offered, exactly like the roster play-triangle (Home.tsx). A null
+  // session (not yet loaded) is treated as not-working.
+  const agentWorking = session !== null && isWorking(session);
+
+  // Retire a stale narration the moment the agent starts working again: stop this screen's own
+  // playback and any shared roster clip. The speaking-state play-triangle is hidden below while
+  // working, so a stale clip can neither keep talking nor be replayed until the next turn parks the
+  // session again.
   useEffect(() => {
+    if (!agentWorking) return;
+    try {
+      audioRef.current?.pause();
+    } catch {
+      /* nothing playing */
+    }
+    stopPlayback();
+  }, [agentWorking]);
+
+  // Auto-play a freshly downloaded clip exactly once, and only while the voice screen is foreground
+  // (decision 4: never auto-play from the list, never while the app is hidden). Never auto-play while
+  // the agent is working again - that narration is stale (the same rule the roster triangle follows).
+  useEffect(() => {
+    if (agentWorking) return;
     if (!phoneReady || generatedAt.length === 0) return;
     if (autoPlayedRef.current === generatedAt) return;
     if (typeof document !== "undefined" && document.hidden) return;
@@ -183,7 +205,7 @@ export function VoiceMode() {
         /* autoplay policy may require a gesture; the play-triangle covers it */
       });
     }
-  }, [phoneReady, generatedAt]);
+  }, [phoneReady, generatedAt, agentWorking]);
 
   const onSwitchOn = useCallback(async () => {
     if (sid.length === 0 || enabling) return;
@@ -310,7 +332,10 @@ export function VoiceMode() {
 
   const voiceOn = localEnabled || Boolean(session?.voiceMode);
   const waitingChoice = voiceOn && menu !== null;
-  const speaking = voiceOn && !waitingChoice && phoneReady && (voice?.spoken.length ?? 0) > 0;
+  // The speaking state (and its play-triangle) is suppressed while the agent is working again: the
+  // finished-turn narration is stale, so the screen falls back to the working card instead of
+  // offering a replay of it.
+  const speaking = voiceOn && !waitingChoice && phoneReady && (voice?.spoken.length ?? 0) > 0 && !agentWorking;
   const working = voiceOn && !waitingChoice && !speaking;
   const progress = dur > 0 ? Math.min(1, pos / dur) : 0;
   const narrative = voice?.spoken ?? "";
@@ -359,24 +384,30 @@ export function VoiceMode() {
           </div>
         )}
 
-        {/* B. WORKING - the Wingman is reading and the phone is downloading the clip. */}
+        {/* B. WORKING - either the Wingman is reading + the phone is downloading the clip, or (when
+            agentWorking) the agent has resumed and the finished-turn narration has been retired: show
+            truthful copy for each so we never promise auto-play that the working gate suppresses. */}
         {working && (
           <>
             <div className="voice-statusbar">
-              <span className="voice-state voice-state-yellow">Wingman is reading...</span>
+              <span className="voice-state voice-state-yellow">
+                {agentWorking ? "Agent is working..." : "Wingman is reading..."}
+              </span>
             </div>
             <div className="voice-narr">
-              <div className="voice-narr-title">Listening</div>
+              <div className="voice-narr-title">{agentWorking ? "Working" : "Listening"}</div>
               <div className="voice-narr-body">
                 {enableNote.length > 0
                   ? enableNote
-                  : "Preparing the spoken summary of the latest turn. This will play automatically."}
+                  : agentWorking
+                    ? "The agent is working on the next step. The Wingman will narrate the next completed turn."
+                    : "Preparing the spoken summary of the latest turn. This will play automatically."}
               </div>
             </div>
             {enableNote.length === 0 && (
               <div className="voice-working">
                 <span className="voice-spinner" aria-hidden="true" />
-                <span className="voice-ref">rendering audio + downloading</span>
+                <span className="voice-ref">{agentWorking ? "working" : "rendering audio + downloading"}</span>
               </div>
             )}
           </>

--- a/mobile/src/sessions/ordering.ts
+++ b/mobile/src/sessions/ordering.ts
@@ -48,6 +48,20 @@ export function effectiveColor(s: SessionDto): string {
   return s.statusColor ?? "unknown";
 }
 
+// True while the agent is actively running a turn - the "working" state. Blue is the authoritative
+// working color (StatusColor.cs: blue = agent working / a turn is in progress); the raw activity /
+// assessed state is checked too so a session mid-turn still counts before its color settles. A
+// deferred (on-hold) session is never "working" - the user parked it. Used to retire a now-stale
+// Wingman voice cue: the roster play-triangle is shown only while a session is red / parked and is
+// removed the instant it starts working again (you no longer want to hear the finished-turn
+// narration).
+export function isWorking(s: SessionDto): boolean {
+  if (s.onHold) return false;
+  if ((s.statusColor ?? "").toLowerCase() === "blue") return true;
+  const state = s.assessedState ?? s.activityState ?? "";
+  return state === "Working";
+}
+
 // Classify a session for triage. On-hold takes precedence over color (the user deferred it);
 // otherwise an effective-red session "needs you", everything else is active.
 export function classify(s: SessionDto): TriageBucket {


### PR DESCRIPTION
## What

On the mobile app, the Wingman voice play-triangle (the green cue that a session has a finished-turn narration to hear) used to stay visible even after the agent resumed working, so a stale spoken summary could still be played. This retires the cue the instant a session starts working again, on both surfaces.

## Changes

- **`mobile/src/sessions/ordering.ts`** - new pure `isWorking(session)` predicate: true when the agent is actively running a turn (blue status color, or a `Working` activity/assessed state). A held (on-hold) session is never "working".
- **`mobile/src/pages/Home.tsx`** (roster) - the trailing voice indicator renders nothing while `isWorking` is true, and if that session's clip is playing at the transition it is stopped.
- **`mobile/src/pages/VoiceMode.tsx`** (session Voice mode screen) - the speaking state and its play-triangle are hidden while working, auto-play is suppressed, playback is stopped on the transition, and the working card shows truthful copy for the agent-working case (no false "will play automatically" promise).

Purely a display/playback gate - the clip cache is untouched; the next turn-end supersedes the old clip as before.

## Verification

- `npm run typecheck` (tsc --noEmit): clean.
- Real `/m` React screens driven in a headless browser with a fixture voice session:
  - Roster: red/parked -> play-triangle shown; blue/working -> none.
  - Voice mode: red/parked -> "Speaking" + play-triangle; blue/working -> "Agent is working..." card, no play-triangle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)