### PR TITLE
Shared hosted-AI readiness check + single-source copy (#938)

### DIFF
--- a/docs/cencon/proof/issue-938/qa-report.html
+++ b/docs/cencon/proof/issue-938/qa-report.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Issue #938 - QA verification - VERIFIED</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: Georgia, "Times New Roman", serif; max-width: 62rem; margin: 2rem auto; padding: 0 1.25rem; line-height: 1.55; }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid #888; padding-bottom: .4rem; }
+  h2 { font-size: 1.2rem; margin-top: 2rem; border-bottom: 1px solid #ccc; padding-bottom: .2rem; }
+  code, pre { font-family: Consolas, "Courier New", monospace; }
+  pre { background: rgba(128,128,128,.12); padding: .8rem 1rem; overflow-x: auto; border-radius: 4px; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #999; padding: .45rem .6rem; text-align: left; vertical-align: top; font-size: .93rem; }
+  th { background: rgba(128,128,128,.18); }
+  .pass { font-weight: bold; }
+  .muted { color: #777; font-size: .9rem; }
+  .verdict { font-size: 1.15rem; font-weight: bold; padding: .6rem 1rem; border: 2px solid #2e7d32; border-radius: 6px; display: inline-block; margin-top: 1rem; }
+</style>
+</head>
+<body>
+
+<h1>Issue #938 - QA verification report</h1>
+<p class="muted">CenCon QA Agent, standalone session. Independent verification of PR #963 (branch <code>issue-938-hosted-ai-readiness</code>), verified against the issue's acceptance criteria - NOT the developer's report.</p>
+
+<h2>How this was verified (independent)</h2>
+<p>A fresh checkout of the pushed PR branch was made in a separate worktree (<code>devthrottle-qa-938</code>, detached at commit <code>be85898a</code>), then built and tested with my own run - the developer's binary and screenshots were not reused. Because #938 is a pure foundation module with no running-app surface (wiring the surfaces is explicitly out of scope, deferred to #939-#943), verification is a clean build plus the unit-test contract plus a code-level review against each criterion; no Director/UI launch applies to this issue.</p>
+<pre>git worktree add ../devthrottle-qa-938 origin/issue-938-hosted-ai-readiness   # HEAD be85898a
+dotnet build cc-director.sln            -> Build succeeded.  0 Warning(s)  0 Error(s)
+dotnet test CcDirector.Core.Tests --filter FullyQualifiedName~HostedAi
+                                        -> Passed!  Failed: 0, Passed: 43, Skipped: 0</pre>
+
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+  <tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (verified)</th><th>Result</th></tr>
+  <tr>
+    <td>1</td>
+    <td>Module + public API exist; documented for the platform issues to consume.</td>
+    <td>Public, documented types the sub-issues can call.</td>
+    <td>Confirmed present and public with XML doc comments: <code>HostedAiState</code>; <code>HostedAiReadiness.CheckAsync()</code>; <code>HostedAiMessages.For()</code> + <code>HostedAiCopyRules</code>; <code>HostedAiMessage</code> / <code>HostedAiCtaAction</code> / <code>HostedAiUrls.Billing</code>; <code>HostedAiErrorMapper.MapCode/ParseErrorCode/Map402</code>; Gateway factory <code>GatewayHostedAi.CreateReadiness()</code>. Whole solution builds 0/0.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>2</td>
+    <td>Unit tests: each (mode, balance, key) -&gt; correct enum; each 402 code -&gt; correct enum; copy passes a forbidden-language check.</td>
+    <td>All combinations tested and green; the copy check is real, not vacuous.</td>
+    <td>43 tests pass. Mode/balance/key matrix covered (BYO no/blank/with key; DevThrottle balance &lt;=0, &gt;0, unknown). Every 402 code covered incl. case + padding, branching on <code>code</code> not <code>type</code>. The forbidden-language checker is proven non-vacuous - it catches seeded violations ("OpenAI", "free credits", "subscription", "Groq") AND passes the real hosted copy; NeedsKey is correctly allowed to name OpenAI.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>3</td>
+    <td>Balance is re-read on demand (prove add-$5 -&gt; Ready without restart in a test).</td>
+    <td>A test flips NeedsCredits -&gt; Ready on the same instance when the balance changes.</td>
+    <td><code>DevThrottle_AddCredits_UnlocksWithoutRestart</code> flips the SAME check instance from NeedsCredits (balance 0) to Ready (balance $5) with no restart; <code>DevThrottle_ReadsBalanceFreshEveryCall</code> proves 3 checks = 3 fresh reads. Code review confirms <code>HostedAiReadiness</code> holds no cache and the Gateway balance provider reads fresh each call.</td>
+    <td class="pass">PASS</td>
+  </tr>
+</table>
+
+<h2>Regression + method lens</h2>
+<table>
+  <tr><th>Check</th><th>Result</th></tr>
+  <tr><td>Single-source 402 refactor is behavior-neutral (<code>BatchTranscriptionPipeline</code> now delegates its parse to the shared mapper).</td><td class="pass">PASS - 16/16 BatchTranscriptionPipeline tests green.</td></tr>
+  <tr><td>Full Core.Tests sweep.</td><td>2773 passed, 6 skipped, 1 failed - see note below.</td></tr>
+  <tr><td>Security (DT-05): the account token is never logged.</td><td class="pass">PASS - <code>GatewayHostedAi</code> logs the balance only, never the token; reads it via the existing <code>GetAccessTokenForForwarding</code>.</td></tr>
+  <tr><td>No new egress host.</td><td class="pass">PASS - the Billing URL resolves from the existing account-egress base (<code>AccountTelemetryClient</code>), no new hard-coded domain.</td></tr>
+  <tr><td>No-fallback rule.</td><td class="pass">PASS - "unknown balance -&gt; Ready" is a deliberate, documented pre-flight courtesy, not a hidden fallback: the runtime 402 (<code>HostedAiErrorMapper</code>) remains the authoritative gate and reports the identical state, exactly per the epic.</td></tr>
+</table>
+
+<h2>The one failing test is pre-existing, not a #938 regression</h2>
+<p><code>NoCrossMachineLoopbackGuardTests.No_new_production_file_hardcodes_cross_machine_loopback</code> fails, flagging <strong>only</strong> <code>src/CcDirector.Core/Configuration/GatewayConfig.cs</code>. Independently confirmed:</p>
+<ul>
+  <li>The branch diff vs its merge-base (<code>457de36b</code>) contains exactly 11 files - all under <code>HostedAi/</code> plus <code>BatchTranscriptionPipeline.cs</code> and the proof docs. <code>GatewayConfig.cs</code> is NOT among them.</li>
+  <li>The same test fails identically on the untouched <code>main</code> checkout.</li>
+</ul>
+<p>Therefore this failure exists on <code>main</code> already (a stale guard allowlist for <code>GatewayConfig.cs</code>) and is out of scope for #938. It does not block this issue. It should be tracked separately.</p>
+
+<div class="verdict">VERIFIED - all 3 acceptance criteria met. QA PASS.</div>
+
+<h2>Standalone note (no merge by QA)</h2>
+<p>This is a standalone QA session, not the implementation-loop, so per the QA contract the merge is left to the human: the issue is moved to <code>flow:done</code> and PR #963 is left open for the owner to squash-merge. (Note: <code>main</code> has since advanced past the branch's base; merging through GitHub will integrate cleanly - the change touches only new <code>HostedAi/</code> files plus a self-contained refactor in <code>BatchTranscriptionPipeline.cs</code>.)</p>
+
+</body>
+</html>

--- a/docs/cencon/proof/issue-938/report.html
+++ b/docs/cencon/proof/issue-938/report.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Issue #938 - Shared hosted-AI readiness check + single-source copy - Proof</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: Georgia, "Times New Roman", serif; max-width: 60rem; margin: 2rem auto; padding: 0 1.25rem; line-height: 1.55; }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid #888; padding-bottom: .4rem; }
+  h2 { font-size: 1.2rem; margin-top: 2rem; border-bottom: 1px solid #ccc; padding-bottom: .2rem; }
+  code, pre { font-family: Consolas, "Courier New", monospace; }
+  pre { background: rgba(128,128,128,.12); padding: .8rem 1rem; overflow-x: auto; border-radius: 4px; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #999; padding: .45rem .6rem; text-align: left; vertical-align: top; font-size: .95rem; }
+  th { background: rgba(128,128,128,.18); }
+  .pass { font-weight: bold; }
+  .muted { color: #777; font-size: .9rem; }
+</style>
+</head>
+<body>
+
+<h1>Issue #938 - Shared hosted-AI readiness check + single-source message copy</h1>
+<p class="muted">Foundation sub-issue of epic #937 (consistent "hosted AI needs credits or a key" gating across every voice / Wingman / text-to-speech surface). Branch <code>issue-938-hosted-ai-readiness</code>.</p>
+
+<h2>What was implemented</h2>
+<p>The single primitive the ~13 voice / Wingman / text-to-speech surfaces will consume, so the "you need credit / you need a key" gate is decided in one place and shown identically everywhere by construction. Hung on the existing centralized routing seam (<code>TranscriptionMode</code> + <code>TranscriptionEndpointResolver</code>), it is pure and delegate-injected in Core, with the real-resource wiring in the Gateway.</p>
+
+<table>
+  <tr><th>File</th><th>Role</th></tr>
+  <tr><td><code>src/CcDirector.Core/HostedAi/HostedAiState.cs</code></td><td>The one typed answer: <code>Ready | NeedsCredits | CapReached | NeedsKey</code>.</td></tr>
+  <tr><td><code>src/CcDirector.Core/HostedAi/HostedAiReadiness.cs</code></td><td>The pre-flight check. <code>CheckAsync()</code> resolves mode -&gt; state; balance is read fresh every call (no cache) so adding $5 unlocks with no restart.</td></tr>
+  <tr><td><code>src/CcDirector.Core/HostedAi/HostedAiMessages.cs</code></td><td>Single-source copy: <code>For(state)</code> returns one message + call-to-action per state. Plus <code>HostedAiCopyRules</code>, the forbidden-language checker.</td></tr>
+  <tr><td><code>src/CcDirector.Core/HostedAi/HostedAiMessage.cs</code></td><td>The message record, the semantic call-to-action enum, and <code>HostedAiUrls</code> (Billing URL resolved from the same account-egress base - no new hard-coded host).</td></tr>
+  <tr><td><code>src/CcDirector.Core/HostedAi/HostedAiErrorMapper.cs</code></td><td>The runtime 402 mapper. Branches on <code>code</code> (not <code>type</code>): <code>insufficient_credits</code> -&gt; NeedsCredits, <code>monthly_limit_reached</code> -&gt; CapReached.</td></tr>
+  <tr><td><code>src/CcDirector.Gateway/HostedAi/GatewayHostedAi.cs</code></td><td>Wires the Core check to the real vault + account credential + credits client. The factory the platform sub-issues (#939-#943) call.</td></tr>
+  <tr><td><code>src/CcDirector.Core/Transcription/BatchTranscriptionPipeline.cs</code></td><td>Refactored: its private 402 code parse now delegates to <code>HostedAiErrorMapper.ParseErrorCode</code>, so the whole stack parses a 402 in exactly one place.</td></tr>
+</table>
+
+<h2>Acceptance criteria -&gt; proof</h2>
+<table>
+  <tr><th>Criterion</th><th>How it is met</th><th>Proof</th></tr>
+  <tr>
+    <td>Module + public API exist; documented for the platform issues to consume.</td>
+    <td><code>HostedAiReadiness.CheckAsync()</code>, <code>HostedAiMessages.For(state)</code>, <code>HostedAiErrorMapper.Map402/MapCode</code>, and the Gateway factory <code>GatewayHostedAi.CreateReadiness(...)</code>. Every type carries XML doc comments naming its role for #939-#943.</td>
+    <td class="pass">Build succeeded, 0 warnings, 0 errors.</td>
+  </tr>
+  <tr>
+    <td>Unit tests: each (mode, balance, key) -&gt; correct enum.</td>
+    <td><code>HostedAiReadinessTests</code>: BYO no/blank key -&gt; NeedsKey; BYO with key -&gt; Ready (and never reads balance); DevThrottle balance &lt;= 0 -&gt; NeedsCredits; &gt; 0 -&gt; Ready; unknown balance -&gt; Ready (does not block).</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>Unit tests: each 402 <code>code</code> -&gt; correct enum (branch on code, not type).</td>
+    <td><code>HostedAiErrorMapperTests</code>: same shared <code>type</code> (<code>insufficient_quota</code>) on both, only <code>code</code> distinguishes; nested + flat + non-JSON body parses; case-insensitive.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>Copy strings pass a forbidden-language check.</td>
+    <td><code>HostedAiMessagesTests</code>: hosted-account copy (NeedsCredits, CapReached) is provably clean of provider names / "free credits" / subscription words; NeedsKey may name OpenAI (the user's own key); the checker itself is proven to catch seeded violations.</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>Balance is re-read on demand (prove add-$5 -&gt; Ready without restart).</td>
+    <td><code>DevThrottle_AddCredits_UnlocksWithoutRestart</code>: the SAME check instance returns NeedsCredits at balance 0, then Ready after the balance flips to $5 - no restart, no new object. <code>DevThrottle_ReadsBalanceFreshEveryCall</code> proves 3 checks = 3 fresh reads (no cache).</td>
+    <td class="pass">PASS</td>
+  </tr>
+</table>
+
+<h2>Test run</h2>
+<pre>dotnet build cc-director.sln
+  Build succeeded.  0 Warning(s)  0 Error(s)
+
+dotnet test CcDirector.Core.Tests --filter FullyQualifiedName~HostedAi
+  Passed!  - Failed: 0, Passed: 43, Skipped: 0, Total: 43</pre>
+<p class="muted">The single-source refactor was re-verified against the existing transcription suite: the combined HostedAi + BatchTranscriptionPipeline filter runs 59 tests, all passing, so the delegated 402 parse is behavior-identical.</p>
+
+<h2>The consistent copy this foundation delivers</h2>
+<table>
+  <tr><th>State</th><th>Message</th><th>Call to action</th></tr>
+  <tr><td>NeedsCredits</td><td>Voice needs credit. Add $5 to turn on transcription, voice mode, and Wingman - enough to last most of a month.</td><td>Add credits -&gt; /account/billing</td></tr>
+  <tr><td>CapReached</td><td>You've hit your monthly spending limit. Raise it in Billing to keep going.</td><td>Open Billing -&gt; /account/billing</td></tr>
+  <tr><td>NeedsKey</td><td>Add your OpenAI key in Settings to use this.</td><td>Open Settings (surface-local)</td></tr>
+  <tr><td>Ready</td><td>(empty - nothing to show)</td><td>(none)</td></tr>
+</table>
+
+<h2>CenCon impact</h2>
+<p>No architecture or security drift. This adds one pure Core module plus a thin Gateway factory on the existing transcription seam; it introduces no new container, no new egress host (the Billing URL resolves from the existing account-egress base), and touches no security rule. The account token is read only through the existing <code>GetAccessTokenForForwarding</code> and is never logged (DT-05).</p>
+
+<h2>Scope note</h2>
+<p>Per the issue's Scope (OUT), this delivers the shared primitive only; wiring the individual surfaces is the per-platform sub-issues #939-#943. No surface behavior changed in this issue except the internal 402-parse consolidation.</p>
+
+<h2>Pre-existing unrelated test note</h2>
+<p><code>NoCrossMachineLoopbackGuardTests.No_new_production_file_hardcodes_cross_machine_loopback</code> fails on this branch, flagging <code>src/CcDirector.Core/Configuration/GatewayConfig.cs</code> - a file this change never touches. It fails identically on the untouched <code>main</code> checkout, so it is a pre-existing condition, not a regression from #938. My new files pass the loopback guard (none are listed).</p>
+
+<p class="pass">I believe this is finished.</p>
+
+</body>
+</html>

--- a/src/CcDirector.Core.Tests/HostedAi/HostedAiErrorMapperTests.cs
+++ b/src/CcDirector.Core.Tests/HostedAi/HostedAiErrorMapperTests.cs
@@ -1,0 +1,67 @@
+using CcDirector.Core.HostedAi;
+using Xunit;
+
+namespace CcDirector.Core.Tests.HostedAi;
+
+/// <summary>
+/// Issue #938 (epic #937): the runtime 402 mapper. It must branch on the machine-readable
+/// <c>code</c> (never the shared <c>type</c>): <c>insufficient_credits</c> -> NeedsCredits,
+/// <c>monthly_limit_reached</c> -> CapReached, and any other 402 -> NeedsCredits (the common case).
+/// The code parse reads both the nested and flat OpenAI-compatible shapes and defaults safely.
+/// </summary>
+public sealed class HostedAiErrorMapperTests
+{
+    [Theory]
+    [InlineData("insufficient_credits", HostedAiState.NeedsCredits)]
+    [InlineData("monthly_limit_reached", HostedAiState.CapReached)]
+    [InlineData("MONTHLY_LIMIT_REACHED", HostedAiState.CapReached)]
+    [InlineData("  monthly_limit_reached  ", HostedAiState.CapReached)]
+    [InlineData("some_other_code", HostedAiState.NeedsCredits)]
+    [InlineData("", HostedAiState.NeedsCredits)]
+    [InlineData(null, HostedAiState.NeedsCredits)]
+    public void MapCode_BranchesOnCode(string? code, HostedAiState expected)
+        => Assert.Equal(expected, HostedAiErrorMapper.MapCode(code));
+
+    [Fact]
+    public void ParseErrorCode_NestedErrorObject()
+    {
+        var body = "{ \"error\": { \"type\": \"insufficient_quota\", \"code\": \"monthly_limit_reached\" } }";
+        Assert.Equal("monthly_limit_reached", HostedAiErrorMapper.ParseErrorCode(body));
+    }
+
+    [Fact]
+    public void ParseErrorCode_FlatCode()
+    {
+        var body = "{ \"code\": \"insufficient_credits\" }";
+        Assert.Equal("insufficient_credits", HostedAiErrorMapper.ParseErrorCode(body));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not json at all")]
+    [InlineData("{ \"error\": { \"type\": \"insufficient_quota\" } }")] // no code field
+    public void ParseErrorCode_MissingOrUnparseable_DefaultsToInsufficientCredits(string body)
+        => Assert.Equal(HostedAiErrorMapper.InsufficientCreditsCode, HostedAiErrorMapper.ParseErrorCode(body));
+
+    [Fact]
+    public void Map402_NestedMonthlyLimit_CapReached()
+    {
+        var body = "{ \"error\": { \"type\": \"insufficient_quota\", \"code\": \"monthly_limit_reached\" } }";
+        Assert.Equal(HostedAiState.CapReached, HostedAiErrorMapper.Map402(body));
+    }
+
+    [Fact]
+    public void Map402_InsufficientCredits_NeedsCredits()
+    {
+        var body = "{ \"error\": { \"code\": \"insufficient_credits\" } }";
+        Assert.Equal(HostedAiState.NeedsCredits, HostedAiErrorMapper.Map402(body));
+    }
+
+    [Fact]
+    public void Map402_NonJsonBody_NeedsCredits()
+    {
+        // A non-JSON 402 body still means out of credits (the transcription path's proven behavior).
+        Assert.Equal(HostedAiState.NeedsCredits, HostedAiErrorMapper.Map402("Payment Required"));
+    }
+}

--- a/src/CcDirector.Core.Tests/HostedAi/HostedAiMessagesTests.cs
+++ b/src/CcDirector.Core.Tests/HostedAi/HostedAiMessagesTests.cs
@@ -1,0 +1,98 @@
+using CcDirector.Core.HostedAi;
+using Xunit;
+
+namespace CcDirector.Core.Tests.HostedAi;
+
+/// <summary>
+/// Issue #938 (epic #937): the single-source copy. Each state maps to the one correct
+/// message + call-to-action, the hosted-account copy passes the forbidden-language rules (no provider
+/// names, no "free credits", no subscription/tier words), and the billing call-to-action carries the
+/// real Billing URL so the CTA reaches <c>/account/billing</c> on every surface.
+/// </summary>
+public sealed class HostedAiMessagesTests
+{
+    [Fact]
+    public void Ready_HasNoMessageOrCta()
+    {
+        var m = HostedAiMessages.For(HostedAiState.Ready);
+        Assert.Equal("", m.Text);
+        Assert.Equal("", m.CtaLabel);
+        Assert.Equal(HostedAiCtaAction.None, m.CtaAction);
+        Assert.Null(m.CtaUrl);
+    }
+
+    [Fact]
+    public void NeedsCredits_AddCredits_OpensBilling()
+    {
+        var m = HostedAiMessages.For(HostedAiState.NeedsCredits);
+        Assert.NotEmpty(m.Text);
+        Assert.Equal("Add credits", m.CtaLabel);
+        Assert.Equal(HostedAiCtaAction.OpenBilling, m.CtaAction);
+        Assert.NotNull(m.CtaUrl);
+        Assert.EndsWith("/account/billing", m.CtaUrl);
+    }
+
+    [Fact]
+    public void CapReached_OpenBilling()
+    {
+        var m = HostedAiMessages.For(HostedAiState.CapReached);
+        Assert.NotEmpty(m.Text);
+        Assert.Equal("Open Billing", m.CtaLabel);
+        Assert.Equal(HostedAiCtaAction.OpenBilling, m.CtaAction);
+        Assert.NotNull(m.CtaUrl);
+        Assert.EndsWith("/account/billing", m.CtaUrl);
+    }
+
+    [Fact]
+    public void NeedsKey_OpenSettings_NoUrl()
+    {
+        var m = HostedAiMessages.For(HostedAiState.NeedsKey);
+        Assert.NotEmpty(m.Text);
+        Assert.Equal("Open Settings", m.CtaLabel);
+        Assert.Equal(HostedAiCtaAction.OpenSettings, m.CtaAction);
+        Assert.Null(m.CtaUrl); // Settings is surface-local, not a web address
+    }
+
+    [Theory]
+    [InlineData(HostedAiState.NeedsCredits)]
+    [InlineData(HostedAiState.CapReached)]
+    public void HostedCopy_PassesForbiddenLanguageRules(HostedAiState state)
+    {
+        var m = HostedAiMessages.For(state);
+        var violations = HostedAiCopyRules.FindViolations(m.Text);
+        Assert.True(HostedAiCopyRules.IsClean(m.Text),
+            $"hosted copy for {state} must name no provider / no 'free credits' / no tier words, found: {string.Join(", ", violations)}");
+    }
+
+    [Fact]
+    public void NeedsKeyCopy_MayNameOpenAi()
+    {
+        // The bring-your-own state is EXEMPT from the provider-name rule - it is the user's own key.
+        var m = HostedAiMessages.For(HostedAiState.NeedsKey);
+        Assert.Contains("OpenAI", m.Text);
+    }
+
+    [Theory]
+    [InlineData("Use your OpenAI key", "openai")]
+    [InlineData("Get free credits now", "free credit")]
+    [InlineData("Upgrade your subscription", "subscription")]
+    [InlineData("Powered by Groq Whisper", "groq")]
+    public void ForbiddenLanguageChecker_CatchesViolations(string text, string expectedHit)
+    {
+        var violations = HostedAiCopyRules.FindViolations(text);
+        Assert.False(HostedAiCopyRules.IsClean(text));
+        Assert.Contains(expectedHit, violations);
+    }
+
+    [Fact]
+    public void ForbiddenLanguageChecker_CleanText_NoViolations()
+    {
+        Assert.Empty(HostedAiCopyRules.FindViolations("Voice needs credit. Add $5 to keep going."));
+    }
+
+    [Fact]
+    public void For_UnknownState_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => HostedAiMessages.For((HostedAiState)999));
+    }
+}

--- a/src/CcDirector.Core.Tests/HostedAi/HostedAiReadinessTests.cs
+++ b/src/CcDirector.Core.Tests/HostedAi/HostedAiReadinessTests.cs
@@ -1,0 +1,130 @@
+using CcDirector.Core.Configuration;
+using CcDirector.Core.HostedAi;
+using Xunit;
+
+namespace CcDirector.Core.Tests.HostedAi;
+
+/// <summary>
+/// Issue #938 (epic #937): the shared pre-flight readiness check. Every (mode, key, balance)
+/// combination must resolve to the one correct <see cref="HostedAiState"/>, an unknown balance must
+/// NOT block, and - the criterion the whole gate exists for - adding $5 must flip a check from
+/// <see cref="HostedAiState.NeedsCredits"/> to <see cref="HostedAiState.Ready"/> with no restart,
+/// proving the balance is re-read fresh on every call (no cache).
+/// </summary>
+public sealed class HostedAiReadinessTests
+{
+    private static HostedAiReadiness Build(
+        TranscriptionMode mode, string? key = null, long? balanceMicros = null)
+        => new(
+            () => mode,
+            _ => key,
+            _ => Task.FromResult(balanceMicros));
+
+    [Fact]
+    public async Task Byo_NoKey_NeedsKey()
+    {
+        var state = await Build(TranscriptionMode.Byo, key: null).CheckAsync();
+        Assert.Equal(HostedAiState.NeedsKey, state);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Byo_BlankKey_NeedsKey(string key)
+    {
+        var state = await Build(TranscriptionMode.Byo, key: key).CheckAsync();
+        Assert.Equal(HostedAiState.NeedsKey, state);
+    }
+
+    [Fact]
+    public async Task Byo_WithKey_Ready()
+    {
+        var state = await Build(TranscriptionMode.Byo, key: "sk-abc123").CheckAsync();
+        Assert.Equal(HostedAiState.Ready, state);
+    }
+
+    [Fact]
+    public async Task Byo_NeverReadsBalance()
+    {
+        var balanceRead = false;
+        var check = new HostedAiReadiness(
+            () => TranscriptionMode.Byo,
+            _ => "sk-abc123",
+            _ => { balanceRead = true; return Task.FromResult<long?>(0); });
+
+        await check.CheckAsync();
+
+        Assert.False(balanceRead); // BYO is a local key read only - no cloud call
+    }
+
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(-1L)]
+    [InlineData(-500_000L)]
+    public async Task DevThrottle_EmptyOrNegativeBalance_NeedsCredits(long balance)
+    {
+        var state = await Build(TranscriptionMode.DevThrottle, balanceMicros: balance).CheckAsync();
+        Assert.Equal(HostedAiState.NeedsCredits, state);
+    }
+
+    [Theory]
+    [InlineData(1L)]
+    [InlineData(5_000_000L)]
+    public async Task DevThrottle_PositiveBalance_Ready(long balance)
+    {
+        var state = await Build(TranscriptionMode.DevThrottle, balanceMicros: balance).CheckAsync();
+        Assert.Equal(HostedAiState.Ready, state);
+    }
+
+    [Fact]
+    public async Task DevThrottle_UnknownBalance_DoesNotBlock_Ready()
+    {
+        // Signed out or the cloud is unreachable -> balance null -> the pre-flight check must not block;
+        // the runtime 402 is the authoritative gate and reports the identical state.
+        var state = await Build(TranscriptionMode.DevThrottle, balanceMicros: null).CheckAsync();
+        Assert.Equal(HostedAiState.Ready, state);
+    }
+
+    [Fact]
+    public async Task DevThrottle_AddCredits_UnlocksWithoutRestart()
+    {
+        // The balance the check reads changes underneath the SAME instance (a $5 top-up). Because the
+        // balance is re-read fresh each call, the very next check flips NeedsCredits -> Ready with no
+        // restart and no new object - the epic's headline acceptance criterion.
+        long balance = 0;
+        var check = new HostedAiReadiness(
+            () => TranscriptionMode.DevThrottle,
+            _ => null,
+            _ => Task.FromResult<long?>(balance));
+
+        Assert.Equal(HostedAiState.NeedsCredits, await check.CheckAsync());
+
+        balance = 5_000_000; // user adds $5
+
+        Assert.Equal(HostedAiState.Ready, await check.CheckAsync());
+    }
+
+    [Fact]
+    public async Task DevThrottle_ReadsBalanceFreshEveryCall()
+    {
+        var reads = 0;
+        var check = new HostedAiReadiness(
+            () => TranscriptionMode.DevThrottle,
+            _ => null,
+            _ => { reads++; return Task.FromResult<long?>(5_000_000); });
+
+        await check.CheckAsync();
+        await check.CheckAsync();
+        await check.CheckAsync();
+
+        Assert.Equal(3, reads); // no caching between calls
+    }
+
+    [Fact]
+    public void Constructor_NullDelegates_Throw()
+    {
+        Assert.Throws<ArgumentNullException>(() => new HostedAiReadiness(null!, _ => null, _ => Task.FromResult<long?>(0)));
+        Assert.Throws<ArgumentNullException>(() => new HostedAiReadiness(() => TranscriptionMode.Byo, null!, _ => Task.FromResult<long?>(0)));
+        Assert.Throws<ArgumentNullException>(() => new HostedAiReadiness(() => TranscriptionMode.Byo, _ => null, null!));
+    }
+}

--- a/src/CcDirector.Core/HostedAi/HostedAiErrorMapper.cs
+++ b/src/CcDirector.Core/HostedAi/HostedAiErrorMapper.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+
+namespace CcDirector.Core.HostedAi;
+
+/// <summary>
+/// Maps a hosted-service HTTP 402 into the shared <see cref="HostedAiState"/> (issue #938, epic #937).
+/// This is the runtime half of the gate: when a feature runs dry mid-use, the 402 the proxy returns is
+/// normalized here so the user sees the SAME message as the pre-flight check
+/// (<see cref="HostedAiReadiness"/>), never "transcription failed: ...402..." or a silent nothing.
+///
+/// Branch on the machine-readable <c>code</c>, NOT the <c>type</c>: the website proxy returns the same
+/// <c>type</c> (<c>insufficient_quota</c>) for both conditions, so only the <c>code</c> distinguishes an
+/// empty balance from a hit monthly cap (server contract in epic #937):
+/// <list type="bullet">
+/// <item><c>insufficient_credits</c> -> <see cref="HostedAiState.NeedsCredits"/></item>
+/// <item><c>monthly_limit_reached</c> -> <see cref="HostedAiState.CapReached"/></item>
+/// </list>
+/// </summary>
+public static class HostedAiErrorMapper
+{
+    /// <summary>The proxy code for an empty account balance.</summary>
+    public const string InsufficientCreditsCode = "insufficient_credits";
+
+    /// <summary>The proxy code for a reached monthly spending limit.</summary>
+    public const string MonthlyLimitReachedCode = "monthly_limit_reached";
+
+    /// <summary>
+    /// Map a 402 error <paramref name="code"/> to a state. <c>monthly_limit_reached</c> is the cap;
+    /// every other value (including <c>insufficient_credits</c>, an unknown code, or null) maps to
+    /// <see cref="HostedAiState.NeedsCredits"/>, because this is only ever consulted for a 402 and an
+    /// empty balance is the common case (matching the existing transcription behavior).
+    /// </summary>
+    public static HostedAiState MapCode(string? code) => (code?.Trim().ToLowerInvariant()) switch
+    {
+        MonthlyLimitReachedCode => HostedAiState.CapReached,
+        _ => HostedAiState.NeedsCredits,
+    };
+
+    /// <summary>
+    /// Best-effort read of the machine-readable error code from an OpenAI-compatible 402 body
+    /// (<c>{ "error": { "code": "insufficient_credits" } }</c> or a flat <c>{ "code": ... }</c>).
+    /// Defaults to <see cref="InsufficientCreditsCode"/> when the body carries no code, since the caller
+    /// only reaches here on a 402. This is the single shared parse the transcription pipeline also uses.
+    /// </summary>
+    public static string ParseErrorCode(string? body)
+    {
+        if (string.IsNullOrWhiteSpace(body)) return InsufficientCreditsCode;
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("error", out var err) && err.ValueKind == JsonValueKind.Object
+                && err.TryGetProperty("code", out var nested) && nested.ValueKind == JsonValueKind.String)
+                return nested.GetString() ?? InsufficientCreditsCode;
+            if (root.TryGetProperty("code", out var flat) && flat.ValueKind == JsonValueKind.String)
+                return flat.GetString() ?? InsufficientCreditsCode;
+        }
+        catch (JsonException)
+        {
+            // A non-JSON 402 body still means out of credits; fall through to the default code.
+        }
+        return InsufficientCreditsCode;
+    }
+
+    /// <summary>Parse the code out of a 402 body and map it to a state in one call.</summary>
+    public static HostedAiState Map402(string? body) => MapCode(ParseErrorCode(body));
+}

--- a/src/CcDirector.Core/HostedAi/HostedAiMessage.cs
+++ b/src/CcDirector.Core/HostedAi/HostedAiMessage.cs
@@ -1,0 +1,65 @@
+using CcDirector.Core.Account;
+
+namespace CcDirector.Core.HostedAi;
+
+/// <summary>
+/// What a surface should do when the user activates the call-to-action on a hosted-AI unavailable
+/// message (issue #938). Kept semantic - NOT a raw URL - because each surface navigates its own way:
+/// the desktop app opens a browser or a dialog, the Cockpit switches to its Settings AI tab, the
+/// mobile app routes within itself. For <see cref="OpenBilling"/> the concrete web address is also
+/// carried on <see cref="HostedAiMessage.CtaUrl"/> for surfaces that just open a browser.
+/// </summary>
+public enum HostedAiCtaAction
+{
+    /// <summary>No action (the <see cref="HostedAiState.Ready"/> message has no call-to-action).</summary>
+    None = 0,
+
+    /// <summary>Open the DevThrottle Billing page so the user can add credits or raise their limit.</summary>
+    OpenBilling = 1,
+
+    /// <summary>Open the local Settings AI tab so the user can add their own OpenAI key.</summary>
+    OpenSettings = 2,
+}
+
+/// <summary>
+/// The single-source copy for one <see cref="HostedAiState"/> (issue #938): the sentence to show, the
+/// call-to-action button label, the semantic action, and - for the billing action - the concrete web
+/// address. Built only by <see cref="HostedAiMessages.For"/> so the wording lives in exactly one place
+/// and is identical across every surface by construction.
+/// </summary>
+/// <param name="Text">The user-facing sentence. Empty for <see cref="HostedAiState.Ready"/>.</param>
+/// <param name="CtaLabel">The call-to-action button label. Empty for <see cref="HostedAiState.Ready"/>.</param>
+/// <param name="CtaAction">What the call-to-action does (semantic - each surface maps it to navigation).</param>
+/// <param name="CtaUrl">The concrete web address for <see cref="HostedAiCtaAction.OpenBilling"/>; null otherwise.</param>
+public sealed record HostedAiMessage(string Text, string CtaLabel, HostedAiCtaAction CtaAction, string? CtaUrl);
+
+/// <summary>
+/// The DevThrottle website addresses the hosted-AI call-to-actions route to (issue #938). Resolved
+/// from the SAME base as the rest of the account egress (<see cref="AccountTelemetryClient.DefaultApiBaseUrl"/>
+/// with the <see cref="AccountTelemetryClient.ApiBaseUrlEnvVar"/> override), so a preview host is honored
+/// and there is no new hard-coded domain. These are website routes (not <c>/api/v1</c> endpoints); the
+/// user opens them in a browser.
+/// </summary>
+public static class HostedAiUrls
+{
+    /// <summary>The Billing page: add credits (top-up) or raise the monthly spending limit.</summary>
+    public const string BillingPath = "/account/billing";
+
+    /// <summary>The onboarding page for a brand-new account.</summary>
+    public const string GetStartedPath = "/account/get-started";
+
+    /// <summary>The website base (env override, else the production default), without a trailing slash.</summary>
+    public static string WebsiteBase()
+    {
+        var fromEnv = Environment.GetEnvironmentVariable(AccountTelemetryClient.ApiBaseUrlEnvVar);
+        if (!string.IsNullOrWhiteSpace(fromEnv))
+            return fromEnv.Trim().TrimEnd('/');
+        return AccountTelemetryClient.DefaultApiBaseUrl;
+    }
+
+    /// <summary>The absolute Billing URL for the add-credits / raise-limit call-to-action.</summary>
+    public static string Billing => WebsiteBase() + BillingPath;
+
+    /// <summary>The absolute onboarding URL.</summary>
+    public static string GetStarted => WebsiteBase() + GetStartedPath;
+}

--- a/src/CcDirector.Core/HostedAi/HostedAiMessages.cs
+++ b/src/CcDirector.Core/HostedAi/HostedAiMessages.cs
@@ -1,0 +1,84 @@
+namespace CcDirector.Core.HostedAi;
+
+/// <summary>
+/// The ONE source of the hosted-AI unavailable copy (issue #938, epic #937). Every voice/Wingman/TTS
+/// surface across desktop, web, mobile, and native calls <see cref="For"/> so the message a user sees
+/// when they have no credits / no key is identical by construction - not 13 hand-written strings that
+/// drift apart.
+///
+/// Copy rules (from epic #937, enforced by <see cref="HostedAiCopyRules"/> and unit-tested):
+/// the hosted-account states (<see cref="HostedAiState.NeedsCredits"/>, <see cref="HostedAiState.CapReached"/>)
+/// name NO provider ("OpenAI", "Groq", ...), say nothing about "free credits", and use no
+/// subscription/tier words. The bring-your-own state (<see cref="HostedAiState.NeedsKey"/>) MAY name
+/// OpenAI, because it is the user's own key.
+/// </summary>
+public static class HostedAiMessages
+{
+    /// <summary>
+    /// The single-source copy for a state. <see cref="HostedAiState.Ready"/> returns an empty message
+    /// (nothing to show); the three unavailable states return the sentence + call-to-action.
+    /// </summary>
+    public static HostedAiMessage For(HostedAiState state) => state switch
+    {
+        HostedAiState.Ready => new HostedAiMessage("", "", HostedAiCtaAction.None, null),
+
+        HostedAiState.NeedsCredits => new HostedAiMessage(
+            "Voice needs credit. Add $5 to turn on transcription, voice mode, and Wingman - enough to last most of a month.",
+            "Add credits",
+            HostedAiCtaAction.OpenBilling,
+            HostedAiUrls.Billing),
+
+        HostedAiState.CapReached => new HostedAiMessage(
+            "You've hit your monthly spending limit. Raise it in Billing to keep going.",
+            "Open Billing",
+            HostedAiCtaAction.OpenBilling,
+            HostedAiUrls.Billing),
+
+        HostedAiState.NeedsKey => new HostedAiMessage(
+            "Add your OpenAI key in Settings to use this.",
+            "Open Settings",
+            HostedAiCtaAction.OpenSettings,
+            null),
+
+        _ => throw new ArgumentOutOfRangeException(nameof(state), state, "Unknown hosted-AI state"),
+    };
+}
+
+/// <summary>
+/// The forbidden-language rules for the hosted-account copy (epic #937). Pure and unit-tested so the
+/// copy is provably clean, not clean by reviewer memory. Applies to the hosted-account states only -
+/// the bring-your-own key copy is allowed to name OpenAI (it is the user's own key).
+/// </summary>
+public static class HostedAiCopyRules
+{
+    /// <summary>Provider names that must never appear in hosted-account copy (case-insensitive).</summary>
+    public static readonly IReadOnlyList<string> ForbiddenProviderNames = new[]
+    {
+        "openai", "groq", "whisper", "kokoro", "glm", "gpt", "anthropic", "claude",
+    };
+
+    /// <summary>Money/marketing phrases that must never appear in hosted-account copy (case-insensitive).</summary>
+    public static readonly IReadOnlyList<string> ForbiddenPhrases = new[]
+    {
+        "free credit", "subscription", "premium", "tier", "free trial",
+    };
+
+    /// <summary>
+    /// Return the forbidden terms found in <paramref name="text"/> (empty when the text is clean). The
+    /// hosted-account states must produce an empty list.
+    /// </summary>
+    public static IReadOnlyList<string> FindViolations(string text)
+    {
+        var hits = new List<string>();
+        if (string.IsNullOrEmpty(text)) return hits;
+        var lower = text.ToLowerInvariant();
+        foreach (var term in ForbiddenProviderNames)
+            if (lower.Contains(term)) hits.Add(term);
+        foreach (var term in ForbiddenPhrases)
+            if (lower.Contains(term)) hits.Add(term);
+        return hits;
+    }
+
+    /// <summary>True when <paramref name="text"/> contains no forbidden hosted-copy term.</summary>
+    public static bool IsClean(string text) => FindViolations(text).Count == 0;
+}

--- a/src/CcDirector.Core/HostedAi/HostedAiReadiness.cs
+++ b/src/CcDirector.Core/HostedAi/HostedAiReadiness.cs
@@ -1,0 +1,72 @@
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.HostedAi;
+
+/// <summary>
+/// The shared pre-flight "can this user use hosted AI right now?" check (issue #938, epic #937). Hung
+/// on the existing centralized routing seam (<see cref="TranscriptionMode"/> +
+/// <see cref="TranscriptionEndpointResolver"/>), it returns ONE typed <see cref="HostedAiState"/> that
+/// every voice/Wingman/TTS surface consults before it lets the user record or fires a hosted call - so
+/// a feature with no way to pay is marked unavailable up front with the consistent message
+/// (<see cref="HostedAiMessages.For"/>), instead of failing badly after the user has already spoken.
+///
+/// Pure of I/O plumbing: the mode, the vault key read, and the account balance read are injected as
+/// delegates, so this class is fully unit-testable and the Gateway owns the wiring
+/// (<c>GatewayHostedAi.CreateReadiness</c>). The balance delegate is invoked FRESH on every
+/// <see cref="CheckAsync"/> (this class holds no cache), so adding $5 unlocks the feature on the next
+/// check with no restart - the acceptance criterion the whole gate exists for.
+/// </summary>
+public sealed class HostedAiReadiness
+{
+    private readonly Func<TranscriptionMode> _modeProvider;
+    private readonly Func<string, string?> _keyProvider;
+    private readonly Func<CancellationToken, Task<long?>> _balanceMicrosProvider;
+
+    /// <param name="modeProvider">Supplies the current transcription/provider mode, read fresh per check
+    /// so a mode change takes effect with no restart.</param>
+    /// <param name="keyProvider">Reads a vault key by name (the bring-your-own OpenAI key check).</param>
+    /// <param name="balanceMicrosProvider">Reads the signed-in account's balance in micro-dollars, fresh
+    /// per check. Returns null when the balance is UNKNOWN (signed out or the cloud is unreachable): the
+    /// pre-flight check must not block on an unknown balance - the authoritative gate is the runtime 402
+    /// (<see cref="HostedAiErrorMapper"/>), which reports the identical state.</param>
+    public HostedAiReadiness(
+        Func<TranscriptionMode> modeProvider,
+        Func<string, string?> keyProvider,
+        Func<CancellationToken, Task<long?>> balanceMicrosProvider)
+    {
+        _modeProvider = modeProvider ?? throw new ArgumentNullException(nameof(modeProvider));
+        _keyProvider = keyProvider ?? throw new ArgumentNullException(nameof(keyProvider));
+        _balanceMicrosProvider = balanceMicrosProvider ?? throw new ArgumentNullException(nameof(balanceMicrosProvider));
+    }
+
+    /// <summary>
+    /// Decide whether hosted AI can run for the configured mode right now:
+    /// <list type="bullet">
+    /// <item>Bring-your-own -> <see cref="HostedAiState.NeedsKey"/> when the vault holds no OpenAI key,
+    /// else <see cref="HostedAiState.Ready"/> (no network - a local key read only).</item>
+    /// <item>DevThrottle hosted -> <see cref="HostedAiState.NeedsCredits"/> when the balance is a known
+    /// value at or below zero, else <see cref="HostedAiState.Ready"/> (including when the balance is
+    /// unknown - see <c>balanceMicrosProvider</c>). The monthly-cap state is generally only known at
+    /// runtime from the 402, so it is not decided here.</item>
+    /// </list>
+    /// </summary>
+    public async Task<HostedAiState> CheckAsync(CancellationToken ct = default)
+    {
+        var mode = _modeProvider();
+        var endpoint = TranscriptionEndpointResolver.Resolve(mode);
+
+        if (mode == TranscriptionMode.Byo)
+        {
+            var key = _keyProvider(endpoint.RequireKeyName());
+            var state = string.IsNullOrWhiteSpace(key) ? HostedAiState.NeedsKey : HostedAiState.Ready;
+            FileLog.Write($"[HostedAiReadiness] CheckAsync: mode=byo, hasKey={state == HostedAiState.Ready} -> {state}");
+            return state;
+        }
+
+        var balance = await _balanceMicrosProvider(ct);
+        var result = balance is long b && b <= 0 ? HostedAiState.NeedsCredits : HostedAiState.Ready;
+        FileLog.Write($"[HostedAiReadiness] CheckAsync: mode=devthrottle, balanceMicros={(balance is null ? "unknown" : balance.ToString())} -> {result}");
+        return result;
+    }
+}

--- a/src/CcDirector.Core/HostedAi/HostedAiState.cs
+++ b/src/CcDirector.Core/HostedAi/HostedAiState.cs
@@ -1,0 +1,28 @@
+namespace CcDirector.Core.HostedAi;
+
+/// <summary>
+/// Whether a hosted-AI feature (transcription, voice mode, Wingman, text-to-speech) can run right now
+/// for this machine's configured provider mode (issue #938, epic #937). ONE typed answer that every
+/// voice/Wingman/TTS surface consumes, so the "you need credit / you need a key" gate is decided in a
+/// single place and shown identically everywhere - never a per-surface hand-written string, a generic
+/// "transcription failed", or a silent nothing.
+///
+/// The pre-flight check (<see cref="HostedAiReadiness.CheckAsync"/>) and the runtime 402 mapper
+/// (<see cref="HostedAiErrorMapper"/>) both produce this same enum, so a feature that is blocked
+/// up front and one that runs dry mid-use are reported with the identical copy
+/// (<see cref="HostedAiMessages.For"/>).
+/// </summary>
+public enum HostedAiState
+{
+    /// <summary>The feature can run: the active mode has a working resource (credits or a key).</summary>
+    Ready = 0,
+
+    /// <summary>DevThrottle hosted mode and the account balance is empty - the user must add credits.</summary>
+    NeedsCredits = 1,
+
+    /// <summary>The account's monthly spending limit has been reached - the user must raise it in Billing.</summary>
+    CapReached = 2,
+
+    /// <summary>Bring-your-own mode and no OpenAI key is configured - the user must add their key.</summary>
+    NeedsKey = 3,
+}

--- a/src/CcDirector.Core/Transcription/BatchTranscriptionPipeline.cs
+++ b/src/CcDirector.Core/Transcription/BatchTranscriptionPipeline.cs
@@ -4,6 +4,7 @@ using CcDirector.Core.Audio;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Dictation;
 using CcDirector.Core.Dictation.Models;
+using CcDirector.Core.HostedAi;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Core.Transcription;
@@ -295,30 +296,11 @@ public sealed class BatchTranscriptionPipeline : IDisposable
         => string.IsNullOrEmpty(s) || s.Length <= max ? s : s[..max] + "...";
 
     /// <summary>
-    /// Best-effort read of the machine-readable error code from an OpenAI-compatible error body
-    /// (<c>{ "error": { "code": "insufficient_credits" } }</c> or a flat <c>{ "code": ... }</c>).
-    /// Defaults to "insufficient_credits" when the body has no code, since the caller only reaches
-    /// here on a 402.
+    /// Best-effort read of the machine-readable error code from an OpenAI-compatible 402 body. Delegates
+    /// to the shared <see cref="HostedAiErrorMapper.ParseErrorCode"/> so the whole stack parses the 402
+    /// code in exactly one place (issue #938) - the transcription path and the epic-wide gate never drift.
     /// </summary>
-    private static string ParseErrorCode(string body)
-    {
-        if (string.IsNullOrWhiteSpace(body)) return "insufficient_credits";
-        try
-        {
-            using var doc = JsonDocument.Parse(body);
-            var root = doc.RootElement;
-            if (root.TryGetProperty("error", out var err) && err.ValueKind == JsonValueKind.Object
-                && err.TryGetProperty("code", out var nested) && nested.ValueKind == JsonValueKind.String)
-                return nested.GetString() ?? "insufficient_credits";
-            if (root.TryGetProperty("code", out var flat) && flat.ValueKind == JsonValueKind.String)
-                return flat.GetString() ?? "insufficient_credits";
-        }
-        catch (JsonException)
-        {
-            // A non-JSON 402 body still means out of credits; fall through to the default code.
-        }
-        return "insufficient_credits";
-    }
+    private static string ParseErrorCode(string body) => HostedAiErrorMapper.ParseErrorCode(body);
 
     public void Dispose()
     {

--- a/src/CcDirector.Gateway/HostedAi/GatewayHostedAi.cs
+++ b/src/CcDirector.Gateway/HostedAi/GatewayHostedAi.cs
@@ -1,0 +1,74 @@
+using CcDirector.Core;
+using CcDirector.Core.Account;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.HostedAi;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.HostedAi;
+
+/// <summary>
+/// Wires the shared, delegate-injected <see cref="HostedAiReadiness"/> check (Core, issue #938) to the
+/// Gateway's real resources: the key vault (the bring-your-own OpenAI key), the account credential
+/// (<see cref="DevThrottleAccountService"/>), and the credits client (<see cref="AccountCreditsClient"/>).
+/// The Gateway is the only place that holds the account token and the vault, so the wiring lives here
+/// while the decision logic stays pure in Core. This is the factory the per-platform sub-issues
+/// (#939-#943) call to obtain a ready-to-use check.
+/// </summary>
+public static class GatewayHostedAi
+{
+    /// <summary>
+    /// Build a <see cref="HostedAiReadiness"/> that reads the bring-your-own key from
+    /// <paramref name="vault"/> and the DevThrottle account balance through
+    /// <paramref name="credits"/> using the token <paramref name="account"/> holds.
+    /// </summary>
+    /// <param name="vault">The Gateway key vault (the single store for the OpenAI/DevThrottle keys).</param>
+    /// <param name="account">The Gateway-hosted account credential service, or null on a host without one
+    /// (then the balance is always unknown and DevThrottle mode reports Ready - the runtime 402 gates it).</param>
+    /// <param name="credits">The cloud credits client (the injectable cloud-egress seam).</param>
+    /// <param name="modeProvider">Supplies the current transcription mode; defaults to
+    /// <see cref="TranscriptionModeConfig.Get"/> so a Cockpit mode change takes effect with no restart.</param>
+    public static HostedAiReadiness CreateReadiness(
+        KeyVault vault,
+        DevThrottleAccountService? account,
+        AccountCreditsClient credits,
+        Func<TranscriptionMode>? modeProvider = null)
+    {
+        if (vault is null) throw new ArgumentNullException(nameof(vault));
+        if (credits is null) throw new ArgumentNullException(nameof(credits));
+
+        return new HostedAiReadiness(
+            modeProvider ?? TranscriptionModeConfig.Get,
+            name => vault.Get(name),
+            ct => ReadBalanceMicrosAsync(account, credits, ct));
+    }
+
+    /// <summary>
+    /// Read the account balance in micro-dollars for the pre-flight check, or null when it is UNKNOWN.
+    /// Signed out (no token) is unknown; a cloud failure is an expected external condition mapped to
+    /// unknown here at the egress boundary - the pre-flight check must never block on a balance it could
+    /// not read (the runtime 402 remains the authoritative, identically-reported gate). The raw token is
+    /// never logged (DT-05).
+    /// </summary>
+    private static async Task<long?> ReadBalanceMicrosAsync(
+        DevThrottleAccountService? account, AccountCreditsClient credits, CancellationToken ct)
+    {
+        var token = account?.GetAccessTokenForForwarding();
+        if (string.IsNullOrEmpty(token))
+        {
+            FileLog.Write("[GatewayHostedAi] ReadBalanceMicros: no account credential -> balance unknown");
+            return null;
+        }
+
+        try
+        {
+            var result = await credits.GetCreditsAsync(token, ct).ConfigureAwait(false);
+            FileLog.Write($"[GatewayHostedAi] ReadBalanceMicros: balanceMicros={result.BalanceMicros}");
+            return result.BalanceMicros;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayHostedAi] ReadBalanceMicros FAILED (balance unknown, not blocking): {ex.Message}");
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Release Notes
Foundation for epic thefrederiksen/devthrottle_internal#661. Adds the one shared "can this user use hosted AI right now?" primitive that every voice, Wingman, and text-to-speech surface will consume, so the "you need credit or a key" gate is decided in one place and shown identically everywhere. No user-facing surface changes yet - that is the per-platform sub-issues (#939-#943).

## Changes
- **HostedAiState** - the one typed answer: `Ready | NeedsCredits | CapReached | NeedsKey`.
- **HostedAiReadiness** - the pre-flight check on the existing `TranscriptionMode` seam. Bring-your-own mode gates on the vault OpenAI key; DevThrottle mode gates on the account balance, read fresh on every call (no cache) so adding five dollars unlocks with no restart. An unknown balance (signed out / cloud unreachable) does not block - the runtime 402 stays the authoritative, identically-reported gate.
- **HostedAiMessages** + **HostedAiCopyRules** - the single source of the unavailable copy and its forbidden-language checker (hosted copy names no provider, no "free credits", no subscription words; the bring-your-own copy may name OpenAI).
- **HostedAiMessage** / **HostedAiUrls** - the message record, the semantic call-to-action, and the Billing URL resolved from the existing account-egress base (no new hard-coded host).
- **HostedAiErrorMapper** - normalizes a runtime 402, branching on the machine `code` (`insufficient_credits`, `monthly_limit_reached`), never the shared `type`.
- **GatewayHostedAi** - wires the Core check to the real vault, account credential, and credits client. The factory the platform sub-issues call.
- **BatchTranscriptionPipeline** - its 402 code parse now delegates to the shared mapper, so the whole stack parses a 402 in exactly one place.

## How to Test
```
dotnet build cc-director.sln
dotnet test src/CcDirector.Core.Tests/CcDirector.Core.Tests.csproj --filter FullyQualifiedName~HostedAi
```

## Expected Result
Build succeeds with 0 warnings / 0 errors. The 43 HostedAi unit tests pass, covering every (mode, balance, key) combination, each 402 code, the forbidden-language rules, and the add-credits-without-restart flow.

## Before / After
- Before: no pre-flight entitlement check exists anywhere; out-of-credits copy is hand-written in many places and only `HostedInferenceBrain` does it well.
- After: one shared, unit-tested readiness check + single-source copy + 402 mapper the ~13 surfaces can consume so messaging is consistent by construction.

Proof: `docs/cencon/proof/issue-938/report.html`

Closes thefrederiksen/devthrottle#938 (foundation of thefrederiksen/devthrottle_internal#661).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
