### PR TITLE
docs(cockpit): mark COCKPIT_DESIGN.md superseded by the React rebuild

### DIFF
--- a/docs/architecture/cockpit/COCKPIT_DESIGN.md
+++ b/docs/architecture/cockpit/COCKPIT_DESIGN.md
@@ -1,6 +1,8 @@
 # The Cockpit - Design (TARGET / PLANNED v1)
 
-**Status:** PLANNED
+**SUPERSEDED:** the Blazor Server design below is replaced by the shipped React rebuild. See [COCKPIT_REACT_REBUILD.md](COCKPIT_REACT_REBUILD.md) for the current, authoritative design. The topology here (one Gateway front door, direct-WebSocket terminal) still holds; only the view technology changed. Read this for history, not for the plan.
+
+**Status:** PLANNED (historical)
 **Date:** 2026-05-31
 **Audience:** Anyone building the Cockpit, or deciding where a session-driving feature should live going forward.
 


### PR DESCRIPTION
The Blazor design doc still read PLANNED with no pointer to the shipped React design. Adds a one-line SUPERSEDED banner directing readers to COCKPIT_REACT_REBUILD.md. Docs-only.