### PR TITLE
Stop shipping cc-comm-queue (retired Communication Manager)

### DIFF
--- a/tools/registry.json
+++ b/tools/registry.json
@@ -247,9 +247,8 @@
       "name": "cc-comm-queue",
       "category": "data-utilities",
       "type": "python",
-      "description": "Communication Manager approval queue CLI",
+      "description": "Communication Manager approval queue CLI (RETIRED - no longer shipped)",
       "built": true,
-      "ship": true,
       "requirements": []
     },
     {


### PR DESCRIPTION
Drops `"ship": true` from the `cc-comm-queue` entry in `tools/registry.json` so the retired Communication Manager approval-queue CLI is no longer selected into the Python tools bundle. The tool source stays in the repo for reference.

The bundle's allowlist (`type == "python" && ship == true` in `build-python-bundle.ps1`) now selects 9 tools; cc-comm-queue is removed, cc-image (added in #1141/#1142) stays.

Shipped set after this change: cc-pdf, cc-html, cc-word, cc-gmail, cc-outlook, cc-playwright, cc-image, cc-vault, cc-devthrottle.

Single-file change, committed via an isolated worktree off `origin/main` to avoid the shared-checkout index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)