### PR TITLE
Fix #1074: authorization-grade claim checks for cloud access-token validation

### DIFF
--- a/docs/cencon/proof/issue-1074/authorization-tests-output.txt
+++ b/docs/cencon/proof/issue-1074/authorization-tests-output.txt
@@ -1,0 +1,11 @@
+  Passed CcDirector.Core.Tests.Account.JwtAccessTokenValidatorAuthorizationTests.ValidateForAuthorization_WithoutExpectedAudienceOrIssuerConfigured_Throws 
+  Passed CcDirector.Core.Tests.Account.JwtAccessTokenValidatorAuthorizationTests.ValidateForAuthorization_WrongIssuer_IsNotValid 
+  Passed CcDirector.Core.Tests.Account.JwtAccessTokenValidatorAuthorizationTests.ValidateForAuthorization_NotYetValid_IsNotValid 
+  Passed CcDirector.Core.Tests.Account.JwtAccessTokenValidatorAuthorizationTests.ValidateForAuthorization_TamperedSignature_IsNotValid 
+  Passed CcDirector.Core.Tests.Account.JwtAccessTokenValidatorAuthorizationTests.ValidateForAuthorization_FullyValidToken_IsValidAndExposesSubject 
+  Passed CcDirector.Core.Tests.Account.JwtAccessTokenValidatorAuthorizationTests.ValidateForAuthorization_Expired_IsNotValid 
+  Passed CcDirector.Core.Tests.Account.JwtAccessTokenValidatorAuthorizationTests.ValidateForAuthorization_WrongAudience_IsNotValid 
+  Passed CcDirector.Core.Tests.Account.JwtAccessTokenValidatorAuthorizationTests.ValidateForAuthorization_ValidTokenWithAudienceArrayContainingExpected_IsValid 
+
+SUMMARY: Passed! - Failed: 0, Passed: 8, Skipped: 0, Total: 8 (JwtAccessTokenValidatorAuthorizationTests)
+FULL CORE PROJECT: Passed! - Failed: 0, Passed: 2837, Skipped: 8, Total: 2845

--- a/docs/cencon/proof/issue-1074/qa-report.html
+++ b/docs/cencon/proof/issue-1074/qa-report.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>QA Proof - Issue #1074</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; margin: 2rem; line-height: 1.5; color: #1a1a1a; }
+  h1 { border-bottom: 3px solid #5319e7; padding-bottom: .3rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #ccc; padding: .5rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #f0edfb; }
+  .pass { color: #0a6b0a; font-weight: bold; }
+  .fail { color: #b00020; font-weight: bold; }
+  code { background: #f4f4f4; padding: .1rem .3rem; border-radius: 3px; }
+  pre { background: #1a1a1a; color: #eee; padding: 1rem; overflow-x: auto; border-radius: 5px; }
+  .verdict { background: #e6f7e6; border: 2px solid #0a6b0a; padding: 1rem; border-radius: 6px; font-size: 1.1rem; }
+</style>
+</head>
+<body>
+<h1>QA Proof Report - Issue #1074</h1>
+<p><strong>Issue:</strong> [Core] Extend cloud access-token validation with audience, issuer, and
+subject claim checks for authorization use<br>
+<strong>Pull request:</strong> #1107 &nbsp; <strong>Branch:</strong> <code>issue-1074-token-authz</code>
+&nbsp; <strong>Head:</strong> <code>e2023a51</code><br>
+<strong>Epic:</strong> #1069 (Phase 1) &nbsp; <strong>Verified by:</strong> QA Agent (independent
+session, isolated worktree) &nbsp; <strong>Date:</strong> 2026-07-06</p>
+
+<h2>Method</h2>
+<p>Verified independently in a dedicated detached git worktree checked out at the PR head
+(<code>e2023a51</code>) - not the developer's binary or screenshots. The change is a non-UI Core
+library change, so the correct proof target is a <code>dotnet test</code> run. In addition to
+re-running the developer's 8 authorization tests, the QA session wrote and ran its OWN independent
+test set (13 tests) covering every acceptance criterion plus extra negative and boundary cases the
+developer did not test (missing subject, foreign-key/bad signature, malformed token, expiry-exactly-now,
+nbf-exactly-now), then removed that QA-only test file to leave the branch clean.</p>
+
+<h2>Acceptance Criteria - Expected vs Actual</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual</th><th>Result</th></tr>
+<tr><td>1</td><td>Wrong <code>aud</code> rejected</td><td>Not valid</td>
+<td>Rejected (dev test <code>WrongAudience_IsNotValid</code> + QA test <code>Qa_WrongAudience_Rejected</code>)</td><td class="pass">PASS</td></tr>
+<tr><td>2</td><td>Wrong <code>iss</code> rejected</td><td>Not valid</td>
+<td>Rejected (dev <code>WrongIssuer_IsNotValid</code> + QA <code>Qa_WrongIssuer_Rejected</code>)</td><td class="pass">PASS</td></tr>
+<tr><td>3</td><td><code>nbf</code> in the future rejected (injected TimeProvider)</td><td>Not valid</td>
+<td>Rejected using a fake <code>TimeProvider</code> (dev <code>NotYetValid_IsNotValid</code> + QA <code>Qa_NotYetValid_Rejected</code>)</td><td class="pass">PASS</td></tr>
+<tr><td>4</td><td>Expired (<code>exp</code> past) rejected; existing expired behavior preserved</td><td>Not valid</td>
+<td>Rejected (dev <code>Expired_IsNotValid</code> + QA <code>Qa_Expired_Rejected</code>, plus boundary <code>Qa_ExpiryExactlyNow_Rejected</code>). Existing <code>Validate</code> tests all still pass.</td><td class="pass">PASS</td></tr>
+<tr><td>5</td><td>Fully valid token accepted AND non-empty <code>sub</code> returned as exact string</td><td>Valid; subject == exact value</td>
+<td>Accepted; <code>Subject</code> == <code>"account-42"</code> (dev) / <code>"qa-subject-777"</code> (QA), both asserted exactly</td><td class="pass">PASS</td></tr>
+<tr><td>6</td><td>Full test class green under <code>dotnet test</code></td><td>All pass</td>
+<td>Auth tests 8/8; full Core project 2837 passed, 8 skipped, 0 failed (see below)</td><td class="pass">PASS</td></tr>
+<tr><td>7</td><td>No network call during validation</td><td>Fully local, no HTTP dependency</td>
+<td>Source grep of <code>JwtAccessTokenValidator.cs</code> for <code>HttpClient/SendAsync/http(s)://</code> etc. found NONE; tests run with no HTTP handler configured</td><td class="pass">PASS</td></tr>
+</table>
+
+<h2>Extra negative / boundary cases (QA independent)</h2>
+<p>The developer's tests did not explicitly cover a MISSING subject, a token signed by a FOREIGN key,
+a malformed token, or the exact <code>exp</code>/<code>nbf</code> boundary instants. The QA session
+added and passed tests for all of these:</p>
+<ul>
+<li><code>Qa_MissingSubjectClaim_Rejected</code> - empty <code>sub</code> rejected, <code>Subject</code> null - PASS</li>
+<li><code>Qa_MissingAudienceClaim_Rejected</code> / <code>Qa_MissingIssuerClaim_Rejected</code> - absent claim rejected - PASS</li>
+<li><code>Qa_TokenSignedWithForeignKey_Rejected</code> - correct claims but wrong signing key rejected - PASS</li>
+<li><code>Qa_MalformedToken_Rejected</code> - non-JWT input rejected - PASS</li>
+<li><code>Qa_ExpiryExactlyNow_Rejected</code> - <code>exp == now</code> rejected (inclusive boundary) - PASS</li>
+<li><code>Qa_NbfExactlyNow_Accepted</code> - <code>nbf == now</code> accepted (inclusive boundary) - PASS</li>
+<li><code>Qa_ExistingValidateBehaviorUnchanged_ValidToken</code> - the outbound <code>Validate</code> path still works with no aud/iss configured - PASS</li>
+</ul>
+
+<h2>Test output (developer authorization tests, re-run by QA)</h2>
+<pre>
+Passed ...JwtAccessTokenValidatorAuthorizationTests.ValidateForAuthorization_WithoutExpectedAudienceOrIssuerConfigured_Throws
+Passed ...ValidateForAuthorization_WrongIssuer_IsNotValid
+Passed ...ValidateForAuthorization_NotYetValid_IsNotValid
+Passed ...ValidateForAuthorization_TamperedSignature_IsNotValid
+Passed ...ValidateForAuthorization_FullyValidToken_IsValidAndExposesSubject
+Passed ...ValidateForAuthorization_Expired_IsNotValid
+Passed ...ValidateForAuthorization_WrongAudience_IsNotValid
+Passed ...ValidateForAuthorization_ValidTokenWithAudienceArrayContainingExpected_IsValid
+Test Run Successful. Total tests: 8
+</pre>
+
+<h2>QA independent test output (13 tests, removed after run)</h2>
+<pre>
+Passed Qa_NotYetValid_Rejected      Passed Qa_NbfExactlyNow_Accepted
+Passed Qa_MissingIssuerClaim_Rejected      Passed Qa_MissingAudienceClaim_Rejected
+Passed Qa_ExpiryExactlyNow_Rejected      Passed Qa_WrongIssuer_Rejected
+Passed Qa_MissingSubjectClaim_Rejected      Passed Qa_Expired_Rejected
+Passed Qa_WrongAudience_Rejected      Passed Qa_FullyValid_AcceptedWithSubject
+Passed Qa_TokenSignedWithForeignKey_Rejected      Passed Qa_MalformedToken_Rejected
+Passed Qa_ExistingValidateBehaviorUnchanged_ValidToken
+Test Run Successful. Total tests: 13, Passed: 13
+</pre>
+
+<h2>Regression sweep</h2>
+<pre>
+Passed!  - Failed: 0, Passed: 2837, Skipped: 8, Total: 2845 - CcDirector.Core.Tests.dll (net10.0)
+Build succeeded. 0 Warning(s) 0 Error(s)
+</pre>
+<p>No adjacent tests broke. The existing <code>Validate(...)</code> path and all its call sites are
+unchanged (both paths now share one local <code>VerifySignature</code>). No CenCon architecture drift
+(existing Core class extended, no container change); the change strengthens claim checking and relaxes
+no blocking security rule.</p>
+
+<div class="verdict">VERIFIED - all 7 acceptance criteria met, plus 7 extra QA negative/boundary cases.
+Full Core suite green (2837 passed, 0 failed). Build clean (0 warnings, 0 errors). Validation is fully
+local with no network dependency.</div>
+</body>
+</html>

--- a/docs/cencon/proof/issue-1074/report.html
+++ b/docs/cencon/proof/issue-1074/report.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Proof - Issue #1074 - Authorization-grade access-token validation</title>
+<style>
+  body { font-family: Segoe UI, Arial, sans-serif; max-width: 900px; margin: 2rem auto; padding: 0 1rem; color: #1e1e1e; line-height: 1.5; }
+  h1 { font-size: 1.5rem; border-bottom: 2px solid #007acc; padding-bottom: .4rem; }
+  h2 { font-size: 1.2rem; margin-top: 1.8rem; color: #007acc; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #ccc; padding: .5rem .6rem; text-align: left; vertical-align: top; font-size: .92rem; }
+  th { background: #f0f6fb; }
+  code, pre { font-family: Consolas, monospace; }
+  pre { background: #1e1e1e; color: #d4d4d4; padding: 1rem; overflow-x: auto; border-radius: 4px; font-size: .85rem; }
+  .pass { color: #107c10; font-weight: bold; }
+  .meta { color: #555; font-size: .9rem; }
+  .box { background: #f7f7f7; border-left: 4px solid #007acc; padding: .8rem 1rem; margin: 1rem 0; }
+</style>
+</head>
+<body>
+<h1>Proof of Completion - Issue #1074</h1>
+<p class="meta">[Core] Extend cloud access-token validation with audience, issuer, and subject claim checks for authorization use. Part of epic #1069 (Phase 1).</p>
+
+<h2>Release Notes</h2>
+<p>The local cloud access-token validator now offers an authorization-grade validation path.
+On top of the existing signature and expiry (<code>exp</code>) checks used to authorize the
+Gateway's own outbound cloud calls, it can now also verify the audience (<code>aud</code>),
+issuer (<code>iss</code>), and not-before (<code>nbf</code>) claims and extract the subject
+(<code>sub</code>). This is the foundation for using a cloud session as a first-class inbound
+credential (epic #1069): a correctly-signed token minted for a different audience or issuer is
+now rejected, a not-yet-valid token is honoured, and the account subject is exposed so a later
+membership check (issue #1079) can confirm the token belongs to this Gateway's account.
+Validation remains fully local - no per-request cloud call - so the Gateway keeps working during
+a cloud outage.</p>
+
+<h2>Changes</h2>
+<ul>
+  <li><code>src/CcDirector.Core/Account/JwtAccessTokenValidator.cs</code>
+    <ul>
+      <li>Added a new <code>AuthorizationTokenValidation</code> result record (<code>IsValid</code>,
+          <code>Subject</code>, <code>ExpiresAtUtc</code>, <code>InvalidReason</code>).</li>
+      <li>Added the <code>ValidateForAuthorization(string accessToken)</code> method: signature +
+          <code>exp</code> + <code>nbf</code> + <code>aud</code> + <code>iss</code> + non-empty
+          <code>sub</code>.</li>
+      <li>Added two optional constructor parameters, <code>expectedAudience</code> and
+          <code>expectedIssuer</code>, mirroring how <code>signingSecret</code> and
+          <code>publicKeySetJson</code> are supplied (configuration, not hard-coded at the call
+          site). Existing constructor call sites are unaffected (all pass the first argument
+          positionally and the rest by name).</li>
+      <li>Extracted the shared <code>VerifySignature</code> path so both <code>Validate</code> and
+          <code>ValidateForAuthorization</code> use the identical, fully-local signature code path.
+          The existing <code>Validate(...)</code> behaviour is unchanged (proven by the pre-existing
+          tests still passing).</li>
+      <li>Audience matching accepts both the single-string and array forms of the <code>aud</code>
+          claim (RFC 7519).</li>
+    </ul>
+  </li>
+  <li><code>src/CcDirector.Core.Tests/Account/Es256TestKey.cs</code> - added
+      <code>CreateAuthorizationToken(...)</code> to mint ES256 tokens carrying the
+      <code>aud</code>/<code>iss</code>/<code>sub</code>/<code>nbf</code> claims (single-string or
+      array audience).</li>
+  <li><code>src/CcDirector.Core.Tests/Account/JwtAccessTokenValidatorAuthorizationTests.cs</code> -
+      new test class (8 tests).</li>
+</ul>
+
+<h2>Acceptance Criteria - Expected vs Actual</h2>
+<table>
+  <tr><th>Acceptance criterion</th><th>Proving test</th><th>Expected</th><th>Actual</th></tr>
+  <tr>
+    <td>Valid signature + valid lifetime but WRONG <code>aud</code> -&gt; not valid</td>
+    <td>ValidateForAuthorization_WrongAudience_IsNotValid</td>
+    <td>IsValid == false</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>Valid signature but WRONG <code>iss</code> -&gt; not valid</td>
+    <td>ValidateForAuthorization_WrongIssuer_IsNotValid</td>
+    <td>IsValid == false</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td><code>nbf</code> in the future -&gt; not valid (injected TimeProvider)</td>
+    <td>ValidateForAuthorization_NotYetValid_IsNotValid</td>
+    <td>IsValid == false</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>Past <code>exp</code> -&gt; not valid for authorization use</td>
+    <td>ValidateForAuthorization_Expired_IsNotValid</td>
+    <td>IsValid == false</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>Fully valid token -&gt; valid AND <code>sub</code> returned as non-empty string (exact value)</td>
+    <td>ValidateForAuthorization_FullyValidToken_IsValidAndExposesSubject</td>
+    <td>IsValid == true, Subject == "account-42"</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>Full test class runs green under <code>dotnet test</code></td>
+    <td>(whole class)</td>
+    <td>8 passed, 0 failed</td>
+    <td class="pass">PASS</td>
+  </tr>
+  <tr>
+    <td>No network call during validation (no HTTP handler configured; no HTTP dependency)</td>
+    <td>All tests construct the validator with only local key material; the validation method has no HttpClient/network dependency (code inspection).</td>
+    <td>Tests pass with no HTTP handler</td>
+    <td class="pass">PASS</td>
+  </tr>
+</table>
+
+<div class="box">
+  <strong>Extra hardening tests (beyond the required set):</strong> tampered-signature rejection,
+  audience-as-array acceptance, and a fail-loud <code>InvalidOperationException</code> when the
+  expected audience/issuer are not configured (no fallback that silently skips the check).
+</div>
+
+<h2>Test Output</h2>
+<pre>
+  Passed ...JwtAccessTokenValidatorAuthorizationTests.ValidateForAuthorization_WithoutExpectedAudienceOrIssuerConfigured_Throws
+  Passed ...JwtAccessTokenValidatorAuthorizationTests.ValidateForAuthorization_WrongIssuer_IsNotValid
+  Passed ...JwtAccessTokenValidatorAuthorizationTests.ValidateForAuthorization_NotYetValid_IsNotValid
+  Passed ...JwtAccessTokenValidatorAuthorizationTests.ValidateForAuthorization_TamperedSignature_IsNotValid
+  Passed ...JwtAccessTokenValidatorAuthorizationTests.ValidateForAuthorization_FullyValidToken_IsValidAndExposesSubject
+  Passed ...JwtAccessTokenValidatorAuthorizationTests.ValidateForAuthorization_Expired_IsNotValid
+  Passed ...JwtAccessTokenValidatorAuthorizationTests.ValidateForAuthorization_WrongAudience_IsNotValid
+  Passed ...JwtAccessTokenValidatorAuthorizationTests.ValidateForAuthorization_ValidTokenWithAudienceArrayContainingExpected_IsValid
+
+  New authorization tests: Passed! - Failed: 0, Passed: 8, Skipped: 0, Total: 8
+  Whole Core test project: Passed! - Failed: 0, Passed: 2837, Skipped: 8, Total: 2845
+  Build: Build succeeded. 0 Warning(s) 0 Error(s)
+</pre>
+<p class="meta">Raw capture: <code>docs/cencon/proof/issue-1074/authorization-tests-output.txt</code></p>
+
+<h2>CenCon Impact</h2>
+<p>No architecture drift and no security-posture regression. The change extends an existing Core
+class (<code>CcDirector.Core.Account.JwtAccessTokenValidator</code>) - no new container, no changed
+container relationship. It strengthens security by adding authorization-grade claim checks; it does
+not relax any blocking security rule. No <code>docs/cencon/</code> file required an update.</p>
+
+<h2>Conclusion</h2>
+<p><strong>I believe this is finished.</strong> Every acceptance criterion is met and proven by a
+passing unit test, the whole Core test project is green, and the solution builds clean with zero
+warnings and zero errors. Validation stays fully local with no network dependency.</p>
+</body>
+</html>

--- a/src/CcDirector.Core.Tests/Account/Es256TestKey.cs
+++ b/src/CcDirector.Core.Tests/Account/Es256TestKey.cs
@@ -69,6 +69,50 @@ internal sealed class Es256TestKey : IDisposable
         return $"{signingInput}.{Base64Url(signature)}";
     }
 
+    /// <summary>
+    /// Creates a valid ES256 token carrying the authorization-mode claims: <c>aud</c> (audience),
+    /// <c>iss</c> (issuer), <c>sub</c> (subject/account id), <c>exp</c> (expiry) and, when supplied,
+    /// <c>nbf</c> (not-before). A null <paramref name="audience"/> (and null
+    /// <paramref name="audienceValues"/>) or null <paramref name="issuer"/> omits that claim entirely
+    /// so the "claim absent" path can be exercised; <paramref name="audienceValues"/> writes the
+    /// audience as a JSON array instead of a single string. Used to prove
+    /// <c>JwtAccessTokenValidator.ValidateForAuthorization</c> (issue #1074).
+    /// </summary>
+    public string CreateAuthorizationToken(
+        DateTime expiresAtUtc,
+        string? audience,
+        string? issuer,
+        string subject = "supabase-account-subject-id",
+        DateTime? notBeforeUtc = null,
+        string[]? audienceValues = null)
+    {
+        var header = Base64Url(JsonSerializer.SerializeToUtf8Bytes(new Dictionary<string, object>
+        {
+            ["alg"] = "ES256",
+            ["typ"] = "JWT",
+            ["kid"] = KeyId,
+        }));
+
+        var payloadClaims = new Dictionary<string, object>
+        {
+            ["sub"] = subject,
+            ["exp"] = new DateTimeOffset(expiresAtUtc, TimeSpan.Zero).ToUnixTimeSeconds(),
+        };
+        if (audienceValues is not null)
+            payloadClaims["aud"] = audienceValues;
+        else if (audience is not null)
+            payloadClaims["aud"] = audience;
+        if (issuer is not null)
+            payloadClaims["iss"] = issuer;
+        if (notBeforeUtc is not null)
+            payloadClaims["nbf"] = new DateTimeOffset(notBeforeUtc.Value, TimeSpan.Zero).ToUnixTimeSeconds();
+
+        var payload = Base64Url(JsonSerializer.SerializeToUtf8Bytes(payloadClaims));
+        var signingInput = $"{header}.{payload}";
+        var signature = _key.SignData(Encoding.ASCII.GetBytes(signingInput), HashAlgorithmName.SHA256);
+        return $"{signingInput}.{Base64Url(signature)}";
+    }
+
     public void Dispose() => _key.Dispose();
 
     private static string Base64Url(byte[] bytes) =>

--- a/src/CcDirector.Core.Tests/Account/JwtAccessTokenValidatorAuthorizationTests.cs
+++ b/src/CcDirector.Core.Tests/Account/JwtAccessTokenValidatorAuthorizationTests.cs
@@ -1,0 +1,160 @@
+using System.Diagnostics.CodeAnalysis;
+using CcDirector.Core.Account;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Account;
+
+/// <summary>
+/// Proves the authorization-mode validation added for epic #1069 (issue #1074): on top of the
+/// signature and <c>exp</c> checks that <see cref="JwtAccessTokenValidator.Validate"/> performs,
+/// <see cref="JwtAccessTokenValidator.ValidateForAuthorization"/> also enforces the audience,
+/// issuer, and not-before claims and exposes the subject. Every check runs entirely locally against
+/// a freshly-generated ES256 signing key - there is no HTTP handler configured and the validator has
+/// no network dependency, so these tests also demonstrate that validation makes no cloud call.
+/// </summary>
+public sealed class JwtAccessTokenValidatorAuthorizationTests : IDisposable
+{
+    private const string ExpectedAudience = "authenticated";
+    private const string ExpectedIssuer = "https://devthrottle.example.supabase.co/auth/v1";
+
+    private static readonly DateTime Now = new(2026, 7, 6, 12, 0, 0, DateTimeKind.Utc);
+
+    private readonly Es256TestKey _key = new();
+
+    public void Dispose() => _key.Dispose();
+
+    private JwtAccessTokenValidator MakeValidator() =>
+        new(TestJwt.SigningSecret, new FakeTimeProvider(Now), _key.PublicKeySetJson(),
+            expectedAudience: ExpectedAudience, expectedIssuer: ExpectedIssuer);
+
+    [Fact]
+    public void ValidateForAuthorization_FullyValidToken_IsValidAndExposesSubject()
+    {
+        var validator = MakeValidator();
+        var token = _key.CreateAuthorizationToken(
+            expiresAtUtc: Now.AddHours(1),
+            audience: ExpectedAudience,
+            issuer: ExpectedIssuer,
+            subject: "account-42",
+            notBeforeUtc: Now.AddMinutes(-5));
+
+        var result = validator.ValidateForAuthorization(token);
+
+        Assert.True(result.IsValid);
+        Assert.Equal("account-42", result.Subject);
+        Assert.Null(result.InvalidReason);
+    }
+
+    [Fact]
+    public void ValidateForAuthorization_WrongAudience_IsNotValid()
+    {
+        var validator = MakeValidator();
+        var token = _key.CreateAuthorizationToken(
+            expiresAtUtc: Now.AddHours(1),
+            audience: "some-other-audience",
+            issuer: ExpectedIssuer);
+
+        var result = validator.ValidateForAuthorization(token);
+
+        Assert.False(result.IsValid);
+        Assert.Null(result.Subject);
+    }
+
+    [Fact]
+    public void ValidateForAuthorization_WrongIssuer_IsNotValid()
+    {
+        var validator = MakeValidator();
+        var token = _key.CreateAuthorizationToken(
+            expiresAtUtc: Now.AddHours(1),
+            audience: ExpectedAudience,
+            issuer: "https://attacker.example.com/auth/v1");
+
+        var result = validator.ValidateForAuthorization(token);
+
+        Assert.False(result.IsValid);
+        Assert.Null(result.Subject);
+    }
+
+    [Fact]
+    public void ValidateForAuthorization_Expired_IsNotValid()
+    {
+        var validator = MakeValidator();
+        var token = _key.CreateAuthorizationToken(
+            expiresAtUtc: Now.AddHours(-1),
+            audience: ExpectedAudience,
+            issuer: ExpectedIssuer);
+
+        var result = validator.ValidateForAuthorization(token);
+
+        Assert.False(result.IsValid);
+        Assert.Null(result.Subject);
+    }
+
+    [Fact]
+    public void ValidateForAuthorization_NotYetValid_IsNotValid()
+    {
+        var validator = MakeValidator();
+        var token = _key.CreateAuthorizationToken(
+            expiresAtUtc: Now.AddHours(1),
+            audience: ExpectedAudience,
+            issuer: ExpectedIssuer,
+            notBeforeUtc: Now.AddMinutes(30));
+
+        var result = validator.ValidateForAuthorization(token);
+
+        Assert.False(result.IsValid);
+        Assert.Null(result.Subject);
+    }
+
+    [Fact]
+    public void ValidateForAuthorization_ValidTokenWithAudienceArrayContainingExpected_IsValid()
+    {
+        // Supabase can mint the audience as an array; the expected value appearing in it is accepted.
+        var validator = MakeValidator();
+        var token = _key.CreateAuthorizationToken(
+            expiresAtUtc: Now.AddHours(1),
+            audience: null,
+            issuer: ExpectedIssuer,
+            audienceValues: new[] { "another-service", ExpectedAudience });
+
+        var result = validator.ValidateForAuthorization(token);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void ValidateForAuthorization_TamperedSignature_IsNotValid()
+    {
+        var validator = MakeValidator();
+        var token = _key.CreateAuthorizationToken(
+            expiresAtUtc: Now.AddHours(1),
+            audience: ExpectedAudience,
+            issuer: ExpectedIssuer);
+        var tampered = token[..^1] + (token[^1] == 'A' ? 'B' : 'A');
+
+        var result = validator.ValidateForAuthorization(tampered);
+
+        Assert.False(result.IsValid);
+        Assert.Null(result.Subject);
+    }
+
+    [Fact]
+    public void ValidateForAuthorization_WithoutExpectedAudienceOrIssuerConfigured_Throws()
+    {
+        // Authorization-mode validation fails loud when the expected values are not configured,
+        // rather than silently skipping the audience/issuer checks (no fallback programming).
+        var validator = new JwtAccessTokenValidator(
+            TestJwt.SigningSecret, new FakeTimeProvider(Now), _key.PublicKeySetJson());
+        var token = _key.CreateAuthorizationToken(Now.AddHours(1), ExpectedAudience, ExpectedIssuer);
+
+        Assert.Throws<InvalidOperationException>(() => validator.ValidateForAuthorization(token));
+    }
+
+    [SuppressMessage("Performance", "CA1812", Justification = "Instantiated by tests via MakeValidator.")]
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+        public FakeTimeProvider(DateTime nowUtc) => _now = new DateTimeOffset(nowUtc, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}

--- a/src/CcDirector.Core/Account/JwtAccessTokenValidator.cs
+++ b/src/CcDirector.Core/Account/JwtAccessTokenValidator.cs
@@ -17,6 +17,20 @@ namespace CcDirector.Core.Account;
 public sealed record AccessTokenValidation(bool IsValid, bool IsExpiredButWellFormed, DateTime? ExpiresAtUtc);
 
 /// <summary>
+/// The outcome of validating a cached access token for AUTHORIZATION use - the stricter,
+/// inbound-credential check (epic #1069). A token is <see cref="IsValid"/> only when its signature
+/// verifies AND its audience, issuer, not-before, and expiry claims all pass AND it carries a
+/// non-empty subject. On success <see cref="Subject"/> carries the token's stable account/user id
+/// (the <c>sub</c> claim) so a later membership check can confirm the token belongs to this
+/// Gateway's account. On failure <see cref="InvalidReason"/> records why, for diagnostics.
+/// </summary>
+/// <param name="IsValid">True only when signature, audience, issuer, not-before, expiry, and subject all pass.</param>
+/// <param name="Subject">The token's <c>sub</c> (account/user id) claim on the valid case; null otherwise.</param>
+/// <param name="ExpiresAtUtc">The token's expiry instant, when present.</param>
+/// <param name="InvalidReason">A short reason for a not-valid result; null on the valid case.</param>
+public sealed record AuthorizationTokenValidation(bool IsValid, string? Subject, DateTime? ExpiresAtUtc, string? InvalidReason);
+
+/// <summary>
 /// Validates a cached access token entirely locally - signature and expiry only - with no network
 /// call. DevThrottle access tokens are Supabase JSON Web Tokens, and two signing schemes are
 /// supported: ES256 (the current Supabase signing keys - an elliptic-curve P-256 signature verified
@@ -31,9 +45,14 @@ public sealed class JwtAccessTokenValidator
     private readonly byte[] _signingSecret;
     private readonly IReadOnlyList<VerificationKey> _publicKeys;
     private readonly TimeProvider _timeProvider;
+    private readonly string? _expectedAudience;
+    private readonly string? _expectedIssuer;
 
     /// <summary>One elliptic-curve P-256 public verification key from the configured key set.</summary>
     private sealed record VerificationKey(string? KeyId, ECParameters PublicKey);
+
+    /// <summary>A token whose structure and signature verified, carrying its decoded payload JSON.</summary>
+    private sealed record VerifiedToken(string? Algorithm, string PayloadJson);
 
     /// <summary>
     /// Creates the validator with the verification material for both supported signing schemes.
@@ -46,7 +65,22 @@ public sealed class JwtAccessTokenValidator
     /// or empty means no ES256 keys are configured, so every ES256 token is reported not valid. A
     /// malformed document throws - a broken key configuration must fail loud, not validate nothing.
     /// </param>
-    public JwtAccessTokenValidator(string signingSecret, TimeProvider? timeProvider = null, string? publicKeySetJson = null)
+    /// <param name="expectedAudience">
+    /// The audience (<c>aud</c>) value a token must carry to pass authorization-mode validation
+    /// (see <see cref="ValidateForAuthorization"/>). Supplied as configuration, not hard-coded at the
+    /// call site. Null when this validator is only used for the outbound-call check (<see cref="Validate"/>);
+    /// authorization-mode validation then fails loud rather than silently skipping the audience check.
+    /// </param>
+    /// <param name="expectedIssuer">
+    /// The issuer (<c>iss</c>) value a token must carry to pass authorization-mode validation. Supplied
+    /// as configuration, not hard-coded at the call site. Null when only <see cref="Validate"/> is used.
+    /// </param>
+    public JwtAccessTokenValidator(
+        string signingSecret,
+        TimeProvider? timeProvider = null,
+        string? publicKeySetJson = null,
+        string? expectedAudience = null,
+        string? expectedIssuer = null)
     {
         if (string.IsNullOrEmpty(signingSecret))
             throw new ArgumentException("Signing secret is required", nameof(signingSecret));
@@ -54,6 +88,8 @@ public sealed class JwtAccessTokenValidator
         _signingSecret = Encoding.UTF8.GetBytes(signingSecret);
         _publicKeys = ParsePublicKeySet(publicKeySetJson);
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _expectedAudience = expectedAudience;
+        _expectedIssuer = expectedIssuer;
     }
 
     /// <summary>
@@ -64,18 +100,95 @@ public sealed class JwtAccessTokenValidator
     /// </summary>
     public AccessTokenValidation Validate(string accessToken)
     {
+        var verified = VerifySignature(accessToken);
+        if (verified is null)
+            return new AccessTokenValidation(IsValid: false, IsExpiredButWellFormed: false, ExpiresAtUtc: null);
+
+        using var doc = JsonDocument.Parse(verified.PayloadJson);
+        var expiresAtUtc = ReadUnixTimeClaim(doc.RootElement, "exp");
+        var nowUtc = _timeProvider.GetUtcNow().UtcDateTime;
+        var expired = expiresAtUtc is not null && expiresAtUtc.Value <= nowUtc;
+
+        FileLog.Write($"[JwtAccessTokenValidator] Validate: signature OK ({verified.Algorithm}), expiresAtUtc={expiresAtUtc:o}, expired={expired}");
+        return new AccessTokenValidation(IsValid: !expired, IsExpiredButWellFormed: expired, ExpiresAtUtc: expiresAtUtc);
+    }
+
+    /// <summary>
+    /// Validates the access token for AUTHORIZATION use (epic #1069) entirely locally - no network
+    /// call. This is the stricter, inbound-credential check: on top of the signature and <c>exp</c>
+    /// expiry that <see cref="Validate"/> checks, it also honours the <c>nbf</c> not-before instant
+    /// and requires the token's <c>aud</c> (audience) and <c>iss</c> (issuer) claims to match the
+    /// expected values supplied at construction, so a correctly-signed token minted for a different
+    /// audience or issuer is rejected. On success it returns the token's <c>sub</c> (account/user id)
+    /// so a later membership check can confirm the token belongs to this Gateway's account.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The expected audience or issuer was not supplied at construction. Authorization-mode validation
+    /// fails loud on a missing expected value rather than silently skipping the check.
+    /// </exception>
+    public AuthorizationTokenValidation ValidateForAuthorization(string accessToken)
+    {
+        if (string.IsNullOrWhiteSpace(_expectedAudience) || string.IsNullOrWhiteSpace(_expectedIssuer))
+            throw new InvalidOperationException(
+                "ValidateForAuthorization requires the expected audience and issuer to be configured at construction");
+
+        AuthorizationTokenValidation Reject(string reason)
+        {
+            FileLog.Write($"[JwtAccessTokenValidator] ValidateForAuthorization: not valid - {reason}");
+            return new AuthorizationTokenValidation(IsValid: false, Subject: null, ExpiresAtUtc: null, InvalidReason: reason);
+        }
+
+        var verified = VerifySignature(accessToken);
+        if (verified is null)
+            return Reject("signature did not verify or the token is malformed");
+
+        using var doc = JsonDocument.Parse(verified.PayloadJson);
+        var root = doc.RootElement;
+        var nowUtc = _timeProvider.GetUtcNow().UtcDateTime;
+
+        var expiresAtUtc = ReadUnixTimeClaim(root, "exp");
+        if (expiresAtUtc is not null && expiresAtUtc.Value <= nowUtc)
+            return Reject("token has expired (exp is in the past)");
+
+        var notBeforeUtc = ReadUnixTimeClaim(root, "nbf");
+        if (notBeforeUtc is not null && notBeforeUtc.Value > nowUtc)
+            return Reject("token is not yet valid (nbf is in the future)");
+
+        if (!AudienceMatches(root, _expectedAudience))
+            return Reject("audience (aud) claim does not match the expected audience");
+
+        var issuer = ReadStringClaim(root, "iss");
+        if (!string.Equals(issuer, _expectedIssuer, StringComparison.Ordinal))
+            return Reject("issuer (iss) claim does not match the expected issuer");
+
+        var subject = ReadStringClaim(root, "sub");
+        if (string.IsNullOrEmpty(subject))
+            return Reject("subject (sub) claim is missing");
+
+        FileLog.Write($"[JwtAccessTokenValidator] ValidateForAuthorization: token accepted ({verified.Algorithm}), expiresAtUtc={expiresAtUtc:o}");
+        return new AuthorizationTokenValidation(IsValid: true, Subject: subject, ExpiresAtUtc: expiresAtUtc, InvalidReason: null);
+    }
+
+    /// <summary>
+    /// Verifies the token's structure and signature and returns its decoded payload JSON on success,
+    /// or null when the token is not a three-part JSON Web Token, its header is malformed, its
+    /// algorithm is unsupported, or its signature does not verify. Both <see cref="Validate"/> and
+    /// <see cref="ValidateForAuthorization"/> go through this single, fully-local signature path.
+    /// </summary>
+    private VerifiedToken? VerifySignature(string accessToken)
+    {
         var parts = accessToken?.Split('.') ?? Array.Empty<string>();
         if (parts.Length != 3)
         {
-            FileLog.Write("[JwtAccessTokenValidator] Validate: not a three-part JSON Web Token");
-            return new AccessTokenValidation(IsValid: false, IsExpiredButWellFormed: false, ExpiresAtUtc: null);
+            FileLog.Write("[JwtAccessTokenValidator] VerifySignature: not a three-part JSON Web Token");
+            return null;
         }
 
         var header = ReadHeader(parts[0]);
         if (header is null)
         {
-            FileLog.Write("[JwtAccessTokenValidator] Validate: token header is malformed");
-            return new AccessTokenValidation(IsValid: false, IsExpiredButWellFormed: false, ExpiresAtUtc: null);
+            FileLog.Write("[JwtAccessTokenValidator] VerifySignature: token header is malformed");
+            return null;
         }
 
         var signatureVerifies = header.Value.Algorithm switch
@@ -86,14 +199,16 @@ public sealed class JwtAccessTokenValidator
         };
 
         if (!signatureVerifies)
-            return new AccessTokenValidation(IsValid: false, IsExpiredButWellFormed: false, ExpiresAtUtc: null);
+            return null;
 
-        var expiresAtUtc = ReadExpiry(parts[1]);
-        var nowUtc = _timeProvider.GetUtcNow().UtcDateTime;
-        var expired = expiresAtUtc is not null && expiresAtUtc.Value <= nowUtc;
+        var payloadJson = DecodeSegment(parts[1]);
+        if (payloadJson is null)
+        {
+            FileLog.Write("[JwtAccessTokenValidator] VerifySignature: payload segment could not be decoded");
+            return null;
+        }
 
-        FileLog.Write($"[JwtAccessTokenValidator] Validate: signature OK ({header.Value.Algorithm}), expiresAtUtc={expiresAtUtc:o}, expired={expired}");
-        return new AccessTokenValidation(IsValid: !expired, IsExpiredButWellFormed: expired, ExpiresAtUtc: expiresAtUtc);
+        return new VerifiedToken(header.Value.Algorithm, payloadJson);
     }
 
     /// <summary>
@@ -227,17 +342,51 @@ public sealed class JwtAccessTokenValidator
         return keys;
     }
 
-    private static DateTime? ReadExpiry(string encodedPayload)
+    /// <summary>
+    /// Reads a Unix-time (seconds-since-epoch) claim such as <c>exp</c> or <c>nbf</c> from the payload,
+    /// or null when it is absent or not a number.
+    /// </summary>
+    private static DateTime? ReadUnixTimeClaim(JsonElement payload, string claimName)
     {
-        var payloadJson = DecodeSegment(encodedPayload);
-        if (payloadJson is null)
+        if (!payload.TryGetProperty(claimName, out var value) || value.ValueKind != JsonValueKind.Number)
             return null;
 
-        using var doc = JsonDocument.Parse(payloadJson);
-        if (!doc.RootElement.TryGetProperty("exp", out var exp) || exp.ValueKind != JsonValueKind.Number)
-            return null;
+        return DateTimeOffset.FromUnixTimeSeconds(value.GetInt64()).UtcDateTime;
+    }
 
-        return DateTimeOffset.FromUnixTimeSeconds(exp.GetInt64()).UtcDateTime;
+    /// <summary>Reads a string claim from the payload, or null when it is absent or not a string.</summary>
+    private static string? ReadStringClaim(JsonElement payload, string claimName)
+    {
+        if (payload.TryGetProperty(claimName, out var value) && value.ValueKind == JsonValueKind.String)
+            return value.GetString();
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns true when the payload's <c>aud</c> claim contains <paramref name="expectedAudience"/>.
+    /// Per RFC 7519 the audience is either a single string or an array of strings; both shapes are
+    /// accepted, matching case-sensitively (an ordinal comparison, as claim values are exact tokens).
+    /// </summary>
+    private static bool AudienceMatches(JsonElement payload, string expectedAudience)
+    {
+        if (!payload.TryGetProperty("aud", out var aud))
+            return false;
+
+        if (aud.ValueKind == JsonValueKind.String)
+            return string.Equals(aud.GetString(), expectedAudience, StringComparison.Ordinal);
+
+        if (aud.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var entry in aud.EnumerateArray())
+            {
+                if (entry.ValueKind == JsonValueKind.String
+                    && string.Equals(entry.GetString(), expectedAudience, StringComparison.Ordinal))
+                    return true;
+            }
+        }
+
+        return false;
     }
 
     private static string? DecodeSegment(string segment)


### PR DESCRIPTION
Closes thefrederiksen/devthrottle#1074. Part of epic thefrederiksen/devthrottle_internal#675 (Phase 1).

## Release Notes
The local cloud access-token validator gains an authorization-grade validation path. On top of the existing signature + `exp` checks (used to authorize the Gateway's outbound cloud calls), it can now also verify the audience (`aud`), issuer (`iss`), and not-before (`nbf`) claims and extract the subject (`sub`). This is the foundation for using a cloud session as a first-class INBOUND credential (epic thefrederiksen/devthrottle_internal#675). Validation stays fully local - no per-request cloud call.

## Changes
- `JwtAccessTokenValidator.cs`: new `AuthorizationTokenValidation` record and `ValidateForAuthorization(...)` method (signature + exp + nbf + aud + iss + non-empty sub). Two new optional constructor params `expectedAudience`/`expectedIssuer` supplied as configuration (not hard-coded at the call site), mirroring `signingSecret`/`publicKeySetJson`. Existing `Validate(...)` behaviour and all existing call sites are unchanged; both paths now share one local `VerifySignature` code path. Audience matching accepts both the single-string and array `aud` forms (RFC 7519).
- Tests: `Es256TestKey.CreateAuthorizationToken(...)` helper + new `JwtAccessTokenValidatorAuthorizationTests` (8 tests).

## How to Test
`dotnet test src/CcDirector.Core.Tests/CcDirector.Core.Tests.csproj --filter "FullyQualifiedName~JwtAccessTokenValidator"`

## Expected Result
New authorization tests: 8 passed, 0 failed. Whole Core project: 2837 passed, 8 skipped, 0 failed. Build: 0 warnings, 0 errors.

## No network call
All tests construct the validator with only local key material and no HTTP handler; the validation method has no HttpClient/network dependency (code inspection). Validation is entirely local.

## Proof
`docs/cencon/proof/issue-1074/report.html` (and `authorization-tests-output.txt`).

## CenCon impact
No architecture drift, no security-posture regression (strengthens claim checking; relaxes no blocking rule). Container: CcDirector.Core only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)