### PR TITLE
Let the Director self-repair a hollow shared Python runtime (#995)

### DIFF
--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -992,7 +992,7 @@ public partial class MainWindow : Window
 
             _lastClis = facts.clis;
             _lastBuildFacts = (facts.built, facts.total, facts.missing);
-            _lastHomeStatus = HomeStatusBuilder.Build(facts.clis, facts.built, facts.total, facts.missing, _lastToolHealth);
+            _lastHomeStatus = HomeStatusBuilder.Build(facts.clis, facts.built, facts.total, facts.missing, _lastToolHealth, _lastBasePythonBroken);
 
             ApplyHomeHealth();
 
@@ -1059,6 +1059,9 @@ public partial class MainWindow : Window
     private List<AgentCliFact>? _lastClis;
     private (int built, int total, List<string> missing)? _lastBuildFacts;
     private CcDirector.Core.Tools.ToolHealthSummary? _lastToolHealth;
+    // Cached result of the last shared base-Python runtime probe (issue #995), so the immediate home render
+    // in RefreshHomeAsync reflects a known-broken runtime without re-launching the probe on the fast path.
+    private bool _lastBasePythonBroken;
     private bool _toolHealthRunning;
 
     // ---- Active cc-* tools indicator state machine (issue #829) ----
@@ -1087,7 +1090,7 @@ public partial class MainWindow : Window
         _toolHealthRunning = true;
         try
         {
-            var summary = await Task.Run(async () =>
+            var (summary, basePythonBroken) = await Task.Run(async () =>
             {
                 var catalog = new ToolCatalogService().GetCatalog();
                 var runner = new ToolTestRunner();
@@ -1106,16 +1109,33 @@ public partial class MainWindow : Window
                     }
                     finally { gate.Release(); }
                 }));
-                return CcDirector.Core.Tools.ToolHealthSummary.From(inputs);
+                // Probe the shared base Python directly. Every Python cc-* tool delegates to it, so if it is
+                // hollow (present but cannot import its standard library) they ALL fail at once - a single,
+                // repairable runtime failure the per-tool breakdown would otherwise show as N unrelated fails.
+                var pyBroken = !CcDirector.Setup.Engine.PythonRuntimeProbe.IsBasePythonHealthy(
+                    CcDirector.Setup.Engine.InstallLayout.Default());
+                return (summary: CcDirector.Core.Tools.ToolHealthSummary.From(inputs), basePythonBroken: pyBroken);
             });
 
             _lastToolHealth = summary;
-            FileLog.Write($"[MainWindow] tool health: pass={summary.Pass}, fail={summary.Fail}, notBuilt={summary.NotBuilt}, broken={summary.Broken}");
+            _lastBasePythonBroken = basePythonBroken;
+            FileLog.Write($"[MainWindow] tool health: pass={summary.Pass}, fail={summary.Fail}, notBuilt={summary.NotBuilt}, broken={summary.Broken}, basePythonBroken={basePythonBroken}");
 
             if (_lastClis is { } clis && _lastBuildFacts is { } bf)
             {
-                _lastHomeStatus = HomeStatusBuilder.Build(clis, bf.built, bf.total, bf.missing, summary);
+                _lastHomeStatus = HomeStatusBuilder.Build(clis, bf.built, bf.total, bf.missing, summary, basePythonBroken);
                 ApplyHomeHealth();
+            }
+
+            // Startup auto self-heal for a hollow shared Python runtime (issue #995): the tool exes exist and
+            // resolve on PATH, so the missing-tools trigger in RefreshHomeAsync never fires - yet every Python
+            // tool is failing because the shared base Python cannot start. Repair re-provisions it. Guarded to
+            // fire at most once per run so a failed repair leaves the manual "Fix" button rather than looping.
+            if (basePythonBroken && !_autoRepairAttempted && !_repairingTools)
+            {
+                _autoRepairAttempted = true;
+                FileLog.Write("[MainWindow] startup auto self-heal: shared base Python runtime is broken, repairing automatically");
+                _ = RepairToolsAsync(auto: true);
             }
         }
         catch (Exception ex)

--- a/src/CcDirector.Core.Tests/Home/HomeStatusBuilderTests.cs
+++ b/src/CcDirector.Core.Tests/Home/HomeStatusBuilderTests.cs
@@ -183,7 +183,7 @@ public class HomeStatusBuilderTests
     // ---------- Test-result-driven tools row (pass/fail/not-built breakdown) ----------
 
     [Fact]
-    public void Build_ToolHealthWithFailure_ShowsBreakdownWarnsAndRoutesToTools()
+    public void Build_ToolHealthWithFailure_ShowsBreakdownWarnsAndOffersRepair()
     {
         var health = new ToolHealthSummary(24, 1, 4,0, new[] { "cc-foo" });
         var status = HomeStatusBuilder.Build(new[] { Cli("Claude Code", true, "2.1") }, 0, 0, null, health);
@@ -194,7 +194,7 @@ public class HomeStatusBuilderTests
         Assert.Contains("1 fail", tools.Detail);
         Assert.Contains("4 not built", tools.Detail);
         Assert.Contains("cc-foo", tools.Detail);
-        Assert.Equal(HomeCheckAction.OpenTools, tools.Action); // a plain failure routes to the Tools page
+        Assert.Equal(HomeCheckAction.RepairTools, tools.Action); // a failing built tool is repairable (issue #995)
         Assert.False(status.AllReady);
     }
 
@@ -232,6 +232,34 @@ public class HomeStatusBuilderTests
         var tools = Row(status, "cc-* tools");
         Assert.Equal(HomeCheckLevel.Warn, tools.Level);
         Assert.Equal(HomeCheckAction.RepairTools, tools.Action); // broken -> one-click Fix
+    }
+
+    [Fact]
+    public void Build_BasePythonBroken_BadRowOffersRepairWithClearMessage()
+    {
+        // The shared base Python is hollow - present but unable to import its standard library - so every
+        // Python cc-* tool fails at once. The row must be red, name the runtime problem, and offer a real
+        // repair (not a navigate-to-Tools) so one click re-provisions the runtime (issue #995).
+        var health = new ToolHealthSummary(0, 9, 0, 0, new[] { "cc-vault", "cc-html", "cc-pdf" });
+        var status = HomeStatusBuilder.Build(
+            new[] { Cli("Claude Code", true, "2.1") }, 0, 0, null, health, basePythonBroken: true);
+
+        var tools = Row(status, "cc-* tools");
+        Assert.Equal(HomeCheckLevel.Bad, tools.Level);
+        Assert.Equal(HomeCheckAction.RepairTools, tools.Action);
+        Assert.Contains("runtime broken", tools.Detail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Build_ToolHealthNotBuiltOnly_StillRoutesToTools_NotRepair()
+    {
+        // Regression guard for the routing change: a not-built-ONLY state (no failing built tool, nothing
+        // broken) is optional tools, not a repairable failure - it must still route to the Tools page.
+        var health = new ToolHealthSummary(24, 0, 4, 0, Array.Empty<string>());
+        var status = HomeStatusBuilder.Build(new[] { Cli("Claude Code", true, "2.1") }, 0, 0, null, health);
+
+        var tools = Row(status, "cc-* tools");
+        Assert.Equal(HomeCheckAction.OpenTools, tools.Action);
     }
 
     [Fact]

--- a/src/CcDirector.Core/Home/HomeStatus.cs
+++ b/src/CcDirector.Core/Home/HomeStatus.cs
@@ -62,13 +62,24 @@ public static class HomeStatusBuilder
         int toolsBuilt,
         int toolsTotal,
         IReadOnlyList<string>? brokenTools = null,
-        Tools.ToolHealthSummary? toolHealth = null)
+        Tools.ToolHealthSummary? toolHealth = null,
+        bool basePythonBroken = false)
     {
+        // The shared base Python being hollow (present but unable to import its standard library) takes down
+        // EVERY Python cc-* tool at once (issue #995). It is a distinct, repairable runtime failure, so it
+        // short-circuits the per-tool breakdown with a clear message and a one-click repair - the repair
+        // re-provisions the base Python.
+        HomeCheck toolsCheck;
+        if (basePythonBroken)
+            toolsCheck = new HomeCheck("cc-* tools", HomeCheckLevel.Bad,
+                "Python runtime broken - the shared Python cannot start; one-click repair reinstalls it",
+                HomeCheckAction.RepairTools);
         // When tool tests have run (toolHealth supplied) the tools row reflects pass/fail/not-built;
         // before that it falls back to the cheap build-status check so the home renders immediately.
-        var toolsCheck = toolHealth is { } h
-            ? BuildToolsFromHealth(h)
-            : BuildTools(toolsBuilt, toolsTotal, brokenTools ?? Array.Empty<string>());
+        else if (toolHealth is { } h)
+            toolsCheck = BuildToolsFromHealth(h);
+        else
+            toolsCheck = BuildTools(toolsBuilt, toolsTotal, brokenTools ?? Array.Empty<string>());
 
         var checks = new List<HomeCheck>
         {
@@ -84,8 +95,10 @@ public static class HomeStatusBuilder
     /// <summary>
     /// The cc-* tools row from actual test results. Green ONLY when every tool passes. Otherwise it
     /// warns and shows the true breakdown ("26 pass · 2 not built" / "24 pass · 1 fail · 4 not built") -
-    /// any failing OR not-built tool surfaces here rather than hiding behind "all systems go". A broken
-    /// (expected-but-missing) tool offers the one-click repair; anything else routes to the Tools page.
+    /// any failing OR not-built tool surfaces here rather than hiding behind "all systems go". A failing
+    /// built tool OR a broken (expected-but-missing) tool offers the one-click repair - a failure is
+    /// repairable, not merely something to look at; a not-built-only state (optional tools) routes to the
+    /// Tools page.
     /// </summary>
     private static HomeCheck BuildToolsFromHealth(Tools.ToolHealthSummary h)
     {
@@ -107,7 +120,7 @@ public static class HomeStatusBuilder
             detail += $" - failing: {shown}";
         }
 
-        var action = h.Broken > 0 ? HomeCheckAction.RepairTools : HomeCheckAction.OpenTools;
+        var action = (h.Broken > 0 || h.Fail > 0) ? HomeCheckAction.RepairTools : HomeCheckAction.OpenTools;
         return new HomeCheck("cc-* tools", HomeCheckLevel.Warn, detail, action);
     }
 

--- a/tools/cc-director-setup-engine.Tests/PythonRuntimeProbeTests.cs
+++ b/tools/cc-director-setup-engine.Tests/PythonRuntimeProbeTests.cs
@@ -1,0 +1,76 @@
+using System.Runtime.Versioning;
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+/// <summary>
+/// Tests for the shared base-Python runtime probe (issue #995): it must report a hollow or absent Python as
+/// unhealthy (so the Director triggers a self-repair) and a real, runnable interpreter as healthy.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class PythonRuntimeProbeTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly InstallLayout _layout;
+
+    public PythonRuntimeProbeTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cc-pyprobe-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+        _layout = new InstallLayout(Path.Combine(_dir, "local"));
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    [Fact]
+    public void CanImportStdlib_MissingFile_False()
+    {
+        Assert.False(PythonRuntimeProbe.CanImportStdlib(Path.Combine(_dir, "nope", "python.exe")));
+    }
+
+    [Fact]
+    public void CanImportStdlib_NonExecutableFile_False()
+    {
+        // A "python.exe" that is not a valid executable (the shape of a hollow/corrupt install) cannot start,
+        // so the probe reports the runtime as dead rather than throwing.
+        var fake = Path.Combine(_dir, "python.exe");
+        File.WriteAllText(fake, "not a real interpreter");
+        Assert.False(PythonRuntimeProbe.CanImportStdlib(fake));
+    }
+
+    [Fact]
+    public void IsBasePythonHealthy_NoPythonDir_False()
+    {
+        // No base Python installed at all -> unhealthy (the Director should offer/trigger a repair).
+        Assert.False(PythonRuntimeProbe.IsBasePythonHealthy(_layout));
+    }
+
+    [Fact]
+    public void CanImportStdlib_RealSystemPython_True()
+    {
+        // If a real Python is available on this machine, the probe must recognize it as healthy. Skipped when
+        // no interpreter is on PATH (the assertion would have nothing to prove).
+        var python = ResolveOnPath("python.exe") ?? ResolveOnPath("python3.exe");
+        if (python is null) return; // no system Python to validate against; nothing to assert
+        Assert.True(PythonRuntimeProbe.CanImportStdlib(python));
+    }
+
+    private static string? ResolveOnPath(string exe)
+    {
+        var path = Environment.GetEnvironmentVariable("PATH") ?? "";
+        foreach (var dir in path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            try
+            {
+                var candidate = Path.Combine(dir.Trim(), exe);
+                if (File.Exists(candidate)) return candidate;
+            }
+            catch { /* malformed PATH entry; skip */ }
+        }
+        return null;
+    }
+}

--- a/tools/cc-director-setup-engine/PythonRuntimeProbe.cs
+++ b/tools/cc-director-setup-engine/PythonRuntimeProbe.cs
@@ -1,0 +1,59 @@
+namespace CcDirector.Setup.Engine;
+
+/// <summary>
+/// Honest health probe for the shared base Python: does the interpreter actually RUN, or is it a hollow
+/// install that only looks present? A Python whose standard library (Lib\ or pythonNNN.zip) went missing -
+/// the exact field failure in issue #994, where an interrupted install stripped it - dies at startup with
+/// "No module named 'encodings'" even though python.exe is still on disk. Every cc-* Python tool shares this
+/// one runtime, so when it is hollow they all fail at once. The Director uses this to detect that state and
+/// trigger a self-repair (issue #995); the installer uses it to verify a freshly-staged Python before
+/// swapping it in and to decide whether an on-disk runtime is healthy enough to skip a rebuild.
+/// </summary>
+public static class PythonRuntimeProbe
+{
+    /// <summary>How long to wait for the interpreter to start and import its standard library. A healthy
+    /// Python does this in well under a second; the bound only stops a wedged process from hanging a caller.</summary>
+    public static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// True when the interpreter at <paramref name="pythonExe"/> can start and import its own standard
+    /// library (<c>python -c "import encodings"</c> exits zero). The mere existence of python.exe does NOT
+    /// prove this - a stripped standard library or a non-executable file both report as a dead runtime
+    /// (false), which the caller treats as "needs (re)provisioning".
+    /// </summary>
+    public static bool CanImportStdlib(string pythonExe)
+    {
+        if (string.IsNullOrWhiteSpace(pythonExe) || !File.Exists(pythonExe)) return false;
+        try
+        {
+            var (exit, _) = ProcessRunner.Run(pythonExe, "-c \"import encodings\"", onStdoutLine: null, Timeout);
+            return exit == 0;
+        }
+        catch
+        {
+            // A process that cannot even start (not a valid interpreter) is a dead runtime, not an error to
+            // surface here.
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// True when the shared base Python for <paramref name="layout"/> is present AND runnable. This is the
+    /// Director-facing entry point: false means the shared runtime is hollow and every Python cc-* tool will
+    /// fail, so a repair (which re-provisions the base Python) is warranted.
+    /// </summary>
+    public static bool IsBasePythonHealthy(InstallLayout layout)
+    {
+        ArgumentNullException.ThrowIfNull(layout);
+        return CanImportStdlib(BasePythonExe(layout));
+    }
+
+    /// <summary>The base Python interpreter path for a layout: python.exe on Windows, bin/python3 elsewhere.</summary>
+    public static string BasePythonExe(InstallLayout layout)
+    {
+        ArgumentNullException.ThrowIfNull(layout);
+        return OperatingSystem.IsWindows()
+            ? Path.Combine(layout.PythonDir, "python.exe")
+            : Path.Combine(layout.PythonDir, "bin", "python3");
+    }
+}

--- a/tools/cc-director-setup-engine/PythonToolsInstaller.cs
+++ b/tools/cc-director-setup-engine/PythonToolsInstaller.cs
@@ -174,7 +174,7 @@ public sealed class PythonToolsInstaller
             var installedBundle = installedAtStart.Get(ComponentId);
             var runtimeHealthy = File.Exists(venvPython)
                 && VenvHasAllTools(manifest.Scripts)
-                && BasePythonRuns(pythonExe);
+                && PythonRuntimeProbe.CanImportStdlib(pythonExe);
             if (installedBundle == manifest.BundleVersion && runtimeHealthy)
             {
                 Step($"Python tools bundle {manifest.BundleVersion} already installed and healthy; skipping rebuild");
@@ -204,7 +204,7 @@ public sealed class PythonToolsInstaller
                     : Path.Combine(staged, "bin", "python3");
                 if (!File.Exists(stagedPythonExe))
                     return Fail(steps, $"staged Python is missing its interpreter at {stagedPythonExe}; the existing Python was left untouched.");
-                if (!BasePythonRuns(stagedPythonExe))
+                if (!PythonRuntimeProbe.CanImportStdlib(stagedPythonExe))
                     return Fail(steps, "staged Python is incomplete - it cannot import its standard library (a partial extract). The existing Python was left untouched.");
 
                 Step("swapping in the verified Python");
@@ -586,30 +586,6 @@ public sealed class PythonToolsInstaller
     {
         if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
         Directory.CreateDirectory(dir);
-    }
-
-    /// <summary>
-    /// True when the interpreter at <paramref name="pythonExe"/> actually runs - specifically, when it can
-    /// import its own standard library. A Python whose Lib\ (or pythonNNN.zip) went missing dies at startup
-    /// with "No module named 'encodings'" (the field failure in issue #994), so the mere existence of
-    /// python.exe does NOT prove the runtime works. A launch that throws (e.g. a non-PE file) is likewise a
-    /// dead runtime. This is the honest health probe for the shared base Python, used both to decide the
-    /// no-op early-out and to verify a freshly-staged Python before swapping it in.
-    /// </summary>
-    private static bool BasePythonRuns(string pythonExe)
-    {
-        if (!File.Exists(pythonExe)) return false;
-        try
-        {
-            var (exit, _) = ProcessRunner.Run(pythonExe, "-c \"import encodings\"", onStdoutLine: null, TimeSpan.FromSeconds(30));
-            return exit == 0;
-        }
-        catch
-        {
-            // A process that cannot even start (not a valid interpreter) is a dead runtime, not an error to
-            // surface here - the caller treats false as "needs (re)provisioning".
-            return false;
-        }
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #995. Builds on #994 (merged).

## The problem

When the shared base Python is hollow — present on disk but unable to start because its standard library is missing — every Python `cc-*` tool fails at once. The Director *detected* this ("0 pass, 9 fail") but could not *fix* it:

1. The startup auto self-heal only fired for **missing** (not-built) tools; here the tool `.exe` files exist and resolve on PATH, they just crash at launch, so it never triggered.
2. The "Fix" button's action was chosen by a "broken = not built" count, which is zero in this state, so it only **navigated to the Tools page**.
3. Even if the repair ran, its health gate checked that the tool `.exe` files **exist**, never that Python **runs** — so it would conclude everything was fine.

## The fix

**Runtime probe (`PythonRuntimeProbe`, engine).** A public probe that actually runs the interpreter (`python -c "import encodings"`). The installer's own health check now reuses it (replacing the private copy added in #994), and the Director runs it during the background tool-health pass. A hollow runtime is surfaced as a single, distinct, repairable signal rather than N unrelated tool failures.

**Route failures to a real repair (`HomeStatus`).** The Home tools row now offers the one-click repair when the base Python is broken **or** any built tool is failing — a failure is repairable, not merely something to look at. A not-built-only state (optional tools) still routes to the Tools page (regression-guarded).

**Auto self-heal on a broken runtime (`MainWindow`).** The startup self-heal now also fires when the base-Python probe reports the runtime is dead, not only when tools are missing. Guarded to fire once per run so a failed repair leaves the manual Fix button rather than looping.

Because of #994, the repair itself already re-provisions the base Python crash-safely (staged verify + whole-directory swap), and its health check now includes this same probe — so a broken runtime is no longer early-outed as "already installed."

## Tests

- `PythonRuntimeProbeTests`: missing / non-executable / absent Python → unhealthy; a real system Python → healthy.
- `HomeStatusBuilderTests`: the base-Python-broken row is red, names the runtime problem, and offers repair; a failing built tool now offers repair; a not-built-only state still routes to Tools.
- Engine suite **226 green**, Core Home suite **19 green**. Engine + Core + Avalonia all build clean.

## Note on CI

`main` is currently red from pre-existing issues unrelated to this change (a documented-flaky `SessionManagerTests.CreateAndKillSession_StatusChanges`, and a `NoCrossMachineLoopbackGuard` failure on `GatewayConfig.cs`/`DesktopHostedAiCta.cs` from earlier merged work). This branch touches none of those files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
