### PR TITLE
Complete orphan instance-file deletes in the stale sweeper (#891)

### DIFF
--- a/src/CcDirector.Gateway.Tests/DirectorRegistryOrphanFileTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorRegistryOrphanFileTests.cs
@@ -1,0 +1,108 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #891: the stale sweeper must complete an orphan instance-file delete that failed once,
+/// so a dead Director's file cannot linger on disk and resurrect as a phantom on the next restart.
+/// </summary>
+public sealed class DirectorRegistryOrphanFileTests
+{
+    private static string TestShellPath =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "cmd.exe" : "/bin/sh";
+
+    private static int DeadPid()
+    {
+        // Spawn a process that exits immediately so its id is a real, now-dead pid.
+        var psi = new ProcessStartInfo(TestShellPath,
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "/c exit" : "-c exit")
+        {
+            CreateNoWindow = true,
+            UseShellExecute = false,
+        };
+        var p = Process.Start(psi)!;
+        p.WaitForExit();
+        return p.Id;
+    }
+
+    private static string WriteInstanceFile(string dir, string id, int pid)
+    {
+        var path = Path.Combine(dir, $"{id}.json");
+        File.WriteAllText(path, JsonSerializer.Serialize(new DirectorDto
+        {
+            DirectorId = id,
+            Pid = pid,
+            ControlEndpoint = "http://127.0.0.1:63302",
+            Source = "file",
+        }));
+        return path;
+    }
+
+    [Fact]
+    public void OrphanSweep_DeletesFileWithDeadPidAndNoLiveEntry()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "cc-orphan-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var path = WriteInstanceFile(dir, Guid.NewGuid().ToString(), DeadPid());
+            Assert.True(File.Exists(path));
+
+            using var reg = new DirectorRegistry(dir);
+            reg.SweepOrphanInstanceFiles();
+
+            Assert.False(File.Exists(path), "an instance file whose recorded pid is dead should be deleted");
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { /* test cleanup */ }
+        }
+    }
+
+    [Fact]
+    public void OrphanSweep_KeepsFileWithLivePid()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "cc-orphan-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            // This test process is alive, so its pid must not be treated as an orphan.
+            var path = WriteInstanceFile(dir, Guid.NewGuid().ToString(), Environment.ProcessId);
+
+            using var reg = new DirectorRegistry(dir);
+            reg.SweepOrphanInstanceFiles();
+
+            Assert.True(File.Exists(path), "a file whose process is still alive must not be deleted");
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { /* test cleanup */ }
+        }
+    }
+
+    [Fact]
+    public void OrphanSweep_KeepsFileWithUnstampedPid()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "cc-orphan-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            // pid <= 0 predates pid stamping: death cannot be proven, so the file is left alone.
+            var path = WriteInstanceFile(dir, Guid.NewGuid().ToString(), 0);
+
+            using var reg = new DirectorRegistry(dir);
+            reg.SweepOrphanInstanceFiles();
+
+            Assert.True(File.Exists(path), "a file with no usable pid must not be deleted");
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { /* test cleanup */ }
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
+++ b/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
@@ -510,7 +510,15 @@ public sealed class DirectorRegistry : IDisposable
                     try { System.Diagnostics.Process.GetProcessById(pid); }
                     catch (ArgumentException) // process not running
                     {
-                        try { File.Delete(f); } catch { }
+                        // Issue #891: do NOT swallow a failed delete. If the file is locked or we lack
+                        // permission it stays on disk; the orphan-file sweep below completes the delete
+                        // on a later pass (this loop iterates the in-memory roster, from which the entry
+                        // is about to be removed, so it would otherwise never be revisited).
+                        try { File.Delete(f); }
+                        catch (Exception ex)
+                        {
+                            FileLog.Write($"[DirectorRegistry] Sweeper could not delete instance file for {kv.Key} (pid {pid} dead); orphan sweep will retry: {ex.Message}");
+                        }
                         if (_directors.TryRemove(kv.Key, out _))
                         {
                             FileLog.Write($"[DirectorRegistry] Sweeper removed orphan (pid {pid} dead): {kv.Key}");
@@ -520,11 +528,93 @@ public sealed class DirectorRegistry : IDisposable
                     catch { /* permission errors etc - leave it for next pass */ }
                 }
             }
+
+            SweepOrphanInstanceFiles();
         }
         catch (Exception ex)
         {
             FileLog.Write($"[DirectorRegistry] SweepStale error: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Directory-level safety net (issue #891). The in-memory sweep above removes a dead Director from
+    /// the roster even if deleting its backing instance file failed (locked, permission). Because that
+    /// loop iterates the in-memory dictionary, such a file is never revisited and, on the next Gateway
+    /// restart, <see cref="LoadExisting"/> re-imports it - which can resurrect a phantom Director if the
+    /// recorded process id has since been recycled to an unrelated live process. This scan completes the
+    /// delete: it enumerates the watch directory for files that have NO live in-memory entry and whose
+    /// recorded process id is dead, and deletes them. Files with a live entry are handled by the sweep
+    /// above; files whose process is still alive, or that predate pid stamping (pid &lt;= 0), are left
+    /// untouched so a healthy Director's file is never removed.
+    /// </summary>
+    internal void SweepOrphanInstanceFiles()
+    {
+        string[] files;
+        try
+        {
+            files = Directory.GetFiles(WatchDirectory, "*.json");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[DirectorRegistry] Orphan-file sweep could not enumerate {WatchDirectory}: {ex.Message}");
+            return;
+        }
+
+        foreach (var f in files)
+        {
+            var id = Path.GetFileNameWithoutExtension(f);
+            // A file backing a still-known Director is the in-memory sweep's responsibility; leave it.
+            if (!string.IsNullOrEmpty(id) && _directors.ContainsKey(id))
+                continue;
+
+            int pid;
+            try
+            {
+                var json = File.ReadAllText(f);
+                if (string.IsNullOrWhiteSpace(json)) continue; // being written; try next pass
+                var dto = JsonSerializer.Deserialize<DirectorDto>(json, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true,
+                });
+                if (dto is null) continue;
+                pid = dto.Pid;
+            }
+            catch (IOException) { continue; /* still being written */ }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[DirectorRegistry] Orphan-file sweep could not read {Path.GetFileName(f)}: {ex.Message}");
+                continue;
+            }
+
+            // Only delete when we can PROVE the process is gone. pid <= 0 predates pid stamping, so we
+            // cannot prove death and must leave the file rather than risk deleting a live Director's.
+            if (pid <= 0 || !IsProcessDead(pid))
+                continue;
+
+            try
+            {
+                File.Delete(f);
+                FileLog.Write($"[DirectorRegistry] Orphan-file sweep deleted stale instance file {Path.GetFileName(f)} (pid {pid} dead)");
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[DirectorRegistry] Orphan-file sweep could not delete {Path.GetFileName(f)} (pid {pid} dead); will retry next sweep: {ex.Message}");
+            }
+        }
+    }
+
+    /// <summary>True when no process with <paramref name="pid"/> is currently running. A permission or
+    /// other unexpected error returns false (do not assume dead) so we never delete on uncertainty.</summary>
+    private static bool IsProcessDead(int pid)
+    {
+        try
+        {
+            using var _ = System.Diagnostics.Process.GetProcessById(pid);
+            return false;
+        }
+        catch (ArgumentException) { return true; }
+        catch { return false; }
     }
 
     public void Dispose()


### PR DESCRIPTION
Closes #891.

## Problem
When the stale sweeper evicted a file-discovered Director whose process was dead, it removed the in-memory entry but its `try { File.Delete(f); } catch { }` swallowed any failure (locked file, permission). Because the sweep iterates the in-memory dictionary rather than the directory, the orphan file was never revisited - it lingered on disk and, on the next Gateway restart, `LoadExisting` re-imported it, which could resurrect a phantom Director if the recorded process id had since been recycled to an unrelated live process.

## Fix (`DirectorRegistry.cs`)
- The inline delete no longer swallows the failure silently - it logs the reason so a stuck file is visible.
- A new directory-level pass, `SweepOrphanInstanceFiles`, runs on every sweep: it scans the watch directory for files that have **no live in-memory entry** and whose **recorded process id is dead**, and completes the delete that failed earlier. Guards so a healthy Director's file is never removed:
  - a file backing a still-known Director is left to the in-memory sweep;
  - a file whose process is still alive is kept;
  - a file with no usable pid (`pid <= 0`, predating pid stamping) is kept - death cannot be proven.

## Tests (`DirectorRegistryOrphanFileTests.cs`)
- An orphan file with a dead pid and no live entry is deleted.
- A file with a live pid (this test process) is kept.
- A file with an unstamped pid is kept.

Full Gateway registry suite (aggregation, reachability, ever-reachable, advertised-endpoint monitor) passes - no regressions.

## Note on #890
I looked at #890 (flag/reject loopback control endpoints at registration) in the same pass and did **not** ship it: the observed red-banner offenders are *same-machine* loopback Directors (reachable while alive), so the real remedy for that symptom is this #891 cleanup plus the existing reachability circuit-breaker. A registration-time loopback flag based on the advertised machine name is unsafe - loopback reachability depends on physical co-location, which the advertised name does not reliably signal (the aggregation test harness registers a genuinely-reachable local endpoint under a foreign machine name). Raising that as a separate decision.

Generated with Claude Code
