### PR TITLE
Out-of-credits UX on the mobile PWA voice surfaces (#942)

### DIFF
--- a/apps/mobile/src/components/CreditsNotice.tsx
+++ b/apps/mobile/src/components/CreditsNotice.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from "react";
+import { onCreditsNeeded, type HostedAiUnavailable } from "@devthrottle/client-core/api/client";
+
+// The ONE app-level out-of-credits notice for the whole PWA (issue #942, epic #937). Whenever any
+// hosted-AI call returns HTTP 402 (out of credits, monthly cap, or - in bring-your-own mode - no key),
+// the client emits the shared body and this shows the single-source message plus a call-to-action that
+// deep-links to Billing. Mounted once at the app root, so every voice/Wingman/text-to-speech surface is
+// covered without each one carrying its own credits UX.
+//
+// Add-$5-without-reload: it clears when the app returns to the foreground (visibilitychange), so after a
+// top-up the next roster/voice poll re-checks and, if funded, produces no new 402 - the notice stays
+// gone with no app reload. A stale notice is also dismissible.
+export function CreditsNotice(): React.ReactElement | null {
+  const [info, setInfo] = useState<HostedAiUnavailable | null>(null);
+
+  // Subscribe to the client-core 402 emitter for the component's lifetime.
+  useEffect(() => onCreditsNeeded(setInfo), []);
+
+  // Returning to the foreground (e.g. back from the Billing tab) clears the notice so the next poll
+  // re-checks against the new balance.
+  useEffect(() => {
+    function onVisibility(): void {
+      if (document.visibilityState === "visible") setInfo(null);
+    }
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => document.removeEventListener("visibilitychange", onVisibility);
+  }, []);
+
+  if (info === null) return null;
+
+  return (
+    <div className="credits-notice">
+      <div className="banner banner-info banner-action">
+        <span>{info.text}</span>
+        <span className="credits-notice-actions">
+          {info.ctaUrl !== null && info.ctaUrl !== "" && (
+            <a className="banner-btn" href={info.ctaUrl} target="_blank" rel="noopener noreferrer">
+              {info.ctaLabel || "Add credits"}
+            </a>
+          )}
+          <button className="banner-btn credits-notice-dismiss" onClick={() => setInfo(null)}>
+            Dismiss
+          </button>
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -12,6 +12,7 @@ import { DeviceCallback } from "@devthrottle/client-core/auth/DeviceCallback";
 import { hasDeviceKey } from "@devthrottle/client-core/auth/deviceKey";
 import { ensureGatewayCookie } from "@devthrottle/client-core/api/client";
 import { ensurePushSubscribed } from "./push/register";
+import { CreditsNotice } from "./components/CreditsNotice";
 import "./styles.css";
 
 // The auth gate (issue #908): every real screen requires an enrolled device key. Without one, the
@@ -65,5 +66,6 @@ if (rootElement === null) {
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <RouterProvider router={router} />
+    <CreditsNotice />
   </React.StrictMode>
 );

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -114,6 +114,36 @@ body {
   cursor: default;
 }
 
+/* Issue #942: the app-level out-of-credits notice floats above the current screen so any surface's
+   402 is covered by one consistent message + call-to-action. */
+.credits-notice {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 2000;
+  padding: 0 12px calc(12px + env(safe-area-inset-bottom));
+  pointer-events: none;
+}
+.credits-notice .banner {
+  pointer-events: auto;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+}
+.credits-notice-actions {
+  display: flex;
+  gap: 8px;
+  flex: none;
+}
+a.banner-btn {
+  text-decoration: none;
+  display: inline-block;
+}
+.credits-notice-dismiss {
+  background: transparent;
+  color: var(--text);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
 .status-line {
   color: var(--text-dim);
   font-size: 14px;

--- a/docs/cencon/proof/issue-942/report.html
+++ b/docs/cencon/proof/issue-942/report.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Issue #942 - Out-of-credits UX on the mobile PWA - Proof</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: Georgia, "Times New Roman", serif; max-width: 62rem; margin: 2rem auto; padding: 0 1.25rem; line-height: 1.55; }
+  h1 { font-size: 1.5rem; border-bottom: 2px solid #888; padding-bottom: .4rem; }
+  h2 { font-size: 1.15rem; margin-top: 2rem; border-bottom: 1px solid #ccc; padding-bottom: .2rem; }
+  code, pre { font-family: Consolas, "Courier New", monospace; }
+  pre { background: rgba(128,128,128,.12); padding: .8rem 1rem; overflow-x: auto; border-radius: 4px; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #999; padding: .45rem .6rem; text-align: left; vertical-align: top; font-size: .92rem; }
+  th { background: rgba(128,128,128,.18); }
+  .pass { font-weight: bold; }
+  .muted { color: #777; font-size: .9rem; }
+</style>
+</head>
+<body>
+
+<h1>Issue #942 - Out-of-credits UX on the mobile PWA voice surfaces</h1>
+<p class="muted">Part of epic #937. The live mobile app is <code>apps/mobile</code> (React over <code>packages/client-core</code>). The Gateway <code>/wingman/*</code> endpoints already return the shared 402 (from #939), so this is client-side.</p>
+
+<h2>Approach (one chokepoint, no per-surface duplication)</h2>
+<p>Every Gateway call funnels through <code>packages/client-core/src/api/client.ts</code>, which throws a <code>GatewayError</code> on a non-2xx. The mobile app had ZERO out-of-credits handling. The fix makes a hosted-AI 402 produce a typed <code>CreditsError</code> whose <code>message</code> IS the shared text - so every surface's existing <code>err.message</code> banner shows the correct copy by construction - and also emits the shared body to ONE app-level notice that renders the "Add credits" call-to-action. No surface had to widen its error state.</p>
+
+<h2>What was implemented</h2>
+<table>
+  <tr><th>File</th><th>Change</th></tr>
+  <tr><td><code>packages/client-core/src/api/client.ts</code></td><td>New <code>HostedAiUnavailable</code> type, <code>CreditsError</code> (message = shared text), <code>onCreditsNeeded</code> app-level emitter, and <code>creditsErrorFrom(body)</code>. Wired into the 402 branch of <code>/wingman/utterance/complete</code> (dictation A4/A5/A6), <code>/wingman/explain</code> (voice mode B2/A6), and <code>/wingman/voice/audio</code> (narration/roster B2/B3).</td></tr>
+  <tr><td><code>packages/client-core/src/api/ai.ts</code></td><td><code>ttsSample</code> (C1 "Play sample") maps a 402 to the shared <code>CreditsError</code>.</td></tr>
+  <tr><td><code>apps/mobile/src/components/CreditsNotice.tsx</code> (new)</td><td>The one app-level notice: subscribes to <code>onCreditsNeeded</code>, shows the shared message + a Billing deep-link (<code>ctaUrl</code>), dismissible; clears on return-to-foreground so a top-up unlocks with no reload.</td></tr>
+  <tr><td><code>apps/mobile/src/main.tsx</code> + <code>styles.css</code></td><td>Mounts <code>&lt;CreditsNotice/&gt;</code> at the app root; floating banner styles reusing the existing <code>banner</code> classes.</td></tr>
+</table>
+
+<h2>Acceptance criteria -&gt; proof</h2>
+<table>
+  <tr><th>Criterion</th><th>How met</th></tr>
+  <tr><td>Not-Ready shows the shared message + a CTA (deep-link to Billing) on every surface.</td><td>Every money endpoint's 402 emits to the app-level <code>CreditsNotice</code> (message + <code>ctaUrl</code> button), and each surface's own banner shows the shared <code>message</code>.</td></tr>
+  <tr><td>Runtime 402 mapped by <code>code</code>; no generic "Transcription failed" for credits.</td><td>The server already branches on <code>code</code> (#939); the client parses that shared body into <code>CreditsError</code> instead of a generic <code>GatewayError</code>.</td></tr>
+  <tr><td>Add-$5 -&gt; works without app reload (re-check on focus / after top-up return).</td><td>The notice clears on <code>visibilitychange</code> to foreground; the roster/voice polls re-fire and, if funded, produce no new 402.</td></tr>
+</table>
+
+<h2>Verification</h2>
+<pre>npm run typecheck --workspaces   -> client-core OK, cockpit OK, mobile OK (tsc --noEmit, no errors)
+npm run build --workspace @devthrottle/mobile   -> vite build OK (PWA generated)</pre>
+
+<h2>CenCon impact</h2>
+<p>No architecture or security drift. Client-side only; consumes the shared 402 the Gateway already returns and the billing URL it carries (<code>ctaUrl</code>) - no new host hard-coded in the client. The device key handling is untouched.</p>
+
+<p class="pass">Mobile out-of-credits UX added at one chokepoint; typechecks and builds.</p>
+
+</body>
+</html>

--- a/packages/client-core/src/api/ai.ts
+++ b/packages/client-core/src/api/ai.ts
@@ -3,7 +3,7 @@
 // the desktop Settings "AI" tab uses - the mobile screen is just a phone-styled front end over them, so
 // there is no backend work here. The AI-settings response shapes are returned by the Gateway via
 // Results.Json without a [Produces] annotation, so they are read with the narrow local types below.
-import { authHeaders, GatewayError } from "./client";
+import { authHeaders, GatewayError, creditsErrorFrom } from "./client";
 
 export type AiProviderId = "devthrottle" | "openai";
 
@@ -105,6 +105,8 @@ export async function ttsSample(text: string, model: string, voice: string): Pro
   });
   if (!res.ok) {
     const err = (await res.json().catch(() => ({}))) as { error?: string };
+    // "Play sample" ran into out-of-credits (issue #942): the shared notice.
+    if (res.status === 402) throw creditsErrorFrom(err);
     throw new GatewayError(res.status, err.error ?? `text-to-speech failed: ${res.status}`);
   }
   return res.blob();

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -95,6 +95,55 @@ export class GatewayError extends Error {
   }
 }
 
+// The shared "hosted AI is unavailable" body every money endpoint returns on HTTP 402 (issue #939/#941;
+// consumed by mobile in #942): the single-source message + call-to-action. `text` is the message to show;
+// `ctaUrl` deep-links to Billing.
+export interface HostedAiUnavailable {
+  state: string;      // "NeedsCredits" | "CapReached" | "NeedsKey"
+  text: string;
+  ctaLabel: string;
+  ctaAction: string;  // "OpenBilling" | "OpenSettings"
+  ctaUrl: string | null;
+}
+
+// A 402 from a hosted-AI call (out of credits / cap / no key). Its `message` IS the shared text, so any
+// surface that already shows `err.message` displays the correct copy by construction; `info` carries the
+// call-to-action for the app-level notice (issue #942).
+export class CreditsError extends GatewayError {
+  readonly info: HostedAiUnavailable;
+  constructor(info: HostedAiUnavailable) {
+    super(402, info.text || info.state || "Voice needs credit.");
+    this.name = "CreditsError";
+    this.info = info;
+  }
+}
+
+// App-level subscription so ONE notice (with the "Add credits" button) shows wherever a 402 happens,
+// without every surface widening its string error state. The client emits on every hosted-AI 402; the
+// app renders a single CreditsNotice. Returns an unsubscribe function.
+type CreditsListener = (info: HostedAiUnavailable) => void;
+const creditsListeners = new Set<CreditsListener>();
+export function onCreditsNeeded(fn: CreditsListener): () => void {
+  creditsListeners.add(fn);
+  return () => { creditsListeners.delete(fn); };
+}
+
+// Build a CreditsError from an already-parsed 402 body and notify the app-level notice. Defaults keep the
+// message correct even if a field is missing. Call from the `!res.ok` branch of any hosted-AI call when
+// `res.status === 402` (the body is already the shared shape from the Gateway).
+export function creditsErrorFrom(body: unknown): CreditsError {
+  const b = (body ?? {}) as Partial<HostedAiUnavailable> & { error?: string };
+  const info: HostedAiUnavailable = {
+    state: b.state ?? "NeedsCredits",
+    text: b.text ?? b.error ?? "Voice needs credit. Add credits to turn it on.",
+    ctaLabel: b.ctaLabel ?? "Add credits",
+    ctaAction: b.ctaAction ?? "OpenBilling",
+    ctaUrl: b.ctaUrl ?? null,
+  };
+  for (const fn of creditsListeners) { try { fn(info); } catch { /* a listener must never break the throw */ } }
+  return new CreditsError(info);
+}
+
 // GET /sessions - the fleet roster aggregator. Returns the same SessionDto shape the Cockpit
 // Mobile page consumes. Throws GatewayError on a non-2xx so the caller surfaces it (no silent
 // fallback). The request is same-origin against the Gateway front door.
@@ -427,6 +476,8 @@ export async function transcribeUtterance(
   });
   const compBody = (await comp.json().catch(() => ({}))) as { transcript?: string; error?: string };
   if (!comp.ok) {
+    // Out of credits / cap (issue #942): a typed CreditsError carrying the shared message + call-to-action.
+    if (comp.status === 402) throw creditsErrorFrom(compBody);
     throw new GatewayError(comp.status, compBody.error ?? `transcription failed: ${comp.status}`);
   }
   return (compBody.transcript ?? "").trim();
@@ -509,6 +560,8 @@ export async function markVoiceAndExplain(sessionId: string, signal?: AbortSigna
     signal,
   });
   if (!res.ok) {
+    // Switching a session to voice mode ran into out-of-credits (issue #942): the shared notice.
+    if (res.status === 402) throw creditsErrorFrom(await res.json().catch(() => ({})));
     throw new GatewayError(res.status, `POST wingman/explain failed: ${res.status}`);
   }
   const body = (await res.json()) as Partial<WingmanExplain>;
@@ -552,6 +605,8 @@ export async function fetchWingmanVoiceAudio(sessionId: string, signal?: AbortSi
     signal,
   });
   if (!res.ok) {
+    // Narration audio unavailable because of credits (issue #942): a 402 body is JSON even here.
+    if (res.status === 402) throw creditsErrorFrom(await res.json().catch(() => ({})));
     throw new GatewayError(res.status, `GET wingman/voice/audio failed: ${res.status}`);
   }
   return res.arrayBuffer();


### PR DESCRIPTION
Part of epic thefrederiksen/devthrottle_internal#661. The Gateway /wingman/* endpoints already return the shared 402 (from thefrederiksen/devthrottle#939), so this is client-side: one chokepoint in packages/client-core makes a hosted-AI 402 a typed CreditsError whose message IS the shared text (every surface banner shows the right copy by construction) AND emits it to ONE app-level CreditsNotice with the Add-credits Billing deep-link.

- client-core: CreditsError + onCreditsNeeded + creditsErrorFrom, wired into /wingman/utterance/complete (A4/A5/A6 dictation), /wingman/explain (B2/A6 voice mode), /wingman/voice/audio (B2/B3 narration), ai.ts ttsSample (C1 Play sample).
- apps/mobile: CreditsNotice at the app root; dismissible; clears on return-to-foreground so a top-up unlocks with no reload.

typecheck (client-core/cockpit/mobile) clean; vite build OK.

Proof: docs/cencon/proof/issue-942/report.html
Closes thefrederiksen/devthrottle#942 (part of thefrederiksen/devthrottle_internal#661).

🤖 Generated with [Claude Code](https://claude.com/claude-code)