### PR TITLE
Fix #1017: CLI/Control-API-spawned sessions inherit default agent settings

### DIFF
--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -2782,6 +2782,25 @@ internal static class ControlEndpoints
                 ? new RawCliAgent(req.Command!, req.CommandArgs)
                 : AgentPluginRegistry.CreateAgent(kind, sessionManager.Options);
 
+            // Issue #1017: a programmatically-created session (the CLI `session spawn`, a Gateway
+            // schedule, any REST client) must inherit the SAME configured agent defaults - most
+            // importantly the permission-mode preset - that the desktop New Session dialog applies,
+            // or it comes up prompting for approval on everything and is unusable for unattended
+            // work. When the caller supplies no Args, resolve the default effective launch line for
+            // the requested kind from the user's configured agent library, exactly as the dialog
+            // does (AgentLaunchDefaults mirrors its default entry selection). An explicitly supplied
+            // Args (even empty) is honored verbatim as a per-session override and skips this. RawCli
+            // carries its whole command line explicitly, so it has nothing to inherit. Empty is
+            // normalized back to null so Claude's legacy DefaultClaudeArgs fallback still applies -
+            // this is the same null-when-empty rule the dialog uses.
+            string? effectiveArgs = req.Args;
+            if (req.Args is null && kind != AgentKind.RawCli)
+            {
+                var resolvedDefault = AgentLaunchDefaults.ResolveDefaultArgs(kind, sessionManager.Options);
+                effectiveArgs = string.IsNullOrWhiteSpace(resolvedDefault) ? null : resolvedDefault;
+                FileLog.Write($"[ControlEndpoints] POST /sessions: no args supplied; applied default agent settings for {kind}: \"{effectiveArgs ?? "(empty)"}\"");
+            }
+
             // Issue #800: enforce a meaningful name at birth. An EXPLICIT name (req.Name supplied,
             // even if blank) that is blank or equal to the bare repository folder name is rejected;
             // an ABSENT name (req.Name == null) is auto-composed from folder + purpose +
@@ -2809,7 +2828,7 @@ internal static class ControlEndpoints
                 session = sessionManager.CreateSession(
                     req.RepoPath,
                     agent,
-                    req.Args,
+                    effectiveArgs,
                     SessionBackendType.ConPty,
                     resumeSessionId: string.IsNullOrWhiteSpace(req.ResumeSessionId) ? null : req.ResumeSessionId,
                     nameFactory: id => SessionName.Compose(

--- a/src/CcDirector.Core.Tests/Configuration/AgentLaunchDefaultsTests.cs
+++ b/src/CcDirector.Core.Tests/Configuration/AgentLaunchDefaultsTests.cs
@@ -1,0 +1,245 @@
+using CcDirector.Core.Agents;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Storage;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Configuration;
+
+/// <summary>
+/// Tests for <see cref="AgentLaunchDefaults.ResolveDefaultArgs"/> (issue #1017): a session created
+/// via the Control API / CLI with no explicit args must inherit the SAME default agent settings the
+/// desktop New Session dialog applies - the selected entry's preset and default model PLUS the
+/// dialog's Bypass-permissions default (ON) - so it is not born prompting for approval on
+/// everything. Shares an isolated CC_DIRECTOR_ROOT (xUnit runs a class's methods sequentially) via
+/// the CcStorageRoot collection, mirroring AgentEntryTests.
+/// </summary>
+[Collection("CcStorageRoot")]
+public sealed class AgentLaunchDefaultsTests : IDisposable
+{
+    private const string ClaudeSkip = "--dangerously-skip-permissions";
+    private const string CopilotAllow = "--allow-all";
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+
+    public AgentLaunchDefaultsTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-launchdefaults-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private static void SeedConfig(string json)
+    {
+        var path = CcStorage.ConfigJson();
+        var dir = Path.GetDirectoryName(path);
+        Assert.NotNull(dir);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(path, json);
+    }
+
+    [Fact]
+    public void ResolveDefaultArgs_ClaudeStandardEntry_AppliesBypassDefault()
+    {
+        // The user configured the Standard (permission-prompting) preset, but the dialog's
+        // Bypass-permissions checkbox defaults to ON, so a UI-created session launches bypassed.
+        // A spawned session with no args must match: Standard preset (no args) + the bypass flag.
+        SeedConfig("""
+        {
+          "agent": {
+            "entries": [
+              { "type": "ClaudeCode", "enabled": true, "executable_path": "C:/tools/claude.cmd",
+                "preset_id": "Standard", "launch_mode": "Guided" }
+            ]
+          }
+        }
+        """);
+
+        var args = AgentLaunchDefaults.ResolveDefaultArgs(AgentKind.ClaudeCode, new AgentOptions());
+
+        Assert.Equal(ClaudeSkip, args);
+    }
+
+    [Fact]
+    public void ResolveDefaultArgs_ClaudeAutomaticEntry_DoesNotDoubleBypass()
+    {
+        // The "Automatic (skip permissions)" preset already carries the bypass flag; the default
+        // must not append a second copy.
+        SeedConfig("""
+        {
+          "agent": {
+            "entries": [
+              { "type": "ClaudeCode", "enabled": true, "executable_path": "C:/tools/claude.cmd",
+                "preset_id": "Automatic (skip permissions)", "launch_mode": "Guided" }
+            ]
+          }
+        }
+        """);
+
+        var args = AgentLaunchDefaults.ResolveDefaultArgs(AgentKind.ClaudeCode, new AgentOptions());
+
+        Assert.Equal(ClaudeSkip, args);
+    }
+
+    [Fact]
+    public void ResolveDefaultArgs_ClaudeStandardWithModel_IncludesModelAndBypass()
+    {
+        // Mirrors the real desktop default: Standard preset + a default model + the bypass default,
+        // so a spawned session runs on the chosen model (not the 200K bare default) AND is usable
+        // without approval prompts (issue #803 / #1017).
+        SeedConfig("""
+        {
+          "agent": {
+            "entries": [
+              { "type": "ClaudeCode", "enabled": true, "executable_path": "C:/tools/claude.cmd",
+                "preset_id": "Standard", "default_model": "opus[1m]", "launch_mode": "Guided" }
+            ]
+          }
+        }
+        """);
+
+        var args = AgentLaunchDefaults.ResolveDefaultArgs(AgentKind.ClaudeCode, new AgentOptions());
+
+        Assert.Contains("--model opus[1m]", args);
+        Assert.Contains(ClaudeSkip, args);
+    }
+
+    [Fact]
+    public void ResolveDefaultArgs_MultipleClaudeEntries_PicksFirstEnabled()
+    {
+        // The New Session dialog pre-selects the first ENABLED entry of the kind; ResolveDefaultArgs
+        // must match. The first entry is disabled and the first enabled one carries model "sonnet",
+        // so the result reflects that entry (not the later "opus" one), plus the bypass default.
+        SeedConfig("""
+        {
+          "agent": {
+            "entries": [
+              { "type": "ClaudeCode", "enabled": false, "executable_path": "C:/tools/claude.cmd",
+                "preset_id": "Standard", "default_model": "haiku", "launch_mode": "Guided" },
+              { "type": "ClaudeCode", "enabled": true, "executable_path": "C:/tools/claude.cmd",
+                "preset_id": "Standard", "default_model": "sonnet", "launch_mode": "Guided" },
+              { "type": "ClaudeCode", "enabled": true, "executable_path": "C:/tools/claude.cmd",
+                "preset_id": "Standard", "default_model": "opus", "launch_mode": "Guided" }
+            ]
+          }
+        }
+        """);
+
+        var args = AgentLaunchDefaults.ResolveDefaultArgs(AgentKind.ClaudeCode, new AgentOptions());
+
+        Assert.Contains("--model sonnet", args);
+        Assert.DoesNotContain("opus", args);
+        Assert.DoesNotContain("haiku", args);
+        Assert.Contains(ClaudeSkip, args);
+    }
+
+    [Fact]
+    public void ResolveDefaultArgs_OnlyDisabledEntry_StillResolvesThatEntry()
+    {
+        // When no entry of the kind is enabled, fall back to any entry of that kind rather than
+        // dropping to the bare driver default - the user did configure this agent.
+        SeedConfig("""
+        {
+          "agent": {
+            "entries": [
+              { "type": "ClaudeCode", "enabled": false, "executable_path": "C:/tools/claude.cmd",
+                "preset_id": "Standard", "launch_mode": "Guided" }
+            ]
+          }
+        }
+        """);
+
+        var args = AgentLaunchDefaults.ResolveDefaultArgs(AgentKind.ClaudeCode, new AgentOptions());
+
+        Assert.Equal(ClaudeSkip, args);
+    }
+
+    [Fact]
+    public void ResolveDefaultArgs_CopilotStandardEntry_AppliesAllowAll()
+    {
+        // Copilot's permission-bypass equivalent is --allow-all; the dialog default applies it, so a
+        // spawned Copilot session must inherit it too.
+        SeedConfig("""
+        {
+          "agent": {
+            "entries": [
+              { "type": "Copilot", "enabled": true, "executable_path": "C:/tools/copilot.cmd",
+                "preset_id": "Standard", "launch_mode": "Guided" }
+            ]
+          }
+        }
+        """);
+
+        var args = AgentLaunchDefaults.ResolveDefaultArgs(AgentKind.Copilot, new AgentOptions());
+
+        Assert.Equal(CopilotAllow, args);
+    }
+
+    [Fact]
+    public void ResolveDefaultArgs_CodexEntry_NoBypassFlag()
+    {
+        // Codex has no permission-bypass flag, so the default is just its preset (Standard = empty).
+        // This confirms the bypass default is applied only to kinds that actually have such a flag.
+        SeedConfig("""
+        {
+          "agent": {
+            "entries": [
+              { "type": "Codex", "enabled": true, "executable_path": "C:/tools/codex.cmd",
+                "preset_id": "Standard", "launch_mode": "Guided" }
+            ]
+          }
+        }
+        """);
+
+        var args = AgentLaunchDefaults.ResolveDefaultArgs(AgentKind.Codex, new AgentOptions());
+
+        Assert.Equal("", args);
+    }
+
+    [Fact]
+    public void ResolveDefaultArgs_NoEntryForKind_FallsBackToCatalogDefaultPreset()
+    {
+        // Codex is not in the configured library, so there is no entry to read. The per-tool config
+        // load then supplies the catalog default preset (Codex's default is Standard = no args), and
+        // Codex has no bypass flag, so the result is empty.
+        SeedConfig("""
+        {
+          "agent": {
+            "entries": [
+              { "type": "ClaudeCode", "enabled": true, "executable_path": "C:/tools/claude.cmd",
+                "preset_id": "Standard", "launch_mode": "Guided" }
+            ]
+          }
+        }
+        """);
+
+        var args = AgentLaunchDefaults.ResolveDefaultArgs(AgentKind.Codex, new AgentOptions());
+
+        Assert.Equal("", args);
+    }
+
+    [Fact]
+    public void ResolveDefaultArgs_RawCli_YieldsEmpty()
+    {
+        // RawCli has no catalog plugin: its command line is supplied explicitly by the caller, so
+        // there is nothing to inherit and no config is read.
+        SeedConfig("{}");
+
+        var args = AgentLaunchDefaults.ResolveDefaultArgs(AgentKind.RawCli, new AgentOptions());
+
+        Assert.Equal("", args);
+    }
+
+    [Fact]
+    public void ResolveDefaultArgs_NullOptions_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => AgentLaunchDefaults.ResolveDefaultArgs(AgentKind.ClaudeCode, null!));
+    }
+}

--- a/src/CcDirector.Core/Configuration/AgentLaunchDefaults.cs
+++ b/src/CcDirector.Core/Configuration/AgentLaunchDefaults.cs
@@ -1,0 +1,103 @@
+using CcDirector.Core.AgentPlugins;
+using CcDirector.Core.Agents;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Configuration;
+
+/// <summary>
+/// Resolves the default effective command-line arguments a programmatically-created session should
+/// launch with, so a session spawned via the Control API / CLI (<c>cc-devthrottle session spawn</c>)
+/// inherits the SAME default agent settings - most importantly the permission mode - as a session
+/// created in the desktop New Session dialog (issue #1017).
+///
+/// The desktop dialog builds a session's launch line in two layers (see
+/// <c>MainWindow.ShowNewSessionDialog</c>):
+///   1. the user's SELECTED <see cref="AgentEntry"/> resolved through
+///      <see cref="AgentToolConfig.ResolveEffectiveCommandLineArguments"/> (preset + default model), then
+///   2. the dialog's per-session "Bypass permissions" checkbox, which DEFAULTS TO ON, appending the
+///      agent's permission-bypass flag (Claude <c>--dangerously-skip-permissions</c>, Cursor
+///      <c>--force</c>, Copilot <c>--allow-all</c>) on top.
+/// A programmatic caller that supplies no args used to get neither layer - it fell through to the
+/// bare driver default and came up prompting for approval on everything, which made it unusable for
+/// unattended work. This helper reproduces BOTH layers so the two paths launch identically.
+/// </summary>
+public static class AgentLaunchDefaults
+{
+    /// <summary>
+    /// The default effective launch arguments for the given agent kind, matching what the desktop
+    /// New Session dialog launches by default:
+    ///   * the FIRST ENABLED entry of that kind in the configured agent library (the entry the
+    ///     dialog pre-selects), resolved through the shared
+    ///     <see cref="AgentToolConfig.ResolveEffectiveCommandLineArguments"/>; when no enabled entry
+    ///     exists, any entry of that kind, then the persisted per-tool config
+    ///     (<see cref="AgentToolConfig.Load"/>), which itself falls back to the catalog default preset;
+    ///   * PLUS the agent's permission-bypass flag for the kinds that have one
+    ///     (Claude / Cursor / Copilot), mirroring the dialog's Bypass-permissions checkbox default of
+    ///     ON. The flag is appended only when the resolved preset does not already carry it, so an
+    ///     entry configured with the "Automatic" preset is not doubled.
+    /// Returns an empty string for a kind with no catalog plugin (e.g. <see cref="AgentKind.RawCli"/>),
+    /// whose command line is supplied explicitly by the caller and has nothing to inherit.
+    /// </summary>
+    public static string ResolveDefaultArgs(AgentKind agentKind, AgentOptions options)
+    {
+        if (options is null) throw new ArgumentNullException(nameof(options));
+
+        // A kind with no catalog plugin (RawCli / Custom) has no presets, model, or permission flag
+        // to inherit; its full command line is always supplied explicitly by the caller.
+        if (!AgentPluginRegistry.Contains(agentKind))
+        {
+            FileLog.Write($"[AgentLaunchDefaults] ResolveDefaultArgs: {agentKind} has no catalog plugin; no defaults to apply");
+            return "";
+        }
+
+        var baseArgs = ResolveEntryArgs(agentKind, options);
+
+        // Layer 2: the dialog's Bypass-permissions checkbox defaults to ON, so a UI-created session
+        // launches with the permission-bypass flag on top of the preset. Replicate that default so a
+        // spawned session has the SAME permission profile and is usable without hand-fixing
+        // permissions. Add only when absent so an "Automatic" preset that already carries the flag is
+        // not doubled.
+        var bypassArg = PermissionBypassArgFor(agentKind);
+        if (bypassArg is not null && !baseArgs.Contains(bypassArg, StringComparison.Ordinal))
+        {
+            baseArgs = string.IsNullOrEmpty(baseArgs) ? bypassArg : $"{baseArgs} {bypassArg}";
+            FileLog.Write($"[AgentLaunchDefaults] ResolveDefaultArgs: {agentKind} applied default permission bypass -> \"{baseArgs}\"");
+        }
+
+        return baseArgs;
+    }
+
+    /// <summary>
+    /// Layer 1: the entry-preset-plus-model arguments for the kind, resolved exactly as the dialog
+    /// resolves its selected entry. Never includes the per-session bypass flag.
+    /// </summary>
+    private static string ResolveEntryArgs(AgentKind agentKind, AgentOptions options)
+    {
+        var entries = AgentEntryStore.LoadEntries(options);
+        var entry = entries.FirstOrDefault(e => e.Enabled && e.Type == agentKind)
+                    ?? entries.FirstOrDefault(e => e.Type == agentKind);
+        if (entry is not null)
+        {
+            var argsFromEntry = entry.ToToolConfig().ResolveEffectiveCommandLineArguments();
+            FileLog.Write($"[AgentLaunchDefaults] ResolveEntryArgs: {agentKind} resolved from entry id={entry.Id}, preset={entry.PresetId}, args=\"{argsFromEntry}\"");
+            return argsFromEntry;
+        }
+
+        var args = AgentToolConfig.Load(agentKind).ResolveEffectiveCommandLineArguments();
+        FileLog.Write($"[AgentLaunchDefaults] ResolveEntryArgs: {agentKind} no configured entry; per-tool config args=\"{args}\"");
+        return args;
+    }
+
+    /// <summary>
+    /// The permission-bypass command-line flag for the kinds that have one, matching the desktop
+    /// dialog's Bypass-permissions checkbox behavior (Claude / Cursor / Copilot). Null for kinds that
+    /// have no such flag (Pi, Codex, Gemini, OpenCode, Grok), which never get a bypass default.
+    /// </summary>
+    private static string? PermissionBypassArgFor(AgentKind agentKind) => agentKind switch
+    {
+        AgentKind.ClaudeCode => AgentToolCatalog.ClaudeSkipPermissionsArg,
+        AgentKind.Cursor => AgentToolCatalog.CursorForceArg,
+        AgentKind.Copilot => AgentToolCatalog.CopilotAllowAllArg,
+        _ => null,
+    };
+}

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -348,6 +348,13 @@ def spawn(
     command_args: Optional[str] = typer.Option(
         None, "--command-args", help="For --agent RawCli: arguments for the command."
     ),
+    args: Optional[str] = typer.Option(
+        None,
+        "--args",
+        help="Override the agent's command-line arguments for this session (issue #1017). "
+        "When omitted, the session inherits the same default agent settings (permission mode, "
+        "default model) the desktop New Session dialog applies.",
+    ),
     controlled_by: Optional[str] = typer.Option(
         None,
         "--controlled-by",
@@ -359,7 +366,7 @@ def spawn(
 ) -> None:
     """Open a new session on the local Director and print its id."""
     spawn_session(
-        repo, agent, prompt, name, purpose, session_type, command, command_args, controlled_by
+        repo, agent, prompt, name, purpose, session_type, command, command_args, controlled_by, args
     )
 
 

--- a/tools/cc-devthrottle/src/session_ops.py
+++ b/tools/cc-devthrottle/src/session_ops.py
@@ -311,6 +311,7 @@ def spawn_session(
     command: Optional[str],
     command_args: Optional[str],
     controlled_by: Optional[str] = None,
+    args: Optional[str] = None,
 ) -> None:
     """Open a new session on the local Director."""
     # Issue #815: spawn the new session as a controlled "Supporting" sub-agent of another session.
@@ -338,6 +339,12 @@ def spawn_session(
         )
 
     body: Dict[str, Any] = {"repoPath": repo, "agent": agent}
+    # Issue #1017: with no --args, the Director applies the SAME default agent settings (permission
+    # mode preset, default model) the desktop New Session dialog uses, so a spawned session is
+    # usable for unattended work without hand-fixing permissions. Passing --args overrides that
+    # default with an explicit command line for this session only.
+    if args is not None:
+        body["args"] = args
     if name:
         body["name"] = name
     if purpose:


### PR DESCRIPTION
Fixes #1017.

## Problem

Sessions created via `cc-devthrottle session spawn` and the Control API `POST /sessions` endpoint did not apply the user's default agent settings - most importantly the permission mode - so they came up prompting for approval on everything and were unusable for unattended agent work. Sessions created in the desktop New Session dialog did get the defaults. This blocked all programmatic session orchestration.

## Root cause

The desktop New Session dialog builds a session's launch line in two layers:

1. the user's selected agent entry (preset + default model), resolved through `AgentToolConfig.ResolveEffectiveCommandLineArguments`, then
2. the dialog's per-session "Bypass permissions" checkbox, which **defaults to ON** and appends the agent's permission-bypass flag (Claude `--dangerously-skip-permissions`, Cursor `--force`, Copilot `--allow-all`) on top.

The CLI never sends args, so `POST /sessions` passed a null `Args` straight to `SessionManager.CreateSession`, and the agent fell back to its bare driver default (`ClaudeAgent` uses `_options.DefaultClaudeArgs`, which is empty) - reading neither layer.

## Fix

- **New shared helper** `AgentLaunchDefaults.ResolveDefaultArgs(AgentKind, AgentOptions)` (in `CcDirector.Core/Configuration`) reproduces both layers the dialog applies: the first enabled configured entry of the requested kind (the entry the dialog pre-selects), plus the default permission-bypass flag for Claude/Cursor/Copilot (added only when the resolved preset does not already carry it, so an "Automatic" preset is not doubled). Falls back to the persisted per-tool/catalog default when no entry exists; returns empty for RawCli.
- **`POST /sessions`** now calls the helper whenever the caller supplies no `Args`. An explicitly-supplied `Args` (even empty) still wins as a per-session override; RawCli is skipped (it carries its own command line).
- **CLI** gains an optional `--args` flag on `session spawn` to pass that explicit override. Default needs no flag.

The default-application is factored into a single Core helper so any programmatic caller (the CLI, Gateway schedules, any REST client) inherits the same defaults.

## Verification

- **Live end-to-end**: built a test Director (slot 5), launched it via Task Scheduler, and `POST /sessions` with `agent=ClaudeCode` and no args. The spawned Claude session launched with `--model opus[1m] --dangerously-skip-permissions` - exactly matching the desktop default (the user's Standard preset + configured `opus[1m]` model + bypass-on) - and came up `Running` / `WaitingForInput`, usable with no approval prompts. Test Director shut down cleanly afterward.
- **Unit tests**: 10 new `AgentLaunchDefaults` tests (Claude Standard applies bypass, Automatic does not double it, model + bypass together, first-enabled selection, disabled-only fallback, Copilot `--allow-all`, Codex no-bypass, no-entry catalog fallback, RawCli empty, null-guard). All pass.
- Full `CcDirector.Core.Tests` suite: 2816 passing. The one failure (`NoCrossMachineLoopbackGuardTests`) is **pre-existing and unrelated** - it flags two committed files this PR does not touch (`src/CcDirector.Avalonia/HostedAi/DesktopHostedAiCta.cs`, `src/CcDirector.Core/Configuration/GatewayConfig.cs`) that contain a loopback literal without an allowlist entry. My new file has no loopback literal and is not flagged.
- Full solution builds clean (0 warnings, 0 errors). Python CLI syntax validated.

## Files

- `src/CcDirector.Core/Configuration/AgentLaunchDefaults.cs` (new)
- `src/CcDirector.Core.Tests/Configuration/AgentLaunchDefaultsTests.cs` (new)
- `src/CcDirector.ControlApi/ControlEndpoints.cs`
- `tools/cc-devthrottle/src/cli.py`
- `tools/cc-devthrottle/src/session_ops.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
