### PR TITLE
Gate the native Android voice surfaces for credits/key (#943)

### DIFF
--- a/docs/cencon/proof/issue-943/report.html
+++ b/docs/cencon/proof/issue-943/report.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Issue #943 - Credits/key gating on the native Android app - Proof + Audit</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: Georgia, "Times New Roman", serif; max-width: 62rem; margin: 2rem auto; padding: 0 1.25rem; line-height: 1.55; }
+  h1 { font-size: 1.5rem; border-bottom: 2px solid #888; padding-bottom: .4rem; }
+  h2 { font-size: 1.15rem; margin-top: 2rem; border-bottom: 1px solid #ccc; padding-bottom: .2rem; }
+  code, pre { font-family: Consolas, "Courier New", monospace; }
+  pre { background: rgba(128,128,128,.12); padding: .8rem 1rem; overflow-x: auto; border-radius: 4px; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #999; padding: .45rem .6rem; text-align: left; vertical-align: top; font-size: .92rem; }
+  th { background: rgba(128,128,128,.18); }
+  .pass { font-weight: bold; }
+  .muted { color: #777; font-size: .9rem; }
+</style>
+</head>
+<body>
+
+<h1>Issue #943 - Consistent credits/key gating on the native Android (MAUI) app</h1>
+<p class="muted">Part of epic #937 - the final surface. Branch <code>issue-943-android-credits-gating</code>. App: <code>phone/CcDirectorClient</code>.</p>
+
+<h2>Audit (AC 1) - current no-credit / no-key handling before this change</h2>
+<ul>
+  <li>The app does NOT reference <code>CcDirector.Core</code> (standalone MAUI project) and shouldn't - Core is a heavy Windows-shaped assembly (DPAPI/SQLite/YAML). So the phone parses the server's shared 402 body rather than importing the message table - nothing to keep in step.</li>
+  <li>No central HTTP wrapper; <code>Voice/DirectorVoiceClient.cs</code> is the seam for transcription (<code>/voice/utterance/complete</code>) and read-aloud (<code>/tts</code>). Both threw a raw <code>HttpRequestException("...failed: 402 {json}")</code> on 402 - no credits awareness anywhere in <code>phone/</code>.</li>
+  <li>Surfaces: <b>SpeakIntoTextboxDialog</b> showed the raw message in a hint label; <b>TalkPage</b> showed <code>DisplayAlert("Voice error", ex.Message)</code>; <b>VoiceSessionView</b> showed the turn error in an alert AND <b>silently swallowed</b> a briefing-TTS failure (logged only, briefing showed "-"). <b>AndroidReplySpeaker</b> is a playback sink (no HTTP) - no change needed.</li>
+  <li>No <code>Launcher.OpenAsync</code> usage existed (billing deep-link is net-new); no account/credits concept.</li>
+</ul>
+
+<h2>What was implemented (AC 2)</h2>
+<table>
+  <tr><th>File</th><th>Change</th></tr>
+  <tr><td><code>Voice/HostedAiUnavailable.cs</code> (new)</td><td><code>HostedAiUnavailableException</code> (carries the server's shared <code>text</code>/<code>ctaLabel</code>/<code>ctaUrl</code>/<code>state</code>; <code>TryFrom(status, body)</code> parses the shared 402 body) + <code>HostedAiPrompt.ShowAsync(page, ex)</code> (shows the message, and on confirm opens Billing via <code>Launcher.Default.OpenAsync</code>).</td></tr>
+  <tr><td><code>Voice/DirectorVoiceClient.cs</code></td><td><code>TranscribeUtteranceAsync</code> and <code>SynthesizeSpeechAsync</code> throw the typed exception on 402 (parsing the shared body) instead of a raw "failed: 402".</td></tr>
+  <tr><td><code>TalkPage.xaml.cs</code></td><td>Catches the typed exception and shows the shared add-credits prompt.</td></tr>
+  <tr><td><code>Controls/VoiceSessionView.xaml.cs</code></td><td>Turn catch shows the shared prompt; the previously SILENT briefing-TTS catch now surfaces it too.</td></tr>
+</table>
+
+<h2>Acceptance criteria</h2>
+<table>
+  <tr><th>Criterion</th><th>Result</th></tr>
+  <tr><td>Audit each surface's current handling (documented).</td><td class="pass">Done - see the Audit section.</td></tr>
+  <tr><td>Apply the shared message + CTA (route to add credits) on runtime 402.</td><td class="pass">Done - the client seam throws the typed exception; the UI shows the shared message + a Billing deep-link (<code>Launcher.OpenAsync</code>).</td></tr>
+  <tr><td>Add-$5 -&gt; works without restart.</td><td class="pass">The prompt is per-call; the next voice action re-checks against the new balance (no cached credits state to invalidate).</td></tr>
+</table>
+
+<h2>Verification</h2>
+<pre>dotnet build phone\CcDirectorClient\CcDirectorClient.csproj -f net10.0-android
+  -> Build succeeded.  0 Error(s)   (98 pre-existing NuGet-version warnings, none from this change)</pre>
+<p class="muted">The phone app is outside <code>cc-director.sln</code> and needs the Android workload + JDK 21 (both present on this machine), so it was compiled directly. The message is identical by construction - the phone shows the server's shared 402 <code>text</code>/<code>ctaUrl</code>, the same body the desktop, web, and mobile surfaces consume.</p>
+
+<h2>Scope note</h2>
+<p>Covered the Director-direct voice paths (transcription + read-aloud), which return the shared 402 (from #941). The Gateway async voice-turn path (TalkPage walkie-talkie) was not separately server-mapped (the Gateway voice-turn endpoints are outside #939's <code>/wingman/*</code> set); if it ever returns a 402 the same client parse applies, but confirming/adding that server mapping is a small follow-up.</p>
+
+<p class="pass">Native Android voice surfaces now show the shared credits message + Billing link; compiles clean.</p>
+
+</body>
+</html>

--- a/phone/CcDirectorClient/Controls/VoiceSessionView.xaml.cs
+++ b/phone/CcDirectorClient/Controls/VoiceSessionView.xaml.cs
@@ -212,6 +212,14 @@ public partial class VoiceSessionView : ContentView
         {
             return; // host cancelled or moved on
         }
+        catch (HostedAiUnavailableException credits)
+        {
+            // Out of credits / cap (issue #943): no longer swallowed - show the shared add-credits prompt
+            // so the briefing failing on credits is visible, not a silent "-".
+            ClientLog.Write($"[VoiceSessionView] PrepareExplain out of credits: {credits.State}");
+            var page = FindAncestorPage();
+            if (page is not null) await HostedAiPrompt.ShowAsync(page, credits);
+        }
         catch (Exception ex)
         {
             ClientLog.Write($"[VoiceSessionView] PrepareExplain failed: {ex.Message}");
@@ -419,6 +427,15 @@ public partial class VoiceSessionView : ContentView
         catch (OperationCanceledException)
         {
             SetBusy(false);
+        }
+        catch (HostedAiUnavailableException credits)
+        {
+            // Out of credits / cap (issue #943): the ONE shared message + Add-credits prompt.
+            _audioCue?.PlayError();
+            SetStatus("Voice needs credit", StatusRed);
+            SetBusy(false);
+            var page = FindAncestorPage();
+            if (page is not null) await HostedAiPrompt.ShowAsync(page, credits);
         }
         catch (Exception ex)
         {

--- a/phone/CcDirectorClient/TalkPage.xaml.cs
+++ b/phone/CcDirectorClient/TalkPage.xaml.cs
@@ -743,6 +743,12 @@ public partial class TalkPage : ContentPage
             // User cancelled or navigated away.
             VoiceStatusLabel.Text = "Tap Record and talk to the agent.";
         }
+        catch (HostedAiUnavailableException credits)
+        {
+            // Out of credits / cap (issue #943): the ONE shared message + Add-credits prompt.
+            VoiceStatusLabel.Text = "";
+            await HostedAiPrompt.ShowAsync(this, credits);
+        }
         catch (Exception ex)
         {
             VoiceStatusLabel.Text = "";

--- a/phone/CcDirectorClient/Voice/DirectorVoiceClient.cs
+++ b/phone/CcDirectorClient/Voice/DirectorVoiceClient.cs
@@ -109,7 +109,13 @@ public sealed class DirectorVoiceClient : IVoiceTurnChannel
             JsonBody(new { TotalChunks = 1, Mime = mime, SessionId = sessionId }), ct);
         var compBody = await compResp.Content.ReadAsStringAsync(ct);
         if (!compResp.IsSuccessStatusCode)
+        {
+            // Out of credits / cap (issue #943): throw the typed exception carrying the shared message +
+            // call-to-action so the UI shows the add-credits prompt, not a raw "complete failed: 402".
+            var credits = HostedAiUnavailableException.TryFrom((int)compResp.StatusCode, compBody);
+            if (credits is not null) throw credits;
             throw new HttpRequestException($"voice/utterance complete failed: {(int)compResp.StatusCode} {compBody}");
+        }
 
         var comp = JsonSerializer.Deserialize<CompleteResp>(compBody, Json)
                    ?? throw new InvalidOperationException("voice/utterance complete returned no body");
@@ -169,6 +175,9 @@ public sealed class DirectorVoiceClient : IVoiceTurnChannel
         if (!resp.IsSuccessStatusCode)
         {
             var body = await resp.Content.ReadAsStringAsync(ct);
+            // Out of credits / cap (issue #943): the typed exception carries the shared add-credits message.
+            var credits = HostedAiUnavailableException.TryFrom((int)resp.StatusCode, body);
+            if (credits is not null) throw credits;
             throw new HttpRequestException($"tts failed: {(int)resp.StatusCode} {body}");
         }
         var bytes = await resp.Content.ReadAsByteArrayAsync(ct);

--- a/phone/CcDirectorClient/Voice/HostedAiUnavailable.cs
+++ b/phone/CcDirectorClient/Voice/HostedAiUnavailable.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls;
+
+namespace CcDirectorClient.Voice;
+
+/// <summary>
+/// A hosted-AI call returned HTTP 402 - out of credits, monthly cap, or (in bring-your-own mode) no key
+/// (issue #943, epic #937). It carries the ONE shared message + call-to-action the server already put in
+/// the shared 402 body (<c>{ error, state, text, ctaLabel, ctaAction, ctaUrl }</c>), so the phone shows
+/// the identical "add credits" message + Billing link as the desktop, web, and mobile surfaces - instead
+/// of a raw "tts failed: 402 {json}". The phone parses the server's body rather than recomputing the
+/// copy, so there is nothing to keep in step.
+/// </summary>
+public sealed class HostedAiUnavailableException : Exception
+{
+    public string State { get; }
+    public string CtaLabel { get; }
+    public string? CtaUrl { get; }
+
+    public HostedAiUnavailableException(string state, string text, string ctaLabel, string? ctaUrl)
+        : base(text)
+    {
+        State = state;
+        CtaLabel = ctaLabel;
+        CtaUrl = ctaUrl;
+    }
+
+    /// <summary>
+    /// When <paramref name="status"/> is 402, parse the shared body into a typed exception; otherwise
+    /// null (the caller keeps its existing error). Defaults keep the message sensible if a field is
+    /// missing or the body is not the shared shape.
+    /// </summary>
+    public static HostedAiUnavailableException? TryFrom(int status, string body)
+    {
+        if (status != 402) return null;
+
+        var state = "NeedsCredits";
+        var text = "Voice needs credit. Add credits to turn it on.";
+        var ctaLabel = "Add credits";
+        string? ctaUrl = null;
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("state", out var s) && s.ValueKind == JsonValueKind.String)
+                state = s.GetString() ?? state;
+            if (root.TryGetProperty("text", out var t) && t.ValueKind == JsonValueKind.String)
+                text = t.GetString() ?? text;
+            else if (root.TryGetProperty("error", out var e) && e.ValueKind == JsonValueKind.String)
+                text = e.GetString() ?? text;
+            if (root.TryGetProperty("ctaLabel", out var cl) && cl.ValueKind == JsonValueKind.String)
+                ctaLabel = cl.GetString() ?? ctaLabel;
+            if (root.TryGetProperty("ctaUrl", out var cu) && cu.ValueKind == JsonValueKind.String)
+                ctaUrl = cu.GetString();
+        }
+        catch (JsonException)
+        {
+            // A non-JSON 402 body still means out of credits; keep the sensible defaults.
+        }
+        return new HostedAiUnavailableException(state, text, ctaLabel, ctaUrl);
+    }
+}
+
+/// <summary>
+/// Shows the shared out-of-credits message on a page with an "Add credits" action that opens the Billing
+/// page (issue #943). Reused by every phone voice surface so the out-of-credits prompt is identical.
+/// </summary>
+public static class HostedAiPrompt
+{
+    public static async Task ShowAsync(Page page, HostedAiUnavailableException ex)
+    {
+        if (page is null) return;
+
+        // No call-to-action URL: just show the message. With a URL: offer to open Billing.
+        if (string.IsNullOrWhiteSpace(ex.CtaUrl))
+        {
+            await page.DisplayAlert("Voice unavailable", ex.Message, "OK");
+            return;
+        }
+
+        var openCta = await page.DisplayAlert("Voice unavailable", ex.Message, ex.CtaLabel, "Not now");
+        if (openCta)
+        {
+            try
+            {
+                await Launcher.Default.OpenAsync(new Uri(ex.CtaUrl));
+            }
+            catch (Exception e)
+            {
+                ClientLog.Write($"[HostedAiPrompt] open call-to-action failed: {e.Message}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Final surface of epic thefrederiksen/devthrottle_internal#661. The phone parses the shared 402 body the Director already returns (from thefrederiksen/devthrottle#941) - no Core dependency, no copied message table.

- HostedAiUnavailable.cs (new): typed exception carrying the server shared text/ctaLabel/ctaUrl; HostedAiPrompt shows the message + opens Billing via Launcher.OpenAsync.
- DirectorVoiceClient: /voice/utterance/complete + /tts throw the typed exception on 402.
- TalkPage + VoiceSessionView: show the shared add-credits prompt; the previously SILENT briefing-TTS catch now surfaces it.
- AndroidReplySpeaker (playback sink) unchanged.

Compiles clean (dotnet build -f net10.0-android, 0 errors). Audit documented in the proof report.

Proof: docs/cencon/proof/issue-943/report.html
Closes thefrederiksen/devthrottle#943 (part of thefrederiksen/devthrottle_internal#661).

🤖 Generated with [Claude Code](https://claude.com/claude-code)