### PR TITLE
fix(cockpit): single-source the Transcription Health failure count (#1253)

### DIFF
--- a/apps/cockpit/src/transcription/TranscriptionHealthView.tsx
+++ b/apps/cockpit/src/transcription/TranscriptionHealthView.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 import {
+  countFailedTurns,
   getTranscriptionStats,
   getTranscriptionTerms,
+  SUCCESS_OUTCOME,
   type TranscriptionStats,
   type TermFrequency,
 } from "@devthrottle/client-core/transcription/transcriptionAnalysisClient";
@@ -41,6 +43,7 @@ export function TranscriptionHealthView() {
   const [stats, setStats] = useState<TranscriptionStats | null>(null);
   const [terms, setTerms] = useState<TermFrequency[]>([]);
   const [loadError, setLoadError] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
 
   const load = useCallback(async (window: number | undefined, signal?: AbortSignal) => {
     try {
@@ -63,13 +66,34 @@ export function TranscriptionHealthView() {
     return () => controller.abort();
   }, [load, days]);
 
-  const failures = stats ? stats.totalTurns - stats.successfulTurns : 0;
+  // Refetch the current window on demand, so the page can be brought up to date without a full
+  // browser reload. Immediate visual feedback: the button reports "Refreshing..." while it runs.
+  const refresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await load(days);
+    } finally {
+      setRefreshing(false);
+    }
+  }, [load, days]);
+
+  // The failure count comes from the same byOutcome map the outcome breakdown renders, so the
+  // number, the banner, and the breakdown are one source and can never contradict each other.
+  const failures = stats ? countFailedTurns(stats) : 0;
   const healthy = stats !== null && stats.totalTurns > 0 && failures === 0;
 
   return (
     <div className="page txh">
       <div className="page-head">
         <h1>Transcription Health</h1>
+        <button
+          type="button"
+          className="txh-refresh"
+          onClick={() => void refresh()}
+          disabled={refreshing}
+        >
+          {refreshing ? "Refreshing..." : "Refresh"}
+        </button>
       </div>
       <p className="txh-lede">
         How fast and how well your voice dictation is working, from this machine only. Nothing here is
@@ -143,7 +167,7 @@ export function TranscriptionHealthView() {
               <h2>Why dictations failed</h2>
               <ul className="txh-outcomes">
                 {Object.entries(stats.byOutcome)
-                  .filter(([code]) => code !== "ok")
+                  .filter(([code]) => code !== SUCCESS_OUTCOME)
                   .map(([code, n]) => (
                     <li key={code}>
                       <span className="txh-count">{n}</span> {outcomeLabel(code)}

--- a/apps/cockpit/src/transcription/transcriptionhealth.css
+++ b/apps/cockpit/src/transcription/transcriptionhealth.css
@@ -6,10 +6,29 @@
   max-width: 860px;
 }
 
+.txh .page-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
 .txh .page-head h1 {
   margin: 0;
   font-size: 22px;
   font-weight: 600;
+}
+.txh-refresh {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.txh-refresh:disabled {
+  color: var(--text-dim);
+  cursor: default;
 }
 .txh-lede {
   color: var(--text-dim);

--- a/packages/client-core/src/transcription/transcriptionAnalysisClient.test.ts
+++ b/packages/client-core/src/transcription/transcriptionAnalysisClient.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  countFailedTurns,
+  SUCCESS_OUTCOME,
+  type TranscriptionStats,
+} from "./transcriptionAnalysisClient";
+
+// Regression tests for issue 1253: the Transcription Health page must derive its failure count from
+// exactly one source - the byOutcome map it also renders as the outcome breakdown - so the failure
+// number, the success banner, and that breakdown can never contradict each other. The old code
+// computed failures as totalTurns minus successfulTurns, a second number that could drift from the
+// map. countFailedTurns is that single source.
+
+function stats(fields: Partial<TranscriptionStats> = {}): TranscriptionStats {
+  return {
+    totalTurns: 0,
+    successfulTurns: 0,
+    byOutcome: {},
+    firstTurnUtc: null,
+    lastTurnUtc: null,
+    transcriptionMs: { count: 0, min: 0, max: 0, avg: 0, p50: 0, p90: 0, p95: 0, p99: 0 },
+    cleanupMs: { count: 0, min: 0, max: 0, avg: 0, p50: 0, p90: 0, p95: 0, p99: 0 },
+    correctedTurns: 0,
+    cleanupAppliedTurns: 0,
+    totalWords: 0,
+    totalCharacters: 0,
+    totalAudioBytes: 0,
+    ...fields,
+  };
+}
+
+describe("countFailedTurns - single source for the failure count", () => {
+  it("sums every non-success entry of byOutcome", () => {
+    const s = stats({
+      byOutcome: { ok: 8, out_of_credits: 2, provider_error: 3 },
+    });
+
+    expect(countFailedTurns(s)).toBe(5);
+  });
+
+  it("returns zero when every dictation succeeded", () => {
+    const s = stats({ byOutcome: { [SUCCESS_OUTCOME]: 10 } });
+
+    expect(countFailedTurns(s)).toBe(0);
+  });
+
+  it("returns zero for an empty window", () => {
+    expect(countFailedTurns(stats())).toBe(0);
+  });
+
+  it("reads byOutcome, not totalTurns minus successfulTurns, so the two cannot drift", () => {
+    // A payload where the subtraction disagrees with the authoritative map: the subtraction would
+    // report one failure, but the map records none. The page must trust the map it renders.
+    const s = stats({
+      totalTurns: 5,
+      successfulTurns: 4,
+      byOutcome: { ok: 5 },
+    });
+
+    expect(s.totalTurns - s.successfulTurns).toBe(1); // the old, drifting derivation
+    expect(countFailedTurns(s)).toBe(0); // the single source the breakdown also uses
+  });
+});

--- a/packages/client-core/src/transcription/transcriptionAnalysisClient.ts
+++ b/packages/client-core/src/transcription/transcriptionAnalysisClient.ts
@@ -38,6 +38,26 @@ export interface TermFrequency {
   count: number;
 }
 
+/** The outcome code the Gateway records for a dictation that transcribed successfully. Every other
+ * code in byOutcome is a failure. This is the one place that defines what "success" means, so the
+ * failure count, the success banner, and the outcome breakdown all agree. */
+export const SUCCESS_OUTCOME = "ok";
+
+/**
+ * How many dictations did not succeed in the window, counted as the sum of every non-success entry
+ * of the byOutcome map. This is the single authority for the failure count: the outcome breakdown
+ * on the page also reads byOutcome, so the failure number, the success banner, and that breakdown
+ * can never disagree. Deriving it here - rather than as totalTurns minus successfulTurns - removes
+ * the second, separately-computed number that could drift from the map the page renders.
+ */
+export function countFailedTurns(stats: TranscriptionStats): number {
+  let failed = 0;
+  for (const [code, count] of Object.entries(stats.byOutcome)) {
+    if (code !== SUCCESS_OUTCOME) failed += count;
+  }
+  return failed;
+}
+
 async function getJson<T>(path: string, signal?: AbortSignal): Promise<T> {
   const res = await fetch(path, {
     method: "GET",


### PR DESCRIPTION
Closes thefrederiksen/devthrottle#1253.

## Problem
The Transcription Health page computed its failure count by client-side subtraction:
`const failures = stats.totalTurns - stats.successfulTurns` - a second, separately-derived
number that lived alongside the authoritative `byOutcome` map the same page renders as the
outcome breakdown. If the two ever disagreed (partial data, counting edge cases), the failure
number, the "all N succeeded" banner, and the breakdown could contradict each other, and the
healthy banner trusted the subtraction. This is an instance of the recorded rule that
presentation state is computed once and never re-derived a second way on the client (#1241).

## What changed
- New `countFailedTurns(stats)` helper in `client-core/transcription/transcriptionAnalysisClient.ts`
  sums every non-success entry of `byOutcome` - the exact map the outcome breakdown reads. The
  failure number, the success banner, and the breakdown now all come from one source and can
  never disagree.
- New exported `SUCCESS_OUTCOME` constant is the single definition of which outcome code counts
  as success; used by both the failure count and the breakdown table filter (was a bare `"ok"`).
- `TranscriptionHealthView.tsx` derives `failures` from `countFailedTurns` instead of the
  subtraction.
- Added a Refresh control in the page header that refetches the current window without a full
  browser reload, showing "Refreshing..." while it runs.

## Acceptance
- The failure number, the success banner, and the outcome table all read `byOutcome`, so they
  can never disagree - one source. VERIFIED by regression test including a payload where the old
  subtraction drifts from the map (`totalTurns - successfulTurns == 1` while the map records 0
  failures; `countFailedTurns` returns 0).
- A Refresh control refetches the statistics. Added to the header.

## Proof
- `packages/client-core` vitest: 158 passed (14 files), including the new 4-test
  `transcriptionAnalysisClient.test.ts` suite.
- `tsc --noEmit` clean for both `packages/client-core` and `apps/cockpit`.
- `apps/cockpit` production build: `vite build` succeeds, 107 modules transformed.

No fallback programming; the load path still fails loudly with an explicit error, never a
fabricated healthy state. Plain English, ASCII only.

Built from an isolated worktree off origin/main per the Cockpit Improvement mission working rules.

Generated with [Claude Code](https://claude.com/claude-code)