### PR TITLE
Issue 1116 terminal submit characterization tests

### DIFF
--- a/docs/cencon/proof/issue-1116/dotnet-test-core-tests.txt
+++ b/docs/cencon/proof/issue-1116/dotnet-test-core-tests.txt
@@ -1,0 +1,27 @@
+  Determining projects to restore...
+  All projects are up-to-date for restore.
+  CcDirector.Gateway.Contracts -> D:\ReposFred\devthrottle\src\CcDirector.Gateway.Contracts\bin\Debug\net10.0\CcDirector.Gateway.Contracts.dll
+  CcDirector.Terminal.Core -> D:\ReposFred\devthrottle\src\CcDirector.Terminal.Core\bin\Debug\net10.0\CcDirector.Terminal.Core.dll
+  CcDirector.Core -> D:\ReposFred\devthrottle\src\CcDirector.Core\bin\Debug\net10.0\CcDirector.Core.dll
+  CcDirector.Core.Tests -> D:\ReposFred\devthrottle\src\CcDirector.Core.Tests\bin\Debug\net10.0\CcDirector.Core.Tests.dll
+Test run for D:\ReposFred\devthrottle\src\CcDirector.Core.Tests\bin\Debug\net10.0\CcDirector.Core.Tests.dll (.NETCoreApp,Version=v10.0)
+A total of 1 test files matched the specified pattern.
+[xUnit.net 00:00:32.52]     CcDirector.Core.Tests.SessionLifecycleTests.KillSession_RunningSession_TransitionsToExited [SKIP]
+[xUnit.net 00:00:32.58]     CcDirector.Core.Tests.SessionLifecycleTests.KillAllSessions_KillsAllRunning [SKIP]
+  Skipped CcDirector.Core.Tests.SessionLifecycleTests.KillSession_RunningSession_TransitionsToExited [1 ms]
+  Skipped CcDirector.Core.Tests.SessionLifecycleTests.KillAllSessions_KillsAllRunning [1 ms]
+[xUnit.net 00:00:43.49]     CcDirector.Core.Tests.Recording.RecordingIngestServiceTests.Worker_TranscribesQueuedRecording_EndToEnd [SKIP]
+  Skipped CcDirector.Core.Tests.Recording.RecordingIngestServiceTests.Worker_TranscribesQueuedRecording_EndToEnd [1 ms]
+[xUnit.net 00:01:16.50]     CcDirector.Core.Tests.SessionEdgeCaseTests.ConcurrentSessionCreation_AllSucceed [SKIP]
+  Skipped CcDirector.Core.Tests.SessionEdgeCaseTests.ConcurrentSessionCreation_AllSucceed [1 ms]
+[xUnit.net 00:01:28.42]     CcDirector.Core.Tests.NulFileWatcherTests.Start_Watcher_DetectsNewNulFile [SKIP]
+[xUnit.net 00:01:28.43]     CcDirector.Core.Tests.NulFileWatcherTests.TryDeleteNulFile_DeletesNulFile [SKIP]
+  Skipped CcDirector.Core.Tests.NulFileWatcherTests.Start_Watcher_DetectsNewNulFile [1 ms]
+  Skipped CcDirector.Core.Tests.NulFileWatcherTests.TryDeleteNulFile_DeletesNulFile [1 ms]
+[xUnit.net 00:03:18.50]     CcDirector.Core.Tests.SessionManagerTests.CreateAndKillSession_StatusChanges [SKIP]
+  Skipped CcDirector.Core.Tests.SessionManagerTests.CreateAndKillSession_StatusChanges [1 ms]
+[xUnit.net 00:03:35.81]     CcDirector.Core.Tests.Drivers.SessionAskRunnerTests.AskAsync_ClaudeCode_RealDriverWithFixtureTranscript_ReturnsParsedAnswer [SKIP]
+  Skipped CcDirector.Core.Tests.Drivers.SessionAskRunnerTests.AskAsync_ClaudeCode_RealDriverWithFixtureTranscript_ReturnsParsedAnswer [1 ms]
+
+Passed!  - Failed:     0, Passed:  2848, Skipped:     8, Total:  2856, Duration: 3 m 35 s - CcDirector.Core.Tests.dll (net10.0)
+

--- a/src/CcDirector.Core.Tests/Drivers/RecordingSessionBackend.cs
+++ b/src/CcDirector.Core.Tests/Drivers/RecordingSessionBackend.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using CcDirector.Core.Backends;
 using CcDirector.Core.Memory;
 
@@ -13,10 +14,16 @@ internal sealed class RecordingSessionBackend : ISessionBackend
 
     public List<byte[]> WrittenBytes { get; } = new();
     public List<string> SentTexts { get; } = new();
+    public List<string> SubmittedTexts { get; } = new();
     public List<string> Starts { get; } = new();
     public int EnterCount { get; private set; }
+    public int LostEnterCount { get; private set; }
     public List<(short Columns, short Rows)> Resizes { get; } = new();
     public int ShutdownCount { get; private set; }
+    public bool SimulateBlindSubmitPath { get; init; }
+    public TimeSpan BlindSubmitDelay { get; init; } = TimeSpan.FromMilliseconds(50);
+    public RecordingEchoScript EchoScript { get; } = new();
+    public string ParkedComposerText { get; private set; } = string.Empty;
 
     public event Action<string>? StatusChanged;
     public event Action<int>? ProcessExited;
@@ -30,20 +37,38 @@ internal sealed class RecordingSessionBackend : ISessionBackend
     public void Write(byte[] data)
     {
         WrittenBytes.Add(data.ToArray());
-        // Echo typed bytes into the terminal buffer when one is attached, like a real TUI
-        // composer - lets echo-verified driver submits (CodexDriver, ClaudeDriver) be tested.
-        Buffer?.Write(data);
+        if (IsEnter(data))
+        {
+            EnterCount++;
+            SubmitComposerIfReady();
+            return;
+        }
+
+        if (IsEscape(data))
+        {
+            EchoScript.ClearComposer();
+            return;
+        }
+
+        EchoScript.RecordTypedText(Encoding.UTF8.GetString(data));
+        EchoScript.ScheduleEcho(Buffer, data);
     }
 
-    public Task SendTextAsync(string text)
+    public async Task SendTextAsync(string text)
     {
         SentTexts.Add(text);
-        return Task.CompletedTask;
+        if (!SimulateBlindSubmitPath)
+            return;
+
+        Write(Encoding.UTF8.GetBytes(text));
+        await Task.Delay(BlindSubmitDelay);
+        Write([0x0D]);
     }
 
     public Task SendEnterAsync()
     {
         EnterCount++;
+        SubmitComposerIfReady();
         return Task.CompletedTask;
     }
 
@@ -62,4 +87,109 @@ internal sealed class RecordingSessionBackend : ISessionBackend
     public void Dispose()
     {
     }
+
+    private void SubmitComposerIfReady()
+    {
+        if (EchoScript.IsComposerReady)
+        {
+            SubmittedTexts.Add(EchoScript.ComposerText);
+            EchoScript.ClearComposer();
+            return;
+        }
+
+        LostEnterCount++;
+        ParkedComposerText = EchoScript.ComposerText;
+    }
+
+    private static bool IsEnter(byte[] data) => data.Length == 1 && data[0] == 0x0D;
+
+    private static bool IsEscape(byte[] data) => data.Length == 1 && data[0] == 0x1B;
+}
+
+internal sealed class RecordingEchoScript
+{
+    private readonly Queue<RecordingEchoStep> _steps = new();
+    private RecordingEchoStep _defaultStep = RecordingEchoStep.Immediate();
+
+    public string ComposerText { get; private set; } = string.Empty;
+    public bool IsComposerReady { get; private set; }
+
+    public void UseDefault(RecordingEchoStep step)
+    {
+        _defaultStep = step;
+    }
+
+    public void Enqueue(RecordingEchoStep step)
+    {
+        _steps.Enqueue(step);
+    }
+
+    public void RecordTypedText(string text)
+    {
+        ComposerText += text;
+        IsComposerReady = false;
+    }
+
+    public void ScheduleEcho(CircularTerminalBuffer? buffer, byte[] typedBytes)
+    {
+        if (buffer is null)
+            return;
+
+        var typedText = Encoding.UTF8.GetString(typedBytes);
+        var step = _steps.Count > 0 ? _steps.Dequeue() : _defaultStep;
+        _ = EchoAsync(buffer, typedText, step);
+    }
+
+    public void ClearComposer()
+    {
+        ComposerText = string.Empty;
+        IsComposerReady = false;
+    }
+
+    private async Task EchoAsync(CircularTerminalBuffer buffer, string typedText, RecordingEchoStep step)
+    {
+        if (step.Mode == RecordingEchoMode.Withheld)
+            return;
+
+        if (!string.IsNullOrEmpty(step.PlaceholderText))
+            buffer.Write(Encoding.UTF8.GetBytes(step.PlaceholderText));
+
+        if (step.Delay > TimeSpan.Zero)
+            await Task.Delay(step.Delay);
+
+        var echoText = step.EchoText ?? typedText;
+        buffer.Write(Encoding.UTF8.GetBytes(echoText));
+        IsComposerReady = step.AcceptsSubmit;
+    }
+}
+
+internal sealed record RecordingEchoStep(
+    RecordingEchoMode Mode,
+    TimeSpan Delay,
+    string? PlaceholderText,
+    string? EchoText,
+    bool AcceptsSubmit)
+{
+    public static RecordingEchoStep Immediate() =>
+        new(RecordingEchoMode.Delayed, TimeSpan.Zero, null, null, true);
+
+    public static RecordingEchoStep Delayed(TimeSpan delay) =>
+        new(RecordingEchoMode.Delayed, delay, null, null, true);
+
+    public static RecordingEchoStep Withheld() =>
+        new(RecordingEchoMode.Withheld, TimeSpan.Zero, null, null, false);
+
+    public static RecordingEchoStep RepaintingPlaceholder(string placeholderText, TimeSpan delay) =>
+        new(RecordingEchoMode.RepaintingPlaceholder, delay, placeholderText, null, true);
+
+    public static RecordingEchoStep SlashCorrupted(string text) =>
+        new(RecordingEchoMode.SlashCorrupted, TimeSpan.Zero, null, "/" + text, false);
+}
+
+internal enum RecordingEchoMode
+{
+    Delayed,
+    Withheld,
+    RepaintingPlaceholder,
+    SlashCorrupted,
 }

--- a/src/CcDirector.Core.Tests/Drivers/TerminalSubmitTests.cs
+++ b/src/CcDirector.Core.Tests/Drivers/TerminalSubmitTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using CcDirector.Core.Agents;
 using CcDirector.Core.Drivers;
 using CcDirector.Core.Memory;
 using Xunit;
@@ -18,6 +19,153 @@ public sealed class TerminalSubmitTests
         Assert.Equal(Encoding.UTF8.GetBytes("hello world"), backend.WrittenBytes[0]);
         Assert.Equal(new byte[] { 0x0D }, backend.WrittenBytes[1]);
         Assert.Empty(backend.SentTexts);
+    }
+
+    [Fact]
+    public async Task EchoVerifiedSubmit_DelayedEcho_WritesEnterOnlyAfterEcho()
+    {
+        var backend = new RecordingSessionBackend { Buffer = new CircularTerminalBuffer() };
+        backend.EchoScript.UseDefault(RecordingEchoStep.Delayed(TimeSpan.FromMilliseconds(120)));
+
+        var submit = TerminalSubmit.EchoVerifiedSubmitAsync(
+            backend,
+            "hello delayed echo",
+            "Test",
+            echoTimeout: TimeSpan.FromSeconds(1),
+            pollInterval: TimeSpan.FromMilliseconds(5),
+            enterSettleDelay: TimeSpan.FromMilliseconds(1));
+
+        await Task.Delay(40);
+
+        Assert.Single(backend.WrittenBytes);
+        Assert.Equal(Encoding.UTF8.GetBytes("hello delayed echo"), backend.WrittenBytes[0]);
+        Assert.Equal(0, backend.EnterCount);
+        Assert.Empty(backend.SubmittedTexts);
+
+        await submit;
+
+        Assert.Equal(2, backend.WrittenBytes.Count);
+        Assert.Equal(new byte[] { 0x0D }, backend.WrittenBytes[1]);
+        Assert.Equal(["hello delayed echo"], backend.SubmittedTexts);
+    }
+
+    [Fact]
+    public async Task EchoVerifiedSubmit_RepaintingPlaceholder_WaitsForRealEchoBeforeEnter()
+    {
+        var backend = new RecordingSessionBackend { Buffer = new CircularTerminalBuffer() };
+        backend.EchoScript.UseDefault(
+            RecordingEchoStep.RepaintingPlaceholder("thinking placeholder", TimeSpan.FromMilliseconds(80)));
+
+        var submit = TerminalSubmit.EchoVerifiedSubmitAsync(
+            backend,
+            "hello after repaint",
+            "Test",
+            echoTimeout: TimeSpan.FromSeconds(1),
+            pollInterval: TimeSpan.FromMilliseconds(5),
+            enterSettleDelay: TimeSpan.FromMilliseconds(1));
+
+        await Task.Delay(30);
+
+        Assert.Single(backend.WrittenBytes);
+        Assert.Equal(0, backend.EnterCount);
+        Assert.Empty(backend.SubmittedTexts);
+
+        await submit;
+
+        Assert.Equal(2, backend.WrittenBytes.Count);
+        Assert.Equal(new byte[] { 0x0D }, backend.WrittenBytes[1]);
+        Assert.Equal(["hello after repaint"], backend.SubmittedTexts);
+    }
+
+    [Fact]
+    public async Task EchoVerifiedSubmit_FirstEchoMissing_EscapesAndRetypesBeforeEnter()
+    {
+        var backend = new RecordingSessionBackend { Buffer = new CircularTerminalBuffer() };
+        backend.EchoScript.Enqueue(RecordingEchoStep.Withheld());
+        backend.EchoScript.Enqueue(RecordingEchoStep.Immediate());
+
+        await TerminalSubmit.EchoVerifiedSubmitAsync(
+            backend,
+            "retry me",
+            "Test",
+            echoTimeout: TimeSpan.FromMilliseconds(30),
+            pollInterval: TimeSpan.FromMilliseconds(5),
+            enterSettleDelay: TimeSpan.FromMilliseconds(1));
+
+        Assert.Equal(4, backend.WrittenBytes.Count);
+        Assert.Equal(Encoding.UTF8.GetBytes("retry me"), backend.WrittenBytes[0]);
+        Assert.Equal(new byte[] { 0x1B }, backend.WrittenBytes[1]);
+        Assert.Equal(Encoding.UTF8.GetBytes("retry me"), backend.WrittenBytes[2]);
+        Assert.Equal(new byte[] { 0x0D }, backend.WrittenBytes[3]);
+        Assert.Equal(["retry me"], backend.SubmittedTexts);
+    }
+
+    [Fact]
+    public async Task EchoVerifiedSubmit_EchoNeverAppears_ThrowsWithoutEnter()
+    {
+        var backend = new RecordingSessionBackend { Buffer = new CircularTerminalBuffer() };
+        backend.EchoScript.UseDefault(RecordingEchoStep.Withheld());
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => TerminalSubmit.EchoVerifiedSubmitAsync(
+                backend,
+                "never echoed",
+                "Test",
+                echoTimeout: TimeSpan.FromMilliseconds(20),
+                pollInterval: TimeSpan.FromMilliseconds(5),
+                enterSettleDelay: TimeSpan.FromMilliseconds(1)));
+
+        Assert.Contains("never echoed", error.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(4, backend.WrittenBytes.Count);
+        Assert.Equal(Encoding.UTF8.GetBytes("never echoed"), backend.WrittenBytes[0]);
+        Assert.Equal(new byte[] { 0x1B }, backend.WrittenBytes[1]);
+        Assert.Equal(Encoding.UTF8.GetBytes("never echoed"), backend.WrittenBytes[2]);
+        Assert.Equal(new byte[] { 0x1B }, backend.WrittenBytes[3]);
+        Assert.Equal(0, backend.EnterCount);
+        Assert.Empty(backend.SubmittedTexts);
+    }
+
+    [Fact]
+    public async Task GenericDriverSubmit_WithheldEchoBlindPath_WritesEnterAndLeavesComposerParked()
+    {
+        var backend = new RecordingSessionBackend
+        {
+            Buffer = new CircularTerminalBuffer(),
+            SimulateBlindSubmitPath = true,
+            BlindSubmitDelay = TimeSpan.FromMilliseconds(10),
+        };
+        backend.EchoScript.UseDefault(RecordingEchoStep.Delayed(TimeSpan.FromMilliseconds(200)));
+
+        await new GenericDriver(AgentKind.Gemini).SubmitAsync(backend, "blind prompt");
+
+        Assert.Equal(["blind prompt"], backend.SentTexts);
+        Assert.Equal(2, backend.WrittenBytes.Count);
+        Assert.Equal(Encoding.UTF8.GetBytes("blind prompt"), backend.WrittenBytes[0]);
+        Assert.Equal(new byte[] { 0x0D }, backend.WrittenBytes[1]);
+        Assert.Equal(1, backend.LostEnterCount);
+        Assert.Equal("blind prompt", backend.ParkedComposerText);
+        Assert.Empty(backend.SubmittedTexts);
+    }
+
+    [Fact]
+    public async Task ClaudeDriverSubmit_SlashCorruptedEcho_ThrowsWithoutEnter()
+    {
+        var backend = new RecordingSessionBackend { Buffer = new CircularTerminalBuffer() };
+        backend.EchoScript.Enqueue(RecordingEchoStep.SlashCorrupted("write this"));
+        backend.EchoScript.Enqueue(RecordingEchoStep.SlashCorrupted("write this"));
+        var driver = new ClaudeDriver(new EmptyTranscriptReader(), TimeSpan.FromMilliseconds(20), TimeSpan.FromMilliseconds(5));
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => driver.SubmitAsync(backend, "write this"));
+
+        Assert.Contains("never matched", error.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(4, backend.WrittenBytes.Count);
+        Assert.Equal(Encoding.UTF8.GetBytes("write this"), backend.WrittenBytes[0]);
+        Assert.Equal(new byte[] { 0x1B }, backend.WrittenBytes[1]);
+        Assert.Equal(Encoding.UTF8.GetBytes("write this"), backend.WrittenBytes[2]);
+        Assert.Equal(new byte[] { 0x1B }, backend.WrittenBytes[3]);
+        Assert.Equal(0, backend.EnterCount);
+        Assert.Empty(backend.SubmittedTexts);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #1116.

Summary:
- Extends the recording session backend with a scriptable composer echo model: delayed echo, withheld echo, and repainting placeholder.
- Adds deterministic characterization tests for echo-verified submit byte order, delayed echo behavior, retry with Escape, failure after the second miss, blind submit parking, and Claude slash-corruption rejection.
- Adds the required proof output at docs/cencon/proof/issue-1116/dotnet-test-core-tests.txt.

Scope note:
- Slash-corruption behavior is characterized on ClaudeDriver because that is where the guard exists today. Moving the guard into TerminalSubmit would change product behavior, which Phase 1 lists as out of scope.

Verification:
- dotnet test src/CcDirector.Core.Tests/CcDirector.Core.Tests.csproj --logger "console;verbosity=minimal"
- Result: Passed, 2848 passed, 8 skipped, 0 failed.
