### PR TITLE
[Mobile] Keep the phone screen awake on every /m page (#981)

### DIFF
--- a/apps/mobile/src/hooks/useScreenWakeLock.ts
+++ b/apps/mobile/src/hooks/useScreenWakeLock.ts
@@ -1,0 +1,75 @@
+import { useEffect } from "react";
+
+// App-level screen wake lock (issue #981): keep the phone awake on EVERY gated page of the /m app
+// while it is foregrounded, not just the Terminal view. It is owned once by the gated layout, so a
+// single sentinel is held for the whole session and navigating between pages never creates a second.
+//
+// A screen wake lock is auto-released by the browser when the tab is hidden, so we re-acquire on
+// visibilitychange when the app returns to the foreground and release when it is backgrounded. Where
+// the Screen Wake Lock API is unavailable this is a silent no-op (no fallback), exactly as the old
+// Terminal-only effect behaved. The [wakeLock] acquired/released logs make the single-sentinel
+// behavior observable for QA (issue #981 acceptance).
+
+type WakeLockSentinelLike = {
+  release: () => Promise<void>;
+  addEventListener?: (type: "release", listener: () => void) => void;
+};
+type WakeLockNavigator = Navigator & {
+  wakeLock?: { request: (type: "screen") => Promise<WakeLockSentinelLike> };
+};
+
+export function useScreenWakeLock(): void {
+  useEffect(() => {
+    const wl = (navigator as WakeLockNavigator).wakeLock;
+    if (!wl) return; // unsupported browser: silent no-op, no fallback
+
+    let sentinel: WakeLockSentinelLike | null = null;
+    let disposed = false;
+
+    const acquire = async () => {
+      if (disposed || sentinel !== null) return; // one sentinel at a time
+      if (document.visibilityState !== "visible") return; // only hold it while foregrounded
+      try {
+        const s = await wl.request("screen");
+        if (disposed) {
+          void s.release().catch(() => {});
+          return;
+        }
+        sentinel = s;
+        console.log("[wakeLock] acquired");
+        // The browser can auto-release the lock (e.g. when the tab is hidden); clear our reference so
+        // returning to the foreground re-acquires cleanly.
+        s.addEventListener?.("release", () => {
+          if (sentinel === s) {
+            sentinel = null;
+            console.log("[wakeLock] released");
+          }
+        });
+      } catch {
+        // Denied or transient; retried on the next visibilitychange.
+      }
+    };
+
+    const release = () => {
+      const s = sentinel;
+      sentinel = null;
+      if (s) {
+        console.log("[wakeLock] released");
+        void s.release().catch(() => {});
+      }
+    };
+
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") void acquire();
+      else release();
+    };
+
+    void acquire();
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      disposed = true;
+      document.removeEventListener("visibilitychange", onVisibility);
+      release();
+    };
+  }, []);
+}

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -13,6 +13,7 @@ import { hasDeviceKey } from "@devthrottle/client-core/auth/deviceKey";
 import { ensureGatewayCookie } from "@devthrottle/client-core/api/client";
 import { ensurePushSubscribed } from "./push/register";
 import { CreditsNotice } from "./components/CreditsNotice";
+import { useScreenWakeLock } from "./hooks/useScreenWakeLock";
 import "./styles.css";
 
 // The auth gate (issue #908): every real screen requires an enrolled device key. Without one, the
@@ -20,7 +21,16 @@ import "./styles.css";
 // can reach them. hasDeviceKey() is read at navigation time, so enrolling (or a 401-triggered
 // clear) re-gates on the next route.
 function RequireDeviceKey() {
-  return hasDeviceKey() ? <Outlet /> : <Navigate to="/signin" replace />;
+  return hasDeviceKey() ? <GatedLayout /> : <Navigate to="/signin" replace />;
+}
+
+// The layout wrapping every gated page. It owns the app-level screen wake lock (issue #981) so the
+// phone stays awake on ANY page (roster, Chat, Voice, New session, AI settings, Terminal) while the
+// app is foregrounded. Because this layout stays mounted across navigations between gated child
+// routes, the lock is acquired once (a single sentinel), not once per page.
+function GatedLayout() {
+  useScreenWakeLock();
+  return <Outlet />;
 }
 
 // Mirror the injected per-machine token into the cc-gateway-token cookie at startup so the live

--- a/apps/mobile/src/pages/Terminal.tsx
+++ b/apps/mobile/src/pages/Terminal.tsx
@@ -61,27 +61,8 @@ export function Terminal() {
     return () => { mirror.dispose(); mirrorRef.current = null; };
   }, [sessionId]);
 
-  // Keep the screen awake while the Terminal view is open (Waze-style, matching the Android tab's
-  // KeepScreenOn). Wake locks drop when the tab is hidden, so re-acquire on visibility return.
-  useEffect(() => {
-    type WakeLockSentinelLike = { release: () => Promise<void> };
-    type WakeLockNavigator = Navigator & { wakeLock?: { request: (t: "screen") => Promise<WakeLockSentinelLike> } };
-    const wl = (navigator as WakeLockNavigator).wakeLock;
-    if (!wl) return; // not supported on this browser; nothing to do (no fallback)
-    let sentinel: WakeLockSentinelLike | null = null;
-    let released = false;
-    const acquire = async () => {
-      try { sentinel = await wl.request("screen"); } catch { /* denied/again on next visibility */ }
-    };
-    const onVisibility = () => { if (document.visibilityState === "visible" && !released) void acquire(); };
-    void acquire();
-    document.addEventListener("visibilitychange", onVisibility);
-    return () => {
-      released = true;
-      document.removeEventListener("visibilitychange", onVisibility);
-      if (sentinel) { void sentinel.release().catch(() => { /* already gone */ }); }
-    };
-  }, []);
+  // The screen is kept awake app-wide by the gated layout's useScreenWakeLock (issue #981), which
+  // covers the Terminal view too - so this page no longer holds its own separate wake lock.
 
   // Flash an action result in the status line, then settle back to the base "read-only" label.
   const flash = useCallback((message: string) => {


### PR DESCRIPTION
Closes #981.

The Screen Wake Lock was only held on the Terminal page, so every other page (roster, Chat, Voice, New session, AI settings) let the phone dim/lock mid-session. This promotes it to a single app-level owner.

- New `useScreenWakeLock` hook, held in a `GatedLayout` that wraps every gated route, so the lock is acquired once (one sentinel) and persists across page navigations rather than once per page.
- Releases on background (tab hidden), re-acquires on foreground.
- Terminal's own per-view wake-lock effect removed (the app-level owner covers it).
- Silent no-op where `navigator.wakeLock` is unavailable (no fallback).

## QA (Vite dev server + Playwright, spying on `navigator.wakeLock`)

Since the wake lock isn't visually observable, verified via a spy harness:
- On mount: a sentinel is acquired.
- Across 3 client-side navigations (home ↔ chat): the gated owner did NOT remount (`ownerMounts` stayed 1) and `maxConcurrent` sentinels stayed **1** — one lock across all routes, no double-acquire.
- Real tab hide/show cycles showed release-then-reacquire, never overlapping (`maxConcurrent` 1 throughout).
- `?nowl=1` (no `navigator.wakeLock`): page renders on every route, zero requests, no error thrown.
- Typecheck + production build clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)