### PR TITLE
Build local slot exes into the script folder

### DIFF
--- a/scripts/local-build-avalonia.ps1
+++ b/scripts/local-build-avalonia.ps1
@@ -21,7 +21,8 @@
 param(
     [switch]$SelfContained,
     [string]$Configuration = "Release",
-    [string]$Slot = ""
+    [string]$Slot = "",
+    [string]$OutputDir = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -114,8 +115,13 @@ if (-not (Test-Path $exePath)) {
     exit 1
 }
 
-# Copy to local_builds directory
-$releasesDir = Join-Path $repoRoot "local_builds"
+# Copy to output directory. Defaults to the repo-root local_builds folder, but callers
+# (e.g. the scripts\local-build\*.bat files) can pass -OutputDir to land the exe elsewhere.
+if ($OutputDir) {
+    $releasesDir = $OutputDir
+} else {
+    $releasesDir = Join-Path $repoRoot "local_builds"
+}
 if (-not (Test-Path $releasesDir)) {
     New-Item -ItemType Directory -Path $releasesDir | Out-Null
 }

--- a/scripts/local-build/.gitignore
+++ b/scripts/local-build/.gitignore
@@ -1,0 +1,3 @@
+# Local dev/test slot builds produced by _local_buildN.bat land here. Do not commit them.
+*.exe
+appsettings.json

--- a/scripts/local-build/_local_build1.bat
+++ b/scripts/local-build/_local_build1.bat
@@ -1,5 +1,5 @@
 @echo off
-powershell -ExecutionPolicy Bypass -File "%~dp0..\local-build-avalonia.ps1" -Slot 1 %*
+powershell -ExecutionPolicy Bypass -File "%~dp0..\local-build-avalonia.ps1" -Slot 1 -OutputDir "%~dp0." %*
 if %ERRORLEVEL% neq 0 (
     echo.
     echo BUILD FAILED - see errors above
@@ -7,5 +7,5 @@ if %ERRORLEVEL% neq 0 (
     exit /b %ERRORLEVEL%
 )
 echo.
-echo Exe location: %~dp0..\..\local_builds\cc-director1.exe
+echo Exe location: %~dp0cc-director1.exe
 pause

--- a/scripts/local-build/_local_build2.bat
+++ b/scripts/local-build/_local_build2.bat
@@ -1,5 +1,5 @@
 @echo off
-powershell -ExecutionPolicy Bypass -File "%~dp0..\local-build-avalonia.ps1" -Slot 2 %*
+powershell -ExecutionPolicy Bypass -File "%~dp0..\local-build-avalonia.ps1" -Slot 2 -OutputDir "%~dp0." %*
 if %ERRORLEVEL% neq 0 (
     echo.
     echo BUILD FAILED - see errors above
@@ -7,5 +7,5 @@ if %ERRORLEVEL% neq 0 (
     exit /b %ERRORLEVEL%
 )
 echo.
-echo Exe location: %~dp0..\..\local_builds\cc-director2.exe
+echo Exe location: %~dp0cc-director2.exe
 pause

--- a/scripts/local-build/_local_build3.bat
+++ b/scripts/local-build/_local_build3.bat
@@ -1,5 +1,5 @@
 @echo off
-powershell -ExecutionPolicy Bypass -File "%~dp0..\local-build-avalonia.ps1" -Slot 3 %*
+powershell -ExecutionPolicy Bypass -File "%~dp0..\local-build-avalonia.ps1" -Slot 3 -OutputDir "%~dp0." %*
 if %ERRORLEVEL% neq 0 (
     echo.
     echo BUILD FAILED - see errors above
@@ -7,5 +7,5 @@ if %ERRORLEVEL% neq 0 (
     exit /b %ERRORLEVEL%
 )
 echo.
-echo Exe location: %~dp0..\..\local_builds\cc-director3.exe
+echo Exe location: %~dp0cc-director3.exe
 pause

--- a/scripts/local-build/_local_build4.bat
+++ b/scripts/local-build/_local_build4.bat
@@ -1,5 +1,5 @@
 @echo off
-powershell -ExecutionPolicy Bypass -File "%~dp0..\local-build-avalonia.ps1" -Slot 4 %*
+powershell -ExecutionPolicy Bypass -File "%~dp0..\local-build-avalonia.ps1" -Slot 4 -OutputDir "%~dp0." %*
 if %ERRORLEVEL% neq 0 (
     echo.
     echo BUILD FAILED - see errors above
@@ -7,5 +7,5 @@ if %ERRORLEVEL% neq 0 (
     exit /b %ERRORLEVEL%
 )
 echo.
-echo Exe location: %~dp0..\..\local_builds\cc-director4.exe
+echo Exe location: %~dp0cc-director4.exe
 pause


### PR DESCRIPTION
The `_local_buildN.bat` scripts in `scripts/local-build/` now build their exe next to themselves instead of the repo-root `local_builds/` directory.

## Changes
- **`scripts/local-build-avalonia.ps1`** — added an optional `-OutputDir` parameter. Defaults to the repo-root `local_builds/` folder, so existing callers (the `cc-director-launch` task, docs, other slots) are unaffected.
- **`_local_build1-4.bat`** — pass `-OutputDir "%~dp0."` and report the correct location. The trailing dot is deliberate: `%~dp0` expands with a trailing backslash, so `"%~dp0"` becomes `"...\local-build\"` where the `\"` escapes the closing quote and PowerShell receives a literal `"` inside the path ("Illegal characters in path"). Ending the argument in `\.` closes the quote correctly.
- **`scripts/local-build/.gitignore`** — new; ignores the build output (`*.exe`) and the runtime `appsettings.json` that lands in that folder.

## Testing
Ran `_local_build4.bat` end-to-end. Build succeeded and `cc-director4.exe` (35.8 MB) landed in `scripts/local-build/`. Confirmed `git check-ignore` excludes the exe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)