### PR TITLE
fix(mobile): stop listing needs-you sessions twice on the Home roster

### DIFF
--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -8,9 +8,10 @@ import { getClipState, playClip, playingSid, stopPlayback, syncVoiceSessions, us
 import { NavDrawer } from "../components/NavDrawer";
 import { enablePush, notificationPermission, pushSupported, reconcileBadge } from "../push/register";
 
-// Home / roster. A "needs you" group first (when any session wants attention), then the full
-// session list, both using the live Gateway /sessions data and the shared triage ordering.
-// Tapping a row opens the session-detail placeholder bound to that session id.
+// Home / roster. A "needs you" group first (when any session wants attention), then an "other
+// sessions" group with everything that is NOT waiting on you - so a session appears in exactly one
+// group and is never listed twice. Both use the live Gateway /sessions data and the shared triage
+// ordering. Tapping a row opens the session-detail placeholder bound to that session id.
 const POLL_INTERVAL_MS = 5000;
 
 export function Home() {
@@ -54,7 +55,10 @@ export function Home() {
   }, [load]);
 
   const needsYou = sessions ? inBucket(sessions, "needsYou") : [];
-  const all = sessions ? inDesktopOrder(sessions) : [];
+  // The bottom group is "the rest": every session that is NOT waiting on you, still in your manual
+  // desktop order. A needs-you session shows only once, at the top - never duplicated down here.
+  const others = sessions ? inDesktopOrder(sessions.filter((s) => classify(s) !== "needsYou")) : [];
+  const total = sessions ? sessions.length : 0;
 
   return (
     <div className="screen">
@@ -81,7 +85,7 @@ export function Home() {
 
       {sessions === null && error === null && <p className="status-line">Loading sessions...</p>}
 
-      {sessions !== null && all.length === 0 && (
+      {sessions !== null && total === 0 && (
         <p className="status-line">No sessions running.</p>
       )}
 
@@ -96,11 +100,11 @@ export function Home() {
         </section>
       )}
 
-      {all.length > 0 && (
+      {others.length > 0 && (
         <section className="group">
-          <h2 className="group-title">All sessions</h2>
+          <h2 className="group-title">Other sessions</h2>
           <ul className="roster">
-            {all.map((s) => (
+            {others.map((s) => (
               <SessionRow key={s.sessionId} session={s} />
             ))}
           </ul>


### PR DESCRIPTION
## What

On the mobile app's Home roster, a session that needs you was listed **twice**: once in the "Needs you" group at the top, and again in the "All sessions" group below (which was drawn from the full, unfiltered session list).

## Fix

The bottom group is now the remainder - every session that is **not** in the needs-you triage bucket - still in the user's manual desktop order. Its heading changes from "All sessions" to "Other sessions". Each session now appears in exactly one group.

The empty-state ("No sessions running.") check now keys off the total session count, so filtering the bottom list cannot make it fire incorrectly when only needs-you sessions exist.

## Scope

- One file: `apps/mobile/src/pages/Home.tsx`.
- No Gateway, data-contract, or ordering changes - purely which sessions each group is allowed to include.
- `npm run typecheck --workspace @devthrottle/mobile` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
