### PR TITLE
Fix the two stale test failures blocking CI on main

### DIFF
--- a/src/CcDirector.Core/Tools/tools-manifest.json
+++ b/src/CcDirector.Core/Tools/tools-manifest.json
@@ -30,11 +30,11 @@
       "note": null
     },
     {
-      "name": "cc-comm-queue",
-      "category": "Communications",
-      "description": "Queue content into the Communication Manager approval workflow.",
-      "smoke": { "args": ["status"], "expectContains": null },
-      "note": null
+      "name": "cc-image",
+      "category": "Media",
+      "description": "Image analysis, OCR, and batch folder cataloging via the DevThrottle API vision model.",
+      "smoke": null,
+      "note": "Auth-gated (needs DEVTHROTTLE_API_KEY). No zero-auth command. Presence + version only."
     },
     {
       "name": "cc-gmail",

--- a/src/CcDirector.HostedAgent.Tests/ClaudeDriverTests.cs
+++ b/src/CcDirector.HostedAgent.Tests/ClaudeDriverTests.cs
@@ -138,7 +138,10 @@ public class ClaudeDriverTests
         backend.Start("x", "", ".", 80, 24);
         // No echo is ever emitted - the TUI is swallowing input.
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+        // The driver throws the specific ComposerNotAcceptingInputException (a subclass of
+        // InvalidOperationException) since #1152; xUnit's ThrowsAsync matches the type exactly, so
+        // assert the exact thrown type rather than the base type.
+        var ex = await Assert.ThrowsAsync<ComposerNotAcceptingInputException>(
             () => FastDriver().SubmitAsync(backend, "hello"));
         Assert.Contains("composer never echoed", ex.Message);
     }


### PR DESCRIPTION
## What

Fix the two pre-existing test failures that have kept the CI Build & Test (.NET) check red on `main`, so gated pull requests can merge again.

## Failure 1 - stale exception assertion (ClaudeDriver)

#1152 changed `ClaudeDriver` to throw the specific `ComposerNotAcceptingInputException` (a subclass of `InvalidOperationException`) when the composer never echoes typed input. The test `ClaudeDriverTests.SubmitAsync_EchoNeverAppears_ThrowsAfterTwoAttempts` still asserted the base type, and xUnit's `ThrowsAsync<T>` matches the type exactly. Fixed by asserting the exact thrown type; the message assertion is unchanged.

## Failure 2 - drifted tools health manifest

`ShippedToolsManifestGuardTests` compares the ship:true python tools in `tools/registry.json` (authoritative) against the Core health manifest `src/CcDirector.Core/Tools/tools-manifest.json`. The manifest had drifted:
- still listed `cc-comm-queue` (the retired Communication Manager tool, no longer ship:true), and
- was missing `cc-image` (ship:true python in the registry).

Fixed by updating the manifest to mirror the registry: remove `cc-comm-queue`, add `cc-image` (auth-gated, presence-and-version only, matching the `cc-gmail` entry).

## Verification

Ran both affected test classes locally: ClaudeDriver echo test passes; both ShippedToolsManifestGuard tests pass.
