### PR TITLE
Honest "Uploading from phone" vs "Transcribing" dictation state (#1181 Task 4)

### DIFF
--- a/packages/client-core/src/api/schema.ts
+++ b/packages/client-core/src/api/schema.ts
@@ -5290,6 +5290,7 @@ export interface components {
             voiceGenerating?: boolean;
             voiceAudioReady?: boolean;
             transcribing?: boolean;
+            dictationStatus?: null | string;
             wingmanEnabled?: boolean;
             remoteRepo?: string;
             remoteThreadUrl?: string;

--- a/packages/client-core/src/sessions/ordering.ts
+++ b/packages/client-core/src/sessions/ordering.ts
@@ -93,6 +93,9 @@ export function dotColor(color: string): string {
 // activity state. Never empty so every row reads cleanly.
 export function contextLine(s: SessionDto): string {
   if (s.onHold) return "On hold";
+  // Issue #1181, Task 4: the honest phase - "Uploading from phone" while the phone is still sending the
+  // audio up, "Transcribing" while the server turns it into text. Falls back to the old blanket flag.
+  if (s.dictationStatus) return s.dictationStatus;
   if (s.transcribing) return "Transcribing...";
   if (s.lastStatusReason) return s.lastStatusReason;
   return s.assessedState ?? s.activityState ?? s.status ?? "";

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -295,6 +295,18 @@ public sealed class SessionDto
     public bool Transcribing { get; set; }
 
     /// <summary>
+    /// Issue #1181, Task 4: the phone-dictation presentation sub-state - which PHASE an inbound
+    /// dictation is in, so a client can show the honest label instead of one blanket "Transcribing...".
+    /// One of: <c>"Uploading from phone"</c> (the phone is still sending the audio up - computed from the
+    /// durable PENDING delivery marker, so it never wedges); <c>"Transcribing"</c> (the audio is up and
+    /// the server is turning it into text - computed from an active transcription run, NOT the 90-second
+    /// idle mark); or <c>null</c> when no dictation is inbound. Stamped by the Gateway aggregator only
+    /// (always null in Director-local responses). Both non-null values drive the orange roster color; the
+    /// clients render this string as the label.
+    /// </summary>
+    public string? DictationStatus { get; set; }
+
+    /// <summary>
     /// Whether the Wingman experience is enabled for this session: auto-explain briefing on
     /// turn-end, Voice + Wingman tabs visible, Yellow "Wingman is reading" state available.
     /// Default OFF. When false the session behaves as a plain terminal -- clients hide the

--- a/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
@@ -94,9 +94,10 @@ public static class SessionOrdering
     /// </summary>
     public static string EffectiveColor(SessionDto s) =>
         s.OnHold ? "grey"
-        // Transcribing orange fires for EITHER source: the Gateway flag (mobile Speak, s.Transcribing) OR
-        // the Director raw fact (desktop dictation, s.IsTranscribing). Both yield orange today.
-        : (s.Transcribing || s.IsTranscribing) ? "orange"
+        // Transcribing orange fires for ANY dictation source: the Task 4 phase label (mobile Speak -
+        // "Uploading from phone" or "Transcribing", s.DictationStatus), the legacy Gateway flag
+        // (s.Transcribing), OR the Director raw fact (desktop dictation, s.IsTranscribing). All orange.
+        : (s.DictationStatus != null || s.Transcribing || s.IsTranscribing) ? "orange"
         // The Gateway user-initiated deep dive (issue #217) is orange, ungated.
         : IsExplaining(s) ? "orange"
         : IsBriefing(s) ? "yellow"
@@ -184,6 +185,10 @@ public static class SessionOrdering
     public static string StateLabel(SessionDto s)
     {
         if (s.OnHold) return "On hold";
+        // Issue #1181, Task 4: the honest phase label wins - "Uploading from phone" while the phone is still
+        // sending the audio, "Transcribing" while the server turns it into text. Falls back to the blanket
+        // "Transcribing" for the legacy flag / the desktop's own dictation.
+        if (s.DictationStatus is { } dictationPhase) return dictationPhase;
         if (s.Transcribing || s.IsTranscribing) return "Transcribing";
         if (IsExplaining(s)) return "Explaining";
         if (IsBriefing(s)) return "Wingman reading";

--- a/src/CcDirector.Gateway.Tests/DictationPresentationTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationPresentationTests.cs
@@ -1,0 +1,63 @@
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1181, Task 4: the phone-dictation presentation sub-state on the SessionDto fold. The Gateway
+/// stamps <see cref="SessionDto.DictationStatus"/> ("Uploading from phone" while the phone is still
+/// sending, "Transcribing" while the server works, null otherwise); these assert that the shared fold
+/// turns it into the right label and the orange color, and that the legacy path still works.
+/// </summary>
+public sealed class DictationPresentationTests
+{
+    private static SessionDto Base(string color = "red") => new()
+    {
+        SessionId = "s1",
+        StatusColor = color,
+        ActivityState = color == "red" ? "WaitingForInput" : "Working",
+        BriefingState = "None",
+    };
+
+    [Fact]
+    public void StateLabel_UploadingFromPhone_ShowsThatPhase()
+    {
+        var s = Base();
+        s.DictationStatus = "Uploading from phone";
+        Assert.Equal("Uploading from phone", SessionOrdering.StateLabel(s));
+    }
+
+    [Fact]
+    public void StateLabel_Transcribing_ShowsThatPhase()
+    {
+        var s = Base();
+        s.DictationStatus = "Transcribing";
+        Assert.Equal("Transcribing", SessionOrdering.StateLabel(s));
+    }
+
+    [Theory]
+    [InlineData("Uploading from phone")]
+    [InlineData("Transcribing")]
+    public void EffectiveColor_IsOrange_WhileADictationIsInbound_EvenOverRed(string phase)
+    {
+        var s = Base("red"); // would be red "needs you" without the dictation
+        s.DictationStatus = phase;
+        Assert.Equal("orange", SessionOrdering.EffectiveColor(s));
+    }
+
+    [Fact]
+    public void StateLabel_FallsBackToTranscribing_ForLegacyFlagWithoutPhase()
+    {
+        var s = Base();
+        s.Transcribing = true; // legacy blanket flag, no DictationStatus
+        Assert.Equal("Transcribing", SessionOrdering.StateLabel(s));
+    }
+
+    [Fact]
+    public void NoDictation_IsNotOrange_AndKeepsBaseLabel()
+    {
+        var s = Base("red");
+        Assert.NotEqual("orange", SessionOrdering.EffectiveColor(s));
+        Assert.Equal("Needs you", SessionOrdering.StateLabel(s));
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -168,7 +168,7 @@ internal static class GatewayDictationEndpoint
             // from then on, so there is no age-swept cache window.
             var entry = _completes.GetOrAdd(uploadId, id => new CompleteEntry(
                 new Lazy<Task<DictationOutcome>>(() => RunCompleteCoreAsync(
-                    id, req, uploads, registry, client, owners, transcription))));
+                    id, req, uploads, registry, client, owners, transcription, transcribingSessions))));
 
             DictationOutcome outcome;
             try
@@ -270,9 +270,14 @@ internal static class GatewayDictationEndpoint
 
     private static async Task<DictationOutcome> RunCompleteCoreAsync(
         string uploadId, DictationCompleteRequest req, VoiceUploadStore uploads, DirectorRegistry registry,
-        DirectorEndpointClient client, SessionOwnerCache? owners, GatewayTranscriptionService transcription)
+        DirectorEndpointClient client, SessionOwnerCache? owners, GatewayTranscriptionService transcription,
+        TranscribingSessions transcribingSessions)
     {
         var sid = req.SessionId!;
+        // Issue #1181, Task 4: this run assembles + transcribes + delivers, so mark the session ACTIVELY
+        // transcribing for its duration. The aggregator reads this to show "Transcribing" (vs the durable
+        // PENDING marker's "Uploading from phone"). Cleared in the finally so it never outlives the run.
+        transcribingSessions.MarkActivelyTranscribing(sid);
         try
         {
             // The configured mode's key must be present before we pay the reassembly + transcribe cost.
@@ -361,6 +366,12 @@ internal static class GatewayDictationEndpoint
         {
             FileLog.Write($"[GatewayDictation] complete sid={sid} uploadId={uploadId} FAILED: {ex.Message}");
             return DictationOutcome.Error(StatusCodes.Status502BadGateway, ex.Message);
+        }
+        finally
+        {
+            // Issue #1181, Task 4: the transcription run is over (delivered, failed, or threw), so drop the
+            // "Transcribing" mark. The durable PENDING/DELIVERED marker now owns the session's state.
+            transcribingSessions.ClearActivelyTranscribing(sid);
         }
     }
 

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -48,6 +48,7 @@ internal static class GatewayEndpoints
         Func<string, Core.HostedAi.HostedAiState?>? voiceUnavailableFor = null,
         Func<string, bool, DateTime?>? needsYouStampFor = null,
         Func<string, bool>? transcribingFor = null,
+        Func<string, string?>? dictationStatusFor = null,
         Transcription.TranscribingSessions? transcribingSessions = null,
         Func<string, (string? RailLine, string? Headline)>? interruptedBriefFor = null,
         Func<string, List<TurnBriefDto>>? briefHistoryFor = null,
@@ -578,6 +579,11 @@ internal static class GatewayEndpoints
                     // (a transcribing session is not "needs you") when the clock reads the final color.
                     if (transcribingFor is not null)
                         s.Transcribing = transcribingFor(s.SessionId);
+                    // Issue #1181, Task 4: the honest phase label - "Uploading from phone" (durable PENDING
+                    // marker) vs "Transcribing" (active run). Drives the same orange, but the clients render
+                    // this string so the user knows whether it is their phone still uploading or the server.
+                    if (dictationStatusFor is not null)
+                        s.DictationStatus = dictationStatusFor(s.SessionId);
                     // The authoritative presentation fold (EffectiveColor / StateLabel / TriageBucket /
                     // NeedsYouSince) is stamped in ONE post-pass AFTER this loop assembles the whole fleet -
                     // see StampFleetRolesAndFold below. It is deferred because SessionRole (which the fold

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -915,6 +915,14 @@ public sealed class GatewayHost : IAsyncDisposable
             // Stamp the orange "Transcribing..." flag while a dictated utterance is being uploaded
             // and transcribed in the background for this session (mobile Speak -> Send).
             transcribingFor: sid => _transcribingSessions.IsTranscribing(sid),
+            // Issue #1181, Task 4: the honest phase label. "Transcribing" while the server is actively
+            // turning the uploaded audio into text (a bounded run); otherwise "Uploading from phone" while
+            // the durable PENDING delivery marker stands (the phone is still sending, and this never wedges
+            // because the marker clears only on delivery/abandon); null when no dictation is inbound.
+            dictationStatusFor: sid =>
+                _transcribingSessions.IsActivelyTranscribing(sid) ? "Transcribing"
+                : _dictationUploads.IsSessionLocked(sid) ? "Uploading from phone"
+                : null,
             // The mobile Speak flow marks/clears this via POST /sessions/{sid}/transcribing.
             transcribingSessions: _transcribingSessions,
             // Issue #212 W3: enrich the Interrupted sessions list from the durable brief store. Always

--- a/src/CcDirector.Gateway/Transcription/TranscribingSessions.cs
+++ b/src/CcDirector.Gateway/Transcription/TranscribingSessions.cs
@@ -89,4 +89,31 @@ public sealed class TranscribingSessions
             FileLog.Write($"[TranscribingSessions] sid={sessionId}: mark idle for over {IdleTimeout.TotalSeconds:0}s, cleared");
         return false;
     }
+
+    // ===== Issue #1181, Task 4: the actual transcription-run phase =====
+    // The marks above cover the WHOLE mobile-Speak window (upload + transcribe) and carry an idle
+    // backstop. Task 4 splits the presentation into "Uploading from phone" (from the durable PENDING
+    // marker) vs "Transcribing" (the server actively turning audio into text). This second set is the
+    // "actively transcribing" signal: set for the duration of the assemble+transcribe+deliver run and
+    // cleared in a finally. No idle timeout is needed - it is bounded by the run; if a crash leaks an
+    // entry, the Gateway restart clears it (in-memory) and the durable marker still shows "Uploading".
+    private readonly ConcurrentDictionary<string, byte> _activelyTranscribing = new();
+
+    /// <summary>Mark a session as ACTIVELY transcribing (the complete-run is assembling/transcribing).</summary>
+    public void MarkActivelyTranscribing(string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId)) return;
+        _activelyTranscribing[sessionId] = 1;
+    }
+
+    /// <summary>Clear the actively-transcribing mark (called in the complete-run's finally).</summary>
+    public void ClearActivelyTranscribing(string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId)) return;
+        _activelyTranscribing.TryRemove(sessionId, out _);
+    }
+
+    /// <summary>True while the server is actively transcribing this session's uploaded audio.</summary>
+    public bool IsActivelyTranscribing(string sessionId)
+        => !string.IsNullOrEmpty(sessionId) && _activelyTranscribing.ContainsKey(sessionId);
 }


### PR DESCRIPTION
Part of issue thefrederiksen/devthrottle_internal#724 (make mobile dictation robust) - Task 4, the presentation sub-state.

## What it does
Splits the one blanket "Transcribing..." roster state into two honest phases, computed once at the Gateway so the phone, cockpit, and desktop all show the same label:
- **"Uploading from phone"** while the phone is still sending the audio up - computed from the durable PENDING delivery marker (#1188), so it never wedges (clears only on delivery/abandon, not a timer).
- **"Transcribing"** while the server is actually turning the uploaded audio into text - computed from an active transcription run (a new bounded, self-clearing signal), NOT the 90-second idle mark.

Both phases still drive the orange roster color; only the label differs.

## How
- New `SessionDto.DictationStatus` carries the phase (`"Uploading from phone"` | `"Transcribing"` | null), stamped by the Gateway aggregator.
- `SessionOrdering.StateLabel` returns it (cockpit shows it with no change) and `EffectiveColor` oranges on it.
- The phone's `contextLine` renders it; `gen:api` added the field to the TypeScript type.
- `TranscribingSessions` gains an "actively transcribing" set, set/cleared around the assemble+transcribe run.

## Testing
- 6 new unit tests (phase -> label + orange, legacy fallback); 124 existing Gateway tests pass; client-core builds and the mobile app typechecks.
- Verified live on the deployed Gateway: a session with an inbound upload marker returns `dictationStatus`/`stateLabel` "Uploading from phone" and `effectiveColor` "orange".

🤖 Generated with [Claude Code](https://claude.com/claude-code)