### PR TITLE
Phase 1a: Director-to-Gateway push stream (+ 1b down-channel proof)

### DIFF
--- a/docs/new_architecture/phase-1a-qa-report.md
+++ b/docs/new_architecture/phase-1a-qa-report.md
@@ -4,6 +4,48 @@ Living QA report for the Phase 1a implementation on branch `feat/director-gatewa
 
 ---
 
+## Increment 2: the SignalR hub (DirectorHub)
+
+**Date:** 2026-07-09
+**Status:** PASS
+
+### What was built
+
+- `DirectorStreamHello` contract - the identity-declaring first message.
+- `CcDirector.Gateway.Streaming.DirectorHub` - the SignalR hub each Director dials out to. It receives
+  `Hello` (binds the connection to one Director), `PushSnapshot`, `PushDelta`, and `RemoveSession`, and
+  records them in the `PushedSessionStore`. It also marks the Director state-reporting in the
+  `DirectorRegistry` so the reconcile poll skips it.
+- Wired into `GatewayHost`: a shared `PushedSessions` store instance, `AddSignalR()`, singleton
+  registration of the store and registry, and `MapHub<DirectorHub>("/director-stream")` mapped after the
+  host-wide auth middleware so the handshake is token-gated like every other route.
+
+### Review items covered
+
+| Item | How | Evidence (test) |
+|------|-----|-----------------|
+| #9 identity binding (Phase 1a form) | The connection is bound to one Director at `Hello`; every later message uses the bound id, so a connection can only ever affect the Director it declared. A message before `Hello` is rejected; an empty id aborts the connection. | `Hello_WithEmptyDirectorId_AbortsAndDoesNotBind`, `PushSnapshot_BeforeHello_ThrowsHubException`, `TwoConnectionsBoundToDifferentDirectors_DoNotCrossContaminate` |
+| auth (transport) | The hub is mapped after the host-wide token middleware; the .NET SignalR client presents its Bearer token on the handshake (verified end-to-end in the integration harness increment). | wired in `GatewayHost` |
+| state-reporting integration | `Hello` marks the Director state-reporting so the reconcile poll skips it | `Hello_BindsConnection_AndMarksStateReporting` |
+
+Also covered: snapshot/delta/remove apply to the bound Director, disconnect unregisters the connection,
+and a restarted Director (new connection, same Director) reseeds.
+
+**Note on the residual for #9:** binding a credential *cryptographically* to a specific Director id needs
+per-Director credentials from the account/device epic; Phase 1a enforces connection-to-Director binding
+(a connection cannot push to a Director other than the one it declared) on top of the existing token gate.
+
+### Test result
+
+```
+dotnet test --filter "DirectorHubTests|PushedSessionStoreTests"
+Passed!  Failed: 0, Passed: 23, Skipped: 0, Total: 23
+```
+
+Build: clean, `TreatWarningsAsErrors=true` (Gateway project compiles with the hub wired in).
+
+---
+
 ## Increment 1: correctness core (config flag + PushedSessionStore)
 
 **Date:** 2026-07-09

--- a/docs/new_architecture/phase-1a-qa-report.md
+++ b/docs/new_architecture/phase-1a-qa-report.md
@@ -16,8 +16,37 @@ environmental - it fails with `websocket closed unexpectedly: no api key` becaus
 transcription provider, and it touches nothing this work changed. With stream mode OFF (the default in
 those tests), `/sessions` is unchanged - the byte-identical guarantee.
 
-Remaining: Phase 1b (#1177) - the synthetic down-channel proof, the Director connection-status UI, skill
-parity verification, and doc wording.
+Phase 1b (#1177): the **down-channel proof is done** (below). Remaining 1b items - the Director
+connection-status UI wiring and the skill parity verification - need a live running app, so they are best
+done as a focused follow-up rather than unit-tested here.
+
+---
+
+## Phase 1b increment: the down-channel proof
+
+**Date:** 2026-07-09
+**Status:** PASS
+
+### What was built
+
+- `GatewayHost.PingDirectorAsync(directorId, message)` - sends a message DOWN a Director's stream and
+  awaits its reply over the SAME connection (SignalR client results), using
+  `PushedSessionStore.GetActiveConnectionId` to address the active connection. Returns null when the
+  Director has no active stream.
+- The Director's `GatewayStreamClient` registers a `Ping` handler that returns `pong:{message}`.
+
+This proves request-both-ways on one outbound-dialed connection (the property portless will depend on).
+Per plan 4.7b it is a synthetic proof, not a migrated production command path (the old assessed-state
+down-producer is retired, so there was no live down-path to move).
+
+### Tests
+
+| Test | Proves |
+|------|--------|
+| `DownChannel_Ping_RoundTripsToTheDirector` | Gateway -> Director request returns the reply over the stream |
+| `DownChannel_Ping_ReturnsNull_WhenNoStreamConnected` | No active stream yields null (no crash) |
+
+Stream suite now 33 passing (adds the 2 above).
 
 ---
 

--- a/docs/new_architecture/phase-1a-qa-report.md
+++ b/docs/new_architecture/phase-1a-qa-report.md
@@ -1,0 +1,42 @@
+# Phase 1a QA report (issue #1176)
+
+Living QA report for the Phase 1a implementation on branch `feat/director-gateway-stream-1a`. One section per verified increment, newest first. Every increment is built with warnings-as-errors and its tests run before it is committed.
+
+---
+
+## Increment 1: correctness core (config flag + PushedSessionStore)
+
+**Date:** 2026-07-09
+**Status:** PASS
+
+### What was built
+
+- `GatewayConfig.StreamMode` (bool, default false) and `GatewayConfig.StreamStaleAfterSeconds` (int, default 20), parsed from the `gateway` block of `config.json`. Opt-in: only a JSON boolean `true` enables stream mode, so a missing/malformed key leaves the Director on the existing pull path (the regression safety net).
+- `SessionDto.Clone()` - a copy safe to hand out from the pushed cache; re-creates the `DriverCapabilities` list so the aggregation cannot contaminate the cache.
+- `CcDirector.Gateway.Streaming.PushedSessionStore` - the Gateway's per-Director cache of pushed session state, enforcing the four correctness rules from plan section 4.4.
+
+### Review items covered
+
+| Item | How | Evidence (test) |
+|------|-----|-----------------|
+| #2 connection generation (not int epoch) | A restarted Director's brand-new connection is authoritative at any sequence | `RestartedDirector_NewConnectionFirstSnapshot_IsAuthoritative` |
+| #3 active-connection ownership | A late disconnect from a superseded connection is ignored | `LateDisconnectFromOldConnection_DoesNotClearTheActiveConnection` |
+| #4 remove/tombstone + snapshot prune | Explicit remove drops a session; a snapshot prunes anything absent | `ApplyRemove_DropsTheSession`, `ApplySnapshot_PrunesSessionsAbsentFromTheSnapshot` |
+| #7 deep-copy on read | Mutating a served session does not mutate the cache | `TryGetFresh_ReturnsDeepCopies_MutatingResultDoesNotAffectStore` |
+| clock recompute (plan addition) | Idle seconds advance from absolute LastActivityAt at serve time | `TryGetFresh_RecomputesIdleSecondsFromLastActivityAt` |
+| stale-cache fallback (#5 groundwork) | A push older than the stale window returns null (caller pulls) | `TryGetFresh_WhenLastPushIsOlderThanStaleWindow_ReturnsNull` |
+
+Also covered: stale-sequence drop, non-active-connection drop, unregister-clears-active, unknown-director, and pre-registration rejection.
+
+### Test result
+
+```
+dotnet test --filter PushedSessionStoreTests
+Passed!  Failed: 0, Passed: 14, Skipped: 0, Total: 14
+```
+
+Build: clean, `TreatWarningsAsErrors=true`.
+
+### Not yet built (later increments)
+
+SignalR hub + auth/identity binding (#9), Director stream client, `/sessions` aggregation dual-mode (#10), the down-channel proof (#8), observability wiring (#11), and the in-process integration harness (plan section 5). Tracked toward Phase 1a completion, then Phase 1b (#1177).

--- a/docs/new_architecture/phase-1a-qa-report.md
+++ b/docs/new_architecture/phase-1a-qa-report.md
@@ -4,6 +4,61 @@ Living QA report for the Phase 1a implementation on branch `feat/director-gatewa
 
 ---
 
+## Increment 3: /sessions aggregation dual-mode + end-to-end harness
+
+**Date:** 2026-07-09
+**Status:** PASS
+
+### What was built
+
+- **Cache-first fetch** in the `GET /sessions` fan-out (`GatewayEndpoints`): if a Director's stream is
+  connected and its last push is within the stale window, its sessions are served from
+  `PushedSessionStore.TryGetFresh` (deep copies with recomputed idle clocks) and the pull is skipped
+  entirely. Every downstream side effect (owner-cache retain/remember, filters, machine/user/tailnet/
+  view-url enrichment, voice/transcription overlays, EffectiveColor + triage, NeedsYouSince,
+  machineErrors) runs **unchanged** on the cached sessions - only the fetch step changed (review #10).
+- **`includeExited` fallback** (review #5): cache-first is gated on `!includeExited`, so an
+  exited-inclusive query always pulls (a live-only snapshot never answers it).
+- **Observability** (review #11): the fan-out logs `served=pushed-cache` on a hit and
+  `served=pull (stream connected but cache stale/empty)` on a fallback, per Director per request, for
+  any stream-participating Director.
+- **Gateway kill-switch**: `GatewayHost` reads `gateway.streamMode` (or an explicit constructor
+  override); when off, the hub is not mapped and `/sessions` never consults the cache - byte-identical
+  to today.
+- **Integration harness** (`StreamIntegrationTests`): boots a real `GatewayHost` (stream mode on) and
+  dials the hub with a real SignalR client over HTTP.
+
+### End-to-end tests (over real HTTP + SignalR)
+
+| Test | Proves | Review item |
+|------|--------|-------------|
+| `StreamPush_IsServedFromCache_WithoutPullingTheDirector` | The Director is registered with an unreachable endpoint; a pushed snapshot appears in `/sessions` with no machine error, so it can only have come from cache | core #1, #10 |
+| `PushDelta_IsReflectedInSessions` | A single-session delta changes the served state | #4 groundwork |
+| `RemoveSession_IsReflectedInSessions` | A remove drops the session from `/sessions` | #4 |
+| `UnauthenticatedConnect_IsRejected` | A hub connection with no token fails the handshake | auth #9 |
+| `StreamModeOff_DoesNotMapTheHub` | With the flag off, `/director-stream/negotiate` is 404 | flag-off parity |
+
+This confirms the whole Gateway side (hub auth, store, aggregation) works on the wire, and that the .NET
+SignalR client's Bearer token satisfies the existing host-wide auth middleware with no middleware change.
+
+### Test result
+
+```
+dotnet test --filter "StreamIntegrationTests|DirectorHubTests|PushedSessionStoreTests"
+Passed!  Failed: 0, Passed: 28, Skipped: 0, Total: 28
+```
+
+Build: clean, `TreatWarningsAsErrors=true`.
+
+### Still remaining for Phase 1a
+
+The Director-side `GatewayStreamClient` (increment 4: dial out, auto-reconnect, snapshot/delta/remove
+from a shared session mapper, feed the connection monitor). The integration harness above already covers
+the Gateway side of the plan's test list; the remaining harness cases (stale-cache fallback, restart
+reseed over the wire) fold in with the client.
+
+---
+
 ## Increment 2: the SignalR hub (DirectorHub)
 
 **Date:** 2026-07-09

--- a/docs/new_architecture/phase-1a-qa-report.md
+++ b/docs/new_architecture/phase-1a-qa-report.md
@@ -2,6 +2,68 @@
 
 Living QA report for the Phase 1a implementation on branch `feat/director-gateway-stream-1a`. One section per verified increment, newest first. Every increment is built with warnings-as-errors and its tests run before it is committed.
 
+## Phase 1a status: FUNCTIONALLY COMPLETE
+
+All four increments are implemented and verified end to end. The full data path works with the real
+components: the Director's `GatewayStreamClient` dials the Gateway, sends `Hello` + a full snapshot,
+pushes deltas/removes; the `DirectorHub` records them in the `PushedSessionStore`; and `GET /sessions`
+serves the Director from that cache instead of pulling it.
+
+**Test totals:** 31 stream tests (14 store + 9 hub + 5 Gateway-integration + 3 real-client end-to-end)
+plus 5 new `GatewayConfig` tests. **Regression: the full Gateway suite is 1388 passed / 1 failed**, and
+the single failure (`DictationEndpointTests.FullPipeline_transcribes_phase0_clip2`) is pre-existing and
+environmental - it fails with `websocket closed unexpectedly: no api key` because it needs a live
+transcription provider, and it touches nothing this work changed. With stream mode OFF (the default in
+those tests), `/sessions` is unchanged - the byte-identical guarantee.
+
+Remaining: Phase 1b (#1177) - the synthetic down-channel proof, the Director connection-status UI, skill
+parity verification, and doc wording.
+
+---
+
+## Increment 4: the Director stream client (GatewayStreamClient)
+
+**Date:** 2026-07-09
+**Status:** PASS
+
+### What was built
+
+- `CcDirector.ControlApi.GatewayStreamClient` - the Director's outbound client. It dials
+  `{gateway.url}/director-stream` with the same token the HTTP client uses (via `AccessTokenProvider`),
+  `WithAutomaticReconnect`, and a supervise loop that restarts the connection after a long outage. On
+  connect AND every reconnect it sends `Hello` + a full `PushSnapshot` (so a Director restart reseeds).
+  `NotifyDelta` / `NotifyRemove` push single changes, fire-and-forget (a drop is reconciled by the next
+  snapshot). Inert unless `gateway.streamMode` is on and a Gateway URL is set.
+- **Shared mapper (review #6):** `ControlEndpoints.Map` is now `internal`, and the client's snapshot
+  source `ControlApiHost.SnapshotFullSessions` builds each `SessionDto` through that exact mapper - so a
+  pushed row equals a pulled row for the same session.
+- **Wired into `ControlApiHost`:** built/started alongside the existing `GatewayClient` (additive), torn
+  down and rebuilt in `ReapplyGatewayAsync`, stopped on host shutdown. The existing session-event
+  subscription (`WireDoorbellPush`) now also pushes a delta on create/state-change and a remove on
+  session removal.
+
+### End-to-end tests (real client -> real Gateway)
+
+| Test | Proves |
+|------|--------|
+| `RealClient_Snapshot_IsServedFromCache` | The real client's snapshot appears in `/sessions` (served from cache, unreachable endpoint) |
+| `RealClient_NotifyDelta_IsReflected` | A pushed delta changes the served state |
+| `RealClient_NotifyRemove_IsReflected` | A pushed remove drops the session |
+
+Plus 5 `GatewayConfig` unit tests for `streamMode` / `staleAfterSeconds` parsing (default off, boolean-only
+enable, positive/non-positive stale window).
+
+### Test result
+
+```
+dotnet test --filter "PushedSessionStoreTests|DirectorHubTests|StreamIntegrationTests|GatewayStreamClientTests"
+Passed!  Failed: 0, Passed: 31, Skipped: 0, Total: 31
+dotnet test --filter GatewayConfigTests
+Passed!  Failed: 0, Passed: 18, Skipped: 0, Total: 18
+```
+
+Build: clean, `TreatWarningsAsErrors=true` (Gateway + ControlApi + both test projects).
+
 ---
 
 ## Increment 3: /sessions aggregation dual-mode + end-to-end harness

--- a/src/CcDirector.ControlApi/CcDirector.ControlApi.csproj
+++ b/src/CcDirector.ControlApi/CcDirector.ControlApi.csproj
@@ -9,6 +9,9 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <!-- Issue #1176 (Phase 1a): the SignalR CLIENT (separate from the server in the shared framework)
+         so the Director can dial the Gateway's DirectorHub and push its session state. -->
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -94,6 +94,9 @@ public sealed class ControlApiHost : IAsyncDisposable
     private WebApplication? _app;
     private InstanceRegistration? _registration;
     private GatewayClient? _gatewayClient;
+    // Issue #1176 (Phase 1a): the outbound push-stream client, running alongside _gatewayClient when
+    // gateway.streamMode is on. Null when stream mode is off, so the Director behaves exactly as today.
+    private GatewayStreamClient? _streamClient;
     private TailscaleServeSelfProvisioner? _serveProvisioner;
     private readonly SemaphoreSlim _gatewayReapplyLock = new(1, 1);
 
@@ -480,6 +483,9 @@ public sealed class ControlApiHost : IAsyncDisposable
         // loaded above for the HTML nav button.
         _gatewayClient = BuildGatewayClient(gatewayConfig);
         _gatewayClient.Start();
+        // Issue #1176 (Phase 1a): additive push stream, alongside the heartbeat/doorbell floor.
+        _streamClient = BuildStreamClient(gatewayConfig);
+        _streamClient?.Start();
         WireDoorbellPush();
 
         IsListening = true;
@@ -592,6 +598,25 @@ public sealed class ControlApiHost : IAsyncDisposable
         return client;
     }
 
+    /// <summary>
+    /// Issue #1176 (Phase 1a): build the push-stream client, or null when stream mode is off / no Gateway
+    /// is configured. Its snapshot source is <see cref="SnapshotFullSessions"/>, which uses the SAME
+    /// mapper as the local /sessions endpoint (review #6) so a pushed row equals a pulled row.
+    /// </summary>
+    private GatewayStreamClient? BuildStreamClient(GatewayConfig gatewayConfig)
+    {
+        if (!gatewayConfig.IsEnabled || !gatewayConfig.StreamMode) return null;
+        return new GatewayStreamClient(gatewayConfig, DirectorId, _version, SnapshotFullSessions);
+    }
+
+    /// <summary>
+    /// Full per-session snapshot for the stream, built through the SAME <see cref="ControlEndpoints.Map"/>
+    /// the local /sessions endpoint uses (issue #1176, review #6), so a pushed snapshot row is identical
+    /// to what a pull would have returned for the same session.
+    /// </summary>
+    private List<SessionDto> SnapshotFullSessions()
+        => _sessionManager.ListSessions().Select(s => ControlEndpoints.Map(s, DirectorId)).ToList();
+
     /// <summary>Per-session mechanical-state snapshot for the heartbeat body (issue #186).</summary>
     private List<SessionStateSnapshot> SnapshotSessionStates()
         => _sessionManager.ListSessions()
@@ -635,6 +660,8 @@ public sealed class ControlApiHost : IAsyncDisposable
                     _ => null,
                 };
                 _gatewayClient?.NotifySessionState(session.Id.ToString(), newState.ToString(), eventName);
+                // Issue #1176 (Phase 1a): push the changed session up the stream as a delta.
+                _streamClient?.NotifyDelta(ControlEndpoints.Map(session, DirectorId));
             };
 
         _sessionManager.OnSessionCreated += session =>
@@ -642,12 +669,15 @@ public sealed class ControlApiHost : IAsyncDisposable
             Attach(session);
             _gatewayClient?.NotifySessionState(session.Id.ToString(), session.ActivityState.ToString(),
                 DoorbellEvents.SessionCreated);
+            _streamClient?.NotifyDelta(ControlEndpoints.Map(session, DirectorId));
         };
         _sessionManager.OnSessionRemoved += session =>
         {
             if (_exitAnnounced.TryAdd(session.Id, 0))
                 _gatewayClient?.NotifySessionState(session.Id.ToString(),
                     Core.Sessions.ActivityState.Exited.ToString(), DoorbellEvents.SessionExited);
+            // Issue #1176 (Phase 1a): tombstone the removed session so the Gateway prunes it immediately.
+            _streamClient?.NotifyRemove(session.Id.ToString());
             // The session is gone from the roster - drop the announce guard so the map
             // never grows past the live roster.
             _exitAnnounced.TryRemove(session.Id, out _);
@@ -678,10 +708,21 @@ public sealed class ControlApiHost : IAsyncDisposable
                 _gatewayClient.Dispose();
                 _gatewayClient = null;
             }
+            // Issue #1176 (Phase 1a): tear down the old stream client before rebuilding, so a settings
+            // change never leaves two streams pushing for the same directorId.
+            if (_streamClient is not null)
+            {
+                try { await _streamClient.StopAsync(); }
+                catch (Exception ex) { FileLog.Write($"[ControlApiHost] ReapplyGateway stream stop error: {ex.Message}"); }
+                await _streamClient.DisposeAsync();
+                _streamClient = null;
+            }
 
             var gatewayConfig = GatewayConfig.Load();
             _gatewayClient = BuildGatewayClient(gatewayConfig);
             _gatewayClient.Start();
+            _streamClient = BuildStreamClient(gatewayConfig);
+            _streamClient?.Start();
         }
         finally
         {
@@ -737,6 +778,14 @@ public sealed class ControlApiHost : IAsyncDisposable
             catch (Exception ex) { FileLog.Write($"[ControlApiHost] GatewayClient.StopAsync error: {ex.Message}"); }
             _gatewayClient.Dispose();
             _gatewayClient = null;
+        }
+        // Issue #1176 (Phase 1a): stop the push stream on host shutdown.
+        if (_streamClient is not null)
+        {
+            try { await _streamClient.StopAsync(); }
+            catch (Exception ex) { FileLog.Write($"[ControlApiHost] GatewayStreamClient.StopAsync error: {ex.Message}"); }
+            await _streamClient.DisposeAsync();
+            _streamClient = null;
         }
 
         _terminalStateDetector?.Dispose();

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -3239,7 +3239,11 @@ internal static class ControlEndpoints
     /// Directors that send empty fields (back-compat for mixed-version fleets) but must NOT
     /// overwrite non-empty Director-supplied values.
     /// </summary>
-    private static SessionDto Map(Session s, string directorId, TurnSummaryCache? cache = null,
+    // Issue #1176 (Phase 1a): internal so the Director's stream client builds its pushed snapshots and
+    // deltas through the EXACT same mapper the local /sessions endpoint uses (review #6), rather than a
+    // second, divergent builder. Callers outside /sessions pass only (session, directorId); the Gateway
+    // aggregator stamps machine/user/tailnet/view-url during aggregation, for pushed and pulled alike.
+    internal static SessionDto Map(Session s, string directorId, TurnSummaryCache? cache = null,
         string machineName = "", string user = "", string tailnetEndpoint = "", string? gatewayUrl = null)
     {
         // Phase 3: StatusColor and LastStatusReason are owned by the SessionStatusWingman

--- a/src/CcDirector.ControlApi/GatewayStreamClient.cs
+++ b/src/CcDirector.ControlApi/GatewayStreamClient.cs
@@ -1,0 +1,188 @@
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// Issue #1176 (Phase 1a): the Director's outbound client for the Gateway's DirectorHub. It dials the
+/// Gateway (never the other way), authenticates with the same token the HTTP client uses, and pushes this
+/// Director's session state UP the stream:
+///
+///   - on connect AND on every reconnect it sends <c>Hello</c> then a full <c>PushSnapshot</c> (the new
+///     connection makes the snapshot authoritative at the Gateway, so a Director restart reseeds cleanly);
+///   - <see cref="NotifyDelta"/> pushes one changed session; <see cref="NotifyRemove"/> pushes a removal.
+///
+/// It runs ALONGSIDE the existing <see cref="GatewayClient"/> in Phase 1a (additive): the heartbeat/
+/// doorbell stay as the reconcile floor. It is inert unless the config has a Gateway URL and
+/// <see cref="GatewayConfig.StreamMode"/> is on, so a Director with stream mode off behaves exactly as today.
+///
+/// Sends are best-effort and fire-and-forget: a dropped delta is harmless because the next snapshot (on
+/// reconnect) re-establishes the full truth, mirroring the doorbell/heartbeat resilience model.
+/// </summary>
+public sealed class GatewayStreamClient : IAsyncDisposable
+{
+    private readonly GatewayConfig _config;
+    private readonly string _directorId;
+    private readonly string _version;
+    private readonly Func<List<SessionDto>> _snapshot;
+
+    private HubConnection? _connection;
+    private long _sequence;
+    private int _started;
+    private volatile bool _disposed;
+
+    /// <summary>Reconnect backoff between long-outage restart attempts once auto-reconnect has given up.</summary>
+    private static readonly TimeSpan RestartDelay = TimeSpan.FromSeconds(5);
+
+    public GatewayStreamClient(GatewayConfig config, string directorId, string version, Func<List<SessionDto>> snapshot)
+    {
+        _config = config ?? throw new ArgumentNullException(nameof(config));
+        _directorId = string.IsNullOrWhiteSpace(directorId) ? throw new ArgumentException("directorId is required", nameof(directorId)) : directorId;
+        _version = version ?? "";
+        _snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
+    }
+
+    /// <summary>True when stream mode is enabled for a configured Gateway. When false, <see cref="Start"/> is a no-op.</summary>
+    public bool IsEnabled => _config.IsEnabled && _config.StreamMode;
+
+    /// <summary>Start dialing the Gateway. Idempotent; inert when <see cref="IsEnabled"/> is false.</summary>
+    public void Start()
+    {
+        if (!IsEnabled) return;
+        if (Interlocked.Exchange(ref _started, 1) == 1) return;
+        FileLog.Write($"[GatewayStreamClient] Start: dialing {_config.Url} for director {_directorId}");
+        _ = SuperviseAsync();
+    }
+
+    // Owns the connection for its whole life: build once, keep it connected, and reseed on every
+    // (re)connection. Auto-reconnect handles transient drops fast; when it gives up (Closed), this loop
+    // restarts the connection so a long Gateway outage self-heals without a Director restart.
+    private async Task SuperviseAsync()
+    {
+        _connection = new HubConnectionBuilder()
+            .WithUrl(_config.Url.TrimEnd('/') + "/director-stream", options =>
+            {
+                var token = _config.Token;
+                if (!string.IsNullOrEmpty(token))
+                    options.AccessTokenProvider = () => Task.FromResult<string?>(token);
+            })
+            .WithAutomaticReconnect(new[]
+            {
+                TimeSpan.Zero, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10),
+            })
+            .Build();
+
+        _connection.Reconnecting += ex => { FileLog.Write($"[GatewayStreamClient] reconnecting: {ex?.Message}"); return Task.CompletedTask; };
+        _connection.Reconnected += async _ => await ReseedAsync();
+
+        while (!_disposed)
+        {
+            if (await TryConnectAsync())
+            {
+                await ReseedAsync();
+                await WaitUntilClosedAsync();      // returns when auto-reconnect has exhausted its attempts
+            }
+            if (_disposed) break;
+            await Task.Delay(RestartDelay);        // long-outage restart
+        }
+    }
+
+    private async Task<bool> TryConnectAsync()
+    {
+        if (_connection is null) return false;
+        try
+        {
+            await _connection.StartAsync();
+            FileLog.Write($"[GatewayStreamClient] connected to {_config.Url}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayStreamClient] connect failed (will retry): {ex.Message}");
+            return false;
+        }
+    }
+
+    private async Task WaitUntilClosedAsync()
+    {
+        if (_connection is null) return;
+        var closed = new TaskCompletionSource();
+        Task OnClosed(Exception? _) { closed.TrySetResult(); return Task.CompletedTask; }
+        _connection.Closed += OnClosed;
+        try
+        {
+            if (_connection.State == HubConnectionState.Disconnected) return;
+            await closed.Task;
+        }
+        finally
+        {
+            _connection.Closed -= OnClosed;
+        }
+    }
+
+    private async Task ReseedAsync()
+    {
+        var conn = _connection;
+        if (conn is null || conn.State != HubConnectionState.Connected) return;
+        try
+        {
+            var seq = Interlocked.Increment(ref _sequence);
+            await conn.InvokeAsync("Hello", new DirectorStreamHello { DirectorId = _directorId, Version = _version });
+            await conn.InvokeAsync("PushSnapshot", seq, _snapshot().ToArray());
+            FileLog.Write($"[GatewayStreamClient] reseeded full snapshot seq={seq}");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayStreamClient] reseed failed (auto-reconnect will retry): {ex.Message}");
+        }
+    }
+
+    /// <summary>Push one changed session. Fire-and-forget; a drop is reconciled by the next snapshot.</summary>
+    public void NotifyDelta(SessionDto session)
+    {
+        if (session is null || string.IsNullOrEmpty(session.SessionId)) return;
+        var conn = _connection;
+        if (conn is null || conn.State != HubConnectionState.Connected) return;
+        var seq = Interlocked.Increment(ref _sequence);
+        _ = SendAsync(() => conn.InvokeAsync("PushDelta", seq, session), "PushDelta");
+    }
+
+    /// <summary>Push a session removal. Fire-and-forget; a drop is reconciled by the next snapshot.</summary>
+    public void NotifyRemove(string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId)) return;
+        var conn = _connection;
+        if (conn is null || conn.State != HubConnectionState.Connected) return;
+        var seq = Interlocked.Increment(ref _sequence);
+        _ = SendAsync(() => conn.InvokeAsync("RemoveSession", seq, sessionId), "RemoveSession");
+    }
+
+    private static async Task SendAsync(Func<Task> send, string what)
+    {
+        try { await send(); }
+        catch (Exception ex) { FileLog.Write($"[GatewayStreamClient] {what} dropped (mid-reconnect?): {ex.Message}"); }
+    }
+
+    public async Task StopAsync()
+    {
+        _disposed = true;
+        if (_connection is not null)
+        {
+            try { await _connection.StopAsync(); }
+            catch (Exception ex) { FileLog.Write($"[GatewayStreamClient] StopAsync error: {ex.Message}"); }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _disposed = true;
+        if (_connection is not null)
+        {
+            try { await _connection.DisposeAsync(); }
+            catch (Exception ex) { FileLog.Write($"[GatewayStreamClient] DisposeAsync error: {ex.Message}"); }
+            _connection = null;
+        }
+    }
+}

--- a/src/CcDirector.ControlApi/GatewayStreamClient.cs
+++ b/src/CcDirector.ControlApi/GatewayStreamClient.cs
@@ -77,6 +77,11 @@ public sealed class GatewayStreamClient : IAsyncDisposable
         _connection.Reconnecting += ex => { FileLog.Write($"[GatewayStreamClient] reconnecting: {ex?.Message}"); return Task.CompletedTask; };
         _connection.Reconnected += async _ => await ReseedAsync();
 
+        // Issue #1176 (Phase 1b): the down-channel proof. The Gateway can call this and await the reply
+        // over the same connection (SignalR client results), demonstrating request-both-ways on one
+        // outbound-dialed stream. A synthetic proof, not a production command handler.
+        _connection.On<string, string>("Ping", message => $"pong:{message}");
+
         while (!_disposed)
         {
             if (await TryConnectAsync())

--- a/src/CcDirector.Core.Tests/Configuration/GatewayConfigTests.cs
+++ b/src/CcDirector.Core.Tests/Configuration/GatewayConfigTests.cs
@@ -132,4 +132,58 @@ public sealed class GatewayConfigTests : IDisposable
 
         Assert.Equal("", cfg.Token);
     }
+
+    // ===== Issue #1176 (Phase 1a): streamMode + staleAfterSeconds =====
+
+    [Fact]
+    public void Load_streamMode_defaults_off_when_absent()
+    {
+        SeedConfig("""{ "gateway": { "url": "http://gw:7878" } }""");
+
+        var cfg = GatewayConfig.Load();
+
+        Assert.False(cfg.StreamMode);
+        Assert.Equal(GatewayConfig.DefaultStreamStaleAfterSeconds, cfg.StreamStaleAfterSeconds);
+    }
+
+    [Fact]
+    public void Load_streamMode_true_when_configured()
+    {
+        SeedConfig("""{ "gateway": { "url": "http://gw:7878", "streamMode": true } }""");
+
+        var cfg = GatewayConfig.Load();
+
+        Assert.True(cfg.StreamMode);
+    }
+
+    [Fact]
+    public void Load_streamMode_false_for_non_boolean_value()
+    {
+        // Only a JSON boolean true enables it; a string "true" must not.
+        SeedConfig("""{ "gateway": { "url": "http://gw:7878", "streamMode": "true" } }""");
+
+        var cfg = GatewayConfig.Load();
+
+        Assert.False(cfg.StreamMode);
+    }
+
+    [Fact]
+    public void Load_staleAfterSeconds_reads_positive_value()
+    {
+        SeedConfig("""{ "gateway": { "url": "http://gw:7878", "staleAfterSeconds": 45 } }""");
+
+        var cfg = GatewayConfig.Load();
+
+        Assert.Equal(45, cfg.StreamStaleAfterSeconds);
+    }
+
+    [Fact]
+    public void Load_staleAfterSeconds_ignores_non_positive_value()
+    {
+        SeedConfig("""{ "gateway": { "url": "http://gw:7878", "staleAfterSeconds": 0 } }""");
+
+        var cfg = GatewayConfig.Load();
+
+        Assert.Equal(GatewayConfig.DefaultStreamStaleAfterSeconds, cfg.StreamStaleAfterSeconds);
+    }
 }

--- a/src/CcDirector.Core/Configuration/GatewayConfig.cs
+++ b/src/CcDirector.Core/Configuration/GatewayConfig.cs
@@ -53,6 +53,26 @@ public sealed class GatewayConfig
     /// </summary>
     public AddressingMode AddressingMode { get; init; } = AddressingModeConfig.Default;
 
+    /// <summary>
+    /// Issue #1176 (Phase 1a): when true, the Director opens a persistent stream to the Gateway and
+    /// pushes its session state, and the Gateway serves <c>GET /sessions</c> from that pushed cache
+    /// when it is fresh. Default false: the Director uses only the existing pull/heartbeat path and the
+    /// Gateway ignores the pushed cache, so behaviour is byte-identical to today. Read from the gateway
+    /// block's <c>streamMode</c> key in config.json.
+    /// </summary>
+    public bool StreamMode { get; init; }
+
+    /// <summary>
+    /// Issue #1176 (Phase 1a): how many seconds a Director's most recent stream push may age before the
+    /// Gateway treats its pushed cache as stale and falls back to pulling that Director for
+    /// <c>GET /sessions</c>. Guards against a wedged stream serving frozen data. Read from the gateway
+    /// block's <c>staleAfterSeconds</c> key; default <see cref="DefaultStreamStaleAfterSeconds"/>.
+    /// </summary>
+    public int StreamStaleAfterSeconds { get; init; } = DefaultStreamStaleAfterSeconds;
+
+    /// <summary>Default value for <see cref="StreamStaleAfterSeconds"/>.</summary>
+    public const int DefaultStreamStaleAfterSeconds = 20;
+
     /// <summary>True when <see cref="Url"/> is configured.</summary>
     public bool IsEnabled => !string.IsNullOrWhiteSpace(Url);
 
@@ -84,6 +104,15 @@ public sealed class GatewayConfig
             var token = (gw.TryGetProperty("token", out var t) ? t.GetString() ?? "" : "").Trim();
             var tailnet = gw.TryGetProperty("tailnetEndpoint", out var te) ? te.GetString() : null;
 
+            // Issue #1176 (Phase 1a). streamMode is opt-in (only a JSON boolean true enables it), so a
+            // missing or malformed key leaves the Director on the existing pull path. staleAfterSeconds
+            // must be a positive integer or the default stands.
+            var streamMode = gw.TryGetProperty("streamMode", out var sm) && sm.ValueKind == JsonValueKind.True;
+            var staleAfterSeconds = gw.TryGetProperty("staleAfterSeconds", out var sa)
+                && sa.ValueKind == JsonValueKind.Number && sa.TryGetInt32(out var sav) && sav > 0
+                    ? sav
+                    : DefaultStreamStaleAfterSeconds;
+
             // Same-machine credential resolution. A Gateway-role install never runs the pairing step
             // (that step, and only that step, writes gateway.token - it is a Workstation-only step), so
             // the Gateway host's own Director/launcher have no configured token and, once host-wide auth
@@ -110,6 +139,8 @@ public sealed class GatewayConfig
                 Token = token,
                 TailnetEndpoint = string.IsNullOrWhiteSpace(tailnet) ? null : tailnet.Trim(),
                 AddressingMode = mode,
+                StreamMode = streamMode,
+                StreamStaleAfterSeconds = staleAfterSeconds,
             };
         }
         catch (Exception ex)

--- a/src/CcDirector.Gateway.Contracts/DirectorStreamMessages.cs
+++ b/src/CcDirector.Gateway.Contracts/DirectorStreamMessages.cs
@@ -1,0 +1,16 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// Issue #1176 (Phase 1a): the first message a Director sends after opening its stream to the Gateway,
+/// declaring which Director this connection speaks for. The hub binds the connection to this identity;
+/// from then on every snapshot/delta/remove from that connection applies only to this Director, so one
+/// connection can never push into another Director's cache.
+/// </summary>
+public sealed class DirectorStreamHello
+{
+    /// <summary>The stable Director id (the same id used for HTTP registration and the /sessions aggregation).</summary>
+    public string DirectorId { get; set; } = "";
+
+    /// <summary>Director build version, for diagnostics.</summary>
+    public string Version { get; set; } = "";
+}

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -298,4 +298,19 @@ public sealed class SessionDto
     /// (queued / in_progress / completed / none). Empty for local sessions.
     /// </summary>
     public string RemoteRunStatus { get; set; } = "";
+
+    /// <summary>
+    /// Issue #1176 (Phase 1a): a copy safe to hand out from the Gateway's pushed-session cache. The
+    /// <c>/sessions</c> aggregation stamps scalar fields (EffectiveColor, DirectorId, MachineName,
+    /// voice/transcription overlays, etc.) on the object it serves, so callers must never receive the
+    /// cached instance itself or one request would contaminate the cache for later ones. Reference-type
+    /// members the aggregator could mutate in place are re-created here; <see cref="VoiceUnavailable"/>
+    /// is only ever replaced wholesale by the aggregator (never mutated), so sharing its reference is safe.
+    /// </summary>
+    public SessionDto Clone()
+    {
+        var copy = (SessionDto)MemberwiseClone();
+        copy.DriverCapabilities = new List<string>(DriverCapabilities);
+        return copy;
+    }
 }

--- a/src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj
+++ b/src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj
@@ -13,6 +13,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Include="xunit" Version="2.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
+    <!-- Issue #1176 (Phase 1a): the SignalR CLIENT (a separate package from the server, which ships in
+         the AspNetCore shared framework) so the integration harness can dial the DirectorHub end to end. -->
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CcDirector.Gateway.Tests/DirectorHubTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorHubTests.cs
@@ -1,0 +1,191 @@
+using System.Security.Claims;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Streaming;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.SignalR;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="DirectorHub"/> (issue #1176). The hub is driven directly against a fake
+/// SignalR caller context, the real <see cref="PushedSessionStore"/>, and a real
+/// <see cref="DirectorRegistry"/> rooted at a temp directory, so message handling and identity binding
+/// are verified without the ASP.NET pipeline (that is the integration harness, a later increment).
+/// </summary>
+public sealed class DirectorHubTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly DirectorRegistry _registry;
+    private readonly PushedSessionStore _store;
+    private DateTime _now = new(2026, 7, 9, 12, 0, 0, DateTimeKind.Utc);
+
+    public DirectorHubTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "cc-hub-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+        _registry = new DirectorRegistry(_tempDir);
+        _store = new PushedSessionStore(() => _now);
+    }
+
+    public void Dispose()
+    {
+        _registry.Dispose();
+        try { Directory.Delete(_tempDir, recursive: true); }
+        catch (Exception) { /* best-effort temp cleanup */ }
+    }
+
+    private (DirectorHub hub, FakeHubCallerContext ctx) NewHub(string connectionId)
+    {
+        var ctx = new FakeHubCallerContext(connectionId);
+        var hub = new DirectorHub(_store, _registry) { Context = ctx };
+        return (hub, ctx);
+    }
+
+    private static DirectorStreamHello Hello(string directorId) => new() { DirectorId = directorId, Version = "test" };
+
+    private static SessionDto Session(string id, string state = "Working") => new() { SessionId = id, ActivityState = state };
+
+    private readonly TimeSpan _staleAfter = TimeSpan.FromSeconds(20);
+
+    [Fact]
+    public void Hello_BindsConnection_AndMarksStateReporting()
+    {
+        var (hub, ctx) = NewHub("conn-1");
+
+        hub.Hello(Hello("dir-A"));
+
+        Assert.False(ctx.Aborted);
+        Assert.True(_registry.IsStateReporting("dir-A"));
+        Assert.True(_store.IsStreamConnected("dir-A"));
+    }
+
+    [Fact]
+    public void PushSnapshot_AfterHello_AppliesToBoundDirector()
+    {
+        var (hub, _) = NewHub("conn-1");
+        hub.Hello(Hello("dir-A"));
+
+        hub.PushSnapshot(0, new[] { Session("s1"), Session("s2") });
+
+        var fresh = _store.TryGetFresh("dir-A", _staleAfter);
+        Assert.NotNull(fresh);
+        Assert.Equal(2, fresh.Count);
+    }
+
+    [Fact]
+    public void Hello_WithEmptyDirectorId_AbortsAndDoesNotBind()
+    {
+        var (hub, ctx) = NewHub("conn-1");
+
+        hub.Hello(Hello("   "));
+
+        Assert.True(ctx.Aborted);
+        Assert.False(_store.IsStreamConnected("dir-A"));
+    }
+
+    [Fact]
+    public void PushSnapshot_BeforeHello_ThrowsHubException()
+    {
+        var (hub, _) = NewHub("conn-1");
+
+        Assert.Throws<HubException>(() => hub.PushSnapshot(0, new[] { Session("s1") }));
+    }
+
+    [Fact]
+    public void PushDelta_AfterHello_UpsertsSession()
+    {
+        var (hub, _) = NewHub("conn-1");
+        hub.Hello(Hello("dir-A"));
+        hub.PushSnapshot(1, new[] { Session("s1", "Working") });
+
+        hub.PushDelta(2, Session("s1", "WaitingForInput"));
+
+        var fresh = _store.TryGetFresh("dir-A", _staleAfter);
+        Assert.NotNull(fresh);
+        Assert.Single(fresh);
+        Assert.Equal("WaitingForInput", fresh[0].ActivityState);
+    }
+
+    [Fact]
+    public void RemoveSession_AfterHello_DropsSession()
+    {
+        var (hub, _) = NewHub("conn-1");
+        hub.Hello(Hello("dir-A"));
+        hub.PushSnapshot(1, new[] { Session("s1"), Session("s2") });
+
+        hub.RemoveSession(2, "s1");
+
+        var fresh = _store.TryGetFresh("dir-A", _staleAfter);
+        Assert.NotNull(fresh);
+        Assert.Single(fresh);
+        Assert.Equal("s2", fresh[0].SessionId);
+    }
+
+    [Fact]
+    public async Task OnDisconnected_UnregistersTheConnection()
+    {
+        var (hub, _) = NewHub("conn-1");
+        hub.Hello(Hello("dir-A"));
+        hub.PushSnapshot(0, new[] { Session("s1") });
+
+        await hub.OnDisconnectedAsync(null);
+
+        Assert.False(_store.IsStreamConnected("dir-A"));
+        Assert.Null(_store.TryGetFresh("dir-A", _staleAfter));
+    }
+
+    [Fact]
+    public void TwoConnectionsBoundToDifferentDirectors_DoNotCrossContaminate()
+    {
+        var (hubA, _) = NewHub("conn-1");
+        var (hubB, _) = NewHub("conn-2");
+        hubA.Hello(Hello("dir-A"));
+        hubB.Hello(Hello("dir-B"));
+
+        hubA.PushSnapshot(0, new[] { Session("a1"), Session("a2") });
+        hubB.PushSnapshot(0, new[] { Session("b1") });
+
+        var a = _store.TryGetFresh("dir-A", _staleAfter);
+        var b = _store.TryGetFresh("dir-B", _staleAfter);
+        Assert.NotNull(a);
+        Assert.NotNull(b);
+        Assert.Equal(2, a.Count);
+        Assert.Single(b);
+        Assert.Equal("b1", b[0].SessionId);
+    }
+
+    [Fact]
+    public void RestartedDirector_SecondConnectionSameDirector_Reseeds()
+    {
+        var (hub1, _) = NewHub("conn-1");
+        hub1.Hello(Hello("dir-A"));
+        hub1.PushSnapshot(42, new[] { Session("old") });
+
+        // Process restart: a brand-new connection for the same Director, sequence back at 0.
+        var (hub2, _) = NewHub("conn-2");
+        hub2.Hello(Hello("dir-A"));
+        hub2.PushSnapshot(0, new[] { Session("fresh") });
+
+        var fresh = _store.TryGetFresh("dir-A", _staleAfter);
+        Assert.NotNull(fresh);
+        Assert.Single(fresh);
+        Assert.Equal("fresh", fresh[0].SessionId);
+    }
+
+    private sealed class FakeHubCallerContext : HubCallerContext
+    {
+        public FakeHubCallerContext(string connectionId) => ConnectionId = connectionId;
+
+        public override string ConnectionId { get; }
+        public override string? UserIdentifier => null;
+        public override ClaimsPrincipal? User => null;
+        public override IDictionary<object, object?> Items { get; } = new Dictionary<object, object?>();
+        public override IFeatureCollection Features { get; } = new FeatureCollection();
+        public override CancellationToken ConnectionAborted => CancellationToken.None;
+
+        public bool Aborted { get; private set; }
+        public override void Abort() => Aborted = true;
+    }
+}

--- a/src/CcDirector.Gateway.Tests/GatewayStreamClientTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayStreamClientTests.cs
@@ -1,0 +1,165 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json.Nodes;
+using CcDirector.ControlApi;
+using CcDirector.Core.Configuration;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+using System.Net;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// End-to-end test of the REAL Director-side <see cref="GatewayStreamClient"/> against a real GatewayHost
+/// (issue #1176, increment 4). The client dials the hub, sends its snapshot, and pushes deltas/removes;
+/// the assertions read the aggregated <c>GET /sessions</c>. The Director is registered with an unreachable
+/// endpoint, so anything that appears in <c>/sessions</c> can only have arrived via the push stream.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class GatewayStreamClientTests : IAsyncLifetime
+{
+    private const string Token = "test-token-streamclient-1176";
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _instancesDir = Path.Combine(Path.GetTempPath(), "cc-streamclient-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;    // set in InitializeAsync
+    private HttpClient _http = null!;        // set in InitializeAsync
+
+    public GatewayStreamClientTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-streamclient-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+        _gateway.Registry.Upsert(new DirectorRegistrationRequest
+        {
+            DirectorId = "dir-A",
+            TailnetEndpoint = "http://127.0.0.1:59993/", // unreachable on purpose
+            MachineName = "test-machine",
+            Pid = 1,
+            Version = "test",
+            StartedAt = DateTime.UtcNow,
+        });
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch (Exception) { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch (Exception) { /* best effort */ }
+    }
+
+    private GatewayStreamClient NewClient(Func<List<SessionDto>> snapshot)
+    {
+        var config = new GatewayConfig { Url = $"http://127.0.0.1:{_gateway.Port}", Token = Token, StreamMode = true };
+        return new GatewayStreamClient(config, "dir-A", "test", snapshot);
+    }
+
+    [Fact]
+    public async Task RealClient_Snapshot_IsServedFromCache()
+    {
+        await using var client = NewClient(() => new List<SessionDto> { Session("s1"), Session("s2") });
+        client.Start();
+
+        await WaitUntil(async () => (await SessionIds()).Contains("s1"), "s1 to appear");
+
+        var ids = await SessionIds();
+        Assert.Contains("s1", ids);
+        Assert.Contains("s2", ids);
+    }
+
+    [Fact]
+    public async Task RealClient_NotifyDelta_IsReflected()
+    {
+        await using var client = NewClient(() => new List<SessionDto> { Session("s1", "Working") });
+        client.Start();
+        await WaitUntil(async () => (await SessionIds()).Contains("s1"), "s1 to appear");
+
+        client.NotifyDelta(Session("s1", "WaitingForInput"));
+
+        await WaitUntil(async () => await StateOf("s1") == "WaitingForInput", "s1 state to change");
+        Assert.Equal("WaitingForInput", await StateOf("s1"));
+    }
+
+    [Fact]
+    public async Task RealClient_NotifyRemove_IsReflected()
+    {
+        await using var client = NewClient(() => new List<SessionDto> { Session("s1"), Session("s2") });
+        client.Start();
+        await WaitUntil(async () => (await SessionIds()).Contains("s2"), "s2 to appear");
+
+        client.NotifyRemove("s2");
+
+        await WaitUntil(async () => !(await SessionIds()).Contains("s2"), "s2 to be removed");
+        var ids = await SessionIds();
+        Assert.Contains("s1", ids);
+        Assert.DoesNotContain("s2", ids);
+    }
+
+    private static SessionDto Session(string id, string state = "Working") =>
+        new() { SessionId = id, ActivityState = state };
+
+    private async Task<List<string>> SessionIds()
+    {
+        var node = await ReadSessionsNode();
+        var arr = node?["sessions"]?.AsArray() ?? node?.AsArray() ?? new JsonArray();
+        var ids = new List<string>();
+        foreach (var s in arr)
+        {
+            var id = s?["sessionId"]?.GetValue<string>();
+            if (!string.IsNullOrEmpty(id)) ids.Add(id);
+        }
+        return ids;
+    }
+
+    private async Task<string?> StateOf(string sessionId)
+    {
+        var node = await ReadSessionsNode();
+        var arr = node?["sessions"]?.AsArray() ?? node?.AsArray() ?? new JsonArray();
+        foreach (var s in arr)
+            if (s?["sessionId"]?.GetValue<string>() == sessionId)
+                return s?["activityState"]?.GetValue<string>();
+        return null;
+    }
+
+    private async Task<JsonNode?> ReadSessionsNode()
+    {
+        var resp = await _http.GetAsync("sessions?envelope=true");
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<JsonNode>();
+    }
+
+    private static async Task WaitUntil(Func<Task<bool>> condition, string what)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await condition()) return;
+            await Task.Delay(100);
+        }
+        throw new TimeoutException($"Timed out waiting for {what}");
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/src/CcDirector.Gateway.Tests/GatewayStreamClientTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayStreamClientTests.cs
@@ -110,6 +110,25 @@ public sealed class GatewayStreamClientTests : IAsyncLifetime
         Assert.DoesNotContain("s2", ids);
     }
 
+    [Fact]
+    public async Task DownChannel_Ping_RoundTripsToTheDirector()
+    {
+        await using var client = NewClient(() => new List<SessionDto> { Session("s1") });
+        client.Start();
+        await WaitUntil(async () => (await SessionIds()).Contains("s1"), "the stream to connect"); // connected
+
+        var pong = await _gateway.PingDirectorAsync("dir-A", "hello");
+
+        Assert.Equal("pong:hello", pong);
+    }
+
+    [Fact]
+    public async Task DownChannel_Ping_ReturnsNull_WhenNoStreamConnected()
+    {
+        var pong = await _gateway.PingDirectorAsync("dir-nobody", "hello");
+        Assert.Null(pong);
+    }
+
     private static SessionDto Session(string id, string state = "Working") =>
         new() { SessionId = id, ActivityState = state };
 

--- a/src/CcDirector.Gateway.Tests/PushedSessionStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/PushedSessionStoreTests.cs
@@ -1,0 +1,268 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Streaming;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="PushedSessionStore"/> - the correctness core of the Phase 1a push stream
+/// (issue #1176). Each test drives an injected clock so the staleness and idle-clock behaviour is
+/// deterministic.
+/// </summary>
+public sealed class PushedSessionStoreTests
+{
+    private DateTime _now = new(2026, 7, 9, 12, 0, 0, DateTimeKind.Utc);
+    private readonly TimeSpan _staleAfter = TimeSpan.FromSeconds(20);
+
+    private PushedSessionStore NewStore() => new(() => _now);
+
+    private static SessionDto Session(string id, string state = "Working", DateTime? lastActivity = null) => new()
+    {
+        SessionId = id,
+        ActivityState = state,
+        LastActivityAt = lastActivity,
+    };
+
+    [Fact]
+    public void TryGetFresh_AfterSnapshotFromActiveConnection_ReturnsSessions()
+    {
+        // Arrange
+        var store = NewStore();
+        store.RegisterConnection("dir-A", "conn-1");
+
+        // Act
+        var applied = store.ApplySnapshot("dir-A", "conn-1", 0, new[] { Session("s1"), Session("s2") });
+        var fresh = store.TryGetFresh("dir-A", _staleAfter);
+
+        // Assert
+        Assert.True(applied);
+        Assert.NotNull(fresh);
+        Assert.Equal(2, fresh.Count);
+        Assert.Contains(fresh, s => s.SessionId == "s1");
+        Assert.Contains(fresh, s => s.SessionId == "s2");
+    }
+
+    [Fact]
+    public void ApplySnapshot_FromNonActiveConnection_IsRejected()
+    {
+        // Arrange
+        var store = NewStore();
+        store.RegisterConnection("dir-A", "conn-1");
+
+        // Act - a stale connection tries to push
+        var applied = store.ApplySnapshot("dir-A", "conn-OLD", 5, new[] { Session("s1") });
+
+        // Assert
+        Assert.False(applied);
+        Assert.Null(store.TryGetFresh("dir-A", _staleAfter));
+    }
+
+    [Fact]
+    public void ApplyDelta_WithStaleSequence_IsRejected()
+    {
+        // Arrange
+        var store = NewStore();
+        store.RegisterConnection("dir-A", "conn-1");
+        store.ApplySnapshot("dir-A", "conn-1", 5, new[] { Session("s1") });
+
+        // Act - sequence 5 already applied; 5 and below must be dropped
+        var stale = store.ApplyDelta("dir-A", "conn-1", 5, Session("s2"));
+
+        // Assert
+        Assert.False(stale);
+        var fresh = store.TryGetFresh("dir-A", _staleAfter);
+        Assert.NotNull(fresh);
+        Assert.Single(fresh);
+        Assert.Equal("s1", fresh[0].SessionId);
+    }
+
+    [Fact]
+    public void ApplyDelta_WithNewerSequence_UpsertsSession()
+    {
+        // Arrange
+        var store = NewStore();
+        store.RegisterConnection("dir-A", "conn-1");
+        store.ApplySnapshot("dir-A", "conn-1", 1, new[] { Session("s1", "Working") });
+
+        // Act
+        var applied = store.ApplyDelta("dir-A", "conn-1", 2, Session("s1", "WaitingForInput"));
+
+        // Assert
+        Assert.True(applied);
+        var fresh = store.TryGetFresh("dir-A", _staleAfter);
+        Assert.NotNull(fresh);
+        Assert.Single(fresh);
+        Assert.Equal("WaitingForInput", fresh[0].ActivityState);
+    }
+
+    [Fact]
+    public void ApplySnapshot_PrunesSessionsAbsentFromTheSnapshot()
+    {
+        // Arrange
+        var store = NewStore();
+        store.RegisterConnection("dir-A", "conn-1");
+        store.ApplySnapshot("dir-A", "conn-1", 1, new[] { Session("s1"), Session("s2"), Session("s3") });
+
+        // Act - a later snapshot no longer contains s2
+        store.ApplySnapshot("dir-A", "conn-1", 2, new[] { Session("s1"), Session("s3") });
+
+        // Assert
+        var fresh = store.TryGetFresh("dir-A", _staleAfter);
+        Assert.NotNull(fresh);
+        Assert.Equal(2, fresh.Count);
+        Assert.DoesNotContain(fresh, s => s.SessionId == "s2");
+    }
+
+    [Fact]
+    public void ApplyRemove_DropsTheSession()
+    {
+        // Arrange
+        var store = NewStore();
+        store.RegisterConnection("dir-A", "conn-1");
+        store.ApplySnapshot("dir-A", "conn-1", 1, new[] { Session("s1"), Session("s2") });
+
+        // Act
+        var removed = store.ApplyRemove("dir-A", "conn-1", 2, "s1");
+
+        // Assert
+        Assert.True(removed);
+        var fresh = store.TryGetFresh("dir-A", _staleAfter);
+        Assert.NotNull(fresh);
+        Assert.Single(fresh);
+        Assert.Equal("s2", fresh[0].SessionId);
+    }
+
+    [Fact]
+    public void RestartedDirector_NewConnectionFirstSnapshot_IsAuthoritative()
+    {
+        // Arrange - a first connection pushed a high sequence, then the Director process restarts and
+        // dials a brand-new connection that (correctly) starts its own sequence at 0.
+        var store = NewStore();
+        store.RegisterConnection("dir-A", "conn-1");
+        store.ApplySnapshot("dir-A", "conn-1", 42, new[] { Session("old") });
+
+        // Act - the restart: new connection, first snapshot at sequence 0 must NOT be rejected.
+        store.RegisterConnection("dir-A", "conn-2");
+        var applied = store.ApplySnapshot("dir-A", "conn-2", 0, new[] { Session("fresh") });
+
+        // Assert
+        Assert.True(applied);
+        var fresh = store.TryGetFresh("dir-A", _staleAfter);
+        Assert.NotNull(fresh);
+        Assert.Single(fresh);
+        Assert.Equal("fresh", fresh[0].SessionId);
+    }
+
+    [Fact]
+    public void LateDisconnectFromOldConnection_DoesNotClearTheActiveConnection()
+    {
+        // Arrange - a reconnect overlap: conn-2 becomes active, THEN conn-1 (superseded) disconnects.
+        var store = NewStore();
+        store.RegisterConnection("dir-A", "conn-1");
+        store.RegisterConnection("dir-A", "conn-2");
+        store.ApplySnapshot("dir-A", "conn-2", 0, new[] { Session("s1") });
+
+        // Act - the late disconnect of the old connection must be ignored.
+        store.UnregisterConnection("dir-A", "conn-1");
+
+        // Assert - the active connection and its cache survive.
+        Assert.True(store.IsStreamConnected("dir-A"));
+        var fresh = store.TryGetFresh("dir-A", _staleAfter);
+        Assert.NotNull(fresh);
+        Assert.Single(fresh);
+    }
+
+    [Fact]
+    public void UnregisterActiveConnection_MakesTryGetFreshReturnNull()
+    {
+        // Arrange
+        var store = NewStore();
+        store.RegisterConnection("dir-A", "conn-1");
+        store.ApplySnapshot("dir-A", "conn-1", 0, new[] { Session("s1") });
+
+        // Act
+        store.UnregisterConnection("dir-A", "conn-1");
+
+        // Assert - no active connection => aggregation must fall back to pull.
+        Assert.False(store.IsStreamConnected("dir-A"));
+        Assert.Null(store.TryGetFresh("dir-A", _staleAfter));
+    }
+
+    [Fact]
+    public void TryGetFresh_WhenLastPushIsOlderThanStaleWindow_ReturnsNull()
+    {
+        // Arrange
+        var store = NewStore();
+        store.RegisterConnection("dir-A", "conn-1");
+        store.ApplySnapshot("dir-A", "conn-1", 0, new[] { Session("s1") });
+
+        // Act - advance the clock past the stale window with no new push.
+        _now = _now.AddSeconds(21);
+
+        // Assert
+        Assert.Null(store.TryGetFresh("dir-A", _staleAfter));
+    }
+
+    [Fact]
+    public void TryGetFresh_ReturnsDeepCopies_MutatingResultDoesNotAffectStore()
+    {
+        // Arrange
+        var store = NewStore();
+        store.RegisterConnection("dir-A", "conn-1");
+        store.ApplySnapshot("dir-A", "conn-1", 0, new[] { Session("s1", "Working") });
+
+        // Act - the aggregation stamps fields on the returned object.
+        var first = store.TryGetFresh("dir-A", _staleAfter);
+        Assert.NotNull(first);
+        first[0].EffectiveColor = "red";
+        first[0].DirectorId = "mutated";
+        first[0].DriverCapabilities.Add("Interrupt");
+
+        // Assert - a later read is pristine.
+        var second = store.TryGetFresh("dir-A", _staleAfter);
+        Assert.NotNull(second);
+        Assert.Null(second[0].EffectiveColor);
+        Assert.Equal("", second[0].DirectorId);
+        Assert.Empty(second[0].DriverCapabilities);
+    }
+
+    [Fact]
+    public void TryGetFresh_RecomputesIdleSecondsFromLastActivityAt()
+    {
+        // Arrange - a quiet session whose last activity was 10s before the snapshot.
+        var store = NewStore();
+        store.RegisterConnection("dir-A", "conn-1");
+        var lastActivity = _now.AddSeconds(-10);
+        store.ApplySnapshot("dir-A", "conn-1", 0, new[] { Session("s1", "WaitingForInput", lastActivity) });
+
+        // Act - 5s later, served from cache with no new push.
+        _now = _now.AddSeconds(5);
+        var fresh = store.TryGetFresh("dir-A", _staleAfter);
+
+        // Assert - idle seconds reflect now - lastActivity (15s), not the frozen value at push time (10s).
+        Assert.NotNull(fresh);
+        Assert.Equal(15d, fresh[0].IdleSeconds, precision: 1);
+    }
+
+    [Fact]
+    public void ApplySnapshot_BeforeAnyConnectionRegistered_IsRejected()
+    {
+        // Arrange
+        var store = NewStore();
+
+        // Act - no RegisterConnection first.
+        var applied = store.ApplySnapshot("dir-A", "conn-1", 0, new[] { Session("s1") });
+
+        // Assert
+        Assert.False(applied);
+        Assert.Null(store.TryGetFresh("dir-A", _staleAfter));
+    }
+
+    [Fact]
+    public void TryGetFresh_ForUnknownDirector_ReturnsNull()
+    {
+        var store = NewStore();
+        Assert.Null(store.TryGetFresh("nobody", _staleAfter));
+        Assert.False(store.IsStreamConnected("nobody"));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/StreamIntegrationTests.cs
+++ b/src/CcDirector.Gateway.Tests/StreamIntegrationTests.cs
@@ -1,0 +1,210 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json.Nodes;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.SignalR.Client;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// End-to-end integration harness for the Phase 1a push stream (issue #1176). Boots a real GatewayHost
+/// with stream mode ON, dials the DirectorHub with a real SignalR client, pushes state, and asserts the
+/// aggregated <c>GET /sessions</c> serves that state from the pushed cache. The Director is registered
+/// with a DELIBERATELY UNREACHABLE control endpoint, so any session that appears in <c>/sessions</c> with
+/// no machine error can only have come from the cache - a pull would have failed. This proves the whole
+/// Gateway side (hub auth, store, aggregation dual-mode) works over the wire.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class StreamIntegrationTests : IAsyncLifetime
+{
+    private const string Token = "test-token-stream-1176";
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _instancesDir = Path.Combine(Path.GetTempPath(), "cc-stream-int-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;   // set in InitializeAsync
+    private HttpClient _http = null!;       // set in InitializeAsync
+
+    public StreamIntegrationTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-stream-int-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch (Exception) { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch (Exception) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task StreamPush_IsServedFromCache_WithoutPullingTheDirector()
+    {
+        RegisterDirector("dir-A", "http://127.0.0.1:59991/"); // unreachable on purpose
+        await using var conn = await ConnectDirectorAsync(Token);
+        await conn.InvokeAsync("Hello", new DirectorStreamHello { DirectorId = "dir-A", Version = "test" });
+        await conn.InvokeAsync("PushSnapshot", 0L, new[] { Session("s1"), Session("s2") });
+
+        var (sessionIds, errorDirectors) = await GetSessionsAsync();
+
+        Assert.Contains("s1", sessionIds);
+        Assert.Contains("s2", sessionIds);
+        Assert.DoesNotContain("dir-A", errorDirectors); // never pulled => no unreachable error
+    }
+
+    [Fact]
+    public async Task PushDelta_IsReflectedInSessions()
+    {
+        RegisterDirector("dir-A", "http://127.0.0.1:59991/");
+        await using var conn = await ConnectDirectorAsync(Token);
+        await conn.InvokeAsync("Hello", new DirectorStreamHello { DirectorId = "dir-A", Version = "test" });
+        await conn.InvokeAsync("PushSnapshot", 1L, new[] { Session("s1", "Working") });
+
+        await conn.InvokeAsync("PushDelta", 2L, Session("s1", "WaitingForInput"));
+
+        var state = await GetSessionStateAsync("s1");
+        Assert.Equal("WaitingForInput", state);
+    }
+
+    [Fact]
+    public async Task RemoveSession_IsReflectedInSessions()
+    {
+        RegisterDirector("dir-A", "http://127.0.0.1:59991/");
+        await using var conn = await ConnectDirectorAsync(Token);
+        await conn.InvokeAsync("Hello", new DirectorStreamHello { DirectorId = "dir-A", Version = "test" });
+        await conn.InvokeAsync("PushSnapshot", 1L, new[] { Session("s1"), Session("s2") });
+
+        await conn.InvokeAsync("RemoveSession", 2L, "s1");
+
+        var (sessionIds, _) = await GetSessionsAsync();
+        Assert.DoesNotContain("s1", sessionIds);
+        Assert.Contains("s2", sessionIds);
+    }
+
+    [Fact]
+    public async Task UnauthenticatedConnect_IsRejected()
+    {
+        var conn = new HubConnectionBuilder()
+            .WithUrl($"http://127.0.0.1:{_gateway.Port}/director-stream") // no token
+            .Build();
+        await Assert.ThrowsAnyAsync<Exception>(() => conn.StartAsync());
+        await conn.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task StreamModeOff_DoesNotMapTheHub()
+    {
+        var offInstances = Path.Combine(Path.GetTempPath(), "cc-stream-off-" + Guid.NewGuid().ToString("N"));
+        var off = new GatewayHost(port: AllocateFreePort(), token: "t2", authEnabled: true,
+            instancesDirectory: offInstances,
+            workListsPath: Path.Combine(offInstances, "worklists", "worklists.json"),
+            streamMode: false);
+        await off.StartAsync();
+        try
+        {
+            using var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{off.Port}/") };
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "t2");
+            var resp = await http.PostAsync("director-stream/negotiate?negotiateVersion=1", content: null);
+            Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode); // hub not mapped when stream mode is off
+        }
+        finally
+        {
+            await off.StopAsync();
+            try { if (Directory.Exists(offInstances)) Directory.Delete(offInstances, true); } catch (Exception) { /* best effort */ }
+        }
+    }
+
+    private void RegisterDirector(string directorId, string endpoint) =>
+        _gateway.Registry.Upsert(new DirectorRegistrationRequest
+        {
+            DirectorId = directorId,
+            TailnetEndpoint = endpoint,
+            MachineName = "test-machine",
+            Pid = 1,
+            Version = "test",
+            StartedAt = DateTime.UtcNow,
+        });
+
+    private async Task<HubConnection> ConnectDirectorAsync(string token)
+    {
+        var conn = new HubConnectionBuilder()
+            .WithUrl($"http://127.0.0.1:{_gateway.Port}/director-stream", options =>
+            {
+                options.AccessTokenProvider = () => Task.FromResult<string?>(token);
+            })
+            .Build();
+        await conn.StartAsync();
+        return conn;
+    }
+
+    private static SessionDto Session(string id, string state = "Working") =>
+        new() { SessionId = id, ActivityState = state };
+
+    private async Task<(List<string> sessionIds, List<string> errorDirectors)> GetSessionsAsync()
+    {
+        var resp = await _http.GetAsync("sessions?envelope=true");
+        resp.EnsureSuccessStatusCode();
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+
+        var sessionsArray = node?["sessions"]?.AsArray() ?? node?.AsArray() ?? new JsonArray();
+        var sessionIds = new List<string>();
+        foreach (var s in sessionsArray)
+        {
+            var id = s?["sessionId"]?.GetValue<string>();
+            if (!string.IsNullOrEmpty(id)) sessionIds.Add(id);
+        }
+
+        var errors = new List<string>();
+        var errorArray = node?["machineErrors"]?.AsArray();
+        if (errorArray is not null)
+        {
+            foreach (var e in errorArray)
+            {
+                var id = e?["directorId"]?.GetValue<string>();
+                if (!string.IsNullOrEmpty(id)) errors.Add(id);
+            }
+        }
+        return (sessionIds, errors);
+    }
+
+    private async Task<string?> GetSessionStateAsync(string sessionId)
+    {
+        var resp = await _http.GetAsync("sessions?envelope=true");
+        resp.EnsureSuccessStatusCode();
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        var sessionsArray = node?["sessions"]?.AsArray() ?? node?.AsArray() ?? new JsonArray();
+        foreach (var s in sessionsArray)
+        {
+            if (s?["sessionId"]?.GetValue<string>() == sessionId)
+                return s?["activityState"]?.GetValue<string>();
+        }
+        return null;
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -54,7 +54,12 @@ internal static class GatewayEndpoints
         SessionOwnerCache? owners = null,
         Gateway.Events.DirectorEventLog? directorEvents = null,
         Voice.GatewayTurnJobStore? turnJobs = null,
-        Pairing.DeviceRegistry? devices = null)
+        Pairing.DeviceRegistry? devices = null,
+        // Issue #1176 (Phase 1a): when non-null, /sessions serves a Director from this push cache instead
+        // of pulling it, whenever that Director's stream is connected and its last push is within
+        // streamStaleAfter. Null (stream mode off) keeps the pull-only behaviour byte-identical to today.
+        Streaming.PushedSessionStore? pushedSessions = null,
+        TimeSpan? streamStaleAfter = null)
     {
         // Issue #376: async voice-turn submit/poll (the phone's reconnect-resilient voice
         // interface). Mapped first for readability; route precedence (literal segments win
@@ -386,8 +391,27 @@ internal static class GatewayEndpoints
                 .ToList();
 
             var includeExitedActual = includeExited ?? false;
+            var streamStale = streamStaleAfter ?? TimeSpan.FromSeconds(Core.Configuration.GatewayConfig.DefaultStreamStaleAfterSeconds);
             var fanoutTasks = directors.Select(async d =>
             {
+                // Issue #1176 (Phase 1a): if this Director's stream is connected and its last push is fresh,
+                // serve its sessions from the pushed cache and skip the pull entirely (no probe, no
+                // control-endpoint round trip). TryGetFresh returns deep copies with recomputed idle clocks,
+                // so the enrichment pipeline below stamps them exactly as it stamps pulled sessions, and the
+                // cache is never contaminated. includeExited is not yet representable in a pushed snapshot,
+                // so those queries always fall through to the pull below.
+                if (pushedSessions is not null && !includeExitedActual)
+                {
+                    var cached = pushedSessions.TryGetFresh(d.DirectorId, streamStale);
+                    if (cached is not null)
+                    {
+                        FileLog.Write($"[GatewayEndpoints] /sessions director={d.DirectorId} served=pushed-cache ({cached.Count} sessions)");
+                        return (Director: d, Sessions: (List<SessionDto>?)cached.ToList(), Error: (string?)null);
+                    }
+                    if (pushedSessions.IsStreamConnected(d.DirectorId))
+                        FileLog.Write($"[GatewayEndpoints] /sessions director={d.DirectorId} served=pull (stream connected but cache stale/empty)");
+                }
+
                 // Reachability circuit-breaker: a Director that has failed recent probes is skipped while
                 // its breaker is open, so it stops costing a per-poll timeout. Still surfaced as an error
                 // so the UI shows it as unreachable - with an ACTIONABLE message (issue #197): an endpoint

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.SignalR; // Issue #1176: ClientProxyExtensions.InvokeAsync (client results) for the down-channel
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -1239,6 +1240,26 @@ public sealed class GatewayHost : IAsyncDisposable
         {
             FileLog.Write($"[GatewayHost] cron sweep FAILED: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Issue #1176 (Phase 1b): the down-channel proof. Sends a message DOWN a Director's stream and awaits
+    /// its reply over the SAME connection (SignalR client results), demonstrating that the Gateway can
+    /// both push to and request from a Director on the one outbound-dialed connection. Returns null when
+    /// that Director has no active stream. NOTE: this is a synthetic proof, not a production command path -
+    /// the retired assessed-state producer meant there was no live down-path to migrate (plan 4.7b).
+    /// </summary>
+    public async Task<string?> PingDirectorAsync(string directorId, string message, CancellationToken ct = default)
+    {
+        var connectionId = PushedSessions.GetActiveConnectionId(directorId);
+        var hub = _app?.Services.GetService(typeof(Microsoft.AspNetCore.SignalR.IHubContext<Streaming.DirectorHub>))
+            as Microsoft.AspNetCore.SignalR.IHubContext<Streaming.DirectorHub>;
+        if (connectionId is null || hub is null)
+        {
+            FileLog.Write($"[GatewayHost] PingDirectorAsync: no active stream for director={directorId}");
+            return null;
+        }
+        return await hub.Clients.Client(connectionId).InvokeAsync<string>("Ping", message, ct);
     }
 
     public async Task StopAsync()

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -40,6 +40,12 @@ public sealed class GatewayHost : IAsyncDisposable
     /// </summary>
     public Streaming.PushedSessionStore PushedSessions { get; }
 
+    // Issue #1176 (Phase 1a): Gateway-side stream feature switch + staleness window, resolved from
+    // config.json (or an explicit constructor override for tests). When off, the hub is not mapped and
+    // /sessions never consults the pushed cache, so behaviour is byte-identical to today.
+    private readonly bool _streamMode;
+    private readonly TimeSpan _streamStaleAfter;
+
     public bool AuthEnabled { get; }
 
     /// <summary>
@@ -296,12 +302,15 @@ public sealed class GatewayHost : IAsyncDisposable
     /// <see cref="Account"/> null on a non-Windows host, where the operating-system credential store is
     /// not yet implemented).
     /// </param>
-    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null)
+    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null)
     {
         Port = port;
         Token = token ?? GatewayAuth.LoadOrCreate();
         Registry = new DirectorRegistry(instancesDirectory);
         PushedSessions = new Streaming.PushedSessionStore();
+        var gatewayConfig = Core.Configuration.GatewayConfig.Load();
+        _streamMode = streamMode ?? gatewayConfig.StreamMode;
+        _streamStaleAfter = TimeSpan.FromSeconds(gatewayConfig.StreamStaleAfterSeconds);
         Devices = new Pairing.DeviceRegistry(devicesPath);
         AuthEnabled = ResolveAuthEnabled(authEnabled);
         if (AuthEnabled)
@@ -826,10 +835,15 @@ public sealed class GatewayHost : IAsyncDisposable
 
         _app.UseRouting();
 
-        // Issue #1176 (Phase 1a): the Director-push stream endpoint. Mapped after the host-wide auth
-        // middleware above, so the handshake is token-gated exactly like every other route; a Director's
-        // .NET SignalR client presents its Bearer token on the negotiate and WebSocket handshake.
-        _app.MapHub<Streaming.DirectorHub>("/director-stream");
+        // Issue #1176 (Phase 1a): the Director-push stream endpoint, mapped only when stream mode is on
+        // (kill-switch: off => the hub does not exist and behaviour is byte-identical to today). Mapped
+        // after the host-wide auth middleware above, so the handshake is token-gated exactly like every
+        // other route; a Director's .NET SignalR client presents its Bearer token on the handshake.
+        if (_streamMode)
+        {
+            _app.MapHub<Streaming.DirectorHub>("/director-stream");
+            FileLog.Write("[GatewayHost] stream mode ON: DirectorHub mapped at /director-stream; /sessions serves from the push cache when fresh");
+        }
 
         // Product version stamped by Directory.Build.props; full form carries the commit SHA.
         var version = AppVersion.Full;
@@ -899,7 +913,11 @@ public sealed class GatewayHost : IAsyncDisposable
             turnJobs: TurnJobs,
             // Issue #1045: pass the per-device-key registry so the voice-turn routes' own token
             // check (issue #369) accepts a phone's enrolled device key, not just the shared token.
-            devices: Devices);
+            devices: Devices,
+            // Issue #1176 (Phase 1a): serve /sessions from the Director-push cache when the stream is
+            // fresh; null when stream mode is off, keeping /sessions byte-identical to today.
+            pushedSessions: _streamMode ? PushedSessions : null,
+            streamStaleAfter: _streamStaleAfter);
 
         // Issue #268: the two raw per-session WebSocket legs (live Terminal stream + dictation)
         // proxied through the Gateway so a remote Cockpit talks same-origin to the Gateway and

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -32,6 +32,14 @@ public sealed class GatewayHost : IAsyncDisposable
     public int Port { get; }
     public string Token { get; }
     public DirectorRegistry Registry { get; }
+
+    /// <summary>
+    /// Issue #1176 (Phase 1a): the Gateway's cache of session state pushed up by stream-connected
+    /// Directors. The <c>/sessions</c> aggregation serves a Director from here (instead of pulling it)
+    /// when that Director's stream is connected and fresh. Empty until Directors connect and push.
+    /// </summary>
+    public Streaming.PushedSessionStore PushedSessions { get; }
+
     public bool AuthEnabled { get; }
 
     /// <summary>
@@ -293,6 +301,7 @@ public sealed class GatewayHost : IAsyncDisposable
         Port = port;
         Token = token ?? GatewayAuth.LoadOrCreate();
         Registry = new DirectorRegistry(instancesDirectory);
+        PushedSessions = new Streaming.PushedSessionStore();
         Devices = new Pairing.DeviceRegistry(devicesPath);
         AuthEnabled = ResolveAuthEnabled(authEnabled);
         if (AuthEnabled)
@@ -717,6 +726,13 @@ public sealed class GatewayHost : IAsyncDisposable
         // the C# DTOs stay the single source of truth for the front-end.
         builder.Services.AddOpenApi();
 
+        // Issue #1176 (Phase 1a): the Director-push stream. The hub and its two collaborators are
+        // registered as singletons so the hub (constructed per-invocation by SignalR's container) and the
+        // /sessions aggregation (wired explicitly below) share the one PushedSessionStore instance.
+        builder.Services.AddSignalR();
+        builder.Services.AddSingleton(PushedSessions);
+        builder.Services.AddSingleton(Registry);
+
         // Honor X-Forwarded-Proto/Host/For from a Tailscale Serve front-end so
         // ctx.Request.Scheme reflects the public scheme the user actually used.
         // Without this, every request appears as plain "http" to the Gateway
@@ -809,6 +825,11 @@ public sealed class GatewayHost : IAsyncDisposable
         _app.UseWebSockets();
 
         _app.UseRouting();
+
+        // Issue #1176 (Phase 1a): the Director-push stream endpoint. Mapped after the host-wide auth
+        // middleware above, so the handshake is token-gated exactly like every other route; a Director's
+        // .NET SignalR client presents its Bearer token on the negotiate and WebSocket handshake.
+        _app.MapHub<Streaming.DirectorHub>("/director-stream");
 
         // Product version stamped by Directory.Build.props; full form carries the commit SHA.
         var version = AppVersion.Full;

--- a/src/CcDirector.Gateway/Streaming/DirectorHub.cs
+++ b/src/CcDirector.Gateway/Streaming/DirectorHub.cs
@@ -1,0 +1,117 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+using Microsoft.AspNetCore.SignalR;
+
+namespace CcDirector.Gateway.Streaming;
+
+/// <summary>
+/// Issue #1176 (Phase 1a): the SignalR hub each Director dials OUT to. It receives the session state a
+/// Director pushes UP - a full snapshot on connect/reconnect, per-session deltas, and removes - and
+/// records it in the <see cref="PushedSessionStore"/> so the <c>/sessions</c> aggregation can serve that
+/// Director from cache instead of pulling it.
+///
+/// Identity binding (review #9): the first message MUST be <see cref="Hello"/>, which binds this
+/// connection to one Director id. Every later message uses that bound id - never a Director id re-sent by
+/// the client - so a connection can only ever affect the Director it declared, and a message that arrives
+/// before Hello is rejected. The transport itself is already authenticated by the host-wide token
+/// middleware (a valid shared token or per-device key); binding a credential cryptographically to a
+/// specific Director id is future work that rides the account/device epic.
+///
+/// The hub holds no state of its own; it is a thin adapter onto <see cref="PushedSessionStore"/> and
+/// <see cref="DirectorRegistry"/>. SignalR constructs it per invocation via dependency injection (the
+/// one place this codebase uses a container, because the framework requires it).
+/// </summary>
+public sealed class DirectorHub : Hub
+{
+    private const string DirectorIdItemKey = "cc.directorId";
+
+    private readonly PushedSessionStore _store;
+    private readonly DirectorRegistry _registry;
+
+    public DirectorHub(PushedSessionStore store, DirectorRegistry registry)
+    {
+        _store = store;
+        _registry = registry;
+    }
+
+    /// <summary>Bind this connection to a Director. Must be the first message; aborts the connection on a bad id.</summary>
+    public void Hello(DirectorStreamHello hello)
+    {
+        if (hello is null || string.IsNullOrWhiteSpace(hello.DirectorId))
+        {
+            FileLog.Write($"[DirectorHub] Hello REJECTED (missing directorId): conn={Short(Context.ConnectionId)}");
+            Context.Abort();
+            return;
+        }
+
+        var directorId = hello.DirectorId.Trim();
+        var alreadyBound = BoundDirectorId();
+        if (alreadyBound is not null && !string.Equals(alreadyBound, directorId, StringComparison.OrdinalIgnoreCase))
+        {
+            FileLog.Write($"[DirectorHub] Hello REJECTED (conn already bound to {alreadyBound}, cannot re-claim {directorId}): conn={Short(Context.ConnectionId)}");
+            Context.Abort();
+            return;
+        }
+
+        Context.Items[DirectorIdItemKey] = directorId;
+        _store.RegisterConnection(directorId, Context.ConnectionId);
+        _registry.MarkStateReporting(directorId);
+        FileLog.Write($"[DirectorHub] Hello: director={directorId} bound to conn={Short(Context.ConnectionId)} (version={hello.Version})");
+    }
+
+    /// <summary>A full snapshot: replaces the bound Director's session set (pruning anything absent).</summary>
+    public void PushSnapshot(long sequence, SessionDto[] sessions)
+    {
+        var directorId = RequireBoundDirector();
+        _store.ApplySnapshot(directorId, Context.ConnectionId, sequence, sessions ?? Array.Empty<SessionDto>());
+    }
+
+    /// <summary>A single-session delta: upserts one session for the bound Director.</summary>
+    public void PushDelta(long sequence, SessionDto session)
+    {
+        var directorId = RequireBoundDirector();
+        if (session is null || string.IsNullOrEmpty(session.SessionId))
+        {
+            FileLog.Write($"[DirectorHub] PushDelta ignored (no session id): director={directorId}, conn={Short(Context.ConnectionId)}");
+            return;
+        }
+        _store.ApplyDelta(directorId, Context.ConnectionId, sequence, session);
+    }
+
+    /// <summary>A remove/tombstone: drops one session from the bound Director's set.</summary>
+    public void RemoveSession(long sequence, string sessionId)
+    {
+        var directorId = RequireBoundDirector();
+        if (string.IsNullOrEmpty(sessionId))
+        {
+            FileLog.Write($"[DirectorHub] RemoveSession ignored (no session id): director={directorId}, conn={Short(Context.ConnectionId)}");
+            return;
+        }
+        _store.ApplyRemove(directorId, Context.ConnectionId, sequence, sessionId);
+    }
+
+    public override Task OnConnectedAsync()
+    {
+        FileLog.Write($"[DirectorHub] connected: conn={Short(Context.ConnectionId)}");
+        return base.OnConnectedAsync();
+    }
+
+    public override Task OnDisconnectedAsync(Exception? exception)
+    {
+        var directorId = BoundDirectorId();
+        if (directorId is not null)
+            _store.UnregisterConnection(directorId, Context.ConnectionId);
+        FileLog.Write($"[DirectorHub] disconnected: conn={Short(Context.ConnectionId)}, director={directorId ?? "(unbound)"} ({exception?.Message ?? "clean"})");
+        return base.OnDisconnectedAsync(exception);
+    }
+
+    private string? BoundDirectorId() =>
+        Context.Items.TryGetValue(DirectorIdItemKey, out var value) && value is string id ? id : null;
+
+    private string RequireBoundDirector() =>
+        BoundDirectorId() ?? throw new HubException("Director stream not initialized: send Hello first.");
+
+    private static string Short(string? id) =>
+        string.IsNullOrEmpty(id) ? "(none)" : (id.Length <= 8 ? id : id[..8]);
+}

--- a/src/CcDirector.Gateway/Streaming/PushedSessionStore.cs
+++ b/src/CcDirector.Gateway/Streaming/PushedSessionStore.cs
@@ -1,0 +1,235 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Streaming;
+
+/// <summary>
+/// Issue #1176 (Phase 1a): the Gateway's in-memory cache of the session state each Director pushes UP
+/// over its persistent stream, replacing the on-demand pull for stream-connected Directors. One entry
+/// per Director (keyed by directorId), holding the sessions that Director last pushed.
+///
+/// Correctness rules this store enforces (Phase 1 plan, section 4.4):
+///  - CONNECTION GENERATION: each stream connection is identified by its SignalR connection id. A new
+///    connection becomes the active connection for its Director and its first message is authoritative.
+///    This is what lets a RESTARTED Director - which dials a brand-new connection - reseed even though a
+///    prior connection had pushed higher sequence numbers (a plain persistent integer epoch would wrongly
+///    reject the restarted Director's snapshot).
+///  - SEQUENCE ORDERING: within one connection, messages carry a monotonic sequence; a message with a
+///    sequence at or below the last applied one is dropped as stale/duplicate.
+///  - ACTIVE-CONNECTION OWNERSHIP: snapshot/delta/remove are accepted only from the currently active
+///    connection. A late disconnect from a superseded connection (a reconnect overlap) does NOT clear the
+///    active connection or the cache.
+///  - SNAPSHOT IS AUTHORITATIVE: a full snapshot replaces the Director's whole session set, pruning any
+///    session not present in it.
+///
+/// Reads (<see cref="TryGetFresh"/>) return deep COPIES so the aggregation may stamp them without
+/// contaminating the cache, and recompute relative time fields (idle seconds) from the absolute
+/// LastActivityAt so a quiet session's idle clock keeps advancing between pushes.
+///
+/// Thread-safe: a <see cref="ConcurrentDictionary{TKey,TValue}"/> of per-Director entries, each guarded
+/// by its own lock.
+/// </summary>
+public sealed class PushedSessionStore
+{
+    private readonly ConcurrentDictionary<string, DirectorEntry> _byDirector = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Func<DateTime> _utcNow;
+
+    /// <summary>
+    /// Create the store. <paramref name="utcNow"/> is a test seam for the staleness and idle-clock logic;
+    /// production passes null and the store reads <see cref="DateTime.UtcNow"/>.
+    /// </summary>
+    public PushedSessionStore(Func<DateTime>? utcNow = null)
+    {
+        _utcNow = utcNow ?? (() => DateTime.UtcNow);
+    }
+
+    /// <summary>
+    /// Mark <paramref name="connectionId"/> as the active stream connection for <paramref name="directorId"/>.
+    /// Existing cached sessions are kept (so a fast reconnect keeps roster continuity), but the sequence
+    /// baseline resets so the new connection's first message - at any sequence - is authoritative. The
+    /// last-received timestamp is deliberately NOT refreshed here: until the new connection actually pushes
+    /// a snapshot, the cache is treated as stale so aggregation falls back to pull.
+    /// </summary>
+    public void RegisterConnection(string directorId, string connectionId)
+    {
+        if (string.IsNullOrWhiteSpace(directorId))
+            throw new ArgumentException("directorId is required", nameof(directorId));
+        if (string.IsNullOrWhiteSpace(connectionId))
+            throw new ArgumentException("connectionId is required", nameof(connectionId));
+
+        var entry = _byDirector.GetOrAdd(directorId, _ => new DirectorEntry());
+        lock (entry.Gate)
+        {
+            entry.ActiveConnectionId = connectionId;
+            entry.LastSequence = -1;
+        }
+        FileLog.Write($"[PushedSessionStore] RegisterConnection: director={directorId}, conn={Short(connectionId)} is now the active connection");
+    }
+
+    /// <summary>
+    /// Clear the active connection for <paramref name="directorId"/> IF <paramref name="connectionId"/> is
+    /// still the active one. A late disconnect from a superseded connection is logged and ignored so it
+    /// cannot wipe a newer active connection. Cached sessions are retained; while no connection is active,
+    /// <see cref="TryGetFresh"/> returns null so aggregation pulls instead.
+    /// </summary>
+    public void UnregisterConnection(string directorId, string connectionId)
+    {
+        if (!_byDirector.TryGetValue(directorId, out var entry))
+            return;
+
+        lock (entry.Gate)
+        {
+            if (!string.Equals(entry.ActiveConnectionId, connectionId, StringComparison.Ordinal))
+            {
+                FileLog.Write($"[PushedSessionStore] UnregisterConnection IGNORED (not active): director={directorId}, conn={Short(connectionId)}, active={Short(entry.ActiveConnectionId)}");
+                return;
+            }
+            entry.ActiveConnectionId = null;
+        }
+        FileLog.Write($"[PushedSessionStore] UnregisterConnection: director={directorId}, conn={Short(connectionId)} cleared; aggregation will fall back to pull");
+    }
+
+    /// <summary>
+    /// Apply a full snapshot: replace the Director's whole session set, pruning any session not present.
+    /// </summary>
+    /// <returns>true if applied; false if rejected (not the active connection, or a stale sequence).</returns>
+    public bool ApplySnapshot(string directorId, string connectionId, long sequence, IReadOnlyList<SessionDto> sessions)
+    {
+        if (sessions is null)
+            throw new ArgumentNullException(nameof(sessions));
+        if (!_byDirector.TryGetValue(directorId, out var entry))
+            return false;
+
+        lock (entry.Gate)
+        {
+            if (!IsAcceptable(entry, directorId, connectionId, sequence, "snapshot"))
+                return false;
+
+            entry.Sessions.Clear();
+            foreach (var s in sessions)
+            {
+                if (!string.IsNullOrEmpty(s.SessionId))
+                    entry.Sessions[s.SessionId] = s;
+            }
+            entry.LastSequence = sequence;
+            entry.ReceivedAtUtc = _utcNow();
+        }
+        return true;
+    }
+
+    /// <summary>Apply a single-session delta: upsert one session.</summary>
+    /// <returns>true if applied; false if rejected.</returns>
+    public bool ApplyDelta(string directorId, string connectionId, long sequence, SessionDto session)
+    {
+        if (session is null)
+            throw new ArgumentNullException(nameof(session));
+        if (string.IsNullOrEmpty(session.SessionId))
+            throw new ArgumentException("session.SessionId is required", nameof(session));
+        if (!_byDirector.TryGetValue(directorId, out var entry))
+            return false;
+
+        lock (entry.Gate)
+        {
+            if (!IsAcceptable(entry, directorId, connectionId, sequence, "delta"))
+                return false;
+
+            entry.Sessions[session.SessionId] = session;
+            entry.LastSequence = sequence;
+            entry.ReceivedAtUtc = _utcNow();
+        }
+        return true;
+    }
+
+    /// <summary>Apply a remove/tombstone: drop one session from the Director's set.</summary>
+    /// <returns>true if applied; false if rejected.</returns>
+    public bool ApplyRemove(string directorId, string connectionId, long sequence, string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId))
+            throw new ArgumentException("sessionId is required", nameof(sessionId));
+        if (!_byDirector.TryGetValue(directorId, out var entry))
+            return false;
+
+        lock (entry.Gate)
+        {
+            if (!IsAcceptable(entry, directorId, connectionId, sequence, "remove"))
+                return false;
+
+            entry.Sessions.Remove(sessionId);
+            entry.LastSequence = sequence;
+            entry.ReceivedAtUtc = _utcNow();
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Return deep COPIES of the Director's cached sessions when the stream is connected and the last push
+    /// is within <paramref name="staleAfter"/>; otherwise null so the caller pulls. Copies are returned so
+    /// the /sessions aggregation may stamp them without contaminating the cache. Relative time fields (idle
+    /// seconds) are recomputed from the absolute LastActivityAt at serve time so a quiet session's idle
+    /// clock keeps advancing between pushes.
+    /// </summary>
+    public IReadOnlyList<SessionDto>? TryGetFresh(string directorId, TimeSpan staleAfter)
+    {
+        if (!_byDirector.TryGetValue(directorId, out var entry))
+            return null;
+
+        lock (entry.Gate)
+        {
+            if (entry.ActiveConnectionId is null)
+                return null;
+            if (entry.ReceivedAtUtc == DateTime.MinValue)
+                return null;
+
+            var now = _utcNow();
+            if (now - entry.ReceivedAtUtc > staleAfter)
+                return null;
+
+            var copies = new List<SessionDto>(entry.Sessions.Count);
+            foreach (var s in entry.Sessions.Values)
+                copies.Add(RecomputeClocks(s.Clone(), now));
+            return copies;
+        }
+    }
+
+    /// <summary>True when this Director currently has an active stream connection (used for diagnostics).</summary>
+    public bool IsStreamConnected(string directorId) =>
+        _byDirector.TryGetValue(directorId, out var entry) && entry.ActiveConnectionId is not null;
+
+    private static bool IsAcceptable(DirectorEntry entry, string directorId, string connectionId, long sequence, string kind)
+    {
+        if (!string.Equals(entry.ActiveConnectionId, connectionId, StringComparison.Ordinal))
+        {
+            FileLog.Write($"[PushedSessionStore] {kind} DROPPED (not the active connection): director={directorId}, conn={Short(connectionId)}, active={Short(entry.ActiveConnectionId)}");
+            return false;
+        }
+        if (sequence <= entry.LastSequence)
+        {
+            FileLog.Write($"[PushedSessionStore] {kind} DROPPED (stale sequence {sequence} <= last {entry.LastSequence}): director={directorId}, conn={Short(connectionId)}");
+            return false;
+        }
+        return true;
+    }
+
+    private static SessionDto RecomputeClocks(SessionDto s, DateTime nowUtc)
+    {
+        if (s.LastActivityAt is DateTime last)
+        {
+            var idle = (nowUtc - last).TotalSeconds;
+            s.IdleSeconds = idle > 0 ? idle : 0;
+        }
+        return s;
+    }
+
+    private static string Short(string? id) =>
+        string.IsNullOrEmpty(id) ? "(none)" : (id.Length <= 8 ? id : id[..8]);
+
+    private sealed class DirectorEntry
+    {
+        public readonly object Gate = new();
+        public string? ActiveConnectionId;
+        public long LastSequence = -1;
+        public DateTime ReceivedAtUtc = DateTime.MinValue;
+        public readonly Dictionary<string, SessionDto> Sessions = new(StringComparer.Ordinal);
+    }
+}

--- a/src/CcDirector.Gateway/Streaming/PushedSessionStore.cs
+++ b/src/CcDirector.Gateway/Streaming/PushedSessionStore.cs
@@ -196,6 +196,18 @@ public sealed class PushedSessionStore
     public bool IsStreamConnected(string directorId) =>
         _byDirector.TryGetValue(directorId, out var entry) && entry.ActiveConnectionId is not null;
 
+    /// <summary>
+    /// The active stream connection id for a Director, or null when none. The Gateway uses it to address a
+    /// message DOWN the stream to that Director (issue #1176, Phase 1b down-channel).
+    /// </summary>
+    public string? GetActiveConnectionId(string directorId)
+    {
+        if (!_byDirector.TryGetValue(directorId, out var entry))
+            return null;
+        lock (entry.Gate)
+            return entry.ActiveConnectionId;
+    }
+
     private static bool IsAcceptable(DirectorEntry entry, string directorId, string connectionId, long sequence, string kind)
     {
         if (!string.Equals(entry.ActiveConnectionId, connectionId, StringComparison.Ordinal))


### PR DESCRIPTION
Implements Phase 1a of the Director-to-Gateway push stream (issue thefrederiksen/devthrottle_internal#721), plus the Phase 1b down-channel proof (#1177). Additive and flag-gated: with `gateway.streamMode` off (the default), behaviour is byte-identical to today.

## What this does

Each Director dials one persistent SignalR connection OUT to the Gateway and pushes its session state up. The Gateway caches it and serves `GET /sessions` from that cache instead of pulling the Director, while keeping the pull path as the fallback.

## Increments (each committed with tests)

1. **Correctness core** - `PushedSessionStore` with the connection-generation guard (#2), active-connection ownership (#3), snapshot prune + remove/tombstone (#4), deep-copy-on-read (#7), serve-time idle-clock recompute; `gateway.streamMode` / `staleAfterSeconds` config; `SessionDto.Clone()`.
2. **`DirectorHub`** - the SignalR endpoint; identity binding (#9); marks the Director state-reporting; token-gated by the host-wide auth middleware.
3. **`/sessions` aggregation dual-mode** - cache-first fetch with every enrichment side effect preserved (#10), `includeExited` pull-fallback (#5), cache-vs-pull observability (#11), Gateway kill-switch.
4. **`GatewayStreamClient`** - the Director's outbound client (dial, auto-reconnect, snapshot on connect/reconnect, delta/remove), reusing the exact `ControlEndpoints.Map` (#6).
5. **Down-channel proof (1b)** - `GatewayHost.PingDirectorAsync` calls the Director over the stream and awaits a reply (SignalR client results), proving request-both-ways.

## Testing

- **33 stream tests** (14 store + 9 hub + 5 Gateway-integration + 5 real-client/down-channel end-to-end) and **5 new `GatewayConfig` tests**, all passing.
- **Full Gateway suite: 1388 passed / 1 failed.** The one failure (`DictationEndpointTests.FullPipeline_transcribes_phase0_clip2`) is pre-existing and environmental - it needs a live transcription API key (`websocket closed unexpectedly: no api key`) and touches nothing this PR changes.
- Clean build with `TreatWarningsAsErrors=true` across Gateway, ControlApi, and both test projects.

QA report with per-increment evidence: `docs/new_architecture/phase-1a-qa-report.md`.

## Not in this PR (later, needs a live app)

The Director connection-status UI wiring and the live fleet-comms / director-skill parity verification (both need a running desktop app / fleet), and the byte-path inversion / portless end-state (explicitly out of scope per the plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
