### PR TITLE
Make the Wingman narration focused and spoken-friendly (#946)

### DIFF
--- a/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
@@ -136,6 +136,24 @@ public sealed class WingmanTranslatorTests
     }
 
     [Fact]
+    public async Task TranslateAsync_PromptInstructsFocusedSpokenFriendlyNarration()
+    {
+        // Issue #946: the narration is LISTENED to, so the prompt must tell the wingman to lead with
+        // the point (focused) and to describe paths/URLs/symbols in words rather than voicing raw
+        // punctuation ("hashtag", "colon slash slash"). This is prompt-only - guard that the rules are
+        // present so they cannot silently regress.
+        var brain = new FakeBrain(_ => "ok");
+        var translator = BuildTranslator(brain);
+
+        await translator.TranslateAsync("q", "I edited file:///D:/repo/x.html");
+
+        var prompt = Assert.Single(brain.Asks);
+        Assert.Contains("BE FOCUSED", prompt);
+        Assert.Contains("SPEAK FOR THE EAR", prompt);
+        Assert.Contains("colon slash slash", prompt); // the concrete "do not voice this" example
+    }
+
+    [Fact]
     public async Task TranslateAsync_EmptyReply_ThrowsBecauseThereIsNothingToTranslate()
     {
         var translator = BuildTranslator(new FakeBrain(_ => "x"));

--- a/src/CcDirector.Gateway/Wingman/WingmanTranslator.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanTranslator.cs
@@ -39,8 +39,15 @@ public sealed class WingmanTranslator
     internal const string FidelityPrompt = """
         You are the wingman: you turn a coding agent's written reply into words a person
         will hear out loud or read on a small screen, in a back-and-forth conversation.
-        Your job is FIDELITY, not brevity: the listener must hear the agent's actual
-        answer, not a looser version of it. Rules:
+        The listener must hear the agent's actual answer with full FIDELITY - every concrete
+        fact, not a looser version - but they are LISTENING, not reading, so say it the way a
+        person would explain it out loud, and lead with the point. Rules:
+        - BE FOCUSED. Lead with the single most important thing first - the answer, the
+          result, or the ask - in your opening sentence, then add only the context needed to
+          understand it, and stop. The listener wants the point, not a tour. Being focused is
+          about DELIVERY, not dropping facts: keep the real answer and every concrete fact
+          below, but say it directly and in the fewest words that carry it - no preamble, no
+          restating the question, no narrating your own process.
         - Preserve the actual answer and every concrete fact: names, numbers, yes/no, the
           decision or result. Never drop the facts that ARE the answer.
         - If the agent wrote real content (a paragraph, a result, a list of findings),
@@ -68,12 +75,19 @@ public sealed class WingmanTranslator
           cannot otherwise anchor from the reply alone.
         - Do not add, embellish, reframe, or change the topic. If the agent did not
           actually answer, say that plainly; never invent an answer.
-        - Make it sound natural to say out loud, but completeness wins over shortness. Use
-          as many sentences as the answer needs; do not pad and do not force a fixed length.
-        - Speak for the ear: do not spell out raw code, commands, file paths, function names,
-          or symbols character by character - instead say in plain words what they ARE and
-          what they DO, keeping the technical meaning intact. Translating for the ear must
-          never mean dropping the technical content.
+        - Make it sound natural to say out loud. Completeness is about the answer's
+          SUBSTANCE, not its length: keep every fact, but do not pad, do not repeat yourself,
+          and do not stretch a short answer into a long one. Use only as many sentences as the
+          answer truly needs.
+        - SPEAK FOR THE EAR, NOT THE SCREEN. This is heard out loud, so never voice raw syntax
+          or punctuation. Do NOT read out file paths, URLs, headings, or code symbols
+          character by character - describe them in plain spoken words instead. Concretely:
+          never say "hashtag", "colon slash slash", "slash", "dot", "backtick", "underscore",
+          or a bare drive letter and colon out loud. For example, "file:///D:/repo/marketing.html"
+          becomes "the marketing HTML file in the repo"; "## Root cause" becomes just "Root
+          cause"; a function like "SweepStale()" becomes "the sweep-stale method". Say what the
+          path, URL, heading, or symbol IS and what it DOES - keep the technical meaning, drop
+          the punctuation. Never spell out the literal characters.
         - The reply may be in ANY language or script. Non-Latin characters are valid
           content, never corruption. Translate faithfully in the same language; never
           refuse or say the text cannot be read.
@@ -85,7 +99,7 @@ public sealed class WingmanTranslator
     /// instructions is shown that the recommended default changed and can switch to it. The content
     /// hash is the real identity; this is the human-facing label.
     /// </summary>
-    public const string DefaultInstructionsVersion = "2";
+    public const string DefaultInstructionsVersion = "3";
 
     private readonly Func<CancellationToken, Task<IAgentBrain>> _brainProvider;
     private readonly Action<string> _log;


### PR DESCRIPTION
Fixes #946. Part of the Voice Mode Cleanup epic (#950).

## Problem

The Wingman narration is listened to, not read, but it rambled and read code punctuation aloud - a file path came out as "file colon slash slash slash D colon...", a Markdown heading as "hashtag".

## Fix (prompt only)

No regex or normalisation cleanup - a language model is the right tool to decide how to say a path out loud. Changes to `WingmanTranslator.FidelityPrompt`:

- **BE FOCUSED**: lead with the answer or the ask in the opening sentence, add only the context needed, then stop - without dropping any concrete fact.
- **SPEAK FOR THE EAR, NOT THE SCREEN**: never voice raw syntax or punctuation; describe paths, URLs, headings, and code symbols in plain spoken words (no "hashtag", "colon slash slash", "backtick", bare drive letters), with concrete examples.
- Reworked the fidelity framing so substance is preserved while the brevity-over-focus bias is removed.
- Bumped `DefaultInstructionsVersion` to `3` so users on a customised prompt are shown the default changed.

## Verification

- New translator test asserts the prompt carries the focus + speak-for-the-ear rules; full Wingman suite passes (68 tests, plus the new one).
- Behavioural quality of the spoken output is judged live on a configured Wingman brain (dogfooded on the phone) - this change is the instructions those brains run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)