### PR TITLE
Gateway publishes its ordered list of reachable addresses to the account (#1233)

### DIFF
--- a/src/CcDirector.Core.Tests/Account/DeviceRegistryClientRegisterHeartbeatTests.cs
+++ b/src/CcDirector.Core.Tests/Account/DeviceRegistryClientRegisterHeartbeatTests.cs
@@ -83,6 +83,54 @@ public sealed class DeviceRegistryClientRegisterHeartbeatTests
     }
 
     [Fact]
+    public async Task RegisterAsync_SendsEndpointUrlsArrayInOrder_AndParsesItBack()
+    {
+        // Issue #1233: the ordered address list is sent as a JSON array and parsed back onto the record.
+        var record =
+            "{\"id\":\"dev-1233\",\"name\":\"GW-HOST\"," +
+            "\"endpoint_url\":\"http://GW-HOST:7878\"," +
+            "\"endpoint_urls\":[\"http://GW-HOST:7878\",\"https://gw.tailnet.ts.net:7878\",\"http://192.168.1.20:7878\"]}";
+        var registerBody = $"{{\"data\":{{\"device_key\":\"{DeviceKeyMarker}\",\"record\":{record}}}}}";
+        var handler = new CapturingHandler(HttpStatusCode.OK, registerBody);
+        var client = ClientOver(handler);
+
+        var urls = new[] { "http://GW-HOST:7878", "https://gw.tailnet.ts.net:7878", "http://192.168.1.20:7878" };
+        var request = new CloudDeviceRegistrationRequest("install-abc", "windows", "GW-HOST", "gateway", "9.9.9", urls[0], urls);
+        var result = await client.RegisterAsync("access-xyz", request);
+
+        // Sent as an ordered JSON array under endpoint_urls.
+        var sent = JsonNode.Parse(handler.Body!)!.AsObject();
+        var sentArray = sent["endpoint_urls"]!.AsArray().Select(n => (string)n!).ToArray();
+        Assert.Equal(urls, sentArray);
+        // endpoint_url is still sent as the first entry (non-breaking).
+        Assert.Equal("http://GW-HOST:7878", (string?)sent["endpoint_url"]);
+
+        // Parsed back onto the record as an ordered list.
+        Assert.Equal(urls, result.Device.EndpointUrls);
+        Assert.Equal("http://GW-HOST:7878", result.Device.EndpointUrl);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_OmitsEndpointUrlsWhenNullOrEmpty_AndParsesNullWhenAbsent()
+    {
+        var registerBody = $"{{\"data\":{{\"device_key\":\"{DeviceKeyMarker}\",\"record\":{{\"id\":\"d\",\"name\":\"n\"}}}}}}";
+
+        // Null list -> field not sent.
+        var nullHandler = new CapturingHandler(HttpStatusCode.OK, registerBody);
+        var nullResult = await ClientOver(nullHandler).RegisterAsync("access-xyz",
+            new CloudDeviceRegistrationRequest("install-abc", "windows", "n", "gateway", "9.9.9", null, null));
+        Assert.False(JsonNode.Parse(nullHandler.Body!)!.AsObject().ContainsKey("endpoint_urls"));
+        // A record with no endpoint_urls parses it as null (not an empty list, not a throw).
+        Assert.Null(nullResult.Device.EndpointUrls);
+
+        // Empty list -> field not sent (never an empty array on the wire).
+        var emptyHandler = new CapturingHandler(HttpStatusCode.OK, registerBody);
+        await ClientOver(emptyHandler).RegisterAsync("access-xyz",
+            new CloudDeviceRegistrationRequest("install-abc", "windows", "n", "gateway", "9.9.9", null, Array.Empty<string>()));
+        Assert.False(JsonNode.Parse(emptyHandler.Body!)!.AsObject().ContainsKey("endpoint_urls"));
+    }
+
+    [Fact]
     public async Task RegisterAsync_OmitsOptionalFieldsWhenNull()
     {
         // Enveloped real-cloud shape: { data: { device_key, record } }.
@@ -174,6 +222,28 @@ public sealed class DeviceRegistryClientRegisterHeartbeatTests
         await ClientOver(withoutUrl).HeartbeatAsync("access-xyz", "install-abc", "9.9.9");
         var sentWithout = JsonNode.Parse(withoutUrl.Body!)!.AsObject();
         Assert.False(sentWithout.ContainsKey("endpoint_url"));
+    }
+
+    [Fact]
+    public async Task HeartbeatAsync_SendsEndpointUrlsWhenGiven_OmitsWhenNullOrEmpty()
+    {
+        // Issue #1233: a Gateway keeps its whole ordered address list current on every heartbeat.
+        var urls = new[] { "http://GW-HOST:7878", "https://gw.tailnet.ts.net:7878" };
+        var withUrls = new CapturingHandler(HttpStatusCode.OK, "{\"data\":{\"recorded\":true}}");
+        await ClientOver(withUrls).HeartbeatAsync("access-xyz", "install-abc", "9.9.9", urls[0], urls);
+        var sentWith = JsonNode.Parse(withUrls.Body!)!.AsObject();
+        Assert.Equal(urls, sentWith["endpoint_urls"]!.AsArray().Select(n => (string)n!).ToArray());
+        Assert.Equal("http://GW-HOST:7878", (string?)sentWith["endpoint_url"]);
+
+        // Omitted list (null) -> the field is not sent, so the account never clears a hand-set value.
+        var withoutUrls = new CapturingHandler(HttpStatusCode.OK, "{\"data\":{\"recorded\":true}}");
+        await ClientOver(withoutUrls).HeartbeatAsync("access-xyz", "install-abc", "9.9.9");
+        Assert.False(JsonNode.Parse(withoutUrls.Body!)!.AsObject().ContainsKey("endpoint_urls"));
+
+        // Empty list -> the field is not sent either (never an empty array on the wire).
+        var emptyUrls = new CapturingHandler(HttpStatusCode.OK, "{\"data\":{\"recorded\":true}}");
+        await ClientOver(emptyUrls).HeartbeatAsync("access-xyz", "install-abc", "9.9.9", null, Array.Empty<string>());
+        Assert.False(JsonNode.Parse(emptyUrls.Body!)!.AsObject().ContainsKey("endpoint_urls"));
     }
 
     [Fact]

--- a/src/CcDirector.Core.Tests/TailscaleIdentityTests.cs
+++ b/src/CcDirector.Core.Tests/TailscaleIdentityTests.cs
@@ -159,6 +159,33 @@ public class TailscaleIdentityTests
     }
 
     [Fact]
+    public void BuildMachineNameUrl_MachineNameAndPort_ComposesHttpUrl()
+    {
+        // Issue #1233: the machine-name path is a plain http hostname URL (NOT a Tailscale address).
+        var url = TailscaleIdentity.BuildMachineNameUrl("SOREN-NORTH", 7878);
+
+        Assert.Equal("http://SOREN-NORTH:7878", url);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BuildMachineNameUrl_EmptyMachineName_Throws(string machineName)
+    {
+        Assert.Throws<ArgumentException>(() => TailscaleIdentity.BuildMachineNameUrl(machineName, 7878));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(65536)]
+    public void BuildMachineNameUrl_InvalidPort_Throws(int port)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => TailscaleIdentity.BuildMachineNameUrl("SOREN-NORTH", port));
+    }
+
+    [Fact]
     public void FormatAdvertisedControlApiEndpoint_WithFrontDoor_ReturnsFrontDoorUnchanged()
     {
         var endpoint = TailscaleIdentity.FormatAdvertisedControlApiEndpoint(

--- a/src/CcDirector.Core/Account/DeviceRegistryClient.cs
+++ b/src/CcDirector.Core/Account/DeviceRegistryClient.cs
@@ -25,7 +25,13 @@ namespace CcDirector.Core.Account;
 /// <param name="LastSeenAt">When the device was last seen, or null when omitted.</param>
 /// <param name="EndpointUrl">The device's reachable front-door URL (for example a gateway's advertised
 /// tailnet address), or null when the device has none. For a "gateway" device this is what the installer
-/// discovers to enroll a Workstation against, so the person never types the gateway address (issue #1206).</param>
+/// discovers to enroll a Workstation against, so the person never types the gateway address (issue #1206).
+/// Kept equal to the first entry of <see cref="EndpointUrls"/> so a reader of this single field keeps
+/// working unchanged (issue #1233, non-breaking).</param>
+/// <param name="EndpointUrls">The device's reachable front-door URLs in priority order (issue #1233), or
+/// null when the device published none. A Gateway publishes machine name first, then its Tailscale address
+/// (only when Tailscale is available), then its local network IP - so a joining machine can try them in
+/// order and use the first that answers. <see cref="EndpointUrl"/> holds the first entry.</param>
 public sealed record CloudDeviceRecord(
     string Id,
     string Name,
@@ -36,7 +42,8 @@ public sealed record CloudDeviceRecord(
     string? KeyLast4,
     string? CreatedAt,
     string? LastSeenAt,
-    string? EndpointUrl);
+    string? EndpointUrl,
+    IReadOnlyList<string>? EndpointUrls = null);
 
 /// <summary>
 /// The request body for registering THIS device with the DevThrottle account:
@@ -52,14 +59,18 @@ public sealed record CloudDeviceRecord(
 /// <param name="AppVersion">The reporting app version, or null when omitted.</param>
 /// <param name="EndpointUrl">This device's reachable front-door URL, or null when it has none. A Gateway
 /// publishes its own advertised address here so an installer on another machine can discover it (issue
-/// #1206); other device types leave it null.</param>
+/// #1206); other device types leave it null. Kept equal to the first entry of <see cref="EndpointUrls"/>.</param>
+/// <param name="EndpointUrls">This device's reachable front-door URLs in priority order (issue #1233), or
+/// null/empty when it has none. A Gateway publishes machine name first, then its Tailscale address (only
+/// when Tailscale is available), then its local network IP; other device types leave it null.</param>
 public sealed record CloudDeviceRegistrationRequest(
     string InstallId,
     string Platform,
     string? Name,
     string? DeviceType,
     string? AppVersion,
-    string? EndpointUrl = null);
+    string? EndpointUrl = null,
+    IReadOnlyList<string>? EndpointUrls = null);
 
 /// <summary>
 /// The result of a device registration: the per-device key the cloud issues ONCE (in plain text, only
@@ -259,6 +270,13 @@ public sealed class DeviceRegistryClient
         // machine can discover it. Sent only when present, so a device with no address never sends the field.
         if (!string.IsNullOrWhiteSpace(request.EndpointUrl))
             body["endpoint_url"] = request.EndpointUrl;
+        // Issue #1233: a Gateway also publishes the WHOLE ordered list of the ways it can be reached (machine
+        // name, then Tailscale when present, then local network IP) so a joining machine tries them in order.
+        // Sent only when non-empty, so a device with no addresses never sends the field. The single
+        // endpoint_url above stays the first entry (non-breaking for readers of the single field).
+        var endpointUrlsArray = BuildEndpointUrlsArray(request.EndpointUrls);
+        if (endpointUrlsArray is not null)
+            body["endpoint_urls"] = endpointUrlsArray;
 
         using var httpRequest = new HttpRequestMessage(HttpMethod.Post, endpoint)
         {
@@ -301,8 +319,10 @@ public sealed class DeviceRegistryClient
     /// <param name="installId">This device's stable install id (identifies the row to advance). Required.</param>
     /// <param name="appVersion">The reporting app version, or null when omitted.</param>
     /// <param name="endpointUrl">This device's reachable front-door URL to publish, or null to omit it.</param>
+    /// <param name="endpointUrls">This device's reachable front-door URLs in priority order to publish (issue
+    /// #1233), or null/empty to omit them. When present, the first entry equals <paramref name="endpointUrl"/>.</param>
     /// <param name="ct">Cancels the request.</param>
-    public async Task<bool> HeartbeatAsync(string accessToken, string installId, string? appVersion = null, string? endpointUrl = null, CancellationToken ct = default)
+    public async Task<bool> HeartbeatAsync(string accessToken, string installId, string? appVersion = null, string? endpointUrl = null, IReadOnlyList<string>? endpointUrls = null, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(accessToken))
             throw new ArgumentException("Access token is required", nameof(accessToken));
@@ -317,6 +337,11 @@ public sealed class DeviceRegistryClient
             body["app_version"] = appVersion;
         if (!string.IsNullOrWhiteSpace(endpointUrl))
             body["endpoint_url"] = endpointUrl;
+        // Issue #1233: keep the whole ordered address list current on every heartbeat (the single
+        // endpoint_url above stays the first entry). Omitted when empty, so the cloud never clears a value.
+        var endpointUrlsArray = BuildEndpointUrlsArray(endpointUrls);
+        if (endpointUrlsArray is not null)
+            body["endpoint_urls"] = endpointUrlsArray;
 
         using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
         {
@@ -439,7 +464,44 @@ public sealed class DeviceRegistryClient
             StringField(obj, "key_last4"),
             StringField(obj, "created_at"),
             StringField(obj, "last_seen_at"),
-            StringField(obj, "endpoint_url"));
+            StringField(obj, "endpoint_url"),
+            StringArrayField(obj, "endpoint_urls"));
+    }
+
+    /// <summary>
+    /// Builds the JSON array to send for <c>endpoint_urls</c> (issue #1233), skipping null/blank entries so
+    /// only real addresses are published. Returns null when the source is null or holds no usable address, so
+    /// the caller omits the field entirely rather than sending an empty array.
+    /// </summary>
+    private static JsonArray? BuildEndpointUrlsArray(IReadOnlyList<string>? urls)
+    {
+        if (urls is null || urls.Count == 0)
+            return null;
+
+        var array = new JsonArray();
+        foreach (var url in urls)
+            if (!string.IsNullOrWhiteSpace(url))
+                array.Add((JsonNode)url);
+
+        return array.Count == 0 ? null : array;
+    }
+
+    /// <summary>
+    /// Reads a string-array field from the object as an ordered list (issue #1233), skipping any non-string
+    /// or blank entry. Returns null when the field is absent or not an array, and null when it holds no
+    /// usable string, so a caller reads "no addresses" as null (never an empty list, never a throw).
+    /// </summary>
+    private static IReadOnlyList<string>? StringArrayField(JsonObject obj, string name)
+    {
+        if (!obj.TryGetPropertyValue(name, out var node) || node is not JsonArray array)
+            return null;
+
+        var values = new List<string>(array.Count);
+        foreach (var item in array)
+            if (item is JsonValue value && value.TryGetValue<string>(out var text) && !string.IsNullOrWhiteSpace(text))
+                values.Add(text);
+
+        return values.Count == 0 ? null : values;
     }
 
     /// <summary>Reads a string field from the object, or null when absent or not a string value.</summary>

--- a/src/CcDirector.Core/Network/TailscaleIdentity.cs
+++ b/src/CcDirector.Core/Network/TailscaleIdentity.cs
@@ -222,6 +222,24 @@ public static class TailscaleIdentity
     }
 
     /// <summary>
+    /// Compose the machine-name endpoint URL <c>http://&lt;machineName&gt;:&lt;port&gt;</c> - the local-network
+    /// path a Gateway advertises FIRST in its address list (issue #1233). This is a plain hostname URL, NOT a
+    /// Tailscale address: on a local network the machine name is the most stable and most direct way to reach
+    /// the host (it survives an IP change), which is why it ranks ahead of the Tailscale front door and the
+    /// raw local network IP. It lives beside the other endpoint-URL builders here so the address builders sit
+    /// together. Pure - unit-tested.
+    /// </summary>
+    public static string BuildMachineNameUrl(string machineName, int port)
+    {
+        if (string.IsNullOrWhiteSpace(machineName))
+            throw new ArgumentException("Machine name is required", nameof(machineName));
+        if (port is <= 0 or > 65535)
+            throw new ArgumentOutOfRangeException(nameof(port), port, "Port must be 1-65535");
+
+        return $"http://{machineName}:{port}";
+    }
+
+    /// <summary>
     /// The Control API endpoint string to advertise to a REMOTE consumer (the session
     /// "Copy Handover Info" clipboard block, the Help/About dialog's "Control endpoint" row)
     /// for this Director's local Control API <paramref name="port"/>. Prefers the Tailscale

--- a/src/CcDirector.Gateway.Tests/Account/GatewayDeviceRegistrationTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/GatewayDeviceRegistrationTests.cs
@@ -62,6 +62,10 @@ public sealed class GatewayDeviceRegistrationTests
         // the field was omitted (a device with no resolved address).
         public string? LastRegisterEndpointUrl { get; private set; }
         public string? LastHeartbeatEndpointUrl { get; private set; }
+        // Issue #1233: the WHOLE ordered endpoint_urls list the Gateway published on the last
+        // register/heartbeat, or null when the field was omitted (a device with no resolved addresses).
+        public IReadOnlyList<string>? LastRegisterEndpointUrls { get; private set; }
+        public IReadOnlyList<string>? LastHeartbeatEndpointUrls { get; private set; }
         public int FailRegisterTimes { get; set; }
         public int DeviceCount => _byInstall.Count;
 
@@ -80,6 +84,7 @@ public sealed class GatewayDeviceRegistrationTests
             {
                 RegisterCallCount++;
                 LastRegisterEndpointUrl = (string?)body["endpoint_url"];
+                LastRegisterEndpointUrls = ReadEndpointUrls(body);
                 if (FailRegisterTimes > 0)
                 {
                     FailRegisterTimes--;
@@ -114,6 +119,7 @@ public sealed class GatewayDeviceRegistrationTests
             {
                 HeartbeatCallCount++;
                 LastHeartbeatEndpointUrl = (string?)body["endpoint_url"];
+                LastHeartbeatEndpointUrls = ReadEndpointUrls(body);
                 var installId = (string)body["install_id"]!;
                 LastHeartbeatInstallId = installId;
                 if (!_byInstall.TryGetValue(installId, out var row))
@@ -128,6 +134,17 @@ public sealed class GatewayDeviceRegistrationTests
 
         private static HttpResponseMessage Json(HttpStatusCode status, string body) =>
             new(status) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+        // Issue #1233: read the endpoint_urls array off a request body, or null when the field was omitted.
+        private static IReadOnlyList<string>? ReadEndpointUrls(JsonObject body)
+        {
+            if (body["endpoint_urls"] is not JsonArray array)
+                return null;
+            var list = new List<string>(array.Count);
+            foreach (var item in array)
+                list.Add((string)item!);
+            return list;
+        }
 
         private sealed class Row
         {
@@ -371,33 +388,120 @@ public sealed class GatewayDeviceRegistrationTests
         Assert.Equal(1, stub.DeviceCount);
     }
 
-    // Issue #1206: this Gateway publishes its own advertised front-door URL as endpoint_url on BOTH the
-    // register and every heartbeat, so an installer on another machine can discover the gateway address from
-    // the account (and an already-installed gateway backfills it via heartbeat).
+    // Issue #1233 (following #1206): this Gateway publishes its own advertised front-door URLs as the ordered
+    // endpoint_urls list on register, so an installer on another machine can discover the gateway addresses
+    // from the account and try them in priority order. The single endpoint_url stays the FIRST list entry
+    // (non-breaking for readers of the single field).
     [Fact]
-    public async Task EndpointUrl_PublishedOnRegisterAndHeartbeat()
+    public async Task EndpointUrls_PublishedOnRegister_InOrder_WithEndpointUrlAsFirstEntry()
     {
-        const string endpointUrl = "https://gw.tailnet.ts.net:7878";
+        var ordered = new[]
+        {
+            "http://GW-TEST-857:7878",           // machine name (first, most stable)
+            "https://gw.tailnet.ts.net:7878",    // tailscale (present)
+            "http://192.168.1.20:7878",          // local network IP (last resort)
+        };
         var account = MakeAccount(signedIn: true);
         var stub = new StubCloudDeviceRegistry();
         var client = ClientOver(stub);
         var keyStore = TempKeyStore();
         var reg = new GatewayDeviceRegistrationService(
             account, client, keyStore, Machine, Platform, AppVersion,
-            installIdProvider: () => InstallId, endpointUrlProvider: () => endpointUrl);
+            installIdProvider: () => InstallId, endpointUrlsProvider: () => ordered);
 
         await reg.EnsureRegisteredAsync();
-        Assert.Equal(endpointUrl, stub.LastRegisterEndpointUrl);
 
-        var heartbeat = new GatewayDeviceHeartbeatService(reg, account, client, AppVersion);
-        await heartbeat.HeartbeatOnceAsync();
-        Assert.Equal(endpointUrl, stub.LastHeartbeatEndpointUrl);
+        Assert.Equal(ordered, stub.LastRegisterEndpointUrls);
+        // endpoint_url stays the first list entry so existing single-field readers keep working.
+        Assert.Equal(ordered[0], stub.LastRegisterEndpointUrl);
     }
 
-    // Issue #1206: when the address cannot be resolved yet (provider returns null), no endpoint_url is sent -
-    // so the cloud never clears a value the user may have set by hand in the portal.
+    // Issue #334 publish refinement: a routine heartbeat where the address set has NOT changed since the last
+    // publish omits endpoint_urls (and endpoint_url) entirely, so the account leaves the stored value
+    // untouched instead of re-writing the same list every few minutes. The heartbeat itself still fires.
     [Fact]
-    public async Task EndpointUrl_UnresolvedProvider_OmitsEndpointUrl()
+    public async Task EndpointUrls_UnchangedHeartbeat_OmitsBothFields()
+    {
+        var ordered = new[] { "http://GW-TEST-857:7878", "http://192.168.1.20:7878" };
+        var account = MakeAccount(signedIn: true);
+        var stub = new StubCloudDeviceRegistry();
+        var client = ClientOver(stub);
+        var keyStore = TempKeyStore();
+        var reg = new GatewayDeviceRegistrationService(
+            account, client, keyStore, Machine, Platform, AppVersion,
+            installIdProvider: () => InstallId, endpointUrlsProvider: () => ordered);
+
+        await reg.EnsureRegisteredAsync();               // publishes the list (and caches it)
+        Assert.Equal(ordered, stub.LastRegisterEndpointUrls);
+
+        var heartbeat = new GatewayDeviceHeartbeatService(reg, account, client, AppVersion);
+        await heartbeat.HeartbeatOnceAsync();            // nothing changed -> omit
+
+        Assert.Equal(1, stub.HeartbeatCallCount);        // the heartbeat still fired (last-seen advanced)...
+        Assert.Null(stub.LastHeartbeatEndpointUrls);     // ...but carried NO address list
+        Assert.Null(stub.LastHeartbeatEndpointUrl);
+    }
+
+    // Issue #334 publish refinement: when the computed set actually changes (for example the LAN IP changes),
+    // the next heartbeat republishes the whole new ordered list; a subsequent unchanged heartbeat omits again.
+    [Fact]
+    public async Task EndpointUrls_ChangedSet_RepublishedOnNextHeartbeat()
+    {
+        var current = new[] { "http://GW-TEST-857:7878", "http://192.168.1.20:7878" };
+        var account = MakeAccount(signedIn: true);
+        var stub = new StubCloudDeviceRegistry();
+        var client = ClientOver(stub);
+        var keyStore = TempKeyStore();
+        var reg = new GatewayDeviceRegistrationService(
+            account, client, keyStore, Machine, Platform, AppVersion,
+            installIdProvider: () => InstallId, endpointUrlsProvider: () => current);
+
+        await reg.EnsureRegisteredAsync();               // publishes [machine, .20]
+        var heartbeat = new GatewayDeviceHeartbeatService(reg, account, client, AppVersion);
+
+        await heartbeat.HeartbeatOnceAsync();            // unchanged -> omit
+        Assert.Null(stub.LastHeartbeatEndpointUrls);
+
+        // The LAN IP changes.
+        current = new[] { "http://GW-TEST-857:7878", "http://192.168.1.55:7878" };
+        await heartbeat.HeartbeatOnceAsync();            // changed -> republish the whole new list
+
+        Assert.Equal(current, stub.LastHeartbeatEndpointUrls);
+        Assert.Equal(current[0], stub.LastHeartbeatEndpointUrl);
+
+        // A further heartbeat with the set unchanged omits again (the stub overwrites its capture each tick).
+        await heartbeat.HeartbeatOnceAsync();
+        Assert.Null(stub.LastHeartbeatEndpointUrls);
+    }
+
+    // Issue #1233: two addresses when Tailscale is not present (machine name + LAN IP), and the single
+    // endpoint_url is still the first entry.
+    [Fact]
+    public async Task EndpointUrls_TwoAddressesWhenNoTailscale()
+    {
+        var ordered = new[]
+        {
+            "http://GW-TEST-857:7878",   // machine name
+            "http://192.168.1.20:7878",  // local network IP
+        };
+        var account = MakeAccount(signedIn: true);
+        var stub = new StubCloudDeviceRegistry();
+        var client = ClientOver(stub);
+        var keyStore = TempKeyStore();
+        var reg = new GatewayDeviceRegistrationService(
+            account, client, keyStore, Machine, Platform, AppVersion,
+            installIdProvider: () => InstallId, endpointUrlsProvider: () => ordered);
+
+        await reg.EnsureRegisteredAsync();
+        Assert.Equal(ordered, stub.LastRegisterEndpointUrls);
+        Assert.Equal(ordered[0], stub.LastRegisterEndpointUrl);
+    }
+
+    // Issue #1233: when no address can be resolved yet (provider returns an empty list), neither endpoint_urls
+    // nor endpoint_url is sent - so the account never clears a value the user may have set by hand (issue #334
+    // heartbeat rule: an omitted/empty list leaves the stored value untouched).
+    [Fact]
+    public async Task EndpointUrls_UnresolvedProvider_OmitsBothFields()
     {
         var account = MakeAccount(signedIn: true);
         var stub = new StubCloudDeviceRegistry();
@@ -405,13 +509,30 @@ public sealed class GatewayDeviceRegistrationTests
         var keyStore = TempKeyStore();
         var reg = new GatewayDeviceRegistrationService(
             account, client, keyStore, Machine, Platform, AppVersion,
-            installIdProvider: () => InstallId, endpointUrlProvider: () => null);
+            installIdProvider: () => InstallId, endpointUrlsProvider: () => Array.Empty<string>());
 
         await reg.EnsureRegisteredAsync();
         Assert.Null(stub.LastRegisterEndpointUrl);
+        Assert.Null(stub.LastRegisterEndpointUrls);
 
         var heartbeat = new GatewayDeviceHeartbeatService(reg, account, client, AppVersion);
         await heartbeat.HeartbeatOnceAsync();
         Assert.Null(stub.LastHeartbeatEndpointUrl);
+        Assert.Null(stub.LastHeartbeatEndpointUrls);
+    }
+
+    // Issue #1233: with no provider wired at all (the pre-#1206 default), nothing is published.
+    [Fact]
+    public async Task EndpointUrls_NoProvider_PublishesNothing()
+    {
+        var account = MakeAccount(signedIn: true);
+        var stub = new StubCloudDeviceRegistry();
+        var client = ClientOver(stub);
+        var keyStore = TempKeyStore();
+        var reg = MakeRegistration(account, client, keyStore); // no endpointUrlsProvider
+
+        await reg.EnsureRegisteredAsync();
+        Assert.Null(stub.LastRegisterEndpointUrl);
+        Assert.Null(stub.LastRegisterEndpointUrls);
     }
 }

--- a/src/CcDirector.Gateway.Tests/GatewayEndpointUrlsTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayEndpointUrlsTests.cs
@@ -1,0 +1,122 @@
+using CcDirector.Gateway;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Proves the pure ordered-address assembly the Gateway publishes as <c>endpoint_urls</c> (issue #1233):
+/// <see cref="GatewayHost.BuildOrderedEndpointUrls"/> orders the machine name, the Tailscale front door
+/// (only when present), and the local network IP, applies an explicit operator override ahead of them all,
+/// de-duplicates, and drops a malformed override so it can never make the account reject the whole
+/// register/heartbeat (issue #334 validation contract). The I/O (probing Tailscale and the LAN) lives in the
+/// Gateway host; this assembler takes the already-resolved pieces, so the priority logic is tested with no
+/// real network.
+/// </summary>
+public sealed class GatewayEndpointUrlsTests
+{
+    private const string MachineName = "http://SOREN-NORTH:7878";
+    private const string Tailscale = "https://soren-north.tail0123.ts.net:7878";
+    private const string LanIp = "http://192.168.1.20:7878";
+
+    // Tailscale present: three addresses in priority order (machine name, Tailscale, LAN IP).
+    [Fact]
+    public void BuildOrderedEndpointUrls_TailscalePresent_ThreeAddressesInPriorityOrder()
+    {
+        var urls = GatewayHost.BuildOrderedEndpointUrls(overrideUrl: null, MachineName, Tailscale, LanIp);
+
+        Assert.Equal(new[] { MachineName, Tailscale, LanIp }, urls);
+    }
+
+    // Tailscale absent (null): two addresses (machine name, then LAN IP).
+    [Fact]
+    public void BuildOrderedEndpointUrls_NoTailscale_TwoAddresses()
+    {
+        var urls = GatewayHost.BuildOrderedEndpointUrls(overrideUrl: null, MachineName, tailscaleUrl: null, LanIp);
+
+        Assert.Equal(new[] { MachineName, LanIp }, urls);
+    }
+
+    // No LAN IP either: just the machine name (always present).
+    [Fact]
+    public void BuildOrderedEndpointUrls_OnlyMachineName_WhenNeitherTailscaleNorLan()
+    {
+        var urls = GatewayHost.BuildOrderedEndpointUrls(overrideUrl: null, MachineName, tailscaleUrl: null, lanUrl: null);
+
+        Assert.Equal(new[] { MachineName }, urls);
+    }
+
+    // A valid, non-loopback operator override ranks FIRST (it is the deliberate hand-set reachable address).
+    [Fact]
+    public void BuildOrderedEndpointUrls_ValidOverride_RanksFirst()
+    {
+        const string over = "https://gateway.example.com:8443";
+
+        var urls = GatewayHost.BuildOrderedEndpointUrls(over, MachineName, Tailscale, LanIp);
+
+        Assert.Equal(new[] { over, MachineName, Tailscale, LanIp }, urls);
+    }
+
+    // An override that equals a discovered address is not duplicated (case-insensitive).
+    [Fact]
+    public void BuildOrderedEndpointUrls_OverrideEqualsMachineName_NoDuplicate()
+    {
+        var urls = GatewayHost.BuildOrderedEndpointUrls("HTTP://SOREN-NORTH:7878", MachineName, Tailscale, LanIp);
+
+        Assert.Equal(new[] { "HTTP://SOREN-NORTH:7878", Tailscale, LanIp }, urls);
+    }
+
+    // A loopback override is never advertised (it is a lie to every remote caller).
+    [Theory]
+    [InlineData("http://127.0.0.1:7878")]
+    [InlineData("http://localhost:7878")]
+    public void BuildOrderedEndpointUrls_LoopbackOverride_Dropped(string loopback)
+    {
+        var urls = GatewayHost.BuildOrderedEndpointUrls(loopback, MachineName, Tailscale, LanIp);
+
+        Assert.Equal(new[] { MachineName, Tailscale, LanIp }, urls);
+    }
+
+    // A malformed / non-http(s) override is dropped so it can never 400 the whole request (issue #334).
+    [Theory]
+    [InlineData("not a url")]
+    [InlineData("ftp://host:21")]
+    [InlineData("gateway.example.com")] // no scheme -> not an absolute http(s) URL
+    public void BuildOrderedEndpointUrls_MalformedOverride_Dropped(string bad)
+    {
+        var urls = GatewayHost.BuildOrderedEndpointUrls(bad, MachineName, Tailscale, LanIp);
+
+        Assert.Equal(new[] { MachineName, Tailscale, LanIp }, urls);
+    }
+
+    // Blank tailscale/LAN entries are skipped (never a blank on the wire).
+    [Fact]
+    public void BuildOrderedEndpointUrls_BlankDiscoveredEntries_Skipped()
+    {
+        var urls = GatewayHost.BuildOrderedEndpointUrls(overrideUrl: null, MachineName, tailscaleUrl: "   ", lanUrl: "");
+
+        Assert.Equal(new[] { MachineName }, urls);
+    }
+
+    [Theory]
+    [InlineData("http://host:7878", true)]
+    [InlineData("https://host.tailnet.ts.net:7878", true)]
+    [InlineData("https://192.168.1.20:7878", true)]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("   ", false)]
+    [InlineData("host:7878", false)]          // no scheme
+    [InlineData("ftp://host:21", false)]      // not http(s)
+    [InlineData("ws://host:7878", false)]     // not http(s)
+    public void IsPublishableHttpUrl_ClassifiesCorrectly(string? url, bool expected)
+    {
+        Assert.Equal(expected, GatewayHost.IsPublishableHttpUrl(url));
+    }
+
+    [Fact]
+    public void IsPublishableHttpUrl_TooLong_False()
+    {
+        var tooLong = "http://" + new string('a', 200) + ":7878"; // > 200 chars
+
+        Assert.False(GatewayHost.IsPublishableHttpUrl(tooLong));
+    }
+}

--- a/src/CcDirector.Gateway/Account/GatewayDeviceHeartbeatService.cs
+++ b/src/CcDirector.Gateway/Account/GatewayDeviceHeartbeatService.cs
@@ -149,12 +149,16 @@ public sealed class GatewayDeviceHeartbeatService : IDisposable
                 return;
             }
 
-            // Issue #1206: publish this Gateway's own advertised front-door URL on every heartbeat. This is
-            // what lets an already-installed Gateway (which registers only once per install, then only
-            // heartbeats) keep its address current and backfill it after updating to this version. Resolved
-            // fresh each tick, so an address that comes up after start heals within one heartbeat cycle.
-            var endpointUrl = _registration.ResolveEndpointUrl();
-            var advanced = await _client.HeartbeatAsync(token, _registration.InstallId, _appVersion, endpointUrl, CancellationToken.None).ConfigureAwait(false);
+            // Issue #1233 (following #1206), with the #334 publish refinement: publish this Gateway's own
+            // advertised front-door URLs only when the computed set has CHANGED since we last published this
+            // run (an IP change, Tailscale coming or going, a hostname change). A routine heartbeat where
+            // nothing changed returns an empty list and omits the field entirely, so the account leaves the
+            // stored value untouched instead of re-writing the same list every few minutes. An address that
+            // comes up after start still heals within one heartbeat cycle (it is a change). The single
+            // endpoint_url stays the first entry when we do publish (non-breaking).
+            var endpointUrls = _registration.NextEndpointUrlsToPublish();
+            var endpointUrl = endpointUrls.Count > 0 ? endpointUrls[0] : null;
+            var advanced = await _client.HeartbeatAsync(token, _registration.InstallId, _appVersion, endpointUrl, endpointUrls, CancellationToken.None).ConfigureAwait(false);
             if (advanced)
             {
                 FileLog.Write($"[GatewayDeviceHeartbeatService] HeartbeatOnceAsync: heartbeat sent for install_id={_registration.InstallId}; last-seen advanced");

--- a/src/CcDirector.Gateway/Account/GatewayDeviceRegistrationService.cs
+++ b/src/CcDirector.Gateway/Account/GatewayDeviceRegistrationService.cs
@@ -37,7 +37,7 @@ public sealed class GatewayDeviceRegistrationService
     private readonly DeviceRegistryClient _client;
     private readonly GatewayDeviceKeyStore _keyStore;
     private readonly Func<string> _installIdProvider;
-    private readonly Func<string?>? _endpointUrlProvider;
+    private readonly Func<IReadOnlyList<string>>? _endpointUrlsProvider;
     private readonly string _machineName;
     private readonly string _platform;
     private readonly string? _appVersion;
@@ -45,6 +45,12 @@ public sealed class GatewayDeviceRegistrationService
 
     private string? _installId;
     private bool _registeredThisRun;
+    // Issue #1233: the endpoint_urls list we last published to the account this run. Guarded by _gate. Null
+    // until the first publish. A heartbeat re-sends the list ONLY when the freshly computed set differs from
+    // this - so a routine heartbeat where nothing changed omits the field and leaves the stored value
+    // untouched (issue #334 rule: an absent field is not applied), instead of re-writing the same value every
+    // few minutes.
+    private IReadOnlyList<string>? _lastPublishedEndpointUrls;
 
     /// <summary>
     /// Creates the registration coordinator.
@@ -60,11 +66,13 @@ public sealed class GatewayDeviceRegistrationService
     /// Tests inject a fixed provider so they never touch the real config root. Resolved lazily on first
     /// use (never at construction) and cached, so constructing this service does no disk I/O.
     /// </param>
-    /// <param name="endpointUrlProvider">
-    /// Resolves THIS Gateway's own reachable front-door URL to publish as the device's <c>endpoint_url</c>
-    /// (issue #1206), so an installer on another machine discovers the gateway address from the account
-    /// instead of the person typing it. Returns null when the address cannot be resolved yet (for example
-    /// Tailscale not up), in which case no address is sent - a heartbeat later backfills it. Null (the
+    /// <param name="endpointUrlsProvider">
+    /// Resolves THIS Gateway's own reachable front-door URLs in priority order to publish as the device's
+    /// <c>endpoint_urls</c> (issue #1233): machine name first, then the Tailscale address (only when Tailscale
+    /// is available), then the local network IP - so an installer on another machine discovers the gateway
+    /// address from the account and tries them in order instead of the person typing one. The single
+    /// <c>endpoint_url</c> (issue #1206) is derived as the first entry. Returns an empty list when no address
+    /// can be resolved yet, in which case no address is sent - a heartbeat later backfills it. Null (the
     /// default, and the pre-#1206 behavior) publishes no address at all.
     /// </param>
     public GatewayDeviceRegistrationService(
@@ -75,7 +83,7 @@ public sealed class GatewayDeviceRegistrationService
         string platform,
         string? appVersion = null,
         Func<string>? installIdProvider = null,
-        Func<string?>? endpointUrlProvider = null)
+        Func<IReadOnlyList<string>>? endpointUrlsProvider = null)
     {
         _account = account ?? throw new ArgumentNullException(nameof(account));
         _client = client ?? throw new ArgumentNullException(nameof(client));
@@ -84,19 +92,93 @@ public sealed class GatewayDeviceRegistrationService
         _platform = platform ?? throw new ArgumentNullException(nameof(platform));
         _appVersion = appVersion;
         _installIdProvider = installIdProvider ?? GatewayInstallId.LoadOrCreate;
-        _endpointUrlProvider = endpointUrlProvider;
+        _endpointUrlsProvider = endpointUrlsProvider;
     }
 
     /// <summary>
-    /// THIS Gateway's own reachable front-door URL to publish as <c>endpoint_url</c> (issue #1206), or null
-    /// when no provider is wired or it cannot resolve the address yet. Read fresh on every register and
-    /// heartbeat so an address that appears (or changes) after start is picked up without a restart. The
-    /// resolver never throws (it reports an unresolved address as null), so this is safe on any path.
+    /// THIS Gateway's own reachable front-door URLs in priority order to publish as <c>endpoint_urls</c>
+    /// (issue #1233), or an empty list when no provider is wired or none can be resolved yet. Read fresh on
+    /// every register and heartbeat so an address that appears (or changes) after start is picked up without a
+    /// restart. The resolver never throws (it reports unresolved addresses as an empty list), so this is safe
+    /// on any path. Blank entries are dropped so only real addresses are published.
+    /// </summary>
+    public IReadOnlyList<string> ResolveEndpointUrls()
+    {
+        var urls = _endpointUrlsProvider?.Invoke();
+        if (urls is null || urls.Count == 0)
+            return Array.Empty<string>();
+
+        var cleaned = new List<string>(urls.Count);
+        foreach (var url in urls)
+            if (!string.IsNullOrWhiteSpace(url))
+                cleaned.Add(url);
+        return cleaned;
+    }
+
+    /// <summary>
+    /// THIS Gateway's own reachable front-door URL to publish as the single <c>endpoint_url</c> field (issue
+    /// #1206) - the FIRST entry of <see cref="ResolveEndpointUrls"/>, so a reader of the single field keeps
+    /// working unchanged (non-breaking, issue #1233). Null when no address can be resolved yet.
     /// </summary>
     public string? ResolveEndpointUrl()
     {
-        var url = _endpointUrlProvider?.Invoke();
-        return string.IsNullOrWhiteSpace(url) ? null : url;
+        var urls = ResolveEndpointUrls();
+        return urls.Count > 0 ? urls[0] : null;
+    }
+
+    /// <summary>
+    /// The endpoint URLs to publish on THIS heartbeat (issue #1233 / the #334 publish refinement): the
+    /// current ordered list ONLY when it differs from what was last published this run (a real change - an IP
+    /// change, Tailscale coming or going, a hostname change), otherwise an EMPTY list so the caller omits the
+    /// field entirely and the account leaves the stored value untouched. This is what stops a routine
+    /// heartbeat from re-writing the same address list every few minutes. When it reports a change it records
+    /// the new list as the last-published set, so the very next unchanged heartbeat omits again. An empty
+    /// resolution (no address available yet) is never published (we never appear to clear a value) and does
+    /// not disturb the recorded set. Thread-safe.
+    /// </summary>
+    public IReadOnlyList<string> NextEndpointUrlsToPublish()
+    {
+        var current = ResolveEndpointUrls();
+        lock (_gate)
+        {
+            // Nothing resolvable yet -> publish nothing (never send an empty list; the account would ignore
+            // it, and we must never look like we are clearing a hand-set value). Leave the recorded set as-is.
+            if (current.Count == 0)
+                return Array.Empty<string>();
+
+            // Unchanged since our last publish -> omit, so the stored value is left untouched.
+            if (_lastPublishedEndpointUrls is not null && EndpointUrlsEqual(_lastPublishedEndpointUrls, current))
+                return Array.Empty<string>();
+
+            _lastPublishedEndpointUrls = current;
+            return current;
+        }
+    }
+
+    /// <summary>
+    /// Records <paramref name="urls"/> as the endpoint_urls set last published this run, so a following
+    /// heartbeat that computes the same set omits the field. Called after a successful register publish.
+    /// A null or empty list clears nothing (leaves the recorded set as-is). Thread-safe.
+    /// </summary>
+    private void MarkEndpointUrlsPublished(IReadOnlyList<string> urls)
+    {
+        if (urls.Count == 0)
+            return;
+        lock (_gate)
+            _lastPublishedEndpointUrls = urls;
+    }
+
+    /// <summary>Ordered, case-insensitive equality of two endpoint_urls lists. Pure - unit-tested via the
+    /// service's publish behaviour. The list order is deterministic (machine name, Tailscale, LAN IP), so an
+    /// ordered compare is the same as a set compare here and also catches a genuine reorder.</summary>
+    private static bool EndpointUrlsEqual(IReadOnlyList<string> a, IReadOnlyList<string> b)
+    {
+        if (a.Count != b.Count)
+            return false;
+        for (var i = 0; i < a.Count; i++)
+            if (!string.Equals(a[i], b[i], StringComparison.OrdinalIgnoreCase))
+                return false;
+        return true;
     }
 
     /// <summary>This Gateway's stable install id, resolved lazily and cached (no disk I/O at construction).</summary>
@@ -150,16 +232,20 @@ public sealed class GatewayDeviceRegistrationService
             return;
         }
 
-        // Issue #1206: publish this Gateway's own advertised front-door URL so an installer on another
-        // machine can discover the gateway address from the account. Null when it cannot resolve yet - a
-        // heartbeat backfills it later.
-        var endpointUrl = ResolveEndpointUrl();
-        FileLog.Write($"[GatewayDeviceRegistrationService] EnsureRegisteredAsync: registering this Gateway as a device, install_id={installId}, name={_machineName}, platform={_platform}, endpoint_url={endpointUrl ?? "(unresolved)"}");
-        var request = new CloudDeviceRegistrationRequest(installId, _platform, _machineName, GatewayDeviceType, _appVersion, endpointUrl);
+        // Issue #1233 (following #1206): publish this Gateway's own advertised front-door URLs in priority
+        // order so an installer on another machine can discover the gateway address from the account and try
+        // them in order. The single endpoint_url stays the first entry (non-breaking). Empty when nothing can
+        // resolve yet - a heartbeat backfills it later.
+        var endpointUrls = ResolveEndpointUrls();
+        var endpointUrl = endpointUrls.Count > 0 ? endpointUrls[0] : null;
+        FileLog.Write($"[GatewayDeviceRegistrationService] EnsureRegisteredAsync: registering this Gateway as a device, install_id={installId}, name={_machineName}, platform={_platform}, endpoint_url={endpointUrl ?? "(unresolved)"}, endpoint_urls=[{string.Join(", ", endpointUrls)}]");
+        var request = new CloudDeviceRegistrationRequest(installId, _platform, _machineName, GatewayDeviceType, _appVersion, endpointUrl, endpointUrls);
         var result = await _client.RegisterAsync(token, request, ct).ConfigureAwait(false);
 
         _keyStore.Save(installId, result.DeviceKey);
         lock (_gate) { _registeredThisRun = true; }
+        // Record what we just published so a following heartbeat with the same set omits endpoint_urls (#1233).
+        MarkEndpointUrlsPublished(endpointUrls);
         FileLog.Write($"[GatewayDeviceRegistrationService] EnsureRegisteredAsync: registered device id={result.Device.Id} and stored its per-device key (key value not logged)");
     }
 

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -458,24 +458,39 @@ public sealed class GatewayHost : IAsyncDisposable
         if (Account is not null)
         {
             var deviceRegistryClient = new Core.Account.DeviceRegistryClient(new HttpClient { Timeout = TimeSpan.FromSeconds(10) });
-            // Issue #1206: resolve THIS Gateway's own advertised front-door URL the same way Directors
-            // advertise theirs - the Tailscale MagicDNS front door (or the LAN IP under LAN addressing mode,
-            // issue #457), keyed on this Gateway's own port and gateway.tailnetEndpoint override. Published
-            // as endpoint_url on register and every heartbeat so an installer on another machine discovers
-            // the gateway address from the account instead of the person typing it. Re-resolved on each call
-            // (never cached) so an address that appears after start heals within one heartbeat cycle; an
-            // unresolved address (for example Tailscale not up) returns null and simply sends no address.
+            // Issue #1233 (following #1206): resolve THIS Gateway's own reachable front-door URLs as an
+            // ORDERED LIST and publish the whole list (endpoint_urls) on register and every heartbeat, so a
+            // joining machine can try them in order and use the first that answers rather than being stuck on
+            // one address. Priority order (the reasoning in issue #1233):
+            //   1. Machine name plus port (http://<MachineName>:<port>) - ALWAYS. The most stable and most
+            //      direct name on a local network (it survives an IP change).
+            //   2. The Tailscale front door - only when Tailscale is actually available on this machine. The
+            //      reliable cross-network path.
+            //   3. The local network IP plus port - the last-resort path (least stable; the IP can change).
+            // So the list is three addresses when Tailscale is available and two when it is not. An explicit
+            // gateway.tailnetEndpoint override, when set (and not loopback), is the operator's hand-set
+            // reachable URL and ranks FIRST - it preserves the pre-#1233 single endpoint_url for operators who
+            // set it, and the client health-checks every candidate so a stale one is simply skipped. The
+            // single endpoint_url (issue #1206) is the first list entry, so existing readers keep working.
+            // Re-resolved on each call (never cached) so an address that appears after start heals within one
+            // heartbeat cycle; the resolvers never throw (they report an unresolved address as unresolved).
             var tailnetResolver = new Core.Network.TailnetIdentityResolver();
             var lanResolver = new Core.Network.LanIdentityResolver();
-            var endpointAddressingMode = gatewayConfig.AddressingMode;
             var endpointOverride = gatewayConfig.TailnetEndpoint;
             var gatewayPort = Port;
-            Func<string?> resolveEndpointUrl = () =>
+            Func<IReadOnlyList<string>> resolveEndpointUrls = () =>
             {
-                var resolution = endpointAddressingMode == Core.Configuration.AddressingMode.Lan
-                    ? lanResolver.ResolveEndpoint(gatewayPort, endpointOverride)
-                    : tailnetResolver.ResolveEndpoint(gatewayPort, endpointOverride);
-                return resolution.IsResolved ? resolution.Endpoint : null;
+                // Do the I/O here (probe Tailscale and the LAN), then hand the resolved pieces to the pure
+                // BuildOrderedEndpointUrls assembler so the ordering/dedup/loopback-skip logic is unit-tested
+                // without a real network. Passing no config override to the resolvers yields the PURE
+                // discovered address (the override is applied separately, ahead of everything, in the assembler).
+                var tailnet = tailnetResolver.ResolveEndpoint(gatewayPort, configOverride: null);
+                var lan = lanResolver.ResolveEndpoint(gatewayPort, configOverride: null);
+                return BuildOrderedEndpointUrls(
+                    endpointOverride,
+                    Core.Network.TailscaleIdentity.BuildMachineNameUrl(Environment.MachineName, gatewayPort),
+                    tailnet.IsResolved ? tailnet.Endpoint : null,
+                    lan.IsResolved ? lan.Endpoint : null);
             };
             _deviceRegistration = new Account.GatewayDeviceRegistrationService(
                 Account,
@@ -484,7 +499,7 @@ public sealed class GatewayHost : IAsyncDisposable
                 machineName: Environment.MachineName,
                 platform: ResolvePlatform(),
                 appVersion: AppVersion.Semver,
-                endpointUrlProvider: resolveEndpointUrl);
+                endpointUrlsProvider: resolveEndpointUrls);
             _childMirror = new Account.ChildDeviceMirrorService(
                 Account,
                 deviceRegistryClient,
@@ -568,6 +583,64 @@ public sealed class GatewayHost : IAsyncDisposable
         if (OperatingSystem.IsMacOS()) return "macos";
         if (OperatingSystem.IsLinux()) return "linux";
         return "unknown";
+    }
+
+    /// <summary>
+    /// Assembles this Gateway's reachable front-door URLs into the ordered, de-duplicated list published as
+    /// <c>endpoint_urls</c> (issue #1233). Pure and side-effect free (the caller does the probing and passes
+    /// the resolved pieces), so the priority order and de-duplication are unit-tested without a real network.
+    /// Order:
+    /// <list type="number">
+    /// <item>An explicit, non-loopback <paramref name="overrideUrl"/> (gateway.tailnetEndpoint) - the
+    /// operator's hand-set reachable address - first; a loopback override is dropped (never advertised).</item>
+    /// <item><paramref name="machineNameUrl"/> - the machine name plus port, always present, the most stable
+    /// local-network name.</item>
+    /// <item><paramref name="tailscaleUrl"/> - the Tailscale front door, only when it was resolved (null when
+    /// Tailscale is unavailable), the reliable cross-network path.</item>
+    /// <item><paramref name="lanUrl"/> - the local network IP plus port, only when it was resolved (null when
+    /// no routable LAN IPv4 exists), the last-resort path.</item>
+    /// </list>
+    /// Blank entries are skipped and duplicates are collapsed case-insensitively (for example when the
+    /// override equals the machine-name URL), so the list carries each distinct reachable address once.
+    /// The operator's <paramref name="overrideUrl"/> is the one caller-supplied value, so it is additionally
+    /// validated as a real http/https URL before being published (issue #334 contract: any non-http(s) or
+    /// unparseable entry would make the account reject the WHOLE register/heartbeat with 400) - a malformed
+    /// override is simply dropped, never sent, so it can never break device registration. The three
+    /// discovered addresses are always well-formed by construction.
+    /// </summary>
+    internal static IReadOnlyList<string> BuildOrderedEndpointUrls(
+        string? overrideUrl, string machineNameUrl, string? tailscaleUrl, string? lanUrl)
+    {
+        var urls = new List<string>();
+        void Add(string? url)
+        {
+            if (!string.IsNullOrWhiteSpace(url) && !urls.Contains(url, StringComparer.OrdinalIgnoreCase))
+                urls.Add(url);
+        }
+
+        // Only a valid, non-loopback http/https override is publishable. A loopback address is a lie to every
+        // remote caller; a non-http(s) or unparseable string would 400 the whole request (issue #334).
+        if (IsPublishableHttpUrl(overrideUrl) && !Core.Network.TailnetIdentityResolver.IsLoopback(overrideUrl))
+            Add(overrideUrl);
+        Add(machineNameUrl);
+        Add(tailscaleUrl);
+        Add(lanUrl);
+        return urls;
+    }
+
+    /// <summary>
+    /// True when <paramref name="url"/> is a publishable front-door address for the account endpoint_urls
+    /// list (issue #334 contract): a non-blank, absolute http or https URL of at most 200 characters. Used to
+    /// keep a malformed operator override out of the published list so it can never 400 the whole request.
+    /// Pure - unit-tested.
+    /// </summary>
+    internal static bool IsPublishableHttpUrl([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url) || url.Length > 200)
+            return false;
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            return false;
+        return uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps;
     }
 
     /// <summary>


### PR DESCRIPTION
## What and why

Fixes the gateway-publish half of thefrederiksen/devthrottle_internal#737 (the server + website half is devthrottle_internal #334).

A machine joining an existing fleet must connect to the gateway, but today the account records exactly one way to reach it (its Tailscale address). If the joining machine cannot reach that one address, it is stuck - there is no second way in. This was hit live during a v1.1.0-rc3 install.

The gateway now resolves and publishes **every** way it can be reached, as an ordered list, so a joining machine can try them in priority order and use the first that answers.

## The ordered list (priority order)

1. **Machine name plus port** (`http://<MachineName>:<port>`) - always. The most stable, most direct name on a local network (survives an IP change).
2. **Tailscale front door** - only when Tailscale is actually available on this machine. The reliable cross-network path.
3. **Local network IP plus port** - the last-resort path (least stable; the IP can change).

So three addresses when Tailscale is present, two when it is not. A valid, non-loopback `gateway.tailnetEndpoint` override ranks first; a **malformed or loopback override is dropped** so it can never make the account reject the whole register/heartbeat.

## Wire shape (coordinated with devthrottle_internal #334)

- New field `endpoint_urls`: an ordered array of address strings, sent on register and heartbeat and parsed back from `GET /devices`.
- The existing single `endpoint_url` (#1206) stays equal to the **first** list entry, so anything reading the single field keeps working (**non-breaking**).
- Server contract confirmed live: each entry a trimmed http(s) URL, <=200 chars, <=12 entries; an absent/empty field leaves the stored value untouched.

## Publish behaviour (agreed with the server side)

Published on register and cached in-process. A heartbeat re-sends the list **only when the computed set actually changes** (IP change, Tailscale coming or going, hostname change). A routine unchanged heartbeat **omits both** `endpoint_urls` and `endpoint_url`, so the account is not re-written every few minutes - at most one write per gateway start.

## Deferred to a follow-up (deliberate)

Seeding the in-process cache from `GET /devices` on restart (to skip the single identical re-write per process start) is deferred and **bundled with an open product decision**: whether a user's website edit should win over the gateway's computed value. Both are the same "reconcile against the account's actual stored value" logic, so they should land together once that rule is decided.

## Tests

- Ordered-list assembly: priority order, de-duplication, malformed/loopback override drop (`GatewayEndpointUrlsTests`).
- Machine-name URL builder (`TailscaleIdentityTests`).
- `endpoint_urls` send/parse on register and heartbeat (`DeviceRegistryClientRegisterHeartbeatTests`).
- Send-only-on-change: publish on register, omit on unchanged heartbeat, republish on a changed set (`GatewayDeviceRegistrationTests`).

Full Core suite (2847 passed) and Gateway suite (1657 passed) green; clean build (0 warnings).

## Not deployed

This PR is not deployed to the live gateway - session 63fa0c95 owns the local gateway redeploy on this machine per the #334 plan. Once merged and redeployed, the gateway's heartbeat publishes the ordered list and the server side verifies it lands and is editable on the account page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)