### PR TITLE
Fix #1048: Gateway clears the Transcribing mark on every dictation outcome

### DIFF
--- a/src/CcDirector.Gateway.Tests/GatewayDictationEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayDictationEndpointTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using CcDirector.Core.HostedAi;
+using CcDirector.Gateway.Api;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The durable server-owned dictation complete handler (issue #1006) clears the orange
+/// "Transcribing..." mark on EVERY terminal outcome, not just the happy paths (issue #1048). The
+/// clear is driven by <see cref="DictationOutcome.IsIncomplete"/>: the wrapper clears the mark unless
+/// the outcome is an incomplete upload (more chunks still coming). These tests lock that contract, the
+/// exact thing that was broken - previously an error return (no key, empty audio, a transcription
+/// failure, out-of-credits, the session gone, or a submit refused because the session was parked on a
+/// modal) left the mark set and leaned on the 20-minute MaxAge backstop, wedging the session orange.
+/// </summary>
+public sealed class GatewayDictationEndpointTests
+{
+    [Fact]
+    public void Submitted_ClearsTheMark()
+    {
+        // A submitted turn is terminal and must clear the mark.
+        var outcome = DictationOutcome.Submitted(submitted: true, movedOn: false, transcript: "hello");
+
+        Assert.False(outcome.IsIncomplete, "a submitted turn must clear the transcribing mark");
+    }
+
+    [Fact]
+    public void MovedOn_ClearsTheMark()
+    {
+        var outcome = DictationOutcome.Submitted(submitted: false, movedOn: true, transcript: "stale");
+
+        Assert.False(outcome.IsIncomplete, "a dropped stale clip must clear the transcribing mark");
+    }
+
+    [Fact]
+    public void Error_ClearsTheMark()
+    {
+        // The regression: an error outcome (e.g. the submit was refused because the session is parked on
+        // a modal like "Approve this batch?") must ALSO clear the mark, not leave it stuck for 20 minutes.
+        var outcome = DictationOutcome.Error(502, "submit to session failed");
+
+        Assert.False(outcome.IsIncomplete, "an error outcome must clear the transcribing mark");
+    }
+
+    [Fact]
+    public void OutOfCredits_ClearsTheMark()
+    {
+        var outcome = DictationOutcome.OutOfCredits(default(HostedAiState));
+
+        Assert.False(outcome.IsIncomplete, "an out-of-credits outcome must clear the transcribing mark");
+    }
+
+    [Fact]
+    public void Incomplete_KeepsTheMark()
+    {
+        // The ONLY outcome that keeps the mark: chunks are still arriving and the client completes again
+        // on the same upload id, so the session is genuinely still transcribing.
+        var outcome = DictationOutcome.Incomplete(new List<int> { 2, 5 });
+
+        Assert.True(outcome.IsIncomplete, "an incomplete upload must keep the transcribing mark");
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -127,6 +127,23 @@ internal static class GatewayDictationEndpoint
         DirectorEndpointClient client, SessionOwnerCache? owners, GatewayTranscriptionService transcription,
         TranscribingSessions transcribingSessions)
     {
+        var outcome = await RunCompleteCoreAsync(uploadId, req, uploads, registry, client, owners, transcription);
+        // The Gateway OWNS the orange "Transcribing..." mark, so it clears it on EVERY terminal outcome -
+        // not just the happy paths (issue #1048). Before this fix an error return (no key, empty audio, a
+        // transcription failure, out-of-credits, the session gone, a submit REFUSED because the session is
+        // parked on a modal, or an unexpected exception) left the mark set and leaned on the 20-minute
+        // MaxAge backstop to clear it - which is exactly what wedged sessions orange for up to 20 minutes.
+        // The ONLY outcome we keep the mark for is an incomplete upload: more chunks are still coming and
+        // the client completes again on the same upload id, so the session is genuinely still transcribing.
+        if (!outcome.IsIncomplete)
+            EndTranscribing(transcribingSessions, req.SessionId!);
+        return outcome;
+    }
+
+    private static async Task<DictationOutcome> RunCompleteCoreAsync(
+        string uploadId, DictationCompleteRequest req, VoiceUploadStore uploads, DirectorRegistry registry,
+        DirectorEndpointClient client, SessionOwnerCache? owners, GatewayTranscriptionService transcription)
+    {
         var sid = req.SessionId!;
         try
         {
@@ -167,7 +184,6 @@ internal static class GatewayDictationEndpoint
             {
                 // Silent/empty clip with no typed text: nothing to submit, but the turn is genuinely done.
                 uploads.Delete(uploadId);
-                EndTranscribing(transcribingSessions, sid);
                 return DictationOutcome.Submitted(false, false, transcript);
             }
 
@@ -184,7 +200,6 @@ internal static class GatewayDictationEndpoint
                 session.TotalBufferBytes > req.BaselineBufferBytes + MovedOnBufferGrowthBytes)
             {
                 uploads.Delete(uploadId);
-                EndTranscribing(transcribingSessions, sid);
                 FileLog.Write($"[GatewayDictation] complete sid={sid} uploadId={uploadId}: session moved on " +
                     $"(buffer {req.BaselineBufferBytes}->{session.TotalBufferBytes}); dropped");
                 return DictationOutcome.Submitted(false, true, transcript);
@@ -195,7 +210,6 @@ internal static class GatewayDictationEndpoint
                 return DictationOutcome.Error(StatusCodes.Status502BadGateway, err ?? "submit to session failed");
 
             uploads.Delete(uploadId);
-            EndTranscribing(transcribingSessions, sid);
             FileLog.Write($"[GatewayDictation] complete sid={sid} uploadId={uploadId}: submitted chars={message.Length}");
             return DictationOutcome.Submitted(true, false, transcript);
         }
@@ -318,6 +332,11 @@ internal sealed class DictationOutcome
 
     /// <summary>Terminal: the server handled the clip (submitted, moved-on, or empty). Do not retry.</summary>
     public bool Terminal => _kind == Kind.Submitted;
+
+    /// <summary>The upload is missing chunks and the client will complete again on the same upload id, so
+    /// the session is still genuinely transcribing - the ONE outcome that must NOT clear the orange mark
+    /// (issue #1048).</summary>
+    public bool IsIncomplete => _kind == Kind.Incomplete;
 
     public static DictationOutcome Submitted(bool submitted, bool movedOn, string transcript)
         => new(Kind.Submitted, submitted: submitted, movedOn: movedOn, transcript: transcript);


### PR DESCRIPTION
Fixes #1048.

## What was actually wrong

The principle in #1048 - all shared session state lives on the Gateway, never the phone - is already the architecture. Issue #1006 moved the mobile dictation flow to a durable, server-owned path: the phone persists the audio locally, streams it to the Gateway, and the Gateway assembles, transcribes, and injects the turn itself. The phone no longer calls `setTranscribing` or `sendPrompt` (there are zero callers left).

The remaining defect was narrower and is the real cause of the stuck-orange state: in `GatewayDictationEndpoint.RunCompleteAsync`, `EndTranscribing` was called only on the success paths (submitted, moved-on, empty). Every error return left the orange "Transcribing..." mark set and leaned on the 20-minute `MaxAge` backstop to clear it:

- no transcription key
- empty assembled audio
- transcription failed / out of credits
- session not found or exited
- **the submit was refused because the session is parked on a modal** (a permission or trust prompt, or Codex's "Approve this batch?") - this is the exact case in #1048
- an unexpected exception

So on any of these the session sat orange for up to 20 minutes, which is why the director logs show `[TranscribingSessions] mark expired after 20 min, cleared` firing routinely rather than rarely.

## The fix

Centralize the clear where the Gateway owns the mark. `RunCompleteAsync` now splits into:

- `RunCompleteCoreAsync` - produces the `DictationOutcome` (transcribe + submit), unchanged behavior.
- `RunCompleteAsync` (wrapper) - clears the mark for every terminal outcome, keeping it only when the outcome is an incomplete upload (the one case where more chunks are still coming and the client completes again on the same upload id, so the session is genuinely still transcribing).

Adds `DictationOutcome.IsIncomplete` and a regression test (`GatewayDictationEndpointTests`) that locks the contract: `Submitted`, moved-on, `Error`, and `OutOfCredits` all clear the mark; only `Incomplete` keeps it. The 20-minute `MaxAge` stays as a genuine last-resort backstop and should now almost never fire.

## Tests

`dotnet test` on `CcDirector.Gateway.Tests` - the 5 new `GatewayDictationEndpointTests` plus the existing `TranscribingSessions` tests pass (13 total).

## Note on the modal case

When the submit is refused because the session is on a prompt, the transcript is not lost: the phone keeps its durable local copy (issue #1006) and re-drives it on the next app load, and the moved-on guard drops it if the session has since advanced. This change ensures the orange mark clears in that case instead of sticking. Fully resurfacing "these words are waiting because the session needs you" in the UI is a good follow-up but is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
