### PR TITLE
Fix mobile session screens sizing to the visible viewport (dvh, not vh)

### DIFF
--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -26,7 +26,7 @@ body {
 }
 
 #root {
-  min-height: 100vh;
+  min-height: 100dvh;
 }
 
 .screen {
@@ -342,13 +342,19 @@ a.banner-btn {
    A full-height column: a status row (status + Keys toggle), the live mirror filling all remaining
    space, and the collapsible controls panel (hidden by default) beneath it. Mirrors the Android
    TalkPage terminal section and RawTerminalPage.cs. */
+/* height uses dvh (the DYNAMIC visible viewport), NOT vh. On a phone 100vh is the tall
+   "toolbar-hidden" viewport, so a 100vh column is built taller than the screen and its top tabs
+   and bottom keys get pushed off the visible area (you must scroll to reach either, never both).
+   100dvh tracks the currently visible height, so the whole column - tabs, body, keys - fits on
+   screen and only the middle body scrolls. The bottom padding also clears the iOS home indicator
+   (the page is viewport-fit=cover). */
 .terminal-screen {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: 100dvh;
   max-width: 680px;
   margin: 0 auto;
-  padding: 0 12px 10px;
+  padding: 0 12px calc(10px + env(safe-area-inset-bottom));
 }
 
 .term-title {


### PR DESCRIPTION
## Problem

On the mobile PWA, when you are in a session on the Chat or Terminal screen you cannot see the bottom keys and the tab bar (Terminal / Chat / Voice) at the same time. You have to scroll the whole screen up and down, and reaching the bottom keys pushes the tabs off the top.

## Cause

The Chat, Terminal, and Voice screens share the `.terminal-screen` shell, which was sized `height: 100vh`. On a phone `100vh` is the tall "toolbar-hidden" viewport, so the flex column is built taller than the visible screen. Its top (the view tabs) and its bottom (the keys / Send row) are pushed past the visible edges, so only one end is reachable at a time. It looks fine in a desktop test browser because desktop has no retracting toolbar, so there `100vh` equals the visible height.

## Fix

- `.terminal-screen` and `#root` now use `100dvh` (the dynamic, currently-visible viewport) instead of `100vh`, so the whole column fits on screen and only the middle body (chat bubbles / terminal mirror) scrolls.
- The shell's bottom padding adds `env(safe-area-inset-bottom)` so the keys clear the iOS home indicator (the page is `viewport-fit=cover`).

One file changed: `apps/mobile/src/styles.css`.

## Verification note

This is a real-phone-only symptom (desktop `100vh` == visible height), so it is verified on a phone: open `/m`, enter a session, confirm the Terminal / Chat / Voice tabs and the bottom keys row are both visible without scrolling, on both the Chat and Terminal screens.
