### PR TITLE
[Mobile] Full-size 'back to sessions' button on the Hold/Remove row

### DIFF
--- a/apps/mobile/src/components/SessionManageBar.tsx
+++ b/apps/mobile/src/components/SessionManageBar.tsx
@@ -94,6 +94,17 @@ export function SessionManageBar({ sessionId }: SessionManageBarProps) {
     <div className="session-manage">
       {error !== null && <div className="banner banner-error" role="alert">{error}</div>}
       <div className="session-manage-row">
+        {/* Back to the roster - the control used on every visit to a session. It shares this row with
+           Hold and Remove (owner request, #1004) so it is a full-size button on the left, not a tiny
+           header link; it is the widest of the three because it is the most-used. */}
+        <button
+          type="button"
+          className="manage-btn manage-back"
+          onClick={() => navigate("/")}
+          aria-label="Back to sessions"
+        >
+          &larr; Sessions
+        </button>
         <button
           type="button"
           className={`manage-btn ${held ? "manage-resume" : "manage-hold"}`}

--- a/apps/mobile/src/pages/Chat.tsx
+++ b/apps/mobile/src/pages/Chat.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { getSessionHistory, listSessions } from "@devthrottle/client-core/api/client";
 import type { SessionHistoryDto } from "@devthrottle/client-core/history/types";
 import {
@@ -225,7 +225,6 @@ export function Chat() {
   return (
     <div className="terminal-screen">
       <header className="app-bar">
-        <Link className="back-link" to="/">&larr; Roster</Link>
         <h1 className="term-title">{name ?? "Session"}</h1>
       </header>
 

--- a/apps/mobile/src/pages/Terminal.tsx
+++ b/apps/mobile/src/pages/Terminal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import "@xterm/xterm/css/xterm.css";
 import { listSessions } from "@devthrottle/client-core/api/client";
 import { TerminalMirror } from "@devthrottle/client-core/terminal/stream";
@@ -92,7 +92,6 @@ export function Terminal() {
   return (
     <div className="terminal-screen">
       <header className="app-bar">
-        <Link className="back-link" to="/">&larr; Roster</Link>
         <h1 className="term-title">{name ?? "Session"}</h1>
       </header>
 

--- a/apps/mobile/src/pages/VoiceMode.tsx
+++ b/apps/mobile/src/pages/VoiceMode.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type ChangeEvent, type SyntheticEvent } from "react";
-import { Link, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import {
   getWingmanVoice,
   listSessions,
@@ -421,7 +421,6 @@ export function VoiceMode() {
   return (
     <div className="terminal-screen">
       <header className="app-bar">
-        <Link className="back-link" to="/">&larr; Roster</Link>
         <h1 className="term-title">{name ?? "Session"}</h1>
       </header>
 

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -1595,8 +1595,10 @@ a.banner-btn {
   cursor: default;
 }
 
-/* Hold = amber (defer), Resume = green (re-activate), Remove = red (destructive) - matching the
+/* Back to sessions = accent blue, and the widest button in the row (the most-used control, #1004).
+   Hold = amber (defer), Resume = green (re-activate), Remove = red (destructive) - matching the
    Android-tab semantic palette already used by .term-esc / .term-enter / .term-stop. */
+.manage-back { flex: 1.6 1 0; background: var(--accent); color: #ffffff; }
 .manage-hold { background: #e8b339; color: #221a06; }
 .manage-resume { background: #5fd08a; color: #06210f; }
 .manage-remove { background: #e5484d; color: #ffffff; }


### PR DESCRIPTION
Follow-up to #1004 (owner feedback): the header back link was still too small next to the large Hold/Remove buttons, and it is used on every visit to a session.

- Move "back to sessions" onto the same row as Hold and Remove, on the left, as a full-size blue button and the widest of the three (most-used action).
- Remove the small header link from the Terminal, Chat, and Voice screens; the session title stays in the header.
- New session and AI settings keep their own header link (they have no manage row).

QA: rendered the real Voice screen (Vite + Playwright, endpoints mocked). Confirmed a single row of three 50px-tall buttons - Sessions (blue, widest, left) | Hold (amber) | Remove (red) - and that the small header back link is gone.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)