### PR TITLE
Pin the Director instances directory in tests so they cannot pollute the real one (#322)

### DIFF
--- a/src/CcDirector.ControlApi/InstanceRegistration.cs
+++ b/src/CcDirector.ControlApi/InstanceRegistration.cs
@@ -16,8 +16,7 @@ namespace CcDirector.ControlApi;
 /// </summary>
 public sealed class InstanceRegistration : IDisposable
 {
-    public static string InstancesDirectory { get; } =
-        Path.Combine(CcStorage.Config(), "director", "instances");
+    public static string InstancesDirectory { get; } = CcStorage.DirectorInstances();
 
     /// <summary>How often the heartbeat re-writes the instance file. Short enough that
     /// accidental cleanups self-heal quickly; long enough not to thrash the disk.</summary>

--- a/src/CcDirector.Core/Storage/CcStorage.cs
+++ b/src/CcDirector.Core/Storage/CcStorage.cs
@@ -14,6 +14,7 @@ namespace CcDirector.Core.Storage;
 /// Environment variable overrides:
 ///   CC_DIRECTOR_ROOT - Override the base directory (default: %LOCALAPPDATA%\cc-director)
 ///   CC_VAULT_PATH    - Override the vault directory specifically
+///   CC_DIRECTOR_INSTANCES_DIR - Override the Director instance-discovery directory specifically
 ///
 /// NOTE: CcStorage methods intentionally omit FileLog.Write calls because
 /// FileLog.LogDir is initialized from CcStorage.ToolLogs(), creating a
@@ -48,6 +49,23 @@ public static class CcStorage
 
     /// <summary>Tool settings, OAuth tokens, credentials, app state.</summary>
     public static string Config() => Path.Combine(Base(), "config");
+
+    /// <summary>
+    /// Director instance-discovery directory: config/director/instances/. Each running Director writes
+    /// a <c>{directorId}.json</c> here and the Gateway watches it. Honors the
+    /// <c>CC_DIRECTOR_INSTANCES_DIR</c> override (issue #322) so tests can pin JUST this directory to a
+    /// throwaway location - keeping a stray test Director's instance file out of the real directory,
+    /// where the live Gateway's file watcher would otherwise discover it, probe its dead ephemeral port,
+    /// and paint a phantom "unreachable" Director - without redirecting the whole storage root.
+    /// </summary>
+    public static string DirectorInstances()
+    {
+        var overridePath = Environment.GetEnvironmentVariable("CC_DIRECTOR_INSTANCES_DIR");
+        if (!string.IsNullOrEmpty(overridePath))
+            return overridePath;
+
+        return Path.Combine(Config(), "director", "instances");
+    }
 
     /// <summary>Generated files: PDFs, reports, transcripts, exports.</summary>
     public static string Output()

--- a/src/CcDirector.Gateway.Tests/InstancesDirectoryIsolationTests.cs
+++ b/src/CcDirector.Gateway.Tests/InstancesDirectoryIsolationTests.cs
@@ -1,0 +1,53 @@
+using CcDirector.ControlApi;
+using CcDirector.Gateway.Discovery;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Regression guard for issue #322: the whole test assembly must resolve the Director
+/// instance-discovery directory to a throwaway per-process temp directory, so no test - even one that
+/// spins a ControlApiHost / InstanceRegistration without passing its own isolated instancesDirectory -
+/// can write an instance file into the REAL %LOCALAPPDATA%\cc-director\config\director\instances\
+/// directory and surface a phantom "unreachable" Director in the live Cockpit. The pin is applied by
+/// <see cref="TestEnvironment"/>'s module initializer via the CC_DIRECTOR_INSTANCES_DIR override that
+/// <c>CcStorage.DirectorInstances</c> honors.
+///
+/// The assertions read the path-caching statics (resolved once, at process start, under the temp
+/// directory). Nothing swaps CC_DIRECTOR_INSTANCES_DIR per-test, so the pinned value is stable for the
+/// whole run.
+/// </summary>
+public sealed class InstancesDirectoryIsolationTests
+{
+    private static string RealInstancesDirectory => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "cc-director", "config", "director", "instances");
+
+    [Fact]
+    public void PinnedInstancesDir_IsUnderTemp_AndNotTheRealDirectory()
+    {
+        Assert.StartsWith(Path.GetTempPath(), TestEnvironment.InstancesDir, StringComparison.OrdinalIgnoreCase);
+        Assert.NotEqual(
+            Path.GetFullPath(RealInstancesDirectory),
+            Path.GetFullPath(TestEnvironment.InstancesDir),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DirectorRegistry_InstancesDirectory_ResolvesToTheTestDirectory()
+    {
+        Assert.Equal(
+            Path.GetFullPath(TestEnvironment.InstancesDir),
+            Path.GetFullPath(DirectorRegistry.InstancesDirectory),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void InstanceRegistration_InstancesDirectory_ResolvesToTheTestDirectory()
+    {
+        Assert.Equal(
+            Path.GetFullPath(TestEnvironment.InstancesDir),
+            Path.GetFullPath(InstanceRegistration.InstancesDirectory),
+            StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/TestEnvironment.cs
+++ b/src/CcDirector.Gateway.Tests/TestEnvironment.cs
@@ -25,10 +25,33 @@ namespace CcDirector.Gateway.Tests;
 /// </summary>
 internal static class TestEnvironment
 {
+    /// <summary>The throwaway per-process Director instance-discovery directory the whole test
+    /// assembly is pinned to (issue #322).</summary>
+    internal static string InstancesDir { get; } =
+        Path.Combine(Path.GetTempPath(), "cc-director-tests", "instances-" + Environment.ProcessId);
+
     [ModuleInitializer]
     internal static void Init()
     {
         CcDirector.Gateway.Briefing.TurnEndWatcher.SweepEnabled = false;
         Environment.SetEnvironmentVariable("CC_GATEWAY_NO_TAILSCALE", "1");
+
+        // Issue #322: pin the Director instance-discovery directory to a throwaway per-process temp
+        // directory so no test can ever write an instance file into the REAL
+        // %LOCALAPPDATA%\cc-director\config\director\instances\ directory. A test that spins a
+        // ControlApiHost / InstanceRegistration WITHOUT passing an isolated instancesDirectory (e.g.
+        // ChatEndpointTests) previously wrote a "1.0.0-test" instance file into the live directory; the
+        // production Gateway's file watcher then discovered it, probed the dead ephemeral loopback port,
+        // and painted a phantom amber "unreachable" Director in the real Cockpit until the sweeper
+        // evicted it. Pinning just this directory by default (via the CC_DIRECTOR_INSTANCES_DIR override
+        // that CcStorage.DirectorInstances honors) makes that pollution impossible even when a call site
+        // forgets its per-instance override - the same "guard at the process level, not per call site"
+        // approach already used for CC_GATEWAY_NO_TAILSCALE above. It is deliberately narrow: the whole
+        // storage root is left alone, so tests that read other real storage (e.g. dictation session
+        // logs) are unaffected. This runs before any test touches the path-caching statics
+        // (DirectorRegistry.InstancesDirectory, InstanceRegistration.InstancesDirectory), so their first
+        // resolution lands under the temp directory.
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_INSTANCES_DIR", InstancesDir);
+        try { Directory.CreateDirectory(InstancesDir); } catch { /* first real use will surface a failure */ }
     }
 }

--- a/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
+++ b/src/CcDirector.Gateway/Discovery/DirectorRegistry.cs
@@ -25,8 +25,7 @@ namespace CcDirector.Gateway.Discovery;
 /// </summary>
 public sealed class DirectorRegistry : IDisposable
 {
-    public static string InstancesDirectory { get; } =
-        Path.Combine(CcStorage.Config(), "director", "instances");
+    public static string InstancesDirectory { get; } = CcStorage.DirectorInstances();
 
     /// <summary>The directory this registry actually watches (the shared default in production).</summary>
     public string WatchDirectory { get; }


### PR DESCRIPTION
Fixes #322.

## Problem

Gateway tests that spin a `ControlApiHost` / `InstanceRegistration` without passing an isolated `instancesDirectory` (e.g. `ChatEndpointTests`) wrote a `1.0.0-test` instance file into the **real** `%LOCALAPPDATA%\cc-director\config\director\instances\` directory. The live Gateway's file watcher then discovered it, probed its dead ephemeral loopback port, and painted a phantom "unreachable" Director in the real Cockpit until the sweeper evicted it.

## Fix

A process-level guard so pollution is impossible by default, even when a call site forgets its per-instance override:

- New `CcStorage.DirectorInstances()` resolves the instance-discovery directory and honors a dedicated `CC_DIRECTOR_INSTANCES_DIR` override (same pattern as `CC_DIRECTOR_ROOT` / `CC_VAULT_PATH`). Production leaves it unset, so behavior is unchanged.
- `InstanceRegistration.InstancesDirectory` and `DirectorRegistry.InstancesDirectory` now derive from it.
- `TestEnvironment`'s module initializer pins `CC_DIRECTOR_INSTANCES_DIR` to a throwaway per-process temp directory, beside the existing `CC_GATEWAY_NO_TAILSCALE` guard.

The override is deliberately **narrow** - only the instances directory is redirected, not the whole storage root - so tests that read other real storage (e.g. dictation session logs) are unaffected. (An earlier whole-root approach broke a dictation test for exactly that reason; this scope is correct.)

## Verification

- New `InstancesDirectoryIsolationTests` asserts both statics resolve to the pinned temp directory and not the real one.
- Full `CcDirector.Gateway.Tests` suite: **1218/1218 pass**.
- Real instances directory: **0** test-signature files before and after a full run.

## Follow-up (out of scope here)

The dictation service also writes session logs into the real user directory during tests - a smaller, separate pollution. Left alone to keep this change scoped; can be filed as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)