### PR TITLE
Fix mobile dictation 401: /dictation endpoints must accept per-device keys

### DIFF
--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -50,11 +50,11 @@ internal static class GatewayDictationEndpoint
 
     public static void Map(IEndpointRouteBuilder app, DirectorRegistry registry, DirectorEndpointClient client,
         SessionOwnerCache? owners, string token, GatewayTranscriptionService transcription,
-        TranscribingSessions transcribingSessions, VoiceUploadStore uploads)
+        TranscribingSessions transcribingSessions, VoiceUploadStore uploads, Pairing.DeviceRegistry devices)
     {
         app.MapPost("/dictation/upload", (DictationUploadRequest? body, HttpContext ctx) =>
         {
-            if (!AuthMiddleware.HasValidToken(ctx, token))
+            if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
             var sid = body?.SessionId ?? "";
             if (!Guid.TryParse(sid, out _))
@@ -71,7 +71,7 @@ internal static class GatewayDictationEndpoint
 
         app.MapPut("/dictation/{uploadId}/chunk/{index:int}", async (string uploadId, int index, HttpContext ctx) =>
         {
-            if (!AuthMiddleware.HasValidToken(ctx, token))
+            if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
             if (!uploads.Exists(uploadId))
                 return Results.Json(new { error = "unknown upload id (register it first)" }, statusCode: StatusCodes.Status404NotFound);
@@ -93,7 +93,7 @@ internal static class GatewayDictationEndpoint
 
         app.MapPost("/dictation/{uploadId}/complete", async (string uploadId, DictationCompleteRequest? req, HttpContext ctx) =>
         {
-            if (!AuthMiddleware.HasValidToken(ctx, token))
+            if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
             if (req is null || req.TotalChunks <= 0 || !Guid.TryParse(req.SessionId ?? "", out _))
                 return Results.Json(new { error = "sessionId (guid) and totalChunks (>0) are required" },

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -899,7 +899,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // in resumable chunks and the Gateway assembles → transcribes → injects the turn into the
         // owning session itself, so a refresh / dropped connection cannot lose a recorded utterance.
         GatewayDictationEndpoint.Map(_app, Registry, _client, SessionOwners, Token,
-            new Transcription.GatewayTranscriptionService(_keyVault), _transcribingSessions, _dictationUploads);
+            new Transcription.GatewayTranscriptionService(_keyVault), _transcribingSessions, _dictationUploads, Devices);
         // Sweep abandoned upload staging + the complete-idempotency cache after ~1 hour.
         _dictationSweepTimer = new System.Threading.Timer(_ =>
         {


### PR DESCRIPTION
**Hotfix.** After thefrederiksen/devthrottle#1006 deployed, mobile transcription broke completely with a 401.

Root cause: the new `/dictation/*` endpoints gate on `AuthMiddleware.HasValidToken(ctx, token)` — the 2-arg overload passes a `null` device registry, so it accepts only the master token/cookie, **not the phone's per-device key** (#469/#908). The mobile PWA authenticates with a per-device key, so every dictation upload/chunk/complete returned 401. The old `/wingman/utterance` transcription path went through the device-key-aware global middleware, which is why it worked.

Reproduced with a real device key against the running Gateway: `/dictation/upload` → 401; old `/wingman/utterance/upload` → 200. Fix passes the `DeviceRegistry` to `HasValidToken` (3-arg) so `/dictation` accepts the device key like every other mobile-facing route. Server transcription itself was fine (verified end-to-end with WAV and WebM → transcribed + submitted).

Gateway builds clean; deploying + verifying the device key now returns 200.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)