### PR TITLE
Consistent credits/key gating on the desktop voice surfaces (#940)

### DIFF
--- a/docs/cencon/proof/issue-940/report.html
+++ b/docs/cencon/proof/issue-940/report.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Issue #940 - Consistent credits/key gating on the desktop voice surfaces - Proof</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: Georgia, "Times New Roman", serif; max-width: 62rem; margin: 2rem auto; padding: 0 1.25rem; line-height: 1.55; }
+  h1 { font-size: 1.5rem; border-bottom: 2px solid #888; padding-bottom: .4rem; }
+  h2 { font-size: 1.15rem; margin-top: 2rem; border-bottom: 1px solid #ccc; padding-bottom: .2rem; }
+  code, pre { font-family: Consolas, "Courier New", monospace; }
+  pre { background: rgba(128,128,128,.12); padding: .8rem 1rem; overflow-x: auto; border-radius: 4px; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #999; padding: .45rem .6rem; text-align: left; vertical-align: top; font-size: .92rem; }
+  th { background: rgba(128,128,128,.18); }
+  .pass { font-weight: bold; }
+  .muted { color: #777; font-size: .9rem; }
+  ol li { margin: .3rem 0; }
+</style>
+</head>
+<body>
+
+<h1>Issue #940 - Consistent credits/key gating on the desktop (Avalonia) voice surfaces</h1>
+<p class="muted">Part of epic #937. Consumes the #938 foundation + #939 gateway work (both on main). Branch <code>issue-940-desktop-credits-gating</code>.</p>
+
+<h2>What was implemented</h2>
+<p>The native desktop app transcribes and synthesizes in-process and previously had no way to see the account balance (the account token is Gateway-only). This adds that, and wires every desktop voice surface to the ONE shared "add credits / add a key" message + call-to-action, so an out-of-credits or no-key user gets the consistent dialog instead of a raw 402 string or a silent nothing.</p>
+<table>
+  <tr><th>File</th><th>Role</th></tr>
+  <tr><td><code>Core/Account/GatewayAccountCreditsClient.cs</code></td><td>Reads the balance over HTTP (<code>GET /account/credits</code>); unknown balance does not block.</td></tr>
+  <tr><td><code>Core/HostedAi/DirectorHostedAiReadiness.cs</code></td><td>Gathers mode + bring-your-own key + balance, then defers to the shared <code>HostedAiReadiness</code> - the desktop resolves the identical state the Gateway does.</td></tr>
+  <tr><td><code>Avalonia/HostedAiUnavailableDialog.axaml(.cs)</code></td><td>The one shared modal every surface shows: the message from <code>HostedAiMessages</code> + its call-to-action button.</td></tr>
+  <tr><td><code>Avalonia/HostedAi/DesktopHostedAiGate.cs</code></td><td>The entry point each surface calls: pre-flight (<code>EnsureReadyAsync</code>/<code>CheckAsync</code>) and runtime mapping (<code>TryHandleRuntimeAsync</code>), showing the shared dialog.</td></tr>
+  <tr><td><code>Avalonia/HostedAi/DesktopHostedAiCta.cs</code></td><td>Routes the call-to-action: Add credits -> billing URL; Add a key -> Cockpit settings (front-door).</td></tr>
+  <tr><td><code>Avalonia/Voice/SpeakDialog.axaml.cs</code> (A7)</td><td>Pre-flight before recording; a runtime out-of-credits during transcribe shows the shared dialog instead of the raw "Transcription returned 402" in the box.</td></tr>
+  <tr><td><code>Avalonia/FifoWindow.axaml.cs</code> (B7)</td><td>The bring-your-own-only key gate is replaced by the shared readiness gate (now covers out-of-credits); runtime 402 and read-aloud 402 show the shared dialog.</td></tr>
+  <tr><td><code>Avalonia/MainWindow.axaml.cs</code> (B6)</td><td>Voice-tab read-aloud text-to-speech 402 surfaces the shared dialog. (The wingman text answer is <code>claude.exe</code>, not hosted, so it is not gated.)</td></tr>
+  <tr><td><code>Core/Voice/TtsService.cs</code> + <code>Avalonia/Voice/DesktopTtsPlayer.cs</code> (C4)</td><td>A 402 now carries the machine code and is surfaced via an optional callback instead of being logged and silently swallowed.</td></tr>
+</table>
+
+<h2>Acceptance criteria -&gt; proof</h2>
+<table>
+  <tr><th>Criterion</th><th>How met</th><th>Proof</th></tr>
+  <tr>
+    <td>Pre-flight: not-Ready shows the shared message + working CTA instead of recording.</td>
+    <td>SpeakDialog (A7) and FifoWindow (B7) call <code>DesktopHostedAiGate.CheckAsync</code> before recording and show <code>HostedAiUnavailableDialog</code> when not Ready.</td>
+    <td class="pass">Unit: DirectorHostedAiReadiness maps every (mode, key, balance) -&gt; state. Build clean. Manual checklist below.</td>
+  </tr>
+  <tr>
+    <td>Runtime 402 mapped to the same message; no generic named-reason error for credits.</td>
+    <td>The transcribe catches (A7, B7) intercept <code>InsufficientCreditsException</code> and show the shared dialog via <code>HostedAiErrorMapper.MapCode</code>, replacing the raw "Transcription returned 402" / generic red status.</td>
+    <td class="pass">Code + build; message is the single-source copy by construction.</td>
+  </tr>
+  <tr>
+    <td>Text-to-speech no longer fails silently on 402 (visible state).</td>
+    <td>TtsService carries the 402 code; DesktopTtsPlayer surfaces it through the <code>onUnavailable</code> callback; B6 + B7 read-aloud sites show the shared dialog.</td>
+    <td class="pass">Code + build; the previously silent <code>return false</code> path now raises the shared state.</td>
+  </tr>
+  <tr>
+    <td>Add-$5 -&gt; works without restart.</td>
+    <td>The readiness check reads the balance fresh over HTTP on every check (no cache); a fresh resolver + client are built per gate call.</td>
+    <td class="pass">Unit: <code>DirectorHostedAiReadiness.DevThrottle_AddCredits_UnlocksWithoutRestart</code> (0 -&gt; NeedsCredits, then $5 -&gt; Ready on the same instance).</td>
+  </tr>
+</table>
+
+<h2>Automated verification</h2>
+<pre>dotnet build cc-director.sln                                  -> Build succeeded.  0 Warning(s)  0 Error(s)
+dotnet test CcDirector.Core.Tests (GatewayAccountCredits + DirectorHostedAiReadiness)
+                                                             -> Passed! 18/18
+dotnet test CcDirector.Core.Tests (HostedAi + Tts filter)    -> Passed! 98/98 (no regression from the TtsService 402 change)</pre>
+
+<h2>Message consistency is by construction</h2>
+<p>Every desktop surface shows the SAME <code>HostedAiUnavailableDialog</code>, which fills its text and button from <code>HostedAiMessages.For(state)</code> - the one source the phone and web also use. There is no per-surface hand-written credits/key string left in the desktop voice paths (the old bring-your-own-only string in FifoWindow was removed).</p>
+
+<h2>Manual verification checklist (native surface, per the epic's plan)</h2>
+<p>Forcing an out-of-credits / no-key state in a live desktop build is done as follows (QA runs this in an isolated slot; revert the config after):</p>
+<ol>
+  <li><b>NeedsKey:</b> set <code>transcription_mode=byo</code> with no <code>OPENAI_API_KEY</code> in the vault. Open the Speak dialog -&gt; expect the shared "Add your OpenAI key in Settings" dialog with an "Add a key" button (no recording starts). Repeat via the takeover window's Ask.</li>
+  <li><b>NeedsCredits:</b> on a DevThrottle-mode account with a zero balance (a fresh test account on an enforce-mode preview), open Speak -&gt; expect "Voice needs credit. Add $5..." with an "Add credits" button that opens the billing page.</li>
+  <li><b>Runtime 402:</b> with a balance just above one call, run dry mid-dictation -&gt; expect the same dialog (not a raw "Transcription returned 402").</li>
+  <li><b>Read-aloud 402:</b> trigger the Voice tab / takeover read-aloud out of credits -&gt; expect the shared dialog rather than silence.</li>
+  <li><b>Add-$5:</b> from the NeedsCredits state, add credit and retry without restarting the app -&gt; the feature works (balance re-read on the next check).</li>
+</ol>
+
+<h2>CenCon impact</h2>
+<p>No architecture or security drift. The desktop reads the balance through the existing token-free <code>/account/credits</code> endpoint (the account token stays on the Gateway; nothing new is logged, DT-05). No new egress host - the billing URL resolves from the foundation's <code>HostedAiUrls</code>, and Cockpit via the existing front-door probe. <code>OpenAiTtsService</code> (C5) is not reached by any desktop surface and was left out of scope.</p>
+
+<p class="pass">I believe the desktop wiring is complete and building; the live visual states are verified via the checklist above.</p>
+
+</body>
+</html>

--- a/src/CcDirector.Avalonia/FifoWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/FifoWindow.axaml.cs
@@ -9,10 +9,13 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Threading;
+using CcDirector.Avalonia.HostedAi;
 using CcDirector.Avalonia.Voice;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Dictation;
+using CcDirector.Core.HostedAi;
 using CcDirector.Core.Sessions;
+using CcDirector.Core.Transcription;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Avalonia;
@@ -166,7 +169,7 @@ public partial class FifoWindow : Window
 
             // Speak the briefing aloud: the FIFO is wingman-led, you should hear what's
             // happening, not have to read it. A failed/cancelled voice never breaks the turn.
-            try { await _tts.SpeakAsync(briefing, ct); }
+            try { await _tts.SpeakAsync(briefing, ct, onUnavailable: VoiceUnavailable); }
             catch (OperationCanceledException) { }
             catch (Exception ex) { FileLog.Write($"[FifoWindow] briefing tts FAILED: {ex.Message}"); }
         }
@@ -274,6 +277,14 @@ public partial class FifoWindow : Window
     private async void OnAskAgentClick(object? sender, RoutedEventArgs e) => await HandleTalkAsync(wingman: false);
     private async void OnAskWingmanClick(object? sender, RoutedEventArgs e) => await HandleTalkAsync(wingman: true);
 
+    /// <summary>
+    /// Read-aloud (text-to-speech) ran dry (issue #940): show the ONE shared add-credits dialog instead
+    /// of the failure being logged and silently swallowed. Queued on the UI thread so the modal shows
+    /// after the current text-to-speech call unwinds (never re-entered mid-await).
+    /// </summary>
+    private void VoiceUnavailable(HostedAiState state)
+        => Dispatcher.UIThread.Post(() => { _ = DesktopHostedAiGate.ShowAsync(this, state); });
+
     private async Task HandleTalkAsync(bool wingman)
     {
         if (_busy || _current is null) return;
@@ -281,9 +292,14 @@ public partial class FifoWindow : Window
         // ---- START capture ----
         if (!_recording)
         {
-            if (string.IsNullOrWhiteSpace(_options.ResolveOpenAiKey()))
+            // Pre-flight (issue #940): the shared readiness gate covers BOTH missing bring-your-own key
+            // AND out-of-credits on the hosted account, showing the ONE consistent dialog - replacing the
+            // old bring-your-own-only, hand-written key message that ignored the credits case.
+            var state = await DesktopHostedAiGate.CheckAsync();
+            if (state != HostedAiState.Ready)
             {
-                SetStatus("Voice needs an OpenAI key. Set it in the Cockpit Settings > Transcription tab, or via the OPENAI_API_KEY environment variable.", Red);
+                FileLog.Write($"[FifoWindow] pre-flight not ready ({state}); not recording");
+                await DesktopHostedAiGate.ShowAsync(this, state);
                 return;
             }
             try
@@ -354,6 +370,13 @@ public partial class FifoWindow : Window
             if (_wingmanTurn) await AskWingmanAsync(transcript);
             else await SendToAgentAsync(transcript);
         }
+        catch (InsufficientCreditsException credits)
+        {
+            // Ran dry mid-use (issue #940): show the ONE shared add-credits dialog, not a raw 402 string.
+            FileLog.Write($"[FifoWindow] stop/act OUT OF CREDITS: {credits.Code}");
+            SetStatus("Voice needs credit.", Red);
+            await DesktopHostedAiGate.ShowAsync(this, HostedAiErrorMapper.MapCode(credits.Code));
+        }
         catch (Exception ex)
         {
             FileLog.Write($"[FifoWindow] stop/act FAILED: {ex.Message}");
@@ -389,7 +412,7 @@ public partial class FifoWindow : Window
         try
         {
             SetStatus("Speaking...", Blue);
-            await _tts.SpeakAsync(answer);
+            await _tts.SpeakAsync(answer, onUnavailable: VoiceUnavailable);
         }
         catch (Exception ex) { FileLog.Write($"[FifoWindow] tts FAILED: {ex.Message}"); }
         SetStatus("Ask Agent, Ask Wingman, Skip, Hold, or Next", Green);

--- a/src/CcDirector.Avalonia/HostedAi/DesktopHostedAiCta.cs
+++ b/src/CcDirector.Avalonia/HostedAi/DesktopHostedAiCta.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.HostedAi;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Avalonia.HostedAi;
+
+/// <summary>
+/// The one place the desktop turns a shared <see cref="HostedAiCtaAction"/> into a destination
+/// (issue #940, epic #937). "Add credits" opens the public billing page directly; "Add a key" opens
+/// the Cockpit (where the AI settings live - the desktop has no local AI-settings screen), resolved
+/// through the Gateway front-door the rest of the app already uses. Centralized so every desktop voice
+/// surface routes the same call-to-action to the same place.
+/// </summary>
+public static class DesktopHostedAiCta
+{
+    /// <summary>
+    /// Open the destination for <paramref name="action"/> in the browser. Billing is a direct public
+    /// URL; Settings resolves the Cockpit front-door first (never a localhost URL, matching the rest of
+    /// the app). Best-effort: a resolve/launch failure is logged, never thrown to the click handler.
+    /// </summary>
+    public static async Task InvokeAsync(HostedAiCtaAction action, CancellationToken ct = default)
+    {
+        FileLog.Write($"[DesktopHostedAiCta] InvokeAsync: action={action}");
+        var url = action switch
+        {
+            HostedAiCtaAction.OpenBilling => HostedAiUrls.Billing,
+            HostedAiCtaAction.OpenSettings => await ResolveCockpitUrlAsync(ct).ConfigureAwait(false),
+            _ => null,
+        };
+        OpenUrl(url);
+    }
+
+    /// <summary>
+    /// Resolve the Cockpit front-door URL by asking the configured Gateway (<c>GET {base}/cockpit</c>),
+    /// the same probe the toolbar Cockpit button uses. Returns null when no tailnet URL is available
+    /// (Tailscale down) - the desktop never opens a localhost URL.
+    /// </summary>
+    private static async Task<string?> ResolveCockpitUrlAsync(CancellationToken ct)
+    {
+        var baseUrl = CockpitUrlResolver.ResolveCockpitBase(GatewayConfig.Load());
+        try
+        {
+            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(8) };
+            var info = await http.GetFromJsonAsync<CockpitInfoDto>(baseUrl + "/cockpit", ct).ConfigureAwait(false);
+            return info?.Url;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[DesktopHostedAiCta] could not resolve the Cockpit URL from {baseUrl}: {ex.Message}");
+            return null;
+        }
+    }
+
+    private static void OpenUrl(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            FileLog.Write("[DesktopHostedAiCta] OpenUrl: no URL to open (call-to-action target unavailable)");
+            return;
+        }
+        try
+        {
+            Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[DesktopHostedAiCta] OpenUrl FAILED for {url}: {ex.Message}");
+        }
+    }
+}

--- a/src/CcDirector.Avalonia/HostedAi/DesktopHostedAiGate.cs
+++ b/src/CcDirector.Avalonia/HostedAi/DesktopHostedAiGate.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using CcDirector.Core.Account;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.HostedAi;
+using CcDirector.Core.Transcription;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia.HostedAi;
+
+/// <summary>
+/// The desktop entry point every voice/Wingman/text-to-speech surface uses to gate on hosted-AI
+/// readiness (issue #940, epic #937). It wires the shared <see cref="DirectorHostedAiReadiness"/> to
+/// the desktop's real plumbing and shows the ONE shared unavailable dialog, so every surface pre-flights
+/// and reports a runtime out-of-credits identically - never a per-surface hand-written string.
+/// </summary>
+public static class DesktopHostedAiGate
+{
+    /// <summary>
+    /// Resolve the current hosted-AI state for the configured mode: reads the mode locally, the
+    /// bring-your-own key through the shared resolver, and the balance over HTTP from the Gateway. A
+    /// fresh resolver + client are built per call so the answer reflects the live state (adding $5 or a
+    /// key is picked up on the next check, no restart).
+    /// </summary>
+    public static Task<HostedAiState> CheckAsync(CancellationToken ct = default)
+    {
+        // A short timeout keeps the pre-flight from stalling the UI: a slow/unknown balance falls open to
+        // Ready (the runtime 402 stays the authoritative gate), so the feature is never blocked on a slow
+        // read - only on a definitive out-of-credits / no-key answer, which returns fast.
+        var credits = new GatewayAccountCreditsClient(new HttpClient { Timeout = TimeSpan.FromSeconds(2) });
+        var readiness = DirectorHostedAiReadiness.Create(new OpenAiKeyResolver(), credits);
+        return readiness.CheckAsync(ct);
+    }
+
+    /// <summary>
+    /// Pre-flight gate: returns true when hosted AI is ready (the caller proceeds). When not ready it
+    /// shows the shared unavailable dialog over <paramref name="owner"/> and returns false (the caller
+    /// must NOT record / call). Never throws out of the check to the caller.
+    /// </summary>
+    public static async Task<bool> EnsureReadyAsync(Window owner, CancellationToken ct = default)
+    {
+        HostedAiState state;
+        try
+        {
+            state = await CheckAsync(ct).ConfigureAwait(true);
+        }
+        catch (Exception ex)
+        {
+            // A failed readiness check must not block the feature (the runtime 402 stays the
+            // authoritative gate) - treat an errored pre-flight as "proceed" and let the call decide.
+            FileLog.Write($"[DesktopHostedAiGate] EnsureReadyAsync check FAILED (proceeding): {ex.Message}");
+            return true;
+        }
+
+        if (state == HostedAiState.Ready) return true;
+        await ShowAsync(owner, state).ConfigureAwait(true);
+        return false;
+    }
+
+    /// <summary>
+    /// Map a runtime exception to the shared state and show the dialog when it is an out-of-credits /
+    /// cap condition (a 402 surfaced as <see cref="InsufficientCreditsException"/>). Returns true when it
+    /// handled the exception (the caller then shows nothing else), false when it was an unrelated error
+    /// the caller should surface its own way.
+    /// </summary>
+    public static async Task<bool> TryHandleRuntimeAsync(Window owner, Exception ex)
+    {
+        if (ex is InsufficientCreditsException credits)
+        {
+            var state = HostedAiErrorMapper.MapCode(credits.Code);
+            FileLog.Write($"[DesktopHostedAiGate] runtime out-of-credits mapped to {state}");
+            await ShowAsync(owner, state).ConfigureAwait(true);
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>Show the one shared unavailable dialog for a state over <paramref name="owner"/>.</summary>
+    public static async Task ShowAsync(Window owner, HostedAiState state)
+    {
+        if (owner is null)
+        {
+            FileLog.Write($"[DesktopHostedAiGate] ShowAsync: no owner window for state={state}; nothing shown");
+            return;
+        }
+        await new HostedAiUnavailableDialog(state).ShowDialog(owner).ConfigureAwait(true);
+    }
+}

--- a/src/CcDirector.Avalonia/HostedAiUnavailableDialog.axaml
+++ b/src/CcDirector.Avalonia/HostedAiUnavailableDialog.axaml
@@ -1,0 +1,29 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="CcDirector.Avalonia.HostedAiUnavailableDialog"
+        Title="Voice unavailable"
+        Width="440" SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        Background="#252526">
+
+    <StackPanel Margin="20" Spacing="18">
+        <TextBlock x:Name="MessageText"
+                   Foreground="#CCCCCC"
+                   FontSize="14"
+                   TextWrapping="Wrap" />
+
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
+            <Button x:Name="CloseButton" Content="Close" MinWidth="80" Height="28"
+                    Click="BtnClose_Click"
+                    Background="#3A3D41" Foreground="#CCCCCC"
+                    BorderThickness="0"
+                    Cursor="Hand" />
+            <Button x:Name="CtaButton" MinWidth="110" Height="28"
+                    Click="BtnCta_Click"
+                    Background="#007ACC" Foreground="White"
+                    BorderThickness="0"
+                    Cursor="Hand" />
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/src/CcDirector.Avalonia/HostedAiUnavailableDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/HostedAiUnavailableDialog.axaml.cs
@@ -1,0 +1,52 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using CcDirector.Avalonia.HostedAi;
+using CcDirector.Core.HostedAi;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia;
+
+/// <summary>
+/// The single shared modal every desktop voice/Wingman/text-to-speech surface shows when hosted AI is
+/// unavailable (issue #940, epic #937): the ONE message from <see cref="HostedAiMessages"/> for the
+/// resolved <see cref="HostedAiState"/> plus its call-to-action button ("Add credits" -> billing, or
+/// "Add a key" -> Cockpit settings). Using one dialog everywhere makes the desktop message identical by
+/// construction with the phone and web, instead of a per-surface hand-written error string.
+/// </summary>
+public partial class HostedAiUnavailableDialog : Window
+{
+    private readonly HostedAiCtaAction _ctaAction;
+
+    /// <summary>Parameterless constructor for the Avalonia designer/loader only.</summary>
+    public HostedAiUnavailableDialog() : this(HostedAiState.NeedsCredits) { }
+
+    /// <summary>Build the dialog for a specific unavailable state, filling the shared copy + call-to-action.</summary>
+    public HostedAiUnavailableDialog(HostedAiState state)
+    {
+        InitializeComponent();
+        var message = HostedAiMessages.For(state);
+        _ctaAction = message.CtaAction;
+        MessageText.Text = message.Text;
+        CtaButton.Content = string.IsNullOrWhiteSpace(message.CtaLabel) ? "OK" : message.CtaLabel;
+        // A state with no call-to-action (should not happen for the unavailable states) hides the button.
+        CtaButton.IsVisible = message.CtaAction != HostedAiCtaAction.None;
+        FileLog.Write($"[HostedAiUnavailableDialog] shown for state={state}, cta={message.CtaAction}");
+    }
+
+    private async void BtnCta_Click(object? sender, RoutedEventArgs e)
+    {
+        // Entry point (click handler): the try-catch lives here; the opener itself never throws out.
+        try
+        {
+            await DesktopHostedAiCta.InvokeAsync(_ctaAction).ConfigureAwait(true);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[HostedAiUnavailableDialog] BtnCta_Click FAILED: {ex.Message}");
+        }
+        Close(true);
+    }
+
+    private void BtnClose_Click(object? sender, RoutedEventArgs e) => Close(false);
+}

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -10,6 +10,8 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Threading;
+using CcDirector.Avalonia.HostedAi;
+using CcDirector.Core.HostedAi;
 using Avalonia.VisualTree;
 using CcDirector.ControlApi;
 using CcDirector.Core.Account;
@@ -4395,6 +4397,14 @@ public partial class MainWindow : Window
     // We watch the session's ActivityState directly (in-process, no double-send): we
     // first wait for it to ENTER Working so a fast poll cannot read the PREVIOUS
     // reply, then wait for it to leave Working into a stopping state.
+    /// <summary>
+    /// Read-aloud (text-to-speech) on the Voice tab ran dry (issue #940): show the ONE shared
+    /// add-credits dialog instead of the failure being logged and silently swallowed. Queued on the UI
+    /// thread so the modal shows after the current text-to-speech call unwinds.
+    /// </summary>
+    private void VoiceUnavailable(HostedAiState state)
+        => Dispatcher.UIThread.Post(() => { _ = DesktopHostedAiGate.ShowAsync(this, state); });
+
     private async Task FollowAgentTurnAndSpeakAsync(SessionViewModel vm)
     {
         var app = global::Avalonia.Application.Current as App;
@@ -4445,7 +4455,7 @@ public partial class MainWindow : Window
         if (!string.IsNullOrWhiteSpace(spoken) && _ttsPlayer is not null)
         {
             VoiceView.SetStatus("Speaking...", "#2B6CB0");
-            await _ttsPlayer.SpeakAsync(spoken);
+            await _ttsPlayer.SpeakAsync(spoken, onUnavailable: VoiceUnavailable);
         }
         VoiceView.SetStatus("Ready", "#5FD08A");
     }
@@ -4484,7 +4494,7 @@ public partial class MainWindow : Window
             if (_ttsPlayer is not null)
             {
                 VoiceView.SetStatus("Speaking...", "#2B6CB0");
-                await _ttsPlayer.SpeakAsync(answer);
+                await _ttsPlayer.SpeakAsync(answer, onUnavailable: VoiceUnavailable);
             }
             VoiceView.SetStatus("Ready", "#5FD08A");
         }

--- a/src/CcDirector.Avalonia/Voice/DesktopTtsPlayer.cs
+++ b/src/CcDirector.Avalonia/Voice/DesktopTtsPlayer.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using CcDirector.Core.Configuration;
+using CcDirector.Core.HostedAi;
 using CcDirector.Core.Utilities;
 using CcDirector.Core.Voice;
 using NAudio.Wave;
@@ -49,7 +50,11 @@ public sealed class DesktopTtsPlayer : IDisposable
     /// take down the caller's turn - but the bool lets a caller (e.g. the playback
     /// dialog) surface the failure instead of closing as if it had spoken.
     /// </summary>
-    public async Task<bool> SpeakAsync(string text, CancellationToken ct = default)
+    /// <param name="onUnavailable">Issue #940: invoked (with the shared state) when generation failed
+    /// because hosted AI is out of credits / capped - so the caller can surface the ONE add-credits
+    /// message instead of the failure being logged and silently swallowed. Not called for ordinary
+    /// generation failures (no key, network), which stay quiet as before.</param>
+    public async Task<bool> SpeakAsync(string text, CancellationToken ct = default, Action<HostedAiState>? onUnavailable = null)
     {
         if (string.IsNullOrWhiteSpace(text)) return false;
 
@@ -58,6 +63,10 @@ public sealed class DesktopTtsPlayer : IDisposable
         if (!result.Success || result.AudioBytes is null)
         {
             FileLog.Write($"[DesktopTtsPlayer] TTS not played: status={result.Status} error={result.ErrorMessage}");
+            // A 402 carries the machine code as its status (issue #940): map it to the shared state and
+            // hand it to the caller so read-aloud out-of-credits is no longer a silent nothing.
+            if (onUnavailable is not null && IsOutOfCreditsStatus(result.Status))
+                onUnavailable(HostedAiErrorMapper.MapCode(result.Status));
             return false;
         }
 
@@ -92,6 +101,11 @@ public sealed class DesktopTtsPlayer : IDisposable
 
         return true;
     }
+
+    /// <summary>True when a failed generation's status is one of the out-of-credits / cap codes a 402
+    /// carries (issue #940), so the shared add-credits state should be surfaced.</summary>
+    private static bool IsOutOfCreditsStatus(string? status) =>
+        status == HostedAiErrorMapper.InsufficientCreditsCode || status == HostedAiErrorMapper.MonthlyLimitReachedCode;
 
     /// <summary>Stop any in-progress playback immediately.</summary>
     public void Stop()

--- a/src/CcDirector.Avalonia/Voice/SpeakDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/Voice/SpeakDialog.axaml.cs
@@ -4,7 +4,10 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Threading;
+using CcDirector.Avalonia.HostedAi;
 using CcDirector.Core.Configuration;
+using CcDirector.Core.HostedAi;
+using CcDirector.Core.Transcription;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Avalonia.Voice;
@@ -177,6 +180,18 @@ public partial class SpeakDialog : Window
         _eqTimer.Start();
         try
         {
+            // Pre-flight (issue #940): do NOT record into a dead feature. If hosted AI is not ready
+            // (out of credits, or no bring-your-own key), close without recording and show the ONE
+            // shared "add credits / add a key" dialog over the owner instead of a raw failure later.
+            var state = await DesktopHostedAiGate.CheckAsync();
+            if (state != HostedAiState.Ready)
+            {
+                FileLog.Write($"[SpeakDialog] pre-flight not ready ({state}); not recording");
+                await DesktopHostedAiGate.ShowAsync(this, state);
+                Close();
+                return;
+            }
+
             // Resolve the saved mic choice to a current device index BEFORE the
             // first capture starts, so we record from the right device from the
             // very first frame. Then show the device list in the selector.
@@ -515,8 +530,27 @@ public partial class SpeakDialog : Window
         catch (Exception ex)
         {
             FileLog.Write($"[SpeakDialog] FinalizeFromRecording FAILED: {ex.Message}");
+            if (await TryShowOutOfCreditsAsync(ex)) return;
             SwitchToFailed(ex.Message);
         }
+    }
+
+    /// <summary>
+    /// If the transcription failed because hosted AI ran out of credits (a 402 surfaced as
+    /// <see cref="InsufficientCreditsException"/>), show the ONE shared "add credits" dialog and close -
+    /// instead of dumping the raw "Transcription returned 402: ..." string into the transcript box
+    /// (issue #940). Returns true when it handled the exception. Any other error falls through to the
+    /// existing failed state.
+    /// </summary>
+    private async Task<bool> TryShowOutOfCreditsAsync(Exception ex)
+    {
+        if (ex is InsufficientCreditsException credits)
+        {
+            await DesktopHostedAiGate.ShowAsync(this, HostedAiErrorMapper.MapCode(credits.Code));
+            Close();
+            return true;
+        }
+        return false;
     }
 
     /// <summary>
@@ -542,6 +576,7 @@ public partial class SpeakDialog : Window
         catch (Exception ex)
         {
             FileLog.Write($"[SpeakDialog] PauseAsync FAILED: {ex.Message}");
+            if (await TryShowOutOfCreditsAsync(ex)) return;
             SwitchToFailed("Pause failed: " + ex.Message);
         }
     }

--- a/src/CcDirector.Core.Tests/Account/GatewayAccountCreditsClientTests.cs
+++ b/src/CcDirector.Core.Tests/Account/GatewayAccountCreditsClientTests.cs
@@ -1,0 +1,151 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using CcDirector.Core.Account;
+using CcDirector.Core.Configuration;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Account;
+
+/// <summary>
+/// Proves the Director-side read-only Gateway credits client (issue #940, epic #937). It reads
+/// <c>GET {gateway.url}/account/credits</c> with the optional Bearer token and surfaces the balance the
+/// desktop hosted-AI readiness check gates on. Because the desktop must never block on an unreadable
+/// balance, a signed-out / unreachable / erroring Gateway is reported as an unknown balance (null),
+/// never thrown. Every test injects a fake handler so no real network call is made.
+/// </summary>
+public sealed class GatewayAccountCreditsClientTests
+{
+    private const string GatewayUrl = "http://127.0.0.1:7878";
+
+    [Fact]
+    public async Task GetCreditsAsync_NoGatewayUrl_ReturnsNotConfigured_AndMakesNoCall()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK, "{}");
+        var client = new GatewayAccountCreditsClient(new HttpClient(handler));
+
+        var credits = await client.GetCreditsAsync(new GatewayConfig { Url = "" });
+
+        Assert.False(credits.GatewayConfigured);
+        Assert.Null(credits.BalanceMicros);       // unknown
+        Assert.Null(handler.Request);              // no network call when no Gateway is configured
+    }
+
+    [Fact]
+    public async Task GetCreditsAsync_SignedIn_ReadsBalance_AndSendsBearer()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK, "{\"signedIn\":true,\"balanceMicros\":5000000,\"lastDebitMicros\":1200}");
+        var client = new GatewayAccountCreditsClient(new HttpClient(handler));
+
+        var credits = await client.GetCreditsAsync(new GatewayConfig { Url = GatewayUrl, Token = "tok-123" });
+
+        Assert.True(credits.GatewayConfigured);
+        Assert.True(credits.Reachable);
+        Assert.True(credits.SignedIn);
+        Assert.Equal(5_000_000, credits.BalanceMicros);
+        Assert.Null(credits.Error);
+
+        Assert.Equal(HttpMethod.Get, handler.Request!.Method);
+        Assert.Equal($"{GatewayUrl}/account/credits", handler.Request.RequestUri!.ToString());
+        Assert.Equal("Bearer", handler.Request.Headers.Authorization!.Scheme);
+        Assert.Equal("tok-123", handler.Request.Headers.Authorization.Parameter);
+    }
+
+    [Fact]
+    public async Task GetCreditsAsync_SignedInZeroBalance_ReturnsZero_NotNull()
+    {
+        // A real zero balance (out of credits) is a KNOWN value the readiness check must gate on -
+        // distinct from unknown/null.
+        var handler = new CapturingHandler(HttpStatusCode.OK, "{\"signedIn\":true,\"balanceMicros\":0}");
+        var client = new GatewayAccountCreditsClient(new HttpClient(handler));
+
+        var credits = await client.GetCreditsAsync(new GatewayConfig { Url = GatewayUrl });
+
+        Assert.True(credits.SignedIn);
+        Assert.Equal(0, credits.BalanceMicros);
+    }
+
+    [Fact]
+    public async Task GetCreditsAsync_SignedOut_BalanceUnknown()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK, "{\"signedIn\":false}");
+        var client = new GatewayAccountCreditsClient(new HttpClient(handler));
+
+        var credits = await client.GetCreditsAsync(new GatewayConfig { Url = GatewayUrl });
+
+        Assert.True(credits.Reachable);
+        Assert.False(credits.SignedIn);
+        Assert.Null(credits.BalanceMicros);   // never a fabricated zero when signed out
+    }
+
+    [Fact]
+    public async Task GetCreditsAsync_NoToken_SendsNoAuthorizationHeader()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK, "{\"signedIn\":false}");
+        var client = new GatewayAccountCreditsClient(new HttpClient(handler));
+
+        await client.GetCreditsAsync(new GatewayConfig { Url = GatewayUrl });
+
+        Assert.Null(handler.Request!.Headers.Authorization);
+    }
+
+    [Fact]
+    public async Task GetCreditsAsync_NonSuccess_BalanceUnknown_WithReason_DoesNotThrow()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.BadGateway, "{\"error\":\"cloud unreachable\"}");
+        var client = new GatewayAccountCreditsClient(new HttpClient(handler));
+
+        var credits = await client.GetCreditsAsync(new GatewayConfig { Url = GatewayUrl });
+
+        Assert.True(credits.GatewayConfigured);
+        Assert.False(credits.Reachable);
+        Assert.Null(credits.BalanceMicros);
+        Assert.NotNull(credits.Error);
+        Assert.Contains("502", credits.Error);
+    }
+
+    [Fact]
+    public async Task GetCreditsAsync_TransportFailure_BalanceUnknown_DoesNotThrow()
+    {
+        var client = new GatewayAccountCreditsClient(new HttpClient(new ThrowingHandler()));
+
+        var credits = await client.GetCreditsAsync(new GatewayConfig { Url = GatewayUrl });
+
+        Assert.False(credits.Reachable);
+        Assert.Null(credits.BalanceMicros);
+        Assert.NotNull(credits.Error);
+    }
+
+    [Fact]
+    public async Task GetCreditsAsync_TrailingSlashUrl_DoesNotDoubleSlash()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK, "{\"signedIn\":false}");
+        var client = new GatewayAccountCreditsClient(new HttpClient(handler));
+
+        await client.GetCreditsAsync(new GatewayConfig { Url = GatewayUrl + "/" });
+
+        Assert.Equal($"{GatewayUrl}/account/credits", handler.Request!.RequestUri!.ToString());
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly string _responseBody;
+        public CapturingHandler(HttpStatusCode status, string responseBody) { _status = status; _responseBody = responseBody; }
+        public HttpRequestMessage? Request { get; private set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Request = request;
+            return Task.FromResult(new HttpResponseMessage(_status)
+            {
+                Content = new StringContent(_responseBody, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            throw new HttpRequestException("connection refused");
+    }
+}

--- a/src/CcDirector.Core.Tests/HostedAi/DirectorHostedAiReadinessTests.cs
+++ b/src/CcDirector.Core.Tests/HostedAi/DirectorHostedAiReadinessTests.cs
@@ -1,0 +1,86 @@
+using CcDirector.Core.Configuration;
+using CcDirector.Core.HostedAi;
+using Xunit;
+
+namespace CcDirector.Core.Tests.HostedAi;
+
+/// <summary>
+/// Issue #940 (epic #937): the Director/desktop readiness helper. It gathers the mode locally, the
+/// bring-your-own key via the resolver, and the balance over HTTP, then defers to the shared
+/// <see cref="HostedAiReadiness"/> - so the desktop resolves the identical state the Gateway does. These
+/// prove it consults only the input the mode needs and maps each combination correctly, including the
+/// add-credits-without-restart flow.
+/// </summary>
+public sealed class DirectorHostedAiReadinessTests
+{
+    private static DirectorHostedAiReadiness Build(
+        TranscriptionMode mode,
+        string? key = null,
+        long? balanceMicros = null,
+        Action? onKeyFetch = null,
+        Action? onBalanceFetch = null)
+        => new(
+            () => mode,
+            _ => { onKeyFetch?.Invoke(); return Task.FromResult(key); },
+            _ => { onBalanceFetch?.Invoke(); return Task.FromResult(balanceMicros); });
+
+    [Fact]
+    public async Task Byo_NoKey_NeedsKey()
+        => Assert.Equal(HostedAiState.NeedsKey, await Build(TranscriptionMode.Byo, key: null).CheckAsync());
+
+    [Fact]
+    public async Task Byo_WithKey_Ready()
+        => Assert.Equal(HostedAiState.Ready, await Build(TranscriptionMode.Byo, key: "sk-abc").CheckAsync());
+
+    [Fact]
+    public async Task Byo_DoesNotFetchBalance()
+    {
+        var balanceFetched = false;
+        await Build(TranscriptionMode.Byo, key: "sk-abc", onBalanceFetch: () => balanceFetched = true).CheckAsync();
+        Assert.False(balanceFetched); // bring-your-own never needs the balance
+    }
+
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(-1L)]
+    public async Task DevThrottle_EmptyBalance_NeedsCredits(long balance)
+        => Assert.Equal(HostedAiState.NeedsCredits, await Build(TranscriptionMode.DevThrottle, balanceMicros: balance).CheckAsync());
+
+    [Fact]
+    public async Task DevThrottle_PositiveBalance_Ready()
+        => Assert.Equal(HostedAiState.Ready, await Build(TranscriptionMode.DevThrottle, balanceMicros: 5_000_000).CheckAsync());
+
+    [Fact]
+    public async Task DevThrottle_UnknownBalance_DoesNotBlock_Ready()
+        => Assert.Equal(HostedAiState.Ready, await Build(TranscriptionMode.DevThrottle, balanceMicros: null).CheckAsync());
+
+    [Fact]
+    public async Task DevThrottle_DoesNotFetchKey()
+    {
+        var keyFetched = false;
+        await Build(TranscriptionMode.DevThrottle, balanceMicros: 5_000_000, onKeyFetch: () => keyFetched = true).CheckAsync();
+        Assert.False(keyFetched); // DevThrottle gates on balance, not the bring-your-own key
+    }
+
+    [Fact]
+    public async Task DevThrottle_AddCredits_UnlocksWithoutRestart()
+    {
+        long balance = 0;
+        var check = new DirectorHostedAiReadiness(
+            () => TranscriptionMode.DevThrottle,
+            _ => Task.FromResult<string?>(null),
+            _ => Task.FromResult<long?>(balance));
+
+        Assert.Equal(HostedAiState.NeedsCredits, await check.CheckAsync());
+        balance = 5_000_000; // user adds $5
+        Assert.Equal(HostedAiState.Ready, await check.CheckAsync());
+    }
+
+    [Fact]
+    public void Constructor_NullDelegates_Throw()
+    {
+        Assert.Throws<ArgumentNullException>(() => new DirectorHostedAiReadiness(null!, _ => Task.FromResult<string?>(null), _ => Task.FromResult<long?>(0)));
+        Assert.Throws<ArgumentNullException>(() => new DirectorHostedAiReadiness(() => TranscriptionMode.Byo, null!, _ => Task.FromResult<long?>(0)));
+        Assert.Throws<ArgumentNullException>(() => new DirectorHostedAiReadiness(() => TranscriptionMode.Byo, _ => Task.FromResult<string?>(null), null!));
+    }
+}

--- a/src/CcDirector.Core/Account/GatewayAccountCreditsClient.cs
+++ b/src/CcDirector.Core/Account/GatewayAccountCreditsClient.cs
@@ -1,0 +1,117 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Core.Account;
+
+/// <summary>
+/// The outcome of reading the signed-in account's credit balance from the Director side (issue #940,
+/// epic #937). The account token lives only on the Gateway, so the desktop cannot read the balance
+/// itself - it asks the Gateway over HTTP (<c>GET /account/credits</c>). The balance is the hosted-AI
+/// readiness gate for DevThrottle mode: the desktop's voice/Wingman/text-to-speech surfaces consult it
+/// before recording so an out-of-credits user sees the consistent add-credits message.
+///
+/// <see cref="BalanceMicros"/> is null when the balance is UNKNOWN (no Gateway configured, signed out,
+/// or the Gateway/cloud is unreachable). The pre-flight readiness check must NOT block on an unknown
+/// balance - the authoritative gate remains the runtime 402 - so this is a non-blocking informational
+/// read reported as a value, never thrown.
+/// </summary>
+/// <param name="GatewayConfigured">Whether a Gateway URL is configured at all (config.json gateway.url).</param>
+/// <param name="Reachable">Whether the Gateway answered the credits request.</param>
+/// <param name="SignedIn">Whether the Gateway holds a valid DevThrottle credential.</param>
+/// <param name="BalanceMicros">The balance in micro-dollars when known, else null (unknown - do not block).</param>
+/// <param name="Error">A short human-readable reason when not reachable, or null on success.</param>
+public sealed record GatewayAccountCredits(
+    bool GatewayConfigured,
+    bool Reachable,
+    bool SignedIn,
+    long? BalanceMicros,
+    string? Error)
+{
+    /// <summary>The state for a Director that has no Gateway URL configured (balance unknown).</summary>
+    public static GatewayAccountCredits NotConfigured() =>
+        new(GatewayConfigured: false, Reachable: false, SignedIn: false, BalanceMicros: null, Error: null);
+}
+
+/// <summary>
+/// A small read-only Director-to-Gateway client for the signed-in account's credit balance (issue #940).
+/// It reads <c>GET {gateway.url}/account/credits</c> (issue #884) and returns the balance the desktop
+/// hosted-AI readiness check gates on. The account token lives on the Gateway, so the Director only ever
+/// READS this - it never holds a token of its own; the response contract (<see cref="AccountCreditsDto"/>)
+/// carries no token field by design (DT-05).
+///
+/// Mirrors <see cref="GatewayAccountStatusClient"/>: the Gateway URL + optional bearer token come from
+/// <see cref="GatewayConfig"/>, the token is sent only as the <c>Authorization: Bearer</c> header and is
+/// never logged, and any failure is reported as a result value (balance unknown, with a short reason)
+/// rather than thrown - the desktop must not block on an unreadable balance.
+/// </summary>
+public sealed class GatewayAccountCreditsClient
+{
+    private readonly HttpClient _http;
+
+    /// <summary><paramref name="http"/> defaults to a short-timeout client; tests inject a stub.</summary>
+    public GatewayAccountCreditsClient(HttpClient? http = null)
+    {
+        _http = http ?? new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+    }
+
+    /// <summary>
+    /// Reads the balance from <c>GET {config.Url}/account/credits</c>. Returns
+    /// <see cref="GatewayAccountCredits.NotConfigured"/> (no network call) when no Gateway URL is set;
+    /// otherwise a result carrying the balance when signed in, or a null balance with a short reason
+    /// when signed out, unreachable, or erroring. Never throws out to the UI (except a real cancel).
+    /// </summary>
+    public async Task<GatewayAccountCredits> GetCreditsAsync(GatewayConfig config, CancellationToken ct = default)
+    {
+        if (config is null)
+            throw new ArgumentNullException(nameof(config));
+
+        if (!config.IsEnabled)
+        {
+            FileLog.Write("[GatewayAccountCreditsClient] GetCreditsAsync: no gateway.url configured -> balance unknown");
+            return GatewayAccountCredits.NotConfigured();
+        }
+
+        var endpoint = $"{config.Url.TrimEnd('/')}/account/credits";
+        FileLog.Write($"[GatewayAccountCreditsClient] GetCreditsAsync: GET {endpoint}");
+
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
+            if (!string.IsNullOrEmpty(config.Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", config.Token);
+
+            using var response = await _http.SendAsync(request, ct).ConfigureAwait(false);
+            FileLog.Write($"[GatewayAccountCreditsClient] GetCreditsAsync: response status={(int)response.StatusCode}");
+
+            if (!response.IsSuccessStatusCode)
+                return new GatewayAccountCredits(GatewayConfigured: true, Reachable: false, SignedIn: false,
+                    BalanceMicros: null, Error: $"The Gateway answered HTTP {(int)response.StatusCode}.");
+
+            var dto = await response.Content.ReadFromJsonAsync<AccountCreditsDto>(ct).ConfigureAwait(false);
+            if (dto is null)
+                return new GatewayAccountCredits(GatewayConfigured: true, Reachable: false, SignedIn: false,
+                    BalanceMicros: null, Error: "The Gateway returned an empty credits response.");
+
+            // Signed out -> balance genuinely unknown (never a fabricated zero). Signed in -> the balance
+            // the readiness check gates on (null when the cloud omitted it, still treated as unknown).
+            var balance = dto.SignedIn ? dto.BalanceMicros : null;
+            FileLog.Write($"[GatewayAccountCreditsClient] GetCreditsAsync: signedIn={dto.SignedIn}, balanceMicros={(balance is null ? "unknown" : balance.ToString())}");
+            return new GatewayAccountCredits(GatewayConfigured: true, Reachable: true, SignedIn: dto.SignedIn,
+                BalanceMicros: balance, Error: null);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayAccountCreditsClient] GetCreditsAsync: could not reach the Gateway: {ex.Message}");
+            return new GatewayAccountCredits(GatewayConfigured: true, Reachable: false, SignedIn: false,
+                BalanceMicros: null, Error: $"Could not reach the Gateway at {config.Url}.");
+        }
+    }
+}

--- a/src/CcDirector.Core/HostedAi/DirectorHostedAiReadiness.cs
+++ b/src/CcDirector.Core/HostedAi/DirectorHostedAiReadiness.cs
@@ -1,0 +1,75 @@
+using CcDirector.Core.Account;
+using CcDirector.Core.Configuration;
+
+namespace CcDirector.Core.HostedAi;
+
+/// <summary>
+/// The Director/desktop-side hosted-AI readiness check (issue #940, epic #937). The desktop app runs
+/// transcription and text-to-speech in-process, so - unlike the Gateway - it must gather the readiness
+/// inputs itself: the mode from local config, the bring-your-own key through the same resolver its
+/// voice surfaces already use, and the account balance over HTTP from the Gateway (the account token is
+/// Gateway-only, so the balance cannot be read locally).
+///
+/// It does NOT re-implement the decision - it gathers the three inputs (async: the key and balance are
+/// I/O) and feeds them to the one shared, unit-tested <see cref="HostedAiReadiness"/>, so the desktop
+/// resolves the identical <see cref="HostedAiState"/> the Gateway does. An unknown balance (signed out /
+/// Gateway unreachable) does NOT block - the runtime 402 stays the authoritative gate - matching the
+/// foundation's contract.
+/// </summary>
+public sealed class DirectorHostedAiReadiness
+{
+    private readonly Func<TranscriptionMode> _modeProvider;
+    private readonly Func<CancellationToken, Task<string?>> _byoKeyProvider;
+    private readonly Func<CancellationToken, Task<long?>> _balanceMicrosProvider;
+
+    /// <param name="modeProvider">Supplies the current mode (local config, read fresh per check).</param>
+    /// <param name="byoKeyProvider">Resolves the bring-your-own OpenAI key (local vault or the Gateway),
+    /// returning null/empty when none is set. Only consulted in bring-your-own mode.</param>
+    /// <param name="balanceMicrosProvider">Reads the account balance in micro-dollars over HTTP, null when
+    /// unknown (signed out / unreachable - do not block). Only consulted in DevThrottle mode.</param>
+    public DirectorHostedAiReadiness(
+        Func<TranscriptionMode> modeProvider,
+        Func<CancellationToken, Task<string?>> byoKeyProvider,
+        Func<CancellationToken, Task<long?>> balanceMicrosProvider)
+    {
+        _modeProvider = modeProvider ?? throw new ArgumentNullException(nameof(modeProvider));
+        _byoKeyProvider = byoKeyProvider ?? throw new ArgumentNullException(nameof(byoKeyProvider));
+        _balanceMicrosProvider = balanceMicrosProvider ?? throw new ArgumentNullException(nameof(balanceMicrosProvider));
+    }
+
+    /// <summary>
+    /// Wire the real desktop plumbing: the mode from <see cref="TranscriptionModeConfig"/>, the key from
+    /// the shared <see cref="OpenAiKeyResolver"/> (the same one the voice surfaces use), and the balance
+    /// from <see cref="GatewayAccountCreditsClient"/> against the configured Gateway.
+    /// </summary>
+    public static DirectorHostedAiReadiness Create(
+        OpenAiKeyResolver keyResolver,
+        GatewayAccountCreditsClient creditsClient,
+        Func<GatewayConfig>? gatewayProvider = null,
+        Func<TranscriptionMode>? modeProvider = null)
+    {
+        if (keyResolver is null) throw new ArgumentNullException(nameof(keyResolver));
+        if (creditsClient is null) throw new ArgumentNullException(nameof(creditsClient));
+        var gateway = gatewayProvider ?? GatewayConfig.Load;
+
+        return new DirectorHostedAiReadiness(
+            modeProvider ?? TranscriptionModeConfig.Get,
+            ct => keyResolver.ResolveAsync(ct),
+            async ct => (await creditsClient.GetCreditsAsync(gateway(), ct)).BalanceMicros);
+    }
+
+    /// <summary>
+    /// Resolve whether hosted AI can run for the configured mode right now. Gathers the mode, and only
+    /// the input the mode needs (the key in bring-your-own mode, the balance in DevThrottle mode), then
+    /// defers the decision to the shared <see cref="HostedAiReadiness"/>.
+    /// </summary>
+    public async Task<HostedAiState> CheckAsync(CancellationToken ct = default)
+    {
+        var mode = _modeProvider();
+        var key = mode == TranscriptionMode.Byo ? await _byoKeyProvider(ct).ConfigureAwait(false) : null;
+        var balance = mode == TranscriptionMode.DevThrottle ? await _balanceMicrosProvider(ct).ConfigureAwait(false) : (long?)null;
+
+        var readiness = new HostedAiReadiness(() => mode, _ => key, _ => Task.FromResult(balance));
+        return await readiness.CheckAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/src/CcDirector.Core/Voice/TtsService.cs
+++ b/src/CcDirector.Core/Voice/TtsService.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using CcDirector.Core.Configuration;
+using CcDirector.Core.HostedAi;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Core.Voice;
@@ -296,7 +297,13 @@ public sealed class TtsService
                 var body = await resp.Content.ReadAsStringAsync(requestCts.Token);
                 var status = (int)resp.StatusCode;
                 FileLog.Write($"[TtsService] chunk {chunkIndex} attempt {attempt} OpenAI returned {status}: {Truncate(body, 400)}");
-                // 5xx is transient (server-side, worth a retry); 4xx is a
+                // Out of credits / monthly cap (issue #940): carry the machine-readable code as the
+                // status so the desktop player maps it to the ONE shared state and surfaces the
+                // add-credits message, instead of swallowing a generic "openai_failed" silently. Not
+                // transient - retrying an out-of-credits call is pointless.
+                if (status == 402)
+                    return TtsResult.Error(HostedAiErrorMapper.ParseErrorCode(body), $"text-to-speech returned 402: {Truncate(body, 300)}", transient: false);
+                // 5xx is transient (server-side, worth a retry); other 4xx is a
                 // permanent request error and must not be retried.
                 var transient = status >= 500;
                 return TtsResult.Error("openai_failed", $"OpenAI returned {status}: {Truncate(body, 300)}", transient);


### PR DESCRIPTION
Part of epic thefrederiksen/devthrottle_internal#661. Wires every native desktop (Avalonia) voice/Wingman/read-aloud surface to the ONE shared "add credits / add a key" message + call-to-action, so an out-of-credits or no-key user gets the consistent dialog instead of a raw 402 string or a silent nothing.

## Plumbing (the desktop could not see its balance before)
- GatewayAccountCreditsClient: reads the balance over HTTP (GET /account/credits); unknown balance does not block.
- DirectorHostedAiReadiness: gathers mode + bring-your-own key + balance, then defers to the shared HostedAiReadiness so the desktop resolves the identical state as the Gateway.

## Shared UI
- HostedAiUnavailableDialog: the one modal every surface shows (message from HostedAiMessages).
- DesktopHostedAiGate: pre-flight + runtime-402 entry point each surface calls.
- DesktopHostedAiCta: Add credits -> billing; Add a key -> Cockpit settings.

## Surfaces
- A7 SpeakDialog: pre-flight before recording; runtime out-of-credits shows the shared dialog, not the raw "Transcription returned 402".
- B7 FifoWindow: the bring-your-own-only key gate replaced by the shared readiness gate (covers out-of-credits); runtime + read-aloud 402 show the shared dialog.
- B6 Voice tab read-aloud: text-to-speech 402 surfaces the shared dialog.
- C4 TtsService/DesktopTtsPlayer: 402 carries the code and is surfaced (no longer silently swallowed).
- C5 OpenAiTtsService: not reached by any desktop surface; out of scope.

## Verification
dotnet build cc-director.sln -> 0/0. Core.Tests plumbing 18/18; HostedAi+Tts filter 98/98 (no regression). Message consistency by construction (one dialog + HostedAiMessages). Native live-state checklist in the proof report.

Proof: docs/cencon/proof/issue-940/report.html

Closes thefrederiksen/devthrottle#940 (part of thefrederiksen/devthrottle_internal#661).

CTA behavior (owner-confirmed default): the desktop buttons open the browser (billing / Cockpit settings), since the desktop has no local AI-settings screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)