### PR TITLE
feat(transcription): duration + silence aware parallel chunking (#324 Phase 2)

### DIFF
--- a/src/CcDirector.Core.Tests/Audio/WavSplitterDurationTests.cs
+++ b/src/CcDirector.Core.Tests/Audio/WavSplitterDurationTests.cs
@@ -1,0 +1,109 @@
+using CcDirector.Core.Audio;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Audio;
+
+/// <summary>
+/// Tests for <see cref="WavSplitter.TrySplitByDuration"/> - the duration + silence aware splitter behind
+/// the transcription reliability epic (#324). It cuts a long PCM WAV into short, bounded parts, nudging
+/// each cut to a nearby quiet point so a word is not sliced, and it is LOSSLESS and NON-OVERLAPPING so
+/// the per-part transcripts join with a single space and no de-duplication.
+/// </summary>
+public sealed class WavSplitterDurationTests
+{
+    private const int Rate = 16000;   // 16 kHz mono 16-bit throughout
+
+    // Build a mono 16-bit WAV of `frames`, each sample = `sample`, with an optional zero (silent) gap.
+    private static byte[] BuildWav(int frames, short sample, int gapStart = -1, int gapEnd = -1)
+    {
+        var pcm = new byte[frames * 2];
+        for (int f = 0; f < frames; f++)
+        {
+            short v = (gapStart >= 0 && f >= gapStart && f < gapEnd) ? (short)0 : sample;
+            pcm[f * 2] = (byte)(v & 0xFF);
+            pcm[f * 2 + 1] = (byte)((v >> 8) & 0xFF);
+        }
+        return PcmWav.Wrap(pcm, Rate, 1, 16);
+    }
+
+    private static byte[] PatternWav(int frames)
+    {
+        var pcm = new byte[frames * 2];
+        for (int f = 0; f < frames; f++)
+        {
+            short v = (short)(f % 1000 - 500);   // a varied, non-silent pattern
+            pcm[f * 2] = (byte)(v & 0xFF);
+            pcm[f * 2 + 1] = (byte)((v >> 8) & 0xFF);
+        }
+        return PcmWav.Wrap(pcm, Rate, 1, 16);
+    }
+
+    private static int DataFrames(byte[] wavPart) => (wavPart.Length - WavSplitter.WavHeaderBytes) / 2;
+
+    [Fact]
+    public void TrySplitByDuration_LongWav_EachPartWithinDurationAndByteBudget()
+    {
+        var wav = PatternWav(300 * Rate);   // 300 seconds
+        Assert.True(WavSplitter.TrySplitByDuration(wav, 60, 90, 5, 4_000_000, out var parts));
+        Assert.NotNull(parts);
+        Assert.True(parts!.Count >= 4, $"expected several parts, got {parts.Count}");
+        Assert.All(parts, p =>
+        {
+            Assert.True(DataFrames(p) <= 90 * Rate, "a part exceeded the 90 s max duration");
+            Assert.True(p.Length <= 4_000_000, "a part exceeded the 4 MB byte budget");
+        });
+    }
+
+    [Fact]
+    public void TrySplitByDuration_IsLosslessAndNonOverlapping()
+    {
+        int frames = 250 * Rate;
+        var wav = PatternWav(frames);
+        Assert.True(WavSplitter.TrySplitByDuration(wav, 60, 90, 5, 4_000_000, out var parts));
+
+        // Concatenating the parts' sample data reproduces the original PCM exactly: no overlap, no gap,
+        // no resample. This is what lets the per-part transcripts join with a plain space.
+        var rejoined = new List<byte>(frames * 2);
+        foreach (var p in parts!)
+            rejoined.AddRange(p[WavSplitter.WavHeaderBytes..]);
+
+        var originalPcm = wav[WavSplitter.WavHeaderBytes..];
+        Assert.Equal(originalPcm.Length, rejoined.Count);
+        Assert.True(originalPcm.AsSpan().SequenceEqual(rejoined.ToArray()), "rejoined PCM differs from the original");
+    }
+
+    [Fact]
+    public void TrySplitByDuration_ShortClip_SinglePart()
+    {
+        var wav = PatternWav(10 * Rate);   // 10 s: within one target window
+        Assert.True(WavSplitter.TrySplitByDuration(wav, 60, 90, 5, 4_000_000, out var parts));
+        Assert.Single(parts!);
+    }
+
+    [Fact]
+    public void TrySplitByDuration_NotPcmWav_ReturnsFalse()
+    {
+        var notWav = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+        Assert.False(WavSplitter.TrySplitByDuration(notWav, 60, 90, 5, 4_000_000, out var parts));
+        Assert.Null(parts);
+    }
+
+    [Fact]
+    public void TrySplitByDuration_PrefersASilentCutNearTheTarget()
+    {
+        // 4 s of loud audio with a 62.5 ms silent gap at 1.875 s - inside the [target-window, target+window]
+        // = [1 s, 3 s] search band around the 2 s target. The first cut must land in that gap, not at the
+        // naive 2 s target boundary, so a word straddling the target is not sliced.
+        int gapStart = 30000, gapEnd = 31000;                 // frames (1.875 s .. 1.9375 s)
+        var wav = BuildWav(4 * Rate, sample: 8000, gapStart, gapEnd);
+
+        // Large byte budget so DURATION (not bytes) governs; target 2 s, max 3 s, window 1 s.
+        Assert.True(WavSplitter.TrySplitByDuration(wav, 2, 3, 1, 100_000_000, out var parts));
+        Assert.True(parts!.Count >= 2);
+
+        int firstCut = DataFrames(parts[0]);
+        Assert.True(firstCut >= gapStart - 400 && firstCut <= gapEnd + 400,
+            $"first cut {firstCut} was not inside the silent gap [{gapStart},{gapEnd}]");
+        Assert.NotEqual(2 * Rate, firstCut);   // it was nudged off the naive 2 s target
+    }
+}

--- a/src/CcDirector.Core.Tests/Transcription/BatchTranscriptionPipelineChunkingTests.cs
+++ b/src/CcDirector.Core.Tests/Transcription/BatchTranscriptionPipelineChunkingTests.cs
@@ -28,31 +28,64 @@ public sealed class BatchTranscriptionPipelineChunkingTests
     // form fields) always fits under it.
     private const long ProviderBodyLimitBytes = 4_500_000;
 
-    // Records every /audio/transcriptions request and its body size, and answers each with a distinct
-    // numbered transcript so the assembled join order can be verified.
+    // Records every /audio/transcriptions request body size, and answers each with a transcript keyed to
+    // the CHUNK INDEX from the part's filename (dictation.{idx}.wav). Because chunks now transcribe in
+    // parallel, keying on the filename - not arrival order - lets a test prove the pipeline joins the
+    // parts in ORIGINAL order regardless of which request the fake answers first. Thread-safe: parallel
+    // chunk requests hit this handler concurrently.
     private sealed class CountingHandler : HttpMessageHandler
     {
-        public List<long> TranscribeBodyBytes { get; } = new();
-        private int _n;
+        private readonly object _lock = new();
+        private readonly List<long> _bodyBytes = new();
+
+        /// <summary>Request body sizes, in the order they were received (arrival order).</summary>
+        public IReadOnlyList<long> TranscribeBodyBytes { get { lock (_lock) return _bodyBytes.ToArray(); } }
+
+        /// <summary>Optional: chunk indices to fail with a 500, to prove one bad chunk fails the job.</summary>
+        public HashSet<int> FailChunkIndices { get; } = new();
+
+        /// <summary>Peak number of transcription requests in flight at once (proves the concurrency cap).</summary>
+        public int MaxConcurrent;
+        private int _inFlight;
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
         {
             var url = request.RequestUri?.ToString() ?? "";
             if (url.EndsWith("/audio/transcriptions", StringComparison.Ordinal))
             {
-                var bytes = request.Content is null ? 0 : (await request.Content.ReadAsByteArrayAsync(ct)).LongLength;
-                TranscribeBodyBytes.Add(bytes);
-                var word = $"seg{_n++}";
-                return new HttpResponseMessage(HttpStatusCode.OK)
+                int now = Interlocked.Increment(ref _inFlight);
+                lock (_lock) { if (now > MaxConcurrent) MaxConcurrent = now; }
+                try
                 {
-                    Content = new StringContent($"{{\"text\": \"{word}\"}}", Encoding.UTF8, "application/json"),
-                };
+                    int idx = ChunkIndexFromFilename(request);
+                    var bytes = request.Content is null ? 0 : (await request.Content.ReadAsByteArrayAsync(ct)).LongLength;
+                    lock (_lock) _bodyBytes.Add(bytes);
+                    await Task.Delay(15, ct);  // hold briefly so siblings pile up and concurrency is observable
+                    if (FailChunkIndices.Contains(idx))
+                        return new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                        { Content = new StringContent("{\"error\":{\"message\":\"boom\"}}", Encoding.UTF8, "application/json") };
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    { Content = new StringContent($"{{\"text\": \"seg{idx}\"}}", Encoding.UTF8, "application/json") };
+                }
+                finally { Interlocked.Decrement(ref _inFlight); }
             }
             // The dictionary corrector's chat endpoint: return no edits so the corrected text equals raw.
             return new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent("{\"choices\":[{\"message\":{\"content\":\"{\\\"edits\\\": []}\"}}]}", Encoding.UTF8, "application/json"),
             };
+        }
+
+        // dictation.3.wav -> 3 ; a single-shot dictation.wav (no numeric part) -> 0.
+        private static int ChunkIndexFromFilename(HttpRequestMessage request)
+        {
+            string file = "";
+            if (request.Content is MultipartFormDataContent mp)
+                foreach (var part in mp)
+                    if (part.Headers.ContentDisposition?.Name?.Trim('"') == "file")
+                    { file = part.Headers.ContentDisposition?.FileName?.Trim('"') ?? ""; break; }
+            var tokens = file.Split('.');
+            return tokens.Length >= 3 && int.TryParse(tokens[^2], out var n) ? n : 0;
         }
     }
 
@@ -168,16 +201,16 @@ public sealed class BatchTranscriptionPipelineChunkingTests
 
         var partCount = handler.TranscribeBodyBytes.Count;
         Assert.True(partCount >= 4);
-        // First report announces the total with zero done; the last report is all parts done.
+        // The first report announces the total with zero done (fired before any chunk runs). Chunks now
+        // complete in PARALLEL, so completion reports arrive in a non-deterministic order - but there is
+        // still exactly one per chunk plus the announcement, every TotalParts is the count, and the
+        // completed values are exactly 0..partCount with none missing or repeated.
         Assert.Equal(new TranscriptionProgress(0, partCount), reports[0]);
-        Assert.Equal(new TranscriptionProgress(partCount, partCount), reports[^1]);
-        // One report per completed part plus the initial announcement, strictly increasing completion.
         Assert.Equal(partCount + 1, reports.Count);
-        for (int i = 1; i < reports.Count; i++)
-        {
-            Assert.Equal(i, reports[i].CompletedParts);
-            Assert.Equal(partCount, reports[i].TotalParts);
-        }
+        Assert.All(reports, r => Assert.Equal(partCount, r.TotalParts));
+        Assert.Equal(
+            Enumerable.Range(0, partCount + 1),
+            reports.Select(r => r.CompletedParts).OrderBy(x => x));
     }
 
     [Fact]
@@ -195,11 +228,57 @@ public sealed class BatchTranscriptionPipelineChunkingTests
         Assert.Equal(new TranscriptionProgress(1, 1), reports[^1]);
     }
 
-    // A synchronous IProgress so the reports are captured in order on the calling thread.
+    [Fact]
+    public async Task TranscribeRawAsync_LongWav_TranscribesChunksInParallel_BoundedByTheCap()
+    {
+        var handler = new CountingHandler();
+        using var pipeline = new BatchTranscriptionPipeline(new HttpClient(handler));
+
+        await pipeline.TranscribeRawAsync(LongWav(), "dictation.wav", DevThrottle());
+
+        Assert.True(handler.TranscribeBodyBytes.Count >= 4);
+        // Actually ran several at once (proves parallelism)...
+        Assert.True(handler.MaxConcurrent >= 2, $"expected concurrent chunks, peak was {handler.MaxConcurrent}");
+        // ...but never more than the cap (proves the bound that protects rate limits / the breaker).
+        Assert.True(handler.MaxConcurrent <= BatchTranscriptionPipeline.MaxParallelChunks,
+            $"peak concurrency {handler.MaxConcurrent} exceeded the cap {BatchTranscriptionPipeline.MaxParallelChunks}");
+    }
+
+    [Fact]
+    public async Task TranscribeRawAsync_OneChunkFails_JobFailsCleanly_NoSilentPartial()
+    {
+        var handler = new CountingHandler();
+        handler.FailChunkIndices.Add(2);   // the third chunk returns HTTP 500 on every attempt
+        using var pipeline = new BatchTranscriptionPipeline(new HttpClient(handler));
+
+        // The whole job surfaces the failure (the proxy's typed 5xx) - it never returns a partial join.
+        await Assert.ThrowsAsync<TranscriptionFailedException>(() =>
+            pipeline.TranscribeRawAsync(LongWav(), "dictation.wav", DevThrottle()));
+    }
+
+    [Fact]
+    public async Task TranscribeRawAsync_UnderByteBudgetButLong_StillSplitsByDuration()
+    {
+        // 120 s of 16 kHz mono 16-bit = 3.84 MB: UNDER the 4 MB byte budget but well over the 90 s max
+        // chunk duration. The old bytes-only gate sent this as ONE slow request; duration splitting now
+        // breaks it into several fast ones.
+        var wav = PcmWav.Wrap(new byte[120 * 16000 * 2], 16000, 1, 16);
+        Assert.True(wav.Length < BatchTranscriptionPipeline.MaxTranscriptionUploadBytes);
+
+        var handler = new CountingHandler();
+        using var pipeline = new BatchTranscriptionPipeline(new HttpClient(handler));
+        await pipeline.TranscribeRawAsync(wav, "dictation.wav", DevThrottle());
+
+        Assert.True(handler.TranscribeBodyBytes.Count >= 2,
+            $"expected a long-but-small clip to split by duration, got {handler.TranscribeBodyBytes.Count} request(s)");
+    }
+
+    // A thread-safe IProgress: chunks now complete in parallel, so reports arrive from worker threads.
     private sealed class SyncProgress<T> : IProgress<T>
     {
         private readonly Action<T> _on;
+        private readonly object _lock = new();
         public SyncProgress(Action<T> on) => _on = on;
-        public void Report(T value) => _on(value);
+        public void Report(T value) { lock (_lock) _on(value); }
     }
 }

--- a/src/CcDirector.Core/Audio/WavSplitter.cs
+++ b/src/CcDirector.Core/Audio/WavSplitter.cs
@@ -67,6 +67,122 @@ public static class WavSplitter
         return true;
     }
 
+    /// <summary>
+    /// Split a PCM WAV into standalone WAV parts by DURATION, preferring a cut at a quiet point
+    /// (near-silence) close to each target boundary so a word is not sliced across two parts. Every
+    /// part is at most <paramref name="maxSeconds"/> long AND at most <paramref name="maxPartBytes"/>,
+    /// so each is a valid, bounded, single-shot upload. The split is LOSSLESS and NON-OVERLAPPING:
+    /// concatenating the parts' sample data reproduces the input exactly, so the per-part transcripts
+    /// join with a single space and no de-duplication. A clip already within one target window comes
+    /// back as a single part. Returns false (and null parts) for anything that is not linear PCM WAV.
+    /// </summary>
+    /// <param name="wav">The complete PCM WAV blob.</param>
+    /// <param name="targetSeconds">Preferred chunk length; the cut is nudged to nearby silence.</param>
+    /// <param name="maxSeconds">Hard cap on a chunk's length (used when no silence is found).</param>
+    /// <param name="silenceWindowSeconds">How far before/after the target to search for a quiet cut.</param>
+    /// <param name="maxPartBytes">Hard cap on a chunk's total byte size (header included).</param>
+    /// <param name="parts">The ordered WAV parts on success; null on failure.</param>
+    public static bool TrySplitByDuration(
+        byte[] wav, int targetSeconds, int maxSeconds, int silenceWindowSeconds, int maxPartBytes,
+        out IReadOnlyList<byte[]>? parts)
+    {
+        parts = null;
+        if (wav is null) throw new ArgumentNullException(nameof(wav));
+        if (targetSeconds <= 0) throw new ArgumentOutOfRangeException(nameof(targetSeconds));
+        if (maxSeconds < targetSeconds) throw new ArgumentOutOfRangeException(nameof(maxSeconds));
+        if (maxPartBytes <= WavHeaderBytes)
+            throw new ArgumentOutOfRangeException(nameof(maxPartBytes), "the byte budget must leave room for the WAV header");
+
+        if (!TryParse(wav, out var fmt, out var dataOffset, out var dataLength))
+            return false;
+
+        int blockAlign = fmt.Channels * fmt.BitsPerSample / 8;
+        if (blockAlign <= 0 || fmt.SampleRate <= 0) return false;
+
+        int framesTotal = dataLength / blockAlign;
+        if (framesTotal <= 0) return false;
+
+        // A single part may never exceed the byte budget OR the max duration, whichever is smaller.
+        long maxFramesByBytes = (maxPartBytes - WavHeaderBytes) / blockAlign;
+        long maxFramesByDuration = (long)maxSeconds * fmt.SampleRate;
+        int hardMaxFrames = (int)Math.Min(maxFramesByBytes, maxFramesByDuration);
+        if (hardMaxFrames <= 0) return false;
+
+        int targetFrames = (int)Math.Min((long)targetSeconds * fmt.SampleRate, hardMaxFrames);
+        int windowFrames = (int)Math.Max(0, Math.Min((long)silenceWindowSeconds * fmt.SampleRate, targetFrames - 1));
+        int probeFrames = Math.Max(1, fmt.SampleRate * 20 / 1000);   // ~20 ms energy window
+
+        var result = new List<byte[]>();
+        int pos = 0;
+        while (pos < framesTotal)
+        {
+            int remaining = framesTotal - pos;
+            int cutLen;
+            if (remaining <= hardMaxFrames && remaining <= targetFrames + windowFrames)
+            {
+                cutLen = remaining;                       // the rest fits in one final part
+            }
+            else
+            {
+                int lo = Math.Max(1, targetFrames - windowFrames);
+                int hi = Math.Min(hardMaxFrames, Math.Min(remaining, targetFrames + windowFrames));
+                if (hi < lo) hi = lo;
+                cutLen = QuietestCut(wav, dataOffset, blockAlign, fmt.BitsPerSample, pos, lo, hi, probeFrames);
+            }
+            if (cutLen <= 0) cutLen = Math.Min(hardMaxFrames, remaining);
+
+            int byteLen = cutLen * blockAlign;
+            var pcm = new byte[byteLen];
+            Array.Copy(wav, dataOffset + pos * blockAlign, pcm, 0, byteLen);
+            result.Add(PcmWav.Wrap(pcm, fmt.SampleRate, fmt.Channels, fmt.BitsPerSample));
+            pos += cutLen;
+        }
+
+        if (result.Count == 0) return false;
+        parts = result;
+        return true;
+    }
+
+    /// <summary>
+    /// The cut length (frames from <paramref name="posFrames"/>) at the center of the quietest ~20 ms
+    /// window whose center lies in [lo, hi]. Deterministic. For non-16-bit PCM the energy scan is
+    /// skipped and the hard boundary <paramref name="hi"/> is returned (a plain duration cut).
+    /// </summary>
+    private static int QuietestCut(byte[] wav, int dataOffset, int blockAlign, int bitsPerSample,
+        int posFrames, int lo, int hi, int probeFrames)
+    {
+        if (hi <= lo) return Math.Max(1, hi);
+        if (bitsPerSample != 16) return hi;
+
+        int step = Math.Max(1, probeFrames / 2);
+        long best = long.MaxValue;
+        int bestCut = hi;
+        for (int c = lo; c <= hi; c += step)
+        {
+            long e = FrameEnergy(wav, dataOffset, blockAlign, posFrames + c, probeFrames);
+            if (e < best) { best = e; bestCut = c; }
+        }
+        return bestCut;
+    }
+
+    /// <summary>Sum of absolute 16-bit sample values over a small window centered on a frame.</summary>
+    private static long FrameEnergy(byte[] wav, int dataOffset, int blockAlign, int centerFrame, int probeFrames)
+    {
+        int start = Math.Max(0, centerFrame - probeFrames / 2);
+        long sum = 0;
+        for (int f = 0; f < probeFrames; f++)
+        {
+            int frameByte = dataOffset + (start + f) * blockAlign;
+            if (frameByte + blockAlign > wav.Length) break;
+            for (int b = 0; b + 1 < blockAlign; b += 2)
+            {
+                short s = (short)(wav[frameByte + b] | (wav[frameByte + b + 1] << 8));
+                sum += Math.Abs((int)s);
+            }
+        }
+        return sum;
+    }
+
     private readonly record struct WavFormat(int SampleRate, int Channels, int BitsPerSample);
 
     /// <summary>

--- a/src/CcDirector.Core/Transcription/BatchTranscriptionPipeline.cs
+++ b/src/CcDirector.Core/Transcription/BatchTranscriptionPipeline.cs
@@ -53,6 +53,29 @@ public sealed class BatchTranscriptionPipeline : IDisposable
     /// </summary>
     public const int MaxTranscriptionUploadBytes = 4_000_000;
 
+    // Chunking parameters (transcription reliability epic, #324). A long recording is split by
+    // DURATION - preferring a cut at nearby silence - into short parts transcribed IN PARALLEL, so an
+    // hour of audio is many fast requests instead of one that times out. These are the shared spec
+    // constants (docs/architecture/transcription-service-design.md); AgentEyes mirrors them exactly.
+
+    /// <summary>Preferred chunk length. Short enough to transcribe fast and stay well under the
+    /// per-request timeout; long enough to keep the part count low.</summary>
+    public const int ChunkTargetSeconds = 60;
+
+    /// <summary>Hard cap on a chunk's length, used when no quiet cut is found near the target.</summary>
+    public const int ChunkMaxSeconds = 90;
+
+    /// <summary>How far before/after the target the splitter searches for a silence to cut on.</summary>
+    public const int ChunkSilenceWindowSeconds = 5;
+
+    /// <summary>Chunks transcribed at once. Bounded so a long recording does not fan out an unbounded
+    /// burst that would trip provider rate limits or the proxy's per-instance breaker.</summary>
+    public const int MaxParallelChunks = 4;
+
+    /// <summary>Extra attempts for a single chunk on a TRANSIENT failure, on top of the proxy's own
+    /// internal provider fallback. A permanent (4xx) failure is not retried.</summary>
+    public const int PerChunkRetries = 1;
+
     private readonly HttpClient _http;
     private readonly bool _ownsHttp;
     private readonly string _cleanupModel;
@@ -167,6 +190,30 @@ public sealed class BatchTranscriptionPipeline : IDisposable
         byte[] audio, string fileName, ResolvedTranscription routing, CancellationToken ct,
         IProgress<TranscriptionProgress>? progress = null)
     {
+        // Duration + silence aware split. For PCM WAV this returns ONE part when the clip is within a
+        // single target window (both bytes AND duration), or several bounded parts otherwise. Note this
+        // splits a WAV that is under the byte budget but LONG in duration too - the old bytes-only gate
+        // let a long-but-small compressed-style WAV through as one slow request.
+        if (WavSplitter.TrySplitByDuration(
+                audio, ChunkTargetSeconds, ChunkMaxSeconds, ChunkSilenceWindowSeconds,
+                MaxTranscriptionUploadBytes, out var parts) && parts is not null)
+        {
+            if (parts.Count == 1)
+            {
+                progress?.Report(new TranscriptionProgress(0, 1));
+                var only = await PostOneAsync(parts[0], fileName, routing, ct);
+                progress?.Report(new TranscriptionProgress(1, 1));
+                return only;
+            }
+
+            FileLog.Write($"[BatchTranscriptionPipeline] split {audio.Length} bytes into {parts.Count} parts "
+                          + $"(target={ChunkTargetSeconds}s, max={ChunkMaxSeconds}s, budget={MaxTranscriptionUploadBytes}); "
+                          + $"transcribing up to {MaxParallelChunks} in parallel");
+            return await TranscribeChunksInParallelAsync(parts, fileName, routing, ct, progress);
+        }
+
+        // Not a splittable PCM WAV. A clip within the byte budget is one POST as before; an over-budget
+        // non-WAV fails loud rather than posting an oversized body (the no-silent-413 rule).
         if (audio.Length <= MaxTranscriptionUploadBytes)
         {
             progress?.Report(new TranscriptionProgress(0, 1));
@@ -175,28 +222,95 @@ public sealed class BatchTranscriptionPipeline : IDisposable
             return only;
         }
 
-        if (!WavSplitter.TrySplit(audio, MaxTranscriptionUploadBytes, out var parts) || parts is null)
-            throw new InvalidOperationException(
-                $"Audio is {audio.Length:N0} bytes, over the {MaxTranscriptionUploadBytes:N0}-byte per-request "
-                + "limit, and is not a PCM WAV that can be split into bounded parts. Capture as PCM WAV so long "
-                + "recordings can be chunked.");
+        throw new InvalidOperationException(
+            $"Audio is {audio.Length:N0} bytes, over the {MaxTranscriptionUploadBytes:N0}-byte per-request "
+            + "limit, and is not a PCM WAV that can be split into bounded parts. Capture as PCM WAV so long "
+            + "recordings can be chunked.");
+    }
 
-        FileLog.Write($"[BatchTranscriptionPipeline] split {audio.Length} bytes into {parts.Count} parts "
-                      + $"(budget={MaxTranscriptionUploadBytes}), transcribing each");
-
+    /// <summary>
+    /// Transcribe the ordered chunks concurrently, at most <see cref="MaxParallelChunks"/> in flight,
+    /// and join the raw per-chunk texts in ORIGINAL order (never completion order). Each chunk is
+    /// retried on a transient failure (<see cref="PerChunkRetries"/>); if any chunk still fails, the
+    /// whole job throws the original typed exception - no silent partial transcripts. The split is
+    /// non-overlapping, so a single space joins the parts with no de-duplication.
+    /// </summary>
+    private async Task<string> TranscribeChunksInParallelAsync(
+        IReadOnlyList<byte[]> parts, string fileName, ResolvedTranscription routing, CancellationToken ct,
+        IProgress<TranscriptionProgress>? progress)
+    {
+        var texts = new string[parts.Count];
+        int completed = 0;
         progress?.Report(new TranscriptionProgress(0, parts.Count));
-        var texts = new List<string>(parts.Count);
-        for (int i = 0; i < parts.Count; i++)
+
+        using var gate = new SemaphoreSlim(MaxParallelChunks);
+
+        async Task ProcessAsync(int idx)
         {
-            var partName = PartFileName(fileName, i);
-            var text = await PostOneAsync(parts[i], partName, routing, ct);
-            FileLog.Write($"[BatchTranscriptionPipeline] part {i + 1}/{parts.Count}: bytes={parts[i].Length}, chars={text.Length}");
-            if (text.Length > 0) texts.Add(text);
-            progress?.Report(new TranscriptionProgress(i + 1, parts.Count));
+            await gate.WaitAsync(ct);
+            try
+            {
+                var text = await PostOneWithRetryAsync(parts[idx], PartFileName(fileName, idx), routing, idx, ct);
+                texts[idx] = text;
+                int done = Interlocked.Increment(ref completed);
+                FileLog.Write($"[BatchTranscriptionPipeline] chunk {idx + 1}/{parts.Count} done: bytes={parts[idx].Length}, chars={text.Length}");
+                progress?.Report(new TranscriptionProgress(done, parts.Count));
+            }
+            finally
+            {
+                gate.Release();
+            }
         }
 
-        return string.Join(" ", texts);
+        var tasks = new Task[parts.Count];
+        for (int i = 0; i < parts.Count; i++) tasks[i] = ProcessAsync(i);
+        await Task.WhenAll(tasks);   // throws the first chunk failure -> job fails clean
+
+        return string.Join(" ", texts.Where(t => !string.IsNullOrEmpty(t)));
     }
+
+    /// <summary>
+    /// One chunk POST with a bounded retry on a TRANSIENT failure (network error, a per-request
+    /// timeout, or a 5xx/429 from the proxy - which has already tried its own provider fallback, so the
+    /// retry gives the breaker a moment to recover). A permanent 4xx (bad request, auth) or a 402
+    /// (out of credits) is NOT retried and propagates its original typed exception so the caller's
+    /// credit/retry handling still works. The chunk index is logged on failure.
+    /// </summary>
+    private async Task<string> PostOneWithRetryAsync(
+        byte[] audio, string fileName, ResolvedTranscription routing, int chunkIndex, CancellationToken ct)
+    {
+        for (int attempt = 0; ; attempt++)
+        {
+            try
+            {
+                return await PostOneAsync(audio, fileName, routing, ct);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex) when (attempt < PerChunkRetries && IsTransient(ex))
+            {
+                FileLog.Write($"[BatchTranscriptionPipeline] chunk {chunkIndex} transient failure "
+                              + $"(attempt {attempt + 1}/{PerChunkRetries + 1}): {ex.Message} - retrying");
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[BatchTranscriptionPipeline] chunk {chunkIndex} failed permanently: {ex.Message}");
+                throw;
+            }
+        }
+    }
+
+    /// <summary>A chunk failure worth one more attempt: a network error, a per-request timeout, or a
+    /// 5xx/429 from the proxy. A 4xx/402 is permanent (do not retry).</summary>
+    private static bool IsTransient(Exception ex) => ex switch
+    {
+        TranscriptionFailedException t => t.IsTransient,
+        HttpRequestException => true,
+        TaskCanceledException => true,
+        _ => false,
+    };
 
     /// <summary>
     /// Name one part of a split upload, keeping the original extension so the server still decodes the


### PR DESCRIPTION
Phase 2 of the transcription reliability epic (design + plan in `devthrottle_internal`, epic thefrederiksen/devthrottle_internal#324). Makes the Gateway the "brain" that transcribes audio of any length reliably.

## What
**`WavSplitter.TrySplitByDuration`** - splits a PCM WAV by DURATION (target 60s, hard cap 90s), nudging each cut to the quietest ~20ms window within +/-5s of the target so a word is not sliced. Lossless and non-overlapping (concatenating the parts reproduces the input), so per-part transcripts join with a single space - no de-dup. WAV-native (no transcode dependency).

**`BatchTranscriptionPipeline`**
- Splits by duration even when a clip is under the byte budget but long (the old bytes-only gate sent those as one slow request).
- Transcribes chunks **in parallel**, bounded to `MaxParallelChunks` (4), order preserved.
- Per-chunk retry (1) on a transient failure, on top of the proxy's own provider fallback; a permanent 4xx/402 propagates its typed exception. Any chunk failing fails the whole job cleanly - **no silent partials**.

## Design note (refinement vs the epic's first sketch)
The epic mentioned a 1.5s audio overlap + text de-dup. I implemented **silence-cut without overlap** instead: it's lossless, deterministic, and far simpler to keep identical across the open Gateway and the closed AgentEyes duplicate. Trade-off: a rare hard-cut where no silence exists in the +/-5s window may split a word. The shared design doc is being updated to match; AgentEyes (Phase 3) mirrors THIS approach.

## Tests
- `WavSplitterDurationTests` (new): lossless round-trip, duration+byte bounds, silence-preference, non-WAV rejection.
- `BatchTranscriptionPipelineChunkingTests` (extended): bounded concurrency, one-chunk-fails -> clean job failure, under-budget-but-long still splits; existing cases updated for parallel completion.
- Full `CcDirector.Core.Tests`: **2921 pass**. The single failure (`ShippedToolsManifestGuardTests` / `cc-comm-queue`) is pre-existing and unrelated to this change.

## Next (epic)
Phase 3: mirror this orchestration into AgentEyes (closed repo) against the same spec + constants.