### PR TITLE
Mission schema: sessions attach to a first-class Mission record

### DIFF
--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -155,6 +155,9 @@ public sealed class ControlApiHost : IAsyncDisposable
         => _gatewayClient?.GetLatestTurnBriefAsync(sessionId, ct) ?? Task.FromResult<Gateway.Contracts.TurnBriefDto?>(null);
 
     private TurnSummaryCache? _turnSummaryCache;
+    // Mission records (mission-as-first-class-unit-of-work): a durable, file-backed store with no runtime
+    // dependencies, so it is ready from construction (unlike the caches wired up in StartAsync).
+    private readonly Core.Sessions.MissionStore _missionStore = new();
     private SessionStatusWingman? _statusWingman;
     private ProactiveExplainService? _proactiveExplain;
     private TerminalStateDetector? _terminalStateDetector;
@@ -388,7 +391,7 @@ public sealed class ControlApiHost : IAsyncDisposable
         // Director's sessions' OUTGOING /fleet/* messages. Built from the Director's options, so it is
         // default-on-generous and config-tunable, and inert (Allow) when disabled.
         var messageSteward = new MessageSteward(_sessionManager.Options.MessageSteward);
-        ControlEndpoints.Map(_app, _sessionManager, DirectorId, _version, _requestShutdownAsync, _authEnabled, _repositoryRegistry, _turnSummaryCache, gatewayUrl, _proactiveExplain, GatewayMonitor, resolveTailnetEndpoint, () => _gatewayClient, messageSteward);
+        ControlEndpoints.Map(_app, _sessionManager, DirectorId, _version, _requestShutdownAsync, _authEnabled, _repositoryRegistry, _turnSummaryCache, gatewayUrl, _proactiveExplain, GatewayMonitor, resolveTailnetEndpoint, () => _gatewayClient, messageSteward, _missionStore);
         // Dictation glossary resolution mirrors the key resolver (#253): the Gateway's shared
         // dictionary when attached, the local cache when standalone. GatewayConfig.Load (not the
         // snapshot) is passed so the resolver re-reads config.json each dictation and self-heals
@@ -612,7 +615,7 @@ public sealed class ControlApiHost : IAsyncDisposable
             // StartAsync has initialized them - BuildStreamClient runs before _proactiveExplain /
             // _turnSummaryCache are set. Additive: verbs that need no service ignore it (issue #1177 inc 6).
             cmd => SessionCommandExecutor.DispatchAsync(_sessionManager, DirectorId, cmd,
-                new SessionCommandServices { ProactiveExplain = _proactiveExplain, TurnSummaryCache = _turnSummaryCache }));
+                new SessionCommandServices { ProactiveExplain = _proactiveExplain, TurnSummaryCache = _turnSummaryCache, MissionStore = _missionStore }));
     }
 
     /// <summary>

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -29,7 +29,7 @@ namespace CcDirector.ControlApi;
 /// </summary>
 internal static class ControlEndpoints
 {
-    public static void Map(IEndpointRouteBuilder app, SessionManager sessionManager, string directorId, string version, Func<Task> requestShutdownAsync, bool authEnabled = false, RepositoryRegistry? repositoryRegistry = null, TurnSummaryCache? turnSummaryCache = null, string? gatewayUrl = null, ProactiveExplainService? proactiveExplain = null, GatewayConnectionMonitor? gatewayMonitor = null, Func<TailnetEndpointResolution>? resolveTailnetEndpoint = null, Func<GatewayClient?>? gatewayClientProvider = null, MessageSteward? messageSteward = null)
+    public static void Map(IEndpointRouteBuilder app, SessionManager sessionManager, string directorId, string version, Func<Task> requestShutdownAsync, bool authEnabled = false, RepositoryRegistry? repositoryRegistry = null, TurnSummaryCache? turnSummaryCache = null, string? gatewayUrl = null, ProactiveExplainService? proactiveExplain = null, GatewayConnectionMonitor? gatewayMonitor = null, Func<TailnetEndpointResolution>? resolveTailnetEndpoint = null, Func<GatewayClient?>? gatewayClientProvider = null, MessageSteward? messageSteward = null, MissionStore? missionStore = null)
     {
         var logoutVisibility = authEnabled ? "" : "style=\"display:none\"";
         // URL of the Gateway this Director is registered with, for the "Gateway" nav
@@ -63,7 +63,10 @@ internal static class ControlEndpoints
                 SessionId = "",
                 PayloadJson = req is null ? "" : SessionCommandExecutor.Serialize(req),
             };
-            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
+            // Pass the Mission store so a create-time MissionId (attach at spawn) resolves+validates
+            // through the SAME executor path the Gateway stream down-channel uses.
+            var createServices = new SessionCommandServices { ProactiveExplain = proactiveExplain, TurnSummaryCache = turnSummaryCache, MissionStore = missionStore };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command, createServices);
 
             if (result.Status == DirectorCommandStatus.BadRequest)
                 return Results.BadRequest(new { error = result.Error });
@@ -1082,6 +1085,70 @@ internal static class ControlEndpoints
                 PayloadJson = req is null ? "" : SessionCommandExecutor.Serialize(req),
             };
             var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
+
+            if (result.Status == DirectorCommandStatus.BadRequest)
+                return Results.BadRequest(new { error = result.Error });
+            if (result.Status != DirectorCommandStatus.Ok)
+                return Results.NotFound(new { error = result.Error });
+            return Results.Content(result.BodyJson ?? "{}", "application/json");
+        });
+
+        // ===== Missions (mission-as-first-class-unit-of-work) =====
+        // A Mission is its OWN persisted record that sessions attach to. These endpoints create and read
+        // the records; POST /sessions/{sid}/mission attaches a session to one.
+
+        // Create a Mission record and return it.
+        app.MapPost("/missions", (NewMissionRequest req) =>
+        {
+            FileLog.Write($"[ControlEndpoints] POST /missions: name=\"{req?.MissionName}\"");
+
+            if (missionStore is null)
+                return Results.Problem("mission store not available", statusCode: 500);
+            if (req is null || string.IsNullOrWhiteSpace(req.MissionName))
+                return Results.BadRequest(new { error = "missionName is required" });
+
+            var mission = missionStore.Create(req.MissionName, req.ParentMissionId);
+            return Results.Json(ToMissionDto(mission), statusCode: 201);
+        });
+
+        // List every Mission record.
+        app.MapGet("/missions", () =>
+        {
+            if (missionStore is null)
+                return Results.Problem("mission store not available", statusCode: 500);
+            return Results.Json(missionStore.List().Select(ToMissionDto).ToList());
+        });
+
+        // Read one Mission record by id.
+        app.MapGet("/missions/{mid}", (string mid) =>
+        {
+            if (!Guid.TryParse(mid, out var missionId))
+                return Results.BadRequest(new { error = "invalid mission id format" });
+            if (missionStore is null)
+                return Results.Problem("mission store not available", statusCode: 500);
+
+            var mission = missionStore.Get(missionId);
+            return mission is null
+                ? Results.NotFound(new { error = "mission not found" })
+                : Results.Json(ToMissionDto(mission));
+        });
+
+        // Attach a session to a Mission (or detach on a blank/absent missionId). Runs through the shared
+        // SessionCommandExecutor so this REST path and the Gateway stream down-channel are identical, exactly
+        // like POST /sessions/{sid}/role. Returns the updated session DTO.
+        app.MapPost("/sessions/{sid}/mission", async (string sid, SetMissionRequest req) =>
+        {
+            if (!Guid.TryParse(sid, out _))
+                return Results.BadRequest(new { error = "invalid session id format" });
+
+            var command = new DirectorCommand
+            {
+                Verb = "attach-mission",
+                SessionId = sid,
+                PayloadJson = req is null ? "" : SessionCommandExecutor.Serialize(req),
+            };
+            var services = new SessionCommandServices { ProactiveExplain = proactiveExplain, TurnSummaryCache = turnSummaryCache, MissionStore = missionStore };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command, services);
 
             if (result.Status == DirectorCommandStatus.BadRequest)
                 return Results.BadRequest(new { error = result.Error });
@@ -3241,6 +3308,14 @@ internal static class ControlEndpoints
     // deltas through the EXACT same mapper the local /sessions endpoint uses (review #6), rather than a
     // second, divergent builder. Callers outside /sessions pass only (session, directorId); the Gateway
     // aggregator stamps machine/user/tailnet/view-url during aggregation, for pushed and pulled alike.
+    /// <summary>Map a Mission record onto its wire DTO (mission-as-first-class-unit-of-work).</summary>
+    internal static MissionDto ToMissionDto(Mission m) => new()
+    {
+        MissionId = m.MissionId,
+        MissionName = m.MissionName,
+        ParentMissionId = m.ParentMissionId,
+    };
+
     internal static SessionDto Map(Session s, string directorId, TurnSummaryCache? cache = null,
         string machineName = "", string user = "", string tailnetEndpoint = "", string? gatewayUrl = null)
     {
@@ -3302,6 +3377,11 @@ internal static class ControlEndpoints
             DriverCapabilities = CapabilityNames(s),
             Name = s.CustomName,
             Number = s.Number,
+            // Mission attachment (mission-as-first-class-unit-of-work): the link + cached display name flow
+            // straight through the Gateway aggregation on the SessionDto; the RESOLVED Mission record lives
+            // in the Director's MissionStore.
+            MissionId = s.MissionId,
+            MissionName = s.MissionName,
             SortOrder = s.SortOrder,
             StatusColor = s.StatusColor,
             LastStatusReason = s.LastStatusReason,

--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -25,6 +25,10 @@ internal sealed class SessionCommandServices
 
     /// <summary>The turn-summary + goal-assessment cache (setting a wingman goal kicks an assessment).</summary>
     public TurnSummaryCache? TurnSummaryCache { get; init; }
+
+    /// <summary>The Mission record store (attaching a session to a Mission, and honoring a create-time
+    /// MissionId, resolve the Mission's display name through it). Null skips Mission resolution.</summary>
+    public MissionStore? MissionStore { get; init; }
 }
 
 /// <summary>
@@ -62,9 +66,10 @@ internal static class SessionCommandExecutor
             "hold" => Hold(sessionManager, command),
             "kill" => await KillAsync(sessionManager, command),
             "patch" => Patch(sessionManager, directorId, command),
-            "create" => Create(sessionManager, directorId, command),
+            "create" => Create(sessionManager, directorId, command, services),
             "wingman-goal" => WingmanGoal(sessionManager, command, services),
             "set-role" => SetRole(sessionManager, directorId, command),
+            "attach-mission" => AttachMission(sessionManager, directorId, command, services),
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unknown verb '{command.Verb}'"),
         };
 
@@ -287,7 +292,7 @@ internal static class SessionCommandExecutor
     /// session mapped through the plain <see cref="ControlEndpoints.Map"/> (the Director's own REST
     /// endpoint re-maps with its identity-stamped mapper for its local 201 response).
     /// </summary>
-    internal static DirectorCommandResult Create(SessionManager sessionManager, string directorId, DirectorCommand command)
+    internal static DirectorCommandResult Create(SessionManager sessionManager, string directorId, DirectorCommand command, SessionCommandServices? services = null)
     {
         var req = Deserialize<NewSessionRequest>(command.PayloadJson);
 
@@ -304,6 +309,18 @@ internal static class SessionCommandExecutor
         // so a mistyped --role never silently drops (the exact --type situation we removed).
         if (req.Role is not null && !SessionRoles.IsValid(req.Role))
             return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unknown role '{req.Role}'. Valid: {string.Join(", ", SessionRoles.All)}");
+
+        // Mission attach at spawn: resolve+validate the Mission BEFORE creating the session, mirroring the
+        // explicit-role check, so attaching to an unknown Mission never silently drops. The resolved record
+        // (below) supplies the cached display name stamped onto the session after it is created.
+        Mission? mission = null;
+        if (req.MissionId is Guid createMissionId)
+        {
+            mission = services?.MissionStore?.Get(createMissionId);
+            if (mission is null)
+                return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest,
+                    $"unknown mission '{createMissionId}'. Create it first with POST /missions.");
+        }
 
         // RawCli requires a Command; validate before constructing the agent.
         if (kind == AgentKind.RawCli && string.IsNullOrWhiteSpace(req.Command))
@@ -388,6 +405,11 @@ internal static class SessionCommandExecutor
         var explicitRole = SessionRoles.Normalize(req.Role);
         if (explicitRole is not null)
             session.SetExplicitRole(explicitRole);
+
+        // Mission attach at spawn: stamp the session's MissionId and cache the resolved display name (the
+        // Mission was validated above). This is the attachment that binds the new session into a pod.
+        if (mission is not null)
+            session.AttachToMission(mission.MissionId, mission.MissionName);
 
         // Issue #212: dispatch a supplied PrePrompt once the agent is actually READY, fire-and-forget so
         // create returns immediately. Readiness = a substantial startup burst followed by a quiet poll;
@@ -499,6 +521,42 @@ internal static class SessionCommandExecutor
 
         session.SetExplicitRole(normalized);
         FileLog.Write($"[SessionCommandExecutor] set-role: session={guid} role={normalized ?? "(cleared)"}");
+        return DirectorCommandResult.Success(Serialize(ControlEndpoints.Map(session, directorId)));
+    }
+
+    /// <summary>
+    /// The <c>attach-mission</c> verb: attach a session to a Mission (or DETACH it on a blank/absent
+    /// MissionId). Invalid id -&gt; BadRequest, missing session -&gt; NotFound, unknown Mission -&gt;
+    /// BadRequest. The Mission's display name is resolved through the Mission store and cached onto the
+    /// session. Returns the updated session mapped through the SAME <see cref="ControlEndpoints.Map"/> the
+    /// stream snapshot uses. Mirrors <see cref="SetRole"/>.
+    /// </summary>
+    internal static DirectorCommandResult AttachMission(SessionManager sessionManager, string directorId, DirectorCommand command, SessionCommandServices? services)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var request = Deserialize<SetMissionRequest>(command.PayloadJson);
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        if (request?.MissionId is not Guid missionId)
+        {
+            // Blank/absent -> detach (mirrors set-role clearing the explicit role).
+            session.AttachToMission(null, null);
+            FileLog.Write($"[SessionCommandExecutor] attach-mission: session={guid} detached");
+            return DirectorCommandResult.Success(Serialize(ControlEndpoints.Map(session, directorId)));
+        }
+
+        var mission = services?.MissionStore?.Get(missionId);
+        if (mission is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest,
+                $"unknown mission '{missionId}'. Create it first with POST /missions.");
+
+        session.AttachToMission(mission.MissionId, mission.MissionName);
+        FileLog.Write($"[SessionCommandExecutor] attach-mission: session={guid} mission={mission.MissionId}");
         return DirectorCommandResult.Success(Serialize(ControlEndpoints.Map(session, directorId)));
     }
 

--- a/src/CcDirector.Core.Tests/MissionStoreTests.cs
+++ b/src/CcDirector.Core.Tests/MissionStoreTests.cs
@@ -1,0 +1,185 @@
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Tests for <see cref="MissionStore"/> - the durable record store behind the first-class Mission
+/// (mission-as-first-class-unit-of-work). Mirrors <see cref="SessionStateStoreTests"/>: each test uses a
+/// throwaway temp file and asserts the create / get / list / delete API plus survival across a fresh store
+/// instance (the "survives a restart" guarantee), and the session-side MissionId/MissionName round-trip
+/// through <see cref="PersistedSession"/>.
+/// </summary>
+public class MissionStoreTests
+{
+    [Fact]
+    public void Create_MintsIdAndPersists_GetReturnsIt()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json");
+        try
+        {
+            var store = new MissionStore(tempFile);
+
+            var mission = store.Create("Session Lifecycle");
+
+            Assert.NotEqual(Guid.Empty, mission.MissionId);
+            Assert.Equal("Session Lifecycle", mission.MissionName);
+            Assert.Null(mission.ParentMissionId);
+
+            var fetched = store.Get(mission.MissionId);
+            Assert.NotNull(fetched);
+            Assert.Equal(mission.MissionId, fetched.MissionId);
+            Assert.Equal("Session Lifecycle", fetched.MissionName);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void Create_WithParent_NestsUnderIt()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json");
+        try
+        {
+            var store = new MissionStore(tempFile);
+            var parent = store.Create("Parent Mission");
+
+            var child = store.Create("Child Mission", parent.MissionId);
+
+            Assert.Equal(parent.MissionId, child.ParentMissionId);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void Create_BlankName_Throws()
+    {
+        var store = new MissionStore(Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json"));
+        Assert.Throws<ArgumentException>(() => store.Create("   "));
+    }
+
+    [Fact]
+    public void List_ReturnsEveryMission_OldestFirst()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json");
+        try
+        {
+            var store = new MissionStore(tempFile);
+            var first = store.Create("First");
+            var second = store.Create("Second");
+
+            var all = store.List();
+
+            Assert.Equal(2, all.Count);
+            Assert.Equal(first.MissionId, all[0].MissionId);
+            Assert.Equal(second.MissionId, all[1].MissionId);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void Get_UnknownId_ReturnsNull()
+    {
+        var store = new MissionStore(Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json"));
+        Assert.Null(store.Get(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void Missions_SurviveANewStoreInstance_PersistReload()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json");
+        try
+        {
+            var created = new MissionStore(tempFile).Create("Durable Mission");
+
+            // A brand-new store instance against the same file models a Director restart.
+            var reopened = new MissionStore(tempFile);
+            var fetched = reopened.Get(created.MissionId);
+
+            Assert.NotNull(fetched);
+            Assert.Equal("Durable Mission", fetched.MissionName);
+            Assert.Single(reopened.List());
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void Delete_RemovesMission_AndReturnsTrue()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json");
+        try
+        {
+            var store = new MissionStore(tempFile);
+            var mission = store.Create("Doomed Mission");
+
+            var removed = store.Delete(mission.MissionId);
+
+            Assert.True(removed);
+            Assert.Null(store.Get(mission.MissionId));
+            Assert.Empty(store.List());
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void Delete_UnknownId_ReturnsFalse()
+    {
+        var store = new MissionStore(Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json"));
+        Assert.False(store.Delete(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void PersistedSession_MissionAttachment_SurvivesRoundTrip()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_store_{Guid.NewGuid()}.json");
+        try
+        {
+            var store = new SessionStateStore(tempFile);
+            var missionId = Guid.NewGuid();
+
+            var session = new PersistedSession
+            {
+                Id = Guid.NewGuid(),
+                RepoPath = @"C:\test\repo",
+                WorkingDirectory = @"C:\test\repo",
+                ClaudeSessionId = "test-session-mission",
+                MissionId = missionId,
+                MissionName = "Session Lifecycle",
+                ActivityState = ActivityState.Idle,
+                CreatedAt = DateTimeOffset.UtcNow,
+            };
+
+            store.Save(new[] { session });
+            var result = store.Load();
+
+            Assert.True(result.Success);
+            Assert.Single(result.Sessions);
+            Assert.Equal(missionId, result.Sessions[0].MissionId);
+            Assert.Equal("Session Lifecycle", result.Sessions[0].MissionName);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+}

--- a/src/CcDirector.Core/Sessions/Mission.cs
+++ b/src/CcDirector.Core/Sessions/Mission.cs
@@ -1,0 +1,25 @@
+namespace CcDirector.Core.Sessions;
+
+/// <summary>
+/// A Mission: the named unit of work a pod of sessions is collectively chartered to accomplish
+/// (see docs/new_architecture/mission-as-first-class-unit-of-work.md). A Mission is its OWN persisted
+/// record - not merely an attachment field on a session - so it survives a Director/Manager restart and
+/// later anchors the cockpit map. Sessions ATTACH to a Mission by its <see cref="MissionId"/>.
+///
+/// Role cardinality (one Architect, one Manager, N Workers) is enforced by the derived role model, so a
+/// Mission deliberately stores NO role seats - only its identity, name, and optional parent for nesting.
+/// </summary>
+public sealed class Mission
+{
+    /// <summary>Stable identity of the Mission, minted at creation. Sessions attach by this value.</summary>
+    public Guid MissionId { get; set; }
+
+    /// <summary>Human-friendly name of the Mission (e.g. "Session Lifecycle").</summary>
+    public string MissionName { get; set; } = string.Empty;
+
+    /// <summary>The parent Mission this one nests under (a tree of Missions), or null for a root Mission.</summary>
+    public Guid? ParentMissionId { get; set; }
+
+    /// <summary>UTC timestamp the Mission was created. Used for stable list ordering.</summary>
+    public DateTimeOffset CreatedAt { get; set; }
+}

--- a/src/CcDirector.Core/Sessions/MissionStore.cs
+++ b/src/CcDirector.Core/Sessions/MissionStore.cs
@@ -1,0 +1,124 @@
+using System.Text.Json;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Sessions;
+
+/// <summary>
+/// Durable store of <see cref="Mission"/> records (see
+/// docs/new_architecture/mission-as-first-class-unit-of-work.md). A Mission is a first-class persisted
+/// record that sessions attach to, so it MUST survive a Director restart - this store persists the whole
+/// set to <c>missions.json</c> in the same director tool-config location as <see cref="SessionStateStore"/>
+/// keeps <c>sessions.json</c>. Mirrors that store's JSON options + logging shape, but exposes a record API
+/// (Create / Get / List / Delete) because a Mission is an addressable record, not a rebuilt-on-save list.
+///
+/// Every mutating call reads, mutates, and rewrites the file under a single lock so concurrent Control API
+/// requests cannot interleave a half-written set.
+/// </summary>
+public sealed class MissionStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly object _lock = new();
+
+    public string FilePath { get; }
+
+    public MissionStore(string? filePath = null)
+    {
+        FilePath = filePath ?? Path.Combine(
+            CcStorage.ToolConfig("director"),
+            "missions.json");
+        FileLog.Write($"[MissionStore] Initialized: FilePath={FilePath}");
+    }
+
+    /// <summary>
+    /// Create and persist a new Mission with a freshly minted id. <paramref name="missionName"/> is
+    /// required (a blank name throws) and <paramref name="parentMissionId"/> nests it under a parent when
+    /// given. Returns the created record.
+    /// </summary>
+    public Mission Create(string missionName, Guid? parentMissionId = null)
+    {
+        if (string.IsNullOrWhiteSpace(missionName))
+            throw new ArgumentException("missionName is required", nameof(missionName));
+
+        FileLog.Write($"[MissionStore] Create: name=\"{missionName}\" parent={parentMissionId?.ToString() ?? "(none)"}");
+
+        var mission = new Mission
+        {
+            MissionId = Guid.NewGuid(),
+            MissionName = missionName.Trim(),
+            ParentMissionId = parentMissionId,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+        lock (_lock)
+        {
+            var missions = LoadAll();
+            missions.Add(mission);
+            SaveAll(missions);
+        }
+
+        FileLog.Write($"[MissionStore] Create: created mission {mission.MissionId}");
+        return mission;
+    }
+
+    /// <summary>Return the Mission with the given id, or null when none exists.</summary>
+    public Mission? Get(Guid missionId)
+    {
+        lock (_lock)
+            return LoadAll().FirstOrDefault(m => m.MissionId == missionId);
+    }
+
+    /// <summary>Return every stored Mission, oldest first.</summary>
+    public IReadOnlyList<Mission> List()
+    {
+        lock (_lock)
+            return LoadAll().OrderBy(m => m.CreatedAt).ToList();
+    }
+
+    /// <summary>Delete the Mission with the given id. Returns true when a record was removed.</summary>
+    public bool Delete(Guid missionId)
+    {
+        FileLog.Write($"[MissionStore] Delete: mission={missionId}");
+        lock (_lock)
+        {
+            var missions = LoadAll();
+            var removed = missions.RemoveAll(m => m.MissionId == missionId) > 0;
+            if (removed)
+                SaveAll(missions);
+            return removed;
+        }
+    }
+
+    /// <summary>Read the full set from disk. An absent file is an empty set; a corrupt file fails loudly.</summary>
+    private List<Mission> LoadAll()
+    {
+        if (!File.Exists(FilePath))
+            return new List<Mission>();
+
+        var json = File.ReadAllText(FilePath);
+        return JsonSerializer.Deserialize<List<Mission>>(json, JsonOptions) ?? new List<Mission>();
+    }
+
+    /// <summary>Write the full set to disk, creating the directory when missing.</summary>
+    private void SaveAll(List<Mission> missions)
+    {
+        var dir = Path.GetDirectoryName(FilePath);
+        if (string.IsNullOrEmpty(dir))
+            throw new InvalidOperationException($"Cannot determine directory from path: {FilePath}");
+
+        if (!Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+            FileLog.Write($"[MissionStore] SaveAll: created directory {dir}");
+        }
+
+        var serialized = JsonSerializer.Serialize(missions, JsonOptions);
+        File.WriteAllText(FilePath, serialized);
+        FileLog.Write($"[MissionStore] SaveAll: saved {missions.Count} mission(s)");
+    }
+}

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -183,6 +183,35 @@ public sealed class Session : IDisposable
         FileLog.Write($"[Session] {Id} explicit role set to {ExplicitRole ?? "(none)"}");
     }
 
+    /// <summary>
+    /// The Mission this session is ATTACHED to (see
+    /// docs/new_architecture/mission-as-first-class-unit-of-work.md), or null when it is attached to no
+    /// Mission. A Mission is its own persisted record (<see cref="Mission"/>); this is the attachment link
+    /// that binds a pod (Architect + Manager + Workers all attach to one Mission). Stamped at spawn (from
+    /// the create request) or later via the attach verb (<see cref="AttachToMission"/>). Persisted so the
+    /// attachment survives a Director restart.
+    /// </summary>
+    public Guid? MissionId { get; internal set; }
+
+    /// <summary>
+    /// The attached Mission's display name, CACHED here so a client can render the Mission without resolving
+    /// <see cref="MissionId"/> against the Mission store. Set alongside <see cref="MissionId"/> at attach
+    /// time; the Mission record remains the source of truth. Null when attached to no Mission. Persisted.
+    /// </summary>
+    public string? MissionName { get; internal set; }
+
+    /// <summary>
+    /// Attach this session to a Mission (or DETACH it when <paramref name="missionId"/> is null). Stamps
+    /// <see cref="MissionId"/> and caches the resolved <see cref="MissionName"/>. The caller resolves the
+    /// name from the Mission store; this only stores what it is given.
+    /// </summary>
+    public void AttachToMission(Guid? missionId, string? missionName)
+    {
+        MissionId = missionId;
+        MissionName = missionId is null ? null : (string.IsNullOrWhiteSpace(missionName) ? null : missionName.Trim());
+        FileLog.Write($"[Session] {Id} attached to mission {MissionId?.ToString() ?? "(none)"} (name={MissionName ?? "(none)"})");
+    }
+
     public Guid Id { get; }
 
     /// <summary>

--- a/src/CcDirector.Core/Sessions/SessionManager.cs
+++ b/src/CcDirector.Core/Sessions/SessionManager.cs
@@ -966,6 +966,8 @@ public sealed class SessionManager : IDisposable
                 ControllerSessionId = s.ControllerSessionId,
                 ExplicitRole = s.ExplicitRole,
                 IsAutoNamed = s.IsAutoNamed,
+                MissionId = s.MissionId,
+                MissionName = s.MissionName,
                 RawStartupText = s.RawStartupText,
                 SelectedTabName = s.SelectedTabName,
                 WingmanEnabled = s.WingmanEnabled,
@@ -1010,6 +1012,8 @@ public sealed class SessionManager : IDisposable
         session.ControllerSessionId = ps.ControllerSessionId;
         session.ExplicitRole = ps.ExplicitRole;
         session.IsAutoNamed = ps.IsAutoNamed;
+        session.MissionId = ps.MissionId;
+        session.MissionName = ps.MissionName;
         session.WingmanEnabled = ps.WingmanEnabled;
         // Issue #820: carry the persisted three-digit number in BEFORE RaiseSessionCreated so
         // AssignSessionNumber reserves this exact number (keeping it across a restart) when it is

--- a/src/CcDirector.Core/Sessions/SessionStateStore.cs
+++ b/src/CcDirector.Core/Sessions/SessionStateStore.cs
@@ -56,6 +56,14 @@ public class PersistedSession
     /// so an explicit human/self rename is never re-auto-named after a restart.</summary>
     public bool IsAutoNamed { get; set; }
 
+    /// <summary>The Mission this session is attached to, or null for none. Persisted so the attachment (the
+    /// pod binding) survives a Director restart. Null for sessions persisted before this field existed.</summary>
+    public Guid? MissionId { get; set; }
+
+    /// <summary>The attached Mission's cached display name, or null for none. Persisted alongside
+    /// <see cref="MissionId"/> so the name renders after a restart without re-resolving the Mission store.</summary>
+    public string? MissionName { get; set; }
+
     public DateTimeOffset CreatedAt { get; set; }
 
     /// <summary>Order in the session list, used to restore UI order after restart.</summary>

--- a/src/CcDirector.Gateway.Contracts/MissionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/MissionDto.cs
@@ -1,0 +1,45 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// A Mission: the named unit of work a pod of sessions is collectively chartered to accomplish
+/// (see docs/new_architecture/mission-as-first-class-unit-of-work.md). A Mission is its OWN
+/// persisted record - not merely an attachment field on a session - so it survives a Manager
+/// restart and later anchors the cockpit map. Sessions ATTACH to a Mission by its
+/// <see cref="MissionId"/>; that attachment (not the spawn tree) is what binds a pod together.
+///
+/// Role cardinality (one Architect, one Manager, N Workers) is enforced by the derived role model
+/// (see <see cref="SessionRoles"/>); the Mission record deliberately does NOT store role seats.
+/// </summary>
+public sealed class MissionDto
+{
+    /// <summary>Stable identity of the Mission, minted at creation. This is the value sessions attach by.</summary>
+    public Guid MissionId { get; set; }
+
+    /// <summary>Human-friendly name of the Mission (e.g. "Session Lifecycle").</summary>
+    public string MissionName { get; set; } = "";
+
+    /// <summary>The parent Mission this one nests under (a tree of Missions), or null for a root Mission.</summary>
+    public Guid? ParentMissionId { get; set; }
+}
+
+/// <summary>
+/// Body of POST /missions on a Director's Control API: create a new Mission record.
+/// </summary>
+public sealed class NewMissionRequest
+{
+    /// <summary>Required. The Mission's human-friendly name. A blank name is rejected with HTTP 400.</summary>
+    public string? MissionName { get; set; }
+
+    /// <summary>Optional parent Mission this one nests under; null (default) creates a root Mission.</summary>
+    public Guid? ParentMissionId { get; set; }
+}
+
+/// <summary>
+/// Body of POST /sessions/{id}/mission: attach a session to a Mission. <see cref="MissionId"/> is the
+/// Mission the session attaches to; a null/absent value DETACHES the session (clears its attachment),
+/// mirroring how <see cref="SetRoleRequest"/> clears an explicit role.
+/// </summary>
+public sealed class SetMissionRequest
+{
+    public Guid? MissionId { get; set; }
+}

--- a/src/CcDirector.Gateway.Contracts/NewSessionRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/NewSessionRequest.cs
@@ -95,6 +95,16 @@ public sealed class NewSessionRequest
     public string? Role { get; set; }
 
     /// <summary>
+    /// Optional Mission to ATTACH the new session to at spawn (see
+    /// docs/new_architecture/mission-as-first-class-unit-of-work.md). When set, the Director stamps the
+    /// session's <see cref="SessionDto.MissionId"/> and caches the resolved
+    /// <see cref="SessionDto.MissionName"/> at birth - the attachment that binds this session into a pod.
+    /// The Mission must already exist (create it with POST /missions); an unknown Mission is REJECTED as a
+    /// bad request. Null leaves the session attached to no Mission.
+    /// </summary>
+    public Guid? MissionId { get; set; }
+
+    /// <summary>
     /// Optional target machine for spawn routing ("start a session on another computer"). Null,
     /// empty, or the local machine name spawns on the LOCAL machine (the default, unchanged); a
     /// remote machine name routes the spawn via the Gateway to a Director on that machine (first

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -76,6 +76,24 @@ public sealed class SessionDto
     public string? Name { get; set; }
 
     /// <summary>
+    /// The Mission this session is ATTACHED to (see
+    /// docs/new_architecture/mission-as-first-class-unit-of-work.md), or null when it is attached to no
+    /// Mission. A Mission is its own persisted record (<see cref="MissionDto"/>); this is the attachment
+    /// link, stamped at spawn (from <see cref="NewSessionRequest.MissionId"/>) or later via
+    /// POST /sessions/{id}/mission. Mirrors <c>Session.MissionId</c> on the owning Director; passes through
+    /// the Gateway aggregation unchanged. Null on Directors that predate this field.
+    /// </summary>
+    public Guid? MissionId { get; set; }
+
+    /// <summary>
+    /// The attached Mission's display name, CACHED on the session for at-a-glance rendering so a client
+    /// does not have to resolve <see cref="MissionId"/> against the Mission store. Resolved and stamped at
+    /// attach time; the Mission record (<see cref="MissionId"/>) remains the source of truth. Null when the
+    /// session is attached to no Mission. Mirrors <c>Session.MissionName</c> on the owning Director.
+    /// </summary>
+    public string? MissionName { get; set; }
+
+    /// <summary>
     /// The session's short, human-friendly three-digit number (100-999), or null when the session
     /// has no number (issue #820). Allocated by the owning Director at creation and stable for the
     /// life of the session - a separate field from <see cref="Name"/>, so a rename never changes it.

--- a/src/CcDirector.Gateway.Tests/MissionCommandTests.cs
+++ b/src/CcDirector.Gateway.Tests/MissionCommandTests.cs
@@ -1,0 +1,209 @@
+using System.Text.Json;
+using CcDirector.ControlApi;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Tests for the Mission-attach command paths (mission-as-first-class-unit-of-work) through the shared
+/// <see cref="SessionCommandExecutor"/>: the <c>attach-mission</c> verb stamps a session's MissionId +
+/// cached MissionName (and detaches on a blank id), and a create-time <see cref="NewSessionRequest.MissionId"/>
+/// attaches the new session at spawn. Mirrors the set-role tests in <see cref="SessionCommandExecutorTests"/>.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class MissionCommandTests
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    // OS shell used as a harmless RawCli agent so create tests exercise the REAL create path without an
+    // installed coding-agent CLI (same approach as SessionCommandExecutorTests).
+    private static string TestShellPath =>
+        System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)
+            ? "cmd.exe" : "/bin/sh";
+
+    private static (SessionManager sm, Session session) NewSession()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        var backend = new ExecuteActionTestBackend();
+        var session = sm.CreateEmbeddedSession(Path.GetTempPath(), null, backend);
+        return (sm, session);
+    }
+
+    private static MissionStore NewMissionStore() =>
+        new(Path.Combine(Path.GetTempPath(), $"test_missions_{Guid.NewGuid()}.json"));
+
+    private static DirectorCommand AttachCommand(string sid, Guid? missionId) => new()
+    {
+        CommandId = "am1",
+        Verb = "attach-mission",
+        SessionId = sid,
+        PayloadJson = JsonSerializer.Serialize(new SetMissionRequest { MissionId = missionId }, Json),
+    };
+
+    private static DirectorCommand CreateCommand(NewSessionRequest req) => new()
+    {
+        CommandId = "c1",
+        Verb = "create",
+        SessionId = "",
+        PayloadJson = JsonSerializer.Serialize(req, Json),
+    };
+
+    [Fact]
+    public async Task AttachMission_StampsMissionIdAndCachesName_AndReturnsUpdatedSession()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var store = NewMissionStore();
+            var mission = store.Create("Session Lifecycle");
+            var services = new SessionCommandServices { MissionStore = store };
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", AttachCommand(session.Id.ToString(), mission.MissionId), services);
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal(mission.MissionId, session.MissionId);
+            Assert.Equal("Session Lifecycle", session.MissionName); // resolved + cached from the store
+
+            var dto = JsonSerializer.Deserialize<SessionDto>(result.BodyJson ?? "", Json);
+            Assert.NotNull(dto);
+            Assert.Equal(mission.MissionId, dto.MissionId);
+            Assert.Equal("Session Lifecycle", dto.MissionName);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task AttachMission_UnknownMission_ReturnsBadRequest_Unchanged()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var services = new SessionCommandServices { MissionStore = NewMissionStore() };
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", AttachCommand(session.Id.ToString(), Guid.NewGuid()), services);
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+            Assert.Null(session.MissionId);
+            Assert.Null(session.MissionName);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task AttachMission_BlankMissionId_DetachesSession()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var store = NewMissionStore();
+            var mission = store.Create("Session Lifecycle");
+            var services = new SessionCommandServices { MissionStore = store };
+
+            await SessionCommandExecutor.DispatchAsync(sm, "dir-A", AttachCommand(session.Id.ToString(), mission.MissionId), services);
+            Assert.Equal(mission.MissionId, session.MissionId);
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", AttachCommand(session.Id.ToString(), null), services);
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Null(session.MissionId); // cleared -> detached
+            Assert.Null(session.MissionName);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task AttachMission_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var store = NewMissionStore();
+            var mission = store.Create("Session Lifecycle");
+            var services = new SessionCommandServices { MissionStore = store };
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", AttachCommand(Guid.NewGuid().ToString(), mission.MissionId), services);
+
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task AttachMission_InvalidSessionId_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var services = new SessionCommandServices { MissionStore = NewMissionStore() };
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", AttachCommand("not-a-guid", Guid.NewGuid()), services);
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task Create_WithMissionId_AttachesNewSessionAtSpawn()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var store = NewMissionStore();
+            var mission = store.Create("Session Lifecycle");
+            var services = new SessionCommandServices { MissionStore = store };
+
+            var command = CreateCommand(new NewSessionRequest
+            {
+                RepoPath = Path.GetTempPath(),
+                Agent = "RawCli",
+                Command = TestShellPath,
+                Name = "mission-create-test",
+                MissionId = mission.MissionId,
+            });
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command, services);
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var dto = JsonSerializer.Deserialize<SessionDto>(result.BodyJson ?? "", Json);
+            Assert.NotNull(dto);
+            Assert.Equal(mission.MissionId, dto.MissionId);
+            Assert.Equal("Session Lifecycle", dto.MissionName);
+
+            Assert.True(Guid.TryParse(dto.SessionId, out var sid));
+            var session = sm.GetSession(sid);
+            Assert.NotNull(session);
+            Assert.Equal(mission.MissionId, session.MissionId);
+            Assert.Equal("Session Lifecycle", session.MissionName);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task Create_WithUnknownMissionId_ReturnsBadRequest_NoSessionCreated()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var services = new SessionCommandServices { MissionStore = NewMissionStore() };
+            var before = sm.ListSessions().Count;
+
+            var command = CreateCommand(new NewSessionRequest
+            {
+                RepoPath = Path.GetTempPath(),
+                Agent = "RawCli",
+                Command = TestShellPath,
+                Name = "bad-mission",
+                MissionId = Guid.NewGuid(), // never created in the store
+            });
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command, services);
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+            Assert.Equal(before, sm.ListSessions().Count); // rejected before creation - no orphan
+        }
+        finally { sm.Dispose(); }
+    }
+}

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.table import Table
 
 from . import __version__
+from . import mission_ops
 from . import schedule_ops
 from . import settings_ops
 from . import setup_ops
@@ -30,6 +31,11 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 session_app = typer.Typer(help="Manage running sessions.", add_completion=False)
+mission_app = typer.Typer(
+    help="Create and list Missions (the unit of work sessions attach to).",
+    add_completion=False,
+    no_args_is_help=True,
+)
 message_app = typer.Typer(help="Send messages between sessions.", add_completion=False)
 settings_app = typer.Typer(
     help="Read and write CC Director settings.", add_completion=False, no_args_is_help=True
@@ -41,6 +47,7 @@ setup_app = typer.Typer(
     help="Install, update, and repair DevThrottle.", add_completion=False, no_args_is_help=True
 )
 app.add_typer(session_app, name="session")
+app.add_typer(mission_app, name="mission")
 app.add_typer(message_app, name="message")
 app.add_typer(settings_app, name="settings")
 app.add_typer(schedule_app, name="schedule")
@@ -382,12 +389,38 @@ def spawn(
         "machine (first available, auto-launched if none is running); an off/unreachable machine fails "
         "loudly with no local fallback.",
     ),
+    mission: Optional[str] = typer.Option(
+        None,
+        "--mission",
+        help="Attach the new session to a Mission by its id at spawn (mission-as-first-class-unit-of-work). "
+        "The Mission must already exist (create one with 'cc-devthrottle mission create'); an unknown "
+        "Mission is rejected by the Director.",
+    ),
 ) -> None:
     """Open a new session on the local Director, or on another computer with --machine, and print its id."""
     spawn_session(
         repo, agent, prompt, name, purpose, command, command_args, controlled_by, args, standalone, role,
-        machine,
+        machine, mission,
     )
+
+
+@mission_app.command("create")
+def mission_create(
+    name: str = typer.Argument(..., help="Human-friendly name for the Mission."),
+    parent: Optional[str] = typer.Option(
+        None, "--parent", help="Parent Mission id to nest this Mission under (a tree of Missions)."
+    ),
+) -> None:
+    """Create a Mission record on the local Director and print its id."""
+    mission_ops.create_mission(name, parent)
+
+
+@mission_app.command("list")
+def mission_list(
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON."),
+) -> None:
+    """List every Mission record on the local Director."""
+    mission_ops.list_missions(json_output)
 
 
 @message_app.command("send")

--- a/tools/cc-devthrottle/src/mission_ops.py
+++ b/tools/cc-devthrottle/src/mission_ops.py
@@ -1,0 +1,84 @@
+"""Mission operations for cc-devthrottle.
+
+A Mission is a first-class persisted record on the local Director that sessions attach to
+(see docs/new_architecture/mission-as-first-class-unit-of-work.md). These commands create and
+list Mission records via the Director Control API (POST /missions, GET /missions), mirroring the
+session/schedule command style.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import typer
+from rich import box
+from rich.console import Console
+from rich.table import Table
+
+# Make cc_shared importable when running from source, matching the existing cc-* tools.
+_tools_dir = str(Path(__file__).resolve().parent.parent.parent)
+if _tools_dir not in sys.path:
+    sys.path.insert(0, _tools_dir)
+
+from cc_shared import director  # noqa: E402
+
+console = Console()
+
+
+def create_mission(name: str, parent: Optional[str]) -> None:
+    """Create a Mission record on the local Director and print its id."""
+    body: Dict[str, Any] = {"missionName": name}
+    if parent:
+        body["parentMissionId"] = parent
+
+    try:
+        resp = director.post_json("missions", body)
+    except director.DirectorError as err:
+        console.print(f"[red]Error:[/red] {err}")
+        raise typer.Exit(1)
+
+    mid = director.field(resp, "missionId", "MissionId")
+    if not mid:
+        console.print("[red]Error:[/red] the Director did not return a mission id.")
+        raise typer.Exit(1)
+
+    label = director.field(resp, "missionName", "MissionName") or name
+    console.print(f"[green]Created[/green] mission ({label}).")
+    console.print(f"id: {mid}")
+    console.print(
+        f'Attach a session at spawn:  cc-devthrottle session spawn <repo> --mission {mid}'
+    )
+
+
+def list_missions(json_output: bool) -> None:
+    """List every Mission record on the local Director."""
+    try:
+        missions = director.get_json("missions") or []
+    except director.DirectorError as err:
+        console.print(f"[red]Error:[/red] {err}")
+        raise typer.Exit(1)
+
+    if json_output:
+        print(json.dumps(missions, indent=2))
+        return
+
+    if not missions:
+        console.print(
+            "No missions on this Director yet. Create one with 'cc-devthrottle mission create <name>'."
+        )
+        return
+
+    table = Table(show_header=True, header_style="bold", box=box.ASCII)
+    table.add_column("Id")
+    table.add_column("Name")
+    table.add_column("Parent")
+
+    for mission in missions:
+        mid = director.field(mission, "missionId", "MissionId")
+        name = director.field(mission, "missionName", "MissionName") or "-"
+        parent = director.field(mission, "parentMissionId", "ParentMissionId") or "-"
+        table.add_row(director.short_id(mid) if mid else "-", name, parent)
+    console.print(table)

--- a/tools/cc-devthrottle/src/session_ops.py
+++ b/tools/cc-devthrottle/src/session_ops.py
@@ -315,6 +315,7 @@ def spawn_session(
     standalone: bool = False,
     role: Optional[str] = None,
     machine: Optional[str] = None,
+    mission: Optional[str] = None,
 ) -> None:
     """Open a new session on the local Director, or on another computer when a remote --machine is given."""
     # Automatic roles: a SESSION-initiated spawn (CC_SESSION_ID present) DEFAULTS to a Worker controlled by
@@ -373,6 +374,9 @@ def spawn_session(
     # against Standalone/Manager/Worker/Architect and rejects an unknown value (never a silent drop).
     if role:
         body["role"] = role
+    # Mission attach at spawn: forward the Mission id; the Director resolves+validates it (unknown -> 400).
+    if mission:
+        body["missionId"] = mission
 
     # "Start a session on another computer": with no --machine, or a --machine that names THIS machine,
     # keep the unchanged LOCAL spawn (POST /sessions on the local Director). A remote machine name routes


### PR DESCRIPTION
Additive: a Mission is its own persisted record (missionId + missionName + parent), sessions attach via missionId; new POST/GET /missions + POST /sessions/{id}/mission attach; mission CLI. Mirrors the SessionRole pattern. 16 new tests; combined-with-latest-main suites green (Gateway 1587, Core 2859).