### PR TITLE
Fix #1136: stop the Gateway auto-mint from leaking inference API keys

### DIFF
--- a/src/CcDirector.Gateway.Tests/TranscriptionKeyAutoProvisionerTests.cs
+++ b/src/CcDirector.Gateway.Tests/TranscriptionKeyAutoProvisionerTests.cs
@@ -219,4 +219,138 @@ public sealed class TranscriptionKeyAutoProvisionerTests : IDisposable
         Assert.Equal(1, minter.Calls);
         Assert.Null(new KeyVault(_vaultPath).Get(TranscriptionEndpointResolver.DevThrottleKeyName));
     }
+
+    // ----- Concurrency: one key per process, never a same-second burst (issue #1136) -----
+
+    /// <summary>A minter that mints a UNIQUE key per call (so a leaked second mint is visible as a second
+    /// distinct key), counts calls atomically, and delays inside MintAsync so concurrent callers overlap
+    /// in the check-then-mint window that the fix closes.</summary>
+    private sealed class UniqueSlowMinter : IInferenceKeyMinter
+    {
+        private int _calls;
+        private readonly TimeSpan _delay;
+        public int Calls => Volatile.Read(ref _calls);
+        public int RevokeCalls;
+        public UniqueSlowMinter(TimeSpan delay) { _delay = delay; }
+        public async Task<MintedInferenceKey?> MintAsync(string accessToken, string label, CancellationToken ct = default)
+        {
+            var n = Interlocked.Increment(ref _calls);
+            await Task.Delay(_delay, ct);
+            return new MintedInferenceKey($"dt_live_unique_{n}", $"id-{n}");
+        }
+        public Task<bool> RevokeAsync(string accessToken, string keyId, CancellationToken ct = default)
+        {
+            Interlocked.Increment(ref RevokeCalls);
+            return Task.FromResult(true);
+        }
+    }
+
+    [Fact]
+    public async Task EnsureAsync_ConcurrentCalls_MintsExactlyOnce()
+    {
+        var vault = new KeyVault(_vaultPath);
+        var minter = new UniqueSlowMinter(TimeSpan.FromMilliseconds(50));
+        var sut = new TranscriptionKeyAutoProvisioner(vault, () => "the.jwt", minter);
+
+        // Fire the ensure from several callers at once (the sign-in hook and the startup task racing).
+        var results = await Task.WhenAll(Enumerable.Range(0, 8).Select(_ => sut.EnsureAsync()));
+
+        // Exactly one mint, exactly one caller stored a key, and the vault holds a single stored key.
+        Assert.Equal(1, minter.Calls);
+        Assert.Equal(1, results.Count(stored => stored));
+        Assert.Equal("dt_live_unique_1", new KeyVault(_vaultPath).Get(TranscriptionEndpointResolver.DevThrottleKeyName));
+    }
+
+    /// <summary>A minter that stores a COMPETING key into the vault during MintAsync, simulating another
+    /// Gateway process that stored first. The store then loses the SetIfAbsent race, so the just-minted
+    /// key must be revoked to avoid an orphan.</summary>
+    private sealed class RaceLosingMinter : IInferenceKeyMinter
+    {
+        private readonly KeyVault _vault;
+        public int RevokeCalls { get; private set; }
+        public string? RevokedId { get; private set; }
+        public RaceLosingMinter(KeyVault vault) { _vault = vault; }
+        public Task<MintedInferenceKey?> MintAsync(string accessToken, string label, CancellationToken ct = default)
+        {
+            // A competitor stores its own key while we are minting.
+            _vault.SetIfAbsent(TranscriptionEndpointResolver.DevThrottleKeyName, "dt_live_competitor");
+            return Task.FromResult<MintedInferenceKey?>(new MintedInferenceKey("dt_live_ours", "our-id"));
+        }
+        public Task<bool> RevokeAsync(string accessToken, string keyId, CancellationToken ct = default)
+        {
+            RevokeCalls++;
+            RevokedId = keyId;
+            return Task.FromResult(true);
+        }
+    }
+
+    [Fact]
+    public async Task EnsureAsync_LostStoreRace_RevokesTheJustMintedKey()
+    {
+        var vault = new KeyVault(_vaultPath);
+        var minter = new RaceLosingMinter(vault);
+        var sut = new TranscriptionKeyAutoProvisioner(vault, () => "the.jwt", minter);
+
+        var stored = await sut.EnsureAsync();
+
+        Assert.False(stored);
+        // The competitor's key is what remains; ours was revoked rather than left as an orphan.
+        Assert.Equal("dt_live_competitor", new KeyVault(_vaultPath).Get(TranscriptionEndpointResolver.DevThrottleKeyName));
+        Assert.Equal(1, minter.RevokeCalls);
+        Assert.Equal("our-id", minter.RevokedId);
+    }
+
+    // ----- Revoke failure keeps the local key so it is reused, not orphaned (issue #1136) -----
+
+    /// <summary>A minter whose RevokeAsync always fails, so we can assert the local key is kept.</summary>
+    private sealed class RevokeFailingMinter : IInferenceKeyMinter
+    {
+        private readonly MintedInferenceKey _minted;
+        public int RevokeCalls { get; private set; }
+        public RevokeFailingMinter(string key, string id) { _minted = new MintedInferenceKey(key, id); }
+        public Task<MintedInferenceKey?> MintAsync(string accessToken, string label, CancellationToken ct = default)
+            => Task.FromResult<MintedInferenceKey?>(_minted);
+        public Task<bool> RevokeAsync(string accessToken, string keyId, CancellationToken ct = default)
+        {
+            RevokeCalls++;
+            return Task.FromResult(false);
+        }
+    }
+
+    [Fact]
+    public async Task RevokeMintedKeyAsync_CloudRevokeFails_KeepsLocalKeyAndId()
+    {
+        var vault = new KeyVault(_vaultPath);
+        var minter = new RevokeFailingMinter("dt_live_kept", "kept-id");
+        var sut = new TranscriptionKeyAutoProvisioner(vault, () => "the.jwt", minter);
+        await sut.EnsureAsync(); // mints + records the id
+
+        var revoked = await sut.RevokeMintedKeyAsync();
+
+        Assert.False(revoked);
+        Assert.Equal(1, minter.RevokeCalls);
+        // The key is kept (not orphaned) so the next start reuses it instead of minting a replacement.
+        var reread = new KeyVault(_vaultPath);
+        Assert.Equal("dt_live_kept", reread.Get(TranscriptionEndpointResolver.DevThrottleKeyName));
+        Assert.Equal("kept-id", reread.Get(TranscriptionKeyAutoProvisioner.InferenceKeyIdVaultName));
+    }
+
+    [Fact]
+    public async Task RevokeMintedKeyAsync_NoAccessToken_KeepsLocalKey_WithoutRevoking()
+    {
+        var vault = new KeyVault(_vaultPath);
+        var minter = new FakeMinter("dt_live_kept", id: "kept-id");
+        // Sign in to mint, then simulate the token being gone at sign-out time.
+        string? token = "the.jwt";
+        var sut = new TranscriptionKeyAutoProvisioner(vault, () => token, minter);
+        await sut.EnsureAsync();
+        token = null;
+
+        var revoked = await sut.RevokeMintedKeyAsync();
+
+        Assert.False(revoked);
+        Assert.Equal(0, minter.RevokeCalls);
+        // No token means no revoke could be attempted, so the key is kept rather than orphaned.
+        Assert.Equal("dt_live_kept", new KeyVault(_vaultPath).Get(TranscriptionEndpointResolver.DevThrottleKeyName));
+    }
 }

--- a/src/CcDirector.Gateway.Tests/TranscriptionKeyAutoProvisionerTests.cs
+++ b/src/CcDirector.Gateway.Tests/TranscriptionKeyAutoProvisionerTests.cs
@@ -300,9 +300,9 @@ public sealed class TranscriptionKeyAutoProvisionerTests : IDisposable
         Assert.Equal("our-id", minter.RevokedId);
     }
 
-    // ----- Revoke failure keeps the local key so it is reused, not orphaned (issue #1136) -----
+    // ----- Sign-out always clears the local key (no account binding -> must not be reused, issue #1136) -----
 
-    /// <summary>A minter whose RevokeAsync always fails, so we can assert the local key is kept.</summary>
+    /// <summary>A minter whose RevokeAsync always fails, so we can assert the local key is still cleared.</summary>
     private sealed class RevokeFailingMinter : IInferenceKeyMinter
     {
         private readonly MintedInferenceKey _minted;
@@ -318,39 +318,22 @@ public sealed class TranscriptionKeyAutoProvisionerTests : IDisposable
     }
 
     [Fact]
-    public async Task RevokeMintedKeyAsync_CloudRevokeFails_KeepsLocalKeyAndId()
+    public async Task RevokeMintedKeyAsync_CloudRevokeFails_StillClearsLocalKey()
     {
+        // Even when the cloud revoke fails, the local key MUST be cleared: it has no account binding, so
+        // leaving it would let the next account signed in on this machine reuse it (issue #1136). The
+        // residual cloud key can be revoked from the website.
         var vault = new KeyVault(_vaultPath);
-        var minter = new RevokeFailingMinter("dt_live_kept", "kept-id");
+        var minter = new RevokeFailingMinter("dt_live_x", "the-id");
         var sut = new TranscriptionKeyAutoProvisioner(vault, () => "the.jwt", minter);
         await sut.EnsureAsync(); // mints + records the id
 
         var revoked = await sut.RevokeMintedKeyAsync();
 
-        Assert.False(revoked);
+        Assert.True(revoked);
         Assert.Equal(1, minter.RevokeCalls);
-        // The key is kept (not orphaned) so the next start reuses it instead of minting a replacement.
         var reread = new KeyVault(_vaultPath);
-        Assert.Equal("dt_live_kept", reread.Get(TranscriptionEndpointResolver.DevThrottleKeyName));
-        Assert.Equal("kept-id", reread.Get(TranscriptionKeyAutoProvisioner.InferenceKeyIdVaultName));
-    }
-
-    [Fact]
-    public async Task RevokeMintedKeyAsync_NoAccessToken_KeepsLocalKey_WithoutRevoking()
-    {
-        var vault = new KeyVault(_vaultPath);
-        var minter = new FakeMinter("dt_live_kept", id: "kept-id");
-        // Sign in to mint, then simulate the token being gone at sign-out time.
-        string? token = "the.jwt";
-        var sut = new TranscriptionKeyAutoProvisioner(vault, () => token, minter);
-        await sut.EnsureAsync();
-        token = null;
-
-        var revoked = await sut.RevokeMintedKeyAsync();
-
-        Assert.False(revoked);
-        Assert.Equal(0, minter.RevokeCalls);
-        // No token means no revoke could be attempted, so the key is kept rather than orphaned.
-        Assert.Equal("dt_live_kept", new KeyVault(_vaultPath).Get(TranscriptionEndpointResolver.DevThrottleKeyName));
+        Assert.Null(reread.Get(TranscriptionEndpointResolver.DevThrottleKeyName));
+        Assert.Null(reread.Get(TranscriptionKeyAutoProvisioner.InferenceKeyIdVaultName));
     }
 }

--- a/src/CcDirector.Gateway/Account/TranscriptionKeyAutoProvisioner.cs
+++ b/src/CcDirector.Gateway/Account/TranscriptionKeyAutoProvisioner.cs
@@ -35,6 +35,17 @@ public sealed class TranscriptionKeyAutoProvisioner
     private readonly IInferenceKeyMinter _minter;
     private readonly string _label;
 
+    /// <summary>
+    /// Serializes provisioning within this process. <see cref="EnsureAsync"/> is fired from BOTH the
+    /// post-sign-in hook and a detached startup task, and those race on a fresh sign-in during startup.
+    /// Without this gate the check-then-mint window lets every concurrent caller find an empty vault and
+    /// mint its own key, so one Gateway leaks several live keys in the same second (issue #1136). The gate
+    /// plus a re-read of the vault after acquiring it collapse the concurrent callers to exactly one mint.
+    /// Never disposed: the provisioner lives for the whole process and this semaphore allocates no
+    /// unmanaged handle unless its wait handle is used (it is not).
+    /// </summary>
+    private readonly SemaphoreSlim _ensureGate = new(1, 1);
+
     /// <param name="vault">The Gateway key vault - where the transcription owner reads the hosted key.</param>
     /// <param name="accessTokenProvider">Supplies the signed-in account JWT (or null when not signed in);
     /// invoked fresh each call so it always reflects the current credential.</param>
@@ -56,37 +67,58 @@ public sealed class TranscriptionKeyAutoProvisioner
     /// </summary>
     public async Task<bool> EnsureAsync(CancellationToken ct = default)
     {
-        var existing = _vault.Get(TranscriptionEndpointResolver.DevThrottleKeyName);
-        if (!string.IsNullOrWhiteSpace(existing))
+        // Serialize the whole check-then-mint sequence so concurrent callers (the sign-in hook and the
+        // startup task) mint at most one key between them (issue #1136).
+        await _ensureGate.WaitAsync(ct);
+        try
         {
-            FileLog.Write("[TranscriptionKeyAutoProvisioner] EnsureAsync: a DevThrottle key is already stored -> nothing to mint");
+            var existing = _vault.Get(TranscriptionEndpointResolver.DevThrottleKeyName);
+            if (!string.IsNullOrWhiteSpace(existing))
+            {
+                FileLog.Write("[TranscriptionKeyAutoProvisioner] EnsureAsync: a DevThrottle key is already stored -> nothing to mint");
+                return false;
+            }
+
+            var accessToken = _accessTokenProvider();
+            if (string.IsNullOrWhiteSpace(accessToken))
+            {
+                FileLog.Write("[TranscriptionKeyAutoProvisioner] EnsureAsync: not signed in (no access token) -> cannot mint yet");
+                return false;
+            }
+
+            FileLog.Write("[TranscriptionKeyAutoProvisioner] EnsureAsync: no DevThrottle key stored and signed in -> minting an inference key");
+            var minted = await _minter.MintAsync(accessToken, _label, ct);
+            if (minted is null || string.IsNullOrWhiteSpace(minted.Key))
+            {
+                FileLog.Write("[TranscriptionKeyAutoProvisioner] EnsureAsync: mint returned no key -> leaving unset (user sees the add-credits/manual state)");
+                return false;
+            }
+
+            // SetIfAbsent (not Set) guards a race with a concurrent manual save or another Gateway process
+            // sharing this account - the first writer wins and we never clobber a key that appeared meanwhile.
+            var stored = _vault.SetIfAbsent(TranscriptionEndpointResolver.DevThrottleKeyName, minted.Key);
+            if (stored)
+            {
+                if (!string.IsNullOrWhiteSpace(minted.Id))
+                    // Record the id so sign-out can revoke THIS auto-minted key (a manual key has no id and
+                    // is never revoked). Set (not SetIfAbsent) because the id belongs to the key we stored.
+                    _vault.Set(InferenceKeyIdVaultName, minted.Id!);
+                FileLog.Write($"[TranscriptionKeyAutoProvisioner] EnsureAsync: minted inference key stored, id recorded={!string.IsNullOrWhiteSpace(minted.Id)}");
+                return true;
+            }
+
+            // A key appeared between our re-read and the store (a concurrent manual save, or another Gateway
+            // process on the same account). We hold a freshly minted key that nothing will use, so revoke it
+            // now rather than leave it as a live orphan on the account (issue #1136). Best-effort.
+            FileLog.Write("[TranscriptionKeyAutoProvisioner] EnsureAsync: a key appeared first -> revoking the key we just minted to avoid an orphan");
+            if (!string.IsNullOrWhiteSpace(minted.Id))
+                await _minter.RevokeAsync(accessToken, minted.Id!, ct);
             return false;
         }
-
-        var accessToken = _accessTokenProvider();
-        if (string.IsNullOrWhiteSpace(accessToken))
+        finally
         {
-            FileLog.Write("[TranscriptionKeyAutoProvisioner] EnsureAsync: not signed in (no access token) -> cannot mint yet");
-            return false;
+            _ensureGate.Release();
         }
-
-        FileLog.Write("[TranscriptionKeyAutoProvisioner] EnsureAsync: no DevThrottle key stored and signed in -> minting an inference key");
-        var minted = await _minter.MintAsync(accessToken, _label, ct);
-        if (minted is null || string.IsNullOrWhiteSpace(minted.Key))
-        {
-            FileLog.Write("[TranscriptionKeyAutoProvisioner] EnsureAsync: mint returned no key -> leaving unset (user sees the add-credits/manual state)");
-            return false;
-        }
-
-        // SetIfAbsent (not Set) guards a race with a concurrent manual save or a second provisioning
-        // pass - the first writer wins and we never clobber a key that appeared meanwhile.
-        var stored = _vault.SetIfAbsent(TranscriptionEndpointResolver.DevThrottleKeyName, minted.Key);
-        if (stored && !string.IsNullOrWhiteSpace(minted.Id))
-            // Record the id so sign-out can revoke THIS auto-minted key (a manual key has no id and is
-            // never revoked). Set (not SetIfAbsent) because the id belongs to the key we just stored.
-            _vault.Set(InferenceKeyIdVaultName, minted.Id!);
-        FileLog.Write($"[TranscriptionKeyAutoProvisioner] EnsureAsync: minted inference key {(stored ? "stored" : "not stored - a key appeared first")}, id recorded={stored && !string.IsNullOrWhiteSpace(minted.Id)}");
-        return stored;
     }
 
     /// <summary>
@@ -94,7 +126,10 @@ public sealed class TranscriptionKeyAutoProvisioner
     /// signed-out install leaves no live key behind. A MANUALLY-pasted key (no recorded id) is left
     /// untouched - it is the user's own key, not ours to revoke. Best-effort: any failure is logged and
     /// swallowed so sign-out never fails; call it BEFORE the credential is cleared (it needs the JWT).
-    /// Returns true when an auto-minted key was revoked and cleared.
+    /// The local key is cleared ONLY when the cloud revoke actually succeeded (or the key was already
+    /// gone). If the revoke could not be attempted or failed, the local key is KEPT so the next start
+    /// reuses it rather than minting a replacement and orphaning the still-live cloud key (issue #1136).
+    /// Returns true only when an auto-minted key was revoked and cleared.
     /// </summary>
     public async Task<bool> RevokeMintedKeyAsync(CancellationToken ct = default)
     {
@@ -106,21 +141,31 @@ public sealed class TranscriptionKeyAutoProvisioner
         }
 
         var accessToken = _accessTokenProvider();
-        if (!string.IsNullOrWhiteSpace(accessToken))
+        if (string.IsNullOrWhiteSpace(accessToken))
         {
-            var revoked = await _minter.RevokeAsync(accessToken, keyId!, ct);
-            FileLog.Write($"[TranscriptionKeyAutoProvisioner] RevokeMintedKeyAsync: cloud revoke result={revoked}");
-        }
-        else
-        {
-            FileLog.Write("[TranscriptionKeyAutoProvisioner] RevokeMintedKeyAsync: no access token to revoke with (clearing locally anyway)");
+            // No token to authenticate the revoke. Do NOT clear the local key: clearing it would make the
+            // next sign-in mint a fresh key while this still-live cloud key becomes an unreachable orphan
+            // (issue #1136). Keeping it means the next start reuses this same key and no orphan is created;
+            // a later sign-out (with a token) can still revoke it.
+            FileLog.Write("[TranscriptionKeyAutoProvisioner] RevokeMintedKeyAsync: no access token to revoke with -> keeping the local key so the next start reuses it (no orphan)");
+            return false;
         }
 
-        // Clear the local copies regardless of the cloud outcome: the key is being signed out, so it must
-        // not remain as this machine's transcription credential. The cloud key, if the revoke failed, can
-        // still be revoked from the website.
+        var revoked = await _minter.RevokeAsync(accessToken, keyId!, ct);
+        if (!revoked)
+        {
+            // The cloud revoke failed and the key is still live. Clearing the local copy now would orphan
+            // it (the next sign-in mints a replacement). Keep both local entries so the next start reuses
+            // the same key instead of minting a new one (issue #1136).
+            FileLog.Write("[TranscriptionKeyAutoProvisioner] RevokeMintedKeyAsync: cloud revoke failed -> keeping the local key so the next start reuses it (no orphan)");
+            return false;
+        }
+
+        // The revoke succeeded (RevokeAsync also reports success for an already-gone 404): the key is no
+        // longer live, so clear the local copies and a signed-out install holds no key.
         _vault.Delete(TranscriptionEndpointResolver.DevThrottleKeyName);
         _vault.Delete(InferenceKeyIdVaultName);
+        FileLog.Write("[TranscriptionKeyAutoProvisioner] RevokeMintedKeyAsync: cloud revoke succeeded -> cleared the local key and id");
         return true;
     }
 }

--- a/src/CcDirector.Gateway/Account/TranscriptionKeyAutoProvisioner.cs
+++ b/src/CcDirector.Gateway/Account/TranscriptionKeyAutoProvisioner.cs
@@ -109,10 +109,19 @@ public sealed class TranscriptionKeyAutoProvisioner
 
             // A key appeared between our re-read and the store (a concurrent manual save, or another Gateway
             // process on the same account). We hold a freshly minted key that nothing will use, so revoke it
-            // now rather than leave it as a live orphan on the account (issue #1136). Best-effort.
-            FileLog.Write("[TranscriptionKeyAutoProvisioner] EnsureAsync: a key appeared first -> revoking the key we just minted to avoid an orphan");
+            // now rather than leave it as a live orphan on the account (issue #1136). The revoke uses the SAME
+            // account token that minted it, so there is no cross-account concern. Best-effort.
             if (!string.IsNullOrWhiteSpace(minted.Id))
+            {
+                FileLog.Write("[TranscriptionKeyAutoProvisioner] EnsureAsync: a key appeared first -> revoking the key we just minted to avoid an orphan");
                 await _minter.RevokeAsync(accessToken, minted.Id!, ct);
+            }
+            else
+            {
+                // No id means we cannot revoke it; the just-minted key may remain on the account. Log it so
+                // the orphan is visible rather than silent.
+                FileLog.Write("[TranscriptionKeyAutoProvisioner] EnsureAsync: a key appeared first but the mint returned no id -> cannot revoke the just-minted key (it may remain on the account)");
+            }
             return false;
         }
         finally
@@ -126,10 +135,13 @@ public sealed class TranscriptionKeyAutoProvisioner
     /// signed-out install leaves no live key behind. A MANUALLY-pasted key (no recorded id) is left
     /// untouched - it is the user's own key, not ours to revoke. Best-effort: any failure is logged and
     /// swallowed so sign-out never fails; call it BEFORE the credential is cleared (it needs the JWT).
-    /// The local key is cleared ONLY when the cloud revoke actually succeeded (or the key was already
-    /// gone). If the revoke could not be attempted or failed, the local key is KEPT so the next start
-    /// reuses it rather than minting a replacement and orphaning the still-live cloud key (issue #1136).
-    /// Returns true only when an auto-minted key was revoked and cleared.
+    ///
+    /// The local key is ALWAYS cleared here (whether or not the cloud revoke succeeded): the stored key
+    /// carries no account binding, so leaving it would let the NEXT account signed in on this machine
+    /// reuse it (spending the wrong account's credits) and would keep a live credential on a signed-out
+    /// machine. If the cloud revoke itself failed, the still-live cloud key can be revoked from the
+    /// website; that residual orphan is the lesser evil versus cross-account reuse. Returns true when an
+    /// auto-minted key was found and cleared.
     /// </summary>
     public async Task<bool> RevokeMintedKeyAsync(CancellationToken ct = default)
     {
@@ -141,31 +153,21 @@ public sealed class TranscriptionKeyAutoProvisioner
         }
 
         var accessToken = _accessTokenProvider();
-        if (string.IsNullOrWhiteSpace(accessToken))
+        if (!string.IsNullOrWhiteSpace(accessToken))
         {
-            // No token to authenticate the revoke. Do NOT clear the local key: clearing it would make the
-            // next sign-in mint a fresh key while this still-live cloud key becomes an unreachable orphan
-            // (issue #1136). Keeping it means the next start reuses this same key and no orphan is created;
-            // a later sign-out (with a token) can still revoke it.
-            FileLog.Write("[TranscriptionKeyAutoProvisioner] RevokeMintedKeyAsync: no access token to revoke with -> keeping the local key so the next start reuses it (no orphan)");
-            return false;
+            var revoked = await _minter.RevokeAsync(accessToken, keyId!, ct);
+            FileLog.Write($"[TranscriptionKeyAutoProvisioner] RevokeMintedKeyAsync: cloud revoke result={revoked}");
+        }
+        else
+        {
+            FileLog.Write("[TranscriptionKeyAutoProvisioner] RevokeMintedKeyAsync: no access token to revoke with (clearing locally anyway)");
         }
 
-        var revoked = await _minter.RevokeAsync(accessToken, keyId!, ct);
-        if (!revoked)
-        {
-            // The cloud revoke failed and the key is still live. Clearing the local copy now would orphan
-            // it (the next sign-in mints a replacement). Keep both local entries so the next start reuses
-            // the same key instead of minting a new one (issue #1136).
-            FileLog.Write("[TranscriptionKeyAutoProvisioner] RevokeMintedKeyAsync: cloud revoke failed -> keeping the local key so the next start reuses it (no orphan)");
-            return false;
-        }
-
-        // The revoke succeeded (RevokeAsync also reports success for an already-gone 404): the key is no
-        // longer live, so clear the local copies and a signed-out install holds no key.
+        // Clear the local copies regardless of the cloud outcome: the stored key has no account binding, so
+        // it must not remain on this machine to be reused by whoever signs in next (issue #1136). If the
+        // cloud revoke failed, that key can still be revoked from the website.
         _vault.Delete(TranscriptionEndpointResolver.DevThrottleKeyName);
         _vault.Delete(InferenceKeyIdVaultName);
-        FileLog.Write("[TranscriptionKeyAutoProvisioner] RevokeMintedKeyAsync: cloud revoke succeeded -> cleared the local key and id");
         return true;
     }
 }


### PR DESCRIPTION
Fixes thefrederiksen/devthrottle#1136.

## Problem

The Gateway auto-mints a DevThrottle inference API key (issue thefrederiksen/devthrottle_internal#650) on sign-in and on startup so hosted transcription, text-to-speech, and Wingman work with zero configuration. In practice it leaked one live cloud key per Gateway start, so an account filled with dozens of unused `cc-director {machine}` keys (116 on one machine), created in same-second bursts, all "Never used", none revoked.

## Root cause of the observed burst

`EnsureAsync` is fired from BOTH the post-sign-in hook and a detached startup task, and they race on a fresh sign-in during startup. Each caller reads an empty vault in the check-then-mint window and mints its own key, so a single Gateway minted several keys in the same second (visible in the created-at timestamps: ~5 keys within one second).

## Fix

1. **Serialize the mint.** `EnsureAsync` now runs the whole check-then-mint sequence behind a `SemaphoreSlim` and re-reads the vault after acquiring it, so concurrent callers mint at most one key.

2. **Revoke a key lost to a store race.** If a key appears between the re-read and the `SetIfAbsent` store (another Gateway process on the same account), the freshly minted key is now revoked (using the same account token that minted it) instead of being silently orphaned. When the mint returned no id, that is logged so the residual key is visible rather than silent.

Sign-out behavior is unchanged: it still always clears the local auto-minted key (see the note below).

## Review outcome (why the sign-out path is NOT changed)

An earlier revision of this PR also changed `RevokeMintedKeyAsync` to KEEP the local key when the cloud revoke failed (to avoid orphaning it). A thorough multi-angle review caught that this introduced a worse regression: `EnsureAsync` decides whether to mint purely on key PRESENCE, with no account binding, so a kept key would be reused by the NEXT account signed in on the same machine (spending the wrong account's credits) and would leave a live billable credential on a signed-out machine. That change was reverted. Sign-out keeps its original always-clear behavior; a residual cloud key from a failed revoke is the lesser evil and can be revoked from the website.

## Not covered here (follow-ups)

- Fully preventing cross-process duplicate mints needs the cloud `POST /api/v1/keys` endpoint to be idempotent per account (reuse-or-create by name); that lives in the website repository.
- Safely reusing an auto-minted key across restarts (instead of always clearing on sign-out) needs the stored key to be bound to the account that minted it; that belongs with the account-source-of-truth work (epic thefrederiksen/devthrottle_internal#675).

## Tests

Added to `TranscriptionKeyAutoProvisionerTests`:
- `EnsureAsync_ConcurrentCalls_MintsExactlyOnce` - 8 concurrent callers collapse to a single mint (fails against the pre-fix code).
- `EnsureAsync_LostStoreRace_RevokesTheJustMintedKey` - a lost `SetIfAbsent` race revokes rather than orphans.
- `RevokeMintedKeyAsync_CloudRevokeFails_StillClearsLocalKey` - sign-out clears the local key even when the cloud revoke fails.

Full class passes: 25 passed, 0 failed.

## Cleanup already done separately

The 116 already-leaked keys on the affected account were revoked, then physically deleted from the `api_keys` table (revoke is a soft delete that sets `revoked_at`; the rows remained until deleted). The account now holds only its legitimate keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
