### PR TITLE
Fix #1056: tell the user a dictation is held (not lost) when the session is busy/on a prompt

### DIFF
--- a/packages/client-core/src/dictation/backgroundSend.test.ts
+++ b/packages/client-core/src/dictation/backgroundSend.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// backgroundTranscribeAndSend drives the server-owned upload+transcribe+inject and reports the
+// outcome back to the host. These tests lock the caveat-#2 behavior (issue #1056): when the turn is
+// not confirmed but the audio was saved durably, the user is told the dictation is HELD and will
+// retry - not a raw technical error and not silence.
+
+vi.mock("../api/client", () => ({ uploadDictationToSession: vi.fn() }));
+vi.mock("./pendingStore", () => ({
+  savePending: vi.fn(),
+  deletePending: vi.fn(),
+  prunePending: vi.fn(),
+}));
+
+import { uploadDictationToSession } from "../api/client";
+import { backgroundTranscribeAndSend, type CapturedUtterance } from "./backgroundSend";
+import { deletePending, savePending } from "./pendingStore";
+
+const captured: CapturedUtterance = { blob: new Blob(["x"]), recordedMs: 1000, prefixText: "" };
+
+describe("backgroundTranscribeAndSend", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("tells the user the dictation is held (not lost) when the turn is not confirmed but the audio was saved", async () => {
+    vi.mocked(savePending).mockResolvedValue(undefined);
+    vi.mocked(uploadDictationToSession).mockResolvedValue({
+      terminal: false, submitted: false, movedOn: false, transcript: "", error: "submit to session failed",
+    });
+    const onError = vi.fn();
+    const onFailed = vi.fn();
+
+    await backgroundTranscribeAndSend("sid", captured, { onError, onFailed });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toContain("saved and will retry");
+    // The raw server error is NOT what the user sees in the held case.
+    expect(onError.mock.calls[0][0]).not.toContain("submit to session failed");
+    expect(onFailed).toHaveBeenCalledTimes(1);
+    // The durable record is kept so resume-on-load re-drives it.
+    expect(deletePending).not.toHaveBeenCalled();
+  });
+
+  it("deletes the durable record and reports nothing on a terminal (submitted) outcome", async () => {
+    vi.mocked(savePending).mockResolvedValue(undefined);
+    vi.mocked(uploadDictationToSession).mockResolvedValue({
+      terminal: true, submitted: true, movedOn: false, transcript: "hi",
+    });
+    const onError = vi.fn();
+
+    await backgroundTranscribeAndSend("sid", captured, { onError });
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(deletePending).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces the raw error when there is no durable store to hold the audio", async () => {
+    vi.mocked(savePending).mockRejectedValue(new Error("no indexeddb"));
+    vi.mocked(uploadDictationToSession).mockResolvedValue({
+      terminal: false, submitted: false, movedOn: false, transcript: "", error: "network down",
+    });
+    const onError = vi.fn();
+
+    await backgroundTranscribeAndSend("sid", captured, { onError });
+
+    expect(onError).toHaveBeenCalledWith("network down");
+  });
+});

--- a/packages/client-core/src/dictation/backgroundSend.ts
+++ b/packages/client-core/src/dictation/backgroundSend.ts
@@ -83,10 +83,19 @@ export async function backgroundTranscribeAndSend(
     });
     if (outcome.terminal) {
       if (persisted) await deletePending(rec.id);
+    } else if (persisted) {
+      // The server did not confirm the turn - most often the session is parked on a prompt or
+      // permission dialog and would not accept the typed words - but the audio is saved durably and
+      // resumePendingDictations() re-drives it on the next app load. Tell the user their dictation is
+      // HELD and will retry, not silently lost, rather than surfacing a raw technical error (issue #1056).
+      hooks.onError?.(
+        "Couldn't send your dictation yet - the session may be busy or waiting on a prompt. " +
+          "It's saved and will retry the next time you open the app.",
+      );
+      hooks.onFailed?.();
     } else {
-      // The server did not confirm the turn; keep the durable record so resume-on-load retries it, and
-      // surface the soft error. (If there is no durable copy, this utterance is genuinely lost - the
-      // onError is then the signal, exactly as before.)
+      // No durable store in this context (rare), so this utterance really is lost - surface the raw error
+      // as before, so the failure is not silent.
       hooks.onError?.(outcome.error ?? "Dictation upload failed");
       hooks.onFailed?.();
     }


### PR DESCRIPTION
## Summary

Follow-up to #1048. When a dictated message cannot be delivered because the session is parked on a prompt or permission dialog (for example Codex's "Approve this batch?"), the audio is already saved durably and re-driven on the next app load (issue #1006), so the words are never lost. But the user was shown a raw technical error ("submit to session failed") with no indication that their dictation is saved and will retry. This surfaces a clear, reassuring message instead.

## Change

In `packages/client-core/src/dictation/backgroundSend.ts`, when the server does not confirm the turn but the audio was persisted durably, tell the user their dictation is held and will retry:

> "Couldn't send your dictation yet - the session may be busy or waiting on a prompt. It's saved and will retry the next time you open the app."

The raw error is still surfaced in the rare case where there is no durable store to hold the audio (so the failure is never silent). A terminal (submitted) outcome deletes the durable record and reports nothing, unchanged.

## Tests

`backgroundSend.test.ts` (new): the held-message branch, the terminal-delete branch, and the no-durable-store raw-error branch.

## Out of scope

A richer UI treatment (a persistent "pending dictation" indicator, or auto-retrying the moment the session leaves the modal rather than on next app load) would be a further improvement, but is not needed to remove the confusing silent/vague behavior.
