### PR TITLE
[Cockpit] Fleet sweep stability (Gateway backend) - grace window + stale envelope (#1215)

### DIFF
--- a/docs/proof/issue-1215/diagnosis.md
+++ b/docs/proof/issue-1215/diagnosis.md
@@ -1,0 +1,84 @@
+# Issue #1215 diagnosis - where a single failed poll drops a Director's sessions
+
+## Summary
+
+The blink is a presentation defect in the roster aggregation, exactly as the issue
+predicted. The `DirectorRegistry` mechanisms (heartbeat timeout, reachability circuit,
+unreachable cooldown, stale sweeper) are sound and are NOT the cause. The defect is in
+the aggregated `GET /sessions` handler: when a single poll to one Director fails, that
+Director's sessions are removed from the aggregated response for that refresh, then
+reappear on the next successful poll.
+
+## Exact code path
+
+File: `src/CcDirector.Gateway/Api/GatewayEndpoints.cs`, the `GET /sessions` handler
+(the roster fan-out that aggregates every Director's sessions).
+
+1. Fan-out per Director (before this change, lines 424-473). For each Director the
+   handler either serves from the pushed cache, short-circuits with an error for a
+   flagged / cooling-down / no-endpoint Director, or pulls over HTTP via
+   `client.ListSessionsWithStatusAsync(ep, includeExitedActual)`. A failed pull returns
+   `(Director: d, Sessions: null, Error: <reason>)` and calls
+   `registry.RecordUnreachable(d.DirectorId, error)`.
+
+2. Aggregation loop (before this change, the original lines 480-492):
+
+   ```csharp
+   foreach (var (d, sessions, error) in results)
+   {
+       if (error is not null)
+       {
+           machineErrors.Add(new MachineErrorDto
+           {
+               DirectorId = d.DirectorId,
+               MachineName = d.MachineName,
+               Error = error,
+           });
+           continue;   // <-- THE DEFECT: the Director's sessions are dropped for this refresh
+       }
+       if (sessions is null) continue;
+       ...
+   }
+   ```
+
+   The `continue` on any non-null `error` means a SINGLE failed poll cycle removes that
+   Director's whole session group from `all` (the aggregated list) and from the envelope's
+   `sessions`. There is no last-known-good retention: the very next successful poll puts the
+   sessions back. Between those two refreshes the Cockpit sees the sessions vanish and then
+   reappear - the "blink".
+
+3. Result assembly and return (before this change, the original lines 606-610):
+
+   ```csharp
+   if (envelope == true)
+       return Results.Json(new { sessions = all, machineErrors });
+   return Results.Json(all);
+   ```
+
+   So both the plain array response and the `?envelope=true` response lose the Director's
+   sessions on the failed cycle. The envelope only gained a `machineErrors` entry (a binary
+   "reachable / unreachable"); it had no notion of "briefly wobbly, still show the last-known
+   sessions".
+
+## Why the registry is not at fault
+
+`DirectorRegistry` keeps the Director registered across a transient miss - its
+`HttpHeartbeatTimeout` is 60 s, its `UnreachableEvictAfter` is 3 minutes, and its
+reachability circuit only opens after `MaxConsecutiveFailures` (3) probe failures. So on
+a one-cycle network hiccup the Director is still in `ListDirectors()`; it is only its
+per-refresh SESSION list that the aggregation drops. The fix therefore belongs in the
+aggregation/presentation layer (this handler), not in the registry, and must not change
+any registry constant.
+
+## Fix direction (implemented in this pull request)
+
+Introduce a Gateway-side last-known-good roster cache
+(`src/CcDirector.Gateway/Discovery/FleetRosterCache.cs`) with a defined grace window of
+`GraceWindowPollCycles = 3` failed poll cycles. On a failed poll the aggregation now
+consults the cache instead of dropping: within the grace window it serves the stored
+snapshot marked Wobbly (with a last-seen timestamp and age); once the grace window is
+exhausted it declares the Director Offline and drops the sessions exactly as before (so a
+genuinely down machine still reads as down promptly, well inside the registry's existing
+eviction bounds). The envelope gains a `directors` array carrying each Director's
+reachability state (online / wobbly / offline) and last-seen age. This is a defined
+presentation state, not a silent retry that hides an outage.

--- a/docs/proof/issue-1215/roster-envelope-shape.md
+++ b/docs/proof/issue-1215/roster-envelope-shape.md
@@ -1,0 +1,122 @@
+# Issue #1215 - roster envelope shape, before and after
+
+`GET /sessions?envelope=true` is what the Cockpit fleet surfaces read
+(`packages/client-core/src/fleet/fleetClient.ts` -> `getSessionsEnvelope`).
+
+A live capture from the running Gateway on `http://127.0.0.1:7878/sessions?envelope=true`
+returned HTTP 401 (the auth gate is ON by default, issue #917 - a credential is required
+even on loopback), so the shapes below are documented from the contract types and the
+unit-tested behaviour of `FleetRosterCache`, per the issue's "captured JSON or documented
+shape" acceptance option.
+
+## BEFORE (drop-on-first-failure)
+
+On a single failed poll to a Director, its sessions were removed from `sessions` for that
+refresh and it appeared only as a `machineErrors` entry. There was no last-known-good
+retention and no "wobbly" concept.
+
+```json
+{
+  "sessions": [
+    { "sessionId": "s-100", "directorId": "dir-A", "name": "build", "activityState": "Working" }
+  ],
+  "machineErrors": [
+    { "directorId": "dir-B", "machineName": "desktop-2", "error": "timeout" }
+  ]
+}
+```
+
+Note: `dir-B`'s sessions are simply GONE from `sessions` on the failed cycle, then
+reappear on the next successful one - the blink.
+
+## AFTER (grace window + stale envelope)
+
+The envelope keeps `sessions` and `machineErrors` unchanged for back-compat, and adds a
+`directors` array: one reachability record per Director the fan-out considered, with the
+three-state marker and a last-seen age. A Wobbly Director's sessions STAY in `sessions`
+(served from the last-known-good snapshot); they are not dropped.
+
+New field types (camelCase on the wire):
+
+- `directors[].directorId` : string
+- `directors[].machineName` : string
+- `directors[].state` : string, one of `"online"`, `"wobbly"`, `"offline"`
+- `directors[].lastSeenUtc` : string | null (ISO 8601 UTC)
+- `directors[].lastSeenAgeSeconds` : number | null (0 when online, null when never seen)
+- `directors[].error` : string | null (the failure reason for wobbly/offline; null when online)
+
+### Example: dir-A online, dir-B WOBBLY (transient miss absorbed, sessions retained)
+
+```json
+{
+  "sessions": [
+    { "sessionId": "s-100", "directorId": "dir-A", "name": "build", "activityState": "Working" },
+    { "sessionId": "s-200", "directorId": "dir-B", "name": "tests", "activityState": "Idle" }
+  ],
+  "machineErrors": [],
+  "directors": [
+    {
+      "directorId": "dir-A",
+      "machineName": "desktop-1",
+      "state": "online",
+      "lastSeenUtc": "2026-07-10T12:00:10Z",
+      "lastSeenAgeSeconds": 0,
+      "error": null
+    },
+    {
+      "directorId": "dir-B",
+      "machineName": "desktop-2",
+      "state": "wobbly",
+      "lastSeenUtc": "2026-07-10T12:00:05Z",
+      "lastSeenAgeSeconds": 5,
+      "error": "timeout"
+    }
+  ]
+}
+```
+
+`dir-B`'s `s-200` is still present in `sessions` (served stale). The Cockpit joins
+`session.directorId` -> `directors[].state` and dims `s-200` in place, showing
+"last seen 5 seconds ago". Nothing disappears, nothing reflows.
+
+### Example: dir-B OFFLINE (grace window exhausted)
+
+After `FleetRosterCache.GraceWindowPollCycles` (3) consecutive failed cycles, the next
+failure drops dir-B's sessions and marks it offline. This matches the historical drop
+behaviour, so a genuinely down machine still reads as down:
+
+```json
+{
+  "sessions": [
+    { "sessionId": "s-100", "directorId": "dir-A", "name": "build", "activityState": "Working" }
+  ],
+  "machineErrors": [
+    { "directorId": "dir-B", "machineName": "desktop-2", "error": "timeout" }
+  ],
+  "directors": [
+    { "directorId": "dir-A", "machineName": "desktop-1", "state": "online",  "lastSeenUtc": "2026-07-10T12:00:20Z", "lastSeenAgeSeconds": 0,  "error": null },
+    { "directorId": "dir-B", "machineName": "desktop-2", "state": "offline", "lastSeenUtc": "2026-07-10T12:00:05Z", "lastSeenAgeSeconds": 15, "error": "timeout" }
+  ]
+}
+```
+
+## Grace-window constant
+
+`FleetRosterCache.GraceWindowPollCycles = 3` (a named constant with an explanatory
+comment in `src/CcDirector.Gateway/Discovery/FleetRosterCache.cs`). Counted in poll
+cycles, matching how `DirectorRegistry`'s reachability circuit counts consecutive
+failures. Three cycles is far shorter than the registry's outer bounds (60 s heartbeat
+timeout, 3 min unreachable-evict), so Offline is still reached promptly and within those
+bounds - the fix never extends them.
+
+## State-transition proof (unit tests)
+
+`src/CcDirector.Gateway.Tests/FleetRosterCacheTests.cs`, all passing:
+
+- `ReachableThenWobblyThenReachable_AbsorbsTransientMiss` (reachable -> wobbly -> reachable)
+- `ReachableThenWobblyThenOffline_TransitionsOnceAfterGraceWindow` (reachable -> wobbly -> offline)
+- `OfflineThenReachable_ReappearsOnline` (offline -> reachable)
+- `RecordUnreachable_NeverReachable_IsOfflineWithNoSnapshot`
+- `WobblyServe_RecomputesIdleClockFromLastActivity`
+- `Forget_ClearsSnapshot_NextFailureIsOffline`
+- `RecordReachable_StoresSnapshot_ReadsOnline`

--- a/packages/client-core/src/fleet/fleetClient.ts
+++ b/packages/client-core/src/fleet/fleetClient.ts
@@ -76,16 +76,49 @@ export interface MachineError {
   error?: string;
 }
 
-// The envelope shape GET /sessions returns with ?envelope=true: the live sessions AND the machines
-// that failed this fan-out. (Plain GET /sessions - api/client listSessions - returns just the array;
-// the Fleet and Directors pages need the machineErrors too, so they ask for the envelope.)
+// The three fleet-sweep presentation states (issue #1215, Cockpit plan phase 6). A Director reads as:
+//  - "online": its last poll succeeded.
+//  - "wobbly": a recent poll failed but is absorbed by the Gateway's grace window - its last-known-good
+//    sessions are STILL in the roster (served stale), shown dimmed with a "last seen N seconds ago" age.
+//  - "offline": the grace window is exhausted; its sessions are dropped from the roster.
+export const REACHABILITY_ONLINE = "online";
+export const REACHABILITY_WOBBLY = "wobbly";
+export const REACHABILITY_OFFLINE = "offline";
+export type ReachabilityState =
+  | typeof REACHABILITY_ONLINE
+  | typeof REACHABILITY_WOBBLY
+  | typeof REACHABILITY_OFFLINE;
+
+// One Director's reachability presentation in the roster envelope (issue #1215). The Cockpit joins a
+// session to its Director by directorId (also stamped on SessionDto.directorId) to decide how to render
+// it, so the list changes appearance IN PLACE and never reflows because of a transient miss.
+export interface DirectorReachability {
+  directorId: string;
+  machineName?: string;
+  /** "online" | "wobbly" | "offline". */
+  state: ReachabilityState;
+  /** When the Gateway last read this Director's sessions (ISO 8601 UTC), or null if never. */
+  lastSeenUtc?: string | null;
+  /** Seconds since last seen, computed by the Gateway at serve time (0 when online, null when never). */
+  lastSeenAgeSeconds?: number | null;
+  /** The last poll's failure reason for wobbly/offline; null while online. */
+  error?: string | null;
+}
+
+// The envelope shape GET /sessions returns with ?envelope=true: the live sessions, the machines that
+// failed this fan-out, AND the per-Director reachability presentation (issue #1215). (Plain GET
+// /sessions - api/client listSessions - returns just the array; the Fleet and Directors pages need the
+// machineErrors and reachability too, so they ask for the envelope.)
 export interface SessionsEnvelope {
   sessions: SessionDto[];
   machineErrors: MachineError[];
+  /** Per-Director reachability for the Online / Wobbly / Offline rendering (issue #1215). */
+  directors: DirectorReachability[];
 }
 
-// GET /sessions?envelope=true - the roster plus the unreachable-machine list. Throws GatewayError on
-// non-2xx so the page surfaces the failure rather than showing a silently empty roster.
+// GET /sessions?envelope=true - the roster plus the unreachable-machine list and per-Director
+// reachability. Throws GatewayError on non-2xx so the page surfaces the failure rather than showing a
+// silently empty roster.
 export async function getSessionsEnvelope(signal?: AbortSignal): Promise<SessionsEnvelope> {
   const res = await fetch("/sessions?envelope=true", {
     method: "GET",
@@ -96,7 +129,11 @@ export async function getSessionsEnvelope(signal?: AbortSignal): Promise<Session
     throw new GatewayError(res.status, `GET /sessions?envelope=true failed: ${res.status}`);
   }
   const body = (await res.json()) as Partial<SessionsEnvelope>;
-  return { sessions: body.sessions ?? [], machineErrors: body.machineErrors ?? [] };
+  return {
+    sessions: body.sessions ?? [],
+    machineErrors: body.machineErrors ?? [],
+    directors: body.directors ?? [],
+  };
 }
 
 // PATCH /sessions/{sid} { name } - rename a session; the Gateway routes to the owning Director and

--- a/src/CcDirector.Gateway.Contracts/DirectorReachabilityDto.cs
+++ b/src/CcDirector.Gateway.Contracts/DirectorReachabilityDto.cs
@@ -1,0 +1,57 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// Issue #1215 (Cockpit plan phase 6): the per-Director reachability presentation record carried in
+/// the envelope response of <c>GET /sessions?envelope=true</c>. It gives the Cockpit the three states
+/// it renders in place - Online, Wobbly (a recent poll failure absorbed by the grace window, its
+/// last-known-good sessions still served but shown dimmed with a "last seen N seconds ago" age), and
+/// Offline (the grace window is exhausted, the Director's sessions are dropped).
+///
+/// One entry per Director the roster fan-out considered on this refresh. The Cockpit joins a session
+/// to its Director by <see cref="DirectorId"/> (also stamped on each <c>SessionDto.DirectorId</c>) to
+/// decide how to present that session, so the list changes appearance in place and never reflows just
+/// because one Director missed a single poll.
+/// </summary>
+public sealed class DirectorReachabilityDto
+{
+    /// <summary>The Director this reachability record describes (matches <c>SessionDto.DirectorId</c>).</summary>
+    public string DirectorId { get; set; } = "";
+
+    /// <summary>Machine hostname (best-effort copy of the Director's registered MachineName).</summary>
+    public string MachineName { get; set; } = "";
+
+    /// <summary>
+    /// The presentation state, one of <see cref="StateOnline"/>, <see cref="StateWobbly"/>, or
+    /// <see cref="StateOffline"/>. Never null.
+    /// </summary>
+    public string State { get; set; } = StateOnline;
+
+    /// <summary>
+    /// When the Gateway last successfully read this Director's sessions (ISO 8601 UTC on the wire), or
+    /// null if it has never been reached. For <see cref="StateWobbly"/> this is the timestamp of the
+    /// last-known-good snapshot being served; for <see cref="StateOnline"/> it is this refresh.
+    /// </summary>
+    public DateTime? LastSeenUtc { get; set; }
+
+    /// <summary>
+    /// How long ago (seconds) the Director was last seen, computed at serve time so the client renders
+    /// "last seen N seconds ago" without depending on its own clock being in sync with the Gateway's.
+    /// Zero for <see cref="StateOnline"/>; null when never seen.
+    /// </summary>
+    public double? LastSeenAgeSeconds { get; set; }
+
+    /// <summary>
+    /// The reason the last poll failed, for <see cref="StateWobbly"/> and <see cref="StateOffline"/>.
+    /// Null while <see cref="StateOnline"/>.
+    /// </summary>
+    public string? Error { get; set; }
+
+    /// <summary>Fully reachable: the last poll succeeded.</summary>
+    public const string StateOnline = "online";
+
+    /// <summary>Recent poll failures absorbed by the grace window; last-known-good sessions are still served, dimmed.</summary>
+    public const string StateWobbly = "wobbly";
+
+    /// <summary>The grace window is exhausted; the Director's sessions are dropped from the roster.</summary>
+    public const string StateOffline = "offline";
+}

--- a/src/CcDirector.Gateway.Tests/FleetRosterCacheTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetRosterCacheTests.cs
@@ -1,0 +1,180 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="FleetRosterCache"/> - the last-known-good roster grace window (issue #1215,
+/// Cockpit plan phase 6). Each test drives an injected clock so the last-seen and idle-clock behaviour is
+/// deterministic. The three named transitions the issue calls out are covered explicitly:
+/// reachable -> wobbly -> reachable, reachable -> wobbly -> offline, and offline -> reachable.
+/// </summary>
+public sealed class FleetRosterCacheTests
+{
+    private DateTime _now = new(2026, 7, 10, 12, 0, 0, DateTimeKind.Utc);
+
+    private FleetRosterCache NewCache() => new(() => _now);
+
+    private static SessionDto Session(string id, string state = "Working", DateTime? lastActivity = null) => new()
+    {
+        SessionId = id,
+        ActivityState = state,
+        LastActivityAt = lastActivity,
+    };
+
+    [Fact]
+    public void RecordReachable_StoresSnapshot_ReadsOnline()
+    {
+        // Arrange
+        var cache = NewCache();
+
+        // Act
+        var projection = cache.RecordReachable("dir-A", new[] { Session("s1"), Session("s2") });
+
+        // Assert
+        Assert.Equal(FleetReachabilityState.Online, projection.State);
+        Assert.Equal(_now, projection.LastSeenUtc);
+        Assert.Equal(0, projection.LastSeenAgeSeconds);
+        Assert.Null(projection.StaleSessions);
+    }
+
+    [Fact]
+    public void ReachableThenWobblyThenReachable_AbsorbsTransientMiss()
+    {
+        // Arrange
+        var cache = NewCache();
+        cache.RecordReachable("dir-A", new[] { Session("s1"), Session("s2") });
+        var seenAt = _now;
+
+        // Act - one failed poll cycle inside the grace window
+        _now = _now.AddSeconds(5);
+        var wobbly = cache.RecordUnreachable("dir-A", "timeout");
+
+        // Assert - served stale, nothing dropped, marked with the last-seen time and age
+        Assert.Equal(FleetReachabilityState.Wobbly, wobbly.State);
+        Assert.NotNull(wobbly.StaleSessions);
+        Assert.Equal(2, wobbly.StaleSessions!.Count);
+        Assert.Contains(wobbly.StaleSessions, s => s.SessionId == "s1");
+        Assert.Contains(wobbly.StaleSessions, s => s.SessionId == "s2");
+        Assert.Equal(seenAt, wobbly.LastSeenUtc);
+        Assert.Equal(5, wobbly.LastSeenAgeSeconds);
+
+        // Act - the Director answers again
+        _now = _now.AddSeconds(5);
+        var backOnline = cache.RecordReachable("dir-A", new[] { Session("s1") });
+
+        // Assert - back to Online, streak reset, last-seen refreshed
+        Assert.Equal(FleetReachabilityState.Online, backOnline.State);
+        Assert.Equal(_now, backOnline.LastSeenUtc);
+        Assert.Equal(0, backOnline.LastSeenAgeSeconds);
+    }
+
+    [Fact]
+    public void ReachableThenWobblyThenOffline_TransitionsOnceAfterGraceWindow()
+    {
+        // Arrange
+        var cache = NewCache();
+        cache.RecordReachable("dir-A", new[] { Session("s1") });
+
+        // Act + Assert - every failure up to and including the grace-window count stays Wobbly (served stale)
+        for (int cycle = 1; cycle <= FleetRosterCache.GraceWindowPollCycles; cycle++)
+        {
+            _now = _now.AddSeconds(2);
+            var projection = cache.RecordUnreachable("dir-A", "timeout");
+            Assert.Equal(FleetReachabilityState.Wobbly, projection.State);
+            Assert.NotNull(projection.StaleSessions);
+            Assert.Single(projection.StaleSessions!);
+        }
+
+        // Act - one failure past the grace window
+        _now = _now.AddSeconds(2);
+        var offline = cache.RecordUnreachable("dir-A", "timeout");
+
+        // Assert - Offline, sessions dropped (nothing to serve), but last-seen is still reported
+        Assert.Equal(FleetReachabilityState.Offline, offline.State);
+        Assert.Null(offline.StaleSessions);
+        Assert.NotNull(offline.LastSeenUtc);
+        Assert.NotNull(offline.LastSeenAgeSeconds);
+    }
+
+    [Fact]
+    public void OfflineThenReachable_ReappearsOnline()
+    {
+        // Arrange - drive the Director all the way to Offline
+        var cache = NewCache();
+        cache.RecordReachable("dir-A", new[] { Session("s1") });
+        for (int cycle = 0; cycle <= FleetRosterCache.GraceWindowPollCycles; cycle++)
+        {
+            _now = _now.AddSeconds(2);
+            cache.RecordUnreachable("dir-A", "timeout");
+        }
+        // Confirm it is Offline before the recovery.
+        _now = _now.AddSeconds(2);
+        Assert.Equal(FleetReachabilityState.Offline, cache.RecordUnreachable("dir-A", "timeout").State);
+
+        // Act - the machine comes back
+        _now = _now.AddSeconds(2);
+        var backOnline = cache.RecordReachable("dir-A", new[] { Session("s9") });
+
+        // Assert - Online again, and the freshly stored snapshot (not the discarded old one) is what a
+        // subsequent Wobbly serves.
+        Assert.Equal(FleetReachabilityState.Online, backOnline.State);
+        _now = _now.AddSeconds(2);
+        var wobbly = cache.RecordUnreachable("dir-A", "timeout");
+        Assert.Equal(FleetReachabilityState.Wobbly, wobbly.State);
+        Assert.NotNull(wobbly.StaleSessions);
+        Assert.Single(wobbly.StaleSessions!);
+        Assert.Equal("s9", wobbly.StaleSessions![0].SessionId);
+    }
+
+    [Fact]
+    public void RecordUnreachable_NeverReachable_IsOfflineWithNoSnapshot()
+    {
+        // Arrange
+        var cache = NewCache();
+
+        // Act - a Director that failed its very first poll (no last-known-good ever stored)
+        var projection = cache.RecordUnreachable("dir-A", "endpoint never answered");
+
+        // Assert - Offline immediately, nothing to serve, and no last-seen time to report
+        Assert.Equal(FleetReachabilityState.Offline, projection.State);
+        Assert.Null(projection.StaleSessions);
+        Assert.Null(projection.LastSeenUtc);
+        Assert.Null(projection.LastSeenAgeSeconds);
+    }
+
+    [Fact]
+    public void WobblyServe_RecomputesIdleClockFromLastActivity()
+    {
+        // Arrange - a session last active 10 seconds before the successful read
+        var cache = NewCache();
+        var lastActivity = _now.AddSeconds(-10);
+        cache.RecordReachable("dir-A", new[] { Session("s1", lastActivity: lastActivity) });
+
+        // Act - a failed poll 30 seconds later serves the stale snapshot
+        _now = _now.AddSeconds(30);
+        var wobbly = cache.RecordUnreachable("dir-A", "timeout");
+
+        // Assert - the served copy's idle clock advanced to now - lastActivity (40s), not the frozen value
+        Assert.Equal(FleetReachabilityState.Wobbly, wobbly.State);
+        Assert.NotNull(wobbly.StaleSessions);
+        Assert.Equal(40, wobbly.StaleSessions![0].IdleSeconds);
+    }
+
+    [Fact]
+    public void Forget_ClearsSnapshot_NextFailureIsOffline()
+    {
+        // Arrange
+        var cache = NewCache();
+        cache.RecordReachable("dir-A", new[] { Session("s1") });
+
+        // Act - the Director is unregistered/evicted, then a later stray failure is recorded
+        cache.Forget("dir-A");
+        var projection = cache.RecordUnreachable("dir-A", "unreachable");
+
+        // Assert - no cached snapshot survives, so it reads Offline rather than serving stale sessions
+        Assert.Equal(FleetReachabilityState.Offline, projection.State);
+        Assert.Null(projection.StaleSessions);
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -66,7 +66,12 @@ internal static class GatewayEndpoints
         // stream via this hook (GatewayHost.SendCommandAsync); a null return means the Director is not
         // stream-connected, so the endpoint falls back to its existing HTTP call. Null here (stream mode
         // off) keeps every command endpoint on the HTTP path, byte-identical to before.
-        DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = null)
+        DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = null,
+        // Issue #1215 (Cockpit plan phase 6): the last-known-good roster cache. When non-null, a single
+        // failed Director poll no longer drops that Director's sessions - the cache serves the last-known-good
+        // snapshot marked stale (Wobbly) through a short grace window, and only declares the Director Offline
+        // once the grace window is exhausted. Null keeps the old drop-on-first-failure behaviour.
+        FleetRosterCache? rosterCache = null)
     {
         // Issue #1188: the enforced session lock. A session is LOCKED for human input exactly while a PENDING
         // dictation record exists for it (a pure projection of the durable record - it never auto-releases;
@@ -476,35 +481,105 @@ internal static class GatewayEndpoints
 
             var all = new List<SessionDto>();
             var machineErrors = new List<MachineErrorDto>();
+            var reachability = new List<DirectorReachabilityDto>();
 
+            // Issue #1215 (Cockpit plan phase 6): first pass - decide, per Director, WHAT to serve and
+            // its reachability state, before any per-session enrichment runs. A successful read is served
+            // as Online. A failed read is handed to the last-known-good cache, which either keeps serving
+            // that Director's stored snapshot marked stale (Wobbly, inside the grace window) or, once the
+            // grace window is exhausted, declares it Offline and drops its sessions. Serving the stale
+            // snapshot through the SAME enrichment below is what makes a transient miss change the entries'
+            // appearance in place instead of removing them, so the roster never reflows.
+            var served = new List<(DirectorDto Director, List<SessionDto> Sessions, bool Stale)>();
             foreach (var (d, sessions, error) in results)
             {
-                if (error is not null)
+                if (error is null && sessions is not null)
+                {
+                    if (rosterCache is not null)
+                        rosterCache.RecordReachable(d.DirectorId, sessions);
+                    reachability.Add(new DirectorReachabilityDto
+                    {
+                        DirectorId = d.DirectorId,
+                        MachineName = d.MachineName ?? "",
+                        State = DirectorReachabilityDto.StateOnline,
+                        LastSeenUtc = DateTime.UtcNow,
+                        LastSeenAgeSeconds = 0,
+                        Error = null,
+                    });
+                    served.Add((d, sessions, Stale: false));
+                    continue;
+                }
+
+                // A failed read. Without the last-known-good cache, keep the historical behaviour: drop
+                // the Director's sessions and surface it as a machine error immediately.
+                var reason = error ?? "unreachable";
+                if (rosterCache is null)
                 {
                     machineErrors.Add(new MachineErrorDto
                     {
                         DirectorId = d.DirectorId,
                         MachineName = d.MachineName,
-                        Error = error,
+                        Error = reason,
                     });
                     continue;
                 }
-                if (sessions is null) continue;
 
-                // Issue #291: this Director just answered (reachable), so its returned list is the
-                // authoritative live set for it. Prune any session the cache still attributes to this
-                // Director that is no longer live here - it exited or disappeared - so the per-session
-                // WS proxy reverts to 404 instead of #288's 503 "owner offline". Computed from the raw
-                // returned list (before the per-session view filters below) and excluding Exited rows
-                // (a Director may include them when includeExited=true). Owners on OTHER Directors are
-                // untouched, so an offline owner's sessions stay cached -> still 503 (#288 unchanged).
-                var liveIds = new HashSet<string>(
-                    sessions
-                        .Where(x => !string.IsNullOrEmpty(x.SessionId)
-                                 && !string.Equals(x.ActivityState, "Exited", StringComparison.OrdinalIgnoreCase))
-                        .Select(x => x.SessionId),
-                    StringComparer.Ordinal);
-                owners?.RetainForDirector(d.DirectorId, liveIds);
+                var projection = rosterCache.RecordUnreachable(d.DirectorId, reason);
+                if (projection.State == FleetReachabilityState.Wobbly && projection.StaleSessions is not null)
+                {
+                    reachability.Add(new DirectorReachabilityDto
+                    {
+                        DirectorId = d.DirectorId,
+                        MachineName = d.MachineName ?? "",
+                        State = DirectorReachabilityDto.StateWobbly,
+                        LastSeenUtc = projection.LastSeenUtc,
+                        LastSeenAgeSeconds = projection.LastSeenAgeSeconds,
+                        Error = reason,
+                    });
+                    served.Add((d, projection.StaleSessions.ToList(), Stale: true));
+                    continue;
+                }
+
+                // Offline: the grace window is exhausted (or the Director was never reachable). Drop its
+                // sessions exactly as before, and record the Offline reachability entry.
+                reachability.Add(new DirectorReachabilityDto
+                {
+                    DirectorId = d.DirectorId,
+                    MachineName = d.MachineName ?? "",
+                    State = DirectorReachabilityDto.StateOffline,
+                    LastSeenUtc = projection.LastSeenUtc,
+                    LastSeenAgeSeconds = projection.LastSeenAgeSeconds,
+                    Error = reason,
+                });
+                machineErrors.Add(new MachineErrorDto
+                {
+                    DirectorId = d.DirectorId,
+                    MachineName = d.MachineName ?? "",
+                    Error = reason,
+                });
+            }
+
+            foreach (var (d, sessions, stale) in served)
+            {
+                // Issue #291: a reachable Director's returned list is the authoritative live set for it.
+                // Prune any session the cache still attributes to this Director that is no longer live here
+                // - it exited or disappeared - so the per-session WS proxy reverts to 404 instead of #288's
+                // 503 "owner offline". Computed from the raw returned list (before the per-session view
+                // filters below) and excluding Exited rows (a Director may include them when
+                // includeExited=true). Owners on OTHER Directors are untouched, so an offline owner's
+                // sessions stay cached -> still 503 (#288 unchanged).
+                // Issue #1215: SKIP this prune for a Wobbly (stale) serve - the Director did NOT answer, so
+                // the stale snapshot is not authoritative and must not evict live ownership records.
+                if (!stale)
+                {
+                    var liveIds = new HashSet<string>(
+                        sessions
+                            .Where(x => !string.IsNullOrEmpty(x.SessionId)
+                                     && !string.Equals(x.ActivityState, "Exited", StringComparison.OrdinalIgnoreCase))
+                            .Select(x => x.SessionId),
+                        StringComparer.Ordinal);
+                    owners?.RetainForDirector(d.DirectorId, liveIds);
+                }
 
                 var baseUrl = DeriveDirectorBaseUrl(ctx, d);
                 var gatewayBaseUrl = DeriveGatewayBaseUrl(ctx);
@@ -605,7 +680,10 @@ internal static class GatewayEndpoints
 
             if (envelope == true)
             {
-                return Results.Json(new { sessions = all, machineErrors });
+                // Issue #1215: the envelope also carries the per-Director reachability (Online / Wobbly /
+                // Offline with a last-seen age), so the Cockpit renders the three states in place. machineErrors
+                // is retained unchanged for back-compat (an Offline Director appears in both).
+                return Results.Json(new { sessions = all, machineErrors, directors = reachability });
             }
             return Results.Json(all);
         })

--- a/src/CcDirector.Gateway/Discovery/FleetRosterCache.cs
+++ b/src/CcDirector.Gateway/Discovery/FleetRosterCache.cs
@@ -1,0 +1,199 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Discovery;
+
+/// <summary>
+/// Issue #1215 (Cockpit plan phase 6): the Gateway's last-known-good roster cache. It exists to stop a
+/// single failed Director poll from making that Director's sessions "blink" out of the aggregated roster
+/// for one refresh and then reappear.
+///
+/// The mechanism is a defined presentation grace window, NOT a fallback that hides an outage:
+///  - Every time a Director's sessions are read successfully, its snapshot is stored and its failure
+///    streak is reset. That Director reads as <see cref="FleetReachabilityState.Online"/>.
+///  - When a poll fails, the failure streak increases. While the streak is within
+///    <see cref="GraceWindowPollCycles"/> AND a last-known-good snapshot exists, the Director reads as
+///    <see cref="FleetReachabilityState.Wobbly"/> and the stored snapshot is served (marked stale, with
+///    the last-seen timestamp) instead of being dropped.
+///  - Once the failure streak passes the grace window, the Director reads as
+///    <see cref="FleetReachabilityState.Offline"/> and its sessions are dropped from the roster.
+///
+/// The grace window is counted in POLL CYCLES (each roster fan-out that considered this Director is one
+/// cycle), matching how the existing reachability circuit in <see cref="DirectorRegistry"/> counts
+/// consecutive failures. Because the window is only a few cycles it is always far shorter than the outer
+/// eviction bounds <see cref="DirectorRegistry"/> already defines (its 60 s heartbeat timeout and 3 min
+/// unreachable-evict), so a genuinely down machine still reaches Offline promptly and within those bounds.
+/// This cache changes presentation only; it does not touch discovery, registration, heartbeats, or the
+/// reachability-circuit constants.
+///
+/// Reads return deep COPIES (via <see cref="SessionDto.Clone"/>) so the aggregation may stamp them
+/// without contaminating the cache, and recompute the idle clock from the absolute LastActivityAt so a
+/// stale session's idle time keeps advancing while it is served through the grace window.
+///
+/// Thread-safe: a <see cref="ConcurrentDictionary{TKey,TValue}"/> of per-Director entries, each guarded
+/// by its own lock.
+/// </summary>
+public sealed class FleetRosterCache
+{
+    /// <summary>
+    /// The grace window, in consecutive failed poll cycles, during which a Director's last-known-good
+    /// snapshot keeps being served (marked Wobbly) before the Director is declared Offline. Three cycles
+    /// absorbs a transient miss (a firewall drop or a single lost poll) yet still reaches Offline quickly,
+    /// well inside the outer eviction bounds <see cref="DirectorRegistry"/> already enforces. This is the
+    /// single named value for the window - do not scatter the number elsewhere.
+    /// </summary>
+    public const int GraceWindowPollCycles = 3;
+
+    private readonly ConcurrentDictionary<string, Entry> _byDirector = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Func<DateTime> _utcNow;
+
+    /// <summary>
+    /// Create the cache. <paramref name="utcNow"/> is a test seam for the last-seen and idle-clock logic;
+    /// production passes null and the cache reads <see cref="DateTime.UtcNow"/>.
+    /// </summary>
+    public FleetRosterCache(Func<DateTime>? utcNow = null)
+    {
+        _utcNow = utcNow ?? (() => DateTime.UtcNow);
+    }
+
+    /// <summary>
+    /// Record a SUCCESSFUL roster read for a Director: store the last-known-good snapshot, stamp the
+    /// last-seen time, and reset the failure streak. Returns the Online projection for the envelope.
+    /// </summary>
+    public DirectorRosterProjection RecordReachable(string directorId, IReadOnlyList<SessionDto> sessions)
+    {
+        if (string.IsNullOrEmpty(directorId))
+            throw new ArgumentException("directorId is required", nameof(directorId));
+        if (sessions is null)
+            throw new ArgumentNullException(nameof(sessions));
+
+        var now = _utcNow();
+        var entry = _byDirector.GetOrAdd(directorId, _ => new Entry());
+        lock (entry.Gate)
+        {
+            entry.Snapshot = sessions.Select(s => s.Clone()).ToList();
+            entry.LastSeenUtc = now;
+            var wasFailing = entry.ConsecutiveFailures > 0;
+            entry.ConsecutiveFailures = 0;
+            if (wasFailing)
+                FileLog.Write($"[FleetRosterCache] {directorId} reachable again; roster presentation ONLINE ({entry.Snapshot.Count} sessions)");
+        }
+        return new DirectorRosterProjection(FleetReachabilityState.Online, now, 0, null);
+    }
+
+    /// <summary>
+    /// Record a FAILED roster read for a Director and project its presentation. Increments the failure
+    /// streak, then decides Wobbly (still inside the grace window with a stored snapshot to serve) or
+    /// Offline (grace window exhausted, or nothing was ever cached). For Wobbly the returned projection
+    /// carries deep copies of the last-known-good sessions to serve; for Offline it carries no sessions.
+    /// </summary>
+    public DirectorRosterProjection RecordUnreachable(string directorId, string? error)
+    {
+        if (string.IsNullOrEmpty(directorId))
+            throw new ArgumentException("directorId is required", nameof(directorId));
+
+        var now = _utcNow();
+        var entry = _byDirector.GetOrAdd(directorId, _ => new Entry());
+        lock (entry.Gate)
+        {
+            entry.ConsecutiveFailures++;
+
+            var withinGrace = entry.ConsecutiveFailures <= GraceWindowPollCycles;
+            var haveSnapshot = entry.Snapshot is not null;
+            if (withinGrace && haveSnapshot)
+            {
+                var age = entry.LastSeenUtc is { } seen ? (now - seen).TotalSeconds : (double?)null;
+                var stale = entry.Snapshot!.Select(s => RecomputeClocks(s.Clone(), now)).ToList();
+                if (entry.ConsecutiveFailures == 1)
+                    FileLog.Write($"[FleetRosterCache] {directorId} poll failed; roster presentation WOBBLY, serving {stale.Count} last-known-good sessions (grace window {GraceWindowPollCycles} cycles): {error ?? "unreachable"}");
+                return new DirectorRosterProjection(FleetReachabilityState.Wobbly, entry.LastSeenUtc, age, stale);
+            }
+
+            // Grace window exhausted (or the Director was never reachable): declare Offline and drop its
+            // sessions. Log the single transition into Offline (the failure exactly at the boundary), not
+            // every subsequent failed cycle, so a long outage does not flood the log.
+            if (haveSnapshot && entry.ConsecutiveFailures == GraceWindowPollCycles + 1)
+            {
+                FileLog.Write($"[FleetRosterCache] {directorId} grace window exhausted after {entry.ConsecutiveFailures - 1} failed cycles; roster presentation OFFLINE (sessions dropped): {error ?? "unreachable"}");
+                entry.Snapshot = null; // the last-known-good is now too old to serve; drop it
+            }
+            var ageOffline = entry.LastSeenUtc is { } lastSeen ? (now - lastSeen).TotalSeconds : (double?)null;
+            return new DirectorRosterProjection(FleetReachabilityState.Offline, entry.LastSeenUtc, ageOffline, null);
+        }
+    }
+
+    /// <summary>
+    /// Forget a Director entirely (it was unregistered or evicted from the registry). Keeps the cache
+    /// from growing without bound as Directors come and go; a Director that re-registers starts with a
+    /// clean slate, exactly as the registry's own reachability state does.
+    /// </summary>
+    public void Forget(string directorId)
+    {
+        if (string.IsNullOrEmpty(directorId)) return;
+        if (_byDirector.TryRemove(directorId, out _))
+            FileLog.Write($"[FleetRosterCache] {directorId} forgotten (unregistered/evicted); roster cache cleared");
+    }
+
+    private static SessionDto RecomputeClocks(SessionDto s, DateTime nowUtc)
+    {
+        if (s.LastActivityAt is DateTime last)
+        {
+            var idle = (nowUtc - last).TotalSeconds;
+            s.IdleSeconds = idle > 0 ? idle : 0;
+        }
+        return s;
+    }
+
+    private sealed class Entry
+    {
+        public readonly object Gate = new();
+        public List<SessionDto>? Snapshot;
+        public DateTime? LastSeenUtc;
+        public int ConsecutiveFailures;
+    }
+}
+
+/// <summary>The three fleet-sweep presentation states (issue #1215).</summary>
+public enum FleetReachabilityState
+{
+    /// <summary>The last poll succeeded.</summary>
+    Online,
+
+    /// <summary>A recent poll failed but is absorbed by the grace window; last-known-good sessions are served, dimmed.</summary>
+    Wobbly,
+
+    /// <summary>The grace window is exhausted; the Director's sessions are dropped.</summary>
+    Offline,
+}
+
+/// <summary>
+/// The roster presentation decision for one Director on one refresh (issue #1215). Carries the state,
+/// the last-seen timestamp and its age, and - only when <see cref="FleetReachabilityState.Wobbly"/> -
+/// the deep-copied last-known-good sessions to serve stale.
+/// </summary>
+public readonly struct DirectorRosterProjection
+{
+    public DirectorRosterProjection(FleetReachabilityState state, DateTime? lastSeenUtc, double? lastSeenAgeSeconds, IReadOnlyList<SessionDto>? staleSessions)
+    {
+        State = state;
+        LastSeenUtc = lastSeenUtc;
+        LastSeenAgeSeconds = lastSeenAgeSeconds;
+        StaleSessions = staleSessions;
+    }
+
+    /// <summary>The presentation state for this Director.</summary>
+    public FleetReachabilityState State { get; }
+
+    /// <summary>When the Director was last read successfully (UTC), or null if never.</summary>
+    public DateTime? LastSeenUtc { get; }
+
+    /// <summary>How long ago (seconds) the Director was last seen; zero when Online, null when never seen.</summary>
+    public double? LastSeenAgeSeconds { get; }
+
+    /// <summary>
+    /// The last-known-good sessions to serve stale, non-null ONLY for <see cref="FleetReachabilityState.Wobbly"/>.
+    /// Null for Online (the caller has the live list) and for Offline (nothing is served).
+    /// </summary>
+    public IReadOnlyList<SessionDto>? StaleSessions { get; }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -43,6 +43,14 @@ public sealed class GatewayHost : IAsyncDisposable
     public Streaming.PushedSessionStore PushedSessions { get; }
 
     /// <summary>
+    /// Issue #1215 (Cockpit plan phase 6): the last-known-good roster cache. The <c>/sessions</c>
+    /// aggregation uses it so a single failed Director poll no longer drops that Director's sessions -
+    /// they are served stale (Wobbly) through a short grace window and only dropped (Offline) once the
+    /// grace window is exhausted. Presentation only; it never touches discovery or the registry constants.
+    /// </summary>
+    public Discovery.FleetRosterCache RosterCache { get; }
+
+    /// <summary>
     /// launcher-persistent-join: the map of which machine's cc-launcher is currently joined over a
     /// persistent stream. When a launcher is stream-connected, the machine lifecycle relay pushes a command
     /// DOWN the open stream instead of dialing the launcher's REST API. Empty until launchers connect and
@@ -322,6 +330,10 @@ public sealed class GatewayHost : IAsyncDisposable
         Token = token ?? GatewayAuth.LoadOrCreate();
         Registry = new DirectorRegistry(instancesDirectory);
         PushedSessions = new Streaming.PushedSessionStore();
+        RosterCache = new Discovery.FleetRosterCache();
+        // Issue #1215: when a Director is unregistered or evicted from the registry, forget its cached
+        // roster too so the cache does not grow without bound; a re-registering Director starts clean.
+        Registry.OnDirectorRemoved += id => RosterCache.Forget(id);
         LauncherConnections = new Streaming.LauncherConnectionRegistry();
         var gatewayConfig = Core.Configuration.GatewayConfig.Load();
         _streamMode = streamMode ?? gatewayConfig.StreamMode;
@@ -958,7 +970,11 @@ public sealed class GatewayHost : IAsyncDisposable
             streamStaleAfter: _streamStaleAfter,
             // Issue #1177 (Phase 1): route per-session commands DOWN the Director's stream when stream mode
             // is on. Null when off, so every command endpoint stays on its HTTP path (byte-identical).
-            sendCommand: _streamMode ? SendCommandAsync : null);
+            sendCommand: _streamMode ? SendCommandAsync : null,
+            // Issue #1215 (Cockpit plan phase 6): the last-known-good roster cache absorbs a transient poll
+            // failure as Wobbly (served stale through a short grace window) instead of blinking the
+            // Director's sessions out of the roster; only a sustained failure reads as Offline.
+            rosterCache: RosterCache);
 
         // Issue #268: the two raw per-session WebSocket legs (live Terminal stream + dictation)
         // proxied through the Gateway so a remote Cockpit talks same-origin to the Gateway and


### PR DESCRIPTION
Part of #1215 (Cockpit improvement plan, phase 6). Gateway BACKEND half only. The Cockpit rendering of the three states is a follow-up handled by the Cockpit Manager on this same issue.

## Diagnosis

The blink is a presentation defect in the roster aggregation, not the registry. In `src/CcDirector.Gateway/Api/GatewayEndpoints.cs`, the `GET /sessions` handler dropped a Director's entire session group on any single failed poll: on a non-null poll `error` it added a `MachineErrorDto` and `continue`d, removing that Director's sessions from the aggregated `sessions` for that refresh. The next successful poll put them back, so the Cockpit saw the sessions vanish and reappear. `DirectorRegistry` keeps the Director registered across a one-cycle miss (60 s heartbeat timeout, 3 min unreachable-evict, circuit opens only after 3 probe failures), so only the per-refresh session list was being lost. Full write-up posted as a comment on #1215 and in `docs/proof/issue-1215/diagnosis.md`.

## Fix

New `src/CcDirector.Gateway/Discovery/FleetRosterCache.cs`: a per-Director last-known-good snapshot with a defined grace window.

- Grace-window constant: `FleetRosterCache.GraceWindowPollCycles = 3` (named constant with an explanatory comment). Counted in poll cycles, matching how the registry's reachability circuit counts consecutive failures. Three cycles is far shorter than the registry's outer eviction bounds, so a genuinely down machine still reaches Offline promptly and within those bounds - the fix never extends them. No registry constant is changed.
- On a successful poll: store the snapshot, reset the failure streak -> Online.
- On a failed poll, within the grace window and with a stored snapshot: serve the stored snapshot marked Wobbly (with last-seen timestamp + age). The `GET /sessions` handler now runs these stale sessions through the SAME enrichment pipeline, so entries change appearance in place and the list never reflows. The owner-prune is skipped for a stale serve (a non-answering Director is not authoritative).
- On a failed poll past the grace window: Offline - drop the sessions exactly as before (historical behaviour preserved for a real outage).

This is a defined presentation state, not a silent retry that hides an outage (project law: no fallback programming).

## Envelope shape (what the Cockpit must render)

`GET /sessions?envelope=true` keeps `sessions` and `machineErrors` unchanged and adds a `directors` array (one reachability record per Director). camelCase on the wire:

- `directors[].directorId` : string (matches `session.directorId`)
- `directors[].machineName` : string
- `directors[].state` : string, one of `"online"` | `"wobbly"` | `"offline"`
- `directors[].lastSeenUtc` : string | null (ISO 8601 UTC)
- `directors[].lastSeenAgeSeconds` : number | null (0 when online, null when never seen)
- `directors[].error` : string | null (failure reason for wobbly/offline; null when online)

A Wobbly Director's sessions STAY in `sessions` (served stale). The Cockpit joins `session.directorId` -> `directors[].state` to dim in place. Example of the stale marker:

```json
{
  "sessions": [
    { "sessionId": "s-200", "directorId": "dir-B", "name": "tests", "activityState": "Idle" }
  ],
  "machineErrors": [],
  "directors": [
    {
      "directorId": "dir-B",
      "machineName": "desktop-2",
      "state": "wobbly",
      "lastSeenUtc": "2026-07-10T12:00:05Z",
      "lastSeenAgeSeconds": 5,
      "error": "timeout"
    }
  ]
}
```

Full before/after in `docs/proof/issue-1215/roster-envelope-shape.md`.

## Client-core

`packages/client-core/src/fleet/fleetClient.ts`: added the `DirectorReachability` type and the `ReachabilityState` union (`online`/`wobbly`/`offline` consts), and extended `SessionsEnvelope` with `directors`. Envelope TYPE only - no files under `apps/cockpit/` or `apps/mobile/` were touched.

## Tests

`src/CcDirector.Gateway.Tests/FleetRosterCacheTests.cs` covers the three required transitions: reachable -> wobbly -> reachable, reachable -> wobbly -> offline, offline -> reachable; plus never-reachable -> offline, idle-clock recompute on a stale serve, and forget-on-evict. Full Gateway test project: 1606 passed, 0 failed. client-core `fleetClient.ts` typechecks clean.

## Notes

- Live roster JSON capture returned HTTP 401 (auth gate ON by default), so the envelope proof is documented from the contract types and the unit-tested behaviour, per the issue's "captured JSON or documented shape" option.
- No test Gateway process was spawned; verification is via unit tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
