### PR TITLE
Lock desktop typing while a phone dictation is arriving (#1181 Task 3b)

### DIFF
--- a/src/CcDirector.Avalonia/FifoWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/FifoWindow.axaml.cs
@@ -397,7 +397,8 @@ public partial class FifoWindow : Window
         // The agent's reply lands in the terminal, so make sure it's visible to watch.
         if (!_terminalVisible) { _terminalVisible = true; ApplyTerminalVisibility(); }
         SetStatus("Sending to agent...", Yellow);
-        await _current.SendTextAsync(transcript + "\n");
+        // Desktop voice FIFO injection is framework-mediated; exempt from the dictation lock (issue #1181, Task 3b).
+        await _current.SendTextAsync(transcript + "\n", SendSource.Internal);
         SetText(ReplyText, $"Sent to {DisplayName(_current)}. Watch the terminal, then Next.");
         SetStatus("Sent - watch the terminal, then Next", Green);
     }

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -82,6 +82,7 @@ public partial class MainWindow : Window
     // Session git status polling
     private readonly CcDirector.Core.Git.GitStatusProvider _gitStatusProvider = new();
     private global::Avalonia.Threading.DispatcherTimer? _sessionGitTimer;
+    private global::Avalonia.Threading.DispatcherTimer? _dictationLockTimer;
     private bool _sessionGitRefreshRunning;
 
     // Interactive TUI mode
@@ -326,6 +327,21 @@ public partial class MainWindow : Window
             await RefreshSessionGitStatusAsync();
         };
         _sessionGitTimer.Start();
+
+        // Issue #1181, Task 3b: refresh each session's "receiving a dictation" flag once a second so the
+        // rail can paint it orange while a phone dictation is inbound. One cheap disk read per session per
+        // tick (the durable marker), NOT per render; the Session raises a change event only when it flips,
+        // so the rail repaints just on the edges. (Task 4 will additionally compute this at the Gateway so
+        // the phone and cockpit show the same state.)
+        _dictationLockTimer = new global::Avalonia.Threading.DispatcherTimer
+        {
+            Interval = TimeSpan.FromSeconds(1),
+        };
+        _dictationLockTimer.Tick += (_, _) =>
+        {
+            foreach (var vm in _sessions) vm.Session.RefreshReceivingDictation();
+        };
+        _dictationLockTimer.Start();
 
         // Scheduler-leader indicator: show "LEADER" pill on the sidebar and
         // append " -- Leader" to the window title while this Director holds
@@ -3063,6 +3079,17 @@ public partial class MainWindow : Window
 
         FileLog.Write($"[MainWindow] SubmitDictatedTextAsync: {text.Length} chars to session {target.Id}");
 
+        // Issue #1181, Task 3b: refuse a desktop-dictated Send while a mobile dictation is already
+        // inbound to this session, so the two dictations cannot collide (same rule as the typed Send).
+        if (target.IsDictationLocked)
+        {
+            FileLog.Write($"[MainWindow] SubmitDictatedTextAsync ignored: session {target.Id} dictation-locked");
+            await MessageBox.ShowAsync(this, "A dictation is arriving",
+                "This session is already receiving a dictation from your phone. Your spoken message was NOT sent, "
+                + "so the two cannot collide. Try again once the first dictation lands.");
+            return;
+        }
+
         // Rewind point, exactly like SendPrompt.
         target.InitializeHistory();
         target.History?.TakeSnapshot();
@@ -5217,6 +5244,23 @@ public partial class MainWindow : Window
             return;
         }
 
+        // Issue #1181, Task 3b: also refuse a typed Send while a MOBILE dictation is inbound to this
+        // session (a durable PENDING delivery marker exists for it - issue #1188). The transcribing
+        // guard above only covers a DESKTOP-initiated dictation, which sets the local IsTranscribing
+        // flag; a mobile dictation does not, so it needs this separate check. Checked before the
+        // compose box is consumed, so the user's text is preserved. A modal pop-up (not the small
+        // notification line, which is easy to miss and gets overwritten by the queue banner) makes it
+        // unmissable; typing and Queue stay fully usable - only an immediate Send is intercepted.
+        if (_activeSession.Session.IsDictationLocked)
+        {
+            FileLog.Write("[MainWindow] SendPrompt ignored: session dictation-locked (mobile dictation inbound)");
+            await MessageBox.ShowAsync(this, "A dictation is arriving",
+                "This session is receiving a dictation from your phone. Your message was NOT sent, so it can't "
+                + "collide with the arriving text.\n\nYour text is still in the box - press Send again once the "
+                + "dictation lands, or press Queue to send it automatically when the session is ready.");
+            return;
+        }
+
         // Strip newlines -- Claude Code prompt expects single-line input
         var text = PromptInput.Text.ReplaceLineEndings(" ").Trim();
         if (string.IsNullOrEmpty(text)) return;
@@ -5495,7 +5539,7 @@ public partial class MainWindow : Window
             return;
         }
 
-        _activeSession.Session.SendText("/handover\n");
+        _activeSession.Session.SendText("/handover\n", SendSource.Internal);
         FileLog.Write($"[MainWindow] BtnHandover_Click: sent /handover to session {_activeSession.Session.Id}");
     }
 
@@ -6457,7 +6501,7 @@ public partial class MainWindow : Window
             + "and what you think we should work on next. Show the scope of remaining work "
             + "and suggest priorities.";
 
-        await session.SendTextAsync(prompt);
+        await session.SendTextAsync(prompt, SendSource.Internal);
         FileLog.Write($"[MainWindow] InjectHandoverPromptAsync: sent handover prompt for session {session.Id}");
     }
 

--- a/src/CcDirector.Avalonia/SessionViewModel.cs
+++ b/src/CcDirector.Avalonia/SessionViewModel.cs
@@ -83,12 +83,24 @@ public class SessionViewModel : INotifyPropertyChanged
         session.OnCachedExplainChanged += OnCachedExplainChangedVm;
         session.OnHoldChanged += OnHoldChangedVm;
         session.OnViewModeChanged += OnViewModeChangedVm;
+        session.OnReceivingDictationChanged += OnReceivingDictationChangedVm;
 
         if (session.PromptQueue != null)
         {
             _queueCount = session.PromptQueue.Count;
             session.PromptQueue.OnQueueChanged += OnQueueChanged;
         }
+    }
+
+    // Issue #1181, Task 3b: the session started or stopped receiving a phone dictation - repaint the
+    // rail strip (orange while receiving) and refresh its reason text.
+    private void OnReceivingDictationChangedVm(bool receiving)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            OnPropertyChanged(nameof(StatusColorBrush));
+            OnPropertyChanged(nameof(StatusReason));
+        });
     }
 
     private void OnStatusColorChanged(string oldColor, string newColor, string reason)
@@ -117,6 +129,10 @@ public class SessionViewModel : INotifyPropertyChanged
         get
         {
             if (Session.OnHold) return OnHoldStatusBrush;
+            // Issue #1181, Task 3b: a session receiving a dictation from the phone shows ORANGE, so the
+            // "a dictation is arriving" state is obvious at a glance in the rail (it overrides the base
+            // red "needs you", which would otherwise hide the fact that input is temporarily locked).
+            if (Session.IsReceivingDictation) return OrangeStatusBrush;
             return (Session.StatusColor?.ToLowerInvariant()) switch
             {
                 "green"  => GreenStatusBrush,
@@ -140,7 +156,9 @@ public class SessionViewModel : INotifyPropertyChanged
     /// override when set, otherwise the wingman's reason for <see cref="Session.StatusColor"/>.</summary>
     public string StatusReason => Session.OnHold
         ? "On hold (set aside by you)"
-        : Session.LastStatusReason ?? "";
+        : Session.IsReceivingDictation
+            ? "Receiving a dictation from your phone"
+            : Session.LastStatusReason ?? "";
 
     private void OnHoldChangedVm(bool onHold)
     {

--- a/src/CcDirector.ControlApi/Chat/ChatService.cs
+++ b/src/CcDirector.ControlApi/Chat/ChatService.cs
@@ -100,7 +100,8 @@ public sealed class ChatService
 
         try
         {
-            await session.SendTextAsync(req.Text);
+            // Chat is a framework-mediated surface; exempt from the dictation lock (issue #1181, Task 3b).
+            await session.SendTextAsync(req.Text, SendSource.Internal);
         }
         catch (Exception ex)
         {

--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -391,6 +391,15 @@ public sealed class ControlApiHost : IAsyncDisposable
         // Director's sessions' OUTGOING /fleet/* messages. Built from the Director's options, so it is
         // default-on-generous and config-tunable, and inert (Allow) when disabled.
         var messageSteward = new MessageSteward(_sessionManager.Options.MessageSteward);
+
+        // Issue #1181, Task 3b: the desktop-side enforced dictation lock. Project the durable PENDING
+        // delivery marker (issue #1188) from the shared dictation-uploads store into Session's send
+        // path, so a human typing on the desktop - or hitting this Director's control API without the
+        // authenticated delivery exemption - is refused while a dictation is inbound to that session.
+        // Same rule the Gateway front door enforces, now also closed on the Director's own in-process
+        // and control-API send paths. Idempotent to set on each start.
+        Core.Sessions.Session.DictationLockCheck = id => Core.Sessions.DictationLockReader.IsSessionLocked(id);
+
         ControlEndpoints.Map(_app, _sessionManager, DirectorId, _version, _requestShutdownAsync, _authEnabled, _repositoryRegistry, _turnSummaryCache, gatewayUrl, _proactiveExplain, GatewayMonitor, resolveTailnetEndpoint, () => _gatewayClient, messageSteward, _missionStore);
         // Dictation glossary resolution mirrors the key resolver (#253): the Gateway's shared
         // dictionary when attached, the local cache when standalone. GatewayConfig.Load (not the

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -358,7 +358,9 @@ internal static class ControlEndpoints
             {
                 try
                 {
-                    await local.SendTextAsync(framed);
+                    // Fleet message delivery is framework-mediated, not a human racing the dictation, so it
+                    // is exempt from the dictation lock (issue #1181, Task 3b).
+                    await local.SendTextAsync(framed, SendSource.Internal);
                     return Results.Json(new FleetSendResponse { Accepted = true, DeliveredCount = 1 });
                 }
                 catch (Exception ex)
@@ -459,7 +461,7 @@ internal static class ControlEndpoints
                 // Best effort per target: one failing session must not abort the rest of a broadcast.
                 try
                 {
-                    await s.SendTextAsync(framed);
+                    await s.SendTextAsync(framed, SendSource.Internal);
                     count++;
                 }
                 catch (Exception ex)
@@ -486,7 +488,7 @@ internal static class ControlEndpoints
                     .Count(m => m.Role == CcDirector.Core.History.ConversationRole.Assistant)
                 : 0;
 
-            await target.SendTextAsync(framed);
+            await target.SendTextAsync(framed, SendSource.Internal);
 
             // Give the target a moment to leave Idle, then wait for it to settle back to Idle.
             var sw = System.Diagnostics.Stopwatch.StartNew();
@@ -2093,7 +2095,7 @@ internal static class ControlEndpoints
                 if (existing.Status is SessionStatus.Exited or SessionStatus.Failed)
                     return Results.StatusCode(StatusCodes.Status409Conflict);
                 target = existing;
-                await target.SendTextAsync(contextText);
+                await target.SendTextAsync(contextText, SendSource.Internal);
             }
             else
             {
@@ -2132,7 +2134,7 @@ internal static class ControlEndpoints
                         if (st is ActivityState.Exited) { FileLog.Write($"[ControlEndpoints] /handover target exited before idle, sid={capturedTarget.Id}"); return; }
                         await Task.Delay(500);
                     }
-                    try { await capturedTarget.SendTextAsync(capturedText); }
+                    try { await capturedTarget.SendTextAsync(capturedText, SendSource.Internal); }
                     catch (Exception ex) { FileLog.Write($"[ControlEndpoints] /handover dispatch FAILED: {ex.Message}"); }
                 });
             }
@@ -2154,9 +2156,17 @@ internal static class ControlEndpoints
             }, statusCode: 201);
         });
 
-        app.MapPost("/sessions/{sid}/prompt", async (string sid, PromptRequest req) =>
+        app.MapPost("/sessions/{sid}/prompt", async (string sid, PromptRequest req, HttpContext httpCtx) =>
         {
-            FileLog.Write($"[ControlEndpoints] POST prompt: sid={sid}, len={req?.Text?.Length ?? 0}");
+            // Issue #1181, Task 3b: the Gateway's OWN dictation delivery reaches a LOCKED session through
+            // this control API (it bypasses the Gateway front door), so it carries the X-Dictation-Delivery
+            // header naming the inbound upload id. The call already arrives with the fleet Bearer token
+            // (DirectorEndpointClient), so the header is only present on an authenticated Gateway call and
+            // cannot be forged from outside the fleet. Its presence marks this send as the dictation's own
+            // arrival (Delivery, exempt); every other caller defaults to UserInput and is checked.
+            var deliveryUploadId = httpCtx.Request.Headers["X-Dictation-Delivery"].ToString();
+            var source = string.IsNullOrWhiteSpace(deliveryUploadId) ? SendSource.UserInput : SendSource.Delivery;
+            FileLog.Write($"[ControlEndpoints] POST prompt: sid={sid}, len={req?.Text?.Length ?? 0}, source={source}");
 
             // Issue #1177 (Phase 1): the prompt body is executed through the shared SessionCommandExecutor
             // so this REST path and the Gateway stream down-channel run identical logic. The executor's
@@ -2167,7 +2177,7 @@ internal static class ControlEndpoints
                 SessionId = sid,
                 PayloadJson = req is null ? "" : SessionCommandExecutor.Serialize(req),
             };
-            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command, source: source);
 
             return result.Status switch
             {
@@ -2175,6 +2185,7 @@ internal static class ControlEndpoints
                 DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
                 DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
                 DirectorCommandStatus.Conflict => Results.StatusCode(StatusCodes.Status409Conflict),
+                DirectorCommandStatus.Locked => Results.Json(new { error = result.Error }, statusCode: StatusCodes.Status423Locked),
                 _ => Results.Problem(result.Error ?? "prompt command failed"),
             };
         });
@@ -2291,7 +2302,9 @@ internal static class ControlEndpoints
 
             var text = item.Text;
             session.PromptQueue.Remove(itemGuid);
-            await session.SendTextAsync(text);
+            // Queue drain is an explicit, ordered mechanism (issue #1181, Task 3b lists it exempt): the
+            // user asked to release this queued item, so it is not blocked by the dictation lock.
+            await session.SendTextAsync(text, SendSource.Internal);
             return Results.Json(new { items = ProjectQueue(session) });
         });
 

--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -51,16 +51,16 @@ internal static class SessionCommandExecutor
     /// Execute a command by verb. Resolves the payload and target session with the shared guards, then
     /// dispatches to the matching verb handler. An unknown verb is a <see cref="DirectorCommandStatus.BadRequest"/>.
     /// </summary>
-    public static async Task<DirectorCommandResult> DispatchAsync(SessionManager sessionManager, string directorId, DirectorCommand command, SessionCommandServices? services = null)
+    public static async Task<DirectorCommandResult> DispatchAsync(SessionManager sessionManager, string directorId, DirectorCommand command, SessionCommandServices? services = null, SendSource source = SendSource.UserInput)
     {
         if (sessionManager is null) throw new ArgumentNullException(nameof(sessionManager));
         if (command is null) throw new ArgumentNullException(nameof(command));
 
-        FileLog.Write($"[SessionCommandExecutor] DispatchAsync: verb={command.Verb}, sid={command.SessionId}, cmdId={command.CommandId}, director={directorId}");
+        FileLog.Write($"[SessionCommandExecutor] DispatchAsync: verb={command.Verb}, sid={command.SessionId}, cmdId={command.CommandId}, source={source}, director={directorId}");
 
         var result = command.Verb switch
         {
-            "prompt" => await PromptAsync(sessionManager, command),
+            "prompt" => await PromptAsync(sessionManager, command, source),
             "interrupt" => await InterruptAsync(sessionManager, command),
             "escape" => await EscapeAsync(sessionManager, command),
             "hold" => Hold(sessionManager, command),
@@ -84,7 +84,7 @@ internal static class SessionCommandExecutor
     /// BadRequest, missing session -&gt; NotFound, Exited/Failed -&gt; Conflict - and returns a serialized
     /// <see cref="PromptResponse"/> on success.
     /// </summary>
-    internal static async Task<DirectorCommandResult> PromptAsync(SessionManager sessionManager, DirectorCommand command)
+    internal static async Task<DirectorCommandResult> PromptAsync(SessionManager sessionManager, DirectorCommand command, SendSource source = SendSource.UserInput)
     {
         if (!Guid.TryParse(command.SessionId, out var guid))
             return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
@@ -97,14 +97,20 @@ internal static class SessionCommandExecutor
         if (session is null)
             return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
 
-        return await SendPromptAsync(session, request);
+        return await SendPromptAsync(session, request, source);
     }
 
     /// <summary>
-    /// The prompt core, past the id/session guards: reject an exited session, capture the pre-send buffer
-    /// cursor, then deliver the text. Shared by the verb handler and directly testable against a session.
+    /// The prompt core, past the id/session guards: reject an exited session, refuse human input while a
+    /// dictation is inbound (issue #1181, Task 3b), capture the pre-send buffer cursor, then deliver the
+    /// text. Shared by the verb handler and directly testable against a session. <paramref name="source"/>
+    /// names who is sending: <see cref="SendSource.UserInput"/> (the default, checked against the lock) or
+    /// the exempt <see cref="SendSource.Delivery"/> (the dictation's own arrival) / <see cref="SendSource.Internal"/>.
+    /// The lock is checked explicitly here (this executor is not a boundary, so it validates and returns a
+    /// status rather than letting <see cref="SessionLockedException"/> bubble); the same predicate backs the
+    /// in-process throw for the desktop send path.
     /// </summary>
-    internal static async Task<DirectorCommandResult> SendPromptAsync(Session session, PromptRequest request)
+    internal static async Task<DirectorCommandResult> SendPromptAsync(Session session, PromptRequest request, SendSource source = SendSource.UserInput)
     {
         if (session is null) throw new ArgumentNullException(nameof(session));
         if (request is null) throw new ArgumentNullException(nameof(request));
@@ -112,10 +118,13 @@ internal static class SessionCommandExecutor
         if (session.Status is SessionStatus.Exited or SessionStatus.Failed)
             return DirectorCommandResult.Fail(DirectorCommandStatus.Conflict, "session has exited");
 
+        if (source == SendSource.UserInput && session.IsDictationLocked)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.Locked, SessionLockedException.LockMessage);
+
         var bufferCursor = session.Buffer?.TotalBytesWritten ?? 0;
 
         if (request.AppendEnter)
-            await session.SendTextAsync(request.Text);
+            await session.SendTextAsync(request.Text, source);
         else
             session.SendInput(Encoding.UTF8.GetBytes(request.Text));
 
@@ -443,7 +452,8 @@ internal static class SessionCommandExecutor
                         await Task.Delay(750);
                     }
                     FileLog.Write($"[SessionCommandExecutor] PrePrompt: dispatching to sid={capturedSession.Id}, len={prePrompt.Length}");
-                    await capturedSession.SendTextAsync(prePrompt);
+                    // Framework pre-prompt (not a human racing the dictation): exempt (issue #1181, Task 3b).
+                    await capturedSession.SendTextAsync(prePrompt, SendSource.Internal);
                 }
                 catch (Exception ex)
                 {

--- a/src/CcDirector.ControlApi/VoiceTurnEndpoint.cs
+++ b/src/CcDirector.ControlApi/VoiceTurnEndpoint.cs
@@ -202,7 +202,8 @@ internal static class VoiceTurnEndpoint
                 FileLog.Write($"[VoiceTurnEndpoint] sid={guid}: sending text len={inputText.Length}, transcriptOffsetBefore={offsetBefore}");
                 try
                 {
-                    await session.SendTextAsync(inputText);
+                    // Voice-turn injection is framework-mediated; exempt from the dictation lock (issue #1181, Task 3b).
+                    await session.SendTextAsync(inputText, SendSource.Internal);
                 }
                 catch (Exception ex)
                 {

--- a/src/CcDirector.Core.Tests/Sessions/DictationLockReaderTests.cs
+++ b/src/CcDirector.Core.Tests/Sessions/DictationLockReaderTests.cs
@@ -1,0 +1,108 @@
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Sessions;
+
+/// <summary>
+/// Issue #1181, Task 3b: the Director-side projection of the enforced dictation lock
+/// (<see cref="DictationLockReader"/>). A session is locked exactly while some upload folder under the
+/// shared dictation-uploads root holds a <c>record.json</c> in state <c>Pending</c> naming it. These
+/// tests write the marker files by hand (the exact on-disk shape the Gateway writes) and assert the read.
+/// A companion Gateway test cross-checks the reader against the real writer.
+/// </summary>
+public sealed class DictationLockReaderTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "cc-dictlock-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); }
+        catch { /* best-effort temp cleanup */ }
+    }
+
+    private void WriteMarker(string uploadId, string state, string sessionId)
+    {
+        var dir = Path.Combine(_root, uploadId);
+        Directory.CreateDirectory(dir);
+        // The exact fields the Gateway's DictationDeliveryRecord serializes (State is a string enum).
+        File.WriteAllText(Path.Combine(dir, "record.json"),
+            $"{{\"State\":\"{state}\",\"Submitted\":false,\"MovedOn\":false,\"Transcript\":\"\",\"Reason\":null,\"SessionId\":\"{sessionId}\"}}");
+    }
+
+    [Fact]
+    public void IsSessionLocked_PendingMarkerNamingTheSession_Locks()
+    {
+        var sid = Guid.NewGuid().ToString();
+        WriteMarker(Guid.NewGuid().ToString("N"), "Pending", sid);
+
+        Assert.True(DictationLockReader.IsSessionLocked(_root, sid));
+    }
+
+    [Theory]
+    [InlineData("Delivered")]
+    [InlineData("Abandoned")]
+    [InlineData("Failed")]
+    public void IsSessionLocked_NonPendingMarker_DoesNotLock(string terminalState)
+    {
+        var sid = Guid.NewGuid().ToString();
+        WriteMarker(Guid.NewGuid().ToString("N"), terminalState, sid);
+
+        Assert.False(DictationLockReader.IsSessionLocked(_root, sid));
+    }
+
+    [Fact]
+    public void IsSessionLocked_PendingForAnotherSession_DoesNotLockThisOne()
+    {
+        WriteMarker(Guid.NewGuid().ToString("N"), "Pending", Guid.NewGuid().ToString());
+
+        Assert.False(DictationLockReader.IsSessionLocked(_root, Guid.NewGuid().ToString()));
+    }
+
+    [Fact]
+    public void IsSessionLocked_CaseInsensitiveOnStateAndSessionId()
+    {
+        var sid = Guid.NewGuid().ToString().ToUpperInvariant();
+        WriteMarker(Guid.NewGuid().ToString("N"), "pending", sid);
+
+        Assert.True(DictationLockReader.IsSessionLocked(_root, sid.ToLowerInvariant()));
+    }
+
+    [Fact]
+    public void IsSessionLocked_OnePendingAmongTerminals_StillLocks()
+    {
+        var sid = Guid.NewGuid().ToString();
+        WriteMarker(Guid.NewGuid().ToString("N"), "Delivered", sid);
+        WriteMarker(Guid.NewGuid().ToString("N"), "Abandoned", sid);
+        WriteMarker(Guid.NewGuid().ToString("N"), "Pending", sid);
+
+        Assert.True(DictationLockReader.IsSessionLocked(_root, sid));
+    }
+
+    [Fact]
+    public void IsSessionLocked_MissingRoot_IsFalse()
+    {
+        Assert.False(DictationLockReader.IsSessionLocked(Path.Combine(_root, "does-not-exist"), Guid.NewGuid().ToString()));
+    }
+
+    [Fact]
+    public void IsSessionLocked_GarbageOrEmptyMarker_IsIgnored()
+    {
+        var sid = Guid.NewGuid().ToString();
+        var dir = Path.Combine(_root, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "record.json"), "{ not valid json");
+        var empty = Path.Combine(_root, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(empty);
+        File.WriteAllText(Path.Combine(empty, "record.json"), "");
+
+        // A half-written or corrupt marker must never wedge a session locked - it is simply skipped.
+        Assert.False(DictationLockReader.IsSessionLocked(_root, sid));
+    }
+
+    [Fact]
+    public void IsSessionLocked_BlankSessionId_IsFalse()
+    {
+        WriteMarker(Guid.NewGuid().ToString("N"), "Pending", Guid.NewGuid().ToString());
+        Assert.False(DictationLockReader.IsSessionLocked(_root, ""));
+    }
+}

--- a/src/CcDirector.Core/Sessions/DictationLockReader.cs
+++ b/src/CcDirector.Core/Sessions/DictationLockReader.cs
@@ -1,0 +1,96 @@
+using System.Text.Json;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Sessions;
+
+/// <summary>
+/// The DIRECTOR-side read of the enforced dictation session lock (issue #1181, Task 3b). The lock is
+/// a pure projection of the durable PENDING delivery marker the Gateway writes at
+/// <see cref="CcStorage.DictationUploads"/><c>/&lt;uploadId&gt;/record.json</c> (issue #1188). A session
+/// is LOCKED exactly while at least one of those markers is in state <c>Pending</c> and names it - the
+/// SAME rule the Gateway enforces at its front door with <c>VoiceUploadStore.IsSessionLocked</c>.
+///
+/// Why a separate reader here rather than calling the Gateway's <c>VoiceUploadStore</c>: the Director
+/// executable references only <c>CcDirector.Gateway.Contracts</c>, not the full Gateway assembly. On a
+/// single machine (the phone-dictates-into-my-desktop case) the Gateway and Director share the same
+/// <c>%LOCALAPPDATA%\cc-director</c>, so the Director reads the identical markers straight from disk -
+/// no network, restart-safe, and the lock never auto-releases because it is a pure function of the
+/// durable markers (exactly the Task 3a philosophy). This reads only the two fields it needs
+/// (<c>State</c>, <c>SessionId</c>) so it does not couple to the Gateway's full record shape; the
+/// writer of record is <c>CcDirector.Gateway.Voice.DictationDeliveryRecord</c>.
+///
+/// Cross-machine (a Director on another box than its Gateway) is NOT covered by this disk read - the
+/// marker lives on the Gateway's machine. That path is a documented follow-up; here the reader simply
+/// finds no marker and reports unlocked, which fails OPEN for the remote desktop only.
+/// </summary>
+public static class DictationLockReader
+{
+    private static readonly JsonSerializerOptions ReadJson = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>
+    /// True when a dictation is inbound to <paramref name="sessionId"/>: some
+    /// <c>record.json</c> under the shared dictation-uploads root is in state <c>Pending</c> and
+    /// names this session. Reads the production root (<see cref="CcStorage.DictationUploads"/>).
+    /// </summary>
+    public static bool IsSessionLocked(Guid sessionId)
+        => IsSessionLocked(CcStorage.DictationUploads(), sessionId.ToString());
+
+    /// <summary>
+    /// Test seam: check against an explicit uploads root. Robust to a missing root, half-written
+    /// markers, and unrelated files - any read error is treated as "no lock from this marker" so a
+    /// transient disk hiccup can never wedge a session locked, only ever miss a lock (fail open),
+    /// which the fail-closed <see cref="SendSource.UserInput"/> default already compensates for.
+    /// </summary>
+    public static bool IsSessionLocked(string uploadsRoot, string sessionId)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId)) return false;
+
+        string[] dirs;
+        try
+        {
+            if (!Directory.Exists(uploadsRoot)) return false;
+            dirs = Directory.GetDirectories(uploadsRoot);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[DictationLockReader] enumerate {uploadsRoot} failed: {ex.Message}");
+            return false;
+        }
+
+        foreach (var dir in dirs)
+        {
+            var marker = ReadMarker(Path.Combine(dir, "record.json"));
+            if (marker is null) continue;
+            if (string.Equals(marker.State, "Pending", StringComparison.OrdinalIgnoreCase)
+                && string.Equals(marker.SessionId, sessionId, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Marker? ReadMarker(string path)
+    {
+        try
+        {
+            if (!File.Exists(path)) return null;
+            var json = File.ReadAllText(path);
+            if (string.IsNullOrWhiteSpace(json)) return null;
+            return JsonSerializer.Deserialize<Marker>(json, ReadJson);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[DictationLockReader] read {path} failed: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>The two fields of the Gateway's durable delivery record this reader needs. The
+    /// <c>State</c> is the string form the Gateway writes with a <c>JsonStringEnumConverter</c>.</summary>
+    private sealed record Marker(string State, string SessionId);
+}

--- a/src/CcDirector.Core/Sessions/SendSource.cs
+++ b/src/CcDirector.Core/Sessions/SendSource.cs
@@ -1,0 +1,28 @@
+namespace CcDirector.Core.Sessions;
+
+/// <summary>
+/// Who is driving a <see cref="Session.SendTextAsync(string, SendSource)"/> call (issue #1181,
+/// Task 3b - the desktop-side enforced dictation lock). The default is <see cref="UserInput"/>,
+/// which is FAIL-CLOSED: a caller that does not name its source is treated as a human typing, so
+/// forgetting to tag a new call site over-blocks (safe) rather than leaking past the lock (unsafe).
+///
+/// While a dictation is inbound to a session (an explicit PENDING delivery marker exists for it -
+/// see <see cref="DictationLockReader"/>) that session is LOCKED: <see cref="UserInput"/> is
+/// rejected so a half-arrived dictation and the user's own typing cannot collide. The two
+/// non-user sources are exempt:
+/// - <see cref="Delivery"/>: the dictation's OWN arrival (the Gateway injecting the transcribed
+///   text). It must reach the session even while locked - it is what the lock is waiting for.
+/// - <see cref="Internal"/>: framework-authored, non-user sends (handover text, queue drain) that
+///   carry no human keystrokes and must not be blocked by the lock.
+/// </summary>
+public enum SendSource
+{
+    /// <summary>A human typing/submitting. Checked against the lock (fail-closed default).</summary>
+    UserInput,
+
+    /// <summary>The inbound dictation's own delivery. Exempt - it is what the lock is held for.</summary>
+    Delivery,
+
+    /// <summary>Framework-authored, non-user text (handover, queue drain). Exempt.</summary>
+    Internal,
+}

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -1454,16 +1454,76 @@ public sealed class Session : IDisposable
     }
 
     /// <summary>
+    /// Host-injected predicate answering "is this session locked because a dictation is inbound to
+    /// it?" (issue #1181, Task 3b). The Director host wires this to <see cref="DictationLockReader"/>
+    /// at startup; left null (never locked) in any process that does not run dictation delivery, and
+    /// in unit tests. A single process-wide hook keeps the lock check on ONE fail-closed checkpoint
+    /// (<see cref="SendTextAsync(string, SendSource)"/>) without threading a dependency through every
+    /// session-creation path. Tests that set it must reset it to null in teardown.
+    /// </summary>
+    public static Func<Guid, bool>? DictationLockCheck { get; set; }
+
+    /// <summary>
+    /// True when a dictation is inbound to THIS session, so a human send into it is refused (issue
+    /// #1181, Task 3b). A pure projection of the durable PENDING delivery marker via the host-injected
+    /// <see cref="DictationLockCheck"/>; false when no host wired the check. This is the single
+    /// predicate both the in-process throw (in <see cref="SendTextAsync(string, SendSource)"/>) and the
+    /// control-API executor's explicit pre-check read, so the two paths cannot disagree.
+    /// </summary>
+    public bool IsDictationLocked => DictationLockCheck?.Invoke(Id) == true;
+
+    private bool _isReceivingDictation;
+
+    /// <summary>
+    /// Cached, change-notifying view of <see cref="IsDictationLocked"/> for the UI (issue #1181, Task 3b).
+    /// The roster reads THIS (a cheap bool) to paint the "receiving a dictation" orange, instead of doing a
+    /// disk read on every render. The host re-evaluates it on a timer via <see cref="RefreshReceivingDictation"/>;
+    /// this is the desktop presentation of the state (Task 4 will additionally surface it from the Gateway for
+    /// the phone and cockpit).
+    /// </summary>
+    public bool IsReceivingDictation => _isReceivingDictation;
+
+    /// <summary>Raised (with the new value) when <see cref="IsReceivingDictation"/> flips.</summary>
+    public event Action<bool>? OnReceivingDictationChanged;
+
+    /// <summary>
+    /// Recompute <see cref="IsReceivingDictation"/> from the durable dictation marker and raise
+    /// <see cref="OnReceivingDictationChanged"/> when it changes. Called on the host's roster-refresh tick
+    /// so the disk read happens once per tick, not once per render.
+    /// </summary>
+    public void RefreshReceivingDictation()
+    {
+        var now = IsDictationLocked;
+        if (now == _isReceivingDictation) return;
+        _isReceivingDictation = now;
+        FileLog.Write($"[Session] IsReceivingDictation -> {now}: session={Id}");
+        OnReceivingDictationChanged?.Invoke(now);
+    }
+
+    /// <summary>
     /// Send text + Enter through the shared terminal submit protocol. ConPTY sessions use one
     /// echo-verified implementation for every agent and route, with bracketed paste for large or
     /// multi-line blocks when the TUI has requested mode 2004; non-PTY transports keep their
     /// backend-specific whole-turn semantics.
+    ///
+    /// <paramref name="source"/> names who is sending (issue #1181, Task 3b). It DEFAULTS to
+    /// <see cref="SendSource.UserInput"/> (fail-closed): a human send into a session that is locked
+    /// because a dictation is inbound throws <see cref="SessionLockedException"/> so the arriving
+    /// dictation and the user's typing cannot collide. The dictation's own arrival
+    /// (<see cref="SendSource.Delivery"/>) and framework-authored sends
+    /// (<see cref="SendSource.Internal"/>) are exempt.
     /// </summary>
-    public async Task SendTextAsync(string text)
+    public async Task SendTextAsync(string text, SendSource source = SendSource.UserInput)
     {
         if (_disposed || Status is SessionStatus.Exited or SessionStatus.Failed) return;
 
-        FileLog.Write($"[Session] SendTextAsync: session={Id}, driver={Driver.Kind}, text=\"{(text.Length > 60 ? text[..60] + "..." : text)}\", len={text.Length}");
+        if (source == SendSource.UserInput && IsDictationLocked)
+        {
+            FileLog.Write($"[Session] SendTextAsync REJECTED (dictation lock): session={Id}, len={text.Length}");
+            throw new SessionLockedException();
+        }
+
+        FileLog.Write($"[Session] SendTextAsync: session={Id}, source={source}, driver={Driver.Kind}, text=\"{(text.Length > 60 ? text[..60] + "..." : text)}\", len={text.Length}");
         if (BackendType is SessionBackendType.ConPty)
         {
             await Drivers.TerminalSubmit.SharedSubmitAsync(
@@ -1485,12 +1545,13 @@ public sealed class Session : IDisposable
         SetActivityState(ActivityState.Working);
     }
 
-    /// <summary>Send text followed by Enter (sync wrapper).</summary>
-    public void SendText(string text)
+    /// <summary>Send text followed by Enter (sync wrapper). See
+    /// <see cref="SendTextAsync(string, SendSource)"/> for what <paramref name="source"/> means.</summary>
+    public void SendText(string text, SendSource source = SendSource.UserInput)
     {
         if (_disposed || Status is SessionStatus.Exited or SessionStatus.Failed) return;
         // Fire and forget for sync API
-        _ = SendTextAsync(text);
+        _ = SendTextAsync(text, source);
     }
 
     /// <summary>Send just an Enter keystroke to the backend.</summary>

--- a/src/CcDirector.Core/Sessions/SessionLockedException.cs
+++ b/src/CcDirector.Core/Sessions/SessionLockedException.cs
@@ -1,0 +1,18 @@
+namespace CcDirector.Core.Sessions;
+
+/// <summary>
+/// Thrown by <see cref="Session.SendTextAsync(string, SendSource)"/> when a human
+/// (<see cref="SendSource.UserInput"/>) tries to send into a session that is LOCKED because a
+/// dictation is inbound to it (issue #1181, Task 3b). Entry points (the desktop typing handler,
+/// the Director control API) catch this and surface the message; it is never expected to escape a
+/// UI/endpoint boundary. The message matches the Gateway front-door lock wording (issue #1188) so
+/// the user sees ONE consistent sentence no matter which surface they typed on.
+/// </summary>
+public sealed class SessionLockedException : Exception
+{
+    /// <summary>The one user-facing sentence, identical to the Gateway front-door 423 (issue #1188).</summary>
+    public const string LockMessage =
+        "This session is receiving a dictation. You cannot send input until it arrives or is cancelled.";
+
+    public SessionLockedException() : base(LockMessage) { }
+}

--- a/src/CcDirector.Core/Voice/Controllers/VoiceModeController.cs
+++ b/src/CcDirector.Core/Voice/Controllers/VoiceModeController.cs
@@ -266,7 +266,8 @@ public class VoiceModeController : IDisposable
             }
 
             State = VoiceState.WaitingForClaude;
-            await _activeSession.SendTextAsync(transcription);
+            // Voice-mode injection is framework-mediated; exempt from the dictation lock (issue #1181, Task 3b).
+            await _activeSession.SendTextAsync(transcription, SendSource.Internal);
 
             // Wait for Claude to finish (ActivityState becomes WaitingForInput)
             await WaitForClaudeResponseAsync(ct);

--- a/src/CcDirector.Gateway.Contracts/DirectorCommandMessages.cs
+++ b/src/CcDirector.Gateway.Contracts/DirectorCommandMessages.cs
@@ -37,6 +37,13 @@ public enum DirectorCommandStatus
     NotFound = 2,
     Conflict = 3,
     Error = 4,
+
+    /// <summary>
+    /// The session is LOCKED because a dictation is inbound to it (issue #1181, Task 3b): human
+    /// input is refused until the dictation arrives or is cancelled. The REST layer maps this to
+    /// HTTP 423 Locked - the same status/message the Gateway front door returns (issue #1188).
+    /// </summary>
+    Locked = 5,
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway.Tests/DictationDesktopLockTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationDesktopLockTests.cs
@@ -1,0 +1,168 @@
+using System.Text.Json;
+using CcDirector.ControlApi;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Voice;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1181, Task 3b: the DESKTOP-side (Director) enforced dictation lock. Two things are proven here:
+///   1. The Director's <see cref="DictationLockReader"/> agrees with the Gateway's real writer
+///      (<see cref="VoiceUploadStore"/>): a PENDING marker locks, a terminal marker unlocks. This is the
+///      cross-format contract - if the Gateway ever changes the record shape, this test catches the drift.
+///   2. The shared <see cref="SessionCommandExecutor"/> refuses a human (<see cref="SendSource.UserInput"/>)
+///      prompt into a locked session with <see cref="DirectorCommandStatus.Locked"/>, while the dictation's
+///      own arrival (<see cref="SendSource.Delivery"/>) is exempt; and <see cref="Session.SendTextAsync"/>
+///      throws for a locked human send but not for the exempt sources.
+/// </summary>
+public sealed class DictationDesktopLockTests
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    // ---- 1. cross-format: the Director reader agrees with the Gateway writer ------------------------
+
+    [Fact]
+    public void Reader_AgreesWithGatewayWriter_PendingLocks_TerminalUnlocks()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "cc-dictlock-xfmt-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var store = new VoiceUploadStore(root);
+            var sid = Guid.NewGuid().ToString();
+            var uploadId = Guid.NewGuid().ToString();
+            store.Register(uploadId);
+
+            store.MarkPending(uploadId, sid);
+            Assert.True(DictationLockReader.IsSessionLocked(root, sid), "a PENDING marker written by the Gateway must lock the Director's read");
+
+            store.MarkDelivered(uploadId, submitted: true, movedOn: false, transcript: "hi");
+            Assert.False(DictationLockReader.IsSessionLocked(root, sid), "a DELIVERED tombstone must unlock");
+        }
+        finally
+        {
+            try { if (Directory.Exists(root)) Directory.Delete(root, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Reader_AgreesWithGatewayWriter_AbandonedUnlocks()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "cc-dictlock-xfmt-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var store = new VoiceUploadStore(root);
+            var sid = Guid.NewGuid().ToString();
+            var uploadId = Guid.NewGuid().ToString();
+            store.Register(uploadId);
+            store.MarkPending(uploadId, sid);
+            Assert.True(DictationLockReader.IsSessionLocked(root, sid));
+
+            store.MarkAbandoned(uploadId, "user_cancelled");
+            Assert.False(DictationLockReader.IsSessionLocked(root, sid), "an ABANDONED tombstone must unlock");
+        }
+        finally
+        {
+            try { if (Directory.Exists(root)) Directory.Delete(root, true); } catch { }
+        }
+    }
+
+    // ---- 2. executor + Session enforcement ---------------------------------------------------------
+
+    [Collection("DirectorRoot")]
+    public sealed class Enforcement
+    {
+        private static (SessionManager sm, Session session) NewSession()
+        {
+            var sm = new SessionManager(new Core.Configuration.AgentOptions());
+            var session = sm.CreateEmbeddedSession(Path.GetTempPath(), null, new ExecuteActionTestBackend());
+            return (sm, session);
+        }
+
+        private static DirectorCommand PromptCommand(string sessionId) => new()
+        {
+            CommandId = "cmd-lock",
+            Verb = "prompt",
+            SessionId = sessionId,
+            PayloadJson = JsonSerializer.Serialize(new PromptRequest { Text = "typed while a dictation arrives", AppendEnter = true }, Json),
+        };
+
+        [Fact]
+        public async Task Executor_UserInputIntoLockedSession_ReturnsLockedWithMessage()
+        {
+            var (sm, session) = NewSession();
+            Session.DictationLockCheck = id => id == session.Id;
+            try
+            {
+                var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", PromptCommand(session.Id.ToString()), source: SendSource.UserInput);
+
+                Assert.Equal(DirectorCommandStatus.Locked, result.Status);
+                Assert.Equal(SessionLockedException.LockMessage, result.Error);
+            }
+            finally
+            {
+                Session.DictationLockCheck = null;
+                sm.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task Executor_DeliveryIntoLockedSession_IsExemptAndSucceeds()
+        {
+            var (sm, session) = NewSession();
+            Session.DictationLockCheck = id => id == session.Id; // locked...
+            try
+            {
+                // ...but the dictation's OWN arrival (Delivery) is exempt - it is what the lock is held for.
+                var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", PromptCommand(session.Id.ToString()), source: SendSource.Delivery);
+
+                Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            }
+            finally
+            {
+                Session.DictationLockCheck = null;
+                sm.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task Executor_UserInputIntoUnlockedSession_Succeeds()
+        {
+            var (sm, session) = NewSession();
+            Session.DictationLockCheck = _ => false; // nothing inbound
+            try
+            {
+                var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", PromptCommand(session.Id.ToString()), source: SendSource.UserInput);
+
+                Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            }
+            finally
+            {
+                Session.DictationLockCheck = null;
+                sm.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task SendTextAsync_UserInputIntoLocked_Throws_ButExemptSourcesDoNot()
+        {
+            var (sm, session) = NewSession();
+            Session.DictationLockCheck = id => id == session.Id;
+            try
+            {
+                await Assert.ThrowsAsync<SessionLockedException>(() => session.SendTextAsync("hi", SendSource.UserInput));
+                await Assert.ThrowsAsync<SessionLockedException>(() => session.SendTextAsync("hi")); // default is UserInput
+
+                // The dictation delivery and framework sends must go through even while locked.
+                await session.SendTextAsync("delivered", SendSource.Delivery);
+                await session.SendTextAsync("internal", SendSource.Internal);
+            }
+            finally
+            {
+                Session.DictationLockCheck = null;
+                sm.Dispose();
+            }
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -337,10 +337,13 @@ internal static class GatewayDictationEndpoint
             }
 
             // The Gateway injects the dictation by calling the owning Director's control API DIRECTLY, which
-            // BYPASSES the Gateway's own /sessions/{sid}/prompt front door. So this delivery is naturally
-            // EXEMPT from the enforced session lock (issue #1188) - the lock (which is on while this upload is
-            // PENDING) blocks other surfaces from typing into the session, never this dictation's own arrival.
-            var (ok, _, err) = await client.PostPromptAsync(endpoint, sid, new PromptRequest { Text = message, AppendEnter = true });
+            // BYPASSES the Gateway's own /sessions/{sid}/prompt front door (issue #1188). That front door
+            // blocks OTHER surfaces from typing into the PENDING session. The Director now ALSO enforces the
+            // lock on its own control API (issue #1181, Task 3b), so this delivery is no longer implicitly
+            // exempt there: it names its upload id via the X-Dictation-Delivery header (deliveryUploadId), and
+            // the Director exempts exactly this send - the dictation's own arrival, which is what the lock is
+            // held for. The header rides the fleet-authenticated call, so it cannot be forged from outside.
+            var (ok, _, err) = await client.PostPromptAsync(endpoint, sid, new PromptRequest { Text = message, AppendEnter = true }, deliveryUploadId: uploadId);
             if (!ok)
                 return DictationOutcome.Error(StatusCodes.Status502BadGateway, err ?? "submit to session failed");
 

--- a/src/CcDirector.Gateway/Discovery/DirectorEndpointClient.cs
+++ b/src/CcDirector.Gateway/Discovery/DirectorEndpointClient.cs
@@ -542,12 +542,25 @@ public sealed class DirectorEndpointClient : IDisposable
         return widgets;
     }
 
-    public async Task<(bool ok, PromptResponse? body, string? error)> PostPromptAsync(string endpoint, string sessionId, PromptRequest req, CancellationToken ct = default)
+    /// <param name="deliveryUploadId">
+    /// When set (issue #1181, Task 3b), this prompt is the Gateway's OWN dictation delivery for that upload
+    /// id, so it is sent with the <c>X-Dictation-Delivery</c> header. The Director reads that header to
+    /// exempt this send from the enforced dictation lock - the delivery is what the lock is waiting for. The
+    /// header rides the same fleet-authenticated call, so it cannot be forged from outside the fleet. Left
+    /// null for every ordinary (human) prompt, which the Director checks against the lock.
+    /// </param>
+    public async Task<(bool ok, PromptResponse? body, string? error)> PostPromptAsync(string endpoint, string sessionId, PromptRequest req, CancellationToken ct = default, string? deliveryUploadId = null)
     {
         try
         {
             // Director side ignores WaitForIdle - that's a Gateway-side concern.
-            var resp = await _actionHttp.PostAsJsonAsync($"{endpoint}/sessions/{sessionId}/prompt", req, ct);
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"{endpoint}/sessions/{sessionId}/prompt")
+            {
+                Content = JsonContent.Create(req),
+            };
+            if (!string.IsNullOrWhiteSpace(deliveryUploadId))
+                request.Headers.TryAddWithoutValidation("X-Dictation-Delivery", deliveryUploadId);
+            var resp = await _actionHttp.SendAsync(request, ct);
             if (!resp.IsSuccessStatusCode)
             {
                 var body = await resp.Content.ReadAsStringAsync(ct);


### PR DESCRIPTION
Part of issue thefrederiksen/devthrottle_internal#724 (make mobile dictation robust) - Task 3b, the desktop-side enforced dictation lock.

## What it does
When a dictation is being sent from the phone into a session, the desktop app now refuses the user's own typing into that same session until the dictation lands or is cancelled, so a half-arrived dictation and typed input cannot collide. The dictation's own delivery still goes through untouched.

## How it works
- The lock is a projection of the durable "pending delivery" marker the Gateway already writes for an inbound dictation (#1188), read directly from the shared on-disk store. Restart-safe; never auto-releases - it clears only when the dictation is delivered or abandoned. (Same-machine setups; a Director remote from its Gateway is a documented follow-up.)
- `Session.SendTextAsync` takes an additive `source` parameter defaulting to `UserInput` (fail-closed). A user send into a locked session is refused; the dictation's own delivery (tagged via an authenticated `X-Dictation-Delivery` header on the Gateway's delivery call) and framework sends (handover, queue drain, pre-prompt, fleet messages, voice, chat) are exempt.
- Enforced in the shared `SessionCommandExecutor` so both the REST control API and the Gateway stream return HTTP 423 Locked with a clear message.
- On the desktop: a typed Send into a locked session shows a clear pop-up (not the easy-to-miss banner); typing and Queue stay usable; the left-panel session strip turns orange while a dictation is inbound.

## Testing
- New unit tests: on-disk lock projection (`DictationLockReaderTests`, incl. a cross-check against the Gateway's real `VoiceUploadStore` writer) and the executor block/exempt behavior (`DictationDesktopLockTests`).
- Existing Core + Gateway suites still pass.
- Verified live on a deployed build: a normal control-API prompt into a locked session returns 423 with the message; the delivery-header prompt returns 200; the desktop pop-up and orange rail confirmed by the owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)