### PR TITLE
Add clean-room architecture docs: portless Director-Gateway stream and Phase 1 plan

### DIFF
--- a/docs/new_architecture/index.html
+++ b/docs/new_architecture/index.html
@@ -1,0 +1,352 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>DevThrottle Architecture</title>
+<style>
+        /* Blueprint Theme - Technical documentation style */
+        
+        :root {
+            /* Colors */
+            --primary: #3B82F6;
+            --primary-light: #60A5FA;
+            --accent: #F59E0B;
+            --text: #374151;
+            --heading: #1E3A5F;
+            --background: #FFFFFF;
+            --code-bg: #F1F5F9;
+            --code-text: #0F172A;
+            --border: #CBD5E1;
+            --link: #3B82F6;
+            --blockquote-text: #64748B;
+            --blockquote-border: #3B82F6;
+            --blockquote-bg: #EFF6FF;
+            --table-header-bg: #1E3A5F;
+            --table-header-text: #FFFFFF;
+            --alt-row-bg: #EFF6FF;
+            --shadow-color: rgba(59, 130, 246, 0.08);
+        
+            /* Fonts */
+            --font-heading: "Segoe UI", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            --font-body: "Segoe UI", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            --font-code: "Consolas", "JetBrains Mono", "Fira Code", Consolas, monospace;
+        
+            /* Style */
+            --heading-letter-spacing: -0.01em;
+            --line-height: 1.65;
+            --radius: 6px;
+            --code-radius: 6px;
+            --shadow-sm: 0 1px 3px rgba(59, 130, 246, 0.08);
+            --shadow-md: 0 4px 12px rgba(59, 130, 246, 0.1);
+        }
+        
+        /* Base styles for all themes */
+        
+        *,
+        *::before,
+        *::after {
+            box-sizing: border-box;
+        }
+        
+        html {
+            font-size: 16px;
+            line-height: var(--line-height);
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            text-rendering: optimizeLegibility;
+        }
+        
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: var(--font-body);
+            color: var(--text);
+            background: var(--background);
+        }
+        
+        .markdown-body {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 3rem 2.5rem;
+        }
+        
+        /* Typography */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            color: var(--heading);
+            margin-top: 1.8em;
+            margin-bottom: 0.6em;
+            font-weight: 600;
+            line-height: 1.25;
+            letter-spacing: var(--heading-letter-spacing);
+            orphans: 3;
+            widows: 3;
+        }
+        
+        h1 {
+            font-size: 2.25em;
+            margin-top: 0;
+        }
+        
+        h2 { font-size: 1.65em; }
+        h3 { font-size: 1.35em; }
+        h4 { font-size: 1.1em; }
+        h5 { font-size: 0.95em; }
+        h6 { font-size: 0.85em; color: var(--blockquote-text); }
+        
+        p {
+            margin: 1em 0;
+            orphans: 3;
+            widows: 3;
+        }
+        
+        /* Links */
+        a {
+            color: var(--link);
+            text-decoration: none;
+            border-bottom: 1px solid transparent;
+            transition: border-color 0.2s ease;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--link);
+        }
+        
+        /* Lists */
+        ul, ol {
+            margin: 1em 0;
+            padding-left: 2em;
+            line-height: var(--line-height);
+        }
+        
+        li {
+            margin: 0.35em 0;
+        }
+        
+        li > ul,
+        li > ol {
+            margin: 0.2em 0;
+        }
+        
+        /* Inline code */
+        code {
+            font-family: var(--font-code);
+            font-size: 0.875em;
+            padding: 0.15em 0.4em;
+            border-radius: var(--radius);
+            background: var(--code-bg);
+            color: var(--code-text);
+        }
+        
+        /* Code blocks */
+        pre {
+            margin: 1.5em 0;
+            padding: 1.25em 1.5em;
+            overflow-x: auto;
+            border-radius: var(--code-radius);
+            background: var(--code-bg);
+            border: 1px solid var(--border);
+            box-shadow: var(--shadow-sm);
+            position: relative;
+        }
+        
+        pre code {
+            padding: 0;
+            background: transparent;
+            border-radius: 0;
+            font-size: 0.875em;
+            line-height: 1.55;
+        }
+        
+        /* Blockquotes */
+        blockquote {
+            margin: 1.5em 0;
+            padding: 0.75em 1.25em;
+            border-left: 4px solid var(--blockquote-border);
+            background: var(--blockquote-bg);
+            color: var(--blockquote-text);
+            border-radius: 0 var(--radius) var(--radius) 0;
+        }
+        
+        blockquote p {
+            margin: 0.4em 0;
+        }
+        
+        blockquote p:first-child {
+            margin-top: 0;
+        }
+        
+        blockquote p:last-child {
+            margin-bottom: 0;
+        }
+        
+        /* Tables */
+        table {
+            width: 100%;
+            border-collapse: separate;
+            border-spacing: 0;
+            margin: 1.5em 0;
+            border-radius: var(--radius);
+            overflow: hidden;
+            box-shadow: var(--shadow-sm);
+            border: 1px solid var(--border);
+        }
+        
+        th, td {
+            padding: 0.75em 1em;
+            text-align: left;
+            border-bottom: 1px solid var(--border);
+        }
+        
+        th {
+            font-weight: 600;
+            background: var(--table-header-bg);
+            color: var(--table-header-text);
+        }
+        
+        tr:last-child td {
+            border-bottom: none;
+        }
+        
+        /* Horizontal rule */
+        hr {
+            border: none;
+            height: 2px;
+            max-width: 200px;
+            margin: 2.5em auto;
+            background: var(--border);
+            border-radius: 1px;
+        }
+        
+        /* Images */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: var(--radius);
+            box-shadow: var(--shadow-sm);
+        }
+        
+        /* Task lists */
+        .task-list-item {
+            list-style-type: none;
+        }
+        
+        .task-list-item input[type="checkbox"] {
+            margin-right: 0.5em;
+        }
+        
+        /* Strong and emphasis */
+        strong {
+            font-weight: 700;
+        }
+        
+        /* Definition lists (if supported by parser) */
+        dt {
+            font-weight: 600;
+            margin-top: 1em;
+        }
+        
+        dd {
+            margin-left: 1.5em;
+            margin-bottom: 0.5em;
+        }
+        
+        
+        /* Blueprint: precise technical documentation */
+        h1 {
+            border-bottom: 2px solid var(--primary);
+            padding-bottom: 0.5em;
+        }
+        
+        h2 {
+            color: var(--primary);
+        }
+        
+        a {
+            font-weight: 500;
+        }
+        
+        code {
+            font-size: 0.85em;
+        }
+        
+        pre {
+            border-left: 4px solid var(--primary);
+            border-radius: 0 var(--code-radius) var(--code-radius) 0;
+        }
+        
+        blockquote {
+            background: var(--blockquote-bg);
+        }
+        
+        /* Callout styling: blockquote with bold first line */
+        blockquote strong:first-child {
+            color: var(--primary);
+        }
+        
+        th {
+            text-transform: uppercase;
+            font-size: 0.8em;
+            letter-spacing: 0.06em;
+        }
+        
+        tr:nth-child(even) td {
+            background: var(--alt-row-bg);
+        }
+        
+        hr {
+            background: var(--primary);
+            max-width: 80px;
+            height: 3px;
+        }
+        
+    </style>
+</head>
+<body>
+<article class="markdown-body">
+<h1>DevThrottle Architecture</h1>
+<p>The authoritative, rebuilt-from-scratch architecture documentation for DevThrottle: cc-director, the Gateway, the Cockpit, and the mobile client.</p>
+<blockquote>
+<p><strong>This is a clean-room rebuild.</strong> Every architecture document is being rewritten here from scratch. The documents in the legacy <code>docs/architecture/</code> tree are not trusted and are not authoritative. A document is authoritative only once it has been deliberately re-vetted and placed in this <code>docs/new_architecture/</code> area. All documents here are HTML.</p>
+</blockquote>
+<hr/>
+<h2>Documents</h2>
+<table>
+<thead>
+<tr>
+<th>Document</th>
+<th>Status</th>
+<th>Covers</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="state-and-color-architecture.html">Session State and Color Architecture</a></td>
+<td>HYBRID</td>
+<td>Who owns session activity state and status color. DECIDED: the Director is a sensor (reports the raw activity fact only), the Gateway is the single interpreter (one fold; owns EffectiveColor, TriageBucket, and StateLabel), clients only render. Includes the sensor-versus-interpreter distinction, the target one-direction flow, the full color scheme and precedence, and the current three-fold and circular-flow violation inventory.</td>
+</tr>
+<tr>
+<td><a href="portless-director-gateway-stream.html">Portless Director: one outbound stream to the Gateway</a></td>
+<td>CANDIDATE</td>
+<td>Proposed transport: each Director dials one persistent, bidirectional connection out to the Gateway and exposes no network-facing ports. State pushes up, commands and requests flow both ways, terminal bytes ride outbound byte streams. Records the invariants (no Director-to-Director; all remote access via the Gateway; loopback stays), the reconnect-is-reseed recovery, the accepted consequences, and the open decisions. UNDER CONSIDERATION -- nothing built.</td>
+</tr>
+<tr>
+<td><a href="phase-1-director-gateway-stream-plan.html">Phase 1 plan: Director-to-Gateway push stream</a></td>
+<td>PLAN</td>
+<td>Implementation plan for the first, safe increment of the portless model: move session-state reporting from Gateway-pull to Director-push over a flag-gated SignalR stream, keeping the pull path as fallback. Filed as GitHub issues <a href="https://github.com/thefrederiksen/devthrottle/issues/1176">#1176</a> (Phase 1a, ready for development) and <a href="https://github.com/thefrederiksen/devthrottle/issues/1177">#1177</a> (Phase 1b, blocked on 1a). Source of record for a development agent is the companion <code>.md</code>.</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2>Conventions</h2>
+<ul>
+<li><strong>HTML only.</strong> Every architecture document in this area is delivered as HTML. (Implementation plans handed to a development agent also keep a companion Markdown source of record.)</li>
+<li><strong>Status on every document.</strong> One of CURRENT (describes code that exists), PLANNED / PLAN (intended design or implementation plan), CANDIDATE (proposed, under consideration, nothing built), or HYBRID (each section labels its own status). CURRENT sections carry a "verified against" date.</li>
+<li><strong>Reference code by symbol name</strong> (class, method, field), never by line number, because line numbers drift on every refactor.</li>
+<li><strong>Trusted only.</strong> Nothing is copied over from the legacy tree wholesale. Each document is re-authored and re-verified before it lands here.</li>
+</ul>
+</article>
+</body>
+</html>

--- a/docs/new_architecture/phase-1-director-gateway-stream-improvements.md
+++ b/docs/new_architecture/phase-1-director-gateway-stream-improvements.md
@@ -1,0 +1,236 @@
+# Phase 1 Director-Gateway stream plan improvements
+
+**Status:** REVIEW NOTES -- companion to `phase-1-director-gateway-stream-plan.md`.
+
+**Date:** 2026-07-09
+
+These notes tighten the Phase 1 plan before implementation. The overall plan is sound: it is additive, flag-gated, Director-initiated, keeps pull fallback, and has the right recovery shape. The changes below reduce migration risk and remove ambiguous implementation choices.
+
+---
+
+## 1. Keep Phase 1 clearly smaller than the portless target
+
+The HTML candidate model describes the eventual end-state: commands, history requests, terminal bytes, and state all flow through Director-initiated outbound streams, and the Director exposes no network-facing API.
+
+Phase 1 should remain narrower:
+
+- Move session-state reporting from Gateway pull to Director push.
+- Serve `GET /sessions` from pushed cache when fresh.
+- Keep the existing pull path as fallback.
+- Prove the down direction with one small message.
+- Do not move commands, terminal bytes, history, fleet-comms routing, or Director port exposure.
+
+Recommended doc change: add a short "Phase 1 vs. eventual portless model" section near the top of the plan so an implementation agent does not accidentally build the full HTML candidate.
+
+---
+
+## 2. Replace simple integer epoch with connection generation
+
+The current plan proposes a monotonic `int epoch` incremented on every reconnect. That is not enough across Director process restarts: a restarted Director can begin again at epoch `1` while the Gateway still holds a higher epoch from the previous process.
+
+Use this model instead:
+
+- `streamGenerationId`: a new GUID created by the Director stream client for each logical connection generation.
+- `sequence`: a monotonic integer within that generation.
+- Gateway state per Director stores the active `connectionId`, `streamGenerationId`, and latest `sequence`.
+- Messages from a non-active generation are ignored.
+- Messages from the active generation with `sequence <= latestSequence` are ignored.
+
+This handles stale messages from old connections and process restarts without relying on a durable local counter.
+
+---
+
+## 3. Define duplicate connection ownership
+
+SignalR reconnects can briefly overlap: an old connection may disconnect after a new connection is already active. `OnDisconnectedAsync` must not remove the new connection's cache or active routing entry.
+
+Required store behavior:
+
+- `Register(directorId, connectionId, streamGenerationId)` marks that connection as active for the Director.
+- `Unregister(directorId, connectionId)` only clears connection routing if `connectionId` is still the active one.
+- Snapshot, delta, and remove messages are accepted only from the active connection/generation.
+- A late disconnect from an older connection is logged and ignored.
+
+Add a unit test for "old disconnect does not clear new active connection."
+
+---
+
+## 4. Add remove/tombstone deltas
+
+`PushDelta(SessionDto session)` only upserts. It cannot represent a session that disappeared from the roster.
+
+Add one of these:
+
+- `RemoveSession(sequence, sessionId)` for explicit deletion.
+- `PushDelta(sequence, SessionDto session, bool removed)` if keeping one method is preferred.
+
+The Director should emit a remove/tombstone when:
+
+- A session is removed from the roster.
+- A session exits and should not appear unless `includeExited=true`.
+
+The Gateway should also treat every full snapshot as authoritative for that Director and prune cached sessions not present in the snapshot.
+
+---
+
+## 5. Specify `includeExited` behavior
+
+The current `/sessions` endpoint supports `includeExited=true`. The pushed cache must define how it answers that query.
+
+Recommended Phase 1 rule:
+
+- Full pushed snapshots include the same default live roster that the current Director `GET /sessions` returns.
+- If `includeExited=true`, the Gateway falls back to pull until the stream snapshot source can produce an equivalent exited-inclusive snapshot.
+
+Alternative rule:
+
+- Build `SnapshotFullSessions(includeExited: true)` and keep both live-only and include-exited cache variants.
+
+Do not silently answer `includeExited=true` from a live-only cache.
+
+---
+
+## 6. Reuse the exact Director `SessionDto` mapper
+
+Avoid creating a second `SessionDto` builder for stream snapshots. The existing Control API `/sessions` mapper already owns many details, including identity fields and display-facing fields.
+
+Recommended implementation:
+
+- Extract the Director-side session mapping into a shared method or small service.
+- Use that same code from:
+  - `ControlEndpoints` `/sessions`
+  - `GatewayStreamClient` full snapshots
+  - `GatewayStreamClient` per-session deltas
+
+Acceptance criterion: a test should compare a stream snapshot row with the equivalent local `/sessions` row for the same session.
+
+---
+
+## 7. Copy cached DTOs before Gateway aggregation stamping
+
+`GatewayEndpoints` mutates each `SessionDto` while aggregating:
+
+- `DirectorId`
+- `MachineName`
+- `User`
+- `TailnetEndpoint`
+- `ViewUrl`
+- voice state
+- transcription state
+- `EffectiveColor`
+- `TriageBucket`
+- `NeedsYouSince`
+
+`PushedSessionStore.TryGetFresh` should return copies of cached `SessionDto` objects, not references to the stored cache. Otherwise one request can contaminate the cache for later requests.
+
+Add a unit test that mutating returned sessions does not mutate the store.
+
+---
+
+## 8. Recheck the down-channel proof
+
+The plan says to move the existing assessed-state down-push from HTTP `POST /sessions/{sid}/assessment` to the hub. The Director receiver exists, but current Gateway code appears to have retired the old assessed-state producer.
+
+Before implementation, choose one:
+
+- If an active Gateway sender exists outside the searched path, reference it explicitly in the plan.
+- If no active sender exists, describe this as adding a small proof message, not moving a live production path.
+- If a better live down-channel exists, use that instead so the proof validates a real workflow.
+
+Keep HTTP fallback for any moved live path.
+
+---
+
+## 9. Bind stream identity, not just token validity
+
+A valid token proves the caller is allowed to connect. It does not by itself prove the caller owns the `directorId` claimed in `DirectorStreamHello`.
+
+Recommended rule:
+
+- Resolve the stream's Director identity from trusted registration/device context where possible.
+- If the client sends `directorId`, verify it is allowed for that credential or matches the currently registered Director identity.
+- Reject spoofed or conflicting `directorId` claims.
+- Log accepted and rejected stream identity decisions with enough detail to debug pairing/config problems.
+
+Add an auth test where a valid credential attempts to claim a different `directorId`.
+
+---
+
+## 10. Preserve all current aggregation side effects
+
+Serving pushed sessions must not bypass the rest of `/sessions` behavior. The cache should replace only the fetch step.
+
+The existing post-fetch pipeline still needs to run:
+
+- `SessionOwnerCache.RetainForDirector`
+- `SessionOwnerCache.Remember`
+- query filters
+- machine/user/tailnet/view-url enrichment
+- voice/transcription overlays
+- effective color and triage classification
+- `NeedsYouSince` stamping
+- envelope `machineErrors`
+
+Implementation guidance: split the current fan-out into "get sessions for Director" and keep the downstream aggregation loop unchanged as much as possible.
+
+---
+
+## 11. Add observability for cache-vs-pull decisions
+
+Phase 1's main acceptance criterion is that the Gateway does not pull stream-connected Directors when the pushed cache is fresh. Make this visible.
+
+Add structured logs or counters for:
+
+- stream connected
+- stream disconnected
+- snapshot accepted
+- delta accepted
+- remove accepted
+- stale message dropped
+- `/sessions` served from pushed cache
+- `/sessions` fell back to pull because cache was missing/stale/unsupported query
+- unauthenticated or identity-conflicting stream rejected
+
+The integration tests can assert through a fake pull client, but runtime logs should make field diagnosis easy.
+
+---
+
+## 12. Recommended implementation split
+
+The current plan is implementable as one large PR, but it is at the upper edge of a safe review.
+
+Recommended split:
+
+### Phase 1a: pushed session state
+
+- Contracts/config flag.
+- Gateway hub and authenticated stream registration.
+- `PushedSessionStore` with generation/sequence guard.
+- snapshot, delta, remove/tombstone.
+- `/sessions` cache-first fetch with stale fallback.
+- integration tests for connect, snapshot, delta, remove, stale fallback, auth, flag off.
+
+### Phase 1b: down-channel and polish
+
+- Down-channel proof message or migrated live down path.
+- Director monitor status integration.
+- reconnect hardening tests.
+- skill parity verification.
+- docs wording updates.
+
+This split proves the high-value state path first and keeps the riskier bidirectional polish separate.
+
+---
+
+## 13. Updated acceptance additions
+
+Add these to the Phase 1 definition of done:
+
+- A Director process restart cannot be blocked by an old higher Gateway epoch.
+- A late disconnect from an old connection cannot remove the active connection or cache.
+- Session deletion/removal is reflected without waiting for stale-cache fallback.
+- `includeExited=true` is either correctly served from an equivalent cache or explicitly falls back to pull.
+- Mutating `SessionDto`s during `/sessions` aggregation does not mutate the pushed cache.
+- A valid credential cannot claim another Director's identity.
+- Runtime logs identify whether each Director in `/sessions` was served from pushed cache or pull fallback.
+

--- a/docs/new_architecture/phase-1-director-gateway-stream-plan.html
+++ b/docs/new_architecture/phase-1-director-gateway-stream-plan.html
@@ -1,0 +1,551 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>Phase 1 implementation plan: Director-to-Gateway push stream</title>
+<style>
+        /* Blueprint Theme - Technical documentation style */
+        
+        :root {
+            /* Colors */
+            --primary: #3B82F6;
+            --primary-light: #60A5FA;
+            --accent: #F59E0B;
+            --text: #374151;
+            --heading: #1E3A5F;
+            --background: #FFFFFF;
+            --code-bg: #F1F5F9;
+            --code-text: #0F172A;
+            --border: #CBD5E1;
+            --link: #3B82F6;
+            --blockquote-text: #64748B;
+            --blockquote-border: #3B82F6;
+            --blockquote-bg: #EFF6FF;
+            --table-header-bg: #1E3A5F;
+            --table-header-text: #FFFFFF;
+            --alt-row-bg: #EFF6FF;
+            --shadow-color: rgba(59, 130, 246, 0.08);
+        
+            /* Fonts */
+            --font-heading: "Segoe UI", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            --font-body: "Segoe UI", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            --font-code: "Consolas", "JetBrains Mono", "Fira Code", Consolas, monospace;
+        
+            /* Style */
+            --heading-letter-spacing: -0.01em;
+            --line-height: 1.65;
+            --radius: 6px;
+            --code-radius: 6px;
+            --shadow-sm: 0 1px 3px rgba(59, 130, 246, 0.08);
+            --shadow-md: 0 4px 12px rgba(59, 130, 246, 0.1);
+        }
+        
+        /* Base styles for all themes */
+        
+        *,
+        *::before,
+        *::after {
+            box-sizing: border-box;
+        }
+        
+        html {
+            font-size: 16px;
+            line-height: var(--line-height);
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            text-rendering: optimizeLegibility;
+        }
+        
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: var(--font-body);
+            color: var(--text);
+            background: var(--background);
+        }
+        
+        .markdown-body {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 3rem 2.5rem;
+        }
+        
+        /* Typography */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            color: var(--heading);
+            margin-top: 1.8em;
+            margin-bottom: 0.6em;
+            font-weight: 600;
+            line-height: 1.25;
+            letter-spacing: var(--heading-letter-spacing);
+            orphans: 3;
+            widows: 3;
+        }
+        
+        h1 {
+            font-size: 2.25em;
+            margin-top: 0;
+        }
+        
+        h2 { font-size: 1.65em; }
+        h3 { font-size: 1.35em; }
+        h4 { font-size: 1.1em; }
+        h5 { font-size: 0.95em; }
+        h6 { font-size: 0.85em; color: var(--blockquote-text); }
+        
+        p {
+            margin: 1em 0;
+            orphans: 3;
+            widows: 3;
+        }
+        
+        /* Links */
+        a {
+            color: var(--link);
+            text-decoration: none;
+            border-bottom: 1px solid transparent;
+            transition: border-color 0.2s ease;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--link);
+        }
+        
+        /* Lists */
+        ul, ol {
+            margin: 1em 0;
+            padding-left: 2em;
+            line-height: var(--line-height);
+        }
+        
+        li {
+            margin: 0.35em 0;
+        }
+        
+        li > ul,
+        li > ol {
+            margin: 0.2em 0;
+        }
+        
+        /* Inline code */
+        code {
+            font-family: var(--font-code);
+            font-size: 0.875em;
+            padding: 0.15em 0.4em;
+            border-radius: var(--radius);
+            background: var(--code-bg);
+            color: var(--code-text);
+        }
+        
+        /* Code blocks */
+        pre {
+            margin: 1.5em 0;
+            padding: 1.25em 1.5em;
+            overflow-x: auto;
+            border-radius: var(--code-radius);
+            background: var(--code-bg);
+            border: 1px solid var(--border);
+            box-shadow: var(--shadow-sm);
+            position: relative;
+        }
+        
+        pre code {
+            padding: 0;
+            background: transparent;
+            border-radius: 0;
+            font-size: 0.875em;
+            line-height: 1.55;
+        }
+        
+        /* Blockquotes */
+        blockquote {
+            margin: 1.5em 0;
+            padding: 0.75em 1.25em;
+            border-left: 4px solid var(--blockquote-border);
+            background: var(--blockquote-bg);
+            color: var(--blockquote-text);
+            border-radius: 0 var(--radius) var(--radius) 0;
+        }
+        
+        blockquote p {
+            margin: 0.4em 0;
+        }
+        
+        blockquote p:first-child {
+            margin-top: 0;
+        }
+        
+        blockquote p:last-child {
+            margin-bottom: 0;
+        }
+        
+        /* Tables */
+        table {
+            width: 100%;
+            border-collapse: separate;
+            border-spacing: 0;
+            margin: 1.5em 0;
+            border-radius: var(--radius);
+            overflow: hidden;
+            box-shadow: var(--shadow-sm);
+            border: 1px solid var(--border);
+        }
+        
+        th, td {
+            padding: 0.75em 1em;
+            text-align: left;
+            border-bottom: 1px solid var(--border);
+        }
+        
+        th {
+            font-weight: 600;
+            background: var(--table-header-bg);
+            color: var(--table-header-text);
+        }
+        
+        tr:last-child td {
+            border-bottom: none;
+        }
+        
+        /* Horizontal rule */
+        hr {
+            border: none;
+            height: 2px;
+            max-width: 200px;
+            margin: 2.5em auto;
+            background: var(--border);
+            border-radius: 1px;
+        }
+        
+        /* Images */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: var(--radius);
+            box-shadow: var(--shadow-sm);
+        }
+        
+        /* Task lists */
+        .task-list-item {
+            list-style-type: none;
+        }
+        
+        .task-list-item input[type="checkbox"] {
+            margin-right: 0.5em;
+        }
+        
+        /* Strong and emphasis */
+        strong {
+            font-weight: 700;
+        }
+        
+        /* Definition lists (if supported by parser) */
+        dt {
+            font-weight: 600;
+            margin-top: 1em;
+        }
+        
+        dd {
+            margin-left: 1.5em;
+            margin-bottom: 0.5em;
+        }
+        
+        
+        /* Blueprint: precise technical documentation */
+        h1 {
+            border-bottom: 2px solid var(--primary);
+            padding-bottom: 0.5em;
+        }
+        
+        h2 {
+            color: var(--primary);
+        }
+        
+        a {
+            font-weight: 500;
+        }
+        
+        code {
+            font-size: 0.85em;
+        }
+        
+        pre {
+            border-left: 4px solid var(--primary);
+            border-radius: 0 var(--code-radius) var(--code-radius) 0;
+        }
+        
+        blockquote {
+            background: var(--blockquote-bg);
+        }
+        
+        /* Callout styling: blockquote with bold first line */
+        blockquote strong:first-child {
+            color: var(--primary);
+        }
+        
+        th {
+            text-transform: uppercase;
+            font-size: 0.8em;
+            letter-spacing: 0.06em;
+        }
+        
+        tr:nth-child(even) td {
+            background: var(--alt-row-bg);
+        }
+        
+        hr {
+            background: var(--primary);
+            max-width: 80px;
+            height: 3px;
+        }
+        
+    </style>
+</head>
+<body>
+<article class="markdown-body">
+<h1>Phase 1 implementation plan: Director-to-Gateway push stream</h1>
+<p><strong>Status:</strong> PLAN -- ready to hand to a development agent. Depends on the candidate model in <code>portless-director-gateway-stream.html</code> (UNDER CONSIDERATION). This phase does NOT commit to the full portless end-state; it delivers one safe, additive increment.</p>
+<p><strong>Date:</strong> 2026-07-09 (merged with the review notes in <code>phase-1-director-gateway-stream-improvements.md</code>)</p>
+<hr/>
+<h2>1. Goal (what "done" means)</h2>
+<p>Establish one persistent, bidirectional connection that each Director dials OUT to the Gateway, and move session-state reporting from <strong>Gateway-pulls-Director</strong> to <strong>Director-pushes-Gateway</strong> over that connection -- with <strong>full feature parity</strong> (everything the fleet and Director skills do today still works) and <strong>zero regression risk</strong> (the change is additive and flag-gated; the existing pull path stays as the fallback).</p>
+<p>At the end of Phase 1:</p>
+<ul>
+<li>Each Director holds an open SignalR connection to the Gateway and pushes a full session snapshot on connect, a fresh snapshot on every reconnect, deltas when a session changes, and a remove when a session disappears.</li>
+<li>The Gateway serves <code>GET /sessions</code> for a stream-connected Director from its <strong>pushed cache</strong>, not by fanning out a pull to that Director -- while running the full existing post-fetch aggregation pipeline unchanged.</li>
+<li>The bidirectional channel is proven by a small synthetic down message (see section 4.7).</li>
+<li>A restart of either side self-heals: the Director auto-reconnects and re-seeds; a connection-generation guard drops stale messages.</li>
+<li>Everything is behind a <code>gateway.streamMode</code> flag. Off = today's behaviour, byte-for-byte.</li>
+</ul>
+<h2>2. Phase 1 vs. the eventual portless model (read this first)</h2>
+<p>The HTML candidate model describes the eventual end-state: commands, history requests, terminal bytes, and state all flow through Director-initiated outbound streams, and the Director exposes no network-facing API. <strong>Phase 1 is deliberately much smaller.</strong> An implementation agent must NOT build the portless end-state. Phase 1 is only:</p>
+<ul>
+<li>Move session-state reporting from Gateway pull to Director push.</li>
+<li>Serve <code>GET /sessions</code> from the pushed cache when fresh; keep pull as fallback.</li>
+<li>Prove the down direction with one small message.</li>
+</ul>
+<p>Everything else stays exactly as it is today (see non-goals).</p>
+<h2>3. Non-goals (explicitly later phases -- do NOT do these here)</h2>
+<ul>
+<li>Inverting the terminal byte path (bytes still go the current direct route).</li>
+<li>Removing or loopback-restricting the Director's REST API (portless). The Director stays fully reachable exactly as today.</li>
+<li>Moving commands / fleet-comms routing (prompt, interrupt, hold, message send/ask/spawn) onto the stream. They keep their current REST paths.</li>
+<li>Storing history on the Gateway.</li>
+</ul>
+<h2>4. Design and task breakdown</h2>
+<p>Split into two work items (section 4.8 explains the split). Each subsection notes the review item it addresses.</p>
+<h3>4.1 Contracts (<code>src/CcDirector.Gateway.Contracts</code>)</h3>
+<ul>
+<li>Reuse <code>SessionDto</code> as the snapshot/delta payload (no new session shape).</li>
+<li><code>DirectorStreamHello</code> record: directorId, version.</li>
+<li>Message envelope carries a <strong>connection generation</strong> and a <strong>sequence</strong> (see 4.4), not a bare integer epoch [review #2].</li>
+<li><code>RemoveSession</code> message: generation, sequence, sessionId [review #4].</li>
+</ul>
+<h3>4.2 Config + flag</h3>
+<ul>
+<li>Add <code>StreamMode</code> (bool, default false) and <code>StaleAfterSeconds</code> (default 20) to <code>GatewayConfig</code>.</li>
+<li>When off: no hub client is created and the Gateway ignores the cache (pure current behaviour). This is the regression safety net.</li>
+</ul>
+<h3>4.3 Gateway hub (<code>src/CcDirector.Gateway</code>)</h3>
+<ul>
+<li>Add <code>Microsoft.AspNetCore.SignalR</code> (<code>builder.Services.AddSignalR()</code> near <code>GatewayHost.cs:709</code>).</li>
+<li>New <code>Streaming/DirectorHub.cs</code>:
+        <ul>
+<li><code>OnConnectedAsync</code> / <code>OnDisconnectedAsync</code>: register/unregister against a <code>directorId</code>; log both.</li>
+<li><code>Hello</code>, <code>PushSnapshot(SessionDto[] sessions)</code>, <code>PushDelta(SessionDto session)</code>, <code>RemoveSession(string sessionId)</code> -- all stamped with the connection generation + sequence and accepted only from the active connection (4.4).</li>
+</ul>
+</li>
+<li>Map the hub: <code>_app.MapHub&lt;DirectorHub&gt;("/director-stream")</code> after <code>UseWebSockets()</code> (already present at <code>GatewayHost.cs:806</code>).</li>
+<li>On connect, call <code>DirectorRegistry.MarkStateReporting(directorId)</code> (line ~149) so the reconcile poll already skips it.</li>
+</ul>
+<h3>4.4 Connection generation + duplicate-connection ownership [review #2, #3]</h3>
+<p>Do NOT use a persistent integer epoch (a restarted Director restarts at 1 while the Gateway holds a higher value, and its snapshot would be wrongly rejected).</p>
+<ul>
+<li>Use SignalR's own <code>ConnectionId</code> as the <strong>generation token</strong>: it is unique per connection and changes on every reconnect and every process restart, so no client-minted GUID is needed. Add a monotonic <code>sequence</code> per connection for ordering within a generation.</li>
+<li><code>PushedSessionStore</code> (singleton) per Director stores: <code>activeConnectionId</code>, latest <code>sequence</code>, <code>receivedAt</code>, and <code>List&lt;SessionDto&gt;</code>.</li>
+<li>Rules:
+        <ul>
+<li>A new connection becomes the active connection for its Director; <strong>its first full snapshot is authoritative</strong> and replaces the cache (this is what unblocks a restarted Director).</li>
+<li>Accept snapshot/delta/remove only from the <code>activeConnectionId</code>; within it, ignore any message with <code>sequence &lt;= latestSequence</code>.</li>
+<li><code>Unregister(directorId, connectionId)</code> clears routing <strong>only if</strong> <code>connectionId</code> is still the active one -- a late disconnect from a superseded connection is logged and ignored [review #3].</li>
+</ul>
+</li>
+<li>Every full snapshot is authoritative: <strong>prune</strong> cached sessions for that Director not present in the snapshot [review #4].</li>
+</ul>
+<h3>4.5 Stream identity binding [review #9]</h3>
+<p>A valid token proves the caller may connect; it does not prove it owns the claimed <code>directorId</code>.</p>
+<ul>
+<li>Resolve the Director identity from trusted registration/device context; if the client sends <code>directorId</code>, verify it is allowed for that credential / matches the registered identity.</li>
+<li>Reject spoofed or conflicting <code>directorId</code> claims; log accepted and rejected identity decisions.</li>
+<li>Authenticate the handshake with the existing token/device-key check (<code>GatewayHost.Devices</code> + <code>HasValidToken</code>, the same 3-arg check the PWA routes use).</li>
+</ul>
+<h3>4.6 Gateway aggregation dual-mode (<code>GatewayEndpoints.cs</code>, fan-out near line 414)</h3>
+<ul>
+<li>Split the current fan-out into "<strong>get sessions for this Director</strong>" (cache-first) and the <strong>existing downstream aggregation loop, unchanged</strong> [review #10]. Serving from cache must replace ONLY the fetch step; every post-fetch side effect still runs: <code>SessionOwnerCache.RetainForDirector</code> / <code>.Remember</code>, query filters, machine/user/tailnet/view-url enrichment, voice/transcription overlays, <code>SessionOrdering.EffectiveColor</code> + triage, <code>NeedsYouSince</code> stamping, and envelope <code>machineErrors</code>.</li>
+<li><code>PushedSessionStore.TryGetFresh(directorId, StaleAfterSeconds)</code> returns <strong>deep copies</strong> of the cached <code>SessionDto</code>s, never references -- the aggregation mutates them, so references would contaminate the cache and race concurrent requests [review #7].</li>
+<li><strong>Recompute time-derived fields at serve time</strong> [addition]: cached <code>IdleSeconds</code> is a relative value frozen at push time and would stop advancing for a quiet session (the "Idle Xm" column would stall precisely when idleness matters). Recompute it from the absolute <code>LastActivityAt</code> in the cached DTO (<code>IdleSeconds = now - LastActivityAt</code>). Absolute timestamps cache correctly; only server-computed relative numbers need recomputing.</li>
+<li>Fall back to the existing pull when: no fresh cache, the stream is stale (&gt; <code>StaleAfterSeconds</code>), or the query is unsupported by the cache (see <code>includeExited</code> below).</li>
+<li><code>includeExited=true</code> [review #5]: full pushed snapshots carry the same default live roster the Director's <code>GET /sessions</code> returns; if <code>includeExited=true</code> is requested, <strong>fall back to pull</strong> until the snapshot source can produce an exited-inclusive snapshot. Never answer <code>includeExited=true</code> from a live-only cache.</li>
+</ul>
+<h3>4.7 Director stream client (<code>src/CcDirector.ControlApi</code>)</h3>
+<ul>
+<li>New <code>GatewayStreamClient.cs</code>:
+        <ul>
+<li><code>HubConnection</code> to <code>{gateway.url}/director-stream</code> with <code>WithAutomaticReconnect(backoff)</code> and the auth token in the handshake.</li>
+<li>On start and on <code>Reconnected</code>: push a full snapshot (the new connection makes it authoritative).</li>
+<li>On session-state change (the existing <code>NotifySessionState</code> call sites): push a <code>PushDelta</code>; on session removal/exit-from-default-roster: push a <code>RemoveSession</code> [review #4].</li>
+<li>Feed <code>GatewayConnectionMonitor</code> so the Director window's status dot shows healthy / reconnecting / down.</li>
+</ul>
+</li>
+<li><strong>Reuse the exact Director <code>SessionDto</code> mapper</strong> [review #6]: extract the Control API <code>/sessions</code> mapping into a shared method/service and call it from <code>ControlEndpoints</code> <code>/sessions</code>, the stream full snapshot, and the per-session delta. Do not write a second builder. Acceptance test compares a stream snapshot row to the local <code>/sessions</code> row for the same session.</li>
+<li>Wire in <code>ControlApiHost.BuildGatewayClient</code> (line 572): when <code>streamMode</code> is on, start <code>GatewayStreamClient</code> <strong>alongside</strong> the existing <code>GatewayClient</code> (heartbeat/doorbell stay as the reconcile floor in Phase 1).</li>
+</ul>
+<h3>4.7b Down-channel proof [review #8 -- corrected]</h3>
+<p>Confirmed: there is no live Gateway sender of assessed-state anymore (only comments remain at <code>GatewayEndpoints.cs:495</code>, <code>GatewayHost.cs:821</code>). So do NOT describe this as moving a live path.</p>
+<ul>
+<li>Add a small <strong>synthetic proof message</strong> (e.g. <code>Ping</code> down, <code>Pong</code>/ack up, or an <code>EchoAssessment</code> the Director applies to a log-only annotation) purely to exercise and test the down direction.</li>
+<li>Do NOT move a real command (hold/prompt/interrupt) onto the stream in Phase 1 -- that is command migration, a non-goal. The real down-channel migration belongs to a later phase.</li>
+</ul>
+<h3>4.8 Observability [review #11]</h3>
+<p>Structured logs/counters for: stream connected, stream disconnected, snapshot accepted, delta accepted, remove accepted, stale message dropped, <code>/sessions</code> served from pushed cache, <code>/sessions</code> fell back to pull (missing/stale/unsupported query), unauthenticated or identity-conflicting stream rejected. Runtime logs must make it obvious, per Director per request, whether the answer came from cache or pull.</p>
+<h2>5. Test harness (required deliverable)</h2>
+<p>Formalise the throwaway spike into a real in-process harness in the Gateway test project (create <code>CcDirector.Gateway.Tests</code> if none exists; follow existing <code>*.Tests</code> conventions). <code>StreamHarness</code> boots a real <code>GatewayHost</code> on an ephemeral port and a real <code>GatewayStreamClient</code> in-process with a fake session source. Assert observed behaviour (via a fake pull client) not internals:</p>
+<ol>
+<li>connect + snapshot -&gt; <code>GET /sessions</code> returns pushed sessions and the pull client was NOT called.</li>
+<li>delta -&gt; a single-session change is reflected without a full snapshot.</li>
+<li>remove/tombstone -&gt; a removed session disappears without waiting for stale fallback [review #4].</li>
+<li>snapshot pruning -&gt; a session absent from a new snapshot is dropped.</li>
+<li>stale-generation / restart -&gt; a Director "process restart" (new connection) reseeds and is not blocked by prior state [review #2].</li>
+<li>late disconnect -&gt; an old connection disconnecting after a new one is active does NOT clear the active cache [review #3].</li>
+<li>stale-cache fallback -&gt; no push within <code>StaleAfterSeconds</code> -&gt; aggregation pulls.</li>
+<li>down-proof -&gt; the synthetic down message reaches the Director and is acked.</li>
+<li>auth reject -&gt; unauthenticated connect refused.</li>
+<li>identity binding -&gt; a valid credential claiming a different <code>directorId</code> is rejected [review #9].</li>
+<li>no cache mutation -&gt; mutating returned sessions during aggregation does not mutate the store [review #7].</li>
+<li>mapper parity -&gt; a stream snapshot row equals the local <code>/sessions</code> row for the same session [review #6].</li>
+<li>clock recompute -&gt; a quiet session's <code>IdleSeconds</code> advances across requests served from cache [addition].</li>
+<li>flag off -&gt; with <code>streamMode=false</code>, behaviour is byte-identical to today (pull only).</li>
+</ol>
+<ul>
+<li>Unit tests: <code>PushedSessionStore</code> generation/sequence/prune logic; <code>GatewayStreamClient</code> snapshot/delta/remove; identity binding; DTO deep-copy.</li>
+</ul>
+<h2>6. Skills update (parity verification -- mostly docs)</h2>
+<p>Phase 1 removes no endpoint, so the skills keep working; the task is to PROVE it and touch up transport wording:</p>
+<ul>
+<li><strong>fleet-comms skill</strong>: with <code>streamMode=on</code>, run every verb (<code>session list</code>, <code>message send</code>, <code>message ask</code>, <code>session spawn</code>, <code>session rename</code>, <code>schedule list</code>) and confirm identical results. Update any line describing the Gateway as "pulling" Directors.</li>
+<li><strong>dev-throttle / director skill</strong>: verify the documented Control API endpoints behave identically; update transport wording. No endpoint is removed, so nothing should break.</li>
+<li>Record the verification (a short pass/fail table) in the pull request as proof.</li>
+</ul>
+<h2>7. Acceptance criteria (definition of done)</h2>
+<ul>
+<li>With <code>streamMode=on</code>, a live Director's sessions appear in <code>GET /sessions</code> via push, and logs confirm the Gateway did not pull that Director.</li>
+<li>A Director <strong>process restart</strong> is not blocked by prior Gateway state; it reseeds within a few seconds [review #2].</li>
+<li>A <strong>late disconnect</strong> from an old connection cannot remove the active connection or cache [review #3].</li>
+<li><strong>Session removal</strong> is reflected without waiting for stale-cache fallback [review #4].</li>
+<li><code>includeExited=true</code> is served from an equivalent cache or explicitly falls back to pull [review #5].</li>
+<li>Stream snapshot rows equal local <code>/sessions</code> rows for the same session (shared mapper) [review #6].</li>
+<li>Mutating <code>SessionDto</code>s during aggregation does not mutate the pushed cache [review #7].</li>
+<li>A valid credential cannot claim another Director's identity [review #9].</li>
+<li>All current <code>/sessions</code> aggregation side effects still run for cache-served Directors [review #10].</li>
+<li>A quiet session's <code>IdleSeconds</code> keeps advancing when served from cache [addition].</li>
+<li>Runtime logs identify, per Director per request, cache vs pull [review #11].</li>
+<li>Killing/restarting the Gateway shows the Director auto-reconnecting and re-seeding with no operator action; the connection indicator reflects healthy / reconnecting / down.</li>
+<li>All harness + unit tests pass in CI; all fleet-comms and director-skill verbs pass the parity check with the flag on; with <code>streamMode=off</code> the regression suite is green.</li>
+</ul>
+<h2>8. Recommended implementation split [review #12]</h2>
+<p>Implementable as one PR, but at the upper edge of a safe review. Preferred split:</p>
+<ul>
+<li><strong>Phase 1a -- pushed session state:</strong> contracts + flag; hub + authenticated + identity-bound registration; <code>PushedSessionStore</code> with generation/sequence guard and prune; snapshot + delta + remove; <code>/sessions</code> cache-first fetch with deep-copy, side-effect preservation, clock recompute, and stale/<code>includeExited</code> fallback; shared mapper; harness tests 1-7, 9-14.</li>
+<li><strong>Phase 1b -- down-channel and polish:</strong> synthetic down-proof message (test 8); Director monitor status integration; reconnect hardening; skill parity verification; doc wording.</li>
+</ul>
+<p>1a proves the high-value state path on its own; 1b keeps the bidirectional polish separate.</p>
+<h2>9. Effort estimate</h2>
+<table>
+<thead>
+<tr>
+<th>Area</th>
+<th>Rough effort (focused human)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Contracts + config/flag</td>
+<td>0.5 day</td>
+</tr>
+<tr>
+<td>Gateway hub + <code>PushedSessionStore</code> (generation/sequence/prune) + auth + identity binding</td>
+<td>3 -- 4 days</td>
+</tr>
+<tr>
+<td>Aggregation dual-mode (deep copy, side-effect preservation, clock recompute, includeExited/stale fallback)</td>
+<td>1.5 -- 2 days</td>
+</tr>
+<tr>
+<td>Director stream client + shared-mapper extraction + monitor</td>
+<td>3 -- 4 days</td>
+</tr>
+<tr>
+<td>Down-channel synthetic proof</td>
+<td>0.5 day</td>
+</tr>
+<tr>
+<td>Observability</td>
+<td>0.5 day</td>
+</tr>
+<tr>
+<td>Test harness + unit/integration tests (14 integration + units)</td>
+<td>3 -- 4 days</td>
+</tr>
+<tr>
+<td>Skill parity verification + doc touch-ups</td>
+<td>1 day</td>
+</tr>
+<tr>
+<td>Integration, debugging, review buffer</td>
+<td>1 -- 2 days</td>
+</tr>
+<tr>
+<td><strong>Total</strong></td>
+<td><strong>~14 -- 18 days (about 3 weeks)</strong></td>
+</tr>
+</tbody>
+</table>
+<p>Size: roughly 2,000 -- 3,000 lines including tests. The added correctness rigor (generation model, tombstones/prune, shared mapper, DTO copies, identity binding, clock recompute, expanded tests) pushed this up from the first draft's estimate. <strong>Strongly prefer the 1a/1b split</strong> rather than one PR at this size.</p>
+<h2>10. Risks and mitigations</h2>
+<ul>
+<li><strong>Silent stream wedge showing stale data</strong> -&gt; <code>StaleAfterSeconds</code> fallback to pull; the heartbeat floor still runs in Phase 1.</li>
+<li><strong>Stale/duplicate messages across reconnects and restarts</strong> -&gt; connection-generation + sequence guard (4.4).</li>
+<li><strong>Cache aliasing corruption</strong> -&gt; deep-copy on read (4.6).</li>
+<li><strong>Identity spoofing</strong> -&gt; stream identity binding (4.5).</li>
+<li><strong>Feature drift between pull and push shapes</strong> -&gt; shared mapper (4.7) + parity test.</li>
+<li><strong>Cross-platform</strong> -&gt; pure .NET; proven identical Windows/Mac in the spike.</li>
+<li><strong>Scope creep toward portless</strong> -&gt; the non-goals + section 2 fence; commands and bytes stay on their current paths.</li>
+</ul>
+<h2>11. Document history</h2>
+<table>
+<thead>
+<tr>
+<th>Date</th>
+<th>Author</th>
+<th>Change</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>2026-07-08</td>
+<td>QA Agent (with the owner)</td>
+<td>Initial Phase 1 plan: additive, flag-gated Director-push stream with pull fallback, a required test harness, and skill parity verification.</td>
+</tr>
+<tr>
+<td>2026-07-09</td>
+<td>QA Agent (with the owner)</td>
+<td>Merged all review notes from <code>phase-1-director-gateway-stream-improvements.md</code>: connection-generation guard replacing int epoch (#2/#3), remove/tombstone + snapshot pruning (#4), includeExited rule (#5), shared SessionDto mapper (#6), deep-copy cached DTOs (#7), corrected dead down-channel to a synthetic proof (#8), stream identity binding (#9), preserved aggregation side effects (#10), observability (#11), 1a/1b split (#12), expanded acceptance (#13); plus the serve-time clock-recompute fix for frozen <code>IdleSeconds</code>. Effort re-estimated to ~14-18 days.</td>
+</tr>
+</tbody>
+</table>
+</article>
+</body>
+</html>

--- a/docs/new_architecture/phase-1-director-gateway-stream-plan.md
+++ b/docs/new_architecture/phase-1-director-gateway-stream-plan.md
@@ -1,0 +1,185 @@
+# Phase 1 implementation plan: Director-to-Gateway push stream
+
+**Status:** PLAN -- ready to hand to a development agent. Depends on the candidate model in `portless-director-gateway-stream.html` (UNDER CONSIDERATION). This phase does NOT commit to the full portless end-state; it delivers one safe, additive increment.
+
+**Date:** 2026-07-09 (merged with the review notes in `phase-1-director-gateway-stream-improvements.md`)
+
+---
+
+## 1. Goal (what "done" means)
+
+Establish one persistent, bidirectional connection that each Director dials OUT to the Gateway, and move session-state reporting from **Gateway-pulls-Director** to **Director-pushes-Gateway** over that connection -- with **full feature parity** (everything the fleet and Director skills do today still works) and **zero regression risk** (the change is additive and flag-gated; the existing pull path stays as the fallback).
+
+At the end of Phase 1:
+
+- Each Director holds an open SignalR connection to the Gateway and pushes a full session snapshot on connect, a fresh snapshot on every reconnect, deltas when a session changes, and a remove when a session disappears.
+- The Gateway serves `GET /sessions` for a stream-connected Director from its **pushed cache**, not by fanning out a pull to that Director -- while running the full existing post-fetch aggregation pipeline unchanged.
+- The bidirectional channel is proven by a small synthetic down message (see section 4.7).
+- A restart of either side self-heals: the Director auto-reconnects and re-seeds; a connection-generation guard drops stale messages.
+- Everything is behind a `gateway.streamMode` flag. Off = today's behaviour, byte-for-byte.
+
+## 2. Phase 1 vs. the eventual portless model (read this first)
+
+The HTML candidate model describes the eventual end-state: commands, history requests, terminal bytes, and state all flow through Director-initiated outbound streams, and the Director exposes no network-facing API. **Phase 1 is deliberately much smaller.** An implementation agent must NOT build the portless end-state. Phase 1 is only:
+
+- Move session-state reporting from Gateway pull to Director push.
+- Serve `GET /sessions` from the pushed cache when fresh; keep pull as fallback.
+- Prove the down direction with one small message.
+
+Everything else stays exactly as it is today (see non-goals).
+
+## 3. Non-goals (explicitly later phases -- do NOT do these here)
+
+- Inverting the terminal byte path (bytes still go the current direct route).
+- Removing or loopback-restricting the Director's REST API (portless). The Director stays fully reachable exactly as today.
+- Moving commands / fleet-comms routing (prompt, interrupt, hold, message send/ask/spawn) onto the stream. They keep their current REST paths.
+- Storing history on the Gateway.
+
+## 4. Design and task breakdown
+
+Split into two work items (section 4.8 explains the split). Each subsection notes the review item it addresses.
+
+### 4.1 Contracts (`src/CcDirector.Gateway.Contracts`)
+- Reuse `SessionDto` as the snapshot/delta payload (no new session shape).
+- `DirectorStreamHello` record: directorId, version.
+- Message envelope carries a **connection generation** and a **sequence** (see 4.4), not a bare integer epoch [review #2].
+- `RemoveSession` message: generation, sequence, sessionId [review #4].
+
+### 4.2 Config + flag
+- Add `StreamMode` (bool, default false) and `StaleAfterSeconds` (default 20) to `GatewayConfig`.
+- When off: no hub client is created and the Gateway ignores the cache (pure current behaviour). This is the regression safety net.
+
+### 4.3 Gateway hub (`src/CcDirector.Gateway`)
+- Add `Microsoft.AspNetCore.SignalR` (`builder.Services.AddSignalR()` near `GatewayHost.cs:709`).
+- New `Streaming/DirectorHub.cs`:
+  - `OnConnectedAsync` / `OnDisconnectedAsync`: register/unregister against a `directorId`; log both.
+  - `Hello`, `PushSnapshot(SessionDto[] sessions)`, `PushDelta(SessionDto session)`, `RemoveSession(string sessionId)` -- all stamped with the connection generation + sequence and accepted only from the active connection (4.4).
+- Map the hub: `_app.MapHub<DirectorHub>("/director-stream")` after `UseWebSockets()` (already present at `GatewayHost.cs:806`).
+- On connect, call `DirectorRegistry.MarkStateReporting(directorId)` (line ~149) so the reconcile poll already skips it.
+
+### 4.4 Connection generation + duplicate-connection ownership [review #2, #3]
+Do NOT use a persistent integer epoch (a restarted Director restarts at 1 while the Gateway holds a higher value, and its snapshot would be wrongly rejected).
+
+- Use SignalR's own `ConnectionId` as the **generation token**: it is unique per connection and changes on every reconnect and every process restart, so no client-minted GUID is needed. Add a monotonic `sequence` per connection for ordering within a generation.
+- `PushedSessionStore` (singleton) per Director stores: `activeConnectionId`, latest `sequence`, `receivedAt`, and `List<SessionDto>`.
+- Rules:
+  - A new connection becomes the active connection for its Director; **its first full snapshot is authoritative** and replaces the cache (this is what unblocks a restarted Director).
+  - Accept snapshot/delta/remove only from the `activeConnectionId`; within it, ignore any message with `sequence <= latestSequence`.
+  - `Unregister(directorId, connectionId)` clears routing **only if** `connectionId` is still the active one -- a late disconnect from a superseded connection is logged and ignored [review #3].
+- Every full snapshot is authoritative: **prune** cached sessions for that Director not present in the snapshot [review #4].
+
+### 4.5 Stream identity binding [review #9]
+A valid token proves the caller may connect; it does not prove it owns the claimed `directorId`.
+- Resolve the Director identity from trusted registration/device context; if the client sends `directorId`, verify it is allowed for that credential / matches the registered identity.
+- Reject spoofed or conflicting `directorId` claims; log accepted and rejected identity decisions.
+- Authenticate the handshake with the existing token/device-key check (`GatewayHost.Devices` + `HasValidToken`, the same 3-arg check the PWA routes use).
+
+### 4.6 Gateway aggregation dual-mode (`GatewayEndpoints.cs`, fan-out near line 414)
+- Split the current fan-out into "**get sessions for this Director**" (cache-first) and the **existing downstream aggregation loop, unchanged** [review #10]. Serving from cache must replace ONLY the fetch step; every post-fetch side effect still runs: `SessionOwnerCache.RetainForDirector` / `.Remember`, query filters, machine/user/tailnet/view-url enrichment, voice/transcription overlays, `SessionOrdering.EffectiveColor` + triage, `NeedsYouSince` stamping, and envelope `machineErrors`.
+- `PushedSessionStore.TryGetFresh(directorId, StaleAfterSeconds)` returns **deep copies** of the cached `SessionDto`s, never references -- the aggregation mutates them, so references would contaminate the cache and race concurrent requests [review #7].
+- **Recompute time-derived fields at serve time** [addition]: cached `IdleSeconds` is a relative value frozen at push time and would stop advancing for a quiet session (the "Idle Xm" column would stall precisely when idleness matters). Recompute it from the absolute `LastActivityAt` in the cached DTO (`IdleSeconds = now - LastActivityAt`). Absolute timestamps cache correctly; only server-computed relative numbers need recomputing.
+- Fall back to the existing pull when: no fresh cache, the stream is stale (> `StaleAfterSeconds`), or the query is unsupported by the cache (see `includeExited` below).
+- `includeExited=true` [review #5]: full pushed snapshots carry the same default live roster the Director's `GET /sessions` returns; if `includeExited=true` is requested, **fall back to pull** until the snapshot source can produce an exited-inclusive snapshot. Never answer `includeExited=true` from a live-only cache.
+
+### 4.7 Director stream client (`src/CcDirector.ControlApi`)
+- New `GatewayStreamClient.cs`:
+  - `HubConnection` to `{gateway.url}/director-stream` with `WithAutomaticReconnect(backoff)` and the auth token in the handshake.
+  - On start and on `Reconnected`: push a full snapshot (the new connection makes it authoritative).
+  - On session-state change (the existing `NotifySessionState` call sites): push a `PushDelta`; on session removal/exit-from-default-roster: push a `RemoveSession` [review #4].
+  - Feed `GatewayConnectionMonitor` so the Director window's status dot shows healthy / reconnecting / down.
+- **Reuse the exact Director `SessionDto` mapper** [review #6]: extract the Control API `/sessions` mapping into a shared method/service and call it from `ControlEndpoints` `/sessions`, the stream full snapshot, and the per-session delta. Do not write a second builder. Acceptance test compares a stream snapshot row to the local `/sessions` row for the same session.
+- Wire in `ControlApiHost.BuildGatewayClient` (line 572): when `streamMode` is on, start `GatewayStreamClient` **alongside** the existing `GatewayClient` (heartbeat/doorbell stay as the reconcile floor in Phase 1).
+
+### 4.7b Down-channel proof [review #8 -- corrected]
+Confirmed: there is no live Gateway sender of assessed-state anymore (only comments remain at `GatewayEndpoints.cs:495`, `GatewayHost.cs:821`). So do NOT describe this as moving a live path.
+- Add a small **synthetic proof message** (e.g. `Ping` down, `Pong`/ack up, or an `EchoAssessment` the Director applies to a log-only annotation) purely to exercise and test the down direction.
+- Do NOT move a real command (hold/prompt/interrupt) onto the stream in Phase 1 -- that is command migration, a non-goal. The real down-channel migration belongs to a later phase.
+
+### 4.8 Observability [review #11]
+Structured logs/counters for: stream connected, stream disconnected, snapshot accepted, delta accepted, remove accepted, stale message dropped, `/sessions` served from pushed cache, `/sessions` fell back to pull (missing/stale/unsupported query), unauthenticated or identity-conflicting stream rejected. Runtime logs must make it obvious, per Director per request, whether the answer came from cache or pull.
+
+## 5. Test harness (required deliverable)
+
+Formalise the throwaway spike into a real in-process harness in the Gateway test project (create `CcDirector.Gateway.Tests` if none exists; follow existing `*.Tests` conventions). `StreamHarness` boots a real `GatewayHost` on an ephemeral port and a real `GatewayStreamClient` in-process with a fake session source. Assert observed behaviour (via a fake pull client) not internals:
+
+1. connect + snapshot -> `GET /sessions` returns pushed sessions and the pull client was NOT called.
+2. delta -> a single-session change is reflected without a full snapshot.
+3. remove/tombstone -> a removed session disappears without waiting for stale fallback [review #4].
+4. snapshot pruning -> a session absent from a new snapshot is dropped.
+5. stale-generation / restart -> a Director "process restart" (new connection) reseeds and is not blocked by prior state [review #2].
+6. late disconnect -> an old connection disconnecting after a new one is active does NOT clear the active cache [review #3].
+7. stale-cache fallback -> no push within `StaleAfterSeconds` -> aggregation pulls.
+8. down-proof -> the synthetic down message reaches the Director and is acked.
+9. auth reject -> unauthenticated connect refused.
+10. identity binding -> a valid credential claiming a different `directorId` is rejected [review #9].
+11. no cache mutation -> mutating returned sessions during aggregation does not mutate the store [review #7].
+12. mapper parity -> a stream snapshot row equals the local `/sessions` row for the same session [review #6].
+13. clock recompute -> a quiet session's `IdleSeconds` advances across requests served from cache [addition].
+14. flag off -> with `streamMode=false`, behaviour is byte-identical to today (pull only).
+- Unit tests: `PushedSessionStore` generation/sequence/prune logic; `GatewayStreamClient` snapshot/delta/remove; identity binding; DTO deep-copy.
+
+## 6. Skills update (parity verification -- mostly docs)
+
+Phase 1 removes no endpoint, so the skills keep working; the task is to PROVE it and touch up transport wording:
+- **fleet-comms skill**: with `streamMode=on`, run every verb (`session list`, `message send`, `message ask`, `session spawn`, `session rename`, `schedule list`) and confirm identical results. Update any line describing the Gateway as "pulling" Directors.
+- **dev-throttle / director skill**: verify the documented Control API endpoints behave identically; update transport wording. No endpoint is removed, so nothing should break.
+- Record the verification (a short pass/fail table) in the pull request as proof.
+
+## 7. Acceptance criteria (definition of done)
+
+- With `streamMode=on`, a live Director's sessions appear in `GET /sessions` via push, and logs confirm the Gateway did not pull that Director.
+- A Director **process restart** is not blocked by prior Gateway state; it reseeds within a few seconds [review #2].
+- A **late disconnect** from an old connection cannot remove the active connection or cache [review #3].
+- **Session removal** is reflected without waiting for stale-cache fallback [review #4].
+- `includeExited=true` is served from an equivalent cache or explicitly falls back to pull [review #5].
+- Stream snapshot rows equal local `/sessions` rows for the same session (shared mapper) [review #6].
+- Mutating `SessionDto`s during aggregation does not mutate the pushed cache [review #7].
+- A valid credential cannot claim another Director's identity [review #9].
+- All current `/sessions` aggregation side effects still run for cache-served Directors [review #10].
+- A quiet session's `IdleSeconds` keeps advancing when served from cache [addition].
+- Runtime logs identify, per Director per request, cache vs pull [review #11].
+- Killing/restarting the Gateway shows the Director auto-reconnecting and re-seeding with no operator action; the connection indicator reflects healthy / reconnecting / down.
+- All harness + unit tests pass in CI; all fleet-comms and director-skill verbs pass the parity check with the flag on; with `streamMode=off` the regression suite is green.
+
+## 8. Recommended implementation split [review #12]
+
+Implementable as one PR, but at the upper edge of a safe review. Preferred split:
+
+- **Phase 1a -- pushed session state:** contracts + flag; hub + authenticated + identity-bound registration; `PushedSessionStore` with generation/sequence guard and prune; snapshot + delta + remove; `/sessions` cache-first fetch with deep-copy, side-effect preservation, clock recompute, and stale/`includeExited` fallback; shared mapper; harness tests 1-7, 9-14.
+- **Phase 1b -- down-channel and polish:** synthetic down-proof message (test 8); Director monitor status integration; reconnect hardening; skill parity verification; doc wording. 
+
+1a proves the high-value state path on its own; 1b keeps the bidirectional polish separate.
+
+## 9. Effort estimate
+
+| Area | Rough effort (focused human) |
+|------|------------------------------|
+| Contracts + config/flag | 0.5 day |
+| Gateway hub + `PushedSessionStore` (generation/sequence/prune) + auth + identity binding | 3 -- 4 days |
+| Aggregation dual-mode (deep copy, side-effect preservation, clock recompute, includeExited/stale fallback) | 1.5 -- 2 days |
+| Director stream client + shared-mapper extraction + monitor | 3 -- 4 days |
+| Down-channel synthetic proof | 0.5 day |
+| Observability | 0.5 day |
+| Test harness + unit/integration tests (14 integration + units) | 3 -- 4 days |
+| Skill parity verification + doc touch-ups | 1 day |
+| Integration, debugging, review buffer | 1 -- 2 days |
+| **Total** | **~14 -- 18 days (about 3 weeks)** |
+
+Size: roughly 2,000 -- 3,000 lines including tests. The added correctness rigor (generation model, tombstones/prune, shared mapper, DTO copies, identity binding, clock recompute, expanded tests) pushed this up from the first draft's estimate. **Strongly prefer the 1a/1b split** rather than one PR at this size.
+
+## 10. Risks and mitigations
+
+- **Silent stream wedge showing stale data** -> `StaleAfterSeconds` fallback to pull; the heartbeat floor still runs in Phase 1.
+- **Stale/duplicate messages across reconnects and restarts** -> connection-generation + sequence guard (4.4).
+- **Cache aliasing corruption** -> deep-copy on read (4.6).
+- **Identity spoofing** -> stream identity binding (4.5).
+- **Feature drift between pull and push shapes** -> shared mapper (4.7) + parity test.
+- **Cross-platform** -> pure .NET; proven identical Windows/Mac in the spike.
+- **Scope creep toward portless** -> the non-goals + section 2 fence; commands and bytes stay on their current paths.
+
+## 11. Document history
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-07-08 | QA Agent (with the owner) | Initial Phase 1 plan: additive, flag-gated Director-push stream with pull fallback, a required test harness, and skill parity verification. |
+| 2026-07-09 | QA Agent (with the owner) | Merged all review notes from `phase-1-director-gateway-stream-improvements.md`: connection-generation guard replacing int epoch (#2/#3), remove/tombstone + snapshot pruning (#4), includeExited rule (#5), shared SessionDto mapper (#6), deep-copy cached DTOs (#7), corrected dead down-channel to a synthetic proof (#8), stream identity binding (#9), preserved aggregation side effects (#10), observability (#11), 1a/1b split (#12), expanded acceptance (#13); plus the serve-time clock-recompute fix for frozen `IdleSeconds`. Effort re-estimated to ~14-18 days. |

--- a/docs/new_architecture/portless-director-gateway-stream.html
+++ b/docs/new_architecture/portless-director-gateway-stream.html
@@ -1,0 +1,513 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>Portless Director: one outbound stream to the Gateway</title>
+<style>
+        /* Blueprint Theme - Technical documentation style */
+        
+        :root {
+            /* Colors */
+            --primary: #3B82F6;
+            --primary-light: #60A5FA;
+            --accent: #F59E0B;
+            --text: #374151;
+            --heading: #1E3A5F;
+            --background: #FFFFFF;
+            --code-bg: #F1F5F9;
+            --code-text: #0F172A;
+            --border: #CBD5E1;
+            --link: #3B82F6;
+            --blockquote-text: #64748B;
+            --blockquote-border: #3B82F6;
+            --blockquote-bg: #EFF6FF;
+            --table-header-bg: #1E3A5F;
+            --table-header-text: #FFFFFF;
+            --alt-row-bg: #EFF6FF;
+            --shadow-color: rgba(59, 130, 246, 0.08);
+        
+            /* Fonts */
+            --font-heading: "Segoe UI", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            --font-body: "Segoe UI", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            --font-code: "Consolas", "JetBrains Mono", "Fira Code", Consolas, monospace;
+        
+            /* Style */
+            --heading-letter-spacing: -0.01em;
+            --line-height: 1.65;
+            --radius: 6px;
+            --code-radius: 6px;
+            --shadow-sm: 0 1px 3px rgba(59, 130, 246, 0.08);
+            --shadow-md: 0 4px 12px rgba(59, 130, 246, 0.1);
+        }
+        
+        /* Base styles for all themes */
+        
+        *,
+        *::before,
+        *::after {
+            box-sizing: border-box;
+        }
+        
+        html {
+            font-size: 16px;
+            line-height: var(--line-height);
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            text-rendering: optimizeLegibility;
+        }
+        
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: var(--font-body);
+            color: var(--text);
+            background: var(--background);
+        }
+        
+        .markdown-body {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 3rem 2.5rem;
+        }
+        
+        /* Typography */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            color: var(--heading);
+            margin-top: 1.8em;
+            margin-bottom: 0.6em;
+            font-weight: 600;
+            line-height: 1.25;
+            letter-spacing: var(--heading-letter-spacing);
+            orphans: 3;
+            widows: 3;
+        }
+        
+        h1 {
+            font-size: 2.25em;
+            margin-top: 0;
+        }
+        
+        h2 { font-size: 1.65em; }
+        h3 { font-size: 1.35em; }
+        h4 { font-size: 1.1em; }
+        h5 { font-size: 0.95em; }
+        h6 { font-size: 0.85em; color: var(--blockquote-text); }
+        
+        p {
+            margin: 1em 0;
+            orphans: 3;
+            widows: 3;
+        }
+        
+        /* Links */
+        a {
+            color: var(--link);
+            text-decoration: none;
+            border-bottom: 1px solid transparent;
+            transition: border-color 0.2s ease;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--link);
+        }
+        
+        /* Lists */
+        ul, ol {
+            margin: 1em 0;
+            padding-left: 2em;
+            line-height: var(--line-height);
+        }
+        
+        li {
+            margin: 0.35em 0;
+        }
+        
+        li > ul,
+        li > ol {
+            margin: 0.2em 0;
+        }
+        
+        /* Inline code */
+        code {
+            font-family: var(--font-code);
+            font-size: 0.875em;
+            padding: 0.15em 0.4em;
+            border-radius: var(--radius);
+            background: var(--code-bg);
+            color: var(--code-text);
+        }
+        
+        /* Code blocks */
+        pre {
+            margin: 1.5em 0;
+            padding: 1.25em 1.5em;
+            overflow-x: auto;
+            border-radius: var(--code-radius);
+            background: var(--code-bg);
+            border: 1px solid var(--border);
+            box-shadow: var(--shadow-sm);
+            position: relative;
+        }
+        
+        pre code {
+            padding: 0;
+            background: transparent;
+            border-radius: 0;
+            font-size: 0.875em;
+            line-height: 1.55;
+        }
+        
+        /* Blockquotes */
+        blockquote {
+            margin: 1.5em 0;
+            padding: 0.75em 1.25em;
+            border-left: 4px solid var(--blockquote-border);
+            background: var(--blockquote-bg);
+            color: var(--blockquote-text);
+            border-radius: 0 var(--radius) var(--radius) 0;
+        }
+        
+        blockquote p {
+            margin: 0.4em 0;
+        }
+        
+        blockquote p:first-child {
+            margin-top: 0;
+        }
+        
+        blockquote p:last-child {
+            margin-bottom: 0;
+        }
+        
+        /* Tables */
+        table {
+            width: 100%;
+            border-collapse: separate;
+            border-spacing: 0;
+            margin: 1.5em 0;
+            border-radius: var(--radius);
+            overflow: hidden;
+            box-shadow: var(--shadow-sm);
+            border: 1px solid var(--border);
+        }
+        
+        th, td {
+            padding: 0.75em 1em;
+            text-align: left;
+            border-bottom: 1px solid var(--border);
+        }
+        
+        th {
+            font-weight: 600;
+            background: var(--table-header-bg);
+            color: var(--table-header-text);
+        }
+        
+        tr:last-child td {
+            border-bottom: none;
+        }
+        
+        /* Horizontal rule */
+        hr {
+            border: none;
+            height: 2px;
+            max-width: 200px;
+            margin: 2.5em auto;
+            background: var(--border);
+            border-radius: 1px;
+        }
+        
+        /* Images */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: var(--radius);
+            box-shadow: var(--shadow-sm);
+        }
+        
+        /* Task lists */
+        .task-list-item {
+            list-style-type: none;
+        }
+        
+        .task-list-item input[type="checkbox"] {
+            margin-right: 0.5em;
+        }
+        
+        /* Strong and emphasis */
+        strong {
+            font-weight: 700;
+        }
+        
+        /* Definition lists (if supported by parser) */
+        dt {
+            font-weight: 600;
+            margin-top: 1em;
+        }
+        
+        dd {
+            margin-left: 1.5em;
+            margin-bottom: 0.5em;
+        }
+        
+        
+        /* Blueprint: precise technical documentation */
+        h1 {
+            border-bottom: 2px solid var(--primary);
+            padding-bottom: 0.5em;
+        }
+        
+        h2 {
+            color: var(--primary);
+        }
+        
+        a {
+            font-weight: 500;
+        }
+        
+        code {
+            font-size: 0.85em;
+        }
+        
+        pre {
+            border-left: 4px solid var(--primary);
+            border-radius: 0 var(--code-radius) var(--code-radius) 0;
+        }
+        
+        blockquote {
+            background: var(--blockquote-bg);
+        }
+        
+        /* Callout styling: blockquote with bold first line */
+        blockquote strong:first-child {
+            color: var(--primary);
+        }
+        
+        th {
+            text-transform: uppercase;
+            font-size: 0.8em;
+            letter-spacing: 0.06em;
+        }
+        
+        tr:nth-child(even) td {
+            background: var(--alt-row-bg);
+        }
+        
+        hr {
+            background: var(--primary);
+            max-width: 80px;
+            height: 3px;
+        }
+        
+    </style>
+</head>
+<body>
+<article class="markdown-body">
+<h1>Portless Director: one outbound stream to the Gateway</h1>
+<p><strong>Status:</strong> CANDIDATE -- UNDER CONSIDERATION. Not decided. This records a target model we are actively brainstorming, so we can see it whole and find the holes. Nothing here is built.</p>
+<p><strong>Date:</strong> 2026-07-08</p>
+<p><strong>Relationship to the state-and-color document:</strong> that document decided the Director is a sensor and the Gateway is the single interpreter (one fold). This document proposes HOW the Director and Gateway talk so that rule holds even across machines and Gateway restarts. It replaces the current three-channel model (register + 15s heartbeat + doorbell) plus the on-demand fan-out pull, with a single persistent connection the Director dials out to the Gateway.</p>
+<hr/>
+<h2>The one idea</h2>
+<p>The Director opens exactly one connection -- outbound -- to the Gateway, and keeps it open. Everything flows over it: raw state pushes up, commands and requests flow down, on-demand requests work in both directions, and terminal bytes ride outbound byte streams the Director dials on demand. The Director exposes NO network-facing ports. The Gateway is the only reachable host in the system.</p>
+<p>Because the Director dials out, it needs no inbound firewall port, no port-forward, and no per-machine tailnet address. It works behind any NAT or firewall that allows outbound HTTPS -- home, corporate, cellular, anywhere.</p>
+<hr/>
+<h2>The invariants (these are the "musts")</h2>
+<ol>
+<li><strong>The Director dials the Gateway. The Gateway never dials the Director.</strong> This is the whole point; it is what makes the Director portless.</li>
+<li><strong>No Director ever talks to another Director.</strong> All cross-session messaging, fleet comms, and remote viewing/control is relayed by the Gateway. If any Director-to-Director path survived, something would still need to be reachable and the benefit collapses.</li>
+<li><strong>All remote access goes through the Gateway.</strong> A phone or another machine can only reach a Director by way of the Gateway.</li>
+<li><strong>The Director keeps a loopback-only API.</strong> <code>127.0.0.1</code> only, for the local agent, the cc-* CLI tools, and the Director's own window. This exposes no network port, so it does not violate portless -- and it means local work never depends on the Gateway being up.</li>
+<li><strong>Who-initiates is not who-can-ask.</strong> One Director-initiated connection still carries requests in both directions. The Gateway can ask the Director for history on demand over the open stream; portless forbids only a new inbound connection, not the request/response pattern.</li>
+</ol>
+<hr/>
+<h2>The picture</h2>
+<div style="width:100%;overflow-x:auto">
+<svg style="max-width:100%;height:auto;font-family:Segoe UI,Arial,sans-serif" viewbox="0 0 980 760" width="980" xmlns="http://www.w3.org/2000/svg">
+<defs>
+<marker id="navy" markerheight="10" markerunits="strokeWidth" markerwidth="10" orient="auto" refx="8" refy="3"><path d="M0,0 L8,3 L0,6 Z" fill="#1E3A5F"></path></marker>
+<marker id="green" markerheight="10" markerunits="strokeWidth" markerwidth="10" orient="auto" refx="8" refy="3"><path d="M0,0 L8,3 L0,6 Z" fill="#22C55E"></path></marker>
+<marker id="grey" markerheight="10" markerunits="strokeWidth" markerwidth="10" orient="auto" refx="8" refy="3"><path d="M0,0 L8,3 L0,6 Z" fill="#6B7280"></path></marker>
+<marker id="red" markerheight="10" markerunits="strokeWidth" markerwidth="10" orient="auto" refx="8" refy="3"><path d="M0,0 L8,3 L0,6 Z" fill="#F14C4C"></path></marker>
+</defs>
+<text fill="#6B7280" font-size="13" font-style="italic" text-anchor="middle" x="490" y="26">Browsers reach only the Gateway (unchanged). Directors dial out to the Gateway. Nothing reaches into a Director.</text>
+<rect fill="#F0FDF4" height="52" rx="8" stroke="#22C55E" stroke-width="2" width="150" x="330" y="44"></rect>
+<text fill="#1E3A5F" font-size="12.5" font-weight="700" text-anchor="middle" x="405" y="66">COCKPIT</text>
+<text fill="#374151" font-size="10.5" text-anchor="middle" x="405" y="84">browser . REST + poll 2s</text>
+<rect fill="#FFF7ED" height="52" rx="8" stroke="#F97316" stroke-width="2" width="150" x="500" y="44"></rect>
+<text fill="#1E3A5F" font-size="12.5" font-weight="700" text-anchor="middle" x="575" y="66">MOBILE PWA</text>
+<text fill="#374151" font-size="10.5" text-anchor="middle" x="575" y="84">browser . REST + poll ~4s</text>
+<line marker-end="url(#navy)" stroke="#1E3A5F" stroke-dasharray="6 5" stroke-width="1.6" x1="405" x2="440" y1="96" y2="196"></line>
+<line marker-end="url(#navy)" stroke="#1E3A5F" stroke-dasharray="6 5" stroke-width="1.6" x1="575" x2="540" y1="96" y2="196"></line>
+<rect fill="#FFFFFF" height="128" rx="12" stroke="#1E3A5F" stroke-width="2.5" width="380" x="300" y="198"></rect>
+<rect fill="#1E3A5F" height="30" rx="12" width="380" x="300" y="198"></rect>
+<rect fill="#1E3A5F" height="15" width="380" x="300" y="213"></rect>
+<text fill="#FFFFFF" font-size="13.5" font-weight="700" text-anchor="middle" x="490" y="219">GATEWAY -- the only reachable host</text>
+<text fill="#374151" font-size="11.5" text-anchor="middle" x="490" y="250">holds the live model . folds state once . relays everything</text>
+<text fill="#374151" font-size="11.5" text-anchor="middle" x="490" y="270">stores turn briefs (history: on-demand or stored -- open)</text>
+<text fill="#6B7280" font-size="11" font-style="italic" text-anchor="middle" x="490" y="292">on restart: waits for Directors to redial and re-seed;</text>
+<text fill="#6B7280" font-size="11" font-style="italic" text-anchor="middle" x="490" y="308">serves last-known snapshot marked "reconnecting" meanwhile</text>
+<rect fill="#EFF6FF" height="188" rx="12" stroke="#3B82F6" stroke-width="2.5" width="360" x="70" y="470"></rect>
+<rect fill="#3B82F6" height="30" rx="12" width="360" x="70" y="470"></rect>
+<rect fill="#3B82F6" height="15" width="360" x="70" y="485"></rect>
+<text fill="#FFFFFF" font-size="13" font-weight="700" x="90" y="491">DIRECTOR A (machine 1)</text>
+<text fill="#374151" font-size="11.5" x="90" y="520">sensor + sessions (sees the terminal bytes)</text>
+<text fill="#374151" font-size="11.5" x="90" y="539">rail UI: renders the Gateway fold over the stream;</text>
+<text fill="#374151" font-size="11.5" x="90" y="555">falls back to dumb blue/red/grey if the stream is down</text>
+<text fill="#9A3412" font-size="11.5" font-weight="700" x="90" y="577">NO inbound ports</text>
+<text fill="#166534" font-size="11.5" font-weight="700" x="90" y="596">loopback API only (127.0.0.1) for the local agent + CLI</text>
+<rect fill="#F9FAFB" height="34" rx="7" stroke="#9CA3AF" stroke-width="1.4" width="260" x="120" y="612"></rect>
+<text fill="#374151" font-size="10.5" text-anchor="middle" x="250" y="633">local agent / cc-* CLI -&gt; loopback (no network)</text>
+<rect fill="#EFF6FF" height="188" rx="12" stroke="#3B82F6" stroke-width="2.5" width="360" x="560" y="470"></rect>
+<rect fill="#3B82F6" height="30" rx="12" width="360" x="560" y="470"></rect>
+<rect fill="#3B82F6" height="15" width="360" x="560" y="485"></rect>
+<text fill="#FFFFFF" font-size="13" font-weight="700" x="580" y="491">DIRECTOR B (machine 2)</text>
+<text fill="#374151" font-size="11.5" x="580" y="520">same shape: sensor + sessions, rail UI,</text>
+<text fill="#9A3412" font-size="11.5" font-weight="700" x="580" y="539">NO inbound ports</text>
+<text fill="#166534" font-size="11.5" font-weight="700" x="580" y="558">loopback API only</text>
+<text fill="#374151" font-size="11.5" x="580" y="580">dials its own outbound stream to the same Gateway</text>
+<line marker-end="url(#green)" stroke="#22C55E" stroke-width="3.5" x1="250" x2="430" y1="470" y2="330"></line>
+<line marker-end="url(#green)" stroke="#22C55E" stroke-width="3.5" x1="740" x2="560" y1="470" y2="330"></line>
+<rect fill="#ECFDF5" height="70" rx="8" stroke="#22C55E" stroke-width="2" width="380" x="300" y="356"></rect>
+<text fill="#166534" font-size="12" font-weight="700" text-anchor="middle" x="490" y="378">ONE outbound stream per Director (Director dials)</text>
+<text fill="#374151" font-size="10.8" text-anchor="middle" x="490" y="397">state pushes UP . commands + requests DOWN . requests BOTH ways</text>
+<text fill="#374151" font-size="10.8" text-anchor="middle" x="490" y="414">terminal bytes: separate outbound byte streams, on demand</text>
+<line stroke="#F14C4C" stroke-dasharray="7 5" stroke-width="2" x1="430" x2="560" y1="556" y2="556"></line>
+<text fill="#B91C1C" font-size="11" font-weight="700" text-anchor="middle" x="495" y="548">X never</text>
+<text fill="#B91C1C" font-size="10.5" text-anchor="middle" x="495" y="640">no Director-to-Director -- all via the Gateway</text>
+<text fill="#6B7280" font-size="10.5" transform="rotate(-90 34 360)" x="34" y="360">reconnect = full snapshot (reseed); an epoch drops stale deltas</text>
+</svg>
+</div>
+<p>The single reading: <strong>one outbound stream carries everything; the Director opens no ports; the Gateway is the only door.</strong> A dropped stream is normal -- the Director redials and re-seeds. When the stream is down the desktop keeps working locally on dumb colors; remote access is simply unavailable until it is back.</p>
+<hr/>
+<h2>What collapses into the stream</h2>
+<p>Everything that is a separate Director-Gateway mechanism today becomes one channel:</p>
+<table>
+<thead>
+<tr>
+<th>Today</th>
+<th>Under this model</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Register on start (HTTP)</td>
+<td>Stream connect (with auth in the handshake)</td>
+</tr>
+<tr>
+<td>Heartbeat every 15s (HTTP push)</td>
+<td>Stream keepalive ping + periodic full-snapshot reseed</td>
+</tr>
+<tr>
+<td>Doorbell on change (HTTP push, best-effort)</td>
+<td>Delta pushed up the stream</td>
+</tr>
+<tr>
+<td>Gateway fan-out PULL of each Director /sessions on client poll</td>
+<td>Gateway serves its own in-memory model; no fan-out</td>
+</tr>
+<tr>
+<td>Assessed-state down-push (HTTP into the Director)</td>
+<td>Message down the stream</td>
+</tr>
+<tr>
+<td>Commands: Gateway -&gt; Director HTTP (needs inbound port)</td>
+<td>Message down the stream (no inbound port)</td>
+</tr>
+<tr>
+<td>Terminal bytes: browser -&gt; Director direct (via tailnet)</td>
+<td>Director-dialed outbound byte stream, relayed by the Gateway</td>
+</tr>
+<tr>
+<td>History/turns: Gateway PULLS Director on demand (inbound)</td>
+<td>Request down the stream; Director answers up it</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2>Recovery: reconnect is the same path as first connect</h2>
+<p>The Director is the source of truth; the Gateway is a disposable derived cache. So the Gateway never "reacquires" -- the Director re-asserts. Every attach (first time or thousandth reconnect) begins by sending a full snapshot of every session's current facts; then deltas flow. No diffing, no gap replay. A monotonic epoch per attach lets the Gateway drop any stale message from a dying connection. Nothing is lost because the durable truth (terminal buffer, transcript files, raw facts) never left the Director.</p>
+<hr/>
+<h2>Consequences we accept, eyes open</h2>
+<ul>
+<li><strong>The Gateway becomes a single point of failure for REMOTE access.</strong> With no direct path, when the Gateway is down no phone or other machine can reach a Director at all. The desktop keeps working locally (loopback + dumb colors). This raises the value of Gateway availability later.</li>
+<li><strong>The Gateway enters the byte data path.</strong> Bytes go Director -&gt; Gateway -&gt; browser instead of browser-direct. Measured load is small (single-digit KB/s per watched session), but the Gateway now relays bytes, not just metadata.</li>
+<li><strong>Local fleet comms now depend on the Gateway.</strong> Session-to-session messaging routes local agent -&gt; loopback -&gt; stream -&gt; Gateway -&gt; target Director. A local command to another session needs the Gateway up.</li>
+</ul>
+<hr/>
+<h2>Connection status in the Director window</h2>
+<p>The Director already shows "connected to the Gateway." Under this model that indicator becomes load-bearing: green when the stream is healthy, yellow while reconnecting, red when the stream is down (and the rail has fallen back to local dumb colors). It is the user's single signal for "is remote access working right now."</p>
+<hr/>
+<h2>Open decisions (to settle before building)</h2>
+<table>
+<thead>
+<tr>
+<th style="text-align:center">ID</th>
+<th>Decision</th>
+<th>Leaning</th>
+<th>Status</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:center">S1</td>
+<td>Move Director-Gateway to a single outbound stream?</td>
+<td>Yes</td>
+<td>UNDER CONSIDERATION</td>
+</tr>
+<tr>
+<td style="text-align:center">S2</td>
+<td>Transport / library</td>
+<td>SignalR over WebSocket for control (auto-reconnect, bidirectional, cross-platform .NET); dedicated outbound WebSockets for bytes</td>
+<td>proposed</td>
+</tr>
+<tr>
+<td style="text-align:center">S3</td>
+<td>Interactive INPUT latency through the Gateway relay</td>
+<td>Measure it; likely acceptable (SSH-like), but it is the main new UX risk</td>
+<td>must test</td>
+</tr>
+<tr>
+<td style="text-align:center">S4</td>
+<td>Commands to a disconnected Director</td>
+<td>Reject immediately ("unreachable"); never queue a mutating command</td>
+<td>proposed</td>
+</tr>
+<tr>
+<td style="text-align:center">S5</td>
+<td>History: on-demand over the stream, or stored on the Gateway</td>
+<td>On-demand unless we want history readable while the Director is offline</td>
+<td>open</td>
+</tr>
+<tr>
+<td style="text-align:center">S6</td>
+<td>Migration</td>
+<td>Dual-mode behind a flag (both paths) during transition; not a big-bang</td>
+<td>proposed</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2>Document history</h2>
+<table>
+<thead>
+<tr>
+<th>Date</th>
+<th>Author</th>
+<th>Change</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>2026-07-08</td>
+<td>QA Agent (with the owner)</td>
+<td>Initial candidate. Records the portless single-outbound-stream model, its invariants, the collapse of today's channels into one stream, the reconnect-is-reseed recovery, the accepted consequences, and the open decisions. UNDER CONSIDERATION -- nothing built.</td>
+</tr>
+</tbody>
+</table>
+</article>
+</body>
+</html>

--- a/docs/new_architecture/state-and-color-architecture.html
+++ b/docs/new_architecture/state-and-color-architecture.html
@@ -1,0 +1,622 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>Session State and Color Architecture</title>
+<style>
+        /* Blueprint Theme - Technical documentation style */
+        
+        :root {
+            /* Colors */
+            --primary: #3B82F6;
+            --primary-light: #60A5FA;
+            --accent: #F59E0B;
+            --text: #374151;
+            --heading: #1E3A5F;
+            --background: #FFFFFF;
+            --code-bg: #F1F5F9;
+            --code-text: #0F172A;
+            --border: #CBD5E1;
+            --link: #3B82F6;
+            --blockquote-text: #64748B;
+            --blockquote-border: #3B82F6;
+            --blockquote-bg: #EFF6FF;
+            --table-header-bg: #1E3A5F;
+            --table-header-text: #FFFFFF;
+            --alt-row-bg: #EFF6FF;
+            --shadow-color: rgba(59, 130, 246, 0.08);
+        
+            /* Fonts */
+            --font-heading: "Segoe UI", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            --font-body: "Segoe UI", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            --font-code: "Consolas", "JetBrains Mono", "Fira Code", Consolas, monospace;
+        
+            /* Style */
+            --heading-letter-spacing: -0.01em;
+            --line-height: 1.65;
+            --radius: 6px;
+            --code-radius: 6px;
+            --shadow-sm: 0 1px 3px rgba(59, 130, 246, 0.08);
+            --shadow-md: 0 4px 12px rgba(59, 130, 246, 0.1);
+        }
+        
+        /* Base styles for all themes */
+        
+        *,
+        *::before,
+        *::after {
+            box-sizing: border-box;
+        }
+        
+        html {
+            font-size: 16px;
+            line-height: var(--line-height);
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            text-rendering: optimizeLegibility;
+        }
+        
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: var(--font-body);
+            color: var(--text);
+            background: var(--background);
+        }
+        
+        .markdown-body {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 3rem 2.5rem;
+        }
+        
+        /* Typography */
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--font-heading);
+            color: var(--heading);
+            margin-top: 1.8em;
+            margin-bottom: 0.6em;
+            font-weight: 600;
+            line-height: 1.25;
+            letter-spacing: var(--heading-letter-spacing);
+            orphans: 3;
+            widows: 3;
+        }
+        
+        h1 {
+            font-size: 2.25em;
+            margin-top: 0;
+        }
+        
+        h2 { font-size: 1.65em; }
+        h3 { font-size: 1.35em; }
+        h4 { font-size: 1.1em; }
+        h5 { font-size: 0.95em; }
+        h6 { font-size: 0.85em; color: var(--blockquote-text); }
+        
+        p {
+            margin: 1em 0;
+            orphans: 3;
+            widows: 3;
+        }
+        
+        /* Links */
+        a {
+            color: var(--link);
+            text-decoration: none;
+            border-bottom: 1px solid transparent;
+            transition: border-color 0.2s ease;
+        }
+        
+        a:hover {
+            border-bottom-color: var(--link);
+        }
+        
+        /* Lists */
+        ul, ol {
+            margin: 1em 0;
+            padding-left: 2em;
+            line-height: var(--line-height);
+        }
+        
+        li {
+            margin: 0.35em 0;
+        }
+        
+        li > ul,
+        li > ol {
+            margin: 0.2em 0;
+        }
+        
+        /* Inline code */
+        code {
+            font-family: var(--font-code);
+            font-size: 0.875em;
+            padding: 0.15em 0.4em;
+            border-radius: var(--radius);
+            background: var(--code-bg);
+            color: var(--code-text);
+        }
+        
+        /* Code blocks */
+        pre {
+            margin: 1.5em 0;
+            padding: 1.25em 1.5em;
+            overflow-x: auto;
+            border-radius: var(--code-radius);
+            background: var(--code-bg);
+            border: 1px solid var(--border);
+            box-shadow: var(--shadow-sm);
+            position: relative;
+        }
+        
+        pre code {
+            padding: 0;
+            background: transparent;
+            border-radius: 0;
+            font-size: 0.875em;
+            line-height: 1.55;
+        }
+        
+        /* Blockquotes */
+        blockquote {
+            margin: 1.5em 0;
+            padding: 0.75em 1.25em;
+            border-left: 4px solid var(--blockquote-border);
+            background: var(--blockquote-bg);
+            color: var(--blockquote-text);
+            border-radius: 0 var(--radius) var(--radius) 0;
+        }
+        
+        blockquote p {
+            margin: 0.4em 0;
+        }
+        
+        blockquote p:first-child {
+            margin-top: 0;
+        }
+        
+        blockquote p:last-child {
+            margin-bottom: 0;
+        }
+        
+        /* Tables */
+        table {
+            width: 100%;
+            border-collapse: separate;
+            border-spacing: 0;
+            margin: 1.5em 0;
+            border-radius: var(--radius);
+            overflow: hidden;
+            box-shadow: var(--shadow-sm);
+            border: 1px solid var(--border);
+        }
+        
+        th, td {
+            padding: 0.75em 1em;
+            text-align: left;
+            border-bottom: 1px solid var(--border);
+        }
+        
+        th {
+            font-weight: 600;
+            background: var(--table-header-bg);
+            color: var(--table-header-text);
+        }
+        
+        tr:last-child td {
+            border-bottom: none;
+        }
+        
+        /* Horizontal rule */
+        hr {
+            border: none;
+            height: 2px;
+            max-width: 200px;
+            margin: 2.5em auto;
+            background: var(--border);
+            border-radius: 1px;
+        }
+        
+        /* Images */
+        img {
+            max-width: 100%;
+            height: auto;
+            border-radius: var(--radius);
+            box-shadow: var(--shadow-sm);
+        }
+        
+        /* Task lists */
+        .task-list-item {
+            list-style-type: none;
+        }
+        
+        .task-list-item input[type="checkbox"] {
+            margin-right: 0.5em;
+        }
+        
+        /* Strong and emphasis */
+        strong {
+            font-weight: 700;
+        }
+        
+        /* Definition lists (if supported by parser) */
+        dt {
+            font-weight: 600;
+            margin-top: 1em;
+        }
+        
+        dd {
+            margin-left: 1.5em;
+            margin-bottom: 0.5em;
+        }
+        
+        
+        /* Blueprint: precise technical documentation */
+        h1 {
+            border-bottom: 2px solid var(--primary);
+            padding-bottom: 0.5em;
+        }
+        
+        h2 {
+            color: var(--primary);
+        }
+        
+        a {
+            font-weight: 500;
+        }
+        
+        code {
+            font-size: 0.85em;
+        }
+        
+        pre {
+            border-left: 4px solid var(--primary);
+            border-radius: 0 var(--code-radius) var(--code-radius) 0;
+        }
+        
+        blockquote {
+            background: var(--blockquote-bg);
+        }
+        
+        /* Callout styling: blockquote with bold first line */
+        blockquote strong:first-child {
+            color: var(--primary);
+        }
+        
+        th {
+            text-transform: uppercase;
+            font-size: 0.8em;
+            letter-spacing: 0.06em;
+        }
+        
+        tr:nth-child(even) td {
+            background: var(--alt-row-bg);
+        }
+        
+        hr {
+            background: var(--primary);
+            max-width: 80px;
+            height: 3px;
+        }
+        
+    </style>
+</head>
+<body>
+<article class="markdown-body">
+<h1>Session State and Color Architecture</h1>
+<p><strong>Status:</strong> HYBRID. The target ownership rule (sections 1-6) is DECIDED (owner, 2026-07-08). The color scheme (section 7) and the violation inventory (section 9) are CURRENT: they describe the code as it exists today.</p>
+<p><strong>Date:</strong> 2026-07-08</p>
+<p><strong>Verified against:</strong> working tree on 2026-07-08 (main). Code is referenced by symbol name; verify before acting.</p>
+<p><strong>Audience:</strong> Anyone who touches session status, activity state, or color in the Director, the Gateway, the Cockpit, or the mobile client. Read this before adding any state or color rule anywhere.</p>
+<hr/>
+<h2>The state map (at a glance)</h2>
+<p>Where every piece of state comes from, where it is decided, and how a change reaches each screen. State converges on the Gateway, is folded exactly once, and fans back out to the viewers. Commands travel the other way: any client sends a command up to the Gateway, which is the only place state actually changes.</p>
+<div style="width:100%;overflow-x:auto">
+<svg style="max-width:100%;height:auto;font-family:Segoe UI,Arial,sans-serif" viewbox="0 0 960 900" width="960" xmlns="http://www.w3.org/2000/svg">
+<defs>
+<marker id="navy" markerheight="10" markerunits="strokeWidth" markerwidth="10" orient="auto" refx="8" refy="3">
+<path d="M0,0 L8,3 L0,6 Z" fill="#1E3A5F"></path>
+</marker>
+<marker id="green" markerheight="10" markerunits="strokeWidth" markerwidth="10" orient="auto" refx="8" refy="3">
+<path d="M0,0 L8,3 L0,6 Z" fill="#22C55E"></path>
+</marker>
+<marker id="orange" markerheight="10" markerunits="strokeWidth" markerwidth="10" orient="auto" refx="8" refy="3">
+<path d="M0,0 L8,3 L0,6 Z" fill="#F97316"></path>
+</marker>
+<marker id="grey" markerheight="10" markerunits="strokeWidth" markerwidth="10" orient="auto" refx="8" refy="3">
+<path d="M0,0 L8,3 L0,6 Z" fill="#6B7280"></path>
+</marker>
+</defs>
+<!-- Agent process (external source) -->
+<rect fill="#F9FAFB" height="52" rx="8" stroke="#9CA3AF" stroke-width="1.5" width="360" x="300" y="16"></rect>
+<text fill="#374151" font-size="14" font-weight="700" text-anchor="middle" x="480" y="40">Agent process (Claude Code, Codex, Gemini)</text>
+<text fill="#6B7280" font-size="11" text-anchor="middle" x="480" y="58">the terminal being observed -- external, not ours</text>
+<!-- Agent -> Director -->
+<line marker-end="url(#grey)" stroke="#6B7280" stroke-width="2" x1="480" x2="480" y1="68" y2="102"></line>
+<text fill="#6B7280" font-size="11.5" x="492" y="90">raw bytes . turn-end . exit . crash</text>
+<!-- Director (sensor) -->
+<rect fill="#EFF6FF" height="120" rx="10" stroke="#3B82F6" stroke-width="2" width="680" x="140" y="104"></rect>
+<rect fill="#3B82F6" height="30" rx="10" width="680" x="140" y="104"></rect>
+<rect fill="#3B82F6" height="15" width="680" x="140" y="119"></rect>
+<text fill="#FFFFFF" font-size="13" font-weight="700" x="160" y="124">DIRECTOR -- SENSOR (the only place that sees the bytes)</text>
+<text fill="#1E3A5F" font-size="12" font-style="italic" x="160" y="154">Tier 1 -- raw facts, written by nothing else:</text>
+<text fill="#374151" font-size="12" x="160" y="174">ActivityState (Working / Waiting) . idle seconds . alt-screen</text>
+<text fill="#374151" font-size="12" x="160" y="192">brand-new . exited . background-running . controller link</text>
+<text fill="#6B7280" font-size="11.5" font-style="italic" x="160" y="212">reports facts only -- never a color, never "needs you"</text>
+<!-- Director -> Gateway -->
+<line marker-end="url(#navy)" stroke="#1E3A5F" stroke-width="2" x1="480" x2="480" y1="224" y2="266"></line>
+<text fill="#1E3A5F" font-size="11.5" x="492" y="250">Tier-1 facts up (no color)</text>
+<!-- Gateway (interpreter, the fold) -->
+<rect fill="#FFFFFF" height="238" rx="12" stroke="#1E3A5F" stroke-width="2.5" width="780" x="90" y="268"></rect>
+<rect fill="#1E3A5F" height="32" rx="12" width="780" x="90" y="268"></rect>
+<rect fill="#1E3A5F" height="16" width="780" x="90" y="284"></rect>
+<text fill="#FFFFFF" font-size="13.5" font-weight="700" x="110" y="290">GATEWAY -- THE ONE INTERPRETER (this is the only place state changes)</text>
+<text fill="#1E3A5F" font-size="12" font-style="italic" x="112" y="326">Tier 2 -- brain / service facts (Gateway-only):</text>
+<text fill="#374151" font-size="11.5" x="112" y="345">briefing . voice preparing/ready . transcribing</text>
+<text fill="#374151" font-size="11.5" x="112" y="362">explaining . assessed-state (refutes the quiet)</text>
+<text fill="#1E3A5F" font-size="12" font-style="italic" x="470" y="326">Tier 3 -- user intent (ALL commands land here):</text>
+<text fill="#374151" font-size="11.5" x="470" y="345">on-hold . voice-mode . wingman-enabled</text>
+<text fill="#374151" font-size="11.5" x="470" y="362">explain-request . rename . reorder</text>
+<!-- the fold bar -->
+<rect fill="#ECFDF5" height="56" rx="8" stroke="#22C55E" stroke-width="2" width="736" x="112" y="384"></rect>
+<text fill="#166534" font-size="13" font-weight="700" text-anchor="middle" x="480" y="407">&gt;&gt; THE ONE FOLD (first match wins)</text>
+<text fill="#1E3A5F" font-size="13" font-weight="700" text-anchor="middle" x="480" y="428">EffectiveColor + TriageBucket + StateLabel</text>
+<text fill="#6B7280" font-size="11.5" font-style="italic" text-anchor="middle" x="480" y="466">computed once, here -- every viewer renders this, none recompute</text>
+<!-- Fold -> viewers -->
+<line marker-end="url(#green)" stroke="#22C55E" stroke-width="3" x1="200" x2="200" y1="506" y2="592"></line>
+<text fill="#166534" font-size="11.5" font-weight="700" x="120" y="545">down-push</text>
+<text fill="#166534" font-size="11.5" font-weight="700" x="120" y="561">(instant)</text>
+<line marker-end="url(#navy)" stroke="#1E3A5F" stroke-dasharray="6 5" stroke-width="2" x1="480" x2="480" y1="506" y2="592"></line>
+<text fill="#1E3A5F" font-size="11.5" x="492" y="551">poll 2s</text>
+<line marker-end="url(#navy)" stroke="#1E3A5F" stroke-dasharray="6 5" stroke-width="2" x1="760" x2="760" y1="506" y2="592"></line>
+<text fill="#1E3A5F" font-size="11.5" x="772" y="551">poll ~4s</text>
+<!-- Viewer boxes -->
+<rect fill="#EFF6FF" height="96" rx="10" stroke="#3B82F6" stroke-width="2" width="220" x="90" y="594"></rect>
+<rect fill="#1E3A5F" height="28" rx="10" width="220" x="90" y="594"></rect>
+<rect fill="#1E3A5F" height="14" width="220" x="90" y="608"></rect>
+<text fill="#FFFFFF" font-size="12.5" font-weight="700" text-anchor="middle" x="200" y="613">DESKTOP RAIL</text>
+<text fill="#374151" font-size="11.5" text-anchor="middle" x="200" y="645">renders the fold</text>
+<text fill="#166534" font-size="11.5" font-weight="700" text-anchor="middle" x="200" y="665">gets down-push -- instant</text>
+<text fill="#6B7280" font-size="10.5" font-style="italic" text-anchor="middle" x="200" y="683">standalone: dumb blue/red/grey</text>
+<rect fill="#F0FDF4" height="96" rx="10" stroke="#22C55E" stroke-width="2" width="220" x="370" y="594"></rect>
+<rect fill="#1E3A5F" height="28" rx="10" width="220" x="370" y="594"></rect>
+<rect fill="#1E3A5F" height="14" width="220" x="370" y="608"></rect>
+<text fill="#FFFFFF" font-size="12.5" font-weight="700" text-anchor="middle" x="480" y="613">COCKPIT (browser)</text>
+<text fill="#374151" font-size="11.5" text-anchor="middle" x="480" y="645">renders the fold</text>
+<text fill="#374151" font-size="11.5" text-anchor="middle" x="480" y="665">polls every 2s</text>
+<rect fill="#FFF7ED" height="96" rx="10" stroke="#F97316" stroke-width="2" width="220" x="650" y="594"></rect>
+<rect fill="#1E3A5F" height="28" rx="10" width="220" x="650" y="594"></rect>
+<rect fill="#1E3A5F" height="14" width="220" x="650" y="608"></rect>
+<text fill="#FFFFFF" font-size="12.5" font-weight="700" text-anchor="middle" x="760" y="613">MOBILE PWA (browser)</text>
+<text fill="#374151" font-size="11.5" text-anchor="middle" x="760" y="645">renders the fold</text>
+<text fill="#374151" font-size="11.5" text-anchor="middle" x="760" y="665">polls every ~4s</text>
+<!-- Command path callout -->
+<rect fill="#FFF7ED" height="70" rx="10" stroke="#F97316" stroke-width="2" width="780" x="90" y="726"></rect>
+<text fill="#9A3412" font-size="12.5" font-weight="700" x="110" y="750">Commands go UP (any client -&gt; Gateway): on-hold . voice-mode . wingman-enabled . explain . rename</text>
+<text fill="#7C2D12" font-size="11.5" x="110" y="770">The Gateway flips the bit, re-folds, and returns the updated session in the response --</text>
+<text fill="#7C2D12" font-size="11.5" x="110" y="787">the client that sent the command renders it instantly (optimistic + authoritative echo).</text>
+<!-- Command up arrow connecting callout to gateway -->
+<line marker-end="url(#orange)" stroke="#F97316" stroke-dasharray="7 5" stroke-width="2.5" x1="832" x2="832" y1="726" y2="510"></line>
+<text fill="#9A3412" font-size="10.5" font-weight="700" transform="rotate(90 838 620)" x="838" y="620"></text>
+<!-- Terminal bytes fast path note -->
+<line stroke="#6B7280" stroke-dasharray="4 4" stroke-width="1.5" x1="120" x2="60" y1="164" y2="164"></line>
+<line stroke="#6B7280" stroke-dasharray="4 4" stroke-width="1.5" x1="60" x2="60" y1="164" y2="642"></line>
+<line marker-end="url(#grey)" stroke="#6B7280" stroke-dasharray="4 4" stroke-width="1.5" x1="60" x2="88" y1="642" y2="642"></line>
+<text fill="#6B7280" font-size="10.5" transform="rotate(-90 52 410)" x="52" y="410">terminal bytes: direct WebSocket, bypasses the fold</text>
+</svg>
+</div>
+<p>The one-line reading: <strong>the Director senses, the Gateway decides, the viewers render.</strong> A change is instant for whoever made it (the command echoes the new state back) and for the desktop rail (a down-push), and lands within one poll for the browsers. Terminal bytes are a separate fast path -- a direct WebSocket from the Director to whichever viewer has the session open -- and never pass through the fold.</p>
+<hr/>
+<h2>Related documents</h2>
+<ul>
+<li>The hands / brain / face vision document (legacy tree). This document supersedes its section 4.2 decision ("the Director owns a dumb always-on two-state signal"): the Director still detects the raw signal, but it no longer owns a state. It reports a fact, and the Gateway owns the state. See section 5.</li>
+<li>The broader "fat Gateway, dumb apps" presentation-consolidation plan (legacy tree). This document is the authority for the state and color slice of that plan.</li>
+<li>Code: <code>TerminalStateDetector</code> (the sensor), <code>SessionStatusWingman</code> (the Director's current color fold, to be removed), <code>SessionOrdering.EffectiveColor</code> (the Gateway's fold, the future single fold), <code>SessionDto</code> (the wire contract).</li>
+</ul>
+<hr/>
+<h2>1. The one rule (DECIDED)</h2>
+<p>The cc-director holds zero authority over interpreted session state and color. It is a sensor, not an interpreter. It observes raw terminal activity and reports it as a fact. The Gateway is the single master of interpreted state and color. Every client renders the Gateway's field; no client re-derives it, including the desktop app when a Gateway is connected.</p>
+<p>This is the settled decision. The rest of the document explains why it is safe, what "sensor" means precisely, and what has to change to get there.</p>
+<hr/>
+<h2>2. Sensor versus interpreter</h2>
+<p>The confusion in the current code comes from conflating two different things under the word "state." Separate them and every ownership question answers itself.</p>
+<p>A <strong>fact</strong> is something only the observer can know. For example: "bytes came out of this terminal at time T," or "this terminal has been silent since time T." Only the process that holds the live terminal can know these. Reporting a fact is not an act of authority; it is a sensor reading.</p>
+<p>An <strong>interpretation</strong> is a judgment layered on top of facts. For example: "silent for 10 seconds, and not being briefed, and not transcribing, and not preparing voice, therefore this session NEEDS YOU, therefore paint it red." Or: "this session is parked on its own background build, therefore paint it purple, not red."</p>
+<p>An interpretation needs inputs beyond the byte stream (briefing state, voice readiness, on-hold, transcribing, sub-agent relationships) and it encodes policy. It belongs to the layer that has all those inputs and owns the policy: the Gateway.</p>
+<p>Restated in plain terms: "when keystrokes happen, the Director just lets the Gateway know, and the Gateway can do anything." The keystroke or byte notification is the sensor reading. Agreed and adopted.</p>
+<hr/>
+<h2>3. Why the sensor must stay in the Director</h2>
+<p>The raw signal is a function of the live terminal byte stream and the rendered terminal grid, not a simple "a key was pressed." The <code>TerminalStateDetector</code> today:</p>
+<ul>
+<li>flags Working the instant a byte arrives, and re-arms an idle countdown on every byte;</li>
+<li>distinguishes a real body change from a footer-only repaint;</li>
+<li>suppresses spinner and animation frames so a spinning session does not read as "working forever";</li>
+<li>applies a brand-new grace window so a fresh session does not flash blue before it has done anything.</li>
+</ul>
+<p>That is genuine raw-signal plumbing that must live next to the bytes. Moving it to the Gateway would mean streaming every byte of every terminal on every machine to the Gateway continuously, which is exactly the coupling this architecture removes.</p>
+<p>So the sensor is local. But it emits a fact (Working or Waiting, plus a timestamp), never a color and never "needs you."</p>
+<hr/>
+<h2>4. Where the silence threshold lives (CONFIRM)</h2>
+<p>Question: the "silent for 10 seconds, therefore waiting" threshold. Does the Director own it, or does the Gateway?</p>
+<p>Recommendation: detection runs in the Director (it must, because the bytes are there), but the threshold is a configuration value with a local default of 10 seconds that the Gateway can override by pushing config down.</p>
+<p>Why: this gives "the Gateway can change the rule fleet-wide without a Director release," which serves the goal that the Director changes as rarely as possible, while keeping the sensor able to run standalone with a sane default. Changing 10 seconds to 5 seconds becomes a Gateway config change, not a Director code change and redeploy.</p>
+<p>What we do not do: forward every raw byte heartbeat to the Gateway and have the Gateway run per-session silence timers for the whole fleet. That adds Gateway-side timing state and a constant heartbeat for no benefit the config-override approach does not already give us.</p>
+<hr/>
+<h2>5. The target flow: one direction, one fold</h2>
+<pre><code>DIRECTOR  (sensor - the only place that sees the bytes)
+           terminal bytes  -&gt;  ActivityState fact: Working | Waiting + sinceTimestamp
+           plus the raw local facts it already knows:
+             isBrandNew, controllerSessionId, isBackgroundRunning, isExited
+                |
+                |  reports facts up (no color, no interpretation)
+                v
+        GATEWAY  (interpreter - the single master of state and color)
+           raw ActivityState fact
+             + briefing state            (Gateway brain owns this)
+             + voice generating / ready  (Gateway WingmanVoiceService owns this)
+             + transcribing              (Gateway owns this)
+             + on-hold, sub-agent support, background, brand-new
+                =&gt;  ONE fold  =&gt;  EffectiveColor + TriageBucket + StateLabel
+                |
+                |  stamps the computed fields on SessionDto, sends down
+                v
+        CLIENTS  (Cockpit, mobile, and the desktop rail when connected)
+           render EffectiveColor / TriageBucket / StateLabel. No re-derivation anywhere.
+        </code></pre>
+<p>The defining property: state and color flow in one direction only, and the fold happens exactly once, at the Gateway. Contrast this with the current circular flow in section 9.</p>
+<hr/>
+<h2>6. What the Director stops doing</h2>
+<p>Under this rule the following moves off the Director:</p>
+<ul>
+<li><strong>Delete the overlay fold.</strong> <code>SessionStatusWingman.ResolveActivityColor</code> currently folds seven overlays (transcribing, briefing, explaining, background, brand-new, supporting, voice-preparing) into <code>Session.StatusColor</code>. That fold is deleted from the Director. It exists once, at the Gateway.</li>
+<li><strong>Stop writing an interpreted status color.</strong> The Director reports the raw ActivityState fact and the underlying raw facts (isBrandNew, controllerSessionId, isBackgroundRunning). It does not decide what color those add up to.</li>
+<li><strong>Stop consuming pushed-down interpreted state to re-fold it.</strong> The Gateway no longer pushes briefing, voice, or assessed state down into the Director so the Director can fold it into a color. That downward re-fold leg is removed; it is the loop described in section 9.</li>
+</ul>
+<p>What the Director keeps: the <code>TerminalStateDetector</code> sensor, the raw fact it emits, and (only for the standalone fallback in section 8) a trivial local color map.</p>
+<hr/>
+<h2>7. The color scheme</h2>
+<p>This is the full set of colors and their meanings, in precedence order (first match wins). Today this logic is split across <code>SessionOrdering.EffectiveColor</code> and <code>SessionStatusWingman.ResolveActivityColor</code>. The target is that it lives once, at the Gateway.</p>
+<table>
+<thead>
+<tr>
+<th style="text-align:center">Order</th>
+<th>Color</th>
+<th>Meaning</th>
+<th>Driven by</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:center">1</td>
+<td><span style="display:inline-block;width:18px;height:18px;border-radius:4px;background:#6B7280;border:1px solid rgba(0,0,0,0.25);vertical-align:middle;margin-right:8px"></span> <strong>Grey</strong> <code>#6B7280</code></td>
+<td>On hold or parked by the user or agent; also an exited process. Sinks to the bottom of triage.</td>
+<td>OnHold, or Exited</td>
+</tr>
+<tr>
+<td style="text-align:center">2</td>
+<td><span style="display:inline-block;width:18px;height:18px;border-radius:4px;background:#F97316;border:1px solid rgba(0,0,0,0.25);vertical-align:middle;margin-right:8px"></span> <strong>Orange</strong> <code>#F97316</code></td>
+<td>Busy receiving input that must not be interrupted: a dictated utterance is transcribing, or a user-requested "explain" deep dive is running. Shown regardless of underlying activity so no one else types into the session.</td>
+<td>Transcribing, or briefing state Explaining</td>
+</tr>
+<tr>
+<td style="text-align:center">3</td>
+<td><span style="display:inline-block;width:18px;height:18px;border-radius:4px;background:#F59E0B;border:1px solid rgba(0,0,0,0.25);vertical-align:middle;margin-right:8px"></span> <strong>Yellow</strong> <code>#F59E0B</code></td>
+<td>The Wingman is reading a finished turn (briefing in flight), or a voice-mode session is preparing its spoken audio. We do not yet know whether it needs you.</td>
+<td>briefing state Briefing at a turn-end, or voice preparing</td>
+</tr>
+<tr>
+<td style="text-align:center">4</td>
+<td><span style="display:inline-block;width:18px;height:18px;border-radius:4px;background:#A855F7;border:1px solid rgba(0,0,0,0.25);vertical-align:middle;margin-right:8px"></span> <strong>Purple</strong> <code>#A855F7</code></td>
+<td>The session is parked on its own background task (a build, a running shell), not on the user.</td>
+<td>IsBackgroundRunning at a turn-end</td>
+</tr>
+<tr>
+<td style="text-align:center">5</td>
+<td><span style="display:inline-block;width:18px;height:18px;border-radius:4px;background:#64748B;border:1px solid rgba(0,0,0,0.25);vertical-align:middle;margin-right:8px"></span> <strong>Slate</strong> <code>#64748B</code></td>
+<td>A sub-agent being driven by another session; it recedes so the operator is not nagged. Red still breaks through this.</td>
+<td>IsControlled and the controller is alive</td>
+</tr>
+<tr>
+<td style="text-align:center">6</td>
+<td><span style="display:inline-block;width:18px;height:18px;border-radius:4px;background:#22C55E;border:1px solid rgba(0,0,0,0.25);vertical-align:middle;margin-right:8px"></span> <strong>Green</strong> <code>#22C55E</code></td>
+<td>Ready: a brand-new session sitting at its prompt, available, not yet having taken a turn.</td>
+<td>IsBrandNew at a turn-end</td>
+</tr>
+<tr>
+<td style="text-align:center">7</td>
+<td><span style="display:inline-block;width:18px;height:18px;border-radius:4px;background:#3B82F6;border:1px solid rgba(0,0,0,0.25);vertical-align:middle;margin-right:8px"></span> <strong>Blue</strong> <code>#3B82F6</code></td>
+<td>Working: the terminal is producing output.</td>
+<td>raw ActivityState = Working</td>
+</tr>
+<tr>
+<td style="text-align:center">8</td>
+<td><span style="display:inline-block;width:18px;height:18px;border-radius:4px;background:#F14C4C;border:1px solid rgba(0,0,0,0.25);vertical-align:middle;margin-right:8px"></span> <strong>Red</strong> <code>#F14C4C</code></td>
+<td>Needs you: the terminal has been silent past the threshold with none of the overlays above applying. The only color that drives the "needs you first" triage bucket.</td>
+<td>raw ActivityState = Waiting</td>
+</tr>
+</tbody>
+</table>
+<p>Two invariants worth stating:</p>
+<ul>
+<li><strong>Red is a verdict, not a raw reading.</strong> A session that has gone silent is not automatically red; it is red only after the overlays above have had their say. This is why the fold must be atomic and in one place: computing it in pieces is what let a session flip into "needs you" mid-brief and back out.</li>
+<li><strong>Red breaks through the slate "supporting" recede</strong> so a genuinely blocked sub-agent still surfaces.</li>
+</ul>
+<hr/>
+<h2>8. The standalone fallback (CONFIRM)</h2>
+<p>The desktop Director app is the permanent fallback and must paint something when no Gateway is present or reachable. The smart overlays (briefing, voice, transcribing) do not even exist without the Gateway, so there is nothing to fold.</p>
+<p>Recommendation: with no Gateway, the desktop app applies one deliberately dumb local map to the raw sensor fact: Working becomes blue, Waiting becomes red, Exited becomes grey. No overlays, ever.</p>
+<p>This is not a violation of section 1. It is a last-resort render of the one fact the app can see when there is no brain to ask, not a policy layer. When a Gateway is connected, the desktop rail renders the Gateway's EffectiveColor field like every other client (render, never recompute), so the desktop and the Cockpit always agree.</p>
+<hr/>
+<h2>9. Current violation inventory (2026-07-08)</h2>
+<p>The code today disagrees with the target in three connected ways.</p>
+<p><strong>Three folds, not one.</strong> The same overlay logic is computed in three places:</p>
+<ol>
+<li><code>SessionStatusWingman.ResolveActivityColor</code> (Director) folds about seven overlays into the session status color.</li>
+<li><code>SessionOrdering.EffectiveColor</code> (Gateway) re-derives the orange and yellow overlays on top of the Director's already-folded status color, and writes EffectiveColor.</li>
+<li><code>packages/client-core/src/sessions/ordering.ts</code> (TypeScript) re-derives the same thing again for the Cockpit, plus inline bypasses in FleetMapView, ExesView, and DirectorDetailView.</li>
+</ol>
+<p><strong>A circular data flow.</strong> The Gateway pushes briefing, transcribing, voice, and assessed state down into the Director; the Director folds them into the status color; that goes up to the Gateway; the Gateway re-folds into EffectiveColor; that goes down to clients; the client re-folds again. State makes a full loop and is interpreted at every hop.</p>
+<p><strong>A contradiction that generates bugs.</strong> <code>SessionOrdering.EffectiveColor</code> documents its assumption as "the Director stamps the raw status color (it no longer knows about briefing)." But <code>SessionStatusWingman</code> does fold briefing, and six other overlays, into the status color. The two layers disagree about whether the status color is raw or already cooked. That exact ambiguity produced the "stuck orange" and "stuck yellow" wedges: the same rule had to be fixed in C# and in TypeScript at the same time.</p>
+<p>The target (sections 1-6) removes all three: one fold, at the Gateway; one direction of flow; and the interpreted status color ceases to exist as a Director field, because the Director emits only the raw fact.</p>
+<hr/>
+<h2>10. Open decisions</h2>
+<table>
+<thead>
+<tr>
+<th style="text-align:center">ID</th>
+<th>Decision</th>
+<th>Recommendation</th>
+<th>Status</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:center">D1</td>
+<td>Does the Director hold state and color authority?</td>
+<td>No. Sensor only; the Gateway is the master.</td>
+<td>DECIDED (owner, 2026-07-08)</td>
+</tr>
+<tr>
+<td style="text-align:center">D2</td>
+<td>Where does the silence threshold live?</td>
+<td>Detection local; threshold a config default of 10 seconds the Gateway can override.</td>
+<td>CONFIRM</td>
+</tr>
+<tr>
+<td style="text-align:center">D3</td>
+<td>What does the desktop paint with no Gateway?</td>
+<td>Trivial local blue, red, or grey from the raw fact; no overlays.</td>
+<td>CONFIRM</td>
+</tr>
+<tr>
+<td style="text-align:center">D4</td>
+<td>When connected, does the desktop rail render the Gateway color or its own?</td>
+<td>Render the Gateway's EffectiveColor field; never recompute.</td>
+<td>CONFIRM</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2>Document history</h2>
+<table>
+<thead>
+<tr>
+<th>Date</th>
+<th>Author</th>
+<th>Change</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>2026-07-08</td>
+<td>QA Agent (with the owner)</td>
+<td>Initial version, authored into the new_architecture area. Records the DECIDED rule (Director is a sensor, the Gateway is the interpreter), the sensor and interpreter distinction, the target one-direction single-fold flow, the current color scheme, the current three-fold and circular-flow violation inventory, and the open decisions. Supersedes the legacy hands / brain / face document section 4.2 on where the two-state signal's ownership lives.</td>
+</tr>
+</tbody>
+</table>
+</article>
+</body>
+</html>


### PR DESCRIPTION
Adds the clean-room architecture documents in `docs/new_architecture/`:

- **Portless Director: one outbound stream to the Gateway** (CANDIDATE, under consideration) - the proposed transport where each Director dials one persistent, bidirectional connection out to the Gateway and exposes no network-facing ports.
- **Phase 1 plan: Director-to-Gateway push stream** (PLAN) - the first, safe, additive increment, merged with its review-notes companion. Filed as issues thefrederiksen/devthrottle_internal#721 (Phase 1a) and thefrederiksen/devthrottle_internal#722 (Phase 1b).
- **Session State and Color Architecture** updates - the color-swatch table and the state-map diagram.
- Index updated to link all three.

Documentation only. No code changes. All HTML rendered and visually verified before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
