### PR TITLE
Stop the wingman voice from reading Markdown marks aloud

### DIFF
--- a/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
@@ -174,6 +174,43 @@ public sealed class WingmanTranslatorTests
     }
 
     [Fact]
+    public async Task TranslateAsync_PromptBansMarkdownSoTtsDoesNotVoiceTheMarks()
+    {
+        // The real defect: the agent reply is Markdown (**bold**, ## headings, "1." lists) and that
+        // string was fed straight to text-to-speech, so the voice read "star star" / "hashtag" out
+        // loud. The fix is prompt-only (fix the model output at the source, not with a regex strip):
+        // the fidelity contract must explicitly forbid Markdown. Guard the rule so it cannot silently
+        // regress.
+        var brain = new FakeBrain(_ => "ok");
+        var translator = BuildTranslator(brain);
+
+        await translator.TranslateAsync("q", "**BPMN Studio** is option 1. ## Root cause: the panel path.");
+
+        var prompt = Assert.Single(brain.Asks);
+        Assert.Contains("NO MARKDOWN", prompt);
+        Assert.Contains("asterisks", prompt);          // the exact characters from the bug report
+        Assert.Contains("star star BPMN Studio star star", prompt); // the concrete failure example
+    }
+
+    [Fact]
+    public void BuildDirectPrompt_BansMarkdownForTheEar()
+    {
+        // The "hey wingman" path is also spoken, so its prompt carries the same no-Markdown rule.
+        var prompt = WingmanTranslator.BuildDirectPrompt("what is going on?");
+        Assert.Contains("NO Markdown", prompt);
+        Assert.Contains("what is going on?", prompt);
+    }
+
+    [Fact]
+    public void BuildDevThrottlePrompt_BansMarkdownBecauseTheAnswerIsShownRawAndMaySpeak()
+    {
+        // The Learning-page answer is rendered as raw text (no Markdown renderer) and may be read
+        // aloud, so formatting marks would show/voice literally. The prompt must forbid them.
+        var prompt = WingmanTranslator.BuildDevThrottlePrompt("How do I start a session?");
+        Assert.Contains("NO Markdown", prompt);
+    }
+
+    [Fact]
     public async Task TranslateAsync_EmptyReply_ThrowsBecauseThereIsNothingToTranslate()
     {
         var translator = BuildTranslator(new FakeBrain(_ => "x"));

--- a/src/CcDirector.Gateway/Wingman/WingmanTranslator.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanTranslator.cs
@@ -89,6 +89,13 @@ public sealed class WingmanTranslator
           cause"; a function like "SweepStale()" becomes "the sweep-stale method". Say what the
           path, URL, heading, or symbol IS and what it DOES - keep the technical meaning, drop
           the punctuation. Never spell out the literal characters.
+        - OUTPUT PLAIN SPOKEN PROSE ONLY - NO MARKDOWN. This is read aloud, so it must contain
+          no formatting characters at all: no asterisks for bold or italics, no hash-mark
+          headings, no numbered or bulleted lists, no backticks, no underscores. Write in
+          flowing sentences. When you need to enumerate, say it in words inside a sentence
+          ("first ... second ... third ..."), never as a "1." / "2." list or a "- " bullet.
+          A person hearing "star star BPMN Studio star star" or "hashtag Root cause" is exactly
+          the failure to avoid - say the words, drop the marks.
         - The reply may be in ANY language or script. Non-Latin characters are valid
           content, never corruption. Translate faithfully in the same language; never
           refuse or say the text cannot be read.
@@ -100,7 +107,7 @@ public sealed class WingmanTranslator
     /// instructions is shown that the recommended default changed and can switch to it. The content
     /// hash is the real identity; this is the human-facing label.
     /// </summary>
-    public const string DefaultInstructionsVersion = "3";
+    public const string DefaultInstructionsVersion = "4";
 
     private readonly Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> _brainProvider;
     private readonly Action<string> _log;
@@ -295,7 +302,10 @@ public sealed class WingmanTranslator
         sb.Append("question is not about DevThrottle, say so plainly and point them back to product help.\n");
         sb.Append("- If you are not sure of a specific detail, say so rather than inventing it; never ");
         sb.Append("guess at a feature that may not exist.\n");
-        sb.Append("- Keep it readable on screen: a short paragraph or a few short points, not an essay.\n\n");
+        sb.Append("- Keep it short and readable: a short paragraph, not an essay. Write plain prose only ");
+        sb.Append("- NO Markdown (no asterisks, hash-mark headings, numbered or bulleted lists, or ");
+        sb.Append("backticks); the answer is shown as raw text and may be read aloud, so formatting ");
+        sb.Append("marks show up literally. Enumerate in words inside a sentence, never as a \"1.\" list.\n\n");
         sb.Append("The person asked:\n");
         sb.Append(question.Trim());
         sb.Append("\n\n");
@@ -469,6 +479,9 @@ public sealed class WingmanTranslator
         sb.Append("You are the wingman, talking directly to a person in a spoken back-and-forth ");
         sb.Append("(not relaying a coding session). Answer their message helpfully and briefly, in ");
         sb.Append("words that are natural to hear out loud - no code, paths, or symbols read aloud. ");
+        sb.Append("Output plain spoken prose only - NO Markdown: no asterisks, hash-mark headings, ");
+        sb.Append("numbered or bulleted lists, or backticks. Write in flowing sentences; enumerate ");
+        sb.Append("in words (\"first ... second ...\"), never as a \"1.\" list. ");
         sb.Append("You do NOT edit files or run commands yourself; if the request needs real code ");
         sb.Append("work, say so plainly and suggest sending it to the working session.\n\n");
         sb.Append("The person said:\n");

--- a/tools/cc-outlook/src/auth.py
+++ b/tools/cc-outlook/src/auth.py
@@ -386,6 +386,80 @@ def _save_profiles(profiles: dict) -> None:
     PROFILES_FILE.write_text(json.dumps(profiles, indent=2), encoding='utf-8')
 
 
+def derive_nickname(email: str) -> str:
+    """
+    Derive a default nickname from an email address.
+
+    The nickname is the domain label immediately before the top-level domain.
+    Examples:
+        email@devthrottle.com          -> devthrottle
+        soren.frederiksen@mindzie.com  -> mindzie
+        user@mail.corp.example.org     -> example
+
+    Args:
+        email: Email address to derive a nickname from
+
+    Returns:
+        The derived nickname (lower-cased)
+
+    Raises:
+        ValueError: If the email has no usable domain
+    """
+    if '@' not in email:
+        raise ValueError(f"Cannot derive a nickname: '{email}' is not an email address.")
+
+    domain = email.rsplit('@', 1)[1].strip().lower()
+    labels = [label for label in domain.split('.') if label]
+
+    if len(labels) >= 2:
+        # Second-to-last label is the registrable name (before the TLD).
+        return labels[-2]
+    if labels:
+        # Domain with no dot (unusual, but handle it rather than fall back silently).
+        return labels[0]
+
+    raise ValueError(f"Cannot derive a nickname from email '{email}': no domain found.")
+
+
+def get_nickname(email: str, profile: Optional[dict] = None) -> str:
+    """
+    Get the nickname for an account.
+
+    Uses the stored nickname when present, otherwise derives it from the email.
+    This makes accounts added before nicknames existed resolve by nickname too,
+    without requiring them to be re-added.
+
+    Args:
+        email: Account email
+        profile: Optional already-loaded profile dict for this account
+
+    Returns:
+        The account's nickname
+    """
+    if profile is None:
+        profile = get_profile(email) or {}
+
+    stored = profile.get('nickname')
+    if stored:
+        return stored
+    return derive_nickname(email)
+
+
+def _build_nickname_map(profiles: dict) -> dict:
+    """
+    Build a mapping of nickname -> account email from the profiles config.
+
+    Nicknames are derived when not explicitly stored, so existing accounts are
+    included. A nickname that collides with an existing account email is skipped
+    for that direction so the exact-email lookup always wins.
+    """
+    nickname_map = {}
+    for email, profile in profiles.get('profiles', {}).items():
+        nickname = get_nickname(email, profile)
+        nickname_map[nickname] = email
+    return nickname_map
+
+
 def get_token_path(account_name: str) -> Path:
     """Get token file path for an account."""
     safe_name = account_name.replace('@', '_').replace('.', '_')
@@ -416,6 +490,7 @@ def list_accounts() -> list:
 
         result.append({
             'name': email,
+            'nickname': get_nickname(email, profile),
             'is_default': email == profiles.get('default'),
             'authenticated': msal_token_path.exists(),
             'client_id': profile.get('client_id', '')[:20] + '...' if profile.get('client_id') else '',
@@ -455,9 +530,26 @@ def resolve_account(account_name: Optional[str] = None) -> str:
     """
     if account_name:
         profiles = _load_profiles()
-        if account_name not in profiles.get('profiles', {}):
-            raise ValueError(f"Account '{account_name}' not found. Run 'cc-outlook accounts list' to see available accounts.")
-        return account_name
+
+        # 1. Exact account-name (email) match first, so existing usage is unchanged.
+        if account_name in profiles.get('profiles', {}):
+            return account_name
+
+        # 2. Then nickname match (case-insensitive; nicknames are stored lower-cased).
+        nickname_map = _build_nickname_map(profiles)
+        if account_name.lower() in nickname_map:
+            return nickname_map[account_name.lower()]
+
+        # Not found: list valid names and nicknames to make the fix obvious.
+        available = []
+        for email, profile in profiles.get('profiles', {}).items():
+            available.append(f"{email} (nickname: {get_nickname(email, profile)})")
+        available_text = ", ".join(available) if available else "none configured"
+        raise ValueError(
+            f"Account '{account_name}' not found. "
+            f"Available accounts: {available_text}. "
+            f"Run 'cc-outlook accounts list' to see them."
+        )
 
     default = get_default_account()
     if not default:
@@ -472,7 +564,8 @@ def get_profile(account_name: str) -> Optional[dict]:
     return profiles.get('profiles', {}).get(account_name)
 
 
-def save_profile(email: str, client_id: str, tenant_id: str = 'common') -> None:
+def save_profile(email: str, client_id: str, tenant_id: str = 'common',
+                 nickname: Optional[str] = None) -> str:
     """
     Save a new account profile.
 
@@ -480,16 +573,37 @@ def save_profile(email: str, client_id: str, tenant_id: str = 'common') -> None:
         email: Email address for the account
         client_id: Azure App Client ID
         tenant_id: Azure Tenant ID (default: 'common')
+        nickname: Optional short nickname. When omitted, it is derived from the
+            email domain (e.g. email@devthrottle.com -> devthrottle).
+
+    Returns:
+        The nickname assigned to the account.
+
+    Raises:
+        ValueError: If the nickname collides with another account's nickname.
     """
     _ensure_config_dirs()
     profiles = _load_profiles()
+
+    resolved_nickname = (nickname or derive_nickname(email)).strip().lower()
+
+    # Nickname must be unique across accounts (excluding this same account on update).
+    for other_email, other_profile in profiles.get('profiles', {}).items():
+        if other_email == email:
+            continue
+        if get_nickname(other_email, other_profile) == resolved_nickname:
+            raise ValueError(
+                f"Nickname '{resolved_nickname}' is already used by account "
+                f"'{other_email}'. Choose a different nickname with --nickname."
+            )
 
     token_file = str(get_token_path(email))
 
     profiles['profiles'][email] = {
         'client_id': client_id,
         'tenant_id': tenant_id,
-        'token_file': token_file
+        'token_file': token_file,
+        'nickname': resolved_nickname,
     }
 
     # Set as default if it's the first account
@@ -497,6 +611,7 @@ def save_profile(email: str, client_id: str, tenant_id: str = 'common') -> None:
         profiles['default'] = email
 
     _save_profiles(profiles)
+    return resolved_nickname
 
 
 def delete_account(account_name: str) -> bool:

--- a/tools/cc-outlook/src/cli.py
+++ b/tools/cc-outlook/src/cli.py
@@ -248,6 +248,7 @@ def accounts_list(
                 {
                     "name": acct["name"],
                     "email": acct["name"],  # For cc-outlook, the account name IS the email
+                    "nickname": acct.get("nickname", ""),
                     "is_default": acct["is_default"],
                     "authenticated": acct["authenticated"],
                     "can_send": acct["authenticated"],
@@ -267,6 +268,7 @@ def accounts_list(
 
     table = Table(title="Outlook Accounts")
     table.add_column("Account", style="cyan")
+    table.add_column("Nickname", style="magenta")
     table.add_column("Default")
     table.add_column("Authenticated")
     table.add_column("Client ID")
@@ -274,6 +276,7 @@ def accounts_list(
     for acct in accts:
         table.add_row(
             acct["name"],
+            acct.get("nickname", ""),
             "[green]*[/green]" if acct["is_default"] else "",
             "[green]Yes[/green]" if acct["authenticated"] else "[yellow]No[/yellow]",
             acct.get("client_id", ""),
@@ -288,6 +291,7 @@ def accounts_add(
     client_id: str = typer.Option(..., "--client-id", "-c", help="Azure App Client ID"),
     tenant_id: str = typer.Option("common", "--tenant-id", "-t", help="Azure Tenant ID (default: common)"),
     set_as_default: bool = typer.Option(False, "--default", "-d", help="Set as default account"),
+    nickname: Optional[str] = typer.Option(None, "--nickname", "-n", help="Short nickname for the account (default: derived from the email domain)"),
 ):
     """Add a new Outlook account."""
     console.print(f"[cyan]Setting up account:[/cyan] {email}")
@@ -295,8 +299,13 @@ def accounts_add(
     console.print()
 
     # Save the profile
-    save_profile(email, client_id, tenant_id)
+    try:
+        assigned_nickname = save_profile(email, client_id, tenant_id, nickname)
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1)
     console.print(f"[green]Profile saved for {email}[/green]")
+    console.print(f"[green]Nickname:[/green] {assigned_nickname} (use it with -a {assigned_nickname})")
 
     if set_as_default or not get_default_account():
         set_default_account(email)

--- a/tools/cc-outlook/tests/test_auth.py
+++ b/tools/cc-outlook/tests/test_auth.py
@@ -213,3 +213,186 @@ class TestResolveAccount:
         # Call with no arguments (should behave like account_name=None)
         result = auth.resolve_account()
         assert result == "solo@example.com"
+
+    def test_resolves_by_stored_nickname(self, _patch_heavy_imports):
+        auth = _patch_heavy_imports
+        profiles = {
+            "profiles": {
+                "email@devthrottle.com": {
+                    "client_id": "cid",
+                    "tenant_id": "common",
+                    "nickname": "devthrottle",
+                }
+            },
+            "default": "email@devthrottle.com",
+        }
+        _write_profiles(auth, profiles)
+
+        assert auth.resolve_account("devthrottle") == "email@devthrottle.com"
+
+    def test_resolves_by_derived_nickname_when_not_stored(self, _patch_heavy_imports):
+        # Backfill case: existing account has no stored nickname.
+        auth = _patch_heavy_imports
+        profiles = {
+            "profiles": {
+                "soren.frederiksen@mindzie.com": {
+                    "client_id": "cid",
+                    "tenant_id": "common",
+                }
+            },
+            "default": "soren.frederiksen@mindzie.com",
+        }
+        _write_profiles(auth, profiles)
+
+        assert auth.resolve_account("mindzie") == "soren.frederiksen@mindzie.com"
+
+    def test_nickname_match_is_case_insensitive(self, _patch_heavy_imports):
+        auth = _patch_heavy_imports
+        profiles = {
+            "profiles": {
+                "email@devthrottle.com": {
+                    "client_id": "cid",
+                    "tenant_id": "common",
+                    "nickname": "devthrottle",
+                }
+            },
+            "default": "email@devthrottle.com",
+        }
+        _write_profiles(auth, profiles)
+
+        assert auth.resolve_account("DevThrottle") == "email@devthrottle.com"
+
+    def test_exact_email_wins_over_nickname(self, _patch_heavy_imports):
+        auth = _patch_heavy_imports
+        profiles = {
+            "profiles": {
+                "email@devthrottle.com": {
+                    "client_id": "cid1",
+                    "tenant_id": "common",
+                    "nickname": "devthrottle",
+                },
+                "soren.frederiksen@mindzie.com": {
+                    "client_id": "cid2",
+                    "tenant_id": "common",
+                    "nickname": "mindzie",
+                },
+            },
+            "default": "email@devthrottle.com",
+        }
+        _write_profiles(auth, profiles)
+
+        # Full email still resolves to itself.
+        assert auth.resolve_account("soren.frederiksen@mindzie.com") == "soren.frederiksen@mindzie.com"
+
+    def test_unknown_account_lists_names_and_nicknames(self, _patch_heavy_imports):
+        auth = _patch_heavy_imports
+        profiles = {
+            "profiles": {
+                "email@devthrottle.com": {
+                    "client_id": "cid",
+                    "tenant_id": "common",
+                    "nickname": "devthrottle",
+                }
+            },
+            "default": "email@devthrottle.com",
+        }
+        _write_profiles(auth, profiles)
+
+        with pytest.raises(ValueError) as exc_info:
+            auth.resolve_account("bogus")
+
+        message = str(exc_info.value)
+        assert "email@devthrottle.com" in message
+        assert "devthrottle" in message
+
+
+# ===========================================================================
+# derive_nickname
+# ===========================================================================
+
+class TestDeriveNickname:
+
+    def test_devthrottle_domain(self, _patch_heavy_imports):
+        auth = _patch_heavy_imports
+        assert auth.derive_nickname("email@devthrottle.com") == "devthrottle"
+
+    def test_mindzie_domain_with_dotted_local_part(self, _patch_heavy_imports):
+        auth = _patch_heavy_imports
+        assert auth.derive_nickname("soren.frederiksen@mindzie.com") == "mindzie"
+
+    def test_subdomain_uses_registrable_label(self, _patch_heavy_imports):
+        auth = _patch_heavy_imports
+        assert auth.derive_nickname("user@mail.corp.example.org") == "example"
+
+    def test_uppercase_domain_lowercased(self, _patch_heavy_imports):
+        auth = _patch_heavy_imports
+        assert auth.derive_nickname("User@DevThrottle.COM") == "devthrottle"
+
+    def test_not_an_email_raises(self, _patch_heavy_imports):
+        auth = _patch_heavy_imports
+        with pytest.raises(ValueError):
+            auth.derive_nickname("not-an-email")
+
+
+# ===========================================================================
+# save_profile (nickname handling)
+# ===========================================================================
+
+class TestSaveProfileNickname:
+
+    def test_auto_derives_nickname(self, _patch_heavy_imports):
+        auth = _patch_heavy_imports
+        _write_profiles(auth, {"profiles": {}, "default": None})
+
+        assigned = auth.save_profile("email@devthrottle.com", "cid", "common")
+        assert assigned == "devthrottle"
+        assert auth.get_profile("email@devthrottle.com")["nickname"] == "devthrottle"
+
+    def test_explicit_nickname_override(self, _patch_heavy_imports):
+        auth = _patch_heavy_imports
+        _write_profiles(auth, {"profiles": {}, "default": None})
+
+        assigned = auth.save_profile("email@devthrottle.com", "cid", "common", nickname="dt")
+        assert assigned == "dt"
+        assert auth.resolve_account("dt") == "email@devthrottle.com"
+
+    def test_duplicate_nickname_rejected(self, _patch_heavy_imports):
+        auth = _patch_heavy_imports
+        _write_profiles(auth, {"profiles": {}, "default": None})
+
+        auth.save_profile("email@devthrottle.com", "cid", "common", nickname="dt")
+        with pytest.raises(ValueError, match="already used"):
+            auth.save_profile("other@example.com", "cid2", "common", nickname="dt")
+
+    def test_updating_same_account_keeps_nickname(self, _patch_heavy_imports):
+        auth = _patch_heavy_imports
+        _write_profiles(auth, {"profiles": {}, "default": None})
+
+        auth.save_profile("email@devthrottle.com", "cid", "common", nickname="dt")
+        # Re-saving the same account with the same nickname must not raise.
+        assigned = auth.save_profile("email@devthrottle.com", "cid-new", "common", nickname="dt")
+        assert assigned == "dt"
+
+
+# ===========================================================================
+# list_accounts (nickname exposure)
+# ===========================================================================
+
+class TestListAccountsNickname:
+
+    def test_nickname_present_in_listing(self, _patch_heavy_imports):
+        auth = _patch_heavy_imports
+        profiles = {
+            "profiles": {
+                "soren.frederiksen@mindzie.com": {
+                    "client_id": "cid",
+                    "tenant_id": "common",
+                }
+            },
+            "default": "soren.frederiksen@mindzie.com",
+        }
+        _write_profiles(auth, profiles)
+
+        accts = auth.list_accounts()
+        assert len(accts) == 1
+        assert accts[0]["nickname"] == "mindzie"


### PR DESCRIPTION
## Problem

In voice mode, the wingman translator's output is the exact text posted to text-to-speech. The fidelity prompt never forbade Markdown, so agent replies containing bold asterisks, hash-mark headings, and numbered lists were sent verbatim to the speech engine and read aloud as "star star ..." and "hashtag ...", making the audio bad to listen to.

Every voice path (voice-turn, explain, turn-end regeneration, menu handling) funnels through `WingmanTranslator`, and its output is the single string handed to `/audio/speech`. So there is one place to fix.

## Fix (prompt-only)

Per the standing rule of fixing wrong model output at the source rather than with a regex-stripping pass:

- Add an explicit plain-spoken-prose / no-Markdown rule to `FidelityPrompt`, with the concrete "star star ... / hashtag ..." failure example.
- Apply the same rule to the two sibling spoken prompts: `BuildDirectPrompt` (the "hey wingman" path) and `BuildDevThrottlePrompt` (the Learning-page answer, which is rendered as raw text and may be spoken, so formatting marks showed/voiced literally there too).
- Bump `DefaultInstructionsVersion` 3 -> 4 so users on the default automatically pick it up and customized users are told the recommended default moved.
- Add regression tests guarding that all three prompts carry the rule.

No `CleanupForSpeech` symbol-stripping was added; if the model still leaks a stray symbol after this, that is the point to reconsider a safety net.

## Testing

- All 20 `WingmanTranslatorTests` pass (including 3 new).
- Deployed to the live Gateway and verified the running build matches the commit; mobile app serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)