### PR TITLE
Open a voice-mode session on its Voice tab from the roster (#948)

### DIFF
--- a/mobile/src/pages/Home.tsx
+++ b/mobile/src/pages/Home.tsx
@@ -158,9 +158,13 @@ function SessionRow({ session }: { session: SessionDto }) {
   // regenerated typed client. Null on sessions/Directors without a number - then no prefix shows.
   const num = session.number;
   const hasNum = num !== null && num !== undefined && String(num).trim().length > 0;
+  // Issue #948: a voice-mode session opens straight on its Voice tab (the surface it is meant to be
+  // used from), not on the default Chat tab; every other session still opens on Chat.
+  const sid = encodeURIComponent(session.sessionId ?? "");
+  const to = session.voiceMode ? `/session/${sid}/voice` : `/session/${sid}`;
   return (
     <li className={`row${attention ? " row-attention" : ""}`}>
-      <Link className="row-link" to={`/session/${encodeURIComponent(session.sessionId ?? "")}`}>
+      <Link className="row-link" to={to}>
         <span className="dot" style={{ backgroundColor: dotColor(color) }} aria-hidden="true" />
         <span className="row-body">
           {/* The name uses the full card width and WRAPS (no truncation) - issue #838. A muted


### PR DESCRIPTION
Fixes #948. Part of the Voice Mode Cleanup epic (#950).

Tapping a session in the mobile roster always opened it on the Chat tab, even when the session was in voice mode. The roster row now links a voice-mode session (`SessionDto.voiceMode`) to its `/voice` route; every other session still opens on Chat.

**Verification:** on the real `/m` roster (Playwright + fixture), a voice-mode row links to `/session/<id>/voice` and a non-voice row links to `/session/<id>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)