### PR TITLE
Stop a stalled voice backend from freezing every Wingman turn for 60 seconds

### DIFF
--- a/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using CcDirector.AgentBrain;
 using CcDirector.Core;
 using CcDirector.Core.HostedAi;
+using CcDirector.Gateway.HostedAi;
 using CcDirector.Gateway.Discovery;
 using CcDirector.Gateway.Wingman;
 using Xunit;
@@ -310,6 +311,69 @@ public sealed class WingmanVoiceServiceTests
         await good.StoreSpokenAsync("sid-2", "spoken", "reply");
         Assert.True(good.HasVoice("sid-2"));
         Assert.Null(good.VoiceUnavailableFor("sid-2"));
+    }
+
+    /// <summary>A text-to-speech transport that throws <see cref="OperationCanceledException"/> - the
+    /// shape a per-attempt timeout takes - for the first <c>_timeouts</c> calls, then returns 200 with
+    /// audio. TtsSynthesis converts each such throw (while the caller's token is live) into a retry, so
+    /// this drives the retry path without a real 15-second wait. With <see cref="int.MaxValue"/> it
+    /// always times out.</summary>
+    private sealed class TtsTimeoutHandler : HttpMessageHandler
+    {
+        private readonly int _timeouts;
+        private int _calls;
+        public int Calls => _calls;
+        public TtsTimeoutHandler(int timeouts) { _timeouts = timeouts; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var n = Interlocked.Increment(ref _calls);
+            if (n <= _timeouts)
+                throw new OperationCanceledException("simulated per-attempt timeout");
+            var resp = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(new byte[] { 9, 9, 9 }),
+            };
+            return Task.FromResult(resp);
+        }
+    }
+
+    private static WingmanVoiceService ServiceWithHandler(HttpMessageHandler handler)
+    {
+        Func<CancellationToken, Task<IAgentBrain>> brain =
+            _ => throw new InvalidOperationException("brain must not be called for the store-spoken path");
+        var vaultPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".vault");
+        var persistPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".json");
+        var vault = new KeyVault(vaultPath);
+        vault.Set("OPENAI_API_KEY", "sk-test");
+        vault.Set("DEVTHROTTLE_API_KEY", "dt_live_test");
+        return new WingmanVoiceService(brain, vault, new DirectorEndpointClient(), persistPath, ttsHttpClient: new HttpClient(handler));
+    }
+
+    [Fact]
+    public async Task StoreSpokenAsync_TtsTimesOutOnceThenSucceeds_RetriesAndMarksReady()
+    {
+        // Regression: a single stalled upstream voice call must be retried, not surfaced as a freeze
+        // or failure. The first attempt times out; the retry returns audio, so the session is ready.
+        var handler = new TtsTimeoutHandler(timeouts: 1);
+        var svc = ServiceWithHandler(handler);
+        await svc.StoreSpokenAsync("sid-retry", "spoken", "reply");
+
+        Assert.Equal(2, handler.Calls);                        // the retry actually fired
+        Assert.True(svc.HasVoice("sid-retry"));                // and produced audio
+        Assert.Null(svc.VoiceUnavailableFor("sid-retry"));
+    }
+
+    [Fact]
+    public async Task StoreSpokenAsync_TtsTimesOutEveryAttempt_GivesUpBounded_NoReady()
+    {
+        // Regression: when every attempt stalls, TtsSynthesis gives up after a BOUNDED number of
+        // attempts (no infinite spin, no 60-second freeze) and the turn-end records no audio.
+        var handler = new TtsTimeoutHandler(timeouts: int.MaxValue);
+        var svc = ServiceWithHandler(handler);
+        await svc.StoreSpokenAsync("sid-dead", "spoken", "reply");
+
+        Assert.Equal(TtsSynthesis.Attempts, handler.Calls);    // exactly the attempt cap, then stop
+        Assert.False(svc.HasVoice("sid-dead"));
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -221,10 +221,10 @@ internal static class GatewayWingmanVoiceEndpoint
             var url = tts.BaseUrl.TrimEnd('/') + "/audio/speech";
             try
             {
-                using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
-                http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", key);
-                using var payload = JsonContent.Create(new { model, voice, input, response_format = "mp3" });
-                using var resp = await http.PostAsync(url, payload, ct);
+                // Short per-attempt timeout + one retry (TtsSynthesis) so a stalled upstream voice
+                // worker fails fast and retries instead of freezing the caller for a flat 60 seconds.
+                using var http = new HttpClient();
+                using var resp = await TtsSynthesis.PostAsync(http, url, key, new { model, voice, input, response_format = "mp3" }, ct);
                 if (!resp.IsSuccessStatusCode)
                 {
                     var body = await resp.Content.ReadAsStringAsync(ct);

--- a/src/CcDirector.Gateway/HostedAi/TtsSynthesis.cs
+++ b/src/CcDirector.Gateway/HostedAi/TtsSynthesis.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.HostedAi;
+
+/// <summary>
+/// Forwards a text-to-speech request to the configured OpenAI-compatible <c>/audio/speech</c>
+/// endpoint with a SHORT per-attempt timeout and a single retry.
+///
+/// The upstream speech model (the DevThrottle proxy forwarding to DeepInfra's Kokoro) is bimodal: a
+/// healthy call returns in about a second, but an intermittently cold or overloaded worker never
+/// answers. The former flat 60-second client timeout with no retry turned one such stall into a full
+/// 60-second freeze on the phone (every wingman turn hung for a minute). A 15-second per-attempt cap
+/// fails fast on the stalled worker, and one retry almost always lands on a warm worker - so the
+/// caller sees about a second normally and about sixteen seconds in the worst realistic case instead
+/// of a minute.
+///
+/// This is NOT a fallback that hides a failure: a genuine provider response (success, 402, any 4xx or
+/// 5xx) is returned immediately with no retry, and when BOTH attempts exceed the per-attempt cap the
+/// caller is told the synthesis failed (a thrown <see cref="TimeoutException"/>). Only the transient
+/// "the worker never answered in time" case is retried.
+/// </summary>
+internal static class TtsSynthesis
+{
+    /// <summary>Per-attempt ceiling. Well above the roughly one-second healthy latency, well below the
+    /// former 60-second freeze.</summary>
+    public static readonly TimeSpan PerAttemptTimeout = TimeSpan.FromSeconds(15);
+
+    /// <summary>Total attempts (that is, one retry). The retry targets the transient stalled-worker case.</summary>
+    public const int Attempts = 2;
+
+    /// <summary>
+    /// POST <c>{ model, voice, input, response_format }</c> to <paramref name="url"/> with bearer
+    /// <paramref name="key"/>. Returns the provider's response (success or error) for the caller to
+    /// read and dispose. Throws <see cref="TimeoutException"/> when every attempt exceeds
+    /// <see cref="PerAttemptTimeout"/>. Honors <paramref name="ct"/>: caller cancellation propagates
+    /// immediately and is never mistaken for a per-attempt timeout.
+    /// </summary>
+    public static async Task<HttpResponseMessage> PostAsync(HttpClient http, string url, string key, object payload, CancellationToken ct)
+    {
+        TimeoutException? lastTimeout = null;
+        for (var attempt = 1; attempt <= Attempts; attempt++)
+        {
+            using var perAttempt = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            perAttempt.CancelAfter(PerAttemptTimeout);
+            using var req = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = JsonContent.Create(payload),
+            };
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", key);
+            try
+            {
+                return await http.SendAsync(req, perAttempt.Token);
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                // Our per-attempt timer fired (the caller did not cancel): the upstream worker stalled.
+                lastTimeout = new TimeoutException(
+                    $"text-to-speech attempt {attempt} exceeded {PerAttemptTimeout.TotalSeconds:0}s");
+                FileLog.Write($"[TtsSynthesis] attempt {attempt}/{Attempts} timed out after " +
+                    $"{PerAttemptTimeout.TotalSeconds:0}s{(attempt < Attempts ? "; retrying" : "; giving up")}");
+            }
+        }
+        throw lastTimeout!;
+    }
+}

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -338,16 +338,13 @@ public sealed class WingmanVoiceService
         var model = TtsModelConfig.Resolve(mode);
         var url = tts.BaseUrl.TrimEnd('/') + "/audio/speech";
         // Reuse the injected client (tests) or a per-call one; auth goes on the request, not the shared
-        // client's default headers, so a shared client is safe under concurrent turn-ends.
-        var http = _ttsHttp ?? new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
+        // client's default headers, so a shared client is safe under concurrent turn-ends. The effective
+        // timeout is the short per-attempt cap inside TtsSynthesis, which also retries once when a
+        // stalled upstream worker never answers - so a flaky voice backend no longer freezes the turn.
+        var http = _ttsHttp ?? new HttpClient();
         try
         {
-            using var req = new HttpRequestMessage(HttpMethod.Post, url)
-            {
-                Content = JsonContent.Create(new { model, voice, input, response_format = "mp3" }),
-            };
-            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", key);
-            using var resp = await http.SendAsync(req, ct);
+            using var resp = await TtsSynthesis.PostAsync(http, url, key, new { model, voice, input, response_format = "mp3" }, ct);
             if (!resp.IsSuccessStatusCode)
             {
                 var body = await resp.Content.ReadAsStringAsync(ct);


### PR DESCRIPTION
## What

The Wingman text-to-speech call used a flat 60-second `HttpClient` timeout with no retry. When the upstream speech worker (the DevThrottle proxy forwarding to DeepInfra's `Kokoro-82M`) intermittently stalled - accepting the request but never returning audio - every Wingman voice turn froze for the full 60 seconds, one after another. To the user that looked like all the Wingman sessions being stuck spinning. The wingman brain (the text reply) was healthy the whole time; only the voice hung.

## Fix

New shared helper `src/CcDirector.Gateway/HostedAi/TtsSynthesis.cs`: posts to the OpenAI-compatible `/audio/speech` endpoint with a **15-second per-attempt timeout and one retry**. Healthy synthesis returns in about a second and a stall never returned inside 60 seconds, so 15 seconds cleanly separates the two - a stall fails fast and the retry almost always lands on a warm worker. Wired into both call sites:

- `WingmanVoiceService.TtsAsync` (the per-session wingman voice)
- the `/wingman/tts` endpoint

Not a fallback: a genuine provider response (success, 402, any 4xx or 5xx) is returned immediately with no retry, and when both attempts time out the caller is told the synthesis failed. **Voice and model resolution are untouched** - the `{ model, voice, input }` values are still resolved by the existing config and passed through verbatim.

## Tests

Two regression tests added (fast; they simulate a per-attempt timeout, no real 15-second wait):
- retry-then-succeed marks the session ready
- a persistently stalled backend gives up after a bounded number of attempts

Build clean (0 warnings, `TreatWarningsAsErrors` on); WingmanVoiceService suite 20/20 green against latest `main`.

## Related

Companion proxy-side hardening (a timeout and retry on the DeepInfra `fetch`) is tracked in `devthrottle_internal#163`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
