### PR TITLE
Show a clear message when the transcription service fails, not a raw error

### DIFF
--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -954,21 +954,51 @@ export async function uploadDictationToSession(
     // The transcription-provider failures (the #1139 502/504 wrapping upstream_timeout) land here. The
     // audio is saved durably, so this is a HELD-and-will-retry state, not a loss - say so, and keep it
     // sticky on screen and on the roster until it retries or the user dismisses it.
-    return failed(providerFailureMessage(body.error, comp.status));
+    return failed(transcriptionFailureMessage(body.error, comp.status));
   }
   publishDictationStatus({ sessionId: sid, uploadId, phase: "done" });
   return { terminal: true, submitted: Boolean(body.submitted), movedOn: Boolean(body.movedOn), transcript: body.transcript ?? "" };
 }
 
-// Turn a raw transcription-provider error into a short, honest, human sentence for the status strip.
-// The audio is durable at this point, so every one of these is a "held, will retry" state.
-function providerFailureMessage(serverError: string | undefined, status: number): string {
+// Turn a raw dictation-complete failure (any non-OK response from POST /dictation/{id}/complete) into a
+// short, honest, plain-English sentence for the status strip and the error banner. The recorded audio is
+// durable at this point, so the transcription-service faults are all "held, will retry" states.
+//
+// This is the SINGLE place a dictation failure is turned into user-facing words. It never surfaces the
+// raw server JSON/text at the user (the bug this fixes: a server-side outage used to reach the user as a
+// raw "Transcription returned 502: {...}" dump), and every known server-side condition gets its own
+// specific line so the user is told WHAT went wrong - a transcription-service outage, a busy session, no
+// method configured - not merely that "transcription failed" (issue #1139 follow-up).
+export function transcriptionFailureMessage(serverError: string | undefined, status: number): string {
   const raw = (serverError ?? "").toLowerCase();
-  if (raw.includes("upstream_timeout") || raw.includes("did not respond") || status === 504)
+
+  // The session the dictation was headed for is gone (exited / not found).
+  if (status === 404 || status === 410 || raw.includes("session not found") || raw.includes("session has exited"))
+    return "That session is no longer available, so your dictation couldn't be delivered.";
+
+  // No transcription method is configured on the Gateway (no key for the selected mode). A plain retry
+  // will not fix it, so point at Settings rather than promising a retry.
+  if (raw.includes("no key configured") || raw.includes("no key set"))
+    return "No transcription method is set up. Open Settings > Transcription and choose one.";
+
+  // The upstream speech-to-text provider took too long to respond.
+  if (status === 504 || raw.includes("upstream_timeout") || raw.includes("timed out") || raw.includes("did not respond"))
     return "The transcription service timed out. Your recording is saved and will retry.";
-  if (raw.includes("upstream_unavailable") || status === 503)
+
+  // The upstream speech-to-text provider is down / circuit-broken ("temporarily unavailable after
+  // repeated failures"). The Gateway wraps the proxy's 503/504 as a 502 whose body carries this code.
+  if (status === 503 || raw.includes("upstream_unavailable") || raw.includes("temporarily unavailable"))
     return "The transcription service is temporarily unavailable. Your recording is saved and will retry.";
-  return `Transcription didn't go through (${serverError ?? status}). Your recording is saved and will retry.`;
+
+  // The transcript was produced but could not be delivered into the session (parked on a prompt or a
+  // permission dialog and refusing typed input).
+  if (raw.includes("submit to session failed"))
+    return "Couldn't deliver your dictation to the session - it may be busy or waiting on a prompt. It's saved and will retry.";
+
+  // Any other server-side transcription fault - the provider itself returned an error ("openai
+  // transcription failed" / upstream_error), an empty assembly, some other 5xx. A real backend problem,
+  // not the user's audio: say so plainly instead of dumping the raw server response.
+  return "The transcription service had a problem and couldn't process your recording. Your recording is saved and will retry.";
 }
 
 function extForMime(mime: string | undefined): string {

--- a/packages/client-core/src/api/transcriptionFailureMessage.test.ts
+++ b/packages/client-core/src/api/transcriptionFailureMessage.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { transcriptionFailureMessage } from "./client";
+
+// transcriptionFailureMessage turns a raw POST /dictation/{id}/complete failure into a plain-English
+// line for the status strip and the error banner. The bug it fixes (issue #1139 follow-up): a server-side
+// transcription outage used to reach the user either as a raw server-JSON dump
+// ("Transcription returned 502: {...}") or as a misleading blanket "session may be busy" guess. Every
+// branch below asserts the user sees a clean, specific, honest sentence - and never the raw server text.
+
+describe("transcriptionFailureMessage", () => {
+  it("maps the upstream provider fault (502 upstream_error / 'openai transcription failed') to a clean line, not raw JSON", () => {
+    const raw =
+      'Transcription returned 502: {"error":{"message":"Transcription failed: openai transcription failed","type":"api_error","code":"upstream_error"}}';
+    const msg = transcriptionFailureMessage(raw, 502);
+    expect(msg).toBe(
+      "The transcription service had a problem and couldn't process your recording. Your recording is saved and will retry.",
+    );
+    // The raw server response never leaks to the user.
+    expect(msg).not.toContain("{");
+    expect(msg).not.toContain("upstream_error");
+    expect(msg).not.toContain("openai");
+  });
+
+  it("maps a circuit-broken upstream (upstream_unavailable, wrapped as 502) to 'temporarily unavailable'", () => {
+    const raw =
+      'Transcription returned 504: {"error":{"message":"Upstream provider is temporarily unavailable after repeated failures. Retry in 60 seconds.","type":"api_error","code":"upstream_unavailable"}}';
+    const msg = transcriptionFailureMessage(raw, 502);
+    expect(msg).toContain("temporarily unavailable");
+    expect(msg).toContain("saved and will retry");
+    expect(msg).not.toContain("{");
+  });
+
+  it("maps a timeout (status 504) to a timed-out line", () => {
+    expect(transcriptionFailureMessage("upstream_timeout", 504)).toContain("timed out");
+  });
+
+  it("maps a gone session (404 / 410) to a session-unavailable line", () => {
+    expect(transcriptionFailureMessage("session has exited", 410)).toContain("no longer available");
+    expect(transcriptionFailureMessage("session not found", 404)).toContain("no longer available");
+  });
+
+  it("maps a missing transcription method to a Settings hint with no false retry promise", () => {
+    const msg = transcriptionFailureMessage("no key configured for transcription mode devthrottle", 503);
+    expect(msg).toContain("Settings");
+    expect(msg).not.toContain("will retry");
+  });
+
+  it("maps an undelivered transcript (submit to session failed) to a busy-session line", () => {
+    expect(transcriptionFailureMessage("submit to session failed", 502)).toContain(
+      "busy or waiting on a prompt",
+    );
+  });
+
+  it("never surfaces raw server text for an unrecognized error", () => {
+    const msg = transcriptionFailureMessage("some totally unexpected internal error blob 0xdeadbeef", 500);
+    expect(msg).not.toContain("0xdeadbeef");
+    expect(msg).not.toContain("blob");
+    expect(msg).toContain("saved and will retry");
+  });
+});

--- a/packages/client-core/src/dictation/backgroundSend.test.ts
+++ b/packages/client-core/src/dictation/backgroundSend.test.ts
@@ -21,10 +21,13 @@ const captured: CapturedUtterance = { blob: new Blob(["x"]), recordedMs: 1000, p
 describe("backgroundTranscribeAndSend", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("tells the user the dictation is held (not lost) when the turn is not confirmed but the audio was saved", async () => {
+  it("surfaces the SPECIFIC held-and-will-retry reason when the turn is not confirmed but the audio was saved", async () => {
     vi.mocked(savePending).mockResolvedValue(undefined);
+    // uploadDictationToSession has already humanized the failure (transcriptionFailureMessage), so the
+    // outcome.error carries the specific reason - here, a server-side transcription-service outage.
     vi.mocked(uploadDictationToSession).mockResolvedValue({
-      terminal: false, submitted: false, movedOn: false, transcript: "", error: "submit to session failed",
+      terminal: false, submitted: false, movedOn: false, transcript: "",
+      error: "The transcription service is temporarily unavailable. Your recording is saved and will retry.",
     });
     const onError = vi.fn();
     const onFailed = vi.fn();
@@ -32,9 +35,11 @@ describe("backgroundTranscribeAndSend", () => {
     await backgroundTranscribeAndSend("sid", captured, { onError, onFailed });
 
     expect(onError).toHaveBeenCalledTimes(1);
+    // The user sees the specific cause (the transcription service is down), not a blanket "session may be
+    // busy" guess, and is told the recording is held.
+    expect(onError.mock.calls[0][0]).toContain("temporarily unavailable");
     expect(onError.mock.calls[0][0]).toContain("saved and will retry");
-    // The raw server error is NOT what the user sees in the held case.
-    expect(onError.mock.calls[0][0]).not.toContain("submit to session failed");
+    expect(onError.mock.calls[0][0]).not.toContain("session may be busy");
     expect(onFailed).toHaveBeenCalledTimes(1);
     // The durable record is kept so resume-on-load re-drives it.
     expect(deletePending).not.toHaveBeenCalled();

--- a/packages/client-core/src/dictation/backgroundSend.ts
+++ b/packages/client-core/src/dictation/backgroundSend.ts
@@ -89,13 +89,15 @@ export async function backgroundTranscribeAndSend(
     if (outcome.terminal) {
       if (persisted) await deletePending(rec.id);
     } else if (persisted) {
-      // The server did not confirm the turn - most often the session is parked on a prompt or
-      // permission dialog and would not accept the typed words - but the audio is saved durably and
-      // resumePendingDictations() re-drives it on the next app load. Tell the user their dictation is
-      // HELD and will retry, not silently lost, rather than surfacing a raw technical error (issue #1056).
+      // The server did not confirm the turn, but the audio is saved durably and resumePendingDictations()
+      // re-drives it on the next app load - a HELD-and-will-retry state, not a loss. Surface the SPECIFIC,
+      // already-humanized reason uploadDictationToSession produced (transcriptionFailureMessage): a
+      // transcription-service outage, a busy session, no method configured, etc. This tells the user WHAT
+      // went wrong instead of a blanket "the session may be busy" guess that a server-side transcription
+      // failure does not fit (issue #1139 follow-up: server-side transcription errors get a real message).
       hooks.onError?.(
-        "Couldn't send your dictation yet - the session may be busy or waiting on a prompt. " +
-          "It's saved and will retry the next time you open the app.",
+        outcome.error ??
+          "Couldn't send your dictation yet - it's saved and will retry the next time you open the app.",
       );
       hooks.onFailed?.();
     } else {
@@ -105,7 +107,14 @@ export async function backgroundTranscribeAndSend(
       hooks.onFailed?.();
     }
   } catch (err) {
-    hooks.onError?.(err instanceof Error ? err.message : "Transcription failed");
+    // A thrown error is a client-side/transport fault (the out-of-credits throw carries its own text; a
+    // bare network failure reaches here). Never leave the user with a bare "transcription failed": say the
+    // recording is kept and will retry.
+    hooks.onError?.(
+      err instanceof Error
+        ? err.message
+        : "Couldn't reach the transcription service. Your recording is saved and will retry.",
+    );
     hooks.onFailed?.();
   }
 }


### PR DESCRIPTION
## Why

While investigating a live outage where all mobile transcriptions were failing, the actual cause was a genuine upstream provider outage (both DeepInfra and OpenAI degraded at the same time; OpenAI's status page confirmed "Partial System Degradation"). Our failover behaved correctly. The real defect on our side was the message the user saw.

On a server-side transcription failure the mobile app surfaced one of two unhelpful things:

- The **raw server response, dumped verbatim** on the dictation status strip, for example `Transcription returned 502: {"error":{"message":"Transcription failed: openai transcription failed","type":"api_error","code":"upstream_error"}}`.
- A misleading **"the session may be busy or waiting on a prompt"** banner that had nothing to do with the real cause (the transcription provider being down).

The owner asked: when the transcription service fails on the server side, tell the user with a clear, specific message instead of a generic "transcription error".

## What changed

- **`packages/client-core/src/api/client.ts`** - replaced `providerFailureMessage` with an exported, tested `transcriptionFailureMessage(serverError, status)` that owns all dictation-failure wording. It never surfaces the raw server text, and maps each condition to its own plain-English line:
  - upstream timeout (504 / `upstream_timeout`) -> "The transcription service timed out. Your recording is saved and will retry."
  - upstream unavailable / circuit-broken (`upstream_unavailable`, "temporarily unavailable") -> "The transcription service is temporarily unavailable..."
  - provider fault (the 502 `upstream_error` / "openai transcription failed" that used to dump raw json) -> "The transcription service had a problem and couldn't process your recording. Your recording is saved and will retry."
  - session gone (404/410), no transcription method configured, transcript not delivered to the session - each its own clean line.
- **`packages/client-core/src/dictation/backgroundSend.ts`** - the error banner now surfaces the specific reason instead of the blanket "session may be busy" guess, and the catch fallback no longer leaves a bare "Transcription failed".

## Testing

- New `transcriptionFailureMessage.test.ts` (7 cases), including a check that the raw server json never reaches the user.
- Updated `backgroundSend.test.ts` to the new contract.
- Full client-core suite: 134 passed. Mobile type check and lint: clean.

## Note on the outage itself

The upstream outage was transient and self-healing (the circuit breaker recovers in ~60s). No proxy code fix was warranted - the failover to OpenAI fired correctly. This PR only improves what the user is told.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)