### PR TITLE
Fix awarenessClient.test.ts strict typecheck errors and gate them (#1010)

### DIFF
--- a/docs/cencon/proof/issue-1010/qa-report.html
+++ b/docs/cencon/proof/issue-1010/qa-report.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Proof - Issue #1010</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem; color: #1a1a1a; background: #fff; }
+  h1 { border-bottom: 3px solid #2b6cb0; padding-bottom: .4rem; }
+  h2 { margin-top: 1.8rem; color: #2b6cb0; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #cbd5e0; padding: .5rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #edf2f7; }
+  .pass { color: #22733a; font-weight: bold; }
+  .fail { color: #b91c1c; font-weight: bold; }
+  code, pre { font-family: Consolas, monospace; background: #f5f5f5; padding: .1rem .3rem; }
+  pre { padding: .7rem; overflow-x: auto; border: 1px solid #ddd; }
+  .verdict { font-size: 1.15rem; padding: .8rem 1rem; background: #e6ffed; border: 1px solid #22733a; border-radius: 6px; }
+</style>
+</head>
+<body>
+<h1>QA Proof Report - Issue #1010</h1>
+<p><strong>Title:</strong> Cockpit React: fix awarenessClient.test.ts typecheck errors introduced by #974<br>
+<strong>Pull request:</strong> #1014 (branch <code>issue-1010-awareness-test-typecheck</code>)<br>
+<strong>QA identity:</strong> QA Agent (independent verification, separate from Developer)<br>
+<strong>Method:</strong> Verified in isolated git worktrees checked out at clean <code>origin/main</code> (baseline) and at the PR head. Every command was re-run by QA - no developer output reused.</p>
+
+<h2>Verdict</h2>
+<p class="verdict">VERIFIED - all acceptance criteria met. Baseline established, fix confirmed, hardening gate proven effective, no type weakening.</p>
+
+<h2>Files changed by the PR</h2>
+<ul>
+  <li><code>packages/client-core/src/awareness/awarenessClient.test.ts</code> - gave the <code>mockFetch</code> helper the real fetch signature <code>(input: RequestInfo | URL, init?: RequestInit)</code> so the recorded mock call arguments are typed as a two-element tuple.</li>
+  <li><code>src/CcDirector.Gateway/CcDirector.Gateway.csproj</code> - added <code>npm run typecheck --workspaces --if-present</code> as a blocking <code>Exec</code> step in the <code>BuildCockpitApp</code> target (runs under <code>RunCockpitBuild=true</code>).</li>
+  <li><code>docs/cencon/proof/issue-1010/report.html</code> - developer proof (context only).</li>
+</ul>
+
+<h2>Acceptance criteria</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (QA-reproduced)</th><th>Result</th></tr>
+<tr>
+  <td>a</td>
+  <td>Strict workspace typecheck including test files passes clean (0 errors); show the exact command green, and that the 7 errors existed on clean origin/main.</td>
+  <td>7 errors on origin/main; 0 on PR.</td>
+  <td>Command: <code>npm run typecheck</code> (root -&gt; <code>tsc --noEmit</code> per workspace, whose <code>include: src</code> covers test files). Baseline origin/main: exit 2, exactly 7 errors (TS2493 x5, TS2352 x2) in <code>awarenessClient.test.ts</code> at lines 30, 32, 57, 59, 78. PR branch: exit 0, no errors.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>b</td>
+  <td>vitest stays green (70/70 or more).</td>
+  <td>70/70 green.</td>
+  <td><code>npm run test --workspace @devthrottle/client-core</code>: 5 files, <strong>70 passed (70)</strong>, exit 0. awarenessClient.test.ts = 7 tests passing.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>c</td>
+  <td>cockpit <code>npm run build</code>, <code>npm run lint</code> (ingress rule), Gateway <code>dotnet build -p:RunCockpitBuild=true</code>, and <code>dotnet build cc-director.sln</code> all clean.</td>
+  <td>All four clean.</td>
+  <td>cockpit build: <code>built in 1.09s</code>, exit 0. lint (<code>eslint .</code>): exit 0, no errors. Gateway build with <code>RunCockpitBuild=true</code>: <strong>Build succeeded, 0 Warning(s), 0 Error(s)</strong> - and the new typecheck gate step ran in-build. Full solution: <strong>Build succeeded, 0 Warning(s), 0 Error(s)</strong>.</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>d</td>
+  <td>The hardening actually works - the new gate step catches the error.</td>
+  <td>Re-introducing a type error makes <code>dotnet build -p:RunCockpitBuild=true</code> FAIL.</td>
+  <td>QA appended a deliberate type error (<code>const __qaProbe: number = "not a number";</code>) to the test file. Gateway gate build FAILED: <code>error TS2322</code> surfaced, the typecheck npm step exited 2, and MSBuild reported <code>error MSB3073</code> at <code>CcDirector.Gateway.csproj(133,5)</code> - <strong>Build FAILED</strong>. Probe reverted; typecheck green again (exit 0).</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>-</td>
+  <td>Fix uses no <code>any</code> / <code>@ts-ignore</code> (type weakening forbidden).</td>
+  <td>No <code>any</code>, no ts-suppress directives.</td>
+  <td>Grep of the test file for <code>\bany\b</code>, <code>@ts-ignore</code>, <code>@ts-expect-error</code>, <code>@ts-nocheck</code>: none found. The fix declares proper <code>RequestInfo | URL</code> / <code>RequestInit</code> parameter types.</td>
+  <td class="pass">PASS</td>
+</tr>
+</table>
+
+<h2>Baseline evidence (clean origin/main)</h2>
+<pre>&gt; @devthrottle/client-core@0.1.0 typecheck
+&gt; tsc --noEmit
+
+src/awareness/awarenessClient.test.ts(30,12): error TS2493: Tuple type '[]' of length '0' has no element at index '0'.
+src/awareness/awarenessClient.test.ts(30,17): error TS2493: Tuple type '[]' of length '0' has no element at index '1'.
+src/awareness/awarenessClient.test.ts(32,13): error TS2352: Conversion of type 'undefined' to type 'RequestInit' may be a mistake ...
+src/awareness/awarenessClient.test.ts(57,12): error TS2493: Tuple type '[]' of length '0' has no element at index '0'.
+src/awareness/awarenessClient.test.ts(57,17): error TS2493: Tuple type '[]' of length '0' has no element at index '1'.
+src/awareness/awarenessClient.test.ts(59,13): error TS2352: Conversion of type 'undefined' to type 'RequestInit' may be a mistake ...
+src/awareness/awarenessClient.test.ts(78,36): error TS2493: Tuple type '[]' of length '0' has no element at index '0'.
+TYPECHECK_EXIT=2  (7 errors)</pre>
+
+<h2>Hardening gate evidence (injected type error on PR branch)</h2>
+<pre>src/awareness/awarenessClient.test.ts(99,7): error TS2322: Type 'string' is not assignable to type 'number'.
+npm error Lifecycle script `typecheck` failed with error : npm error code 2
+CcDirector.Gateway.csproj(133,5): error MSB3073: The command "npm run typecheck --workspaces --if-present" exited with code 2.
+Build FAILED.    3 Error(s)</pre>
+<p>Probe reverted immediately after; PR branch returned to a clean tree and a green typecheck.</p>
+
+<h2>Regression sweep</h2>
+<p>Change is confined to one test file plus a build-gate step. Full <code>dotnet build cc-director.sln</code> clean (all projects incl. Cockpit, Gateway, Avalonia and their test projects), cockpit production build clean, and the entire vitest suite green - no adjacent breakage observed. CenCon: no security rule affected; no architecture/security-profile change requiring doc updates.</p>
+
+<p><em>Verified by the QA Agent, CenCon Development Method, 2026-07-05.</em></p>
+</body>
+</html>

--- a/docs/cencon/proof/issue-1010/report.html
+++ b/docs/cencon/proof/issue-1010/report.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Issue #1010 - Developer Agent Proof</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+         max-width: 960px; margin: 0 auto; padding: 24px; line-height: 1.5; }
+  h1 { font-size: 1.5rem; border-bottom: 2px solid #888; padding-bottom: 8px; }
+  h2 { font-size: 1.15rem; margin-top: 28px; }
+  code, pre { font-family: Consolas, "Courier New", monospace; }
+  pre { background: #1e1e1e; color: #d4d4d4; padding: 12px; border-radius: 6px;
+        overflow-x: auto; font-size: 0.85rem; }
+  table { border-collapse: collapse; width: 100%; margin: 12px 0; }
+  th, td { border: 1px solid #999; padding: 6px 10px; text-align: left; vertical-align: top;
+           font-size: 0.9rem; }
+  th { background: rgba(128,128,128,0.15); }
+  .pass { color: #1a7f37; font-weight: bold; }
+  .fail { color: #cf222e; font-weight: bold; }
+  .meta { font-size: 0.85rem; color: #666; }
+</style>
+</head>
+<body>
+<h1>Issue #1010 - Fix awarenessClient.test.ts typecheck errors introduced by #974</h1>
+<p class="meta">Developer Agent (CenCon Development Method) &middot; Branch
+<code>issue-1010-awareness-test-typecheck</code> &middot; PR #1014 &middot; 2026-07-05</p>
+
+<h2>What was implemented</h2>
+<p>Issue #974 (turn rail / awareness panes) added
+<code>packages/client-core/src/awareness/awarenessClient.test.ts</code>. Its
+<code>mockFetch</code> helper used a zero-parameter <code>vi.fn(async () =&gt; ...)</code>
+implementation. Vitest infers the recorded call arguments (<code>mock.calls</code>) from the
+mock implementation's parameter list, so with no parameters <code>mock.calls[0]</code> was typed
+as the empty tuple <code>[]</code>. Destructuring <code>[url, init]</code> and reading
+<code>calls[0][0]</code> then failed a strict <code>tsc --noEmit</code> with TS2493 (x5), and
+casting the resulting <code>undefined</code> to <code>RequestInit</code> failed with TS2352 (x2)
+&mdash; 7 errors total. These slipped past vitest (esbuild, does not typecheck) and past the
+declaration build (<code>tsconfig.build.json</code> excludes <code>*.test.ts</code>).</p>
+
+<p><strong>Fix (no behavior change, no <code>any</code>, no <code>@ts-ignore</code>):</strong>
+give <code>mockFetch</code> the real <code>fetch</code> signature
+<code>(input: RequestInfo | URL, init?: RequestInit)</code>, so the recorded call arguments are a
+correctly typed two-element tuple.</p>
+
+<p><strong>Hardening (recommended by the issue):</strong> wire the test-inclusive strict
+typecheck (<code>npm run typecheck --workspaces --if-present</code>, which runs
+<code>tsc --noEmit</code> whose tsconfig <code>include: ["src"]</code> covers test files) as a
+blocking step in the <code>BuildCockpitApp</code> target in
+<code>src/CcDirector.Gateway/CcDirector.Gateway.csproj</code>. The gate previously ran only
+<code>npm run build</code> (vite/esbuild, no typecheck), so this class of error could not be
+caught at build time.</p>
+
+<h2>The exact command that surfaced the 7 errors</h2>
+<p><code>npm run typecheck</code> (root) &rarr; runs <code>tsc --noEmit</code> per workspace,
+including the test files under <code>src/</code>.</p>
+
+<h3>BEFORE (on clean origin/main / before the fix)</h3>
+<pre>&gt; @devthrottle/client-core@0.1.0 typecheck
+&gt; tsc --noEmit
+
+src/awareness/awarenessClient.test.ts(30,12): error TS2493: Tuple type '[]' of length '0' has no element at index '0'.
+src/awareness/awarenessClient.test.ts(30,17): error TS2493: Tuple type '[]' of length '0' has no element at index '1'.
+src/awareness/awarenessClient.test.ts(32,13): error TS2352: Conversion of type 'undefined' to type 'RequestInit' may be a mistake ...
+src/awareness/awarenessClient.test.ts(57,12): error TS2493: Tuple type '[]' of length '0' has no element at index '0'.
+src/awareness/awarenessClient.test.ts(57,17): error TS2493: Tuple type '[]' of length '0' has no element at index '1'.
+src/awareness/awarenessClient.test.ts(59,13): error TS2352: Conversion of type 'undefined' to type 'RequestInit' may be a mistake ...
+src/awareness/awarenessClient.test.ts(78,36): error TS2493: Tuple type '[]' of length '0' has no element at index '0'.
+Lifecycle script `typecheck` failed with error: code 2   (7 errors)</pre>
+
+<h3>AFTER (this branch)</h3>
+<pre>&gt; devthrottle-workspace@0.0.0 typecheck
+&gt; npm run typecheck --workspaces --if-present
+
+&gt; @devthrottle/client-core@0.1.0 typecheck
+&gt; tsc --noEmit
+
+&gt; @devthrottle/cockpit@0.1.0 typecheck
+&gt; tsc --noEmit
+
+&gt; @devthrottle/mobile@0.1.0 typecheck
+&gt; tsc --noEmit
+
+exit 0  (0 errors)</pre>
+
+<h2>Acceptance criteria &rarr; proof</h2>
+<table>
+<tr><th>Criterion</th><th>Expected</th><th>Actual</th><th>Result</th></tr>
+<tr>
+  <td>Strict workspace typecheck incl. test files passes clean (0 errors)</td>
+  <td><code>npm run typecheck</code> exits 0</td>
+  <td>7 errors before &rarr; 0 errors after; exit 0</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>vitest stays green (70/70 or more)</td>
+  <td>All tests pass</td>
+  <td><code>npm run test --workspace @devthrottle/client-core</code>: 5 files, 70 passed (incl. 7 awareness tests)</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>Cockpit <code>npm run build</code> clean</td>
+  <td>Build succeeds</td>
+  <td>vite build OK, 103 modules, built in ~1.1s</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td><code>npm run lint</code> clean (ingress rule)</td>
+  <td>No lint errors</td>
+  <td><code>eslint .</code> exit 0</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>Gateway <code>dotnet build -p:RunCockpitBuild=true</code> clean</td>
+  <td>Build succeeds; new typecheck step runs</td>
+  <td>Build succeeded, 0 Warning(s), 0 Error(s); typecheck step executed in-gate</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td><code>dotnet build cc-director.sln</code> clean</td>
+  <td>Build succeeds</td>
+  <td>Build succeeded, 0 Warning(s), 0 Error(s)</td>
+  <td class="pass">PASS</td>
+</tr>
+<tr>
+  <td>Strict test typecheck added to build gate (optional/recommended)</td>
+  <td>Class of error blocking at build time</td>
+  <td><code>npm run typecheck --workspaces --if-present</code> added to <code>BuildCockpitApp</code> in <code>CcDirector.Gateway.csproj</code></td>
+  <td class="pass">DONE</td>
+</tr>
+</table>
+
+<h2>Files changed</h2>
+<ul>
+  <li><code>packages/client-core/src/awareness/awarenessClient.test.ts</code> &mdash; typed the
+  <code>mockFetch</code> mock with the real fetch signature.</li>
+  <li><code>src/CcDirector.Gateway/CcDirector.Gateway.csproj</code> &mdash; added the
+  test-inclusive strict typecheck as a blocking step in the cockpit build gate.</li>
+</ul>
+
+<h2>CenCon impact</h2>
+<p>No drift. This is a test-type correction plus a build-gate step; it changes neither the
+architecture (no container added/removed/re-wired) nor the security posture (no DT-rule affected).
+No <code>docs/cencon/</code> update required.</p>
+
+<h2>Conclusion</h2>
+<p class="pass">I believe this is finished. The 7 strict typecheck errors are resolved with no
+behavior change and no type weakening, vitest stays 70/70 green, all four builds are clean, and the
+strict test-inclusive typecheck is now a blocking build-gate step so this class of error cannot slip
+through again.</p>
+</body>
+</html>

--- a/packages/client-core/src/awareness/awarenessClient.test.ts
+++ b/packages/client-core/src/awareness/awarenessClient.test.ts
@@ -4,13 +4,17 @@ import { generateRecap, getRecap, getTurnSummaries } from "./awarenessClient";
 // Awareness Gateway reads (issue #974). These exercise the root-relative paths (Gateway-only-ingress),
 // the 404-to-empty degrade on turn-summaries, and that a POST recap is issued for a fresh generation.
 
+// Mirror the real fetch signature (input, init) so the mock's recorded call arguments are typed as a
+// two-element tuple. Without the declared parameters, vitest infers mock.calls[0] as the empty tuple
+// [], and reading calls[0][0] / destructuring [url, init] fails a strict tsc --noEmit (issue #1010).
 function mockFetch(status: number, body: unknown) {
-  return vi.fn(async () =>
-    ({
-      ok: status >= 200 && status < 300,
-      status,
-      json: async () => body,
-    }) as unknown as Response,
+  return vi.fn(
+    async (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => body,
+      }) as unknown as Response,
   );
 }
 

--- a/src/CcDirector.Gateway/CcDirector.Gateway.csproj
+++ b/src/CcDirector.Gateway/CcDirector.Gateway.csproj
@@ -125,6 +125,12 @@
   <Target Name="BuildCockpitApp" BeforeTargets="AssignTargetPaths" Condition="'$(RunCockpitBuild)' == 'true'">
     <Message Importance="high" Text="[BuildCockpitApp] building the React Cockpit ($(Configuration)) from $(CockpitDir) via the workspace at $(WorkspaceRoot)" />
     <Exec Command="npm ci" WorkingDirectory="$(WorkspaceRoot)" />
+    <!-- Issue #1010: the workspace build (vite / esbuild) does not type-check, and the per-package
+         declaration build (tsconfig.build.json) excludes the test files, so a strictly-typed test file
+         could regress unnoticed. Run the test-inclusive strict typecheck (tsc noEmit over every
+         workspace, whose tsconfig include of "src" covers test files) as a blocking build-gate step. -->
+    <Message Importance="high" Text="[BuildCockpitApp] running the strict test-inclusive typecheck (npm run typecheck) across all workspaces" />
+    <Exec Command="npm run typecheck --workspaces --if-present" WorkingDirectory="$(WorkspaceRoot)" />
     <Exec Command="npm run build --workspace @devthrottle/cockpit" WorkingDirectory="$(WorkspaceRoot)" />
     <RemoveDir Directories="$(CockpitWwwroot)" />
     <ItemGroup>


### PR DESCRIPTION
Closes #1010 (follow-up to #967 / #974).

## Release Notes
Fixes 7 pre-existing TypeScript strict-typecheck errors in the Cockpit shared library test file `packages/client-core/src/awareness/awarenessClient.test.ts` (introduced by #974) and wires the test-inclusive strict typecheck into the cockpit build gate so the class cannot regress.

## Changes
- `packages/client-core/src/awareness/awarenessClient.test.ts`: give the `mockFetch` helper the real `fetch` signature `(input: RequestInfo | URL, init?: RequestInit)`. Vitest infers `mock.calls` from the mock implementation's parameters; the old zero-parameter `vi.fn(async () => ...)` typed `mock.calls[0]` as the empty tuple `[]`, so `const [url, init] = ...` and `calls[0][0]` tripped TS2493 (x5) and the resulting `undefined` cast to `RequestInit` tripped TS2352 (x2). No behavior change, no `any`, no `@ts-ignore`.
- `src/CcDirector.Gateway/CcDirector.Gateway.csproj`: add `npm run typecheck --workspaces --if-present` as a blocking step in the `BuildCockpitApp` target (runs under `RunCockpitBuild=true`). The build gate previously ran only `npm run build` (vite/esbuild, no typecheck) and the declaration build (`tsconfig.build.json`) excludes `*.test.ts`, so strict-typed test regressions slipped through.

## How to Test
From the workspace root:
- `npm run typecheck` (was 7 errors on `origin/main`, now 0)
- `npm run test --workspace @devthrottle/client-core` (70/70 green)
- `npm run build --workspace @devthrottle/cockpit` (clean)
- `npm run lint` (clean, ingress rule)
- `dotnet build src/CcDirector.Gateway/CcDirector.Gateway.csproj -p:RunCockpitBuild=true` (clean; now runs the typecheck step)
- `dotnet build cc-director.sln` (clean)

## Expected Result
Strict workspace typecheck passes with 0 errors; vitest stays 70/70; all builds clean.

## Before / After
- Before: `npm run typecheck` exits 2 with 7 errors (TS2493 x5, TS2352 x2) in `awarenessClient.test.ts`.
- After: `npm run typecheck` exits 0; the same check now runs as a blocking gate step during the Cockpit build.

Proof: docs/cencon/proof/issue-1010/report.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)