### PR TITLE
fix(dictation): defer delivery until the session is idle at its prompt (#1135)

### DIFF
--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -3153,14 +3153,24 @@ public partial class MainWindow : Window
         if (sweeper is null) return;
         try
         {
-            await Task.Run(() => sweeper.SweepAsync(sessionId =>
-            {
-                if (!Guid.TryParse(sessionId, out var gid)) return null;
-                var session = _sessionManager?.GetSession(gid);
-                if (session is null) return null;
-                return text => global::Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
-                    () => SubmitDictatedTextAsync(session, text));
-            }));
+            await Task.Run(() => sweeper.SweepAsync(
+                resolveSubmit: sessionId =>
+                {
+                    if (!Guid.TryParse(sessionId, out var gid)) return null;
+                    var session = _sessionManager?.GetSession(gid);
+                    if (session is null) return null;
+                    return text => global::Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+                        () => SubmitDictatedTextAsync(session, text));
+                },
+                isSessionReady: sessionId =>
+                {
+                    // Only deliver into a session idle at its prompt (issue #1135): typing a dictation
+                    // into a Working, streaming composer is what piled up duplicate copies of the sentence.
+                    if (!Guid.TryParse(sessionId, out var gid)) return false;
+                    var session = _sessionManager?.GetSession(gid);
+                    return session is not null
+                        && global::CcDirector.Core.Dictation.DictationReadiness.IsReadyForDelivery(session.ActivityState);
+                }));
         }
         catch (Exception ex)
         {
@@ -3244,7 +3254,7 @@ public partial class MainWindow : Window
         var noun = total == 1 ? "dictation is" : "dictations are";
         var message = parked == total
             ? $"{total} {noun} saved and waiting - transcription needs your attention (add credits or set a key). They will be sent automatically once resolved; you will not lose them."
-            : $"{total} {noun} saved and being sent automatically - the transcription service was slow. You will not lose them.";
+            : $"{total} {noun} saved and being sent automatically as soon as the session is ready for input. You will not lose them.";
         ShowNotification(message);
         _heldNoticeShown = true;
     }

--- a/src/CcDirector.Avalonia/Voice/BackgroundDictationSend.cs
+++ b/src/CcDirector.Avalonia/Voice/BackgroundDictationSend.cs
@@ -90,9 +90,13 @@ public static class BackgroundDictationSend
                 return;
             }
 
-            // 3. Deliver the saved clip once now. If it does not deliver, it stays saved and the sweeper
-            //    retries it automatically - so this attempt failing is a HELD clip, never a lost one.
-            var result = await sweeper.TryDeliverAsync(pending, submit);
+            // 3. Deliver the saved clip once now, but only if the target session is idle at its prompt.
+            //    Typing a dictation into a busy, streaming composer is what let a failed-echo submit
+            //    pile up duplicate copies of the sentence (issue #1135); if the session is busy now the
+            //    clip stays saved and the background sweep delivers it the moment it is ready. If it does
+            //    not deliver, it stays saved and the sweeper retries automatically - a HELD clip, never lost.
+            var result = await sweeper.TryDeliverAsync(
+                pending, submit, isSessionReady: () => DictationReadiness.IsReadyForDelivery(target.ActivityState));
             if (result is not null)
             {
                 FileLog.Write($"[BackgroundDictationSend] immediate attempt for session {target.Id}: {result.Outcome}");

--- a/src/CcDirector.Core.Tests/Dictation/DictationDeliveryServiceTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/DictationDeliveryServiceTests.cs
@@ -185,6 +185,45 @@ public sealed class DictationDeliveryServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task DeliverAsync_SessionNotReady_Defers_WithoutTranscribingSubmittingOrBumpingAttempt()
+    {
+        // issue #1135: a session that is busy working must not be typed into. The clip is deferred
+        // BEFORE any transcription cost, the composer is never touched, and the attempt count is not
+        // bumped - so it is not treated as a failure and nothing accumulates in the composer.
+        var rec = _store.Save("s", "", SampleWav);
+        var transcriber = FakeTranscriber.Returning("hello");
+        var svc = new DictationDeliveryService(transcriber, _store);
+        var submitCalls = 0;
+
+        var result = await svc.DeliverAsync(
+            rec, _ => { submitCalls++; return Task.CompletedTask; }, isSessionReady: () => false);
+
+        Assert.Equal(DictationDeliveryOutcome.DeferredSessionBusy, result.Outcome);
+        Assert.False(result.Delivered);
+        Assert.Equal(0, submitCalls);            // never typed into the busy composer
+        Assert.Equal(0, transcriber.Calls);      // deferred before paying to transcribe
+        var kept = _store.LoadAll();
+        Assert.Single(kept);                     // clip kept for a later sweep
+        Assert.Equal(PendingDictationStatus.Pending, kept[0].Status);
+        Assert.Equal(0, kept[0].AttemptCount);   // a deferral is not a failed attempt
+    }
+
+    [Fact]
+    public async Task DeliverAsync_SessionReady_DeliversNormally()
+    {
+        var rec = _store.Save("s", "", SampleWav);
+        var svc = new DictationDeliveryService(FakeTranscriber.Returning("hello"), _store);
+        var submitted = new List<string>();
+
+        var result = await svc.DeliverAsync(
+            rec, t => { submitted.Add(t); return Task.CompletedTask; }, isSessionReady: () => true);
+
+        Assert.Equal(DictationDeliveryOutcome.Delivered, result.Outcome);
+        Assert.Equal(new[] { "hello" }, submitted);
+        Assert.Empty(_store.LoadAll());          // delivered => deleted
+    }
+
+    [Fact]
     public async Task DeliverAsync_AudioMissing_ReportsLostNoAudio_NeverSilent()
     {
         var rec = _store.Save("s", "", SampleWav);

--- a/src/CcDirector.Core.Tests/Dictation/DictationReadinessTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/DictationReadinessTests.cs
@@ -1,0 +1,23 @@
+using CcDirector.Core.Dictation;
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Dictation;
+
+/// <summary>
+/// The readiness gate that stops a dictation from being typed into a busy, streaming composer
+/// (issue #1135). A dictation may only land when the session is idle at its prompt; every other
+/// activity state defers.
+/// </summary>
+public sealed class DictationReadinessTests
+{
+    [Theory]
+    [InlineData(ActivityState.WaitingForInput, true)]  // at the prompt, needs the user - safe to type
+    [InlineData(ActivityState.Idle, true)]             // ready at the prompt
+    [InlineData(ActivityState.Working, false)]         // streaming output - the state that piled up copies
+    [InlineData(ActivityState.WaitingForPerm, false)]  // a permission prompt a free-text line would answer wrongly
+    [InlineData(ActivityState.Starting, false)]        // composer still initializing
+    [InlineData(ActivityState.Exited, false)]          // gone
+    public void IsReadyForDelivery_OnlyWhenIdleAtThePrompt(ActivityState state, bool expected)
+        => Assert.Equal(expected, DictationReadiness.IsReadyForDelivery(state));
+}

--- a/src/CcDirector.Core.Tests/Dictation/PendingDictationSweeperTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/PendingDictationSweeperTests.cs
@@ -156,6 +156,52 @@ public sealed class PendingDictationSweeperTests : IDisposable
     }
 
     [Fact]
+    public async Task SweepAsync_DefersClipWhoseSessionIsBusy_KeepsIt_NeverTypesIntoTheComposer()
+    {
+        // issue #1135: the session is loaded but not idle at its prompt. The clip must be deferred, not
+        // typed in, so a failed-echo submit can never pile up duplicate copies.
+        _store.Save("busy", "", SampleWav);
+        var sweeper = new PendingDictationSweeper(_store, Delivery(FakeTranscriber.Returning("hi")));
+        var submitted = new List<string>();
+
+        var report = await sweeper.SweepAsync(Present(submitted, "busy"), isSessionReady: _ => false);
+
+        Assert.Equal(0, report.Delivered);
+        Assert.Equal(1, report.DeferredSessionBusy);
+        Assert.Empty(submitted);              // never typed into a busy composer
+        Assert.Single(_store.LoadAll());      // kept for a later sweep
+        Assert.True(report.StillHeld > 0);
+    }
+
+    [Fact]
+    public async Task SweepAsync_DeliversWhenSessionIsReady()
+    {
+        _store.Save("ready", "", SampleWav);
+        var sweeper = new PendingDictationSweeper(_store, Delivery(FakeTranscriber.Returning("hi")));
+        var submitted = new List<string>();
+
+        var report = await sweeper.SweepAsync(Present(submitted, "ready"), isSessionReady: _ => true);
+
+        Assert.Equal(1, report.Delivered);
+        Assert.Equal(new[] { "hi" }, submitted);
+        Assert.Empty(_store.LoadAll());
+    }
+
+    [Fact]
+    public async Task SweepAsync_NullReadiness_DeliversEveryPresentClip_AsBefore()
+    {
+        // Backward-compatible: with no readiness predicate every loaded session is treated as ready.
+        _store.Save("present", "", SampleWav);
+        var sweeper = new PendingDictationSweeper(_store, Delivery(FakeTranscriber.Returning("hi")));
+        var submitted = new List<string>();
+
+        var report = await sweeper.SweepAsync(Present(submitted, "present"));
+
+        Assert.Equal(1, report.Delivered);
+        Assert.Equal(new[] { "hi" }, submitted);
+    }
+
+    [Fact]
     public async Task SweepAsync_MixedBatch_DeliversPresentAndHoldsAbsent()
     {
         _store.Save("present", "", SampleWav);

--- a/src/CcDirector.Core/Dictation/DictationDeliveryService.cs
+++ b/src/CcDirector.Core/Dictation/DictationDeliveryService.cs
@@ -41,10 +41,24 @@ public sealed class DictationDeliveryService
     /// clip, not a lost one. (An empty transcript is still a delivered outcome: the audio was silence,
     /// the turn is a no-op the submit delegate guards, and keeping the clip would retry silence forever.)
     /// </summary>
-    public async Task<DictationDeliveryResult> DeliverAsync(PendingDictation pending, Func<string, Task> submit, CancellationToken ct = default)
+    public async Task<DictationDeliveryResult> DeliverAsync(
+        PendingDictation pending, Func<string, Task> submit, Func<bool>? isSessionReady = null, CancellationToken ct = default)
     {
         if (pending is null) throw new ArgumentNullException(nameof(pending));
         if (submit is null) throw new ArgumentNullException(nameof(submit));
+
+        // Readiness gate (issue #1135): only type a dictation into a session whose composer is idle at
+        // the prompt. Typing while the agent is Working (streaming output) makes the echo-verified submit
+        // false-negative and throw AFTER the text has already landed in the composer; the durable retry
+        // loop then re-types the same words on the next sweep, piling up duplicate copies of the one
+        // sentence. Deferring here - before any transcription or attempt bump - leaves the clip Pending
+        // and untouched, so a later sweep delivers it the moment the session returns to the prompt. The
+        // clip is durable on disk, so deferring loses nothing.
+        if (isSessionReady is not null && !isSessionReady())
+        {
+            FileLog.Write($"[DictationDeliveryService] deferred id={pending.Id}: session not ready for input");
+            return new DictationDeliveryResult(DictationDeliveryOutcome.DeferredSessionBusy, pending, null);
+        }
 
         byte[] audio;
         try
@@ -156,6 +170,12 @@ public enum DictationDeliveryOutcome
     /// <summary>The saved audio could not be read back (disk error / removed). Nothing to deliver -
     /// reported, not silent.</summary>
     LostNoAudio,
+
+    /// <summary>The target session was not idle at its prompt (Working, on a permission prompt, or
+    /// starting), so the clip was deferred WITHOUT transcribing, submitting, or bumping its attempt
+    /// count (issue #1135). Audio kept, status left Pending; a later sweep delivers it once the session
+    /// returns to the prompt. Not a failure - the words were never at risk.</summary>
+    DeferredSessionBusy,
 }
 
 /// <summary>The result of one delivery attempt: how it ended, the (updated) record, and any error text.</summary>

--- a/src/CcDirector.Core/Dictation/DictationReadiness.cs
+++ b/src/CcDirector.Core/Dictation/DictationReadiness.cs
@@ -1,0 +1,25 @@
+using CcDirector.Core.Sessions;
+
+namespace CcDirector.Core.Dictation;
+
+/// <summary>
+/// Whether a saved dictation may be typed into a session right now (issue #1135). A dictation is
+/// delivered by typing it into the session's composer and pressing Enter; that is only safe when the
+/// composer is idle at the prompt. While the agent is Working its composer repaints as output streams,
+/// which makes the echo-verified submit false-negative and throw AFTER the text has already landed - and
+/// the durable retry loop then re-types the same words on the next sweep, piling up duplicate copies of
+/// the one sentence. So delivery is gated on the session sitting at the prompt; every other state defers
+/// until it returns there.
+/// </summary>
+public static class DictationReadiness
+{
+    /// <summary>
+    /// True only when the session's composer is idle at the prompt and will cleanly accept a typed
+    /// dictation: <see cref="ActivityState.WaitingForInput"/> or <see cref="ActivityState.Idle"/>.
+    /// <see cref="ActivityState.Working"/> (streaming output), <see cref="ActivityState.WaitingForPerm"/>
+    /// (a permission prompt a free-text line would answer wrongly), <see cref="ActivityState.Starting"/>
+    /// and <see cref="ActivityState.Exited"/> all defer.
+    /// </summary>
+    public static bool IsReadyForDelivery(ActivityState state)
+        => state is ActivityState.WaitingForInput or ActivityState.Idle;
+}

--- a/src/CcDirector.Core/Dictation/PendingDictationSweeper.cs
+++ b/src/CcDirector.Core/Dictation/PendingDictationSweeper.cs
@@ -61,13 +61,14 @@ public sealed class PendingDictationSweeper
     /// honoring the in-flight guard. Returns the delivery result, or null if the clip was already being
     /// delivered by another caller.
     /// </summary>
-    public async Task<DictationDeliveryResult?> TryDeliverAsync(PendingDictation pending, Func<string, Task> submit, CancellationToken ct = default)
+    public async Task<DictationDeliveryResult?> TryDeliverAsync(
+        PendingDictation pending, Func<string, Task> submit, Func<bool>? isSessionReady = null, CancellationToken ct = default)
     {
         if (pending is null) throw new ArgumentNullException(nameof(pending));
         if (!Claim(pending.Id)) return null;
         try
         {
-            return await _delivery.DeliverAsync(pending, submit, ct);
+            return await _delivery.DeliverAsync(pending, submit, isSessionReady, ct);
         }
         finally
         {
@@ -79,9 +80,15 @@ public sealed class PendingDictationSweeper
     /// One full sweep: prune stale clips, then attempt delivery for every Pending clip whose session is
     /// currently present. <paramref name="resolveSubmit"/> maps a saved clip's SessionId to a submit
     /// delegate, or null when that session is not currently loaded (the clip is left for a later sweep).
+    /// <paramref name="isSessionReady"/> reports whether that session's composer is idle at the prompt
+    /// right now; a loaded-but-busy session defers WITHOUT being typed into (issue #1135). When null,
+    /// every loaded session is treated as ready (the pre-#1135 behavior).
     /// Returns a tally the caller turns into the held notice.
     /// </summary>
-    public async Task<SweepReport> SweepAsync(Func<string, Func<string, Task>?> resolveSubmit, CancellationToken ct = default)
+    public async Task<SweepReport> SweepAsync(
+        Func<string, Func<string, Task>?> resolveSubmit,
+        Func<string, bool>? isSessionReady = null,
+        CancellationToken ct = default)
     {
         if (resolveSubmit is null) throw new ArgumentNullException(nameof(resolveSubmit));
 
@@ -107,7 +114,8 @@ public sealed class PendingDictationSweeper
                 continue;
             }
 
-            var result = await TryDeliverAsync(record, submit, ct);
+            var ready = isSessionReady is null ? (Func<bool>?)null : () => isSessionReady(record.SessionId);
+            var result = await TryDeliverAsync(record, submit, ready, ct);
             if (result is null)
             {
                 report.AlreadyInFlight++;
@@ -119,7 +127,8 @@ public sealed class PendingDictationSweeper
 
         FileLog.Write($"[PendingDictationSweeper] sweep: delivered={report.Delivered}, willRetry={report.HeldWillRetry}, "
             + $"needsCredits={report.NeedsCredits}, needsConfig={report.NeedsConfiguration}, permanent={report.PermanentError}, "
-            + $"waitingForSession={report.WaitingForSession}, parked={report.ParkedNeedingAttention}, pruned={report.Pruned}");
+            + $"deferredBusy={report.DeferredSessionBusy}, waitingForSession={report.WaitingForSession}, "
+            + $"parked={report.ParkedNeedingAttention}, pruned={report.Pruned}");
         return report;
     }
 
@@ -146,12 +155,13 @@ public sealed class SweepReport
     public int WaitingForSession { get; set; }
     public int ParkedNeedingAttention { get; set; }
     public int AlreadyInFlight { get; set; }
+    public int DeferredSessionBusy { get; set; }
     public int Pruned { get; set; }
 
     /// <summary>Clips still saved on disk after this sweep that the user should know are held - anything
     /// not delivered this pass and not a transient no-op. Drives whether the held notice is shown.</summary>
     public int StillHeld => HeldWillRetry + NeedsCredits + NeedsConfiguration + PermanentError
-                            + WaitingForSession + ParkedNeedingAttention + AlreadyInFlight;
+                            + WaitingForSession + ParkedNeedingAttention + AlreadyInFlight + DeferredSessionBusy;
 
     public void Tally(DictationDeliveryOutcome outcome)
     {
@@ -163,6 +173,7 @@ public sealed class SweepReport
             case DictationDeliveryOutcome.NeedsConfiguration: NeedsConfiguration++; break;
             case DictationDeliveryOutcome.PermanentError: PermanentError++; break;
             case DictationDeliveryOutcome.LostNoAudio: LostNoAudio++; break;
+            case DictationDeliveryOutcome.DeferredSessionBusy: DeferredSessionBusy++; break;
         }
     }
 }


### PR DESCRIPTION
Fixes thefrederiksen/devthrottle#1135.

## The bug

A dictation spoken once was injected into a session more than a dozen times as one giant prompt of the same sentence repeated over and over. Traced from the Director log: the transcription was correct and happened exactly once (one clean 114-character sentence), so the duplication is entirely in delivery.

The durable dictation delivery loop (added in thefrederiksen/devthrottle_internal#703) typed the words into a session that was busy working. A busy session's composer repaints constantly as output streams, which tears the terminal byte stream, so the echo-verified submit could not confirm the echo and threw - even though the text had already landed in the composer. The delivery loop treated that as a clean, retryable failure and retyped the same words every 30 seconds, piling another copy on top each time (the "Terminal tail" in each failed attempt's log line shows the sentence growing across attempts). When the session finally went idle, every accumulated copy was submitted together.

## Why the fix is in the shared layer, not a driver

This is a shared-layer problem, not a per-driver one. The retry loop sits above the driver, and the echo-verified submit is shared by every interactive driver (Claude, Codex, Cursor, Pi, generic - see the table in thefrederiksen/devthrottle#1135). So the fix lives in the shared dictation layer and covers all agents at once.

## The fix: a readiness gate

A dictation is now only typed into a session whose composer is idle at the prompt (`WaitingForInput` or `Idle`). While it is `Working`, on a permission prompt, or starting, the clip is deferred **without** being transcribed, submitted, or counted as a failed attempt. The clip is durable on disk, so deferring loses nothing: a later sweep delivers it the moment the session returns to the prompt.

- **`DictationReadiness`** (new) - the single readiness rule (idle-at-the-prompt only).
- **`DictationDeliveryService.DeliverAsync`** - an `isSessionReady` gate that returns a new `DeferredSessionBusy` outcome before any cost.
- **`PendingDictationSweeper`** - threads the predicate through `SweepAsync`/`TryDeliverAsync` and tallies the deferrals; unchanged when no predicate is supplied.
- **Both call sites** (the immediate Send and the 30-second background sweep) pass the session's live `ActivityState` through the gate.

## Deliberate behavior change

A dictation aimed at a busy session now lands cleanly after that turn ends instead of being injected mid-stream. Worst case it delivers on the next sweep, within 30 seconds of the session going idle. The held-notice wording was updated to match.

## Follow-up hardening (not in this PR, noted in thefrederiksen/devthrottle#1135)

Clear-the-composer-on-echo-failure and a retry cap in `TerminalSubmit` would harden every submit caller. They are secondary; the readiness gate alone makes this incident impossible.

## Tests

- `DictationReadinessTests` - the readiness truth table across every `ActivityState`.
- `DictationDeliveryServiceTests` - a not-ready session defers without transcribing/submitting/bumping the attempt count and keeps the clip; a ready session delivers normally.
- `PendingDictationSweeperTests` - the sweep defers a busy session without typing, delivers when ready, and is unchanged when no readiness predicate is given.
- Full dictation suite: 213 passed, 0 failed. Core and Avalonia build clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
