### PR TITLE
fix(gateway): stop wedging sessions orange "Transcribing..." (#1126)

### DIFF
--- a/src/CcDirector.Gateway.Tests/GatewayDictationEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayDictationEndpointTests.cs
@@ -9,11 +9,15 @@ namespace CcDirector.Gateway.Tests;
 /// <summary>
 /// The durable server-owned dictation complete handler (issue #1006) clears the orange
 /// "Transcribing..." mark on EVERY terminal outcome, not just the happy paths (issue #1048). The
-/// clear is driven by <see cref="DictationOutcome.IsIncomplete"/>: the wrapper clears the mark unless
-/// the outcome is an incomplete upload (more chunks still coming). These tests lock that contract, the
-/// exact thing that was broken - previously an error return (no key, empty audio, a transcription
-/// failure, out-of-credits, the session gone, or a submit refused because the session was parked on a
-/// modal) left the mark set and leaned on the 20-minute MaxAge backstop, wedging the session orange.
+/// clear is driven by <see cref="DictationOutcome.IsIncomplete"/>: the handler clears the mark unless
+/// the outcome is an incomplete upload (more chunks still coming). Issue #1126 moved that clear OUTSIDE
+/// the single-flight completion cache so a resent completion for an already-finished upload id (which
+/// returns the cached outcome without re-running the core) still clears the mark, and shortened the
+/// backstop from a fixed 20-minute age to a short idle window. These tests lock the terminal-vs-incomplete
+/// contract that decides whether the mark is cleared - the exact thing that was originally broken:
+/// previously an error return (no key, empty audio, a transcription failure, out-of-credits, the session
+/// gone, or a submit refused because the session was parked on a modal) left the mark set and leaned on
+/// the backstop, wedging the session orange.
 /// </summary>
 public sealed class GatewayDictationEndpointTests
 {

--- a/src/CcDirector.Gateway.Tests/TranscribingSessionsTests.cs
+++ b/src/CcDirector.Gateway.Tests/TranscribingSessionsTests.cs
@@ -63,25 +63,25 @@ public sealed class TranscribingSessionsTests
     }
 
     [Fact]
-    public void IsTranscribing_WithinMaxAge_StaysTrue()
+    public void IsTranscribing_WithinIdleTimeout_StaysTrue()
     {
         var now = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
         var store = new TranscribingSessions(() => now);
         store.Begin("sid-1");
 
-        now = now.Add(TranscribingSessions.MaxAge); // exactly at the cap is still live
+        now = now.Add(TranscribingSessions.IdleTimeout); // exactly at the cap is still live
 
         Assert.True(store.IsTranscribing("sid-1"));
     }
 
     [Fact]
-    public void IsTranscribing_PastMaxAge_ExpiresAndClears()
+    public void IsTranscribing_PastIdleTimeout_ExpiresAndClears()
     {
         var now = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
         var store = new TranscribingSessions(() => now);
         store.Begin("sid-1");
 
-        now = now.Add(TranscribingSessions.MaxAge).AddSeconds(1); // just past the cap
+        now = now.Add(TranscribingSessions.IdleTimeout).AddSeconds(1); // just past the cap
 
         Assert.False(store.IsTranscribing("sid-1"));
         // The stale mark is removed, so a later read is still false even if the clock rewinds.
@@ -95,11 +95,52 @@ public sealed class TranscribingSessionsTests
         var now = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
         var store = new TranscribingSessions(() => now);
         store.Begin("sid-1");
-        now = now.Add(TranscribingSessions.MaxAge).AddMinutes(5);
+        now = now.Add(TranscribingSessions.IdleTimeout).AddMinutes(5);
         Assert.False(store.IsTranscribing("sid-1")); // expired
 
         store.Begin("sid-1"); // a fresh Send re-marks with the current time
 
         Assert.True(store.IsTranscribing("sid-1"));
+    }
+
+    [Fact]
+    public void Refresh_KeepsAnActiveMarkAlivePastTheIdleWindow()
+    {
+        // A slow upload that streams progress just under the idle window on each step must never be cut
+        // short: each Refresh restarts the idle clock, so the mark survives well past IdleTimeout in
+        // total as long as progress keeps arriving (issue #1126).
+        var now = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var store = new TranscribingSessions(() => now);
+        store.Begin("sid-1");
+
+        for (var step = 0; step < 5; step++)
+        {
+            now = now.Add(TranscribingSessions.IdleTimeout).Subtract(TimeSpan.FromSeconds(1)); // just shy of idle
+            store.Refresh("sid-1");
+        }
+
+        Assert.True(store.IsTranscribing("sid-1")); // still live after 5x the idle window of active upload
+    }
+
+    [Fact]
+    public void Refresh_DoesNotResurrectAClearedMark()
+    {
+        var store = new TranscribingSessions();
+        store.Begin("sid-1");
+        store.End("sid-1");
+
+        store.Refresh("sid-1"); // must not re-mark a session that was already cleared
+
+        Assert.False(store.IsTranscribing("sid-1"));
+    }
+
+    [Fact]
+    public void Refresh_UnknownSession_IsNoOp()
+    {
+        var store = new TranscribingSessions();
+
+        store.Refresh("never-began"); // must not throw or create a mark
+
+        Assert.False(store.IsTranscribing("never-began"));
     }
 }

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -48,6 +48,12 @@ internal static class GatewayDictationEndpoint
     private sealed record CompleteEntry(DateTime At, Lazy<Task<DictationOutcome>> Task);
     private static readonly ConcurrentDictionary<string, CompleteEntry> _completes = new();
 
+    // uploadId -> sessionId, captured at register so the chunk handler (which only has the uploadId)
+    // can refresh the session's orange "Transcribing..." heartbeat as chunks stream in (issue #1126).
+    // Pruned when the upload reaches a terminal completion; a leaked entry for a never-completed upload
+    // is a single guid-pair and is bounded by real abandoned-upload volume.
+    private static readonly ConcurrentDictionary<string, string> _uploadSids = new();
+
     public static void Map(IEndpointRouteBuilder app, DirectorRegistry registry, DirectorEndpointClient client,
         SessionOwnerCache? owners, string token, GatewayTranscriptionService transcription,
         TranscribingSessions transcribingSessions, VoiceUploadStore uploads, Pairing.DeviceRegistry devices)
@@ -64,6 +70,7 @@ internal static class GatewayDictationEndpoint
             // upload id, so a resumed upload after a tab death maps back to the same staging dir.
             var key = ctx.Request.Headers["Idempotency-Key"].ToString();
             var uploadId = uploads.Register(string.IsNullOrWhiteSpace(key) ? null : key);
+            _uploadSids[uploadId] = sid;
             try { transcribingSessions.Begin(sid); } catch { /* the orange mark is a nicety */ }
             FileLog.Write($"[GatewayDictation] upload registered sid={sid} uploadId={uploadId}");
             return Results.Json(new { upload_id = uploadId });
@@ -82,6 +89,10 @@ internal static class GatewayDictationEndpoint
             try
             {
                 await uploads.StoreChunkAsync(uploadId, index, ms.ToArray(), string.IsNullOrEmpty(sha) ? null : sha, ctx.RequestAborted);
+                // Heartbeat: a stored chunk is progress, so keep the orange mark alive past its idle
+                // backstop for a slow upload that streams over more than the idle window (issue #1126).
+                if (_uploadSids.TryGetValue(uploadId, out var chunkSid))
+                    transcribingSessions.Refresh(chunkSid);
                 return Results.Json(new { ok = true, index });
             }
             catch (Exception ex)
@@ -99,10 +110,14 @@ internal static class GatewayDictationEndpoint
                 return Results.Json(new { error = "sessionId (guid) and totalChunks (>0) are required" },
                     statusCode: StatusCodes.Status400BadRequest);
 
+            // A completion attempt is progress - keep the orange mark alive across the server-side
+            // transcribe so a slow transcribe cannot let it age out mid-flight (issue #1126).
+            transcribingSessions.Refresh(req.SessionId!);
+
             var entry = _completes.GetOrAdd(uploadId, id => new CompleteEntry(
                 DateTime.UtcNow,
-                new Lazy<Task<DictationOutcome>>(() => RunCompleteAsync(
-                    id, req, uploads, registry, client, owners, transcription, transcribingSessions))));
+                new Lazy<Task<DictationOutcome>>(() => RunCompleteCoreAsync(
+                    id, req, uploads, registry, client, owners, transcription))));
 
             DictationOutcome outcome;
             try
@@ -114,30 +129,25 @@ internal static class GatewayDictationEndpoint
                 _completes.TryRemove(uploadId, out _); // transient: let a retry re-run
                 return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status502BadGateway);
             }
+
+            // The Gateway OWNS the orange "Transcribing..." mark, so it clears it here - OUTSIDE the
+            // single-flight cache - on EVERY terminal outcome (issue #1048, extended by #1126). Doing the
+            // clear here, not inside the cached RunCompleteCoreAsync, means a RESENT completion for an
+            // already-finished upload id (which returns the cached outcome WITHOUT re-running the core, so
+            // the old in-core clear never fired again) still clears the mark. The ONLY outcome we keep the
+            // mark for is an incomplete upload: more chunks are still coming and the client completes again
+            // on the same upload id, so the session is genuinely still transcribing.
+            if (!outcome.IsIncomplete)
+            {
+                EndTranscribing(transcribingSessions, req.SessionId!);
+                _uploadSids.TryRemove(uploadId, out _);
+            }
             // Only a truly terminal outcome (submitted / moved-on) is kept for idempotent dedupe; anything
             // retryable (transient error, incomplete upload, out-of-credits) is dropped so the next
             // complete re-runs the real work.
             if (!outcome.Terminal) _completes.TryRemove(uploadId, out _);
             return outcome.ToResult();
         });
-    }
-
-    private static async Task<DictationOutcome> RunCompleteAsync(
-        string uploadId, DictationCompleteRequest req, VoiceUploadStore uploads, DirectorRegistry registry,
-        DirectorEndpointClient client, SessionOwnerCache? owners, GatewayTranscriptionService transcription,
-        TranscribingSessions transcribingSessions)
-    {
-        var outcome = await RunCompleteCoreAsync(uploadId, req, uploads, registry, client, owners, transcription);
-        // The Gateway OWNS the orange "Transcribing..." mark, so it clears it on EVERY terminal outcome -
-        // not just the happy paths (issue #1048). Before this fix an error return (no key, empty audio, a
-        // transcription failure, out-of-credits, the session gone, a submit REFUSED because the session is
-        // parked on a modal, or an unexpected exception) left the mark set and leaned on the 20-minute
-        // MaxAge backstop to clear it - which is exactly what wedged sessions orange for up to 20 minutes.
-        // The ONLY outcome we keep the mark for is an incomplete upload: more chunks are still coming and
-        // the client completes again on the same upload id, so the session is genuinely still transcribing.
-        if (!outcome.IsIncomplete)
-            EndTranscribing(transcribingSessions, req.SessionId!);
-        return outcome;
     }
 
     private static async Task<DictationOutcome> RunCompleteCoreAsync(

--- a/src/CcDirector.Gateway/Transcription/TranscribingSessions.cs
+++ b/src/CcDirector.Gateway/Transcription/TranscribingSessions.cs
@@ -14,58 +14,79 @@ namespace CcDirector.Gateway.Transcription;
 /// In-memory by design (transient UI state, not a durable record): a Gateway restart simply clears
 /// it, which is the correct resting state.
 ///
-/// The client's explicit <see cref="End"/> call is the authoritative clear (it fires in the phone's
-/// finally block once the transcript has been submitted or has failed). The <see cref="MaxAge"/>
-/// backstop only exists so a client that goes offline mid-upload - phone locked, app killed, network
-/// dropped - cannot wedge a session orange forever: a mark older than the cap is treated as expired
-/// on the next read and removed. The cap is deliberately generous (longer than any realistic
-/// dictation upload) so it never cuts a genuine transcription short.
+/// The clear is authoritative from two directions. The happy path is the explicit <see cref="End"/>
+/// call the dictation-upload flow makes on every terminal outcome. The safety net is the
+/// <see cref="IdleTimeout"/> backstop: a mark that has seen no progress (no <see cref="Begin"/> or
+/// <see cref="Refresh"/>) for the idle window is treated as abandoned on the next read and removed,
+/// so a client that goes offline mid-upload - phone locked, app killed, network dropped - or a
+/// completion that the explicit clear somehow missed cannot wedge a session orange for long.
+///
+/// The window is deliberately an IDLE timeout, not a fixed age from the first mark: the active upload
+/// path calls <see cref="Refresh"/> as it makes progress (each chunk stored, each completion attempt),
+/// so a genuinely slow upload keeps its mark alive and is never cut short, while an abandoned one goes
+/// quiet and ages out within the idle window. Issue #1126 shortened this from a fixed 20-minute age -
+/// which wedged sessions orange for a full 20 minutes whenever the explicit clear was skipped - to
+/// this short idle window.
 /// </summary>
 public sealed class TranscribingSessions
 {
-    /// <summary>How long a mark may stand before it is treated as a stale, abandoned mark. Longer
-    /// than any realistic record-then-upload-then-transcribe round trip, including a long clip on a
-    /// poor phone network, so it only ever fires for a client that never called <see cref="End"/>.</summary>
-    public static readonly TimeSpan MaxAge = TimeSpan.FromMinutes(20);
+    /// <summary>How long a mark may stand with NO progress (no <see cref="Begin"/> or
+    /// <see cref="Refresh"/>) before it is treated as a stale, abandoned mark and removed. Comfortably
+    /// longer than the gap between progress events on a healthy upload (a dictation clip is small and
+    /// each stored chunk / completion attempt refreshes the mark), so it only ever fires for a client
+    /// that has genuinely stopped making progress.</summary>
+    public static readonly TimeSpan IdleTimeout = TimeSpan.FromSeconds(90);
 
-    private readonly ConcurrentDictionary<string, DateTime> _since = new(); // sid -> mark time (UTC)
+    private readonly ConcurrentDictionary<string, DateTime> _lastProgress = new(); // sid -> last progress time (UTC)
     private readonly Func<DateTime> _utcNow;
 
     /// <summary>Production uses the wall clock; tests inject a controllable clock so the
-    /// <see cref="MaxAge"/> backstop is exercisable without waiting real minutes.</summary>
+    /// <see cref="IdleTimeout"/> backstop is exercisable without waiting real seconds.</summary>
     public TranscribingSessions(Func<DateTime>? utcNow = null)
     {
         _utcNow = utcNow ?? (() => DateTime.UtcNow);
     }
 
-    /// <summary>Mark a session as transcribing (idempotent). Refreshes the mark time so a fresh Send
-    /// restarts the backstop clock rather than inheriting an older mark's age.</summary>
+    /// <summary>Mark a session as transcribing (idempotent). Stamps the progress time so a fresh Send
+    /// restarts the idle backstop clock rather than inheriting an older mark's age.</summary>
     public void Begin(string sessionId)
     {
         ArgumentException.ThrowIfNullOrEmpty(sessionId);
-        _since[sessionId] = _utcNow();
+        _lastProgress[sessionId] = _utcNow();
         FileLog.Write($"[TranscribingSessions] sid={sessionId}: begin transcribing");
     }
 
+    /// <summary>Record progress on an EXISTING mark (a chunk stored, a completion attempt) so an active
+    /// but slow upload keeps its mark alive past the idle backstop. A no-op when the session is not
+    /// currently marked: Refresh keeps a live mark alive, it never resurrects a cleared one.</summary>
+    public void Refresh(string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId)) return;
+        // Only bump an existing mark. Using TryGetValue-then-set (not an unconditional write) keeps a
+        // Refresh that races an End from re-creating the mark End just removed.
+        if (_lastProgress.ContainsKey(sessionId))
+            _lastProgress[sessionId] = _utcNow();
+    }
+
     /// <summary>Clear a session's transcribing mark (idempotent). The authoritative clear, called by
-    /// the client once the transcript has been submitted or the attempt has failed.</summary>
+    /// the dictation-upload flow on every terminal outcome.</summary>
     public void End(string sessionId)
     {
         ArgumentException.ThrowIfNullOrEmpty(sessionId);
-        if (_since.TryRemove(sessionId, out _))
+        if (_lastProgress.TryRemove(sessionId, out _))
             FileLog.Write($"[TranscribingSessions] sid={sessionId}: end transcribing");
     }
 
-    /// <summary>Whether the session is currently transcribing. A mark older than <see cref="MaxAge"/>
-    /// is treated as an abandoned mark and removed, so a crashed/offline client cannot wedge the
-    /// session orange forever.</summary>
+    /// <summary>Whether the session is currently transcribing. A mark that has seen no progress for
+    /// <see cref="IdleTimeout"/> is treated as an abandoned mark and removed on read, so a
+    /// crashed/offline client cannot wedge the session orange.</summary>
     public bool IsTranscribing(string sessionId)
     {
         if (string.IsNullOrEmpty(sessionId)) return false;
-        if (!_since.TryGetValue(sessionId, out var since)) return false;
-        if (_utcNow() - since <= MaxAge) return true;
-        if (_since.TryRemove(sessionId, out _))
-            FileLog.Write($"[TranscribingSessions] sid={sessionId}: mark expired after {MaxAge.TotalMinutes:0} min, cleared");
+        if (!_lastProgress.TryGetValue(sessionId, out var since)) return false;
+        if (_utcNow() - since <= IdleTimeout) return true;
+        if (_lastProgress.TryRemove(sessionId, out _))
+            FileLog.Write($"[TranscribingSessions] sid={sessionId}: mark idle for over {IdleTimeout.TotalSeconds:0}s, cleared");
         return false;
     }
 }


### PR DESCRIPTION
## Problem

Sessions get wedged in the orange "Transcribing..." state and stay there for a long time (up to a full 20 minutes) with no dictation actually in flight. The Gateway logs show this firing 5 times over the last 3 days - e.g. session `0b1cb647` was marked at 19:24:33 and only cleared by the fixed 20-minute backstop at 19:44:41.

Orange means "a dictated utterance is being transcribed and submitted into this session, so nobody else should type into it." It is a Gateway-owned busy mark whose clear was skipped in three real situations, all of which fell through to a deliberately generous 20-minute safety timer:

- the client registered an upload and never sent completion (tab closed, network dropped, phone locked, upload never finished chunking);
- the client resent completion for an already-finished upload id - the single-flight completion cache returned the cached outcome without re-running the in-core clear, so the mark was never cleared (this is exactly what the `0b1cb647` log shows: upload id `f6c1c62f...` had already completed at 19:11:51, was re-registered at 19:24:33, and its completion hit the cache);
- completion returned "incomplete" and the client gave up.

Issue #1048 (closed) fixed a fourth situation (an error return) by clearing on every terminal outcome inside the core, but left the three above open and did not shorten the 20-minute window.

## Fix

- Replace the fixed 20-minute age backstop with a **90-second idle** timeout measured from last progress, plus a `Refresh` heartbeat the active upload path calls on each stored chunk and each completion attempt. A genuine slow upload keeps its mark alive and is never cut short; an abandoned one ages out within the idle window instead of 20 minutes.
- Move the mark-clearing (`End`) **outside** the single-flight completion cache so a resent completion for an already-finished upload id still clears the mark.

The desktop dictation path (`Session.IsTranscribing`) was verified already bounded by its HTTP timeouts (~2 minutes worst case: 120s transcribe + 10s key + 10s dictionary + mic stop), so it is left unchanged rather than adding unnecessary code.

## Tests

- New `TranscribingSessions` coverage: idle-window expiry, refresh-keeps-an-active-mark-alive-past-the-idle-window, refresh-does-not-resurrect-a-cleared-mark, refresh-unknown-session-is-a-no-op.
- Existing `DictationOutcome` terminal-vs-incomplete contract tests updated for the relocated clear.
- Full Gateway test suite green (1348 passed).

Closes #1126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
