### PR TITLE
Fix #1155: self-heal the mobile PWA when a stale service-worker shell 404s

### DIFF
--- a/apps/mobile/src/components/StaleShellRecovery.tsx
+++ b/apps/mobile/src/components/StaleShellRecovery.tsx
@@ -1,0 +1,136 @@
+import { useEffect } from "react";
+import { Outlet, isRouteErrorResponse, useRouteError } from "react-router-dom";
+
+// Self-healing recovery for a stale service-worker shell (issue #1155).
+//
+// The mobile app is an offline-capable Progressive Web App: its service worker precaches the app
+// shell and serves navigations from that cache. When a new build adds a client-side route, a
+// returning browser can still be served the PREVIOUSLY cached shell for a load (the service worker
+// serves cache-first, and a new worker only takes control on a later load). If that cached shell's
+// router does not know the route being navigated to - the device-enrollment callback
+// (/m/device-callback) is the one that bit us - React Router renders its raw "404 Not Found" and the
+// user dead-ends, unable to sign in.
+//
+// skipWaiting + clientsClaim (already on via registerType: "autoUpdate") do NOT prevent this: the old
+// worker has already rendered the stale shell before the background update+reload can win the race.
+// The only deterministic cure is to recover AT the point of failure: when a navigation matches no
+// route, throw away the service worker and its caches and reload once, which forces the browser to
+// fetch the current shell straight from the Gateway (the Gateway always serves the up-to-date
+// index.html with no-cache). After that reload the router is current and the route resolves.
+//
+// A single per-session guard prevents a reload loop: a genuinely non-existent URL cannot self-heal,
+// so after one refresh we stop and show a plain message instead of reloading forever.
+
+const RECOVERED_KEY = "cc.staleShellRecovered";
+
+function hasRecovered(): boolean {
+  try {
+    return sessionStorage.getItem(RECOVERED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function markRecovered(): void {
+  try {
+    sessionStorage.setItem(RECOVERED_KEY, "1");
+  } catch {
+    /* private mode / storage disabled: the guard degrades to "may reload again", still bounded by
+       the fact that a fresh shell resolves the route on the first reload in the real (stale) case. */
+  }
+}
+
+function clearRecovered(): void {
+  try {
+    sessionStorage.removeItem(RECOVERED_KEY);
+  } catch {
+    /* best effort */
+  }
+}
+
+// Drop every service worker registration and cache for this origin, then reload. Best effort: if any
+// step throws we still reload, because a plain reload alone often lets the newly-activated worker
+// serve the current shell.
+async function purgeAndReload(): Promise<void> {
+  try {
+    if ("serviceWorker" in navigator) {
+      const regs = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(regs.map((r) => r.unregister()));
+    }
+    if (typeof caches !== "undefined") {
+      const keys = await caches.keys();
+      await Promise.all(keys.map((k) => caches.delete(k)));
+    }
+  } catch {
+    /* fall through to the reload regardless */
+  }
+  window.location.reload();
+}
+
+const container: React.CSSProperties = {
+  maxWidth: 420,
+  margin: "0 auto",
+  padding: "2.5rem 1.25rem",
+  textAlign: "center",
+};
+
+/**
+ * The router's top-level errorElement. On a no-route match (a stale shell whose router lacks the
+ * navigated route) it purges the service worker + caches and reloads once so the browser picks up the
+ * current shell. Any other error, or a 404 that survived the one refresh, shows a plain message with
+ * a way back to the app.
+ */
+export function RouteRecoveryBoundary() {
+  const error = useRouteError();
+  const isNotFound = isRouteErrorResponse(error) && error.status === 404;
+  const recovered = hasRecovered();
+  const willSelfHeal = isNotFound && !recovered;
+
+  useEffect(() => {
+    if (!willSelfHeal) return;
+    markRecovered();
+    void purgeAndReload();
+  }, [willSelfHeal]);
+
+  if (willSelfHeal) {
+    return (
+      <div style={container}>
+        <h1>Updating&hellip;</h1>
+        <p style={{ opacity: 0.8 }}>Loading the latest version of DevThrottle.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={container}>
+      <h1>Something went wrong</h1>
+      <p style={{ opacity: 0.8, marginBottom: "1.5rem" }}>
+        {isNotFound
+          ? "This page could not be loaded. Please refresh, or return to DevThrottle."
+          : "An unexpected error occurred. Please return to DevThrottle and try again."}
+      </p>
+      <button
+        type="button"
+        onClick={() => {
+          clearRecovered();
+          window.location.assign("/m/");
+        }}
+        style={{ padding: "0.8rem 1.25rem", fontSize: "1rem", fontWeight: 600, borderRadius: 10, border: "none", cursor: "pointer" }}
+      >
+        Go to DevThrottle
+      </button>
+    </div>
+  );
+}
+
+/**
+ * The router's root layout. It exists so every real (matched) route renders through here, which lets
+ * us clear the one-shot recovery guard on any successful load - so a later stale episode in a very
+ * long-lived session can self-heal again.
+ */
+export function RootLayout() {
+  useEffect(() => {
+    clearRecovered();
+  }, []);
+  return <Outlet />;
+}

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -15,6 +15,7 @@ import { ensurePushSubscribed } from "./push/register";
 import { CreditsNotice } from "./components/CreditsNotice";
 import { useScreenWakeLock } from "./hooks/useScreenWakeLock";
 import { resumePendingDictations } from "@devthrottle/client-core/dictation/backgroundSend";
+import { RouteRecoveryBoundary, RootLayout } from "./components/StaleShellRecovery";
 import "./styles.css";
 
 // The auth gate (issue #908): every real screen requires an enrolled device key. Without one, the
@@ -59,22 +60,31 @@ void ensurePushSubscribed();
 // The app is served under /m, so the router is rooted there. A hard navigation to a deep link
 // (e.g. /m/session/<id>) is served the injected index.html by the Gateway and the router then
 // resolves it client-side.
+// All routes hang off a root layout that carries the errorElement, so a no-route match (the symptom
+// of a stale service-worker shell whose router lacks the navigated route, issue #1155) is caught by
+// RouteRecoveryBoundary and self-healed instead of dead-ending on React Router's raw 404.
 const router = createBrowserRouter(
   [
-    // Ungated: reachable before the phone has enrolled.
-    { path: "/signin", element: <SignIn /> },
-    { path: "/device-callback", element: <DeviceCallback /> },
-    // Gated: everything real requires an enrolled device key.
     {
-      element: <RequireDeviceKey />,
+      element: <RootLayout />,
+      errorElement: <RouteRecoveryBoundary />,
       children: [
-        { path: "/", element: <Home /> },
-        { path: "/settings", element: <AiSettings /> },
-        { path: "/new", element: <NewSession /> },
-        { path: "/session/:sessionId", element: <Chat /> },
-        { path: "/session/:sessionId/chat", element: <Chat /> },
-        { path: "/session/:sessionId/terminal", element: <Terminal /> },
-        { path: "/session/:sessionId/voice", element: <VoiceMode /> },
+        // Ungated: reachable before the phone has enrolled.
+        { path: "/signin", element: <SignIn /> },
+        { path: "/device-callback", element: <DeviceCallback /> },
+        // Gated: everything real requires an enrolled device key.
+        {
+          element: <RequireDeviceKey />,
+          children: [
+            { path: "/", element: <Home /> },
+            { path: "/settings", element: <AiSettings /> },
+            { path: "/new", element: <NewSession /> },
+            { path: "/session/:sessionId", element: <Chat /> },
+            { path: "/session/:sessionId/chat", element: <Chat /> },
+            { path: "/session/:sessionId/terminal", element: <Terminal /> },
+            { path: "/session/:sessionId/voice", element: <VoiceMode /> },
+          ],
+        },
       ],
     },
   ],


### PR DESCRIPTION
Closes #1155.

## Problem
When the mobile Progressive Web App at `/m` serves a browser a previously cached shell whose router does not know a route a newer build added, the user dead-ends on React Router's raw "Unexpected Application Error! 404 Not Found". The sign-in enrollment callback (`/m/device-callback`) is exactly such a route, so this blocked sign-in entirely. Prompt service-worker activation (`skipWaiting`/`clientsClaim`, already on) does not prevent it, because the old worker renders the stale shell before the background update can reload.

## Fix
New `apps/mobile/src/components/StaleShellRecovery.tsx`:
- `RouteRecoveryBoundary` - the router's top-level `errorElement`. On a no-route match it unregisters the service worker, clears caches, and reloads once, so the browser fetches the current shell from the Gateway. A per-session guard means a genuinely missing route recovers at most once, then shows a plain message with a way back - never an infinite loop.
- `RootLayout` - clears the guard on any successful load so a later stale episode can self-heal again.

`apps/mobile/src/main.tsx` - all routes now hang off `RootLayout` with the recovery boundary. No `vite.config.ts` change (offline precache intentionally left intact).

## Verification (built + deployed to the development Gateway, driven in a real headless browser)
- Real stale-shell case: cached the fixed build, deployed a build adding a `/probe` route the cached shell lacks, navigated to it -> the fresh route rendered (not the raw 404) in one self-heal reload, no loop.
- Enrollment callback still matches and runs, never the raw 404.
- Genuine 404 recovers once then shows the friendly message - no loop.

Note: a browser already stuck on a pre-fix cached shell needs one manual "Clear site data" (or a private window) this one time, since the self-healing code only exists in builds from this fix forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)