### PR TITLE
Scheduled runs close themselves when done (#1200)

### DIFF
--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -3393,6 +3393,11 @@ internal static class ControlEndpoints
             VoiceMode = s.VoiceMode,
             OnHold = s.OnHold,
             WingmanEnabled = s.WingmanEnabled,
+            // Scheduled-run auto-dismiss (issue #1200): the flag + the agent's parsed verdict ride the
+            // snapshot/delta path up to the Gateway's auto-dismiss sweep, which closes the session over the
+            // stream on "done". Reported straight from the Session; the Gateway is the actor.
+            AutoDismiss = s.AutoDismiss,
+            DismissVerdict = s.DismissVerdict,
             // Raw local facts for the Gateway color fold (issue #1177, Phase 2). Reported straight from
             // the Session; the Director does NOT fold them into a color here (StatusColor is unchanged).
             IsBrandNew = s.IsBrandNew,

--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -396,6 +396,18 @@ internal static class SessionCommandExecutor
         session.WingmanEnabled = req.WingmanEnabled;
         FileLog.Write($"[SessionCommandExecutor] create: sid={session.Id} wingmanEnabled={session.WingmanEnabled}");
 
+        // Scheduled-run auto-dismiss (issue #1200): a cron seed marks the session auto-dismiss so it closes
+        // itself when it finishes with nothing needing a human. Only then attach the verdict watcher, which
+        // parses the agent's CC-DISMISS sentinel off the transcript at each turn-end and stamps the verdict
+        // (which flows up to the Gateway's auto-dismiss sweep). A human-started session leaves this false and
+        // is never watched or auto-closed.
+        session.AutoDismiss = req.AutoDismiss;
+        if (session.AutoDismiss)
+        {
+            new AutoDismissVerdictWatcher().Attach(session);
+            FileLog.Write($"[SessionCommandExecutor] create: sid={session.Id} autoDismiss=true (verdict watcher attached)");
+        }
+
         // Automatic session roles (chunk 3): the name was AUTO-composed unless the caller gave an explicit
         // --name. Marking it lets a later explicit rename win and never be re-auto-named.
         session.IsAutoNamed = string.IsNullOrWhiteSpace(explicitName);

--- a/src/CcDirector.Core.Tests/AutoDismissVerdictWatcherTests.cs
+++ b/src/CcDirector.Core.Tests/AutoDismissVerdictWatcherTests.cs
@@ -1,0 +1,119 @@
+using CcDirector.Core.Backends;
+using CcDirector.Core.Drivers;
+using CcDirector.Core.Memory;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Wingman;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="AutoDismissVerdictWatcher"/> (issue #1200): reading an auto-dismiss session's
+/// assistant text from the transcript (via an injected reader, no disk), parsing the CC-DISMISS verdict, and
+/// stamping <see cref="Session.DismissVerdict"/>. The conservative rule is verified: no block leaves the
+/// verdict null, so the Gateway never auto-closes without an explicit "done".
+/// </summary>
+public sealed class AutoDismissVerdictWatcherTests
+{
+    [Fact]
+    public void ScanAndStamp_DoneBlockInFinalMessage_StampsDone()
+    {
+        using var session = NewAutoDismissSession();
+        var reader = new FakeReader(TextWidget("All quiet.\n\nCC-DISMISS\nverdict: done\nreason: nothing to act on\n"));
+
+        new AutoDismissVerdictWatcher(reader).ScanAndStamp(session);
+
+        Assert.Equal("done", session.DismissVerdict);
+    }
+
+    [Fact]
+    public void ScanAndStamp_NeedsHumanBlock_StampsNeedsHuman()
+    {
+        using var session = NewAutoDismissSession();
+        var reader = new FakeReader(TextWidget("CC-DISMISS\nverdict: needs-human\nreason: a report to file\n"));
+
+        new AutoDismissVerdictWatcher(reader).ScanAndStamp(session);
+
+        Assert.Equal("needs-human", session.DismissVerdict);
+    }
+
+    [Fact]
+    public void ScanAndStamp_NoBlock_LeavesVerdictNull()
+    {
+        using var session = NewAutoDismissSession();
+        var reader = new FakeReader(TextWidget("Just a normal reply with no sentinel."));
+
+        new AutoDismissVerdictWatcher(reader).ScanAndStamp(session);
+
+        Assert.Null(session.DismissVerdict);
+    }
+
+    [Fact]
+    public void ScanAndStamp_VerdictAcrossTurns_LastWins()
+    {
+        using var session = NewAutoDismissSession();
+        // Two turns: an early "done" then a later "needs-human". The concatenated scan must land on the last.
+        var reader = new FakeReader(
+            TextWidget("CC-DISMISS\nverdict: done\nreason: first pass\n"),
+            TextWidget("CC-DISMISS\nverdict: needs-human\nreason: found something\n"));
+
+        new AutoDismissVerdictWatcher(reader).ScanAndStamp(session);
+
+        Assert.Equal("needs-human", session.DismissVerdict);
+    }
+
+    [Fact]
+    public void ReadAssistantText_NoClaudeSessionId_ReturnsNull()
+    {
+        // A non-Claude / not-yet-hooked session has no transcript; the watcher must not throw and must not stamp.
+        using var session = new Session(
+            Guid.NewGuid(), repoPath: @"C:\repo", workingDirectory: @"C:\repo", claudeArgs: null,
+            backend: new NullBackend(), claudeSessionId: null, activityState: ActivityState.WaitingForInput,
+            createdAt: DateTimeOffset.UtcNow, customName: null, customColor: null) { AutoDismiss = true };
+        var reader = new FakeReader(TextWidget("CC-DISMISS\nverdict: done\n"));
+
+        Assert.Null(new AutoDismissVerdictWatcher(reader).ReadAssistantText(session));
+    }
+
+    private static Session NewAutoDismissSession() =>
+        new Session(
+            Guid.NewGuid(), repoPath: @"C:\repo", workingDirectory: @"C:\repo", claudeArgs: null,
+            backend: new NullBackend(), claudeSessionId: "cs-1", activityState: ActivityState.WaitingForInput,
+            createdAt: DateTimeOffset.UtcNow, customName: null, customColor: null)
+        { AutoDismiss = true };
+
+    private static TurnWidgetDto TextWidget(string content) => new() { Kind = "Text", Content = content };
+
+    /// <summary>An <see cref="ITranscriptReader"/> that returns a fixed widget list, no disk access.</summary>
+    private sealed class FakeReader : ITranscriptReader
+    {
+        private readonly List<TurnWidgetDto> _widgets;
+        public FakeReader(params TurnWidgetDto[] widgets) => _widgets = widgets.ToList();
+        public List<TurnWidgetDto> ReadWidgets(string claudeSessionId, string repoPath) => _widgets;
+        public SessionUsageDto? ReadUsage(string claudeSessionId, string repoPath) => null;
+        public List<(string ClaudeSessionId, DateTime LastWriteUtc)> ListTranscripts(string repoPath) => new();
+    }
+
+    private sealed class NullBackend : ISessionBackend
+    {
+        public CircularTerminalBuffer? Buffer => null;
+        public int ProcessId => 1;
+        public string Status => "Null";
+        public bool IsRunning => true;
+        public bool HasExited => false;
+
+#pragma warning disable CS0067
+        public event Action<string>? StatusChanged;
+        public event Action<int>? ProcessExited;
+#pragma warning restore CS0067
+
+        public void Start(string executable, string args, string workingDir, short cols, short rows, Dictionary<string, string>? environmentVars = null) { }
+        public void Write(byte[] data) { }
+        public Task SendTextAsync(string text) => Task.CompletedTask;
+        public Task SendEnterAsync() => Task.CompletedTask;
+        public void Resize(short cols, short rows) { }
+        public Task GracefulShutdownAsync(int timeoutMs = 5000) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+}

--- a/src/CcDirector.Core.Tests/DismissVerdictSignalTests.cs
+++ b/src/CcDirector.Core.Tests/DismissVerdictSignalTests.cs
@@ -1,0 +1,98 @@
+using CcDirector.Core.Wingman;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="DismissVerdictSignal"/> (issue #1200): parsing the CC-DISMISS verdict block
+/// an auto-dismiss run prints as its final message. The conservative rule is central - no complete block,
+/// or an unrecognized verdict, yields null so a session is NEVER auto-closed without an explicit "done".
+/// </summary>
+public sealed class DismissVerdictSignalTests
+{
+    [Fact]
+    public void ParseLatest_DoneBlock_ParsesVerdictAndReason()
+    {
+        var text = "Here is the digest. Nothing needs you today.\n\nCC-DISMISS\nverdict: done\nreason: quiet day, 0 to act\n";
+
+        var sig = DismissVerdictSignal.ParseLatest(text);
+
+        Assert.NotNull(sig);
+        Assert.Equal(DismissVerdict.Done, sig!.Verdict);
+        Assert.Equal("done", sig.Wire);
+        Assert.Equal("quiet day, 0 to act", sig.Reason);
+    }
+
+    [Fact]
+    public void ParseLatest_NeedsHumanBlock_ParsesVerdict()
+    {
+        var sig = DismissVerdictSignal.ParseLatest("CC-DISMISS\nverdict: needs-human\nreason: one PR needs a reply\n");
+
+        Assert.NotNull(sig);
+        Assert.Equal(DismissVerdict.NeedsHuman, sig!.Verdict);
+        Assert.Equal("needs-human", sig.Wire);
+    }
+
+    [Fact]
+    public void ParseLatest_NoBlock_ReturnsNull()
+    {
+        Assert.Null(DismissVerdictSignal.ParseLatest("just a normal message, no sentinel here"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ParseLatest_EmptyText_ReturnsNull(string? text)
+    {
+        Assert.Null(DismissVerdictSignal.ParseLatest(text));
+    }
+
+    [Fact]
+    public void ParseLatest_UnrecognizedVerdict_ReturnsNull()
+    {
+        // A block with a bad verdict is incomplete -> null (never guess a close).
+        Assert.Null(DismissVerdictSignal.ParseLatest("CC-DISMISS\nverdict: maybe\nreason: unsure\n"));
+    }
+
+    [Fact]
+    public void ParseLatest_MarkerWithoutVerdict_ReturnsNull()
+    {
+        Assert.Null(DismissVerdictSignal.ParseLatest("CC-DISMISS\nreason: forgot the verdict\n"));
+    }
+
+    [Fact]
+    public void ParseLatest_LastBlockWins_NeedsHumanSupersedesEarlierDone()
+    {
+        // A later turn's verdict must win, so a done that a subsequent turn overrides never closes the session.
+        var text =
+            "CC-DISMISS\nverdict: done\nreason: first pass\n" +
+            "...later the run found something...\n" +
+            "CC-DISMISS\nverdict: needs-human\nreason: found a report to file\n";
+
+        var sig = DismissVerdictSignal.ParseLatest(text);
+
+        Assert.NotNull(sig);
+        Assert.Equal(DismissVerdict.NeedsHuman, sig!.Verdict);
+    }
+
+    [Fact]
+    public void ParseLatest_FencedBlock_IsAccepted()
+    {
+        // The agent may wrap the block in a markdown code fence; the marker and fields tolerate backticks.
+        var text = "```\nCC-DISMISS\nverdict: done\nreason: fenced\n```";
+
+        var sig = DismissVerdictSignal.ParseLatest(text);
+
+        Assert.NotNull(sig);
+        Assert.Equal(DismissVerdict.Done, sig!.Verdict);
+    }
+
+    [Fact]
+    public void ParseLatest_CaseInsensitiveVerdictValue()
+    {
+        var sig = DismissVerdictSignal.ParseLatest("CC-DISMISS\nverdict: DONE\n");
+
+        Assert.NotNull(sig);
+        Assert.Equal(DismissVerdict.Done, sig!.Verdict);
+    }
+}

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -580,6 +580,38 @@ public sealed class Session : IDisposable
     public bool WingmanEnabled { get; set; } = false;
 
     /// <summary>
+    /// Scheduled-run auto-dismiss (issue #1200): true when this session is an AUTOMATED run (a cron seed)
+    /// that should close itself when it finishes with nothing needing a human. Only sessions with this set
+    /// are ever auto-closed; a human-started session leaves it false and is never touched. Set once at birth
+    /// from <see cref="Gateway.Contracts.NewSessionRequest.AutoDismiss"/>. See <see cref="DismissVerdict"/>.
+    /// </summary>
+    public bool AutoDismiss { get; set; } = false;
+
+    /// <summary>
+    /// Scheduled-run auto-dismiss (issue #1200): the agent's explicit end-of-run verdict, parsed from the
+    /// finished turn's final message (a <c>CC-DISMISS</c> block, see <see cref="Wingman.DismissVerdictSignal"/>).
+    /// <c>"done"</c> = nothing needs the human (safe to auto-close); <c>"needs-human"</c> = keep it open.
+    /// Null until a verdict is seen - the conservative default that guarantees a session is never auto-closed
+    /// without an explicit <c>done</c>. Set on the Director via <see cref="SetDismissVerdict"/>; flows to the
+    /// Gateway on <see cref="Gateway.Contracts.SessionDto.DismissVerdict"/>.
+    /// </summary>
+    public string? DismissVerdict { get; private set; }
+
+    /// <summary>
+    /// Record the agent's parsed end-of-run verdict for auto-dismiss (issue #1200). Idempotent per value:
+    /// only logs on a change. A null/blank argument clears it (a fresh turn that produced no verdict). This
+    /// is the only writer of <see cref="DismissVerdict"/>.
+    /// </summary>
+    public void SetDismissVerdict(string? verdict)
+    {
+        var normalized = string.IsNullOrWhiteSpace(verdict) ? null : verdict.Trim().ToLowerInvariant();
+        if (string.Equals(normalized, DismissVerdict, StringComparison.Ordinal))
+            return;
+        DismissVerdict = normalized;
+        FileLog.Write($"[Session] SetDismissVerdict: session={Id} verdict={normalized ?? "(cleared)"}");
+    }
+
+    /// <summary>
     /// The <see cref="WingmanEnabled"/> value captured just before voice mode was enabled
     /// for this session, so the prior state can be restored when voice mode ends. Null when
     /// voice mode is not active (the value is transient and is not persisted). Voice mode

--- a/src/CcDirector.Core/Wingman/AutoDismissVerdictWatcher.cs
+++ b/src/CcDirector.Core/Wingman/AutoDismissVerdictWatcher.cs
@@ -1,0 +1,92 @@
+using CcDirector.Core.Drivers;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Wingman;
+
+/// <summary>
+/// Director-side detector for the scheduled-run auto-dismiss verdict (issue #1200). It watches an
+/// auto-dismiss session's turn-ends and, from the agent's OWN transcript (not the terminal buffer, so it is
+/// robust to the alternate-screen full-screen mode), parses the <c>CC-DISMISS</c> sentinel the run prints
+/// as its final message and stamps <see cref="Session.DismissVerdict"/>. That verdict then flows UP to the
+/// Gateway on the session DTO, where the auto-dismiss sweep closes the session over the stream on
+/// <c>done</c>. Reading the transcript (via the same <see cref="ITranscriptReader"/> the Director already
+/// uses for briefs) rather than scraping the terminal is deliberate: the sentinel is the agent's real
+/// message text, unaffected by ANSI/alt-screen rendering.
+///
+/// Only Claude sessions carry a transcript today, so a non-Claude auto-dismiss run simply never stamps a
+/// verdict and is never auto-closed - the conservative default.
+/// </summary>
+public sealed class AutoDismissVerdictWatcher
+{
+    private readonly ITranscriptReader _transcripts;
+
+    /// <param name="transcripts">Transcript reader (a test seam); production passes null for the disk-backed reader.</param>
+    public AutoDismissVerdictWatcher(ITranscriptReader? transcripts = null)
+    {
+        _transcripts = transcripts ?? new ClaudeTranscriptReader();
+    }
+
+    /// <summary>
+    /// Subscribe to <paramref name="session"/>'s turn-ends so its verdict is (re)parsed each time the agent
+    /// settles. A no-op for a session that is not auto-dismiss (so a normal human session is never scanned).
+    /// The scan runs off the state-change callback thread (fire-and-forget) so it never blocks the detector.
+    /// </summary>
+    public void Attach(Session session)
+    {
+        if (session is null || !session.AutoDismiss)
+            return;
+
+        session.OnActivityStateChanged += (oldState, newState) =>
+        {
+            _ = oldState; // unused: we only care about the state we transitioned INTO
+            // A turn is over only when the session settles to WaitingForInput (the dumb quiet timer). At that
+            // point the final assistant message - which carries any CC-DISMISS block - is in the transcript.
+            if (newState is not ActivityState.WaitingForInput)
+                return;
+            _ = Task.Run(() => ScanAndStamp(session));
+        };
+        FileLog.Write($"[AutoDismissVerdictWatcher] attached: session={session.Id}");
+    }
+
+    /// <summary>
+    /// Read the session's latest assistant text, parse the last <c>CC-DISMISS</c> block, and stamp the
+    /// verdict when one is present. A boundary (fire-and-forget target): it owns its try/catch so a
+    /// transcript read fault never escapes onto a background thread.
+    /// </summary>
+    internal void ScanAndStamp(Session session)
+    {
+        try
+        {
+            var text = ReadAssistantText(session);
+            var signal = DismissVerdictSignal.ParseLatest(text);
+            if (signal is not null)
+                session.SetDismissVerdict(signal.Wire);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[AutoDismissVerdictWatcher] scan FAILED: session={session.Id}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Concatenate the session's assistant text widgets in chronological order. Parsing the whole
+    /// (rather than only the last widget) keeps "last verdict wins" correct even when the block is embedded
+    /// in a longer final message or a later turn supersedes an earlier verdict. Returns null when the
+    /// transcript is unavailable (no ClaudeSessionId yet, or a non-Claude agent).
+    /// </summary>
+    internal string? ReadAssistantText(Session session)
+    {
+        if (string.IsNullOrEmpty(session.ClaudeSessionId))
+            return null;
+
+        var widgets = _transcripts.ReadWidgets(session.ClaudeSessionId, session.RepoPath);
+        if (widgets.Count == 0)
+            return null;
+
+        var texts = widgets
+            .Where(w => string.Equals(w.Kind, "Text", StringComparison.Ordinal) && !string.IsNullOrWhiteSpace(w.Content))
+            .Select(w => w.Content);
+        return string.Join("\n", texts);
+    }
+}

--- a/src/CcDirector.Core/Wingman/DismissVerdictSignal.cs
+++ b/src/CcDirector.Core/Wingman/DismissVerdictSignal.cs
@@ -1,0 +1,138 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Wingman;
+
+/// <summary>
+/// The two verdicts an automated (auto-dismiss) run can end on (issue #1200). An agent whose session was
+/// launched with auto-dismiss ends its run by printing a <c>CC-DISMISS</c> block; the Director parses the
+/// verdict and the Gateway acts on it: <see cref="Done"/> closes the session over the stream, so it never
+/// lingers in the rail; <see cref="NeedsHuman"/> keeps it open exactly like a normal session.
+/// </summary>
+public enum DismissVerdict
+{
+    /// <summary>The run finished and nothing needs the human - safe to close the session.</summary>
+    Done,
+
+    /// <summary>The run finished but something needs the human (a decision, an approval, a flagged item) - keep the session open.</summary>
+    NeedsHuman,
+}
+
+/// <summary>
+/// The parsed <c>CC-DISMISS</c> sentinel block (issue #1200), modeled on the work-list runner's
+/// <c>IMPL-LOOP-TERMINAL</c> sentinel. An auto-dismiss run prints exactly one such block as its final
+/// message so a supervisor learns the outcome WITHOUT parsing prose:
+///
+/// <code>
+/// CC-DISMISS
+/// verdict: done | needs-human
+/// reason: &lt;one line - why this verdict&gt;
+/// </code>
+///
+/// The verdict string on <see cref="Session.DismissVerdict"/> uses the wire spellings <c>"done"</c> /
+/// <c>"needs-human"</c> (see <see cref="Verdict"/> -&gt; <see cref="Wire"/>).
+/// </summary>
+public sealed class DismissVerdictSignal
+{
+    /// <summary>Which of the two verdicts the run ended on.</summary>
+    public DismissVerdict Verdict { get; init; }
+
+    /// <summary>The single human-readable line explaining the verdict (may be empty).</summary>
+    public string Reason { get; init; } = "";
+
+    private const string Marker = "CC-DISMISS";
+
+    /// <summary>The wire spelling stored on the session / DTO for this verdict ("done" | "needs-human").</summary>
+    public string Wire => Verdict == DismissVerdict.Done ? "done" : "needs-human";
+
+    /// <summary>
+    /// Find the LAST complete <c>CC-DISMISS</c> block in <paramref name="text"/> (typically an agent's final
+    /// assistant message) and parse it. Returns null when no complete block is present - the conservative
+    /// default that keeps a session open until the agent explicitly declares its verdict. Reading the LAST
+    /// block makes the parse idempotent against text that is re-read as the session keeps producing output,
+    /// and lets a later verdict supersede an earlier one within the same message.
+    /// </summary>
+    public static DismissVerdictSignal? ParseLatest(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return null;
+
+        var lines = text.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+
+        DismissVerdictSignal? latest = null;
+        for (var i = 0; i < lines.Length; i++)
+        {
+            // The marker may be fenced or lightly decorated (```, bullets); accept a line that IS the marker
+            // once stripped of surrounding backticks/space, so a markdown code fence around the block is fine.
+            if (!IsMarkerLine(lines[i]))
+                continue;
+
+            var parsed = ParseBlock(lines, i);
+            if (parsed is not null)
+                latest = parsed;
+        }
+
+        return latest;
+    }
+
+    private static bool IsMarkerLine(string line) =>
+        line.Trim().Trim('`').Trim().Equals(Marker, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Parse a single block whose marker line is at <paramref name="markerIndex"/>. Fields are the
+    /// <c>key: value</c> lines immediately following the marker, in any order, up to the first line that is
+    /// not a recognized field. A block missing a recognized <c>verdict</c> is incomplete and returns null.
+    /// </summary>
+    private static DismissVerdictSignal? ParseBlock(string[] lines, int markerIndex)
+    {
+        DismissVerdict? verdict = null;
+        var reason = "";
+
+        for (var i = markerIndex + 1; i < lines.Length; i++)
+        {
+            var line = lines[i].Trim().Trim('`').Trim();
+            if (line.Length == 0)
+                continue;
+
+            var colon = line.IndexOf(':');
+            if (colon <= 0)
+                break; // not a key: value field - the block has ended
+
+            var key = line[..colon].Trim().ToLowerInvariant();
+            var value = line[(colon + 1)..].Trim();
+
+            switch (key)
+            {
+                case "verdict":
+                    verdict = ParseVerdict(value);
+                    break;
+                case "reason":
+                    reason = value;
+                    break;
+                default:
+                    // A non-field line after the marker ends the block.
+                    return Build(verdict, reason);
+            }
+        }
+
+        return Build(verdict, reason);
+    }
+
+    private static DismissVerdictSignal? Build(DismissVerdict? verdict, string reason)
+    {
+        if (verdict is null)
+        {
+            FileLog.Write("[DismissVerdictSignal] incomplete block (missing or unrecognized verdict)");
+            return null;
+        }
+
+        return new DismissVerdictSignal { Verdict = verdict.Value, Reason = reason };
+    }
+
+    private static DismissVerdict? ParseVerdict(string value) => value.ToLowerInvariant() switch
+    {
+        "done" => DismissVerdict.Done,
+        "needs-human" => DismissVerdict.NeedsHuman,
+        "needshuman" => DismissVerdict.NeedsHuman,
+        _ => null,
+    };
+}

--- a/src/CcDirector.Gateway.Contracts/CronJobDto.cs
+++ b/src/CcDirector.Gateway.Contracts/CronJobDto.cs
@@ -116,6 +116,15 @@ public sealed class CronJobAction
     /// starting a single seeded session. Null/empty = a seed action.
     /// </summary>
     public string? WorkListName { get; set; }
+
+    /// <summary>
+    /// Scheduled-run auto-dismiss (issue #1200): when true (the default for a seed action), the session the
+    /// fire starts is launched with <see cref="NewSessionRequest.AutoDismiss"/> so it closes itself once it
+    /// finishes with nothing needing a human (the agent's <c>CC-DISMISS: done</c> verdict), instead of
+    /// lingering in the rail. Set false to keep a scheduled run open like a normal interactive session. Only
+    /// consulted for seed actions; a work-list drain manages its own sessions.
+    /// </summary>
+    public bool AutoDismiss { get; set; } = true;
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway.Contracts/NewSessionRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/NewSessionRequest.cs
@@ -114,6 +114,16 @@ public sealed class NewSessionRequest
     /// target Director.
     /// </summary>
     public string? Machine { get; set; }
+
+    /// <summary>
+    /// Scheduled-run auto-dismiss (issue #1200). When true, this session is an AUTOMATED run that should
+    /// close ITSELF once it finishes with nothing that needs a human: the agent ends its run by emitting a
+    /// <c>CC-DISMISS</c> verdict block (see <c>Session.DismissVerdict</c>), and on <c>done</c> the Gateway
+    /// closes the session over the Director stream so it never lingers in the rail. On <c>needs-human</c>
+    /// (or no verdict) it stays open exactly like a normal session. Default false: a human-started session
+    /// is NEVER auto-closed. Set true only by the cron starter for scheduled seed runs.
+    /// </summary>
+    public bool AutoDismiss { get; set; } = false;
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -303,6 +303,23 @@ public sealed class SessionDto
     /// </summary>
     public bool WingmanEnabled { get; set; } = false;
 
+    /// <summary>
+    /// Scheduled-run auto-dismiss (issue #1200): true when this session is an AUTOMATED run that should
+    /// close itself when it finishes with nothing needing a human (mirrors <c>Session.AutoDismiss</c>).
+    /// Only sessions carrying this flag are ever auto-closed; human-started sessions leave it false and are
+    /// never touched. Rides the existing snapshot/delta path; defaults false on Directors that predate it.
+    /// </summary>
+    public bool AutoDismiss { get; set; } = false;
+
+    /// <summary>
+    /// Scheduled-run auto-dismiss (issue #1200): the agent's explicit end-of-run verdict parsed from its
+    /// final message (mirrors <c>Session.DismissVerdict</c>). <c>"done"</c> = nothing needs the human, safe
+    /// to auto-close; <c>"needs-human"</c> = keep the session open. Null when the run has not yet emitted a
+    /// verdict (the conservative default - a session is never auto-closed without an explicit <c>done</c>).
+    /// Only meaningful when <see cref="AutoDismiss"/> is true.
+    /// </summary>
+    public string? DismissVerdict { get; set; }
+
     // ===== Raw local facts for the Gateway color fold (issue #1177, Phase 2) =====
     // These are RAW FACTS the Director reports straight from the Session - it does NOT fold them into a
     // color. The Gateway is the single fold: it computes EffectiveColor / TriageBucket / StateLabel from

--- a/src/CcDirector.Gateway.Tests/AutoDismissSweeperTests.cs
+++ b/src/CcDirector.Gateway.Tests/AutoDismissSweeperTests.cs
@@ -1,0 +1,129 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Running;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="AutoDismissSweeper"/> (issue #1200): selecting which auto-dismiss sessions to
+/// close (only auto-dismiss + verdict "done" + settled at a turn-end) and issuing the close over the stream
+/// via the "kill" verb - never twice for the same session, and only when a stream is actually connected.
+/// </summary>
+public sealed class AutoDismissSweeperTests
+{
+    private static SessionDto Session(
+        string id, bool autoDismiss = true, string? verdict = "done",
+        string activity = "WaitingForInput", string status = "Running") => new()
+    {
+        SessionId = id,
+        AutoDismiss = autoDismiss,
+        DismissVerdict = verdict,
+        ActivityState = activity,
+        Status = status,
+    };
+
+    [Fact]
+    public void SelectDismissable_PicksAutoDismissDoneSettled()
+    {
+        var input = new[] { ("d1", Session("s1")) };
+
+        var picks = AutoDismissSweeper.SelectDismissable(input);
+
+        Assert.Single(picks);
+        Assert.Equal("s1", picks[0].Session.SessionId);
+        Assert.Equal("d1", picks[0].DirectorId);
+    }
+
+    [Fact]
+    public void SelectDismissable_SkipsNonAutoDismiss()
+    {
+        var input = new[] { ("d1", Session("s1", autoDismiss: false)) };
+        Assert.Empty(AutoDismissSweeper.SelectDismissable(input));
+    }
+
+    [Fact]
+    public void SelectDismissable_SkipsNeedsHumanAndNoVerdict()
+    {
+        var input = new[]
+        {
+            ("d1", Session("needs", verdict: "needs-human")),
+            ("d1", Session("none", verdict: null)),
+        };
+        Assert.Empty(AutoDismissSweeper.SelectDismissable(input));
+    }
+
+    [Fact]
+    public void SelectDismissable_SkipsMidTurnOrPermissionOrExited()
+    {
+        var input = new[]
+        {
+            ("d1", Session("working", activity: "Working")),
+            ("d1", Session("perm", activity: "WaitingForPerm")),
+            ("d1", Session("exited", status: "Exited")),
+        };
+        Assert.Empty(AutoDismissSweeper.SelectDismissable(input));
+    }
+
+    [Fact]
+    public void SelectDismissable_HonorsAlreadyClosingFilter()
+    {
+        var input = new[] { ("d1", Session("s1")) };
+        Assert.Empty(AutoDismissSweeper.SelectDismissable(input, alreadyClosing: sid => sid == "s1"));
+    }
+
+    [Fact]
+    public async Task SweepAsync_ClosesQualifyingSession_OverStream_WithKillVerb()
+    {
+        var sent = new List<(string DirectorId, DirectorCommand Command)>();
+        DirectorCommandResult? Ok(string dir, DirectorCommand cmd)
+        {
+            sent.Add((dir, cmd));
+            return DirectorCommandResult.Success();
+        }
+
+        var sweeper = new AutoDismissSweeper(
+            () => new[] { ("d1", Session("s1")) },
+            (dir, cmd, ct) => Task.FromResult(Ok(dir, cmd)));
+
+        var closed = await sweeper.SweepAsync(CancellationToken.None);
+
+        Assert.Equal(1, closed);
+        Assert.Single(sent);
+        Assert.Equal("kill", sent[0].Command.Verb);
+        Assert.Equal("s1", sent[0].Command.SessionId);
+        Assert.Equal("d1", sent[0].DirectorId);
+    }
+
+    [Fact]
+    public async Task SweepAsync_DoesNotCloseTwice_WhenSessionLingersOneExtraSweep()
+    {
+        var sendCount = 0;
+        var snapshot = new[] { ("d1", Session("s1")) };
+        var sweeper = new AutoDismissSweeper(
+            () => snapshot,
+            (dir, cmd, ct) => { sendCount++; return Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Success()); });
+
+        await sweeper.SweepAsync(CancellationToken.None);
+        // Same session still present next sweep (its removal tombstone has not arrived yet): must NOT re-kill.
+        await sweeper.SweepAsync(CancellationToken.None);
+
+        Assert.Equal(1, sendCount);
+    }
+
+    [Fact]
+    public async Task SweepAsync_NoStream_ReturnsNull_RetriesNextSweep()
+    {
+        var sendCount = 0;
+        var sweeper = new AutoDismissSweeper(
+            () => new[] { ("d1", Session("s1")) },
+            (dir, cmd, ct) => { sendCount++; return Task.FromResult<DirectorCommandResult?>(null); });
+
+        var closed1 = await sweeper.SweepAsync(CancellationToken.None);
+        var closed2 = await sweeper.SweepAsync(CancellationToken.None);
+
+        // A null result means "no active stream" - nothing closed, and the session is retried (not marked done).
+        Assert.Equal(0, closed1);
+        Assert.Equal(0, closed2);
+        Assert.Equal(2, sendCount);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/PushedSessionStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/PushedSessionStoreTests.cs
@@ -43,6 +43,36 @@ public sealed class PushedSessionStoreTests
     }
 
     [Fact]
+    public void SnapshotFresh_ReturnsSessionsFromAllFreshConnections_WithDirectorId()
+    {
+        // Issue #1200: the auto-dismiss sweep enumerates every fresh session paired with its Director.
+        var store = NewStore();
+        store.RegisterConnection("dir-A", "conn-A");
+        store.RegisterConnection("dir-B", "conn-B");
+        store.ApplySnapshot("dir-A", "conn-A", 0, new[] { Session("s1") });
+        store.ApplySnapshot("dir-B", "conn-B", 0, new[] { Session("s2") });
+
+        var all = store.SnapshotFresh(_staleAfter);
+
+        Assert.Equal(2, all.Count);
+        Assert.Contains(all, t => t.DirectorId == "dir-A" && t.Session.SessionId == "s1");
+        Assert.Contains(all, t => t.DirectorId == "dir-B" && t.Session.SessionId == "s2");
+    }
+
+    [Fact]
+    public void SnapshotFresh_ExcludesStaleAndDisconnectedDirectors()
+    {
+        var store = NewStore();
+        store.RegisterConnection("dir-A", "conn-A");
+        store.ApplySnapshot("dir-A", "conn-A", 0, new[] { Session("s1") });
+
+        // Advance past the stale window: the cache is now stale, so the sweep must not act on it.
+        _now = _now.Add(_staleAfter).AddSeconds(1);
+
+        Assert.Empty(store.SnapshotFresh(_staleAfter));
+    }
+
+    [Fact]
     public void ApplySnapshot_FromNonActiveConnection_IsRejected()
     {
         // Arrange

--- a/src/CcDirector.Gateway.Tests/StreamCommandTests.cs
+++ b/src/CcDirector.Gateway.Tests/StreamCommandTests.cs
@@ -8,6 +8,7 @@ using CcDirector.ControlApi;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Sessions;
 using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Running;
 using Xunit;
 
 namespace CcDirector.Gateway.Tests;
@@ -100,6 +101,64 @@ public sealed class StreamCommandTests : IAsyncLifetime
         Assert.True(result.Ok);
         Assert.Equal(command.CommandId, result.CommandId);
         Assert.Contains("over-the-stream", BufferText(session));
+    }
+
+    [Fact]
+    public async Task AutoDismiss_DoneVerdict_ClosesSessionOverTheStream_EndToEnd()
+    {
+        // Issue #1200 end-to-end: a real auto-dismiss session that declared "done" is closed by the Gateway's
+        // auto-dismiss sweep sending the "kill" verb DOWN the real SignalR stream. This proves the WHOLE loop
+        // over the live stream: the verdict rides UP on the pushed session DTO, the sweep addresses the owning
+        // Director from the pushed cache, the kill flows DOWN, and the Director actually kills+removes the
+        // session (no phantom - RemoveSession runs). No mocks of the channel; the same GatewayHost wiring.
+        var session = _directorSessions.CreateEmbeddedSession(Path.GetTempPath(), null, new ExecuteActionTestBackend());
+        session.AutoDismiss = true;
+        session.SetDismissVerdict("done");   // what the Director's verdict watcher stamps from the CC-DISMISS block
+
+        await using var client = NewClient(new CountingDispatcher(_directorSessions));
+        client.Start();
+        await WaitForStream();
+        await WaitForPushedSession(session.Id.ToString());
+
+        // The verdict actually reached the Gateway UP the stream, on the pushed DTO.
+        var pushed = _gateway.PushedSessions.SnapshotFresh(TimeSpan.FromSeconds(30));
+        var mine = pushed.Single(t => t.Session.SessionId == session.Id.ToString());
+        Assert.True(mine.Session.AutoDismiss);
+        Assert.Equal("done", mine.Session.DismissVerdict);
+
+        // The real Gateway sweep, wired exactly as GatewayHost wires it (pushed snapshot + SendCommandAsync).
+        var sweeper = new AutoDismissSweeper(
+            () => _gateway.PushedSessions.SnapshotFresh(TimeSpan.FromSeconds(30)),
+            _gateway.SendCommandAsync);
+
+        var closed = await sweeper.SweepAsync(CancellationToken.None);
+
+        Assert.Equal(1, closed);
+        // The kill executed on the Director over the stream: the session is gone from the roster (killed+removed).
+        Assert.Null(_directorSessions.GetSession(session.Id));
+    }
+
+    [Fact]
+    public async Task AutoDismiss_NeedsHumanVerdict_LeavesSessionOpen_EndToEnd()
+    {
+        // The mirror case: a "needs-human" verdict must NOT close the session, even over a live stream.
+        var session = _directorSessions.CreateEmbeddedSession(Path.GetTempPath(), null, new ExecuteActionTestBackend());
+        session.AutoDismiss = true;
+        session.SetDismissVerdict("needs-human");
+
+        await using var client = NewClient(new CountingDispatcher(_directorSessions));
+        client.Start();
+        await WaitForStream();
+        await WaitForPushedSession(session.Id.ToString());
+
+        var sweeper = new AutoDismissSweeper(
+            () => _gateway.PushedSessions.SnapshotFresh(TimeSpan.FromSeconds(30)),
+            _gateway.SendCommandAsync);
+
+        var closed = await sweeper.SweepAsync(CancellationToken.None);
+
+        Assert.Equal(0, closed);
+        Assert.NotNull(_directorSessions.GetSession(session.Id)); // still open
     }
 
     [Fact]
@@ -808,8 +867,11 @@ public sealed class StreamCommandTests : IAsyncLifetime
         return new GatewayStreamClient(config, DirectorId, "test", SnapshotDirectorSessions, dispatcher.DispatchAsync, rePushInterval);
     }
 
+    // Map with the SAME production mapper the Director uses to push its roster UP the stream
+    // (ControlApiHost.SnapshotFullSessions), so pushed DTOs carry every field a real Director sends -
+    // including Status and the issue #1200 AutoDismiss / DismissVerdict fields the auto-dismiss sweep reads.
     private List<SessionDto> SnapshotDirectorSessions() =>
-        _directorSessions.ListSessions().Select(s => new SessionDto { SessionId = s.Id.ToString(), ActivityState = s.ActivityState.ToString() }).ToList();
+        _directorSessions.ListSessions().Select(s => ControlEndpoints.Map(s, DirectorId)).ToList();
 
     private static DirectorCommand PromptCommand(string sessionId, PromptRequest req) => new()
     {

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -235,6 +235,15 @@ public sealed class GatewayHost : IAsyncDisposable
     // StartAsync, disposed in StopAsync.
     private System.Threading.Timer? _cronTimer;
     private static readonly TimeSpan CronSweepInterval = TimeSpan.FromMinutes(1);
+
+    // Scheduled-run auto-dismiss (issue #1200): wakes ~every 15s and closes automated runs that declared
+    // themselves done, over the Director stream. Created in StartAsync only when stream mode is on (the
+    // feature has no REST fallback), disposed in StopAsync. Freshness matches the aggregation's pushed-cache
+    // staleness so a session whose Director stopped pushing is not acted on from a stale snapshot.
+    private System.Threading.Timer? _autoDismissTimer;
+    private Running.AutoDismissSweeper? _autoDismissSweeper;
+    private static readonly TimeSpan AutoDismissSweepInterval = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan AutoDismissStaleAfter = TimeSpan.FromSeconds(30);
     private readonly Running.WorkListRunnerManager _runnerManager = new();
     // Issue #218: Gateway-owned clock for when each session entered the red / NEEDS-YOU state.
     private readonly NeedsYouClock _needsYouClock = new();
@@ -1215,6 +1224,18 @@ public sealed class GatewayHost : IAsyncDisposable
         _cronTimer = new System.Threading.Timer(_ => SweepCron(), null, CronSweepInterval, CronSweepInterval);
         FileLog.Write($"[GatewayHost] cron sweep started: every {CronSweepInterval.TotalSeconds:0}s");
 
+        // Scheduled-run auto-dismiss (issue #1200): close automated runs that declared themselves done, by
+        // sending the kill verb DOWN the Director stream. Only when stream mode is on - the close has no REST
+        // fallback by design (the Gateway owns session lifecycle and reaches the Director through its stream).
+        if (_streamMode)
+        {
+            _autoDismissSweeper = new Running.AutoDismissSweeper(
+                () => PushedSessions.SnapshotFresh(AutoDismissStaleAfter),
+                SendCommandAsync);
+            _autoDismissTimer = new System.Threading.Timer(_ => SweepAutoDismiss(), null, AutoDismissSweepInterval, AutoDismissSweepInterval);
+            FileLog.Write($"[GatewayHost] auto-dismiss sweep started: every {AutoDismissSweepInterval.TotalSeconds:0}s");
+        }
+
         // Issue #629: start the durable telemetry retry-queue flusher. It drains any events restored
         // from disk on construction (so a backend outage that spanned the previous run's lifetime now
         // delivers) and every event the relay enqueues going forward, in FIFO order, retrying with
@@ -1276,6 +1297,23 @@ public sealed class GatewayHost : IAsyncDisposable
         catch (Exception ex)
         {
             FileLog.Write($"[GatewayHost] cron sweep FAILED: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// The auto-dismiss sweep timer callback (issue #1200; a boundary - it owns the try/catch so a sweep
+    /// failure never crashes the timer thread). Closes automated runs that declared themselves done, over the
+    /// Director stream. Fire-and-forget: the async sweep runs on the thread pool so the timer thread returns.
+    /// </summary>
+    private void SweepAutoDismiss()
+    {
+        try
+        {
+            _ = _autoDismissSweeper?.SweepAsync(CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayHost] auto-dismiss sweep FAILED: {ex.Message}");
         }
     }
 
@@ -1353,6 +1391,8 @@ public sealed class GatewayHost : IAsyncDisposable
 
         try { _cronTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] cron timer dispose error: {ex.Message}"); }
         _cronTimer = null;
+        try { _autoDismissTimer?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] auto-dismiss timer dispose error: {ex.Message}"); }
+        _autoDismissTimer = null;
 
         try { _endpointMonitor?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] endpoint monitor dispose error: {ex.Message}"); }
         _endpointMonitor = null;

--- a/src/CcDirector.Gateway/Running/AutoDismissSweeper.cs
+++ b/src/CcDirector.Gateway/Running/AutoDismissSweeper.cs
@@ -1,0 +1,148 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Running;
+
+/// <summary>
+/// Scheduled-run auto-dismiss (issue #1200): the Gateway-side actor that CLOSES an automated run once it has
+/// declared it is done. On each sweep it reads the fresh pushed-session snapshot, selects the sessions that
+/// are auto-dismiss AND carry the agent's <c>done</c> verdict AND have settled at a turn-end, and closes each
+/// one by sending the <c>kill</c> verb DOWN that Director's stream (never the Director's REST Control API) -
+/// the same graceful kill+remove the Cockpit close uses, so no phantom "interrupted" journal entry is left.
+///
+/// The verdict is what lets this override the dumb red "needs you" badge: a finished run always goes red on
+/// the 10-second silence timer, but an explicit <c>done</c> means nothing actually needs the human, so the
+/// session is closed rather than left cluttering the rail. A <c>needs-human</c> verdict (or no verdict) is
+/// never closed - it stays open exactly like a normal session.
+///
+/// The whole feature rides the stream: with stream mode off there is no down-channel, so the Gateway does not
+/// run this sweep at all (there is deliberately no REST fallback for the close).
+/// </summary>
+internal sealed class AutoDismissSweeper
+{
+    private readonly Func<IReadOnlyList<(string DirectorId, SessionDto Session)>> _snapshot;
+    private readonly DirectorCommandRouter.SendDirectorCommandAsync _sendCommand;
+
+    // Sessions we have already issued a kill for, so a session that lingers one extra sweep (before its
+    // removal tombstone propagates up the stream) is not killed twice. Pruned opportunistically each sweep.
+    private readonly ConcurrentDictionary<string, byte> _closing = new(StringComparer.Ordinal);
+
+    /// <param name="snapshot">Returns the fresh pushed sessions across all stream-connected Directors (PushedSessionStore.SnapshotFresh).</param>
+    /// <param name="sendCommand">The down-channel command sender (GatewayHost.SendCommandAsync); required - the feature only runs with the stream on.</param>
+    public AutoDismissSweeper(
+        Func<IReadOnlyList<(string DirectorId, SessionDto Session)>> snapshot,
+        DirectorCommandRouter.SendDirectorCommandAsync sendCommand)
+    {
+        _snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
+        _sendCommand = sendCommand ?? throw new ArgumentNullException(nameof(sendCommand));
+    }
+
+    /// <summary>The verdict string (see <c>Session.DismissVerdict</c>) that authorizes an auto-close.</summary>
+    public const string VerdictDone = "done";
+
+    /// <summary>
+    /// Select the sessions that should be auto-closed this pass. Pure and testable: a session qualifies when
+    /// it is auto-dismiss, its verdict is <c>done</c>, and it has SETTLED at a turn-end - Running lifecycle,
+    /// and an activity state of WaitingForInput or Idle (NOT Working: it may have started a fresh turn after
+    /// emitting the verdict; NOT WaitingForPerm: a real permission prompt must never be steam-rolled). Already
+    /// exited/exiting sessions and ones we have already issued a kill for are excluded.
+    /// </summary>
+    public static IReadOnlyList<(string DirectorId, SessionDto Session)> SelectDismissable(
+        IEnumerable<(string DirectorId, SessionDto Session)> sessions,
+        Func<string, bool>? alreadyClosing = null)
+    {
+        var picks = new List<(string, SessionDto)>();
+        foreach (var (directorId, s) in sessions)
+        {
+            if (s is null || string.IsNullOrEmpty(s.SessionId))
+                continue;
+            if (!s.AutoDismiss)
+                continue;
+            if (!string.Equals(s.DismissVerdict, VerdictDone, StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (!IsSettledAtTurnEnd(s))
+                continue;
+            if (alreadyClosing is not null && alreadyClosing(s.SessionId))
+                continue;
+            picks.Add((directorId, s));
+        }
+        return picks;
+    }
+
+    private static bool IsSettledAtTurnEnd(SessionDto s)
+    {
+        // Only close a live session that is quietly waiting - not one mid-turn, mid-permission, or gone.
+        if (!string.Equals(s.Status, "Running", StringComparison.OrdinalIgnoreCase))
+            return false;
+        return string.Equals(s.ActivityState, "WaitingForInput", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(s.ActivityState, "Idle", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Run one sweep: select the dismissable sessions and close each over its Director's stream. Best-effort
+    /// and isolated per session (one close failure never blocks the others). Returns the count closed. A
+    /// session whose stream close returns null (no active stream) is left for a later sweep - the feature has
+    /// no REST fallback by design.
+    /// </summary>
+    public async Task<int> SweepAsync(CancellationToken ct)
+    {
+        var snapshot = _snapshot();
+        PruneClosing(snapshot);
+
+        var picks = SelectDismissable(snapshot, sid => _closing.ContainsKey(sid));
+        var closed = 0;
+        foreach (var (directorId, session) in picks)
+        {
+            ct.ThrowIfCancellationRequested();
+            // Mark before sending so a slow round-trip cannot let the next sweep issue a duplicate kill.
+            _closing.TryAdd(session.SessionId, 0);
+            try
+            {
+                var result = await DirectorCommandRouter.TrySendAsync(
+                    _sendCommand, directorId, "kill", session.SessionId, payload: null, ct);
+                if (result is null)
+                {
+                    // No active stream right now; drop the mark so a later sweep retries once the stream is back.
+                    _closing.TryRemove(session.SessionId, out _);
+                    FileLog.Write($"[AutoDismissSweeper] session={session.SessionId} director={directorId}: no stream, will retry");
+                    continue;
+                }
+                if (result.Ok)
+                {
+                    closed++;
+                    FileLog.Write($"[AutoDismissSweeper] closed session={session.SessionId} director={directorId} (verdict=done) over the stream");
+                }
+                else
+                {
+                    // A typed failure (e.g. NotFound = already gone) is terminal for this session; keep the
+                    // mark so we do not hammer it, and let its removal tombstone drop it from the snapshot.
+                    FileLog.Write($"[AutoDismissSweeper] session={session.SessionId} director={directorId}: close returned {result.Status}: {result.Error}");
+                }
+            }
+            catch (Exception ex)
+            {
+                _closing.TryRemove(session.SessionId, out _);
+                FileLog.Write($"[AutoDismissSweeper] close FAILED: session={session.SessionId} director={directorId}: {ex.Message}");
+            }
+        }
+
+        if (closed > 0)
+            FileLog.Write($"[AutoDismissSweeper] sweep closed {closed} auto-dismiss session(s)");
+        return closed;
+    }
+
+    /// <summary>Forget close-marks for sessions no longer present in the snapshot (they are gone, or their Director dropped).</summary>
+    private void PruneClosing(IReadOnlyList<(string DirectorId, SessionDto Session)> snapshot)
+    {
+        if (_closing.IsEmpty)
+            return;
+        var present = new HashSet<string>(snapshot.Select(t => t.Session.SessionId), StringComparer.Ordinal);
+        foreach (var sid in _closing.Keys)
+        {
+            if (!present.Contains(sid))
+                _closing.TryRemove(sid, out _);
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Running/DirectorCronSessionStarter.cs
+++ b/src/CcDirector.Gateway/Running/DirectorCronSessionStarter.cs
@@ -31,6 +31,10 @@ public sealed class DirectorCronSessionStarter : ICronSessionStarter
             RepoPath = job.Action.RepoPath,
             Agent = "ClaudeCode",
             PrePrompt = job.Action.Seed,
+            // Scheduled-run auto-dismiss (issue #1200): a seed run defaults to closing itself when it
+            // finishes with nothing needing a human, so an hourly job stops piling leftover sessions into
+            // the rail. The job can opt out (AutoDismiss=false) to keep the run open like a normal session.
+            AutoDismiss = job.Action.AutoDismiss,
         };
 
         FileLog.Write($"[DirectorCronSessionStarter] start: job={job.Id}, machine={job.Target.Machine}, repo={job.Action.RepoPath}, seed={job.Action.Seed}");

--- a/src/CcDirector.Gateway/Streaming/PushedSessionStore.cs
+++ b/src/CcDirector.Gateway/Streaming/PushedSessionStore.cs
@@ -227,6 +227,35 @@ public sealed class PushedSessionStore
         return null;
     }
 
+    /// <summary>
+    /// Issue #1200 (auto-dismiss sweep): enumerate every FRESH pushed session across all stream-connected
+    /// Directors, each paired with its owning directorId so the caller can address a command DOWN that
+    /// Director's stream. Applies the same active-connection + freshness rules as <see cref="TryGetFresh"/>
+    /// and returns deep COPIES with recomputed idle clocks, so a caller may inspect them without touching the
+    /// cache. A Director with no active connection or a stale cache contributes nothing.
+    /// </summary>
+    public IReadOnlyList<(string DirectorId, SessionDto Session)> SnapshotFresh(TimeSpan staleAfter)
+    {
+        var now = _utcNow();
+        var result = new List<(string, SessionDto)>();
+        foreach (var kvp in _byDirector)
+        {
+            var entry = kvp.Value;
+            lock (entry.Gate)
+            {
+                if (entry.ActiveConnectionId is null)
+                    continue;
+                if (entry.ReceivedAtUtc == DateTime.MinValue)
+                    continue;
+                if (now - entry.ReceivedAtUtc > staleAfter)
+                    continue;
+                foreach (var s in entry.Sessions.Values)
+                    result.Add((kvp.Key, RecomputeClocks(s.Clone(), now)));
+            }
+        }
+        return result;
+    }
+
     /// <summary>True when this Director currently has an active stream connection (used for diagnostics).</summary>
     public bool IsStreamConnected(string directorId) =>
         _byDirector.TryGetValue(directorId, out var entry) && entry.ActiveConnectionId is not null;


### PR DESCRIPTION
Closes #1200.

## Problem

Scheduled cron seed runs (for example the hourly inbound-watch skill) leave their session sitting in the rail after they finish, marked "needs you" by the dumb ten-second silence timer whether or not anything actually needs a human. Running something every hour piles up leftovers to close by hand, so the automation becomes more annoying than helpful.

## What this does

An automated run now closes itself when it finishes with nothing for the human, and stays open only when it genuinely needs one.

- **AutoDismiss flag** marks scheduled seed runs (`CronJobAction.AutoDismiss`, default true), threaded `NewSessionRequest` -> `Session` -> `SessionDto`. Only flagged sessions are ever auto-closed; human-started sessions are never touched.
- **Explicit verdict**: the agent ends its run with a `CC-DISMISS` block (`verdict: done | needs-human`), mirroring the work-list `IMPL-LOOP-TERMINAL` pattern. The Director parses it from the **transcript** (robust to the alternate/full screen), not the terminal, at each turn-end and stamps `Session.DismissVerdict`, which flows up on the session snapshot.
- **Close over the stream**: the Gateway auto-dismiss sweep closes a settled auto-dismiss session whose verdict is `done` by sending the `kill` verb DOWN the Director stream (`DirectorCommandRouter` / `GatewayHost.SendCommandAsync`) - never the Director's REST Control API. The `kill` is the existing graceful kill+remove, so it leaves no phantom "interrupted" journal entry. The sweep only runs with stream mode on; there is no REST fallback by design.
- **Conservative**: no verdict, `needs-human`, a mid-turn / permission state, or no active stream all leave the session open. A run is never closed without an explicit `done`.

First consumer: the `/inbound-watch` skill emits the verdict (`done` on a quiet day, `needs-human` when anything needs Soren). That skill is an untracked local file, so it is not part of this branch.

## Tests

- `DismissVerdictSignalTests` - parsing the CC-DISMISS block (done / needs-human / none / last-wins / fenced / bad verdict).
- `AutoDismissVerdictWatcherTests` - Director-side transcript read (fake reader) + stamping, and the no-transcript case.
- `AutoDismissSweeperTests` - the selection rule (auto-dismiss + done + settled), close over the stream with the `kill` verb, no double-close, and no-stream retry.
- `PushedSessionStoreTests` - the new `SnapshotFresh` enumeration and staleness exclusion.

Full solution builds clean (0 warnings, 0 errors). Regression: Gateway 1597 passed / 0 failed, Core 2874 passed / 8 pre-existing skips / 0 failed.

## Not yet done

Live end-to-end proof on the running Gateway (stream mode on) - watching a real hourly run close itself - still to do; the tests prove the logic, not the live loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
