### PR TITLE
Cancel a stuck dictation from the phone (#1181 Task 5, part 1)

### DIFF
--- a/apps/mobile/src/components/DictationStatusStrip.tsx
+++ b/apps/mobile/src/components/DictationStatusStrip.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { retryPendingDictation } from "@devthrottle/client-core/dictation/backgroundSend";
+import { abandonPendingDictation, retryPendingDictation } from "@devthrottle/client-core/dictation/backgroundSend";
 import { clearDictationStatus, useDictationStatusFor } from "@devthrottle/client-core/dictation/status";
 
 // The on-screen live-status strip for a dictation Send, shown on the Terminal, Chat, and Voice
@@ -49,6 +49,9 @@ export function DictationStatusStrip({ sessionId }: { sessionId: string | undefi
         <button type="button" className="dictate-strip-btn" onClick={() => void onUploadNow()} disabled={uploadingNow}>
           {uploadingNow ? "Uploading..." : "Upload now"}
         </button>
+        <button type="button" className="dictate-strip-btn dictate-strip-cancel" onClick={() => void abandonPendingDictation(status.uploadId)} disabled={uploadingNow}>
+          Cancel
+        </button>
       </div>
     );
   }
@@ -68,6 +71,9 @@ export function DictationStatusStrip({ sessionId }: { sessionId: string | undefi
         <span className="dictate-strip-text">{status.error ?? "Saved on your device - you can retry it."}</span>
         <button type="button" className="dictate-strip-btn" onClick={() => void onRetry()} disabled={uploadingNow}>
           {uploadingNow ? "Retrying..." : "Retry"}
+        </button>
+        <button type="button" className="dictate-strip-btn dictate-strip-cancel" onClick={() => void abandonPendingDictation(status.uploadId)} disabled={uploadingNow}>
+          Cancel
         </button>
       </div>
     );

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -1977,6 +1977,13 @@ a.banner-btn {
   color: var(--text-dim);
   border: 1px solid var(--border);
 }
+/* Issue #1181, Task 5: Cancel a stuck dictation. Secondary/outlined so it reads as the "give up"
+   action next to the primary "Upload now" / "Retry". */
+.dictate-strip-cancel {
+  background: transparent;
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+}
 
 /* The roster row badge: same status, compact, on its own line under the meta line. */
 .row-dictate {

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -1162,6 +1162,23 @@ async function ackDictation(encodedUploadId: string): Promise<void> {
   }
 }
 
+// POST /dictation/{uploadId}/abandon (issue #1181, Task 5): the user gave up on this dictation. Tells the
+// Gateway to mark the durable upload ABANDONED - discarding the staged audio and clearing the session lock.
+// Unlike the fire-and-forget ack, this RETURNS whether the Gateway actually confirmed: the caller must know,
+// because if the marker is not cleared the session would stay locked/orange forever. Returns false when the
+// call could not reach a healthy Gateway, so the caller keeps the abandoning record and retries.
+export async function abandonDictation(uploadId: string): Promise<boolean> {
+  try {
+    const res = await fetch(`/dictation/${encodeURIComponent(uploadId)}/abandon`, {
+      method: "POST",
+      headers: { Accept: "application/json", ...authHeaders() },
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
 // Turn a raw dictation-complete failure (any non-OK response from POST /dictation/{id}/complete) into a
 // short, honest, plain-English sentence for the status strip and the error banner.
 //

--- a/packages/client-core/src/dictation/backgroundSend.test.ts
+++ b/packages/client-core/src/dictation/backgroundSend.test.ts
@@ -15,7 +15,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 //   - a genuinely permanent failure PARKS the clip (keeps the audio, stops the auto-loop) and only an
 //     explicit Retry re-drives it, while transient failures still auto-retry (issue #1184).
 
-vi.mock("../api/client", () => ({ uploadDictationToSession: vi.fn() }));
+vi.mock("../api/client", () => ({ uploadDictationToSession: vi.fn(), abandonDictation: vi.fn() }));
 vi.mock("./pendingStore", () => ({
   savePending: vi.fn(),
   deletePending: vi.fn(),
@@ -23,8 +23,9 @@ vi.mock("./pendingStore", () => ({
   listPending: vi.fn(),
 }));
 
-import { uploadDictationToSession, type DictationSubmitResult } from "../api/client";
+import { abandonDictation, uploadDictationToSession, type DictationSubmitResult } from "../api/client";
 import {
+  abandonPendingDictation,
   backgroundTranscribeAndSend,
   resumePendingDictations,
   retryPendingDictation,
@@ -82,6 +83,7 @@ beforeEach(() => {
   vi.mocked(deletePending).mockResolvedValue(undefined);
   vi.mocked(getPending).mockResolvedValue(null);
   vi.mocked(listPending).mockResolvedValue([]);
+  vi.mocked(abandonDictation).mockResolvedValue(true);
 });
 
 afterEach(() => {
@@ -281,5 +283,47 @@ describe("parking permanently-failed clips (#1184)", () => {
     // A transient outcome never parks the record.
     const parkedSave = vi.mocked(savePending).mock.calls.find((c) => c[0].parkedReason);
     expect(parkedSave).toBeUndefined();
+  });
+});
+
+// Issue #1181, Task 5: the user explicitly abandons a stuck dictation from the phone.
+describe("abandonPendingDictation", () => {
+  it("tells the Gateway to abandon, drops the on-device copy, and never uploads", async () => {
+    vi.mocked(getPending).mockResolvedValue(makeRecord("id-abandon"));
+
+    await abandonPendingDictation("id-abandon");
+
+    // Marked abandoning durably (so a reload does not resume uploading it)...
+    const abandoningSave = vi.mocked(savePending).mock.calls.find((c) => c[0].id === "id-abandon");
+    expect(abandoningSave?.[0].abandoning).toBe(true);
+    // ...the Gateway was told to abandon the durable upload...
+    expect(abandonDictation).toHaveBeenCalledWith("id-abandon");
+    // ...the on-device copy was dropped on confirmation...
+    expect(deletePending).toHaveBeenCalledWith("id-abandon");
+    // ...and it never uploaded the clip.
+    expect(uploadDictationToSession).not.toHaveBeenCalled();
+    expect(statusFor("id-abandon")).toBeUndefined();
+  });
+
+  it("when the Gateway is unreachable, keeps the record (retries) and still never uploads", async () => {
+    vi.mocked(getPending).mockResolvedValue(makeRecord("id-abandon-offline"));
+    vi.mocked(abandonDictation).mockResolvedValue(false); // could not reach the Gateway
+
+    await abandonPendingDictation("id-abandon-offline");
+
+    // The abandon was attempted, but the on-device copy is NOT dropped (or the session would wedge locked)...
+    expect(abandonDictation).toHaveBeenCalledWith("id-abandon-offline");
+    expect(deletePending).not.toHaveBeenCalled();
+    // ...and a cancelled clip is never uploaded, even while the abandon is still being retried.
+    expect(uploadDictationToSession).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op for an id already gone (delivered, or abandoned from another surface)", async () => {
+    vi.mocked(getPending).mockResolvedValue(null);
+
+    await abandonPendingDictation("id-missing");
+
+    expect(abandonDictation).not.toHaveBeenCalled();
+    expect(deletePending).not.toHaveBeenCalled();
   });
 });

--- a/packages/client-core/src/dictation/backgroundSend.ts
+++ b/packages/client-core/src/dictation/backgroundSend.ts
@@ -1,4 +1,4 @@
-import { uploadDictationToSession } from "../api/client";
+import { abandonDictation, uploadDictationToSession } from "../api/client";
 import { deletePending, getPending, listPending, savePending, type PendingDictation } from "./pendingStore";
 import { clearDictationStatus, publishDictationStatus } from "./status";
 
@@ -199,6 +199,31 @@ export async function retryPendingDictation(uploadId: string): Promise<void> {
   await driveRecord(rec, { resumed: true, attempt: 0 });
 }
 
+// The user explicitly ABANDONS a dictation (issue #1181, Task 5). The strip clears IMMEDIATELY so cancel
+// feels instant, and the record is marked `abandoning` and driven: the loop tells the Gateway to abandon
+// (discarding the staged audio and clearing the session lock), then drops the on-device copy. If the
+// Gateway cannot be reached the record is kept and the abandon is retried silently, so the session can
+// never wedge locked - the cancel always reaches the durable marker eventually. A no-op for an id already
+// gone (delivered, or abandoned from another surface).
+export async function abandonPendingDictation(uploadId: string): Promise<void> {
+  clearScheduled(uploadId);
+  clearDictationStatus(uploadId); // instant: the user asked to cancel, so the strip goes away now
+  let rec: PendingDictation | null;
+  try {
+    rec = await getPending(uploadId);
+  } catch {
+    return;
+  }
+  if (rec === null) return; // already delivered or abandoned; nothing on device to drive
+  const abandoning: PendingDictation = { ...rec, abandoning: true };
+  try {
+    await savePending(abandoning); // durable, so a reload keeps abandoning it rather than resuming upload
+  } catch {
+    // Could not persist the flag: still drive the in-memory abandoning record below.
+  }
+  await driveRecord(abandoning, { resumed: true, attempt: 0 });
+}
+
 // ---- internals -------------------------------------------------------------------------------------
 
 interface DriveOptions {
@@ -217,6 +242,19 @@ async function driveRecord(rec: PendingDictation, opts: DriveOptions): Promise<v
   clearScheduled(rec.id); // we are driving now; cancel any waiting timer
 
   try {
+    if (rec.abandoning) {
+      // The user cancelled this clip (issue #1181, Task 5): do NOT upload it. Tell the Gateway to abandon
+      // the durable upload; on confirmation drop the on-device copy, otherwise retry silently (no strip -
+      // the cancel already cleared it) so the session's lock is always released eventually.
+      if (isOffline() || !(await abandonDictation(rec.id))) {
+        scheduleNext(rec, opts.attempt, false);
+        return;
+      }
+      await deletePending(rec.id);
+      clearDictationStatus(rec.id);
+      return;
+    }
+
     if (isOffline()) {
       // No point calling out with no network: show waiting-for-connection and lean on the `online`
       // listener, with a slow fallback timer so we still recover even if that event is missed.

--- a/packages/client-core/src/dictation/pendingStore.ts
+++ b/packages/client-core/src/dictation/pendingStore.ts
@@ -38,6 +38,11 @@ export interface PendingDictation {
    *  timer) - the forever-loop stops. It is cleared only by an explicit user Retry, which moves the record
    *  back to active. Absent for a normal, still-auto-retrying clip. */
   parkedReason?: string;
+  /** Set when the user ABANDONED this clip (issue #1181, Task 5). The record is kept ONLY to carry the
+   *  abandon through to the Gateway: while set, the retry loop no longer uploads it - it calls
+   *  /dictation/{id}/abandon instead, and deletes the on-device copy once the Gateway confirms (retrying
+   *  silently if the Gateway is unreachable, so the session never wedges locked). Absent for a normal clip. */
+  abandoning?: boolean;
 }
 
 const DB_NAME = "dt-dictation";

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -215,6 +215,39 @@ internal static class GatewayDictationEndpoint
             FileLog.Write($"[GatewayDictation] ack uploadId={uploadId} retired={retired}");
             return Results.Json(new { ok = true, retired });
         });
+
+        // User-initiated ABANDON (issue #1181, Task 5): the user gives up on this dictation. Marks the
+        // durable record ABANDONED - a terminal tombstone that DISCARDS the staged audio and clears the
+        // session lock (the PENDING marker is gone, so IsSessionLocked is false and the session un-oranges).
+        // Idempotent and safe against a race with delivery: if the turn already DELIVERED we do NOT abandon
+        // (it landed) and say so; otherwise the id becomes ABANDONED. The client that still holds the audio
+        // reconciles on its next contact - a re-register / re-complete of an abandoned id returns dropped, so
+        // it drops its on-device copy with no resurrection and no duplicate. Abandon may target ANY surface's
+        // dictation because it addresses the durable upload id, not the caller.
+        app.MapPost("/dictation/{uploadId}/abandon", (string uploadId, HttpContext ctx) =>
+        {
+            if (!AuthMiddleware.HasValidToken(ctx, token, devices))
+                return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
+
+            var existing = uploads.ReadRecord(uploadId);
+            if (existing is { State: DictationDeliveryState.Delivered })
+            {
+                FileLog.Write($"[GatewayDictation] abandon uploadId={uploadId}: already DELIVERED, not abandoning");
+                return Results.Json(new { ok = true, upload_id = uploadId, abandoned = false, already_delivered = true });
+            }
+
+            uploads.MarkAbandoned(uploadId, "user_abandoned");
+            // Clear the in-memory transcribing marks so the roster un-oranges at once (the durable PENDING
+            // marker - the "Uploading from phone" source - is already gone via MarkAbandoned).
+            var sid = existing?.SessionId;
+            if (!string.IsNullOrEmpty(sid))
+            {
+                EndTranscribing(transcribingSessions, sid);
+                transcribingSessions.ClearActivelyTranscribing(sid);
+            }
+            FileLog.Write($"[GatewayDictation] abandon uploadId={uploadId} sid={sid}: marked ABANDONED, staging discarded");
+            return Results.Json(new { ok = true, upload_id = uploadId, abandoned = true });
+        });
     }
 
     // Map a NON-Ok transcription result to the dictation outcome, or null when the result is Ok and the


### PR DESCRIPTION
Part of issue thefrederiksen/devthrottle_internal#724 - Task 5, the abandon/kill trigger. First increment: **Gateway + phone** (desktop + cockpit triggers are a fast-follow). The reconciliation half - a re-register/re-complete of an abandoned id returns `dropped` so the phone drops its copy - was already built in Task 2.

## What it does
- **Gateway:** `POST /dictation/{uploadId}/abandon` marks the durable record ABANDONED (discards the staged audio, clears the session lock so it un-oranges at once). Idempotent; safe against a race with delivery (a turn that already DELIVERED is not abandoned).
- **Phone:** a **Cancel** control on the dictation strip's "held" and "parked" states. Clears the strip immediately, marks the record `abandoning`, and drives it: the loop tells the Gateway to abandon instead of uploading, then drops the on-device copy. If the Gateway is unreachable it retries the abandon **silently** - never resuming the upload, never wedging the session locked.

## Testing
- 3 new client tests (abandon drops + never uploads; unreachable Gateway keeps retrying; no-op when gone); 36 existing dictation tests pass; client-core builds, mobile typechecks.
- Verified live on the deployed Gateway: uploading -> `POST abandon` -> `dictationStatus` clears, color back to normal, record is an Abandoned tombstone.

## Follow-up
Desktop + cockpit "Cancel dictation" triggers (they'll call the same, already-proven endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)