### PR TITLE
Use the fast transcription path for the Voice tab Respond dictation (#949)

### DIFF
--- a/mobile/src/pages/VoiceMode.tsx
+++ b/mobile/src/pages/VoiceMode.tsx
@@ -15,6 +15,7 @@ import {
   type WingmanVoice,
 } from "../api/client";
 import { DictationDialog } from "../dictation/DictationDialog";
+import { backgroundTranscribeAndSend, type CapturedUtterance } from "../dictation/backgroundSend";
 import { SessionManageBar } from "../components/SessionManageBar";
 import { ViewTabs } from "../components/ViewTabs";
 import { ensureClip, getClipState, stopPlayback, useVoiceClips } from "../voice/clips";
@@ -330,6 +331,22 @@ export function VoiceMode() {
     [sid],
   );
 
+  // Issue #949: the fast fire-and-forget Send - the SAME path the Terminal/Chat Speak use. When Send is
+  // pressed while still recording, the dialog hands up the captured audio and closes immediately; the
+  // transcode/upload/transcribe/submit then runs in the background (the roster shows the session
+  // orange), so dictating a reply in voice mode is as fast as dictating anywhere else instead of
+  // blocking on the transcription. The PAUSED-stage Send still uses onRespondSend (text already in hand).
+  const onRespondSendAudio = useCallback(
+    (captured: CapturedUtterance) => {
+      setResponding(false);
+      if (sid.length === 0) return;
+      void backgroundTranscribeAndSend(sid, captured, {
+        onError: (message) => setError(message),
+      });
+    },
+    [sid],
+  );
+
   const onPressSingle = useCallback(
     async (opt: WingmanMenuOption) => {
       if (sid.length === 0) return;
@@ -562,6 +579,7 @@ export function VoiceMode() {
         <DictationDialog
           showInsert={false}
           onSend={(text) => void onRespondSend(text)}
+          onSendAudio={onRespondSendAudio}
           onClose={() => setResponding(false)}
         />
       )}


### PR DESCRIPTION
Fixes #949. Part of the Voice Mode Cleanup epic (#950).

## Problem

The Voice tab's Respond dictation used `DictationDialog`'s blocking transcribe-then-submit path (`onSend`), so Send held the dialog open until the whole clip was uploaded and transcribed. The Terminal/Chat Speak buttons wire the dialog's fire-and-forget `onSendAudio` path (`backgroundTranscribeAndSend`), which closes the dialog immediately and transcribes in the background.

## Fix

Wire the same `onSendAudio` -> `backgroundTranscribeAndSend` path into the Voice-mode Respond dialog. The PAUSED-stage Send still uses `onRespondSend` (text already in hand). No composer/caret in voice mode, so the default compose (dictation alone) is correct.

## Verification

- Typecheck clean.
- On the real `/m` Voice screen (Playwright + fake mic): pressing Send while recording closes the dialog immediately and fires `POST /sessions/<id>/transcribing` (the fast background path), instead of blocking on the transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)