### PR TITLE
Enforce fleet-broadcast scope at the Gateway Hub (#1229)

### DIFF
--- a/.claude/skills/fleet-comms/SKILL.md
+++ b/.claude/skills/fleet-comms/SKILL.md
@@ -48,6 +48,7 @@ repository folder name, is rejected - pass something meaningful or a purpose.
 ```
 cc-devthrottle message send 4c810000 "I finished the API layer - you can start the frontend."
 cc-devthrottle message send docs "Please update the API page when you get a chance."
+cc-devthrottle message send all "Heads up team: I am about to rebase our shared branch."
 cc-devthrottle message ask 9b2f "What database schema is loaded in your repo?"
 cc-devthrottle message ask docs "What is the title of the API page?" --timeout-ms 60000
 ```
@@ -60,16 +61,20 @@ always single-target and waits for the target's answer.
 Every incoming fleet message interrupts the receiving agent: it is typed into that agent's composer
 and starts a turn. So a message you send is a demand on someone else's attention. Keep it scoped.
 
-- Default scope is your own mission or team: a manager and its workers, and workers with their
-  siblings on the same piece of work. Message those sessions freely.
-- Do NOT broadcast to the whole fleet. `message send all` reaches every session on every machine
-  and in every repository - almost all of which have nothing to do with your work - and freezes
-  each one. Do not reach for it as a convenience.
-- For a notice your own team needs, message the specific sessions on your team, not the fleet.
-- For git coordination on a shared working tree, message only the sessions that share that exact
-  checkout - not the fleet. Sessions in other repositories cannot be affected by your git.
-- A true fleet-wide message needs a human's approval first. The Gateway Hub enforces these limits
-  and refuses an unjustified fleet-wide send (see issue #1229); do not try to route around it.
+- Default scope is your own team: the sessions in your Mission, or - if you are a solo session -
+  the sessions in the same repository on the same machine. A manager and its workers are one team.
+  Message those sessions freely.
+- `message send all` reaches ONLY your team, not the whole fleet. This is the everyday broadcast:
+  use it for a heads-up your teammates need. It never touches sessions in other repositories or
+  other missions, so it will not freeze the fleet.
+- For git coordination on a shared working tree, `message send all` already reaches only the
+  sessions that share your checkout - that is exactly who a shared-tree hold concerns.
+- A WHOLE-FLEET broadcast (`message send all --everyone`) is different: it interrupts every session
+  on every machine and repository. The Gateway Hub refuses it unless a human has issued a broadcast
+  grant, and it requires a `--reason`:
+  `cc-devthrottle message send all "..." --everyone --reason "why" --grant <id>`.
+  Almost nobody should need this. If you think you do, ask the human for a grant - do not try to
+  route around the Hub (it enforces the limit and also rate-limits repeated broadcasts). See issue #1229.
 
 ## Health check
 

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -428,15 +428,48 @@ internal static class ControlEndpoints
                 try
                 {
                     var fleet = await gw.ListFleetSessionsAsync(ct);
-                    var targets = fleet
-                        .Select(s => s.SessionId)
-                        .Where(idStr => !string.IsNullOrWhiteSpace(idStr)
-                            && !string.Equals(idStr, req.FromSessionId, StringComparison.OrdinalIgnoreCase))
-                        .ToList();
-                    if (targets.Count == 0)
-                        return Results.Json(new FleetSendResponse { Accepted = true, DeliveredCount = 0 });
 
-                    var resp = await gw.FanoutToFleetAsync(targets, framed, ct);
+                    // Issue #1229: by default a broadcast reaches only the sender's own team - the sessions
+                    // sharing its group, or (for a solo session) the sessions in the same repository on the
+                    // same machine. Only an explicit fleet-wide request (Everyone) targets every session,
+                    // and the Gateway Hub then gates that on a human-issued grant. Narrowing here is a
+                    // convenience; the Gateway enforces the same rule as the authority.
+                    var senderDto = fleet.FirstOrDefault(s =>
+                        string.Equals(s.SessionId, req.FromSessionId, StringComparison.OrdinalIgnoreCase));
+                    BroadcastScope? senderScope = senderDto is not null
+                        ? BroadcastScope.FromAggregatedSession(senderDto)
+                        : null;
+
+                    var targets = fleet
+                        .Where(s => !string.IsNullOrWhiteSpace(s.SessionId)
+                            && !string.Equals(s.SessionId, req.FromSessionId, StringComparison.OrdinalIgnoreCase))
+                        .Where(s => req.Everyone
+                            || (senderScope?.Includes(BroadcastScope.FromAggregatedSession(s)) ?? false))
+                        .Select(s => s.SessionId)
+                        .ToList();
+
+                    if (targets.Count == 0)
+                        return Results.Json(new FleetSendResponse
+                        {
+                            Accepted = true,
+                            DeliveredCount = 0,
+                            Warning = req.Everyone ? null : "No other sessions are on your team.",
+                        });
+
+                    var resp = await gw.FanoutToFleetAsync(
+                        targets, framed, req.FromSessionId,
+                        req.Everyone ? req.Reason : null,
+                        req.Everyone ? req.GrantId : null,
+                        ct);
+
+                    // The Hub refused on scope grounds (fleet-wide without a grant, or over the rate limit).
+                    if (resp.Denied)
+                    {
+                        FileLog.Write($"[ControlEndpoints] /fleet/broadcast DENIED by Hub: {resp.DeniedReason}");
+                        return Results.Json(new FleetSendResponse { Accepted = false, DeliveredCount = 0, Error = resp.DeniedReason },
+                            statusCode: StatusCodes.Status403Forbidden);
+                    }
+
                     var delivered = resp.Results.Count(r => r.Error is null);
                     return Results.Json(new FleetSendResponse { Accepted = true, DeliveredCount = delivered });
                 }
@@ -451,9 +484,22 @@ internal static class ControlEndpoints
                 }
             }
 
+            // Standalone (no Gateway): the "fleet" is only this Director's own sessions, so there is no
+            // cross-repo/cross-machine storm to guard and no Hub to mint grants. Still honor the team
+            // default (issue #1229): a plain broadcast reaches the sender's team; Everyone reaches all
+            // local sessions.
+            var senderLocal = Guid.TryParse(req.FromSessionId, out var senderGuid)
+                ? sessionManager.GetSession(senderGuid)
+                : null;
+            BroadcastScope? senderLocalScope = senderLocal is not null
+                ? new BroadcastScope(senderLocal.MissionId?.ToString(), senderLocal.GroupId?.ToString(), senderLocal.RepoPath, Environment.MachineName)
+                : null;
+
             var locals = sessionManager.ListSessions()
                 .Where(s => s.ActivityState != ActivityState.Exited)
                 .Where(s => !string.Equals(s.Id.ToString(), req.FromSessionId, StringComparison.OrdinalIgnoreCase))
+                .Where(s => req.Everyone
+                    || (senderLocalScope?.Includes(new BroadcastScope(s.MissionId?.ToString(), s.GroupId?.ToString(), s.RepoPath, Environment.MachineName)) ?? false))
                 .ToList();
             var count = 0;
             foreach (var s in locals)

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -265,8 +265,12 @@ public sealed class GatewayClient : IDisposable
     /// <summary>
     /// Relay a broadcast to many sessions via the Gateway's POST /fanout. Fire-and-forget
     /// (WaitForIdle=false). Throws when the Gateway is disabled or the call fails.
+    /// Issue #1229: carries the sender's id (so the Hub can decide the broadcast's scope from its own
+    /// fleet view) plus an optional reason and human-issued grant id for a fleet-wide broadcast. The
+    /// Hub may REFUSE on scope grounds, which comes back as a 2xx <see cref="FanoutResponse"/> with
+    /// <see cref="FanoutResponse.Denied"/> set - the caller surfaces that, it is not an error here.
     /// </summary>
-    public async Task<FanoutResponse> FanoutToFleetAsync(List<string> sessionIds, string text, CancellationToken ct = default)
+    public async Task<FanoutResponse> FanoutToFleetAsync(List<string> sessionIds, string text, string? fromSessionId = null, string? reason = null, string? grantId = null, CancellationToken ct = default)
     {
         if (!_config.IsEnabled)
             throw new InvalidOperationException("Gateway is not configured; cannot broadcast to the fleet.");
@@ -274,7 +278,16 @@ public sealed class GatewayClient : IDisposable
             throw new ArgumentException("At least one target session id is required", nameof(sessionIds));
 
         FileLog.Write($"[GatewayClient] FanoutToFleetAsync: POST /fanout to {sessionIds.Count} session(s)");
-        var body = new FanoutRequest { SessionIds = sessionIds, Text = text, AppendEnter = true, WaitForIdle = false };
+        var body = new FanoutRequest
+        {
+            SessionIds = sessionIds,
+            Text = text,
+            AppendEnter = true,
+            WaitForIdle = false,
+            FromSessionId = fromSessionId,
+            Reason = reason,
+            GrantId = grantId,
+        };
         using var resp = await _http.PostAsJsonAsync("fanout", body, ct);
         if (!resp.IsSuccessStatusCode)
             throw new InvalidOperationException($"Gateway fanout returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");

--- a/src/CcDirector.Core/Sessions/FleetPreamble.cs
+++ b/src/CcDirector.Core/Sessions/FleetPreamble.cs
@@ -34,16 +34,16 @@ public static class FleetPreamble
             "  cc-devthrottle session whoami        print your own id, name, machine, and repo",
             "  cc-devthrottle session rename \"name\" rename this session (uses CC_SESSION_ID)",
             "  cc-devthrottle message send <id> \"msg\"  message a specific session",
+            "  cc-devthrottle message send all \"msg\"   message your OWN TEAM (your mission / same repo)",
             "  cc-devthrottle message ask <id> \"question\"  ask a session and wait for its answer",
             "  cc-devthrottle session spawn <repo>  open a new session on this Director",
             "  cc-devthrottle schedule list       list Gateway schedules",
             "  cc-devthrottle setup status        show local setup status",
             "Address a session by a short prefix of its id or by its name. You reach the fleet through your",
             "own Director (CC_DIRECTOR_API); no Gateway address or token is needed.",
-            "Every message you send interrupts the receiving agent. Message only the specific sessions on",
-            "your own team or mission that need it. Do NOT broadcast to the whole fleet - a fleet-wide send",
-            "reaches every machine and repo, freezes them all, and the Gateway Hub refuses it without a",
-            "human's approval (issue #1229).",
+            "Every message you send interrupts the receiving agent. 'message send all' reaches only your own",
+            "team, which is what you want. Do NOT try to reach the WHOLE fleet ('--everyone') - it freezes",
+            "every session on every machine and repo; the Gateway Hub refuses it without a human grant (issue #1229).",
         };
 
         return string.Join("\n", lines);

--- a/src/CcDirector.Gateway.Contracts/BroadcastScope.cs
+++ b/src/CcDirector.Gateway.Contracts/BroadcastScope.cs
@@ -1,0 +1,63 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// The scope a session belongs to for broadcast purposes (issue #1229). A broadcast may reach the
+/// sender's own team freely; reaching beyond it needs a human-issued grant. "Team" is derived from
+/// the fleet view the Gateway already aggregates, NOT from anything the caller claims, in this order
+/// of precedence:
+///
+///   * A session attached to a MISSION (the first-class unit of work) travels with that Mission - the
+///     Architect, Manager, and Workers of one Mission share a <see cref="MissionId"/>, so they are in
+///     scope for each other. This is the primary team boundary.
+///   * Otherwise a GROUPED session (issue #225 <c>GroupId</c>) travels with its group.
+///   * Otherwise a SOLO session is scoped to its own working area: the same repository on the same
+///     machine. Sessions sharing that checkout are the ones a shared-tree notice actually concerns.
+///
+/// Lives in the Contracts assembly so BOTH the Director (which narrows an "all" broadcast to the
+/// sender's team before relaying) and the Gateway (which enforces the same rule as the authority)
+/// share one definition and cannot drift apart.
+/// </summary>
+public readonly record struct BroadcastScope(string? MissionId, string? GroupId, string RepoPath, string MachineName)
+{
+    /// <summary>True when this session is attached to a Mission - its primary team boundary.</summary>
+    public bool HasMission => !string.IsNullOrWhiteSpace(MissionId);
+
+    /// <summary>True when this session belongs to a group (issue #225) rather than running solo.</summary>
+    public bool IsGrouped => !string.IsNullOrWhiteSpace(GroupId);
+
+    /// <summary>
+    /// Build a scope from an aggregated fleet <see cref="SessionDto"/> - the shape the Gateway's
+    /// GET /sessions returns, where <see cref="SessionDto.MachineName"/> is populated. Use the
+    /// Gateway-internal builder instead when the session record is Director-local (machine empty).
+    /// </summary>
+    public static BroadcastScope FromAggregatedSession(SessionDto session)
+        => new(session.MissionId?.ToString(), session.GroupId, session.RepoPath, session.MachineName);
+
+    /// <summary>
+    /// True when <paramref name="target"/> is inside THIS sender's team, by the precedence above: a
+    /// Mission-attached sender includes every session in the same Mission; else a grouped sender
+    /// includes its group; else a solo sender includes every session in the same repository on the
+    /// same machine. Repository comparison is case- and separator-insensitive so "D:\Repo" and
+    /// "d:/repo/" match the same checkout.
+    /// </summary>
+    public bool Includes(BroadcastScope target)
+    {
+        if (HasMission)
+            return string.Equals(MissionId, target.MissionId, StringComparison.OrdinalIgnoreCase);
+
+        if (IsGrouped)
+            return string.Equals(GroupId, target.GroupId, StringComparison.OrdinalIgnoreCase);
+
+        return NormalizeRepo(RepoPath) == NormalizeRepo(target.RepoPath)
+            && string.Equals(MachineName ?? "", target.MachineName ?? "", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Normalize a repository path for comparison: trim, unify separators, drop a trailing
+    /// separator, lowercase. Windows paths are case-insensitive, so "D:\Repo\" and "d:/repo" are one
+    /// checkout.</summary>
+    private static string NormalizeRepo(string? repoPath)
+    {
+        if (string.IsNullOrWhiteSpace(repoPath)) return "";
+        return repoPath.Trim().Replace('\\', '/').TrimEnd('/').ToLowerInvariant();
+    }
+}

--- a/src/CcDirector.Gateway.Contracts/FanoutRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/FanoutRequest.cs
@@ -19,6 +19,28 @@ public sealed class FanoutRequest
 
     /// <summary>Per-session timeout in milliseconds. Default 300000 (5 min).</summary>
     public int TimeoutMs { get; set; } = 300_000;
+
+    /// <summary>
+    /// The broadcasting session's own GUID (issue #1229). The Gateway looks the sender up in its
+    /// own aggregated fleet view to decide the broadcast's allowed scope; it never trusts a role or
+    /// mission claim carried in the body. Null when unknown - an unknown sender is treated as
+    /// out-of-scope for every target, so a fleet-wide fan-out from an unidentified caller is denied.
+    /// </summary>
+    public string? FromSessionId { get; set; }
+
+    /// <summary>
+    /// Why this broadcast reaches beyond the sender's own team/mission (issue #1229). Required when
+    /// the recipients cross the sender's scope; logged by the Hub and surfaced to the human. Ignored
+    /// for an in-scope fan-out.
+    /// </summary>
+    public string? Reason { get; set; }
+
+    /// <summary>
+    /// A human-issued broadcast grant id (issue #1229) that authorizes reaching beyond the sender's
+    /// team/mission. Minted only through the Hub's auth-guarded grant endpoint - there is no Director
+    /// relay for minting, so an agent cannot mint its own. Null for an ordinary in-scope fan-out.
+    /// </summary>
+    public string? GrantId { get; set; }
 }
 
 /// <summary>
@@ -34,6 +56,17 @@ public sealed class FanoutResponse
 
     /// <summary>UTC timestamp all results were collected (or timeouts hit).</summary>
     public DateTime FinishedAt { get; set; }
+
+    /// <summary>
+    /// True when the Hub REFUSED the fan-out on scope grounds (issue #1229): the recipients reach
+    /// beyond the sender's team/mission and no valid grant was presented, or the sender exceeded the
+    /// per-sender broadcast rate limit. When true, nothing was delivered and <see cref="Results"/> is
+    /// empty; <see cref="DeniedReason"/> carries the human-readable explanation.
+    /// </summary>
+    public bool Denied { get; set; }
+
+    /// <summary>The plain-English reason the Hub refused the fan-out, when <see cref="Denied"/> is true.</summary>
+    public string? DeniedReason { get; set; }
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway.Contracts/FleetMessageRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/FleetMessageRequest.cs
@@ -35,6 +35,22 @@ public sealed class FleetBroadcastRequest
     /// <summary>The calling session's own GUID (its CC_SESSION_ID); excluded from the recipients
     /// and used to stamp the sender header.</summary>
     public string? FromSessionId { get; set; }
+
+    /// <summary>
+    /// Issue #1229: when false (the default), the broadcast reaches only the sender's own team - the
+    /// sessions sharing its group, or (for a solo session) the sessions in the same repository on the
+    /// same machine. When true, the caller is explicitly asking to reach the WHOLE fleet, which the
+    /// Gateway Hub allows only with a valid <see cref="GrantId"/> and a <see cref="Reason"/>.
+    /// </summary>
+    public bool Everyone { get; set; }
+
+    /// <summary>Issue #1229: why a fleet-wide broadcast is warranted. Required (with a grant) when
+    /// <see cref="Everyone"/> is true; logged by the Hub and surfaced to the human.</summary>
+    public string? Reason { get; set; }
+
+    /// <summary>Issue #1229: a human-issued broadcast grant id authorizing a fleet-wide broadcast.
+    /// Null for the ordinary team-scoped broadcast.</summary>
+    public string? GrantId { get; set; }
 }
 
 /// <summary>Response from POST /fleet/send and POST /fleet/broadcast.</summary>
@@ -45,6 +61,10 @@ public sealed class FleetSendResponse
 
     /// <summary>How many sessions the message was delivered to.</summary>
     public int DeliveredCount { get; set; }
+
+    /// <summary>Non-blocking note for an accepted send - e.g. a team-scoped broadcast (issue #1229)
+    /// that matched no other team member. Null when there is nothing to note.</summary>
+    public string? Warning { get; set; }
 
     /// <summary>Error message when Accepted is false.</summary>
     public string? Error { get; set; }

--- a/src/CcDirector.Gateway.Tests/BroadcastGovernorTests.cs
+++ b/src/CcDirector.Gateway.Tests/BroadcastGovernorTests.cs
@@ -1,0 +1,112 @@
+using System;
+using CcDirector.Gateway.Api;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for the Hub's broadcast governance state (issue #1229): the human-issued grant store and
+/// the per-sender broadcast rate limiter. Uses an injected clock so time-based behaviour is
+/// deterministic.
+/// </summary>
+public sealed class BroadcastGovernorTests
+{
+    private sealed class FakeClock
+    {
+        public DateTime Now = new(2026, 7, 10, 12, 0, 0, DateTimeKind.Utc);
+        public DateTime Get() => Now;
+        public void Advance(TimeSpan by) => Now += by;
+    }
+
+    // ===== Grants =====
+
+    [Fact]
+    public void MintedGrant_isValid_untilItExpires()
+    {
+        var clock = new FakeClock();
+        var gov = new BroadcastGovernor(grantTtl: TimeSpan.FromMinutes(10), now: clock.Get);
+
+        var grant = gov.MintGrant();
+        Assert.True(gov.IsGrantValid(grant));
+
+        clock.Advance(TimeSpan.FromMinutes(9));
+        Assert.True(gov.IsGrantValid(grant));
+
+        clock.Advance(TimeSpan.FromMinutes(2)); // now 11 minutes in, past the 10-minute TTL
+        Assert.False(gov.IsGrantValid(grant));
+    }
+
+    [Fact]
+    public void UnknownOrBlankGrant_isNeverValid()
+    {
+        var gov = new BroadcastGovernor();
+        Assert.False(gov.IsGrantValid(null));
+        Assert.False(gov.IsGrantValid(""));
+        Assert.False(gov.IsGrantValid("   "));
+        Assert.False(gov.IsGrantValid("not-a-real-grant"));
+    }
+
+    [Fact]
+    public void EachMintedGrant_isDistinct()
+    {
+        var gov = new BroadcastGovernor();
+        Assert.NotEqual(gov.MintGrant(), gov.MintGrant());
+    }
+
+    // ===== Rate limiting =====
+
+    [Fact]
+    public void SenderIsAllowed_upToTheLimit_thenDenied()
+    {
+        var clock = new FakeClock();
+        var gov = new BroadcastGovernor(maxPerWindow: 3, window: TimeSpan.FromSeconds(60), now: clock.Get);
+
+        Assert.True(gov.TryRecordSend("sender-1").Allowed);
+        Assert.True(gov.TryRecordSend("sender-1").Allowed);
+        Assert.True(gov.TryRecordSend("sender-1").Allowed);
+
+        var fourth = gov.TryRecordSend("sender-1");
+        Assert.False(fourth.Allowed);
+        Assert.Equal(3, fourth.LimitPerWindow);
+        Assert.Equal(60, fourth.WindowSeconds);
+    }
+
+    [Fact]
+    public void RateLimit_isPerSender_notGlobal()
+    {
+        var gov = new BroadcastGovernor(maxPerWindow: 1);
+
+        Assert.True(gov.TryRecordSend("sender-a").Allowed);
+        Assert.False(gov.TryRecordSend("sender-a").Allowed);
+        Assert.True(gov.TryRecordSend("sender-b").Allowed); // a different sender has its own budget
+    }
+
+    [Fact]
+    public void RateLimit_windowSlidesForward_soOldSendsFallOff()
+    {
+        var clock = new FakeClock();
+        var gov = new BroadcastGovernor(maxPerWindow: 2, window: TimeSpan.FromSeconds(60), now: clock.Get);
+
+        Assert.True(gov.TryRecordSend("s").Allowed);
+        Assert.True(gov.TryRecordSend("s").Allowed);
+        Assert.False(gov.TryRecordSend("s").Allowed);
+
+        clock.Advance(TimeSpan.FromSeconds(61)); // both prior sends are now outside the window
+        Assert.True(gov.TryRecordSend("s").Allowed);
+    }
+
+    [Fact]
+    public void BlankSender_isExempt_fromRateLimiting()
+    {
+        var gov = new BroadcastGovernor(maxPerWindow: 1);
+        Assert.True(gov.TryRecordSend(null).Allowed);
+        Assert.True(gov.TryRecordSend("").Allowed);
+        Assert.True(gov.TryRecordSend(null).Allowed);
+    }
+
+    [Fact]
+    public void Constructor_rejectsAZeroLimit()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BroadcastGovernor(maxPerWindow: 0));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/FanoutAndEventsTests.cs
+++ b/src/CcDirector.Gateway.Tests/FanoutAndEventsTests.cs
@@ -116,6 +116,66 @@ public sealed class FanoutAndEventsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task BroadcastGrant_requires_auth()
+    {
+        // Issue #1229: the grant-mint endpoint is behind the host-wide auth wall, so an unauthenticated
+        // caller (an agent that somehow reached the Gateway directly) cannot mint its own grant.
+        var resp = await _http.PostAsync("fleet/broadcast-grants", null);
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task BroadcastGrant_mints_a_grant_for_an_authenticated_caller()
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Post, "fleet/broadcast-grants");
+        req.Headers.Add("Authorization", "Bearer test-token");
+        var resp = await _http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        using var doc = System.Text.Json.JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.True(doc.RootElement.TryGetProperty("grantId", out var grantId));
+        Assert.False(string.IsNullOrWhiteSpace(grantId.GetString()));
+    }
+
+    [Fact]
+    public async Task Fanout_rate_limits_repeated_broadcasts_from_one_sender()
+    {
+        // Issue #1229: the Hub rate-limits how often any one session may broadcast (default 5 per 60s),
+        // so a runaway agent cannot storm the fleet in a loop. The denial round-trips as a 2xx
+        // FanoutResponse with Denied set - proving the FromSessionId flows to the Hub and the governor
+        // acts on it. (Target resolution is irrelevant to the rate limit, so no live PTY session needed.)
+        var sender = Guid.NewGuid().ToString();
+
+        async Task<FanoutResponse> Broadcast()
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Post, "fanout")
+            {
+                Content = JsonContent.Create(new FanoutRequest
+                {
+                    SessionIds = new() { Guid.NewGuid().ToString() },
+                    Text = "heads up",
+                    WaitForIdle = false,
+                    FromSessionId = sender,
+                }),
+            };
+            req.Headers.Add("Authorization", "Bearer test-token");
+            var resp = await _http.SendAsync(req);
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            return (await resp.Content.ReadFromJsonAsync<FanoutResponse>())!;
+        }
+
+        for (var i = 0; i < 5; i++)
+        {
+            var ok = await Broadcast();
+            Assert.False(ok.Denied);
+        }
+
+        var sixth = await Broadcast();
+        Assert.True(sixth.Denied);
+        Assert.Contains("Too many broadcasts", sixth.DeniedReason);
+    }
+
+    [Fact]
     public async Task Events_endpoint_streams_director_events()
     {
         // Connect to the SSE stream and AWAIT the response headers BEFORE booting the

--- a/src/CcDirector.Gateway.Tests/FleetBroadcastPolicyTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetBroadcastPolicyTests.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for the pure fleet-broadcast scope policy (issue #1229): who may reach whom, and when a
+/// broadcast beyond the sender's team is refused. Pure and machine-independent - no host spun up.
+/// </summary>
+public sealed class FleetBroadcastPolicyTests
+{
+    private static BroadcastScope Mission(string missionId, string repo = "D:\\Repo", string machine = "M1")
+        => new(missionId, GroupId: null, repo, machine);
+
+    private static BroadcastScope Group(string groupId, string repo = "D:\\Repo", string machine = "M1")
+        => new(MissionId: null, groupId, repo, machine);
+
+    private static BroadcastScope Solo(string repo, string machine)
+        => new(MissionId: null, GroupId: null, repo, machine);
+
+    private static List<(string, BroadcastScope)> Targets(params (string Id, BroadcastScope Scope)[] t)
+    {
+        var list = new List<(string, BroadcastScope)>();
+        foreach (var (id, scope) in t) list.Add((id, scope));
+        return list;
+    }
+
+    // ===== In-scope: the free lane =====
+
+    [Fact]
+    public void SameMission_isAllowedInScope_withoutGrant()
+    {
+        var sender = Mission("mission-x");
+        var targets = Targets(("a", Mission("mission-x")), ("b", Mission("mission-x")));
+
+        var d = FleetBroadcastPolicy.Evaluate(sender, targets, hasValidGrant: false, reason: null);
+
+        Assert.True(d.Allowed);
+        Assert.Equal(BroadcastOutcome.AllowedInScope, d.Outcome);
+        Assert.Equal(2, d.InScopeTargetIds.Count);
+        Assert.Empty(d.OutOfScopeTargetIds);
+    }
+
+    [Fact]
+    public void SameGroup_isAllowedInScope()
+    {
+        var sender = Group("group-1");
+        var targets = Targets(("a", Group("group-1")));
+
+        var d = FleetBroadcastPolicy.Evaluate(sender, targets, hasValidGrant: false, reason: null);
+
+        Assert.True(d.Allowed);
+        Assert.Equal(BroadcastOutcome.AllowedInScope, d.Outcome);
+    }
+
+    [Fact]
+    public void SoloSameRepoAndMachine_isAllowedInScope_caseAndSeparatorInsensitive()
+    {
+        var sender = Solo("D:\\ReposFred\\devthrottle", "SOREN_NORTH");
+        var targets = Targets(("a", Solo("d:/reposfred/devthrottle/", "soren_north")));
+
+        var d = FleetBroadcastPolicy.Evaluate(sender, targets, hasValidGrant: false, reason: null);
+
+        Assert.True(d.Allowed);
+        Assert.Equal(BroadcastOutcome.AllowedInScope, d.Outcome);
+    }
+
+    [Fact]
+    public void EmptyTargets_isAllowed()
+    {
+        var d = FleetBroadcastPolicy.Evaluate(Mission("x"), Targets(), hasValidGrant: false, reason: null);
+        Assert.True(d.Allowed);
+        Assert.Equal(BroadcastOutcome.AllowedInScope, d.Outcome);
+    }
+
+    // ===== Out of scope: the wall =====
+
+    [Fact]
+    public void DifferentMission_isDenied_withoutGrant()
+    {
+        var sender = Mission("mission-x");
+        var targets = Targets(("a", Mission("mission-x")), ("b", Mission("mission-y")));
+
+        var d = FleetBroadcastPolicy.Evaluate(sender, targets, hasValidGrant: false, reason: null);
+
+        Assert.False(d.Allowed);
+        Assert.Equal(BroadcastOutcome.DeniedOutOfScope, d.Outcome);
+        Assert.Equal(new[] { "a" }, d.InScopeTargetIds);
+        Assert.Equal(new[] { "b" }, d.OutOfScopeTargetIds);
+        Assert.Contains("#1229", d.DeniedReason);
+    }
+
+    [Fact]
+    public void SoloDifferentRepo_isDenied_theIncidentCase()
+    {
+        // The real incident: a session in one repo broadcasting to sessions in other repos.
+        var sender = Solo("D:\\ReposMindzie\\mindzieDocs", "SOREN_NORTH");
+        var targets = Targets(
+            ("a", Solo("D:\\ReposFred\\cc-consult", "SOREN_NORTH")),
+            ("b", Solo("D:\\ReposFred\\AgentEyes", "SOREN_NORTH")));
+
+        var d = FleetBroadcastPolicy.Evaluate(sender, targets, hasValidGrant: false, reason: null);
+
+        Assert.False(d.Allowed);
+        Assert.Equal(BroadcastOutcome.DeniedOutOfScope, d.Outcome);
+        Assert.Equal(2, d.OutOfScopeTargetIds.Count);
+    }
+
+    [Fact]
+    public void SoloDifferentMachine_isDenied_evenSameRepoPath()
+    {
+        var sender = Solo("D:\\Repo", "MACHINE_A");
+        var targets = Targets(("a", Solo("D:\\Repo", "MACHINE_B")));
+
+        var d = FleetBroadcastPolicy.Evaluate(sender, targets, hasValidGrant: false, reason: null);
+
+        Assert.False(d.Allowed);
+        Assert.Equal(BroadcastOutcome.DeniedOutOfScope, d.Outcome);
+    }
+
+    // ===== Grant path =====
+
+    [Fact]
+    public void OutOfScope_withValidGrantAndReason_isAllowedByGrant()
+    {
+        var sender = Mission("mission-x");
+        var targets = Targets(("a", Mission("mission-y")));
+
+        var d = FleetBroadcastPolicy.Evaluate(sender, targets, hasValidGrant: true, reason: "fleet-wide maintenance notice");
+
+        Assert.True(d.Allowed);
+        Assert.Equal(BroadcastOutcome.AllowedByGrant, d.Outcome);
+    }
+
+    [Fact]
+    public void OutOfScope_withGrantButNoReason_isDeniedMissingReason()
+    {
+        var sender = Mission("mission-x");
+        var targets = Targets(("a", Mission("mission-y")));
+
+        var d = FleetBroadcastPolicy.Evaluate(sender, targets, hasValidGrant: true, reason: "   ");
+
+        Assert.False(d.Allowed);
+        Assert.Equal(BroadcastOutcome.DeniedMissingReason, d.Outcome);
+    }
+
+    // ===== Unknown sender =====
+
+    [Fact]
+    public void UnknownSender_withTargets_isDenied_withoutGrant()
+    {
+        var targets = Targets(("a", Mission("mission-y")));
+
+        var d = FleetBroadcastPolicy.Evaluate(sender: null, targets, hasValidGrant: false, reason: null);
+
+        Assert.False(d.Allowed);
+        Assert.Equal(BroadcastOutcome.DeniedUnknownSender, d.Outcome);
+        Assert.Equal(new[] { "a" }, d.OutOfScopeTargetIds);
+    }
+
+    [Fact]
+    public void UnknownSender_withValidGrantAndReason_isAllowedByGrant()
+    {
+        var targets = Targets(("a", Mission("mission-y")), ("b", Solo("D:\\X", "M")));
+
+        var d = FleetBroadcastPolicy.Evaluate(sender: null, targets, hasValidGrant: true, reason: "operator broadcast");
+
+        Assert.True(d.Allowed);
+        Assert.Equal(BroadcastOutcome.AllowedByGrant, d.Outcome);
+    }
+
+    [Fact]
+    public void UnknownSender_withNoTargets_isAllowed()
+    {
+        var d = FleetBroadcastPolicy.Evaluate(sender: null, Targets(), hasValidGrant: false, reason: null);
+        Assert.True(d.Allowed);
+    }
+
+    [Fact]
+    public void MissionPrecedence_missionWins_overRepo()
+    {
+        // Same repo/machine but DIFFERENT mission => out of scope. Mission is the team boundary.
+        var sender = new BroadcastScope("mission-x", GroupId: null, "D:\\Repo", "M1");
+        var targets = Targets(("a", new BroadcastScope("mission-y", GroupId: null, "D:\\Repo", "M1")));
+
+        var d = FleetBroadcastPolicy.Evaluate(sender, targets, hasValidGrant: false, reason: null);
+
+        Assert.False(d.Allowed);
+        Assert.Equal(BroadcastOutcome.DeniedOutOfScope, d.Outcome);
+    }
+}

--- a/src/CcDirector.Gateway/Api/BroadcastGovernor.cs
+++ b/src/CcDirector.Gateway/Api/BroadcastGovernor.cs
@@ -1,0 +1,112 @@
+using System.Collections.Concurrent;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>Result of a per-sender broadcast rate-limit check (issue #1229).</summary>
+/// <param name="Allowed">True when the sender is under the limit and the send was recorded.</param>
+/// <param name="LimitPerWindow">The configured maximum broadcasts per window.</param>
+/// <param name="WindowSeconds">The window length in seconds.</param>
+public readonly record struct RateLimitResult(bool Allowed, int LimitPerWindow, int WindowSeconds);
+
+/// <summary>
+/// The stateful half of the Hub's broadcast governance (issue #1229): it mints and validates the
+/// human-issued broadcast grants that let a message reach beyond the sender's team, and it rate-limits
+/// how often any one session may broadcast so a runaway agent cannot storm the fleet even inside its
+/// own team. Kept separate from the pure <see cref="FleetBroadcastPolicy"/> so the scope rule stays
+/// I/O-free; this class owns the in-memory state. Thread-safe. One instance per Gateway process.
+///
+/// Grants are validated (not consumed one-shot) for their short lifetime, so a human who authorizes a
+/// fleet-wide announcement can send it without the grant evaporating on the first attempt; the short
+/// time-to-live bounds the exposure.
+/// </summary>
+public sealed class BroadcastGovernor
+{
+    private readonly int _maxPerWindow;
+    private readonly TimeSpan _window;
+    private readonly TimeSpan _grantTtl;
+    private readonly Func<DateTime> _now;
+
+    // senderId -> UTC timestamps of its recent recorded broadcasts (pruned to the window on each check).
+    private readonly ConcurrentDictionary<string, List<DateTime>> _sends = new(StringComparer.OrdinalIgnoreCase);
+
+    // grantId -> UTC expiry.
+    private readonly ConcurrentDictionary<string, DateTime> _grants = new();
+
+    private readonly object _sendsLock = new();
+
+    /// <param name="maxPerWindow">Maximum broadcasts one session may make per window. Default 5.</param>
+    /// <param name="window">The rolling rate-limit window. Default 60 seconds.</param>
+    /// <param name="grantTtl">How long a minted grant stays valid. Default 10 minutes.</param>
+    /// <param name="now">Clock seam for tests. Default <see cref="DateTime.UtcNow"/>.</param>
+    public BroadcastGovernor(int maxPerWindow = 5, TimeSpan? window = null, TimeSpan? grantTtl = null, Func<DateTime>? now = null)
+    {
+        if (maxPerWindow < 1) throw new ArgumentOutOfRangeException(nameof(maxPerWindow), "The rate limit must allow at least one broadcast per window.");
+        _maxPerWindow = maxPerWindow;
+        _window = window ?? TimeSpan.FromSeconds(60);
+        _grantTtl = grantTtl ?? TimeSpan.FromMinutes(10);
+        _now = now ?? (() => DateTime.UtcNow);
+    }
+
+    /// <summary>The configured maximum broadcasts per window (for messages and diagnostics).</summary>
+    public int MaxPerWindow => _maxPerWindow;
+
+    /// <summary>The configured rate-limit window in whole seconds (for messages and diagnostics).</summary>
+    public int WindowSeconds => (int)_window.TotalSeconds;
+
+    /// <summary>
+    /// Mint a fresh broadcast grant, valid for the configured time-to-live. Returns the opaque grant
+    /// id the caller hands to the broadcaster. Only reachable through the Hub's auth-guarded grant
+    /// endpoint - there is no Director relay for minting, so an agent cannot mint its own.
+    /// </summary>
+    public string MintGrant()
+    {
+        var id = Guid.NewGuid().ToString("N");
+        _grants[id] = _now() + _grantTtl;
+        return id;
+    }
+
+    /// <summary>
+    /// True when <paramref name="grantId"/> names a grant that exists and has not expired. Prunes any
+    /// expired grants it encounters. A null/blank id is never valid.
+    /// </summary>
+    public bool IsGrantValid(string? grantId)
+    {
+        if (string.IsNullOrWhiteSpace(grantId)) return false;
+        PruneExpiredGrants();
+        return _grants.TryGetValue(grantId, out var expiry) && expiry > _now();
+    }
+
+    /// <summary>
+    /// Record a broadcast by <paramref name="senderId"/> against the rolling window and report whether
+    /// it is under the limit. When the sender is over the limit nothing is recorded and
+    /// <see cref="RateLimitResult.Allowed"/> is false. A null/blank sender id is exempt (it cannot be
+    /// tracked); the scope policy already denies an unidentified fleet-wide sender.
+    /// </summary>
+    public RateLimitResult TryRecordSend(string? senderId)
+    {
+        if (string.IsNullOrWhiteSpace(senderId))
+            return new RateLimitResult(true, _maxPerWindow, WindowSeconds);
+
+        var now = _now();
+        var cutoff = now - _window;
+
+        lock (_sendsLock)
+        {
+            var stamps = _sends.GetOrAdd(senderId, _ => new List<DateTime>());
+            stamps.RemoveAll(t => t < cutoff);
+            if (stamps.Count >= _maxPerWindow)
+                return new RateLimitResult(false, _maxPerWindow, WindowSeconds);
+
+            stamps.Add(now);
+            return new RateLimitResult(true, _maxPerWindow, WindowSeconds);
+        }
+    }
+
+    private void PruneExpiredGrants()
+    {
+        var now = _now();
+        foreach (var kvp in _grants)
+            if (kvp.Value <= now)
+                _grants.TryRemove(kvp.Key, out _);
+    }
+}

--- a/src/CcDirector.Gateway/Api/FleetBroadcastPolicy.cs
+++ b/src/CcDirector.Gateway/Api/FleetBroadcastPolicy.cs
@@ -1,0 +1,113 @@
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>Why the Hub allowed or refused a broadcast (issue #1229). Drives logging and the message
+/// the sender sees.</summary>
+public enum BroadcastOutcome
+{
+    /// <summary>Every recipient is inside the sender's own team; delivered without a grant.</summary>
+    AllowedInScope,
+
+    /// <summary>Recipients reach beyond the team, but a valid human grant authorized it.</summary>
+    AllowedByGrant,
+
+    /// <summary>Recipients reach beyond the team and no valid grant was presented.</summary>
+    DeniedOutOfScope,
+
+    /// <summary>A grant was presented for an out-of-team broadcast but no reason was given.</summary>
+    DeniedMissingReason,
+
+    /// <summary>The sender could not be identified, so no scope could be established.</summary>
+    DeniedUnknownSender,
+}
+
+/// <summary>The Hub's scope verdict for one broadcast (issue #1229). Pure data - the caller logs it
+/// and either delivers or refuses.</summary>
+public sealed record BroadcastDecision(
+    bool Allowed,
+    BroadcastOutcome Outcome,
+    string? DeniedReason,
+    IReadOnlyList<string> InScopeTargetIds,
+    IReadOnlyList<string> OutOfScopeTargetIds);
+
+/// <summary>
+/// Pure, I/O-free decision for whether a fan-out may proceed on SCOPE grounds (issue #1229). Kept
+/// separate from delivery and from the stateful rate-limit / grant store (<see cref="BroadcastGovernor"/>)
+/// so the who-may-reach-whom rule is unit-testable in isolation, mirroring
+/// <see cref="CcDirector.ControlApi.FleetMessaging"/>.
+/// </summary>
+public static class FleetBroadcastPolicy
+{
+    /// <summary>The plain-English refusal the sender sees when a broadcast leaves its team without a
+    /// grant. ASCII only so it renders in every agent terminal.</summary>
+    public const string OutOfScopeMessage =
+        "This broadcast reaches sessions outside your own team (a different repository, machine, or group). "
+        + "Message only the sessions on your own team, or ask a human to issue a broadcast grant for a "
+        + "genuine fleet-wide message. See issue #1229.";
+
+    /// <summary>
+    /// Decide whether a broadcast from <paramref name="sender"/> to <paramref name="targets"/> may
+    /// proceed. <paramref name="sender"/> is null when the caller could not be identified in the
+    /// fleet view. <paramref name="hasValidGrant"/> is the governor's verdict on the presented grant
+    /// id. <paramref name="reason"/> is the caller's justification (required only when a grant carries
+    /// an out-of-team broadcast).
+    /// </summary>
+    /// <param name="targets">Every recipient with the scope the Hub resolved for it. Empty is allowed
+    /// (nothing to deliver).</param>
+    public static BroadcastDecision Evaluate(
+        BroadcastScope? sender,
+        IReadOnlyList<(string SessionId, BroadcastScope Scope)> targets,
+        bool hasValidGrant,
+        string? reason)
+    {
+        targets ??= Array.Empty<(string, BroadcastScope)>();
+
+        // An unknown sender has no team, so every recipient is out of scope. A valid human grant is
+        // still the override - a human vouching for the broadcast does not need the sender resolved.
+        if (sender is null)
+        {
+            if (targets.Count == 0)
+                return new BroadcastDecision(true, BroadcastOutcome.AllowedInScope, null,
+                    Array.Empty<string>(), Array.Empty<string>());
+
+            var allIds = targets.Select(t => t.SessionId).ToList();
+            if (!hasValidGrant)
+                return new BroadcastDecision(false, BroadcastOutcome.DeniedUnknownSender,
+                    "The broadcasting session could not be identified in the fleet, so its team is unknown. "
+                    + "Re-send from a live session, or use a human-issued grant. See issue #1229.",
+                    Array.Empty<string>(), allIds);
+
+            if (string.IsNullOrWhiteSpace(reason))
+                return new BroadcastDecision(false, BroadcastOutcome.DeniedMissingReason,
+                    "A fleet-wide broadcast needs a reason. See issue #1229.",
+                    Array.Empty<string>(), allIds);
+
+            return new BroadcastDecision(true, BroadcastOutcome.AllowedByGrant, null,
+                Array.Empty<string>(), allIds);
+        }
+
+        var inScope = new List<string>();
+        var outOfScope = new List<string>();
+        foreach (var (sessionId, scope) in targets)
+        {
+            if (sender.Value.Includes(scope)) inScope.Add(sessionId);
+            else outOfScope.Add(sessionId);
+        }
+
+        // Everyone is on the sender's team: the free, everyday lane (manager <-> workers, same repo).
+        if (outOfScope.Count == 0)
+            return new BroadcastDecision(true, BroadcastOutcome.AllowedInScope, null, inScope, outOfScope);
+
+        // The broadcast leaves the team. Only a valid human grant lets it through, and only with a reason.
+        if (!hasValidGrant)
+            return new BroadcastDecision(false, BroadcastOutcome.DeniedOutOfScope, OutOfScopeMessage, inScope, outOfScope);
+
+        if (string.IsNullOrWhiteSpace(reason))
+            return new BroadcastDecision(false, BroadcastOutcome.DeniedMissingReason,
+                "A broadcast beyond your team needs a reason to accompany the grant. See issue #1229.",
+                inScope, outOfScope);
+
+        return new BroadcastDecision(true, BroadcastOutcome.AllowedByGrant, null, inScope, outOfScope);
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -90,6 +90,11 @@ internal static class GatewayEndpoints
         // so this value is never consulted and location stays on the HTTP pull, byte-identical to today.
         var streamStaleResolved = streamStaleAfter ?? TimeSpan.FromSeconds(Core.Configuration.GatewayConfig.DefaultStreamStaleAfterSeconds);
 
+        // Issue #1229: the Hub's broadcast governance state - the human-issued grant store and the
+        // per-sender broadcast rate limiter. One instance per Gateway process, shared by the grant-mint
+        // endpoint and the /fanout guard below. The pure scope rule lives in FleetBroadcastPolicy.
+        var broadcastGovernor = new BroadcastGovernor();
+
         // Issue #376: async voice-turn submit/poll (the phone's reconnect-resilient voice
         // interface). Mapped first for readability; route precedence (literal segments win
         // over the catch-all session forwarder) does the actual dispatch.
@@ -1458,6 +1463,19 @@ internal static class GatewayEndpoints
             }, statusCode: 201);
         });
 
+        // Issue #1229: mint a human-issued broadcast grant. Reaching beyond a sender's own team needs
+        // one of these. This endpoint sits behind the host-wide auth middleware (the shared token or a
+        // per-device key) and has NO Director relay, so an agent - which can only reach its own Director,
+        // never the Gateway directly - cannot mint its own grant. A human tool holding the token mints
+        // one and hands the id to the broadcaster. (A dedicated human-approval surface can tighten who
+        // may mint in a later pass.)
+        app.MapPost("/fleet/broadcast-grants", () =>
+        {
+            var grantId = broadcastGovernor.MintGrant();
+            FileLog.Write("[GatewayEndpoints] POST /fleet/broadcast-grants: minted a broadcast grant");
+            return Results.Json(new { grantId, expiresInSeconds = (int)TimeSpan.FromMinutes(10).TotalSeconds });
+        });
+
         app.MapPost("/fanout", async (FanoutRequest req) =>
         {
             if (req is null || req.SessionIds is null || req.SessionIds.Count == 0)
@@ -1465,17 +1483,72 @@ internal static class GatewayEndpoints
             if (string.IsNullOrEmpty(req.Text))
                 return Results.BadRequest(new { error = "text is required" });
 
-            FileLog.Write($"[GatewayEndpoints] POST fanout: count={req.SessionIds.Count}, len={req.Text.Length}");
+            FileLog.Write($"[GatewayEndpoints] POST fanout: count={req.SessionIds.Count}, len={req.Text.Length}, from={req.FromSessionId}");
 
-            var startedAt = DateTime.UtcNow;
-
-            // Resolve all directors once up-front
+            // Resolve all directors once up-front, capturing each target's broadcast scope (issue #1229).
             var directorBySession = new Dictionary<string, DirectorDto>();
+            var targetScopes = new List<(string SessionId, BroadcastScope Scope)>();
             foreach (var sid in req.SessionIds)
             {
                 var (d, s) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
-                if (d is not null && s is not null) directorBySession[sid] = d;
+                if (d is not null && s is not null)
+                {
+                    directorBySession[sid] = d;
+                    targetScopes.Add((sid, BuildBroadcastScope(d, s)));
+                }
             }
+
+            // Issue #1229: the Hub decides whether this broadcast may reach every recipient. A broadcast
+            // that stays inside the sender's own team (its group, or - for a solo session - the same repo
+            // on the same machine) is free; one that reaches beyond it is refused unless a human grant
+            // (plus a reason) authorizes it. The sender's scope is read from the Gateway's OWN fleet view,
+            // never trusted from the request body.
+            BroadcastScope? senderScope = null;
+            if (!string.IsNullOrWhiteSpace(req.FromSessionId))
+            {
+                var (sd, ss) = await LocateSessionAsync(registry, client, req.FromSessionId, pushedSessions, streamStaleResolved);
+                if (sd is not null && ss is not null) senderScope = BuildBroadcastScope(sd, ss);
+            }
+
+            // Only resolve a grant when a recipient is genuinely out of team and a reason accompanies it,
+            // so a valid grant is not spent validating a malformed request.
+            var anyOutOfScope = senderScope is null
+                ? targetScopes.Count > 0
+                : targetScopes.Any(t => !senderScope.Value.Includes(t.Scope));
+            var hasValidGrant = anyOutOfScope
+                && !string.IsNullOrWhiteSpace(req.Reason)
+                && broadcastGovernor.IsGrantValid(req.GrantId);
+
+            var decision = FleetBroadcastPolicy.Evaluate(senderScope, targetScopes, hasValidGrant, req.Reason);
+            if (!decision.Allowed)
+            {
+                FileLog.Write($"[GatewayEndpoints] fanout DENIED ({decision.Outcome}): from={req.FromSessionId}, targets={req.SessionIds.Count}, outOfScope={decision.OutOfScopeTargetIds.Count}, reason='{req.Reason}'");
+                return Results.Json(new FanoutResponse
+                {
+                    Denied = true,
+                    DeniedReason = decision.DeniedReason,
+                    StartedAt = DateTime.UtcNow,
+                    FinishedAt = DateTime.UtcNow,
+                });
+            }
+
+            // Rate-limit even an in-team broadcast so a runaway agent cannot storm the fleet in a loop.
+            var rate = broadcastGovernor.TryRecordSend(req.FromSessionId);
+            if (!rate.Allowed)
+            {
+                FileLog.Write($"[GatewayEndpoints] fanout RATE-LIMITED: from={req.FromSessionId}, limit={rate.LimitPerWindow}/{rate.WindowSeconds}s");
+                return Results.Json(new FanoutResponse
+                {
+                    Denied = true,
+                    DeniedReason = $"Too many broadcasts in a short time (limit {rate.LimitPerWindow} per {rate.WindowSeconds} seconds). Wait a moment and try again. See issue #1229.",
+                    StartedAt = DateTime.UtcNow,
+                    FinishedAt = DateTime.UtcNow,
+                });
+            }
+
+            FileLog.Write($"[GatewayEndpoints] fanout ALLOWED ({decision.Outcome}): from={req.FromSessionId}, inScope={decision.InScopeTargetIds.Count}, outOfScope={decision.OutOfScopeTargetIds.Count}");
+
+            var startedAt = DateTime.UtcNow;
 
             // Send to all in parallel
             var sendTasks = req.SessionIds.Select(async sid =>
@@ -1703,6 +1776,16 @@ internal static class GatewayEndpoints
     // so it fans out to all Directors in parallel rather than scanning them one-by-one:
     // total latency is bounded by the slowest single lookup (~the client timeout) instead
     // of summing one timeout per Director. Exactly one Director should own a given sid.
+    // Issue #1229: build the broadcast scope for a session from the Gateway's aggregated view. The
+    // group id and repository come from the session record; the machine comes from the owning Director
+    // (a Director-local session record leaves MachineName empty). This is the ground truth the Hub keys
+    // its who-may-reach-whom decision on - never a role/mission claim carried in the request body.
+    private static BroadcastScope BuildBroadcastScope(DirectorDto director, SessionDto session)
+    {
+        var machine = string.IsNullOrWhiteSpace(session.MachineName) ? (director.MachineName ?? "") : session.MachineName;
+        return new BroadcastScope(session.MissionId?.ToString(), session.GroupId, session.RepoPath, machine);
+    }
+
     private static async Task<(DirectorDto? director, SessionDto? session)> LocateSessionAsync(
         DirectorRegistry registry, DirectorEndpointClient client, string sid,
         Streaming.PushedSessionStore? pushedSessions, TimeSpan streamStale)

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -425,11 +425,29 @@ def mission_list(
 
 @message_app.command("send")
 def message_send(
-    target: str = typer.Argument(..., help="Target session id, id prefix, or name - or 'all'."),
+    target: str = typer.Argument(..., help="Target session id, id prefix, or name - or 'all' for your team."),
     message: str = typer.Argument(..., help="The message text to send."),
+    everyone: bool = typer.Option(
+        False,
+        "--everyone",
+        help="Broadcast to the WHOLE fleet, not just your own team. Every message interrupts the "
+        "receiving agent, so this is gated by the Gateway Hub: it needs a human-issued grant (--grant) "
+        "and a --reason, and is refused otherwise (issue #1229). Without this flag, 'all' reaches only "
+        "your team - the sessions in your Mission, or (solo) the same repository on the same machine.",
+    ),
+    reason: Optional[str] = typer.Option(
+        None,
+        "--reason",
+        help="Why a fleet-wide broadcast is warranted. Required with --everyone; logged by the Hub.",
+    ),
+    grant: Optional[str] = typer.Option(
+        None,
+        "--grant",
+        help="A human-issued broadcast grant id authorizing a fleet-wide broadcast (--everyone).",
+    ),
 ) -> None:
-    """Send a message to one session, or every session when TARGET is 'all'."""
-    send_message(target, message)
+    """Send a message to one session, or to your team when TARGET is 'all' (add --everyone for the whole fleet)."""
+    send_message(target, message, everyone=everyone, reason=reason, grant=grant)
 
 
 @message_app.command("ask")

--- a/tools/cc-devthrottle/src/session_ops.py
+++ b/tools/cc-devthrottle/src/session_ops.py
@@ -229,28 +229,49 @@ def _report_delivery(resp: Any, who: str) -> None:
     accepted = False
     count = 0
     err: Optional[str] = None
+    warning: Optional[str] = None
     if isinstance(resp, dict):
         accepted = bool(resp.get("accepted", resp.get("Accepted", False)))
         count = int(resp.get("deliveredCount", resp.get("DeliveredCount", 0)) or 0)
         err = resp.get("error") or resp.get("Error")
+        warning = resp.get("warning") or resp.get("Warning")
     if accepted:
         console.print(f"[green]Delivered[/green] to {who} ({count} session(s)).")
+        if warning:
+            console.print(f"[yellow]Note:[/yellow] {warning}")
     else:
         console.print(f"[red]Not delivered:[/red] {err or 'unknown error'}")
         raise typer.Exit(1)
 
 
-def send_message(target: str, message: str) -> None:
-    """Send a message to one session, or broadcast with target 'all'."""
+def send_message(
+    target: str,
+    message: str,
+    everyone: bool = False,
+    reason: str | None = None,
+    grant: str | None = None,
+) -> None:
+    """Send a message to one session, or broadcast with target 'all'.
+
+    A plain 'all' reaches only the sender's team (its Mission, or - solo - the same repository on the
+    same machine). --everyone asks to reach the whole fleet, which the Gateway Hub gates on a human
+    grant plus a reason (issue #1229)."""
     me = director.session_id()
 
     if target.strip().lower() == "all":
+        body = {"text": message, "fromSessionId": me}
+        if everyone:
+            body["everyone"] = True
+            if reason:
+                body["reason"] = reason
+            if grant:
+                body["grantId"] = grant
         try:
-            resp = director.post_json("fleet/broadcast", {"text": message, "fromSessionId": me})
+            resp = director.post_json("fleet/broadcast", body)
         except director.DirectorError as err:
             console.print(f"[red]Error:[/red] {err}")
             raise typer.Exit(1)
-        _report_delivery(resp, "everyone")
+        _report_delivery(resp, "the whole fleet" if everyone else "your team")
         return
 
     chosen = _resolve_target(target, command_name="cc-devthrottle message send")


### PR DESCRIPTION
Closes #1229.

## What this does

A single session broadcast to all 16 fleet sessions across every repository and machine, freezing each one. The Gateway Hub now decides **who a broadcast may reach**, so the everyday in-team notice stays free and a whole-fleet blast becomes hard, justified, and rare.

**Scope (the team boundary).** A broadcast may reach the sender's own team without friction:
- the sessions in its **Mission** (the first-class unit of work), or
- for a solo session, the sessions in the **same repository on the same machine**.

Reaching beyond that is **refused** unless a human-issued grant plus a reason authorizes it. The Hub reads the sender's scope from its **own aggregated fleet view** - it never trusts a role or mission claim carried in the request body.

## Why the Hub

The Gateway is the only component that sees the whole fleet and the trust boundary an agent cannot route around (an agent reaches only its own Director; there is no Director relay for minting a grant). So enforcement lives in the Gateway `/fanout` handler, mirroring the existing `DictationLock` gate.

## Changes

- **Contracts:** `BroadcastScope` (precedence Mission -> Group -> repo+machine), placed in the shared Contracts assembly so the Director and Gateway share one rule and cannot drift. `FanoutRequest` gains `FromSessionId`/`Reason`/`GrantId`; `FanoutResponse` gains `Denied`/`DeniedReason`; `FleetBroadcastRequest` gains `Everyone`/`Reason`/`GrantId`.
- **Gateway:** pure `FleetBroadcastPolicy` (the scope verdict) + `BroadcastGovernor` (in-memory human-grant store + per-sender rate limit, injectable clock). `/fanout` resolves the sender and every target's scope, evaluates the policy, rate-limits, and refuses with a plain-English reason. New auth-guarded `POST /fleet/broadcast-grants` mints a grant - there is **no Director relay** for it, so an agent cannot mint its own.
- **Director:** `/fleet/broadcast` narrows `all` to the sender's team by default, passes the sender id/reason/grant through, and surfaces a Hub denial as `403`.
- **cc-devthrottle:** `message send all` now means **your team**; `--everyone` (with `--reason`/`--grant`) requests a whole-fleet broadcast the Hub gates.
- **Guidance:** the `fleet-comms` skill and `FleetPreamble` (injected into every session at launch) updated to teach the team default.

## Tests

- `FleetBroadcastPolicyTests` - the scope rule (in-scope by mission/group/repo, out-of-scope denial incl. the real incident shape, grant + missing-reason, unknown sender).
- `BroadcastGovernorTests` - grant validity/expiry and per-sender rate limiting with an injected clock.
- End-to-end (`FanoutAndEventsTests`) - grant-mint auth + mint, and a rate-limit denial round-tripping through the real Gateway `/fanout`.
- **Full Gateway suite green: 1632 passed.** Solution builds with 0 warnings.

## Deliberate scope boundaries (follow-ups)

- Single targeted sends (`/sessions/{sid}/prompt`) are **not** gated - that path also serves the desktop/Cockpit, and a single message is not the chatter-storm problem. Looping individual sends is a known residual.
- A dedicated human-approval surface for issuing grants (a desktop/Cockpit button) can tighten who may mint; today any holder of the shared token can, which agents cannot reach.

## When it takes effect

The skill reaches installed machines once they pull skills from `main`; the Director/Gateway changes land with the next build. The guidance (already merged in #1231) is advisory; this PR is the enforced wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)