### PR TITLE
feat(wingman): split fast and thinking model tiers

### DIFF
--- a/apps/cockpit/src/settings/SettingsView.tsx
+++ b/apps/cockpit/src/settings/SettingsView.tsx
@@ -18,6 +18,7 @@ import {
   getAiModels,
   getAiProvider,
   setAiProvider,
+  setWingmanFastModel,
   setTtsModel,
   setTtsVoice,
   setWingmanModel,
@@ -282,6 +283,7 @@ function AiTab() {
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState("");
   const [testMsg, setTestMsg] = useState("");
+  const [fastTestMsg, setFastTestMsg] = useState("");
   const [sampleMsg, setSampleMsg] = useState("");
 
   // The OpenAI key panel state (shown when the OpenAI provider is selected). We never read the value
@@ -339,13 +341,14 @@ function AiTab() {
     setBusy(true);
     setMsg("Saving...");
     setTestMsg("");
+    setFastTestMsg("");
     try {
       setSnap(await setAiProvider(p));
       await loadModels();
       setMsg(
         p === "devthrottle"
-          ? "Using DevThrottle hosted AI - billed to your account credits."
-          : "Using OpenAI. Add your key below if you have not.",
+          ? "Using DevThrottle hosted AI. Models reset to the DevThrottle defaults."
+          : "Using OpenAI. Models reset to the OpenAI defaults. Add your key below if you have not.",
       );
     } catch (e) {
       setMsg(errText(e));
@@ -361,7 +364,7 @@ function AiTab() {
     try {
       await setWingmanModel(model);
       setSnap({ ...snap, wingmanModel: model });
-      setMsg("Wingman model set. Test it to confirm.");
+      setMsg("Thinking model set. Test it to confirm.");
     } catch (e) {
       setMsg(errText(e));
     } finally {
@@ -374,6 +377,29 @@ function AiTab() {
     setTestMsg("Testing " + snap.wingmanModel + "...");
     const r = await testChat(snap.wingmanModel);
     setTestMsg(r.ok ? `OK - replied "${r.reply}" in ${r.seconds}s.` : "Failed: " + r.error);
+    setBusy(false);
+  };
+
+  const chooseFastWingman = async (model: string) => {
+    setBusy(true);
+    setMsg("Saving...");
+    setFastTestMsg("");
+    try {
+      await setWingmanFastModel(model);
+      setSnap({ ...snap, wingmanFastModel: model });
+      setMsg("Fast model set. Test it to confirm.");
+    } catch (e) {
+      setMsg(errText(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const runFastTest = async () => {
+    setBusy(true);
+    setFastTestMsg("Testing " + snap.wingmanFastModel + "...");
+    const r = await testChat(snap.wingmanFastModel);
+    setFastTestMsg(r.ok ? `OK - replied "${r.reply}" in ${r.seconds}s.` : "Failed: " + r.error);
     setBusy(false);
   };
 
@@ -478,7 +504,7 @@ function AiTab() {
       </div>
 
       <div className="settings-field">
-        <label htmlFor="settings-ai-model">Wingman model</label>
+        <label htmlFor="settings-ai-model">Thinking model</label>
         <select
           id="settings-ai-model"
           className="settings-select"
@@ -496,7 +522,34 @@ function AiTab() {
           <button type="button" className="settings-btn" disabled={busy} onClick={() => void runTest()}>
             Test
           </button>
-          <span className="settings-inline-msg">{testMsg}</span>
+          <span className="settings-inline-msg">
+            {testMsg || "Used for talk-to-the-wingman and product questions."}
+          </span>
+        </div>
+      </div>
+
+      <div className="settings-field">
+        <label htmlFor="settings-ai-fast-model">Fast model</label>
+        <select
+          id="settings-ai-fast-model"
+          className="settings-select"
+          value={snap.wingmanFastModel}
+          disabled={busy}
+          onChange={(e) => void chooseFastWingman(e.target.value)}
+        >
+          {ensureIds(snap.wingmanFastModel, chatModels).map((id) => (
+            <option key={id} value={id}>
+              {id}
+            </option>
+          ))}
+        </select>
+        <div className="settings-actions">
+          <button type="button" className="settings-btn" disabled={busy} onClick={() => void runFastTest()}>
+            Test
+          </button>
+          <span className="settings-inline-msg">
+            {fastTestMsg || "Used for spoken turn summaries, menus, and choice mapping."}
+          </span>
         </div>
       </div>
 

--- a/apps/mobile/src/pages/AiSettings.tsx
+++ b/apps/mobile/src/pages/AiSettings.tsx
@@ -7,6 +7,7 @@ import {
   getAiModels,
   getAiProvider,
   setAiProvider,
+  setWingmanFastModel,
   setTtsModel,
   setTtsVoice,
   setWingmanModel,
@@ -27,6 +28,7 @@ export function AiSettings() {
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState("");
   const [testMsg, setTestMsg] = useState("");
+  const [fastTestMsg, setFastTestMsg] = useState("");
   const [sampleMsg, setSampleMsg] = useState("");
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
@@ -75,6 +77,7 @@ export function AiSettings() {
     setBusy(true);
     setMsg("Saving...");
     setTestMsg("");
+    setFastTestMsg("");
     try {
       setSnap(await setAiProvider(p));
       await loadModels();
@@ -93,7 +96,7 @@ export function AiSettings() {
     try {
       await setWingmanModel(model);
       setSnap({ ...snap, wingmanModel: model });
-      setMsg("Wingman model set. Test it to confirm.");
+      setMsg("Thinking model set. Test it to confirm.");
     } catch (e) {
       setMsg(errText(e));
     } finally {
@@ -106,6 +109,29 @@ export function AiSettings() {
     setTestMsg("Testing " + snap.wingmanModel + "...");
     const r = await testChat(snap.wingmanModel);
     setTestMsg(r.ok ? `OK - replied "${r.reply}" in ${r.seconds}s.` : "Failed: " + r.error);
+    setBusy(false);
+  };
+
+  const chooseFastWingman = async (model: string) => {
+    setBusy(true);
+    setMsg("Saving...");
+    setFastTestMsg("");
+    try {
+      await setWingmanFastModel(model);
+      setSnap({ ...snap, wingmanFastModel: model });
+      setMsg("Fast model set. Test it to confirm.");
+    } catch (e) {
+      setMsg(errText(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const runFastTest = async () => {
+    setBusy(true);
+    setFastTestMsg("Testing " + snap.wingmanFastModel + "...");
+    const r = await testChat(snap.wingmanFastModel);
+    setFastTestMsg(r.ok ? `OK - replied "${r.reply}" in ${r.seconds}s.` : "Failed: " + r.error);
     setBusy(false);
   };
 
@@ -176,7 +202,7 @@ export function AiSettings() {
       </div>
 
       <div className="setting-block">
-        <label className="setting-label" htmlFor="ai-model">Wingman model</label>
+        <label className="setting-label" htmlFor="ai-model">Thinking model</label>
         <select id="ai-model" className="setting-select" value={snap.wingmanModel} disabled={busy} onChange={(e) => void chooseWingman(e.target.value)}>
           {ensure(snap.wingmanModel, chatModels).map((id) => (
             <option key={id} value={id}>{id}</option>
@@ -184,7 +210,20 @@ export function AiSettings() {
         </select>
         <div className="setting-actions">
           <button type="button" className="setting-btn" disabled={busy} onClick={() => void runTest()}>Test</button>
-          <span className="setting-msg">{testMsg}</span>
+          <span className="setting-msg">{testMsg || "Talk-to-the-wingman and product questions."}</span>
+        </div>
+      </div>
+
+      <div className="setting-block">
+        <label className="setting-label" htmlFor="ai-fast-model">Fast model</label>
+        <select id="ai-fast-model" className="setting-select" value={snap.wingmanFastModel} disabled={busy} onChange={(e) => void chooseFastWingman(e.target.value)}>
+          {ensure(snap.wingmanFastModel, chatModels).map((id) => (
+            <option key={id} value={id}>{id}</option>
+          ))}
+        </select>
+        <div className="setting-actions">
+          <button type="button" className="setting-btn" disabled={busy} onClick={() => void runFastTest()}>Test</button>
+          <span className="setting-msg">{fastTestMsg || "Spoken turn summaries and menus."}</span>
         </div>
       </div>
 

--- a/packages/client-core/src/api/ai.ts
+++ b/packages/client-core/src/api/ai.ts
@@ -11,6 +11,7 @@ export type AiProviderId = "devthrottle" | "openai";
 export interface AiProviderSnapshot {
   provider: AiProviderId;
   wingmanModel: string;
+  wingmanFastModel: string;
   transcriptionModel: string;
   ttsModel: string;
   ttsVoice: string;
@@ -85,6 +86,10 @@ export async function testChat(model: string): Promise<ChatTestResult> {
 
 export function setWingmanModel(model: string): Promise<{ model: string }> {
   return putJson<{ model: string }>("/gateway/ai/wingman-model", { model });
+}
+
+export function setWingmanFastModel(model: string): Promise<{ model: string }> {
+  return putJson<{ model: string }>("/gateway/ai/wingman-fast-model", { model });
 }
 
 export function setTtsModel(model: string): Promise<{ model: string }> {

--- a/src/CcDirector.Core.Tests/Configuration/ProviderRoutingTests.cs
+++ b/src/CcDirector.Core.Tests/Configuration/ProviderRoutingTests.cs
@@ -30,6 +30,24 @@ public sealed class ProviderRoutingTests
     }
 
     [Fact]
+    public void ResolveWingmanFast_DevThrottle_UsesProxyBaseAndFastModel()
+    {
+        var ep = TranscriptionEndpointResolver.ResolveWingmanFast(TranscriptionMode.DevThrottle);
+        Assert.Equal(TranscriptionEndpointResolver.DevThrottleBaseUrl, ep.BaseUrl);
+        Assert.Equal(TranscriptionEndpointResolver.DevThrottleKeyName, ep.KeyName);
+        Assert.Equal("Qwen/Qwen2.5-72B-Instruct", ep.Model);
+    }
+
+    [Fact]
+    public void ResolveWingmanFast_Byo_UsesOpenAiBaseAndMiniModel()
+    {
+        var ep = TranscriptionEndpointResolver.ResolveWingmanFast(TranscriptionMode.Byo);
+        Assert.Equal(TranscriptionEndpointResolver.OpenAiBaseUrl, ep.BaseUrl);
+        Assert.Equal(TranscriptionEndpointResolver.OpenAiKeyName, ep.KeyName);
+        Assert.Equal("gpt-5.5-mini", ep.Model);
+    }
+
+    [Fact]
     public void ResolveTts_DevThrottle_UsesProxyBaseAndTtsModel()
     {
         var ep = TranscriptionEndpointResolver.ResolveTts(TranscriptionMode.DevThrottle);

--- a/src/CcDirector.Core.Tests/Configuration/WingmanModelConfigTests.cs
+++ b/src/CcDirector.Core.Tests/Configuration/WingmanModelConfigTests.cs
@@ -58,4 +58,39 @@ public sealed class WingmanModelConfigTests : IDisposable
         WingmanModelConfig.Set("zai-org/GLM-5.2");
         Assert.Equal("zai-org/GLM-5.2", CcDirectorConfigService.ReadRaw()["brain_model"]!.GetValue<string>());
     }
+
+    [Fact]
+    public void ResolveFast_Unset_UsesProviderFastDefault()
+    {
+        Assert.Equal("Qwen/Qwen2.5-72B-Instruct", WingmanModelConfig.ResolveFast(TranscriptionMode.DevThrottle));
+        Assert.Equal("gpt-5.5-mini", WingmanModelConfig.ResolveFast(TranscriptionMode.Byo));
+    }
+
+    [Fact]
+    public void ResolveFast_StaleClaudeAlias_FallsForwardToProviderFastDefault()
+    {
+        WingmanModelConfig.SetFast("opus");
+        Assert.Equal("Qwen/Qwen2.5-72B-Instruct", WingmanModelConfig.ResolveFast(TranscriptionMode.DevThrottle));
+    }
+
+    [Fact]
+    public void SetFast_PersistsToSeparateKey_AndDoesNotTouchThinking()
+    {
+        WingmanModelConfig.Set("zai-org/GLM-5.2");
+        WingmanModelConfig.SetFast("Qwen/Qwen2.5-72B-Instruct");
+
+        var raw = CcDirectorConfigService.ReadRaw();
+        Assert.Equal("zai-org/GLM-5.2", raw["brain_model"]!.GetValue<string>());
+        Assert.Equal("Qwen/Qwen2.5-72B-Instruct", raw["brain_model_fast"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Resolve_ByRole_DispatchesToThinkingOrFast()
+    {
+        WingmanModelConfig.Set("zai-org/GLM-5.2");
+        WingmanModelConfig.SetFast("Qwen/Qwen2.5-72B-Instruct");
+
+        Assert.Equal("zai-org/GLM-5.2", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle, WingmanModelRole.Thinking));
+        Assert.Equal("Qwen/Qwen2.5-72B-Instruct", WingmanModelConfig.Resolve(TranscriptionMode.DevThrottle, WingmanModelRole.Fast));
+    }
 }

--- a/src/CcDirector.Core/Configuration/TranscriptionEndpoint.cs
+++ b/src/CcDirector.Core/Configuration/TranscriptionEndpoint.cs
@@ -152,6 +152,16 @@ public static class TranscriptionEndpointResolver
     public const string OpenAiWingmanModel = "gpt-5.5";
 
     /// <summary>
+    /// The DEFAULT fast wingman chat model per provider. Fast wingman calls are response-only tasks
+    /// like spoken turn summaries, menu detection, and choice mapping where latency matters more than
+    /// deeper reasoning.
+    /// </summary>
+    public const string DevThrottleWingmanFastModel = "Qwen/Qwen2.5-72B-Instruct";
+
+    /// <summary>The default OpenAI fast wingman chat model. See <see cref="DevThrottleWingmanFastModel"/>.</summary>
+    public const string OpenAiWingmanFastModel = "gpt-5.5-mini";
+
+    /// <summary>
     /// The DEFAULT text-to-speech model per provider. The catalogs differ (verified live): the
     /// DevThrottle proxy serves open TTS models like <c>hexgrad/Kokoro-82M</c> (it does NOT serve
     /// OpenAI's <c>tts-1</c>), OpenAI serves <c>tts-1</c>. The user can pick any speech model from the
@@ -189,6 +199,17 @@ public static class TranscriptionEndpointResolver
     {
         TranscriptionMode.Byo => new ProviderEndpoint(OpenAiBaseUrl, OpenAiKeyName, OpenAiWingmanModel),
         TranscriptionMode.DevThrottle => new ProviderEndpoint(DevThrottleBaseUrl, DevThrottleKeyName, DevThrottleWingmanModel),
+        _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unknown transcription mode"),
+    };
+
+    /// <summary>
+    /// Resolve the fast wingman chat-completions target for <paramref name="mode"/>. Same base URL and
+    /// key as <see cref="ResolveWingman"/>; only the default model differs.
+    /// </summary>
+    public static ProviderEndpoint ResolveWingmanFast(TranscriptionMode mode) => mode switch
+    {
+        TranscriptionMode.Byo => new ProviderEndpoint(OpenAiBaseUrl, OpenAiKeyName, OpenAiWingmanFastModel),
+        TranscriptionMode.DevThrottle => new ProviderEndpoint(DevThrottleBaseUrl, DevThrottleKeyName, DevThrottleWingmanFastModel),
         _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unknown transcription mode"),
     };
 

--- a/src/CcDirector.Core/Configuration/WingmanModelConfig.cs
+++ b/src/CcDirector.Core/Configuration/WingmanModelConfig.cs
@@ -19,8 +19,11 @@ namespace CcDirector.Core.Configuration;
 /// </summary>
 public static class WingmanModelConfig
 {
-    /// <summary>The config.json key the choice is stored under (shared with the legacy brain model).</summary>
+    /// <summary>The config.json key the thinking model is stored under (shared with the legacy brain model).</summary>
     public const string ConfigKey = "brain_model";
+
+    /// <summary>The config.json key the fast wingman model is stored under.</summary>
+    public const string FastConfigKey = "brain_model_fast";
 
     /// <summary>Claude tier aliases that predate the hosted wingman and cannot run on the proxy; treated
     /// as "not chosen" so they fall forward to the provider default.</summary>
@@ -31,21 +34,56 @@ public static class WingmanModelConfig
     /// The hosted wingman model for <paramref name="mode"/>: the saved brain_model when it is a real
     /// hosted model id, else the provider default (<see cref="TranscriptionEndpointResolver.ResolveWingman"/>).
     /// </summary>
-    public static string Resolve(TranscriptionMode mode)
+    public static string Resolve(TranscriptionMode mode) =>
+        ResolveKey(ConfigKey, () => TranscriptionEndpointResolver.ResolveWingman(mode).Model);
+
+    /// <summary>
+    /// The hosted fast wingman model for <paramref name="mode"/>: the saved brain_model_fast when it
+    /// is a real hosted model id, else the provider default
+    /// (<see cref="TranscriptionEndpointResolver.ResolveWingmanFast"/>).
+    /// </summary>
+    public static string ResolveFast(TranscriptionMode mode) =>
+        ResolveKey(FastConfigKey, () => TranscriptionEndpointResolver.ResolveWingmanFast(mode).Model);
+
+    /// <summary>Resolve the model for the requested wingman role.</summary>
+    public static string Resolve(TranscriptionMode mode, WingmanModelRole role) => role switch
     {
-        var node = CcDirectorConfigService.ReadRaw()[ConfigKey];
-        if (node is JsonValue v && v.GetValueKind() == JsonValueKind.String)
-        {
-            var model = v.GetValue<string>().Trim();
-            if (model.Length > 0 && !ClaudeAliases.Contains(model))
-                return model;
-        }
-        return TranscriptionEndpointResolver.ResolveWingman(mode).Model;
-    }
+        WingmanModelRole.Thinking => Resolve(mode),
+        WingmanModelRole.Fast => ResolveFast(mode),
+        _ => throw new ArgumentOutOfRangeException(nameof(role), role, "Unknown wingman model role"),
+    };
 
     /// <summary>Persist the chosen wingman model to config.json (merge-patch).</summary>
     public static void Set(string model)
     {
         CcDirectorConfigService.MergePatch(new JsonObject { [ConfigKey] = model.Trim() });
     }
+
+    /// <summary>Persist the chosen fast wingman model to config.json (merge-patch).</summary>
+    public static void SetFast(string model)
+    {
+        CcDirectorConfigService.MergePatch(new JsonObject { [FastConfigKey] = model.Trim() });
+    }
+
+    private static string ResolveKey(string configKey, Func<string> providerDefault)
+    {
+        var node = CcDirectorConfigService.ReadRaw()[configKey];
+        if (node is JsonValue v && v.GetValueKind() == JsonValueKind.String)
+        {
+            var model = v.GetValue<string>().Trim();
+            if (model.Length > 0 && !ClaudeAliases.Contains(model))
+                return model;
+        }
+        return providerDefault();
+    }
+}
+
+/// <summary>Which hosted model tier a wingman call should use.</summary>
+public enum WingmanModelRole
+{
+    /// <summary>Quality-sensitive paths such as direct Wingman conversation and product Q&amp;A.</summary>
+    Thinking = 0,
+
+    /// <summary>Latency-sensitive response-only paths such as summaries and menu handling.</summary>
+    Fast = 1,
 }

--- a/src/CcDirector.Gateway.Tests/AiModelsEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/AiModelsEndpointTests.cs
@@ -66,6 +66,18 @@ public sealed class AiModelsEndpointTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Put_wingman_fast_model_persists_and_snapshot_reflects_it()
+    {
+        var resp = await _http.PutAsJsonAsync("gateway/ai/wingman-fast-model", new { model = "qwen-fast" });
+        resp.EnsureSuccessStatusCode();
+        Assert.Equal("qwen-fast", (string?)(await resp.Content.ReadFromJsonAsync<JsonObject>())!["model"]);
+
+        Assert.Equal("qwen-fast", (string?)CcDirectorConfigService.ReadRaw()["brain_model_fast"]);
+        var snap = await _http.GetFromJsonAsync<JsonObject>("gateway/ai-provider");
+        Assert.Equal("qwen-fast", (string?)snap!["wingmanFastModel"]);
+    }
+
+    [Fact]
     public async Task Put_tts_model_persists_and_snapshot_reflects_it()
     {
         var resp = await _http.PutAsJsonAsync("gateway/ai/tts-model", new { model = "kokoro" });
@@ -82,6 +94,7 @@ public sealed class AiModelsEndpointTests : IAsyncLifetime
     {
         var snap = await _http.GetFromJsonAsync<JsonObject>("gateway/ai-provider");
         Assert.Equal("zai-org/GLM-5.2", (string?)snap!["wingmanModel"]);   // provider default when unset
+        Assert.Equal("Qwen/Qwen2.5-72B-Instruct", (string?)snap["wingmanFastModel"]);
         Assert.Equal("hexgrad/Kokoro-82M", (string?)snap["ttsModel"]);
     }
 
@@ -98,6 +111,8 @@ public sealed class AiModelsEndpointTests : IAsyncLifetime
     {
         Assert.Equal(HttpStatusCode.BadRequest,
             (await _http.PutAsJsonAsync("gateway/ai/wingman-model", new { model = "   " })).StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest,
+            (await _http.PutAsJsonAsync("gateway/ai/wingman-fast-model", new { model = "   " })).StatusCode);
         Assert.Equal(HttpStatusCode.BadRequest,
             (await _http.PutAsync("gateway/ai/tts-model", new StringContent("[1,2]", Encoding.UTF8, "application/json"))).StatusCode);
     }

--- a/src/CcDirector.Gateway.Tests/AiProviderEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/AiProviderEndpointTests.cs
@@ -60,6 +60,7 @@ public sealed class AiProviderEndpointTests : IAsyncLifetime
         Assert.NotNull(obj);
         Assert.Equal("devthrottle", (string?)obj!["provider"]);
         Assert.Equal("zai-org/GLM-5.2", (string?)obj["wingmanModel"]);
+        Assert.Equal("Qwen/Qwen2.5-72B-Instruct", (string?)obj["wingmanFastModel"]);
         Assert.Equal("whisper-large-v3", (string?)obj["transcriptionModel"]);
         Assert.Equal("af_bella", (string?)obj["ttsVoice"]);   // DevThrottle (Kokoro) default voice
         var voices = obj["voices"] as JsonArray;
@@ -76,16 +77,19 @@ public sealed class AiProviderEndpointTests : IAsyncLifetime
         var echoed = await resp.Content.ReadFromJsonAsync<JsonObject>();
         Assert.Equal("openai", (string?)echoed!["provider"]);
         Assert.Equal("gpt-5.5", (string?)echoed["wingmanModel"]);
+        Assert.Equal("gpt-5.5-mini", (string?)echoed["wingmanFastModel"]);
 
         // Durable on disk: transcription_mode flips to byo AND the wingman model default is persisted.
         var onDisk = CcDirectorConfigService.ReadRaw();
         Assert.Equal("byo", (string?)onDisk["transcription_mode"]);
         Assert.Equal("gpt-5.5", (string?)onDisk["brain_model"]);
+        Assert.Equal("gpt-5.5-mini", (string?)onDisk["brain_model_fast"]);
 
         // The GET reflects the saved choice after a reload.
         var obj = await _http.GetFromJsonAsync<JsonObject>("gateway/ai-provider");
         Assert.Equal("openai", (string?)obj!["provider"]);
         Assert.Equal("gpt-5.5", (string?)obj["wingmanModel"]);
+        Assert.Equal("gpt-5.5-mini", (string?)obj["wingmanFastModel"]);
     }
 
     [Fact]
@@ -98,6 +102,7 @@ public sealed class AiProviderEndpointTests : IAsyncLifetime
         var onDisk = CcDirectorConfigService.ReadRaw();
         Assert.Equal("devthrottle", (string?)onDisk["transcription_mode"]);
         Assert.Equal("zai-org/GLM-5.2", (string?)onDisk["brain_model"]);
+        Assert.Equal("Qwen/Qwen2.5-72B-Instruct", (string?)onDisk["brain_model_fast"]);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using CcDirector.AgentBrain;
+using CcDirector.Core.Configuration;
 using CcDirector.Core.Drivers;
 using CcDirector.Gateway.Wingman;
 using Xunit;
@@ -61,7 +62,7 @@ public sealed class WingmanTranslatorTests
     }
 
     private static WingmanTranslator BuildTranslator(FakeBrain brain)
-        => new(_ => Task.FromResult<IAgentBrain>(brain), log: _ => { });
+        => new((_, _) => Task.FromResult<IAgentBrain>(brain), log: _ => { });
 
     [Fact]
     public async Task TranslateAsync_ReturnsTheSpokenTranslation_FromBetweenTheMarkers()
@@ -74,6 +75,25 @@ public sealed class WingmanTranslatorTests
             "I patched the auth flow in `LoginService.cs` and the suite is green: 73/73.");
 
         Assert.Equal("The login bug is fixed. All seventy-three tests passed.", result.Spoken);
+    }
+
+    [Fact]
+    public async Task ModelRole_SummaryUsesFast_TalkToWingmanUsesThinking()
+    {
+        var brain = new FakeBrain(_ => "ok");
+        var roles = new List<WingmanModelRole>();
+        var translator = new WingmanTranslator(
+            (role, _) =>
+            {
+                roles.Add(role);
+                return Task.FromResult<IAgentBrain>(brain);
+            },
+            log: _ => { });
+
+        await translator.TranslateAsync("recent context", "the agent reply to translate");
+        await translator.AskDirectAsync("hey wingman, what is going on?");
+
+        Assert.Equal(new[] { WingmanModelRole.Fast, WingmanModelRole.Thinking }, roles);
     }
 
     [Fact]
@@ -93,7 +113,7 @@ public sealed class WingmanTranslatorTests
     public async Task TranslateAsync_ClearsTheContext_EvenWhenTheAskThrows()
     {
         var brain = new ThrowingBrain();
-        var translator = new WingmanTranslator(_ => Task.FromResult<IAgentBrain>(brain), log: _ => { });
+        var translator = new WingmanTranslator((_, _) => Task.FromResult<IAgentBrain>(brain), log: _ => { });
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => translator.TranslateAsync("q", "some reply"));
@@ -167,7 +187,7 @@ public sealed class WingmanTranslatorTests
         // reply IS the spoken answer (it was told to output only that), so we use it rather than
         // 502 - the reliability fix for the explain/voice-turn path.
         var brain = new NoMarkersBrain();   // returns "just some text with no markers at all"
-        var translator = new WingmanTranslator(_ => Task.FromResult<IAgentBrain>(brain), log: _ => { });
+        var translator = new WingmanTranslator((_, _) => Task.FromResult<IAgentBrain>(brain), log: _ => { });
         var result = await translator.TranslateAsync("q", "a reply");
         Assert.Equal("just some text with no markers at all", result.Spoken);
     }

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using CcDirector.AgentBrain;
 using CcDirector.Core;
+using CcDirector.Core.Configuration;
 using CcDirector.Core.HostedAi;
 using CcDirector.Gateway.HostedAi;
 using CcDirector.Gateway.Discovery;
@@ -20,8 +21,8 @@ public sealed class WingmanVoiceServiceTests
     private static WingmanVoiceService NewService()
     {
         // The flag methods never touch the brain; a provider that throws proves that.
-        Func<CancellationToken, Task<IAgentBrain>> brain =
-            _ => throw new InvalidOperationException("brain must not be called for flag state");
+        Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> brain =
+            (_, _) => throw new InvalidOperationException("brain must not be called for flag state");
         var vaultPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".vault");
         var persistPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".json");
         return new WingmanVoiceService(brain, new KeyVault(vaultPath), new DirectorEndpointClient(), persistPath);
@@ -70,8 +71,8 @@ public sealed class WingmanVoiceServiceTests
     /// the same on-disk cache (the gateway-restart case). The empty vault means TtsAsync returns null.</summary>
     private static WingmanVoiceService ServiceAt(string persistPath)
     {
-        Func<CancellationToken, Task<IAgentBrain>> brain =
-            _ => throw new InvalidOperationException("brain must not be called");
+        Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> brain =
+            (_, _) => throw new InvalidOperationException("brain must not be called");
         var vaultPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".vault");
         return new WingmanVoiceService(brain, new KeyVault(vaultPath), new DirectorEndpointClient(), persistPath);
     }
@@ -256,8 +257,8 @@ public sealed class WingmanVoiceServiceTests
     /// the stub ignores the URL, so the mapped state depends only on the response.</summary>
     private static WingmanVoiceService ServiceWithTts(HttpStatusCode status, string body, byte[]? audio = null)
     {
-        Func<CancellationToken, Task<IAgentBrain>> brain =
-            _ => throw new InvalidOperationException("brain must not be called for the store-spoken path");
+        Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> brain =
+            (_, _) => throw new InvalidOperationException("brain must not be called for the store-spoken path");
         var vaultPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".vault");
         var persistPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".json");
         var vault = new KeyVault(vaultPath);
@@ -339,8 +340,8 @@ public sealed class WingmanVoiceServiceTests
 
     private static WingmanVoiceService ServiceWithHandler(HttpMessageHandler handler)
     {
-        Func<CancellationToken, Task<IAgentBrain>> brain =
-            _ => throw new InvalidOperationException("brain must not be called for the store-spoken path");
+        Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> brain =
+            (_, _) => throw new InvalidOperationException("brain must not be called for the store-spoken path");
         var vaultPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".vault");
         var persistPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".json");
         var vault = new KeyVault(vaultPath);

--- a/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
@@ -19,8 +19,9 @@ namespace CcDirector.Gateway.Api;
 ///
 ///   GET  /gateway/ai/models?kind=chat|speech -> { models:[ {id, description, voices[], defaultVoice} ] }
 ///   POST /gateway/ai/test-chat  { model }    -> { ok, reply, seconds } | { error }
-///   PUT  /gateway/ai/wingman-model { model } -> { model }
-///   PUT  /gateway/ai/tts-model     { model } -> { model }
+///   PUT  /gateway/ai/wingman-model      { model } -> { model }
+///   PUT  /gateway/ai/wingman-fast-model { model } -> { model }
+///   PUT  /gateway/ai/tts-model          { model } -> { model }
 ///
 /// DevThrottle serves a TYPED catalog (GET /models?type=chat|speech) where each speech model carries its
 /// own voices. OpenAI's /models is a flat, untyped list with no voices, so for OpenAI we return the known
@@ -94,7 +95,22 @@ internal static class AiModelsEndpoint
                     return Results.BadRequest(new { error = "body { \"model\": \"<id>\" } is required" });
                 var model = body.Model.Trim();
                 WingmanModelConfig.Set(model);
-                FileLog.Write($"[AiModelsEndpoint] wingman model set: {model}");
+                FileLog.Write($"[AiModelsEndpoint] wingman thinking model set: {model}");
+                return Results.Json(new { model });
+            }
+            catch (JsonException) { return Results.BadRequest(new { error = "invalid JSON" }); }
+        });
+
+        app.MapPut("/gateway/ai/wingman-fast-model", async (HttpContext ctx) =>
+        {
+            try
+            {
+                var body = await JsonSerializer.DeserializeAsync<ModelBody>(ctx.Request.Body, JsonOpts, ctx.RequestAborted);
+                if (body is null || string.IsNullOrWhiteSpace(body.Model))
+                    return Results.BadRequest(new { error = "body { \"model\": \"<id>\" } is required" });
+                var model = body.Model.Trim();
+                WingmanModelConfig.SetFast(model);
+                FileLog.Write($"[AiModelsEndpoint] wingman fast model set: {model}");
                 return Results.Json(new { model });
             }
             catch (JsonException) { return Results.BadRequest(new { error = "invalid JSON" }); }

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -59,7 +59,7 @@ internal static class GatewayWingmanVoiceEndpoint
         IEndpointRouteBuilder app,
         DirectorRegistry registry,
         DirectorEndpointClient client,
-        Func<CancellationToken, Task<IAgentBrain>> brainProvider,
+        Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> brainProvider,
         KeyVault vault,
         WingmanVoiceService voice,
         Func<string>? instructionsProvider = null)

--- a/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
@@ -268,8 +268,8 @@ internal static class SettingsEndpoints
         // The consolidated AI provider (the one switch that drives transcription + wingman + TTS).
         // A projection of transcription_mode: "devthrottle" (hosted, ours) or "openai" (bring-your-own
         // OpenAI key). GET returns the derived wingman + transcription models, the TTS voice, and the
-        // selectable voices. PUT sets transcription_mode AND the provider-default wingman model
-        // (brain_model) atomically, so one choice moves all three capabilities to the same provider.
+        // selectable voices. PUT sets transcription_mode AND the provider-default wingman models
+        // atomically, so one choice moves all capabilities to the same provider.
         app.MapGet("/gateway/ai-provider", () => Results.Json(AiProviderSnapshot()));
 
         app.MapPut("/gateway/ai-provider", async (HttpContext ctx) =>
@@ -288,6 +288,7 @@ internal static class SettingsEndpoints
                 // is not an OpenAI voice; zai-org/GLM-5.2 is not an OpenAI model), so a value saved for one
                 // provider would fail against the other. One switch moves all three cleanly.
                 var wingmanModel = Core.Configuration.TranscriptionEndpointResolver.ResolveWingman(mode).Model;
+                var wingmanFastModel = Core.Configuration.TranscriptionEndpointResolver.ResolveWingmanFast(mode).Model;
                 var ttsModel = Core.Configuration.TranscriptionEndpointResolver.DefaultTtsModel(mode);
                 var ttsVoice = Core.Configuration.TranscriptionEndpointResolver.DefaultTtsVoice(mode);
                 Core.Configuration.CcDirectorConfigService.MergePatch(
@@ -295,10 +296,11 @@ internal static class SettingsEndpoints
                     {
                         ["transcription_mode"] = mode.ToConfigString(),
                         ["brain_model"] = wingmanModel,
+                        ["brain_model_fast"] = wingmanFastModel,
                         ["tts_model"] = ttsModel,
                         ["tts_voice"] = ttsVoice,
                     });
-                FileLog.Write($"[SettingsEndpoints] ai_provider set: mode={mode.ToConfigString()}, wingmanModel={wingmanModel}, ttsModel={ttsModel}, ttsVoice={ttsVoice}");
+                FileLog.Write($"[SettingsEndpoints] ai_provider set: mode={mode.ToConfigString()}, wingmanModel={wingmanModel}, wingmanFastModel={wingmanFastModel}, ttsModel={ttsModel}, ttsVoice={ttsVoice}");
                 return Results.Json(AiProviderSnapshot());
             }
             catch (JsonException ex)
@@ -455,9 +457,10 @@ internal static class SettingsEndpoints
         return new
         {
             provider = ProviderString(mode),
-            // The saved wingman-model choice (falls forward to the provider default for a stale/unset
-            // value), so a model picked on the AI tab round-trips across a reload.
+            // The saved wingman-model choices fall forward to provider defaults for stale/unset values,
+            // so models picked on the AI tab round-trip across a reload.
             wingmanModel = Core.Configuration.WingmanModelConfig.Resolve(mode),
+            wingmanFastModel = Core.Configuration.WingmanModelConfig.ResolveFast(mode),
             transcriptionModel = Core.Configuration.TranscriptionEndpointResolver.Resolve(mode).Model,
             ttsModel = Core.Configuration.TtsModelConfig.Resolve(mode),
             ttsVoice = Core.Configuration.TtsVoiceConfig.Resolve(mode),

--- a/src/CcDirector.Gateway/Api/WingmanInstructionsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/WingmanInstructionsEndpoint.cs
@@ -1,4 +1,5 @@
 using CcDirector.AgentBrain;
+using CcDirector.Core.Configuration;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Wingman;
 using Microsoft.AspNetCore.Builder;
@@ -20,7 +21,7 @@ internal static class WingmanInstructionsEndpoint
     private const int MaxTestRecords = 5;
 
     public static void Map(IEndpointRouteBuilder app, WingmanInstructionsStore store,
-        WingmanTrainingStore training, Func<CancellationToken, Task<IAgentBrain>> brainProvider)
+        WingmanTrainingStore training, Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> brainProvider)
     {
         var translator = new WingmanTranslator(brainProvider);
 

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -598,22 +598,18 @@ public sealed class GatewayHost : IAsyncDisposable
     public GatewayTurnBriefStore TurnBriefs => _turnBriefStore;
 
     /// <summary>
-    /// Build the wingman's brain for the CURRENTLY selected AI provider (the consolidated AI-provider
-    /// setting). The wingman is a stateless hosted chat-completions call - <c>glm-5.2</c> on the
-    /// DevThrottle inference proxy or <c>gpt-5.5</c> on OpenAI - not the warm <c>claude.exe</c> brain,
-    /// because that agent speaks the Anthropic protocol and cannot run those OpenAI-compatible models.
-    /// The provider and credential are read at CALL time, so a settings change is honored on the next
-    /// turn without a Gateway restart. The credential comes from the Gateway vault; when it is missing
-    /// (not signed in / no OpenAI key) the ask throws a clear, actionable error rather than a fallback.
+    /// Build the wingman's brain for the CURRENTLY selected AI provider and requested model role. The
+    /// wingman is a stateless hosted chat-completions call, not the warm <c>claude.exe</c> brain,
+    /// because that agent speaks the Anthropic protocol and cannot run these OpenAI-compatible models.
+    /// The provider, credential, and role-specific model are read at CALL time, so a settings change is
+    /// honored on the next turn without a Gateway restart.
     /// </summary>
-    private Task<CcDirector.AgentBrain.IAgentBrain> WingmanBrainAsync(CancellationToken ct)
+    private Task<CcDirector.AgentBrain.IAgentBrain> WingmanBrainAsync(Core.Configuration.WingmanModelRole role, CancellationToken ct)
     {
         var mode = Core.Configuration.TranscriptionModeConfig.Get();
         var ep = Core.Configuration.TranscriptionEndpointResolver.ResolveWingman(mode);
         var key = _keyVault.Get(ep.KeyName) ?? "";
-        // The model is the user's saved choice (AI tab "Wingman model" picker) when set to a real hosted
-        // model, else the provider default (glm-5.2 / gpt-5.5) - never a stale Claude alias.
-        var model = Core.Configuration.WingmanModelConfig.Resolve(mode);
+        var model = Core.Configuration.WingmanModelConfig.Resolve(mode, role);
         CcDirector.AgentBrain.IAgentBrain brain =
             new Wingman.HostedInferenceBrain(ep.BaseUrl, key, model, log: FileLog.Write);
         return Task.FromResult(brain);

--- a/src/CcDirector.Gateway/Wingman/WingmanTranslator.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanTranslator.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using CcDirector.AgentBrain;
+using CcDirector.Core.Configuration;
 using CcDirector.Core.Drivers;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
@@ -101,7 +102,7 @@ public sealed class WingmanTranslator
     /// </summary>
     public const string DefaultInstructionsVersion = "3";
 
-    private readonly Func<CancellationToken, Task<IAgentBrain>> _brainProvider;
+    private readonly Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> _brainProvider;
     private readonly Action<string> _log;
     private readonly Func<string> _instructions;
 
@@ -113,7 +114,7 @@ public sealed class WingmanTranslator
     /// the ACTIVE wingman instructions at call time - the user's edited/versioned prompt when set,
     /// else the deployed <see cref="FidelityPrompt"/> default; omit it to always use the default.
     /// </summary>
-    public WingmanTranslator(Func<CancellationToken, Task<IAgentBrain>> brainProvider, Action<string>? log = null, Func<string>? instructionsProvider = null)
+    public WingmanTranslator(Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> brainProvider, Action<string>? log = null, Func<string>? instructionsProvider = null)
     {
         _brainProvider = brainProvider ?? throw new ArgumentNullException(nameof(brainProvider));
         _log = log ?? FileLog.Write;
@@ -168,7 +169,7 @@ public sealed class WingmanTranslator
 
         var prompt = BuildPrompt(instructions ?? FidelityPrompt, recentContext ?? "", latestReply);
 
-        var brain = await _brainProvider(ct);
+        var brain = await _brainProvider(WingmanModelRole.Fast, ct);
         AskResult ask;
         try
         {
@@ -208,7 +209,7 @@ public sealed class WingmanTranslator
         _log($"[WingmanTranslator] AskDirectAsync: userLen={userMessage.Length}");
         var prompt = BuildDirectPrompt(userMessage);
 
-        var brain = await _brainProvider(ct);
+        var brain = await _brainProvider(WingmanModelRole.Thinking, ct);
         AskResult ask;
         try
         {
@@ -243,7 +244,7 @@ public sealed class WingmanTranslator
         _log($"[WingmanTranslator] AskAboutDevThrottleAsync: questionLen={question.Length}");
         var prompt = BuildDevThrottlePrompt(question);
 
-        var brain = await _brainProvider(ct);
+        var brain = await _brainProvider(WingmanModelRole.Thinking, ct);
         AskResult ask;
         try
         {
@@ -304,7 +305,7 @@ public sealed class WingmanTranslator
         if (string.IsNullOrWhiteSpace(terminalText)) return new WingmanMenu { IsMenu = false };
         _log($"[WingmanTranslator] DetectMenuAsync: terminalLen={terminalText.Length}");
 
-        var brain = await _brainProvider(ct);
+        var brain = await _brainProvider(WingmanModelRole.Fast, ct);
         AskResult ask;
         try { ask = await brain.AskAsync(BuildMenuDetectPrompt(terminalText), ct); }
         finally { await brain.ClearAsync(CancellationToken.None); }
@@ -325,7 +326,7 @@ public sealed class WingmanTranslator
     {
         if (menu?.Options is null || menu.Options.Count == 0 || string.IsNullOrWhiteSpace(userText)) return -1;
 
-        var brain = await _brainProvider(ct);
+        var brain = await _brainProvider(WingmanModelRole.Fast, ct);
         AskResult ask;
         try { ask = await brain.AskAsync(BuildMenuMapPrompt(menu, userText), ct); }
         finally { await brain.ClearAsync(CancellationToken.None); }

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -52,7 +52,7 @@ public sealed class WingmanVoiceService
 
     /// <param name="ttsHttpClient">Optional HTTP client for the text-to-speech call (tests inject a stub
     /// over a fake handler, issue #939). A per-call 60-second client is created when null.</param>
-    public WingmanVoiceService(Func<CancellationToken, Task<IAgentBrain>> brainProvider, KeyVault vault, DirectorEndpointClient client, string? persistPath = null, WingmanTrainingStore? training = null, Func<string>? instructionsProvider = null, HttpClient? ttsHttpClient = null)
+    public WingmanVoiceService(Func<Core.Configuration.WingmanModelRole, CancellationToken, Task<IAgentBrain>> brainProvider, KeyVault vault, DirectorEndpointClient client, string? persistPath = null, WingmanTrainingStore? training = null, Func<string>? instructionsProvider = null, HttpClient? ttsHttpClient = null)
     {
         _translator = new WingmanTranslator(brainProvider, instructionsProvider: instructionsProvider);
         _vault = vault;


### PR DESCRIPTION
## Summary
- add a separate fast Wingman model tier persisted as brain_model_fast
- route spoken summaries, menu detection, and choice mapping to Fast while direct Wingman/product Q&A stay on Thinking
- expose Thinking/Fast model selectors in Cockpit and mobile AI settings

## Verification
- dotnet build src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj
- dotnet build src/CcDirector.Core.Tests/CcDirector.Core.Tests.csproj --no-restore
- dotnet test src/CcDirector.Core.Tests/CcDirector.Core.Tests.csproj --filter FullyQualifiedName~WingmanModelConfigTests|FullyQualifiedName~ProviderRoutingTests --no-restore
- dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj --filter FullyQualifiedName~AiProviderEndpointTests|FullyQualifiedName~AiModelsEndpointTests|FullyQualifiedName~WingmanTranslatorTests|FullyQualifiedName~WingmanVoiceServiceTests --no-restore
- npm run typecheck --workspace @devthrottle/cockpit
- npm run typecheck --workspace @devthrottle/mobile
- npm run build --workspace @devthrottle/cockpit
- npm run build --workspace @devthrottle/mobile