### PR TITLE
[Mobile PWA] Voice mode opens instantly from cache - no OFF-state flash (#1015)

### DIFF
--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -164,7 +164,9 @@ function SessionRow({ session }: { session: SessionDto }) {
   const to = session.voiceMode ? `/session/${sid}/voice` : `/session/${sid}`;
   return (
     <li className={`row${attention ? " row-attention" : ""}`}>
-      <Link className="row-link" to={to}>
+      {/* Hand the known voice-mode state to the destination (issue #1015) so the Voice screen paints
+          the right state on the first render instead of flashing OFF while its first poll resolves. */}
+      <Link className="row-link" to={to} state={{ voiceMode: Boolean(session.voiceMode) }}>
         <span className="dot" style={{ backgroundColor: dotColor(color) }} aria-hidden="true" />
         <span className="row-body">
           {/* The name uses the full card width and WRAPS (no truncation) - issue #838. A muted

--- a/apps/mobile/src/pages/VoiceMode.tsx
+++ b/apps/mobile/src/pages/VoiceMode.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type ChangeEvent, type SyntheticEvent } from "react";
-import { useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 import {
   getWingmanVoice,
   listSessions,
@@ -14,7 +14,7 @@ import { DictationDialog } from "@devthrottle/client-core/dictation/DictationDia
 import { backgroundTranscribeAndSend, type CapturedUtterance } from "@devthrottle/client-core/dictation/backgroundSend";
 import { SessionManageBar } from "../components/SessionManageBar";
 import { ViewTabs } from "../components/ViewTabs";
-import { ensureClip, getClipState, stopPlayback, useVoiceClips } from "../voice/clips";
+import { ensureClip, getClipState, getVoiceMeta, saveVoiceMeta, stopPlayback, useVoiceClips } from "../voice/clips";
 import { positionFor, saveMark, wasAutoPlayed } from "../voice/playbackPositions";
 import { isWorking } from "@devthrottle/client-core/sessions/ordering";
 
@@ -70,10 +70,19 @@ export function VoiceMode() {
   const { sessionId } = useParams<{ sessionId: string }>();
   const sid = sessionId ?? "";
 
+  // The roster hands the known voice-mode state on navigation (issue #1015), so the screen renders
+  // the right state on the FIRST paint instead of flashing OFF while its first poll resolves.
+  const location = useLocation();
+  const seededVoiceOn = (location.state as { voiceMode?: boolean } | null)?.voiceMode;
+
   const [name, setName] = useState<string | null>(null);
   const [session, setSession] = useState<SessionDto | null>(null);
-  const [voice, setVoice] = useState<WingmanVoice | null>(null);
+  // Seed the narration state + text from the on-device cache so it shows instantly (issue #1015).
+  const [voice, setVoice] = useState<WingmanVoice | null>(() => getVoiceMeta(sid));
   const [error, setError] = useState<string | null>(null);
+  // Whether a real poll has resolved the true state yet. Until it has, we never paint the OFF card -
+  // the screen starts blank (or ON when the roster seeded it) and only shows OFF once confirmed.
+  const [pollDone, setPollDone] = useState(false);
 
   // Optimistic "this session is now a voice session" the instant Switch is tapped, so the screen
   // moves to the working state immediately (responsive UI) before the roster reflects voiceMode.
@@ -90,6 +99,13 @@ export function VoiceMode() {
   // Re-render this screen when a clip download completes (phone-ready).
   useVoiceClips();
   const clip = getClipState(sid);
+
+  // Warm the clip from the on-device cache (Cache Storage, no network) so a cold entry can show and
+  // start playback instantly when the roster already prefetched it (issue #1015).
+  useEffect(() => {
+    const meta = getVoiceMeta(sid);
+    if (meta?.ready && meta.generatedAt) void ensureClip(sid, meta.generatedAt);
+  }, [sid]);
 
   // ----- playback element + progress (display only) -----
   const audioRef = useRef<HTMLAudioElement | null>(null);
@@ -136,6 +152,7 @@ export function VoiceMode() {
         // Only re-render when a field the screen uses actually changed (issue #951).
         setSession((prev) => (sameSessionForVoice(prev, match) ? prev : match));
         if (match?.name && match.name.trim()) setName(match.name.trim());
+        setPollDone(true); // the true state is now known - OFF may render from here on if applicable
 
         const on = localEnabledRef.current || Boolean(match?.voiceMode);
         if (!on) {
@@ -146,6 +163,7 @@ export function VoiceMode() {
 
         const v = await getWingmanVoice(sid, signal);
         setVoice((prev) => (sameVoice(prev, v) ? prev : v));
+        saveVoiceMeta(sid, v); // keep the cached state + text fresh for the next instant entry (#1015)
         // Kick the phone-side download the moment a (new) clip is ready on the Gateway.
         if (v.ready && v.generatedAt) void ensureClip(sid, v.generatedAt);
         setError(null);
@@ -413,7 +431,9 @@ export function VoiceMode() {
     [sid, session],
   );
 
-  const voiceOn = localEnabled || Boolean(session?.voiceMode);
+  // Until the first poll resolves, trust the roster's seed so a voice session drops straight into the
+  // ON state; once the poll has spoken, the real session flag governs (a stale seed cannot stick).
+  const voiceOn = localEnabled || Boolean(session?.voiceMode) || (!pollDone && seededVoiceOn === true);
   // The speaking state (and its play-triangle) is suppressed while the agent is working again: the
   // finished-turn narration is stale, so the screen falls back to the working card instead of
   // offering a replay of it.
@@ -450,8 +470,9 @@ export function VoiceMode() {
           <div className="banner banner-error" role="alert">{error}</div>
         )}
 
-        {/* A. OFF - one clear "Switch to voice mode" button. */}
-        {!voiceOn && (
+        {/* A. OFF - one clear "Switch to voice mode" button. Only ever shown once a poll has confirmed
+            the session is NOT in voice mode, so the screen never flashes OFF then flips (issue #1015). */}
+        {!voiceOn && pollDone && (
           <div className="voice-off">
             <p className="voice-off-title">Voice mode is off for this session.</p>
             <p className="voice-hint">Turn it on and the Wingman will start narrating every turn.</p>

--- a/apps/mobile/src/voice/clips.ts
+++ b/apps/mobile/src/voice/clips.ts
@@ -13,7 +13,7 @@
 // layer beneath it (a cold start re-reads bytes from the cache with no network).
 
 import { useEffect, useState } from "react";
-import { fetchWingmanVoiceAudio, getWingmanVoice, type SessionDto } from "@devthrottle/client-core/api/client";
+import { fetchWingmanVoiceAudio, getWingmanVoice, type SessionDto, type WingmanVoice } from "@devthrottle/client-core/api/client";
 
 export type ClipPhase = "none" | "downloading" | "ready" | "error";
 
@@ -128,6 +128,31 @@ export async function ensureClip(sid: string, generatedAt: string): Promise<void
   }
 }
 
+// ----- Voice metadata cache (issue #1015): the narration state + spoken TEXT, cached alongside the
+// audio so the Voice screen can render and start speaking from cache with no network round-trip.
+// localStorage (small JSON, survives reloads); absence is capability-detected, not a fallback.
+const META_PREFIX = "dt.voice.meta.";
+
+/** Persist a session's latest voice metadata (readiness + spoken narration text). */
+export function saveVoiceMeta(sid: string, voice: WingmanVoice): void {
+  try {
+    if (typeof localStorage !== "undefined") localStorage.setItem(META_PREFIX + sid, JSON.stringify(voice));
+  } catch {
+    // storage unavailable/full; the in-memory poll still drives the screen this page load
+  }
+}
+
+/** The cached voice metadata for a session, or null - read synchronously to seed the first render. */
+export function getVoiceMeta(sid: string): WingmanVoice | null {
+  try {
+    if (typeof localStorage === "undefined") return null;
+    const raw = localStorage.getItem(META_PREFIX + sid);
+    return raw ? (JSON.parse(raw) as WingmanVoice) : null;
+  } catch {
+    return null;
+  }
+}
+
 // Pull every gateway-ready voice session's current clip down to the phone. Called from the roster
 // poll so a voice session's card can flip from the yellow "working" state to the play-triangle the
 // moment its audio is local. Per-session metadata misses are isolated: one session's transient
@@ -140,6 +165,8 @@ export async function syncVoiceSessions(sessions: SessionDto[]): Promise<void> {
       const sid = s.sessionId ?? "";
       try {
         const voice = await getWingmanVoice(sid);
+        // Cache the state + narration text (issue #1015) so entering the screen shows it instantly.
+        saveVoiceMeta(sid, voice);
         if (voice.ready && voice.generatedAt) await ensureClip(sid, voice.generatedAt);
       } catch {
         // Transient per-session miss (Director briefly unreachable); retried on the next poll tick.


### PR DESCRIPTION
Closes #1015.

Tapping a voice-mode session used to flash "Voice mode is off" then flip to speaking after the first poll, and on a bad connection it blocked because only the audio clip was cached (the voice-mode flag and narration text were re-fetched every entry).

- **Home hands the known state to the destination** (`<Link state={{ voiceMode }}>`), so the Voice screen knows the truth on the first render.
- **Never paints OFF until known:** `VoiceMode` starts blank, drops straight into the ON state when the roster seeded a voice session, and shows OFF only once a poll confirms it. A stale seed can't stick - the real session flag governs once the poll returns.
- **State + text cached alongside the audio:** `voice/clips.ts` `saveVoiceMeta`/`getVoiceMeta` (written by the background `syncVoiceSessions`); `VoiceMode` seeds its `voice` from cache and warms the clip from Cache Storage on mount, so it shows the narration and starts playback with no network round-trip.

## QA (real VoiceMode via Vite + Playwright, deliberately slow poll)
- Seeded voice session: **no OFF flash**, shows **Speaking** with the **cached narration text** before the poll resolves.
- Cold voice session: never flashes OFF.
- Non-voice session: first paint **blank**, OFF appears **only after** the poll confirms it.
- Typecheck + build clean.

Not deployed (per the recent pattern - deploy later).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)