### PR TITLE
[Mobile] Voice-mode audio player bar (resume, restart, seek) + bigger back button

### DIFF
--- a/apps/mobile/src/pages/VoiceMode.tsx
+++ b/apps/mobile/src/pages/VoiceMode.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type ChangeEvent, type SyntheticEvent } from "react";
 import { Link, useParams } from "react-router-dom";
 import {
   getWingmanVoice,
@@ -15,6 +15,7 @@ import { backgroundTranscribeAndSend, type CapturedUtterance } from "@devthrottl
 import { SessionManageBar } from "../components/SessionManageBar";
 import { ViewTabs } from "../components/ViewTabs";
 import { ensureClip, getClipState, stopPlayback, useVoiceClips } from "../voice/clips";
+import { positionFor, saveMark, wasAutoPlayed } from "../voice/playbackPositions";
 import { isWorking } from "@devthrottle/client-core/sessions/ordering";
 
 // Session Voice mode (issue #850): the hands-free Wingman narration screen, the third session view
@@ -99,10 +100,14 @@ export function VoiceMode() {
     audioRef.current = el;
     if (el !== null) liveAudioRef.current = el;
   }, []);
-  const autoPlayedRef = useRef<string>(""); // the generatedAt we have already auto-played
+  // The generatedAt whose saved position we have already restored onto the current audio element, so
+  // we seek to the remembered spot exactly once per (session, clip) mount and never fight the user's
+  // own seeking/restart afterwards (issue #1003 per-session resume).
+  const restoredForRef = useRef<string>("");
   const [pos, setPos] = useState(0);
   const [dur, setDur] = useState(0);
   const [playing, setPlaying] = useState(false);
+  const [resumed, setResumed] = useState(false); // showed "picked up where you left off" this mount
 
   // Stop the narration when you LEAVE the voice screen (roster, another view tab, the drawer) so it
   // never keeps talking after you have moved on - the bug this fixes. Runs once, on unmount.
@@ -193,18 +198,29 @@ export function VoiceMode() {
   useEffect(() => {
     if (agentWorking) return;
     if (!phoneReady || generatedAt.length === 0) return;
-    if (autoPlayedRef.current === generatedAt) return;
     if (typeof document !== "undefined" && document.hidden) return;
-    autoPlayedRef.current = generatedAt;
+    // Only auto-play a genuinely NEW clip: one this device has not auto-played AND that has no
+    // remembered position for this session. A clip you already listened part-way is restored to its
+    // saved spot (onLoadedMeta) and waits for you to press play - returning to a session, or flipping
+    // back to it, must never restart the narration from the top (issue #1003).
+    if (wasAutoPlayed(sid, generatedAt)) return;
+    if (positionFor(sid, generatedAt) > 0) return;
     const el = audioRef.current;
     if (el) {
       stopPlayback(); // never overlap a roster clip with this screen's playback
       el.currentTime = 0;
+      saveMark(sid, { generatedAt, pos: 0, dur: el.duration || 0, autoPlayed: true });
       void el.play().catch(() => {
         /* autoplay policy may require a gesture; the play-triangle covers it */
       });
     }
-  }, [phoneReady, generatedAt, agentWorking]);
+  }, [phoneReady, generatedAt, agentWorking, sid]);
+
+  // A new turn's clip resets the per-mount resume guards so its saved position (0) restores cleanly.
+  useEffect(() => {
+    lastSavedSecRef.current = -1;
+    setResumed(false);
+  }, [generatedAt]);
 
   const onSwitchOn = useCallback(async () => {
     if (sid.length === 0 || enabling) return;
@@ -245,7 +261,8 @@ export function VoiceMode() {
     setVoice(null);
     setEnableNote("");
     setSession((prev) => (prev ? { ...prev, voiceMode: false } : prev));
-    autoPlayedRef.current = "";
+    restoredForRef.current = "";
+    setResumed(false);
     try {
       // Two calls, matching the on path's two: tell the Director to leave voice (roster flag) AND
       // tell the Gateway to stop keeping voice (stops the per-turn Opus + text-to-speech, issue #859).
@@ -256,22 +273,110 @@ export function VoiceMode() {
     }
   }, [sid]);
 
+  // The whole second we last persisted, so onTimeUpdate saves the position roughly once a second
+  // rather than on every ~4Hz tick (issue #1003 per-session resume).
+  const lastSavedSecRef = useRef<number>(-1);
+
+  // Persist how far this session has listened. `started` marks the clip as having begun on this
+  // device, so returning to the session resumes (never auto-restarts). autoPlayed, once set, stays set.
+  const persist = useCallback(
+    (el: HTMLAudioElement, opts?: { started?: boolean }) => {
+      if (generatedAt.length === 0) return;
+      const autoPlayed = wasAutoPlayed(sid, generatedAt) || Boolean(opts?.started);
+      saveMark(sid, { generatedAt, pos: el.currentTime, dur: el.duration || 0, autoPlayed });
+    },
+    [sid, generatedAt],
+  );
+
+  // Metadata is loaded: publish the duration and, exactly once per (session, clip), restore the
+  // remembered position so you pick up where you left off. Guarded so it never fights a later seek.
+  const onLoadedMeta = useCallback(
+    (e: SyntheticEvent<HTMLAudioElement>) => {
+      const el = e.currentTarget;
+      setDur(el.duration || 0);
+      if (generatedAt.length === 0 || restoredForRef.current === generatedAt) return;
+      restoredForRef.current = generatedAt;
+      const saved = positionFor(sid, generatedAt);
+      if (saved > 0 && el.duration > 0 && saved < el.duration - 0.5) {
+        el.currentTime = saved;
+        setPos(saved);
+        setResumed(true);
+      }
+    },
+    [sid, generatedAt],
+  );
+
+  // Playback progressed: reflect it and save the position about once per second.
+  const onTimeUpdate = useCallback(
+    (e: SyntheticEvent<HTMLAudioElement>) => {
+      const el = e.currentTarget;
+      setPos(el.currentTime);
+      const sec = Math.floor(el.currentTime);
+      if (sec !== lastSavedSecRef.current) {
+        lastSavedSecRef.current = sec;
+        persist(el);
+      }
+    },
+    [persist],
+  );
+
+  const onEndedAudio = useCallback(
+    (e: SyntheticEvent<HTMLAudioElement>) => {
+      const el = e.currentTarget;
+      setPos(el.duration || 0);
+      setPlaying(false);
+      persist(el); // remember it was listened to the end
+    },
+    [persist],
+  );
+
+  // Drag the slider to listen from anywhere.
+  const onSeek = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const el = audioRef.current;
+      if (!el) return;
+      const t = Number(e.target.value);
+      el.currentTime = t;
+      setPos(t);
+      setResumed(false);
+      persist(el);
+    },
+    [persist],
+  );
+
+  // Restart the clip from the beginning ("listen again from scratch").
+  const onRestart = useCallback(() => {
+    const el = audioRef.current;
+    if (!el) return;
+    stopPlayback();
+    el.currentTime = 0;
+    setPos(0);
+    setResumed(false);
+    persist(el, { started: true });
+    void el.play().catch(() => {
+      /* ignore - a tap already gestured */
+    });
+  }, [persist]);
+
   // Play/pause toggle - the clear "stop the speech" control the person asked for. Tapping while it is
-  // speaking pauses it immediately; tapping when paused resumes (or replays from the start once ended).
+  // speaking pauses it immediately; tapping when paused resumes from where it left off (or replays
+  // from the start once it has ended).
   const onTogglePlay = useCallback(() => {
     const el = audioRef.current;
     if (!el) return;
     if (!el.paused) {
       el.pause();
       stopPlayback(); // also stop any roster clip playing through the shared player
+      persist(el);
       return;
     }
     stopPlayback(); // never let two clips play at once
     if (el.ended || (el.duration > 0 && el.currentTime >= el.duration)) el.currentTime = 0;
+    persist(el, { started: true });
     void el.play().catch(() => {
       /* ignore - a tap already gestured */
     });
-  }, []);
+  }, [persist]);
 
   const onRespondSend = useCallback(
     async (text: string) => {
@@ -311,7 +416,6 @@ export function VoiceMode() {
   // offering a replay of it.
   const speaking = voiceOn && phoneReady && (voice?.spoken.length ?? 0) > 0 && !agentWorking;
   const working = voiceOn && !speaking;
-  const progress = dur > 0 ? Math.min(1, pos / dur) : 0;
   const narrative = voice?.spoken ?? "";
 
   return (
@@ -331,14 +435,11 @@ export function VoiceMode() {
         ref={setAudioEl}
         src={clip.url ?? undefined}
         preload="auto"
-        onLoadedMetadata={(e) => setDur(e.currentTarget.duration)}
-        onTimeUpdate={(e) => setPos(e.currentTarget.currentTime)}
+        onLoadedMetadata={onLoadedMeta}
+        onTimeUpdate={onTimeUpdate}
         onPlay={() => setPlaying(true)}
         onPause={() => setPlaying(false)}
-        onEnded={(e) => {
-          setPos(e.currentTarget.duration);
-          setPlaying(false);
-        }}
+        onEnded={onEndedAudio}
         style={{ display: "none" }}
       />
 
@@ -387,35 +488,56 @@ export function VoiceMode() {
           </>
         )}
 
-        {/* C. SPEAKING - the clip plays; the narrative is shown; replay or dictate a reply. */}
+        {/* C. SPEAKING - the audio bar and Respond are pinned at the TOP (the controls you actually
+            use in voice mode); the response text sits BELOW and scrolls. In voice mode the text is a
+            nice-to-have, so a long response must never push the controls off-screen - the top block
+            is sticky (issue #1003, voice-mode screen layout). */}
         {speaking && (
           <>
-            <div className="voice-statusbar">
-              <span className="voice-state voice-state-green">Speaking</span>
+            <div className="voice-top">
+              <div className="voice-statusbar">
+                <span className="voice-state voice-state-green">Speaking</span>
+                {resumed && <span className="voice-ref">picked up where you left off</span>}
+              </div>
+              <div className="voice-player">
+                <button
+                  type="button"
+                  className="voice-tri-btn"
+                  onClick={onTogglePlay}
+                  aria-label={playing ? "Pause" : "Play"}
+                >
+                  <span className={playing ? "voice-pause" : "voice-tri"} aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  className="voice-restart-btn"
+                  onClick={onRestart}
+                  aria-label="Restart from the beginning"
+                >
+                  <span className="voice-restart" aria-hidden="true" />
+                </button>
+                <input
+                  type="range"
+                  className="voice-seek"
+                  min={0}
+                  max={dur > 0 ? dur : 0}
+                  step="any"
+                  value={dur > 0 ? Math.min(pos, dur) : 0}
+                  onChange={onSeek}
+                  aria-label="Seek through the narration"
+                />
+                <span className="voice-ref voice-clock">{formatClock(pos)} / {formatClock(dur)}</span>
+              </div>
+              <button type="button" className="voice-respond" onClick={() => setResponding(true)}>
+                Respond
+              </button>
             </div>
-            <div className="voice-narr">
+            <div className="voice-narr voice-narr-scroll">
               <div className="voice-narr-title">{narrative}</div>
               <div className="voice-narr-body">
-                {playing ? "Tap to stop the voice, or answer below." : "Tap to replay, or just answer below."}
+                {playing ? "Speaking. Tap pause to stop, or Respond to answer." : "Tap play to listen, or Respond to answer."}
               </div>
             </div>
-            <div className="voice-player">
-              <button
-                type="button"
-                className="voice-tri-btn"
-                onClick={onTogglePlay}
-                aria-label={playing ? "Stop the voice" : "Play"}
-              >
-                <span className={playing ? "voice-pause" : "voice-tri"} aria-hidden="true" />
-              </button>
-              <div className="voice-progress" aria-hidden="true">
-                <div className="voice-progress-fill" style={{ width: `${progress * 100}%` }} />
-              </div>
-              <span className="voice-ref">{formatClock(pos)}</span>
-            </div>
-            <button type="button" className="voice-respond" onClick={() => setResponding(true)}>
-              Respond
-            </button>
           </>
         )}
 

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -39,9 +39,9 @@ body {
   position: sticky;
   top: 0;
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 10px;
-  padding: 16px 0 12px;
+  padding: 12px 0;
   background: var(--bg);
   border-bottom: 1px solid var(--border);
   z-index: 5;
@@ -65,10 +65,30 @@ body {
   text-decoration: none;
 }
 
+/* Issue #1004: a real, thumb-sized tap target (>= 44x44, Apple HIG) with button chrome instead of a
+   tiny text link - the PWA is used hands-busy (in the car, in voice mode) and "back to Roster" must
+   be hittable without looking. Shared by every per-session screen via .back-link. */
 .back-link {
-  font-size: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  box-sizing: border-box;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 8px 14px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
   color: var(--accent);
-  margin-right: 6px;
+  font-size: 15px;
+  font-weight: 700;
+  flex: 0 0 auto;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.back-link:active {
+  background: var(--surface-2);
 }
 
 .banner {
@@ -932,12 +952,26 @@ a.banner-btn {
   }
 }
 
-/* C. Speaking: the player row (replay triangle + progress + clock). */
+/* The pinned top controls on the voice screen: the audio bar + Respond stay reachable at the TOP
+   even when the response text below is long (issue #1003, voice-mode layout). Sticky so it stays put
+   while the narrative scrolls beneath it inside .voice-body. */
+.voice-top {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  background: var(--bg);
+  padding-top: 2px;
+  padding-bottom: 10px;
+  margin-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+/* C. Speaking: the player row (play/pause + restart + seek slider + clock). */
 .voice-player {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin: 4px 0 12px;
+  gap: 8px;
+  margin: 8px 0;
 }
 
 .voice-tri-btn {
@@ -971,22 +1005,109 @@ a.banner-btn {
   border-right: 4px solid #ffffff;
 }
 
-.voice-progress {
-  position: relative;
-  flex: 1 1 auto;
-  height: 6px;
-  background: var(--surface-2);
-  border-radius: 999px;
-  overflow: hidden;
+/* Restart-from-the-start button (issue #1003, "listen again from scratch"). CSS-only skip-to-start
+   glyph (a bar + a left triangle), no unicode. */
+.voice-restart-btn {
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--surface);
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
 }
 
-.voice-progress-fill {
+.voice-restart {
+  position: relative;
+  display: inline-block;
+  width: 13px;
+  height: 13px;
+  color: var(--text);
+}
+
+.voice-restart::before {
+  content: "";
   position: absolute;
   left: 0;
   top: 0;
   bottom: 0;
-  background: #22c55e;
+  width: 3px;
+  border-radius: 1px;
+  background: currentColor;
+}
+
+.voice-restart::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0;
+  height: 0;
+  border-top: 6px solid transparent;
+  border-bottom: 6px solid transparent;
+  border-right: 9px solid currentColor;
+}
+
+/* Seek slider - drag to listen from anywhere (issue #1003). Sized for touch on iOS/Android; the
+   visible track is thin but the control is a tall, easy hit area. */
+.voice-seek {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 24px;
+  margin: 0;
+  background: transparent;
+  -webkit-appearance: none;
+  appearance: none;
+  cursor: pointer;
+}
+
+.voice-seek::-webkit-slider-runnable-track {
+  height: 6px;
   border-radius: 999px;
+  background: var(--surface-2);
+}
+
+.voice-seek::-moz-range-track {
+  height: 6px;
+  border-radius: 999px;
+  background: var(--surface-2);
+}
+
+.voice-seek::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  margin-top: -6px;
+  border-radius: 50%;
+  background: #22c55e;
+  border: 2px solid var(--bg);
+}
+
+.voice-seek::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--bg);
+  border-radius: 50%;
+  background: #22c55e;
+}
+
+/* The clock reads position / total; tabular figures so it does not jitter as it ticks. */
+.voice-clock {
+  flex: 0 0 auto;
+  min-width: 78px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+/* The response text sits below the pinned controls and scrolls with the body (issue #1003). */
+.voice-narr-scroll {
+  margin-top: 0;
 }
 
 .voice-respond {

--- a/apps/mobile/src/voice/playbackPositions.ts
+++ b/apps/mobile/src/voice/playbackPositions.ts
@@ -1,0 +1,78 @@
+// Per-session audio playback position memory (issue #1003).
+//
+// Remembers how far into the current clip each session's listener has got, so flipping between
+// sessions and coming back resumes exactly where you left off - the positions never bleed across
+// sessions because every mark is keyed by session id. The stored generatedAt guards against
+// restoring a stale position onto a newer clip (a new turn's narration starts from the beginning).
+//
+// localStorage is the durable backing so a mark also survives a reload; a small in-memory mirror
+// avoids re-parsing on every render. The localStorage access is wrapped only to detect the rare
+// contexts where it is unavailable (private-mode quota, disabled storage) - capability detection in
+// the same spirit as voice/clips.ts's Cache Storage layer, NOT an error-hiding fallback: when it is
+// absent the in-memory map still drives resume for the life of the page.
+
+export interface PlaybackMark {
+  /** The clip (its generatedAt stamp) this position belongs to. */
+  generatedAt: string;
+  /** Seconds listened into that clip. */
+  pos: number;
+  /** Clip duration in seconds (0 until metadata is known). */
+  dur: number;
+  /** Whether this clip has already auto-played once on this device (so returning does not restart it). */
+  autoPlayed: boolean;
+}
+
+const KEY_PREFIX = "dt.voice.pos.";
+const _mem = new Map<string, PlaybackMark>();
+
+function storageKey(sid: string): string {
+  return KEY_PREFIX + sid;
+}
+
+function readStore(sid: string): PlaybackMark | null {
+  try {
+    if (typeof localStorage === "undefined") return null;
+    const raw = localStorage.getItem(storageKey(sid));
+    if (raw === null) return null;
+    return JSON.parse(raw) as PlaybackMark;
+  } catch {
+    // Storage unavailable/unreadable in this context; the in-memory mirror still serves this page.
+    return null;
+  }
+}
+
+function writeStore(sid: string, mark: PlaybackMark): void {
+  try {
+    if (typeof localStorage === "undefined") return;
+    localStorage.setItem(storageKey(sid), JSON.stringify(mark));
+  } catch {
+    // Storage unavailable/full; the in-memory mirror still holds it for this page.
+  }
+}
+
+/** The remembered mark for a session (in-memory first, then durable store), or null when none. */
+export function getMark(sid: string): PlaybackMark | null {
+  const mem = _mem.get(sid);
+  if (mem !== undefined) return mem;
+  const stored = readStore(sid);
+  if (stored !== null) _mem.set(sid, stored);
+  return stored;
+}
+
+/** Persist how far this session has listened (in memory and in the durable store). */
+export function saveMark(sid: string, mark: PlaybackMark): void {
+  _mem.set(sid, mark);
+  writeStore(sid, mark);
+}
+
+/** The saved position for a specific clip, or 0 when there is no mark or it belongs to another clip. */
+export function positionFor(sid: string, generatedAt: string): number {
+  const m = getMark(sid);
+  return m !== null && m.generatedAt === generatedAt ? m.pos : 0;
+}
+
+/** True once this exact clip has auto-played on this device, so returning to it will not restart it. */
+export function wasAutoPlayed(sid: string, generatedAt: string): boolean {
+  const m = getMark(sid);
+  return m !== null && m.generatedAt === generatedAt && m.autoPlayed;
+}


### PR DESCRIPTION
## What this does

Mobile PWA voice-mode improvements, implemented and QA'd end-to-end.

**Audio player bar (#1003)** on the voice screen:
- Play / pause that resumes from where it left off (not a restart).
- Restart-from-the-start control ("listen again from scratch").
- Draggable seek slider with a position / duration clock.
- Per-session position memory: each session remembers how far you listened, so flipping between sessions and returning resumes each session at its own spot. Persisted to localStorage in a new `voice/playbackPositions.ts`. A returning session no longer auto-restarts the narration from the top; it shows "picked up where you left off".

**Voice-screen layout (#1003):** the audio bar and Respond are pinned at the top; the response text sits below and scrolls. In voice mode the text is a nice-to-have, so a long response never pushes the controls off the top of the screen (the top block is sticky).

**Bigger back button (#1004):** the "back to Roster" control is now a real 44x44 tap target with button chrome instead of a tiny text link. Shared `.back-link`, so every mobile session screen (Chat, Terminal, Voice, New session, AI settings) gets it.

## Files

- `apps/mobile/src/pages/VoiceMode.tsx` - the player bar, per-session resume wiring, top-pinned layout.
- `apps/mobile/src/voice/playbackPositions.ts` - new per-session playback-position memory (localStorage-backed).
- `apps/mobile/src/styles.css` - `.back-link` tap target, `.voice-top` sticky controls, seek slider, restart button, clock.

## QA (rendered the real VoiceMode screen via Vite + Playwright with the three endpoints mocked and a real generated WAV clip)

- Back button measured 44px tall with button chrome.
- Audio bar + Respond confirmed inside the pinned top block, above the text; controls stayed pinned when the long response text was scrolled to the bottom.
- Seek slider is a real range input (max = duration); dragging to 8s moved playback to 0:08 / 0:12.
- Play advanced the clock and saved the position; restart reset to 0 and played.
- Per-session resume: a partial saved position restored to 5.0s on reload with "picked up where you left off", and did not auto-restart. A fully-listened clip correctly does not resume at the end.
- Typecheck + production build clean.

Closes #1003
Closes #1004

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
