### PR TITLE
Cockpit New-session dialog: choose model and permission mode, remembered across uses (#1243)

### DIFF
--- a/apps/cockpit/src/sessions/NewSessionDialog.tsx
+++ b/apps/cockpit/src/sessions/NewSessionDialog.tsx
@@ -27,6 +27,62 @@ export interface NewSessionDialogProps {
   onCreated: (sessionId: string) => void;
 }
 
+// A launch choice: the value we remember (key), what the user reads (label), and the exact command-line
+// fragment it contributes (arg - empty string means "add nothing", which is the Director's own default).
+interface LaunchChoice {
+  key: string;
+  label: string;
+  arg: string;
+}
+
+// Model choices. "Default" adds no argument, so the Director launches the agent's built-in default model;
+// the others pass "--model <name>" exactly (issue #1243).
+const MODEL_CHOICES: LaunchChoice[] = [
+  { key: "default", label: "Default", arg: "" },
+  { key: "opus", label: "Opus", arg: "--model opus" },
+  { key: "sonnet", label: "Sonnet", arg: "--model sonnet" },
+];
+
+// Permission choices. "Ask for permissions" adds no argument (the agent stops for each permission prompt);
+// "Skip permission prompts" passes --dangerously-skip-permissions so the session starts working at once.
+// We do not steer the user toward either - the default selection is simply their last-used choice.
+const PERMISSION_CHOICES: LaunchChoice[] = [
+  { key: "ask", label: "Ask for permissions", arg: "" },
+  { key: "skip", label: "Skip permission prompts", arg: "--dangerously-skip-permissions" },
+];
+
+const MODEL_STORAGE_KEY = "cockpit.newSession.model";
+const PERMISSION_STORAGE_KEY = "cockpit.newSession.permission";
+
+// Read the last-used choice key from localStorage, falling back to the first choice when nothing was
+// stored or the stored key no longer matches a known choice.
+function loadChoiceKey(storageKey: string, choices: LaunchChoice[]): string {
+  try {
+    const saved = window.localStorage.getItem(storageKey);
+    if (saved && choices.some((c) => c.key === saved)) return saved;
+  } catch {
+    /* localStorage can be unavailable (private mode); fall back to the first choice */
+  }
+  return choices[0].key;
+}
+
+// Save the chosen key so the next open of the dialog pre-selects it.
+function saveChoiceKey(storageKey: string, key: string): void {
+  try {
+    window.localStorage.setItem(storageKey, key);
+  } catch {
+    /* localStorage can be unavailable (private mode); remembering the choice is best-effort */
+  }
+}
+
+// Assemble the launch-argument string from the two chosen fragments, dropping the empty ("default")
+// ones. Returns "" when both are default, so createSession sends no "args" at all.
+function buildLaunchArgs(modelKey: string, permissionKey: string): string {
+  const model = MODEL_CHOICES.find((c) => c.key === modelKey);
+  const permission = PERMISSION_CHOICES.find((c) => c.key === permissionKey);
+  return [model?.arg ?? "", permission?.arg ?? ""].filter((a) => a.length > 0).join(" ");
+}
+
 function directorLabel(d: DirectorInfo): string {
   if (d.machineName.trim()) return d.machineName.trim();
   return d.directorId || "director";
@@ -49,6 +105,14 @@ export function NewSessionDialog({ onClose, onCreated }: NewSessionDialogProps) 
   const [manualPath, setManualPath] = useState("");
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
+
+  // Launch options, pre-selected from the last-used choice (issue #1243). Lazy initial state reads
+  // localStorage exactly once.
+  const [modelKey, setModelKey] = useState(() => loadChoiceKey(MODEL_STORAGE_KEY, MODEL_CHOICES));
+  const [permissionKey, setPermissionKey] = useState(() =>
+    loadChoiceKey(PERMISSION_STORAGE_KEY, PERMISSION_CHOICES),
+  );
+  const launchArgs = buildLaunchArgs(modelKey, permissionKey);
 
   // Guards against a stale repo response landing after the user switched machines.
   const reposReqRef = useRef(0);
@@ -120,8 +184,11 @@ export function NewSessionDialog({ onClose, onCreated }: NewSessionDialogProps) 
       }
       setCreating(true);
       setCreateError(null);
+      // Remember the choices so the next open pre-selects them (issue #1243).
+      saveChoiceKey(MODEL_STORAGE_KEY, modelKey);
+      saveChoiceKey(PERMISSION_STORAGE_KEY, permissionKey);
       try {
-        const session = await createSession(selectedId, path);
+        const session = await createSession(selectedId, path, launchArgs);
         const sid = session.sessionId;
         if (!sid) throw new Error("The created session had no id.");
         onCreated(sid);
@@ -132,7 +199,7 @@ export function NewSessionDialog({ onClose, onCreated }: NewSessionDialogProps) 
         setCreating(false);
       }
     },
-    [creating, selectedId, onCreated],
+    [creating, selectedId, onCreated, launchArgs, modelKey, permissionKey],
   );
 
   return (
@@ -227,6 +294,52 @@ export function NewSessionDialog({ onClose, onCreated }: NewSessionDialogProps) 
                   }
                 }}
               />
+            </div>
+          </div>
+
+          {/* Step 3: launch options (model and permission mode), remembered across uses */}
+          <div className="newsess-step">
+            <div className="newsess-step-label">3. Launch options</div>
+
+            <div className="newsess-opt-label" id="newsess-model-label">
+              Model
+            </div>
+            <div className="newsess-seg" role="group" aria-labelledby="newsess-model-label">
+              {MODEL_CHOICES.map((c) => (
+                <button
+                  key={c.key}
+                  type="button"
+                  className={`newsess-seg-btn${c.key === modelKey ? " sel" : ""}`}
+                  aria-pressed={c.key === modelKey}
+                  disabled={creating}
+                  onClick={() => setModelKey(c.key)}
+                >
+                  {c.label}
+                </button>
+              ))}
+            </div>
+
+            <div className="newsess-opt-label" id="newsess-permission-label">
+              Permission mode
+            </div>
+            <div className="newsess-seg" role="group" aria-labelledby="newsess-permission-label">
+              {PERMISSION_CHOICES.map((c) => (
+                <button
+                  key={c.key}
+                  type="button"
+                  className={`newsess-seg-btn${c.key === permissionKey ? " sel" : ""}`}
+                  aria-pressed={c.key === permissionKey}
+                  disabled={creating}
+                  onClick={() => setPermissionKey(c.key)}
+                >
+                  {c.label}
+                </button>
+              ))}
+            </div>
+
+            <div className="newsess-opt-label">Arguments passed to the session</div>
+            <div className="newsess-args mono" aria-live="polite">
+              {launchArgs.length > 0 ? launchArgs : "(none - default model, asks for permissions)"}
             </div>
           </div>
 

--- a/apps/cockpit/src/styles.css
+++ b/apps/cockpit/src/styles.css
@@ -459,6 +459,61 @@ body {
   border-color: var(--accent);
 }
 
+.newsess-opt-label {
+  font-size: 11.5px;
+  color: var(--text-dim);
+  margin: 10px 0 5px;
+}
+
+.newsess-opt-label:first-child {
+  margin-top: 0;
+}
+
+.newsess-seg {
+  display: flex;
+  gap: 4px;
+}
+
+.newsess-seg-btn {
+  flex: 1;
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 7px 10px;
+  font-size: 12.5px;
+  cursor: pointer;
+}
+
+.newsess-seg-btn:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+
+.newsess-seg-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.newsess-seg-btn.sel {
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--accent);
+  color: var(--accent);
+}
+
+.newsess-args {
+  background: var(--code-bg);
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 7px 10px;
+  font-size: 12px;
+  word-break: break-word;
+}
+
+.newsess-args.mono {
+  font-family: "Cascadia Mono", Consolas, Menlo, monospace;
+}
+
 .newsess-error {
   padding: 8px 10px;
   background: rgba(241, 76, 76, 0.1);

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -685,13 +685,22 @@ export async function getRepos(directorId: string, signal?: AbortSignal): Promis
 // and wingmanEnabled=false, type omitted, exactly like the Android NewSessionPanel
 // (FleetParser.BuildCreateBody). Returns the created SessionDto so the caller can open it. The
 // Gateway answers 201 on success; throws GatewayError on non-2xx with the server's reason.
+//
+// launchArgs is the exact command-line argument string the Director passes to the agent (for example
+// "--model opus --dangerously-skip-permissions"). Session launch applies no defaults, so a session
+// created with no launchArgs comes up on the default model and blocked on a permission prompt - the
+// caller decides. An empty or whitespace-only launchArgs sends no "args" at all, matching the
+// historic behavior; callers that do not care (the mobile NewSession flow) simply omit it.
 export async function createSession(
   directorId: string,
   repoPath: string,
+  launchArgs?: string | null,
   signal?: AbortSignal,
 ): Promise<SessionDto> {
   const id = encodeURIComponent(directorId);
   const body: NewSessionRequest = { repoPath: repoPath.trim(), agent: "ClaudeCode", wingmanEnabled: false };
+  const trimmedArgs = (launchArgs ?? "").trim();
+  if (trimmedArgs.length > 0) body.args = trimmedArgs;
   const res = await fetch(`/directors/${id}/sessions`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },


### PR DESCRIPTION
Closes #1243.

## What was wrong
Starting a session from the Cockpit sent no launch arguments, so the new session came up on the default model and blocked on a permission prompt. The first thing the user did after creating a session was fix it by hand.

## What changed
- `packages/client-core/src/api/client.ts`: `createSession` gains an optional `launchArgs` parameter (before the `AbortSignal`). A non-empty value is trimmed and set on the existing `NewSessionRequest.args`; empty or whitespace-only sends no `args`, exactly matching the historic behavior. The mobile NewSession flow passes nothing and behaves as today.
- `apps/cockpit/src/sessions/NewSessionDialog.tsx`: a third "Launch options" step with two controls:
  - Model: Default (no argument) / Opus / Sonnet (`--model <name>`).
  - Permission mode: Ask for permissions (no argument) / Skip permission prompts (`--dangerously-skip-permissions`).
  The assembled argument string is shown read-only under the controls and threaded into `createSession`. Each control pre-selects the last-used choice from localStorage; the choices are saved when a session is created. The dialog does not steer the user toward either permission mode - the default selection is simply whatever they picked last time.
- `apps/cockpit/src/styles.css`: styles for the segmented controls and the read-only argument line, matching the existing dialog palette.

## Verification (Playwright against the real dialog on the Vite dev server, Gateway responses shimmed)
- Default state shows "Arguments passed to the session: (none - default model, asks for permissions)".
- Selecting Opus + Skip permission prompts shows `--model opus --dangerously-skip-permissions`.
- The POST body captured on create was exactly:
  `{"repoPath":"D:\ReposFred\devthrottle","agent":"ClaudeCode","wingmanEnabled":false,"args":"--model opus --dangerously-skip-permissions"}`
  which proves the choices are threaded into the `Args` field; an all-default run sends no `args`.
- After reloading the dialog, Opus and Skip permission prompts are pre-selected (last-used persistence).

Build/tests: `tsc --noEmit` passes for client-core, cockpit, and mobile (mobile still compiles against the changed signature); `vite build` for cockpit succeeds.

Screenshot (Opus + Skip permission prompts selected, argument line populated):
The proof screenshots were captured locally; the dialog matches the existing dark palette with the new "3. Launch options" step.

Built from an isolated worktree off `origin/main`; only the three files above are staged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)