### PR TITLE
fix(desktop): show session rail orange while dictations are held/queued

### DIFF
--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -3256,19 +3256,40 @@ public partial class MainWindow : Window
     {
         var store = _pendingDictationStore;
         if (store is null) return;
-        int total, parked, composerBlocked;
+        System.Collections.Generic.IReadOnlyList<global::CcDirector.Core.Dictation.PendingDictation> all;
         try
         {
-            var all = store.LoadAll();
-            total = all.Count;
-            parked = all.Count(r => r.Status == global::CcDirector.Core.Dictation.PendingDictationStatus.NeedsAttention);
-            composerBlocked = all.Count(r => r.Status == global::CcDirector.Core.Dictation.PendingDictationStatus.ComposerBlocked);
+            all = store.LoadAll();
         }
         catch (Exception ex)
         {
             FileLog.Write($"[MainWindow] RefreshHeldDictationNotice FAILED: {ex.Message}");
             return;
         }
+
+        // Keep each session's rail orange while it has held dictations (issue: only the phone-arrival
+        // lock and the brief immediate transcription attempt were orange, so a queued/held desktop clip
+        // read red). The durable store is the single source of truth; sessions with no held clips are
+        // zeroed so the overlay clears the moment their queue drains. Runs on the UI thread.
+        try
+        {
+            var perSession = all
+                .GroupBy(r => r.SessionId, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.Count(), StringComparer.OrdinalIgnoreCase);
+            foreach (var vm in _sessions)
+            {
+                var sid = vm.Session.Id.ToString();
+                vm.Session.PendingDictationCount = perSession.TryGetValue(sid, out var n) ? n : 0;
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[MainWindow] pending-dictation rail sync FAILED: {ex.Message}");
+        }
+
+        var total = all.Count;
+        var parked = all.Count(r => r.Status == global::CcDirector.Core.Dictation.PendingDictationStatus.NeedsAttention);
+        var composerBlocked = all.Count(r => r.Status == global::CcDirector.Core.Dictation.PendingDictationStatus.ComposerBlocked);
 
         if (total == 0)
         {

--- a/src/CcDirector.Avalonia/SessionViewModel.cs
+++ b/src/CcDirector.Avalonia/SessionViewModel.cs
@@ -84,6 +84,7 @@ public class SessionViewModel : INotifyPropertyChanged
         session.OnHoldChanged += OnHoldChangedVm;
         session.OnViewModeChanged += OnViewModeChangedVm;
         session.OnReceivingDictationChanged += OnReceivingDictationChangedVm;
+        session.OnPendingDictationCountChanged += OnPendingDictationCountChangedVm;
 
         if (session.PromptQueue != null)
         {
@@ -95,6 +96,17 @@ public class SessionViewModel : INotifyPropertyChanged
     // Issue #1181, Task 3b: the session started or stopped receiving a phone dictation - repaint the
     // rail strip (orange while receiving) and refresh its reason text.
     private void OnReceivingDictationChangedVm(bool receiving)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            OnPropertyChanged(nameof(StatusColorBrush));
+            OnPropertyChanged(nameof(StatusReason));
+        });
+    }
+
+    // Held desktop dictations queued for this session changed - repaint the rail strip (orange while
+    // any are waiting) and refresh its reason text, the same way the phone-dictation lock does above.
+    private void OnPendingDictationCountChangedVm(int count)
     {
         Dispatcher.UIThread.Post(() =>
         {
@@ -133,6 +145,9 @@ public class SessionViewModel : INotifyPropertyChanged
             // "a dictation is arriving" state is obvious at a glance in the rail (it overrides the base
             // red "needs you", which would otherwise hide the fact that input is temporarily locked).
             if (Session.IsReceivingDictation) return OrangeStatusBrush;
+            // Desktop dictations held/queued for this session (Speak Send, delivered by the background
+            // sweeper) keep the rail orange for the whole wait, not just the brief immediate attempt.
+            if (Session.PendingDictationCount > 0) return OrangeStatusBrush;
             return (Session.StatusColor?.ToLowerInvariant()) switch
             {
                 "green"  => GreenStatusBrush,
@@ -158,7 +173,9 @@ public class SessionViewModel : INotifyPropertyChanged
         ? "On hold (set aside by you)"
         : Session.IsReceivingDictation
             ? "Receiving a dictation from your phone"
-            : Session.LastStatusReason ?? "";
+            : Session.PendingDictationCount > 0
+                ? "Dictation queued - sending when the session is ready"
+                : Session.LastStatusReason ?? "";
 
     private void OnHoldChangedVm(bool onHold)
     {

--- a/src/CcDirector.Core.Tests/Sessions/SessionPendingDictationTests.cs
+++ b/src/CcDirector.Core.Tests/Sessions/SessionPendingDictationTests.cs
@@ -1,0 +1,52 @@
+using CcDirector.Core.Agents;
+using CcDirector.Core.Backends;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Tests.Wingman;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Sessions;
+
+/// <summary>
+/// The desktop rail paints a session ORANGE while it has held/queued desktop dictations
+/// (SessionViewModel reads <see cref="Session.PendingDictationCount"/> &gt; 0, alongside the
+/// phone-arrival <see cref="Session.IsReceivingDictation"/>). These pin the model contract that
+/// drives that repaint: the count is change-notifying and coalesces no-op writes, so the rail is
+/// nudged exactly when the held-dictation queue actually changes and not on every roster tick.
+/// </summary>
+public sealed class SessionPendingDictationTests
+{
+    private static Session CreateSession(SessionManager manager)
+        => manager.CreateEmbeddedSession(System.IO.Path.GetTempPath(), null, new BufferOnlyBackend());
+
+    [Fact]
+    public void PendingDictationCount_raises_change_event_with_new_value()
+    {
+        using var manager = new SessionManager(new AgentOptions { ClaudePath = TestShell.Path });
+        var session = CreateSession(manager);
+
+        var observed = new System.Collections.Generic.List<int>();
+        session.OnPendingDictationCountChanged += observed.Add;
+
+        session.PendingDictationCount = 7;   // clips queued
+        session.PendingDictationCount = 0;   // queue drained
+
+        Assert.Equal(new[] { 7, 0 }, observed);
+        Assert.Equal(0, session.PendingDictationCount);
+    }
+
+    [Fact]
+    public void PendingDictationCount_setting_same_value_does_not_re_notify()
+    {
+        using var manager = new SessionManager(new AgentOptions { ClaudePath = TestShell.Path });
+        var session = CreateSession(manager);
+
+        var fires = 0;
+        session.OnPendingDictationCountChanged += _ => fires++;
+
+        session.PendingDictationCount = 3;
+        session.PendingDictationCount = 3;   // no change - the roster tick re-syncs the same count
+
+        Assert.Equal(1, fires);
+    }
+}

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -1500,6 +1500,32 @@ public sealed class Session : IDisposable
         OnReceivingDictationChanged?.Invoke(now);
     }
 
+    private int _pendingDictationCount;
+
+    /// <summary>
+    /// How many recorded-but-not-yet-delivered desktop dictations are currently held on disk for this
+    /// session (the durable <c>PendingDictationStore</c>). Distinct from <see cref="IsReceivingDictation"/>,
+    /// which is the phone-dictation arrival lock (issue #1181): this is the desktop Speak queue that the
+    /// background sweeper is still delivering. The roster paints the rail ORANGE while it is greater than
+    /// zero so a session with dictations waiting reads busy-with-dictation for the whole time - not just
+    /// the brief immediate transcription attempt. Transient (in-memory only); the host's held-dictation
+    /// refresh keeps it in step with the store, and <see cref="OnPendingDictationCountChanged"/> notifies
+    /// the roster so it can repaint the rail.
+    /// </summary>
+    public int PendingDictationCount
+    {
+        get => _pendingDictationCount;
+        set
+        {
+            if (_pendingDictationCount == value) return;
+            _pendingDictationCount = value;
+            OnPendingDictationCountChanged?.Invoke(value);
+        }
+    }
+
+    /// <summary>Raised (with the new value) when <see cref="PendingDictationCount"/> changes.</summary>
+    public event Action<int>? OnPendingDictationCountChanged;
+
     /// <summary>
     /// Send text + Enter through the shared terminal submit protocol. ConPTY sessions use one
     /// echo-verified implementation for every agent and route, with bracketed paste for large or


### PR DESCRIPTION
## What

Makes the desktop session rail read **orange while a session has held/queued desktop dictations**, not only while a phone dictation is arriving or during the brief immediate transcription attempt.

Fixes thefrederiksen/devthrottle#1202.

## Note: re-based on the Phase 2.3 refactor

The original version of this fix layered orange onto the old `SessionStatusWingman` overlay. That mechanism was removed by the Phase 2.3 refactor (#1177 - the Director now computes only the dumb blue/red/gray standalone map; the Gateway owns overlay colors) and thefrederiksen/devthrottle#1204 added a phone-arrival orange via `Session.IsReceivingDictation`. This PR is re-implemented against that new architecture.

## Change

- New `Session.PendingDictationCount` (transient, change-notifying) - the count of held clips in the durable `PendingDictationStore` for a session.
- `SessionViewModel.StatusColorBrush` now returns orange when `PendingDictationCount > 0`, right next to the existing `IsReceivingDictation` arm, with a "Dictation queued - sending when the session is ready" reason. The view model subscribes to the new change event and repaints, exactly like the phone-arrival flag.
- `MainWindow.RefreshHeldDictationNotice` - already run on save, delivery result, and every sweeper tick - now syncs each session's count from the durable store and zeroes drained queues so the orange clears itself.

## Proof

- New Core tests (`SessionPendingDictationTests`) pin the change-notification contract the rail relies on (fires with the new value; coalesces no-op re-syncs): 2 passed.
- `CcDirector.Core` and `CcDirector.Avalonia` build clean (0 warnings / 0 errors).
- NOTE: the owner slot-5-verified the ORIGINAL (pre-refactor) implementation live; this re-based version has not yet been live-verified, only built + unit-tested. Recommend a quick re-verify on slot 5 before merge.
