### PR TITLE
Fix mobile Wingman voice state

### DIFF
--- a/apps/mobile/src/pages/VoiceMode.tsx
+++ b/apps/mobile/src/pages/VoiceMode.tsx
@@ -46,6 +46,8 @@ function sameSessionForVoice(a: SessionDto | null, b: SessionDto | null): boolea
     && a.name === b.name
     && Boolean(a.voiceMode) === Boolean(b.voiceMode)
     && Boolean(a.onHold) === Boolean(b.onHold)
+    && Boolean(a.voiceGenerating) === Boolean(b.voiceGenerating)
+    && Boolean(a.voiceAudioReady) === Boolean(b.voiceAudioReady)
     && a.statusColor === b.statusColor
     && a.assessedState === b.assessedState
     && a.activityState === b.activityState;
@@ -439,7 +441,18 @@ export function VoiceMode() {
   // finished-turn narration is stale, so the screen falls back to the working card instead of
   // offering a replay of it.
   const speaking = voiceOn && phoneReady && (voice?.spoken.length ?? 0) > 0 && !agentWorking;
-  const working = voiceOn && !speaking;
+  const gatewayPreparing = voiceOn && !speaking && !agentWorking && Boolean(session?.voiceGenerating);
+  const phoneDownloadPending =
+    voiceOn && !speaking && !agentWorking && Boolean(session?.voiceAudioReady) && clip.phase !== "error";
+  const audioUnavailable =
+    voiceOn
+    && pollDone
+    && !speaking
+    && !agentWorking
+    && !gatewayPreparing
+    && !phoneDownloadPending
+    && enableNote.length === 0;
+  const working = voiceOn && !speaking && !audioUnavailable;
   const narrative = voice?.spoken ?? "";
 
   return (
@@ -484,6 +497,24 @@ export function VoiceMode() {
               {enabling ? "Switching..." : "Switch to voice mode"}
             </button>
           </div>
+        )}
+
+        {audioUnavailable && (
+          <>
+            <div className="voice-statusbar">
+              <span className="voice-state voice-state-red">Voice unavailable</span>
+            </div>
+            <div className="voice-narr">
+              <div className="voice-narr-title">No playable narration is available.</div>
+              <div className="voice-narr-body">
+                {clip.phase === "error"
+                  ? "The phone could not download the spoken audio for this turn."
+                  : narrative.length > 0
+                    ? narrative
+                    : "The Gateway is not generating audio for this turn, and no audio is ready to play."}
+              </div>
+            </div>
+          </>
         )}
 
         {/* B. WORKING - either the Wingman is reading + the phone is downloading the clip, or (when

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -907,6 +907,12 @@ a.banner-btn {
   border: 1px solid rgba(34, 197, 94, 0.4);
 }
 
+.voice-state-red {
+  background: rgba(241, 76, 76, 0.14);
+  color: var(--attention);
+  border: 1px solid rgba(241, 76, 76, 0.45);
+}
+
 .voice-ref {
   font-size: 11px;
   color: var(--text-dim);

--- a/packages/client-core/src/api/schema.ts
+++ b/packages/client-core/src/api/schema.ts
@@ -5271,6 +5271,8 @@ export interface components {
             railLine?: null | string;
             /** Format: date-time */
             needsYouSince?: null | string;
+            effectiveColor?: null | string;
+            triageBucket?: null | string;
             backendType?: string;
             driverCapabilities?: string[];
             /** Format: date-time */

--- a/packages/client-core/src/sessions/ordering.test.ts
+++ b/packages/client-core/src/sessions/ordering.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { SessionDto } from "../api/client";
+import { classify, effectiveColor } from "./ordering";
+
+// A minimal voice-mode session for the color rule. Only the fields the rule reads are set;
+// the rest of SessionDto is irrelevant here so we cast a partial.
+function voice(opts: {
+  color: string;
+  activityState: string;
+  generating: boolean;
+  audioReady: boolean;
+  voiceMode?: boolean;
+}): SessionDto {
+  return {
+    sessionId: "v",
+    statusColor: opts.color,
+    activityState: opts.activityState,
+    voiceMode: opts.voiceMode ?? true,
+    voiceGenerating: opts.generating,
+    voiceAudioReady: opts.audioReady,
+  } as unknown as SessionDto;
+}
+
+describe("effectiveColor voice-mode preparing rule (mirrors C# SessionOrdering)", () => {
+  it("uses the Gateway-stamped effective color and triage bucket when present", () => {
+    const s = {
+      ...voice({ color: "red", activityState: "WaitingForInput", generating: false, audioReady: false }),
+      effectiveColor: "orange",
+      triageBucket: "active",
+    } as unknown as SessionDto;
+
+    expect(effectiveColor(s)).toBe("orange");
+    expect(classify(s)).toBe("active");
+  });
+
+  it("holds yellow while the wingman is actively generating this turn's voice", () => {
+    expect(effectiveColor(voice({ color: "red", activityState: "WaitingForInput", generating: true, audioReady: false })))
+      .toBe("yellow");
+  });
+
+  it("stays yellow while generating even if a stale clip is cached", () => {
+    expect(effectiveColor(voice({ color: "red", activityState: "WaitingForPerm", generating: true, audioReady: true })))
+      .toBe("yellow");
+  });
+
+  it("is red once audio is ready and nothing is generating", () => {
+    expect(effectiveColor(voice({ color: "red", activityState: "WaitingForInput", generating: false, audioReady: true })))
+      .toBe("red");
+  });
+
+  it("regression 2026-07-08: text-to-speech failure (no audio, not generating) resolves to red, NOT a stuck yellow wedge", () => {
+    // A DeepInfra 504/timeout produces no audio, so the turn ends with audioReady=false and
+    // nothing generating. This must become red "needs you" rather than the old permanent yellow.
+    const s = voice({ color: "red", activityState: "WaitingForInput", generating: false, audioReady: false });
+    expect(effectiveColor(s)).toBe("red");
+    expect(classify(s)).toBe("needsYou");
+  });
+
+  it("leaves a working (blue) voice session untouched", () => {
+    expect(effectiveColor(voice({ color: "blue", activityState: "Working", generating: true, audioReady: false })))
+      .toBe("blue");
+  });
+
+  it("does not apply the voice rule to a non-voice session", () => {
+    expect(effectiveColor(voice({ color: "red", activityState: "WaitingForInput", generating: true, audioReady: false, voiceMode: false })))
+      .toBe("red");
+  });
+});

--- a/packages/client-core/src/sessions/ordering.test.ts
+++ b/packages/client-core/src/sessions/ordering.test.ts
@@ -1,68 +1,49 @@
 import { describe, expect, it } from "vitest";
 import type { SessionDto } from "../api/client";
-import { classify, effectiveColor } from "./ordering";
+import { classify, dotColor, effectiveColor, inBucket } from "./ordering";
 
-// A minimal voice-mode session for the color rule. Only the fields the rule reads are set;
-// the rest of SessionDto is irrelevant here so we cast a partial.
-function voice(opts: {
-  color: string;
-  activityState: string;
-  generating: boolean;
-  audioReady: boolean;
-  voiceMode?: boolean;
-}): SessionDto {
+function session(fields: Partial<SessionDto> & { sessionId?: string } = {}): SessionDto {
   return {
-    sessionId: "v",
-    statusColor: opts.color,
-    activityState: opts.activityState,
-    voiceMode: opts.voiceMode ?? true,
-    voiceGenerating: opts.generating,
-    voiceAudioReady: opts.audioReady,
+    sessionId: "s1",
+    createdAt: "2026-07-08T00:00:00Z",
+    sortOrder: 0,
+    ...fields,
   } as unknown as SessionDto;
 }
 
-describe("effectiveColor voice-mode preparing rule (mirrors C# SessionOrdering)", () => {
-  it("uses the Gateway-stamped effective color and triage bucket when present", () => {
-    const s = {
-      ...voice({ color: "red", activityState: "WaitingForInput", generating: false, audioReady: false }),
-      effectiveColor: "orange",
-      triageBucket: "active",
-    } as unknown as SessionDto;
+describe("Gateway-stamped session presentation state", () => {
+  it("uses effectiveColor and triageBucket from /sessions", () => {
+    const s = session({ effectiveColor: "yellow", triageBucket: "active" });
 
-    expect(effectiveColor(s)).toBe("orange");
+    expect(effectiveColor(s)).toBe("yellow");
     expect(classify(s)).toBe("active");
   });
 
-  it("holds yellow while the wingman is actively generating this turn's voice", () => {
-    expect(effectiveColor(voice({ color: "red", activityState: "WaitingForInput", generating: true, audioReady: false })))
-      .toBe("yellow");
+  it("fails loudly when effectiveColor is missing", () => {
+    expect(() => effectiveColor(session({ triageBucket: "active" })))
+      .toThrow("Gateway /sessions missing effectiveColor");
   });
 
-  it("stays yellow while generating even if a stale clip is cached", () => {
-    expect(effectiveColor(voice({ color: "red", activityState: "WaitingForPerm", generating: true, audioReady: true })))
-      .toBe("yellow");
+  it("fails loudly when triageBucket is missing", () => {
+    expect(() => classify(session({ effectiveColor: "red" })))
+      .toThrow("Gateway /sessions missing triageBucket");
   });
 
-  it("is red once audio is ready and nothing is generating", () => {
-    expect(effectiveColor(voice({ color: "red", activityState: "WaitingForInput", generating: false, audioReady: true })))
-      .toBe("red");
+  it("fails loudly when triageBucket is invalid", () => {
+    expect(() => classify(session({ effectiveColor: "red", triageBucket: "waiting" } as Partial<SessionDto>)))
+      .toThrow("invalid triageBucket");
   });
 
-  it("regression 2026-07-08: text-to-speech failure (no audio, not generating) resolves to red, NOT a stuck yellow wedge", () => {
-    // A DeepInfra 504/timeout produces no audio, so the turn ends with audioReady=false and
-    // nothing generating. This must become red "needs you" rather than the old permanent yellow.
-    const s = voice({ color: "red", activityState: "WaitingForInput", generating: false, audioReady: false });
-    expect(effectiveColor(s)).toBe("red");
-    expect(classify(s)).toBe("needsYou");
+  it("filters by the Gateway-stamped bucket", () => {
+    const sessions = [
+      session({ sessionId: "a", effectiveColor: "red", triageBucket: "needsYou", sortOrder: 2 }),
+      session({ sessionId: "b", effectiveColor: "blue", triageBucket: "active", sortOrder: 1 }),
+    ];
+
+    expect(inBucket(sessions, "needsYou").map((s) => s.sessionId)).toEqual(["a"]);
   });
 
-  it("leaves a working (blue) voice session untouched", () => {
-    expect(effectiveColor(voice({ color: "blue", activityState: "Working", generating: true, audioReady: false })))
-      .toBe("blue");
-  });
-
-  it("does not apply the voice rule to a non-voice session", () => {
-    expect(effectiveColor(voice({ color: "red", activityState: "WaitingForInput", generating: true, audioReady: false, voiceMode: false })))
-      .toBe("red");
+  it("fails loudly on unknown Gateway colors", () => {
+    expect(() => dotColor("chartreuse")).toThrow("Unknown Gateway effectiveColor");
   });
 });

--- a/packages/client-core/src/sessions/ordering.ts
+++ b/packages/client-core/src/sessions/ordering.ts
@@ -1,7 +1,6 @@
-// Client-side triage + ordering for the roster. A faithful port of the C# SessionOrdering
-// policy (src/CcDirector.Gateway.Contracts/SessionOrdering.cs) so the mobile roster groups and
-// orders sessions exactly like the desktop Cockpit Mobile page does. Kept as pure functions so
-// it is unit-testable and shared by the Home page.
+// Client-side ordering helpers for the roster. Presentation state is Gateway-owned: /sessions must
+// provide effectiveColor and triageBucket. The browser shell is deliberately dumb and fails loudly
+// if that contract is broken instead of reconstructing the Gateway state machine in TypeScript.
 import type { SessionDto } from "../api/client";
 
 export type TriageBucket = "needsYou" | "active" | "onHold";
@@ -22,43 +21,18 @@ export function inDesktopOrder(sessions: SessionDto[]): SessionDto[] {
   });
 }
 
-function isExplaining(s: SessionDto): boolean {
-  return s.briefingState === "Explaining";
+function requireGatewayField(value: string | null | undefined, field: string, sid: string | undefined): string {
+  const text = value?.trim();
+  if (!text) {
+    throw new Error(`Gateway /sessions missing ${field} for session ${sid ?? "(unknown)"}. Redeploy Gateway and mobile together.`);
+  }
+  return text;
 }
 
-function isBriefing(s: SessionDto): boolean {
-  return s.briefingState === "Briefing" && (s.statusColor ?? "").toLowerCase() === "red";
-}
-
-// Hold yellow ("preparing voice") only while the wingman is ACTIVELY generating this turn's
-// spoken summary, so the roster does not flash red mid-generation; once generation ends the
-// session shows its real color (red/needs-you, with the play triangle when audio is ready).
-// This used to also hold yellow whenever audio was not yet ready (|| !voiceAudioReady), but a
-// text-to-speech failure (a DevThrottle/DeepInfra 504 or timeout) produces no audio, which left
-// the session stuck yellow/orange forever while it actually needed the user (the "stuck orange,
-// says needs you" report, 2026-07-08). Gating on voiceGenerating alone gives a terminal exit.
-function isVoicePreparing(s: SessionDto): boolean {
-  if (!s.voiceMode) return false;
-  if ((s.statusColor ?? "").toLowerCase() !== "red") return false;
-  const state = s.assessedState ?? s.activityState ?? "";
-  const waiting = state === "WaitingForInput" || state === "WaitingForPerm";
-  if (!waiting) return false;
-  return Boolean(s.voiceGenerating);
-}
-
-// The ONE effective status color every client renders and triages on (issue #196): on-hold
-// greys out, a session whose dictated utterance is being transcribed in the background is orange,
-// a user-requested explain is orange, the wingman reading a finished turn is yellow,
-// a voice-mode session preparing audio is yellow - otherwise the raw Director status color.
+// The ONE effective status color every client renders and triages on. It is stamped by the Gateway
+// after folding on-hold, transcribing, explaining, briefing, and voice-generation state.
 export function effectiveColor(s: SessionDto): string {
-  const stamped = (s as GatewayStampedSession).effectiveColor;
-  if (stamped && stamped.trim().length > 0) return stamped;
-  if (s.onHold) return "grey";
-  if (s.transcribing) return "orange";
-  if (isExplaining(s)) return "orange";
-  if (isBriefing(s)) return "yellow";
-  if (isVoicePreparing(s)) return "yellow";
-  return s.statusColor ?? "unknown";
+  return requireGatewayField((s as GatewayStampedSession).effectiveColor, "effectiveColor", s.sessionId);
 }
 
 // True while the agent is actively running a turn - the "working" state. Blue is the authoritative
@@ -75,13 +49,11 @@ export function isWorking(s: SessionDto): boolean {
   return state === "Working";
 }
 
-// Classify a session for triage. On-hold takes precedence over color (the user deferred it);
-// otherwise an effective-red session "needs you", everything else is active.
+// Classify a session for triage. The Gateway owns this fold; the client consumes the stamped bucket.
 export function classify(s: SessionDto): TriageBucket {
-  const stamped = (s as GatewayStampedSession).triageBucket;
+  const stamped = requireGatewayField((s as GatewayStampedSession).triageBucket, "triageBucket", s.sessionId);
   if (stamped === "needsYou" || stamped === "active" || stamped === "onHold") return stamped;
-  if (s.onHold) return "onHold";
-  return effectiveColor(s) === "red" ? "needsYou" : "active";
+  throw new Error(`Gateway /sessions returned invalid triageBucket '${stamped}' for session ${s.sessionId ?? "(unknown)"}.`);
 }
 
 export function inBucket(sessions: SessionDto[], bucket: TriageBucket): SessionDto[] {
@@ -103,7 +75,9 @@ const COLORS: Record<string, string> = {
 };
 
 export function dotColor(color: string): string {
-  return COLORS[color] ?? "#6B7280";
+  const value = COLORS[color];
+  if (!value) throw new Error(`Unknown Gateway effectiveColor '${color}'.`);
+  return value;
 }
 
 // One short context line per row: the on-hold note, else the latest status reason, else the

--- a/packages/client-core/src/sessions/ordering.ts
+++ b/packages/client-core/src/sessions/ordering.ts
@@ -5,6 +5,10 @@
 import type { SessionDto } from "../api/client";
 
 export type TriageBucket = "needsYou" | "active" | "onHold";
+type GatewayStampedSession = SessionDto & {
+  effectiveColor?: string | null;
+  triageBucket?: TriageBucket | string | null;
+};
 
 // The stable "desktop order": honor the owning Director's SortOrder (the user-controlled,
 // drag-to-reorder, persisted order), then CreatedAt as a deterministic tie-break.
@@ -26,13 +30,20 @@ function isBriefing(s: SessionDto): boolean {
   return s.briefingState === "Briefing" && (s.statusColor ?? "").toLowerCase() === "red";
 }
 
+// Hold yellow ("preparing voice") only while the wingman is ACTIVELY generating this turn's
+// spoken summary, so the roster does not flash red mid-generation; once generation ends the
+// session shows its real color (red/needs-you, with the play triangle when audio is ready).
+// This used to also hold yellow whenever audio was not yet ready (|| !voiceAudioReady), but a
+// text-to-speech failure (a DevThrottle/DeepInfra 504 or timeout) produces no audio, which left
+// the session stuck yellow/orange forever while it actually needed the user (the "stuck orange,
+// says needs you" report, 2026-07-08). Gating on voiceGenerating alone gives a terminal exit.
 function isVoicePreparing(s: SessionDto): boolean {
   if (!s.voiceMode) return false;
   if ((s.statusColor ?? "").toLowerCase() !== "red") return false;
   const state = s.assessedState ?? s.activityState ?? "";
   const waiting = state === "WaitingForInput" || state === "WaitingForPerm";
   if (!waiting) return false;
-  return Boolean(s.voiceGenerating) || !s.voiceAudioReady;
+  return Boolean(s.voiceGenerating);
 }
 
 // The ONE effective status color every client renders and triages on (issue #196): on-hold
@@ -40,6 +51,8 @@ function isVoicePreparing(s: SessionDto): boolean {
 // a user-requested explain is orange, the wingman reading a finished turn is yellow,
 // a voice-mode session preparing audio is yellow - otherwise the raw Director status color.
 export function effectiveColor(s: SessionDto): string {
+  const stamped = (s as GatewayStampedSession).effectiveColor;
+  if (stamped && stamped.trim().length > 0) return stamped;
   if (s.onHold) return "grey";
   if (s.transcribing) return "orange";
   if (isExplaining(s)) return "orange";
@@ -65,6 +78,8 @@ export function isWorking(s: SessionDto): boolean {
 // Classify a session for triage. On-hold takes precedence over color (the user deferred it);
 // otherwise an effective-red session "needs you", everything else is active.
 export function classify(s: SessionDto): TriageBucket {
+  const stamped = (s as GatewayStampedSession).triageBucket;
+  if (stamped === "needsYou" || stamped === "active" || stamped === "onHold") return stamped;
   if (s.onHold) return "onHold";
   return effectiveColor(s) === "red" ? "needsYou" : "active";
 }

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -137,16 +137,16 @@ public sealed class SessionDto
     /// Gateway-owned presentation color after all overlays are folded in
     /// (<see cref="SessionOrdering.EffectiveColor"/>): on-hold, transcribing, explaining,
     /// briefing, and voice-generation state. Stamped by the Gateway aggregator so browser
-    /// clients do not need to reimplement the session state machine. Empty/null on
-    /// Director-local responses and older Gateways; clients may fall back to deriving it.
+    /// clients do not reimplement the session state machine. Required on Gateway /sessions
+    /// responses; Director-local responses may leave it null.
     /// </summary>
     public string? EffectiveColor { get; set; }
 
     /// <summary>
     /// Gateway-owned triage bucket after the same effective-color fold:
     /// "needsYou" | "active" | "onHold". Stamped by the Gateway aggregator as the
-    /// authoritative grouping value for mobile/Cockpit rosters. Empty/null on
-    /// Director-local responses and older Gateways; clients may fall back to deriving it.
+    /// authoritative grouping value for mobile/Cockpit rosters. Required on Gateway /sessions
+    /// responses; Director-local responses may leave it null.
     /// </summary>
     public string? TriageBucket { get; set; }
 

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -133,6 +133,23 @@ public sealed class SessionDto
     /// </summary>
     public DateTime? NeedsYouSince { get; set; }
 
+    /// <summary>
+    /// Gateway-owned presentation color after all overlays are folded in
+    /// (<see cref="SessionOrdering.EffectiveColor"/>): on-hold, transcribing, explaining,
+    /// briefing, and voice-generation state. Stamped by the Gateway aggregator so browser
+    /// clients do not need to reimplement the session state machine. Empty/null on
+    /// Director-local responses and older Gateways; clients may fall back to deriving it.
+    /// </summary>
+    public string? EffectiveColor { get; set; }
+
+    /// <summary>
+    /// Gateway-owned triage bucket after the same effective-color fold:
+    /// "needsYou" | "active" | "onHold". Stamped by the Gateway aggregator as the
+    /// authoritative grouping value for mobile/Cockpit rosters. Empty/null on
+    /// Director-local responses and older Gateways; clients may fall back to deriving it.
+    /// </summary>
+    public string? TriageBucket { get; set; }
+
     /// <summary>Backend type: ConPty / UnixPty / Pipe / Studio / Embedded.</summary>
     public string BackendType { get; set; } = "";
 
@@ -222,8 +239,9 @@ public sealed class SessionDto
     /// Issue #553: true when the Gateway has fetchable, playable cached audio for this session
     /// (<c>WingmanVoiceService.HasVoice</c>) - the SINGLE truthful "there is voice you can play right
     /// now" signal. Stamped by the Gateway aggregator only; always false in Director-local responses.
-    /// A voice-mode session waiting for the user only turns red once this is true; before then it
-    /// holds yellow (see <see cref="SessionOrdering.EffectiveColor"/>).
+    /// This controls whether a play affordance is available; the "preparing voice" color is driven
+    /// by <see cref="VoiceGenerating"/>, not by missing audio, so a TTS failure cannot wedge a
+    /// session outside Needs You forever.
     /// </summary>
     public bool VoiceAudioReady { get; set; }
 

--- a/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
@@ -50,12 +50,19 @@ public static class SessionOrdering
         s.BriefingState == "Explaining";
 
     /// <summary>
-    /// Issue #553: true while a VOICE-MODE session that is waiting for the user must hold yellow
-    /// ("preparing voice / not ready yet") rather than red. The voice is not ready to play until the
-    /// Gateway has fetchable audio (<see cref="SessionDto.VoiceAudioReady"/>), so a voice-mode session
-    /// whose raw color is red stays yellow while the wingman is still generating
-    /// (<see cref="SessionDto.VoiceGenerating"/>) OR before the audio exists. It only turns red once
-    /// audio is ready - it must NEVER show red/needs-you in voice mode before audio is available.
+    /// Issue #553: true while a VOICE-MODE waiting session is ACTIVELY generating its spoken summary,
+    /// so the roster holds yellow ("preparing voice") rather than flashing red mid-generation. Once
+    /// generation ends the session shows its real color - red "needs you", with the roster play
+    /// triangle appearing separately when <see cref="SessionDto.VoiceAudioReady"/> is true.
+    ///
+    /// This used to ALSO hold yellow whenever audio was not yet ready (<c>|| !VoiceAudioReady</c>),
+    /// on the assumption that audio always eventually arrives. It does not: a text-to-speech
+    /// failure (a DevThrottle/DeepInfra 504 or timeout) produces NO audio, so <c>VoiceAudioReady</c>
+    /// stayed false with nothing generating - and the session was stuck yellow/orange FOREVER while
+    /// it actually needed the user (the "stuck orange, says needs you" report, 2026-07-08). Gating
+    /// the hold on <see cref="SessionDto.VoiceGenerating"/> alone gives a terminal exit: when a turn's
+    /// voice fails, the session correctly becomes red/needs-you instead of a permanent wedge.
+    ///
     /// Gated on raw red and on WaitingForInput/WaitingForPerm so a working (blue) session is untouched.
     /// </summary>
     public static bool IsVoicePreparing(SessionDto s)
@@ -66,7 +73,7 @@ public static class SessionOrdering
         var waiting = string.Equals(state, "WaitingForInput", StringComparison.OrdinalIgnoreCase)
                    || string.Equals(state, "WaitingForPerm", StringComparison.OrdinalIgnoreCase);
         if (!waiting) return false;
-        return s.VoiceGenerating || !s.VoiceAudioReady;
+        return s.VoiceGenerating;
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway.Tests/SessionOrderingTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionOrderingTests.cs
@@ -178,10 +178,13 @@ public sealed class SessionOrderingTests
     };
 
     [Fact]
-    public void EffectiveColor_VoiceWaiting_NoAudio_IsYellow()
+    public void EffectiveColor_VoiceWaiting_NoAudio_NotGenerating_IsRed_NotStuckYellow()
     {
-        // Voice mode, waiting for the user, no playable audio yet -> hold yellow, not red.
-        Assert.Equal("yellow", SessionOrdering.EffectiveColor(
+        // Regression (2026-07-08): a text-to-speech failure (DeepInfra 504/timeout) produces no
+        // audio, so a voice-mode waiting session ends with audioReady=false and nothing generating.
+        // This must resolve to red "needs you" - NOT the old permanent yellow/orange wedge that had
+        // no exit when audio never arrived. The hold is now gated on VoiceGenerating alone.
+        Assert.Equal("red", SessionOrdering.EffectiveColor(
             Voice("red", "WaitingForInput", generating: false, audioReady: false)));
     }
 
@@ -219,10 +222,20 @@ public sealed class SessionOrderingTests
     }
 
     [Fact]
-    public void Classify_VoiceWaitingNoAudio_IsActive_NotNeedsYou()
+    public void Classify_VoiceWaiting_StillGenerating_IsActive_NotNeedsYou()
     {
-        // While voice is still preparing the session must not sit in NEEDS YOU.
+        // While voice is ACTIVELY generating the session must not sit in NEEDS YOU (it is preparing).
         Assert.Equal(SessionOrdering.TriageBucket.Active, SessionOrdering.Classify(
+            Voice("red", "WaitingForInput", generating: true, audioReady: false)));
+    }
+
+    [Fact]
+    public void Classify_VoiceWaiting_NoAudio_NotGenerating_IsNeedsYou()
+    {
+        // Regression (2026-07-08): once generation has ended with no audio (text-to-speech failed),
+        // the session genuinely needs the user - it must surface in NEEDS YOU, not hide in Active
+        // behind a stuck "preparing voice" state forever.
+        Assert.Equal(SessionOrdering.TriageBucket.NeedsYou, SessionOrdering.Classify(
             Voice("red", "WaitingForInput", generating: false, audioReady: false)));
     }
 

--- a/src/CcDirector.Gateway.Tests/SessionsAggregationTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionsAggregationTests.cs
@@ -99,6 +99,32 @@ public sealed class SessionsAggregationTests : IAsyncLifetime
         Assert.Contains(sessions, s => s.SessionId == "b1" && s.MachineName == "MACHINE_B");
     }
 
+    [Fact]
+    public async Task Aggregator_stamps_authoritative_effective_color_and_triage_bucket()
+    {
+        var red = Sample("red1", "ClaudeCode", "repo", "WaitingForInput", "red");
+        var briefing = Sample("brief1", "ClaudeCode", "repo", "WaitingForInput", "red");
+        briefing.BriefingState = "Briefing";
+        var parked = Sample("hold1", "ClaudeCode", "repo", "WaitingForInput", "red");
+        parked.OnHold = true;
+        var fake = await StartFake("M", "u", new[] { red, briefing, parked });
+        await Register(fake);
+
+        var sessions = await GetSessions();
+
+        var redOut = Assert.Single(sessions, s => s.SessionId == "red1");
+        Assert.Equal("red", redOut.EffectiveColor);
+        Assert.Equal("needsYou", redOut.TriageBucket);
+
+        var briefingOut = Assert.Single(sessions, s => s.SessionId == "brief1");
+        Assert.Equal("yellow", briefingOut.EffectiveColor);
+        Assert.Equal("active", briefingOut.TriageBucket);
+
+        var parkedOut = Assert.Single(sessions, s => s.SessionId == "hold1");
+        Assert.Equal("grey", parkedOut.EffectiveColor);
+        Assert.Equal("onHold", parkedOut.TriageBucket);
+    }
+
     // ---------- error surfacing ----------
 
     [Fact]

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -508,9 +508,8 @@ internal static class GatewayEndpoints
                     // Issue #553: surface the two voice readiness booleans the color rule and the /m
                     // client read directly. VoiceGenerating = the wingman is producing this session's
                     // spoken summary now; VoiceAudioReady = the gateway has fetchable, playable audio
-                    // (the SINGLE truthful "there is voice you can play right now" signal). These hold
-                    // a voice-mode waiting session yellow until audio exists, then let it go red - see
-                    // SessionOrdering.IsVoicePreparing (the color fold reads these next refresh).
+                    // (the SINGLE truthful "there is voice you can play right now" signal). VoiceGenerating
+                    // is the only "preparing voice" hold; VoiceAudioReady controls playback affordances.
                     if (voiceGeneratingFor is not null)
                         s.VoiceGenerating = voiceGeneratingFor(s.SessionId);
                     if (voiceAudioReadyFor is not null)
@@ -527,6 +526,17 @@ internal static class GatewayEndpoints
                     // (a transcribing session is not "needs you") when the clock reads the final color.
                     if (transcribingFor is not null)
                         s.Transcribing = transcribingFor(s.SessionId);
+                    // Authoritative presentation state for browser clients. The raw fields above remain
+                    // for diagnostics and backward compatibility, but the Gateway owns the fold so the
+                    // phone/Cockpit do not need a second state machine that can drift from C#.
+                    var effectiveColor = SessionOrdering.EffectiveColor(s);
+                    s.EffectiveColor = effectiveColor;
+                    s.TriageBucket = SessionOrdering.Classify(s) switch
+                    {
+                        SessionOrdering.TriageBucket.NeedsYou => "needsYou",
+                        SessionOrdering.TriageBucket.OnHold => "onHold",
+                        _ => "active",
+                    };
                     // Issue #218: stamp NeedsYouSince AFTER the briefing/rail fields above, so the
                     // EffectiveColor fold sees this refresh's final BriefingState/RailLine/OnHold -
                     // a session still being briefed/explained is effective yellow/orange (not red)
@@ -534,7 +544,7 @@ internal static class GatewayEndpoints
                     // timestamp on first red, holds it while red, and clears it when it leaves red.
                     if (needsYouStampFor is not null)
                     {
-                        var isRed = string.Equals(SessionOrdering.EffectiveColor(s), "red", StringComparison.OrdinalIgnoreCase);
+                        var isRed = string.Equals(effectiveColor, "red", StringComparison.OrdinalIgnoreCase);
                         s.NeedsYouSince = needsYouStampFor(s.SessionId, isRed);
                     }
                     // Issue #335: ViewUrl - use the Director-supplied value when present (it carries

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -301,7 +301,14 @@ public sealed class WingmanVoiceService
             {
                 var t = await _translator.TranslateAsync(recentContext, lastReply, ct);
                 await StoreSpokenAsync(sid, t.Spoken, lastReply, ct);
-                FileLog.Write($"[WingmanVoiceService] voice ready: sid={sid}, spokenLen={t.Spoken.Length}");
+                // Log the TRUE outcome: StoreSpokenAsync only makes the session playable when the
+                // text-to-speech synthesis actually returned audio. Logging "voice ready"
+                // unconditionally (the old behavior) hid every failed synthesis behind a success
+                // line, which made a text-to-speech outage look like it was working in the log.
+                if (HasVoice(sid))
+                    FileLog.Write($"[WingmanVoiceService] voice ready: sid={sid}, spokenLen={t.Spoken.Length}");
+                else
+                    FileLog.Write($"[WingmanVoiceService] voice NOT ready (text-to-speech produced no audio): sid={sid}, spokenLen={t.Spoken.Length}");
                 // Training capture (no-op unless the setting is on); fire-and-forget so it never
                 // delays the turn. CancellationToken.None so a captured turn is not lost on shutdown.
                 _ = _training.CaptureAsync(_client, endpoint, sid, "generate", lastReply, recentContext, t.Spoken, t.ReplySeconds, CancellationToken.None);


### PR DESCRIPTION
Fixes the mobile Wingman voice stuck/preparing state by making Gateway-stamped session presentation authoritative and failing loud when voice audio is unavailable.\n\nCommits included:\n- 106f7742 Fix mobile voice state source of truth\n- a1f78b6c Require gateway-stamped session state\n- 97fd1a0b Fail loud when mobile voice audio is unavailable\n\nValidation performed locally:\n- npm test --workspace @devthrottle/client-core\n- npm run build --workspace @devthrottle/mobile\n- targeted gateway tests for session ordering/aggregation/voice\n- redeploy-gateway.ps1 build/typecheck/redeploy\n- Chrome mobile CDP smoke against /m/ and the affected /m/session/.../voice route