### PR TITLE
Hide the Wingman narration toggle on the Fleet Map

### DIFF
--- a/apps/cockpit/src/fleet/FleetMapView.tsx
+++ b/apps/cockpit/src/fleet/FleetMapView.tsx
@@ -51,7 +51,11 @@ export function FleetMapView() {
   const [machineErrors, setMachineErrors] = useState<MachineError[]>([]);
   const [lastError, setLastError] = useState<string | null>(null);
   const [pivot, setPivot] = useState<Pivot>("machine");
-  const [wingman, setWingman] = useState(false);
+  // The Wingman narration overlay is not implemented and is not planned, so its toggle is hidden from
+  // the header (see below). Keep the value wired as a constant false so the narration code paths stay
+  // intact for an easy future restore - flip this back to useState and restore the toggle to bring it
+  // back.
+  const wingman = false;
 
   const loadRoster = useCallback(async (signal?: AbortSignal) => {
     try {
@@ -130,15 +134,9 @@ export function FleetMapView() {
               </button>
             ))}
           </div>
-          <label className={wingman ? "fmap-wm on" : "fmap-wm"}>
-            <input
-              type="checkbox"
-              checked={wingman}
-              onChange={(e) => setWingman(e.target.checked)}
-            />
-            <span className="fmap-wm-sw" aria-hidden="true" />
-            <span>Wingman narration</span>
-          </label>
+          {/* The "Wingman narration" toggle is hidden for now: the narration overlay is not
+              implemented and is not planned. Restore this <label> (and the useState above) to bring
+              the feature back. */}
         </div>
       </header>
 


### PR DESCRIPTION
## What

Hide the "Wingman narration" toggle from the Fleet Map header. The narration overlay it controls (the per-node live one-line read) is not implemented and is not planned, so the toggle exposed a feature that does nothing.

## Changes

- Remove the "Wingman narration" toggle from the header controls (`FleetMapView.tsx`).
- Pin the narration value to a constant `false` so every downstream narration code path (canvas overlay, redraw dependency, node styling) stays intact and correct with narration off. This keeps the change a one-spot reversal: restore the toggle and the `useState` to bring the feature back.

## Left intentionally unchanged

The yellow "Wingman reading" node color and its legend entry stay. That status reflects a real session activity state (`effectiveColor` in client-core), independent of this narration overlay, so it is not part of what is being hidden.

## Verification

Cockpit build passes (`tsc --noEmit` clean under `noUnusedLocals`, `vite build` succeeds). Rendered the built Fleet Map and confirmed the header now shows only the By machine / By repository / By agent control, with no "Wingman narration" toggle.
