### PR TITLE
fix(dictation): persist desktop sends before transcription

### DIFF
--- a/docs/architecture/dictation/DICTATION_UX_SPEC.md
+++ b/docs/architecture/dictation/DICTATION_UX_SPEC.md
@@ -234,3 +234,42 @@ From PAUSED there is nothing to transcribe (the text already exists), so Send
 submits instantly with no background step and no Transcribing state. Insert always
 waits for the transcript, on every surface, because Insert exists to hand back
 editable text.
+
+### Desktop durability: a Send can never lose the recording (issue #1130)
+
+Fire-and-forget must never mean fire-and-forget-the-audio. On the desktop the
+recorded clip used to live only in memory, so when the one background transcription
+call failed - most often the DevThrottle proxy returning `504 upstream_timeout`
+because the speech provider was briefly slow - the audio was discarded with only a
+log line and nothing submitted. That is fixed by making the desktop Send durable,
+mirroring the mobile server-owned durable upload (issues #1006/#1056):
+
+1. **Persist before any network.** The instant Send is pressed, the whole recorded
+   clip is written to disk as a WAV under
+   `%LOCALAPPDATA%\cc-director\pending-dictations\<id>.wav` with a JSON sidecar
+   (target session, the PAUSED prefix, the typed text before/after the caret,
+   attempt count, last error). The transcription call happens only after the audio
+   is safely on disk.
+2. **Delete only on delivery.** The saved clip is removed only once its words have
+   been transcribed and submitted into the session. Every failure keeps it.
+3. **Retry automatically, no restart needed.** A background sweeper retries every
+   saved clip whose session is present on a timer (every 30 seconds), so a transient
+   outage recovers on its own. A transient failure (a 5xx/429, a timeout, a dropped
+   connection - the 504 included) stays eligible for retry; a "needs the user"
+   failure (out of credits, no transcription key) is parked so the retry does not
+   hammer a call that will keep failing.
+4. **Re-drive on the next launch.** On startup any clip parked for "needs you" is
+   promoted back to retryable (in case the user has since fixed it) and every saved
+   clip is re-driven into its session once that session is loaded, so even an
+   application crash mid-transcribe recovers.
+5. **Never silent.** While any clip is held, a persistent notice tells the user
+   their words are saved and being sent automatically. The single path that can
+   still lose a clip - the local disk being unwritable AND the immediate
+   transcription failing - is reported loudly, never silently.
+6. **Stale prune.** A clip is discarded undelivered only when it is older than seven
+   days (its session is certainly gone by then) - generous because on the desktop
+   the saved audio is the only copy.
+
+The orange **Transcribing** roster flag still shows only for the immediate attempt;
+a held clip is surfaced by the persistent notice instead, so the user is never
+blocked from carrying on.

--- a/src/CcDirector.Avalonia.Tests/BatchDictationRecorderStopWavTests.cs
+++ b/src/CcDirector.Avalonia.Tests/BatchDictationRecorderStopWavTests.cs
@@ -1,0 +1,69 @@
+using CcDirector.Avalonia.Voice;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Dictation;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// The durable fire-and-forget Send (issue #1130) saves the recorded audio to disk BEFORE transcribing
+/// it, so the recorder had to expose the whole captured clip as a WAV without transcribing. These tests
+/// prove <see cref="BatchDictationRecorder.StopAndGetWavAsync"/> returns the complete capture - tail
+/// included - and still enforces the completeness gate, driven through the fake-microphone seam with no
+/// real mic and no network.
+/// </summary>
+public sealed class BatchDictationRecorderStopWavTests
+{
+    private sealed class FakeMic : IAudioSource
+    {
+        private readonly byte[] _tail;
+        public FakeMic(byte[] tail) => _tail = tail;
+        public event Action<byte[]>? OnAudioChunk;
+        public string Description => "Fake Test Microphone";
+        public void Start() { }
+        public void Stop() { }
+        public void Emit(byte[] chunk) => OnAudioChunk?.Invoke(chunk);
+        public async Task StopAsync(TimeSpan drainTimeout)
+        {
+            await Task.Delay(20);
+            if (_tail.Length > 0) OnAudioChunk?.Invoke(_tail);
+        }
+    }
+
+    private static BatchDictationRecorder NewRecorder(FakeMic fake)
+        // The transcribe-override is never called by StopAndGetWavAsync, but the internal test
+        // constructor requires one; give it a stub that would fail the test loudly if it ever ran.
+        => new(new AgentOptions(), _ => fake,
+            (_, _, _) => throw new InvalidOperationException("StopAndGetWavAsync must not transcribe"));
+
+    [Fact]
+    public async Task StopAndGetWavAsync_ReturnsWholeCaptureAsWav_IncludingTailDeliveredDuringDrain()
+    {
+        var body = new byte[] { 1, 2, 3, 4 };
+        var tail = new byte[] { 5, 6, 7, 8 };
+        var expectedPcm = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+        var fake = new FakeMic(tail);
+        await using var recorder = NewRecorder(fake);
+
+        await recorder.StartAsync();
+        fake.Emit(body);
+
+        var captured = await recorder.StopAndGetWavAsync();
+
+        // The clip is a WAV: a header followed by exactly the captured PCM, tail included and in order.
+        Assert.NotNull(captured.Wav);
+        Assert.True(captured.Wav.Length > expectedPcm.Length, "WAV must include a header plus the PCM");
+        var pcmSuffix = captured.Wav.AsSpan(captured.Wav.Length - expectedPcm.Length).ToArray();
+        Assert.Equal(expectedPcm, pcmSuffix);
+    }
+
+    [Fact]
+    public async Task StopAndGetWavAsync_NoAudioCaptured_EnforcesCompletenessGate()
+    {
+        var fake = new FakeMic(Array.Empty<byte>());
+        await using var recorder = NewRecorder(fake);
+        await recorder.StartAsync();
+
+        await Assert.ThrowsAsync<NoAudioCapturedException>(() => recorder.StopAndGetWavAsync());
+    }
+}

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -242,6 +242,14 @@ public partial class MainWindow : Window
         var app = (App)global::Avalonia.Application.Current!;
         _sessionManager = app.SessionManager;
 
+        // Durable dictation recovery (issue #1130): retry and re-drive any dictations saved from a
+        // previous run or a failed send, so a transient transcription outage or a crash never loses
+        // recorded audio. Kicks a background scan now and starts the retry timer; the disk scan runs
+        // off the UI thread.
+        var dictationOptions = _sessionManager.Options;
+        if (dictationOptions is not null)
+            StartDictationRecovery(dictationOptions);
+
         SessionList.ItemsSource = _sessions;
         SlimSessionList.ItemsSource = _sessions;
         QueueItemsList.ItemsSource = _queueItems;
@@ -1504,6 +1512,10 @@ public partial class MainWindow : Window
 
             progress.SetComplete();
             FileLog.Write($"[MainWindow] LoadWorkspaceAsync: workspace '{workspace.Name}' loaded");
+
+            // Now that this workspace's sessions are live, re-drive any dictations saved for them from a
+            // previous run (issue #1130) instead of waiting for the next timer sweep.
+            _ = SweepDictationsAsync();
         }
         finally
         {
@@ -2978,19 +2990,24 @@ public partial class MainWindow : Window
                 var recorder = dlg.BackgroundRecorder;
                 var composerText = existingTextBefore;
                 var caret = caretBefore;
+                // Split the typed text at the caret so the durable record can reproduce the exact
+                // composed turn on any retry, dropping neither the typed part nor the dictation.
+                var before = composerText[..caret];
+                var after = composerText[caret..];
                 PromptInput.Text = "";
-                FileLog.Write($"[MainWindow] BtnSpeak_Click: background dictation send to session {target.Id}, composer chars={composerText.Length}, caret={caret}");
+                EnsureDictationInfra(options);
+                FileLog.Write($"[MainWindow] BtnSpeak_Click: durable background dictation send to session {target.Id}, composer chars={composerText.Length}, caret={caret}");
                 _ = global::CcDirector.Avalonia.Voice.BackgroundDictationSend.RunAsync(
                     recorder, dlg.BackgroundPrefix, target,
-                    dictation => global::Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
-                        () => SubmitDictatedTextAsync(
-                            target,
-                            global::CcDirector.Avalonia.Voice.DictationText.InsertAt(composerText, caret, dictation))),
-                    onFailed: () => global::Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
-                    {
-                        RestoreDictatedComposerText(target, composerText);
-                        return Task.CompletedTask;
-                    }));
+                    _pendingDictationStore!, _dictationSweeper!, _dictationTranscriber!,
+                    submit: text => global::Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+                        () => SubmitDictatedTextAsync(target, text)),
+                    before: before,
+                    after: after,
+                    onResult: result => global::Avalonia.Threading.Dispatcher.UIThread.Post(
+                        () => OnDictationDeliveryResult(result)),
+                    onLost: err => global::Avalonia.Threading.Dispatcher.UIThread.Post(
+                        () => OnDictationLost(target, composerText, err)));
                 return;
             }
 
@@ -3066,21 +3083,170 @@ public partial class MainWindow : Window
         ScheduleEnterRetry(target);
     }
 
+    // ===== Durable dictation delivery (issue #1130) =====
+    //
+    // The desktop fire-and-forget Send saves its recorded audio to disk BEFORE any transcription call
+    // and deletes it ONLY once the words are delivered, so a failed or slow transcription (the 504
+    // upstream_timeout that lost the user's audio), an unreachable server, or a crash can never lose a
+    // recording. The immediate attempt runs in BackgroundDictationSend; anything it does not deliver
+    // stays saved and is retried by _dictationSweeper on a timer and re-driven at the next launch.
+
+    private global::CcDirector.Core.Dictation.PendingDictationStore? _pendingDictationStore;
+    private global::CcDirector.Core.Dictation.PendingDictationSweeper? _dictationSweeper;
+    private global::CcDirector.Core.Transcription.IDictationTranscriber? _dictationTranscriber;
+    private global::Avalonia.Threading.DispatcherTimer? _dictationSweepTimer;
+    private bool _dictationInfraReady;
+    private bool _heldNoticeShown;
+
+    /// <summary>How often the background sweep retries any saved-but-undelivered dictation, so a
+    /// transient transcription outage recovers on its own without the user restarting Director.</summary>
+    private static readonly TimeSpan DictationSweepInterval = TimeSpan.FromSeconds(30);
+
     /// <summary>
-    /// Restore typed compose text after a fire-and-forget dictation Send failed to transcribe (the
-    /// send it was folded into never happened, and the box was cleared when the dialog closed). If the
-    /// target session is still on screen, put the words back at the front of the box; otherwise stash
-    /// them in that session's saved compose text so they reappear when the user returns. Never silent:
-    /// a notification tells the user the dictation failed but their typed text was kept.
+    /// Build the durable-dictation store, transcriber, and sweeper once (idempotent). Needs
+    /// <see cref="AgentOptions"/> for the transcriber's method/dictionary resolution, so it is built the
+    /// first time a dictation is sent or when the window finishes loading, whichever comes first.
     /// </summary>
-    private void RestoreDictatedComposerText(Session target, string composerText)
+    private void EnsureDictationInfra(AgentOptions options)
     {
-        if (string.IsNullOrEmpty(composerText)) return;
-        if (_activeSession?.Session == target)
-            InsertIntoPromptInputAt(composerText, 0);
-        else
-            target.PendingPromptText = global::CcDirector.Avalonia.Voice.DictationText.Join(composerText, target.PendingPromptText ?? "");
-        ShowNotification("Dictation failed to transcribe - your typed text was kept.");
+        if (_dictationInfraReady) return;
+        _pendingDictationStore = new global::CcDirector.Core.Dictation.PendingDictationStore();
+        _dictationTranscriber = new global::CcDirector.Core.Transcription.DictationTranscriber(options);
+        var delivery = new global::CcDirector.Core.Dictation.DictationDeliveryService(_dictationTranscriber, _pendingDictationStore);
+        _dictationSweeper = new global::CcDirector.Core.Dictation.PendingDictationSweeper(_pendingDictationStore, delivery);
+        _dictationInfraReady = true;
+        FileLog.Write("[MainWindow] durable dictation infrastructure ready");
+    }
+
+    /// <summary>
+    /// Start the background dictation recovery: promote any clip parked for "needs credits / needs a
+    /// key" back to retryable (the user may have fixed it since), run one sweep now (for sessions
+    /// already loaded), and start the timer that keeps retrying held clips so a transient outage
+    /// recovers without a restart. Called from the window-loaded hook, off the UI thread for the disk scan.
+    /// </summary>
+    private void StartDictationRecovery(AgentOptions options)
+    {
+        EnsureDictationInfra(options);
+        _ = Task.Run(() =>
+        {
+            try { _dictationSweeper!.PromoteParkedToPending(); }
+            catch (Exception ex) { FileLog.Write($"[MainWindow] PromoteParked FAILED: {ex.Message}"); }
+        }).ContinueWith(_ => SweepDictationsAsync());
+
+        if (_dictationSweepTimer is null)
+        {
+            _dictationSweepTimer = new global::Avalonia.Threading.DispatcherTimer { Interval = DictationSweepInterval };
+            _dictationSweepTimer.Tick += (_, _) => _ = SweepDictationsAsync();
+            _dictationSweepTimer.Start();
+        }
+    }
+
+    /// <summary>
+    /// One background sweep: re-drive every saved dictation whose session is currently loaded, leave the
+    /// rest for a later sweep, and refresh the held notice. Runs off the UI thread (disk + network);
+    /// each submit marshals back to the UI thread. Safe to call concurrently - the sweeper's in-flight
+    /// guard prevents double-delivery.
+    /// </summary>
+    private async Task SweepDictationsAsync()
+    {
+        var sweeper = _dictationSweeper;
+        if (sweeper is null) return;
+        try
+        {
+            await Task.Run(() => sweeper.SweepAsync(sessionId =>
+            {
+                if (!Guid.TryParse(sessionId, out var gid)) return null;
+                var session = _sessionManager?.GetSession(gid);
+                if (session is null) return null;
+                return text => global::Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+                    () => SubmitDictatedTextAsync(session, text));
+            }));
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[MainWindow] SweepDictationsAsync FAILED: {ex.Message}");
+        }
+        global::Avalonia.Threading.Dispatcher.UIThread.Post(RefreshHeldDictationNotice);
+    }
+
+    /// <summary>
+    /// Handle the immediate result of a fire-and-forget Send. Success is silent. A held clip refreshes
+    /// the persistent notice so the user knows their words are saved and retrying. A "needs the user"
+    /// outcome adds a specific note. Runs on the UI thread.
+    /// </summary>
+    private void OnDictationDeliveryResult(global::CcDirector.Core.Dictation.DictationDeliveryResult result)
+    {
+        try
+        {
+            if (result.Outcome == global::CcDirector.Core.Dictation.DictationDeliveryOutcome.LostNoAudio)
+                FileLog.Write($"[MainWindow] dictation delivery reported LostNoAudio: {result.Error}");
+            RefreshHeldDictationNotice();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[MainWindow] OnDictationDeliveryResult FAILED: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// The single lossy path (issue #1130): the audio could not be saved to disk AND the immediate
+    /// transcription failed, so the dictation is lost. Put any typed compose text back so at least that
+    /// survives, and tell the user loudly - never silent. Runs on the UI thread.
+    /// </summary>
+    private void OnDictationLost(Session target, string composerText, string error)
+    {
+        try
+        {
+            if (!string.IsNullOrEmpty(composerText))
+            {
+                if (_activeSession?.Session == target)
+                    InsertIntoPromptInputAt(composerText, 0);
+                else
+                    target.PendingPromptText = global::CcDirector.Avalonia.Voice.DictationText.Join(composerText, target.PendingPromptText ?? "");
+            }
+            ShowNotification($"Dictation could not be saved to disk or transcribed and was lost: {error}. Please try again.");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[MainWindow] OnDictationLost FAILED: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Show or clear the persistent held-dictation notice from the current store contents. Any saved
+    /// clip means recorded words are safe and will be delivered automatically; the notice reassures the
+    /// user they will not lose them. Only clears a notice this method itself set, so it never wipes an
+    /// unrelated notification. Runs on the UI thread.
+    /// </summary>
+    private void RefreshHeldDictationNotice()
+    {
+        var store = _pendingDictationStore;
+        if (store is null) return;
+        int total, parked;
+        try
+        {
+            var all = store.LoadAll();
+            total = all.Count;
+            parked = all.Count(r => r.Status == global::CcDirector.Core.Dictation.PendingDictationStatus.NeedsAttention);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[MainWindow] RefreshHeldDictationNotice FAILED: {ex.Message}");
+            return;
+        }
+
+        if (total == 0)
+        {
+            if (_heldNoticeShown) { ClearNotification(); _heldNoticeShown = false; }
+            return;
+        }
+
+        var noun = total == 1 ? "dictation is" : "dictations are";
+        var message = parked == total
+            ? $"{total} {noun} saved and waiting - transcription needs your attention (add credits or set a key). They will be sent automatically once resolved; you will not lose them."
+            : $"{total} {noun} saved and being sent automatically - the transcription service was slow. You will not lose them.";
+        ShowNotification(message);
+        _heldNoticeShown = true;
     }
 
     private void BtnOpenInBrowser_Click(object? sender, RoutedEventArgs e)

--- a/src/CcDirector.Avalonia/Voice/BackgroundDictationSend.cs
+++ b/src/CcDirector.Avalonia/Voice/BackgroundDictationSend.cs
@@ -1,69 +1,139 @@
+using CcDirector.Core.Dictation;
 using CcDirector.Core.Sessions;
+using CcDirector.Core.Transcription;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Avalonia.Voice;
 
 /// <summary>
-/// The fire-and-forget desktop dictation send (docs/architecture/dictation/DICTATION_UX_SPEC.md
-/// section 10), the desktop twin of the mobile PWA's background send. The Speak dialog handed us the
-/// still-capturing recorder the instant Send was pressed and closed itself, releasing the screen;
-/// this runs the rest - transcribe the clip, join it onto the leading text, and submit it into the
-/// session - OFF the UI thread, while the session shows orange "Transcribing..." so nobody else
-/// starts typing into it mid-dictation.
+/// The DURABLE fire-and-forget desktop dictation send (issue #1130), the desktop twin of the mobile
+/// PWA's server-owned durable upload (#1006). The Speak dialog handed us the still-capturing recorder
+/// the instant Send was pressed and closed itself, releasing the screen; this runs the rest OFF the UI
+/// thread.
 ///
-/// It marks <see cref="Session.IsTranscribing"/> for the duration (the SessionStatusWingman paints
-/// the badge orange), and clears it in a finally so a transcription or submit failure never leaves a
-/// session stuck orange. It owns the recorder and disposes it when done.
+/// The guarantee: the recorded audio is written to the durable
+/// <see cref="PendingDictationStore"/> on disk BEFORE any transcription call, and is deleted ONLY once
+/// the words are transcribed and delivered into the session. So a failed or slow transcription (the 504
+/// upstream_timeout that lost the user's audio), an unreachable transcription server, or an application
+/// crash can never lose a recorded utterance - it is retried in the background and re-driven on the next
+/// launch. Nothing short of the disk itself being lost can drop it.
+///
+/// The immediate attempt runs here; if it does not deliver, the clip stays saved and the
+/// <see cref="PendingDictationSweeper"/> (a background timer + launch scan the MainWindow owns) keeps
+/// retrying it. The session shows orange "Transcribing..." only for this immediate attempt; a held clip
+/// is surfaced by the persistent notice instead, so the user is never blocked from carrying on.
 /// </summary>
 public static class BackgroundDictationSend
 {
-    /// <summary>
-    /// Transcribe <paramref name="recorder"/>'s clip, prepend <paramref name="prefix"/>, and hand the
-    /// joined text to <paramref name="submit"/> - which the caller wires to its normal per-session
-    /// submit path (it is responsible for marshaling to the UI thread if its submit touches UI). The
-    /// session shows orange until this returns.
-    /// </summary>
     /// <param name="recorder">The detached, still-capturing recorder. Owned and disposed here.</param>
-    /// <param name="prefix">Already-transcribed text from earlier Pause/Resume segments, joined ahead
-    /// of this segment's transcript to form the full dictation; may be empty.</param>
+    /// <param name="prefix">Already-transcribed text from earlier Pause/Resume segments, joined ahead of
+    /// this segment's transcript; may be empty.</param>
     /// <param name="target">The session the message is being dictated into (marked orange meanwhile).</param>
-    /// <param name="submit">Places the dictated words (the caller inserts them at the caret inside any
-    /// typed text) and submits the result. Called even for an empty dictation, because the caller may
-    /// still have typed text to submit; the caller guards a fully-empty message itself.</param>
-    /// <param name="onFailed">Invoked when transcription throws, so the caller can restore any typed
-    /// text it cleared at dialog-close time (the send it was folded into never happened).</param>
-    public static async Task RunAsync(BatchDictationRecorder recorder, string prefix, Session target, Func<string, Task> submit, Func<Task>? onFailed = null)
+    /// <param name="store">The durable pending-dictation store the audio is saved to before transcription.</param>
+    /// <param name="sweeper">The delivery driver; its in-flight guard prevents this immediate attempt and
+    /// a concurrent background sweep from double-delivering the same clip.</param>
+    /// <param name="transcriber">Used only for the rare best-effort send when the durable save itself
+    /// fails (disk unavailable) - the one path where a failure really can lose the clip, so it is loud.</param>
+    /// <param name="before">Text the user had typed before the caret when Send was pressed (usually empty
+    /// for Send); persisted so a background retry reproduces the composed turn faithfully.</param>
+    /// <param name="after">Text the user had typed after the caret when Send was pressed.</param>
+    /// <param name="submit">Submits the fully-composed turn text into the session (the delivery layer has
+    /// already inserted the dictation at the caret inside the typed text).</param>
+    /// <param name="onResult">Called on the UI thread with the immediate delivery result, so the caller
+    /// can refresh the held notice and surface credits/configuration prompts. Null for a fully-lost clip
+    /// (durable save failed AND the best-effort send failed) - that is reported via <paramref name="onLost"/>.</param>
+    /// <param name="onLost">Called on the UI thread only in the single lossy case: the audio could not be
+    /// saved to disk AND the immediate transcription failed. Never silent.</param>
+    public static async Task RunAsync(
+        BatchDictationRecorder recorder,
+        string prefix,
+        Session target,
+        PendingDictationStore store,
+        PendingDictationSweeper sweeper,
+        IDictationTranscriber transcriber,
+        Func<string, Task> submit,
+        string before = "",
+        string after = "",
+        Action<DictationDeliveryResult>? onResult = null,
+        Action<string>? onLost = null)
     {
-        // This is the root of a detached background task (the dialog is already gone), so it is an
-        // entry point: catch here so a transcription/submit failure is logged and the orange mark is
-        // cleared, never left as an unobserved exception.
         FileLog.Write($"[BackgroundDictationSend] start: session={target.Id}");
         target.IsTranscribing = true;
         try
         {
-            var result = await recorder.TranscribeAsync();
-            var dictation = DictationText.Join(prefix, result.CleanedTranscript).Trim();
-            // Hand the dictated words to the caller to place at the caret and submit. Always call it -
-            // even for an empty dictation - because the caller may still have typed text to send; it
-            // guards a fully-empty message itself, so a mis-tapped silent Send with an empty box sends
-            // nothing.
-            FileLog.Write($"[BackgroundDictationSend] transcribed {dictation.Length} chars for session {target.Id}");
-            await submit(dictation);
+            // 1. Stop the mic and get the whole clip as a WAV. An interrupted turn with no audio throws
+            //    the completeness gate - there is nothing to save or send, and nothing was lost.
+            CapturedAudio captured;
+            try
+            {
+                captured = await recorder.StopAndGetWavAsync();
+            }
+            catch (NoAudioCapturedException ex)
+            {
+                FileLog.Write($"[BackgroundDictationSend] no audio captured for session {target.Id}: {ex.Message}");
+                return;
+            }
+
+            // 2. Persist DURABLY before any network call. This is the whole guarantee.
+            PendingDictation pending;
+            try
+            {
+                pending = store.Save(target.Id.ToString(), prefix, captured.Wav, before, after);
+            }
+            catch (Exception saveEx)
+            {
+                // The one path that can still lose audio: we could not write to disk at all. Do a
+                // best-effort in-memory send and, if that also fails, tell the user loudly - silence
+                // would be worse (mobile's "not persisted" branch).
+                FileLog.Write($"[BackgroundDictationSend] DURABLE SAVE FAILED for session {target.Id}: {saveEx.Message}");
+                await BestEffortEphemeralSendAsync(prefix, before, after, captured.Wav, transcriber, submit, onLost);
+                return;
+            }
+
+            // 3. Deliver the saved clip once now. If it does not deliver, it stays saved and the sweeper
+            //    retries it automatically - so this attempt failing is a HELD clip, never a lost one.
+            var result = await sweeper.TryDeliverAsync(pending, submit);
+            if (result is not null)
+            {
+                FileLog.Write($"[BackgroundDictationSend] immediate attempt for session {target.Id}: {result.Outcome}");
+                onResult?.Invoke(result);
+            }
         }
         catch (Exception ex)
         {
-            FileLog.Write($"[BackgroundDictationSend] FAILED for session {target.Id}: {ex.Message}");
-            if (onFailed is not null)
-            {
-                try { await onFailed(); }
-                catch (Exception restoreEx) { FileLog.Write($"[BackgroundDictationSend] onFailed restore error: {restoreEx.Message}"); }
-            }
+            // Root of a detached task: never let it fault unobserved. Even here the audio is already on
+            // disk (saved at step 2 before anything that could throw), so the sweeper will still recover it.
+            FileLog.Write($"[BackgroundDictationSend] unexpected error for session {target.Id}: {ex.Message}");
         }
         finally
         {
             target.IsTranscribing = false;
             try { await recorder.DisposeAsync(); }
             catch (Exception ex) { FileLog.Write($"[BackgroundDictationSend] recorder dispose error: {ex.Message}"); }
+        }
+    }
+
+    /// <summary>
+    /// Last resort when the durable save itself failed: transcribe the in-memory clip once and submit it.
+    /// On failure the words really are lost, so it is reported loudly via <paramref name="onLost"/> -
+    /// never silent. This is the ONLY lossy path, and it needs the local disk to be unwritable to reach.
+    /// </summary>
+    private static async Task BestEffortEphemeralSendAsync(
+        string prefix, string before, string after, byte[] wav,
+        IDictationTranscriber transcriber, Func<string, Task> submit, Action<string>? onLost)
+    {
+        try
+        {
+            var transcript = await transcriber.TranscribeAsync(wav);
+            var dictation = DictationText.Join(prefix, transcript.CleanedTranscript);
+            var text = DictationText.InsertAt(before + after, before.Length, dictation).Trim();
+            await submit(text);
+            FileLog.Write("[BackgroundDictationSend] best-effort ephemeral send delivered (no durable copy)");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[BackgroundDictationSend] best-effort ephemeral send FAILED (words lost): {ex.Message}");
+            onLost?.Invoke(ex.Message);
         }
     }
 }

--- a/src/CcDirector.Avalonia/Voice/BatchDictationRecorder.cs
+++ b/src/CcDirector.Avalonia/Voice/BatchDictationRecorder.cs
@@ -189,33 +189,39 @@ public sealed class BatchDictationRecorder : IAsyncDisposable
     }
 
     /// <summary>
-    /// Stop the microphone, then transcribe the whole captured clip exactly once
-    /// through the shared batch pipeline (the user-selected method), applying the
-    /// dictionary corrector only. Returns the raw transcript, the corrected
-    /// transcript, and how many dictionary words were corrected.
-    ///
-    /// Enforces the completeness gate (issue #586): a turn that captured no audio
-    /// fails loud with <see cref="NoAudioCapturedException"/> rather than producing
-    /// a partial/empty transcript. Transcription failures throw so the caller
-    /// surfaces them - a missing transcript is a real failure, not papered over.
+    /// Stop the microphone, drain NAudio's final buffered audio, and return the whole captured clip as
+    /// a WAV blob WITHOUT transcribing it. This is the durable-dictation split (issue #1130): the
+    /// fire-and-forget Send saves these bytes to disk the instant Send is pressed, then transcribes the
+    /// saved copy - so a failed or slow transcription can never lose the recording. Enforces the same
+    /// completeness gate as <see cref="TranscribeAsync"/> (an empty capture throws
+    /// <see cref="NoAudioCapturedException"/>), so an interrupted turn with no audio is never persisted.
+    /// The recorder is consumed (stopped) here; call this OR <see cref="TranscribeAsync"/>, once.
     /// </summary>
-    public async Task<DictationResult> TranscribeAsync(CancellationToken ct = default)
+    public async Task<CapturedAudio> StopAndGetWavAsync()
+    {
+        FileLog.Write("[BatchDictationRecorder] StopAndGetWavAsync");
+        var (pcm, _, _) = await StopAndSnapshotAsync();
+        var wav = WavWriter.WrapPcm16(
+            pcm, MicAudioCapture.SampleRate, MicAudioCapture.Channels, MicAudioCapture.BitsPerSample);
+        return new CapturedAudio(wav, _recordingStopwatch?.ElapsedMilliseconds ?? 0);
+    }
+
+    /// <summary>
+    /// Stop the mic, WAIT for NAudio to flush its final buffered audio, then snapshot the whole-turn PCM.
+    /// Shared by <see cref="TranscribeAsync"/> and <see cref="StopAndGetWavAsync"/> so both paths capture
+    /// the identical bytes. WaveInEvent keeps capturing for up to one buffer after the stop and delivers
+    /// the trailing words via AppendChunk on its worker thread, then raises RecordingStopped; StopAsync
+    /// completes on that event, so the whole tail of speech is appended before the snapshot. Detaching
+    /// the handler BEFORE the drain (the old order) discarded that tail and clipped the end of speech.
+    /// Enforces the completeness gate (issue #586): an empty capture throws <see cref="NoAudioCapturedException"/>.
+    /// </summary>
+    private async Task<(byte[] Pcm, CaptureHealth? Health, string Device)> StopAndSnapshotAsync()
     {
         if (_disposed) throw new ObjectDisposedException(nameof(BatchDictationRecorder));
         if (!_started) throw new InvalidOperationException("BatchDictationRecorder not started");
         if (_stopped) throw new InvalidOperationException("BatchDictationRecorder already stopped");
         _stopped = true;
 
-        FileLog.Write("[BatchDictationRecorder] TranscribeAsync");
-
-        // Stop the mic and WAIT for NAudio to flush its final buffered audio before
-        // snapshotting. WaveInEvent keeps capturing for up to one buffer after the
-        // stop and delivers the trailing words via AppendChunk on its worker thread,
-        // then raises RecordingStopped; StopAsync completes on that event, so the
-        // whole tail of speech is appended to _audio before the snapshot below.
-        // Detaching the handler BEFORE the drain (the old order) discarded that tail
-        // and clipped the end of the user's speech. Only after the drain do we detach,
-        // so no genuinely-late chunk can race the snapshot; the lock guards it anyway.
         var device = _mic?.Description ?? MicDevices.DescribeDevice(_micDeviceNumber);
         CaptureHealth? captureHealth = null;
         if (_mic is not null)
@@ -240,9 +246,28 @@ public sealed class BatchDictationRecorder : IAsyncDisposable
         // device the user must check.
         if (pcm.Length == 0)
         {
-            FileLog.Write("[BatchDictationRecorder] TranscribeAsync: no audio captured; refusing to transcribe (completeness gate)");
+            FileLog.Write("[BatchDictationRecorder] no audio captured; refusing (completeness gate)");
             throw new NoAudioCapturedException(device);
         }
+
+        return (pcm, captureHealth, device);
+    }
+
+    /// <summary>
+    /// Stop the microphone, then transcribe the whole captured clip exactly once
+    /// through the shared batch pipeline (the user-selected method), applying the
+    /// dictionary corrector only. Returns the raw transcript, the corrected
+    /// transcript, and how many dictionary words were corrected.
+    ///
+    /// Enforces the completeness gate (issue #586): a turn that captured no audio
+    /// fails loud with <see cref="NoAudioCapturedException"/> rather than producing
+    /// a partial/empty transcript. Transcription failures throw so the caller
+    /// surfaces them - a missing transcript is a real failure, not papered over.
+    /// </summary>
+    public async Task<DictationResult> TranscribeAsync(CancellationToken ct = default)
+    {
+        FileLog.Write("[BatchDictationRecorder] TranscribeAsync");
+        var (pcm, captureHealth, device) = await StopAndSnapshotAsync();
 
         // Test seam: hand the snapshotted PCM to the injected stub instead of the real
         // network pipeline. The empty-audio gate above still runs first, so the stub
@@ -368,6 +393,13 @@ public sealed class BatchDictationRecorder : IAsyncDisposable
 /// byte-for-byte whenever no dictionary term matched.
 /// </summary>
 public sealed record DictationResult(string RawTranscript, string CleanedTranscript, int DictionaryWordsCorrected);
+
+/// <summary>
+/// The whole captured dictation clip as an uploadable WAV blob plus how long it was recorded
+/// (issue #1130). Returned by <see cref="BatchDictationRecorder.StopAndGetWavAsync"/> so the durable
+/// fire-and-forget Send can persist the bytes to disk before transcribing them.
+/// </summary>
+public sealed record CapturedAudio(byte[] Wav, long RecordingMs);
 
 /// <summary>
 /// Minimal RIFF/WAV container writer for raw PCM16. The desktop mic delivers raw

--- a/src/CcDirector.Core.Tests/Dictation/DictationDeliveryServiceTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/DictationDeliveryServiceTests.cs
@@ -60,6 +60,33 @@ public sealed class DictationDeliveryServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task DeliverAsync_InsertsDictationAtCaretInsideTypedText_SoRetriesNeverDropTheTypedPart()
+    {
+        // The user had typed "start end" with the caret between the words, then dictated "middle".
+        var rec = _store.Save("s", "", SampleWav, before: "start", after: "end");
+        var svc = new DictationDeliveryService(FakeTranscriber.Returning("middle"), _store);
+        var submitted = new List<string>();
+
+        var result = await svc.DeliverAsync(rec, t => { submitted.Add(t); return Task.CompletedTask; });
+
+        Assert.Equal(DictationDeliveryOutcome.Delivered, result.Outcome);
+        Assert.Equal(new[] { "start middle end" }, submitted);
+    }
+
+    [Fact]
+    public async Task DeliverAsync_WithPrefixAndTypedText_ComposesInOrder()
+    {
+        // Earlier paused segment "one", this segment "two", typed suffix "tail" after the caret.
+        var rec = _store.Save("s", "one", SampleWav, before: "", after: "tail");
+        var svc = new DictationDeliveryService(FakeTranscriber.Returning("two"), _store);
+        var submitted = new List<string>();
+
+        await svc.DeliverAsync(rec, t => { submitted.Add(t); return Task.CompletedTask; });
+
+        Assert.Equal(new[] { "one two tail" }, submitted);
+    }
+
+    [Fact]
     public async Task DeliverAsync_EmptyTranscript_IsDelivered_AndClipRemoved_SoSilenceIsNotRetriedForever()
     {
         var rec = _store.Save("s", "", SampleWav);

--- a/src/CcDirector.Core.Tests/Dictation/DictationDeliveryServiceTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/DictationDeliveryServiceTests.cs
@@ -1,0 +1,172 @@
+using CcDirector.Core.Dictation;
+using CcDirector.Core.Transcription;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Dictation;
+
+/// <summary>
+/// The delivery engine holds the keep-vs-delete rule that is the core of issue #1130: audio is deleted
+/// ONLY when delivered, and every kind of failure keeps it with the right status. Each branch is pinned
+/// here with a fake transcriber - no mic, no network.
+/// </summary>
+public sealed class DictationDeliveryServiceTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly PendingDictationStore _store;
+    private static readonly byte[] SampleWav = { 9, 8, 7, 6, 5 };
+
+    public DictationDeliveryServiceTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "delivery-tests-" + Guid.NewGuid().ToString("N"));
+        _store = new PendingDictationStore(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch { /* best effort */ }
+    }
+
+    private sealed class FakeTranscriber : IDictationTranscriber
+    {
+        private readonly Func<byte[], DictationTranscript> _fn;
+        public int Calls { get; private set; }
+        public FakeTranscriber(Func<byte[], DictationTranscript> fn) => _fn = fn;
+        public static FakeTranscriber Returning(string text)
+            => new(_ => new DictationTranscript(text, text, 0));
+        public static FakeTranscriber Throwing(Exception ex)
+            => new(_ => throw ex);
+        public Task<DictationTranscript> TranscribeAsync(byte[] wav, CancellationToken ct = default)
+        {
+            Calls++;
+            return Task.FromResult(_fn(wav));
+        }
+    }
+
+    [Fact]
+    public async Task DeliverAsync_Success_SubmitsJoinedText_AndDeletesTheClip()
+    {
+        var rec = _store.Save("s", "hello", SampleWav);
+        var transcriber = FakeTranscriber.Returning("world");
+        var svc = new DictationDeliveryService(transcriber, _store);
+        var submitted = new List<string>();
+
+        var result = await svc.DeliverAsync(rec, t => { submitted.Add(t); return Task.CompletedTask; });
+
+        Assert.Equal(DictationDeliveryOutcome.Delivered, result.Outcome);
+        Assert.True(result.Delivered);
+        Assert.Equal(new[] { "hello world" }, submitted); // prefix joined ahead of the transcript
+        Assert.Empty(_store.LoadAll());                    // delivered => deleted
+    }
+
+    [Fact]
+    public async Task DeliverAsync_EmptyTranscript_IsDelivered_AndClipRemoved_SoSilenceIsNotRetriedForever()
+    {
+        var rec = _store.Save("s", "", SampleWav);
+        var svc = new DictationDeliveryService(FakeTranscriber.Returning(""), _store);
+        var submitCalls = 0;
+
+        var result = await svc.DeliverAsync(rec, _ => { submitCalls++; return Task.CompletedTask; });
+
+        Assert.Equal(DictationDeliveryOutcome.Delivered, result.Outcome);
+        Assert.Equal(1, submitCalls);        // submit is still called; the delegate guards an empty turn
+        Assert.Empty(_store.LoadAll());
+    }
+
+    [Fact]
+    public async Task DeliverAsync_Transient504_KeepsClipPending_ForAutomaticRetry()
+    {
+        var rec = _store.Save("s", "", SampleWav);
+        var ex = new TranscriptionFailedException(504, "Transcription returned 504: upstream_timeout");
+        var svc = new DictationDeliveryService(FakeTranscriber.Throwing(ex), _store);
+        var submitCalls = 0;
+
+        var result = await svc.DeliverAsync(rec, _ => { submitCalls++; return Task.CompletedTask; });
+
+        Assert.Equal(DictationDeliveryOutcome.HeldWillRetry, result.Outcome);
+        Assert.True(result.WillRetryAutomatically);
+        Assert.Equal(0, submitCalls);
+        var kept = _store.LoadAll();
+        Assert.Single(kept);
+        Assert.Equal(PendingDictationStatus.Pending, kept[0].Status);   // eligible for retry
+        Assert.Equal(1, kept[0].AttemptCount);
+    }
+
+    [Fact]
+    public async Task DeliverAsync_NetworkException_KeepsClipPending_ForAutomaticRetry()
+    {
+        var rec = _store.Save("s", "", SampleWav);
+        var svc = new DictationDeliveryService(FakeTranscriber.Throwing(new HttpRequestException("connection reset")), _store);
+
+        var result = await svc.DeliverAsync(rec, _ => Task.CompletedTask);
+
+        Assert.Equal(DictationDeliveryOutcome.HeldWillRetry, result.Outcome);
+        Assert.Equal(PendingDictationStatus.Pending, _store.LoadAll()[0].Status);
+    }
+
+    [Fact]
+    public async Task DeliverAsync_OutOfCredits_ParksNeedsAttention_KeepsClip()
+    {
+        var rec = _store.Save("s", "", SampleWav);
+        var svc = new DictationDeliveryService(
+            FakeTranscriber.Throwing(new InsufficientCreditsException("insufficient_credits", "out of credits")), _store);
+
+        var result = await svc.DeliverAsync(rec, _ => Task.CompletedTask);
+
+        Assert.Equal(DictationDeliveryOutcome.NeedsCredits, result.Outcome);
+        Assert.Equal(PendingDictationStatus.NeedsAttention, _store.LoadAll()[0].Status);
+    }
+
+    [Fact]
+    public async Task DeliverAsync_NoMethodConfigured_ParksNeedsAttention_KeepsClip()
+    {
+        var rec = _store.Save("s", "", SampleWav);
+        var svc = new DictationDeliveryService(
+            FakeTranscriber.Throwing(new TranscriptionUnavailableException("OpenAI key is not set.")), _store);
+
+        var result = await svc.DeliverAsync(rec, _ => Task.CompletedTask);
+
+        Assert.Equal(DictationDeliveryOutcome.NeedsConfiguration, result.Outcome);
+        Assert.Equal(PendingDictationStatus.NeedsAttention, _store.LoadAll()[0].Status);
+    }
+
+    [Fact]
+    public async Task DeliverAsync_PermanentProviderError_ParksNeedsAttention_KeepsClip()
+    {
+        var rec = _store.Save("s", "", SampleWav);
+        var svc = new DictationDeliveryService(
+            FakeTranscriber.Throwing(new TranscriptionFailedException(400, "Transcription returned 400: bad request")), _store);
+
+        var result = await svc.DeliverAsync(rec, _ => Task.CompletedTask);
+
+        Assert.Equal(DictationDeliveryOutcome.PermanentError, result.Outcome);
+        Assert.Equal(PendingDictationStatus.NeedsAttention, _store.LoadAll()[0].Status);
+    }
+
+    [Fact]
+    public async Task DeliverAsync_SubmitThrows_KeepsClipForRetry_NeverLosesIt()
+    {
+        // A transcription that SUCCEEDS but whose submit fails (e.g. the session momentarily unavailable)
+        // must not lose the words: the clip stays saved and retryable.
+        var rec = _store.Save("s", "", SampleWav);
+        var svc = new DictationDeliveryService(FakeTranscriber.Returning("hello"), _store);
+
+        var result = await svc.DeliverAsync(rec, _ => throw new InvalidOperationException("session busy"));
+
+        Assert.Equal(DictationDeliveryOutcome.HeldWillRetry, result.Outcome);
+        Assert.Single(_store.LoadAll());
+    }
+
+    [Fact]
+    public async Task DeliverAsync_AudioMissing_ReportsLostNoAudio_NeverSilent()
+    {
+        var rec = _store.Save("s", "", SampleWav);
+        _store.Delete(rec); // audio gone before delivery
+        var svc = new DictationDeliveryService(FakeTranscriber.Returning("x"), _store);
+
+        var result = await svc.DeliverAsync(rec, _ => Task.CompletedTask);
+
+        Assert.Equal(DictationDeliveryOutcome.LostNoAudio, result.Outcome);
+        Assert.NotNull(result.Error);
+    }
+}

--- a/src/CcDirector.Core.Tests/Dictation/PendingDictationStoreTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/PendingDictationStoreTests.cs
@@ -1,0 +1,165 @@
+using CcDirector.Core.Dictation;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Dictation;
+
+/// <summary>
+/// The durable store is the whole guarantee behind issue #1130: audio written before any network call,
+/// deleted only when delivered, and readable back on the next launch. These tests pin that contract
+/// against a temp directory - no application state, no network.
+/// </summary>
+public sealed class PendingDictationStoreTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly PendingDictationStore _store;
+    private static readonly byte[] SampleWav = { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+    public PendingDictationStoreTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "pending-dictation-tests-" + Guid.NewGuid().ToString("N"));
+        _store = new PendingDictationStore(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch { /* best effort temp cleanup */ }
+    }
+
+    [Fact]
+    public void Save_WritesAudioAndSidecar_AndReturnsPendingRecord()
+    {
+        var rec = _store.Save("session-1", "prefix words", SampleWav);
+
+        Assert.False(string.IsNullOrWhiteSpace(rec.Id));
+        Assert.Equal("session-1", rec.SessionId);
+        Assert.Equal("prefix words", rec.Prefix);
+        Assert.Equal(0, rec.AttemptCount);
+        Assert.Equal(PendingDictationStatus.Pending, rec.Status);
+        Assert.True(_store.HasAudio(rec));
+        Assert.Equal(SampleWav, _store.ReadAudio(rec));
+    }
+
+    [Fact]
+    public void Save_EmptyAudio_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => _store.Save("session-1", "", Array.Empty<byte>()));
+    }
+
+    [Fact]
+    public void ReadAudio_ReturnsTheExactBytesSaved_AcrossANewStoreInstance()
+    {
+        var rec = _store.Save("session-1", "", SampleWav);
+
+        // A brand-new store over the same directory models the next launch reading it back.
+        var reopened = new PendingDictationStore(_dir);
+        var loaded = reopened.LoadAll();
+
+        Assert.Single(loaded);
+        Assert.Equal(rec.Id, loaded[0].Id);
+        Assert.Equal(SampleWav, reopened.ReadAudio(loaded[0]));
+    }
+
+    [Fact]
+    public void Delete_RemovesBothAudioAndSidecar()
+    {
+        var rec = _store.Save("session-1", "", SampleWav);
+        _store.Delete(rec);
+
+        Assert.False(_store.HasAudio(rec));
+        Assert.Empty(_store.LoadAll());
+    }
+
+    [Fact]
+    public void RecordFailedAttempt_BumpsCountAndSetsStatusAndError_KeepingAudio()
+    {
+        var rec = _store.Save("session-1", "", SampleWav);
+
+        var after = _store.RecordFailedAttempt(rec, "Transcription returned 504", PendingDictationStatus.Pending);
+
+        Assert.Equal(1, after.AttemptCount);
+        Assert.Equal(PendingDictationStatus.Pending, after.Status);
+        Assert.Contains("504", after.LastError);
+        Assert.True(_store.HasAudio(after)); // audio is never touched by a failed attempt
+
+        // Persisted: a reload sees the bumped count and status.
+        var reloaded = _store.LoadAll();
+        Assert.Single(reloaded);
+        Assert.Equal(1, reloaded[0].AttemptCount);
+    }
+
+    [Fact]
+    public void RecordFailedAttempt_CanParkNeedsAttention()
+    {
+        var rec = _store.Save("session-1", "", SampleWav);
+        var after = _store.RecordFailedAttempt(rec, "insufficient_credits", PendingDictationStatus.NeedsAttention);
+        Assert.Equal(PendingDictationStatus.NeedsAttention, after.Status);
+    }
+
+    [Fact]
+    public void LoadAll_SkipsAndCleansAnOrphanSidecarWithNoAudio()
+    {
+        var rec = _store.Save("session-1", "", SampleWav);
+        // Simulate a torn write / manual audio removal: delete just the audio, leave the sidecar.
+        File.Delete(Path.Combine(_dir, rec.Id + ".wav"));
+
+        var loaded = _store.LoadAll();
+
+        Assert.Empty(loaded);
+        // The orphan sidecar is cleaned up so it does not linger.
+        Assert.False(File.Exists(Path.Combine(_dir, rec.Id + ".json")));
+    }
+
+    [Fact]
+    public void LoadAll_SkipsACorruptSidecar_WithoutFailingTheWholeScan()
+    {
+        var good = _store.Save("session-good", "", SampleWav);
+        // A corrupt sidecar alongside its (irrelevant) audio must not block the good record.
+        File.WriteAllText(Path.Combine(_dir, "garbage.json"), "{ this is not valid json ");
+        File.WriteAllBytes(Path.Combine(_dir, "garbage.wav"), SampleWav);
+
+        var loaded = _store.LoadAll();
+
+        Assert.Single(loaded);
+        Assert.Equal(good.Id, loaded[0].Id);
+    }
+
+    [Fact]
+    public void LoadAll_ReturnsOldestFirst()
+    {
+        var a = _store.Save("s", "", SampleWav);
+        var b = _store.Save("s", "", SampleWav);
+        // Force a known chronological order regardless of clock resolution.
+        _store.WriteSidecar(a with { CreatedUtc = "2020-01-01T00:00:00.0000000Z" });
+        _store.WriteSidecar(b with { CreatedUtc = "2020-01-02T00:00:00.0000000Z" });
+
+        var loaded = _store.LoadAll();
+
+        Assert.Equal(2, loaded.Count);
+        Assert.Equal(a.Id, loaded[0].Id);
+        Assert.Equal(b.Id, loaded[1].Id);
+    }
+
+    [Fact]
+    public void PruneOlderThan_DropsStaleClips_KeepsFreshOnes()
+    {
+        var stale = _store.Save("s", "", SampleWav);
+        var fresh = _store.Save("s", "", SampleWav);
+        _store.WriteSidecar(stale with { CreatedUtc = DateTime.UtcNow.AddDays(-30).ToString("o") });
+        _store.WriteSidecar(fresh with { CreatedUtc = DateTime.UtcNow.ToString("o") });
+
+        var pruned = _store.PruneOlderThan(TimeSpan.FromDays(7));
+
+        Assert.Equal(1, pruned);
+        var loaded = _store.LoadAll();
+        Assert.Single(loaded);
+        Assert.Equal(fresh.Id, loaded[0].Id);
+    }
+
+    [Fact]
+    public void LoadAll_OnMissingDirectory_ReturnsEmpty()
+    {
+        var store = new PendingDictationStore(Path.Combine(_dir, "does-not-exist-yet"));
+        Assert.Empty(store.LoadAll());
+    }
+}

--- a/src/CcDirector.Core.Tests/Dictation/PendingDictationSweeperTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/PendingDictationSweeperTests.cs
@@ -1,0 +1,174 @@
+using CcDirector.Core.Dictation;
+using CcDirector.Core.Transcription;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Dictation;
+
+/// <summary>
+/// The sweeper is what recovers a held clip without a restart (issue #1130): it re-drives every Pending
+/// clip whose session is present, leaves the rest, prunes stale ones, and never double-delivers. Pinned
+/// here with fakes - no timer, no UI, no network.
+/// </summary>
+public sealed class PendingDictationSweeperTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly PendingDictationStore _store;
+    private static readonly byte[] SampleWav = { 4, 4, 4, 4 };
+
+    public PendingDictationSweeperTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "sweeper-tests-" + Guid.NewGuid().ToString("N"));
+        _store = new PendingDictationStore(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch { /* best effort */ }
+    }
+
+    private sealed class FakeTranscriber : IDictationTranscriber
+    {
+        private readonly Func<byte[], Task<DictationTranscript>> _fn;
+        public FakeTranscriber(Func<byte[], Task<DictationTranscript>> fn) => _fn = fn;
+        public static FakeTranscriber Returning(string text)
+            => new(_ => Task.FromResult(new DictationTranscript(text, text, 0)));
+        public Task<DictationTranscript> TranscribeAsync(byte[] wav, CancellationToken ct = default) => _fn(wav);
+    }
+
+    private DictationDeliveryService Delivery(IDictationTranscriber t) => new(t, _store);
+
+    /// <summary>A session resolver where only the ids in <paramref name="present"/> are deliverable.</summary>
+    private static Func<string, Func<string, Task>?> Present(List<string> sink, params string[] present)
+    {
+        var set = new HashSet<string>(present, StringComparer.Ordinal);
+        return sid => set.Contains(sid) ? (t => { sink.Add(t); return Task.CompletedTask; }) : null;
+    }
+
+    [Fact]
+    public async Task SweepAsync_DeliversPendingClipWhoseSessionIsPresent_AndRemovesIt()
+    {
+        _store.Save("present", "", SampleWav);
+        var sweeper = new PendingDictationSweeper(_store, Delivery(FakeTranscriber.Returning("hi")));
+        var submitted = new List<string>();
+
+        var report = await sweeper.SweepAsync(Present(submitted, "present"));
+
+        Assert.Equal(1, report.Delivered);
+        Assert.Equal(new[] { "hi" }, submitted);
+        Assert.Empty(_store.LoadAll());
+        Assert.Equal(0, report.StillHeld);
+    }
+
+    [Fact]
+    public async Task SweepAsync_LeavesClipWhoseSessionIsNotLoadedYet_ForALaterSweep()
+    {
+        _store.Save("not-loaded", "", SampleWav);
+        var sweeper = new PendingDictationSweeper(_store, Delivery(FakeTranscriber.Returning("hi")));
+        var submitted = new List<string>();
+
+        var report = await sweeper.SweepAsync(Present(submitted /* nothing present */));
+
+        Assert.Equal(0, report.Delivered);
+        Assert.Equal(1, report.WaitingForSession);
+        Assert.Single(_store.LoadAll());     // kept
+        Assert.True(report.StillHeld > 0);
+    }
+
+    [Fact]
+    public async Task SweepAsync_SkipsParkedNeedsAttentionClips()
+    {
+        var rec = _store.Save("present", "", SampleWav);
+        _store.WriteSidecar(rec with { Status = PendingDictationStatus.NeedsAttention });
+        var sweeper = new PendingDictationSweeper(_store, Delivery(FakeTranscriber.Returning("hi")));
+        var submitted = new List<string>();
+
+        var report = await sweeper.SweepAsync(Present(submitted, "present"));
+
+        Assert.Equal(0, report.Delivered);
+        Assert.Equal(1, report.ParkedNeedingAttention);
+        Assert.Empty(submitted);
+        Assert.Single(_store.LoadAll());     // parked clip stays until promoted
+    }
+
+    [Fact]
+    public void PromoteParkedToPending_FlipsNeedsAttentionBackToPending()
+    {
+        var a = _store.Save("s", "", SampleWav);
+        var b = _store.Save("s", "", SampleWav);
+        _store.WriteSidecar(a with { Status = PendingDictationStatus.NeedsAttention });
+        // b stays Pending
+        var sweeper = new PendingDictationSweeper(_store, Delivery(FakeTranscriber.Returning("hi")));
+
+        var promoted = sweeper.PromoteParkedToPending();
+
+        Assert.Equal(1, promoted);
+        Assert.All(_store.LoadAll(), r => Assert.Equal(PendingDictationStatus.Pending, r.Status));
+        _ = b;
+    }
+
+    [Fact]
+    public async Task SweepAsync_PrunesStaleClipsFirst()
+    {
+        var stale = _store.Save("present", "", SampleWav);
+        _store.WriteSidecar(stale with { CreatedUtc = DateTime.UtcNow.AddDays(-30).ToString("o") });
+        var sweeper = new PendingDictationSweeper(_store, Delivery(FakeTranscriber.Returning("hi")), staleAfter: TimeSpan.FromDays(7));
+        var submitted = new List<string>();
+
+        var report = await sweeper.SweepAsync(Present(submitted, "present"));
+
+        Assert.Equal(1, report.Pruned);
+        Assert.Equal(0, report.Delivered);   // it was pruned before any delivery attempt
+        Assert.Empty(submitted);
+        Assert.Empty(_store.LoadAll());
+    }
+
+    [Fact]
+    public async Task TryDeliverAsync_WhileClipAlreadyInFlight_ReturnsNull_NoDoubleDelivery()
+    {
+        var rec = _store.Save("present", "", SampleWav);
+        var gate = new TaskCompletionSource();
+        var transcribeStarted = new TaskCompletionSource();
+        var blocking = new FakeTranscriber(async _ =>
+        {
+            transcribeStarted.TrySetResult();
+            await gate.Task;                       // hold the first delivery inside transcription
+            return new DictationTranscript("hi", "hi", 0);
+        });
+        var sweeper = new PendingDictationSweeper(_store, Delivery(blocking));
+        var submitted = new List<string>();
+        Func<string, Task> submit = t => { lock (submitted) submitted.Add(t); return Task.CompletedTask; };
+
+        // Start the first delivery; wait until it is inside transcription (id claimed).
+        var first = sweeper.TryDeliverAsync(rec, submit);
+        await transcribeStarted.Task;
+
+        // A second attempt for the SAME id is refused while the first is in flight.
+        var second = await sweeper.TryDeliverAsync(rec, submit);
+        Assert.Null(second);
+
+        // Let the first finish; it delivers exactly once.
+        gate.SetResult();
+        var firstResult = await first;
+        Assert.NotNull(firstResult);
+        Assert.Equal(DictationDeliveryOutcome.Delivered, firstResult!.Outcome);
+        Assert.Single(submitted);
+    }
+
+    [Fact]
+    public async Task SweepAsync_MixedBatch_DeliversPresentAndHoldsAbsent()
+    {
+        _store.Save("present", "", SampleWav);
+        _store.Save("absent", "", SampleWav);
+        var sweeper = new PendingDictationSweeper(_store, Delivery(FakeTranscriber.Returning("hi")));
+        var submitted = new List<string>();
+
+        var report = await sweeper.SweepAsync(Present(submitted, "present"));
+
+        Assert.Equal(1, report.Delivered);
+        Assert.Equal(1, report.WaitingForSession);
+        var remaining = _store.LoadAll();
+        Assert.Single(remaining);
+        Assert.Equal("absent", remaining[0].SessionId);
+    }
+}

--- a/src/CcDirector.Core.Tests/Transcription/BatchTranscriptionPipelineTests.cs
+++ b/src/CcDirector.Core.Tests/Transcription/BatchTranscriptionPipelineTests.cs
@@ -150,13 +150,19 @@ public sealed class BatchTranscriptionPipelineTests
     }
 
     [Fact]
-    public async Task TranscribeRawAsync_500_StillThrowsGenericInvalidOperation_NotOutOfCredits()
+    public async Task TranscribeRawAsync_500_ThrowsTypedTranscriptionFailure_NotOutOfCredits()
     {
-        // A non-402 provider failure must NOT be mistaken for out-of-credits.
+        // A non-402 provider failure must NOT be mistaken for out-of-credits. It now carries the status
+        // code so the durable dictation retry loop (issue #1130) can classify it - a 500 is transient.
+        // The typed exception still derives from InvalidOperationException, so pre-#1130 catches work.
         using var pipeline = new BatchTranscriptionPipeline(new HttpClient(new StatusHandler(HttpStatusCode.InternalServerError, "boom")));
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        var ex = await Assert.ThrowsAsync<TranscriptionFailedException>(() =>
             pipeline.TranscribeRawAsync(new byte[] { 1, 2, 3 }, "utterance.webm", DevThrottle()));
+        Assert.Equal(500, ex.StatusCode);
+        Assert.True(ex.IsTransient);
+        Assert.IsAssignableFrom<InvalidOperationException>(ex);
+        Assert.IsNotType<InsufficientCreditsException>(ex);
     }
 
     // ----- Acceptance criterion: a dictionary hit is swapped and reported -----

--- a/src/CcDirector.Core.Tests/Transcription/TranscriptionFailedExceptionTests.cs
+++ b/src/CcDirector.Core.Tests/Transcription/TranscriptionFailedExceptionTests.cs
@@ -1,0 +1,49 @@
+using CcDirector.Core.Transcription;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Transcription;
+
+/// <summary>
+/// The transient/permanent split (issue #1130) decides whether the durable dictation retry loop keeps
+/// auto-retrying a clip or parks it. Getting it wrong either hammers a doomed request or gives up on a
+/// recoverable blip - the exact 504 that lost the user's audio - so it is pinned here.
+/// </summary>
+public sealed class TranscriptionFailedExceptionTests
+{
+    [Theory]
+    [InlineData(500)]
+    [InlineData(502)]
+    [InlineData(503)]
+    [InlineData(504)] // the DevThrottle proxy upstream_timeout that started issue #1130
+    [InlineData(408)]
+    [InlineData(429)]
+    [InlineData(425)]
+    public void IsTransient_ServerAndThrottleStatuses_AreRetryable(int status)
+    {
+        var ex = new TranscriptionFailedException(status, $"Transcription returned {status}");
+        Assert.True(ex.IsTransient, $"status {status} should be retryable");
+        Assert.Equal(status, ex.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(400)]
+    [InlineData(401)]
+    [InlineData(403)]
+    [InlineData(404)]
+    [InlineData(413)] // payload too large - retrying the identical body fails identically
+    [InlineData(422)]
+    public void IsTransient_ClientRequestErrors_AreNotRetryable(int status)
+    {
+        var ex = new TranscriptionFailedException(status, $"Transcription returned {status}");
+        Assert.False(ex.IsTransient, $"status {status} should not be retried");
+    }
+
+    [Fact]
+    public void TranscriptionFailedException_IsAnInvalidOperationException_SoExistingCatchesStillWork()
+    {
+        // Callers written before the typed exception catch InvalidOperationException; the new type must
+        // still be caught by them.
+        var ex = new TranscriptionFailedException(504, "Transcription returned 504");
+        Assert.IsAssignableFrom<InvalidOperationException>(ex);
+    }
+}

--- a/src/CcDirector.Core/Dictation/DictationDeliveryService.cs
+++ b/src/CcDirector.Core/Dictation/DictationDeliveryService.cs
@@ -1,0 +1,169 @@
+using CcDirector.Core.Transcription;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Dictation;
+
+/// <summary>
+/// The single engine that turns a durably-saved dictation into a delivered turn, and decides whether to
+/// delete it (delivered) or keep it for a later retry (issue #1130). Both the immediate post-Send
+/// attempt and the background sweep / next-launch re-drive go through here, so the keep-vs-delete rule
+/// lives in exactly one tested place.
+///
+/// The contract, mirroring the mobile durable-dictation contract (issue #1006/#1056):
+///   * The audio is deleted ONLY on a delivered outcome. Every failure keeps the saved audio.
+///   * A transient failure (slow/unavailable transcription service, a 5xx/429, a network drop) leaves
+///     the clip <see cref="PendingDictationStatus.Pending"/> - the sweeper will retry it automatically.
+///   * A "needs the user" failure (out of credits, no key configured) parks it
+///     <see cref="PendingDictationStatus.NeedsAttention"/> so the sweeper stops hammering a call that
+///     will keep failing; the next launch promotes it back to try once more.
+///   * Success is silent - the delivered turn is the proof.
+///
+/// This engine is deliberately UI-free: it takes the submit action as a delegate and returns a
+/// structured <see cref="DictationDeliveryResult"/>; the desktop layer maps that to notifications.
+/// </summary>
+public sealed class DictationDeliveryService
+{
+    private readonly IDictationTranscriber _transcriber;
+    private readonly PendingDictationStore _store;
+
+    public DictationDeliveryService(IDictationTranscriber transcriber, PendingDictationStore store)
+    {
+        _transcriber = transcriber ?? throw new ArgumentNullException(nameof(transcriber));
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+    }
+
+    /// <summary>
+    /// Attempt to transcribe and deliver one saved clip exactly once. Reads the audio back from the
+    /// store (proving the durable copy is intact), transcribes it, joins it onto the clip's prefix, and
+    /// hands the text to <paramref name="submit"/>. On success the clip is deleted; on any failure the
+    /// clip is kept with its status updated, and the failure is classified into the returned result.
+    /// Never throws for a transcription/submit failure - the whole point is that a failure is a held
+    /// clip, not a lost one. (An empty transcript is still a delivered outcome: the audio was silence,
+    /// the turn is a no-op the submit delegate guards, and keeping the clip would retry silence forever.)
+    /// </summary>
+    public async Task<DictationDeliveryResult> DeliverAsync(PendingDictation pending, Func<string, Task> submit, CancellationToken ct = default)
+    {
+        if (pending is null) throw new ArgumentNullException(nameof(pending));
+        if (submit is null) throw new ArgumentNullException(nameof(submit));
+
+        byte[] audio;
+        try
+        {
+            audio = _store.ReadAudio(pending);
+        }
+        catch (Exception ex)
+        {
+            // The saved audio is unreadable (deleted out from under us, disk error). Nothing to deliver
+            // and nothing to keep - report it loudly rather than silently dropping.
+            FileLog.Write($"[DictationDeliveryService] audio unreadable id={pending.Id}: {ex.Message}");
+            return new DictationDeliveryResult(DictationDeliveryOutcome.LostNoAudio, pending, ex.Message);
+        }
+
+        try
+        {
+            var transcript = await _transcriber.TranscribeAsync(audio, ct);
+            // Reproduce the exact composed turn: the dictation (this segment joined onto any earlier
+            // paused segments) inserted at the caret inside whatever the user had typed. Persisting
+            // Before/After means a background retry drops neither the typed text nor the dictation.
+            var dictation = Join(pending.Prefix, transcript.CleanedTranscript);
+            var text = InsertAtCaret(pending.Before, pending.After, dictation).Trim();
+            await submit(text);
+            _store.Delete(pending);
+            FileLog.Write($"[DictationDeliveryService] delivered id={pending.Id}, chars={text.Length}");
+            return new DictationDeliveryResult(DictationDeliveryOutcome.Delivered, pending, null);
+        }
+        catch (InsufficientCreditsException ex)
+        {
+            var kept = _store.RecordFailedAttempt(pending, ex.Message, PendingDictationStatus.NeedsAttention);
+            return new DictationDeliveryResult(DictationDeliveryOutcome.NeedsCredits, kept, ex.Message);
+        }
+        catch (TranscriptionUnavailableException ex)
+        {
+            var kept = _store.RecordFailedAttempt(pending, ex.Message, PendingDictationStatus.NeedsAttention);
+            return new DictationDeliveryResult(DictationDeliveryOutcome.NeedsConfiguration, kept, ex.Message);
+        }
+        catch (TranscriptionFailedException ex) when (!ex.IsTransient)
+        {
+            // A permanent provider rejection (a 4xx other than 402/408/429): retrying sends the identical
+            // request for the identical rejection. Park it so the sweeper stops, but keep the audio.
+            var kept = _store.RecordFailedAttempt(pending, ex.Message, PendingDictationStatus.NeedsAttention);
+            return new DictationDeliveryResult(DictationDeliveryOutcome.PermanentError, kept, ex.Message);
+        }
+        catch (Exception ex)
+        {
+            // Everything else - a transient 5xx/429 (the 504 upstream_timeout that started all this), a
+            // network drop, a timeout - is retryable. Keep it Pending so the sweeper tries again.
+            var kept = _store.RecordFailedAttempt(pending, ex.Message, PendingDictationStatus.Pending);
+            return new DictationDeliveryResult(DictationDeliveryOutcome.HeldWillRetry, kept, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Join an already-transcribed prefix and this segment's transcript with exactly one separating
+    /// space unless a boundary space already exists - the same rule the desktop dialog uses so a
+    /// re-driven clip reads identically to a live one.
+    /// </summary>
+    private static string Join(string left, string right)
+    {
+        if (string.IsNullOrEmpty(left)) return right ?? "";
+        if (string.IsNullOrEmpty(right)) return left;
+        var leftEndsWithSpace = char.IsWhiteSpace(left[^1]);
+        var rightStartsWithSpace = char.IsWhiteSpace(right[0]);
+        if (leftEndsWithSpace || rightStartsWithSpace) return left + right;
+        return left + " " + right;
+    }
+
+    /// <summary>
+    /// Insert <paramref name="insert"/> between the typed <paramref name="before"/> and
+    /// <paramref name="after"/> halves, adding one separating space on a side only when the adjacent
+    /// character is not already whitespace - the same rule the desktop Insert button uses, so a re-driven
+    /// send lands the words exactly where a live one would. With both halves empty this returns the
+    /// dictation unchanged (the common "just talk and Send" case).
+    /// </summary>
+    private static string InsertAtCaret(string before, string after, string insert)
+    {
+        before ??= "";
+        after ??= "";
+        if (string.IsNullOrEmpty(insert)) return before + after;
+        var needsSpaceBefore = before.Length > 0 && !char.IsWhiteSpace(before[^1]);
+        var needsSpaceAfter = after.Length > 0 && !char.IsWhiteSpace(after[0]);
+        var mid = (needsSpaceBefore ? " " : "") + insert + (needsSpaceAfter ? " " : "");
+        return before + mid + after;
+    }
+}
+
+/// <summary>How a delivery attempt ended.</summary>
+public enum DictationDeliveryOutcome
+{
+    /// <summary>Transcribed and submitted into the session; the saved clip was deleted.</summary>
+    Delivered,
+
+    /// <summary>A transient failure (slow/unavailable service, 5xx/429, network drop). Audio kept,
+    /// status Pending - the sweeper will retry automatically.</summary>
+    HeldWillRetry,
+
+    /// <summary>Out of transcription credits. Audio kept, parked NeedsAttention until the user adds credits.</summary>
+    NeedsCredits,
+
+    /// <summary>No transcription method configured (no key, or Gateway unreachable). Audio kept, parked
+    /// NeedsAttention until the user sets one.</summary>
+    NeedsConfiguration,
+
+    /// <summary>A permanent provider rejection (a non-retryable 4xx). Audio kept, parked NeedsAttention;
+    /// retrying would fail identically.</summary>
+    PermanentError,
+
+    /// <summary>The saved audio could not be read back (disk error / removed). Nothing to deliver -
+    /// reported, not silent.</summary>
+    LostNoAudio,
+}
+
+/// <summary>The result of one delivery attempt: how it ended, the (updated) record, and any error text.</summary>
+public sealed record DictationDeliveryResult(DictationDeliveryOutcome Outcome, PendingDictation Pending, string? Error)
+{
+    /// <summary>True when the clip was delivered and removed from the store.</summary>
+    public bool Delivered => Outcome == DictationDeliveryOutcome.Delivered;
+
+    /// <summary>True when the clip is still saved and eligible for an automatic background retry.</summary>
+    public bool WillRetryAutomatically => Outcome == DictationDeliveryOutcome.HeldWillRetry;
+}

--- a/src/CcDirector.Core/Dictation/PendingDictation.cs
+++ b/src/CcDirector.Core/Dictation/PendingDictation.cs
@@ -1,0 +1,58 @@
+namespace CcDirector.Core.Dictation;
+
+/// <summary>
+/// Whether a saved dictation is eligible for automatic background retry, or is parked waiting for the
+/// user to do something before a retry can possibly succeed.
+/// </summary>
+public enum PendingDictationStatus
+{
+    /// <summary>Eligible for automatic retry - the last failure was transient (a slow or briefly
+    /// unavailable transcription service, or a session that was not on screen yet).</summary>
+    Pending,
+
+    /// <summary>Parked: the last failure needs the user to act before a retry can succeed (out of
+    /// credits, or no transcription key set). The background sweeper skips these so it does not hammer a
+    /// call that will keep failing; the next Director launch promotes them back to
+    /// <see cref="Pending"/> to try once more in case the user has since fixed it.</summary>
+    NeedsAttention,
+}
+
+/// <summary>
+/// One recorded-but-not-yet-delivered desktop dictation, saved durably on disk the instant Send is
+/// pressed (issue #1130). The recorded audio lives next to this record as a WAV file; this is its
+/// metadata sidecar. A record exists only while its audio has not yet been transcribed and delivered
+/// into its session - it is deleted the moment delivery succeeds. Field names are stable (the JSON
+/// sidecar is read back on the next launch); add optional fields rather than renaming.
+/// </summary>
+public sealed record PendingDictation
+{
+    /// <summary>Stable id; also the WAV/sidecar file stem. A GUID "N" string.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>The session this dictation is being delivered into (the desktop Session.Id, a GUID string).</summary>
+    public required string SessionId { get; init; }
+
+    /// <summary>Already-transcribed text from earlier Pause/Resume segments, joined ahead of this
+    /// clip's transcript to form the full dictation. Empty in the common "just talk and Send" case.</summary>
+    public required string Prefix { get; init; }
+
+    /// <summary>Text the user had typed BEFORE the caret when Send was pressed; the dictation is inserted
+    /// at the caret inside it. Empty in the common "just talk and Send" case. Persisted so a background
+    /// retry reproduces the exact composed turn, never dropping the typed part.</summary>
+    public string Before { get; init; } = "";
+
+    /// <summary>Text the user had typed AFTER the caret when Send was pressed. See <see cref="Before"/>.</summary>
+    public string After { get; init; } = "";
+
+    /// <summary>When the audio was recorded (ISO 8601 UTC), for the stale-clip prune.</summary>
+    public required string CreatedUtc { get; init; }
+
+    /// <summary>How many delivery attempts have failed so far. Purely diagnostic.</summary>
+    public int AttemptCount { get; init; }
+
+    /// <summary>The most recent failure message, for diagnostics and the log. Null before the first failure.</summary>
+    public string? LastError { get; init; }
+
+    /// <summary>Whether this clip is eligible for automatic retry (see <see cref="PendingDictationStatus"/>).</summary>
+    public PendingDictationStatus Status { get; init; } = PendingDictationStatus.Pending;
+}

--- a/src/CcDirector.Core/Dictation/PendingDictationStore.cs
+++ b/src/CcDirector.Core/Dictation/PendingDictationStore.cs
@@ -1,0 +1,200 @@
+using System.Text.Json;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Dictation;
+
+/// <summary>
+/// The durable on-disk store for desktop fire-and-forget dictations (issue #1130). Every Send writes
+/// its recorded audio here BEFORE any transcription call, so a failed or slow transcription, an
+/// unreachable transcription server, or an application crash can never lose the spoken words: the clip
+/// is retried in the background and re-driven on the next launch. A record is deleted only once the
+/// dictation has been transcribed and delivered into its session.
+///
+/// Layout, under <c>%LOCALAPPDATA%\cc-director\pending-dictations\</c> (or a test-supplied directory):
+///   &lt;id&gt;.wav   - the recorded PCM WAV, exactly as the microphone produced it
+///   &lt;id&gt;.json  - the <see cref="PendingDictation"/> sidecar (target session, prefix, attempts, error)
+///
+/// This is the desktop peer of the mobile server-owned durable upload (issue #1006). The store is
+/// deliberately UI-free and takes its directory by injection, so it is fully unit-testable against a
+/// temp folder with no application state.
+/// </summary>
+public sealed class PendingDictationStore
+{
+    private readonly string _dir;
+    private readonly object _gate = new();
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    /// <param name="directory">The folder to store clips in. Defaults to the shared
+    /// <see cref="CcStorage.PendingDictations"/> location; tests pass a temp directory.</param>
+    public PendingDictationStore(string? directory = null)
+    {
+        _dir = string.IsNullOrWhiteSpace(directory) ? CcStorage.PendingDictations() : directory;
+    }
+
+    /// <summary>The directory this store writes to (for diagnostics and user-facing "saved at" messages).</summary>
+    public string Directory => _dir;
+
+    private string WavPath(string id) => Path.Combine(_dir, id + ".wav");
+    private string SidecarPath(string id) => Path.Combine(_dir, id + ".json");
+
+    /// <summary>
+    /// Persist a recorded clip durably and return its record. The audio is written first, then the
+    /// sidecar, so a record is never visible without its audio. Throws if the write fails - the caller
+    /// must know durability was NOT achieved (the mobile contract's "not persisted" branch) rather than
+    /// believe a clip is safe when it is not.
+    /// </summary>
+    public PendingDictation Save(string sessionId, string prefix, byte[] wav, string before = "", string after = "")
+    {
+        if (string.IsNullOrWhiteSpace(sessionId)) throw new ArgumentException("sessionId is required", nameof(sessionId));
+        if (wav is null || wav.Length == 0) throw new ArgumentException("wav is empty", nameof(wav));
+
+        var record = new PendingDictation
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            SessionId = sessionId,
+            Prefix = prefix ?? "",
+            Before = before ?? "",
+            After = after ?? "",
+            CreatedUtc = DateTime.UtcNow.ToString("o"),
+            AttemptCount = 0,
+            LastError = null,
+            Status = PendingDictationStatus.Pending,
+        };
+
+        System.IO.Directory.CreateDirectory(_dir);
+        lock (_gate)
+        {
+            File.WriteAllBytes(WavPath(record.Id), wav);
+            File.WriteAllText(SidecarPath(record.Id), JsonSerializer.Serialize(record, JsonOptions));
+        }
+        FileLog.Write($"[PendingDictationStore] saved {wav.Length} bytes: id={record.Id}, session={sessionId}");
+        return record;
+    }
+
+    /// <summary>Read the recorded audio for a saved clip. Throws if the audio file is missing.</summary>
+    public byte[] ReadAudio(PendingDictation pending)
+    {
+        if (pending is null) throw new ArgumentNullException(nameof(pending));
+        return File.ReadAllBytes(WavPath(pending.Id));
+    }
+
+    /// <summary>True when the clip's audio file still exists on disk.</summary>
+    public bool HasAudio(PendingDictation pending)
+        => pending is not null && File.Exists(WavPath(pending.Id));
+
+    /// <summary>
+    /// Record a failed delivery attempt: bump the attempt count, store the error, and set the status so
+    /// the sweeper knows whether to keep auto-retrying (<see cref="PendingDictationStatus.Pending"/>) or
+    /// park it for user action (<see cref="PendingDictationStatus.NeedsAttention"/>). Returns the
+    /// updated record. The audio is untouched.
+    /// </summary>
+    public PendingDictation RecordFailedAttempt(PendingDictation pending, string error, PendingDictationStatus status)
+    {
+        if (pending is null) throw new ArgumentNullException(nameof(pending));
+        var updated = pending with
+        {
+            AttemptCount = pending.AttemptCount + 1,
+            LastError = Truncate(error, 500),
+            Status = status,
+        };
+        WriteSidecar(updated);
+        FileLog.Write($"[PendingDictationStore] attempt {updated.AttemptCount} failed: id={updated.Id}, status={status}, error={updated.LastError}");
+        return updated;
+    }
+
+    /// <summary>Overwrite a clip's sidecar with a new record (e.g. promoting NeedsAttention to Pending on launch).</summary>
+    public void WriteSidecar(PendingDictation pending)
+    {
+        if (pending is null) throw new ArgumentNullException(nameof(pending));
+        System.IO.Directory.CreateDirectory(_dir);
+        lock (_gate)
+        {
+            File.WriteAllText(SidecarPath(pending.Id), JsonSerializer.Serialize(pending, JsonOptions));
+        }
+    }
+
+    /// <summary>Delete a delivered (or pruned) clip: both its audio and its sidecar. Best-effort and idempotent.</summary>
+    public void Delete(PendingDictation pending)
+    {
+        if (pending is null) throw new ArgumentNullException(nameof(pending));
+        lock (_gate)
+        {
+            TryDeleteFile(WavPath(pending.Id));
+            TryDeleteFile(SidecarPath(pending.Id));
+        }
+        FileLog.Write($"[PendingDictationStore] deleted id={pending.Id}");
+    }
+
+    /// <summary>
+    /// Load every saved clip, oldest first (the order they should be re-driven). A sidecar without its
+    /// audio, or one that will not parse, is skipped (and the orphan cleaned up) rather than failing the
+    /// whole scan - one corrupt record must not block the rest from being recovered.
+    /// </summary>
+    public IReadOnlyList<PendingDictation> LoadAll()
+    {
+        if (!System.IO.Directory.Exists(_dir)) return Array.Empty<PendingDictation>();
+
+        var records = new List<PendingDictation>();
+        foreach (var sidecar in System.IO.Directory.EnumerateFiles(_dir, "*.json"))
+        {
+            PendingDictation? record = null;
+            try
+            {
+                record = JsonSerializer.Deserialize<PendingDictation>(File.ReadAllText(sidecar));
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[PendingDictationStore] skipping unreadable sidecar {Path.GetFileName(sidecar)}: {ex.Message}");
+            }
+
+            if (record is null || string.IsNullOrWhiteSpace(record.Id))
+                continue;
+
+            if (!File.Exists(WavPath(record.Id)))
+            {
+                // Sidecar with no audio: nothing to deliver, clean up the orphan.
+                FileLog.Write($"[PendingDictationStore] orphan sidecar (no audio) id={record.Id}; removing");
+                TryDeleteFile(sidecar);
+                continue;
+            }
+
+            records.Add(record);
+        }
+
+        records.Sort((a, b) => string.CompareOrdinal(a.CreatedUtc, b.CreatedUtc));
+        return records;
+    }
+
+    /// <summary>
+    /// Delete clips older than <paramref name="maxAge"/> - the only place a saved dictation is discarded
+    /// without being delivered. The window is generous (days, not the mobile hour) because on the
+    /// desktop the audio is the single copy; a clip is dropped only when it is so old its session is
+    /// certainly gone. Returns how many were pruned.
+    /// </summary>
+    public int PruneOlderThan(TimeSpan maxAge)
+    {
+        var cutoff = DateTime.UtcNow - maxAge;
+        var pruned = 0;
+        foreach (var record in LoadAll())
+        {
+            if (DateTime.TryParse(record.CreatedUtc, null, System.Globalization.DateTimeStyles.RoundtripKind, out var created)
+                && created.ToUniversalTime() < cutoff)
+            {
+                FileLog.Write($"[PendingDictationStore] pruning stale clip id={record.Id}, created={record.CreatedUtc}");
+                Delete(record);
+                pruned++;
+            }
+        }
+        return pruned;
+    }
+
+    private static string Truncate(string s, int max)
+        => string.IsNullOrEmpty(s) || s.Length <= max ? (s ?? "") : s[..max] + "...";
+
+    private static void TryDeleteFile(string path)
+    {
+        try { if (File.Exists(path)) File.Delete(path); }
+        catch (Exception ex) { FileLog.Write($"[PendingDictationStore] delete file failed ({path}): {ex.Message}"); }
+    }
+}

--- a/src/CcDirector.Core/Dictation/PendingDictationSweeper.cs
+++ b/src/CcDirector.Core/Dictation/PendingDictationSweeper.cs
@@ -1,0 +1,168 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Dictation;
+
+/// <summary>
+/// Drives the durable pending-dictation store (issue #1130): it prunes truly stale clips, promotes
+/// parked clips back for another try at launch, and re-attempts delivery for every saved clip whose
+/// session is currently present. The desktop layer owns the cadence (a timer + a launch scan + a
+/// post-Send nudge) and calls in here; all the "which clips, deliver once each, do not double-deliver,
+/// count what remains" logic lives here so it can be unit-tested with no UI and no timer.
+///
+/// Concurrency: a clip already being delivered (by an overlapping sweep or the immediate post-Send
+/// attempt) is skipped, so the same audio is never transcribed or submitted twice at once.
+/// </summary>
+public sealed class PendingDictationSweeper
+{
+    /// <summary>
+    /// How old a saved clip may get before it is pruned undelivered. Generous by design - on the desktop
+    /// the saved audio is the only copy, so a clip is discarded only when it is so old its session is
+    /// certainly gone. (The mobile store uses one hour; the desktop keeps days.)
+    /// </summary>
+    public static readonly TimeSpan DefaultStaleAfter = TimeSpan.FromDays(7);
+
+    private readonly PendingDictationStore _store;
+    private readonly DictationDeliveryService _delivery;
+    private readonly TimeSpan _staleAfter;
+
+    private readonly object _gate = new();
+    private readonly HashSet<string> _inFlight = new(StringComparer.Ordinal);
+
+    public PendingDictationSweeper(PendingDictationStore store, DictationDeliveryService delivery, TimeSpan? staleAfter = null)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _delivery = delivery ?? throw new ArgumentNullException(nameof(delivery));
+        _staleAfter = staleAfter ?? DefaultStaleAfter;
+    }
+
+    /// <summary>
+    /// Promote every parked (<see cref="PendingDictationStatus.NeedsAttention"/>) clip back to
+    /// <see cref="PendingDictationStatus.Pending"/> so the next sweep retries it. Called once at launch:
+    /// a clip parked for "out of credits" or "no key" gets a fresh chance in case the user has since
+    /// fixed it. Returns how many were promoted.
+    /// </summary>
+    public int PromoteParkedToPending()
+    {
+        var promoted = 0;
+        foreach (var record in _store.LoadAll())
+        {
+            if (record.Status == PendingDictationStatus.NeedsAttention)
+            {
+                _store.WriteSidecar(record with { Status = PendingDictationStatus.Pending });
+                promoted++;
+            }
+        }
+        if (promoted > 0) FileLog.Write($"[PendingDictationSweeper] promoted {promoted} parked clip(s) to pending");
+        return promoted;
+    }
+
+    /// <summary>
+    /// Deliver one specific clip (the immediate post-Send attempt, where the target session is known),
+    /// honoring the in-flight guard. Returns the delivery result, or null if the clip was already being
+    /// delivered by another caller.
+    /// </summary>
+    public async Task<DictationDeliveryResult?> TryDeliverAsync(PendingDictation pending, Func<string, Task> submit, CancellationToken ct = default)
+    {
+        if (pending is null) throw new ArgumentNullException(nameof(pending));
+        if (!Claim(pending.Id)) return null;
+        try
+        {
+            return await _delivery.DeliverAsync(pending, submit, ct);
+        }
+        finally
+        {
+            Release(pending.Id);
+        }
+    }
+
+    /// <summary>
+    /// One full sweep: prune stale clips, then attempt delivery for every Pending clip whose session is
+    /// currently present. <paramref name="resolveSubmit"/> maps a saved clip's SessionId to a submit
+    /// delegate, or null when that session is not currently loaded (the clip is left for a later sweep).
+    /// Returns a tally the caller turns into the held notice.
+    /// </summary>
+    public async Task<SweepReport> SweepAsync(Func<string, Func<string, Task>?> resolveSubmit, CancellationToken ct = default)
+    {
+        if (resolveSubmit is null) throw new ArgumentNullException(nameof(resolveSubmit));
+
+        var pruned = _store.PruneOlderThan(_staleAfter);
+        var report = new SweepReport { Pruned = pruned };
+
+        foreach (var record in _store.LoadAll())
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (record.Status != PendingDictationStatus.Pending)
+            {
+                report.ParkedNeedingAttention++;
+                continue;
+            }
+
+            var submit = resolveSubmit(record.SessionId);
+            if (submit is null)
+            {
+                // The session is not loaded right now (a fresh launch before its workspace opened, or a
+                // closed session). Keep the clip and try again on a later sweep.
+                report.WaitingForSession++;
+                continue;
+            }
+
+            var result = await TryDeliverAsync(record, submit, ct);
+            if (result is null)
+            {
+                report.AlreadyInFlight++;
+                continue;
+            }
+
+            report.Tally(result.Outcome);
+        }
+
+        FileLog.Write($"[PendingDictationSweeper] sweep: delivered={report.Delivered}, willRetry={report.HeldWillRetry}, "
+            + $"needsCredits={report.NeedsCredits}, needsConfig={report.NeedsConfiguration}, permanent={report.PermanentError}, "
+            + $"waitingForSession={report.WaitingForSession}, parked={report.ParkedNeedingAttention}, pruned={report.Pruned}");
+        return report;
+    }
+
+    private bool Claim(string id)
+    {
+        lock (_gate) return _inFlight.Add(id);
+    }
+
+    private void Release(string id)
+    {
+        lock (_gate) _inFlight.Remove(id);
+    }
+}
+
+/// <summary>The tally of one sweep - what happened to each saved clip, for the held notice and the log.</summary>
+public sealed class SweepReport
+{
+    public int Delivered { get; set; }
+    public int HeldWillRetry { get; set; }
+    public int NeedsCredits { get; set; }
+    public int NeedsConfiguration { get; set; }
+    public int PermanentError { get; set; }
+    public int LostNoAudio { get; set; }
+    public int WaitingForSession { get; set; }
+    public int ParkedNeedingAttention { get; set; }
+    public int AlreadyInFlight { get; set; }
+    public int Pruned { get; set; }
+
+    /// <summary>Clips still saved on disk after this sweep that the user should know are held - anything
+    /// not delivered this pass and not a transient no-op. Drives whether the held notice is shown.</summary>
+    public int StillHeld => HeldWillRetry + NeedsCredits + NeedsConfiguration + PermanentError
+                            + WaitingForSession + ParkedNeedingAttention + AlreadyInFlight;
+
+    public void Tally(DictationDeliveryOutcome outcome)
+    {
+        switch (outcome)
+        {
+            case DictationDeliveryOutcome.Delivered: Delivered++; break;
+            case DictationDeliveryOutcome.HeldWillRetry: HeldWillRetry++; break;
+            case DictationDeliveryOutcome.NeedsCredits: NeedsCredits++; break;
+            case DictationDeliveryOutcome.NeedsConfiguration: NeedsConfiguration++; break;
+            case DictationDeliveryOutcome.PermanentError: PermanentError++; break;
+            case DictationDeliveryOutcome.LostNoAudio: LostNoAudio++; break;
+        }
+    }
+}

--- a/src/CcDirector.Core/Storage/CcStorage.cs
+++ b/src/CcDirector.Core/Storage/CcStorage.cs
@@ -116,6 +116,18 @@ public static class CcStorage
     public static string DictationUploads() => Ensure(Path.Combine(Base(), "dictation-uploads"));
 
     /// <summary>
+    /// Durable pending-dictation store for the DESKTOP fire-and-forget Send (issue #1130):
+    /// base/pending-dictations/. The instant Send is pressed the recorded audio is written here as
+    /// &lt;id&gt;.wav with a &lt;id&gt;.json sidecar (target session, prefix text, attempt count, last error),
+    /// BEFORE any transcription call. It is deleted only once the dictation is transcribed and
+    /// delivered into its session, so a failed or slow transcription, an app crash, or an unreachable
+    /// transcription server can never lose recorded speech - it is retried live and re-driven on the
+    /// next launch. This is the desktop peer of the mobile server-owned durable upload
+    /// (<see cref="DictationUploads"/>, issue #1006). Owned by the desktop app.
+    /// </summary>
+    public static string PendingDictations() => Ensure(Path.Combine(Base(), "pending-dictations"));
+
+    /// <summary>
     /// Wingman training data (issue #531 follow-up): base/wingman-training/. When the
     /// "wingman_training_capture" setting is on, every wingman summary appends one JSON-lines record
     /// here holding up to 20,000 characters of the session terminal, the agent reply + context the

--- a/src/CcDirector.Core/Transcription/BatchTranscriptionPipeline.cs
+++ b/src/CcDirector.Core/Transcription/BatchTranscriptionPipeline.cs
@@ -245,8 +245,12 @@ public sealed class BatchTranscriptionPipeline : IDisposable
         if ((int)resp.StatusCode == 402)
             throw new InsufficientCreditsException(ParseErrorCode(body), $"Transcription returned 402: {Truncate(body, 400)}");
 
+        // Any other non-success status becomes a typed failure carrying the status code, so the durable
+        // dictation retry loop (issue #1130) can tell a transient 5xx/429 (retry) from a permanent 4xx
+        // (do not retry). The message format is unchanged, and the type still derives from
+        // InvalidOperationException so existing catches keep working.
         if (!resp.IsSuccessStatusCode)
-            throw new InvalidOperationException($"Transcription returned {(int)resp.StatusCode}: {Truncate(body, 400)}");
+            throw new TranscriptionFailedException((int)resp.StatusCode, $"Transcription returned {(int)resp.StatusCode}: {Truncate(body, 400)}");
 
         using var doc = JsonDocument.Parse(body);
         if (!doc.RootElement.TryGetProperty("text", out var textProp))

--- a/src/CcDirector.Core/Transcription/DictationTranscriber.cs
+++ b/src/CcDirector.Core/Transcription/DictationTranscriber.cs
@@ -1,0 +1,61 @@
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Dictation;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Transcription;
+
+/// <summary>
+/// Transcribes a saved WAV blob through the ONE shared batch pipeline
+/// (<see cref="BatchTranscriptionPipeline"/>), resolving the user-selected method and dictation
+/// dictionary exactly as the live desktop recorder does, then applying the validated dictionary
+/// corrector only. This is the transcription half of the desktop dictation path split out so it can run
+/// against a clip read back from disk (issue #1130): the durable delivery loop transcribes here, with
+/// no microphone and no dialog, on a live retry or a next-launch re-drive.
+///
+/// Failures are surfaced as typed exceptions the delivery loop classifies:
+/// <see cref="TranscriptionUnavailableException"/> (no method configured),
+/// <see cref="InsufficientCreditsException"/> (402), <see cref="TranscriptionFailedException"/>
+/// (provider HTTP error with its status code), or a raw network exception.
+/// </summary>
+public sealed class DictationTranscriber : IDictationTranscriber
+{
+    private readonly OpenAiKeyResolver _keyResolver;
+    private readonly DictionaryResolver _dictionaryResolver;
+    private readonly string? _cleanupModel;
+    private readonly string _profile;
+
+    public DictationTranscriber(AgentOptions options, string profile = "default")
+    {
+        if (options is null) throw new ArgumentNullException(nameof(options));
+        // Same resolution the live recorder uses: the Gateway vault / routing when attached, the local
+        // key vault and dictionary cache when standalone.
+        _keyResolver = new OpenAiKeyResolver();
+        _dictionaryResolver = new DictionaryResolver(options);
+        _cleanupModel = options.DictationCleanupModel;
+        _profile = string.IsNullOrWhiteSpace(profile) ? "default" : profile;
+    }
+
+    public async Task<DictationTranscript> TranscribeAsync(byte[] wav, CancellationToken ct = default)
+    {
+        if (wav is null || wav.Length == 0)
+            throw new ArgumentException("wav is empty", nameof(wav));
+
+        var routing = await _keyResolver.ResolveEndpointAsync(ct);
+        if (routing is null)
+            throw new TranscriptionUnavailableException(_keyResolver.UnavailableMessage);
+
+        var dictionary = await _dictionaryResolver.ResolveAsync(ct);
+
+        using var pipeline = new BatchTranscriptionPipeline(cleanupModel: _cleanupModel);
+        var batch = await pipeline.TranscribeAsync(wav, "dictation.wav", routing, dictionary, _profile, ct);
+
+        FileLog.Write($"[DictationTranscriber] transcribed: rawLen={batch.RawTranscript.Length}, "
+            + $"correctedLen={batch.CorrectedTranscript.Length}, changed={batch.ChangedWords.Count}, "
+            + $"mode={routing.Mode.ToConfigString()}, model={routing.Model}");
+
+        return new DictationTranscript(
+            RawTranscript: batch.RawTranscript,
+            CleanedTranscript: batch.CorrectedTranscript,
+            DictionaryWordsCorrected: batch.ChangedWords.Count);
+    }
+}

--- a/src/CcDirector.Core/Transcription/IDictationTranscriber.cs
+++ b/src/CcDirector.Core/Transcription/IDictationTranscriber.cs
@@ -1,0 +1,27 @@
+namespace CcDirector.Core.Transcription;
+
+/// <summary>
+/// Transcribes a complete WAV audio blob into text, applying the dictation dictionary corrector only
+/// (never a free-text reword). This is the seam the durable dictation delivery loop (issue #1130) uses
+/// so it can transcribe a clip read back from disk - during a live retry or a next-launch re-drive -
+/// without any microphone or dialog. Tests supply a fake to drive the retry/keep/delete logic with no
+/// network.
+/// </summary>
+public interface IDictationTranscriber
+{
+    /// <summary>
+    /// Transcribe the WAV bytes. Throws on failure - never returns a partial or empty result to paper
+    /// over a provider error: <see cref="InsufficientCreditsException"/> for 402,
+    /// <see cref="TranscriptionUnavailableException"/> when no method is configured,
+    /// <see cref="TranscriptionFailedException"/> for a provider HTTP error (carrying the status so the
+    /// caller can tell transient from permanent), or a network exception when the call could not be made.
+    /// </summary>
+    Task<DictationTranscript> TranscribeAsync(byte[] wav, CancellationToken ct = default);
+}
+
+/// <summary>
+/// The text of one transcribed dictation: the raw transcript, the dictionary-corrected transcript, and
+/// how many dictionary terms were swapped. <see cref="CleanedTranscript"/> equals
+/// <see cref="RawTranscript"/> byte-for-byte when no dictionary term matched.
+/// </summary>
+public sealed record DictationTranscript(string RawTranscript, string CleanedTranscript, int DictionaryWordsCorrected);

--- a/src/CcDirector.Core/Transcription/TranscriptionFailedException.cs
+++ b/src/CcDirector.Core/Transcription/TranscriptionFailedException.cs
@@ -1,0 +1,35 @@
+namespace CcDirector.Core.Transcription;
+
+/// <summary>
+/// Thrown by the batch transcription transport when the provider returns a non-success HTTP status
+/// (other than 402 out-of-credits, which has its own <see cref="InsufficientCreditsException"/>).
+/// Carries the status code so callers can tell a TRANSIENT failure (the provider was briefly slow or
+/// unavailable - retry) from a PERMANENT one (the request itself is wrong - do not retry).
+///
+/// Derives from <see cref="InvalidOperationException"/> so existing callers that catch the previous
+/// generic exception keep working unchanged; the message format is identical too. What is new is the
+/// typed <see cref="StatusCode"/> and the <see cref="IsTransient"/> classification the durable
+/// dictation retry loop (issue #1130) relies on.
+/// </summary>
+public sealed class TranscriptionFailedException : InvalidOperationException
+{
+    /// <summary>The HTTP status code the transcription provider returned.</summary>
+    public int StatusCode { get; }
+
+    public TranscriptionFailedException(int statusCode, string message) : base(message)
+    {
+        StatusCode = statusCode;
+    }
+
+    /// <summary>
+    /// True when the status is one a retry can plausibly clear: request timeout (408), too-early (425),
+    /// rate limit (429), or any server-side 5xx (500/502/503/504 - the DevThrottle proxy returns 504
+    /// upstream_timeout when the speech provider is slow). A 4xx other than these is the caller's
+    /// request being rejected and will fail again identically, so it is NOT retried.
+    /// </summary>
+    public bool IsTransient => IsTransientStatus(StatusCode);
+
+    /// <summary>Classify a raw HTTP status the same way <see cref="IsTransient"/> does.</summary>
+    public static bool IsTransientStatus(int statusCode)
+        => statusCode is 408 or 425 or 429 || (statusCode >= 500 && statusCode <= 599);
+}

--- a/src/CcDirector.Core/Transcription/TranscriptionUnavailableException.cs
+++ b/src/CcDirector.Core/Transcription/TranscriptionUnavailableException.cs
@@ -1,0 +1,19 @@
+namespace CcDirector.Core.Transcription;
+
+/// <summary>
+/// Thrown when transcription cannot run because no method is configured: no transcription key is set,
+/// or a configured Gateway is unreachable so its routing cannot be fetched. This is NOT a provider
+/// rejection of the audio - the audio was never sent. The durable dictation retry loop (issue #1130)
+/// treats it as "needs the user to act" (set a key / bring the Gateway up) rather than auto-retrying a
+/// call that will keep failing, and keeps the recorded audio saved so it delivers once a method exists.
+///
+/// Carries the mode-appropriate <see cref="Message"/> from
+/// <see cref="Configuration.OpenAiKeyResolver.UnavailableMessage"/> so the user is told exactly where
+/// to set the key.
+/// </summary>
+public sealed class TranscriptionUnavailableException : Exception
+{
+    public TranscriptionUnavailableException(string message) : base(message)
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- persist desktop fire-and-forget dictation audio to disk before transcription
- add pending-dictation delivery/retry services and startup/timer recovery in Director
- add focused tests for pending store, delivery classification, sweeper behavior, transcription failures, and recorder WAV capture

## Verification
- dotnet build src\CcDirector.Avalonia\CcDirector.Avalonia.csproj --verbosity minimal
- dotnet test src\CcDirector.Core.Tests\CcDirector.Core.Tests.csproj --filter 'FullyQualifiedName~DictationDeliveryServiceTests|FullyQualifiedName~PendingDictationStoreTests|FullyQualifiedName~PendingDictationSweeperTests|FullyQualifiedName~TranscriptionFailedExceptionTests' --verbosity minimal
- dotnet test src\CcDirector.Avalonia.Tests\CcDirector.Avalonia.Tests.csproj --filter 'FullyQualifiedName~BatchDictationRecorderStopWavTests' --verbosity minimal