### PR TITLE
Fix small-bug batch: cc-playwright help (#177), agent name in notice (#763), SQLite override re-check (#544)

### DIFF
--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -5026,10 +5026,12 @@ public partial class MainWindow : Window
         // Inject user prompt into Clean view immediately for instant feedback
         CleanView.InjectUserPrompt(text);
 
-        // Notify user when large input is redirected to a temp file
+        // Notify user when large input is redirected to a temp file. Name the
+        // active session's actual agent, not a hardcoded "Claude Code".
         if (CcDirector.Core.Input.LargeInputHandler.IsLargeInput(text))
         {
-            ShowNotification($"Text over {CcDirector.Core.Input.LargeInputHandler.LargeInputThreshold:N0} chars -- saved to temp file and @filepath sent to Claude Code ({text.Length:N0} chars)");
+            var agentName = AgentPluginRegistry.Get(_activeSession.Session.AgentKind).DisplayName;
+            ShowNotification(CcDirector.Core.Input.LargeInputHandler.FormatRedirectNotice(agentName, text.Length));
         }
         else
         {

--- a/src/CcDirector.Core.Tests/LargeInputHandlerTests.cs
+++ b/src/CcDirector.Core.Tests/LargeInputHandlerTests.cs
@@ -150,4 +150,25 @@ public class LargeInputHandlerTests : IDisposable
         // Document the expected threshold value
         Assert.Equal(1000, LargeInputHandler.LargeInputThreshold);
     }
+
+    [Fact]
+    public void FormatRedirectNotice_NamesTheGivenAgent()
+    {
+        // Issue #763: the notice must name the active session's actual agent,
+        // not a hardcoded "Claude Code".
+        var notice = LargeInputHandler.FormatRedirectNotice("Codex", 1802);
+
+        Assert.Contains("sent to Codex", notice);
+        Assert.DoesNotContain("Claude Code", notice);
+        Assert.Contains("1,802 chars", notice);
+    }
+
+    [Fact]
+    public void FormatRedirectNotice_UsesEachAgentNameVerbatim()
+    {
+        foreach (var name in new[] { "Claude Code", "Pi", "Gemini", "OpenCode", "Grok", "GitHub Copilot" })
+        {
+            Assert.Contains($"sent to {name}", LargeInputHandler.FormatRedirectNotice(name, 1500));
+        }
+    }
 }

--- a/src/CcDirector.Core/CcDirector.Core.csproj
+++ b/src/CcDirector.Core/CcDirector.Core.csproj
@@ -17,7 +17,10 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.2" />
     <!-- Pin the patched native SQLite library (3.0.x) to resolve advisory GHSA-2m69-gcr7-jv3q
          (NU1903 high-severity). All of SQLitePCLRaw <= 2.1.11 is vulnerable and Microsoft.Data.Sqlite
-         still pulls 2.1.11 transitively, so override its native bundle + core to the patched 3.0 line. -->
+         still pulls 2.1.11 transitively, so override its native bundle + core to the patched 3.0 line.
+         Re-evaluated 2026-07-05 (issue #544): still required. The latest stable Microsoft.Data.Sqlite
+         (10.0.9) continues to depend on SQLitePCLRaw 2.1.11; only the unreleased 11.0 preview line has
+         moved to 3.0.3. Remove this override once a stable Microsoft.Data.Sqlite depends on 3.0.x. -->
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="SQLitePCLRaw.core" Version="3.0.3" />
     <PackageReference Include="YamlDotNet" Version="16.2.1" />

--- a/src/CcDirector.Core/Input/LargeInputHandler.cs
+++ b/src/CcDirector.Core/Input/LargeInputHandler.cs
@@ -30,6 +30,16 @@ public static class LargeInputHandler
         || text.Contains('\r');
 
     /// <summary>
+    /// Builds the notification shown when large input is redirected to a temp file.
+    /// The agent name is passed in so the message reflects the active session's
+    /// actual agent instead of a hardcoded "Claude Code".
+    /// </summary>
+    /// <param name="agentName">Display name of the active session's agent.</param>
+    /// <param name="textLength">Length of the original text, in characters.</param>
+    public static string FormatRedirectNotice(string agentName, int textLength) =>
+        $"Text over {LargeInputThreshold:N0} chars -- saved to temp file and @filepath sent to {agentName} ({textLength:N0} chars)";
+
+    /// <summary>
     /// Creates a temp file in {workingDir}/.temp/ and returns the full path.
     /// The file contains the original text and can be referenced via @filepath in Claude Code.
     /// </summary>

--- a/src/CcDirector.Engine/CcDirector.Engine.csproj
+++ b/src/CcDirector.Engine/CcDirector.Engine.csproj
@@ -16,7 +16,10 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.2" />
     <!-- Pin the patched native SQLite library (3.0.x) to resolve advisory GHSA-2m69-gcr7-jv3q
          (NU1903 high-severity). All of SQLitePCLRaw <= 2.1.11 is vulnerable and Microsoft.Data.Sqlite
-         still pulls 2.1.11 transitively, so override its native bundle + core to the patched 3.0 line. -->
+         still pulls 2.1.11 transitively, so override its native bundle + core to the patched 3.0 line.
+         Re-evaluated 2026-07-05 (issue #544): still required. The latest stable Microsoft.Data.Sqlite
+         (10.0.9) continues to depend on SQLitePCLRaw 2.1.11; only the unreleased 11.0 preview line has
+         moved to 3.0.3. Remove this override once a stable Microsoft.Data.Sqlite depends on 3.0.x. -->
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="SQLitePCLRaw.core" Version="3.0.3" />
   </ItemGroup>

--- a/tools/cc-playwright/tests/test_cli.py
+++ b/tools/cc-playwright/tests/test_cli.py
@@ -446,6 +446,23 @@ def test_browser_command_lines_filter_includes_chromium(monkeypatch):
         assert name in joined
 
 
+# --------------------------------------------------------------------------
+# Issue #177: `start -h` must format its help without crashing. A bare '%' in
+# a help string (e.g. an unescaped %LOCALAPPDATA%) makes argparse raise
+# ValueError while expanding help. The percent must be doubled to '%%'.
+# --------------------------------------------------------------------------
+
+def test_start_help_does_not_crash(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["cc-playwright", "start", "-h"])
+    # argparse prints help and exits 0 for -h; it must NOT raise ValueError.
+    with pytest.raises(SystemExit) as ex:
+        cli.main()
+    assert ex.value.code == 0
+    out = capsys.readouterr().out
+    # A literal percent survives argparse expansion (proves it was escaped).
+    assert "%LOCALAPPDATA%" in out
+
+
 def test_connect_error_message_does_not_say_brave(monkeypatch):
     # State says running so we reach the connect attempt, which fails.
     monkeypatch.setattr(cli, "_load_state",


### PR DESCRIPTION
## Summary

Three small bugs cleared in one batch.

- **#177** - `cc-playwright start -h` no longer crashes. The source already escaped the percent sign in the help text; the reported crash was in an older installed copy. Added a regression test that proves the help formats without raising.
- **#763** - the large-input notification named the wrong agent. Sending a long prompt to any non-Claude session showed "sent to Claude Code" for every agent. It now names the active session's actual agent. The message was extracted into a testable helper.
- **#544** - re-evaluated the SQLitePCLRaw 3.0.3 security override. Still required: the latest stable Microsoft.Data.Sqlite still depends on the vulnerable 2.1.11, and only an unreleased preview moved to 3.0.3. Kept the override and recorded the re-check plus the condition for removing it later.

## Tests

cc-playwright suite: 30 passed. Core suite (LargeInputHandler): 16 passed. Avalonia project builds clean.

Closes #177
Closes #763
Closes #544

Generated with Claude Code
