### PR TITLE
Mobile: restore the About version screen and show each cc-director port in the New session picker

### DIFF
--- a/apps/mobile/src/components/NavDrawer.tsx
+++ b/apps/mobile/src/components/NavDrawer.tsx
@@ -36,6 +36,9 @@ export function NavDrawer() {
             <Link className="drawer-item" to="/settings" onClick={close}>
               AI settings
             </Link>
+            <Link className="drawer-item" to="/about" onClick={close}>
+              About
+            </Link>
           </nav>
         </div>
       )}

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -7,6 +7,7 @@ import { Terminal } from "./pages/Terminal";
 import { Chat } from "./pages/Chat";
 import { VoiceMode } from "./pages/VoiceMode";
 import { AiSettings } from "./pages/AiSettings";
+import { About } from "./pages/About";
 import { SignIn } from "@devthrottle/client-core/auth/SignIn";
 import { DeviceCallback } from "@devthrottle/client-core/auth/DeviceCallback";
 import { hasDeviceKey } from "@devthrottle/client-core/auth/deviceKey";
@@ -78,6 +79,7 @@ const router = createBrowserRouter(
           children: [
             { path: "/", element: <Home /> },
             { path: "/settings", element: <AiSettings /> },
+            { path: "/about", element: <About /> },
             { path: "/new", element: <NewSession /> },
             { path: "/session/:sessionId", element: <Chat /> },
             { path: "/session/:sessionId/chat", element: <Chat /> },

--- a/apps/mobile/src/pages/About.tsx
+++ b/apps/mobile/src/pages/About.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { getGatewayHealth, gatewayErrorMessage, type GatewayHealth } from "@devthrottle/client-core/api/client";
+
+export function About() {
+  const [health, setHealth] = useState<GatewayHealth | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const bundle = useMemo(() => currentBundleName(), []);
+  const sw = serviceWorkerState();
+  const displayMode = isStandalone() ? "Installed PWA" : "Browser tab";
+
+  useEffect(() => {
+    const controller = new AbortController();
+    getGatewayHealth(controller.signal)
+      .then((h) => {
+        setHealth(h);
+        setError(null);
+      })
+      .catch((err) => {
+        if (!controller.signal.aborted) setError(gatewayErrorMessage(err));
+      });
+    return () => controller.abort();
+  }, []);
+
+  const version = health?.version ?? "Loading...";
+  const sha = shortSha(version);
+
+  return (
+    <div className="screen">
+      <header className="app-bar">
+        <Link className="back-link" to="/">
+          Back
+        </Link>
+        <h1>About</h1>
+      </header>
+
+      {error !== null && (
+        <div className="banner banner-error" role="alert">
+          {error}
+        </div>
+      )}
+
+      <section className="about-panel" aria-label="Application version">
+        <div className="about-product">DevThrottle Mobile</div>
+        <div className="about-version">{version}</div>
+        {sha !== "" && <div className="about-sha">Build {sha}</div>}
+      </section>
+
+      <section className="about-list" aria-label="Runtime details">
+        <AboutRow label="Mobile bundle" value={bundle} />
+        <AboutRow label="Gateway status" value={health?.status ?? "Loading..."} />
+        <AboutRow label="Gateway time" value={formatTime(health?.serverTime)} />
+        <AboutRow label="Directors" value={health ? String(health.directors) : "Loading..."} />
+        <AboutRow label="Sessions" value={health ? String(health.sessions) : "Loading..."} />
+        <AboutRow label="Service worker" value={sw} />
+        <AboutRow label="Display" value={displayMode} />
+      </section>
+    </div>
+  );
+}
+
+function AboutRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="about-row">
+      <span className="about-label">{label}</span>
+      <span className="about-value">{value}</span>
+    </div>
+  );
+}
+
+function currentBundleName(): string {
+  if (typeof document === "undefined") return "unknown";
+  const scripts = Array.from(document.scripts)
+    .map((s) => s.getAttribute("src") ?? "")
+    .filter((src) => src.includes("/assets/") && src.endsWith(".js"));
+  const src = scripts.at(-1);
+  if (!src) return "unknown";
+  return src.substring(src.lastIndexOf("/") + 1);
+}
+
+function serviceWorkerState(): string {
+  if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) return "not supported";
+  return navigator.serviceWorker.controller ? "active" : "not controlling yet";
+}
+
+function isStandalone(): boolean {
+  if (typeof window === "undefined") return false;
+  const nav = navigator as Navigator & { standalone?: boolean };
+  return window.matchMedia("(display-mode: standalone)").matches || Boolean(nav.standalone);
+}
+
+function shortSha(version: string): string {
+  const plus = version.indexOf("+");
+  if (plus < 0) return "";
+  return version.substring(plus + 1, plus + 8);
+}
+
+function formatTime(value: string | undefined): string {
+  if (!value) return "Loading...";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}

--- a/apps/mobile/src/pages/NewSession.tsx
+++ b/apps/mobile/src/pages/NewSession.tsx
@@ -74,6 +74,15 @@ function directorLabel(d: DirectorInfo): string {
   return d.directorId || "director";
 }
 
+// The Control API port for a Director, parsed from its controlEndpoint (e.g. "http://127.0.0.1:7880"
+// or "https://host.ts.net:7881" -> "7880" / "7881"). This is what tells apart several cc-director
+// slots running on the SAME machine, so it is shown on every picker row and is the number to quote to
+// an agent to say which cc-director a session was started on. Empty when the endpoint carries no port.
+function directorPort(d: DirectorInfo): string {
+  const match = /:(\d+)(?:\/|$)/.exec(d.controlEndpoint ?? "");
+  return match ? match[1] : "";
+}
+
 function repoLabel(r: RepoInfo): string {
   if (r.name.trim()) return r.name.trim();
   const parts = r.path.replace(/[\\/]+$/, "").split(/[\\/]/).filter(Boolean);
@@ -192,7 +201,10 @@ export function NewSession() {
               <li key={d.directorId} className={`row${d.directorId === selectedId ? " row-selected" : ""}`}>
                 <button type="button" className="picker-link" onClick={() => setSelectedId(d.directorId)}>
                   <span className="row-body">
-                    <span className="row-name">{directorLabel(d)}</span>
+                    <span className="row-name">
+                      {directorLabel(d)}
+                      {directorPort(d) !== "" && <span className="row-port"> port {directorPort(d)}</span>}
+                    </span>
                     <span className="row-context">{directorSubtitle(d, now)}</span>
                   </span>
                   {d.directorId === selectedId && <span className="picker-check" aria-hidden="true">selected</span>}

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -1996,3 +1996,58 @@ a.banner-btn {
   height: 12px;
   border-width: 2px;
 }
+
+/* ===== About screen ===== */
+.about-panel {
+  margin: 16px 0;
+  padding: 16px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.about-product {
+  font-size: 18px;
+  font-weight: 800;
+  margin-bottom: 8px;
+}
+.about-version {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+.about-sha {
+  margin-top: 8px;
+  color: var(--text-dim);
+  font-size: 13px;
+}
+.about-list {
+  border-top: 1px solid var(--border);
+}
+.about-row {
+  display: grid;
+  grid-template-columns: minmax(96px, 36%) minmax(0, 1fr);
+  gap: 12px;
+  padding: 13px 0;
+  border-bottom: 1px solid var(--border);
+  align-items: start;
+}
+.about-label {
+  color: var(--text-dim);
+  font-size: 13px;
+}
+.about-value {
+  color: var(--text);
+  font-size: 13px;
+  overflow-wrap: anywhere;
+  text-align: right;
+}
+
+/* The Control API port shown on each machine row in the New session picker, so several cc-director
+   slots on one machine are told apart and the number can be quoted to an agent. */
+.row-port {
+  color: var(--accent, #4c8dff);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-weight: 600;
+}

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -35,6 +35,18 @@ export interface DirectorInfo {
   startedAt: string;
   /** When the Gateway last heard from this Director (ISO 8601), or empty. Used to default-select. */
   lastSeen: string;
+  /** The Director's Control API endpoint, e.g. "http://127.0.0.1:7880" or a tailnet URL. Carries the
+   *  PORT, which is what distinguishes several Directors (slots) on the SAME machine in the picker. */
+  controlEndpoint: string;
+}
+
+/** GET /healthz - what the running Gateway reports about itself. Backs the mobile About screen. */
+export interface GatewayHealth {
+  status: string;
+  directors: number;
+  sessions: number;
+  version: string;
+  serverTime: string;
 }
 
 // One recently-used repository on a Director, projected from GET /directors/{id}/repos. Also not in
@@ -598,6 +610,20 @@ export async function uploadImage(sessionId: string, file: File, signal?: AbortS
 // owner's Hold/Remove decision. Every call carries the same Bearer the rest of the client uses, so
 // the whole flow works with global Gateway auth on or off.
 
+// GET /healthz - the running Gateway's own status and version. No auth needed. Backs the mobile
+// About screen so the user can confirm which build they are on.
+export async function getGatewayHealth(signal?: AbortSignal): Promise<GatewayHealth> {
+  const res = await fetch("/healthz", {
+    method: "GET",
+    headers: { Accept: "application/json" },
+    signal,
+  });
+  if (!res.ok) {
+    throw new GatewayError(res.status, `GET /healthz failed: ${res.status}`);
+  }
+  return (await res.json()) as GatewayHealth;
+}
+
 // GET /directors - the fleet's machines (Directors). Sorted most-recently-seen first so the picker
 // can default-select the top one (matching FleetParser.ParseDirectors), tie-broken by machine name.
 // Entries with no directorId are dropped (they cannot be addressed). Throws GatewayError on non-2xx
@@ -619,6 +645,7 @@ export async function getDirectors(signal?: AbortSignal): Promise<DirectorInfo[]
       version: String(d.version ?? ""),
       startedAt: String(d.startedAt ?? ""),
       lastSeen: String(d.lastSeen ?? ""),
+      controlEndpoint: String(d.controlEndpoint ?? ""),
     }))
     .filter((d) => d.directorId.length > 0);
   list.sort((a, b) => {


### PR DESCRIPTION
Two small mobile (/m PWA) fixes requested by the owner.

## 1. Restore the About version screen
The mobile About screen (`apps/mobile/src/pages/About.tsx`, plus the nav-drawer link and the `/about` route) was built earlier on an unmerged branch (`fix/gateway-transcription-current`) and never reached main, so the phone had no way to show which build it is on. This restores it: it reads the running version from `GET /healthz` and shows the build commit, gateway status, service-worker state, and display mode.

## 2. Show each cc-director's port in the New session picker
`DirectorInfo` now carries the Director Control API endpoint (already present in the `/directors` response, just not surfaced), and each machine row in "Start a session" shows its port (e.g. `SOREN_NORTH  port 7881`). Several cc-director slots run on the same machine, so the port is what tells them apart, and it is the number to quote to an agent to say which cc-director a session was started on.

Client-only (the /m PWA + a small client-core addition). Typecheck passes across all workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)