### PR TITLE
fix(wingman): strip ragged answer markers so they stop leaking into speech

### DIFF
--- a/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
@@ -192,6 +192,40 @@ public sealed class WingmanTranslatorTests
         Assert.Equal("just some text with no markers at all", result.Spoken);
     }
 
+    [Fact]
+    public async Task TranslateAsync_RaggedOpeningMarker_IsStrippedNotSpoken()
+    {
+        // The real leak users saw: the model emitted "===DEVTHROTTLE-ANSWER-BEGIN==" (two trailing
+        // equals instead of three). An exact-string match missed it and the ragged marker was
+        // spoken/shown at the front of the answer. The tolerant matcher must strip it clean.
+        var raggedOpen = SessionAskRunner.AnswerBeginMarker.TrimEnd('=') + "==";      // "...BEGIN=="
+        var raggedClose = "==" + SessionAskRunner.AnswerEndMarker.TrimStart('=');     // "==...END==="
+        var brain = new FixedReplyBrain($"{raggedOpen}\nThe session started fine.\n{raggedClose}");
+        var translator = new WingmanTranslator((_, _) => Task.FromResult<IAgentBrain>(brain), log: _ => { });
+
+        var result = await translator.TranslateAsync("q", "a reply");
+
+        Assert.Equal("The session started fine.", result.Spoken);
+        Assert.DoesNotContain("=", result.Spoken);
+        Assert.DoesNotContain("DEVTHROTTLE-ANSWER", result.Spoken);
+    }
+
+    /// <summary>A brain that returns a fixed, test-supplied reply verbatim (raw markers included).</summary>
+    private sealed class FixedReplyBrain : IAgentBrain
+    {
+        private readonly string _reply;
+        public FixedReplyBrain(string reply) => _reply = reply;
+        public string? SessionId => "fixed";
+        public Task<AskResult> AskAsync(string prompt, CancellationToken ct = default)
+            => Task.FromResult(new AskResult { Text = _reply });
+        public Task CancelAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<ClearResult> ClearAsync(CancellationToken ct = default) => Task.FromResult(new ClearResult());
+        public Task RestartAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task KillAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<BrainHealth> GetHealthAsync(CancellationToken ct = default) => Task.FromResult(new BrainHealth());
+        public void Dispose() { }
+    }
+
     private sealed class NoMarkersBrain : IAgentBrain
     {
         public string? SessionId => "nomarkers";

--- a/src/CcDirector.Gateway/Wingman/WingmanTranslator.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanTranslator.cs
@@ -122,26 +122,40 @@ public sealed class WingmanTranslator
     }
 
     /// <summary>
-    /// Pull the spoken answer out of the brain's reply. The brain is asked to wrap its answer in
-    /// the shared markers, but an LLM does not always honor a formatting instruction perfectly - so
-    /// when the markers are absent we use the whole reply (it WAS told to output only the spoken
-    /// version). This tolerance is the difference between a reliable summary and a 502: never throw
-    /// away a good answer over a missing delimiter. Internal so a test can assert both paths.
+    /// Tolerant matchers for the answer delimiters. The model is TOLD to wrap its answer in the
+    /// exact "===DEVTHROTTLE-ANSWER-BEGIN===" / "===DEVTHROTTLE-ANSWER-END===" markers, but an LLM
+    /// does not reproduce a literal delimiter perfectly every time - it may emit two equals signs
+    /// instead of three, drop one, or add a stray space. An exact-string match then misses the
+    /// ragged marker and leaks it into what the listener hears. So these match on the stable marker
+    /// TEXT and swallow whatever run of '=' and surrounding whitespace came with it. Equals signs
+    /// are never part of a real spoken answer, so consuming a "==" or "====" run is always safe.
+    /// </summary>
+    private static readonly Regex BeginMarkerRegex =
+        new(@"=*\s*" + Regex.Escape(SessionAskRunner.AnswerBeginMarker.Trim('=')) + @"\s*=*", RegexOptions.Compiled);
+    private static readonly Regex EndMarkerRegex =
+        new(@"=*\s*" + Regex.Escape(SessionAskRunner.AnswerEndMarker.Trim('=')) + @"\s*=*", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Pull the spoken answer out of the brain's reply, tolerating a ragged delimiter (see
+    /// <see cref="BeginMarkerRegex"/>). When no opening marker is present the brain answered without
+    /// the wrapper, so the whole reply IS the spoken answer (it WAS told to output only that) -
+    /// never throw a good answer away over a missing delimiter. Internal so a test can assert both
+    /// paths.
     /// </summary>
     internal static string ExtractSpoken(string reply)
     {
         if (string.IsNullOrEmpty(reply)) return "";
-        var begin = reply.IndexOf(SessionAskRunner.AnswerBeginMarker, StringComparison.Ordinal);
-        if (begin >= 0)
+        var begin = BeginMarkerRegex.Match(reply);
+        if (begin.Success)
         {
-            var contentStart = begin + SessionAskRunner.AnswerBeginMarker.Length;
-            var end = reply.IndexOf(SessionAskRunner.AnswerEndMarker, contentStart, StringComparison.Ordinal);
-            return (end > contentStart ? reply[contentStart..end] : reply[contentStart..]).Trim();
+            var afterBegin = reply[(begin.Index + begin.Length)..];
+            var end = EndMarkerRegex.Match(afterBegin);
+            return (end.Success ? afterBegin[..end.Index] : afterBegin).Trim();
         }
-        // No markers: the brain answered without the wrapper. Use the whole reply, minus any stray
-        // closing marker the model may have emitted on its own.
-        var stray = reply.IndexOf(SessionAskRunner.AnswerEndMarker, StringComparison.Ordinal);
-        return (stray >= 0 ? reply[..stray] : reply).Trim();
+        // No opening marker: the brain answered without the wrapper. Use the whole reply, minus any
+        // stray closing marker the model may have emitted on its own.
+        var stray = EndMarkerRegex.Match(reply);
+        return (stray.Success ? reply[..stray.Index] : reply).Trim();
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

In mobile voice mode, the wingman sometimes prefixed its spoken/displayed answer with a stray internal delimiter, for example:

```
===DEVTHROTTLE-ANSWER-BEGIN== The session started fine...
```

`===DEVTHROTTLE-ANSWER-BEGIN===` / `===DEVTHROTTLE-ANSWER-END===` are internal markers the wingman asks the model to wrap its answer in, so the code can slice out just the spoken part. They are never meant to be seen.

## Root cause

`WingmanTranslator.ExtractSpoken` matched the marker by exact string. An LLM does not reproduce a literal delimiter perfectly every time - it sometimes emits two equals signs instead of three (note the `==` in the example above), drops one, or adds a stray space. A near-miss then failed the exact match, fell through to the "no markers" fallback, and returned the whole raw reply with the ragged marker still at the front.

## Fix

Match the delimiters tolerantly: two compiled regexes anchor on the stable marker text and swallow whatever run of `=` and surrounding whitespace came with it. Equals signs are never part of a real spoken answer, so consuming a `==` or `====` run is always safe. All wingman paths (voice translate, direct ask, DevThrottle Q&A, menu detection) funnel through `ExtractSpoken`, so they are all fixed at once. The prompt builders are unchanged - the model is still told to emit the exact marker; we just no longer trust it to be byte-perfect when reading the answer back.

## Test

Adds a regression test reproducing the exact leak (a reply wrapped in `===DEVTHROTTLE-ANSWER-BEGIN==` with two trailing equals) and asserting the spoken result carries no equals signs and no marker text. All 17 WingmanTranslator tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
