### PR TITLE
Gateway multi-address: client priority-order connect + installer Test button (#1233)

### DIFF
--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -50,6 +50,12 @@ public sealed class GatewayClient : IDisposable
     private readonly Func<List<SessionStateSnapshot>>? _sessionStates;
     private readonly GatewayConnectionMonitor? _monitor;
     private readonly HttpClient _http;
+
+    // The gateway address currently in use (issue #1233). Starts as _config.Url and is narrowed at
+    // Start() to the first reachable entry of _config.CandidateUrls (machine name -> Tailscale -> IP).
+    // volatile: read by the fleet-relay one-off clients on other threads.
+    private volatile string _activeUrl = "";
+
     private DateTime _lastVerifyStartedUtc = DateTime.MinValue;
     private int _verifying; // re-entrancy guard: never stack a second handshake on a slow one
 
@@ -106,6 +112,20 @@ public sealed class GatewayClient : IDisposable
     /// endpoint verified (or verification is disabled). Surfaced for diagnostics.</summary>
     public string? LastVerifyError { get; private set; }
 
+    /// <summary>
+    /// The gateway address currently in use (issue #1233): <see cref="GatewayConfig.Url"/> until
+    /// <see cref="Start"/> narrows it to the first reachable entry of
+    /// <see cref="GatewayConfig.CandidateUrls"/>. Exposed for tests and diagnostics.
+    /// </summary>
+    internal string ActiveUrl => _activeUrl;
+
+    /// <summary>
+    /// Reachability probe for a single gateway candidate (issue #1233): returns null when the
+    /// address answers GET /healthz, otherwise a reason. Injectable so candidate selection is
+    /// unit-tested without a live gateway; production probes /healthz with a short timeout.
+    /// </summary>
+    internal Func<string, CancellationToken, Task<string?>> ProbeGatewayCandidate { get; set; }
+
     public bool IsEnabled => _config.IsEnabled;
     public bool IsRegistered => _registered;
 
@@ -131,13 +151,16 @@ public sealed class GatewayClient : IDisposable
             ? LanResolver.ResolveEndpoint(_port, _config.TailnetEndpoint)
             : IdentityResolver.ResolveEndpoint(_port, _config.TailnetEndpoint);
 
+        _activeUrl = _config.Url;
+        ProbeGatewayCandidate = (url, ct) => ProbeGatewayHealthzAsync(url, ct);
+
         _http = new HttpClient
         {
             Timeout = TimeSpan.FromSeconds(10),
         };
         if (_config.IsEnabled)
         {
-            _http.BaseAddress = new Uri(_config.Url.TrimEnd('/') + "/");
+            _http.BaseAddress = new Uri(_activeUrl.TrimEnd('/') + "/");
             if (!string.IsNullOrEmpty(_config.Token))
                 _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _config.Token);
         }
@@ -245,7 +268,7 @@ public sealed class GatewayClient : IDisposable
         FileLog.Write($"[GatewayClient] AskFleetAsync: POST /sessions/{toSessionId}/prompt (wait <= {timeoutMs}ms)");
         using var http = new HttpClient
         {
-            BaseAddress = new Uri(_config.Url.TrimEnd('/') + "/"),
+            BaseAddress = new Uri(_activeUrl.TrimEnd('/') + "/"),
             Timeout = TimeSpan.FromMilliseconds(timeoutMs + 15_000),
         };
         if (!string.IsNullOrEmpty(_config.Token))
@@ -321,7 +344,7 @@ public sealed class GatewayClient : IDisposable
         FileLog.Write($"[GatewayClient] SpawnOnMachineAsync: POST /machines/{machine}/sessions, repo={req.RepoPath}, agent={req.Agent}");
         using var http = new HttpClient
         {
-            BaseAddress = new Uri(_config.Url.TrimEnd('/') + "/"),
+            BaseAddress = new Uri(_activeUrl.TrimEnd('/') + "/"),
             Timeout = TimeSpan.FromSeconds(120),
         };
         if (!string.IsNullOrEmpty(_config.Token))
@@ -421,10 +444,11 @@ public sealed class GatewayClient : IDisposable
         _monitor?.Reset(gatewayConfigured: true);
 
         _cts = new CancellationTokenSource();
-        FileLog.Write($"[GatewayClient] Start: gateway={_config.Url}, directorId={_directorId}, port={_port}");
+        FileLog.Write($"[GatewayClient] Start: candidates=[{string.Join(", ", _config.CandidateUrls)}], directorId={_directorId}, port={_port}");
 
-        // Kick off the first registration in the background. RegisterLoop retries on failure.
-        _ = Task.Run(() => RegisterLoop(_cts.Token));
+        // Choose the reachable gateway address from the ordered candidate list (issue #1233), THEN
+        // register. Both run in the background so a slow probe never blocks Director startup.
+        _ = Task.Run(() => SelectActiveUrlThenRegisterAsync(_cts.Token));
 
         _heartbeat = new Timer(_ => HeartbeatTick(), null, HeartbeatInterval, HeartbeatInterval);
     }
@@ -470,6 +494,66 @@ public sealed class GatewayClient : IDisposable
 
     // ===== Internals =====
 
+    /// <summary>
+    /// Narrow the active gateway address to the first reachable candidate, then run the registration
+    /// loop (issue #1233). Selection only probes /healthz; a failure there is non-fatal - registration
+    /// still proceeds against the current active address and its backoff retries.
+    /// </summary>
+    private async Task SelectActiveUrlThenRegisterAsync(CancellationToken ct)
+    {
+        try { await SelectActiveUrlAsync(ct); }
+        catch (OperationCanceledException) { return; }
+        catch (Exception ex) { FileLog.Write($"[GatewayClient] candidate selection failed, using {_activeUrl}: {ex.Message}"); }
+        await RegisterLoop(ct);
+    }
+
+    /// <summary>
+    /// Walk <see cref="GatewayConfig.CandidateUrls"/> in priority order (machine name, then Tailscale,
+    /// then IP) and switch the active address to the first that answers GET /healthz (issue #1233).
+    /// Setting the shared client's base address here is safe: this runs before the first register
+    /// request. With a single candidate (older installs, or a manual override with no discovered
+    /// fallbacks) there is nothing to choose and the method is a no-op. When nothing answers yet, the
+    /// active address is left as-is so <see cref="RegisterLoop"/> still attempts it and retries.
+    /// Internal so the selection wiring is unit-tested through <see cref="ProbeGatewayCandidate"/>.
+    /// </summary>
+    internal async Task SelectActiveUrlAsync(CancellationToken ct)
+    {
+        var candidates = _config.CandidateUrls;
+        if (candidates.Count <= 1) return;
+
+        var selection = await GatewayEndpointSelector.SelectAsync(candidates, ProbeGatewayCandidate, ct);
+        if (selection.Found)
+        {
+            if (!string.Equals(selection.ChosenUrl, _activeUrl, StringComparison.OrdinalIgnoreCase))
+            {
+                FileLog.Write($"[GatewayClient] selected reachable gateway {selection.ChosenUrl} from {candidates.Count} candidate(s)");
+                SetActiveUrl(selection.ChosenUrl!);
+            }
+        }
+        else
+        {
+            FileLog.Write($"[GatewayClient] no gateway candidate answered among {candidates.Count}; will attempt {_activeUrl} and retry");
+        }
+    }
+
+    // Point the shared client at a newly chosen gateway address. Only call before the first request is
+    // sent on _http - HttpClient forbids changing BaseAddress afterwards - which is the Start-time
+    // selection above, before RegisterLoop.
+    private void SetActiveUrl(string url)
+    {
+        _activeUrl = url;
+        _http.BaseAddress = new Uri(url.TrimEnd('/') + "/");
+    }
+
+    // Default candidate probe: GET <url>/healthz with a short timeout. /healthz is unauthenticated so
+    // no token is presented. Never throws - a transport failure or timeout becomes a reason string,
+    // which makes GatewayEndpointSelector move to the next candidate.
+    private static async Task<string?> ProbeGatewayHealthzAsync(string url, CancellationToken ct)
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        return await GatewayEndpointSelector.ProbeHealthzAsync(url, http, ct);
+    }
+
     private async Task RegisterLoop(CancellationToken ct)
     {
         var delay = TimeSpan.FromSeconds(2);
@@ -493,7 +577,7 @@ public sealed class GatewayClient : IDisposable
             catch (Exception ex)
             {
                 FileLog.Write($"[GatewayClient] Register attempt failed: {ex.Message}");
-                _monitor?.ReportRegistrationFailure($"Cannot reach the Gateway at {_config.Url}: {ex.Message}");
+                _monitor?.ReportRegistrationFailure($"Cannot reach the Gateway at {_activeUrl}: {ex.Message}");
             }
 
             try { await Task.Delay(delay, ct); }
@@ -736,7 +820,7 @@ public sealed class GatewayClient : IDisposable
             if (resp.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.MethodNotAllowed)
             {
                 _monitor.CompleteHandshake(nonce, null,
-                    $"The Gateway at {_config.Url} does not support the verify handshake - update the Gateway");
+                    $"The Gateway at {_activeUrl} does not support the verify handshake - update the Gateway");
                 return null;
             }
             if (!resp.IsSuccessStatusCode)
@@ -785,7 +869,7 @@ public sealed class GatewayClient : IDisposable
         {
             // Includes the HttpClient timeout (TaskCanceledException without ct signaled):
             // leg 1 itself is down or crawling.
-            _monitor.CompleteHandshake(nonce, null, $"Cannot reach the Gateway at {_config.Url}: {ex.Message}");
+            _monitor.CompleteHandshake(nonce, null, $"Cannot reach the Gateway at {_activeUrl}: {ex.Message}");
             return null;
         }
         finally

--- a/src/CcDirector.Core.Tests/Configuration/GatewayConfigCandidateUrlsTests.cs
+++ b/src/CcDirector.Core.Tests/Configuration/GatewayConfigCandidateUrlsTests.cs
@@ -1,0 +1,84 @@
+using CcDirector.Core.Configuration;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Configuration;
+
+/// <summary>
+/// Tests for <see cref="GatewayConfig.CandidateUrls"/> - the ordered set of gateway addresses a
+/// client tries when connecting (issue #1233). The active/manual <see cref="GatewayConfig.Url"/>
+/// comes first (a manual override wins), then the discovered fallbacks in <see cref="GatewayConfig.Urls"/>,
+/// de-duplicated. These construct the config directly, so they exercise the ordering with no file I/O.
+/// </summary>
+public class GatewayConfigCandidateUrlsTests
+{
+    [Fact]
+    public void CandidateUrls_UrlOnly_ReturnsJustTheUrl()
+    {
+        var cfg = new GatewayConfig { Url = "http://machine:7878" };
+
+        Assert.Equal(new[] { "http://machine:7878" }, cfg.CandidateUrls);
+    }
+
+    [Fact]
+    public void CandidateUrls_UrlFirstThenFallbacks_InOrder()
+    {
+        var cfg = new GatewayConfig
+        {
+            Url = "http://machine:7878",
+            Urls = new[] { "https://machine.tail.ts.net:7878", "http://192.168.1.20:7878" },
+        };
+
+        Assert.Equal(
+            new[] { "http://machine:7878", "https://machine.tail.ts.net:7878", "http://192.168.1.20:7878" },
+            cfg.CandidateUrls);
+    }
+
+    [Fact]
+    public void CandidateUrls_ActiveUrlAlsoInFallbackList_IsNotDuplicated()
+    {
+        var cfg = new GatewayConfig
+        {
+            Url = "http://machine:7878",
+            Urls = new[] { "http://machine:7878", "https://machine.tail.ts.net:7878" },
+        };
+
+        Assert.Equal(
+            new[] { "http://machine:7878", "https://machine.tail.ts.net:7878" },
+            cfg.CandidateUrls);
+    }
+
+    [Fact]
+    public void CandidateUrls_DuplicateDiffersOnlyByCase_IsNotDuplicated()
+    {
+        var cfg = new GatewayConfig
+        {
+            Url = "http://MACHINE:7878",
+            Urls = new[] { "http://machine:7878" },
+        };
+
+        Assert.Single(cfg.CandidateUrls);
+        Assert.Equal("http://MACHINE:7878", cfg.CandidateUrls[0]);
+    }
+
+    [Fact]
+    public void CandidateUrls_NoActiveUrl_ReturnsFallbacksOnly()
+    {
+        var cfg = new GatewayConfig
+        {
+            Url = "",
+            Urls = new[] { "https://machine.tail.ts.net:7878", "http://192.168.1.20:7878" },
+        };
+
+        Assert.Equal(
+            new[] { "https://machine.tail.ts.net:7878", "http://192.168.1.20:7878" },
+            cfg.CandidateUrls);
+    }
+
+    [Fact]
+    public void CandidateUrls_NothingConfigured_IsEmpty()
+    {
+        var cfg = new GatewayConfig();
+
+        Assert.Empty(cfg.CandidateUrls);
+    }
+}

--- a/src/CcDirector.Core.Tests/Network/GatewayAddressTests.cs
+++ b/src/CcDirector.Core.Tests/Network/GatewayAddressTests.cs
@@ -1,0 +1,124 @@
+using CcDirector.Core.Network;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Network;
+
+/// <summary>
+/// Tests for <see cref="GatewayAddress"/> - the manual gateway-address entry helper used by the
+/// installer connect step and the app settings (issue #1233): computer name plus port, and
+/// normalizing a pasted full address.
+/// </summary>
+public class GatewayAddressTests
+{
+    [Fact]
+    public void TryFromComputerNameAndPort_ValidNameAndPort_BuildsHttpUrl()
+    {
+        var ok = GatewayAddress.TryFromComputerNameAndPort("SOREN-NORTH", 7878, out var url, out var error);
+
+        Assert.True(ok);
+        Assert.Equal("http://SOREN-NORTH:7878", url);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void TryFromComputerNameAndPort_TrimsName()
+    {
+        var ok = GatewayAddress.TryFromComputerNameAndPort("  MACHINE  ", 7878, out var url, out _);
+
+        Assert.True(ok);
+        Assert.Equal("http://MACHINE:7878", url);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void TryFromComputerNameAndPort_BlankName_Fails(string? name)
+    {
+        var ok = GatewayAddress.TryFromComputerNameAndPort(name, 7878, out var url, out var error);
+
+        Assert.False(ok);
+        Assert.Equal("", url);
+        Assert.NotNull(error);
+    }
+
+    [Theory]
+    [InlineData("http://machine")]
+    [InlineData("machine/path")]
+    public void TryFromComputerNameAndPort_NameIsAFullAddress_Fails(string name)
+    {
+        var ok = GatewayAddress.TryFromComputerNameAndPort(name, 7878, out _, out var error);
+
+        Assert.False(ok);
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void TryFromComputerNameAndPort_NameWithSpace_Fails()
+    {
+        var ok = GatewayAddress.TryFromComputerNameAndPort("my machine", 7878, out _, out var error);
+
+        Assert.False(ok);
+        Assert.NotNull(error);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(70000)]
+    public void TryFromComputerNameAndPort_PortOutOfRange_Fails(int port)
+    {
+        var ok = GatewayAddress.TryFromComputerNameAndPort("MACHINE", port, out _, out var error);
+
+        Assert.False(ok);
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void TryNormalize_BareHostAndPort_AddsHttpScheme()
+    {
+        var ok = GatewayAddress.TryNormalize("machine:7878", out var url, out var error);
+
+        Assert.True(ok);
+        Assert.Equal("http://machine:7878", url);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void TryNormalize_FullHttpUrl_TrimsTrailingSlash()
+    {
+        var ok = GatewayAddress.TryNormalize("http://machine:7878/", out var url, out _);
+
+        Assert.True(ok);
+        Assert.Equal("http://machine:7878", url);
+    }
+
+    [Fact]
+    public void TryNormalize_TailscaleHttpsUrl_IsAccepted()
+    {
+        var ok = GatewayAddress.TryNormalize("https://soren-north.tail1234.ts.net:7878", out var url, out _);
+
+        Assert.True(ok);
+        Assert.Equal("https://soren-north.tail1234.ts.net:7878", url);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryNormalize_Blank_Fails(string input)
+    {
+        var ok = GatewayAddress.TryNormalize(input, out _, out var error);
+
+        Assert.False(ok);
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void TryNormalize_NonHttpScheme_Fails()
+    {
+        var ok = GatewayAddress.TryNormalize("ftp://machine:21", out _, out var error);
+
+        Assert.False(ok);
+        Assert.NotNull(error);
+    }
+}

--- a/src/CcDirector.Core.Tests/Network/GatewayEndpointSelectorTests.cs
+++ b/src/CcDirector.Core.Tests/Network/GatewayEndpointSelectorTests.cs
@@ -1,0 +1,164 @@
+using CcDirector.Core.Network;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Network;
+
+/// <summary>
+/// Tests for <see cref="GatewayEndpointSelector"/> - the priority-order walker that picks the
+/// first reachable gateway address from an ordered candidate list (issue #1233). The probe is
+/// injected, so these exercise the ordering and fall-through policy with no live gateway.
+/// </summary>
+public class GatewayEndpointSelectorTests
+{
+    // A probe that reports the given set of URLs reachable (null reason) and everything else
+    // unreachable, and records the order in which it was asked so tests can assert that later
+    // candidates were never probed once an earlier one won.
+    private static Func<string, CancellationToken, Task<string?>> ProbeThatAccepts(
+        List<string> probedOrder, params string[] reachable)
+    {
+        var ok = new HashSet<string>(reachable, StringComparer.OrdinalIgnoreCase);
+        return (url, _) =>
+        {
+            probedOrder.Add(url);
+            return Task.FromResult<string?>(ok.Contains(url) ? null : $"unreachable: {url}");
+        };
+    }
+
+    [Fact]
+    public async Task SelectAsync_FirstCandidateReachable_ChoosesItAndDoesNotProbeRest()
+    {
+        var probed = new List<string>();
+        var candidates = new[] { "http://MACHINE:7878", "https://machine.tail.ts.net:7878", "http://192.168.1.20:7878" };
+
+        var result = await GatewayEndpointSelector.SelectAsync(
+            candidates, ProbeThatAccepts(probed, "http://MACHINE:7878"));
+
+        Assert.True(result.Found);
+        Assert.Equal("http://MACHINE:7878", result.ChosenUrl);
+        Assert.Single(probed);                              // stopped at the first
+        Assert.Equal("http://MACHINE:7878", probed[0]);
+    }
+
+    [Fact]
+    public async Task SelectAsync_FallsThroughToTailscale_WhenMachineNameUnreachable()
+    {
+        var probed = new List<string>();
+        var candidates = new[] { "http://MACHINE:7878", "https://machine.tail.ts.net:7878", "http://192.168.1.20:7878" };
+
+        var result = await GatewayEndpointSelector.SelectAsync(
+            candidates, ProbeThatAccepts(probed, "https://machine.tail.ts.net:7878"));
+
+        Assert.True(result.Found);
+        Assert.Equal("https://machine.tail.ts.net:7878", result.ChosenUrl);
+        // Machine name was tried first, then Tailscale won - IP is never reached.
+        Assert.Equal(new[] { "http://MACHINE:7878", "https://machine.tail.ts.net:7878" }, probed);
+    }
+
+    [Fact]
+    public async Task SelectAsync_FallsThroughToIp_WhenMachineNameAndTailscaleUnreachable()
+    {
+        var probed = new List<string>();
+        var candidates = new[] { "http://MACHINE:7878", "https://machine.tail.ts.net:7878", "http://192.168.1.20:7878" };
+
+        var result = await GatewayEndpointSelector.SelectAsync(
+            candidates, ProbeThatAccepts(probed, "http://192.168.1.20:7878"));
+
+        Assert.True(result.Found);
+        Assert.Equal("http://192.168.1.20:7878", result.ChosenUrl);
+        Assert.Equal(candidates, probed);                   // all three tried, in order
+    }
+
+    [Fact]
+    public async Task SelectAsync_NoCandidateReachable_ReturnsNotFoundWithEveryAttempt()
+    {
+        var probed = new List<string>();
+        var candidates = new[] { "http://MACHINE:7878", "https://machine.tail.ts.net:7878", "http://192.168.1.20:7878" };
+
+        var result = await GatewayEndpointSelector.SelectAsync(
+            candidates, ProbeThatAccepts(probed /* accepts nothing */));
+
+        Assert.False(result.Found);
+        Assert.Null(result.ChosenUrl);
+        Assert.Equal(3, result.Attempts.Count);
+        Assert.All(result.Attempts, a => Assert.False(a.Reachable));
+        Assert.All(result.Attempts, a => Assert.NotNull(a.Reason));
+    }
+
+    [Fact]
+    public async Task SelectAsync_EmptyList_ReturnsNotFound()
+    {
+        var result = await GatewayEndpointSelector.SelectAsync(
+            Array.Empty<string>(), (_, _) => Task.FromResult<string?>(null));
+
+        Assert.False(result.Found);
+        Assert.Empty(result.Attempts);
+    }
+
+    [Fact]
+    public async Task SelectAsync_BlankCandidates_AreRecordedAndSkippedNeverProbed()
+    {
+        var probed = new List<string>();
+        var candidates = new[] { "", "   ", "http://MACHINE:7878" };
+
+        var result = await GatewayEndpointSelector.SelectAsync(
+            candidates, ProbeThatAccepts(probed, "http://MACHINE:7878"));
+
+        Assert.True(result.Found);
+        Assert.Equal("http://MACHINE:7878", result.ChosenUrl);
+        Assert.Single(probed);                              // blanks were never probed
+        Assert.Equal("http://MACHINE:7878", probed[0]);
+        Assert.Equal(3, result.Attempts.Count);             // both blanks recorded as failed attempts
+        Assert.False(result.Attempts[0].Reachable);
+        Assert.False(result.Attempts[1].Reachable);
+    }
+
+    [Fact]
+    public async Task SelectAsync_CandidateIsTrimmed_BeforeProbing()
+    {
+        var probed = new List<string>();
+        var result = await GatewayEndpointSelector.SelectAsync(
+            new[] { "  http://MACHINE:7878  " }, ProbeThatAccepts(probed, "http://MACHINE:7878"));
+
+        Assert.True(result.Found);
+        Assert.Equal("http://MACHINE:7878", result.ChosenUrl);
+        Assert.Equal("http://MACHINE:7878", probed[0]);
+    }
+
+    [Fact]
+    public async Task SelectAsync_ProbeThatThrows_IsTreatedAsFailedAttemptAndWalkContinues()
+    {
+        var candidates = new[] { "http://MACHINE:7878", "https://machine.tail.ts.net:7878" };
+        var result = await GatewayEndpointSelector.SelectAsync(candidates, (url, _) =>
+        {
+            if (url == "http://MACHINE:7878") throw new HttpRequestException("connection refused");
+            return Task.FromResult<string?>(null);          // Tailscale answers
+        });
+
+        Assert.True(result.Found);
+        Assert.Equal("https://machine.tail.ts.net:7878", result.ChosenUrl);
+        Assert.False(result.Attempts[0].Reachable);
+        Assert.Contains("probe threw", result.Attempts[0].Reason);
+    }
+
+    [Fact]
+    public async Task SelectAsync_CancellationRequested_Throws()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            GatewayEndpointSelector.SelectAsync(
+                new[] { "http://MACHINE:7878" },
+                (_, _) => Task.FromResult<string?>(null),
+                cts.Token));
+    }
+
+    [Fact]
+    public async Task SelectAsync_NullArguments_Throw()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            GatewayEndpointSelector.SelectAsync(null!, (_, _) => Task.FromResult<string?>(null)));
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            GatewayEndpointSelector.SelectAsync(Array.Empty<string>(), null!));
+    }
+}

--- a/src/CcDirector.Core/Configuration/GatewayConfig.cs
+++ b/src/CcDirector.Core/Configuration/GatewayConfig.cs
@@ -26,8 +26,52 @@ namespace CcDirector.Core.Configuration;
 /// </summary>
 public sealed class GatewayConfig
 {
-    /// <summary>Gateway base URL, e.g. <c>http://gateway.tailnet.example:7878</c>.</summary>
+    /// <summary>Gateway base URL, e.g. <c>http://gateway.tailnet.example:7878</c>. This is the
+    /// ACTIVE / preferred address: the one a manual override writes, and the first candidate tried
+    /// when connecting (a manually set address wins over the auto-discovered fallbacks).</summary>
     public string Url { get; init; } = "";
+
+    /// <summary>
+    /// The ordered list of FALLBACK gateway addresses discovered from the account (issue #1233):
+    /// machine name plus port, the Tailscale address when Tailscale is available, and the local
+    /// network IP plus port, in priority order. Read from the <c>gateway.urls</c> array in
+    /// config.json. Empty on older installs that only ever wrote <c>gateway.url</c>, in which case
+    /// behaviour is unchanged (one candidate). Use <see cref="CandidateUrls"/> to get the full
+    /// ordered set to try, which puts <see cref="Url"/> first.
+    /// </summary>
+    public IReadOnlyList<string> Urls { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// The full ordered set of addresses to try when connecting to the gateway (issue #1233):
+    /// <see cref="Url"/> first (the active/manual address wins), then each entry of
+    /// <see cref="Urls"/>, de-duplicated (case-insensitive) so the active address is not probed
+    /// twice when it also appears in the discovered list. A client walks these in order and
+    /// connects through the first that answers (see <see cref="Network.GatewayEndpointSelector"/>).
+    /// </summary>
+    public IReadOnlyList<string> CandidateUrls
+    {
+        get
+        {
+            var list = new List<string>();
+            AddCandidate(list, Url);
+            foreach (var u in Urls)
+                AddCandidate(list, u);
+            return list;
+        }
+    }
+
+    // Append a trimmed, non-blank candidate unless an equal one (case-insensitive) is already present.
+    private static void AddCandidate(List<string> list, string? candidate)
+    {
+        if (string.IsNullOrWhiteSpace(candidate)) return;
+        var trimmed = candidate.Trim();
+        foreach (var existing in list)
+        {
+            if (string.Equals(existing, trimmed, StringComparison.OrdinalIgnoreCase))
+                return;
+        }
+        list.Add(trimmed);
+    }
 
     /// <summary>
     /// Bearer token the Director/launcher present to the Gateway. Normally the enrolled per-device key
@@ -104,6 +148,21 @@ public sealed class GatewayConfig
             var token = (gw.TryGetProperty("token", out var t) ? t.GetString() ?? "" : "").Trim();
             var tailnet = gw.TryGetProperty("tailnetEndpoint", out var te) ? te.GetString() : null;
 
+            // Issue #1233: the ordered fallback candidate list discovered from the account. A missing
+            // or malformed key leaves it empty so the install behaves exactly as before (one candidate,
+            // gateway.url). Only non-blank string entries are kept, trimmed, in the order given.
+            var urls = new List<string>();
+            if (gw.TryGetProperty("urls", out var urlsEl) && urlsEl.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in urlsEl.EnumerateArray())
+                {
+                    if (item.ValueKind != JsonValueKind.String) continue;
+                    var s = item.GetString();
+                    if (!string.IsNullOrWhiteSpace(s))
+                        urls.Add(s.Trim());
+                }
+            }
+
             // Issue #1176 (Phase 1a). streamMode is opt-in (only a JSON boolean true enables it), so a
             // missing or malformed key leaves the Director on the existing pull path. staleAfterSeconds
             // must be a positive integer or the default stands.
@@ -136,6 +195,7 @@ public sealed class GatewayConfig
             return new GatewayConfig
             {
                 Url = url,
+                Urls = urls,
                 Token = token,
                 TailnetEndpoint = string.IsNullOrWhiteSpace(tailnet) ? null : tailnet.Trim(),
                 AddressingMode = mode,

--- a/src/CcDirector.Core/Network/GatewayAddress.cs
+++ b/src/CcDirector.Core/Network/GatewayAddress.cs
@@ -1,0 +1,90 @@
+namespace CcDirector.Core.Network;
+
+/// <summary>
+/// Builds and validates a gateway address a person types in the installer connect step or the
+/// app's gateway settings (issue #1233).
+///
+/// The primary manual form is a computer name plus a port - the simplest, most reliable thing to
+/// type on a local network - which becomes <c>http://&lt;name&gt;:&lt;port&gt;</c> and works whenever the
+/// gateway machine is not blocking that port with a firewall. A full address the user pastes (for
+/// example a Tailscale <c>https://…</c> URL) is also accepted, normalized, and validated.
+///
+/// Pure and side-effect free so both entry paths are unit-tested directly, and so the installer and
+/// the settings dialog build the exact same URL from the same input.
+/// </summary>
+public static class GatewayAddress
+{
+    /// <summary>Lowest valid TCP port.</summary>
+    public const int MinPort = 1;
+
+    /// <summary>Highest valid TCP port.</summary>
+    public const int MaxPort = 65535;
+
+    /// <summary>
+    /// Build <c>http://&lt;computerName&gt;:&lt;port&gt;</c> from a machine name and a port. Returns true and
+    /// the url when the name is a bare host (non-blank, no scheme, slash, or space) and the port is
+    /// in range; otherwise false and a human-readable <paramref name="error"/> the UI can show. The
+    /// name is trimmed. For anything that is already a full address, use <see cref="TryNormalize"/>.
+    /// </summary>
+    public static bool TryFromComputerNameAndPort(string? computerName, int port, out string url, out string? error)
+    {
+        url = string.Empty;
+        var name = (computerName ?? string.Empty).Trim();
+
+        if (name.Length == 0)
+        {
+            error = "Enter the gateway computer name.";
+            return false;
+        }
+        if (name.Contains("://", StringComparison.Ordinal) || name.Contains('/'))
+        {
+            error = "Enter just the computer name here, not a full address.";
+            return false;
+        }
+        if (name.Contains(' '))
+        {
+            error = "A computer name cannot contain spaces.";
+            return false;
+        }
+        if (port < MinPort || port > MaxPort)
+        {
+            error = $"Port must be a number between {MinPort} and {MaxPort}.";
+            return false;
+        }
+
+        url = $"http://{name}:{port}";
+        error = null;
+        return true;
+    }
+
+    /// <summary>
+    /// Normalize a full address a person pasted. When the input carries no scheme, <c>http://</c> is
+    /// assumed (the common local-network case); the result must then parse as an absolute http or
+    /// https URL. Returns true and the normalized url (trailing slash trimmed), or false and a
+    /// reason. Used for the "paste a full address" path (for example a Tailscale https URL).
+    /// </summary>
+    public static bool TryNormalize(string? input, out string url, out string? error)
+    {
+        url = string.Empty;
+        var raw = (input ?? string.Empty).Trim();
+
+        if (raw.Length == 0)
+        {
+            error = "Enter a gateway address.";
+            return false;
+        }
+        if (!raw.Contains("://", StringComparison.Ordinal))
+            raw = "http://" + raw;
+
+        if (!Uri.TryCreate(raw, UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            error = "That is not a valid http or https address.";
+            return false;
+        }
+
+        url = raw.TrimEnd('/');
+        error = null;
+        return true;
+    }
+}

--- a/src/CcDirector.Core/Network/GatewayEndpointSelector.cs
+++ b/src/CcDirector.Core/Network/GatewayEndpointSelector.cs
@@ -1,0 +1,128 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Network;
+
+/// <summary>
+/// One attempt to reach a candidate gateway address: the address tried, whether it answered,
+/// and - when it did not - a human-readable reason. The full ordered list of attempts is kept
+/// so the caller (installer test panel, Director connect log) can show exactly what was tried
+/// and why each earlier candidate was skipped.
+/// </summary>
+public sealed record GatewayEndpointAttempt(string Url, bool Reachable, string? Reason);
+
+/// <summary>
+/// The outcome of walking an ordered candidate list: the first address that answered
+/// (<see cref="ChosenUrl"/>, null when none did) and every attempt made, in order.
+/// </summary>
+public sealed record GatewayEndpointSelection(string? ChosenUrl, IReadOnlyList<GatewayEndpointAttempt> Attempts)
+{
+    /// <summary>True when a reachable gateway address was found.</summary>
+    public bool Found => ChosenUrl is not null;
+}
+
+/// <summary>
+/// Picks the first reachable gateway address from an ordered candidate list (issue #1233).
+///
+/// A gateway now advertises several ways to be reached (machine name plus port, its Tailscale
+/// address when Tailscale is available, and its local network IP plus port). A joining client -
+/// the installer connect step and the Director's own registration - is handed that ordered list
+/// and must connect through the FIRST candidate that actually answers, in priority order:
+///
+///   1. machine name (the local-network path, and the most stable name)
+///   2. Tailscale (the reliable cross-network path)
+///   3. raw IP address (last resort - it can change)
+///
+/// This walker keeps that policy in ONE place. It probes each candidate in the order given and
+/// stops at the first that answers, so callers never invent their own ordering. The reachability
+/// probe is injected so the selection logic is unit-tested without a live gateway; production
+/// callers pass <see cref="ProbeHealthzAsync"/>, the same GET /healthz check the rest of the
+/// Director-to-Gateway client uses.
+/// </summary>
+public static class GatewayEndpointSelector
+{
+    /// <summary>
+    /// Walk <paramref name="candidates"/> in order and return the first that the
+    /// <paramref name="probe"/> reports reachable. The probe returns null when the address
+    /// answered, otherwise a reason string. Blank candidates are recorded and skipped, never
+    /// probed. Every candidate examined before the winner is recorded in
+    /// <see cref="GatewayEndpointSelection.Attempts"/>; candidates AFTER the winner are not
+    /// probed (first reachable wins). Returns a selection with a null <c>ChosenUrl</c> when no
+    /// candidate answered.
+    /// </summary>
+    public static async Task<GatewayEndpointSelection> SelectAsync(
+        IReadOnlyList<string> candidates,
+        Func<string, CancellationToken, Task<string?>> probe,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(candidates);
+        ArgumentNullException.ThrowIfNull(probe);
+
+        var attempts = new List<GatewayEndpointAttempt>();
+        foreach (var raw in candidates)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var url = (raw ?? string.Empty).Trim();
+            if (url.Length == 0)
+            {
+                attempts.Add(new GatewayEndpointAttempt(raw ?? string.Empty, false, "blank candidate address"));
+                continue;
+            }
+
+            string? reason;
+            try
+            {
+                reason = await probe(url, ct);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // A probe that throws is a failed attempt, not a fatal error: record the reason
+                // and keep walking so one broken candidate never hides a reachable later one.
+                reason = $"probe threw: {ex.Message}";
+            }
+
+            attempts.Add(new GatewayEndpointAttempt(url, reason is null, reason));
+            if (reason is null)
+            {
+                FileLog.Write($"[GatewayEndpointSelector] chose {url} (attempt {attempts.Count} of {candidates.Count})");
+                return new GatewayEndpointSelection(url, attempts);
+            }
+
+            FileLog.Write($"[GatewayEndpointSelector] {url} not reachable: {reason}");
+        }
+
+        FileLog.Write($"[GatewayEndpointSelector] no reachable gateway among {attempts.Count} candidate(s)");
+        return new GatewayEndpointSelection(null, attempts);
+    }
+
+    /// <summary>
+    /// The production reachability probe: GET &lt;url&gt;/healthz and treat a 2xx as reachable.
+    /// This is the same health check <see cref="GatewayClient.ProbeAdvertisedEndpointAsync"/>
+    /// uses for a Director's own endpoint, applied here to a candidate GATEWAY address. Returns
+    /// null when the gateway answered, otherwise a reason. Never throws - a transport failure or
+    /// timeout becomes a reason string so <see cref="SelectAsync"/> moves to the next candidate.
+    /// The caller supplies the <see cref="HttpClient"/> so its timeout governs how long each
+    /// candidate is given before we fall through to the next.
+    /// </summary>
+    public static async Task<string?> ProbeHealthzAsync(string url, HttpClient http, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(http);
+        try
+        {
+            using var resp = await http.GetAsync($"{url.TrimEnd('/')}/healthz", ct);
+            return resp.IsSuccessStatusCode ? null : $"healthz answered HTTP {(int)resp.StatusCode}";
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return "healthz probe timed out";
+        }
+        catch (Exception ex)
+        {
+            return $"healthz probe failed: {ex.Message}";
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/GatewayClientCandidateSelectionTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayClientCandidateSelectionTests.cs
@@ -1,0 +1,81 @@
+using CcDirector.ControlApi;
+using CcDirector.Core.Configuration;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Tests for <see cref="GatewayClient"/>'s priority-order candidate selection (issue #1233):
+/// before registering, the client narrows its active address to the first entry of
+/// <see cref="GatewayConfig.CandidateUrls"/> that answers. The reachability probe is injected via
+/// <see cref="GatewayClient.ProbeGatewayCandidate"/> so these run with no live gateway.
+/// </summary>
+public class GatewayClientCandidateSelectionTests
+{
+    private const string MachineUrl = "http://MACHINE:7878";
+    private const string TailscaleUrl = "https://machine.tail.ts.net:7878";
+    private const string IpUrl = "http://192.168.1.20:7878";
+
+    private static GatewayClient NewClient(GatewayConfig cfg, params string[] reachable)
+    {
+        var ok = new HashSet<string>(reachable, StringComparer.OrdinalIgnoreCase);
+        var client = new GatewayClient(cfg, Guid.NewGuid().ToString(), port: 65500, version: "9.9.9-test");
+        client.ProbeGatewayCandidate = (url, _) =>
+            Task.FromResult<string?>(ok.Contains(url) ? null : $"unreachable: {url}");
+        return client;
+    }
+
+    [Fact]
+    public async Task SelectActiveUrlAsync_SingleCandidate_IsNoOp()
+    {
+        using var client = NewClient(new GatewayConfig { Url = MachineUrl });
+
+        await client.SelectActiveUrlAsync(CancellationToken.None);
+
+        Assert.Equal(MachineUrl, client.ActiveUrl);
+    }
+
+    [Fact]
+    public async Task SelectActiveUrlAsync_FirstCandidateReachable_KeepsIt()
+    {
+        var cfg = new GatewayConfig { Url = MachineUrl, Urls = new[] { TailscaleUrl, IpUrl } };
+        using var client = NewClient(cfg, MachineUrl);
+
+        await client.SelectActiveUrlAsync(CancellationToken.None);
+
+        Assert.Equal(MachineUrl, client.ActiveUrl);
+    }
+
+    [Fact]
+    public async Task SelectActiveUrlAsync_MachineNameDown_SwitchesToTailscale()
+    {
+        var cfg = new GatewayConfig { Url = MachineUrl, Urls = new[] { TailscaleUrl, IpUrl } };
+        using var client = NewClient(cfg, TailscaleUrl, IpUrl);
+
+        await client.SelectActiveUrlAsync(CancellationToken.None);
+
+        Assert.Equal(TailscaleUrl, client.ActiveUrl);
+    }
+
+    [Fact]
+    public async Task SelectActiveUrlAsync_OnlyIpReachable_SwitchesToIp()
+    {
+        var cfg = new GatewayConfig { Url = MachineUrl, Urls = new[] { TailscaleUrl, IpUrl } };
+        using var client = NewClient(cfg, IpUrl);
+
+        await client.SelectActiveUrlAsync(CancellationToken.None);
+
+        Assert.Equal(IpUrl, client.ActiveUrl);
+    }
+
+    [Fact]
+    public async Task SelectActiveUrlAsync_NoneReachable_LeavesActiveUrlUnchanged()
+    {
+        var cfg = new GatewayConfig { Url = MachineUrl, Urls = new[] { TailscaleUrl, IpUrl } };
+        using var client = NewClient(cfg /* nothing reachable */);
+
+        await client.SelectActiveUrlAsync(CancellationToken.None);
+
+        Assert.Equal(MachineUrl, client.ActiveUrl);
+    }
+}

--- a/tools/cc-director-setup-engine.Tests/GatewayAccountEnrollRunnerTestAddressTests.cs
+++ b/tools/cc-director-setup-engine.Tests/GatewayAccountEnrollRunnerTestAddressTests.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+/// <summary>
+/// Tests for <see cref="GatewayAccountEnrollRunner.TestGatewayAddressAsync"/> - the installer's mandatory
+/// reachability Test gate (issue #1233). The person enters a computer name plus port (or pastes a full
+/// address), hits Test, and the install may only proceed once the gateway actually answers GET /healthz.
+/// A fake handler stands in for the gateway, so no live gateway is needed. Neither sign-in nor persist may
+/// run for a reachability test (it happens before the person commits), which the injected throwers assert.
+/// </summary>
+public class GatewayAccountEnrollRunnerTestAddressTests
+{
+    private sealed class HealthzHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly bool _throw;
+        public string? LastPath;
+
+        public HealthzHandler(HttpStatusCode status, bool @throw = false)
+        {
+            _status = status;
+            _throw = @throw;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            LastPath = request.RequestUri!.AbsolutePath;
+            if (_throw) throw new HttpRequestException("connection refused");
+            return Task.FromResult(new HttpResponseMessage(_status));
+        }
+    }
+
+    private static GatewayAccountEnrollRunner Runner(HttpMessageHandler handler) =>
+        new(signIn: _ => throw new InvalidOperationException("sign-in must not run for a reachability test"),
+            handlerFactory: () => handler,
+            persist: (_, _) => throw new InvalidOperationException("persist must not run for a reachability test"));
+
+    [Fact]
+    public async Task TestGatewayAddressAsync_ComputerNameAndPort_Reachable_ReturnsBuiltUrl()
+    {
+        var handler = new HealthzHandler(HttpStatusCode.OK);
+        var runner = Runner(handler);
+
+        var result = await runner.TestGatewayAddressAsync("SOREN-NORTH", 7878, CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.Equal("http://SOREN-NORTH:7878", result.Value);
+        Assert.Equal("/healthz", handler.LastPath);      // it really probed /healthz
+    }
+
+    [Fact]
+    public async Task TestGatewayAddressAsync_FullPastedHttpsUrl_IsNormalizedAndProbed()
+    {
+        var handler = new HealthzHandler(HttpStatusCode.OK);
+        var runner = Runner(handler);
+
+        // A pasted Tailscale https address: the port argument is ignored; the address is used as-is.
+        var result = await runner.TestGatewayAddressAsync("https://soren-north.tail1234.ts.net:7878", 1, CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.Equal("https://soren-north.tail1234.ts.net:7878", result.Value);
+    }
+
+    [Fact]
+    public async Task TestGatewayAddressAsync_GatewayAnswersNon2xx_Fails()
+    {
+        var handler = new HealthzHandler(HttpStatusCode.ServiceUnavailable);
+        var runner = Runner(handler);
+
+        var result = await runner.TestGatewayAddressAsync("MACHINE", 7878, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("Could not reach", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task TestGatewayAddressAsync_TransportFails_Fails()
+    {
+        var handler = new HealthzHandler(HttpStatusCode.OK, @throw: true);
+        var runner = Runner(handler);
+
+        var result = await runner.TestGatewayAddressAsync("MACHINE", 7878, CancellationToken.None);
+
+        Assert.False(result.Success);
+    }
+
+    [Theory]
+    [InlineData("", 7878)]
+    [InlineData("MACHINE", 0)]
+    [InlineData("MACHINE", 70000)]
+    [InlineData("has space", 7878)]
+    public async Task TestGatewayAddressAsync_InvalidInput_FailsWithoutProbing(string name, int port)
+    {
+        var handler = new HealthzHandler(HttpStatusCode.OK);
+        var runner = Runner(handler);
+
+        var result = await runner.TestGatewayAddressAsync(name, port, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Null(handler.LastPath);                   // rejected before any network call
+    }
+}

--- a/tools/cc-director-setup-engine/GatewayAccountEnrollRunner.cs
+++ b/tools/cc-director-setup-engine/GatewayAccountEnrollRunner.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http.Json;
 using CcDirector.Core.Account;
 using CcDirector.Core.Configuration;
+using CcDirector.Core.Network;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -275,6 +276,54 @@ public sealed class GatewayAccountEnrollRunner
         var url = gatewayUrl.Trim();
         EngineLog.Write($"[GatewayAccountEnrollRunner] EnrollWithDiscoveredGatewayAsync: gateway={url}, deviceId={deviceId}, machine={machineName}");
         return await RegisterAndEnrollAsync(tokens, url, deviceId, machineName, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Test that a gateway is actually reachable at a user-entered address BEFORE the install commits to it
+    /// (issue #1233 - the mandatory Test gate). Accepts either a bare computer name plus <paramref name="port"/>
+    /// (built into <c>http://name:port</c> - the primary manual form) or a full address pasted into
+    /// <paramref name="computerNameOrUrl"/> (normalized, e.g. a Tailscale https URL). Probes GET /healthz with
+    /// the configured timeout. On success it returns the RESOLVED url (the connect step then enrolls against
+    /// exactly that); on failure it returns a clear, calm reason and NO url, so the installer never registers
+    /// this machine against an address it could not reach. /healthz is unauthenticated, so the person can prove
+    /// the address works first, then Connect (which signs in and enrolls). Never throws for an expected failure.
+    /// </summary>
+    /// <param name="computerNameOrUrl">A bare gateway computer name, or a full pasted gateway address.</param>
+    /// <param name="port">The gateway port, used only when <paramref name="computerNameOrUrl"/> is a bare name.</param>
+    /// <param name="ct">Cancels the probe.</param>
+    public async Task<OperationResult<string>> TestGatewayAddressAsync(
+        string? computerNameOrUrl, int port, CancellationToken ct = default)
+    {
+        var raw = (computerNameOrUrl ?? string.Empty).Trim();
+        if (raw.Length == 0)
+            return OperationResult<string>.Fail("Enter the gateway computer name and port.");
+
+        // A pasted full address (has a scheme) is normalized as-is; anything else is a bare computer name
+        // combined with the port. Both paths validate before we probe.
+        string url;
+        string? buildError;
+        if (raw.Contains("://", StringComparison.Ordinal))
+        {
+            if (!GatewayAddress.TryNormalize(raw, out url, out buildError))
+                return OperationResult<string>.Fail(buildError!);
+        }
+        else if (!GatewayAddress.TryFromComputerNameAndPort(raw, port, out url, out buildError))
+        {
+            return OperationResult<string>.Fail(buildError!);
+        }
+
+        EngineLog.Write($"[GatewayAccountEnrollRunner] TestGatewayAddressAsync: probing {url}/healthz");
+        using var http = new HttpClient(_handlerFactory(), disposeHandler: true) { Timeout = _httpTimeout };
+        var reason = await GatewayEndpointSelector.ProbeHealthzAsync(url, http, ct).ConfigureAwait(false);
+        if (reason is null)
+        {
+            EngineLog.Write($"[GatewayAccountEnrollRunner] TestGatewayAddressAsync: {url} is reachable");
+            return OperationResult<string>.Ok(url);
+        }
+
+        EngineLog.Write($"[GatewayAccountEnrollRunner] TestGatewayAddressAsync: {url} not reachable: {reason}");
+        return OperationResult<string>.Fail(
+            $"Could not reach a gateway at {url}. Check the computer name and port, and that the gateway is running and not blocked by a firewall.");
     }
 
     /// <summary>

--- a/tools/cc-director-setup/Steps/GatewayConnectStep.xaml
+++ b/tools/cc-director-setup/Steps/GatewayConnectStep.xaml
@@ -40,6 +40,80 @@
                            TextWrapping="Wrap"
                            Margin="0,8,0,0" />
 
+                <!-- Issue #1233: a way to enter the gateway address by hand is always available (and is
+                     revealed automatically if auto-detect cannot reach a gateway). -->
+                <Button x:Name="ManualToggleButton"
+                        Content="Enter your gateway address manually"
+                        HorizontalAlignment="Left"
+                        Margin="0,10,0,0"
+                        Padding="0"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        Foreground="{StaticResource AccentBrush}"
+                        Cursor="Hand"
+                        FontSize="12"
+                        Click="ManualToggleButton_Click" />
+
+                <!-- Manual entry + Test gate (issue #1233): shown when the person clicks the link above, or
+                     when auto-detect cannot reach a gateway. Type the gateway computer name and port (or
+                     paste a full address), click Test to PROVE it is reachable, then Connect. The install
+                     cannot proceed on an address that has not been tested reachable. -->
+                <StackPanel x:Name="ManualPanel"
+                            Margin="0,16,0,0"
+                            Visibility="Collapsed">
+                    <TextBlock x:Name="ManualNoteText"
+                               Text="Enter your gateway's computer name and port, then click Test."
+                               Foreground="{StaticResource DimText}"
+                               FontSize="11"
+                               TextWrapping="Wrap" />
+                    <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                        <StackPanel>
+                            <TextBlock Text="Computer name" Foreground="{StaticResource DimText}" FontSize="11" />
+                            <TextBox x:Name="AddressBox"
+                                     Width="240" Height="30"
+                                     Margin="0,3,0,0"
+                                     VerticalContentAlignment="Center"
+                                     Background="#1E1E1E" Foreground="#CCCCCC"
+                                     BorderBrush="#3C3C3C" BorderThickness="1"
+                                     TextChanged="ManualField_TextChanged" />
+                        </StackPanel>
+                        <StackPanel Margin="12,0,0,0">
+                            <TextBlock Text="Port" Foreground="{StaticResource DimText}" FontSize="11" />
+                            <TextBox x:Name="PortBox"
+                                     Text="7878"
+                                     Width="80" Height="30"
+                                     Margin="0,3,0,0"
+                                     VerticalContentAlignment="Center"
+                                     Background="#1E1E1E" Foreground="#CCCCCC"
+                                     BorderBrush="#3C3C3C" BorderThickness="1"
+                                     TextChanged="ManualField_TextChanged" />
+                        </StackPanel>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,12,0,0">
+                        <Button x:Name="TestButton"
+                                Content="Test"
+                                Width="90" Height="34"
+                                FontSize="14"
+                                Style="{StaticResource PrimaryButton}"
+                                Click="TestButton_Click" />
+                        <TextBlock x:Name="TestResultText"
+                                   VerticalAlignment="Center"
+                                   Margin="12,0,0,0"
+                                   FontSize="12"
+                                   TextWrapping="Wrap"
+                                   Visibility="Collapsed" />
+                    </StackPanel>
+                    <Button x:Name="ManualConnectButton"
+                            Content="Connect to this gateway"
+                            Width="240" Height="36"
+                            FontSize="14"
+                            Margin="0,12,0,0"
+                            HorizontalAlignment="Left"
+                            IsEnabled="False"
+                            Style="{StaticResource PrimaryButton}"
+                            Click="ManualConnectButton_Click" />
+                </StackPanel>
+
                 <!-- Gateway chooser (issue #1206): shown only when the account has more than one gateway.
                      Gateways are listed by NAME - a raw URL is never shown. -->
                 <StackPanel x:Name="ChooserPanel"

--- a/tools/cc-director-setup/Steps/GatewayConnectStep.xaml.cs
+++ b/tools/cc-director-setup/Steps/GatewayConnectStep.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Setup.Engine;
@@ -8,26 +9,25 @@ using CcDirectorSetup.Services;
 namespace CcDirectorSetup.Steps;
 
 /// <summary>
-/// The mandatory gateway-join step for a Workstation install (issues #646, #1198, #1206). A machine that
-/// joins an existing fleet must connect to its gateway before the install can finish - the gateway is the
-/// account authority, so a Workstation with no gateway connection is useless.
+/// The mandatory gateway-join step for a Workstation install (issues #646, #1198, #1206, #1233). A machine
+/// that joins an existing fleet must connect to its gateway before the install can finish - the gateway is
+/// the account authority, so a Workstation with no gateway connection is useless.
 ///
-/// Joining is DevThrottle account sign-in, and the person never types a gateway address (issue #1206): they
-/// click "Sign in to DevThrottle", which opens the system browser to sign in, then the installer reads the
-/// account's devices and discovers the gateway's own published front-door URL. With exactly one gateway it
-/// connects automatically; with more than one it shows a NAME-based chooser (never a raw URL); with none it
-/// shows a clear "start and sign in your gateway first" message. The chosen gateway's URL is used to
-/// register this machine as an account device, exchange its key at the gateway for a local per-device key,
-/// and persist the gateway URL + key to config.json (all in <see cref="GatewayAccountEnrollRunner"/>).
+/// Joining is DevThrottle account sign-in. The step first tries to find the gateway automatically: the person
+/// clicks "Sign in to DevThrottle", the system browser opens, and the installer reads the account's devices
+/// and discovers the gateway's own published front-door address (issue #1206). With exactly one gateway it
+/// connects automatically; with more than one it shows a NAME-based chooser.
 ///
-/// Until the join succeeds the step stays unverified, so the wizard keeps Next/Finish disabled (mirrors the
-/// forced Sign-in gate, issue #657). A cancelled sign-in, no reachable gateway, a different account, or an
-/// unreachable gateway shows a clear message and does NOT mark the step verified, so the install cannot
-/// complete. The step raises <see cref="Connected"/> exactly once, when a local device key is issued and
-/// persisted.
+/// Issue #1233 adds a manual path and a mandatory Test gate. If auto-detect cannot reach a gateway it is NOT
+/// treated as an error - the manual entry is revealed calmly so the person can type the gateway's computer
+/// name and port (or paste a full address). Either way, an address must pass a real reachability Test (GET
+/// /healthz) before Connect is allowed, so the install can never register this machine against an address it
+/// has not proven reachable.
 ///
-/// This step is only shown on the Workstation path; the Gateway role IS the gateway and signs in on its
-/// own dedicated step instead.
+/// Until the join succeeds the step stays unverified, so the wizard keeps Next/Finish disabled. A cancelled
+/// sign-in, no reachable gateway, a different account, or an unreachable gateway shows a clear message and
+/// does NOT mark the step verified. The step raises <see cref="Connected"/> exactly once, when a local device
+/// key is issued and persisted. This step is only shown on the Workstation path.
 /// </summary>
 public partial class GatewayConnectStep : UserControl
 {
@@ -35,6 +35,11 @@ public partial class GatewayConnectStep : UserControl
     private readonly string _deviceId;
     private readonly string _machineName;
     private CancellationTokenSource? _cts;
+
+    // The gateway address the person entered manually AND that passed the reachability Test (issue #1233).
+    // Null until a Test succeeds; cleared whenever the address fields change, so Connect is only ever enabled
+    // for an address proven reachable in the current field state.
+    private string? _manualTestedUrl;
 
     /// <summary>True once the gateway has issued a local device key and it was persisted. The wizard gates
     /// Next on this; once true it stays true so returning via Back keeps the state.</summary>
@@ -49,8 +54,8 @@ public partial class GatewayConnectStep : UserControl
 
     /// <summary>Constructor seam so a test or proof harness can inject a runner (e.g. one with a fake
     /// sign-in and a fake HTTP handler). When no runner is supplied a default one is built that drives the
-    /// real browser sign-in, discovers the account's gateways, registers the account device, enrolls at the
-    /// chosen gateway, and persists the issued local key to config.json.</summary>
+    /// real browser sign-in, discovers the account's gateways, tests reachability, registers the account
+    /// device, enrolls at the chosen gateway, and persists the issued local key to config.json.</summary>
     public GatewayConnectStep(GatewayAccountEnrollRunner? runner)
     {
         InitializeComponent();
@@ -78,7 +83,10 @@ public partial class GatewayConnectStep : UserControl
             var discovered = await _runner.SignInAndDiscoverGatewaysAsync(_cts.Token);
             if (!discovered.Success || discovered.Value is null)
             {
-                ShowRetryable(discovered.ErrorMessage ?? "Could not find your gateway. Please try again.");
+                // Auto-detect could not find a reachable gateway. Issue #1233: this is NOT an error - offer
+                // the manual entry calmly so the person can type the address themselves.
+                RevealManualEntry(discovered.ErrorMessage
+                    ?? "We could not find your gateway automatically. Enter its address below.");
                 return;
             }
 
@@ -96,7 +104,7 @@ public partial class GatewayConnectStep : UserControl
         catch (Exception ex)
         {
             SetupLog.Write($"[GatewayConnectStep] SignInButton_Click FAILED: {ex}");
-            ShowRetryable("Connecting to the gateway failed unexpectedly. Please try again.");
+            ShowRetryable("Connecting to the gateway failed unexpectedly. Please try again, or enter the address below.");
         }
         finally
         {
@@ -142,6 +150,131 @@ public partial class GatewayConnectStep : UserControl
         ApplyResult(result);
     }
 
+    // ===== Manual entry + Test gate (issue #1233) =====
+
+    /// <summary>Reveal the manual-entry panel so the person can type the gateway address. Auto-detect stays
+    /// available alongside it (the Sign-in button is re-enabled). An optional note explains why it appeared
+    /// (for example, "no reachable gateway found") in a neutral tone - never as an error.</summary>
+    private void RevealManualEntry(string? note)
+    {
+        if (!string.IsNullOrWhiteSpace(note))
+            ManualNoteText.Text = note;
+        WaitingPanel.Visibility = Visibility.Collapsed;
+        StatusText.Visibility = Visibility.Collapsed;
+        ManualPanel.Visibility = Visibility.Visible;
+        SignInButton.IsEnabled = true;
+        ManualToggleButton.IsEnabled = true;
+        TestButton.IsEnabled = true;
+        ManualConnectButton.IsEnabled = _manualTestedUrl is not null;
+    }
+
+    private void ManualToggleButton_Click(object sender, RoutedEventArgs e)
+    {
+        SetupLog.Write("[GatewayConnectStep] ManualToggleButton_Click");
+        RevealManualEntry(null);
+        AddressBox.Focus();
+    }
+
+    private async void TestButton_Click(object sender, RoutedEventArgs e)
+    {
+        SetupLog.Write("[GatewayConnectStep] TestButton_Click");
+        try
+        {
+            var address = (AddressBox.Text ?? string.Empty).Trim();
+            var isFullUrl = address.Contains("://", StringComparison.Ordinal);
+
+            // A pasted full address carries its own port; a bare computer name needs a valid port here.
+            var port = 0;
+            if (!isFullUrl && !int.TryParse((PortBox.Text ?? string.Empty).Trim(), out port))
+            {
+                _manualTestedUrl = null;
+                ManualConnectButton.IsEnabled = false;
+                ShowTestResult("Enter a valid port number (for example 7878).", ok: false);
+                return;
+            }
+
+            TestButton.IsEnabled = false;
+            ShowTestResult("Testing...", ok: null);
+            _cts = new CancellationTokenSource();
+
+            var result = await _runner.TestGatewayAddressAsync(address, port, _cts.Token);
+            if (result.Success && result.Value is not null)
+            {
+                _manualTestedUrl = result.Value;
+                ManualConnectButton.IsEnabled = true;
+                ShowTestResult("Reachable. Click Connect to continue.", ok: true);
+            }
+            else
+            {
+                _manualTestedUrl = null;
+                ManualConnectButton.IsEnabled = false;
+                ShowTestResult(result.ErrorMessage ?? "Could not reach a gateway at that address.", ok: false);
+            }
+        }
+        catch (Exception ex)
+        {
+            SetupLog.Write($"[GatewayConnectStep] TestButton_Click FAILED: {ex}");
+            _manualTestedUrl = null;
+            ManualConnectButton.IsEnabled = false;
+            ShowTestResult("The test failed unexpectedly. Please try again.", ok: false);
+        }
+        finally
+        {
+            TestButton.IsEnabled = true;
+            _cts?.Dispose();
+            _cts = null;
+        }
+    }
+
+    private async void ManualConnectButton_Click(object sender, RoutedEventArgs e)
+    {
+        SetupLog.Write("[GatewayConnectStep] ManualConnectButton_Click");
+        if (_manualTestedUrl is null)
+        {
+            ShowTestResult("Click Test first to check the address.", ok: false);
+            return;
+        }
+        try
+        {
+            _cts = new CancellationTokenSource();
+            EnterWaitingState("Connecting to your gateway...", cancellable: false);
+            var result = await _runner.VerifyAndSaveAsync(_manualTestedUrl, _deviceId, _machineName, _cts.Token);
+            ApplyResult(result);
+        }
+        catch (Exception ex)
+        {
+            SetupLog.Write($"[GatewayConnectStep] ManualConnectButton_Click FAILED: {ex}");
+            ShowRetryable("Connecting to the gateway failed unexpectedly. Please try again.");
+        }
+        finally
+        {
+            _cts?.Dispose();
+            _cts = null;
+        }
+    }
+
+    /// <summary>Editing the address or port invalidates any prior successful Test: the person must Test again
+    /// before Connect, so the install can never enroll against an address that has not been proven reachable
+    /// in its CURRENT text. Guards null controls: this fires while XAML sets the default port during init.</summary>
+    private void ManualField_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        _manualTestedUrl = null;
+        if (ManualConnectButton is not null) ManualConnectButton.IsEnabled = false;
+        if (TestResultText is not null) TestResultText.Visibility = Visibility.Collapsed;
+    }
+
+    private void ShowTestResult(string message, bool? ok)
+    {
+        TestResultText.Text = message;
+        TestResultText.Foreground = ok switch
+        {
+            true => (Brush)FindResource("SuccessBrush"),
+            false => new SolidColorBrush(Color.FromRgb(0xE0, 0x56, 0x56)),
+            _ => (Brush)FindResource("DimText"),
+        };
+        TestResultText.Visibility = Visibility.Visible;
+    }
+
     private void CancelButton_Click(object sender, RoutedEventArgs e)
     {
         SetupLog.Write("[GatewayConnectStep] CancelButton_Click: cancelling the sign-in wait");
@@ -152,10 +285,13 @@ public partial class GatewayConnectStep : UserControl
     }
 
     /// <summary>Shows the waiting row with the given message: hide any prior chooser/message/success, disable
-    /// the Sign-in button, and enable Cancel only when the wait is cancellable (the sign-in wait).</summary>
+    /// the action buttons, and enable Cancel only when the wait is cancellable (the sign-in wait).</summary>
     private void EnterWaitingState(string message, bool cancellable)
     {
         SignInButton.IsEnabled = false;
+        ManualToggleButton.IsEnabled = false;
+        TestButton.IsEnabled = false;
+        ManualConnectButton.IsEnabled = false;
         StatusText.Visibility = Visibility.Collapsed;
         SuccessPanel.Visibility = Visibility.Collapsed;
         ChooserPanel.Visibility = Visibility.Collapsed;
@@ -165,14 +301,16 @@ public partial class GatewayConnectStep : UserControl
         WaitingPanel.Visibility = Visibility.Visible;
     }
 
-    /// <summary>Shows the name-based gateway chooser (issue #1206), hiding the Sign-in button and the waiting
-    /// row. The Connect button enables once a gateway is selected.</summary>
+    /// <summary>Shows the name-based gateway chooser (issue #1206), hiding the waiting row. The manual panel is
+    /// hidden here to keep the choice clear, but the "enter manually" link stays available.</summary>
     private void ShowChooser(IReadOnlyList<DiscoveredGateway> gateways)
     {
         SetupLog.Write($"[GatewayConnectStep] ShowChooser: {gateways.Count} gateways");
         WaitingPanel.Visibility = Visibility.Collapsed;
         StatusText.Visibility = Visibility.Collapsed;
+        ManualPanel.Visibility = Visibility.Collapsed;
         SignInButton.IsEnabled = false;
+        ManualToggleButton.IsEnabled = true;
         GatewayList.ItemsSource = gateways;
         ChooseConnectButton.IsEnabled = false;
         ChooserPanel.Visibility = Visibility.Visible;
@@ -192,7 +330,9 @@ public partial class GatewayConnectStep : UserControl
             SetupLog.Write("[GatewayConnectStep] ApplyResult: connected");
             IsVerified = true;
             SignInButton.Visibility = Visibility.Collapsed;
+            ManualToggleButton.Visibility = Visibility.Collapsed;
             ChooserPanel.Visibility = Visibility.Collapsed;
+            ManualPanel.Visibility = Visibility.Collapsed;
             SuccessText.Text = "Connected to the gateway. Click Next to continue.";
             SuccessPanel.Visibility = Visibility.Visible;
             Connected?.Invoke(this, EventArgs.Empty);
@@ -203,9 +343,10 @@ public partial class GatewayConnectStep : UserControl
         ShowRetryable(result.ErrorMessage ?? "The gateway did not accept the sign-in.");
     }
 
-    /// <summary>Returns the step to a retryable state with a message - the chooser and waiting row are
-    /// hidden and the Sign-in button is re-enabled so the user can try again. The step stays UNVERIFIED, so
-    /// the wizard keeps Next disabled and the install cannot complete.</summary>
+    /// <summary>Returns the step to a retryable state with a message: the chooser and waiting row are hidden,
+    /// the Sign-in button is re-enabled, and the manual entry is offered (revealed) so the person can try a
+    /// different address. The step stays UNVERIFIED, so the wizard keeps Next disabled and the install cannot
+    /// complete.</summary>
     private void ShowRetryable(string message)
     {
         WaitingPanel.Visibility = Visibility.Collapsed;
@@ -213,5 +354,9 @@ public partial class GatewayConnectStep : UserControl
         StatusText.Text = message;
         StatusText.Visibility = Visibility.Visible;
         SignInButton.IsEnabled = true;
+        ManualToggleButton.IsEnabled = true;
+        ManualPanel.Visibility = Visibility.Visible;
+        TestButton.IsEnabled = true;
+        ManualConnectButton.IsEnabled = _manualTestedUrl is not null;
     }
 }


### PR DESCRIPTION
Client-side half of thefrederiksen/devthrottle_internal#737. Pairs with thefrederiksen/devthrottle#1235 (gateway-publish) and the already-live server + website.

## What this adds
- **Priority-order selection** (`GatewayEndpointSelector`): walks the ordered address list and connects through the first that answers `GET /healthz`. Order: machine name, then Tailscale, then IP. Records every attempt.
- **Config candidate list** (`GatewayConfig.CandidateUrls`): the active/manual `gateway.url` first (a manual override wins), then the discovered `gateway.urls` fallbacks, de-duplicated. Old installs with a single `url` are unchanged.
- **Manual-entry helper** (`GatewayAddress`): computer name + port to `http://name:port`, plus normalizing a pasted full address (e.g. a Tailscale `https://…` URL).
- **Director runtime selection** (`GatewayClient`): before registering, picks the reachable gateway from `CandidateUrls` (chosen before the first request, no mid-flight client swap). Injectable probe.
- **Installer connect step**: restores manual entry (computer name + port) with a **mandatory Test gate** — Connect stays disabled until a real `/healthz` reachability test passes, so the workstation is never registered against an untested address. Auto-detect finding nothing is not an error; it reveals manual entry calmly.
- **`GatewayAccountEnrollRunner.TestGatewayAddressAsync`**: the reachability test behind the Test button.

## Tests
~46 unit tests added, all green. WPF installer builds clean.

## Not in this PR (follow-ups)
- Wiring the installer **auto-detect** to walk the full account list in priority order — needs `CloudDeviceRecord.EndpointUrls` from thefrederiksen/devthrottle#1235.
- The **in-app runtime override** (change the gateway address after install; manual wins).

## Coordination
- thefrederiksen/devthrottle#1235 (gateway publishes the ordered list) must merge before the auto-detect wire-up compiles.
- The local gateway redeploy on the owner's machine (so the account shows the full list) is done separately after thefrederiksen/devthrottle#1235 merges.

Refs thefrederiksen/devthrottle_internal#737.