### PR TITLE
feat(mobile): order the "Needs you" group oldest-waiting first

### DIFF
--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { listSessions, type SessionDto } from "@devthrottle/client-core/api/client";
-import { classify, contextLine, dotColor, effectiveColor, inBucket, inDesktopOrder, isWorking, repoLeaf } from "@devthrottle/client-core/sessions/ordering";
+import { classify, contextLine, dotColor, effectiveColor, inBucket, inDesktopOrder, inWaitingOrder, isWorking, repoLeaf } from "@devthrottle/client-core/sessions/ordering";
 import { useDictationStatusFor } from "@devthrottle/client-core/dictation/status";
 import { useNow, waitingLabel } from "@devthrottle/client-core/sessions/waiting";
 import { getClipState, playClip, playingSid, stopPlayback, syncVoiceSessions, useVoiceClips } from "../voice/clips";
@@ -54,7 +54,11 @@ export function Home() {
     };
   }, [load]);
 
-  const needsYou = sessions ? inBucket(sessions, "needsYou") : [];
+  // The "Needs you" group is a waiting line: the session that has been waiting for you the longest
+  // sits at the top, and a session that only just started needing you drops in at the bottom
+  // (inWaitingOrder). This keeps the list from reshuffling under you as sessions change state, and
+  // lets you work it top to bottom, dealing with the longest-neglected session first.
+  const needsYou = sessions ? inWaitingOrder(sessions) : [];
   // The bottom group is "the rest": every session that is NOT waiting on you, still in your manual
   // desktop order. A needs-you session shows only once, at the top - never duplicated down here.
   const others = sessions ? inDesktopOrder(sessions.filter((s) => classify(s) !== "needsYou")) : [];

--- a/packages/client-core/src/sessions/ordering.test.ts
+++ b/packages/client-core/src/sessions/ordering.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { SessionDto } from "../api/client";
-import { classify, dotColor, effectiveColor, inBucket, isWorking, stateLabel } from "./ordering";
+import { classify, dotColor, effectiveColor, inBucket, inWaitingOrder, isWorking, stateLabel } from "./ordering";
 
 function session(fields: Partial<SessionDto> & { sessionId?: string } = {}): SessionDto {
   return {
@@ -73,5 +73,39 @@ describe("Gateway-stamped session presentation state", () => {
     expect(isWorking(session({ effectiveColor: "red", activityState: "WaitingForInput" }))).toBe(false);
     // On-hold is never working, even if blue.
     expect(isWorking(session({ effectiveColor: "blue", onHold: true }))).toBe(false);
+  });
+});
+
+describe("needs-you waiting-line order", () => {
+  const needsYou = (id: string, needsYouSince?: string, extra: Partial<SessionDto> = {}) =>
+    session({ sessionId: id, effectiveColor: "red", triageBucket: "needsYou", needsYouSince, ...extra } as Partial<SessionDto>);
+
+  it("puts the longest wait at the top and the newest wait at the bottom", () => {
+    const sessions = [
+      needsYou("new", "2026-07-09T12:00:00Z"),
+      needsYou("oldest", "2026-07-09T09:00:00Z"),
+      needsYou("middle", "2026-07-09T10:30:00Z"),
+    ];
+
+    expect(inWaitingOrder(sessions).map((s) => s.sessionId)).toEqual(["oldest", "middle", "new"]);
+  });
+
+  it("keeps only needs-you sessions and ignores manual desktop sortOrder", () => {
+    const sessions = [
+      needsYou("waited-most", "2026-07-09T08:00:00Z", { sortOrder: 99 }),
+      session({ sessionId: "active", effectiveColor: "blue", triageBucket: "active" }),
+      needsYou("waited-least", "2026-07-09T11:00:00Z", { sortOrder: 1 }),
+    ];
+
+    expect(inWaitingOrder(sessions).map((s) => s.sessionId)).toEqual(["waited-most", "waited-least"]);
+  });
+
+  it("sorts a session with no wait stamp to the bottom", () => {
+    const sessions = [
+      needsYou("no-stamp", undefined),
+      needsYou("has-stamp", "2026-07-09T09:00:00Z"),
+    ];
+
+    expect(inWaitingOrder(sessions).map((s) => s.sessionId)).toEqual(["has-stamp", "no-stamp"]);
   });
 });

--- a/packages/client-core/src/sessions/ordering.ts
+++ b/packages/client-core/src/sessions/ordering.ts
@@ -68,6 +68,37 @@ export function inBucket(sessions: SessionDto[], bucket: TriageBucket): SessionD
   return inDesktopOrder(sessions.filter((s) => classify(s) === bucket));
 }
 
+// The "waiting line" order for the needs-you group (the mobile roster's top group). The session that
+// has been asking for you the LONGEST sits at the top; a session that only just started needing you
+// drops in at the BOTTOM. This keeps the list from reshuffling under you as new work arrives and
+// makes it a natural first-in, first-handled queue when you work from the top down. Ordered by
+// needsYouSince ascending - the earliest stamp is the oldest wait. A session with no parseable stamp
+// sorts to the bottom, and createdAt then sessionId break ties so equal waits never jitter between
+// polls. This intentionally ignores the drag-to-reorder desktop SortOrder: the needs-you group is a
+// queue by wait time, not the user's manual arrangement.
+export function inWaitingOrder(sessions: SessionDto[]): SessionDto[] {
+  return sessions
+    .filter((s) => classify(s) === "needsYou")
+    .sort((a, b) => {
+      const wa = waitingSinceMs(a);
+      const wb = waitingSinceMs(b);
+      if (wa !== wb) return wa - wb;
+      const created = String(a.createdAt ?? "").localeCompare(String(b.createdAt ?? ""));
+      if (created !== 0) return created;
+      return String(a.sessionId ?? "").localeCompare(String(b.sessionId ?? ""));
+    });
+}
+
+// The needsYouSince stamp parsed to epoch milliseconds for the waiting-line sort. A missing or
+// unparseable stamp returns positive infinity so that session sorts to the bottom of the queue
+// (we cannot place it in the line, so it never jumps ahead of a session with a real wait time).
+function waitingSinceMs(s: SessionDto): number {
+  const raw = String(s.needsYouSince ?? "").trim();
+  if (raw.length === 0) return Number.POSITIVE_INFINITY;
+  const parsed = Date.parse(raw);
+  return Number.isNaN(parsed) ? Number.POSITIVE_INFINITY : parsed;
+}
+
 // Map an effective color to its dot hex. Mirrors the m.js palette so the mobile roster's dots
 // match the existing prototype and the desktop rail.
 const COLORS: Record<string, string> = {


### PR DESCRIPTION
## What
The mobile roster's **Needs you** group now behaves like a waiting line:

- The session that has been waiting for you the **longest** sits at the **top**.
- A session that only just started needing you drops in at the **bottom**.

## Why
Previously the group used the drag-to-reorder desktop `SortOrder`, so the list could reshuffle as sessions changed state, and there was no first-in, first-handled reading of it. Ordering by `needsYouSince` ascending:

1. Keeps the list **stable** as new work arrives (nothing jumps to the top and shoves the rest down).
2. Makes it a natural **first-in, first-handled queue** - work it top to bottom and you always deal with the longest-neglected session first.

## How
- Adds `inWaitingOrder()` to the shared `client-core` ordering module. Sorts the needs-you sessions by `needsYouSince` ascending; a missing/unparseable stamp sorts to the bottom, and `createdAt` then `sessionId` break ties so equal waits do not jitter between polls. It intentionally ignores the manual desktop `SortOrder` for this group.
- Switches the mobile Home roster to use it for the **Needs you** group. The **Other sessions** group keeps the manual desktop order unchanged.
- Unit tests cover longest-first ordering, needs-you-only filtering (ignoring `sortOrder`), and the missing-stamp-to-bottom rule.

## Verification
- `client-core`: 13 unit tests pass (existing + 3 new), `tsc --noEmit` clean.
- `apps/mobile`: `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)