### PR TITLE
Fix cc-outlook flag crash (#455) and empty attachments list (#530)

### DIFF
--- a/tools/cc-outlook/src/outlook_api.py
+++ b/tools/cc-outlook/src/outlook_api.py
@@ -815,16 +815,22 @@ class OutlookClient:
         if not message:
             raise ValueError(f"Message not found: {message_id}")
 
-        # Set flag using the internal attribute
-        flag_data = {'flagStatus': flag_status}
-        if due_date and flag_status == 'flagged':
-            # Convert to UTC so the due date is not shifted by the local offset.
-            flag_data['dueDateTime'] = {
-                'dateTime': _to_utc(due_date).isoformat(),
-                'timeZone': 'UTC'
-            }
+        # Message.flag is a read-only property in the O365 library, so it cannot
+        # be assigned directly (that raises "property 'flag' has no setter").
+        # The flag is changed through its MessageFlag helper methods instead.
+        status = flag_status.strip().lower()
+        if status == 'flagged':
+            message.flag.set_flagged(due_date=due_date)
+        elif status in ('complete', 'completed'):
+            message.flag.set_completed()
+        elif status in ('notflagged', 'clear'):
+            message.flag.delete_flag()
+        else:
+            raise ValueError(
+                f"Unsupported flag status: {flag_status}. "
+                "Use 'flagged', 'complete', or 'notFlagged'."
+            )
 
-        message.flag = flag_data
         message.save_message()
 
         return True
@@ -866,7 +872,10 @@ class OutlookClient:
             List of attachment dicts
         """
         mailbox = self.account.mailbox()
-        message = mailbox.get_message(object_id=message_id)
+        # The attachments collection is not populated unless the message is
+        # fetched with download_attachments=True. Without it, message.attachments
+        # is always empty and the command wrongly reports "No attachments".
+        message = mailbox.get_message(object_id=message_id, download_attachments=True)
 
         if not message:
             raise ValueError(f"Message not found: {message_id}")
@@ -899,7 +908,8 @@ class OutlookClient:
             Dict with download info
         """
         mailbox = self.account.mailbox()
-        message = mailbox.get_message(object_id=message_id)
+        # Attachments are only present when fetched with download_attachments=True.
+        message = mailbox.get_message(object_id=message_id, download_attachments=True)
 
         if not message:
             raise ValueError(f"Message not found: {message_id}")

--- a/tools/cc-outlook/tests/test_outlook_fixes.py
+++ b/tools/cc-outlook/tests/test_outlook_fixes.py
@@ -232,3 +232,96 @@ class TestCreateEventTimezone:
         args, kwargs = event.recurrence.set_daily.call_args
         assert args[0] == 1
         assert kwargs.get("start") == naive.date()
+
+
+class TestFlagMessage:
+    """Regression tests for issue #455.
+
+    flag_message previously did `message.flag = flag_data`, but the O365
+    Message.flag property has no setter, so every flag command crashed with
+    "property 'flag' of 'Message' object has no setter". The fix drives the
+    MessageFlag helper methods (set_flagged / set_completed / delete_flag).
+    """
+
+    def _client_with_inbox_message(self):
+        account = MagicMock()
+        message = MagicMock()
+        account.mailbox.return_value.get_message.return_value = message
+        client = OutlookClient(account=account)
+        return client, message
+
+    def test_flagged_calls_set_flagged(self):
+        client, message = self._client_with_inbox_message()
+        due = datetime(2027, 1, 2, 9, 0)
+
+        result = client.flag_message("id-1", flag_status="flagged", due_date=due)
+
+        assert result is True
+        message.flag.set_flagged.assert_called_once_with(due_date=due)
+        message.save_message.assert_called_once()
+
+    def test_complete_calls_set_completed(self):
+        client, message = self._client_with_inbox_message()
+
+        client.flag_message("id-1", flag_status="complete")
+
+        message.flag.set_completed.assert_called_once()
+        message.save_message.assert_called_once()
+
+    def test_notflagged_calls_delete_flag(self):
+        client, message = self._client_with_inbox_message()
+
+        client.flag_message("id-1", flag_status="notFlagged")
+
+        message.flag.delete_flag.assert_called_once()
+        message.save_message.assert_called_once()
+
+    def test_unknown_status_raises(self):
+        client, message = self._client_with_inbox_message()
+
+        with pytest.raises(ValueError):
+            client.flag_message("id-1", flag_status="bogus")
+
+
+class TestListAttachments:
+    """Regression tests for issue #530.
+
+    list_attachments / download_attachment fetched the message without
+    download_attachments=True, so message.attachments was always empty and the
+    command wrongly reported "No attachments". The fix loads the attachments
+    when fetching the message.
+    """
+
+    def _client(self):
+        account = MagicMock()
+        client = OutlookClient(account=account)
+        return client, account.mailbox.return_value
+
+    def test_list_attachments_requests_download(self):
+        client, mailbox = self._client()
+        att = MagicMock()
+        att.attachment_id = "att-1"
+        att.name = "invite.ics"
+        mailbox.get_message.return_value.attachments = [att]
+
+        result = client.list_attachments("msg-1")
+
+        # The message must be fetched WITH attachments loaded.
+        _, kwargs = mailbox.get_message.call_args
+        assert kwargs.get("download_attachments") is True
+        assert len(result) == 1
+        assert result[0]["id"] == "att-1"
+        assert result[0]["name"] == "invite.ics"
+
+    def test_download_attachment_requests_download(self):
+        client, mailbox = self._client()
+        att = MagicMock()
+        att.attachment_id = "att-1"
+        att.name = "invite.ics"
+        mailbox.get_message.return_value.attachments = [att]
+
+        client.download_attachment("msg-1", "att-1", "C:/tmp/invite.ics")
+
+        _, kwargs = mailbox.get_message.call_args
+        assert kwargs.get("download_attachments") is True
+        att.save.assert_called_once_with("C:/tmp/invite.ics")


### PR DESCRIPTION
## Summary

Two real cc-outlook bugs, both root-caused and fixed with regression tests.

### #455 - `flag` command crashed
`flag_message` assigned to `message.flag` directly, but the Outlook library's
`Message.flag` property is read-only (no setter), so every flag command crashed
with "property 'flag' of 'Message' object has no setter". It now uses the flag
helper methods: `set_flagged`, `set_completed`, and `delete_flag`.

### #530 - `attachments` returned "No attachments"
`list_attachments` and `download_attachment` fetched the message without loading
its attachments, so `message.attachments` was always empty and the command
wrongly reported "No attachments" even for messages that clearly had them. Both
now fetch the message with `download_attachments` enabled.

## Tests

Added 6 regression tests (4 for the flag fix, 2 for the attachments fix). Full
cc-outlook suite: 82 passed.

## Note on live verification

The tests mock the mailbox (no network). A full end-to-end check against a live
mailbox - actually flagging a message and listing a real attachment - needs a
signed-in Outlook account and was not run here.

Closes #455
Closes #530

Generated with Claude Code
