### PR TITLE
Bind Codex Wingman history to the owning session

### DIFF
--- a/src/CcDirector.Core.Tests/Codex/CodexRolloutLocatorTests.cs
+++ b/src/CcDirector.Core.Tests/Codex/CodexRolloutLocatorTests.cs
@@ -74,6 +74,31 @@ public class CodexRolloutLocatorTests
     }
 
     [Fact]
+    public void Scan_WithNotBefore_PicksClosestLaunchRollout_NotNewestSameRepo()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "codex-sessions-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        const string target = @"C:\target\repo";
+        var firstLaunch = new DateTimeOffset(2026, 6, 19, 10, 0, 0, TimeSpan.Zero);
+        var firstTimestamp = new DateTimeOffset(2026, 6, 19, 10, 0, 20, TimeSpan.Zero);
+        var secondTimestamp = new DateTimeOffset(2026, 6, 19, 11, 0, 0, TimeSpan.Zero);
+
+        var firstRollout = WriteRollout(dir, "first-target", target, mtimeSeconds: 200, timestamp: firstTimestamp);
+        WriteRollout(dir, "second-target", target, mtimeSeconds: 400, timestamp: secondTimestamp);
+
+        try
+        {
+            var found = CodexRolloutLocator.Scan(target, dir, firstLaunch);
+            Assert.Equal(firstRollout, found, ignoreCase: true);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void Scan_WithNotBefore_ReturnsNullUntilCurrentRolloutAppears()
     {
         var dir = Path.Combine(Path.GetTempPath(), "codex-sessions-" + Guid.NewGuid().ToString("N"));

--- a/src/CcDirector.Core.Tests/Codex/CodexTranscriptReaderTests.cs
+++ b/src/CcDirector.Core.Tests/Codex/CodexTranscriptReaderTests.cs
@@ -20,6 +20,7 @@ public class CodexTranscriptReaderTests
         """{"timestamp":"2026-06-19T17:29:08Z","type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"permissions preamble"}]}}""",
         """{"timestamp":"2026-06-19T17:30:00Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"read the file"}]}}""",
         """{"timestamp":"2026-06-19T17:30:01Z","type":"response_item","payload":{"type":"reasoning","summary":[],"encrypted_content":"gAAAA"}}""",
+        """{"timestamp":"2026-06-19T17:30:01Z","type":"response_item","payload":{"type":"message","role":"assistant","phase":"commentary","content":[{"type":"output_text","text":"I am checking files now."}]}}""",
         """{"timestamp":"2026-06-19T17:30:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Sure, reading it."}]}}""",
         """{"timestamp":"2026-06-19T17:30:03Z","type":"response_item","payload":{"type":"function_call","name":"shell_command","arguments":"{\"command\":\"cat x\"}","call_id":"call_1"}}""",
         """{"timestamp":"2026-06-19T17:30:04Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_1","output":"file contents"}}""",
@@ -39,7 +40,7 @@ public class CodexTranscriptReaderTests
 
             // 5 conversation messages survive (the user prompt, two assistant texts, the tool
             // call, and the tool output). session_meta, event_msg, developer, encrypted
-            // reasoning, turn_context, and the truncated line are dropped.
+            // reasoning, commentary progress, turn_context, and the truncated line are dropped.
             Assert.Equal(5, history.Messages.Count);
 
             Assert.Equal(ConversationRole.User, history.Messages[0].Role);

--- a/src/CcDirector.Core/Codex/CodexRolloutLocator.cs
+++ b/src/CcDirector.Core/Codex/CodexRolloutLocator.cs
@@ -81,8 +81,12 @@ public static class CodexRolloutLocator
             return null;
         }
 
-        // Newest first; the active session's rollout is normally the newest matching file, so
-        // we usually inspect only one or two session_meta lines.
+        // Without a launch time, keep the repo-level behavior: newest matching rollout wins.
+        // With a launch time, bind to the rollout whose session_meta timestamp is closest to that
+        // Director session's creation. Multiple Codex sessions can run in the same repo; choosing
+        // "newest for cwd" makes an older Director session read a newer sibling session's history.
+        var launchUtc = notBefore?.ToUniversalTime();
+        var launchCandidates = new List<(string Path, DateTimeOffset Timestamp)>();
         foreach (var file in files)
         {
             var meta = ReadSessionMeta(file.FullName);
@@ -90,10 +94,15 @@ public static class CodexRolloutLocator
                 && NormalizePath(meta.Cwd) == target
                 && IsWithinLaunchWindow(meta.Timestamp, file, notBefore))
             {
-                return file.FullName;
+                if (launchUtc is null)
+                    return file.FullName;
+                launchCandidates.Add((file.FullName, CandidateTimestamp(meta.Timestamp, file)));
             }
         }
-        return null;
+        return launchCandidates
+            .OrderBy(c => Math.Abs((c.Timestamp - launchUtc!.Value).TotalMilliseconds))
+            .Select(c => c.Path)
+            .FirstOrDefault();
     }
 
     /// <summary>Read cwd and timestamp from a rollout's first line (its session_meta), or null.</summary>
@@ -139,9 +148,12 @@ public static class CodexRolloutLocator
         if (notBefore is null)
             return true;
 
-        var candidateTimestamp = metadataTimestamp ?? new DateTimeOffset(file.LastWriteTimeUtc, TimeSpan.Zero);
+        var candidateTimestamp = CandidateTimestamp(metadataTimestamp, file);
         return candidateTimestamp >= notBefore.Value.ToUniversalTime() - LaunchClockSkew;
     }
+
+    private static DateTimeOffset CandidateTimestamp(DateTimeOffset? metadataTimestamp, FileInfo file)
+        => metadataTimestamp ?? new DateTimeOffset(file.LastWriteTimeUtc, TimeSpan.Zero);
 
     private static DateTimeOffset? ParseTimestamp(JsonElement obj)
         => obj.TryGetProperty("timestamp", out var ts)

--- a/src/CcDirector.Core/Codex/CodexTranscriptReader.cs
+++ b/src/CcDirector.Core/Codex/CodexTranscriptReader.cs
@@ -75,6 +75,8 @@ public static class CodexTranscriptReader
                     var role = GetString(p, "role");
                     if (role is "developer" or "system")
                         return null; // system/permissions preamble, not conversation
+                    if (role == "assistant" && GetString(p, "phase") == "commentary")
+                        return null; // transient progress update; Wingman should narrate final answers
                     var text = ExtractMessageText(p);
                     if (text.Length == 0)
                         return null;


### PR DESCRIPTION
## Summary
- bind Codex rollout discovery to the Director session launch time when available, instead of always taking the newest rollout for the repo
- skip Codex assistant messages marked `phase: commentary` so Wingman narrates final answers, not progress updates
- add regression tests for same-repo Codex sessions and commentary filtering

## Why
Mobile Wingman could narrate a completely unrelated response when multiple Codex sessions were open in the same repo. It could also narrate transient Codex progress updates as if they were the latest answer.

## Validation
- dotnet test src/CcDirector.Core.Tests/CcDirector.Core.Tests.csproj --filter FullyQualifiedName~Codex /p:UseSharedCompilation=false
- dotnet build src/CcDirector.Core/CcDirector.Core.csproj /p:UseSharedCompilation=false