### PR TITLE
[Mobile] Durable, server-owned dictation upload - a refresh never loses recorded audio (#1006)

### DIFF
--- a/apps/mobile/src/components/SessionControls.tsx
+++ b/apps/mobile/src/components/SessionControls.tsx
@@ -173,12 +173,12 @@ export function SessionControls({ sessionId, onFlash, onError, showKeyRows }: Se
       onFlash("Transcribing...");
       void backgroundTranscribeAndSend(sessionId, captured, {
         onError,
-        // Insert the dictated words at the snapshotted caret inside the typed text, then submit.
-        compose: (dictation) => insertAt(composerText, caret, dictation),
-        // On a genuine transcription failure the audio is unrecoverable, but the typed text is not:
-        // put it back (ahead of anything typed since) so Send never silently loses it. If the user has
-        // navigated away this component is unmounted and setInput is a harmless no-op; the onError
-        // notification is then the signal.
+        // Insert the dictated words at the snapshotted caret inside the typed text: the Gateway submits
+        // before + dictation + after. The caret splits the typed text into the two halves.
+        composeParts: { before: composerText.slice(0, caret), after: composerText.slice(caret) },
+        // On a send that does not complete the audio is kept durably for resume, but the typed text is
+        // client-only: put it back (ahead of anything typed since) so Send never silently loses it. If
+        // the user navigated away this component is unmounted and setInput is a harmless no-op.
         onFailed: () => {
           if (composerText.trim().length > 0) setInput((cur) => joinText(composerText, cur));
         },

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -14,6 +14,7 @@ import { ensureGatewayCookie } from "@devthrottle/client-core/api/client";
 import { ensurePushSubscribed } from "./push/register";
 import { CreditsNotice } from "./components/CreditsNotice";
 import { useScreenWakeLock } from "./hooks/useScreenWakeLock";
+import { resumePendingDictations } from "@devthrottle/client-core/dictation/backgroundSend";
 import "./styles.css";
 
 // The auth gate (issue #908): every real screen requires an enrolled device key. Without one, the
@@ -30,6 +31,11 @@ function RequireDeviceKey() {
 // routes, the lock is acquired once (a single sentinel), not once per page.
 function GatedLayout() {
   useScreenWakeLock();
+  // Resume any recorded-but-unsent dictation once the phone is enrolled (issue #1006): a clip whose
+  // upload was interrupted by a refresh / crash / dropped connection is re-driven to the session here.
+  React.useEffect(() => {
+    void resumePendingDictations();
+  }, []);
   return <Outlet />;
 }
 

--- a/apps/mobile/src/pages/VoiceMode.tsx
+++ b/apps/mobile/src/pages/VoiceMode.tsx
@@ -405,9 +405,12 @@ export function VoiceMode() {
       if (sid.length === 0) return;
       void backgroundTranscribeAndSend(sid, captured, {
         onError: (message) => setError(message),
+        // Record the session's terminal-byte position now, so a clip resumed later is not injected
+        // into a session that has moved on (issue #1006 guard).
+        baselineBufferBytes: Number(session?.totalBufferBytes ?? 0),
       });
     },
-    [sid],
+    [sid, session],
   );
 
   const voiceOn = localEnabled || Boolean(session?.voiceMode);

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -732,6 +732,141 @@ async function sha256Hex(bytes: Uint8Array): Promise<string> {
     .join("");
 }
 
+// ===== Durable, server-owned dictation upload (issue #1006) =====================================
+// Streams the raw recorded audio to the Gateway in resumable, SHA-checked chunks; the Gateway then
+// assembles, transcribes, and INJECTS the turn into the session itself. Once every chunk is up the
+// turn lands even if this tab dies. Idempotent by uploadId, so a resume re-runs safely.
+
+/** Outcome of a durable dictation submit. `terminal` means the server handled it (submitted or
+ *  dropped as stale) and the durable local copy can be deleted; otherwise retry it on resume. */
+export interface DictationSubmitResult {
+  terminal: boolean;
+  submitted: boolean;
+  movedOn: boolean;
+  transcript: string;
+  error?: string;
+}
+
+export interface DictationUploadArgs {
+  sessionId: string;
+  /** The durable record id; also the server upload id and Idempotency-Key. */
+  uploadId: string;
+  /** Raw recorded audio exactly as the microphone produced it. */
+  audio: Blob;
+  before: string;
+  after: string;
+  prefix: string;
+  baselineBufferBytes: number;
+  resumed: boolean;
+}
+
+const CHUNK_RETRIES = 4;
+
+export async function uploadDictationToSession(
+  args: DictationUploadArgs,
+  signal?: AbortSignal,
+): Promise<DictationSubmitResult> {
+  const fail = (error: string): DictationSubmitResult => ({ terminal: false, submitted: false, movedOn: false, transcript: "", error });
+
+  // 1. Register (idempotent: the same id re-opens the same staging after a resume).
+  const reg = await fetch(`/dictation/upload`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json", "Idempotency-Key": args.uploadId, ...authHeaders() },
+    body: JSON.stringify({ sessionId: args.sessionId, baselineBufferBytes: args.baselineBufferBytes }),
+    signal,
+  });
+  if (!reg.ok) return fail(`register failed: ${reg.status}`);
+  const regBody = (await reg.json().catch(() => ({}))) as { upload_id?: string };
+  const id = encodeURIComponent(regBody.upload_id ?? args.uploadId);
+
+  // 2. Upload chunks with per-chunk retry, so a dropped chunk on a bad connection resumes at that
+  //    chunk instead of restarting the whole clip.
+  const bytes = new Uint8Array(await args.audio.arrayBuffer());
+  const ranges = planUploadChunks(bytes.length, MAX_UPLOAD_CHUNK_BYTES);
+  for (const range of ranges) {
+    const part = bytes.subarray(range.start, range.end);
+    const sha = await sha256Hex(part);
+    let ok = false;
+    let lastErr = "";
+    for (let attempt = 0; attempt < CHUNK_RETRIES && !ok; attempt++) {
+      try {
+        const put = await fetch(`/dictation/${id}/chunk/${range.index}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/octet-stream", "X-Chunk-Sha256": sha, ...authHeaders() },
+          body: part,
+          signal,
+        });
+        ok = put.ok;
+        if (!ok) lastErr = `chunk ${range.index}: ${put.status}`;
+      } catch (e) {
+        lastErr = e instanceof Error ? e.message : String(e);
+      }
+      if (!ok && attempt < CHUNK_RETRIES - 1) await uploadBackoff(400 * (attempt + 1), signal);
+    }
+    if (!ok) return fail(lastErr);
+  }
+
+  // 3. Complete: the server assembles, transcribes, and injects the turn.
+  const completeBody = {
+    sessionId: args.sessionId,
+    totalChunks: ranges.length,
+    mime: args.audio.type || "audio/webm",
+    ext: extForMime(args.audio.type),
+    before: args.before,
+    after: args.after,
+    prefix: args.prefix,
+    baselineBufferBytes: args.baselineBufferBytes,
+    resumed: args.resumed,
+  };
+  const complete = (): Promise<Response> =>
+    fetch(`/dictation/${id}/complete`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
+      body: JSON.stringify(completeBody),
+      signal,
+    });
+
+  let comp = await complete();
+  if (comp.status === 409) {
+    // Some chunks did not land; re-send exactly those, then complete once more.
+    const body = (await comp.json().catch(() => ({}))) as { missing?: number[] };
+    for (const i of body.missing ?? []) {
+      const r = ranges[i];
+      if (!r) continue;
+      const part = bytes.subarray(r.start, r.end);
+      await fetch(`/dictation/${id}/chunk/${i}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/octet-stream", "X-Chunk-Sha256": await sha256Hex(part), ...authHeaders() },
+        body: part,
+        signal,
+      });
+    }
+    comp = await complete();
+  }
+
+  if (comp.status === 402) throw creditsErrorFrom(await comp.json().catch(() => ({})));
+  const body = (await comp.json().catch(() => ({}))) as { submitted?: boolean; movedOn?: boolean; transcript?: string; error?: string };
+  if (!comp.ok) return fail(body.error ?? `complete: ${comp.status}`);
+  return { terminal: true, submitted: Boolean(body.submitted), movedOn: Boolean(body.movedOn), transcript: body.transcript ?? "" };
+}
+
+function extForMime(mime: string | undefined): string {
+  const m = (mime ?? "").toLowerCase();
+  if (m.includes("webm")) return "webm";
+  if (m.includes("ogg")) return "ogg";
+  if (m.includes("mp4") || m.includes("m4a") || m.includes("aac")) return "m4a";
+  if (m.includes("mpeg") || m.includes("mp3")) return "mp3";
+  if (m.includes("wav")) return "wav";
+  return "webm";
+}
+
+function uploadBackoff(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(resolve, ms);
+    signal?.addEventListener("abort", () => { clearTimeout(t); reject(new Error("aborted")); }, { once: true });
+  });
+}
+
 // ===== Wingman Voice mode (issue #850): the mobile hands-free narration loop =====
 // The whole backend is already built and proven on the desktop Cockpit voice tab and the native
 // phone app (the explain/voice/ready/menu endpoints below). These typed helpers are the mobile

--- a/packages/client-core/src/dictation/backgroundSend.ts
+++ b/packages/client-core/src/dictation/backgroundSend.ts
@@ -1,88 +1,128 @@
-import { sendPrompt, setTranscribing, transcribeUtterance } from "../api/client";
-import { logCaptureHealth } from "./captureHealth";
-import { joinText } from "./transcript";
-import { blobToWav16kMono } from "./wav";
+import { uploadDictationToSession } from "../api/client";
+import { deletePending, prunePending, savePending, type PendingDictation } from "./pendingStore";
 
-// The fire-and-forget Send pipeline for the mobile Speak dialog. The instant the user hits Send the
-// dialog captures the recorded audio buffer, hands it here, and closes - the screen is released
-// immediately, because everything left to do (transcode, upload, transcribe, submit) needs the
-// buffer, not the user, and the result cannot be viewed on that screen anyway (Send submits straight
-// into the session). This function then does that whole chain in the background while the roster
-// shows the session orange ("Transcribing...") so nobody else starts using it.
+// The durable Send pipeline for the mobile Speak dialog (issue #1006). The instant the user hits Send
+// the dialog hands the recorded audio here and closes; we persist the raw audio locally (IndexedDB)
+// BEFORE any network work, then stream it to the Gateway in resumable chunks. The Gateway assembles,
+// transcribes, and INJECTS the turn into the session itself, so once the audio is uploaded a dead tab
+// or a dropped connection can no longer lose it. If anything is interrupted, the durable record
+// survives and resumePendingDictations() (called on app load) re-drives the upload+submit.
 //
 // It deliberately lives OUTSIDE the DictationDialog component: the dialog unmounts (and disposes its
-// recorder) the moment Send is pressed, so the work must not be tied to the dialog's lifecycle. The
-// captured Blob is independent of the recorder, so disposing the recorder does not affect it.
+// recorder) the moment Send is pressed, so the work must not be tied to the dialog's lifecycle.
 
-/** The audio buffer + context the dialog hands up when Send is pressed while still recording. */
+/** How long a recorded-but-unsent clip is kept before it is pruned unsent (issue #1006): an hour.
+ *  This is a temporary out-of-bandwidth buffer, not a mailbox - a clip we never managed to send
+ *  within the hour is dropped rather than injected into a session that has long since moved on. */
+const PENDING_TTL_MS = 60 * 60 * 1000;
+
+/** The audio buffer + context the dialog hands up when Send is pressed. */
 export interface CapturedUtterance {
-  /** The raw recorded audio exactly as the microphone produced it (WebM/Opus etc.); transcoded to
-   *  WAV here, off the dialog's critical path, so the screen is released before any transcode. */
+  /** The raw recorded audio exactly as the microphone produced it (WebM/Opus etc.). */
   blob: Blob;
   /** Wall-clock milliseconds the segment was capturing (capture-health, issue #863). */
   recordedMs: number;
-  /** Earlier Pause/Resume dictation segments, joined ahead of this final segment's transcript to form
-   *  the full dictation. Empty in the common "just talk and Send" case (no pause). */
+  /** Earlier Pause/Resume dictation segments, already turned to text, joined ahead of this final
+   *  segment. Empty in the common "just talk and Send" case. */
   prefixText: string;
 }
 
-/** Callbacks so the host can surface a failure. Success is silent - the submitted turn IS the proof
- *  and the roster's orange flag clearing is the visible completion signal. */
+/** Callbacks so the host can surface a failure. Success is silent - the submitted turn IS the proof. */
 export interface BackgroundSendHooks {
   onError?: (message: string) => void;
-  /** Called when the transcribe/submit chain throws, so the host can restore anything (e.g. the typed
-   *  compose text) it cleared at dialog-close time for a send that never went. */
+  /** Called when the send does not complete (kept durably for resume), so the host can restore any
+   *  typed compose text it cleared at dialog-close time. */
   onFailed?: () => void;
-  /** Place the dictated words into the final message. The host uses this to insert them at the caret
-   *  inside any typed compose text (like the Insert button), then this result is submitted. Defaults
-   *  to submitting the dictation alone. Called even for an empty dictation, so a Send pressed with
-   *  typed text present still submits that text; a fully-empty message submits nothing. */
-  compose?: (dictation: string) => string;
+  /** Typed text the caret split the dictation around (Terminal Speak's Insert-then-Enter). The voice
+   *  case omits this and the transcript is submitted alone. */
+  composeParts?: { before: string; after: string };
+  /** The session's TotalBufferBytes at record time, for the Gateway's "session moved on" guard when a
+   *  clip is resumed later. Omit when unknown (the guard is then skipped for safety). */
+  baselineBufferBytes?: number;
 }
 
-// Mark the session transcribing (roster -> orange), transcode + upload + transcribe the captured
-// audio, submit the joined transcript into the session, then clear the transcribing mark. The mark
-// is cleared in a finally so a transcode/transcribe/submit failure still releases the orange state.
+// Persist the recorded audio durably, then drive the server-owned upload+transcribe+inject. On a
+// terminal outcome (submitted, or dropped as stale) the durable record is deleted; otherwise it is
+// kept so the next app load resumes it.
 export async function backgroundTranscribeAndSend(
   sessionId: string,
   captured: CapturedUtterance,
   hooks: BackgroundSendHooks = {},
 ): Promise<void> {
-  // Flip the roster to orange first, so the busy signal shows from the moment the screen is released.
-  // Best-effort: a marker failure must not abort the actual transcription+send the user asked for.
+  const rec: PendingDictation = {
+    id: crypto.randomUUID(),
+    sessionId,
+    blob: captured.blob,
+    recordedMs: captured.recordedMs,
+    before: hooks.composeParts?.before ?? "",
+    after: hooks.composeParts?.after ?? "",
+    prefix: captured.prefixText ?? "",
+    baselineBufferBytes: hooks.baselineBufferBytes ?? 0,
+    createdAt: Date.now(),
+  };
+
+  // Save the audio the instant Send is pressed - even if this tab dies right now, it is not lost.
+  let persisted = false;
   try {
-    await setTranscribing(sessionId, true);
+    await savePending(rec);
+    persisted = true;
   } catch {
-    /* the marker is a visual nicety; press on with the real work */
+    // No durable store in this context (rare): press on with a best-effort, non-durable send.
   }
 
   try {
-    const transcoded = await blobToWav16kMono(captured.blob);
-    const health = {
-      recordedMs: captured.recordedMs,
-      decodedSeconds: transcoded.decodedSeconds,
-      sourceBytes: transcoded.sourceBytes,
-    };
-    logCaptureHealth("mobile", health);
-    const segment = await transcribeUtterance(transcoded.wav, health);
-    const dictation = joinText(captured.prefixText, segment).trim();
-    // Let the host place the dictation (it inserts at the caret inside any typed text); default to the
-    // dictation alone. The typed text survives an empty/silent clip because compose still returns it,
-    // and a fully-empty message submits nothing so a mis-tapped Send does not fire a blank turn.
-    const message = (hooks.compose ? hooks.compose(dictation) : dictation).trim();
-    if (message.length > 0) {
-      await sendPrompt(sessionId, message, true);
+    const outcome = await uploadDictationToSession({
+      sessionId,
+      uploadId: rec.id,
+      audio: rec.blob,
+      before: rec.before,
+      after: rec.after,
+      prefix: rec.prefix,
+      baselineBufferBytes: rec.baselineBufferBytes,
+      resumed: false,
+    });
+    if (outcome.terminal) {
+      if (persisted) await deletePending(rec.id);
+    } else {
+      // The server did not confirm the turn; keep the durable record so resume-on-load retries it, and
+      // surface the soft error. (If there is no durable copy, this utterance is genuinely lost - the
+      // onError is then the signal, exactly as before.)
+      hooks.onError?.(outcome.error ?? "Dictation upload failed");
+      hooks.onFailed?.();
     }
   } catch (err) {
     hooks.onError?.(err instanceof Error ? err.message : "Transcription failed");
     hooks.onFailed?.();
-  } finally {
-    // Authoritative clear - releases the orange roster state whether the transcript submitted or the
-    // attempt failed. Best-effort; the Gateway also expires an abandoned mark as a backstop.
+  }
+}
+
+// Re-drive every recorded-but-unsent dictation on app load: prune anything past the TTL, then resume
+// the upload+submit for the rest. Idempotent by upload id, so a clip that actually landed before the
+// tab died is de-duplicated by the Gateway rather than double-submitted. Best-effort: a clip that
+// still cannot send is kept for the next load (until it ages out).
+export async function resumePendingDictations(): Promise<void> {
+  let survivors: PendingDictation[];
+  try {
+    survivors = await prunePending(PENDING_TTL_MS);
+  } catch {
+    return; // no durable store; nothing to resume
+  }
+  for (const rec of survivors) {
     try {
-      await setTranscribing(sessionId, false);
+      const outcome = await uploadDictationToSession({
+        sessionId: rec.sessionId,
+        uploadId: rec.id,
+        audio: rec.blob,
+        before: rec.before,
+        after: rec.after,
+        prefix: rec.prefix,
+        baselineBufferBytes: rec.baselineBufferBytes,
+        resumed: true,
+      });
+      if (outcome.terminal) await deletePending(rec.id);
+      // Non-terminal: keep it for the next load.
     } catch {
-      /* the Gateway's stale-mark backstop clears it if this never lands */
+      // Credits/network still down: keep the record; the next launch retries until the TTL prunes it.
     }
   }
 }

--- a/packages/client-core/src/dictation/pendingStore.ts
+++ b/packages/client-core/src/dictation/pendingStore.ts
@@ -1,0 +1,103 @@
+// Durable local store for recorded dictation audio (issue #1006).
+//
+// The instant Send is pressed, the raw recorded audio is written here (IndexedDB, which holds Blobs
+// on disk) BEFORE any network work. So a page refresh, a tab crash, a phone reboot, or a dropped
+// connection can no longer lose a just-recorded utterance: the audio survives, and the app re-drives
+// the upload+submit on the next load. A record is deleted only when the server confirms it owns the
+// turn (submitted or deliberately dropped as stale); records older than the TTL are pruned unsent.
+//
+// IndexedDB (not localStorage) because the audio is binary and can be minutes long; localStorage is
+// string-only and tiny. Absence of IndexedDB (rare, e.g. some private modes) is capability-detected -
+// the caller falls back to a non-durable send for that one utterance, never a crash.
+
+export interface PendingDictation {
+  /** Client-generated GUID; doubles as the server upload id and Idempotency-Key. */
+  id: string;
+  sessionId: string;
+  /** The raw recorded audio exactly as the microphone produced it (WebM/Opus etc.). */
+  blob: Blob;
+  recordedMs: number;
+  /** Typed text before the caret (Terminal Speak compose); empty for the voice case. */
+  before: string;
+  /** Typed text after the caret; empty for the voice case. */
+  after: string;
+  /** Earlier paused dictation segments already turned to text, joined ahead of this clip. */
+  prefix: string;
+  /** The session's TotalBufferBytes when the clip was recorded (server moved-on guard). */
+  baselineBufferBytes: number;
+  /** Epoch milliseconds the clip was recorded, for the TTL. */
+  createdAt: number;
+}
+
+const DB_NAME = "dt-dictation";
+const STORE = "pending";
+const DB_VERSION = 1;
+
+function hasIndexedDb(): boolean {
+  try {
+    return typeof indexedDB !== "undefined";
+  } catch {
+    return false;
+  }
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE, { keyPath: "id" });
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error ?? new Error("indexedDB open failed"));
+  });
+}
+
+function tx<T>(mode: IDBTransactionMode, run: (store: IDBObjectStore) => IDBRequest<T>): Promise<T> {
+  return openDb().then(
+    (db) =>
+      new Promise<T>((resolve, reject) => {
+        const t = db.transaction(STORE, mode);
+        const req = run(t.objectStore(STORE));
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error ?? new Error("indexedDB request failed"));
+        t.oncomplete = () => db.close();
+      }),
+  );
+}
+
+/** True where durable storage is available (a microphone-capable PWA normally is). */
+export function pendingStoreAvailable(): boolean {
+  return hasIndexedDb();
+}
+
+/** Persist a recorded dictation the instant Send is pressed. Rejects only if IndexedDB is unusable. */
+export async function savePending(rec: PendingDictation): Promise<void> {
+  if (!hasIndexedDb()) throw new Error("durable dictation store unavailable");
+  await tx("readwrite", (s) => s.put(rec));
+}
+
+/** Every pending dictation still on disk (oldest first). Empty when the store is unavailable. */
+export async function listPending(): Promise<PendingDictation[]> {
+  if (!hasIndexedDb()) return [];
+  const all = await tx<PendingDictation[]>("readonly", (s) => s.getAll() as IDBRequest<PendingDictation[]>);
+  return all.sort((a, b) => a.createdAt - b.createdAt);
+}
+
+/** Remove a record once the server has confirmed the turn (submitted or dropped as stale). */
+export async function deletePending(id: string): Promise<void> {
+  if (!hasIndexedDb()) return;
+  await tx("readwrite", (s) => s.delete(id));
+}
+
+/** Delete records older than maxAgeMs (unsent, now stale) and return the survivors to resume. */
+export async function prunePending(maxAgeMs: number): Promise<PendingDictation[]> {
+  const all = await listPending();
+  const cutoff = Date.now() - maxAgeMs;
+  const survivors: PendingDictation[] = [];
+  for (const rec of all) {
+    if (rec.createdAt < cutoff) await deletePending(rec.id);
+    else survivors.push(rec);
+  }
+  return survivors;
+}

--- a/src/CcDirector.Core/Storage/CcStorage.cs
+++ b/src/CcDirector.Core/Storage/CcStorage.cs
@@ -107,6 +107,15 @@ public static class CcStorage
     public static string VoiceTurnUploads() => Ensure(Path.Combine(Base(), "voice-turn-uploads"));
 
     /// <summary>
+    /// Resumable upload staging for durable dictation (issue #1006): base/dictation-uploads/&lt;uploadId&gt;/.
+    /// The mobile app persists the raw audio locally the instant Send is pressed and streams it here in
+    /// SHA-checked chunks; once assembled the Gateway transcribes it and injects the turn into the owning
+    /// session itself, so a dead tab or a dropped connection cannot lose a recorded utterance. Abandoned
+    /// staging dirs are swept after ~1 hour. Owned by the Gateway.
+    /// </summary>
+    public static string DictationUploads() => Ensure(Path.Combine(Base(), "dictation-uploads"));
+
+    /// <summary>
     /// Wingman training data (issue #531 follow-up): base/wingman-training/. When the
     /// "wingman_training_capture" setting is on, every wingman summary appends one JSON-lines record
     /// here holding up to 20,000 characters of the session terminal, the agent reply + context the

--- a/src/CcDirector.Gateway.Tests/VoiceUploadStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceUploadStoreTests.cs
@@ -142,4 +142,25 @@ public sealed class VoiceUploadStoreTests : IDisposable
         _store.Delete(id);
         Assert.False(_store.Exists(id));
     }
+
+    [Fact]
+    public async Task SweepAbandoned_RemovesStaleUploads_KeepsFresh()
+    {
+        // Issue #1006: an upload whose client dropped before completing must not leak forever. The
+        // sweep removes staging dirs older than maxAge and leaves recent ones untouched.
+        var stale = _store.Register(null);
+        await _store.StoreChunkAsync(stale, 0, Bytes("old"), null);
+        var fresh = _store.Register(null);
+        await _store.StoreChunkAsync(fresh, 0, Bytes("new"), null);
+
+        // Age the stale upload's staging dir two hours into the past.
+        var staleDir = Path.Combine(_root, Guid.Parse(stale).ToString("N"));
+        Directory.SetLastWriteTimeUtc(staleDir, DateTime.UtcNow.AddHours(-2));
+
+        var removed = _store.SweepAbandoned(TimeSpan.FromHours(1));
+
+        Assert.Equal(1, removed);
+        Assert.False(_store.Exists(stale));
+        Assert.True(_store.Exists(fresh));
+    }
 }

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -1,0 +1,335 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.HostedAi;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.HostedAi;
+using CcDirector.Gateway.Transcription;
+using CcDirector.Gateway.Util;
+using CcDirector.Gateway.Voice;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// Durable, server-owned dictation upload (issue #1006).
+///
+/// The mobile app persists the raw recorded audio locally (IndexedDB) the instant Send is pressed,
+/// then streams it here in SHA-checked chunks. Once the clip is fully uploaded the GATEWAY assembles
+/// it, transcribes it, and injects the resulting text into the owning session ITSELF. So once the
+/// audio reaches the server a dead tab, a page refresh, or a dropped connection can no longer lose a
+/// recorded utterance: the client only has to get the bytes up (resumable, retry-per-chunk from the
+/// durable local copy), and the server finishes the turn.
+///
+///   POST /dictation/upload               { sessionId, baselineBufferBytes } + Idempotency-Key -> { upload_id }
+///   PUT  /dictation/{uploadId}/chunk/{i}  octet-stream + X-Chunk-Sha256                        -> { ok }
+///   POST /dictation/{uploadId}/complete   { sessionId,totalChunks,mime,ext,before,after,baselineBufferBytes,resumed }
+///                                          -> 200 { submitted, movedOn, transcript } | 409 { missing } | 402 | 5xx
+///
+/// A retried complete is single-flighted per uploadId so the turn is submitted at most once. Abandoned
+/// uploads are swept after ~1 hour (<see cref="VoiceUploadStore.SweepAbandoned"/> + <see cref="SweepCompletes"/>).
+/// Every route is token-gated via <see cref="AuthMiddleware.HasValidToken"/> so it holds even when the
+/// production tray Gateway runs with the global auth middleware off.
+/// </summary>
+internal static class GatewayDictationEndpoint
+{
+    // How much the session's terminal output may grow after a RESUMED clip was recorded before we treat
+    // it as "moved on" and refuse to inject the now-stale dictation (issue #1006 guard). Immediate
+    // (non-resumed) sends always inject; the 1-hour staging sweep is the hard backstop for staleness.
+    private const long MovedOnBufferGrowthBytes = 512;
+
+    // Single-flight + idempotency cache for complete, keyed by uploadId: concurrent or retried completes
+    // await the SAME work, and a terminal outcome is cached so a retry after a dropped response returns
+    // it instead of submitting a second turn. Non-terminal outcomes (error/incomplete/no-key) are NOT
+    // cached, so a genuine retry re-runs. Swept by age (SweepCompletes).
+    private sealed record CompleteEntry(DateTime At, Lazy<Task<DictationOutcome>> Task);
+    private static readonly ConcurrentDictionary<string, CompleteEntry> _completes = new();
+
+    public static void Map(IEndpointRouteBuilder app, DirectorRegistry registry, DirectorEndpointClient client,
+        SessionOwnerCache? owners, string token, GatewayTranscriptionService transcription,
+        TranscribingSessions transcribingSessions, VoiceUploadStore uploads)
+    {
+        app.MapPost("/dictation/upload", (DictationUploadRequest? body, HttpContext ctx) =>
+        {
+            if (!AuthMiddleware.HasValidToken(ctx, token))
+                return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
+            var sid = body?.SessionId ?? "";
+            if (!Guid.TryParse(sid, out _))
+                return Results.Json(new { error = "sessionId (guid) is required" }, statusCode: StatusCodes.Status400BadRequest);
+
+            // The client's locally-generated id (its IndexedDB record id) is the Idempotency-Key AND the
+            // upload id, so a resumed upload after a tab death maps back to the same staging dir.
+            var key = ctx.Request.Headers["Idempotency-Key"].ToString();
+            var uploadId = uploads.Register(string.IsNullOrWhiteSpace(key) ? null : key);
+            try { transcribingSessions.Begin(sid); } catch { /* the orange mark is a nicety */ }
+            FileLog.Write($"[GatewayDictation] upload registered sid={sid} uploadId={uploadId}");
+            return Results.Json(new { upload_id = uploadId });
+        });
+
+        app.MapPut("/dictation/{uploadId}/chunk/{index:int}", async (string uploadId, int index, HttpContext ctx) =>
+        {
+            if (!AuthMiddleware.HasValidToken(ctx, token))
+                return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
+            if (!uploads.Exists(uploadId))
+                return Results.Json(new { error = "unknown upload id (register it first)" }, statusCode: StatusCodes.Status404NotFound);
+
+            var sha = ctx.Request.Headers["X-Chunk-Sha256"].ToString();
+            using var ms = new MemoryStream();
+            await ctx.Request.Body.CopyToAsync(ms, ctx.RequestAborted);
+            try
+            {
+                await uploads.StoreChunkAsync(uploadId, index, ms.ToArray(), string.IsNullOrEmpty(sha) ? null : sha, ctx.RequestAborted);
+                return Results.Json(new { ok = true, index });
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[GatewayDictation] chunk uploadId={uploadId} index={index} FAILED: {ex.Message}");
+                return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status400BadRequest);
+            }
+        });
+
+        app.MapPost("/dictation/{uploadId}/complete", async (string uploadId, DictationCompleteRequest? req, HttpContext ctx) =>
+        {
+            if (!AuthMiddleware.HasValidToken(ctx, token))
+                return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
+            if (req is null || req.TotalChunks <= 0 || !Guid.TryParse(req.SessionId ?? "", out _))
+                return Results.Json(new { error = "sessionId (guid) and totalChunks (>0) are required" },
+                    statusCode: StatusCodes.Status400BadRequest);
+
+            var entry = _completes.GetOrAdd(uploadId, id => new CompleteEntry(
+                DateTime.UtcNow,
+                new Lazy<Task<DictationOutcome>>(() => RunCompleteAsync(
+                    id, req, uploads, registry, client, owners, transcription, transcribingSessions))));
+
+            DictationOutcome outcome;
+            try
+            {
+                outcome = await entry.Task.Value;
+            }
+            catch (Exception ex)
+            {
+                _completes.TryRemove(uploadId, out _); // transient: let a retry re-run
+                return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status502BadGateway);
+            }
+            // Only a truly terminal outcome (submitted / moved-on) is kept for idempotent dedupe; anything
+            // retryable (transient error, incomplete upload, out-of-credits) is dropped so the next
+            // complete re-runs the real work.
+            if (!outcome.Terminal) _completes.TryRemove(uploadId, out _);
+            return outcome.ToResult();
+        });
+    }
+
+    private static async Task<DictationOutcome> RunCompleteAsync(
+        string uploadId, DictationCompleteRequest req, VoiceUploadStore uploads, DirectorRegistry registry,
+        DirectorEndpointClient client, SessionOwnerCache? owners, GatewayTranscriptionService transcription,
+        TranscribingSessions transcribingSessions)
+    {
+        var sid = req.SessionId!;
+        try
+        {
+            // The configured mode's key must be present before we pay the reassembly + transcribe cost.
+            var routing = transcription.Resolve();
+            if (routing.Key is null)
+                return DictationOutcome.Error(StatusCodes.Status503ServiceUnavailable,
+                    $"no key configured for transcription mode {routing.Mode}");
+
+            var assembled = await uploads.AssembleAsync(uploadId, req.TotalChunks);
+            if (assembled.Status == "unknown_upload")
+                return DictationOutcome.Error(StatusCodes.Status404NotFound, "unknown upload id");
+            if (assembled.Status == "incomplete")
+                return DictationOutcome.Incomplete(assembled.Missing);
+            var audio = assembled.Audio;
+            if (audio is null || audio.Length == 0)
+            {
+                uploads.Delete(uploadId);
+                return DictationOutcome.Error(StatusCodes.Status502BadGateway, "assembled recording was empty");
+            }
+
+            var result = await transcription.TranscribeAsync(
+                audio, "audio." + (req.Ext ?? "wav"), req.Mime ?? "audio/wav", applyCorrection: true, CancellationToken.None);
+            if (result.Outcome == TranscriptionOutcome.OutOfCredits)
+                return DictationOutcome.OutOfCredits(HostedAiErrorMapper.MapCode(result.Code));
+            if (result.Outcome != TranscriptionOutcome.Ok)
+                return DictationOutcome.Error(StatusCodes.Status502BadGateway, result.Error ?? "transcription failed");
+
+            var transcript = (result.Text ?? "").Trim();
+            // Compose the final message: any typed text the caret split the dictation around (before /
+            // after), any earlier paused dictation segments already turned to text (prefix), and this
+            // clip's transcript, space-joined skipping empties. The common voice case is transcript alone.
+            var parts = new[] { req.Before, req.Prefix, transcript, req.After }
+                .Where(p => !string.IsNullOrWhiteSpace(p))
+                .Select(p => p!.Trim());
+            var message = string.Join(" ", parts).Trim();
+            if (message.Length == 0)
+            {
+                // Silent/empty clip with no typed text: nothing to submit, but the turn is genuinely done.
+                uploads.Delete(uploadId);
+                EndTranscribing(transcribingSessions, sid);
+                return DictationOutcome.Submitted(false, false, transcript);
+            }
+
+            var (endpoint, session) = await LocateAsync(registry, client, owners, sid);
+            if (endpoint is null)
+                return DictationOutcome.Error(
+                    session is null ? StatusCodes.Status404NotFound : StatusCodes.Status410Gone,
+                    session is null ? "session not found" : "session has exited");
+
+            // Moved-on guard (issue #1006): for a RESUMED clip, if the session's terminal output grew
+            // materially since the clip was recorded, other turns happened - drop the stale dictation
+            // rather than inject it into a session that has moved on. Immediate sends skip this.
+            if (req.Resumed && session is not null && req.BaselineBufferBytes > 0 &&
+                session.TotalBufferBytes > req.BaselineBufferBytes + MovedOnBufferGrowthBytes)
+            {
+                uploads.Delete(uploadId);
+                EndTranscribing(transcribingSessions, sid);
+                FileLog.Write($"[GatewayDictation] complete sid={sid} uploadId={uploadId}: session moved on " +
+                    $"(buffer {req.BaselineBufferBytes}->{session.TotalBufferBytes}); dropped");
+                return DictationOutcome.Submitted(false, true, transcript);
+            }
+
+            var (ok, _, err) = await client.PostPromptAsync(endpoint, sid, new PromptRequest { Text = message, AppendEnter = true });
+            if (!ok)
+                return DictationOutcome.Error(StatusCodes.Status502BadGateway, err ?? "submit to session failed");
+
+            uploads.Delete(uploadId);
+            EndTranscribing(transcribingSessions, sid);
+            FileLog.Write($"[GatewayDictation] complete sid={sid} uploadId={uploadId}: submitted chars={message.Length}");
+            return DictationOutcome.Submitted(true, false, transcript);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayDictation] complete sid={sid} uploadId={uploadId} FAILED: {ex.Message}");
+            return DictationOutcome.Error(StatusCodes.Status502BadGateway, ex.Message);
+        }
+    }
+
+    /// <summary>Drop cached complete outcomes older than <paramref name="maxAge"/> (idempotency window).</summary>
+    public static int SweepCompletes(TimeSpan maxAge)
+    {
+        var cutoff = DateTime.UtcNow - maxAge;
+        var removed = 0;
+        foreach (var kv in _completes)
+            if (kv.Value.At < cutoff && _completes.TryRemove(kv.Key, out _)) removed++;
+        return removed;
+    }
+
+    private static void EndTranscribing(TranscribingSessions t, string sid)
+    {
+        try { t.End(sid); } catch { /* the Gateway's stale-mark backstop clears it if this throws */ }
+    }
+
+    // Resolve the owning Director's dialable endpoint + current session row (for the exited/moved-on gates).
+    private static async Task<(string? endpoint, SessionDto? session)> LocateAsync(
+        DirectorRegistry registry, DirectorEndpointClient client, SessionOwnerCache? owners, string sid)
+    {
+        if (owners?.OwnerOf(sid) is { } ownerId && registry.Get(ownerId) is { } cachedDir && DialEndpoint(cachedDir) is { } cachedEp)
+        {
+            var s = await client.GetSessionAsync(cachedEp, sid);
+            if (s is not null && !IsExited(s)) return (cachedEp, s);
+        }
+        var (director, session) = await LocateOwningDirectorAsync(registry, client, sid);
+        if (director is null || session is null) return (null, null);
+        if (IsExited(session)) return (null, session);
+        owners?.Remember(sid, director.DirectorId);
+        return (DialEndpoint(director), session);
+    }
+
+    private static async Task<(DirectorDto? director, SessionDto? session)> LocateOwningDirectorAsync(
+        DirectorRegistry registry, DirectorEndpointClient client, string sid)
+    {
+        var lookups = registry.ListDirectors().Select(async d =>
+        {
+            var ep = (d.ControlEndpoint ?? "").TrimEnd('/');
+            var s = await client.GetSessionAsync(ep, sid);
+            return (director: d, session: s);
+        }).ToList();
+        var results = await Task.WhenAll(lookups);
+        foreach (var (director, session) in results)
+            if (session is not null) return (director, session);
+        return (null, null);
+    }
+
+    private static bool IsExited(SessionDto session)
+        => string.Equals(session.Status, "Exited", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(session.Status, "Failed", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(session.ActivityState, "Exited", StringComparison.OrdinalIgnoreCase);
+
+    private static string? DialEndpoint(DirectorDto d)
+    {
+        var endpoint = !string.IsNullOrWhiteSpace(d.ControlEndpoint) ? d.ControlEndpoint : d.TailnetEndpoint;
+        return string.IsNullOrWhiteSpace(endpoint) ? null : endpoint.TrimEnd('/');
+    }
+}
+
+/// <summary>Register-time body: the session and the client's record-time terminal-byte baseline.</summary>
+public sealed class DictationUploadRequest
+{
+    public string? SessionId { get; set; }
+    public long BaselineBufferBytes { get; set; }
+}
+
+/// <summary>Complete-time body.</summary>
+public sealed class DictationCompleteRequest
+{
+    public string? SessionId { get; set; }
+    public int TotalChunks { get; set; }
+    public string? Mime { get; set; }
+    public string? Ext { get; set; }
+    /// <summary>Typed text before the caret (prepended to the transcript). Empty for the voice case.</summary>
+    public string? Before { get; set; }
+    /// <summary>Typed text after the caret (appended to the transcript). Empty for the voice case.</summary>
+    public string? After { get; set; }
+    /// <summary>Earlier paused dictation segments already turned to text, joined ahead of this clip.</summary>
+    public string? Prefix { get; set; }
+    /// <summary>The session's TotalBufferBytes when the clip was recorded (for the moved-on guard).</summary>
+    public long BaselineBufferBytes { get; set; }
+    /// <summary>True when this complete is a resume after a reload/relaunch (applies the moved-on guard).</summary>
+    public bool Resumed { get; set; }
+}
+
+/// <summary>Terminal or retryable outcome of a dictation complete, mapped to an HTTP result.</summary>
+internal sealed class DictationOutcome
+{
+    private enum Kind { Submitted, Error, Incomplete, OutOfCredits }
+    private readonly Kind _kind;
+    private readonly bool _submitted;
+    private readonly bool _movedOn;
+    private readonly string _transcript;
+    private readonly int _status;
+    private readonly string? _error;
+    private readonly HostedAiState _creditsState;
+    private readonly IReadOnlyList<int> _missing;
+
+    private DictationOutcome(Kind kind, bool submitted = false, bool movedOn = false, string transcript = "",
+        int status = 0, string? error = null, HostedAiState creditsState = default, IReadOnlyList<int>? missing = null)
+    {
+        _kind = kind;
+        _submitted = submitted;
+        _movedOn = movedOn;
+        _transcript = transcript;
+        _status = status;
+        _error = error;
+        _creditsState = creditsState;
+        _missing = missing ?? Array.Empty<int>();
+    }
+
+    /// <summary>Terminal: the server handled the clip (submitted, moved-on, or empty). Do not retry.</summary>
+    public bool Terminal => _kind == Kind.Submitted;
+
+    public static DictationOutcome Submitted(bool submitted, bool movedOn, string transcript)
+        => new(Kind.Submitted, submitted: submitted, movedOn: movedOn, transcript: transcript);
+    public static DictationOutcome Error(int status, string error) => new(Kind.Error, status: status, error: error);
+    public static DictationOutcome Incomplete(IReadOnlyList<int> missing) => new(Kind.Incomplete, missing: missing);
+    public static DictationOutcome OutOfCredits(HostedAiState state) => new(Kind.OutOfCredits, creditsState: state);
+
+    public IResult ToResult() => _kind switch
+    {
+        Kind.Submitted => Results.Json(new { submitted = _submitted, movedOn = _movedOn, transcript = _transcript }),
+        Kind.Incomplete => Results.Json(new { status = "incomplete", missing = _missing }, statusCode: StatusCodes.Status409Conflict),
+        Kind.OutOfCredits => HostedAiHttp.PaymentRequiredResult(_creditsState),
+        _ => Results.Json(new { error = _error }, statusCode: _status),
+    };
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -226,6 +226,11 @@ public sealed class GatewayHost : IAsyncDisposable
     // Shared training-data store: the voice service WRITES captures, the instructions A/B test READS them.
     private readonly Wingman.WingmanTrainingStore _trainingStore = new();
     private System.Threading.Timer? _voiceSweepTimer;
+    // Durable dictation upload staging (issue #1006): the phone streams recorded audio here in chunks;
+    // the Gateway assembles, transcribes, and injects the turn itself. A background timer sweeps
+    // abandoned uploads after ~1 hour so an interrupted upload never leaks.
+    private readonly Voice.VoiceUploadStore _dictationUploads = new(CcDirector.Core.Storage.CcStorage.DictationUploads());
+    private System.Threading.Timer? _dictationSweepTimer;
     private AdvertisedEndpointMonitor? _endpointMonitor;
     // Issue #629: the durable, bounded, restart-surviving retry queue behind the login-telemetry
     // relay. Constructed here (loads any events a previous run left on disk), wired into the relay
@@ -901,6 +906,22 @@ public sealed class GatewayHost : IAsyncDisposable
         _voiceSweepTimer = new System.Threading.Timer(_ => { _ = SweepVoiceSessionsAsync(); }, null,
             TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(45));
 
+        // Durable, server-owned dictation upload (issue #1006): the phone streams recorded audio here
+        // in resumable chunks and the Gateway assembles → transcribes → injects the turn into the
+        // owning session itself, so a refresh / dropped connection cannot lose a recorded utterance.
+        GatewayDictationEndpoint.Map(_app, Registry, _client, SessionOwners, Token,
+            new Transcription.GatewayTranscriptionService(_keyVault), _transcribingSessions, _dictationUploads);
+        // Sweep abandoned upload staging + the complete-idempotency cache after ~1 hour.
+        _dictationSweepTimer = new System.Threading.Timer(_ =>
+        {
+            try
+            {
+                _dictationUploads.SweepAbandoned(TimeSpan.FromHours(1));
+                GatewayDictationEndpoint.SweepCompletes(TimeSpan.FromHours(1));
+            }
+            catch (Exception ex) { FileLog.Write($"[GatewayHost] dictation sweep error: {ex.Message}"); }
+        }, null, TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(15));
+
         // Central key vault (docs/architecture/gateway/GATEWAY_KEY_VAULT.md): set keys once
         // here (via the Cockpit Keys page); Directors pull them on demand. Inherits the
         // host-wide token middleware above.
@@ -1196,6 +1217,8 @@ public sealed class GatewayHost : IAsyncDisposable
         // supervisor's dispose gracefully stops the hosted claude.exe (never leaked).
         try { _voiceSweepTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] voice sweep dispose error: {ex.Message}"); }
         _voiceSweepTimer = null;
+        try { _dictationSweepTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] dictation sweep dispose error: {ex.Message}"); }
+        _dictationSweepTimer = null;
         try { _turnEndWatcher?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] watcher dispose error: {ex.Message}"); }
         _turnEndWatcher = null;
         try { Brain.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] brain dispose error: {ex.Message}"); }

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -134,6 +134,41 @@ public sealed class VoiceUploadStore
         return AssembleResult.Ok(bytes);
     }
 
+    /// <summary>
+    /// Delete staging dirs whose last write is older than <paramref name="maxAge"/> — abandoned uploads
+    /// whose client dropped before completing (the staging is only deleted on success, so without this
+    /// an interrupted upload would leak forever). Best-effort per dir; returns how many were removed.
+    /// </summary>
+    public int SweepAbandoned(TimeSpan maxAge)
+    {
+        var removed = 0;
+        var cutoff = DateTime.UtcNow - maxAge;
+        try
+        {
+            foreach (var dir in Directory.EnumerateDirectories(_root))
+            {
+                try
+                {
+                    if (Directory.GetLastWriteTimeUtc(dir) < cutoff)
+                    {
+                        Directory.Delete(dir, recursive: true);
+                        removed++;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[VoiceUploadStore] Sweep dir={dir} failed: {ex.Message}");
+                }
+            }
+            if (removed > 0) FileLog.Write($"[VoiceUploadStore] SweepAbandoned removed={removed} older than {maxAge}");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[VoiceUploadStore] SweepAbandoned failed: {ex.Message}");
+        }
+        return removed;
+    }
+
     /// <summary>Delete the staging dir for an upload. Best-effort; called once the turn is started.</summary>
     public void Delete(string uploadId)
     {


### PR DESCRIPTION
Closes #1006.

A page refresh (or any tab loss) during transcription used to lose the recorded audio permanently - the whole transcode → upload → transcribe → submit chain ran in the tab's memory. This makes a recorded utterance durable the instant Send is pressed and hands it to the Gateway, which finishes the turn itself. Full end-to-end (client durability + server-owned inject), as requested - not a partial fix.

## Client (`packages/client-core`, `apps/mobile`)
- **Persist-first:** the raw recorded audio is written to **IndexedDB** the moment Send is pressed (new `dictation/pendingStore.ts`) - survives refresh, crash, reboot.
- **Resumable upload:** streamed to the Gateway in SHA-checked chunks with per-chunk retry (`uploadDictationToSession`), so a dropped connection resumes at the next chunk instead of restarting.
- **Resume on load + TTL:** `resumePendingDictations()` (wired into the gated layout) re-drives any recorded-but-unsent clip; anything older than **1 hour** is pruned rather than injected into a session that has moved on.

## Server (`CcDirector.Gateway`)
- New `/dictation/upload`, `/dictation/{id}/chunk/{i}`, `/dictation/{id}/complete` endpoints (`GatewayDictationEndpoint`): assemble the chunks, transcribe via the shared transcription service, and **inject the turn into the owning session** via the Director - so once the audio is uploaded, a dead client cannot lose it.
- **Idempotent** per uploadId (a retried complete never double-submits) and a **"session moved on" guard** that drops a resumed clip if the session's terminal output grew materially since it was recorded.
- **1-hour sweep** of abandoned upload staging + the idempotency cache (`VoiceUploadStore.SweepAbandoned` + a `GatewayHost` timer).

## QA
- **Client harness** (Vite + Playwright, real IndexedDB, mocked `/dictation/*`): (1) Send with the connection down → audio persisted, send fails, **nothing lost**; (2) connection restored → resume re-drives the upload and submits (`resumed=true`, correct baseline), record deleted; (3) a 2-hour-old clip is **pruned, never submitted**.
- **Gateway tests:** 11/11 upload-store tests pass, including the new `SweepAbandoned` test.
- Typecheck + client build + Gateway build all clean.

Not deployed (per request - deploy later).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)