### PR TITLE
Consistent credits/key gating on the web voice surfaces (#941)

### DIFF
--- a/docs/cencon/proof/issue-941/report.html
+++ b/docs/cencon/proof/issue-941/report.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Issue #941 - Credits/key gating on the web voice surfaces - Proof</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: Georgia, "Times New Roman", serif; max-width: 62rem; margin: 2rem auto; padding: 0 1.25rem; line-height: 1.55; }
+  h1 { font-size: 1.5rem; border-bottom: 2px solid #888; padding-bottom: .4rem; }
+  h2 { font-size: 1.15rem; margin-top: 2rem; border-bottom: 1px solid #ccc; padding-bottom: .2rem; }
+  code, pre { font-family: Consolas, "Courier New", monospace; }
+  pre { background: rgba(128,128,128,.12); padding: .8rem 1rem; overflow-x: auto; border-radius: 4px; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #999; padding: .45rem .6rem; text-align: left; vertical-align: top; font-size: .92rem; }
+  th { background: rgba(128,128,128,.18); }
+  .pass { font-weight: bold; }
+  .muted { color: #777; font-size: .9rem; }
+</style>
+</head>
+<body>
+
+<h1>Issue #941 - Consistent credits/key gating on the web (Cockpit + Director web) voice surfaces</h1>
+<p class="muted">Part of epic #937. Branch <code>issue-941-web-credits-gating</code>. Foundation #938 + gateway #939 + desktop #940 already on main.</p>
+
+<h2>Approach</h2>
+<p>The web surfaces display the server's error field raw, so the highest-leverage fix is server-side: every Director endpoint the web calls now maps a hosted-proxy 402 to the ONE shared payload, whose <code>error</code> field mirrors the shared message text. That makes the correct "Voice needs credit. Add $5..." message appear by construction; the two surfaces that previously HID the failure got a small client fix.</p>
+
+<h2>What was implemented</h2>
+<table>
+  <tr><th>File</th><th>Change</th></tr>
+  <tr><td><code>Core/HostedAi/HostedAiPayload.cs</code> (new)</td><td>The single wire shape (pure, no ASP.NET) shared by the Gateway, the Control API, and the WebSocket frame; <code>error</code> mirrors the shared text; JSON names pinned.</td></tr>
+  <tr><td><code>Gateway/HostedAi/HostedAiHttp.cs</code></td><td>Refactored to build the 402 from <code>HostedAiPayload</code> - Gateway and Control API now return the identical body (behavior-identical to #939).</td></tr>
+  <tr><td><code>ControlApi/DictationEndpoint.cs</code> (A1/A2)</td><td>The <code>/dictate</code> WebSocket now sends the shared message + <code>hostedAi</code> payload on out-of-credits, instead of "transcription failed: ...402...".</td></tr>
+  <tr><td><code>Core/Voice/VoiceService.cs</code> + <code>ControlApi/ControlEndpoints.cs</code> (A3)</td><td>The Voice-tab transcription (<code>/voice/utterance/complete</code>) carries the 402 code and returns the shared 402 payload; the client (session-view) shows the shared message.</td></tr>
+  <tr><td><code>ControlApi/ControlEndpoints.cs</code> + <code>Web/session-view.html</code> (C3)</td><td>Director <code>/tts</code> returns the shared 402; the web player shows the message instead of silently falling back to the robotic browser voice.</td></tr>
+</table>
+
+<h2>Coverage note (honest scope)</h2>
+<p>Wired the real credits-bearing web surfaces: dictation (A1 Cockpit composer + A2 session-view composer, both via <code>/dictate</code>), Voice-tab transcription (A3), and Director-web read-aloud (C3). <b>Not wired:</b> B4 (Cockpit <code>voice.js</code> wmAsk) and B5 (Cockpit Learning "Ask Wingman") - both call the warm <code>claude.exe</code> wingman, NOT the hosted credit proxy, so they never produce a real out-of-credits 402 (the map confirmed this). Their dictation input still flows through <code>/dictate</code>, which IS covered. The old Blazor Cockpit is still live (the React <code>apps/cockpit</code> is a placeholder stub), so wiring it was worthwhile.</p>
+
+<h2>Verification</h2>
+<pre>dotnet build cc-director.sln                                  -> Build succeeded.  0 Warning(s)  0 Error(s)
+dotnet test CcDirector.Core.Tests   (HostedAiPayload)         -> Passed! 5/5
+dotnet test CcDirector.Gateway.Tests (HostedAi + brain + transcription) -> Passed! 29/29 (HostedAiHttp refactor behavior-identical)
+dotnet test CcDirector.Core.Tests   (HostedAi)                -> Passed! 53/53</pre>
+
+<h2>CenCon impact</h2>
+<p>No architecture or security drift. The shared payload reuses the foundation's <code>HostedAiMessages</code> / billing URL; no new egress host; nothing new logged. The Gateway 402 body is unchanged (the refactor is byte-identical), and the Control API now returns the same shape.</p>
+
+<p class="pass">Server-side 402 mapping + the two client fixes are complete and building; the credits-bearing web surfaces show the shared message.</p>
+
+</body>
+</html>

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1545,6 +1545,13 @@ internal static class ControlEndpoints
             var svc = new VoiceUtteranceService(sessionManager, sessionManager.Options);
             var resp = await svc.CompleteAsync(id, req.TotalChunks, req.Mime ?? "audio/webm", repoPath,
                 req.SessionId ?? "", sessionName, ctx.RequestAborted);
+            // Out of credits / cap (issue #941): the transcribe carried the machine code as the status;
+            // return the ONE shared 402 payload so the Voice tab shows the add-credits message + CTA.
+            if (resp.Status == Core.HostedAi.HostedAiErrorMapper.InsufficientCreditsCode
+                || resp.Status == Core.HostedAi.HostedAiErrorMapper.MonthlyLimitReachedCode)
+                return Results.Json(
+                    Core.HostedAi.HostedAiPayload.For(Core.HostedAi.HostedAiErrorMapper.MapCode(resp.Status)),
+                    statusCode: Core.HostedAi.HostedAiPayload.PaymentRequired);
             // "incomplete" is a client-recoverable state (re-send missing chunks), so 409.
             return resp.Status == "incomplete"
                 ? Results.Json(resp, statusCode: StatusCodes.Status409Conflict)
@@ -1670,6 +1677,15 @@ internal static class ControlEndpoints
             var result = await svc.GenerateAsync(req.Text, req.Voice, req.Model, ctx.RequestAborted);
             if (!result.Success || result.AudioBytes is null)
             {
+                // Out of credits / cap (issue #941): a 402 carries the machine code as the status; return
+                // the ONE shared payload (402) so the web player shows the add-credits message + CTA
+                // instead of silently falling back to the robotic browser voice.
+                if (result.Status == Core.HostedAi.HostedAiErrorMapper.InsufficientCreditsCode
+                    || result.Status == Core.HostedAi.HostedAiErrorMapper.MonthlyLimitReachedCode)
+                    return Results.Json(
+                        Core.HostedAi.HostedAiPayload.For(Core.HostedAi.HostedAiErrorMapper.MapCode(result.Status)),
+                        statusCode: Core.HostedAi.HostedAiPayload.PaymentRequired);
+
                 var status = result.Status switch
                 {
                     "no_key" => StatusCodes.Status503ServiceUnavailable,

--- a/src/CcDirector.ControlApi/DictationEndpoint.cs
+++ b/src/CcDirector.ControlApi/DictationEndpoint.cs
@@ -5,6 +5,7 @@ using CcDirector.Core.Audio;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Dictation;
 using CcDirector.Core.Dictation.Models;
+using CcDirector.Core.HostedAi;
 using CcDirector.Core.Transcription;
 using CcDirector.Core.Utilities;
 using Microsoft.AspNetCore.Builder;
@@ -296,6 +297,16 @@ internal static class DictationEndpoint
             });
 
             transcript = await pipeline.TranscribeAsync(wav, "dictation.wav", routing, dictionary, profile, ct, progress);
+        }
+        catch (InsufficientCreditsException credits)
+        {
+            // Out of credits / cap (issue #941): send the ONE shared message (mirrored into the raw
+            // `message` field the overlay already shows) plus the richer `hostedAi` shape so the client
+            // can render the add-credits call-to-action - instead of "transcription failed: ...402...".
+            var payload = HostedAiPayload.For(HostedAiErrorMapper.MapCode(credits.Code));
+            FileLog.Write($"[DictationEndpoint] sid={sessionId} OUT OF CREDITS: {credits.Code}");
+            clientError = payload.Text;
+            await SendJsonAsync(ws, new { type = "error", message = payload.Text, hostedAi = payload }, ct);
         }
         catch (Exception ex)
         {

--- a/src/CcDirector.ControlApi/Web/session-view.html
+++ b/src/CcDirector.ControlApi/Web/session-view.html
@@ -3212,6 +3212,17 @@
               return;   // resolved later by onended / onerror
             }
           }
+          // Out of credits / cap (issue #941): the server returns 402 with the ONE shared message.
+          // Show it instead of silently masking the problem with the robotic browser voice, so the
+          // credits state is visible on this surface too.
+          if (resp.status === 402) {
+            stopCue();
+            let msg = 'Voice needs credit.';
+            try { const p = await resp.json(); msg = p.text || p.error || msg; } catch {}
+            setVoiceState(msg, 'err');
+            done();
+            return;
+          }
           // /tts returned but produced no audio: fall through to the browser fallback.
           stopCue();
         } catch {
@@ -3383,6 +3394,9 @@
       }, VOICE_TIMEOUTS.complete);
       const body = await r.json().catch(() => null);
       if (r.ok && body) return body;
+      // Out of credits / cap (issue #941): return the shared 402 payload so the caller shows the
+      // add-credits message instead of throwing a generic "complete failed (HTTP 402)".
+      if (r.status === 402 && body) return body;
       if (r.status === 409) { await waitForUploadDrain(); await new Promise(r => setTimeout(r, 500)); continue; }
       throw new Error('complete failed (HTTP ' + r.status + ')');
     }
@@ -3757,6 +3771,12 @@
       await waitForUploadDrain();
       const voiceResp = await completeUtterance(totalChunks, mimeType);
       stopCue();
+      // Out of credits / cap (issue #941): the ONE shared message, not a raw failure.
+      if (voiceResp && (voiceResp.state === 'NeedsCredits' || voiceResp.state === 'CapReached')) {
+        setVoiceState(voiceResp.text || voiceResp.error || 'Voice needs credit.', 'error');
+        appendVoiceBubble('system', voiceResp.text || voiceResp.error || 'Voice needs credit.');
+        return;
+      }
       if (voiceResp.status === 'no_key') {
         setVoiceState('Voice mode disabled: ' + (voiceResp.error || 'no OpenAI key'), 'error');
         appendVoiceBubble('system', 'Voice mode disabled. ' + (voiceResp.error || ''));

--- a/src/CcDirector.Core.Tests/HostedAi/HostedAiPayloadTests.cs
+++ b/src/CcDirector.Core.Tests/HostedAi/HostedAiPayloadTests.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using CcDirector.Core.HostedAi;
+using Xunit;
+
+namespace CcDirector.Core.Tests.HostedAi;
+
+/// <summary>
+/// Issue #941 (epic #937): the shared server-boundary wire shape. Every web/native client keys off
+/// these exact field names, and the <c>error</c> field must mirror the shared text so a raw-display
+/// client shows the right copy. Proves the payload carries the single-source copy and serializes to the
+/// pinned camelCase names regardless of a serializer's casing policy.
+/// </summary>
+public sealed class HostedAiPayloadTests
+{
+    [Theory]
+    [InlineData(HostedAiState.NeedsCredits, "NeedsCredits", "OpenBilling")]
+    [InlineData(HostedAiState.CapReached, "CapReached", "OpenBilling")]
+    [InlineData(HostedAiState.NeedsKey, "NeedsKey", "OpenSettings")]
+    public void For_CarriesSharedCopy_AndErrorMirrorsText(HostedAiState state, string expectedState, string expectedAction)
+    {
+        var p = HostedAiPayload.For(state);
+        var m = HostedAiMessages.For(state);
+
+        Assert.Equal(expectedState, p.State);
+        Assert.Equal(expectedAction, p.CtaAction);
+        Assert.Equal(m.Text, p.Text);
+        Assert.Equal(m.Text, p.Error);      // error mirrors text so raw-display clients show the right copy
+        Assert.Equal(m.CtaLabel, p.CtaLabel);
+        Assert.Equal(m.CtaUrl, p.CtaUrl);
+    }
+
+    [Fact]
+    public void Serializes_WithPinnedCamelCaseNames()
+    {
+        // Default options (no camelCase policy): the [JsonPropertyName] pins must still produce the
+        // exact wire names the clients read.
+        var json = JsonSerializer.Serialize(HostedAiPayload.For(HostedAiState.NeedsCredits));
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("error", out _));
+        Assert.True(root.TryGetProperty("state", out _));
+        Assert.True(root.TryGetProperty("text", out _));
+        Assert.True(root.TryGetProperty("ctaLabel", out _));
+        Assert.True(root.TryGetProperty("ctaAction", out _));
+        Assert.True(root.TryGetProperty("ctaUrl", out _));
+    }
+
+    [Fact]
+    public void FromBody_BranchesOnCode()
+    {
+        Assert.Equal("CapReached", HostedAiPayload.FromBody("{\"error\":{\"code\":\"monthly_limit_reached\"}}").State);
+        Assert.Equal("NeedsCredits", HostedAiPayload.FromBody("{\"error\":{\"code\":\"insufficient_credits\"}}").State);
+        Assert.Equal("NeedsCredits", HostedAiPayload.FromBody("not json").State); // default
+    }
+}

--- a/src/CcDirector.Core/HostedAi/HostedAiPayload.cs
+++ b/src/CcDirector.Core/HostedAi/HostedAiPayload.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace CcDirector.Core.HostedAi;
+
+/// <summary>
+/// The single wire shape for a hosted-AI unavailable response, shared by every server boundary that
+/// reports out-of-credits / no-key to a client (issue #941, epic #937): the Gateway 402
+/// (<c>HostedAiHttp</c>), the Director Control API endpoints, and the <c>/dictate</c> WebSocket error
+/// frame. Built from the one copy source (<see cref="HostedAiMessages"/>), so every web and native
+/// client shows the identical message by construction.
+///
+/// The <see cref="Error"/> field deliberately mirrors <see cref="Text"/>: the existing web surfaces
+/// display the server's <c>error</c> string raw, so putting the shared copy there makes the correct
+/// message appear with no per-client change, while a client taught the richer shape can read
+/// <see cref="State"/> and <see cref="CtaUrl"/> to render the call-to-action. Pure (no ASP.NET
+/// dependency) so it lives in Core and both the Gateway and the Control API serialize the same shape.
+/// The JSON names are pinned so the wire contract does not depend on a serializer's casing policy.
+/// </summary>
+public sealed record HostedAiPayload(
+    [property: JsonPropertyName("error")] string Error,
+    [property: JsonPropertyName("state")] string State,
+    [property: JsonPropertyName("text")] string Text,
+    [property: JsonPropertyName("ctaLabel")] string CtaLabel,
+    [property: JsonPropertyName("ctaAction")] string CtaAction,
+    [property: JsonPropertyName("ctaUrl")] string? CtaUrl)
+{
+    /// <summary>HTTP 402 Payment Required - the status the hosted proxy uses for out-of-credits / cap.</summary>
+    public const int PaymentRequired = 402;
+
+    /// <summary>Build the shared payload for a state from the single-source copy.</summary>
+    public static HostedAiPayload For(HostedAiState state)
+    {
+        var m = HostedAiMessages.For(state);
+        return new HostedAiPayload(
+            Error: m.Text,
+            State: state.ToString(),
+            Text: m.Text,
+            CtaLabel: m.CtaLabel,
+            CtaAction: m.CtaAction.ToString(),
+            CtaUrl: m.CtaUrl);
+    }
+
+    /// <summary>Build the shared payload directly from a proxy 402 body (branches on the machine code).</summary>
+    public static HostedAiPayload FromBody(string? body) => For(HostedAiErrorMapper.Map402(body));
+}

--- a/src/CcDirector.Core/Voice/VoiceService.cs
+++ b/src/CcDirector.Core/Voice/VoiceService.cs
@@ -135,6 +135,13 @@ public sealed class VoiceService
         {
             transcription = await TranscribeAndCorrectAsync(audio, fileName, routing, ct);
         }
+        catch (InsufficientCreditsException credits)
+        {
+            // Out of credits / cap (issue #941): carry the machine code as the status so the endpoint
+            // maps it to the shared 402 message, instead of a generic "transcribe_failed".
+            FileLog.Write($"[VoiceService] TranscribeAndCleanAsync OUT OF CREDITS: {credits.Code}");
+            return new VoiceCommandResponse { Status = credits.Code, Error = credits.Message };
+        }
         catch (Exception ex)
         {
             FileLog.Write($"[VoiceService] TranscribeAndCleanAsync transcribe FAILED: {ex.Message}");

--- a/src/CcDirector.Gateway/HostedAi/HostedAiHttp.cs
+++ b/src/CcDirector.Gateway/HostedAi/HostedAiHttp.cs
@@ -31,18 +31,9 @@ public static class HostedAiHttp
         };
     }
 
-    /// <summary>The HTTP 402 response for a state, carrying the shared message + call-to-action.</summary>
+    /// <summary>The HTTP 402 response for a state, carrying the shared message + call-to-action. The
+    /// wire shape is the single-source <see cref="HostedAiPayload"/> (issue #941), so the Gateway and the
+    /// Director Control API return the identical body.</summary>
     public static IResult PaymentRequiredResult(HostedAiState state)
-    {
-        var dto = Dto(state);
-        return Results.Json(new
-        {
-            error = dto.Text,
-            state = dto.State,
-            text = dto.Text,
-            ctaLabel = dto.CtaLabel,
-            ctaAction = dto.CtaAction,
-            ctaUrl = dto.CtaUrl,
-        }, statusCode: PaymentRequired);
-    }
+        => Results.Json(HostedAiPayload.For(state), statusCode: PaymentRequired);
 }


### PR DESCRIPTION
Part of epic thefrederiksen/devthrottle_internal#661. Server-side: the Director endpoints the web calls now map a hosted-proxy 402 to the ONE shared payload (error field mirrors the shared message), so the correct add-credits message appears by construction; two surfaces that hid the failure got a small client fix.

- HostedAiPayload (new, Core): single wire shape shared by Gateway + Control API + /dictate WS frame. HostedAiHttp refactored onto it (behavior-identical to thefrederiksen/devthrottle#939).
- A1/A2 dictation (/dictate WS): shared message + payload on out-of-credits.
- A3 Voice tab: VoiceService carries the 402; /voice/utterance/complete returns the shared 402; session-view shows it.
- C3 read-aloud (/tts): shared 402; session-view shows the message instead of silently using the robotic browser voice.
- Not wired: B4 voice.js / B5 Learning (both claude.exe wingman, not the credit proxy -> no real 402). Old Blazor Cockpit is still live (React apps/cockpit is a stub).

Build clean. HostedAiPayload 5/5, Gateway HostedAi 29/29, Core HostedAi 53/53.

Proof: docs/cencon/proof/issue-941/report.html

Closes thefrederiksen/devthrottle#941 (part of thefrederiksen/devthrottle_internal#661).

🤖 Generated with [Claude Code](https://claude.com/claude-code)