### PR TITLE
Fix mobile Wingman voice for Codex sessions

### DIFF
--- a/apps/mobile/src/pages/VoiceMode.tsx
+++ b/apps/mobile/src/pages/VoiceMode.tsx
@@ -454,11 +454,12 @@ export function VoiceMode() {
     && enableNote.length === 0;
   const working = voiceOn && !speaking && !audioUnavailable;
   const narrative = voice?.spoken ?? "";
+  const title = session?.number ? `${session.number} ${name ?? "Session"}` : name ?? "Session";
 
   return (
     <div className="terminal-screen">
       <header className="app-bar">
-        <h1 className="term-title">{name ?? "Session"}</h1>
+        <h1 className="term-title">{title}</h1>
       </header>
 
       <ViewTabs sessionId={sessionId} active="voice" />

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -8,6 +8,7 @@ using CcDirector.Core.Agents;
 using CcDirector.Core.Backends;
 using CcDirector.Core.Claude;
 using CcDirector.Core.Configuration;
+using CcDirector.Core.History;
 using CcDirector.Core.Network;
 using CcDirector.Core.Sessions;
 using CcDirector.Core.Storage;
@@ -1057,6 +1058,23 @@ internal static class ControlEndpoints
                 SessionId = sid,
                 ClaudeSessionId = session.ClaudeSessionId,
             };
+
+            if (session.AgentKind != AgentKind.ClaudeCode)
+            {
+                if (!SessionHistoryReader.IsSupported(session))
+                {
+                    resp.Status = "unsupported";
+                    resp.Error = $"Agent {session.AgentKind} does not expose conversation history.";
+                    return Results.Json(resp);
+                }
+
+                var history = SessionHistoryReader.Read(session);
+                resp.JsonlPath = SessionHistoryReader.ResolveTranscriptPath(session);
+                resp.LineCount = history.Messages.Count;
+                resp.Widgets = BuildTurnWidgetsFromHistory(history);
+                resp.Status = "ok";
+                return Results.Json(resp);
+            }
 
             if (string.IsNullOrEmpty(session.ClaudeSessionId))
             {
@@ -3319,6 +3337,68 @@ internal static class ControlEndpoints
         var resolution = resolver();
         var tailnetEndpoint = resolution.IsResolved ? resolution.Endpoint : "";
         return (machineName, user, tailnetEndpoint);
+    }
+
+    /// <summary>
+    /// Convert the agent-agnostic conversation history into the legacy turn widget shape consumed by
+    /// the Gateway Wingman voice path. Assistant text must stay Kind="Text": that is the contract
+    /// WingmanTranslator uses to find the latest reply to summarize and speak.
+    /// </summary>
+    private static List<TurnWidgetDto> BuildTurnWidgetsFromHistory(ConversationHistory history)
+    {
+        var widgets = new List<TurnWidgetDto>();
+        foreach (var message in history.Messages)
+        {
+            foreach (var part in message.Parts)
+            {
+                var text = part.Text?.Trim();
+                if (string.IsNullOrEmpty(text)) continue;
+
+                widgets.Add(part.Kind switch
+                {
+                    ConversationPartKind.Text when message.Role == ConversationRole.Assistant => new TurnWidgetDto
+                    {
+                        Kind = "Text",
+                        Header = "Agent",
+                        Content = text,
+                    },
+                    ConversationPartKind.Text => new TurnWidgetDto
+                    {
+                        Kind = "UserMessage",
+                        Header = "You",
+                        Content = text,
+                    },
+                    ConversationPartKind.Thinking => new TurnWidgetDto
+                    {
+                        Kind = "Thinking",
+                        Header = "Thinking",
+                        Content = text,
+                    },
+                    ConversationPartKind.ToolUse => new TurnWidgetDto
+                    {
+                        Kind = "GenericTool",
+                        Header = part.ToolName ?? "Tool",
+                        Content = text,
+                        ToolUseId = part.ToolId ?? "",
+                    },
+                    ConversationPartKind.ToolResult => new TurnWidgetDto
+                    {
+                        Kind = "GenericTool",
+                        Header = "Tool result",
+                        Content = text,
+                        ToolUseId = part.ToolId ?? "",
+                    },
+                    _ => new TurnWidgetDto
+                    {
+                        Kind = part.Kind.ToString(),
+                        Header = part.Kind.ToString(),
+                        Content = text,
+                    },
+                });
+            }
+        }
+
+        return widgets;
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
@@ -119,7 +119,7 @@ public sealed class WingmanVoiceServiceTests
         {
             var svc = ServiceAt(persistPath);
             var audio = new byte[] { 1, 2, 3, 4, 5 };
-            svc.StoreReadyAudioForTest("sid-1", "spoken text", "reply text", audio);
+            svc.StoreReadyAudioForTest("sid-1", "spoken text", "reply text", audio, "audio/wav");
             Assert.True(svc.HasVoice("sid-1"));
 
             // Simulate a gateway restart: a brand-new service over the same path.
@@ -133,6 +133,31 @@ public sealed class WingmanVoiceServiceTests
             Assert.NotNull(ready);
             Assert.Equal("spoken text", ready.Spoken);
             Assert.Equal("reply text", ready.Reply);
+            Assert.Equal("audio/wav", ready.ContentType);
+        }
+        finally { Cleanup(persistPath); }
+    }
+
+    [Fact]
+    public void ReadyAudio_ReloadsLegacyWavCacheWithDetectedContentType()
+    {
+        // Older cache metadata had no content type. Kokoro can return WAV bytes, so reload must detect
+        // RIFF instead of serving those bytes as audio/mpeg.
+        var persistPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".json");
+        try
+        {
+            var dir = Path.GetDirectoryName(persistPath)!;
+            var audioDir = Path.Combine(dir, "voice-audio");
+            Directory.CreateDirectory(audioDir);
+            File.WriteAllBytes(Path.Combine(audioDir, "sid-1.mp3"), new byte[] { (byte)'R', (byte)'I', (byte)'F', (byte)'F', 1, 2, 3 });
+            File.WriteAllText(Path.Combine(audioDir, "sid-1.json"),
+                "{\"Spoken\":\"spoken\",\"Reply\":\"reply\",\"AtUtc\":\"2026-01-01T00:00:00Z\"}");
+
+            var reloaded = ServiceAt(persistPath);
+
+            var ready = reloaded.Get("sid-1");
+            Assert.NotNull(ready);
+            Assert.Equal("audio/wav", ready.ContentType);
         }
         finally { Cleanup(persistPath); }
     }

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -91,7 +91,7 @@ internal static class GatewayWingmanVoiceEndpoint
         {
             var audio = voice.GetAudio(sid);
             return audio is { Length: > 0 }
-                ? Results.Bytes(audio, "audio/mpeg", enableRangeProcessing: true)
+                ? Results.Bytes(audio, voice.GetAudioContentType(sid) ?? "audio/mpeg", enableRangeProcessing: true)
                 : Results.Json(new { error = "no voice ready for this session" }, statusCode: StatusCodes.Status404NotFound);
         });
 

--- a/src/CcDirector.Gateway/Discovery/DirectorEndpointClient.cs
+++ b/src/CcDirector.Gateway/Discovery/DirectorEndpointClient.cs
@@ -433,14 +433,89 @@ public sealed class DirectorEndpointClient : IDisposable
         try
         {
             var resp = await _http.GetAsync($"{endpoint}/sessions/{sessionId}/turns", ct);
-            if (!resp.IsSuccessStatusCode) return null;
-            return await resp.Content.ReadFromJsonAsync<TurnsResponse>(cancellationToken: ct);
+            TurnsResponse? turns = null;
+            if (resp.IsSuccessStatusCode)
+                turns = await resp.Content.ReadFromJsonAsync<TurnsResponse>(cancellationToken: ct);
+
+            if (HasSpeakableAgentText(turns))
+                return turns;
+
+            var historyTurns = await GetHistoryTurnsAsync(endpoint, sessionId, ct);
+            return historyTurns ?? turns;
         }
         catch (Exception ex)
         {
             FileLog.Write($"[DirectorEndpointClient] GetTurnsAsync FAILED: endpoint={endpoint}, sid={sessionId}, error={ex.Message}");
             return null;
         }
+    }
+
+    private async Task<TurnsResponse?> GetHistoryTurnsAsync(string endpoint, string sessionId, CancellationToken ct)
+    {
+        try
+        {
+            var resp = await _http.GetAsync($"{endpoint}/sessions/{sessionId}/history", ct);
+            if (!resp.IsSuccessStatusCode) return null;
+            var history = await resp.Content.ReadFromJsonAsync<SessionHistoryDto>(cancellationToken: ct);
+            if (history is null || !history.IsSupported) return null;
+
+            var widgets = BuildTurnWidgetsFromHistory(history);
+            if (widgets.Count == 0) return null;
+
+            return new TurnsResponse
+            {
+                SessionId = sessionId,
+                Status = history.Status,
+                Error = history.Error,
+                LineCount = history.Messages.Count,
+                Widgets = widgets,
+            };
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[DirectorEndpointClient] GetHistoryTurnsAsync FAILED: endpoint={endpoint}, sid={sessionId}, error={ex.Message}");
+            return null;
+        }
+    }
+
+    private static bool HasSpeakableAgentText(TurnsResponse? turns)
+        => turns?.Widgets.Any(w => string.Equals(w.Kind, "Text", StringComparison.Ordinal) && !string.IsNullOrWhiteSpace(w.Content)) == true;
+
+    private static List<TurnWidgetDto> BuildTurnWidgetsFromHistory(SessionHistoryDto history)
+    {
+        var widgets = new List<TurnWidgetDto>();
+        foreach (var message in history.Messages)
+        {
+            var assistant = string.Equals(message.Role, "Assistant", StringComparison.OrdinalIgnoreCase);
+            foreach (var part in message.Parts)
+            {
+                var text = part.Text?.Trim();
+                if (string.IsNullOrEmpty(text)) continue;
+                widgets.Add(part.Kind switch
+                {
+                    "Text" when assistant => new TurnWidgetDto { Kind = "Text", Header = "Agent", Content = text },
+                    "Text" => new TurnWidgetDto { Kind = "UserMessage", Header = "You", Content = text },
+                    "Thinking" => new TurnWidgetDto { Kind = "Thinking", Header = "Thinking", Content = text },
+                    "ToolUse" => new TurnWidgetDto
+                    {
+                        Kind = "GenericTool",
+                        Header = part.ToolName ?? "Tool",
+                        Content = text,
+                        ToolUseId = part.ToolId ?? "",
+                    },
+                    "ToolResult" => new TurnWidgetDto
+                    {
+                        Kind = "GenericTool",
+                        Header = "Tool result",
+                        Content = text,
+                        ToolUseId = part.ToolId ?? "",
+                    },
+                    _ => new TurnWidgetDto { Kind = part.Kind, Header = part.Kind, Content = text },
+                });
+            }
+        }
+
+        return widgets;
     }
 
     public async Task<(bool ok, PromptResponse? body, string? error)> PostPromptAsync(string endpoint, string sessionId, PromptRequest req, CancellationToken ct = default)

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -26,13 +26,13 @@ namespace CcDirector.Gateway.Wingman;
 /// </summary>
 public sealed class WingmanVoiceService
 {
-    public sealed record VoiceReady(string Spoken, string Reply, byte[] Audio, DateTime AtUtc);
+    public sealed record VoiceReady(string Spoken, string Reply, byte[] Audio, DateTime AtUtc, string ContentType = "audio/mpeg");
 
     /// <summary>The outcome of one text-to-speech synthesis (issue #939): the audio bytes on success,
     /// or the shared <see cref="HostedAiState"/> when hosted AI is unavailable (out of credits, cap
     /// reached, or - in bring-your-own mode - no key) so the caller can surface it instead of a silent
     /// null. Both null means a generic provider error (logged, no shared state).</summary>
-    private sealed record TtsResult(byte[]? Audio, HostedAiState? Unavailable);
+    private sealed record TtsResult(byte[]? Audio, string? ContentType, HostedAiState? Unavailable);
 
     private readonly WingmanTranslator _translator;
     private readonly KeyVault _vault;
@@ -48,7 +48,7 @@ public sealed class WingmanVoiceService
 
     /// <summary>On-disk shape of one ready session's metadata (the audio bytes live next to it as
     /// an .mp3). Persisted so the play triangle / playability survives a gateway restart (issue #553).</summary>
-    private sealed record PersistedVoice(string Spoken, string Reply, DateTime AtUtc);
+    private sealed record PersistedVoice(string Spoken, string Reply, DateTime AtUtc, string? ContentType = null);
 
     /// <param name="ttsHttpClient">Optional HTTP client for the text-to-speech call (tests inject a stub
     /// over a fake handler, issue #939). A per-call 60-second client is created when null.</param>
@@ -108,7 +108,8 @@ public sealed class WingmanVoiceService
                 if (audio.Length == 0) continue;
                 var meta = JsonSerializer.Deserialize<PersistedVoice>(File.ReadAllText(metaPath));
                 if (meta is null) continue;
-                _ready[sid] = new VoiceReady(meta.Spoken, meta.Reply, audio, meta.AtUtc);
+                var contentType = NormalizeContentType(meta.ContentType) ?? DetectAudioContentType(audio);
+                _ready[sid] = new VoiceReady(meta.Spoken, meta.Reply, audio, meta.AtUtc, contentType);
                 loaded++;
             }
             FileLog.Write($"[WingmanVoiceService] loaded {loaded} ready voice audio cache(s) from disk");
@@ -125,7 +126,7 @@ public sealed class WingmanVoiceService
             // .mp3 and the .json) never sees a session ready before its bytes are on disk.
             File.WriteAllBytes(Path.Combine(_audioDir, sid + ".mp3"), ready.Audio);
             File.WriteAllText(Path.Combine(_audioDir, sid + ".json"),
-                JsonSerializer.Serialize(new PersistedVoice(ready.Spoken, ready.Reply, ready.AtUtc)));
+                JsonSerializer.Serialize(new PersistedVoice(ready.Spoken, ready.Reply, ready.AtUtc, ready.ContentType)));
         }
         catch (Exception ex) { FileLog.Write($"[WingmanVoiceService] save ready audio FAILED sid={sid}: {ex.Message}"); }
     }
@@ -188,6 +189,7 @@ public sealed class WingmanVoiceService
 
     public VoiceReady? Get(string sid) => _ready.TryGetValue(sid, out var v) ? v : null;
     public byte[]? GetAudio(string sid) => _ready.TryGetValue(sid, out var v) ? v.Audio : null;
+    public string? GetAudioContentType(string sid) => _ready.TryGetValue(sid, out var v) ? v.ContentType : null;
 
     /// <summary>Mark the session as a voice session (persisted, so the gateway keeps its voice fresh
     /// across restarts via the background sweep + turn-end).</summary>
@@ -251,7 +253,7 @@ public sealed class WingmanVoiceService
         if (tts.Audio is { Length: > 0 })
         {
             _voiceUnavailable.TryRemove(sid, out _);   // success clears any prior unavailable-state (dismissible)
-            StoreReady(sid, spoken, reply ?? "", tts.Audio);
+            StoreReady(sid, spoken, reply ?? "", tts.Audio, tts.ContentType);
         }
         else if (tts.Unavailable is HostedAiState state)
         {
@@ -267,17 +269,18 @@ public sealed class WingmanVoiceService
     /// persist it to disk so it survives a gateway restart (issue #553). The single place the success
     /// branch lives - the test seam (<see cref="StoreReadyAudioForTest"/>) reuses it so persistence is
     /// exercised without a live OpenAI call.</summary>
-    private void StoreReady(string sid, string spoken, string reply, byte[] audio)
+    private void StoreReady(string sid, string spoken, string reply, byte[] audio, string? contentType)
     {
-        var ready = new VoiceReady(spoken, reply, audio, DateTime.UtcNow);
+        var ready = new VoiceReady(spoken, reply, audio, DateTime.UtcNow,
+            NormalizeContentType(contentType) ?? DetectAudioContentType(audio));
         _ready[sid] = ready;
         SaveReadyAudio(sid, ready);
     }
 
     /// <summary>Test seam: store ready audio exactly as a successful synthesis would (in-memory +
     /// durable), so the persistence round-trip can be tested without calling OpenAI.</summary>
-    internal void StoreReadyAudioForTest(string sid, string spoken, string reply, byte[] audio)
-        => StoreReady(sid, spoken, reply, audio);
+    internal void StoreReadyAudioForTest(string sid, string spoken, string reply, byte[] audio, string? contentType = null)
+        => StoreReady(sid, spoken, reply, audio, contentType);
 
     /// <summary>
     /// Regenerate the voice for a session from its latest turn: read the last reply, translate it,
@@ -338,7 +341,7 @@ public sealed class WingmanVoiceService
         if (string.IsNullOrWhiteSpace(key))
             // No key for the mode: bring-your-own means the user must add their OpenAI key; the hosted
             // mode with no key is a sign-in gap (outside the credits/key gate), left silent as before.
-            return new TtsResult(null, mode == TranscriptionMode.Byo ? HostedAiState.NeedsKey : (HostedAiState?)null);
+            return new TtsResult(null, null, mode == TranscriptionMode.Byo ? HostedAiState.NeedsKey : (HostedAiState?)null);
 
         var input = text.Length > 4000 ? text[..4000] : text;
         var voice = TtsVoiceConfig.Resolve(mode);
@@ -359,12 +362,41 @@ public sealed class WingmanVoiceService
                 // Out of credits / monthly cap (402): map by code to the shared state so the caller
                 // records the consistent unavailable state instead of a silent null (issue #939).
                 if ((int)resp.StatusCode == HostedAiHttp.PaymentRequired)
-                    return new TtsResult(null, HostedAiErrorMapper.Map402(body));
-                return new TtsResult(null, null);   // other provider error: logged, no shared state
+                    return new TtsResult(null, null, HostedAiErrorMapper.Map402(body));
+                return new TtsResult(null, null, null);   // other provider error: logged, no shared state
             }
-            return new TtsResult(await resp.Content.ReadAsByteArrayAsync(ct), null);
+            var contentType = resp.Content.Headers.ContentType?.MediaType;
+            return new TtsResult(await resp.Content.ReadAsByteArrayAsync(ct), contentType, null);
         }
-        catch (Exception ex) { FileLog.Write($"[WingmanVoiceService] tts FAILED: {ex.Message}"); return new TtsResult(null, null); }
+        catch (Exception ex) { FileLog.Write($"[WingmanVoiceService] tts FAILED: {ex.Message}"); return new TtsResult(null, null, null); }
         finally { if (_ttsHttp is null) http.Dispose(); }
+    }
+
+    private static string? NormalizeContentType(string? contentType)
+    {
+        if (string.IsNullOrWhiteSpace(contentType)) return null;
+        var mediaType = contentType.Split(';', 2)[0].Trim().ToLowerInvariant();
+        return mediaType.Length == 0 ? null : mediaType;
+    }
+
+    private static string DetectAudioContentType(byte[] audio)
+    {
+        if (audio.Length >= 4
+            && audio[0] == (byte)'R'
+            && audio[1] == (byte)'I'
+            && audio[2] == (byte)'F'
+            && audio[3] == (byte)'F')
+            return "audio/wav";
+
+        if (audio.Length >= 3
+            && audio[0] == (byte)'I'
+            && audio[1] == (byte)'D'
+            && audio[2] == (byte)'3')
+            return "audio/mpeg";
+
+        if (audio.Length >= 2 && audio[0] == 0xFF && (audio[1] & 0xE0) == 0xE0)
+            return "audio/mpeg";
+
+        return "audio/mpeg";
     }
 }


### PR DESCRIPTION
## Summary
- let Gateway Wingman voice read Codex session history when legacy /turns has no speakable text
- show the session number in the mobile Voice screen title
- preserve/detect cached Wingman audio content type so Kokoro WAV output is served as audio/wav

## Validation
- dotnet build src/CcDirector.ControlApi/CcDirector.ControlApi.csproj --no-restore /p:UseSharedCompilation=false
- npm run build --workspace @devthrottle/mobile
- dotnet build src/CcDirector.Gateway/CcDirector.Gateway.csproj /p:UseSharedCompilation=false
- dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj --filter WingmanVoiceServiceTests /p:UseSharedCompilation=false