### PR TITLE
Fix #1079: Gateway account-membership check - accept a cloud session only for the account that owns this Gateway

### DIFF
--- a/docs/cencon/proof/issue-1079/core-subject-tests.txt
+++ b/docs/cencon/proof/issue-1079/core-subject-tests.txt
@@ -1,0 +1,5 @@
+  Passed CcDirector.Core.Tests.Account.DevThrottleAccountServiceTests.GetAccountSubject_StoredCredential_ReturnsSubjectWithoutNetwork [243 ms]
+  Passed CcDirector.Core.Tests.Account.DevThrottleAccountServiceTests.GetAccountSubject_NoStoredCredential_ReturnsNull [< 1 ms]
+  Passed CcDirector.Core.Tests.Account.JwtIdentityReaderTests.ReadSubject_TokenWithoutSubjectClaim_ReturnsNull [< 1 ms]
+  Passed CcDirector.Core.Tests.Account.JwtIdentityReaderTests.ReadSubject_MalformedToken_ReturnsNull [< 1 ms]
+  Passed CcDirector.Core.Tests.Account.JwtIdentityReaderTests.ReadSubject_TokenWithSubjectClaim_ReturnsSubject [< 1 ms]

--- a/docs/cencon/proof/issue-1079/membership-tests.txt
+++ b/docs/cencon/proof/issue-1079/membership-tests.txt
@@ -1,0 +1,5 @@
+  Passed CcDirector.Gateway.Tests.Account.GatewayAccountMembershipTests.Check_TokenForSameAccount_IsMember [36 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayAccountMembershipTests.Check_TokenForDifferentAccount_IsNotMember [2 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayAccountMembershipTests.Check_PresentedTokenNotAuthorizationValid_IsNotMember [1 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayAccountMembershipTests.Check_ReasonStrings_CarryNoPersonallyIdentifyingInformation [1 ms]
+  Passed CcDirector.Gateway.Tests.Account.GatewayAccountMembershipTests.Check_GatewayNotSignedIn_IsNotMember [< 1 ms]

--- a/docs/cencon/proof/issue-1079/qa-independent-tests.cs.txt
+++ b/docs/cencon/proof/issue-1079/qa-independent-tests.cs.txt
@@ -1,0 +1,175 @@
+using CcDirector.Core.Account;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Account;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Account;
+
+/// <summary>
+/// QA Agent's OWN independent verification of issue #1079 (written fresh, not the developer's tests).
+/// Uses realistic globally-unique-identifier shaped account subjects, exercises the full accept /
+/// refuse / signed-out matrix, captures the ACTUAL log lines the membership check emits and asserts
+/// they carry no personally identifiable information (no subject id, no email marker, no token text),
+/// and proves the check is fully local by wiring a token refresher that throws on any use.
+/// THIS FILE IS QA-ONLY PROOF and is removed before the pull request is merged.
+/// </summary>
+public sealed class QaIndependentMembershipTests : IDisposable
+{
+    private static readonly DateTime Now = new(2026, 7, 6, 15, 0, 0, DateTimeKind.Utc);
+
+    // Realistic Supabase-shaped account subjects (globally unique identifiers).
+    private const string AccountA = "9f3c1c2e-7a41-4a2b-8f6d-0b5e2d9c4a11";
+    private const string AccountB = "2b7d8e90-1f34-4c56-a789-cdef01234567";
+
+    private readonly string _tempDir;
+
+    public QaIndependentMembershipTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "qa-1079-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private GatewayAccountMembership MakeMembership(string? signedInSubject)
+    {
+        var store = new QaInMemoryStore();
+        var validator = new JwtAccessTokenValidator("qa-independent-secret-not-used-by-check");
+        var eventLog = new AuthEventLog(Path.Combine(_tempDir, "auth-events.jsonl"));
+        var service = new DevThrottleAccountService(store, validator, eventLog, new QaThrowingRefresher());
+
+        if (signedInSubject is not null)
+        {
+            var ownToken = GatewayTestJwt.CreateWithSubject(Now.AddHours(2), signedInSubject);
+            service.StoreTokens(new DevThrottleTokens(ownToken, "qa-refresh-token"));
+        }
+
+        return new GatewayAccountMembership(service);
+    }
+
+    private static AuthorizationTokenValidation Valid(string subject) =>
+        new(IsValid: true, Subject: subject, ExpiresAtUtc: Now.AddHours(1), InvalidReason: null);
+
+    // Criterion 1: signed in as A, presented token subject A -> accept.
+    [Fact]
+    public void Qa_SameAccount_Accepted()
+    {
+        var result = MakeMembership(AccountA).Check(Valid(AccountA));
+        Assert.True(result.IsMember);
+    }
+
+    // Criterion 2: signed in as A, presented token subject B -> refuse.
+    [Fact]
+    public void Qa_DifferentAccount_Refused()
+    {
+        var result = MakeMembership(AccountA).Check(Valid(AccountB));
+        Assert.False(result.IsMember);
+    }
+
+    // Criterion 2 strictness: subjects that differ only by letter case are DIFFERENT accounts
+    // (comparison must be ordinal, not case-insensitive).
+    [Fact]
+    public void Qa_SubjectDifferingOnlyByCase_Refused()
+    {
+        var result = MakeMembership(AccountA).Check(Valid(AccountA.ToUpperInvariant()));
+        Assert.False(result.IsMember);
+    }
+
+    // Criterion 3: signed-out Gateway (no stored credential) refuses ANY token, even a valid one.
+    [Fact]
+    public void Qa_SignedOutGateway_RefusesEverything()
+    {
+        var result = MakeMembership(signedInSubject: null).Check(Valid(AccountA));
+        Assert.False(result.IsMember);
+    }
+
+    // Defence in depth: a presented validation that is not valid, or carries no subject, is refused
+    // even when the Gateway IS signed in and the (absent) subject would otherwise "match".
+    [Fact]
+    public void Qa_InvalidOrSubjectlessPresentedToken_Refused()
+    {
+        var membership = MakeMembership(AccountA);
+
+        var notValid = membership.Check(new AuthorizationTokenValidation(false, AccountA, Now, "expired"));
+        var noSubject = membership.Check(new AuthorizationTokenValidation(true, null, Now.AddHours(1), null));
+        var emptySubject = membership.Check(new AuthorizationTokenValidation(true, "", Now.AddHours(1), null));
+
+        Assert.False(notValid.IsMember);
+        Assert.False(noSubject.IsMember);
+        Assert.False(emptySubject.IsMember);
+    }
+
+    // Criterion 5 (personally identifiable information): capture the ACTUAL log lines emitted across
+    // accept, mismatch, and signed-out decisions - including the DevThrottleAccountService and
+    // JwtIdentityReader lines underneath - and assert none contains an account subject, an email
+    // marker, or any fragment of a token.
+    [Fact]
+    public void Qa_ActualLogLines_ContainNoPersonallyIdentifiableInformation()
+    {
+        using var logScope = FileLog.RedirectForTests();
+
+        var signedIn = MakeMembership(AccountA);
+        var accept = signedIn.Check(Valid(AccountA));
+        var mismatch = signedIn.Check(Valid(AccountB));
+        var signedOut = MakeMembership(signedInSubject: null).Check(Valid(AccountA));
+
+        Assert.True(accept.IsMember);
+        Assert.False(mismatch.IsMember);
+        Assert.False(signedOut.IsMember);
+
+        var ownToken = GatewayTestJwt.CreateWithSubject(Now.AddHours(2), AccountA);
+        var lines = logScope.DrainAndReadLines();
+        Assert.NotEmpty(lines);
+        var dumpPath = Environment.GetEnvironmentVariable("QA_1079_LOG_DUMP");
+        if (!string.IsNullOrEmpty(dumpPath))
+            File.WriteAllLines(dumpPath, lines);
+        foreach (var line in lines)
+        {
+            Assert.DoesNotContain(AccountA, line, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(AccountB, line, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("@", line, StringComparison.Ordinal);
+            Assert.DoesNotContain(ownToken.Split('.')[1], line, StringComparison.Ordinal);
+        }
+
+        // The Reason strings surfaced to callers are also free of identifying values.
+        foreach (var reason in new[] { accept.Reason, mismatch.Reason, signedOut.Reason })
+        {
+            Assert.DoesNotContain(AccountA, reason, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(AccountB, reason, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("@", reason, StringComparison.Ordinal);
+        }
+    }
+
+    // Criterion 4 (fully local): the refresher throws on ANY use and no HTTP handler exists anywhere
+    // in the fixture - a network attempt of any kind would fail these tests. Run the whole decision
+    // matrix under that constraint.
+    [Fact]
+    public void Qa_WholeDecisionMatrix_MakesNoNetworkCall()
+    {
+        var membership = MakeMembership(AccountA);
+
+        Assert.True(membership.Check(Valid(AccountA)).IsMember);
+        Assert.False(membership.Check(Valid(AccountB)).IsMember);
+        Assert.False(MakeMembership(null).Check(Valid(AccountA)).IsMember);
+        // Reaching here means the throwing refresher was never invoked and no handler was needed.
+    }
+
+    private sealed class QaInMemoryStore : IProtectedTokenStore
+    {
+        private DevThrottleTokens? _tokens;
+        public bool HasTokens => _tokens is not null;
+        public void Save(DevThrottleTokens tokens) => _tokens = tokens;
+        public DevThrottleTokens? Load() => _tokens;
+        public void Clear() => _tokens = null;
+    }
+
+    private sealed class QaThrowingRefresher : ITokenRefresher
+    {
+        public Task<TokenRefreshResult> RefreshAsync(string refreshToken, CancellationToken ct = default) =>
+            throw new InvalidOperationException("QA: the membership check must never reach the network seam");
+    }
+}

--- a/docs/cencon/proof/issue-1079/qa-log-sample.txt
+++ b/docs/cencon/proof/issue-1079/qa-log-sample.txt
@@ -1,0 +1,16 @@
+2026-07-06 12:06:49.933 [DevThrottleAccountService] StoreTokens: storing token pair in credential store
+2026-07-06 12:06:49.934 [AuthEventLog] RecordLoggedIn
+2026-07-06 12:06:49.940 [DevThrottleAccountService] StoreTokens: stored
+2026-07-06 12:06:49.940 [DevThrottleAccountService] GetAccountSubject: reading the account subject from the cached credential (no network call)
+2026-07-06 12:06:49.941 [JwtIdentityReader] ReadSubject: extracting the subject claim from the cached access token (no network call)
+2026-07-06 12:06:49.942 [JwtIdentityReader] ReadSubject: subject resolved
+2026-07-06 12:06:49.942 [DevThrottleAccountService] GetAccountSubject: subject=resolved
+2026-07-06 12:06:49.942 [GatewayAccountMembership] Check: accept - the presented token's account matches this Gateway's account
+2026-07-06 12:06:49.942 [DevThrottleAccountService] GetAccountSubject: reading the account subject from the cached credential (no network call)
+2026-07-06 12:06:49.942 [JwtIdentityReader] ReadSubject: extracting the subject claim from the cached access token (no network call)
+2026-07-06 12:06:49.942 [JwtIdentityReader] ReadSubject: subject resolved
+2026-07-06 12:06:49.942 [DevThrottleAccountService] GetAccountSubject: subject=resolved
+2026-07-06 12:06:49.942 [GatewayAccountMembership] Check: refuse - the presented token's account does not match this Gateway's account
+2026-07-06 12:06:49.942 [DevThrottleAccountService] GetAccountSubject: reading the account subject from the cached credential (no network call)
+2026-07-06 12:06:49.942 [DevThrottleAccountService] GetAccountSubject: no stored credential -> no subject
+2026-07-06 12:06:49.942 [GatewayAccountMembership] Check: refuse - this Gateway has no signed-in account

--- a/docs/cencon/proof/issue-1079/qa-report.html
+++ b/docs/cencon/proof/issue-1079/qa-report.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Verification Report - Issue 1079</title>
+<style>
+body { font-family: Segoe UI, Arial, sans-serif; max-width: 1000px; margin: 2em auto; color: #222; line-height: 1.5; }
+h1 { border-bottom: 3px solid #2b6cb0; padding-bottom: 8px; }
+h2 { color: #2b6cb0; margin-top: 1.6em; }
+table { border-collapse: collapse; width: 100%; margin: 1em 0; }
+th, td { border: 1px solid #cbd5e0; padding: 8px 10px; text-align: left; vertical-align: top; }
+th { background: #edf2f7; }
+.pass { color: #276749; font-weight: bold; }
+pre { background: #f7fafc; border: 1px solid #e2e8f0; padding: 12px; overflow-x: auto; font-size: 13px; }
+.verdict { background: #f0fff4; border: 2px solid #276749; padding: 14px 18px; font-size: 1.1em; margin: 1.5em 0; }
+.note { background: #fffaf0; border: 1px solid #ed8936; padding: 10px 14px; }
+</style>
+</head>
+<body>
+<h1>QA Verification Report - Issue #1079</h1>
+<p><strong>Issue:</strong> [Gateway] Account-membership check: accept a cloud session only for the account that owns this Gateway (epic #1069, Phase A)<br>
+<strong>Pull request:</strong> #1108 (branch <code>issue-1079-account-membership</code>, head <code>de2dc18d</code>)<br>
+<strong>QA Agent:</strong> independent verification in an isolated git worktree, fresh checkout of the pull request head - the developer's binaries, tests, and proof were NOT reused as evidence.<br>
+<strong>Date:</strong> 2026-07-06</p>
+
+<div class="note"><strong>Rescope note (epic #1069 design simplification, 2026-07-06):</strong> the epic dropped "cloud session as a standing per-request credential". This membership check is the enrollment / sign-in-guard seam, not a per-request AuthMiddleware credential. The component was verified against the issue's own acceptance criteria, which are unchanged by the rescope. QA confirmed the component is standalone: no references to <code>GatewayAccountMembership</code> exist outside its own file and its tests, and <code>AuthMiddleware</code> is untouched by the diff.</div>
+
+<h2>How QA verified (independent of the developer)</h2>
+<ul>
+<li>Created an isolated worktree at the pull request head <code>de2dc18d</code> (detached; never the shared checkout).</li>
+<li>Built the full solution: <strong>Build succeeded, 0 Warning(s), 0 Error(s)</strong>.</li>
+<li>Ran the developer's tests, then wrote and ran QA's OWN seven-test suite (<code>QaIndependentMembershipTests</code>, temporary file, removed after the run - source reproduced below) with realistic globally-unique-identifier subjects, a case-sensitivity strictness check, invalid/subject-less presented tokens, a throwing token refresher proving no network call, and a capture of the ACTUAL log lines via the <code>FileLog.RedirectForTests</code> seam.</li>
+<li>Ran the full Gateway and Core test suites as the regression sweep.</li>
+<li>Verified the merged result (pull request head on top of <code>origin/main</code>) - the merge fast-forwards because the pull request branched from the current main tip <code>a6d0c763</code> (the #1074 dependency), so the merged tree is identical to the verified tree.</li>
+</ul>
+
+<h2>Acceptance criteria - Expected vs Actual</h2>
+<table>
+<tr><th>#</th><th>Criterion</th><th>Expected</th><th>Actual (QA's own evidence)</th><th>Verdict</th></tr>
+<tr><td>1</td><td>Gateway signed in as account A + token with subject A</td><td>Membership check returns accept</td><td>Developer test <code>Check_TokenForSameAccount_IsMember</code> passed AND QA's own <code>Qa_SameAccount_Accepted</code> (globally-unique-identifier subject <code>9f3c1c2e-...</code>) passed: <code>IsMember == true</code></td><td class="pass">PASS</td></tr>
+<tr><td>2</td><td>Gateway signed in as account A + token with subject B</td><td>Membership check returns refuse</td><td><code>Check_TokenForDifferentAccount_IsNotMember</code> passed AND QA's <code>Qa_DifferentAccount_Refused</code> passed; QA additionally proved comparison is ordinal (case-different subject refused, <code>Qa_SubjectDifferingOnlyByCase_Refused</code>)</td><td class="pass">PASS</td></tr>
+<tr><td>3</td><td>Gateway has no signed-in identity</td><td>Any presented token refused</td><td><code>Check_GatewayNotSignedIn_IsNotMember</code> passed AND QA's <code>Qa_SignedOutGateway_RefusesEverything</code> passed (no stored credential, valid token for A refused)</td><td class="pass">PASS</td></tr>
+<tr><td>4</td><td>No network call per check (fully local)</td><td>Tests run with no HTTP handler; code reads local cached identity only</td><td>QA fixture wires a token refresher that THROWS on any use and no HTTP handler exists; the entire decision matrix ran green (<code>Qa_WholeDecisionMatrix_MakesNoNetworkCall</code>). Code inspection: <code>Check</code> reads <code>DevThrottleAccountService.GetAccountSubject()</code> which only does <code>_store.Load()</code> under the lock plus a local base64 payload decode in <code>JwtIdentityReader.ReadSubject</code> - no HttpClient, no refresher use</td><td class="pass">PASS</td></tr>
+<tr><td>5</td><td>No personally identifiable information in any log line (no email, no raw subject, no token)</td><td>Accept/refuse log lines carry only fixed, non-identifying text</td><td>QA captured the ACTUAL log lines emitted across accept / mismatch / signed-out decisions (sample below) and asserted programmatically (<code>Qa_ActualLogLines_ContainNoPersonallyIdentifiableInformation</code>) that no line contains either account subject, an @ character, or any fragment of the token payload. All fixed strings; <code>GetAccountSubject</code> logs only <code>subject=resolved</code> / <code>&lt;none&gt;</code></td><td class="pass">PASS</td></tr>
+<tr><td>6</td><td><code>dotnet test</code> for the affected projects green</td><td>All membership and subject tests pass</td><td>Developer's 5 Gateway membership tests + 5 Core subject tests: all passed in QA's own run. QA's own 7 tests: all passed. Full suites: see regression sweep</td><td class="pass">PASS</td></tr>
+</table>
+
+<h2>Captured log sample (criterion 5)</h2>
+<p>Actual lines written by the membership check flow, drained synchronously via the test log seam - accept, mismatch, and signed-out. The signed-in subject was <code>9f3c1c2e-7a41-4a2b-8f6d-0b5e2d9c4a11</code> and the presented mismatching subject was <code>2b7d8e90-1f34-4c56-a789-cdef01234567</code>; neither value (nor any email or token text) appears:</p>
+<pre>2026-07-06 12:06:49.933 [DevThrottleAccountService] StoreTokens: storing token pair in credential store
+2026-07-06 12:06:49.934 [AuthEventLog] RecordLoggedIn
+2026-07-06 12:06:49.940 [DevThrottleAccountService] StoreTokens: stored
+2026-07-06 12:06:49.940 [DevThrottleAccountService] GetAccountSubject: reading the account subject from the cached credential (no network call)
+2026-07-06 12:06:49.941 [JwtIdentityReader] ReadSubject: extracting the subject claim from the cached access token (no network call)
+2026-07-06 12:06:49.942 [JwtIdentityReader] ReadSubject: subject resolved
+2026-07-06 12:06:49.942 [DevThrottleAccountService] GetAccountSubject: subject=resolved
+2026-07-06 12:06:49.942 [GatewayAccountMembership] Check: accept - the presented token&#x27;s account matches this Gateway&#x27;s account
+2026-07-06 12:06:49.942 [DevThrottleAccountService] GetAccountSubject: reading the account subject from the cached credential (no network call)
+2026-07-06 12:06:49.942 [JwtIdentityReader] ReadSubject: extracting the subject claim from the cached access token (no network call)
+2026-07-06 12:06:49.942 [JwtIdentityReader] ReadSubject: subject resolved
+2026-07-06 12:06:49.942 [DevThrottleAccountService] GetAccountSubject: subject=resolved
+2026-07-06 12:06:49.942 [GatewayAccountMembership] Check: refuse - the presented token&#x27;s account does not match this Gateway&#x27;s account
+2026-07-06 12:06:49.942 [DevThrottleAccountService] GetAccountSubject: reading the account subject from the cached credential (no network call)
+2026-07-06 12:06:49.942 [DevThrottleAccountService] GetAccountSubject: no stored credential -&gt; no subject
+2026-07-06 12:06:49.942 [GatewayAccountMembership] Check: refuse - this Gateway has no signed-in account
+</pre>
+
+<h2>Regression sweep</h2>
+<pre>Full test suites run by QA in the isolated worktree (all on the merged tree, which is byte-identical to the pull request head because the merge fast-forwards from the current main tip):
+
+  CcDirector.Gateway.Tests (full):  Passed! 1318/1318   (clean uncontended run)
+  CcDirector.Core.Tests (full):     Passed! 2842 passed, 0 failed, 8 skipped (pre-existing skips)
+  Developer's membership tests:     5/5 passed (Gateway) + 5/5 passed (Core subject tests)
+  QA's own independent tests:       7/7 passed
+
+Flakiness investigation (documented for transparency): two of five full Gateway.Tests runs during this QA session showed an identical cluster of 30 failing tests (DispatchEndpointTests, ExecuteActionEndpointTests, ToolRunEndpointTests, SessionNumberBackfillTests.BackfillEndpoint_RequiresBearerToken_WhenAuthEnabled). QA reproduced the SAME 30-test cluster on pure origin/main WITHOUT this pull request (1313 tests there; the pull request adds 5, all passing), and an immediate rerun on the same main binaries then passed 1313/1313. Every affected fixture also passes in isolation on the pull request tree. Conclusion: a pre-existing, nondeterministic, machine-environment-dependent flake on main, equal on both trees - zero test regressions are attributable to pull request #1108. The account/membership tests under verification passed in every single run.</pre>
+
+<h2>Scope and method checks</h2>
+<ul>
+<li>Diff touches exactly 10 files (component, subject reader, account-service accessor, tests, proof) - <code>AuthMiddleware</code> and the request pipeline are untouched (issue OUT scope respected; wiring is issue #1c's seam).</li>
+<li>No references to <code>GatewayAccountMembership</code> outside its own file and tests - the component is the standalone seam the rescoped epic expects.</li>
+<li>CenCon: <code>docs/cencon/</code> contains only proof directories in this repository - no architecture or security manifest existed to update; no blocking security rule violated. The change is security-positive (account-boundary refusal, personally-identifiable-information-free logging).</li>
+<li>Merge check: pull request head <code>de2dc18d</code> is a direct child of <code>origin/main</code> tip <code>a6d0c763</code> - merge is a clean fast-forward; merged tree == verified tree; merged build clean (0 warnings, 0 errors).</li>
+</ul>
+
+<h2>QA's own test source (run then removed - proof artifact)</h2>
+<pre>using CcDirector.Core.Account;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Account;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Account;
+
+/// &lt;summary&gt;
+/// QA Agent&#x27;s OWN independent verification of issue #1079 (written fresh, not the developer&#x27;s tests).
+/// Uses realistic globally-unique-identifier shaped account subjects, exercises the full accept /
+/// refuse / signed-out matrix, captures the ACTUAL log lines the membership check emits and asserts
+/// they carry no personally identifiable information (no subject id, no email marker, no token text),
+/// and proves the check is fully local by wiring a token refresher that throws on any use.
+/// THIS FILE IS QA-ONLY PROOF and is removed before the pull request is merged.
+/// &lt;/summary&gt;
+public sealed class QaIndependentMembershipTests : IDisposable
+{
+    private static readonly DateTime Now = new(2026, 7, 6, 15, 0, 0, DateTimeKind.Utc);
+
+    // Realistic Supabase-shaped account subjects (globally unique identifiers).
+    private const string AccountA = &quot;9f3c1c2e-7a41-4a2b-8f6d-0b5e2d9c4a11&quot;;
+    private const string AccountB = &quot;2b7d8e90-1f34-4c56-a789-cdef01234567&quot;;
+
+    private readonly string _tempDir;
+
+    public QaIndependentMembershipTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), &quot;qa-1079-&quot; + Guid.NewGuid().ToString(&quot;N&quot;));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private GatewayAccountMembership MakeMembership(string? signedInSubject)
+    {
+        var store = new QaInMemoryStore();
+        var validator = new JwtAccessTokenValidator(&quot;qa-independent-secret-not-used-by-check&quot;);
+        var eventLog = new AuthEventLog(Path.Combine(_tempDir, &quot;auth-events.jsonl&quot;));
+        var service = new DevThrottleAccountService(store, validator, eventLog, new QaThrowingRefresher());
+
+        if (signedInSubject is not null)
+        {
+            var ownToken = GatewayTestJwt.CreateWithSubject(Now.AddHours(2), signedInSubject);
+            service.StoreTokens(new DevThrottleTokens(ownToken, &quot;qa-refresh-token&quot;));
+        }
+
+        return new GatewayAccountMembership(service);
+    }
+
+    private static AuthorizationTokenValidation Valid(string subject) =&gt;
+        new(IsValid: true, Subject: subject, ExpiresAtUtc: Now.AddHours(1), InvalidReason: null);
+
+    // Criterion 1: signed in as A, presented token subject A -&gt; accept.
+    [Fact]
+    public void Qa_SameAccount_Accepted()
+    {
+        var result = MakeMembership(AccountA).Check(Valid(AccountA));
+        Assert.True(result.IsMember);
+    }
+
+    // Criterion 2: signed in as A, presented token subject B -&gt; refuse.
+    [Fact]
+    public void Qa_DifferentAccount_Refused()
+    {
+        var result = MakeMembership(AccountA).Check(Valid(AccountB));
+        Assert.False(result.IsMember);
+    }
+
+    // Criterion 2 strictness: subjects that differ only by letter case are DIFFERENT accounts
+    // (comparison must be ordinal, not case-insensitive).
+    [Fact]
+    public void Qa_SubjectDifferingOnlyByCase_Refused()
+    {
+        var result = MakeMembership(AccountA).Check(Valid(AccountA.ToUpperInvariant()));
+        Assert.False(result.IsMember);
+    }
+
+    // Criterion 3: signed-out Gateway (no stored credential) refuses ANY token, even a valid one.
+    [Fact]
+    public void Qa_SignedOutGateway_RefusesEverything()
+    {
+        var result = MakeMembership(signedInSubject: null).Check(Valid(AccountA));
+        Assert.False(result.IsMember);
+    }
+
+    // Defence in depth: a presented validation that is not valid, or carries no subject, is refused
+    // even when the Gateway IS signed in and the (absent) subject would otherwise &quot;match&quot;.
+    [Fact]
+    public void Qa_InvalidOrSubjectlessPresentedToken_Refused()
+    {
+        var membership = MakeMembership(AccountA);
+
+        var notValid = membership.Check(new AuthorizationTokenValidation(false, AccountA, Now, &quot;expired&quot;));
+        var noSubject = membership.Check(new AuthorizationTokenValidation(true, null, Now.AddHours(1), null));
+        var emptySubject = membership.Check(new AuthorizationTokenValidation(true, &quot;&quot;, Now.AddHours(1), null));
+
+        Assert.False(notValid.IsMember);
+        Assert.False(noSubject.IsMember);
+        Assert.False(emptySubject.IsMember);
+    }
+
+    // Criterion 5 (personally identifiable information): capture the ACTUAL log lines emitted across
+    // accept, mismatch, and signed-out decisions - including the DevThrottleAccountService and
+    // JwtIdentityReader lines underneath - and assert none contains an account subject, an email
+    // marker, or any fragment of a token.
+    [Fact]
+    public void Qa_ActualLogLines_ContainNoPersonallyIdentifiableInformation()
+    {
+        using var logScope = FileLog.RedirectForTests();
+
+        var signedIn = MakeMembership(AccountA);
+        var accept = signedIn.Check(Valid(AccountA));
+        var mismatch = signedIn.Check(Valid(AccountB));
+        var signedOut = MakeMembership(signedInSubject: null).Check(Valid(AccountA));
+
+        Assert.True(accept.IsMember);
+        Assert.False(mismatch.IsMember);
+        Assert.False(signedOut.IsMember);
+
+        var ownToken = GatewayTestJwt.CreateWithSubject(Now.AddHours(2), AccountA);
+        var lines = logScope.DrainAndReadLines();
+        Assert.NotEmpty(lines);
+        var dumpPath = Environment.GetEnvironmentVariable(&quot;QA_1079_LOG_DUMP&quot;);
+        if (!string.IsNullOrEmpty(dumpPath))
+            File.WriteAllLines(dumpPath, lines);
+        foreach (var line in lines)
+        {
+            Assert.DoesNotContain(AccountA, line, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(AccountB, line, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(&quot;@&quot;, line, StringComparison.Ordinal);
+            Assert.DoesNotContain(ownToken.Split(&#x27;.&#x27;)[1], line, StringComparison.Ordinal);
+        }
+
+        // The Reason strings surfaced to callers are also free of identifying values.
+        foreach (var reason in new[] { accept.Reason, mismatch.Reason, signedOut.Reason })
+        {
+            Assert.DoesNotContain(AccountA, reason, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(AccountB, reason, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(&quot;@&quot;, reason, StringComparison.Ordinal);
+        }
+    }
+
+    // Criterion 4 (fully local): the refresher throws on ANY use and no HTTP handler exists anywhere
+    // in the fixture - a network attempt of any kind would fail these tests. Run the whole decision
+    // matrix under that constraint.
+    [Fact]
+    public void Qa_WholeDecisionMatrix_MakesNoNetworkCall()
+    {
+        var membership = MakeMembership(AccountA);
+
+        Assert.True(membership.Check(Valid(AccountA)).IsMember);
+        Assert.False(membership.Check(Valid(AccountB)).IsMember);
+        Assert.False(MakeMembership(null).Check(Valid(AccountA)).IsMember);
+        // Reaching here means the throwing refresher was never invoked and no handler was needed.
+    }
+
+    private sealed class QaInMemoryStore : IProtectedTokenStore
+    {
+        private DevThrottleTokens? _tokens;
+        public bool HasTokens =&gt; _tokens is not null;
+        public void Save(DevThrottleTokens tokens) =&gt; _tokens = tokens;
+        public DevThrottleTokens? Load() =&gt; _tokens;
+        public void Clear() =&gt; _tokens = null;
+    }
+
+    private sealed class QaThrowingRefresher : ITokenRefresher
+    {
+        public Task&lt;TokenRefreshResult&gt; RefreshAsync(string refreshToken, CancellationToken ct = default) =&gt;
+            throw new InvalidOperationException(&quot;QA: the membership check must never reach the network seam&quot;);
+    }
+}
+</pre>
+
+<div class="verdict">VERIFIED - all acceptance criteria met. Issue #1079 PASSES independent QA verification.</div>
+</body>
+</html>

--- a/docs/cencon/proof/issue-1079/report.html
+++ b/docs/cencon/proof/issue-1079/report.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Issue #1079 - Gateway account-membership check - Proof</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+         max-width: 900px; margin: 2rem auto; padding: 0 1rem; line-height: 1.55; }
+  h1 { font-size: 1.5rem; border-bottom: 2px solid #888; padding-bottom: .4rem; }
+  h2 { font-size: 1.15rem; margin-top: 2rem; }
+  code, pre { font-family: Consolas, Menlo, monospace; }
+  pre { background: rgba(127,127,127,.12); padding: .8rem; border-radius: 6px; overflow-x: auto; font-size: .85rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; font-size: .9rem; }
+  th, td { border: 1px solid #999; padding: .5rem .6rem; text-align: left; vertical-align: top; }
+  th { background: rgba(127,127,127,.18); }
+  .pass { color: #1a7f37; font-weight: 700; }
+  .box { background: rgba(127,127,127,.10); border-left: 4px solid #888; padding: .6rem 1rem; border-radius: 0 6px 6px 0; }
+</style>
+</head>
+<body>
+<h1>Issue #1079 - Gateway account-membership check</h1>
+<p><strong>Epic:</strong> #1069 (Phase 1) &nbsp;|&nbsp; <strong>Builds on:</strong> #1074 (authorization-grade claim checks)
+&nbsp;|&nbsp; <strong>Branch:</strong> <code>issue-1079-account-membership</code></p>
+
+<div class="box">
+<p><strong>What this adds.</strong> Once #1074 validates a presented cloud access token for authorization use
+(signature, audience, issuer, not-before, expiry) and extracts its stable subject, this issue adds the
+membership check: the Gateway accepts the token only when its subject equals the account THIS Gateway is
+signed in to. A perfectly valid token minted for a DIFFERENT DevThrottle account is refused, and a
+signed-out Gateway accepts no cloud session. This is the account-level ownership gate that lets #1c later
+wire a cloud session into <code>AuthMiddleware</code>. No request-pipeline change is made here.</p>
+</div>
+
+<h2>What was implemented</h2>
+<table>
+<tr><th>Layer</th><th>File</th><th>Change</th></tr>
+<tr><td>Core</td><td><code>src/CcDirector.Core/Account/JwtIdentityReader.cs</code></td>
+    <td>New <code>ReadSubject(accessToken)</code> - reads the stable <code>sub</code> claim locally (no network); never logs the subject value.</td></tr>
+<tr><td>Core</td><td><code>src/CcDirector.Core/Account/DevThrottleAccountService.cs</code></td>
+    <td>New public <code>GetAccountSubject()</code> - the Gateway's own account key, read from the same cached credential <code>GetIdentity</code> uses (no network); logs only whether one resolved, never the value.</td></tr>
+<tr><td>Gateway</td><td><code>src/CcDirector.Gateway/Account/GatewayAccountMembership.cs</code></td>
+    <td>New membership-check component + <code>AccountMembershipResult</code> record. <code>Check(AuthorizationTokenValidation)</code> accepts only on subject equality; refuses on mismatch, on a not-valid presented token, or when the Gateway is signed out. PII-free accept/refuse logging.</td></tr>
+</table>
+
+<h2>Acceptance criteria - how each is met</h2>
+<table>
+<tr><th>Criterion</th><th>How met</th><th>Proof</th></tr>
+<tr><td>Gateway signed in as A, token subject A -> accept</td>
+    <td>Own subject read from cached credential equals presented subject (ordinal) -> <code>IsMember=true</code></td>
+    <td class="pass">Check_TokenForSameAccount_IsMember PASS</td></tr>
+<tr><td>Gateway signed in as A, token subject B -> refuse</td>
+    <td>Subjects differ -> <code>IsMember=false</code></td>
+    <td class="pass">Check_TokenForDifferentAccount_IsNotMember PASS</td></tr>
+<tr><td>Gateway has no signed-in identity -> refuse</td>
+    <td><code>GetAccountSubject()</code> returns null (no credential) -> refuse "gateway is not signed in"</td>
+    <td class="pass">Check_GatewayNotSignedIn_IsNotMember PASS</td></tr>
+<tr><td>No network call (local cached identity only)</td>
+    <td>Tests build the service with an in-memory store and a refresher that THROWS if invoked; no HTTP handler configured. The check reads the cached credential only.</td>
+    <td class="pass">All 5 membership tests PASS (a network call would throw and fail them)</td></tr>
+<tr><td>No personally identifiable information in any log line</td>
+    <td>The component logs only accept/refuse + a non-identifying reason; the subject value and token are never logged. A unit test asserts the accept/mismatch/signed-out <em>reason</em> strings contain no subject id and no "@".</td>
+    <td class="pass">Check_ReasonStrings_CarryNoPersonallyIdentifyingInformation PASS (+ code inspection below)</td></tr>
+<tr><td><code>dotnet test</code> runs green</td>
+    <td>Membership + Core subject tests all pass; full Gateway.Tests (1318) and Core account tests (188) green.</td>
+    <td class="pass">See test output below</td></tr>
+</table>
+
+<h2>Test output (captured)</h2>
+<p>Gateway membership tests (<code>src/CcDirector.Gateway.Tests</code>):</p>
+<pre>
+Passed  GatewayAccountMembershipTests.Check_TokenForSameAccount_IsMember [36 ms]
+Passed  GatewayAccountMembershipTests.Check_TokenForDifferentAccount_IsNotMember [2 ms]
+Passed  GatewayAccountMembershipTests.Check_PresentedTokenNotAuthorizationValid_IsNotMember [1 ms]
+Passed  GatewayAccountMembershipTests.Check_ReasonStrings_CarryNoPersonallyIdentifyingInformation [1 ms]
+Passed  GatewayAccountMembershipTests.Check_GatewayNotSignedIn_IsNotMember [&lt; 1 ms]
+
+Passed!  - Failed: 0, Passed: 5, Skipped: 0, Total: 5
+</pre>
+<p>Core subject-extraction tests (<code>src/CcDirector.Core.Tests</code>):</p>
+<pre>
+Passed  DevThrottleAccountServiceTests.GetAccountSubject_StoredCredential_ReturnsSubjectWithoutNetwork [243 ms]
+Passed  DevThrottleAccountServiceTests.GetAccountSubject_NoStoredCredential_ReturnsNull [&lt; 1 ms]
+Passed  JwtIdentityReaderTests.ReadSubject_TokenWithSubjectClaim_ReturnsSubject [&lt; 1 ms]
+Passed  JwtIdentityReaderTests.ReadSubject_TokenWithoutSubjectClaim_ReturnsNull [&lt; 1 ms]
+Passed  JwtIdentityReaderTests.ReadSubject_MalformedToken_ReturnsNull [&lt; 1 ms]
+</pre>
+<p>Full suites (regression):</p>
+<pre>
+CcDirector.Core.Tests    (filter ~Account):  Passed: 188, Failed: 0
+CcDirector.Gateway.Tests (full project):     Passed: 1318, Failed: 0
+Solution build:                              Build succeeded. 0 Warning(s), 0 Error(s)
+</pre>
+
+<h2>No personally identifiable information - accept/refuse log lines (code inspection)</h2>
+<p>These are the only lines the membership check emits. None contains an email, a raw subject id, or any
+token contents - only the decision and a generic reason:</p>
+<pre>
+[GatewayAccountMembership] Check: accept - the presented token's account matches this Gateway's account
+[GatewayAccountMembership] Check: refuse - the presented token's account does not match this Gateway's account
+[GatewayAccountMembership] Check: refuse - this Gateway has no signed-in account
+[GatewayAccountMembership] Check: refuse - the presented token is not authorization-valid (no subject to match)
+</pre>
+<p>The subject-reading helpers likewise log only whether a subject resolved, never the value:</p>
+<pre>
+[DevThrottleAccountService] GetAccountSubject: subject=resolved        (or "&lt;none&gt;")
+[JwtIdentityReader] ReadSubject: subject resolved                      (or "no subject claim present")
+</pre>
+
+<h2>CenCon impact</h2>
+<p>No drift. Additive Core + Gateway change; no <code>architecture_manifest.yaml</code> or
+<code>security_profile.yaml</code> is present in this checkout to update. The change honors the
+never-log-token / no-PII rule (the account subject is treated as identifying and is never logged).
+No change to <code>AuthMiddleware</code> or the request pipeline (that is issue #1c).</p>
+
+<h2>Conclusion</h2>
+<p class="pass">I believe this is finished. Every acceptance criterion is met and proven by passing
+tests; the build is clean with zero warnings; no PII reaches the log.</p>
+</body>
+</html>

--- a/src/CcDirector.Core.Tests/Account/DevThrottleAccountServiceTests.cs
+++ b/src/CcDirector.Core.Tests/Account/DevThrottleAccountServiceTests.cs
@@ -326,6 +326,31 @@ public sealed class DevThrottleAccountServiceTests : IDisposable
         Assert.Null(service.GetIdentity());
     }
 
+    // Issue #1079: the install's own account subject (sub claim) is read from the cached credential,
+    // with no network call - the account key the membership check compares a presented token against.
+    [Fact]
+    public void GetAccountSubject_StoredCredential_ReturnsSubjectWithoutNetwork()
+    {
+        var store = new InMemoryTokenStore();
+        var refresher = new StubTokenRefresher(null);
+        var service = MakeService(store, refresher);
+        service.StoreTokens(new DevThrottleTokens(TestJwt.Create(_now.AddHours(1)), "refresh-1"));
+
+        var subject = service.GetAccountSubject();
+
+        Assert.Equal("test-user", subject); // TestJwt sets sub = "test-user"
+        Assert.False(refresher.WasCalled);
+    }
+
+    // No stored credential -> no subject (a signed-out install exposes no account key).
+    [Fact]
+    public void GetAccountSubject_NoStoredCredential_ReturnsNull()
+    {
+        var service = MakeService(new InMemoryTokenStore());
+
+        Assert.Null(service.GetAccountSubject());
+    }
+
     private sealed class FixedTime : TimeProvider
     {
         private readonly DateTimeOffset _now;

--- a/src/CcDirector.Core.Tests/Account/JwtIdentityReaderTests.cs
+++ b/src/CcDirector.Core.Tests/Account/JwtIdentityReaderTests.cs
@@ -48,4 +48,35 @@ public sealed class JwtIdentityReaderTests
     {
         Assert.Null(JwtIdentityReader.Read("not-a-jwt"));
     }
+
+    // Issue #1079: the subject (sub) claim is read from the cached access token's payload.
+    [Fact]
+    public void ReadSubject_TokenWithSubjectClaim_ReturnsSubject()
+    {
+        var token = TestJwt.Create(Expiry); // TestJwt sets sub = "test-user"
+
+        Assert.Equal("test-user", JwtIdentityReader.ReadSubject(token));
+    }
+
+    // A non-JSON-Web-Token string yields no subject (not a fabricated one).
+    [Fact]
+    public void ReadSubject_MalformedToken_ReturnsNull()
+    {
+        Assert.Null(JwtIdentityReader.ReadSubject("not-a-jwt"));
+    }
+
+    // A well-formed token whose payload carries no subject claim yields null.
+    [Fact]
+    public void ReadSubject_TokenWithoutSubjectClaim_ReturnsNull()
+    {
+        var header = Base64Url("{\"alg\":\"none\",\"typ\":\"JWT\"}");
+        var payload = Base64Url("{\"email\":\"user@example.com\"}");
+        var token = $"{header}.{payload}.signature";
+
+        Assert.Null(JwtIdentityReader.ReadSubject(token));
+    }
+
+    private static string Base64Url(string json) =>
+        Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(json))
+            .TrimEnd('=').Replace('+', '-').Replace('/', '_');
 }

--- a/src/CcDirector.Core/Account/DevThrottleAccountService.cs
+++ b/src/CcDirector.Core/Account/DevThrottleAccountService.cs
@@ -281,6 +281,38 @@ public sealed class DevThrottleAccountService
     }
 
     /// <summary>
+    /// Returns this install's own account subject - the stable <c>sub</c> (account/user id) claim read
+    /// locally from the cached access token, with NO network call - or null when no credential is stored
+    /// or the cached token carries no subject claim. This is the account KEY the Gateway's account-
+    /// membership check compares a presented cloud token against (issue #1079): a presented token is a
+    /// member only when its subject equals this value. Read from the same cached credential
+    /// <see cref="GetIdentity"/> uses, and like it this decodes the token's claims without a signature
+    /// re-check (the credential was already accepted by the gate). The subject is a personally-
+    /// identifying account id and is NEVER written to the log; this method logs only whether one was
+    /// resolved (security: no personally identifiable information in logs).
+    /// </summary>
+    public string? GetAccountSubject()
+    {
+        FileLog.Write("[DevThrottleAccountService] GetAccountSubject: reading the account subject from the cached credential (no network call)");
+
+        DevThrottleTokens? tokens;
+        lock (_gate)
+        {
+            tokens = _store.Load();
+        }
+
+        if (tokens is null)
+        {
+            FileLog.Write("[DevThrottleAccountService] GetAccountSubject: no stored credential -> no subject");
+            return null;
+        }
+
+        var subject = JwtIdentityReader.ReadSubject(tokens.AccessToken);
+        FileLog.Write($"[DevThrottleAccountService] GetAccountSubject: subject={(subject is null ? "<none>" : "resolved")}");
+        return subject;
+    }
+
+    /// <summary>
     /// Returns the stored access token to attach when this install acts as the single egress to the
     /// cloud (the Gateway forwarding telemetry on the Director's behalf, issue #639), or null when the
     /// install is not signed in. "Signed in" here is the same local check <see cref="IsLoggedIn"/>

--- a/src/CcDirector.Core/Account/JwtIdentityReader.cs
+++ b/src/CcDirector.Core/Account/JwtIdentityReader.cs
@@ -58,6 +58,50 @@ public static class JwtIdentityReader
         return new AccountIdentity(email, provider);
     }
 
+    /// <summary>
+    /// Reads the stable subject (<c>sub</c>) claim - the account/user id - from the access token's
+    /// payload, entirely locally with no network call. Returns null when the token is not a three-part
+    /// JSON Web Token, the payload cannot be decoded, or the subject claim is absent or empty. Like
+    /// <see cref="Read"/>, this decodes the payload only and does NOT verify the signature - it is used
+    /// on a credential the gate has already accepted, to surface the account key for the account-
+    /// membership check (issue #1079). The returned subject is a personally-identifying account id and
+    /// is NEVER written to the log; this method logs only whether a subject was present.
+    /// </summary>
+    public static string? ReadSubject(string accessToken)
+    {
+        FileLog.Write("[JwtIdentityReader] ReadSubject: extracting the subject claim from the cached access token (no network call)");
+
+        var parts = accessToken?.Split('.') ?? Array.Empty<string>();
+        if (parts.Length != 3)
+        {
+            FileLog.Write("[JwtIdentityReader] ReadSubject: not a three-part JSON Web Token -> no subject");
+            return null;
+        }
+
+        var payloadJson = DecodeSegment(parts[1]);
+        if (payloadJson is null)
+        {
+            FileLog.Write("[JwtIdentityReader] ReadSubject: payload could not be decoded -> no subject");
+            return null;
+        }
+
+        using var doc = JsonDocument.Parse(payloadJson);
+        var root = doc.RootElement;
+
+        if (root.TryGetProperty("sub", out var sub) && sub.ValueKind == JsonValueKind.String)
+        {
+            var subject = sub.GetString();
+            if (!string.IsNullOrWhiteSpace(subject))
+            {
+                FileLog.Write("[JwtIdentityReader] ReadSubject: subject resolved");
+                return subject;
+            }
+        }
+
+        FileLog.Write("[JwtIdentityReader] ReadSubject: no subject claim present -> no subject");
+        return null;
+    }
+
     /// <summary>Reads the <c>email</c> claim from the payload, or null when it is absent or not a string.</summary>
     private static string? ReadEmail(JsonElement root)
     {

--- a/src/CcDirector.Gateway.Tests/Account/GatewayAccountMembershipTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/GatewayAccountMembershipTests.cs
@@ -1,0 +1,149 @@
+using CcDirector.Core.Account;
+using CcDirector.Gateway.Account;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Account;
+
+/// <summary>
+/// Proves the Gateway account-membership check (issue #1079): a presented, already-authorization-valid
+/// cloud token is accepted only when its subject matches the account THIS Gateway is signed in to.
+/// A valid token minted for a different account is refused, and a signed-out Gateway accepts nothing.
+///
+/// The credential service under test is built over an in-memory token store and a refresher that
+/// THROWS if it is ever called, so these tests run cross-platform, use no HTTP handler, and
+/// demonstrate that the membership check makes no network call - if it did, the throwing refresher
+/// would fail the test.
+/// </summary>
+public sealed class GatewayAccountMembershipTests : IDisposable
+{
+    private static readonly DateTime Now = new(2026, 7, 6, 12, 0, 0, DateTimeKind.Utc);
+
+    private readonly string _tempDir;
+    private readonly string _authEventsPath;
+
+    public GatewayAccountMembershipTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "cc-gw-membership-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+        _authEventsPath = Path.Combine(_tempDir, "devthrottle-auth-events.jsonl");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    /// <summary>
+    /// Builds the credential service over an in-memory store and a throwing refresher (no network),
+    /// signed in as <paramref name="ownSubject"/> when it is provided, or signed out when it is null.
+    /// </summary>
+    private DevThrottleAccountService MakeAccount(string? ownSubject)
+    {
+        var store = new InMemoryTokenStore();
+        var validator = new JwtAccessTokenValidator("membership-test-unused-secret");
+        var eventLog = new AuthEventLog(_authEventsPath);
+        var service = new DevThrottleAccountService(store, validator, eventLog, new ThrowingTokenRefresher());
+
+        if (ownSubject is not null)
+        {
+            var ownToken = GatewayTestJwt.CreateWithSubject(Now.AddHours(1), ownSubject);
+            service.StoreTokens(new DevThrottleTokens(ownToken, "own-refresh-token"));
+        }
+
+        return service;
+    }
+
+    /// <summary>A presented token that passed #1074 authorization validation, carrying its subject.</summary>
+    private static AuthorizationTokenValidation ValidPresentedToken(string subject) =>
+        new(IsValid: true, Subject: subject, ExpiresAtUtc: Now.AddHours(1), InvalidReason: null);
+
+    // Acceptance criterion 1: Gateway signed in as account A, a token whose subject is A -> accept.
+    [Fact]
+    public void Check_TokenForSameAccount_IsMember()
+    {
+        var membership = new GatewayAccountMembership(MakeAccount(ownSubject: "account-A"));
+
+        var result = membership.Check(ValidPresentedToken("account-A"));
+
+        Assert.True(result.IsMember);
+    }
+
+    // Acceptance criterion 2: Gateway signed in as account A, a token whose subject is B -> refuse.
+    [Fact]
+    public void Check_TokenForDifferentAccount_IsNotMember()
+    {
+        var membership = new GatewayAccountMembership(MakeAccount(ownSubject: "account-A"));
+
+        var result = membership.Check(ValidPresentedToken("account-B"));
+
+        Assert.False(result.IsMember);
+    }
+
+    // Acceptance criterion 3: Gateway has no signed-in identity -> any token is refused.
+    [Fact]
+    public void Check_GatewayNotSignedIn_IsNotMember()
+    {
+        var membership = new GatewayAccountMembership(MakeAccount(ownSubject: null));
+
+        var result = membership.Check(ValidPresentedToken("account-A"));
+
+        Assert.False(result.IsMember);
+    }
+
+    // Defence in depth: a presented result that is not authorization-valid can never be a member.
+    [Fact]
+    public void Check_PresentedTokenNotAuthorizationValid_IsNotMember()
+    {
+        var membership = new GatewayAccountMembership(MakeAccount(ownSubject: "account-A"));
+
+        var invalid = new AuthorizationTokenValidation(
+            IsValid: false, Subject: null, ExpiresAtUtc: null, InvalidReason: "audience mismatch");
+        var result = membership.Check(invalid);
+
+        Assert.False(result.IsMember);
+    }
+
+    // No personally identifiable information in the accept/refuse reason: neither the account subject
+    // nor an email marker appears in the reason string for any decision (accept, mismatch, signed-out).
+    [Fact]
+    public void Check_ReasonStrings_CarryNoPersonallyIdentifyingInformation()
+    {
+        const string ownSubject = "account-A-1a2b3c";
+        const string otherSubject = "account-B-9x8y7z";
+
+        var signedIn = new GatewayAccountMembership(MakeAccount(ownSubject));
+        var accept = signedIn.Check(ValidPresentedToken(ownSubject));
+        var mismatch = signedIn.Check(ValidPresentedToken(otherSubject));
+
+        var signedOut = new GatewayAccountMembership(MakeAccount(ownSubject: null));
+        var noAccount = signedOut.Check(ValidPresentedToken(ownSubject));
+
+        foreach (var reason in new[] { accept.Reason, mismatch.Reason, noAccount.Reason })
+        {
+            Assert.DoesNotContain(ownSubject, reason, StringComparison.Ordinal);
+            Assert.DoesNotContain(otherSubject, reason, StringComparison.Ordinal);
+            Assert.DoesNotContain("@", reason, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>In-memory <see cref="IProtectedTokenStore"/> so the check runs without the Windows-only store.</summary>
+    private sealed class InMemoryTokenStore : IProtectedTokenStore
+    {
+        private DevThrottleTokens? _tokens;
+        public bool HasTokens => _tokens is not null;
+        public void Save(DevThrottleTokens tokens) => _tokens = tokens;
+        public DevThrottleTokens? Load() => _tokens;
+        public void Clear() => _tokens = null;
+    }
+
+    /// <summary>
+    /// A refresher that throws if invoked. The membership check reads the cached credential only, so it
+    /// must never reach the network seam - if it did, this would fail the test (proves no network call).
+    /// </summary>
+    private sealed class ThrowingTokenRefresher : ITokenRefresher
+    {
+        public Task<TokenRefreshResult> RefreshAsync(string refreshToken, CancellationToken ct = default) =>
+            throw new InvalidOperationException("The membership check must not make a network call");
+    }
+}

--- a/src/CcDirector.Gateway.Tests/Account/GatewayTestJwt.cs
+++ b/src/CcDirector.Gateway.Tests/Account/GatewayTestJwt.cs
@@ -17,7 +17,15 @@ internal static class GatewayTestJwt
 
     /// <summary>Creates a valid HS256 token signed with <paramref name="secret"/>, expiring at <paramref name="expiresAtUtc"/>.</summary>
     public static string Create(DateTime expiresAtUtc, string secret = SigningSecret) =>
-        Build(expiresAtUtc, email: null, provider: null, secret);
+        Build(expiresAtUtc, email: null, provider: null, subject: "gateway-test-user", secret);
+
+    /// <summary>
+    /// Creates a valid HS256 token carrying a specific <c>sub</c> (account/user id) claim, so the
+    /// account-membership check (issue #1079) can be proven with the Gateway signed in as one account
+    /// and a presented token minted for another.
+    /// </summary>
+    public static string CreateWithSubject(DateTime expiresAtUtc, string subject, string secret = SigningSecret) =>
+        Build(expiresAtUtc, email: null, provider: null, subject, secret);
 
     /// <summary>
     /// Creates a valid HS256 token whose payload also carries the Supabase-shaped identity claims: an
@@ -25,9 +33,9 @@ internal static class GatewayTestJwt
     /// is null the provider claim is omitted so the "provider absent" path can be exercised.
     /// </summary>
     public static string CreateWithIdentity(DateTime expiresAtUtc, string email, string? provider, string secret = SigningSecret) =>
-        Build(expiresAtUtc, email, provider, secret);
+        Build(expiresAtUtc, email, provider, subject: "gateway-test-user", secret);
 
-    private static string Build(DateTime expiresAtUtc, string? email, string? provider, string secret)
+    private static string Build(DateTime expiresAtUtc, string? email, string? provider, string subject, string secret)
     {
         var header = Base64Url(JsonSerializer.SerializeToUtf8Bytes(new Dictionary<string, object>
         {
@@ -37,7 +45,7 @@ internal static class GatewayTestJwt
 
         var payloadClaims = new Dictionary<string, object>
         {
-            ["sub"] = "gateway-test-user",
+            ["sub"] = subject,
             ["exp"] = new DateTimeOffset(expiresAtUtc, TimeSpan.Zero).ToUnixTimeSeconds(),
         };
         if (email is not null)

--- a/src/CcDirector.Gateway/Account/GatewayAccountMembership.cs
+++ b/src/CcDirector.Gateway/Account/GatewayAccountMembership.cs
@@ -1,0 +1,86 @@
+using CcDirector.Core.Account;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Account;
+
+/// <summary>
+/// The outcome of the Gateway's account-membership check (issue #1079). <see cref="IsMember"/> is
+/// true only when a presented, already-authorization-valid cloud token belongs to the account this
+/// Gateway is signed in to. <see cref="Reason"/> carries a short, NON-identifying explanation for
+/// diagnostics - it never contains an email address, a raw subject id, or any token contents.
+/// </summary>
+/// <param name="IsMember">True only when the presented token's account matches this Gateway's own account.</param>
+/// <param name="Reason">A short, personally-identifying-information-free reason for the accept/refuse decision.</param>
+public sealed record AccountMembershipResult(bool IsMember, string Reason);
+
+/// <summary>
+/// Answers the one question that stands between a signature-valid cloud token and trusting it as an
+/// inbound credential (epic #1069, issue #1079): does this token belong to MY account? Issue #1074's
+/// <see cref="JwtAccessTokenValidator.ValidateForAuthorization"/> already confirms a presented token
+/// is correctly signed, unexpired, and minted for the expected audience/issuer, and extracts its
+/// stable subject (account id). This component takes that validation result and accepts it only when
+/// its subject equals the subject of the account THIS Gateway is signed in to - so a token that is
+/// perfectly valid but was minted for a DIFFERENT DevThrottle account is refused, and a signed-out
+/// Gateway accepts no cloud session at all.
+///
+/// The Gateway's own account subject is read locally from the cached credential
+/// (<see cref="DevThrottleAccountService.GetAccountSubject"/>), the same source the outbound calls
+/// use - the check makes NO network call. It logs only the accept/refuse decision and a
+/// non-identifying reason; no email, no subject id, and no token contents ever reach the log
+/// (security: no personally identifiable information in logs).
+///
+/// This is only the account-equality decision. Wiring it into the request pipeline
+/// (<c>AuthMiddleware</c>) is a separate step (issue #1c) and is not done here.
+/// </summary>
+public sealed class GatewayAccountMembership
+{
+    private readonly DevThrottleAccountService _account;
+
+    /// <summary>
+    /// Creates the membership check over the Gateway-hosted credential service that holds this
+    /// Gateway's own signed-in account.
+    /// </summary>
+    /// <param name="account">The Gateway's DevThrottle credential service (source of this Gateway's own account subject).</param>
+    public GatewayAccountMembership(DevThrottleAccountService account)
+    {
+        _account = account ?? throw new ArgumentNullException(nameof(account));
+    }
+
+    /// <summary>
+    /// Decides whether the presented, already-authorization-valid cloud token belongs to this
+    /// Gateway's account. Returns accept only when the token's validated subject equals this Gateway's
+    /// own account subject. Refuses when the presented token is not authorization-valid, when this
+    /// Gateway has no signed-in account, or when the subjects differ. Makes no network call.
+    /// </summary>
+    /// <param name="presentedToken">The presented cloud token's #1074 authorization-validation result, carrying its subject.</param>
+    public AccountMembershipResult Check(AuthorizationTokenValidation presentedToken)
+    {
+        if (presentedToken is null)
+            throw new ArgumentNullException(nameof(presentedToken));
+
+        // Defence in depth: the caller is expected to pass an already-valid result, but a not-valid
+        // result (or one with no subject) can never be a member - there is no account to match on.
+        if (!presentedToken.IsValid || string.IsNullOrEmpty(presentedToken.Subject))
+        {
+            FileLog.Write("[GatewayAccountMembership] Check: refuse - the presented token is not authorization-valid (no subject to match)");
+            return new AccountMembershipResult(false, "presented token is not authorization-valid");
+        }
+
+        var ownSubject = _account.GetAccountSubject();
+        if (string.IsNullOrEmpty(ownSubject))
+        {
+            FileLog.Write("[GatewayAccountMembership] Check: refuse - this Gateway has no signed-in account");
+            return new AccountMembershipResult(false, "gateway is not signed in to any account");
+        }
+
+        var isMember = string.Equals(ownSubject, presentedToken.Subject, StringComparison.Ordinal);
+        if (isMember)
+        {
+            FileLog.Write("[GatewayAccountMembership] Check: accept - the presented token's account matches this Gateway's account");
+            return new AccountMembershipResult(true, "presented token account matches this gateway's account");
+        }
+
+        FileLog.Write("[GatewayAccountMembership] Check: refuse - the presented token's account does not match this Gateway's account");
+        return new AccountMembershipResult(false, "presented token account does not match this gateway's account");
+    }
+}


### PR DESCRIPTION
## Release Notes
The Gateway now refuses a cloud access token that is perfectly valid but was minted for a DIFFERENT DevThrottle account. On top of thefrederiksen/devthrottle#1074's authorization-grade validation (signature, audience, issuer, not-before, expiry, subject), the Gateway confirms the token's account equals the account it is signed in to. A signed-out Gateway accepts no cloud session. Part of epic thefrederiksen/devthrottle_internal#675, Phase 1; the safety gate that lets #1c wire a cloud session into `AuthMiddleware`.

## Changes
- **Core** `JwtIdentityReader.ReadSubject` - reads the stable `sub` (account/user id) claim locally, no network; never logs the value.
- **Core** `DevThrottleAccountService.GetAccountSubject` - the Gateway's own account key, read from the same cached credential `GetIdentity` uses (no network); logs only whether one resolved.
- **Gateway** `GatewayAccountMembership.Check(AuthorizationTokenValidation)` + `AccountMembershipResult` - accepts only on subject equality; refuses on mismatch, on a not-valid presented token, or when the Gateway is signed out. PII-free accept/refuse logging.
- No change to `AuthMiddleware` or the request pipeline (issue #1c).

## How to Test
```
dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj --filter "FullyQualifiedName~GatewayAccountMembership"
dotnet test src/CcDirector.Core.Tests/CcDirector.Core.Tests.csproj --filter "FullyQualifiedName~ReadSubject|FullyQualifiedName~GetAccountSubject"
```

## Expected Result
All membership tests pass: account-A accepted, account-B refused, no-identity refused, no-network (a throwing refresher would fail the test if any network call were made), and the accept/refuse reason strings carry no email or raw subject id. Solution builds with 0 warnings / 0 errors; full Gateway.Tests (1318) and Core account tests (188) green.

## Before / After
- Before: the account boundary was unchecked - any valid DevThrottle token could satisfy the account gate (once #1c wired it in).
- After: only a token whose subject matches this Gateway's own account is a member; a valid token for another account, and any token on a signed-out Gateway, is refused.

Proof: docs/cencon/proof/issue-1079/report.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)