### PR TITLE
perf(gateway): route per-session actions through the session-owner cache (#1240)

### DIFF
--- a/src/CcDirector.Gateway.Tests/SessionOwnerResolveTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionOwnerResolveTests.cs
@@ -1,0 +1,147 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1240: per-session Gateway actions must resolve the owning Director through the
+/// session-owner cache instead of scanning the whole fleet on every call. These tests exercise
+/// <see cref="GatewayEndpoints.ResolveOwnerAsync"/> - the extracted resolution the real
+/// LocateSessionAsync delegates to - by counting how many Directors get probed. The probe stands
+/// in for the live Control API call, so the three cache paths are verified with no HTTP and no
+/// live Director.
+/// </summary>
+public sealed class SessionOwnerResolveTests
+{
+    private static DirectorDto Director(string id) =>
+        new() { DirectorId = id, ControlEndpoint = $"http://127.0.0.1:0/{id}" };
+
+    private static SessionDto Session(string sid) => new() { SessionId = sid };
+
+    // A fleet of three Directors, only one of which owns the session. The probe records which
+    // Directors it was asked about, so a test can assert "one lookup" versus "one per Director".
+    private static (IReadOnlyCollection<DirectorDto> directors, System.Func<string, DirectorDto?> getById)
+        BuildFleet(params string[] ids)
+    {
+        var directors = ids.Select(Director).ToList();
+        var byId = directors.ToDictionary(d => d.DirectorId);
+        return (directors, id => byId.TryGetValue(id, out var d) ? d : null);
+    }
+
+    [Fact]
+    public async Task ResolveOwner_CacheHit_ProbesOnlyTheCachedDirector()
+    {
+        var (directors, getById) = BuildFleet("d-1", "d-2", "d-3");
+        const string sid = "session-abc";
+        var owners = new SessionOwnerCache();
+        owners.Remember(sid, "d-2"); // d-2 is the known owner
+
+        var probed = new List<string>();
+        Task<SessionDto?> Probe(DirectorDto d)
+        {
+            probed.Add(d.DirectorId);
+            return Task.FromResult<SessionDto?>(d.DirectorId == "d-2" ? Session(sid) : null);
+        }
+
+        var (director, session) = await GatewayEndpoints.ResolveOwnerAsync(directors, getById, owners, sid, Probe);
+
+        Assert.NotNull(director);
+        Assert.Equal("d-2", director!.DirectorId);
+        Assert.NotNull(session);
+        // The whole point of the issue: exactly one Director lookup, not one per Director.
+        Assert.Equal(new[] { "d-2" }, probed);
+    }
+
+    [Fact]
+    public async Task ResolveOwner_StaleCacheEntry_FallsBackToScanAndReRemembersTheNewOwner()
+    {
+        var (directors, getById) = BuildFleet("d-1", "d-2", "d-3");
+        const string sid = "session-moved";
+        var owners = new SessionOwnerCache();
+        owners.Remember(sid, "d-2"); // stale: the session actually moved to d-3
+
+        var probed = new List<string>();
+        Task<SessionDto?> Probe(DirectorDto d)
+        {
+            probed.Add(d.DirectorId);
+            // d-2 (the cached owner) no longer knows the session; d-3 now owns it.
+            return Task.FromResult<SessionDto?>(d.DirectorId == "d-3" ? Session(sid) : null);
+        }
+
+        var (director, session) = await GatewayEndpoints.ResolveOwnerAsync(directors, getById, owners, sid, Probe);
+
+        Assert.NotNull(director);
+        Assert.Equal("d-3", director!.DirectorId);
+        Assert.NotNull(session);
+        // The cached owner was tried first, then the full scan located the real owner.
+        Assert.Contains("d-2", probed);
+        Assert.Contains("d-3", probed);
+        // The cache self-corrected: a subsequent action now hits d-3 directly.
+        Assert.Equal("d-3", owners.OwnerOf(sid));
+    }
+
+    [Fact]
+    public async Task ResolveOwner_ColdCache_ScansTheWholeFleetAndRemembersTheOwner()
+    {
+        var (directors, getById) = BuildFleet("d-1", "d-2", "d-3");
+        const string sid = "session-cold";
+        var owners = new SessionOwnerCache(); // nothing cached
+
+        var probed = new List<string>();
+        Task<SessionDto?> Probe(DirectorDto d)
+        {
+            probed.Add(d.DirectorId);
+            return Task.FromResult<SessionDto?>(d.DirectorId == "d-1" ? Session(sid) : null);
+        }
+
+        var (director, session) = await GatewayEndpoints.ResolveOwnerAsync(directors, getById, owners, sid, Probe);
+
+        Assert.NotNull(director);
+        Assert.Equal("d-1", director!.DirectorId);
+        Assert.NotNull(session);
+        // Cold cache behaves exactly as before the issue: every Director is probed.
+        Assert.Equal(3, probed.Count);
+        // And the owner is now remembered so the next action takes the one-lookup fast path.
+        Assert.Equal("d-1", owners.OwnerOf(sid));
+    }
+
+    [Fact]
+    public async Task ResolveOwner_NoCacheSupplied_ScansTheWholeFleet()
+    {
+        var (directors, getById) = BuildFleet("d-1", "d-2");
+        const string sid = "session-nocache";
+
+        var probed = new List<string>();
+        Task<SessionDto?> Probe(DirectorDto d)
+        {
+            probed.Add(d.DirectorId);
+            return Task.FromResult<SessionDto?>(d.DirectorId == "d-2" ? Session(sid) : null);
+        }
+
+        var (director, _) = await GatewayEndpoints.ResolveOwnerAsync(directors, getById, owners: null, sid, Probe);
+
+        Assert.NotNull(director);
+        Assert.Equal("d-2", director!.DirectorId);
+        Assert.Equal(2, probed.Count);
+    }
+
+    [Fact]
+    public async Task ResolveOwner_UnknownSession_ReturnsNullAndCachesNothing()
+    {
+        var (directors, getById) = BuildFleet("d-1", "d-2");
+        const string sid = "session-nowhere";
+        var owners = new SessionOwnerCache();
+
+        var (director, session) = await GatewayEndpoints.ResolveOwnerAsync(
+            directors, getById, owners, sid, _ => Task.FromResult<SessionDto?>(null));
+
+        Assert.Null(director);
+        Assert.Null(session);
+        Assert.Null(owners.OwnerOf(sid));
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -796,7 +796,7 @@ internal static class GatewayEndpoints
 
         app.MapGet("/sessions/{sid}", async (HttpContext ctx, string sid) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
+            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             var baseUrl = DeriveDirectorBaseUrl(ctx, director);
@@ -813,7 +813,7 @@ internal static class GatewayEndpoints
         // Director's own Control API, never through the Gateway.
         app.MapDelete("/sessions/{sid}", async (string sid) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
+            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             var ep = (director.ControlEndpoint ?? "").TrimEnd('/');
@@ -833,7 +833,7 @@ internal static class GatewayEndpoints
         // Session View on the gateway side can render WHY a dot is the color it is.
         app.MapGet("/sessions/{sid}/wingman", async (string sid) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
+            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             var ep = (director.ControlEndpoint ?? "").TrimEnd('/');
@@ -850,7 +850,7 @@ internal static class GatewayEndpoints
             var explain = string.Equals(req?.Mode, "explain", StringComparison.OrdinalIgnoreCase);
             if (req is null || (!explain && string.IsNullOrWhiteSpace(req.Question)))
                 return Results.BadRequest(new WingmanAskResult { Status = "bad_request", Error = "question is required" });
-            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
+            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             var ep = (director.ControlEndpoint ?? "").TrimEnd('/');
@@ -863,7 +863,7 @@ internal static class GatewayEndpoints
         // Forward "set the session goal" to the owning Director. Body forwards verbatim.
         app.MapPost("/sessions/{sid}/wingman/goal", async (string sid, WingmanGoalRequest req, CancellationToken ct) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
+            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             var ep = (director.ControlEndpoint ?? "").TrimEnd('/');
@@ -884,7 +884,7 @@ internal static class GatewayEndpoints
         // stream first (DirectorCommandRouter), HTTP fallback otherwise. The Ok body is the updated SessionDto.
         app.MapPost("/sessions/{sid}/role", async (string sid, SetRoleRequest req, CancellationToken ct) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
+            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             var ep = (director.ControlEndpoint ?? "").TrimEnd('/');
@@ -901,7 +901,7 @@ internal static class GatewayEndpoints
         // Forward the FIFO "park / un-park this session" (hold) call to the owning Director.
         app.MapPost("/sessions/{sid}/hold", async (string sid, HoldRequest req, CancellationToken ct) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
+            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             var ep = (director.ControlEndpoint ?? "").TrimEnd('/');
@@ -929,7 +929,7 @@ internal static class GatewayEndpoints
         {
             if (transcribingSessions is null)
                 return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
-            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
+            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             var transcribing = req?.Transcribing ?? false;
@@ -945,7 +945,7 @@ internal static class GatewayEndpoints
             if (req is null)
                 return Results.BadRequest(new { error = "request body is required" });
 
-            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
+            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
 
@@ -976,7 +976,7 @@ internal static class GatewayEndpoints
 
         app.MapGet("/sessions/{sid}/buffer", async (string sid, int? lines, bool? raw, long? since) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
+            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null)
                 return Results.NotFound(new { error = "session not found across any director" });
 
@@ -993,7 +993,7 @@ internal static class GatewayEndpoints
             if (req is null || string.IsNullOrEmpty(req.Text))
                 return Results.BadRequest(new { error = "text is required" });
 
-            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
+            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
 
@@ -1056,7 +1056,7 @@ internal static class GatewayEndpoints
 
         app.MapPost("/sessions/{sid}/interrupt", async (string sid) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
+            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
 
@@ -1074,7 +1074,7 @@ internal static class GatewayEndpoints
 
         app.MapPost("/sessions/{sid}/escape", async (string sid) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
+            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
 
@@ -1094,7 +1094,7 @@ internal static class GatewayEndpoints
         app.MapPost("/sessions/{sid}/upload-image", async (string sid, HttpContext ctx) =>
         {
             if (DictationLock(sid) is { } locked) return locked; // issue #1188
-            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
+            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
 
@@ -1342,7 +1342,7 @@ internal static class GatewayEndpoints
 
         app.MapGet("/sessions/{sid}/summary", async (string sid) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
+            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             var summary = await client.GetSummaryAsync(director!.ControlEndpoint, sid);
@@ -1357,7 +1357,7 @@ internal static class GatewayEndpoints
         // is just routing.
         app.MapGet("/sessions/{sid}/recap", async (string sid) =>
         {
-            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
+            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             var recap = await client.GetRecapAsync(director.ControlEndpoint, sid);
@@ -1369,7 +1369,7 @@ internal static class GatewayEndpoints
         app.MapPost("/sessions/{sid}/recap", async (string sid, HttpContext ctx) =>
         {
             if (DictationLock(sid) is { } locked) return locked; // issue #1188
-            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
+            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             var model = ctx.Request.Query["model"].ToString();
@@ -1395,7 +1395,7 @@ internal static class GatewayEndpoints
 
             FileLog.Write($"[GatewayEndpoints] POST /handover: from={req.FromSessionId} toSid={req.ToSessionId} toRepo={req.ToRepoPath} toDir={req.ToDirectorId}");
 
-            var (sourceDirector, sourceSession) = await LocateSessionAsync(registry, client, req.FromSessionId, pushedSessions, streamStaleResolved);
+            var (sourceDirector, sourceSession) = await LocateSessionAsync(registry, client, req.FromSessionId, pushedSessions, streamStaleResolved, owners);
             if (sourceSession is null || sourceDirector is null)
                 return Results.NotFound(new { error = "source session not found across any director" });
 
@@ -1490,7 +1490,7 @@ internal static class GatewayEndpoints
             var targetScopes = new List<(string SessionId, BroadcastScope Scope)>();
             foreach (var sid in req.SessionIds)
             {
-                var (d, s) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
+                var (d, s) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
                 if (d is not null && s is not null)
                 {
                     directorBySession[sid] = d;
@@ -1506,7 +1506,7 @@ internal static class GatewayEndpoints
             BroadcastScope? senderScope = null;
             if (!string.IsNullOrWhiteSpace(req.FromSessionId))
             {
-                var (sd, ss) = await LocateSessionAsync(registry, client, req.FromSessionId, pushedSessions, streamStaleResolved);
+                var (sd, ss) = await LocateSessionAsync(registry, client, req.FromSessionId, pushedSessions, streamStaleResolved, owners);
                 if (sd is not null && ss is not null) senderScope = BuildBroadcastScope(sd, ss);
             }
 
@@ -1788,7 +1788,8 @@ internal static class GatewayEndpoints
 
     private static async Task<(DirectorDto? director, SessionDto? session)> LocateSessionAsync(
         DirectorRegistry registry, DirectorEndpointClient client, string sid,
-        Streaming.PushedSessionStore? pushedSessions, TimeSpan streamStale)
+        Streaming.PushedSessionStore? pushedSessions, TimeSpan streamStale,
+        SessionOwnerCache? owners = null)
     {
         // Issue #1177 (Phase 4a): resolve the owning Director from the pushed stream cache FIRST. A
         // remotely-unreachable (portless) Director advertises an empty ControlEndpoint, so the HTTP-pull loop
@@ -1810,16 +1811,61 @@ internal static class GatewayEndpoints
             }
         }
 
-        var lookups = registry.ListDirectors().Select(async d =>
-        {
-            var ep = (d.ControlEndpoint ?? "").TrimEnd('/');
-            var s = await client.GetSessionAsync(ep, sid);
-            return (director: d, session: s);
-        }).ToList();
+        // Issue #1240: consult the session-owner cache before fanning out to the whole fleet. The probe
+        // that reaches a Director is the real Control API call; ResolveOwnerAsync decides which Directors
+        // to probe (one cached owner, or every Director on a cold/stale cache) and keeps the cache warm.
+        return await ResolveOwnerAsync(
+            registry.ListDirectors(),
+            registry.Get,
+            owners,
+            sid,
+            d => client.GetSessionAsync((d.ControlEndpoint ?? "").TrimEnd('/'), sid));
+    }
 
+    /// <summary>
+    /// Resolve the Director that owns <paramref name="sid"/>, trying the session-owner cache first and
+    /// falling back to a full fleet scan (issue #1240). Extracted from <see cref="LocateSessionAsync"/> so
+    /// the cache-hit, stale-cache, and cold-cache paths are unit-testable without a live Director: the
+    /// caller supplies <paramref name="probe"/>, the single call that reaches a Director for a session.
+    ///
+    /// Order:
+    ///   1. Cache hit: ask exactly ONE Director (the cached owner). One probe instead of one per machine -
+    ///      the whole point of the issue. A confirmed answer returns immediately.
+    ///   2. Stale cache entry (the cached owner no longer knows the session - it moved or died): fall through
+    ///      to the full scan. This is not fallback programming; the scan is the authoritative path and the
+    ///      cache is only a fast front for it. The scan re-<see cref="SessionOwnerCache.Remember"/>s the real
+    ///      owner so subsequent actions hit the cache again.
+    ///   3. Cold cache (never observed, or no cache supplied): full scan, exactly as before the issue.
+    /// </summary>
+    internal static async Task<(DirectorDto? director, SessionDto? session)> ResolveOwnerAsync(
+        IReadOnlyCollection<DirectorDto> directors,
+        Func<string, DirectorDto?> getDirectorById,
+        SessionOwnerCache? owners,
+        string sid,
+        Func<DirectorDto, Task<SessionDto?>> probe)
+    {
+        if (owners?.OwnerOf(sid) is { } cachedOwnerId && getDirectorById(cachedOwnerId) is { } cachedDir)
+        {
+            var cachedSession = await probe(cachedDir);
+            if (cachedSession is not null)
+            {
+                FileLog.Write($"[GatewayEndpoints] ResolveOwner: sid={sid} located=owner-cache, director={cachedOwnerId} (one lookup)");
+                return (cachedDir, cachedSession);
+            }
+            FileLog.Write($"[GatewayEndpoints] ResolveOwner: sid={sid} owner-cache stale (director {cachedOwnerId} no longer owns it); scanning the fleet");
+        }
+
+        var lookups = directors.Select(async d => (director: d, session: await probe(d))).ToList();
         var results = await Task.WhenAll(lookups);
         foreach (var (director, session) in results)
-            if (session is not null) return (director, session);
+            if (session is not null)
+            {
+                owners?.Remember(sid, director.DirectorId);
+                FileLog.Write($"[GatewayEndpoints] ResolveOwner: sid={sid} located=fleet-scan, director={director.DirectorId} ({lookups.Count} lookups)");
+                return (director, session);
+            }
+
+        FileLog.Write($"[GatewayEndpoints] ResolveOwner: sid={sid} not found across {lookups.Count} director(s)");
         return (null, null);
     }
 


### PR DESCRIPTION
Closes thefrederiksen/devthrottle#1240.

## Problem
Every mutating per-session Gateway action resolved the owning Director by scanning the whole fleet on every call. `LocateSessionAsync` fanned out `GetSessionAsync` to every registered Director and took the first non-null answer, so every keystroke on the prompt path (and interrupt, escape, hold, transcribing, upload-image, recap, wingman ask/goal, rename, kill, request-deletion) paid a full fleet fan-out. The right pattern already existed and was used by the WebSocket proxy: consult `SessionOwnerCache` first and fall back to a live resolve only on a miss.

## What changed
- `LocateSessionAsync` now consults `SessionOwnerCache` before fanning out, via a new extracted `ResolveOwnerAsync` helper (`src/CcDirector.Gateway/Api/GatewayEndpoints.cs`).
  - **Cache hit**: probe exactly one Director (the cached owner), one lookup instead of one per machine.
  - **Stale entry**: the cached owner no longer knows the session (it moved or died), so fall through to the authoritative full scan and re-remember the real owner. The scan is the authoritative path; the cache is only a fast front for it, so this is not fallback programming.
  - **Cold cache**: full scan exactly as before the change, and the found owner is remembered so the next action takes the one-lookup path.
- The resolved path (owner-cache vs fleet-scan, with the lookup count) is logged per the enterprise logging rule so the win is visible in the Gateway log.
- `owners` is threaded into the existing call sites; the pushed-stream cache fast path (#1177) is unchanged and still runs first.

## Tests
New `src/CcDirector.Gateway.Tests/SessionOwnerResolveTests.cs` exercises `ResolveOwnerAsync` by counting how many Directors are probed (no live host, no HTTP):
- cache hit -> exactly one probe (the cached owner)
- stale cache entry -> cached owner probed, then full scan finds the new owner, and the cache self-corrects
- cold cache -> whole fleet probed, owner then remembered
- no cache supplied -> whole fleet probed
- unknown session -> null, nothing cached

Result: `Passed! - Failed: 0, Passed: 5`. The related owner-cache and forwarding suites (`SessionOwnerCacheTests`, `WingmanAskForwarding`, `CockpitParity`) still pass (22/22). Gateway project builds with 0 warnings, 0 errors.

## Acceptance mapping
- "A prompt to a cached session produces exactly one Director lookup, not one per Director" -> `ResolveOwner_CacheHit_ProbesOnlyTheCachedDirector` asserts a single probe.
- "Kill a Director and recreate the session elsewhere: the next action still finds it and subsequent actions hit the cache" -> `ResolveOwner_StaleCacheEntry_FallsBackToScanAndReRemembersTheNewOwner` asserts fall-back plus re-remember.
- "Unit tests for the cache-hit path, the stale-cache-entry path, and the cold-cache path" -> all three present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)