### PR TITLE
Launcher-persistent-join + start a session on another computer

### DIFF
--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -51,6 +51,34 @@ internal static class ControlEndpoints
             return Map(s, directorId, cache, mn, usr, ep, gatewayUrl);
         }
 
+        // Create a session LOCALLY through the shared SessionCommandExecutor (issue #1177 Phase 1), then
+        // build the identity-stamped 201 response. Shared by POST /sessions and the local branch of
+        // POST /fleet/spawn so both create identically; the Machine routing field is advisory here (the
+        // routing decision is made before the request reaches this Director).
+        async Task<IResult> CreateLocalSessionAsync(NewSessionRequest? req)
+        {
+            var command = new DirectorCommand
+            {
+                Verb = "create",
+                SessionId = "",
+                PayloadJson = req is null ? "" : SessionCommandExecutor.Serialize(req),
+            };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
+
+            if (result.Status == DirectorCommandStatus.BadRequest)
+                return Results.BadRequest(new { error = result.Error });
+            if (result.Status != DirectorCommandStatus.Ok)
+                return Results.Problem(result.Error ?? "create failed", statusCode: 500);
+
+            var created = SessionCommandExecutor.Deserialize<SessionDto>(result.BodyJson);
+            if (created is null || !Guid.TryParse(created.SessionId, out var newGuid))
+                return Results.Problem("created session id missing", statusCode: 500);
+            var session = sessionManager.GetSession(newGuid);
+            return session is null
+                ? Results.Problem("created session not found", statusCode: 500)
+                : Results.Json(MapWithIdentity(session, turnSummaryCache), statusCode: 201);
+        }
+
         // ===== Healthz =====
         app.MapGet("/healthz", () => Results.Json(new HealthDto
         {
@@ -598,6 +626,49 @@ internal static class ControlEndpoints
                 {
                     Answered = false, Status = "failed", Error = ex.Message,
                 }, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        });
+
+        // POST /fleet/spawn - "start a session on another computer". The body is a NewSessionRequest whose
+        // Machine field selects the target: empty / "local" / this Director's own machine name spawns
+        // LOCALLY (unchanged local behavior); any other machine name routes the spawn through the Gateway to
+        // a Director on that machine (first available, auto-launched if none is running). A remote spawn
+        // FAILS LOUD when no Gateway is configured or the machine is off / unreachable - it NEVER falls back
+        // to a local spawn.
+        app.MapPost("/fleet/spawn", async (NewSessionRequest req, CancellationToken ct) =>
+        {
+            if (req is null || string.IsNullOrWhiteSpace(req.RepoPath))
+                return Results.BadRequest(new { error = "repoPath is required" });
+
+            var machine = req.Machine?.Trim();
+            var isLocal = string.IsNullOrEmpty(machine)
+                || string.Equals(machine, "local", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(machine, Environment.MachineName, StringComparison.OrdinalIgnoreCase);
+
+            if (isLocal)
+            {
+                FileLog.Write($"[ControlEndpoints] POST /fleet/spawn: LOCAL, repo={req.RepoPath}, agent={req.Agent}");
+                return await CreateLocalSessionAsync(req);
+            }
+
+            FileLog.Write($"[ControlEndpoints] POST /fleet/spawn: machine={machine}, repo={req.RepoPath}, agent={req.Agent}");
+            var gw = gatewayClientProvider?.Invoke();
+            if (gw is not { IsEnabled: true })
+                return Results.Json(
+                    new { error = $"Cannot start a session on '{machine}': no Gateway is configured on this Director." },
+                    statusCode: StatusCodes.Status502BadGateway);
+
+            try
+            {
+                var dto = await gw.SpawnOnMachineAsync(machine!, req, ct);
+                return Results.Json(dto, statusCode: StatusCodes.Status201Created);
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[ControlEndpoints] POST /fleet/spawn relay to {machine} FAILED: {ex.Message}");
+                return Results.Json(
+                    new { error = $"Cannot start a session on '{machine}': {ex.Message}" },
+                    statusCode: StatusCodes.Status502BadGateway);
             }
         });
 
@@ -2860,29 +2931,9 @@ internal static class ControlEndpoints
             // the shared SessionCommandExecutor so this REST path and the Gateway stream down-channel
             // create identically. The Director's own 201 response is still built with the identity-stamped
             // MapWithIdentity (unchanged), so this endpoint stays byte-identical; the executor returns the
-            // plain stream DTO that the Gateway stamps during aggregation.
-            var command = new DirectorCommand
-            {
-                Verb = "create",
-                SessionId = "",
-                PayloadJson = req is null ? "" : SessionCommandExecutor.Serialize(req),
-            };
-            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
-
-            if (result.Status == DirectorCommandStatus.BadRequest)
-                return Results.BadRequest(new { error = result.Error });
-            if (result.Status != DirectorCommandStatus.Ok)
-                return Results.Problem(result.Error ?? "create failed", statusCode: 500);
-
-            // Re-fetch the created session by the id the executor returned so the local response carries
-            // the identity fields (MachineName/User/TailnetEndpoint), exactly as before.
-            var created = SessionCommandExecutor.Deserialize<SessionDto>(result.BodyJson);
-            if (created is null || !Guid.TryParse(created.SessionId, out var newGuid))
-                return Results.Problem("created session id missing", statusCode: 500);
-            var session = sessionManager.GetSession(newGuid);
-            return session is null
-                ? Results.Problem("created session not found", statusCode: 500)
-                : Results.Json(MapWithIdentity(session, turnSummaryCache), statusCode: 201);
+            // plain stream DTO that the Gateway stamps during aggregation. The Machine routing field (if any)
+            // is advisory here - a POST /sessions always creates on THIS Director.
+            return await CreateLocalSessionAsync(req);
         });
 
         // ===== REST: Create a GitHub Actions remote session =====

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -286,6 +286,50 @@ public sealed class GatewayClient : IDisposable
     }
 
     /// <summary>
+    /// Start a session on ANOTHER machine ("start a session on another computer"), via the Gateway's
+    /// POST /machines/{machine}/sessions relay. The Gateway resolves the machine to a Director (launching
+    /// one through the launcher when none is running) and creates the session there. Fail-loud like the
+    /// other fleet relays: THROWS when the Gateway is disabled, the machine is off / unreachable, or the
+    /// create fails - it NEVER falls back to a local spawn. Returns the new session on success.
+    ///
+    /// Uses a DEDICATED HttpClient with a generous timeout: the shared <c>_http</c> has a 10s ceiling, but
+    /// a remote spawn may auto-launch a Director and wait (bounded) for it to register, which legitimately
+    /// exceeds 10s (same reasoning as <see cref="AskFleetAsync"/>).
+    /// </summary>
+    public async Task<SessionDto> SpawnOnMachineAsync(string machine, NewSessionRequest req, CancellationToken ct = default)
+    {
+        if (!_config.IsEnabled)
+            throw new InvalidOperationException("Gateway is not configured; cannot start a session on another machine.");
+        if (string.IsNullOrWhiteSpace(machine))
+            throw new ArgumentException("Target machine is required", nameof(machine));
+        if (req is null)
+            throw new ArgumentNullException(nameof(req));
+
+        FileLog.Write($"[GatewayClient] SpawnOnMachineAsync: POST /machines/{machine}/sessions, repo={req.RepoPath}, agent={req.Agent}");
+        using var http = new HttpClient
+        {
+            BaseAddress = new Uri(_config.Url.TrimEnd('/') + "/"),
+            Timeout = TimeSpan.FromSeconds(120),
+        };
+        if (!string.IsNullOrEmpty(_config.Token))
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _config.Token);
+
+        using var resp = await http.PostAsJsonAsync($"machines/{Uri.EscapeDataString(machine)}/sessions", req, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var detail = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(
+                $"Gateway could not start a session on '{machine}': HTTP {(int)resp.StatusCode} {resp.ReasonPhrase} {detail}".TrimEnd());
+        }
+
+        var parsed = await resp.Content.ReadFromJsonAsync<SessionDto>(ct);
+        if (parsed is null)
+            throw new InvalidOperationException("Gateway start-on-machine returned an unparsable body.");
+        FileLog.Write($"[GatewayClient] SpawnOnMachineAsync: started sid={parsed.SessionId} on machine={machine}");
+        return parsed;
+    }
+
+    /// <summary>
     /// Start the registration lifecycle. Fire-and-forget: the first register attempt
     /// runs in the background so a slow or unreachable Gateway never blocks Director
     /// startup. The heartbeat timer is set up regardless.

--- a/src/CcDirector.Gateway.Contracts/LauncherCommandMessages.cs
+++ b/src/CcDirector.Gateway.Contracts/LauncherCommandMessages.cs
@@ -1,0 +1,72 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// launcher-persistent-join: a lifecycle command the Gateway sends DOWN a launcher's persistent stream.
+/// <see cref="Verb"/> selects the action on the launcher; the remaining fields carry the payload the verb
+/// needs (all optional - each verb reads only the fields it uses).
+///
+/// This is the launcher twin of <see cref="DirectorCommand"/>. It rides the SAME outbound-dialed connection
+/// (the launcher dials the Gateway; the Gateway never dials the launcher), and the launcher executes it
+/// through the SAME <c>DirectorSupervisor</c> / <c>LaunchService</c> actions the loopback REST endpoints use,
+/// so the stream path and the REST relay path cannot drift.
+///
+/// Verbs: "director/start", "director/stop", "director/restart", "launch".
+/// </summary>
+public sealed class LauncherCommand
+{
+    /// <summary>Selects the action on the launcher: "director/start", "director/stop", "director/restart", or "launch".</summary>
+    public string Verb { get; set; } = "";
+
+    /// <summary>Optional workspace/context hint for a launch, reserved for future verbs. Unused by the current verbs.</summary>
+    public string? Workspace { get; set; }
+
+    /// <summary>For "launch": the absolute path to the executable. For lifecycle verbs: the target Director exe (informational).</summary>
+    public string? Path { get; set; }
+
+    /// <summary>For "launch": optional command-line arguments.</summary>
+    public string? Args { get; set; }
+
+    /// <summary>For "launch": optional working directory (defaults to the executable's directory).</summary>
+    public string? Cwd { get; set; }
+
+    /// <summary>For "launch": when true, run headless (no window); when false, GUI mode with clean parentage.</summary>
+    public bool Headless { get; set; }
+
+    /// <summary>
+    /// True when the caller confirmed a protected-slot lifecycle action. The Gateway's slot guard already
+    /// runs before the command is pushed; this echoes the caller's confirmation for the launcher's audit log.
+    /// </summary>
+    public bool ConfirmProtected { get; set; }
+}
+
+/// <summary>The outcome category of a <see cref="LauncherCommand"/>. The stream path has no HTTP status codes.</summary>
+public enum LauncherCommandStatus
+{
+    Ok = 0,
+    BadRequest = 1,
+    Error = 2,
+}
+
+/// <summary>
+/// launcher-persistent-join: the reply to a <see cref="LauncherCommand"/>, returned to the Gateway over the
+/// same connection (SignalR client results). The launcher twin of <see cref="DirectorCommandResult"/>.
+/// </summary>
+public sealed class LauncherCommandResult
+{
+    /// <summary>The outcome category.</summary>
+    public LauncherCommandStatus Status { get; set; }
+
+    /// <summary>A human-readable error message on failure; null on success.</summary>
+    public string? Error { get; set; }
+
+    /// <summary>True when the command succeeded.</summary>
+    public bool IsOk => Status == LauncherCommandStatus.Ok;
+
+    /// <summary>Build a success result.</summary>
+    public static LauncherCommandResult Ok() =>
+        new() { Status = LauncherCommandStatus.Ok };
+
+    /// <summary>Build a failure result with the given status and message.</summary>
+    public static LauncherCommandResult Fail(LauncherCommandStatus status, string error) =>
+        new() { Status = status, Error = error };
+}

--- a/src/CcDirector.Gateway.Contracts/LauncherStreamMessages.cs
+++ b/src/CcDirector.Gateway.Contracts/LauncherStreamMessages.cs
@@ -1,0 +1,23 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// launcher-persistent-join: the first message a cc-launcher sends after opening its persistent stream to
+/// the Gateway, declaring which machine this connection speaks for. The <see cref="LauncherHub"/> binds the
+/// connection to this identity; from then on every command the Gateway pushes DOWN this connection reaches
+/// only this machine's launcher, so one connection can never drive another machine's launcher.
+///
+/// This is the launcher twin of <see cref="DirectorStreamHello"/> (the Director's UP-channel Hello). A
+/// launcher only ever RECEIVES commands after Hello - it pushes no session state - so this is the only
+/// message it sends up the stream.
+/// </summary>
+public sealed class LauncherStreamHello
+{
+    /// <summary>The machine name (the same key the launcher registers under via POST /launchers/register).</summary>
+    public string MachineName { get; set; } = "";
+
+    /// <summary>The launcher's loopback REST port, for diagnostics and cross-referencing the registry entry.</summary>
+    public int Port { get; set; }
+
+    /// <summary>Launcher build version, for diagnostics.</summary>
+    public string Version { get; set; } = "";
+}

--- a/src/CcDirector.Gateway.Contracts/NewSessionRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/NewSessionRequest.cs
@@ -93,6 +93,17 @@ public sealed class NewSessionRequest
     /// inferred from the spawn graph. Null leaves the role to auto-derivation.
     /// </summary>
     public string? Role { get; set; }
+
+    /// <summary>
+    /// Optional target machine for spawn routing ("start a session on another computer"). Null,
+    /// empty, or the local machine name spawns on the LOCAL machine (the default, unchanged); a
+    /// remote machine name routes the spawn via the Gateway to a Director on that machine (first
+    /// available, auto-launched if none is running). This field is ADVISORY on a Director's own
+    /// POST /sessions - the Director always creates locally and its identity comes from
+    /// <c>Environment.MachineName</c>; the routing decision is made before the request reaches the
+    /// target Director.
+    /// </summary>
+    public string? Machine { get; set; }
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway.Tests/LauncherCommandRouterTests.cs
+++ b/src/CcDirector.Gateway.Tests/LauncherCommandRouterTests.cs
@@ -1,0 +1,127 @@
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="LauncherCommandRouter"/> (launcher-persistent-join), the launcher twin of the
+/// Director command router. It is the ONE place the Gateway decides "push down the launcher stream, or fall
+/// back to the HTTP relay". A null return is the fall-back signal, for BOTH the flag-off case (the send
+/// delegate is null) and the flag-on-but-launcher-offline case (the delegate returns null); a non-null result
+/// - success OR a typed failure - is authoritative.
+/// </summary>
+public sealed class LauncherCommandRouterTests
+{
+    private static LauncherCommand StartCommand() => new() { Verb = "director/start" };
+
+    [Fact]
+    public async Task TrySendAsync_NullDelegate_ReturnsNull_ForRestFallback()
+    {
+        // Arrange + Act - stream mode off: the host passes a null send delegate.
+        var result = await LauncherCommandRouter.TrySendAsync(null, "machine-A", StartCommand(), CancellationToken.None);
+
+        // Assert - null tells the caller to use the existing HTTP relay.
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task TrySendAsync_DelegateReturnsResult_ReturnsThatResult()
+    {
+        // Arrange - the launcher is online: the delegate returns an authoritative result.
+        var expected = LauncherCommandResult.Ok();
+        LauncherCommandRouter.SendLauncherCommandAsync del = (_, _, _) => Task.FromResult<LauncherCommandResult?>(expected);
+
+        // Act
+        var result = await LauncherCommandRouter.TrySendAsync(del, "machine-A", StartCommand(), CancellationToken.None);
+
+        // Assert - the stream result is returned unchanged; the caller must NOT also relay over HTTP.
+        Assert.Same(expected, result);
+    }
+
+    [Fact]
+    public async Task TrySendAsync_DelegateReturnsNull_ReturnsNull_ForRestFallback()
+    {
+        // Arrange - stream mode on but the launcher has no active connection: the delegate returns null.
+        LauncherCommandRouter.SendLauncherCommandAsync del = (_, _, _) => Task.FromResult<LauncherCommandResult?>(null);
+
+        // Act
+        var result = await LauncherCommandRouter.TrySendAsync(del, "machine-A", StartCommand(), CancellationToken.None);
+
+        // Assert - still the HTTP-relay fall-back signal.
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task TrySendAsync_PassesMachineNameAndCommand_ToTheDelegate()
+    {
+        // Arrange
+        string? seenMachine = null;
+        string? seenVerb = null;
+        LauncherCommandRouter.SendLauncherCommandAsync del = (machine, cmd, _) =>
+        {
+            seenMachine = machine;
+            seenVerb = cmd.Verb;
+            return Task.FromResult<LauncherCommandResult?>(LauncherCommandResult.Ok());
+        };
+
+        // Act
+        await LauncherCommandRouter.TrySendAsync(del, "machine-Z", new LauncherCommand { Verb = "director/restart" }, CancellationToken.None);
+
+        // Assert - the router forwards the routing key and command verbatim.
+        Assert.Equal("machine-Z", seenMachine);
+        Assert.Equal("director/restart", seenVerb);
+    }
+
+    [Fact]
+    public async Task TrySendAsync_DelegateReturnsTypedFailure_IsReturnedAuthoritatively()
+    {
+        // Arrange - the launcher rejected the command; a typed failure is authoritative, not a fall-back.
+        var failure = LauncherCommandResult.Fail(LauncherCommandStatus.BadRequest, "unknown verb: bogus");
+        LauncherCommandRouter.SendLauncherCommandAsync del = (_, _, _) => Task.FromResult<LauncherCommandResult?>(failure);
+
+        // Act
+        var result = await LauncherCommandRouter.TrySendAsync(del, "machine-A", new LauncherCommand { Verb = "bogus" }, CancellationToken.None);
+
+        // Assert - a non-null failure is returned as-is (the caller must NOT relay over HTTP).
+        Assert.Same(failure, result);
+        Assert.NotNull(result);
+        Assert.False(result!.IsOk);
+    }
+}
+
+/// <summary>
+/// Unit tests for the <see cref="LauncherCommandResult"/> factory helpers (launcher-persistent-join).
+/// </summary>
+public sealed class LauncherCommandResultTests
+{
+    [Fact]
+    public void Ok_ProducesOkStatus_WithNoError()
+    {
+        var result = LauncherCommandResult.Ok();
+
+        Assert.Equal(LauncherCommandStatus.Ok, result.Status);
+        Assert.Null(result.Error);
+        Assert.True(result.IsOk);
+    }
+
+    [Fact]
+    public void Fail_ProducesTheGivenStatusAndMessage()
+    {
+        var result = LauncherCommandResult.Fail(LauncherCommandStatus.Error, "boom");
+
+        Assert.Equal(LauncherCommandStatus.Error, result.Status);
+        Assert.Equal("boom", result.Error);
+        Assert.False(result.IsOk);
+    }
+
+    [Fact]
+    public void Fail_WithBadRequest_IsNotOk()
+    {
+        var result = LauncherCommandResult.Fail(LauncherCommandStatus.BadRequest, "path is required for launch");
+
+        Assert.Equal(LauncherCommandStatus.BadRequest, result.Status);
+        Assert.Equal("path is required for launch", result.Error);
+        Assert.False(result.IsOk);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/LauncherConnectionRegistryTests.cs
+++ b/src/CcDirector.Gateway.Tests/LauncherConnectionRegistryTests.cs
@@ -1,0 +1,128 @@
+using CcDirector.Gateway.Streaming;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="LauncherConnectionRegistry"/> (launcher-persistent-join). The launcher twin of
+/// the connection-tracking half of <see cref="PushedSessionStore"/>: a thread-safe machine-name to
+/// connection-id map whose one delicate behaviour is that a superseded connection's LATE disconnect must not
+/// wipe a newer connection registered for the same machine (atomic compare-remove).
+/// </summary>
+public sealed class LauncherConnectionRegistryTests
+{
+    private static LauncherConnectionRegistry NewRegistry() => new();
+
+    [Fact]
+    public void RegisterConnection_ThenGetActiveConnectionId_ReturnsIt_AndIsStreamConnectedIsTrue()
+    {
+        // Arrange
+        var registry = NewRegistry();
+
+        // Act
+        registry.RegisterConnection("machine-A", "conn-1");
+
+        // Assert
+        Assert.Equal("conn-1", registry.GetActiveConnectionId("machine-A"));
+        Assert.True(registry.IsStreamConnected("machine-A"));
+    }
+
+    [Fact]
+    public void GetActiveConnectionId_IsCaseInsensitiveOnMachineName()
+    {
+        // Arrange
+        var registry = NewRegistry();
+        registry.RegisterConnection("Machine-A", "conn-1");
+
+        // Assert - the map is keyed case-insensitively (OrdinalIgnoreCase).
+        Assert.Equal("conn-1", registry.GetActiveConnectionId("machine-a"));
+        Assert.True(registry.IsStreamConnected("MACHINE-A"));
+    }
+
+    [Fact]
+    public void Unregister_ClearsTheActiveConnection()
+    {
+        // Arrange
+        var registry = NewRegistry();
+        registry.RegisterConnection("machine-A", "conn-1");
+
+        // Act
+        registry.Unregister("conn-1");
+
+        // Assert
+        Assert.False(registry.IsStreamConnected("machine-A"));
+        Assert.Null(registry.GetActiveConnectionId("machine-A"));
+    }
+
+    [Fact]
+    public void Reconnect_SecondConnectionSameMachine_Supersedes()
+    {
+        // Arrange - a launcher restart / reconnect: a new connection for the same machine wins.
+        var registry = NewRegistry();
+        registry.RegisterConnection("machine-A", "conn-1");
+
+        // Act
+        registry.RegisterConnection("machine-A", "conn-2");
+
+        // Assert
+        Assert.Equal("conn-2", registry.GetActiveConnectionId("machine-A"));
+    }
+
+    [Fact]
+    public void LateUnregisterOfSupersededConnection_DoesNotWipeNewerConnection()
+    {
+        // Arrange - a reconnect overlap: conn-2 becomes the active connection for the machine, THEN conn-1
+        // (the superseded old connection) disconnects late. The atomic compare-remove must ignore the stale
+        // disconnect so the newer connection keeps owning the machine.
+        var registry = NewRegistry();
+        registry.RegisterConnection("machine-A", "conn-1");
+        registry.RegisterConnection("machine-A", "conn-2");
+
+        // Act
+        registry.Unregister("conn-1");
+
+        // Assert - the newer connection still owns the machine.
+        Assert.True(registry.IsStreamConnected("machine-A"));
+        Assert.Equal("conn-2", registry.GetActiveConnectionId("machine-A"));
+    }
+
+    [Fact]
+    public void UnregisterUnknownConnection_IsANoOp()
+    {
+        // Arrange
+        var registry = NewRegistry();
+        registry.RegisterConnection("machine-A", "conn-1");
+
+        // Act - a connection id the registry never held.
+        registry.Unregister("conn-does-not-exist");
+
+        // Assert - the active connection is untouched.
+        Assert.True(registry.IsStreamConnected("machine-A"));
+        Assert.Equal("conn-1", registry.GetActiveConnectionId("machine-A"));
+    }
+
+    [Fact]
+    public void GetActiveConnectionId_ForUnknownMachine_ReturnsNull()
+    {
+        var registry = NewRegistry();
+        Assert.Null(registry.GetActiveConnectionId("nobody"));
+        Assert.False(registry.IsStreamConnected("nobody"));
+    }
+
+    [Fact]
+    public void TwoMachines_DoNotCrossContaminate()
+    {
+        // Arrange - two machines each with their own launcher connection.
+        var registry = NewRegistry();
+        registry.RegisterConnection("machine-A", "conn-A");
+        registry.RegisterConnection("machine-B", "conn-B");
+
+        // Act - one disconnects.
+        registry.Unregister("conn-A");
+
+        // Assert - the other is unaffected.
+        Assert.False(registry.IsStreamConnected("machine-A"));
+        Assert.True(registry.IsStreamConnected("machine-B"));
+        Assert.Equal("conn-B", registry.GetActiveConnectionId("machine-B"));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/LauncherStreamIntegrationTests.cs
+++ b/src/CcDirector.Gateway.Tests/LauncherStreamIntegrationTests.cs
@@ -1,0 +1,164 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.SignalR.Client;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// End-to-end integration harness for launcher-persistent-join, the launcher twin of
+/// <see cref="StreamIntegrationTests"/>. Boots a real GatewayHost with stream mode ON, dials the
+/// <c>LauncherHub</c> at <c>/launcher-stream</c> with a real SignalR client, sends <c>Hello</c>, and asserts
+/// the connection is registered. It then has the Gateway push a command DOWN the stream and asserts the
+/// client's <c>Command</c> handler runs and returns a result over the same connection (SignalR client
+/// results). This proves the whole join + command-dispatch path over the wire: hub auth, identity binding,
+/// the connection registry, and <c>GatewayHost.SendLauncherCommandAsync</c>'s stream-vs-fallback decision.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class LauncherStreamIntegrationTests : IAsyncLifetime
+{
+    private const string Token = "test-token-launcher-join";
+    private const string Machine = "launcher-test-machine";
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _instancesDir = Path.Combine(Path.GetTempPath(), "cc-launcher-int-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;   // set in InitializeAsync
+
+    public LauncherStreamIntegrationTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-launcher-int-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch (Exception) { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch (Exception) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task Hello_RegistersTheLauncherConnection()
+    {
+        await using var conn = await ConnectLauncherAsync(Token);
+        conn.On<LauncherCommand, LauncherCommandResult>("Command", _ => Task.FromResult(LauncherCommandResult.Ok()));
+
+        await conn.InvokeAsync("Hello", new LauncherStreamHello { MachineName = Machine, Port = 7878, Version = "test" });
+
+        Assert.True(_gateway.LauncherConnections.IsStreamConnected(Machine));
+    }
+
+    [Fact]
+    public async Task GatewayPushesCommand_DownTheStream_ClientHandlerRunsAndReturnsResult()
+    {
+        LauncherCommand? received = null;
+        await using var conn = await ConnectLauncherAsync(Token);
+        conn.On<LauncherCommand, LauncherCommandResult>("Command", cmd =>
+        {
+            received = cmd;
+            return Task.FromResult(LauncherCommandResult.Ok());
+        });
+        await conn.InvokeAsync("Hello", new LauncherStreamHello { MachineName = Machine, Port = 7878, Version = "test" });
+
+        var result = await _gateway.SendLauncherCommandAsync(Machine, new LauncherCommand { Verb = "director/restart" });
+
+        Assert.NotNull(result);
+        Assert.True(result!.IsOk);
+        Assert.NotNull(received);
+        Assert.Equal("director/restart", received!.Verb);
+    }
+
+    [Fact]
+    public async Task ClientReturnsTypedFailure_IsReturnedAuthoritatively()
+    {
+        await using var conn = await ConnectLauncherAsync(Token);
+        conn.On<LauncherCommand, LauncherCommandResult>("Command",
+            _ => Task.FromResult(LauncherCommandResult.Fail(LauncherCommandStatus.BadRequest, "unknown verb: bogus")));
+        await conn.InvokeAsync("Hello", new LauncherStreamHello { MachineName = Machine, Port = 7878, Version = "test" });
+
+        var result = await _gateway.SendLauncherCommandAsync(Machine, new LauncherCommand { Verb = "bogus" });
+
+        Assert.NotNull(result);
+        Assert.False(result!.IsOk);
+        Assert.Equal(LauncherCommandStatus.BadRequest, result.Status);
+        Assert.Equal("unknown verb: bogus", result.Error);
+    }
+
+    [Fact]
+    public async Task SendLauncherCommandAsync_ForOfflineMachine_ReturnsNull_ForRestFallback()
+    {
+        // No launcher has joined for this machine => no active stream connection => null, which the caller
+        // treats as "no stream" and falls back to the existing HTTP relay.
+        var result = await _gateway.SendLauncherCommandAsync("no-such-machine", new LauncherCommand { Verb = "director/start" });
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task UnauthenticatedConnect_IsRejected()
+    {
+        var conn = new HubConnectionBuilder()
+            .WithUrl($"http://127.0.0.1:{_gateway.Port}/launcher-stream") // no token
+            .Build();
+        await Assert.ThrowsAnyAsync<Exception>(() => conn.StartAsync());
+        await conn.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task StreamModeOff_DoesNotMapTheLauncherHub()
+    {
+        var offInstances = Path.Combine(Path.GetTempPath(), "cc-launcher-off-" + Guid.NewGuid().ToString("N"));
+        var off = new GatewayHost(port: AllocateFreePort(), token: "t2", authEnabled: true,
+            instancesDirectory: offInstances,
+            workListsPath: Path.Combine(offInstances, "worklists", "worklists.json"),
+            streamMode: false);
+        await off.StartAsync();
+        try
+        {
+            using var http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{off.Port}/") };
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "t2");
+            var resp = await http.PostAsync("launcher-stream/negotiate?negotiateVersion=1", content: null);
+            Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode); // hub not mapped when stream mode is off
+        }
+        finally
+        {
+            await off.StopAsync();
+            try { if (Directory.Exists(offInstances)) Directory.Delete(offInstances, true); } catch (Exception) { /* best effort */ }
+        }
+    }
+
+    private async Task<HubConnection> ConnectLauncherAsync(string token)
+    {
+        var conn = new HubConnectionBuilder()
+            .WithUrl($"http://127.0.0.1:{_gateway.Port}/launcher-stream", options =>
+            {
+                options.AccessTokenProvider = () => Task.FromResult<string?>(token);
+            })
+            .Build();
+        await conn.StartAsync();
+        return conn;
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/src/CcDirector.Gateway.Tests/MachineSessionSpawnerTests.cs
+++ b/src/CcDirector.Gateway.Tests/MachineSessionSpawnerTests.cs
@@ -1,0 +1,100 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Running;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="MachineSessionSpawner"/> - the single resolve-then-create path shared by
+/// the cron firing engine and the interactive POST /machines/{machine}/sessions relay ("start a session
+/// on another computer"). A stub resolver stands in for the live registry/launcher and a fake create
+/// delegate stands in for the Director's session-create call, so the resolve-then-create DECISION is
+/// verified without a live Director. Covers the good path (resolver returns an endpoint -> create ->
+/// success) and the fail-loud path (resolver returns an offline Error -> failure, and the create is
+/// NEVER attempted, i.e. no local fallback).
+/// </summary>
+public sealed class MachineSessionSpawnerTests
+{
+    /// <summary>A resolver that returns a fixed <see cref="DirectorTargetResult"/> and counts its calls.</summary>
+    private sealed class StubResolver : IDirectorTargetResolver
+    {
+        private readonly DirectorTargetResult _result;
+        public int ResolveCount { get; private set; }
+        public string? LastMachine { get; private set; }
+
+        public StubResolver(DirectorTargetResult result) => _result = result;
+
+        public Task<DirectorTargetResult> ResolveAsync(string machine, CancellationToken ct)
+        {
+            ResolveCount++;
+            LastMachine = machine;
+            return Task.FromResult(_result);
+        }
+    }
+
+    [Fact]
+    public async Task Spawn_ResolverReturnsEndpoint_CreatesSession_ReturnsIt()
+    {
+        var resolver = new StubResolver(new DirectorTargetResult("http://127.0.0.1:7900", "d-new", null));
+        string? seenEndpoint = null;
+        NewSessionRequest? seenReq = null;
+        var spawner = new MachineSessionSpawner(resolver, (endpoint, req, ct) =>
+        {
+            seenEndpoint = endpoint;
+            seenReq = req;
+            return Task.FromResult<(bool, SessionDto?, string?)>((true, new SessionDto { SessionId = "sid-123" }, null));
+        });
+
+        var request = new NewSessionRequest { RepoPath = @"C:\repo", Agent = "ClaudeCode" };
+        var (ok, dto, error, directorId) = await spawner.SpawnOnMachineAsync("MACHINE_A", request, CancellationToken.None);
+
+        Assert.True(ok);
+        Assert.NotNull(dto);
+        Assert.Equal("sid-123", dto!.SessionId);
+        Assert.Null(error);
+        Assert.Equal("d-new", directorId);
+        // The create was made against the resolved endpoint with the same request.
+        Assert.Equal("http://127.0.0.1:7900", seenEndpoint);
+        Assert.Same(request, seenReq);
+        Assert.Equal("MACHINE_A", resolver.LastMachine);
+    }
+
+    [Fact]
+    public async Task Spawn_ResolverReturnsOfflineError_FailsLoud_DoesNotCreateLocally()
+    {
+        var resolver = new StubResolver(
+            new DirectorTargetResult(null, null, "no Director on 'MACHINE_B' and the launcher could not start one"));
+        var createCalled = false;
+        var spawner = new MachineSessionSpawner(resolver, (endpoint, req, ct) =>
+        {
+            createCalled = true;
+            return Task.FromResult<(bool, SessionDto?, string?)>((true, new SessionDto { SessionId = "must-not-happen" }, null));
+        });
+
+        var (ok, dto, error, _) = await spawner.SpawnOnMachineAsync(
+            "MACHINE_B", new NewSessionRequest { RepoPath = @"C:\repo" }, CancellationToken.None);
+
+        Assert.False(ok);
+        Assert.Null(dto);
+        Assert.NotNull(error);
+        Assert.Contains("could not start one", error!);
+        // No local fallback: the create is never attempted when the machine cannot be resolved.
+        Assert.False(createCalled);
+    }
+
+    [Fact]
+    public async Task Spawn_CreateFails_ReportsTheCreateError_KeepsResolvedDirectorId()
+    {
+        var resolver = new StubResolver(new DirectorTargetResult("http://127.0.0.1:7901", "d-live", null));
+        var spawner = new MachineSessionSpawner(resolver, (endpoint, req, ct) =>
+            Task.FromResult<(bool, SessionDto?, string?)>((false, null, "director returned 500: boom")));
+
+        var (ok, dto, error, directorId) = await spawner.SpawnOnMachineAsync(
+            "MACHINE_A", new NewSessionRequest { RepoPath = @"C:\repo" }, CancellationToken.None);
+
+        Assert.False(ok);
+        Assert.Null(dto);
+        Assert.Equal("director returned 500: boom", error);
+        Assert.Equal("d-live", directorId);   // still carries the resolved Director for the run record
+    }
+}

--- a/src/CcDirector.Gateway/Api/LauncherCommandRouter.cs
+++ b/src/CcDirector.Gateway/Api/LauncherCommandRouter.cs
@@ -1,0 +1,37 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// launcher-persistent-join: the ONE place the Gateway decides "push this lifecycle command DOWN the
+/// launcher's persistent stream, or fall back to the HTTP relay". The machine relay routes through
+/// <see cref="TrySendAsync"/> so the decision is uniform across verbs and cannot diverge. The launcher twin
+/// of <see cref="DirectorCommandRouter"/>.
+///
+/// The decision itself lives in the injected <paramref name="sendCommand"/> delegate (the Gateway host
+/// passes <c>GatewayHost.SendLauncherCommandAsync</c> when stream mode is ON, and null when it is off). That
+/// delegate returns null when the launcher has no active stream connection, so a null return here means "no
+/// stream - use the HTTP relay" for BOTH the flag-off and the flag-on-but-offline cases. A non-null result -
+/// success OR a typed failure - is authoritative and the endpoint must not also call the HTTP relay.
+/// </summary>
+internal static class LauncherCommandRouter
+{
+    /// <summary>The signature of the "send a command down a launcher's stream" hook, non-null only when stream mode is on.</summary>
+    public delegate Task<LauncherCommandResult?> SendLauncherCommandAsync(string machineName, LauncherCommand command, CancellationToken ct);
+
+    /// <summary>
+    /// Try to route a command down the launcher's stream. Returns the stream result, or null to signal the
+    /// caller to fall back to its existing HTTP relay (stream mode off, or the launcher is not stream-connected).
+    /// </summary>
+    public static async Task<LauncherCommandResult?> TrySendAsync(
+        SendLauncherCommandAsync? sendCommand, string machineName, LauncherCommand command, CancellationToken ct)
+    {
+        if (sendCommand is null)
+            return null;
+
+        var result = await sendCommand(machineName, command, ct);
+        FileLog.Write($"[LauncherCommandRouter] {command.Verb} machine={machineName}: {(result is null ? "no stream -> HTTP relay fallback" : $"stream status={result.Status}")}");
+        return result;
+    }
+}

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -51,7 +51,8 @@ internal static class MachineEndpoints
     private static readonly Regex SlotFromPath =
         new(@"cc-director(\d*)\.exe$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-    public static void Map(IEndpointRouteBuilder app, LauncherRegistry launchers)
+    public static void Map(IEndpointRouteBuilder app, LauncherRegistry launchers,
+        LauncherCommandRouter.SendLauncherCommandAsync? sendLauncherCommand = null)
     {
         // ===== Launcher self-registration surface =====
 
@@ -105,21 +106,21 @@ internal static class MachineEndpoints
         app.MapPost("/machines/{machine}/director/restart", async (string machine, HttpContext ctx, CancellationToken ct) =>
         {
             FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/director/restart: caller={ctx.Connection.RemoteIpAddress}");
-            return await RelayDirectorLifecycleAsync(machine, "restart", ctx, launchers, ct);
+            return await RelayDirectorLifecycleAsync(machine, "restart", ctx, launchers, sendLauncherCommand, ct);
         });
 
         // POST /machines/{machine}/director/start
         app.MapPost("/machines/{machine}/director/start", async (string machine, HttpContext ctx, CancellationToken ct) =>
         {
             FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/director/start: caller={ctx.Connection.RemoteIpAddress}");
-            return await RelayDirectorLifecycleAsync(machine, "start", ctx, launchers, ct);
+            return await RelayDirectorLifecycleAsync(machine, "start", ctx, launchers, sendLauncherCommand, ct);
         });
 
         // POST /machines/{machine}/director/stop
         app.MapPost("/machines/{machine}/director/stop", async (string machine, HttpContext ctx, CancellationToken ct) =>
         {
             FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/director/stop: caller={ctx.Connection.RemoteIpAddress}");
-            return await RelayDirectorLifecycleAsync(machine, "stop", ctx, launchers, ct);
+            return await RelayDirectorLifecycleAsync(machine, "stop", ctx, launchers, sendLauncherCommand, ct);
         });
 
         // POST /machines/{machine}/launch - relay a generic launch request to the launcher.
@@ -127,17 +128,32 @@ internal static class MachineEndpoints
         {
             FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/launch: caller={ctx.Connection.RemoteIpAddress}");
 
+            // Forward the original request body verbatim to the launcher.
+            LaunchRelayBody? body = null;
+            try { body = await ctx.Request.ReadFromJsonAsync<LaunchRelayBody>(ct); }
+            catch { /* treat as null -> launcher will 400 */ }
+
+            // launcher-persistent-join: prefer the persistent stream. When stream mode is on and the launcher
+            // is joined, push the launch DOWN the open connection instead of dialing its REST API. A null
+            // result means no stream (flag off, or launcher offline), so fall through to the REST relay below.
+            var launchStreamCmd = new LauncherCommand
+            {
+                Verb = "launch",
+                Path = body?.Path,
+                Args = body?.Args,
+                Cwd = body?.Cwd,
+                Headless = body?.Headless ?? false,
+            };
+            var launchStreamResult = await LauncherCommandRouter.TrySendAsync(sendLauncherCommand, machine, launchStreamCmd, ct);
+            if (launchStreamResult is not null)
+                return MapLauncherStreamResult(machine, "launch", launchStreamResult);
+
             var (launcher, token, networkAddress, err) = ResolveLauncher(machine, launchers);
             if (err is not null)
             {
                 FileLog.Write($"[MachineEndpoints] /machines/{machine}/launch: {err.Value.log}");
                 return err.Value.result;
             }
-
-            // Forward the original request body verbatim to the launcher.
-            LaunchRelayBody? body = null;
-            try { body = await ctx.Request.ReadFromJsonAsync<LaunchRelayBody>(ct); }
-            catch { /* treat as null -> launcher will 400 */ }
 
             using var http = BuildLauncherClient(launcher!.Port, token!, networkAddress!);
             IResult result;
@@ -172,7 +188,8 @@ internal static class MachineEndpoints
     /// Enforces the slot guard for restart/stop verbs.
     /// </summary>
     private static async Task<IResult> RelayDirectorLifecycleAsync(
-        string machine, string verb, HttpContext ctx, LauncherRegistry launchers, CancellationToken ct)
+        string machine, string verb, HttpContext ctx, LauncherRegistry launchers,
+        LauncherCommandRouter.SendLauncherCommandAsync? sendLauncherCommand, CancellationToken ct)
     {
         // Parse optional body for confirmProtected flag and target exe path.
         // Use JsonDocument to avoid internal-class reflection issues with System.Text.Json.
@@ -213,6 +230,20 @@ internal static class MachineEndpoints
                 }, statusCode: 403);
             }
         }
+
+        // launcher-persistent-join: prefer the persistent stream. When stream mode is on and the launcher is
+        // joined, push the lifecycle verb DOWN the open connection instead of dialing its REST API. The slot
+        // guard above has already run, so a protected-slot action is still gated identically. A null result
+        // means no stream (flag off, or launcher offline), so fall through to the REST relay below unchanged.
+        var streamCmd = new LauncherCommand
+        {
+            Verb = $"director/{verb}",
+            Path = exePathFromBody,
+            ConfirmProtected = confirmProtectedFromBody == true,
+        };
+        var streamResult = await LauncherCommandRouter.TrySendAsync(sendLauncherCommand, machine, streamCmd, ct);
+        if (streamResult is not null)
+            return MapLauncherStreamResult(machine, verb, streamResult);
 
         var (launcher, token, networkAddress, err) = ResolveLauncher(machine, launchers);
         if (err is not null)
@@ -290,6 +321,33 @@ internal static class MachineEndpoints
         };
         http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
         return http;
+    }
+
+    /// <summary>
+    /// launcher-persistent-join: render a <see cref="LauncherCommandResult"/> from the stream path as the
+    /// same <see cref="RelayResult"/> envelope the REST relay returns, so a stream-served call is
+    /// indistinguishable to the caller. Ok -> 200; BadRequest -> 400; Error -> 502 (launcher-side failure,
+    /// mirroring the REST relay's "launcher unreachable" 502).
+    /// </summary>
+    private static IResult MapLauncherStreamResult(string machine, string verb, LauncherCommandResult result)
+    {
+        var status = result.Status switch
+        {
+            LauncherCommandStatus.Ok => 200,
+            LauncherCommandStatus.BadRequest => 400,
+            _ => 502,
+        };
+        var payload = result.IsOk
+            ? JsonSerializer.Serialize(new { ok = true, via = "stream" })
+            : JsonSerializer.Serialize(new { error = result.Error, via = "stream" });
+        FileLog.Write($"[MachineEndpoints] relay /director/{verb} machine={machine} via=stream -> status={status}");
+        return Results.Json(new RelayResult
+        {
+            Machine = machine,
+            Verb = verb,
+            RelayStatus = status,
+            Payload = payload,
+        }, statusCode: status);
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Running;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -52,8 +53,11 @@ internal static class MachineEndpoints
         new(@"cc-director(\d*)\.exe$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     public static void Map(IEndpointRouteBuilder app, LauncherRegistry launchers,
+        MachineSessionSpawner spawner,
         LauncherCommandRouter.SendLauncherCommandAsync? sendLauncherCommand = null)
     {
+        if (spawner is null) throw new ArgumentNullException(nameof(spawner));
+
         // ===== Launcher self-registration surface =====
 
         // POST /launchers/register - the launcher POSTs this on startup and after reconnects.
@@ -114,6 +118,27 @@ internal static class MachineEndpoints
         {
             FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/director/start: caller={ctx.Connection.RemoteIpAddress}");
             return await RelayDirectorLifecycleAsync(machine, "start", ctx, launchers, sendLauncherCommand, ct);
+        });
+
+        // POST /machines/{machine}/sessions - "start a session on another computer". Resolve the machine
+        // to a Director (auto-launching one via the launcher if none is running) and create the session
+        // there through the SAME resolve-then-create path the cron firing engine uses. Fail loud: an
+        // off/unreachable machine or a create failure returns 502 with the error - NEVER a local spawn.
+        app.MapPost("/machines/{machine}/sessions", async (string machine, NewSessionRequest req, CancellationToken ct) =>
+        {
+            FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions: repo={req?.RepoPath}, agent={req?.Agent}");
+            if (req is null || string.IsNullOrWhiteSpace(req.RepoPath))
+                return Results.BadRequest(new { error = "repoPath is required" });
+
+            var (ok, dto, error, _) = await spawner.SpawnOnMachineAsync(machine, req, ct);
+            if (!ok || dto is null)
+            {
+                FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions FAILED: {error}");
+                return Results.Json(new { error = error ?? $"could not start a session on '{machine}'", machine }, statusCode: 502);
+            }
+
+            FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions: started sid={dto.SessionId}");
+            return Results.Json(dto, statusCode: 201);
         });
 
         // POST /machines/{machine}/director/stop

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -42,6 +42,14 @@ public sealed class GatewayHost : IAsyncDisposable
     /// </summary>
     public Streaming.PushedSessionStore PushedSessions { get; }
 
+    /// <summary>
+    /// launcher-persistent-join: the map of which machine's cc-launcher is currently joined over a
+    /// persistent stream. When a launcher is stream-connected, the machine lifecycle relay pushes a command
+    /// DOWN the open stream instead of dialing the launcher's REST API. Empty until launchers connect and
+    /// only consulted when stream mode is on.
+    /// </summary>
+    public Streaming.LauncherConnectionRegistry LauncherConnections { get; }
+
     // Issue #1176 (Phase 1a): Gateway-side stream feature switch + staleness window, resolved from
     // config.json (or an explicit constructor override for tests). When off, the hub is not mapped and
     // /sessions never consults the pushed cache, so behaviour is byte-identical to today.
@@ -311,6 +319,7 @@ public sealed class GatewayHost : IAsyncDisposable
         Token = token ?? GatewayAuth.LoadOrCreate();
         Registry = new DirectorRegistry(instancesDirectory);
         PushedSessions = new Streaming.PushedSessionStore();
+        LauncherConnections = new Streaming.LauncherConnectionRegistry();
         var gatewayConfig = Core.Configuration.GatewayConfig.Load();
         _streamMode = streamMode ?? gatewayConfig.StreamMode;
         _streamStaleAfter = TimeSpan.FromSeconds(gatewayConfig.StreamStaleAfterSeconds);
@@ -741,6 +750,9 @@ public sealed class GatewayHost : IAsyncDisposable
         builder.Services.AddSignalR();
         builder.Services.AddSingleton(PushedSessions);
         builder.Services.AddSingleton(Registry);
+        // launcher-persistent-join: the LauncherHub (constructed per-invocation by SignalR) and
+        // SendLauncherCommandAsync share this one connection registry.
+        builder.Services.AddSingleton(LauncherConnections);
 
         // Honor X-Forwarded-Proto/Host/For from a Tailscale Serve front-end so
         // ctx.Request.Scheme reflects the public scheme the user actually used.
@@ -843,6 +855,13 @@ public sealed class GatewayHost : IAsyncDisposable
         {
             _app.MapHub<Streaming.DirectorHub>("/director-stream");
             FileLog.Write("[GatewayHost] stream mode ON: DirectorHub mapped at /director-stream; /sessions serves from the push cache when fresh");
+
+            // launcher-persistent-join: the launcher-push stream endpoint, mapped under the SAME kill-switch
+            // as DirectorHub. When a launcher joins, the machine lifecycle relay pushes commands DOWN this
+            // stream instead of dialing the launcher's REST API; off => the hub does not exist and the relay
+            // uses REST exactly as today.
+            _app.MapHub<Streaming.LauncherHub>("/launcher-stream");
+            FileLog.Write("[GatewayHost] stream mode ON: LauncherHub mapped at /launcher-stream; machine lifecycle relay prefers the stream when a launcher is joined");
         }
 
         // Product version stamped by Directory.Build.props; full form carries the commit SHA.
@@ -1127,7 +1146,9 @@ public sealed class GatewayHost : IAsyncDisposable
         // Issue #331: launcher registration + cross-machine Director lifecycle relay.
         // Launchers POST /launchers/register on startup; relay callers POST
         // /machines/{machine}/director/restart|start|stop to reach that machine's Director.
-        MachineEndpoints.Map(_app, Launchers);
+        // launcher-persistent-join: pass the stream-send hook only when stream mode is on. The relay tries
+        // this first and falls back to the REST relay when it returns null (stream off, or launcher offline).
+        MachineEndpoints.Map(_app, Launchers, _streamMode ? SendLauncherCommandAsync : null);
 
         // The Cockpit Settings page surface (docs/architecture/gateway/SETTINGS_OWNERSHIP.md):
         // one snapshot GET plus brain-restart and autostart actions. Reads this host directly
@@ -1293,6 +1314,29 @@ public sealed class GatewayHost : IAsyncDisposable
         }
         FileLog.Write($"[GatewayHost] SendCommandAsync: director={directorId}, verb={command.Verb}, sid={command.SessionId}, cmdId={command.CommandId}");
         return await hub.Clients.Client(connectionId).InvokeAsync<DirectorCommandResult>("Command", command, ct);
+    }
+
+    /// <summary>
+    /// launcher-persistent-join: push a lifecycle command DOWN a machine's launcher stream and await its
+    /// result over the SAME connection (SignalR client results), modeled exactly on <see cref="SendCommandAsync"/>.
+    /// Returns null when that machine's launcher has no active stream connection (or the hub is unavailable),
+    /// which the caller treats as "no stream" and falls back to the HTTP relay. Any non-null result - success
+    /// OR a typed failure - means the stream handled the command and its outcome is authoritative.
+    /// </summary>
+    public async Task<LauncherCommandResult?> SendLauncherCommandAsync(string machineName, LauncherCommand command, CancellationToken ct = default)
+    {
+        if (command is null) throw new ArgumentNullException(nameof(command));
+
+        var connectionId = LauncherConnections.GetActiveConnectionId(machineName);
+        var hub = _app?.Services.GetService(typeof(Microsoft.AspNetCore.SignalR.IHubContext<Streaming.LauncherHub>))
+            as Microsoft.AspNetCore.SignalR.IHubContext<Streaming.LauncherHub>;
+        if (connectionId is null || hub is null)
+        {
+            FileLog.Write($"[GatewayHost] SendLauncherCommandAsync: no active stream for machine={machineName}, verb={command.Verb}");
+            return null;
+        }
+        FileLog.Write($"[GatewayHost] SendLauncherCommandAsync: machine={machineName}, verb={command.Verb}");
+        return await hub.Clients.Client(connectionId).InvokeAsync<LauncherCommandResult>("Command", command, ct);
     }
 
     public async Task StopAsync()

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -218,6 +218,9 @@ public sealed class GatewayHost : IAsyncDisposable
     private Account.ChildDeviceMirrorService? _childMirror;
 
     private readonly DirectorEndpointClient _client;
+    // The single resolve-then-create path for spawning a session on a target machine (cron + the
+    // interactive POST /machines/{machine}/sessions relay). Built in the constructor, used by both.
+    private readonly Running.MachineSessionSpawner _machineSessionSpawner;
     private readonly TailscaleServeProvisioner _serveProvisioner;
     private readonly GatewayTurnBriefStore _turnBriefStore;
     private readonly KeyVault _keyVault;
@@ -410,6 +413,9 @@ public sealed class GatewayHost : IAsyncDisposable
         var cronTargetResolver = new Running.RegistryDirectorTargetResolver(
             () => Registry.ListDirectors(),
             new Running.RelayDirectorLauncher(Port, Token));
+        // The single resolve-then-create path shared by the cron firing engine and the interactive
+        // POST /machines/{machine}/sessions relay ("start a session on another computer").
+        _machineSessionSpawner = new Running.MachineSessionSpawner(_client, cronTargetResolver);
         // A work-list cron job (#484) drains a named list via the shipped #274 runner on the resolved
         // Director, launching the drain in the background on the shared runner manager.
         var cronWorkListRunner = new Running.DirectorCronWorkListRunner(
@@ -433,7 +439,7 @@ public sealed class GatewayHost : IAsyncDisposable
             $"http://127.0.0.1:{Port}",
             new HttpClient { Timeout = TimeSpan.FromSeconds(10) });
         _cronEngine = new Running.CronEngine(
-            _cronJobs, _cronRuns, new Running.DirectorCronSessionStarter(_client, cronTargetResolver),
+            _cronJobs, _cronRuns, new Running.DirectorCronSessionStarter(_machineSessionSpawner),
             cronWorkListRunner, cronNotifier, new Running.SystemClock());
 
         // Web Push (mobile app-icon "needs you" dot): load (or generate on first run) the VAPID key
@@ -1148,7 +1154,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // /machines/{machine}/director/restart|start|stop to reach that machine's Director.
         // launcher-persistent-join: pass the stream-send hook only when stream mode is on. The relay tries
         // this first and falls back to the REST relay when it returns null (stream off, or launcher offline).
-        MachineEndpoints.Map(_app, Launchers, _streamMode ? SendLauncherCommandAsync : null);
+        MachineEndpoints.Map(_app, Launchers, _machineSessionSpawner, _streamMode ? SendLauncherCommandAsync : null);
 
         // The Cockpit Settings page surface (docs/architecture/gateway/SETTINGS_OWNERSHIP.md):
         // one snapshot GET plus brain-restart and autostart actions. Reads this host directly

--- a/src/CcDirector.Gateway/Running/DirectorCronSessionStarter.cs
+++ b/src/CcDirector.Gateway/Running/DirectorCronSessionStarter.cs
@@ -1,40 +1,30 @@
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
-using CcDirector.Gateway.Discovery;
 
 namespace CcDirector.Gateway.Running;
 
 /// <summary>
-/// Production <see cref="ICronSessionStarter"/> (epic #479, #483, #503). Resolves the job's target
-/// MACHINE to a Director via <see cref="IDirectorTargetResolver"/> (launching one if none is running)
-/// and starts a session over the Gateway's existing <see cref="DirectorEndpointClient"/> using the
-/// SAME session-create + seed-prompt path the Cockpit and the work-list runner use. No new Director
-/// surface is introduced; an unresolvable target is reported as an error, not thrown.
+/// Production <see cref="ICronSessionStarter"/> (epic #479, #483, #503). Builds the cron job's
+/// session request (the ONLY cron-specific work here) and hands it to the shared
+/// <see cref="MachineSessionSpawner"/>, which resolves the target MACHINE to a Director (launching one
+/// if none is running) and starts the session over the Gateway's existing session-create path. Cron
+/// and the interactive POST /machines/{machine}/sessions relay therefore share ONE resolve-then-create
+/// method; no new Director surface is introduced, and an unresolvable target is reported as an error,
+/// not thrown.
 /// </summary>
 public sealed class DirectorCronSessionStarter : ICronSessionStarter
 {
-    private readonly DirectorEndpointClient _client;
-    private readonly IDirectorTargetResolver _resolver;
+    private readonly MachineSessionSpawner _spawner;
 
-    public DirectorCronSessionStarter(DirectorEndpointClient client, IDirectorTargetResolver resolver)
+    public DirectorCronSessionStarter(MachineSessionSpawner spawner)
     {
-        _client = client ?? throw new ArgumentNullException(nameof(client));
-        _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+        _spawner = spawner ?? throw new ArgumentNullException(nameof(spawner));
     }
 
     public async Task<(string? sessionId, string? directorId, string? error)> StartAsync(CronJobDto job, CancellationToken ct)
     {
         if (job is null)
             throw new ArgumentNullException(nameof(job));
-
-        var target = await _resolver.ResolveAsync(job.Target.Machine, ct);
-        if (string.IsNullOrEmpty(target.Endpoint))
-        {
-            FileLog.Write($"[DirectorCronSessionStarter] start FAILED: job={job.Id}, machine={job.Target.Machine}, {target.Error}");
-            return (null, target.DirectorId, target.Error ?? "could not resolve a director on the target machine");
-        }
-
-        FileLog.Write($"[DirectorCronSessionStarter] start: job={job.Id}, machine={job.Target.Machine}, director={target.DirectorId}, endpoint={target.Endpoint}, seed={job.Action.Seed}");
 
         var req = new NewSessionRequest
         {
@@ -43,14 +33,16 @@ public sealed class DirectorCronSessionStarter : ICronSessionStarter
             PrePrompt = job.Action.Seed,
         };
 
-        var (ok, body, error) = await _client.CreateSessionAsync(target.Endpoint, req, ct);
-        if (!ok || body is null || string.IsNullOrEmpty(body.SessionId))
+        FileLog.Write($"[DirectorCronSessionStarter] start: job={job.Id}, machine={job.Target.Machine}, repo={job.Action.RepoPath}, seed={job.Action.Seed}");
+
+        var (ok, dto, error, directorId) = await _spawner.SpawnOnMachineAsync(job.Target.Machine, req, ct);
+        if (!ok || dto is null || string.IsNullOrEmpty(dto.SessionId))
         {
-            FileLog.Write($"[DirectorCronSessionStarter] start FAILED: job={job.Id}, error={error}");
-            return (null, target.DirectorId, error ?? "director did not return a session id");
+            FileLog.Write($"[DirectorCronSessionStarter] start FAILED: job={job.Id}, machine={job.Target.Machine}, {error}");
+            return (null, directorId, error ?? "could not start a session on the target machine");
         }
 
-        FileLog.Write($"[DirectorCronSessionStarter] started: job={job.Id}, sid={body.SessionId}, director={target.DirectorId}");
-        return (body.SessionId, target.DirectorId, null);
+        FileLog.Write($"[DirectorCronSessionStarter] started: job={job.Id}, sid={dto.SessionId}, director={directorId}");
+        return (dto.SessionId, directorId, null);
     }
 }

--- a/src/CcDirector.Gateway/Running/MachineSessionSpawner.cs
+++ b/src/CcDirector.Gateway/Running/MachineSessionSpawner.cs
@@ -1,0 +1,78 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+
+namespace CcDirector.Gateway.Running;
+
+/// <summary>
+/// The SINGLE resolve-then-create path for starting a session on a target MACHINE ("start a session
+/// on another computer"). Resolves the machine to a runnable Director via
+/// <see cref="IDirectorTargetResolver"/> (launching one through the launcher when none is running)
+/// and creates the session on it over the Gateway's existing <see cref="DirectorEndpointClient"/>.
+/// Both the cron firing engine (<see cref="DirectorCronSessionStarter"/>) and the interactive
+/// POST /machines/{machine}/sessions relay call this ONE method, so scheduled and on-demand spawns
+/// route identically with no duplicated resolve/create logic.
+///
+/// Fail-fast and loud: when the machine is off / unreachable the resolver returns an Error and this
+/// reports it as a failure - it NEVER falls back to a local spawn.
+/// </summary>
+public sealed class MachineSessionSpawner
+{
+    /// <summary>
+    /// The create-session call. Production binds <see cref="DirectorEndpointClient.CreateSessionAsync"/>;
+    /// tests inject a fake so the resolve-then-create decision is verified without a live Director.
+    /// </summary>
+    public delegate Task<(bool ok, SessionDto? body, string? error)> CreateSessionDelegate(
+        string endpoint, NewSessionRequest req, CancellationToken ct);
+
+    private readonly IDirectorTargetResolver _resolver;
+    private readonly CreateSessionDelegate _create;
+
+    /// <param name="client">The Gateway's Director Control API client; its
+    /// <see cref="DirectorEndpointClient.CreateSessionAsync"/> is the production create call.</param>
+    /// <param name="resolver">Resolves the target machine to a Director, launching one on demand.</param>
+    public MachineSessionSpawner(DirectorEndpointClient client, IDirectorTargetResolver resolver)
+        : this(resolver, (client ?? throw new ArgumentNullException(nameof(client))).CreateSessionAsync)
+    {
+    }
+
+    /// <summary>Test seam: inject the resolver and a fake create call directly.</summary>
+    internal MachineSessionSpawner(IDirectorTargetResolver resolver, CreateSessionDelegate create)
+    {
+        _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+        _create = create ?? throw new ArgumentNullException(nameof(create));
+    }
+
+    /// <summary>
+    /// Resolve <paramref name="machine"/> to a Director (launching one if none is running) and create the
+    /// session described by <paramref name="req"/> on it. Returns <c>ok=false</c> with the resolver's or
+    /// the Director's error - and NEVER a local fallback - when the machine cannot be resolved or the create
+    /// fails. <c>directorId</c> is the resolved Director (for the cron run record); it is populated even on a
+    /// failure the resolver could attribute to a Director.
+    /// </summary>
+    public async Task<(bool ok, SessionDto? dto, string? error, string? directorId)> SpawnOnMachineAsync(
+        string machine, NewSessionRequest req, CancellationToken ct)
+    {
+        if (req is null)
+            throw new ArgumentNullException(nameof(req));
+
+        var target = await _resolver.ResolveAsync(machine, ct);
+        if (string.IsNullOrEmpty(target.Endpoint))
+        {
+            FileLog.Write($"[MachineSessionSpawner] SpawnOnMachineAsync FAILED: machine={machine}, {target.Error}");
+            return (false, null, target.Error ?? "could not resolve a director on the target machine", target.DirectorId);
+        }
+
+        FileLog.Write($"[MachineSessionSpawner] SpawnOnMachineAsync: machine={machine}, director={target.DirectorId}, endpoint={target.Endpoint}, repo={req.RepoPath}");
+
+        var (ok, body, error) = await _create(target.Endpoint, req, ct);
+        if (!ok || body is null || string.IsNullOrEmpty(body.SessionId))
+        {
+            FileLog.Write($"[MachineSessionSpawner] SpawnOnMachineAsync FAILED: machine={machine}, error={error}");
+            return (false, null, error ?? "director did not return a session id", target.DirectorId);
+        }
+
+        FileLog.Write($"[MachineSessionSpawner] SpawnOnMachineAsync: started sid={body.SessionId}, director={target.DirectorId}");
+        return (true, body, null, target.DirectorId);
+    }
+}

--- a/src/CcDirector.Gateway/Streaming/LauncherConnectionRegistry.cs
+++ b/src/CcDirector.Gateway/Streaming/LauncherConnectionRegistry.cs
@@ -1,0 +1,77 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Streaming;
+
+/// <summary>
+/// launcher-persistent-join: the Gateway's map of which machine's cc-launcher is currently connected over a
+/// persistent stream, keyed by machine name (case-insensitive) with the SignalR connection id as the value.
+///
+/// It is the launcher twin of the connection-tracking half of <see cref="PushedSessionStore"/>, but far
+/// simpler: a launcher pushes no session state, so there is nothing to cache - only the live connection id
+/// the Gateway addresses a command DOWN. One machine -> one active connection. A new connection from the
+/// same machine (a launcher restart / reconnect) supersedes the prior one.
+///
+/// Thread-safe via a <see cref="ConcurrentDictionary{TKey,TValue}"/>. Registered as a DI singleton so the
+/// hub (constructed per-invocation by SignalR's container) and <c>GatewayHost.SendLauncherCommandAsync</c>
+/// share the one instance.
+/// </summary>
+public sealed class LauncherConnectionRegistry
+{
+    private readonly ConcurrentDictionary<string, string> _byMachine =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Mark <paramref name="connectionId"/> as the active stream connection for <paramref name="machineName"/>,
+    /// superseding any prior connection for that machine (a reconnect wins).
+    /// </summary>
+    public void RegisterConnection(string machineName, string connectionId)
+    {
+        if (string.IsNullOrWhiteSpace(machineName))
+            throw new ArgumentException("machineName is required", nameof(machineName));
+        if (string.IsNullOrWhiteSpace(connectionId))
+            throw new ArgumentException("connectionId is required", nameof(connectionId));
+
+        _byMachine[machineName] = connectionId;
+        FileLog.Write($"[LauncherConnectionRegistry] RegisterConnection: machine={machineName}, conn={Short(connectionId)} is now the active connection");
+    }
+
+    /// <summary>
+    /// Clear the entry whose active connection is <paramref name="connectionId"/>. A late disconnect from a
+    /// superseded connection removes nothing (the newer connection owns the machine), because the atomic
+    /// key/value remove only succeeds when the stored connection id still matches.
+    /// </summary>
+    public void Unregister(string connectionId)
+    {
+        if (string.IsNullOrWhiteSpace(connectionId))
+            return;
+
+        foreach (var kv in _byMachine)
+        {
+            if (!string.Equals(kv.Value, connectionId, StringComparison.Ordinal))
+                continue;
+
+            // Atomic compare-and-remove: only removes when the machine still maps to THIS connection id,
+            // so a superseded connection's late disconnect cannot wipe a newer active connection.
+            if (((ICollection<KeyValuePair<string, string>>)_byMachine).Remove(kv))
+                FileLog.Write($"[LauncherConnectionRegistry] Unregister: machine={kv.Key}, conn={Short(connectionId)} cleared");
+            else
+                FileLog.Write($"[LauncherConnectionRegistry] Unregister IGNORED (superseded): machine={kv.Key}, conn={Short(connectionId)}");
+            return;
+        }
+    }
+
+    /// <summary>
+    /// The active stream connection id for a machine's launcher, or null when none. The Gateway uses it to
+    /// address a command DOWN the stream to that launcher.
+    /// </summary>
+    public string? GetActiveConnectionId(string machineName) =>
+        _byMachine.TryGetValue(machineName, out var connectionId) ? connectionId : null;
+
+    /// <summary>True when this machine's launcher currently has an active stream connection.</summary>
+    public bool IsStreamConnected(string machineName) =>
+        _byMachine.ContainsKey(machineName);
+
+    private static string Short(string? id) =>
+        string.IsNullOrEmpty(id) ? "(none)" : (id.Length <= 8 ? id : id[..8]);
+}

--- a/src/CcDirector.Gateway/Streaming/LauncherHub.cs
+++ b/src/CcDirector.Gateway/Streaming/LauncherHub.cs
@@ -1,0 +1,78 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.SignalR;
+
+namespace CcDirector.Gateway.Streaming;
+
+/// <summary>
+/// launcher-persistent-join: the SignalR hub each cc-launcher dials OUT to, so the always-on launcher stays
+/// joined to the Gateway and the Gateway can PUSH a lifecycle command (start/stop/restart a Director, or a
+/// generic launch) DOWN the open stream instead of dialing the launcher's loopback REST API.
+///
+/// This is the launcher twin of <see cref="DirectorHub"/>, but one-directional up: a launcher only sends
+/// <see cref="Hello"/> (the identity binding) - it pushes no session state. Every command flows the other
+/// way, invoked by the Gateway on the client. So the only inbound method here is Hello.
+///
+/// Identity binding: the first message MUST be <see cref="Hello"/>, which binds this connection to one
+/// machine name in <see cref="Microsoft.AspNetCore.SignalR.HubCallerContext.Items"/> and registers it in the
+/// <see cref="LauncherConnectionRegistry"/>. A re-claim to a different machine on the same connection is
+/// rejected. The transport itself is already authenticated by the host-wide token middleware (the shared
+/// token or a per-device key), exactly like <see cref="DirectorHub"/>.
+///
+/// The hub holds no state of its own; it is a thin adapter onto <see cref="LauncherConnectionRegistry"/>.
+/// SignalR constructs it per invocation via dependency injection.
+/// </summary>
+public sealed class LauncherHub : Hub
+{
+    private const string MachineNameItemKey = "cc.launcherMachine";
+
+    private readonly LauncherConnectionRegistry _registry;
+
+    public LauncherHub(LauncherConnectionRegistry registry)
+    {
+        _registry = registry;
+    }
+
+    /// <summary>Bind this connection to a machine's launcher. Must be the first message; aborts on a bad name.</summary>
+    public void Hello(LauncherStreamHello hello)
+    {
+        if (hello is null || string.IsNullOrWhiteSpace(hello.MachineName))
+        {
+            FileLog.Write($"[LauncherHub] Hello REJECTED (missing machineName): conn={Short(Context.ConnectionId)}");
+            Context.Abort();
+            return;
+        }
+
+        var machine = hello.MachineName.Trim();
+        var alreadyBound = BoundMachine();
+        if (alreadyBound is not null && !string.Equals(alreadyBound, machine, StringComparison.OrdinalIgnoreCase))
+        {
+            FileLog.Write($"[LauncherHub] Hello REJECTED (conn already bound to {alreadyBound}, cannot re-claim {machine}): conn={Short(Context.ConnectionId)}");
+            Context.Abort();
+            return;
+        }
+
+        Context.Items[MachineNameItemKey] = machine;
+        _registry.RegisterConnection(machine, Context.ConnectionId);
+        FileLog.Write($"[LauncherHub] Hello: machine={machine} bound to conn={Short(Context.ConnectionId)} (port={hello.Port}, version={hello.Version})");
+    }
+
+    public override Task OnConnectedAsync()
+    {
+        FileLog.Write($"[LauncherHub] connected: conn={Short(Context.ConnectionId)}");
+        return base.OnConnectedAsync();
+    }
+
+    public override Task OnDisconnectedAsync(Exception? exception)
+    {
+        _registry.Unregister(Context.ConnectionId);
+        FileLog.Write($"[LauncherHub] disconnected: conn={Short(Context.ConnectionId)}, machine={BoundMachine() ?? "(unbound)"} ({exception?.Message ?? "clean"})");
+        return base.OnDisconnectedAsync(exception);
+    }
+
+    private string? BoundMachine() =>
+        Context.Items.TryGetValue(MachineNameItemKey, out var value) && value is string name ? name : null;
+
+    private static string Short(string? id) =>
+        string.IsNullOrEmpty(id) ? "(none)" : (id.Length <= 8 ? id : id[..8]);
+}

--- a/src/CcDirector.Launcher/CcDirector.Launcher.csproj
+++ b/src/CcDirector.Launcher/CcDirector.Launcher.csproj
@@ -22,6 +22,10 @@
   <!-- ASP.NET Core Kestrel: the Launcher hosts a minimal loopback REST API. -->
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <!-- launcher-persistent-join: the SignalR CLIENT (separate from the server in the shared framework)
+         so the Launcher can dial the Gateway's LauncherHub and receive lifecycle commands down the stream.
+         Same package + version the Director's ControlApi uses for GatewayStreamClient. -->
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CcDirector.Launcher/LauncherStreamClient.cs
+++ b/src/CcDirector.Launcher/LauncherStreamClient.cs
@@ -1,0 +1,215 @@
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace CcDirector.Launcher;
+
+/// <summary>
+/// launcher-persistent-join: the launcher's outbound client for the Gateway's LauncherHub. It dials the
+/// Gateway (never the other way), authenticates with the same token the HTTP registration uses, and keeps a
+/// persistent stream open so the Gateway can PUSH a lifecycle command DOWN it - start/stop/restart the
+/// installed Director, or a generic launch - instead of dialing this launcher's loopback REST API.
+///
+/// It is the launcher twin of the Director's <c>GatewayStreamClient</c>, but simpler: a launcher pushes no
+/// session state, so on connect/reconnect it sends only <see cref="LauncherStreamHello"/>, then waits for
+/// commands on the down-channel and executes them through the SAME <see cref="DirectorSupervisor"/> /
+/// <see cref="LaunchService"/> actions the REST endpoints use.
+///
+/// It runs ALONGSIDE the existing <see cref="GatewayRegistrationClient"/> (which stays for registration and
+/// heartbeat metadata). It is inert unless the config has a Gateway URL and <see cref="GatewayConfig.StreamMode"/>
+/// is on, so a launcher with stream mode off behaves exactly as today and the Gateway relays over REST.
+/// </summary>
+public sealed class LauncherStreamClient : IAsyncDisposable
+{
+    private readonly GatewayConfig _config;
+    private readonly int _port;
+    private readonly string _version;
+    private readonly DirectorSupervisor _supervisor;
+    private readonly LaunchService _launchService;
+
+    private HubConnection? _connection;
+    private int _started;
+    private volatile bool _disposed;
+
+    /// <summary>Reconnect backoff between long-outage restart attempts once auto-reconnect has given up.</summary>
+    private static readonly TimeSpan RestartDelay = TimeSpan.FromSeconds(5);
+
+    public LauncherStreamClient(GatewayConfig config, int port, string version, DirectorSupervisor supervisor, LaunchService launchService)
+    {
+        _config = config ?? throw new ArgumentNullException(nameof(config));
+        _port = port;
+        _version = version ?? "";
+        _supervisor = supervisor ?? throw new ArgumentNullException(nameof(supervisor));
+        _launchService = launchService ?? throw new ArgumentNullException(nameof(launchService));
+    }
+
+    /// <summary>True when stream mode is enabled for a configured Gateway. When false, <see cref="Start"/> is a no-op.</summary>
+    public bool IsEnabled => _config.IsEnabled && _config.StreamMode;
+
+    /// <summary>Start dialing the Gateway. Idempotent; inert when <see cref="IsEnabled"/> is false.</summary>
+    public void Start()
+    {
+        if (!IsEnabled) return;
+        if (Interlocked.Exchange(ref _started, 1) == 1) return;
+        FileLog.Write($"[LauncherStreamClient] Start: dialing {_config.Url}/launcher-stream for machine {Environment.MachineName}");
+        _ = SuperviseAsync();
+    }
+
+    // Owns the connection for its whole life: build once, keep it connected, and re-Hello on every
+    // (re)connection. Auto-reconnect handles transient drops fast; when it gives up (Closed), this loop
+    // restarts the connection so a long Gateway outage self-heals without a launcher restart.
+    private async Task SuperviseAsync()
+    {
+        _connection = new HubConnectionBuilder()
+            .WithUrl(_config.Url.TrimEnd('/') + "/launcher-stream", options =>
+            {
+                var token = _config.Token;
+                if (!string.IsNullOrEmpty(token))
+                    options.AccessTokenProvider = () => Task.FromResult<string?>(token);
+            })
+            .WithAutomaticReconnect(new[]
+            {
+                TimeSpan.Zero, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10),
+            })
+            .Build();
+
+        _connection.Reconnecting += ex => { FileLog.Write($"[LauncherStreamClient] reconnecting: {ex?.Message}"); return Task.CompletedTask; };
+        _connection.Reconnected += async _ => await SayHelloAsync();
+
+        // The production down-channel. The Gateway invokes "Command" with a LauncherCommand and awaits the
+        // LauncherCommandResult over the same connection (SignalR client results). This handler is a
+        // boundary, so it catches: a dispatch fault becomes an Error result the Gateway can fall back on,
+        // never a faulted hub invocation.
+        _connection.On<LauncherCommand, LauncherCommandResult>("Command", cmd => DispatchAsync(cmd));
+
+        while (!_disposed)
+        {
+            if (await TryConnectAsync())
+            {
+                await SayHelloAsync();
+                await WaitUntilClosedAsync();      // returns when auto-reconnect has exhausted its attempts
+            }
+            if (_disposed) break;
+            await Task.Delay(RestartDelay);        // long-outage restart
+        }
+    }
+
+    // Execute one command through the same supervisor/launch actions the loopback REST endpoints use, so
+    // the stream path and the REST relay path cannot drift. A boundary: any fault becomes an Error result.
+    private async Task<LauncherCommandResult> DispatchAsync(LauncherCommand cmd)
+    {
+        try
+        {
+            if (cmd is null)
+                return LauncherCommandResult.Fail(LauncherCommandStatus.BadRequest, "command is required");
+
+            FileLog.Write($"[LauncherStreamClient] Command received: verb={cmd.Verb}, path={cmd.Path ?? "(none)"}, confirmProtected={cmd.ConfirmProtected}");
+            switch (cmd.Verb)
+            {
+                case "director/start":
+                    _supervisor.Start();
+                    return LauncherCommandResult.Ok();
+
+                case "director/stop":
+                    await _supervisor.StopAsync();
+                    return LauncherCommandResult.Ok();
+
+                case "director/restart":
+                    await _supervisor.RestartAsync();
+                    return LauncherCommandResult.Ok();
+
+                case "launch":
+                    if (string.IsNullOrWhiteSpace(cmd.Path))
+                        return LauncherCommandResult.Fail(LauncherCommandStatus.BadRequest, "path is required for launch");
+                    _launchService.Launch(
+                        new LaunchRequest { Path = cmd.Path!, Args = cmd.Args, Cwd = cmd.Cwd, Headless = cmd.Headless },
+                        caller: "launcher-stream");
+                    return LauncherCommandResult.Ok();
+
+                default:
+                    FileLog.Write($"[LauncherStreamClient] Command declined (unknown verb): {cmd.Verb}");
+                    return LauncherCommandResult.Fail(LauncherCommandStatus.BadRequest, $"unknown verb: {cmd.Verb}");
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[LauncherStreamClient] Command FAILED: verb={cmd?.Verb}, error={ex.Message}");
+            return LauncherCommandResult.Fail(LauncherCommandStatus.Error, ex.Message);
+        }
+    }
+
+    private async Task<bool> TryConnectAsync()
+    {
+        if (_connection is null) return false;
+        try
+        {
+            await _connection.StartAsync();
+            FileLog.Write($"[LauncherStreamClient] connected to {_config.Url}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[LauncherStreamClient] connect failed (will retry): {ex.Message}");
+            return false;
+        }
+    }
+
+    private async Task SayHelloAsync()
+    {
+        var conn = _connection;
+        if (conn is null || conn.State != HubConnectionState.Connected) return;
+        try
+        {
+            await conn.InvokeAsync("Hello", new LauncherStreamHello
+            {
+                MachineName = Environment.MachineName,
+                Port = _port,
+                Version = _version,
+            });
+            FileLog.Write($"[LauncherStreamClient] Hello sent: machine={Environment.MachineName}, port={_port}");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[LauncherStreamClient] Hello failed (auto-reconnect will retry): {ex.Message}");
+        }
+    }
+
+    private async Task WaitUntilClosedAsync()
+    {
+        if (_connection is null) return;
+        var closed = new TaskCompletionSource();
+        Task OnClosed(Exception? _) { closed.TrySetResult(); return Task.CompletedTask; }
+        _connection.Closed += OnClosed;
+        try
+        {
+            if (_connection.State == HubConnectionState.Disconnected) return;
+            await closed.Task;
+        }
+        finally
+        {
+            _connection.Closed -= OnClosed;
+        }
+    }
+
+    public async Task StopAsync()
+    {
+        _disposed = true;
+        if (_connection is not null)
+        {
+            try { await _connection.StopAsync(); }
+            catch (Exception ex) { FileLog.Write($"[LauncherStreamClient] StopAsync error: {ex.Message}"); }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _disposed = true;
+        if (_connection is not null)
+        {
+            try { await _connection.DisposeAsync(); }
+            catch (Exception ex) { FileLog.Write($"[LauncherStreamClient] DisposeAsync error: {ex.Message}"); }
+            _connection = null;
+        }
+    }
+}

--- a/src/CcDirector.Launcher/LauncherTrayController.cs
+++ b/src/CcDirector.Launcher/LauncherTrayController.cs
@@ -33,6 +33,7 @@ public sealed class LauncherTrayController : IDisposable
     private Bitmap? _icon;
     private LauncherHost? _host;
     private GatewayRegistrationClient? _gatewayClient;
+    private LauncherStreamClient? _launcherStreamClient;
     private HostState _state = HostState.Starting;
     private bool _disposed;
 
@@ -226,6 +227,14 @@ public sealed class LauncherTrayController : IDisposable
             var launcherToken = LauncherAuth.LoadOrCreateToken();
             _gatewayClient = new GatewayRegistrationClient(gwConfig, _port, launcherToken, version);
             _gatewayClient.Start();
+
+            // launcher-persistent-join: when gateway.streamMode is on, also JOIN the Gateway over a
+            // persistent SignalR stream so the Gateway can push lifecycle commands DOWN the open connection
+            // instead of dialing this launcher's REST API. Runs alongside the registration client (which
+            // stays for metadata). Start() is a no-op unless a Gateway is configured AND stream mode is on,
+            // so with the flag off behaviour is unchanged and the Gateway relays over REST as today.
+            _launcherStreamClient = new LauncherStreamClient(gwConfig, _port, version, directorSupervisor, launchService);
+            _launcherStreamClient.Start();
         }
         catch (Exception ex)
         {
@@ -259,6 +268,13 @@ public sealed class LauncherTrayController : IDisposable
     {
         FileLog.Write("[LauncherTrayController] QuitAsync");
         _lifetime.Cancel();
+
+        // launcher-persistent-join: close the persistent stream before shutting down.
+        if (_launcherStreamClient is not null)
+        {
+            await _launcherStreamClient.StopAsync();
+            _launcherStreamClient = null;
+        }
 
         // Issue #331: unregister from the Gateway before shutting down the REST host.
         if (_gatewayClient is not null)
@@ -448,6 +464,9 @@ public sealed class LauncherTrayController : IDisposable
         if (_disposed) return;
         _disposed = true;
         _lifetime.Cancel();
+        try { _launcherStreamClient?.StopAsync().GetAwaiter().GetResult(); }
+        catch (Exception ex) { FileLog.Write($"[LauncherTrayController] Dispose stream client stop error: {ex.Message}"); }
+        _launcherStreamClient = null;
         try { _gatewayClient?.StopAsync().GetAwaiter().GetResult(); }
         catch (Exception ex) { FileLog.Write($"[LauncherTrayController] Dispose gateway client stop error: {ex.Message}"); }
         _gatewayClient = null;

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -374,10 +374,19 @@ def spawn(
         "(case-insensitive). Sticky, and wins over auto-derivation - the way to declare an Architect. An "
         "unknown value is rejected by the Director.",
     ),
+    machine: Optional[str] = typer.Option(
+        None,
+        "--machine",
+        help="Start the session on ANOTHER computer. Omit (or name this machine) to spawn locally, "
+        "unchanged. A remote machine name routes the spawn through the Gateway to a Director on that "
+        "machine (first available, auto-launched if none is running); an off/unreachable machine fails "
+        "loudly with no local fallback.",
+    ),
 ) -> None:
-    """Open a new session on the local Director and print its id."""
+    """Open a new session on the local Director, or on another computer with --machine, and print its id."""
     spawn_session(
-        repo, agent, prompt, name, purpose, command, command_args, controlled_by, args, standalone, role
+        repo, agent, prompt, name, purpose, command, command_args, controlled_by, args, standalone, role,
+        machine,
     )
 
 

--- a/tools/cc-devthrottle/src/session_ops.py
+++ b/tools/cc-devthrottle/src/session_ops.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import platform
 import sys
 import tempfile
 import time
@@ -313,8 +314,9 @@ def spawn_session(
     args: Optional[str] = None,
     standalone: bool = False,
     role: Optional[str] = None,
+    machine: Optional[str] = None,
 ) -> None:
-    """Open a new session on the local Director."""
+    """Open a new session on the local Director, or on another computer when a remote --machine is given."""
     # Automatic roles: a SESSION-initiated spawn (CC_SESSION_ID present) DEFAULTS to a Worker controlled by
     # the spawner, so it stays quiet and reports to its manager instead of nagging the human. The opt-out
     # (guard 1) is --standalone / --controlled-by none: a deliberate human-facing PEER with no controller. A
@@ -372,8 +374,23 @@ def spawn_session(
     if role:
         body["role"] = role
 
+    # "Start a session on another computer": with no --machine, or a --machine that names THIS machine,
+    # keep the unchanged LOCAL spawn (POST /sessions on the local Director). A remote machine name routes
+    # the spawn through the local Director's POST /fleet/spawn, which forwards it via the Gateway to a
+    # Director on that machine (first available, auto-launched if none is running). An off/unreachable
+    # machine fails loudly (DirectorError -> red error + exit 1) with NO local fallback.
+    target_machine = machine.strip() if machine else ""
+    is_local = (
+        not target_machine
+        or target_machine.lower() == "local"
+        or target_machine.lower() == platform.node().lower()
+    )
+
     try:
-        resp = director.post_json("sessions", body)
+        if is_local:
+            resp = director.post_json("sessions", body)
+        else:
+            resp = director.post_json("fleet/spawn", {"machine": target_machine, **body})
     except director.DirectorError as err:
         console.print(f"[red]Error:[/red] {err}")
         raise typer.Exit(1)


### PR DESCRIPTION
Two Lifecycle-mission pieces, both additive and off-by-default: (1) launcher-persistent-join - cc-launcher joins the Gateway over a persistent SignalR stream so the Gateway can push lifecycle commands (enables starting the app on a remote machine); (2) start a session on another computer - session spawn gains an optional --machine target, routing remote spawns via the Gateway to a Director on the named machine (auto-launched if none), fail-fast if offline. Local spawn unchanged. 25 new tests; full suites green (Gateway 1581, Core 2850, no regressions).