### PR TITLE
Shut test Directors down cleanly instead of force-killing them (#960)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,9 @@ The `local_builds` directory holds the **main** build `cc-director.exe` (the use
 
 #### Cleaning up your own test Director
 
-Only kill processes whose path matches the slot YOU launched (e.g. `cc-director5.exe`). Confirm via `Get-Process | Select-Object Id, ProcessName, Path` before sending `Stop-Process`. Never use a blanket `Stop-Process -Name cc-director*` — that would kill the main build and the user's working sessions.
+**Shut a test Director down cleanly, do NOT force-kill it.** Send `POST http://127.0.0.1:<port>/shutdown` to its Control API — that makes the Director kill its own sessions and delete its crash journal, so it does not leave a phantom "interrupted" entry in the fleet (issue #960). A force-kill (`Stop-Process -Force`) gives the process no chance to clean up and DOES leave that phantom journal, so it is the last resort only — use it only if the graceful shutdown does not exit in time (the Director is genuinely stuck). The `scripts\agent-session-isolation.ps1 teardown` verb already does this.
+
+When you must force-kill as a last resort: only kill a process whose path matches the slot YOU launched (e.g. `cc-director5.exe`). Confirm via `Get-Process | Select-Object Id, ProcessName, Path` first. Never use a blanket `Stop-Process -Name cc-director*` — that would kill the main build and the user's working sessions.
 
 For non-session-creating tests (HTML rendering, REST endpoint smoke, build-only verification) launching from your context is still fine. Only session-creation tests need the Task Scheduler path.
 

--- a/scripts/agent-session-isolation.ps1
+++ b/scripts/agent-session-isolation.ps1
@@ -217,6 +217,59 @@ function Stop-OwnLaunchedDirector([int]$DirectorPid, [string]$ExePath) {
     Stop-Process -Id $DirectorPid -Force -Confirm:$false
 }
 
+# Read the configured gateway token so a shutdown call is accepted if the Director enforces
+# auth (issue #916). Best effort - empty when unavailable.
+function Get-ShutdownToken {
+    $cfg = Join-Path $env:LOCALAPPDATA 'cc-director\config\config.json'
+    if (-not (Test-Path $cfg)) { return '' }
+    try {
+        $j = Get-Content $cfg -Raw | ConvertFrom-Json
+        if ($j.gateway -and $j.gateway.token) { return [string]$j.gateway.token }
+    } catch {}
+    return ''
+}
+
+# Stop a Director the RIGHT way (issue #960): ask it to shut down through its Control API so it
+# kills its own sessions and deletes its crash journal - a clean shutdown leaves NO "interrupted"
+# entry, exactly like quitting from the UI, even mid-run. A force-kill cannot clean up after
+# itself, so it is the LAST RESORT, used only when the graceful shutdown does not exit in time
+# (the Director is genuinely stuck) or when no Control API port is known.
+function Stop-DirectorCleanly([int]$DirectorPid, [int]$Port, [string]$ExePath) {
+    $exited = $false
+    if ($Port -gt 0) {
+        $headers = @{}
+        $tok = Get-ShutdownToken
+        if ($tok) { $headers['Authorization'] = "Bearer $tok" }
+        Write-Host "[teardown] requesting clean shutdown: POST http://127.0.0.1:$Port/shutdown (PID $DirectorPid)"
+        try { Invoke-WebRequest "http://127.0.0.1:$Port/shutdown" -Method POST -Headers $headers -UseBasicParsing -TimeoutSec 5 | Out-Null } catch {}
+        $deadline = (Get-Date).AddSeconds(15)
+        while ((Get-Date) -lt $deadline) {
+            if ($null -eq (Get-Process -Id $DirectorPid -ErrorAction SilentlyContinue)) { $exited = $true; break }
+            Start-Sleep -Milliseconds 250
+        }
+    } else {
+        Write-Host "[teardown] no Control API port known for PID $DirectorPid - cannot shut down cleanly"
+    }
+
+    if (-not $exited) {
+        # LAST RESORT: the clean shutdown did not take (no port, or the process is stuck). A
+        # force-kill gives the process no chance to delete its crash journal, so this path DOES
+        # leave an "interrupted" entry - it is used only when there is no other option.
+        $alive = Get-Process -Id $DirectorPid -ErrorAction SilentlyContinue
+        if ($alive -and $alive.Path -and ($alive.Path -ieq $ExePath)) {
+            Write-Host "[teardown] clean shutdown did not exit in time - FORCE killing PID $DirectorPid (last resort)"
+            Stop-Process -Id $DirectorPid -Force -Confirm:$false
+        }
+    }
+
+    $deadline2 = (Get-Date).AddSeconds(10)
+    while ((Get-Date) -lt $deadline2) {
+        if ($null -eq (Get-Process -Id $DirectorPid -ErrorAction SilentlyContinue)) { return }
+        Start-Sleep -Milliseconds 250
+    }
+    if (Get-Process -Id $DirectorPid -ErrorAction SilentlyContinue) { Fail "PID $DirectorPid did not exit within the timeout." }
+}
+
 function Invoke-Launch {
     $m = Read-Manifest $Manifest
 
@@ -345,15 +398,9 @@ function Invoke-Teardown {
     }
     foreach ($p in $targets) {
         Write-Host "[teardown] stopping PID $($p.Id) ($($p.Path))"
-        Stop-Process -Id $p.Id -Force -Confirm:$false
-        $deadline = (Get-Date).AddSeconds(15)
-        while ((Get-Date) -lt $deadline) {
-            $alive = Get-Process -Id $p.Id -ErrorAction SilentlyContinue
-            if ($null -eq $alive) { break }
-            Start-Sleep -Milliseconds 250
-        }
-        $alive = Get-Process -Id $p.Id -ErrorAction SilentlyContinue
-        if ($alive) { Fail "PID $($p.Id) did not exit within 15s." }
+        # Clean shutdown via the Control API (force-kill only as a last resort) so this test
+        # Director does not leave a phantom "interrupted" crash journal (issue #960).
+        Stop-DirectorCleanly -DirectorPid $p.Id -Port ([int]$m.port) -ExePath $m.exePath
         Write-Host "[teardown] PID $($p.Id) exited"
     }
 


### PR DESCRIPTION
## Investigation (issue #960)

Correlated the last 7 days of crash journals against the Director logs on SOREN_NORTH:

- **No code crashes.** All 12 recent unclean shutdowns stop mid-normal-work with **no exception** in the log - the signature of an external kill, not an app bug.
- **Mostly dev/test churn.** 11 of 12 were short-lived Directors (1-4 minutes, one 27 seconds) running in **per-issue git worktrees** (`devthrottle-wt-810`, `wt-qa-820`, ...) - the developer/QA agents' throwaway test Directors.
- **One real loss:** a Director that ran 2.6 days with 9 real sessions died abruptly (no exception, died alone so not a reboot) - looks like an out-of-memory / manual kill of a heavy long-lived process.

## Root cause + fix

The Director's REST `POST /shutdown` already kills its sessions and deletes its crash journal (a clean shutdown, even mid-run, leaves no "interrupted" entry). The noise came from the automation **force-killing** test Directors instead - a `Stop-Process -Force` can't run cleanup.

Fix is in the automation only (the app was already correct):
- `agent-session-isolation.ps1` teardown now stops a test Director via `POST /shutdown` (`Stop-DirectorCleanly` helper); force-kill is the last resort only, if the graceful shutdown doesn't exit in time.
- `CLAUDE.md` slot-cleanup guidance updated accordingly.
- `test-degradation.ps1` left as-is on purpose (it force-kills to simulate a crash - the point of that resilience test).

New test Directors now exit cleanly and leave nothing behind. The ~80 existing old journals are historical; #961's auto-expire would sweep them.

Related follow-up worth filing: the one real crash smells like memory pressure on a big long-lived Director - a candidate reliability item (watch memory, warn before the OS kills it).

Generated with Claude Code
