### PR TITLE
Hide the work lists feature from the Cockpit user interface

### DIFF
--- a/apps/cockpit/src/AppShell.tsx
+++ b/apps/cockpit/src/AppShell.tsx
@@ -22,7 +22,9 @@ const NAV_ITEMS: ReadonlyArray<{ to: string; label: string; subtree?: string }> 
   { to: "/fleet-map", label: "Fleet Map" },
   { to: "/directors", label: "Directors" },
   { to: "/schedule", label: "Schedule" },
-  { to: "/lists", label: "Lists" },
+  // "Lists" (work lists) is hidden from the rail for now - GitHub issues already are the queue, so
+  // the named-priority-list feature is unnecessary. The /lists route is left registered (so any
+  // bookmarked URL still resolves) pending a decision on removing the feature entirely.
   { to: "/dictionary", label: "Dictionary" },
   { to: "/learn", label: "Learning" },
   { to: "/account", label: "Account" },

--- a/apps/cockpit/src/schedule/ScheduleView.tsx
+++ b/apps/cockpit/src/schedule/ScheduleView.tsx
@@ -80,7 +80,10 @@ const EMPTY_FORM: FormState = {
   name: "",
   machine: "",
   repoPath: "",
-  actionKind: "worklist",
+  // New jobs default to the skill / prompt action. The "work list" action is hidden for now (the
+  // named-work-list feature is being retired - GitHub issues are the queue), so no new work-list-
+  // backed schedule can be created; see the hidden "What to run" selector below.
+  actionKind: "seed",
   workListName: "",
   seed: "",
   scheduleKind: "oneOff",
@@ -480,7 +483,7 @@ export function ScheduleView() {
                 <input
                   className={formErrors.name ? "invalid" : undefined}
                   value={form.name}
-                  placeholder="e.g. Tonight - drain work list"
+                  placeholder="e.g. Nightly issue sweep"
                   onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
                 />
                 {formErrors.name && <div className="sched-fld-err">{formErrors.name}</div>}
@@ -517,16 +520,11 @@ export function ScheduleView() {
                 {formErrors.repoPath && <div className="sched-fld-err">{formErrors.repoPath}</div>}
               </div>
 
-              <div className="sched-fld">
-                <label className="sched-fld-label">What to run</label>
-                <select
-                  value={form.actionKind}
-                  onChange={(e) => setForm((f) => ({ ...f, actionKind: e.target.value as "worklist" | "seed" }))}
-                >
-                  <option value="worklist">Run a named work list</option>
-                  <option value="seed">Run a skill / prompt</option>
-                </select>
-              </div>
+              {/* The "What to run" selector is hidden for now: the named-work-list feature is being
+                  retired (GitHub issues are the queue), so a new job can only be a skill / prompt.
+                  The action defaults to "seed" (see EMPTY_FORM). An existing work-list job still loads
+                  its actionKind and renders its field below (no data loss), it just cannot be newly
+                  chosen. Restore this <select> to bring the work-list action back. */}
 
               {form.actionKind === "worklist" ? (
                 <div className="sched-fld">


### PR DESCRIPTION
## What

Hide the named work lists feature from the desktop Cockpit user interface. GitHub issues already are the work queue, so the feature is unnecessary. This hides its two entry points for now, pending a decision on removing it entirely.

Nothing is deleted. The `/lists` route, the client library, and the whole Gateway work list backend are left in place, so this is a small, fully reversible change.

## Changes

- **Navigation rail** (`AppShell.tsx`): remove the "Lists" item. The `/lists` route stays registered so any bookmarked address still resolves instead of failing.
- **Schedule page** (`ScheduleView.tsx`): hide the "What to run" selector and default a new job to the skill or prompt action, so no new work-list-backed schedule can be created. An existing work-list job still loads and shows its field, so no data is lost.
- **Placeholder**: replace the job name placeholder that referenced draining a work list with a neutral example.

## Verification

- Cockpit build passes (`tsc --noEmit` clean, `vite build` succeeds).
- Rendered the built output and confirmed the navigation rail no longer shows Lists, and the new-cron-job form goes Name to Run on to Repository path to Skill / prompt with no "What to run" dropdown or "Work list name" field.

## Follow-up

A separate decision on whether to remove the work lists feature entirely (frontend `lists/` folder, client-core files, the Gateway `WorkList*` and item-status code, the cron "run a named work list" action, and its tests).
