### PR TITLE
Stop dictation pile-up into a session wedged at the startup screen (#1135 follow-up)

### DIFF
--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -3166,6 +3166,10 @@ public partial class MainWindow : Window
                 {
                     // Only deliver into a session idle at its prompt (issue #1135): typing a dictation
                     // into a Working, streaming composer is what piled up duplicate copies of the sentence.
+                    // A session wedged at Claude Code's startup splash also reads as ready here, but the
+                    // pile-up it caused is stopped at the clip level instead: the first submit probe that
+                    // the composer never echoes parks the clip ComposerBlocked, and the sweep skips a
+                    // non-Pending clip, so it is never re-typed (DictationDeliveryService.DeliverAsync).
                     if (!Guid.TryParse(sessionId, out var gid)) return false;
                     var session = _sessionManager?.GetSession(gid);
                     return session is not null
@@ -3232,12 +3236,13 @@ public partial class MainWindow : Window
     {
         var store = _pendingDictationStore;
         if (store is null) return;
-        int total, parked;
+        int total, parked, composerBlocked;
         try
         {
             var all = store.LoadAll();
             total = all.Count;
             parked = all.Count(r => r.Status == global::CcDirector.Core.Dictation.PendingDictationStatus.NeedsAttention);
+            composerBlocked = all.Count(r => r.Status == global::CcDirector.Core.Dictation.PendingDictationStatus.ComposerBlocked);
         }
         catch (Exception ex)
         {
@@ -3252,9 +3257,16 @@ public partial class MainWindow : Window
         }
 
         var noun = total == 1 ? "dictation is" : "dictations are";
-        var message = parked == total
-            ? $"{total} {noun} saved and waiting - transcription needs your attention (add credits or set a key). They will be sent automatically once resolved; you will not lose them."
-            : $"{total} {noun} saved and being sent automatically as soon as the session is ready for input. You will not lose them.";
+        string message;
+        if (parked == total)
+            message = $"{total} {noun} saved and waiting - transcription needs your attention (add credits or set a key). They will be sent automatically once resolved; you will not lose them.";
+        else if (composerBlocked == total)
+            // A real submit probe already failed against the session's composer (it is starting up or
+            // wedged), so the words are held rather than re-typed over and over (issue #1135). They will
+            // be delivered when the session is accepting input again.
+            message = $"{total} {noun} saved - the target session is not accepting input yet (starting up or stuck). They will be sent automatically once the session is ready; you will not lose them.";
+        else
+            message = $"{total} {noun} saved and being sent automatically as soon as the session is ready for input. You will not lose them.";
         ShowNotification(message);
         _heldNoticeShown = true;
     }

--- a/src/CcDirector.Core.Tests/Dictation/DictationDeliveryServiceTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/DictationDeliveryServiceTests.cs
@@ -1,4 +1,5 @@
 using CcDirector.Core.Dictation;
+using CcDirector.Core.Drivers;
 using CcDirector.Core.Transcription;
 using Xunit;
 
@@ -174,14 +175,39 @@ public sealed class DictationDeliveryServiceTests : IDisposable
     public async Task DeliverAsync_SubmitThrows_KeepsClipForRetry_NeverLosesIt()
     {
         // A transcription that SUCCEEDS but whose submit fails (e.g. the session momentarily unavailable)
-        // must not lose the words: the clip stays saved and retryable.
+        // must not lose the words: the clip stays saved and retryable. A plain InvalidOperationException
+        // is NOT the composer-not-echoing case, so it stays Pending (auto-retry), not ComposerBlocked.
         var rec = _store.Save("s", "", SampleWav);
         var svc = new DictationDeliveryService(FakeTranscriber.Returning("hello"), _store);
 
         var result = await svc.DeliverAsync(rec, _ => throw new InvalidOperationException("session busy"));
 
         Assert.Equal(DictationDeliveryOutcome.HeldWillRetry, result.Outcome);
-        Assert.Single(_store.LoadAll());
+        var kept = _store.LoadAll();
+        Assert.Single(kept);
+        Assert.Equal(PendingDictationStatus.Pending, kept[0].Status);
+    }
+
+    [Fact]
+    public async Task DeliverAsync_ComposerNeverEchoed_ParksComposerBlocked_SoTheSweepStopsReTyping()
+    {
+        // issue #1135 gap: transcription SUCCEEDS, but the submit types into a session whose composer
+        // never echoes (the startup splash / a wedged session) and throws AFTER typing. Re-typing on the
+        // next sweep would stack another unsubmitted copy - the pile-up. This is parked ComposerBlocked
+        // (kept, but skipped by the sweep), distinct from the transient HeldWillRetry so only a REAL
+        // submit-probe failure - not a mere brand-new session - stops the auto-retry.
+        var rec = _store.Save("s", "", SampleWav);
+        var svc = new DictationDeliveryService(FakeTranscriber.Returning("hello"), _store);
+
+        var result = await svc.DeliverAsync(
+            rec, _ => throw new ComposerNotAcceptingInputException("composer never echoed"));
+
+        Assert.Equal(DictationDeliveryOutcome.ComposerNotReady, result.Outcome);
+        Assert.False(result.WillRetryAutomatically);          // the sweep must NOT keep re-typing
+        var kept = _store.LoadAll();
+        Assert.Single(kept);                                  // words kept, never lost
+        Assert.Equal(PendingDictationStatus.ComposerBlocked, kept[0].Status);
+        Assert.Equal(1, kept[0].AttemptCount);
     }
 
     [Fact]

--- a/src/CcDirector.Core.Tests/Dictation/PendingDictationSweeperTests.cs
+++ b/src/CcDirector.Core.Tests/Dictation/PendingDictationSweeperTests.cs
@@ -92,6 +92,36 @@ public sealed class PendingDictationSweeperTests : IDisposable
     }
 
     [Fact]
+    public async Task SweepAsync_SkipsComposerBlockedClips_SoItNeverReTypesIntoAWedgedComposer()
+    {
+        // issue #1135: a clip parked ComposerBlocked already had a submit probe fail against the
+        // session's composer. The sweep must skip it - re-typing is exactly what stacked duplicate copies.
+        var rec = _store.Save("present", "", SampleWav);
+        _store.WriteSidecar(rec with { Status = PendingDictationStatus.ComposerBlocked });
+        var sweeper = new PendingDictationSweeper(_store, Delivery(FakeTranscriber.Returning("hi")));
+        var submitted = new List<string>();
+
+        var report = await sweeper.SweepAsync(Present(submitted, "present"));
+
+        Assert.Equal(0, report.Delivered);
+        Assert.Empty(submitted);              // never re-typed into the wedged composer
+        Assert.Single(_store.LoadAll());      // kept until a launch promotes it
+    }
+
+    [Fact]
+    public void PromoteParkedToPending_AlsoPromotesComposerBlocked_ForOneMoreProbeNextLaunch()
+    {
+        var rec = _store.Save("s", "", SampleWav);
+        _store.WriteSidecar(rec with { Status = PendingDictationStatus.ComposerBlocked });
+        var sweeper = new PendingDictationSweeper(_store, Delivery(FakeTranscriber.Returning("hi")));
+
+        var promoted = sweeper.PromoteParkedToPending();
+
+        Assert.Equal(1, promoted);
+        Assert.Equal(PendingDictationStatus.Pending, _store.LoadAll()[0].Status);
+    }
+
+    [Fact]
     public void PromoteParkedToPending_FlipsNeedsAttentionBackToPending()
     {
         var a = _store.Save("s", "", SampleWav);

--- a/src/CcDirector.Core.Tests/Drivers/TerminalSubmitTests.cs
+++ b/src/CcDirector.Core.Tests/Drivers/TerminalSubmitTests.cs
@@ -105,7 +105,7 @@ public sealed class TerminalSubmitTests
         var backend = new RecordingSessionBackend { Buffer = new CircularTerminalBuffer() };
         backend.EchoScript.UseDefault(RecordingEchoStep.CustomEcho("world"));
 
-        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+        var error = await Assert.ThrowsAsync<ComposerNotAcceptingInputException>(
             () => TerminalSubmit.EchoVerifiedSubmitAsync(
                 backend,
                 "hello world",
@@ -147,7 +147,7 @@ public sealed class TerminalSubmitTests
         var backend = new RecordingSessionBackend { Buffer = new CircularTerminalBuffer() };
         backend.EchoScript.UseDefault(RecordingEchoStep.Withheld());
 
-        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+        var error = await Assert.ThrowsAsync<ComposerNotAcceptingInputException>(
             () => TerminalSubmit.EchoVerifiedSubmitAsync(
                 backend,
                 "never echoed",
@@ -175,7 +175,7 @@ public sealed class TerminalSubmitTests
         };
         backend.EchoScript.UseDefault(RecordingEchoStep.Withheld());
 
-        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+        var error = await Assert.ThrowsAsync<ComposerNotAcceptingInputException>(
             () => TerminalSubmit.EchoVerifiedSubmitAsync(
                 backend,
                 "generic prompt",
@@ -198,7 +198,7 @@ public sealed class TerminalSubmitTests
         backend.EchoScript.Enqueue(RecordingEchoStep.SlashCorrupted("write this"));
         var driver = new ClaudeDriver(new EmptyTranscriptReader(), TimeSpan.FromMilliseconds(20), TimeSpan.FromMilliseconds(5));
 
-        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+        var error = await Assert.ThrowsAsync<ComposerNotAcceptingInputException>(
             () => driver.SubmitAsync(backend, "write this"));
 
         Assert.Contains("never echoed", error.Message, StringComparison.OrdinalIgnoreCase);

--- a/src/CcDirector.Core/Dictation/DictationDeliveryService.cs
+++ b/src/CcDirector.Core/Dictation/DictationDeliveryService.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Drivers;
 using CcDirector.Core.Transcription;
 using CcDirector.Core.Utilities;
 
@@ -103,6 +104,20 @@ public sealed class DictationDeliveryService
             var kept = _store.RecordFailedAttempt(pending, ex.Message, PendingDictationStatus.NeedsAttention);
             return new DictationDeliveryResult(DictationDeliveryOutcome.PermanentError, kept, ex.Message);
         }
+        catch (ComposerNotAcceptingInputException ex)
+        {
+            // The transcription succeeded but the target session's composer never echoed the typed text,
+            // so the submit threw AFTER typing (issue #1135): the session is at Claude Code's startup
+            // splash or otherwise wedged. Re-typing on the next sweep would stack another unsubmitted copy
+            // - the exact pile-up. Park it ComposerBlocked (kept, but skipped by the sweep) so a real
+            // submit-probe failure - NOT a mere brand-new session - is what stops the re-typing; the next
+            // launch promotes it back to Pending for one more probe once the session has been recreated.
+            // Crucially this is caught BEFORE the generic transient branch below, so a transcription
+            // failure (nothing typed) still lands there and keeps auto-retrying - the durable guarantee
+            // for the first dictated turn is preserved.
+            var kept = _store.RecordFailedAttempt(pending, ex.Message, PendingDictationStatus.ComposerBlocked);
+            return new DictationDeliveryResult(DictationDeliveryOutcome.ComposerNotReady, kept, ex.Message);
+        }
         catch (Exception ex)
         {
             // Everything else - a transient 5xx/429 (the 504 upstream_timeout that started all this), a
@@ -170,6 +185,12 @@ public enum DictationDeliveryOutcome
     /// <summary>The saved audio could not be read back (disk error / removed). Nothing to deliver -
     /// reported, not silent.</summary>
     LostNoAudio,
+
+    /// <summary>Transcription succeeded but the target session's composer never echoed the typed text, so
+    /// the submit threw after typing (the session is at the startup splash or wedged). Audio kept, parked
+    /// <see cref="PendingDictationStatus.ComposerBlocked"/> so the sweep stops re-typing and stacking
+    /// copies (issue #1135); the next launch promotes it for one more probe.</summary>
+    ComposerNotReady,
 
     /// <summary>The target session was not idle at its prompt (Working, on a permission prompt, or
     /// starting), so the clip was deferred WITHOUT transcribing, submitting, or bumping its attempt

--- a/src/CcDirector.Core/Dictation/PendingDictation.cs
+++ b/src/CcDirector.Core/Dictation/PendingDictation.cs
@@ -15,6 +15,15 @@ public enum PendingDictationStatus
     /// call that will keep failing; the next Director launch promotes them back to
     /// <see cref="Pending"/> to try once more in case the user has since fixed it.</summary>
     NeedsAttention,
+
+    /// <summary>Parked: a terminal submit probe already typed this dictation into the target session's
+    /// composer and it never echoed the text back, so the composer is not accepting input right now (the
+    /// session is starting up or wedged). Re-typing would only stack another unsubmitted copy, so the
+    /// sweeper skips a clip in this state instead of re-typing it every pass (the issue #1135 pile-up).
+    /// The audio is kept; the next Director launch promotes it back to <see cref="Pending"/> for one more
+    /// probe once the session has been recreated. Distinct from <see cref="NeedsAttention"/> because the
+    /// blocker is the session's composer, not the transcription account, so the user notice differs.</summary>
+    ComposerBlocked,
 }
 
 /// <summary>

--- a/src/CcDirector.Core/Dictation/PendingDictationSweeper.cs
+++ b/src/CcDirector.Core/Dictation/PendingDictationSweeper.cs
@@ -36,17 +36,19 @@ public sealed class PendingDictationSweeper
     }
 
     /// <summary>
-    /// Promote every parked (<see cref="PendingDictationStatus.NeedsAttention"/>) clip back to
-    /// <see cref="PendingDictationStatus.Pending"/> so the next sweep retries it. Called once at launch:
-    /// a clip parked for "out of credits" or "no key" gets a fresh chance in case the user has since
-    /// fixed it. Returns how many were promoted.
+    /// Promote every parked clip back to <see cref="PendingDictationStatus.Pending"/> so the next sweep
+    /// retries it. Called once at launch: a clip parked for "out of credits" or "no key"
+    /// (<see cref="PendingDictationStatus.NeedsAttention"/>) gets a fresh chance in case the user has
+    /// since fixed it, and a clip parked because the session's composer would not take it
+    /// (<see cref="PendingDictationStatus.ComposerBlocked"/>) gets one more probe now that the session
+    /// has been recreated fresh. Returns how many were promoted.
     /// </summary>
     public int PromoteParkedToPending()
     {
         var promoted = 0;
         foreach (var record in _store.LoadAll())
         {
-            if (record.Status == PendingDictationStatus.NeedsAttention)
+            if (record.Status is PendingDictationStatus.NeedsAttention or PendingDictationStatus.ComposerBlocked)
             {
                 _store.WriteSidecar(record with { Status = PendingDictationStatus.Pending });
                 promoted++;
@@ -127,8 +129,8 @@ public sealed class PendingDictationSweeper
 
         FileLog.Write($"[PendingDictationSweeper] sweep: delivered={report.Delivered}, willRetry={report.HeldWillRetry}, "
             + $"needsCredits={report.NeedsCredits}, needsConfig={report.NeedsConfiguration}, permanent={report.PermanentError}, "
-            + $"deferredBusy={report.DeferredSessionBusy}, waitingForSession={report.WaitingForSession}, "
-            + $"parked={report.ParkedNeedingAttention}, pruned={report.Pruned}");
+            + $"composerNotReady={report.ComposerNotReady}, deferredBusy={report.DeferredSessionBusy}, "
+            + $"waitingForSession={report.WaitingForSession}, parked={report.ParkedNeedingAttention}, pruned={report.Pruned}");
         return report;
     }
 
@@ -151,6 +153,7 @@ public sealed class SweepReport
     public int NeedsCredits { get; set; }
     public int NeedsConfiguration { get; set; }
     public int PermanentError { get; set; }
+    public int ComposerNotReady { get; set; }
     public int LostNoAudio { get; set; }
     public int WaitingForSession { get; set; }
     public int ParkedNeedingAttention { get; set; }
@@ -161,7 +164,8 @@ public sealed class SweepReport
     /// <summary>Clips still saved on disk after this sweep that the user should know are held - anything
     /// not delivered this pass and not a transient no-op. Drives whether the held notice is shown.</summary>
     public int StillHeld => HeldWillRetry + NeedsCredits + NeedsConfiguration + PermanentError
-                            + WaitingForSession + ParkedNeedingAttention + AlreadyInFlight + DeferredSessionBusy;
+                            + ComposerNotReady + WaitingForSession + ParkedNeedingAttention
+                            + AlreadyInFlight + DeferredSessionBusy;
 
     public void Tally(DictationDeliveryOutcome outcome)
     {
@@ -172,6 +176,7 @@ public sealed class SweepReport
             case DictationDeliveryOutcome.NeedsCredits: NeedsCredits++; break;
             case DictationDeliveryOutcome.NeedsConfiguration: NeedsConfiguration++; break;
             case DictationDeliveryOutcome.PermanentError: PermanentError++; break;
+            case DictationDeliveryOutcome.ComposerNotReady: ComposerNotReady++; break;
             case DictationDeliveryOutcome.LostNoAudio: LostNoAudio++; break;
             case DictationDeliveryOutcome.DeferredSessionBusy: DeferredSessionBusy++; break;
         }

--- a/src/CcDirector.Core/Drivers/ComposerNotAcceptingInputException.cs
+++ b/src/CcDirector.Core/Drivers/ComposerNotAcceptingInputException.cs
@@ -1,0 +1,15 @@
+namespace CcDirector.Core.Drivers;
+
+/// <summary>
+/// Thrown by <see cref="TerminalSubmit"/> when an echo-verified submit types text into a session's
+/// composer but the composer never echoes it back after two attempts - the TUI is not accepting input
+/// (a modal, a picker, or a composer still initializing at the startup splash). It is a distinct type,
+/// not a bare <see cref="InvalidOperationException"/>, so a caller that retries a submit can tell "the
+/// composer would not take this turn" apart from every other failure and stop re-typing instead of
+/// stacking duplicate copies (issue #1135). It derives from <see cref="InvalidOperationException"/> so
+/// existing generic catches keep working unchanged.
+/// </summary>
+public sealed class ComposerNotAcceptingInputException : InvalidOperationException
+{
+    public ComposerNotAcceptingInputException(string message) : base(message) { }
+}

--- a/src/CcDirector.Core/Drivers/TerminalSubmit.cs
+++ b/src/CcDirector.Core/Drivers/TerminalSubmit.cs
@@ -163,7 +163,7 @@ public static class TerminalSubmit
             return;
         }
 
-        throw new InvalidOperationException(
+        throw new ComposerNotAcceptingInputException(
             $"[{driverTag}] EchoVerifiedSubmit: the composer never echoed the typed text after 2 attempts - " +
             "the TUI is not accepting input (a modal, a picker, or a composer still initializing). " +
             $"Terminal tail: {TailOf(buffer)}");


### PR DESCRIPTION
## Problem

Follow-up to issue thefrederiksen/devthrottle#1135. A dictation spoken once was being typed into a session's terminal composer over and over, stacking four or more duplicate copies that never submit (seen live on session 87a4b307 at the Claude Code startup splash).

The thefrederiksen/devthrottle#1135 readiness gate only checks the session activity state, which is derived from byte silence. A session sitting at the startup splash, or otherwise wedged, is byte silent, so it reads as ready even though its composer will not accept a submitted turn. The background sweep kept re-typing the same dictation into it every thirty seconds.

## What this changes

Move the veto from the session to the clip, triggered by a real submit failure instead of by the session being new:

- `TerminalSubmit` throws a typed `ComposerNotAcceptingInputException` (a subclass of `InvalidOperationException`, so existing catches are unaffected) when the composer never echoes the typed text.
- `DictationDeliveryService` catches it before the generic transient branch, parks the clip as the new `ComposerBlocked` status, and returns the new `ComposerNotReady` outcome. The sweep already skips non-pending clips, so a blocked clip is never re-typed.
- A transcription failure still lands in the generic branch and stays pending, so it keeps retrying automatically. This preserves the durable guarantee for the very first dictated turn in a fresh session, which a session-level brand-new veto would have deadlocked.
- `PromoteParkedToPending` promotes a `ComposerBlocked` clip back to pending at the next launch for one more probe once the session has been recreated.
- The held notice shows a distinct message when a clip is blocked on the session composer rather than on the transcription account.

## Why not the simpler session-level gate

The first attempt gated the sweep on the session not being brand new. An independent Codex review found that deadlocks the durable guarantee: a brand-new session whose first-ever dictation hits a transient transcription failure (the original thefrederiksen/devthrottle_internal#703 and thefrederiksen/devthrottle_internal#706 case) never submits, so the brand-new flag never clears and the sweep defers forever. Keying on an actual composer submit failure avoids that.

## Known residual

A single immediate probe into a wedged composer can still strand one or two copies, because `TerminalSubmit` retypes internally before it reports failure and Escape does not clear the startup splash. That is the true root cause and is tracked separately in issue thefrederiksen/devthrottle_internal#713 (make the echo-verified submit idempotent). Once that lands, this gate can be simplified or removed.

## Tests

- New: composer-never-echoed delivery parks `ComposerBlocked` and returns `ComposerNotReady`; a plain submit exception still stays pending; the sweep skips `ComposerBlocked` clips; launch promotes them back to pending; the four `TerminalSubmit` echo-failure tests now assert the specific exception type.
- Dictation and TerminalSubmit suites: 228 passed. Full Core suite: 2913 passed, 8 skipped. The one unrelated failure (`ShippedToolsManifestGuardTests`, cc-comm-queue manifest drift from thefrederiksen/devthrottle#1149) touches no file in this change.

Closes thefrederiksen/devthrottle#1135.
