### PR TITLE
Fix #1045: voice-turn routes accept a phone's per-device key; delete the device-key-blind token check

### DIFF
--- a/src/CcDirector.Gateway.Tests/GatewayVoiceTurnAsyncTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayVoiceTurnAsyncTests.cs
@@ -191,6 +191,38 @@ public sealed class GatewayVoiceTurnAsyncTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
     }
 
+    [Fact]
+    public async Task Submit_PerDeviceKey_IsAccepted_NotOnlyTheSharedToken()
+    {
+        // Issue #1045 (regression): a phone enrolled with its OWN per-device key - the #908 path that
+        // no longer injects the shared machine token - must authenticate to the voice-turn routes,
+        // exactly as it does on every globally-gated route. Before the fix these routes called the
+        // device-key-blind two-argument HasValidToken(ctx, token) and 401'd every per-device key
+        // ("41 error"), making the async voice-turn feature unusable from an enrolled phone.
+        var sid = AdoptQuickIdleSession();
+        var deviceKey = _gateway.Devices.Register("phone-1045", "PHONE").DeviceKey;
+
+        using var phone = NewAnonymousClient(bearer: deviceKey);
+        var resp = await phone.PostAsJsonAsync($"sessions/{sid}/voice-turn/submit", new { text = "What is 2 + 2?" });
+
+        Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Audio_PerDeviceKey_IsAccepted()
+    {
+        // The audio-fetch route is token-gated on the same check; prove a per-device key reaches the
+        // bytes (200) rather than being rejected at the gate (401), so a phone can play its reply.
+        var (sid, turnId, audio) = SeedReplyWithAudio();
+        var deviceKey = _gateway.Devices.Register("phone-1045-audio", "PHONE").DeviceKey;
+
+        using var phone = NewAnonymousClient(bearer: deviceKey);
+        var resp = await phone.GetAsync($"sessions/{sid}/voice-turn/{turnId}/audio");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal(audio, await resp.Content.ReadAsByteArrayAsync());
+    }
+
     // ===== Ask Wingman about DevThrottle (issue #472) =====
 
     [Fact]

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -53,13 +53,16 @@ internal static class GatewayEndpoints
         Func<string, List<TurnBriefDto>>? briefHistoryFor = null,
         SessionOwnerCache? owners = null,
         Gateway.Events.DirectorEventLog? directorEvents = null,
-        Voice.GatewayTurnJobStore? turnJobs = null)
+        Voice.GatewayTurnJobStore? turnJobs = null,
+        Pairing.DeviceRegistry? devices = null)
     {
         // Issue #376: async voice-turn submit/poll (the phone's reconnect-resilient voice
         // interface). Mapped first for readability; route precedence (literal segments win
         // over the catch-all session forwarder) does the actual dispatch.
+        // Issue #1045: the device registry is passed through so the voice-turn routes' own token
+        // check accepts a phone's per-device key, not only the shared machine token.
         if (turnJobs is not null)
-            GatewayVoiceTurnEndpoint.Map(app, turnJobs, registry, client, owners, token);
+            GatewayVoiceTurnEndpoint.Map(app, turnJobs, registry, client, owners, token, devices);
 
         // Issue #469 closed the secret-embedding phone-pairing QR endpoints (/pair/qr.png and
         // /pair/payload) that put the shared fleet token directly in a QR/link - a full compromise

--- a/src/CcDirector.Gateway/Api/GatewayVoiceTurnEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayVoiceTurnEndpoint.cs
@@ -42,6 +42,12 @@ namespace CcDirector.Gateway.Api;
 /// - the same Bearer-or-cookie check every other protected route uses - enforced HERE so the
 /// gate holds even in production mode, where the global auth middleware is off
 /// (the tray Gateway runs authEnabled=false). Missing/wrong token -> 401.
+///
+/// Issue #1045: the token check is passed the per-device-key registry so a phone enrolled with its
+/// own device key (the #908 path that no longer injects the master token) authenticates here exactly
+/// as it does on every globally-gated route. Before this, these routes used the device-key-blind
+/// two-argument overload and 401'd every per-device key - the async voice-turn feature was unusable
+/// from an enrolled phone. That overload is now deleted, so the registry can never be omitted again.
 /// </summary>
 internal static class GatewayVoiceTurnEndpoint
 {
@@ -50,7 +56,7 @@ internal static class GatewayVoiceTurnEndpoint
     private static readonly TimeSpan DirectorTurnTimeout = TimeSpan.FromMinutes(5);
 
     public static void Map(IEndpointRouteBuilder app, GatewayTurnJobStore store, DirectorRegistry registry,
-        DirectorEndpointClient client, SessionOwnerCache? owners, string token,
+        DirectorEndpointClient client, SessionOwnerCache? owners, string token, Pairing.DeviceRegistry? devices,
         VoiceUploadStore? uploads = null, VoiceTurnArchive? archive = null)
     {
         // Disk-backed singletons captured by the route closures: the resumable upload staging and
@@ -66,7 +72,7 @@ internal static class GatewayVoiceTurnEndpoint
             // Issue #369: token-gated even when the global AuthMiddleware is off (the
             // production tray Gateway runs authEnabled=false). Same mechanism as every
             // other protected Gateway route - Bearer header or the gateway cookie.
-            if (!AuthMiddleware.HasValidToken(ctx, token))
+            if (!AuthMiddleware.HasValidToken(ctx, token, devices))
             {
                 FileLog.Write($"[GatewayVoiceTurn] submit sid={sid}: missing or invalid token from {ctx.Connection.RemoteIpAddress} -> 401");
                 return Results.Json(new { error = "missing or invalid token" },
@@ -117,7 +123,7 @@ internal static class GatewayVoiceTurnEndpoint
 
         app.MapPost("/sessions/{sid}/voice-turn/upload", (string sid, HttpContext ctx) =>
         {
-            if (!AuthMiddleware.HasValidToken(ctx, token))
+            if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
             if (!Guid.TryParse(sid, out _))
                 return Results.Json(new { error = "invalid session id format" }, statusCode: StatusCodes.Status400BadRequest);
@@ -133,7 +139,7 @@ internal static class GatewayVoiceTurnEndpoint
         app.MapPut("/sessions/{sid}/voice-turn/upload/{uploadId}/chunk/{index:int}",
             async (string sid, string uploadId, int index, HttpContext ctx) =>
         {
-            if (!AuthMiddleware.HasValidToken(ctx, token))
+            if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
             if (!uploads.Exists(uploadId))
                 return Results.Json(new { error = "unknown upload id (register it first)" }, statusCode: StatusCodes.Status404NotFound);
@@ -157,7 +163,7 @@ internal static class GatewayVoiceTurnEndpoint
         app.MapPost("/sessions/{sid}/voice-turn/upload/{uploadId}/complete",
             async (string sid, string uploadId, VoiceTurnCompleteRequest? req, HttpContext ctx) =>
         {
-            if (!AuthMiddleware.HasValidToken(ctx, token))
+            if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
             if (!Guid.TryParse(sid, out _))
                 return Results.Json(new { error = "invalid session id format" }, statusCode: StatusCodes.Status400BadRequest);
@@ -218,7 +224,7 @@ internal static class GatewayVoiceTurnEndpoint
         app.MapGet("/sessions/{sid}/voice-turn/{turnId}", (string sid, string turnId, HttpContext ctx) =>
         {
             // Issue #369: same token gate as the submit route above.
-            if (!AuthMiddleware.HasValidToken(ctx, token))
+            if (!AuthMiddleware.HasValidToken(ctx, token, devices))
             {
                 FileLog.Write($"[GatewayVoiceTurn] poll sid={sid} turnId={turnId}: missing or invalid token from {ctx.Connection.RemoteIpAddress} -> 401");
                 return Results.Json(new { error = "missing or invalid token" },
@@ -291,7 +297,7 @@ internal static class GatewayVoiceTurnEndpoint
         // Gateway restart - the artifact that "sits in the session". 404 once neither has it.
         app.MapGet("/sessions/{sid}/voice-turn/{turnId}/audio", (string sid, string turnId, HttpContext ctx) =>
         {
-            if (!AuthMiddleware.HasValidToken(ctx, token))
+            if (!AuthMiddleware.HasValidToken(ctx, token, devices))
             {
                 FileLog.Write($"[GatewayVoiceTurn] audio sid={sid} turnId={turnId}: missing or invalid token from {ctx.Connection.RemoteIpAddress} -> 401");
                 return Results.Json(new { error = "missing or invalid token" },
@@ -341,7 +347,7 @@ internal static class GatewayVoiceTurnEndpoint
         // The session's completed voice turns, newest first (read from the durable archive).
         app.MapGet("/sessions/{sid}/voice-turns", (string sid, HttpContext ctx, string? since) =>
         {
-            if (!AuthMiddleware.HasValidToken(ctx, token))
+            if (!AuthMiddleware.HasValidToken(ctx, token, devices))
                 return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
 
             DateTime? sinceUtc = null;

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -864,7 +864,10 @@ public sealed class GatewayHost : IAsyncDisposable
             // Issue #330: doorbell event-vocabulary pings land in the per-director event ring.
             directorEvents: DirectorEvents,
             // Issue #376: async voice-turn submit/poll rides the host-owned job store.
-            turnJobs: TurnJobs);
+            turnJobs: TurnJobs,
+            // Issue #1045: pass the per-device-key registry so the voice-turn routes' own token
+            // check (issue #369) accepts a phone's enrolled device key, not just the shared token.
+            devices: Devices);
 
         // Issue #268: the two raw per-session WebSocket legs (live Terminal stream + dictation)
         // proxied through the Gateway so a remote Cockpit talks same-origin to the Gateway and

--- a/src/CcDirector.Gateway/Util/AuthMiddleware.cs
+++ b/src/CcDirector.Gateway/Util/AuthMiddleware.cs
@@ -102,13 +102,14 @@ internal static class AuthMiddleware
     /// ordinal compare against the per-machine gateway token). Used by the global middleware
     /// above and by endpoints that must stay token-gated even when the global middleware is
     /// off (issue #369: the voice-turn submit/poll surface in production mode).
-    /// </summary>
-    public static bool HasValidToken(HttpContext ctx, string token) => HasValidToken(ctx, token, null);
-
-    /// <summary>
-    /// As <see cref="HasValidToken(HttpContext, string)"/> but, per issue #469, ALSO accepts a
-    /// Bearer that matches an active per-device key in the <paramref name="devices"/> registry, so
-    /// an enrolled Director authenticates with its own unique key rather than the shared token.
+    ///
+    /// Per issue #469/#908, this ALSO accepts a Bearer or cookie that matches an active per-device
+    /// key in the <paramref name="devices"/> registry, so an enrolled device (phone or Director)
+    /// authenticates with its own unique key rather than the shared token. Every caller must pass
+    /// the registry: issue #1045 deleted the device-key-blind two-argument overload because a route
+    /// that omitted the registry silently 401'd every per-device key (it bit voice-turn). Pass
+    /// <c>null</c> for <paramref name="devices"/> ONLY when per-device-key auth is genuinely
+    /// inapplicable (there is no registry on this host).
     /// </summary>
     public static bool HasValidToken(HttpContext ctx, string token, DeviceRegistry? devices)
     {


### PR DESCRIPTION
Fixes thefrederiksen/devthrottle#1045.

## Problem
The Gateway voice-turn submit/upload/poll/audio routes token-check with the two-argument `AuthMiddleware.HasValidToken(ctx, token)`, which passes a null device registry and so accepts only the shared machine token. A phone enrolled with its own per-device key (the thefrederiksen/devthrottle_internal#658 path that no longer injects the master token) got a 401 on every voice-turn call - the feature was unusable from an enrolled phone. Same class of bug as dictation (#1006, fixed in thefrederiksen/devthrottle#1033); voice-turn authenticates per-route and was missed.

## Fix
- Thread the device registry (`GatewayHost.Devices`) through `GatewayEndpoints.Map` into `GatewayVoiceTurnEndpoint.Map`; all seven call sites now use `HasValidToken(ctx, token, devices)`.
- **Delete the two-argument `HasValidToken` overload entirely** so no future route can silently reintroduce the device-key-blind check - the compiler now forces every caller to pass the registry.
- Add regression tests: a per-device key is accepted on both the submit and audio routes.

## Verification
- Build: 0 warnings, 0 errors (the clean compile proves the deleted overload had no other callers).
- Tests: 38/38 pass in the affected suites, including the 2 new regression tests, against current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)