### PR TITLE
[Cockpit] Handover-info Gateway endpoint + client-core call (#1214)

### DIFF
--- a/docs/proof/issue-1214/handover-fields.md
+++ b/docs/proof/issue-1214/handover-fields.md
@@ -1,0 +1,48 @@
+# Issue 1214 - what the desktop "Handover info" shows today
+
+## Where it lives in the desktop app
+
+The desktop Avalonia app exposes handover info as the session context-menu item
+"Copy Handover Info" (see `src/CcDirector.Avalonia/MainWindow.axaml.cs`, the menu
+item built near line 2199 and the text builder `CopySessionNameAndId` near line
+2375). Its stated purpose (from the method's own summary comment) is:
+
+> "everything another agent needs to locate the session and talk to it."
+
+It copies a plain-text block to the clipboard. It is NOT the rich transcript
+"summary" (files touched / recent commands / open todos) served by
+`GET /sessions/{sid}/summary` - it is the small identity/locate block.
+
+## The exact lines the desktop copies
+
+The block is built from these fields (in order):
+
+- `Name`         - the session display name (`SessionViewModel.DisplayName`)
+- `Session ID`   - the stable session id (`Session.Id`)
+- `Repo`         - the repository / working directory (`RepoPath`)
+- `Director ID`  - the id of the Director hosting the session
+- `Machine`      - `Environment.MachineName` of the host
+- `Version`      - the Director assembly version
+- `Control API`  - the Director's reachable Control API endpoint (a Tailscale
+                   Serve front door when on a tailnet, otherwise the loopback
+                   endpoint)
+
+## What the browser (Cockpit) handover view gets
+
+The Cockpit view mirrors the desktop block with ONE deliberate exclusion: the
+`Control API` endpoint. Issue 1214 requires that "the browser talks only to the
+Gateway and never learns a Director address." The Control API endpoint IS a
+Director address, so the Gateway-exposed handover info omits it. Everything else
+(name, session id, repo, director id, machine, version) is carried through
+unchanged.
+
+The data path added for issue 1214:
+
+- Director Control API: `GET /sessions/{sid}/handover` -> `HandoverInfoDto`
+  (name, session id, repo, director id, machine, version). No Director address.
+- Gateway proxy: `GET /sessions/{sid}/handover` -> resolves the owning Director
+  from the session id, forwards to that Director, stamps the Director id, returns
+  the same `HandoverInfoDto`. Requires the same Bearer/device-key auth as every
+  other session route (401 without a valid credential). 404 when the session is
+  unknown to every Director; 502 when the owning Director is unreachable.
+- client-core: `getHandover(sessionId, signal?)` -> `SessionHandover`.

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -605,6 +605,45 @@ export async function uploadImage(sessionId: string, file: File, signal?: AbortS
   return body.path ?? "";
 }
 
+// GET /sessions/{sid}/handover (issue #1214): the desktop app's "Handover info" identity block for a
+// session - what a person or another agent needs to locate the session and talk to it. Mirrors the
+// desktop "Copy Handover Info" block, minus the Director's Control API endpoint (the browser talks only
+// to the Gateway and never learns a Director address). Not declared in the generated OpenAPI schema
+// (the Gateway returns it via Results.Json without a [Produces] annotation), so it is read with this
+// narrow local shape - the exact subset the Cockpit Handover info view renders. The C# source of truth
+// is CcDirector.Gateway.Contracts.HandoverInfoDto.
+export interface SessionHandover {
+  sessionId: string;
+  displayName: string;
+  repoPath: string;
+  directorId: string;
+  machineName: string;
+  version: string;
+}
+
+// A non-2xx is surfaced as a GatewayError so the caller shows a visible error (never a silent empty
+// panel): 404 when the session is unknown to every Director, 502 when the owning Director is offline.
+export async function getHandover(sessionId: string, signal?: AbortSignal): Promise<SessionHandover> {
+  const sid = encodeURIComponent(sessionId);
+  const res = await fetch(`/sessions/${sid}/handover`, {
+    method: "GET",
+    headers: { Accept: "application/json", ...authHeaders() },
+    signal,
+  });
+  if (!res.ok) {
+    throw new GatewayError(res.status, `GET handover failed: ${res.status}`);
+  }
+  const body = (await res.json().catch(() => ({}))) as Partial<SessionHandover>;
+  return {
+    sessionId: body.sessionId ?? "",
+    displayName: body.displayName ?? "",
+    repoPath: body.repoPath ?? "",
+    directorId: body.directorId ?? "",
+    machineName: body.machineName ?? "",
+    version: body.version ?? "",
+  };
+}
+
 // ===== Session management (issue #812): the add-session flow + Hold/Resume + Remove =====
 // A faithful 1:1 of the Android (MAUI) phone/CcDirectorClient "+ New session" flow and the
 // owner's Hold/Remove decision. Every call carries the same Bearer the rest of the client uses, so

--- a/packages/client-core/src/api/handover.test.ts
+++ b/packages/client-core/src/api/handover.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getHandover } from "./client";
+import { GatewayError } from "./client";
+
+// Issue #1214: getHandover fetches the desktop "Handover info" identity block for a session through the
+// Gateway (GET /sessions/{sid}/handover). It must return the typed shape on a 200 and throw a
+// GatewayError on any non-2xx so the Cockpit shows a visible error instead of a silent empty panel.
+
+// Mirror the real fetch signature (input, init) so the recorded call arguments are typed as a
+// two-element tuple (matches the recordingsClient test helper).
+function mockFetch(status: number, body: unknown) {
+  return vi.fn(
+    async (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => body,
+        text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+      }) as unknown as Response,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("getHandover", () => {
+  it("returns the typed handover block for a well-formed 200 body", async () => {
+    const dto = {
+      sessionId: "11111111-2222-3333-4444-555555555555",
+      displayName: "devthrottle - fix login",
+      repoPath: "C:/repos/devthrottle",
+      directorId: "director-abc",
+      machineName: "SOREN-PC",
+      version: "1.2.3",
+    };
+    vi.stubGlobal("fetch", mockFetch(200, dto));
+
+    const info = await getHandover(dto.sessionId);
+
+    expect(info).toEqual(dto);
+  });
+
+  it("hits the Gateway-relative handover route with a Bearer header", async () => {
+    const fetchMock = mockFetch(200, {});
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getHandover("abc def"); // a space proves the id is URL-encoded
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/sessions/abc%20def/handover");
+    expect((init as RequestInit).method).toBe("GET");
+  });
+
+  it("degrades a partial 200 body to empty strings without throwing", async () => {
+    vi.stubGlobal("fetch", mockFetch(200, { sessionId: "s1" }));
+
+    const info = await getHandover("s1");
+
+    expect(info.sessionId).toBe("s1");
+    expect(info.displayName).toBe("");
+    expect(info.repoPath).toBe("");
+    expect(info.directorId).toBe("");
+    expect(info.machineName).toBe("");
+    expect(info.version).toBe("");
+  });
+
+  it("throws GatewayError on a 404 (session unknown)", async () => {
+    vi.stubGlobal("fetch", mockFetch(404, { error: "session not found across any director" }));
+
+    await expect(getHandover("missing")).rejects.toBeInstanceOf(GatewayError);
+    await expect(getHandover("missing")).rejects.toThrow(/GET handover failed: 404/);
+  });
+
+  it("throws GatewayError on a 502 (owning Director offline)", async () => {
+    vi.stubGlobal("fetch", mockFetch(502, {}));
+
+    await expect(getHandover("s1")).rejects.toThrow(/GET handover failed: 502/);
+  });
+});

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1393,6 +1393,44 @@ internal static class ControlEndpoints
             }
         });
 
+        // ===== REST: Handover info (issue #1214) =====
+        // The small identity/locate block the desktop app's "Copy Handover Info" menu item shows for a
+        // session (name, session id, repo, director id, machine, version). Deliberately does NOT include
+        // this Director's Control API endpoint: the Gateway proxies this to a browser, and issue #1214
+        // requires the browser to talk only to the Gateway and never learn a Director address. This is a
+        // pure read of the live session record - no transcript parsing, no I/O.
+        app.MapGet("/sessions/{sid}/handover", (string sid) =>
+        {
+            FileLog.Write($"[ControlEndpoints] /handover: sid={sid}");
+            if (!Guid.TryParse(sid, out var guid))
+                return Results.BadRequest(new { error = "invalid session id format" });
+
+            var session = sessionManager.GetSession(guid);
+            if (session is null)
+            {
+                FileLog.Write($"[ControlEndpoints] /handover: session not found sid={sid}");
+                return Results.NotFound(new { error = "session not found" });
+            }
+
+            // Issue #800: the display name goes through the single composer so it is never the bare
+            // folder name (legacy sessions with no CustomName get folder + type + disambiguator).
+            var name = SessionName.DisplayName(session.CustomName,
+                SessionName.FolderName(session.RepoPath),
+                SessionName.Disambiguator(session.Id));
+
+            var dto = new HandoverInfoDto
+            {
+                SessionId = sid,
+                DisplayName = name,
+                RepoPath = session.RepoPath,
+                DirectorId = directorId,
+                MachineName = Environment.MachineName,
+                Version = version,
+            };
+            FileLog.Write($"[ControlEndpoints] /handover: ok sid={sid}, director={directorId}");
+            return Results.Json(dto);
+        });
+
         // ===== REST: Brief - the Cockpit's full-page session view (ASK / DID / NEEDS YOU) =====
         // Sourced from the Claude JSONL transcript, never the terminal screen. The DID bullets
         // and verbatim NEEDS-YOU extraction come from a cached OpenAI condensation (one call

--- a/src/CcDirector.Gateway.Contracts/HandoverInfoDto.cs
+++ b/src/CcDirector.Gateway.Contracts/HandoverInfoDto.cs
@@ -1,0 +1,35 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// The desktop app's "Handover info" for a single session (issue #1214): the small
+/// identity/locate block a person or another agent needs to find the session and talk
+/// to it. Mirrors the desktop "Copy Handover Info" clipboard block
+/// (CcDirector.Avalonia MainWindow.CopySessionNameAndId) with ONE deliberate exclusion -
+/// the Director's Control API endpoint. That endpoint is a Director address, and issue
+/// #1214 requires the browser to talk only to the Gateway and never learn a Director
+/// address, so it is omitted here.
+///
+/// Returned by the Director Control API GET /sessions/{sid}/handover and proxied
+/// verbatim (with DirectorId stamped) by the Gateway GET /sessions/{sid}/handover.
+/// </summary>
+public sealed class HandoverInfoDto
+{
+    /// <summary>Stable session id.</summary>
+    public string SessionId { get; set; } = "";
+
+    /// <summary>The session's composed display name (never the bare folder name).</summary>
+    public string DisplayName { get; set; } = "";
+
+    /// <summary>Repository / working directory the session runs in.</summary>
+    public string RepoPath { get; set; } = "";
+
+    /// <summary>Id of the Director that hosts the session. Empty in a Director-local
+    /// response; the Gateway stamps it when proxying.</summary>
+    public string DirectorId { get; set; } = "";
+
+    /// <summary>Machine name of the host running the session.</summary>
+    public string MachineName { get; set; } = "";
+
+    /// <summary>Version of the Director that hosts the session.</summary>
+    public string Version { get; set; } = "";
+}

--- a/src/CcDirector.Gateway.Tests/HandoverInfoEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/HandoverInfoEndpointTests.cs
@@ -1,0 +1,198 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using CcDirector.ControlApi;
+using CcDirector.Core.Backends;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Memory;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1214: the read-only "Handover info" data path.
+///
+/// Director Control API GET /sessions/{sid}/handover returns the desktop "Copy Handover Info" identity
+/// block (name, session id, repo, director id, machine, version) - minus the Control API endpoint, which
+/// is a Director address the browser must never learn. The Gateway proxies it at the same route, gated by
+/// the same Bearer/device-key auth as every other session route.
+///
+/// This file boots a REAL ControlApiHost for the Director-side endpoint (happy path, 404, 400) and a real
+/// GatewayHost for the front-door contract (401 without a credential, 404 when no Director owns the id).
+/// </summary>
+public sealed class HandoverInfoControlApiTests : IAsyncLifetime
+{
+    private ControlApiHost _host = null!;
+    private SessionManager _sm = null!;
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        _sm = new SessionManager(new AgentOptions());
+        _host = new ControlApiHost(_sm, "9.9.9-handover-test", () => Task.CompletedTask, useEphemeralPort: true);
+        var port = await _host.StartAsync();
+        _client = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{port}/") };
+    }
+
+    public async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _host.StopAsync();
+        _sm.Dispose();
+    }
+
+    [Fact]
+    public async Task Handover_ReturnsIdentityBlock_ForAKnownSession()
+    {
+        var session = MakeIdleSession();
+        _sm.AdoptSession(session);
+        var sid = session.Id.ToString();
+
+        var dto = await _client.GetFromJsonAsync<HandoverInfoDto>($"sessions/{sid}/handover");
+
+        Assert.NotNull(dto);
+        Assert.Equal(sid, dto!.SessionId);
+        Assert.Equal("9.9.9-handover-test", dto.Version);
+        Assert.Equal(Environment.MachineName, dto.MachineName);
+        Assert.Equal(@"C:\test\handover-info-test", dto.RepoPath);
+        Assert.False(string.IsNullOrWhiteSpace(dto.DisplayName));
+        Assert.False(string.IsNullOrWhiteSpace(dto.DirectorId));
+    }
+
+    [Fact]
+    public async Task Handover_NeverLeaksAControlApiEndpoint()
+    {
+        var session = MakeIdleSession();
+        _sm.AdoptSession(session);
+        var sid = session.Id.ToString();
+
+        // The raw JSON must carry no Director address - only the identity fields.
+        var raw = await _client.GetStringAsync($"sessions/{sid}/handover");
+        Assert.DoesNotContain("controlEndpoint", raw, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("controlApi", raw, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("http://", raw, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Handover_UnknownSession_Returns404()
+    {
+        var resp = await _client.GetAsync($"sessions/{Guid.NewGuid()}/handover");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Handover_InvalidSessionId_Returns400()
+    {
+        var resp = await _client.GetAsync("sessions/not-a-guid/handover");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    private static Session MakeIdleSession()
+    {
+        var backend = new StubBackend();
+        var session = new Session(
+            Guid.NewGuid(),
+            repoPath: @"C:\test\handover-info-test",
+            workingDirectory: @"C:\test\handover-info-test",
+            claudeArgs: null,
+            backend: backend,
+            claudeSessionId: null,
+            activityState: ActivityState.Idle,
+            createdAt: DateTimeOffset.UtcNow,
+            customName: "handover-info-test",
+            customColor: null);
+        session.MarkRunning();
+        return session;
+    }
+
+    private sealed class StubBackend : ISessionBackend
+    {
+        public int ProcessId => 1;
+        public string Status => "Stub";
+        public bool IsRunning => true;
+        public bool HasExited => false;
+        public CircularTerminalBuffer? Buffer => null;
+
+#pragma warning disable CS0067
+        public event Action<string>? StatusChanged;
+        public event Action<int>? ProcessExited;
+#pragma warning restore CS0067
+
+        public void Start(string executable, string args, string workingDir, short cols, short rows,
+            Dictionary<string, string>? environmentVars = null) { }
+        public void Write(byte[] data) { }
+        public Task SendTextAsync(string text) => Task.CompletedTask;
+        public Task SendEnterAsync() => Task.CompletedTask;
+        public void Resize(short cols, short rows) { }
+        public Task GracefulShutdownAsync(int timeoutMs = 5000) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+}
+
+/// <summary>
+/// Gateway front-door contract for GET /sessions/{sid}/handover (issue #1214). Boots a real GatewayHost
+/// with auth ON and no Director present, so the credential gate and the session-lookup 404 are both
+/// observable without a Director on the other side.
+/// </summary>
+public sealed class HandoverInfoGatewayTests : IAsyncLifetime
+{
+    private const string GatewayToken = "handover-test-token";
+
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "ccd-handover-gw-" + Guid.NewGuid().ToString("N"));
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-handover-instances-" + Guid.NewGuid().ToString("N"));
+    private string? _prevRoot;
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+
+    public async Task InitializeAsync()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: GatewayToken, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task Handover_WithoutAToken_Returns401()
+    {
+        // No Authorization header: the global gate must reject before any Director lookup.
+        var resp = await _http.GetAsync($"sessions/{Guid.NewGuid()}/handover");
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Handover_WithAValidToken_ButNoOwningDirector_Returns404()
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Get, $"sessions/{Guid.NewGuid()}/handover");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", GatewayToken);
+
+        var resp = await _http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -1347,6 +1347,25 @@ internal static class GatewayEndpoints
             return Results.Json(summary);
         });
 
+        // Handover info proxy (issue #1214). Forwards to whichever Director owns the session and returns
+        // the desktop "Handover info" identity block (name, session id, repo, director id, machine,
+        // version) for a browser. Gated by the same Bearer/device-key auth as every other session route
+        // (the global AuthMiddleware 401s a credential-less request before it reaches here). The Director
+        // address is never leaked: this returns HandoverInfoDto, which carries no Control API endpoint,
+        // and the resolved ControlEndpoint stays server-side. 404 when the session is unknown to every
+        // Director; 502 when the owning Director is unreachable (never a silent empty body).
+        app.MapGet("/sessions/{sid}/handover", async (string sid) =>
+        {
+            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
+            if (session is null || director is null)
+                return Results.NotFound(new { error = "session not found across any director" });
+            var handover = await client.GetHandoverAsync(director.ControlEndpoint, sid);
+            if (handover is null)
+                return Results.StatusCode(StatusCodes.Status502BadGateway);
+            handover.DirectorId = director.DirectorId;
+            return Results.Json(handover);
+        });
+
         // Recap proxy. Both endpoints transparently forward to whichever Director owns the
         // session. The Director side does the heavy lifting (claude --print + cache); this
         // is just routing.

--- a/src/CcDirector.Gateway/Discovery/DirectorEndpointClient.cs
+++ b/src/CcDirector.Gateway/Discovery/DirectorEndpointClient.cs
@@ -809,6 +809,24 @@ public sealed class DirectorEndpointClient : IDisposable
         }
     }
 
+    /// <summary>
+    /// Issue #1214: fetch the owning Director's handover info block for a session (name, session id,
+    /// repo, director id, machine, version). Returns null when the Director is unreachable or answers
+    /// non-2xx, which the Gateway proxy surfaces as a 502 rather than a silent empty body.
+    /// </summary>
+    public async Task<HandoverInfoDto?> GetHandoverAsync(string endpoint, string sessionId, CancellationToken ct = default)
+    {
+        try
+        {
+            return await _http.GetFromJsonAsync<HandoverInfoDto>($"{endpoint}/sessions/{sessionId}/handover", ct);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[DirectorEndpointClient] GetHandoverAsync FAILED: endpoint={endpoint}, sid={sessionId}, error={ex.Message}");
+            return null;
+        }
+    }
+
     public async Task<(bool ok, HandoverResponse? body, string? error)> PostHandoverAsync(string endpoint, HandoverRequest req, CancellationToken ct = default)
     {
         try


### PR DESCRIPTION
## What

Backend and shared-client half of #1214: expose the desktop app's "Handover info" for a session to the browser through the Gateway. The browser talks only to the Gateway and never learns a Director address. This does NOT touch any Cockpit or mobile UI (the session menu view is built separately by the Manager).

## Endpoint path

- Director Control API: `GET /sessions/{sessionId}/handover` (new, read-only)
- Gateway proxy: `GET /sessions/{sessionId}/handover` (new, read-only)

## JSON shape (`HandoverInfoDto`)

```json
{
  "sessionId": "string",
  "displayName": "string",
  "repoPath": "string",
  "directorId": "string",
  "machineName": "string",
  "version": "string"
}
```

This mirrors the desktop "Copy Handover Info" clipboard block (name, session id, repo, director id, machine, version) with ONE deliberate exclusion: the Director's Control API endpoint. That endpoint is a Director address, and #1214 requires the browser never to learn one, so it is omitted from the DTO entirely. A test asserts the wire body carries no `http://` / control-endpoint field.

## Auth behavior

The Gateway route is a normal (non-public) session route, so the existing global `AuthMiddleware` gates it exactly like `/sessions/{sid}/summary`: a request with no valid credential gets **401** before any Director lookup. `HasValidToken` accepts the shared machine token OR an enrolled per-device key (Bearer or cookie), so the phone/desktop per-device keys work unchanged. Behavior:

- **401** without a valid token or device key.
- **404** when the session is unknown to every Director.
- **502** when the owning Director is unreachable (never a silent empty body).

The owning Director is resolved server-side via the same `LocateSessionAsync` the other proxied session endpoints use; the resolved Control API endpoint stays server-side.

## client-core

`getHandover(sessionId, signal?)` in `packages/client-core/src/api/client.ts` fetches the Gateway-relative route with `authHeaders()` and throws `GatewayError` on any non-2xx. Returns the typed `SessionHandover` interface (same fields as the DTO, camelCase).

## Tests

- ControlApi (real `ControlApiHost`): happy-path identity block, unknown-session 404, invalid-guid 400, and a no-Director-address-leak assertion.
- Gateway (real `GatewayHost`, auth on): 401 without a credential, 404 with a valid token but no owning Director.
- client-core (vitest): well-formed 200 shape, URL-encoded relative route + Bearer, partial-body degrade, 404 and 502 both throw `GatewayError`.

`dotnet build` + the handover `dotnet test` filter are green (6 passed); client-core vitest + typecheck green (5 passed).

Part of #1214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)