### PR TITLE
Keep the Cockpit left menu the same on every page (#957)

### DIFF
--- a/src/CcDirector.Cockpit.Tests/NavMenuParityTests.cs
+++ b/src/CcDirector.Cockpit.Tests/NavMenuParityTests.cs
@@ -1,0 +1,117 @@
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace CcDirector.Cockpit.Tests;
+
+/// <summary>
+/// Issue #957: the Cockpit left menu must stay the same on every page. The menu is defined
+/// twice - once in the Blazor <c>NavMenu.razor</c> (rendered on Blazor pages) and once in
+/// <c>tool-nav.js</c> (rendered on the plain-HTML tool pages such as Settings). If the two
+/// drift, navigating from a Blazor page to Settings visibly changes the menu. These two lists
+/// had drifted (tool-nav.js was missing Learning, Account, and Telemetry). This test pins them
+/// together: the ordered set of VISIBLE menu entries (and the separator) must be identical in
+/// both files, so the menu can never silently change between pages again.
+/// </summary>
+public class NavMenuParityTests
+{
+    // "SEP" marks the divider; other tokens are "href|Label".
+    private const string Separator = "SEP";
+
+    [Fact]
+    public void BlazorNavMenu_And_ToolNavJs_ExposeTheSameVisibleMenu()
+    {
+        var blazor = ParseBlazorNav(ReadSource("Components/Layout/NavMenu.razor"));
+        var toolNav = ParseToolNav(ReadSource("wwwroot/pages/tool-nav.js"));
+
+        // Guard against a broken parser silently returning empty lists (which would make the
+        // equality check pass for the wrong reason): both must contain the known anchors.
+        Assert.Contains("/|Home", blazor);
+        Assert.Contains("/settings|Settings", blazor);
+        Assert.Contains("/telemetry|Telemetry", blazor);
+        Assert.Contains(Separator, blazor);
+        Assert.True(blazor.Count >= 8, $"expected a full menu, parsed only {blazor.Count} items");
+
+        Assert.Equal(blazor, toolNav);
+    }
+
+    private static string ReadSource(string relativeToCockpitProject, [CallerFilePath] string thisFile = "")
+    {
+        // thisFile: ...\src\CcDirector.Cockpit.Tests\NavMenuParityTests.cs
+        var testsDir = Path.GetDirectoryName(thisFile)!;
+        var srcDir = Path.GetDirectoryName(testsDir)!;
+        var path = Path.Combine(srcDir, "CcDirector.Cockpit", relativeToCockpitProject.Replace('/', Path.DirectorySeparatorChar));
+        Assert.True(File.Exists(path), $"expected source file not found: {path}");
+        return File.ReadAllText(path);
+    }
+
+    /// <summary>
+    /// Ordered visible entries from NavMenu.razor: every &lt;NavLink&gt;/&lt;a&gt; with class
+    /// "nv-item" that is NOT hidden with style="display:none", plus the nv-sep divider.
+    /// </summary>
+    private static List<string> ParseBlazorNav(string razor)
+    {
+        var tokens = new List<string>();
+        // Match, in document order, either a nav item element (up to its nv-label text) or a separator.
+        var rx = new Regex(
+            "<(?:NavLink|a)\\b(?<attrs>[^>]*?)class=\"nv-item\"(?<rest>.*?)<span class=\"nv-label\">(?<label>[^<]*)</span>"
+            + "|<div class=\"nv-sep\">",
+            RegexOptions.Singleline);
+
+        foreach (Match m in rx.Matches(razor))
+        {
+            if (!m.Groups["label"].Success)
+            {
+                tokens.Add(Separator);
+                continue;
+            }
+
+            var openingTag = m.Groups["attrs"].Value + m.Groups["rest"].Value;
+            if (openingTag.Contains("display:none"))
+                continue; // hidden item - not part of the visible menu
+
+            var href = Regex.Match(openingTag, "href=\"(?<h>[^\"]*)\"").Groups["h"].Value;
+            var label = m.Groups["label"].Value.Trim();
+            tokens.Add($"{href}|{label}");
+        }
+
+        return tokens;
+    }
+
+    /// <summary>
+    /// Ordered visible entries from tool-nav.js: every ITEMS entry that is NOT marked
+    /// alpha:true, plus the { sep:true } divider.
+    /// </summary>
+    private static List<string> ParseToolNav(string js)
+    {
+        var start = js.IndexOf("var ITEMS", StringComparison.Ordinal);
+        var arrOpen = js.IndexOf('[', start);
+        var arrClose = js.IndexOf("];", arrOpen, StringComparison.Ordinal);
+        var body = js.Substring(arrOpen + 1, arrClose - arrOpen - 1);
+
+        var tokens = new List<string>();
+        foreach (var raw in body.Split('\n'))
+        {
+            var line = raw.Trim();
+            if (line.Length == 0 || line.StartsWith("//"))
+                continue;
+
+            if (line.Contains("sep: true") || line.Contains("sep:true"))
+            {
+                tokens.Add(Separator);
+                continue;
+            }
+
+            var hrefMatch = Regex.Match(line, "href:\\s*\"(?<h>[^\"]*)\"");
+            if (!hrefMatch.Success)
+                continue;
+            if (line.Contains("alpha: true") || line.Contains("alpha:true"))
+                continue; // hidden item - not part of the visible menu
+
+            var label = Regex.Match(line, "label:\\s*\"(?<l>[^\"]*)\"").Groups["l"].Value.Trim();
+            tokens.Add($"{hrefMatch.Groups["h"].Value}|{label}");
+        }
+
+        return tokens;
+    }
+}

--- a/src/CcDirector.Cockpit/wwwroot/pages/tool-nav.js
+++ b/src/CcDirector.Cockpit/wwwroot/pages/tool-nav.js
@@ -28,7 +28,10 @@
     { href: "/exes",        label: "Builds",    icon: '<path d="M8 1.5 14 5v6l-6 3.5L2 11V5l6-3.5zM2 5l6 3.5L14 5M8 8.5v6"/>', alpha: true },
     { href: "/transcripts", label: "Recordings",icon: '<rect x="6" y="1.5" width="4" height="8" rx="2"/><path d="M3.5 7.5a4.5 4.5 0 0 0 9 0M8 12v2.5"/>', alpha: true },
     { href: "/dictionary",  label: "Dictionary",icon: '<path d="M3 2.5h8.5A1.5 1.5 0 0 1 13 4v9.5H4.5A1.5 1.5 0 0 1 3 12V2.5zM3 11.5h10M6 5.5h4"/>' },
+    { href: "/learn",       label: "Learning",  icon: '<path d="M2 4.5 8 2l6 2.5L8 7 2 4.5zM4 6v3.5c0 1 1.8 2 4 2s4-1 4-2V6M14 5v3.5"/>' },
     // The standalone "API Keys" item was folded into Settings > Transcription (issue #497).
+    { href: "/account",     label: "Account",   icon: '<circle cx="8" cy="5.5" r="2.75"/><path d="M3 13.5c0-2.5 2.2-4 5-4s5 1.5 5 4"/>' },
+    { href: "/telemetry",   label: "Telemetry", icon: '<path d="M8 1.5a6.5 6.5 0 0 0-6.5 6.5M8 4.5a3.5 3.5 0 0 0-3.5 3.5"/><circle cx="8" cy="8" r="1.25"/>' },
     { href: "/about",       label: "About",     icon: '<circle cx="8" cy="8" r="6.5"/><path d="M8 7.25v3.75M8 5h.01"/>' }
   ];
 


### PR DESCRIPTION
## Summary

The Cockpit left menu changed when you clicked Settings. Root cause: the menu is defined twice - the Blazor `NavMenu.razor` (every normal page) and a separate plain-HTML copy in `tool-nav.js` for the pages that are not Blazor (Settings). The two had drifted: the Settings copy was missing **Learning, Account, and Telemetry**, so opening Settings replaced the nine-item menu with a six-item one.

## Fix

- Re-synced the plain-HTML menu (`tool-nav.js`) to match the Blazor menu, so both show the same nine visible items in the same order.
- Added `NavMenuParityTests` which parses both menu definitions and fails the build if their visible entries ever drift apart again - so this cannot silently return.

## Tests

Full Cockpit suite: 119 passed (including the new parity guard).

Closes #957

Generated with Claude Code
