### PR TITLE
Move Cockpit server-side secrets/logic behind the Gateway (#970)

### DIFF
--- a/docs/cencon/proof/issue-970/live-github-967.txt
+++ b/docs/cencon/proof/issue-970/live-github-967.txt
@@ -1,0 +1,4 @@
+REQUEST: GET http://127.0.0.1:59174/gateway/lists/item-status?source=github&id=967
+(browser sends only the same-origin cc-gateway-token; the GitHub token stays on the Gateway)
+RESPONSE STATUS: 200
+RESPONSE BODY: {"title":"[Epic] Rebuild the Cockpit in React (retire Blazor Server)","status":"queued","detail":null}

--- a/docs/cencon/proof/issue-970/live-github-968.txt
+++ b/docs/cencon/proof/issue-970/live-github-968.txt
@@ -1,0 +1,4 @@
+REQUEST: GET http://127.0.0.1:50339/gateway/lists/item-status?source=github&id=968
+(browser sends only the same-origin cc-gateway-token; the GitHub token stays on the Gateway)
+RESPONSE STATUS: 200
+RESPONSE BODY: {"title":"Cockpit React: stand up packages/client-core + Gateway-only-ingress lint rule; retarget mobile","status":"done","detail":null}

--- a/docs/cencon/proof/issue-970/live-github-970.txt
+++ b/docs/cencon/proof/issue-970/live-github-970.txt
@@ -1,0 +1,4 @@
+REQUEST: GET http://127.0.0.1:50334/gateway/lists/item-status?source=github&id=970
+(browser sends only the same-origin cc-gateway-token; the GitHub token stays on the Gateway)
+RESPONSE STATUS: 200
+RESPONSE BODY: {"title":"Cockpit React: move server-side secrets and logic behind the Gateway","status":"queued","detail":null}

--- a/docs/cencon/proof/issue-970/qa-live-github-967.txt
+++ b/docs/cencon/proof/issue-970/qa-live-github-967.txt
@@ -1,0 +1,4 @@
+REQUEST: GET http://127.0.0.1:63899/gateway/lists/item-status?source=github&id=967
+(browser sends only the same-origin cc-gateway-token; the GitHub token stays on the Gateway)
+RESPONSE STATUS: 200
+RESPONSE BODY: {"title":"[Epic] Rebuild the Cockpit in React (retire Blazor Server)","status":"queued","detail":null}

--- a/docs/cencon/proof/issue-970/qa-live-github-970.txt
+++ b/docs/cencon/proof/issue-970/qa-live-github-970.txt
@@ -1,0 +1,4 @@
+REQUEST: GET http://127.0.0.1:63911/gateway/lists/item-status?source=github&id=970
+(browser sends only the same-origin cc-gateway-token; the GitHub token stays on the Gateway)
+RESPONSE STATUS: 200
+RESPONSE BODY: {"title":"Cockpit React: move server-side secrets and logic behind the Gateway","status":"running","detail":null}

--- a/docs/cencon/proof/issue-970/qa-report.html
+++ b/docs/cencon/proof/issue-970/qa-report.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>QA Proof - Issue #970</title>
+<style>
+  body { font-family: -apple-system, Segoe UI, Roboto, sans-serif; max-width: 960px; margin: 2rem auto; padding: 0 1rem; color: #1a1a1a; line-height: 1.5; }
+  h1 { border-bottom: 2px solid #5319e7; padding-bottom: .4rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #ccc; padding: .5rem .6rem; text-align: left; vertical-align: top; }
+  th { background: #f3f0fb; }
+  .pass { color: #0a7d24; font-weight: bold; }
+  code, pre { background: #f5f5f5; padding: .1rem .3rem; border-radius: 3px; font-family: Consolas, monospace; }
+  pre { padding: .7rem; overflow-x: auto; }
+  .verdict { background: #e7fbe9; border: 1px solid #0a7d24; padding: 1rem; border-radius: 6px; font-size: 1.1rem; }
+</style>
+</head>
+<body>
+<h1>QA Proof Report - Issue #970</h1>
+<p><strong>Issue:</strong> Cockpit React: move server-side secrets and logic behind the Gateway (epic #967)<br>
+<strong>Pull request:</strong> #989 &nbsp; <strong>Branch:</strong> issue-970-gateway-secrets<br>
+<strong>QA identity:</strong> independent QA Agent, isolated worktree <code>devthrottle-wt-970</code><br>
+<strong>Date:</strong> 2026-07-05</p>
+
+<h2>Baseline delta (the critical check)</h2>
+<p>The developer reported ~30 pre-existing Gateway failures on <code>origin/main</code>. QA established the
+baseline independently by running the Gateway test project in isolation on each side:</p>
+<table>
+<tr><th>Checkout</th><th>Gateway test project result</th></tr>
+<tr><td><code>origin/main</code> (6d48384c)</td><td>Passed 1237, Failed 0</td></tr>
+<tr><td>PR branch (abe5716a)</td><td>Passed 1263, Failed 0</td></tr>
+</table>
+<p>Delta introduced by the PR: <strong>+26 tests, all passing, ZERO new failures.</strong>
+Run as a single project the Gateway suite is green on both sides; the ~30 failures the developer saw
+appear only when the ENTIRE solution suite is run in parallel (cross-collection interference) and are
+unrelated to this PR. Either way the PR adds no new failing test.</p>
+
+<h2>Acceptance criteria</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (QA-verified)</th><th>Result</th></tr>
+<tr>
+  <td>1</td>
+  <td>No GitHub token / secret in the shipped browser bundle</td>
+  <td>No <code>ghp_</code>, <code>github_pat_</code>, <code>github_token</code>, <code>api.github.com</code>, <code>credentials.env</code> in built bundles</td>
+  <td>Built <code>apps/cockpit/dist</code>, <code>apps/mobile/dist</code>, <code>packages/client-core/dist</code> and grepped source + dist: NO matches. The only <code>Bearer</code> is the runtime same-origin Gateway device token, not a baked secret.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>2</td>
+  <td>Lists per-item title + status resolve through a same-origin Gateway call</td>
+  <td>Browser calls root-relative <code>/gateway/lists/item-status</code>; Gateway holds the token and returns {title,status,detail}</td>
+  <td><code>itemStatus.ts</code> fetches root-relative <code>/gateway/lists/item-status</code>. LIVE: a real GatewayHost over loopback HTTP resolved issue 967 -&gt; <code>status:"queued"</code> and issue 970 (flow:ready-qa) -&gt; <code>status:"running"</code>, real titles, token held server-side, no token in the response body. See qa-live-github-*.txt.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>3</td>
+  <td>LinkDetector reproduced in client-core with tests, matching the C# recognizer</td>
+  <td>TypeScript port + passing tests covering the shared C# cases</td>
+  <td><code>historyLinks.ts</code> is a faithful port of <code>CcDirector.Core/Utilities/LinkDetector.cs</code>; 44 vitest cases pass, covering the drive-letter guard, <code>file://</code> URLs, line-number stripping, quoted spans, priority ordering, and first-seen dedup.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>4</td>
+  <td>Brief degrade path produces the same result, no secret in browser</td>
+  <td>Same output as the C# BriefFallback; pure text, no secret</td>
+  <td><code>briefFallback.ts</code> is a byte-for-byte port of C# <code>BriefFallback.FinalParagraph</code> (mirrors Core <code>BriefBuilder.FallbackNeedsYou</code>); 5 vitest cases pass mirroring the C# BriefBuilder cases. Pure text handling, no network/secret.</td>
+  <td class="pass">PASS</td>
+</tr>
+</table>
+
+<h2>Method / regression checks</h2>
+<table>
+<tr><th>Check</th><th>Result</th></tr>
+<tr><td><code>dotnet build cc-director.sln</code> (PR branch)</td><td class="pass">Build succeeded. 0 Warning(s), 0 Error(s)</td></tr>
+<tr><td>New Gateway endpoint + resolver tests (ItemStatus | GitHubItemStatusResolver)</td><td class="pass">Passed 26, Failed 0</td></tr>
+<tr><td>client-core vitest (historyLinks 44 + briefFallback 5)</td><td class="pass">49 passed</td></tr>
+<tr><td>TypeScript typecheck (tsc --noEmit)</td><td class="pass">clean</td></tr>
+<tr><td>eslint (Gateway-only-ingress rule)</td><td class="pass">clean</td></tr>
+<tr><td>Gateway status mapping fidelity (flow:done/needs-human/failed/ready-qa/qa-failed -&gt; badge)</td><td class="pass">GatewayWorkItemStatus.MapStatus matches the Cockpit GitHubItemStatusClient.MapStatus line for line</td></tr>
+</table>
+
+<h2>Live endpoint transcripts (QA-produced)</h2>
+<pre>REQUEST: GET http://127.0.0.1:63899/gateway/lists/item-status?source=github&amp;id=967
+RESPONSE STATUS: 200
+RESPONSE BODY: {"title":"[Epic] Rebuild the Cockpit in React (retire Blazor Server)","status":"queued","detail":null}
+
+REQUEST: GET http://127.0.0.1:63911/gateway/lists/item-status?source=github&amp;id=970
+RESPONSE STATUS: 200
+RESPONSE BODY: {"title":"Cockpit React: move server-side secrets and logic behind the Gateway","status":"running","detail":null}</pre>
+<p>Both resolved through a running GatewayHost; the GitHub token was read on the Gateway and never appears in the response.</p>
+
+<div class="verdict">VERIFIED - all acceptance criteria met. The PR introduces zero new test failures over the origin/main baseline and adds 26 passing tests. Clean PASS.</div>
+</body>
+</html>

--- a/docs/cencon/proof/issue-970/report.html
+++ b/docs/cencon/proof/issue-970/report.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Issue #970 - Move server-side secrets and logic behind the Gateway - Proof</title>
+<style>
+  body { font-family: -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 2rem; line-height: 1.55; color: #1b1f23; background: #fff; }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid #1d76db; padding-bottom: .4rem; }
+  h2 { font-size: 1.2rem; margin-top: 2rem; color: #1d76db; }
+  code, pre { font-family: Consolas, Menlo, monospace; }
+  pre { background: #f6f8fa; border: 1px solid #e1e4e8; border-radius: 6px; padding: .8rem; overflow-x: auto; font-size: .85rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #d0d7de; padding: .5rem .6rem; text-align: left; vertical-align: top; font-size: .9rem; }
+  th { background: #f6f8fa; }
+  .ok { color: #1a7f37; font-weight: 600; }
+  .muted { color: #57606a; }
+  .box { border: 1px solid #d0d7de; border-radius: 6px; padding: .8rem 1rem; background: #f6f8fa; }
+</style>
+</head>
+<body>
+<h1>Issue #970 - Cockpit React: move server-side secrets and logic behind the Gateway</h1>
+<p class="muted">Developer Agent proof. Part of epic #967 (Cockpit React rebuild). Branch <code>issue-970-gateway-secrets</code>.</p>
+
+<h2>What was implemented</h2>
+<p>The React Cockpit is a browser single-page application that must hold <strong>no secret</strong>. The three things
+the Blazor Cockpit did server-side (because they need a secret or the Director host) were moved behind the Gateway:</p>
+<ol>
+  <li><strong>GitHub item status endpoint.</strong> New Gateway endpoint
+    <code>GET /gateway/lists/item-status?source&amp;id</code> resolving a work-list item's title +
+    <code>flow:*</code>-derived status. The GitHub token is read on the Gateway host from the shared credentials file
+    at point of use and never leaves the Gateway. Ported the Cockpit's <code>GitHubItemStatusClient</code> fetch +
+    flow-label mapping into <code>GitHubItemStatusResolver</code> (injectable HttpClient + token provider for tests).
+    Registered in <code>GatewayHost</code> next to the work-list routes, inheriting the host-wide token middleware.</li>
+  <li><strong>LinkDetector port.</strong> Hardened the client-core TypeScript port
+    (<code>packages/client-core/src/history/historyLinks.ts</code>) so the History links do not diverge from the C#
+    recognizer: added the drive-letter boundary guard <code>(?&lt;![A-Za-z])</code> and <code>file://</code> URL
+    handling (surfaced as local Path links), matching <code>src/CcDirector.Core/Utilities/LinkDetector.cs</code>.
+    Added a vitest suite mirroring the applicable shared cases from the C# <code>LinkDetectorTests</code>.</li>
+  <li><strong>Brief fallback composition.</strong> Ported <code>BriefFallback.FinalParagraph</code> to a secret-free
+    client-core function <code>finalParagraph()</code> (<code>packages/client-core/src/brief/briefFallback.ts</code>)
+    with tests mirroring the C# <code>BriefBuilderTests</code> fallback cases.</li>
+  <li><strong>Browser API client.</strong> <code>resolveItemStatus()</code>
+    (<code>packages/client-core/src/api/itemStatus.ts</code>) calls the new endpoint through a root-relative,
+    same-origin path - no absolute host, no token (passes the Gateway-only-ingress lint rule).</li>
+</ol>
+
+<h2>Acceptance criteria &rarr; how each is met</h2>
+<table>
+  <tr><th>Criterion</th><th>How it is satisfied</th><th>Proof</th></tr>
+  <tr>
+    <td>No GitHub token (or any other secret) in the shipped browser bundle.</td>
+    <td>The token stays on the Gateway; the browser only calls a root-relative path. Grep of all browser
+      client code (client-core src+dist, cockpit dist, mobile src) for token / credential / api.github.com
+      strings is empty.</td>
+    <td class="ok">PASS - see "No secret in the bundle" below and <code>test-summary.txt</code></td>
+  </tr>
+  <tr>
+    <td>The Lists view's per-item title and status resolve through a same-origin Gateway call.</td>
+    <td><code>GET /gateway/lists/item-status</code> on the Gateway + <code>resolveItemStatus()</code> in client-core.
+      Proven live against a real <code>GatewayHost</code> resolving real GitHub issues.</td>
+    <td class="ok">PASS - live transcripts <code>live-github-967/968/970.txt</code></td>
+  </tr>
+  <tr>
+    <td><code>LinkDetector</code>'s behavior reproduced in client-core with tests matching the C# recognizer.</td>
+    <td>Hardened <code>historyLinks.ts</code> (boundary guard + <code>file://</code>) + 44 vitest cases mirroring
+      the applicable subset of <code>LinkDetectorTests.cs</code>.</td>
+    <td class="ok">PASS - vitest 44 passed</td>
+  </tr>
+  <tr>
+    <td>The Brief degrade path produces the same result, with no secret in the browser.</td>
+    <td><code>finalParagraph()</code> is a byte-for-byte port of <code>BriefFallback.FinalParagraph</code>; pure text,
+      no secret. 5 vitest cases mirror the C# fallback tests.</td>
+    <td class="ok">PASS - vitest 5 passed</td>
+  </tr>
+</table>
+
+<h2>Live proof - endpoint resolving real GitHub through a real Gateway</h2>
+<p>A real <code>GatewayHost</code> (the same class the Gateway tray hosts) was started in-process; the endpoint was
+called over loopback HTTP. The response carries only <code>{ title, status, detail }</code> - never the token.
+Status is derived live from each issue's <code>flow:*</code> label:</p>
+<pre>#967 (epic, no flow label):    {"title":"[Epic] Rebuild the Cockpit in React (retire Blazor Server)","status":"queued","detail":null}
+#970 (flow:in-progress):       {"title":"Cockpit React: move server-side secrets and logic behind the Gateway","status":"queued","detail":null}
+#968 (flow:done):              {"title":"Cockpit React: stand up packages/client-core + Gateway-only-ingress lint rule; retarget mobile","status":"done","detail":null}</pre>
+<p class="muted">Full request/response transcripts: <code>live-github-967.txt</code>, <code>live-github-968.txt</code>,
+<code>live-github-970.txt</code>.</p>
+
+<h2>No secret in the bundle</h2>
+<div class="box">
+<pre>grep -rniE "github_token|ghp_|github_pat_|credentials.env|api.github.com|x-github-api"
+     packages/client-core/src  packages/client-core/dist  apps/cockpit/dist  apps/mobile/src
+  -> NO matches (comments aside). The only fetch in itemStatus.ts is:
+       fetch(`/gateway/lists/item-status?${q}`, ...)   // root-relative, same-origin, no token</pre>
+</div>
+
+<h2>Build &amp; test results</h2>
+<table>
+  <tr><th>Check</th><th>Result</th></tr>
+  <tr><td><code>dotnet build cc-director.sln</code></td><td class="ok">Build succeeded. 0 Warning(s), 0 Error(s)</td></tr>
+  <tr><td>New Gateway endpoint + resolver tests (26)</td><td class="ok">26 passed</td></tr>
+  <tr><td>Full Gateway suite (this branch)</td><td>1233 passed, 30 failed / 1263</td></tr>
+  <tr><td>Full Gateway suite (origin/main baseline, unchanged code)</td><td>1207 passed, 30 failed / 1237</td></tr>
+  <tr><td>client-core vitest</td><td class="ok">49 passed (historyLinks 44, briefFallback 5)</td></tr>
+  <tr><td>client-core typecheck / build / lint</td><td class="ok">clean</td></tr>
+  <tr><td>apps/cockpit vite build</td><td class="ok">built, 35 modules</td></tr>
+</table>
+<p><strong>On the 30 Gateway failures:</strong> they are <em>pre-existing</em> full-suite flakiness (auth-state
+pollution in <code>ToolRunEndpointTests</code> and peers - each passes in isolation). The identical 30 failures occur
+on the untouched <code>origin/main</code> baseline. This branch adds 26 tests, all passing
+(1233 = baseline 1207 + 26), and introduces <strong>zero</strong> new failures.</p>
+
+<h2>CenCon impact</h2>
+<p>No architecture or security drift. This change <em>strengthens</em> the existing posture - Gateway-only ingress and
+"the browser holds no secret" - by moving the last GitHub-token use out of the browser-facing path and onto the
+Gateway. No blocking security rule affected. No <code>docs/cencon/</code> manifest files exist to update beyond this proof.</p>
+
+<h2>Verdict</h2>
+<p class="ok">I believe this is finished. All four acceptance criteria are met and proven; the solution builds clean;
+the browser bundle carries no secret.</p>
+</body>
+</html>

--- a/docs/cencon/proof/issue-970/test-summary.txt
+++ b/docs/cencon/proof/issue-970/test-summary.txt
@@ -1,0 +1,30 @@
+Issue #970 - proof of tests and build (worktree devthrottle-wt-970, branch issue-970-gateway-secrets)
+
+.NET
+----
+dotnet build cc-director.sln
+  -> Build succeeded. 0 Warning(s) 0 Error(s)
+
+dotnet test CcDirector.Gateway.Tests --filter "ItemStatus|GitHubItemStatusResolver"
+  -> Passed! Failed: 0, Passed: 26  (the new endpoint + resolver tests)
+
+Full Gateway suite (this branch):     Failed: 30, Passed: 1233, Total: 1263
+Full Gateway suite (origin/main base): Failed: 30, Passed: 1207, Total: 1237
+  -> The SAME 30 failures exist on the untouched baseline (pre-existing full-suite auth
+     flakiness in ToolRunEndpointTests and peers; each passes in isolation). This branch adds
+     26 tests, ALL passing (1233 = 1207 + 26), and introduces ZERO new failures.
+
+TypeScript (packages/client-core)
+---------------------------------
+npm run test  (vitest)     -> 49 passed (historyLinks 44, briefFallback 5)
+npm run typecheck (tsc)    -> clean
+npm run build (tsc decl)   -> clean
+npm run lint (eslint, Gateway-only-ingress rule) -> clean
+npm run build @devthrottle/cockpit (vite) -> built, 35 modules
+
+No secret in the shipped browser bundle
+---------------------------------------
+grep -rniE "github_token|ghp_|github_pat_|credentials.env|api.github.com|x-github-api"
+   over packages/client-core/src, packages/client-core/dist, apps/cockpit/dist, apps/mobile/src
+   -> NO matches. The GitHub token lives only on the Gateway; the browser calls the
+      root-relative same-origin path /gateway/lists/item-status.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -62,4 +62,14 @@ export default [
       "no-restricted-syntax": ["error", ...bannedAbsoluteUrl],
     },
   },
+  {
+    // Unit tests are not shipped client code - they never run in the browser and make no real
+    // request. Their fixtures legitimately contain absolute-URL string literals as TEST DATA (e.g.
+    // the link recognizer must be exercised with "https://example.com"), so the Gateway-only-ingress
+    // ban does not apply to them.
+    files: ["**/*.test.{ts,tsx}"],
+    rules: {
+      "no-restricted-syntax": "off",
+    },
+  },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -3381,6 +3381,118 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.8.tgz",
+      "integrity": "sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.8",
+        "@vitest/utils": "2.1.8",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.8.tgz",
+      "integrity": "sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.8",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.8.tgz",
+      "integrity": "sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.8",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.8.tgz",
+      "integrity": "sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.8.tgz",
+      "integrity": "sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.8.tgz",
+      "integrity": "sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.8",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.8.tgz",
+      "integrity": "sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xterm/xterm": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
@@ -3507,6 +3619,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async": {
@@ -3689,6 +3811,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -3770,6 +3902,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3793,6 +3942,16 @@
       "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -3968,6 +4127,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -4168,6 +4337,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -4455,6 +4631,16 @@
       },
       "funding": {
         "url": "https://github.com/bgub/eta?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -5826,6 +6012,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6194,6 +6387,23 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -6845,6 +7055,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6912,6 +7129,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -7140,6 +7371,20 @@
         "node": ">=10"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -7186,6 +7431,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -7586,6 +7861,519 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.8.tgz",
+      "integrity": "sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite-plugin-pwa": {
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-0.21.1.tgz",
@@ -7613,6 +8401,599 @@
       },
       "peerDependenciesMeta": {
         "@vite-pwa/assets-generator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.8.tgz",
+      "integrity": "sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.8",
+        "@vitest/mocker": "2.1.8",
+        "@vitest/pretty-format": "^2.1.8",
+        "@vitest/runner": "2.1.8",
+        "@vitest/snapshot": "2.1.8",
+        "@vitest/spy": "2.1.8",
+        "@vitest/utils": "2.1.8",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.8",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.8",
+        "@vitest/ui": "2.1.8",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.8.tgz",
+      "integrity": "sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
           "optional": true
         }
       }
@@ -7739,6 +9120,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -8059,7 +9457,8 @@
       "devDependencies": {
         "@types/react": "18.3.12",
         "openapi-typescript": "7.4.4",
-        "typescript": "5.7.2"
+        "typescript": "5.7.2",
+        "vitest": "2.1.8"
       },
       "peerDependencies": {
         "react": "^18.3.1",

--- a/packages/client-core/package.json
+++ b/packages/client-core/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run",
     "gen:api": "openapi-typescript http://127.0.0.1:7878/openapi/v1.json --output src/api/schema.ts"
   },
   "dependencies": {
@@ -26,6 +27,7 @@
   "devDependencies": {
     "@types/react": "18.3.12",
     "openapi-typescript": "7.4.4",
-    "typescript": "5.7.2"
+    "typescript": "5.7.2",
+    "vitest": "2.1.8"
   }
 }

--- a/packages/client-core/src/api/itemStatus.ts
+++ b/packages/client-core/src/api/itemStatus.ts
@@ -1,0 +1,51 @@
+// Work-item title + status for the Cockpit Lists view (issue #275), resolved through the Gateway so
+// the browser holds NO secret (issue #970). The Blazor Cockpit called GitHub itself with a bearer
+// token; the React Cockpit is a browser single-page application, so the resolve moved onto the
+// Gateway. This calls it same-origin through a root-relative path - the GitHub token never reaches
+// the browser (it stays on the Gateway host).
+import { authHeaders, GatewayError } from "./client";
+
+// The per-item badge, derived live from the github item's flow:* label. These strings are the wire
+// contract with the Gateway's ItemStatusEndpoint (kept in step with GatewayWorkItemStatus.ToWire):
+//   queued      - no flow label / flow:ready-dev / flow:in-progress / a non-github source
+//   running     - flow:ready-qa or the transient flow:qa-failed (a loop is on it)
+//   done        - flow:done
+//   needs-human - flow:needs-human
+//   failed      - flow:failed
+//   unknown     - could not be derived (GitHub unreachable / no token) - shown explicitly, never as
+//                 a wrong "queued" (the no-fallback rule)
+export type WorkItemStatus =
+  | "queued"
+  | "running"
+  | "done"
+  | "needs-human"
+  | "failed"
+  | "unknown";
+
+// The GitHub-derived view of one work-list item: its display title plus the flow-derived status. For
+// a non-github item only status (queued) is meaningful; title is null and the row shows the bare id.
+export interface WorkItemInfo {
+  title: string | null;
+  status: WorkItemStatus;
+  detail: string | null;
+}
+
+// GET /gateway/lists/item-status?source={source}&id={id} - resolve one work-list item ref. Never
+// carries a secret: the response is only { title, status, detail }, and the request authenticates
+// with the same-origin device key the rest of the client uses.
+export async function resolveItemStatus(
+  source: string,
+  id: string,
+  signal?: AbortSignal,
+): Promise<WorkItemInfo> {
+  const q = `source=${encodeURIComponent(source)}&id=${encodeURIComponent(id)}`;
+  const res = await fetch(`/gateway/lists/item-status?${q}`, {
+    method: "GET",
+    headers: { Accept: "application/json", ...authHeaders() },
+    signal,
+  });
+  if (!res.ok) {
+    throw new GatewayError(res.status, `GET item-status failed: ${res.status}`);
+  }
+  return (await res.json()) as WorkItemInfo;
+}

--- a/packages/client-core/src/brief/briefFallback.test.ts
+++ b/packages/client-core/src/brief/briefFallback.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { finalParagraph } from "./briefFallback";
+
+// Mirrors the C# BriefBuilderTests FallbackNeedsYou cases (and the Cockpit BriefFallback it derives
+// from) so the Brief degrade path produces the same result in the browser as it did server-side
+// (issue #970).
+
+describe("finalParagraph", () => {
+  it("returns the final non-empty paragraph", () => {
+    const reply = "I did a bunch of work.\n\nHere are details.\n\nApprove 1+2 and I'll continue?";
+    expect(finalParagraph(reply)).toBe("Approve 1+2 and I'll continue?");
+  });
+
+  it("handles Windows line endings", () => {
+    const reply = "Work done.\r\n\r\nShall I proceed?";
+    expect(finalParagraph(reply)).toBe("Shall I proceed?");
+  });
+
+  it("returns null for null/blank input", () => {
+    expect(finalParagraph(null)).toBeNull();
+    expect(finalParagraph(undefined)).toBeNull();
+    expect(finalParagraph("   ")).toBeNull();
+  });
+
+  it("keeps the tail of an over-long paragraph", () => {
+    const reply = "intro\n\n" + "a".repeat(1000);
+    const got = finalParagraph(reply, 100);
+    expect(got).not.toBeNull();
+    expect(got!.length).toBe(100);
+  });
+
+  it("skips a trailing whitespace-only paragraph", () => {
+    const reply = "The real ask is here.\n\n   ";
+    expect(finalParagraph(reply)).toBe("The real ask is here.");
+  });
+});

--- a/packages/client-core/src/brief/briefFallback.ts
+++ b/packages/client-core/src/brief/briefFallback.ts
@@ -1,0 +1,29 @@
+// TypeScript port of the Cockpit's BriefFallback (src/CcDirector.Cockpit/Services/BriefFallback.cs,
+// itself a mirror of Core BriefBuilder.FallbackNeedsYou). The Brief has a degrade path for an OLD
+// Director that serves only /summary (no structured brief): the reply's final non-empty paragraph is
+// shown as the "needs you" block, verbatim by construction. This composition is pure text handling
+// with no secret, so in the React Cockpit it runs in the browser (issue #970) exactly as the C# did.
+
+/**
+ * The final non-empty paragraph of a reply, or null when the reply is empty/whitespace. Paragraphs
+ * are split on blank lines; if the chosen paragraph is longer than maxChars, its LAST maxChars are
+ * kept (the tail carries the ask), matching the C# BriefFallback.FinalParagraph byte-for-byte.
+ */
+export function finalParagraph(
+  reply: string | null | undefined,
+  maxChars = 600,
+): string | null {
+  if (!reply || reply.trim().length === 0) return null;
+
+  const paragraphs = reply
+    .replace(/\r\n/g, "\n")
+    .split("\n\n")
+    .filter((p) => p.length > 0);
+
+  for (let i = paragraphs.length - 1; i >= 0; i--) {
+    const p = paragraphs[i].trim();
+    if (p.length === 0) continue;
+    return p.length <= maxChars ? p : p.slice(p.length - maxChars);
+  }
+  return null;
+}

--- a/packages/client-core/src/history/historyLinks.test.ts
+++ b/packages/client-core/src/history/historyLinks.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from "vitest";
+import { extractLinks, tryConvertFileUrlToLocalPath } from "./historyLinks";
+
+// These mirror the applicable subset of the C# LinkDetectorTests
+// (src/CcDirector.Core.Tests/LinkDetectorTests.cs) - the cases the History browser call exercises:
+// FindAllLinkMatches(line, repoPath = null, pathExistsCheck = null), which yields URLs + ABSOLUTE
+// paths only (relative-path guessing and the on-disk space-extension need a repo root + an existence
+// check the browser does not have). Keeping these in step with the C# recognizer is the guarantee
+// that the History links do not diverge (issue #970).
+
+// Convenience: extractLinks dedups per body; for a single link on one line it returns [{text,isUrl}].
+function links(line: string) {
+  return extractLinks(line);
+}
+
+describe("quoted paths", () => {
+  it.each([
+    ['Check "D:\\Projects\\file.txt" for details', "D:\\Projects\\file.txt"],
+    ["Check 'D:\\Projects\\file.txt' for details", "D:\\Projects\\file.txt"],
+    ["Check `D:\\Projects\\file.txt` for details", "D:\\Projects\\file.txt"],
+  ])("matches a quoted Windows path: %s", (line, expected) => {
+    expect(links(line)).toEqual([{ text: expected, isUrl: false }]);
+  });
+
+  it("matches a quoted path containing spaces", () => {
+    const line = '"D:\\Projects\\course\\sample-course\\AI Agents Join the Club.pdf"';
+    expect(links(line)).toEqual([
+      { text: "D:\\Projects\\course\\sample-course\\AI Agents Join the Club.pdf", isUrl: false },
+    ]);
+  });
+
+  it("matches a quoted unix path", () => {
+    expect(links('"/c/Users/test/my file.txt"')).toEqual([
+      { text: "/c/Users/test/my file.txt", isUrl: false },
+    ]);
+  });
+
+  it("does not match empty quotes", () => {
+    expect(links('he said ""')).toEqual([]);
+  });
+
+  it("still matches the unquoted part when the quote is unclosed", () => {
+    expect(links('"D:\\path\\file.txt')).toEqual([{ text: "D:\\path\\file.txt", isUrl: false }]);
+  });
+
+  it("returns a single match when quoted and unquoted overlap", () => {
+    expect(links('"D:\\path\\file.txt"')).toEqual([{ text: "D:\\path\\file.txt", isUrl: false }]);
+  });
+});
+
+describe("absolute windows paths", () => {
+  it.each(["D:\\path\\file.txt", "C:\\Users\\test\\Documents\\report.pdf", "D:/path/file.txt"])(
+    "matches %s",
+    (path) => {
+      expect(links(path)).toEqual([{ text: path, isUrl: false }]);
+    },
+  );
+
+  it("strips a trailing :line number", () => {
+    expect(links("D:\\path\\file.cs:42")).toEqual([{ text: "D:\\path\\file.cs", isUrl: false }]);
+  });
+
+  it("strips a trailing :line:col number", () => {
+    expect(links("D:\\path\\file.cs:42:10")).toEqual([{ text: "D:\\path\\file.cs", isUrl: false }]);
+  });
+
+  it("matches just the path when embedded in prose", () => {
+    expect(links("Error in D:\\src\\file.cs:10 at runtime")).toEqual([
+      { text: "D:\\src\\file.cs", isUrl: false },
+    ]);
+  });
+
+  it("strips a trailing comma", () => {
+    expect(links("Check D:\\path\\file.txt, then proceed")).toEqual([
+      { text: "D:\\path\\file.txt", isUrl: false },
+    ]);
+  });
+
+  it("strips a trailing period", () => {
+    expect(links("Check D:\\path\\file.txt. Then proceed")).toEqual([
+      { text: "D:\\path\\file.txt", isUrl: false },
+    ]);
+  });
+
+  it("does not include following parentheses", () => {
+    expect(links("(see D:\\path\\file.txt)")).toEqual([{ text: "D:\\path\\file.txt", isUrl: false }]);
+  });
+
+  it("without an existence check, a path with spaces stops at the first space", () => {
+    expect(links("Created at D:\\Test Root\\Outer Folder\\file.md.")[0]).toEqual({
+      text: "D:\\Test",
+      isUrl: false,
+    });
+  });
+});
+
+describe("unix paths", () => {
+  it.each(["/c/Users/test/file.txt", "/d/Projects/myapp/src/main.cs"])("matches %s", (path) => {
+    expect(links(path)).toEqual([{ text: path, isUrl: false }]);
+  });
+});
+
+describe("urls", () => {
+  it.each([
+    "https://example.com",
+    "http://example.com/path",
+    "https://github.com/user/repo/blob/main/file.cs",
+  ])("matches %s", (url) => {
+    expect(links(url)).toEqual([{ text: url, isUrl: true }]);
+  });
+
+  it("matches a git@ url", () => {
+    expect(links("git@github.com:user/repo.git")).toEqual([
+      { text: "git@github.com:user/repo.git", isUrl: true },
+    ]);
+  });
+
+  it("matches a url in the middle of text", () => {
+    expect(links("Visit https://docs.example.com/guide for help")).toEqual([
+      { text: "https://docs.example.com/guide", isUrl: true },
+    ]);
+  });
+
+  it("strips a trailing period from a url", () => {
+    expect(links("Visit https://example.com/page. Thanks")).toEqual([
+      { text: "https://example.com/page", isUrl: true },
+    ]);
+  });
+
+  it("strips a trailing period from a localhost url", () => {
+    expect(links("available at http://localhost:4001.")).toEqual([
+      { text: "http://localhost:4001", isUrl: true },
+    ]);
+  });
+});
+
+describe("ordering and dedup", () => {
+  it("returns urls before absolute paths, both detected", () => {
+    expect(links("See D:\\file.txt and https://example.com for more")).toEqual([
+      { text: "https://example.com", isUrl: true },
+      { text: "D:\\file.txt", isUrl: false },
+    ]);
+  });
+
+  it("returns multiple non-overlapping paths", () => {
+    expect(links("D:\\file1.txt and D:\\file2.txt")).toEqual([
+      { text: "D:\\file1.txt", isUrl: false },
+      { text: "D:\\file2.txt", isUrl: false },
+    ]);
+  });
+
+  it("dedups repeated links across lines, first-seen order", () => {
+    const body = "D:\\a.txt\nhttps://x.com\nD:\\a.txt";
+    expect(extractLinks(body)).toEqual([
+      { text: "D:\\a.txt", isUrl: false },
+      { text: "https://x.com", isUrl: true },
+    ]);
+  });
+});
+
+describe("drive-letter boundary guard (issue #252)", () => {
+  it("does not mis-claim a letter inside a word as a drive path", () => {
+    const result = links("node:/foo/bar baz");
+    expect(result.some((l) => l.text.startsWith("e:"))).toBe(false);
+  });
+
+  it("still matches an ordinary absolute path after the guard", () => {
+    expect(links("See D:\\Repos\\file.txt here")).toEqual([
+      { text: "D:\\Repos\\file.txt", isUrl: false },
+    ]);
+  });
+});
+
+describe("file:// urls (issue #252)", () => {
+  it("surfaces the whole span as a local Path link, not a broken e:/ path", () => {
+    const line = "file:///D:/ReposFred/cc-consult/marketing/marketing.html";
+    const result = links(line);
+    expect(result).toEqual([
+      { text: "D:\\ReposFred\\cc-consult\\marketing\\marketing.html", isUrl: false },
+    ]);
+    expect(result[0].text).not.toContain("e:\\\\");
+  });
+
+  it("resolves a file url in a sentence", () => {
+    expect(links("Report at file:///D:/Repos/x.html now")).toEqual([
+      { text: "D:\\Repos\\x.html", isUrl: false },
+    ]);
+  });
+
+  it("strips a trailing period on a file url", () => {
+    expect(links("See file:///D:/Repos/x.html.")).toEqual([
+      { text: "D:\\Repos\\x.html", isUrl: false },
+    ]);
+  });
+
+  it("decodes percent-encoded spaces", () => {
+    expect(links("file:///D:/My%20Docs/report.md")).toEqual([
+      { text: "D:\\My Docs\\report.md", isUrl: false },
+    ]);
+  });
+
+  it.each([
+    ["file:///D:/Repos/x.html", "D:\\Repos\\x.html"],
+    ["file:///C:/a/b.txt", "C:\\a\\b.txt"],
+  ])("tryConvertFileUrlToLocalPath(%s)", (url, expected) => {
+    expect(tryConvertFileUrlToLocalPath(url)).toBe(expected);
+  });
+
+  it.each(["", "https://example.com/x", "not a url"])(
+    "tryConvertFileUrlToLocalPath returns null for %s",
+    (input) => {
+      expect(tryConvertFileUrlToLocalPath(input)).toBeNull();
+    },
+  );
+});
+
+describe("edge cases", () => {
+  it.each(["", "   "])("returns [] for empty/whitespace body: %s", (body) => {
+    expect(extractLinks(body)).toEqual([]);
+  });
+
+  it("returns [] for null/undefined", () => {
+    expect(extractLinks(null)).toEqual([]);
+    expect(extractLinks(undefined)).toEqual([]);
+  });
+});

--- a/packages/client-core/src/history/historyLinks.ts
+++ b/packages/client-core/src/history/historyLinks.ts
@@ -11,13 +11,18 @@ export interface HistoryLink {
   isUrl: boolean;
 }
 
-// Absolute Windows paths (e.g. C:\path\to\file or C:/path/to/file). In C# the verbatim string's
-// "" is a single quote char inside the negated class.
-const AbsoluteWindowsPathRegex = /[A-Za-z]:[/\\][^\s"'`<>|*?()[\]]+/g;
+// Absolute Windows paths (e.g. C:\path\to\file or C:/path/to/file). The (?<![A-Za-z]) guard keeps a
+// drive letter that is really part of a longer word from being mis-claimed (e.g. the "e" of "file:"
+// in "file:///D:/..."), matching the C# AbsoluteWindowsPathRegex (issue #252).
+const AbsoluteWindowsPathRegex = /(?<![A-Za-z])[A-Za-z]:[/\\][^\s"'`<>|*?()[\]]+/g;
 // Unix-style absolute paths (e.g. /c/path/to/file for Git Bash / WSL).
 const AbsoluteUnixPathRegex = /\/[a-z]\/[^\s"'`<>|*?()[\]]+/gi;
 // URLs (http/https or git@).
 const UrlRegex = /https?:\/\/[^\s"'`<>()[\]]+|git@[^\s"'`<>()[\]]+/gi;
+// file:// URLs (RFC 8089), e.g. file:///D:/path/file.html. These name a LOCAL file, so they surface
+// as Path links with the whole file://... span claimed and the resolved local path as the text
+// (issue #252). Matched before the Windows/Unix path matchers so the whole span is one link.
+const FileUrlRegex = /file:\/\/[^\s"'`<>|*?()[\]]+/gi;
 // Characters that look like a path start inside a quoted span.
 const PathLikeRegex = /^(?:[A-Za-z]:[/\\]|\/[a-z]\/|\.{0,2}[/\\]|[A-Za-z_][A-Za-z0-9_-]*[/\\])/i;
 
@@ -88,6 +93,20 @@ function findAllLinkMatches(lineText: string): LinkMatch[] {
     if (overlaps(claimed, start, end)) continue;
     const url = stripTrailingPunctuation(m[0]);
     matches.push({ text: url, isUrl: true });
+    claimed.push({ start, end });
+  }
+
+  // 2b. file:// URLs -> the resolved LOCAL file path (a Path link). The whole file://... span is
+  //     claimed, but the text is the local path so the link opens the actual file. Runs before the
+  //     path matchers so they cannot mis-claim the drive letter inside the URL.
+  for (const m of lineText.matchAll(FileUrlRegex)) {
+    const start = m.index ?? 0;
+    const end = start + m[0].length;
+    if (overlaps(claimed, start, end)) continue;
+    const span = stripTrailingPunctuation(m[0]);
+    const localPath = tryConvertFileUrlToLocalPath(span);
+    if (localPath === null) continue;
+    matches.push({ text: localPath, isUrl: false });
     claimed.push({ start, end });
   }
 
@@ -166,6 +185,39 @@ function extractQuotedSpans(text: string): QuotedSpan[] {
     i++;
   }
   return spans;
+}
+
+// Convert a file:// URL to the local Windows path it names, e.g. file:///D:/My%20Docs/report.md ->
+// D:\My Docs\report.md (issue #252). Mirrors the C# TryConvertFileUrlToLocalPath (which uses
+// Uri.LocalPath): percent-encoding is decoded and forward slashes become backslashes. Returns null
+// for anything that is not an absolute file URL, so the caller falls through to the path matchers.
+export function tryConvertFileUrlToLocalPath(fileUrl: string): string | null {
+  if (!fileUrl) return null;
+  let url: URL;
+  try {
+    url = new URL(fileUrl);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "file:") return null;
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(url.pathname);
+  } catch {
+    return null;
+  }
+
+  // A UNC path (file://server/share) keeps the host as the leading \\server; otherwise the pathname
+  // is /D:/... where the leading slash precedes the drive letter and must be dropped.
+  let local: string;
+  if (url.host) {
+    local = `\\\\${url.host}${decoded}`;
+  } else {
+    local = decoded.startsWith("/") ? decoded.slice(1) : decoded;
+  }
+  local = local.replace(/\//g, "\\");
+  return local.length === 0 ? null : local;
 }
 
 function isRelativePath(path: string): boolean {

--- a/packages/client-core/tsconfig.build.json
+++ b/packages/client-core/tsconfig.build.json
@@ -9,5 +9,8 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "dist"
-  }
+  },
+  // The unit tests are type-checked by `npm run typecheck` (tsconfig.json includes them) but are not
+  // part of the shipped library, so they are excluded from the declaration build.
+  "exclude": ["**/*.test.ts"]
 }

--- a/src/CcDirector.Gateway.Tests/GitHubItemStatusResolverTests.cs
+++ b/src/CcDirector.Gateway.Tests/GitHubItemStatusResolverTests.cs
@@ -1,0 +1,197 @@
+using System.Net;
+using System.Text;
+using CcDirector.Gateway.Api;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unit coverage for the Gateway-side work-item resolver (issue #970). Proves the ported GitHub fetch
+/// + flow-label mapping behaves exactly like the Cockpit's GitHubItemStatusClient did, using a stub
+/// HTTP handler so no network or credentials file is touched. The token is supplied through the
+/// injected provider - never read from a browser - which is the whole point of moving it here.
+/// </summary>
+public sealed class GitHubItemStatusResolverTests
+{
+    private static readonly Func<(string?, string?)> GoodToken = () => ("test-token", null);
+    private static readonly Func<(string?, string?)> NoToken = () => (null, "GITHUB_TOKEN not configured.");
+
+    // ---- flow:* label mapping (mirrors the Cockpit GitHubItemStatusClientTests, issue #275) ----
+
+    [Fact]
+    public void MapStatus_NoLabels_ReturnsQueued()
+        => Assert.Equal(GatewayWorkItemStatus.Queued, GitHubItemStatusResolver.MapStatus(Array.Empty<string>()));
+
+    [Theory]
+    [InlineData("flow:ready-dev")]
+    [InlineData("flow:in-progress")]
+    [InlineData("flow:rejected")]
+    public void MapStatus_NotYetDrained_ReturnsQueued(string label)
+        => Assert.Equal(GatewayWorkItemStatus.Queued, GitHubItemStatusResolver.MapStatus(new[] { label }));
+
+    [Theory]
+    [InlineData("flow:ready-qa")]
+    [InlineData("flow:qa-failed")]
+    public void MapStatus_InLoop_ReturnsRunning(string label)
+        => Assert.Equal(GatewayWorkItemStatus.Running, GitHubItemStatusResolver.MapStatus(new[] { label }));
+
+    [Fact]
+    public void MapStatus_Done_ReturnsDone()
+        => Assert.Equal(GatewayWorkItemStatus.Done, GitHubItemStatusResolver.MapStatus(new[] { "flow:done" }));
+
+    [Fact]
+    public void MapStatus_NeedsHuman_ReturnsNeedsHuman()
+        => Assert.Equal(GatewayWorkItemStatus.NeedsHuman, GitHubItemStatusResolver.MapStatus(new[] { "flow:needs-human" }));
+
+    [Fact]
+    public void MapStatus_Failed_ReturnsFailed()
+        => Assert.Equal(GatewayWorkItemStatus.Failed, GitHubItemStatusResolver.MapStatus(new[] { "flow:failed" }));
+
+    [Fact]
+    public void MapStatus_DoneWinsOverRunning_ReturnsDone()
+        => Assert.Equal(GatewayWorkItemStatus.Done, GitHubItemStatusResolver.MapStatus(new[] { "flow:ready-qa", "flow:done" }));
+
+    [Fact]
+    public void MapStatus_NeedsHumanWinsOverRunning_ReturnsNeedsHuman()
+        => Assert.Equal(GatewayWorkItemStatus.NeedsHuman, GitHubItemStatusResolver.MapStatus(new[] { "flow:qa-failed", "flow:needs-human" }));
+
+    [Fact]
+    public void MapStatus_IgnoresUnrelatedLabels_ReturnsQueued()
+        => Assert.Equal(GatewayWorkItemStatus.Queued, GitHubItemStatusResolver.MapStatus(new[] { "enhancement", "cockpit" }));
+
+    [Fact]
+    public void MapStatus_IsCaseInsensitive_ReturnsDone()
+        => Assert.Equal(GatewayWorkItemStatus.Done, GitHubItemStatusResolver.MapStatus(new[] { "FLOW:DONE" }));
+
+    // ---- ResolveAsync end to end over a stub GitHub ----
+
+    [Fact]
+    public async Task NonGithubSource_ResolvesQueued_WithoutAnyCall()
+    {
+        var handler = new StubHandler(_ => throw new InvalidOperationException("must not call GitHub for a non-github source"));
+        var resolver = NewResolver(handler, GoodToken);
+
+        var info = await resolver.ResolveAsync("devops", "42");
+
+        Assert.Equal(GatewayWorkItemStatus.Queued, info.Status);
+        Assert.Null(info.Title);
+        Assert.Contains("devops", info.Detail);
+        Assert.Equal(0, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task MissingToken_ResolvesUnknown_WithoutAnyCall()
+    {
+        var handler = new StubHandler(_ => throw new InvalidOperationException("must not call GitHub without a token"));
+        var resolver = NewResolver(handler, NoToken);
+
+        var info = await resolver.ResolveAsync("github", "970");
+
+        Assert.Equal(GatewayWorkItemStatus.Unknown, info.Status);
+        Assert.Equal("GITHUB_TOKEN not configured.", info.Detail);
+        Assert.Equal(0, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task GithubItem_WithFlowDone_ResolvesTitleAndDone()
+    {
+        var handler = new StubHandler(_ => Json(HttpStatusCode.OK,
+            """{ "title": "Rebuild the Cockpit", "labels": [ { "name": "cockpit" }, { "name": "flow:done" } ] }"""));
+        var resolver = NewResolver(handler, GoodToken);
+
+        var info = await resolver.ResolveAsync("github", "967");
+
+        Assert.Equal("Rebuild the Cockpit", info.Title);
+        Assert.Equal(GatewayWorkItemStatus.Done, info.Status);
+        Assert.Null(info.Detail);
+    }
+
+    [Fact]
+    public async Task GithubItem_NoFlowLabel_ResolvesTitleAndQueued()
+    {
+        var handler = new StubHandler(_ => Json(HttpStatusCode.OK,
+            """{ "title": "Some open issue", "labels": [ { "name": "enhancement" } ] }"""));
+        var resolver = NewResolver(handler, GoodToken);
+
+        var info = await resolver.ResolveAsync("github", "1");
+
+        Assert.Equal("Some open issue", info.Title);
+        Assert.Equal(GatewayWorkItemStatus.Queued, info.Status);
+    }
+
+    [Fact]
+    public async Task GithubItem_SendsBearerToken_AndCanonicalRepoPath()
+    {
+        HttpRequestMessage? seen = null;
+        var handler = new StubHandler(req => { seen = req; return Json(HttpStatusCode.OK, """{ "title": "x", "labels": [] }"""); });
+        var resolver = NewResolver(handler, GoodToken, owner: "thefrederiksen", repo: "devthrottle");
+
+        await resolver.ResolveAsync("github", "970");
+
+        Assert.NotNull(seen);
+        Assert.Equal("Bearer", seen!.Headers.Authorization?.Scheme);
+        Assert.Equal("test-token", seen.Headers.Authorization?.Parameter);
+        Assert.EndsWith("repos/thefrederiksen/devthrottle/issues/970", seen.RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task GithubItem_NotFound_ResolvesUnknownWithDetail()
+    {
+        var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+        var resolver = NewResolver(handler, GoodToken);
+
+        var info = await resolver.ResolveAsync("github", "999999");
+
+        Assert.Equal(GatewayWorkItemStatus.Unknown, info.Status);
+        Assert.Null(info.Title);
+        Assert.Contains("not found", info.Detail);
+    }
+
+    [Fact]
+    public async Task GithubItem_ServerError_ResolvesUnknownWithDetail()
+    {
+        var handler = new StubHandler(_ => Json(HttpStatusCode.Forbidden, """{ "message": "rate limited" }"""));
+        var resolver = NewResolver(handler, GoodToken);
+
+        var info = await resolver.ResolveAsync("github", "970");
+
+        Assert.Equal(GatewayWorkItemStatus.Unknown, info.Status);
+        Assert.Contains("403", info.Detail);
+    }
+
+    [Fact]
+    public async Task GithubUnreachable_ResolvesUnknown_NotThrow()
+    {
+        var handler = new StubHandler(_ => throw new HttpRequestException("connection refused"));
+        var resolver = NewResolver(handler, GoodToken);
+
+        var info = await resolver.ResolveAsync("github", "970");
+
+        Assert.Equal(GatewayWorkItemStatus.Unknown, info.Status);
+        Assert.Contains("GitHub unreachable", info.Detail);
+    }
+
+    private static GitHubItemStatusResolver NewResolver(
+        StubHandler handler, Func<(string?, string?)> token, string owner = "devthrottle", string repo = "devthrottle")
+    {
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.github.com/") };
+        return new GitHubItemStatusResolver(http, token, owner, repo);
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode code, string body)
+        => new(code) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _respond;
+        public int CallCount { get; private set; }
+
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) => _respond = respond;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            return Task.FromResult(_respond(request));
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/ItemStatusEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/ItemStatusEndpointTests.cs
@@ -1,0 +1,104 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using CcDirector.Gateway;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Proves the work-item status endpoint is wired live on a real <see cref="GatewayHost"/> (issue
+/// #970): the browser can resolve a work-list item's title + status through a same-origin Gateway
+/// call, so the React Cockpit never holds the GitHub token. The deterministic cases use a non-github
+/// source (no network, no credentials). A separate env-gated case resolves a real GitHub issue
+/// through the live endpoint to capture the human proof transcript.
+/// </summary>
+public sealed class ItemStatusEndpointTests : IAsyncLifetime
+{
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-itemstatus-" + Guid.NewGuid().ToString("N"));
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: FreePort(), token: "test-token", authEnabled: true,
+            instancesDirectory: _instancesDir, cockpitProxyPort: 1,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
+        await _gateway.StartAsync();
+
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "test-token");
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { }
+    }
+
+    [Fact]
+    public async Task NonGithubSource_ResolvesQueued_SameOrigin_NoToken()
+    {
+        var resp = await _http.GetAsync("gateway/lists/item-status?source=devops&id=123");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        var root = doc.RootElement;
+        Assert.Equal("queued", root.GetProperty("status").GetString());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("title").ValueKind);
+        Assert.Contains("devops", root.GetProperty("detail").GetString());
+    }
+
+    [Theory]
+    [InlineData("gateway/lists/item-status?source=github")]
+    [InlineData("gateway/lists/item-status?id=970")]
+    [InlineData("gateway/lists/item-status")]
+    public async Task MissingParameters_Return400(string url)
+    {
+        var resp = await _http.GetAsync(url);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    /// <summary>
+    /// LIVE proof (issue #970): resolves a real GitHub issue through the running Gateway endpoint,
+    /// with the token read on the Gateway from the shared credentials file. Runs only when
+    /// DEVTHROTTLE_LIVE_GITHUB_PROOF is set to the output transcript path (kept offline/CI-safe by
+    /// default). Set DEVTHROTTLE_GITHUB_OWNER / _REPO / a target id to point at the real repo.
+    /// </summary>
+    [Fact]
+    public async Task Live_ResolvesRealGithubIssue_ThroughGateway()
+    {
+        var outPath = Environment.GetEnvironmentVariable("DEVTHROTTLE_LIVE_GITHUB_PROOF");
+        if (string.IsNullOrWhiteSpace(outPath))
+            return; // gated off by default
+
+        var id = Environment.GetEnvironmentVariable("DEVTHROTTLE_LIVE_GITHUB_ID") ?? "967";
+        var resp = await _http.GetAsync($"gateway/lists/item-status?source=github&id={id}");
+        var body = await resp.Content.ReadAsStringAsync();
+
+        var transcript =
+            $"REQUEST: GET http://127.0.0.1:{_gateway.Port}/gateway/lists/item-status?source=github&id={id}\r\n" +
+            $"(browser sends only the same-origin cc-gateway-token; the GitHub token stays on the Gateway)\r\n" +
+            $"RESPONSE STATUS: {(int)resp.StatusCode}\r\n" +
+            $"RESPONSE BODY: {body}\r\n";
+        File.WriteAllText(outPath, transcript);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        using var doc = JsonDocument.Parse(body);
+        // The response carries only title/status/detail - never the token.
+        Assert.DoesNotContain("ghp_", body);
+        Assert.DoesNotContain("github_pat_", body);
+        Assert.False(string.IsNullOrWhiteSpace(doc.RootElement.GetProperty("title").GetString()));
+    }
+
+    private static int FreePort()
+    {
+        using var l = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        l.Start();
+        return ((IPEndPoint)l.LocalEndpoint).Port;
+    }
+}

--- a/src/CcDirector.Gateway/Api/ItemStatusEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/ItemStatusEndpoint.cs
@@ -1,0 +1,248 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The per-work-item title + status surface the Cockpit Lists view reads (issue #275, moved behind
+/// the Gateway for the React rebuild, issue #970). The Blazor Cockpit fetched this from GitHub
+/// itself with a bearer token held on the Cockpit server. The React Cockpit is a browser
+/// single-page application that must hold NO secret, so the resolve moves onto the Gateway: the
+/// browser calls this endpoint same-origin (root-relative) and the GitHub token never leaves the
+/// Gateway host.
+///
+///   GET /gateway/lists/item-status?source={source}&amp;id={id}
+///        -> { title: string|null, status: "queued"|"running"|"done"|"needs-human"|"failed"|"unknown", detail: string|null }
+///
+/// Status is DERIVED from the item's <c>flow:*</c> label (never stored), so the badge always follows
+/// the label. A non-github source resolves to "queued" without a network call. An unreachable GitHub
+/// or a missing token resolves to "unknown" with a human-readable detail (the no-fallback rule: the
+/// row shows the failure explicitly rather than a wrong "queued").
+/// </summary>
+internal static class ItemStatusEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app, GitHubItemStatusResolver resolver)
+    {
+        app.MapGet("/gateway/lists/item-status", async (string? source, string? id, CancellationToken ct) =>
+        {
+            if (string.IsNullOrWhiteSpace(source) || string.IsNullOrWhiteSpace(id))
+                return Results.BadRequest(new { error = "source and id query parameters are required" });
+
+            var info = await resolver.ResolveAsync(source, id, ct);
+            return Results.Json(new
+            {
+                title = info.Title,
+                status = ToWire(info.Status),
+                detail = info.Detail,
+            });
+        });
+    }
+
+    /// <summary>
+    /// Stable lowercase wire name for each status. The browser maps these to its badge labels, so the
+    /// contract is these exact strings (kept in step with the client-core WorkItemStatus type).
+    /// </summary>
+    internal static string ToWire(GatewayWorkItemStatus status) => status switch
+    {
+        GatewayWorkItemStatus.Queued => "queued",
+        GatewayWorkItemStatus.Running => "running",
+        GatewayWorkItemStatus.Done => "done",
+        GatewayWorkItemStatus.NeedsHuman => "needs-human",
+        GatewayWorkItemStatus.Failed => "failed",
+        _ => "unknown",
+    };
+}
+
+/// <summary>
+/// The per-item status badge, derived live from a github item's <c>flow:*</c> label. Mirrors the
+/// Cockpit's WorkItemStatus (issue #275); duplicated here because the Gateway does not reference the
+/// Cockpit project - the Gateway now owns the resolve.
+/// </summary>
+internal enum GatewayWorkItemStatus
+{
+    Queued,
+    Running,
+    Done,
+    NeedsHuman,
+    Failed,
+    Unknown,
+}
+
+/// <summary>The GitHub-derived view of one work-list item: its display title plus flow-derived status.</summary>
+internal sealed record WorkItemInfo(string? Title, GatewayWorkItemStatus Status, string? Detail);
+
+/// <summary>
+/// Resolves a work-list item's title + status from GitHub, with the token held on the Gateway (issue
+/// #970). Ported from the Cockpit's GitHubItemStatusClient. The HttpClient and the token provider are
+/// injected so the resolve can be exercised in tests without touching the real credentials file or
+/// api.github.com; <see cref="CreateDefault"/> wires the production surface.
+/// </summary>
+internal sealed class GitHubItemStatusResolver
+{
+    private const string TokenKey = "GITHUB_TOKEN";
+
+    private readonly HttpClient _http;
+    private readonly Func<(string? token, string? error)> _tokenProvider;
+    private readonly string _owner;
+    private readonly string _repo;
+
+    public GitHubItemStatusResolver(
+        HttpClient http, Func<(string? token, string? error)> tokenProvider, string owner, string repo)
+    {
+        _http = http;
+        _tokenProvider = tokenProvider;
+        _owner = owner;
+        _repo = repo;
+    }
+
+    /// <summary>
+    /// Production wiring: a real HttpClient against api.github.com, the token read from the shared
+    /// credentials file at point of use, and the canonical repo (overridable for private forks via
+    /// DEVTHROTTLE_GITHUB_OWNER / DEVTHROTTLE_GITHUB_REPO).
+    /// </summary>
+    public static GitHubItemStatusResolver CreateDefault()
+    {
+        var http = new HttpClient
+        {
+            BaseAddress = new Uri("https://api.github.com/"),
+            Timeout = TimeSpan.FromSeconds(10),
+        };
+        return new GitHubItemStatusResolver(
+            http,
+            ReadCredentialsFileToken,
+            ReadRepositorySetting("DEVTHROTTLE_GITHUB_OWNER", "devthrottle"),
+            ReadRepositorySetting("DEVTHROTTLE_GITHUB_REPO", "devthrottle"));
+    }
+
+    /// <summary>
+    /// Resolve title + status for one item ref. A non-github source resolves to Queued (no call). A
+    /// github item is fetched and mapped from its flow label. Never throws for an unreachable GitHub
+    /// or a missing token: it returns Unknown + a human-readable detail so the list still renders and
+    /// the failure is shown explicitly rather than masked as a wrong "queued".
+    /// </summary>
+    public async Task<WorkItemInfo> ResolveAsync(string source, string id, CancellationToken ct = default)
+    {
+        if (!string.Equals(source, "github", StringComparison.OrdinalIgnoreCase))
+            return new WorkItemInfo(Title: null, Status: GatewayWorkItemStatus.Queued, Detail: $"{source} item (not runnable in v1)");
+
+        var (token, tokenError) = _tokenProvider();
+        if (token is null)
+        {
+            FileLog.Write($"[GitHubItemStatusResolver] github id={id} - no token: {tokenError}");
+            return new WorkItemInfo(Title: null, Status: GatewayWorkItemStatus.Unknown, Detail: tokenError);
+        }
+
+        try
+        {
+            return await FetchAsync(id, token, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (HttpRequestException ex)
+        {
+            FileLog.Write($"[GitHubItemStatusResolver] github id={id} transport failure: {ex.Message}");
+            return new WorkItemInfo(Title: null, Status: GatewayWorkItemStatus.Unknown, Detail: $"GitHub unreachable: {ex.Message}");
+        }
+    }
+
+    private async Task<WorkItemInfo> FetchAsync(string id, string token, CancellationToken ct)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Get, $"repos/{_owner}/{_repo}/issues/{Uri.EscapeDataString(id)}");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        req.Headers.UserAgent.ParseAdd("devthrottle-gateway");
+        req.Headers.Add("X-GitHub-Api-Version", "2022-11-28");
+
+        using var resp = await _http.SendAsync(req, ct);
+        if (resp.StatusCode == HttpStatusCode.NotFound)
+            return new WorkItemInfo(Title: null, Status: GatewayWorkItemStatus.Unknown, Detail: $"GitHub issue #{id} not found in {_owner}/{_repo}");
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            return new WorkItemInfo(Title: null, Status: GatewayWorkItemStatus.Unknown,
+                Detail: $"GitHub returned {(int)resp.StatusCode} for #{id}: {Truncate(body, 120)}");
+        }
+
+        var stream = await resp.Content.ReadAsStreamAsync(ct);
+        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
+        var root = doc.RootElement;
+
+        var title = root.TryGetProperty("title", out var t) && t.ValueKind == JsonValueKind.String ? t.GetString() : null;
+
+        var labels = new List<string>();
+        if (root.TryGetProperty("labels", out var labelsEl) && labelsEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var label in labelsEl.EnumerateArray())
+            {
+                if (label.TryGetProperty("name", out var n) && n.ValueKind == JsonValueKind.String)
+                {
+                    var name = n.GetString();
+                    if (!string.IsNullOrEmpty(name)) labels.Add(name);
+                }
+            }
+        }
+
+        return new WorkItemInfo(title, MapStatus(labels), Detail: null);
+    }
+
+    /// <summary>
+    /// Map an issue's flow:* labels to a status badge. When several flow labels are present the
+    /// terminal/escalation states win over the in-flight ones, which win over queued.
+    /// </summary>
+    internal static GatewayWorkItemStatus MapStatus(IReadOnlyCollection<string> labels)
+    {
+        bool Has(string label) => labels.Any(l => string.Equals(l, label, StringComparison.OrdinalIgnoreCase));
+
+        if (Has("flow:done")) return GatewayWorkItemStatus.Done;
+        if (Has("flow:needs-human")) return GatewayWorkItemStatus.NeedsHuman;
+        if (Has("flow:failed")) return GatewayWorkItemStatus.Failed;
+        // The loop is still on the item while it is in QA (qa-failed is a transient mid-loop bounce).
+        if (Has("flow:ready-qa") || Has("flow:qa-failed")) return GatewayWorkItemStatus.Running;
+        // No flow label, or flow:ready-dev / flow:in-progress / flow:rejected: not yet drained.
+        return GatewayWorkItemStatus.Queued;
+    }
+
+    /// <summary>
+    /// Read GITHUB_TOKEN from the shared credentials file at point of use (so the secret only enters
+    /// the process when a github item is actually resolved). Returns a null token + a fixable message
+    /// when the file or key is absent - no silent fallback to an empty token.
+    /// </summary>
+    private static (string? token, string? error) ReadCredentialsFileToken()
+    {
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var path = Path.Combine(localAppData, "cc-director", "config", "credentials.env");
+        if (!File.Exists(path))
+            return (null, $"GITHUB_TOKEN not configured (no {path}); per-item GitHub status unavailable.");
+
+        foreach (var raw in File.ReadAllLines(path))
+        {
+            var line = raw.Trim();
+            if (line.Length == 0 || line.StartsWith('#')) continue;
+            var eq = line.IndexOf('=');
+            if (eq <= 0) continue;
+            if (!string.Equals(line[..eq].Trim(), TokenKey, StringComparison.Ordinal)) continue;
+            var value = line[(eq + 1)..].Trim().Trim('"');
+            return string.IsNullOrEmpty(value)
+                ? (null, $"{TokenKey} is present in {path} but empty.")
+                : (value, null);
+        }
+
+        return (null, $"{TokenKey} not found in {path}.");
+    }
+
+    private static string ReadRepositorySetting(string variable, string fallback)
+    {
+        var value = Environment.GetEnvironmentVariable(variable);
+        return string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
+    }
+
+    private static string Truncate(string s, int max)
+        => string.IsNullOrEmpty(s) || s.Length <= max ? s : s[..max] + "...";
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1005,6 +1005,13 @@ public sealed class GatewayHost : IAsyncDisposable
         // like the rest of the Gateway surface.
         WorkListEndpoints.Map(_app, _workLists);
 
+        // Per-work-item title + status for the Cockpit Lists view (issue #275, moved behind the
+        // Gateway for the React rebuild, issue #970). The React Cockpit is a browser SPA that holds
+        // no secret, so the GitHub resolve lives here: the browser calls GET
+        // /gateway/lists/item-status?source&id same-origin and the GitHub token never leaves the
+        // Gateway host. Inherits the host-wide token middleware above.
+        Api.ItemStatusEndpoint.Map(_app, Api.GitHubItemStatusResolver.CreateDefault());
+
         // Cron jobs (epic #479, part 1 = #482): the REST CRUD surface over the cron-job definition
         // store. Manages definitions only - the background firing engine is part 2 (#483).
         // Persisted to cronjobs.json across restarts (write-through + reload-on-start with


### PR DESCRIPTION
Closes part of #967. Implements #970.

## Release Notes
The React Cockpit holds no secret: the GitHub work-item status resolve moved onto the Gateway, the LinkDetector recognizer and the Brief fallback are ported to `client-core` TypeScript.

## Changes
- **Gateway endpoint** `GET /gateway/lists/item-status?source&id` (`ItemStatusEndpoint.cs` + `GitHubItemStatusResolver`) resolving a work-list item's title + `flow:*`-derived status. The GitHub token is read on the Gateway host from the shared credentials file at point of use and never leaves the Gateway. Registered in `GatewayHost` beside the work-list routes (inherits the host-wide token middleware).
- **LinkDetector port** hardened (`packages/client-core/src/history/historyLinks.ts`): drive-letter boundary guard `(?<![A-Za-z])` + `file://` URL handling, matching `src/CcDirector.Core/Utilities/LinkDetector.cs`. Vitest suite mirrors the applicable shared `LinkDetectorTests` cases.
- **Brief fallback** ported to secret-free `finalParagraph()` (`packages/client-core/src/brief/briefFallback.ts`), tests mirror the C# `BriefBuilderTests` fallback cases.
- **Browser client** `resolveItemStatus()` (`packages/client-core/src/api/itemStatus.ts`) calls the endpoint through a root-relative same-origin path.
- Added vitest to `client-core`; test files exempted from the Gateway-only-ingress lint rule (URL fixtures are test data).

## How to Test
- `dotnet build cc-director.sln` -> clean.
- `dotnet test CcDirector.Gateway.Tests --filter "ItemStatus|GitHubItemStatusResolver"` -> 26 passed.
- `npm run test/typecheck/lint --workspace @devthrottle/client-core` -> 49 tests pass, clean.
- Live: the endpoint resolves real GitHub issues through a real `GatewayHost` (transcripts in proof).

## Expected Result
Title + status resolve same-origin through the Gateway; no GitHub token in the browser bundle (grep of client code is empty).

## Before / After
Before: the Cockpit server held the GitHub token and composed the Brief fallback; the browser could not do this without a secret. After: the Gateway holds the token behind `/gateway/lists/item-status`, and the recognizer + fallback are secret-free `client-core` TypeScript.

Proof: docs/cencon/proof/issue-970/report.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)