### PR TITLE
fix(gateway): stop publishing the Director's tailnetEndpoint as the Gateway front door (#1237)

### DIFF
--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -467,27 +467,30 @@ public sealed class GatewayHost : IAsyncDisposable
             //   2. The Tailscale front door - only when Tailscale is actually available on this machine. The
             //      reliable cross-network path.
             //   3. The local network IP plus port - the last-resort path (least stable; the IP can change).
-            // So the list is three addresses when Tailscale is available and two when it is not. An explicit
-            // gateway.tailnetEndpoint override, when set (and not loopback), is the operator's hand-set
-            // reachable URL and ranks FIRST - it preserves the pre-#1233 single endpoint_url for operators who
-            // set it, and the client health-checks every candidate so a stale one is simply skipped. The
-            // single endpoint_url (issue #1206) is the first list entry, so existing readers keep working.
+            // So the list is three addresses when Tailscale is available and two when it is not, and every entry
+            // is a real Gateway front door on this Gateway's own port. The Gateway applies NO operator endpoint
+            // override here: gateway.tailnetEndpoint is the DIRECTOR's advertised-endpoint override and can
+            // legitimately point at a Director on a different port (for example 7883). Feeding it into the
+            // Gateway's published list ranked that Director URL FIRST, so item[0] was not reachable as a Gateway
+            // at all (issue #1237). If a Gateway-specific operator override is ever wanted, add a NEW
+            // gateway-only config key and pass it as overrideUrl - never reuse the Director's tailnetEndpoint.
+            // The single endpoint_url (issue #1206) is the first list entry, so existing readers keep working.
             // Re-resolved on each call (never cached) so an address that appears after start heals within one
             // heartbeat cycle; the resolvers never throw (they report an unresolved address as unresolved).
             var tailnetResolver = new Core.Network.TailnetIdentityResolver();
             var lanResolver = new Core.Network.LanIdentityResolver();
-            var endpointOverride = gatewayConfig.TailnetEndpoint;
             var gatewayPort = Port;
             Func<IReadOnlyList<string>> resolveEndpointUrls = () =>
             {
                 // Do the I/O here (probe Tailscale and the LAN), then hand the resolved pieces to the pure
                 // BuildOrderedEndpointUrls assembler so the ordering/dedup/loopback-skip logic is unit-tested
                 // without a real network. Passing no config override to the resolvers yields the PURE
-                // discovered address (the override is applied separately, ahead of everything, in the assembler).
+                // discovered address, and the assembler is given no override either (see #1237 above).
                 var tailnet = tailnetResolver.ResolveEndpoint(gatewayPort, configOverride: null);
                 var lan = lanResolver.ResolveEndpoint(gatewayPort, configOverride: null);
                 return BuildOrderedEndpointUrls(
-                    endpointOverride,
+                    // No operator override: gateway.tailnetEndpoint is the Director's key, not the Gateway's (#1237).
+                    overrideUrl: null,
                     Core.Network.TailscaleIdentity.BuildMachineNameUrl(Environment.MachineName, gatewayPort),
                     tailnet.IsResolved ? tailnet.Endpoint : null,
                     lan.IsResolved ? lan.Endpoint : null);


### PR DESCRIPTION
Fixes #1237.

## The bug

On soren-north, the Gateway published `endpoint_urls[0] = http://soren-north.taildb08ed.ts.net:7883`, which is **cc-director2** (a Director), not the Gateway (7878). A client that trusts item[0] as the front door hits a Director.

## Root cause

`GatewayHost` fed `gateway.tailnetEndpoint` into `BuildOrderedEndpointUrls` as the top-ranked override. But `tailnetEndpoint`'s own definition is *"Optional override for the **Director's own** routable URL"* — it can legitimately point at a Director on a different port (here 7883). Reusing the Director's key for the Gateway's own published list ranked a Director URL first.

## Fix

The Gateway applies **no** operator override when assembling its own list. The published list is now exactly the three auto-discovered front doors on the Gateway's own port — machine-name, Tailscale (when present), LAN IP — so `item[0]` is a real Gateway address. The three auto addresses were already correct; only the override was wrong.

- One-line behavioural change: pass `overrideUrl: null` instead of `gatewayConfig.TailnetEndpoint`.
- The pure `BuildOrderedEndpointUrls` assembler is unchanged and still accepts an `overrideUrl` — so if a Gateway-specific operator override is ever wanted, add a **new gateway-only config key** and pass it there. Never reuse the Director's `tailnetEndpoint`.

## Not a config fix

`7883` correctly points at a running Director — nothing to change in config. Only the Gateway's reuse of that key was the defect.

## Verification

`dotnet test CcDirector.Gateway.Tests --filter EndpointUrls` → **27 passed** (the null-override ordering — machine-name front door first — is locked by the existing `BuildOrderedEndpointUrls_TailscalePresent_ThreeAddressesInPriorityOrder`).

Note: the caller wiring (the `resolveEndpointUrls` lambda) has no direct unit seam; the change is a hardcoded `overrideUrl: null`, which is self-evidently correct, plus an inline comment naming #1237 so the Director key is never re-wired in.

## Rollout

After merge, redeploy this Gateway to republish the corrected list; session 91a13151 will re-verify the roster row.