### PR TITLE
Cockpit shared user-interface kit + one confirmation dialog + palette document (#1244)

### DIFF
--- a/apps/cockpit/src/account/AccountView.tsx
+++ b/apps/cockpit/src/account/AccountView.tsx
@@ -10,6 +10,7 @@ import {
   type AccountDevicesResponse,
 } from "@devthrottle/client-core/account/accountClient";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
+import { ErrorBanner, LoadingState, PageHeader } from "../components";
 
 // The Account page (issue #978, epic #967) - the React port of the Blazor Cockpit Account.razor
 // (#853/#648/#854). A pure client of the Gateway account endpoints: the credential lives on the
@@ -227,18 +228,21 @@ export function AccountView() {
 
   return (
     <div className="page acct">
-      <div className="page-head">
-        <h1>DevThrottle Account</h1>
-      </div>
-      <p className="acct-lede">
-        The DevThrottle identity this Gateway is signed in as, and the devices registered to the account.
-        The credential lives on the Gateway; this page never sees the raw token.
-      </p>
+      <PageHeader
+        title="DevThrottle Account"
+        subtitle={
+          "The DevThrottle identity this Gateway is signed in as, and the devices registered to the " +
+          "account. The credential lives on the Gateway; this page never sees the raw token."
+        }
+      />
 
       {error !== null ? (
-        <div className="acct-error">Could not load account status from the Gateway: {error}</div>
+        <ErrorBanner
+          message={`Could not load account status from the Gateway: ${error}`}
+          onRetry={() => void loadStatus()}
+        />
       ) : status === null ? (
-        <p className="acct-loading">Loading...</p>
+        <LoadingState />
       ) : status.signedIn ? (
         <>
           <div className="acct-card">
@@ -278,16 +282,12 @@ export function AccountView() {
             </p>
 
             {devicesLoading ? (
-              <p className="acct-devices-loading">Loading devices...</p>
+              <LoadingState message="Loading devices..." />
             ) : devicesError !== null ? (
-              <div className="acct-devices-error">
-                Could not load your devices from the Gateway: {devicesError}
-                <div className="acct-devices-retry-row">
-                  <button className="acct-btn" onClick={() => void loadDevices()}>
-                    Try again
-                  </button>
-                </div>
-              </div>
+              <ErrorBanner
+                message={`Could not load your devices from the Gateway: ${devicesError}`}
+                onRetry={() => void loadDevices()}
+              />
             ) : devices !== null && !devices.signedIn ? (
               <div className="acct-devices-signedout">
                 The Gateway reports it is no longer signed in, so the device list is unavailable. Sign in

--- a/apps/cockpit/src/components/Button.tsx
+++ b/apps/cockpit/src/components/Button.tsx
@@ -1,0 +1,29 @@
+import type { ButtonHTMLAttributes } from "react";
+
+// The shared Cockpit button (issue #1244). Every page in the Cockpit used to hand-roll its own button
+// class (act-btn, sched-btn, qbtn, linkbtn, and roughly fifteen more), so a button looked and behaved
+// differently on every page. This one component gives the whole app four named button variants on the
+// shared navy palette (docs/CockpitVisualStyle.md), so a "primary" or a "danger" button reads the same
+// everywhere. It forwards every native button attribute (onClick, disabled, type, title, ...), so it is
+// a drop-in replacement for a plain <button>.
+
+/**
+ * The four button roles the Cockpit needs.
+ *   - primary: the main action on a surface (accent blue). One per surface.
+ *   - secondary: a supporting action (a bordered navy button). The default.
+ *   - danger: a destructive action (red). Always the confirm button of a ConfirmDialog.
+ *   - ghost: a borderless link-like action that blends into its surface (a small inline control).
+ */
+export type ButtonVariant = "primary" | "secondary" | "danger" | "ghost";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /** The button role; defaults to "secondary" (a plain supporting action). */
+  variant?: ButtonVariant;
+}
+
+export function Button({ variant = "secondary", className, type, ...rest }: ButtonProps) {
+  // Default type to "button": a Cockpit button is an action, never an accidental form submit.
+  const classes = ["ui-btn", `ui-btn-${variant}`];
+  if (className !== undefined && className.length > 0) classes.push(className);
+  return <button type={type ?? "button"} className={classes.join(" ")} {...rest} />;
+}

--- a/apps/cockpit/src/components/ConfirmDialog.tsx
+++ b/apps/cockpit/src/components/ConfirmDialog.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
+import { Button } from "./Button";
+
+// The one confirmation dialog every destructive action in the Cockpit routes through (issue #1244).
+// Before this, destructive actions were handled three different ways: a good inline confirmation on the
+// Account page, a blocking browser window.confirm/alert on Exes and the Voice Recorder, and NO
+// confirmation at all on Schedule delete, Clear context, Clear queue, and screenshot delete. This is the
+// single in-app dialog that replaces all three, so "are you sure?" looks and behaves the same across the
+// whole app and can never again be a browser pop-up.
+//
+// It manages its own busy and error lifecycle so a calling page does not have to. The contract for the
+// action is simple and fails loudly (no fallback):
+//   - onConfirm may be synchronous or async. If it returns a promise, the dialog shows a busy state
+//     until the promise settles.
+//   - On success the dialog calls onClose (the caller clears its pending target, which unmounts it).
+//   - On failure (a thrown error) the dialog stays open and shows exactly what went wrong, so the
+//     person can read the error and either retry or cancel - the failure is never swallowed.
+
+export interface ConfirmDialogProps {
+  /** Whether the dialog is shown. Drive this from a "pending action" state on the calling page. */
+  open: boolean;
+  /** The question, e.g. "Delete this cron job?". */
+  title: string;
+  /** The body: what will happen, and any warning (for example, "This cannot be undone."). */
+  message: ReactNode;
+  /** The confirm button label; defaults to "Confirm". Use a verb, e.g. "Delete" or "Clear". */
+  confirmLabel?: string;
+  /** The cancel button label; defaults to "Cancel". */
+  cancelLabel?: string;
+  /**
+   * Whether the confirm button is styled as destructive (red). Defaults to true, because this dialog
+   * exists for destructive actions; pass false for a heavy-but-safe action (for example, a rebuild).
+   */
+  danger?: boolean;
+  /** The confirm button label while the action runs; defaults to "Working...". */
+  busyLabel?: string;
+  /** Runs when the person confirms. Return a promise to have the dialog show a busy state and, on a
+   *  thrown error, surface it inline. */
+  onConfirm: () => void | Promise<void>;
+  /** Runs when the person cancels, dismisses (backdrop or Escape), or the action succeeds. */
+  onClose: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  danger = true,
+  busyLabel = "Working...",
+  onConfirm,
+  onClose,
+}: ConfirmDialogProps) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset the transient busy/error each time the dialog opens, so a previous failure never bleeds into
+  // a fresh confirmation.
+  useEffect(() => {
+    if (open) {
+      setBusy(false);
+      setError(null);
+    }
+  }, [open]);
+
+  // Escape dismisses the dialog, but never while its action is mid-flight (that would orphan the
+  // in-flight request behind a closed dialog).
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !busy) onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, busy, onClose]);
+
+  if (!open) return null;
+
+  const runConfirm = async () => {
+    setError(null);
+    try {
+      const result = onConfirm();
+      if (result instanceof Promise) {
+        setBusy(true);
+        await result;
+      }
+      onClose();
+    } catch (err) {
+      // Fail loudly: keep the dialog open and show precisely what went wrong.
+      setError(gatewayErrorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      className="ui-modal-backdrop"
+      onClick={() => {
+        if (!busy) onClose();
+      }}
+    >
+      <div
+        className="ui-confirm"
+        role="alertdialog"
+        aria-modal="true"
+        aria-label={title}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="ui-confirm-title">{title}</div>
+        <div className="ui-confirm-message">{message}</div>
+        {error !== null && <div className="ui-confirm-error">{error}</div>}
+        <div className="ui-confirm-actions">
+          <Button variant="secondary" disabled={busy} onClick={onClose}>
+            {cancelLabel}
+          </Button>
+          <Button variant={danger ? "danger" : "primary"} disabled={busy} onClick={() => void runConfirm()}>
+            {busy ? busyLabel : confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/cockpit/src/components/EmptyState.tsx
+++ b/apps/cockpit/src/components/EmptyState.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+
+// The shared Cockpit empty state (issue #1244) - the "there is nothing here yet" message a page shows
+// when a list or a folder is legitimately empty (distinct from an error, which uses ErrorBanner). An
+// optional title gives it a heading, and an optional action slot offers the obvious next step (for
+// example, a "New cron job" button on an empty Schedule page).
+
+export interface EmptyStateProps {
+  /** An optional short heading above the message. */
+  title?: string;
+  /** The plain-English explanation of why the surface is empty and what to do. */
+  message: string;
+  /** An optional action (a button) offering the obvious next step. */
+  action?: ReactNode;
+}
+
+export function EmptyState({ title, message, action }: EmptyStateProps) {
+  return (
+    <div className="ui-empty">
+      {title !== undefined && title.length > 0 && <div className="ui-empty-title">{title}</div>}
+      <div className="ui-empty-message">{message}</div>
+      {action !== undefined && <div className="ui-empty-action">{action}</div>}
+    </div>
+  );
+}

--- a/apps/cockpit/src/components/ErrorBanner.tsx
+++ b/apps/cockpit/src/components/ErrorBanner.tsx
@@ -1,0 +1,28 @@
+import { Button } from "./Button";
+
+// The shared Cockpit error banner (issue #1244). When a Gateway or cloud read fails, a page must say so
+// loudly rather than showing a fabricated empty or signed-out view (the no-fallback rule). This is the
+// one red banner every page uses to surface that failure, with an optional Retry button when the action
+// can simply be tried again. role="alert" makes a screen reader announce the failure immediately.
+
+export interface ErrorBannerProps {
+  /** The plain-English failure message (usually gatewayErrorMessage of the caught error). */
+  message: string;
+  /** When provided, a retry control appears and calls this; omit it when there is nothing to retry. */
+  onRetry?: () => void;
+  /** The retry control's label; defaults to "Try again". */
+  retryLabel?: string;
+}
+
+export function ErrorBanner({ message, onRetry, retryLabel = "Try again" }: ErrorBannerProps) {
+  return (
+    <div className="ui-error-banner" role="alert">
+      <span className="ui-error-banner-text">{message}</span>
+      {onRetry !== undefined && (
+        <Button variant="secondary" className="ui-error-banner-retry" onClick={onRetry}>
+          {retryLabel}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/cockpit/src/components/LoadingState.tsx
+++ b/apps/cockpit/src/components/LoadingState.tsx
@@ -1,0 +1,16 @@
+// The shared Cockpit loading indicator (issue #1244). Every page wrote its own "Loading..." line in a
+// slightly different wording and style; this gives them one. role="status" lets a screen reader
+// announce that the page is loading (the accessibility follow-up in issue #1248 builds on this).
+
+export interface LoadingStateProps {
+  /** The message to show; defaults to the plain "Loading..." every page used. */
+  message?: string;
+}
+
+export function LoadingState({ message = "Loading..." }: LoadingStateProps) {
+  return (
+    <div className="ui-loading" role="status">
+      {message}
+    </div>
+  );
+}

--- a/apps/cockpit/src/components/PageHeader.tsx
+++ b/apps/cockpit/src/components/PageHeader.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+
+// The shared Cockpit page header (issue #1244). The Cockpit had roughly eighteen distinct page-header
+// class names, one per page, so the title, the one-line description, and the right-aligned actions sat
+// at different sizes and spacings on every page. This one component gives every page the same header:
+// a title, an optional one-line subtitle beneath it, and an optional actions slot pinned to the right.
+
+export interface PageHeaderProps {
+  /** The page title (rendered as the page's single h1). */
+  title: string;
+  /** An optional one-line description shown beneath the title. */
+  subtitle?: string;
+  /** Optional right-aligned actions (buttons, links) for this page. */
+  actions?: ReactNode;
+}
+
+export function PageHeader({ title, subtitle, actions }: PageHeaderProps) {
+  return (
+    <header className="ui-page-header">
+      <div className="ui-page-header-text">
+        <h1 className="ui-page-title">{title}</h1>
+        {subtitle !== undefined && subtitle.length > 0 && (
+          <p className="ui-page-subtitle">{subtitle}</p>
+        )}
+      </div>
+      {actions !== undefined && <div className="ui-page-header-actions">{actions}</div>}
+    </header>
+  );
+}

--- a/apps/cockpit/src/components/StatusMessage.tsx
+++ b/apps/cockpit/src/components/StatusMessage.tsx
@@ -1,0 +1,23 @@
+import type { Flash } from "./useFlash";
+
+// The presentational half of the transient-status helper (issue #1244): it renders a single Flash from
+// useFlash as a small coloured status line. It renders nothing when there is no message, so a page can
+// mount it unconditionally. An error flash announces itself to a screen reader; info/success are
+// polite. This replaces the window.alert pop-ups that used to report action results.
+
+export interface StatusMessageProps {
+  /** The flash to render (from useFlash), or null to render nothing. */
+  flash: Flash | null;
+}
+
+export function StatusMessage({ flash }: StatusMessageProps) {
+  if (flash === null) return null;
+  return (
+    <span
+      className={`ui-status ui-status-${flash.kind}`}
+      role={flash.kind === "error" ? "alert" : "status"}
+    >
+      {flash.text}
+    </span>
+  );
+}

--- a/apps/cockpit/src/components/components.css
+++ b/apps/cockpit/src/components/components.css
@@ -1,0 +1,228 @@
+/* The shared Cockpit user-interface kit stylesheet (issue #1244). Every rule here uses the app theme
+   tokens from styles.css (:root) - nothing hard-codes a color outside that token block, exactly as the
+   rest of the Cockpit does. See docs/CockpitVisualStyle.md for the written palette these tokens define.
+   Class names are prefixed "ui-" so the kit never collides with a page's own classes. */
+
+/* ===== Button (four variants) ================================================================== */
+.ui-btn {
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.2;
+  padding: 6px 14px;
+  border-radius: 7px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  color: var(--text);
+  background: var(--surface-2);
+}
+
+.ui-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* secondary - the default supporting action: a bordered navy button. */
+.ui-btn-secondary {
+  background: var(--surface-2);
+  border-color: var(--border);
+  color: var(--text);
+}
+.ui-btn-secondary:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* primary - the main action on a surface: accent blue. */
+.ui-btn-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #ffffff;
+  font-weight: 600;
+}
+.ui-btn-primary:hover:not(:disabled) {
+  color: #ffffff;
+  filter: brightness(1.1);
+}
+
+/* danger - a destructive action: red. Always the confirm button of a ConfirmDialog. */
+.ui-btn-danger {
+  background: var(--attention);
+  border-color: var(--attention);
+  color: #ffffff;
+  font-weight: 600;
+}
+.ui-btn-danger:hover:not(:disabled) {
+  color: #ffffff;
+  filter: brightness(1.1);
+}
+
+/* ghost - a borderless, link-like inline action that blends into its surface. */
+.ui-btn-ghost {
+  background: none;
+  border-color: transparent;
+  color: var(--accent);
+  padding: 4px 8px;
+}
+.ui-btn-ghost:hover:not(:disabled) {
+  color: var(--text);
+}
+
+/* ===== PageHeader ============================================================================== */
+.ui-page-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.ui-page-header-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.ui-page-title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.ui-page-subtitle {
+  margin: 6px 0 0;
+  max-width: 70ch;
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.ui-page-header-actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ===== LoadingState =========================================================================== */
+.ui-loading {
+  color: var(--text-dim);
+  font-size: 13px;
+  padding: 8px 2px;
+}
+
+/* ===== EmptyState ============================================================================= */
+.ui-empty {
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1.55;
+  padding: 12px 2px;
+}
+
+.ui-empty-title {
+  color: var(--text);
+  font-size: 15px;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.ui-empty-message {
+  max-width: 60ch;
+}
+
+.ui-empty-action {
+  margin-top: 12px;
+}
+
+/* ===== ErrorBanner ============================================================================ */
+.ui-error-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: rgba(241, 76, 76, 0.1);
+  border: 1px solid rgba(241, 76, 76, 0.4);
+  border-radius: 8px;
+  padding: 12px 14px;
+  color: var(--attention);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.ui-error-banner-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.ui-error-banner-retry {
+  flex: 0 0 auto;
+}
+
+/* ===== ConfirmDialog =========================================================================== */
+/* The modal backdrop is shared by the kit; it matches the app's existing modal dimming (the new-session
+   and Schedule dialogs use the same look). */
+.ui-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 16px;
+}
+
+.ui-confirm {
+  width: 440px;
+  max-width: 100%;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.5);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ui-confirm-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.ui-confirm-message {
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--text-dim);
+  white-space: pre-wrap;
+}
+
+.ui-confirm-error {
+  background: rgba(241, 76, 76, 0.1);
+  border: 1px solid rgba(241, 76, 76, 0.4);
+  border-radius: 6px;
+  padding: 8px 10px;
+  color: var(--attention);
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+
+.ui-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+/* ===== StatusMessage ========================================================================== */
+.ui-status {
+  font-size: 12px;
+  line-height: 1.4;
+}
+.ui-status-info {
+  color: var(--text-dim);
+}
+.ui-status-success {
+  color: var(--accent);
+}
+.ui-status-error {
+  color: var(--attention);
+}

--- a/apps/cockpit/src/components/index.ts
+++ b/apps/cockpit/src/components/index.ts
@@ -1,0 +1,28 @@
+// The shared Cockpit user-interface kit (issue #1244). Import components from "../components" so a page
+// never reaches for a one-off button class again. The kit's stylesheet (components.css) is imported once
+// in main.tsx alongside the app theme, so these components style themselves from the shared navy
+// palette recorded in docs/CockpitVisualStyle.md.
+
+export { Button } from "./Button";
+export type { ButtonProps, ButtonVariant } from "./Button";
+
+export { PageHeader } from "./PageHeader";
+export type { PageHeaderProps } from "./PageHeader";
+
+export { LoadingState } from "./LoadingState";
+export type { LoadingStateProps } from "./LoadingState";
+
+export { EmptyState } from "./EmptyState";
+export type { EmptyStateProps } from "./EmptyState";
+
+export { ErrorBanner } from "./ErrorBanner";
+export type { ErrorBannerProps } from "./ErrorBanner";
+
+export { ConfirmDialog } from "./ConfirmDialog";
+export type { ConfirmDialogProps } from "./ConfirmDialog";
+
+export { StatusMessage } from "./StatusMessage";
+export type { StatusMessageProps } from "./StatusMessage";
+
+export { useFlash } from "./useFlash";
+export type { Flash, FlashController } from "./useFlash";

--- a/apps/cockpit/src/components/useFlash.ts
+++ b/apps/cockpit/src/components/useFlash.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// A small transient-status helper for action results (issue #1244). Several pages hand-rolled the same
+// "show a short result message, then clear it after a few seconds" logic with their own timers (the
+// action bar's flash, the Voice Recorder's clearLater). This hook is that one helper: it holds a single
+// transient message and clears it automatically, cancelling any pending clear on unmount so a timer
+// never fires into an unmounted component.
+
+/** How long a flashed message stays up before it clears itself, unless the caller overrides it. */
+const DEFAULT_FLASH_MS = 5000;
+
+export interface Flash {
+  /** The kind of result, so StatusMessage can colour it; defaults to "info". */
+  kind: "info" | "success" | "error";
+  /** The message text. */
+  text: string;
+}
+
+export interface FlashController {
+  /** The current flash, or null when nothing is showing. */
+  flash: Flash | null;
+  /** Show a message; it clears itself after `ms` (default five seconds). */
+  show: (text: string, kind?: Flash["kind"], ms?: number) => void;
+  /** Clear the current message immediately. */
+  clear: () => void;
+}
+
+export function useFlash(): FlashController {
+  const [flash, setFlash] = useState<Flash | null>(null);
+  const timerRef = useRef<number | null>(null);
+
+  const clearTimer = () => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  const clear = useCallback(() => {
+    clearTimer();
+    setFlash(null);
+  }, []);
+
+  const show = useCallback((text: string, kind: Flash["kind"] = "info", ms: number = DEFAULT_FLASH_MS) => {
+    clearTimer();
+    setFlash({ kind, text });
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null;
+      setFlash(null);
+    }, ms);
+  }, []);
+
+  // Cancel any pending clear when the owning component unmounts.
+  useEffect(() => clearTimer, []);
+
+  return { flash, show, clear };
+}

--- a/apps/cockpit/src/exes/ExesView.tsx
+++ b/apps/cockpit/src/exes/ExesView.tsx
@@ -10,19 +10,34 @@ import {
 } from "@devthrottle/client-core/exes/exesClient";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 import { dotColor } from "@devthrottle/client-core/sessions/ordering";
+import { ConfirmDialog, EmptyState, ErrorBanner, LoadingState, StatusMessage, useFlash } from "../components";
 
 // The Exes management page (issue #977, epic #967) - the React port of the Blazor Cockpit
 // Exes.razor(.css) (#183). It lists the Directors running on THIS computer + their sessions and the
 // 1-4 build slots, refreshes on a 3s timer that never fires over an in-flight build, and offers
 // Kill / Build & start / Delete against the same Gateway endpoints. It reads and drives same-origin
 // through the Gateway front door (client-core) - never a Director address.
+//
+// This page is one of the first three to adopt the shared user-interface kit (issue #1244): every
+// destructive action now asks through the shared ConfirmDialog instead of a blocking browser
+// window.confirm, and every action result is a StatusMessage instead of a browser window.alert.
 const REFRESH_MS = 3000;
+
+// The action awaiting confirmation. Exes has three heavy actions, so a discriminated union feeds the
+// single ConfirmDialog: killing a Director (destructive), deleting a slot build (destructive), and
+// building + starting a slot (heavy but not destructive - danger: false).
+type PendingAction =
+  | { kind: "kill"; dir: ExesDirector }
+  | { kind: "deleteSlot"; slot: number }
+  | { kind: "buildSlot"; slot: number };
 
 export function ExesView() {
   const [data, setData] = useState<ExesList | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false); // never refresh over an in-flight build (mirrors state.busy)
   const [buildingSlot, setBuildingSlot] = useState<number | null>(null);
+  const [pending, setPending] = useState<PendingAction | null>(null);
+  const result = useFlash();
 
   // busyRef mirrors busy so the interval callback reads the latest value without re-subscribing.
   const busyRef = useRef(false);
@@ -56,48 +71,29 @@ export function ExesView() {
       ? "loading..."
       : `${data.directors.length} director${data.directors.length === 1 ? "" : "s"} on ${data.machineName}`;
 
-  // ---- actions ----
+  // ---- actions (run once the ConfirmDialog is confirmed) ----
+  // Each leaves failures to throw so the dialog surfaces them (fail loudly); on success it flashes a
+  // StatusMessage. None uses a browser pop-up.
   const killDir = async (dir: ExesDirector) => {
-    const label = dir.slot != null ? `slot ${dir.slot}` : `PID ${dir.pid}`;
-    const ok = window.confirm(
-      `Kill Director ${label} (PID ${dir.pid})?\n\nThis terminates the process and ALL of its running sessions. Unsaved work in those sessions will be lost.`,
-    );
-    if (!ok) return;
-    try {
-      await killDirector(dir.directorId);
-    } catch (err) {
-      window.alert(`Kill failed: ${gatewayErrorMessage(err)}`);
-    }
+    await killDirector(dir.directorId);
     await new Promise((r) => window.setTimeout(r, 600));
     await refresh();
+    result.show(`Director ${dir.slot != null ? `slot ${dir.slot}` : `PID ${dir.pid}`} killed.`, "success");
   };
 
   const removeSlot = async (n: number) => {
-    const ok = window.confirm(
-      `Delete the slot ${n} build?\n\nThis removes local_builds/cc-director${n}.exe from disk. You can rebuild it with "Build & start".`,
-    );
-    if (!ok) return;
-    try {
-      await deleteSlot(n);
-    } catch (err) {
-      window.alert(`Delete failed: ${gatewayErrorMessage(err)}`);
-    }
+    await deleteSlot(n);
     await refresh();
+    result.show(`Slot ${n} build deleted.`, "success");
   };
 
   const buildStart = async (n: number) => {
-    const ok = window.confirm(
-      `Build slot ${n} and launch it?\n\nThis runs the build script (about a minute) and then starts cc-director${n}.exe. The slot must not already be running.`,
-    );
-    if (!ok) return;
     setBusy(true);
     busyRef.current = true;
     setBuildingSlot(n);
     try {
-      const result = await buildStartSlot(n);
-      window.alert(`Slot ${n} built and started (PID ${result.pid}).`);
-    } catch (err) {
-      window.alert(`Build & start failed:\n\n${gatewayErrorMessage(err)}`);
+      const built = await buildStartSlot(n);
+      result.show(`Slot ${n} built and started (PID ${built.pid}).`, "success");
     } finally {
       setBusy(false);
       busyRef.current = false;
@@ -106,11 +102,15 @@ export function ExesView() {
     await refresh();
   };
 
+  // Derive the ConfirmDialog's copy and confirmed action from the pending action.
+  const confirm = describePending(pending, { killDir, removeSlot, buildStart });
+
   return (
     <div className="ex-root">
       <header className="ex-header">
         <h1>DEVTHROTTLE &middot; EXES</h1>
         <span className="ex-stats">{statsText}</span>
+        <StatusMessage flash={result.flash} />
         <span className="ex-spacer" />
         <Link className="ex-link ex-link-accent" to="/">
           sessions
@@ -121,10 +121,10 @@ export function ExesView() {
       </header>
 
       <main className="ex-main">
-        {error !== null && <div className="ex-error">{error}</div>}
+        {error !== null && <ErrorBanner message={error} onRetry={() => void refresh()} />}
 
         {data === null ? (
-          <div className="ex-empty">Loading...</div>
+          <LoadingState />
         ) : (
           <>
             {!hasRepoRoot && (
@@ -141,7 +141,7 @@ export function ExesView() {
             </h2>
 
             {data.directors.length === 0 ? (
-              <div className="ex-empty">No Director processes are running on this computer.</div>
+              <EmptyState message="No Director processes are running on this computer." />
             ) : (
               data.directors.map((dir) => (
                 <div className="ex-dir" key={dir.directorId}>
@@ -159,7 +159,11 @@ export function ExesView() {
                         Director &rarr;
                       </a>
                     )}
-                    <button className="ex-btn ex-danger" onClick={() => void killDir(dir)} disabled={busy}>
+                    <button
+                      className="ex-btn ex-danger"
+                      onClick={() => setPending({ kind: "kill", dir })}
+                      disabled={busy}
+                    >
                       Kill
                     </button>
                   </div>
@@ -199,7 +203,7 @@ export function ExesView() {
             {/* ----- build slots ----- */}
             <h2 className="ex-section">Build slots (1-4)</h2>
             {!hasRepoRoot ? (
-              <div className="ex-empty">Unavailable (see notice above).</div>
+              <EmptyState message="Unavailable (see notice above)." />
             ) : (
               <div className="ex-slots">
                 {data.slots.map((sl) => {
@@ -225,12 +229,16 @@ export function ExesView() {
                         <div className="ex-sub">no exe in local_builds</div>
                       )}
                       <div className="ex-actions">
-                        <button className="ex-btn" onClick={() => void buildStart(sl.slot)} disabled={running || busy}>
+                        <button
+                          className="ex-btn"
+                          onClick={() => setPending({ kind: "buildSlot", slot: sl.slot })}
+                          disabled={running || busy}
+                        >
                           {buildingSlot === sl.slot ? "Building..." : "Build & start"}
                         </button>
                         <button
                           className="ex-btn ex-danger"
-                          onClick={() => void removeSlot(sl.slot)}
+                          onClick={() => setPending({ kind: "deleteSlot", slot: sl.slot })}
                           disabled={!sl.exists || running || busy}
                         >
                           Delete
@@ -244,8 +252,78 @@ export function ExesView() {
           </>
         )}
       </main>
+
+      {confirm !== null && (
+        <ConfirmDialog
+          open
+          title={confirm.title}
+          message={confirm.message}
+          confirmLabel={confirm.confirmLabel}
+          busyLabel={confirm.busyLabel}
+          danger={confirm.danger}
+          onConfirm={confirm.onConfirm}
+          onClose={() => setPending(null)}
+        />
+      )}
     </div>
   );
+}
+
+// Turn a pending action into the ConfirmDialog's copy and its confirmed handler. Kept as a plain
+// function (not inline JSX) so the three actions read as a single table.
+function describePending(
+  pending: PendingAction | null,
+  actions: {
+    killDir: (dir: ExesDirector) => Promise<void>;
+    removeSlot: (n: number) => Promise<void>;
+    buildStart: (n: number) => Promise<void>;
+  },
+): {
+  title: string;
+  message: string;
+  confirmLabel: string;
+  busyLabel: string;
+  danger: boolean;
+  onConfirm: () => Promise<void>;
+} | null {
+  if (pending === null) return null;
+  switch (pending.kind) {
+    case "kill": {
+      const label = pending.dir.slot != null ? `slot ${pending.dir.slot}` : `PID ${pending.dir.pid}`;
+      return {
+        title: `Kill Director ${label}?`,
+        message:
+          `This terminates the process (PID ${pending.dir.pid}) and ALL of its running sessions. ` +
+          "Unsaved work in those sessions will be lost. This cannot be undone.",
+        confirmLabel: "Kill Director",
+        busyLabel: "Killing...",
+        danger: true,
+        onConfirm: () => actions.killDir(pending.dir),
+      };
+    }
+    case "deleteSlot":
+      return {
+        title: `Delete the slot ${pending.slot} build?`,
+        message:
+          `This removes local_builds/cc-director${pending.slot}.exe from disk. You can rebuild it ` +
+          'later with "Build & start".',
+        confirmLabel: "Delete",
+        busyLabel: "Deleting...",
+        danger: true,
+        onConfirm: () => actions.removeSlot(pending.slot),
+      };
+    case "buildSlot":
+      return {
+        title: `Build slot ${pending.slot} and launch it?`,
+        message:
+          `This runs the build script (about a minute) and then starts cc-director${pending.slot}.exe. ` +
+          "The slot must not already be running.",
+        confirmLabel: "Build & start",
+        busyLabel: "Building...",
+        danger: false,
+        onConfirm: () => actions.buildStart(pending.slot),
+      };
+  }
 }
 
 // ---- display helpers (mirroring exes.html / Exes.razor exactly) ----

--- a/apps/cockpit/src/main.tsx
+++ b/apps/cockpit/src/main.tsx
@@ -29,6 +29,7 @@ import { AboutView } from "./about/AboutView";
 import { SettingsView } from "./settings/SettingsView";
 import { FeedbackView } from "./feedback/FeedbackView";
 import "./styles.css";
+import "./components/components.css";
 import "./fleet/fleet.css";
 import "./fleet/fleetmap.css";
 import "./schedule/schedule.css";

--- a/apps/cockpit/src/schedule/ScheduleView.tsx
+++ b/apps/cockpit/src/schedule/ScheduleView.tsx
@@ -19,6 +19,7 @@ import {
 import type { SessionDto } from "@devthrottle/client-core/api/client";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 import { clockLabel } from "../fleet/format";
+import { ConfirmDialog } from "../components";
 
 // The Schedule page (issue #976, epic #967) - the React port of the Blazor Cockpit Schedule.razor
 // (issue #488). The human's window into cron jobs: a pure CLIENT of the Gateway's /cron/jobs surface
@@ -116,6 +117,10 @@ export function ScheduleView() {
   const [saving, setSaving] = useState(false);
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const [formError, setFormError] = useState<string | null>(null);
+
+  // The cron job awaiting delete confirmation. Deleting a job removes the schedule permanently, so it
+  // asks through the shared ConfirmDialog (issue #1244) instead of firing on the first click.
+  const [pendingDelete, setPendingDelete] = useState<CronJob | null>(null);
 
   // selectedRef mirrors selectedId so the poll can refetch the open job's runs without re-subscribing.
   const selectedRef = useRef<string | null>(null);
@@ -269,19 +274,17 @@ export function ScheduleView() {
     [refresh],
   );
 
+  // The actual delete, run once the ConfirmDialog is confirmed. A failure is left to throw so the
+  // dialog surfaces it (fail loudly) rather than being swallowed into the page banner.
   const remove = useCallback(
     async (job: CronJob) => {
       setActionError(null);
-      try {
-        await deleteCronJob(job.id);
-        if (selectedRef.current === job.id) {
-          setSelectedId(null);
-          setRuns([]);
-        }
-        await refresh();
-      } catch (err) {
-        setActionError(`Delete failed: ${gatewayErrorMessage(err)}`);
+      await deleteCronJob(job.id);
+      if (selectedRef.current === job.id) {
+        setSelectedId(null);
+        setRuns([]);
       }
+      await refresh();
     },
     [refresh],
   );
@@ -417,7 +420,7 @@ export function ScheduleView() {
                     <button className="sched-linkbtn" onClick={() => openEdit(job)}>
                       Edit
                     </button>
-                    <button className="sched-linkbtn del" onClick={() => void remove(job)}>
+                    <button className="sched-linkbtn del" onClick={() => setPendingDelete(job)}>
                       Delete
                     </button>
                   </td>
@@ -714,6 +717,23 @@ export function ScheduleView() {
           </div>
         </div>
       )}
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="Delete this cron job?"
+        message={
+          pendingDelete === null
+            ? ""
+            : `Delete "${pendingDelete.name}"? This removes the schedule permanently and stops it from ` +
+              "running again. This cannot be undone."
+        }
+        confirmLabel="Delete"
+        busyLabel="Deleting..."
+        onConfirm={async () => {
+          if (pendingDelete !== null) await remove(pendingDelete);
+        }}
+        onClose={() => setPendingDelete(null)}
+      />
     </div>
   );
 }

--- a/apps/cockpit/src/sessions/QueuePanel.tsx
+++ b/apps/cockpit/src/sessions/QueuePanel.tsx
@@ -9,6 +9,7 @@ import {
   gatewayErrorMessage,
   type QueueItem,
 } from "@devthrottle/client-core/api/client";
+import { ConfirmDialog } from "../components";
 
 // The prompt queue panel (issue #972) - the React port of the Blazor Cockpit queue tab. Every verb
 // goes to the owning Director through the Gateway and returns the authoritative queue, so the list is
@@ -28,6 +29,9 @@ export function QueuePanel({ sessionId, queue, onQueue, onPop }: QueuePanelProps
   const [error, setError] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingText, setEditingText] = useState("");
+  // Clearing the whole queue drops every queued prompt, so it asks through the shared ConfirmDialog
+  // (issue #1244) rather than firing on the first click.
+  const [confirmClear, setConfirmClear] = useState(false);
 
   const run = useCallback(
     async (verb: () => Promise<QueueItem[]>) => {
@@ -68,7 +72,7 @@ export function QueuePanel({ sessionId, queue, onQueue, onPop }: QueuePanelProps
       <div className="qpanel-head">
         <span className="qpanel-title">Queue{queue.length > 0 ? ` (${queue.length})` : ""}</span>
         {queue.length > 0 && sessionId && (
-          <button type="button" className="linkbtn" disabled={busy} onClick={() => void run(() => clearQueue(sessionId))}>
+          <button type="button" className="linkbtn" disabled={busy} onClick={() => setConfirmClear(true)}>
             Clear
           </button>
         )}
@@ -155,6 +159,23 @@ export function QueuePanel({ sessionId, queue, onQueue, onPop }: QueuePanelProps
           })}
         </ul>
       )}
+
+      <ConfirmDialog
+        open={confirmClear}
+        title="Clear the prompt queue?"
+        message={`This removes ${
+          queue.length === 1 ? "the 1 queued prompt" : `all ${queue.length} queued prompts`
+        }. This cannot be undone.`}
+        confirmLabel="Clear queue"
+        busyLabel="Clearing..."
+        onConfirm={async () => {
+          if (sessionId === undefined) return;
+          // Let a failure throw so the dialog surfaces it (fail loudly); the Gateway returns the
+          // authoritative (now empty) queue on success.
+          onQueue(await clearQueue(sessionId));
+        }}
+        onClose={() => setConfirmClear(false)}
+      />
     </div>
   );
 }

--- a/apps/cockpit/src/sessions/ScreenshotsPanel.tsx
+++ b/apps/cockpit/src/sessions/ScreenshotsPanel.tsx
@@ -6,6 +6,7 @@ import {
   gatewayErrorMessage,
   type ScreenshotInfo,
 } from "@devthrottle/client-core/api/client";
+import { ConfirmDialog } from "../components";
 
 // The screenshots gallery panel (issue #972) - the React port of the Blazor Cockpit screenshots tab.
 // The folder lives on the owning Director's machine; the Cockpit asks in the context of the selected
@@ -34,6 +35,9 @@ export function ScreenshotsPanel({ sessionId, onInsert }: ScreenshotsPanelProps)
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loadedOnce, setLoadedOnce] = useState(false);
+  // Deleting a screenshot removes the file from the Director's disk, so it asks through the shared
+  // ConfirmDialog (issue #1244); this holds the file name awaiting confirmation.
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null);
 
   const load = useCallback(
     async (signal?: AbortSignal) => {
@@ -66,20 +70,14 @@ export function ScreenshotsPanel({ sessionId, onInsert }: ScreenshotsPanelProps)
     return () => controller.abort();
   }, [load]);
 
-  const onDelete = useCallback(
+  // The actual delete, run once the ConfirmDialog is confirmed. A failure is left to throw so the
+  // dialog surfaces it (fail loudly); on success the row drops from the gallery.
+  const performDelete = useCallback(
     async (fileName: string) => {
       if (!sessionId) return;
-      setBusy(true);
-      setError(null);
-      try {
-        await deleteScreenshot(sessionId, fileName);
-        setShots((cur) => cur.filter((s) => s.fileName !== fileName));
-        setTotal((t) => Math.max(0, t - 1));
-      } catch (err) {
-        setError(gatewayErrorMessage(err));
-      } finally {
-        setBusy(false);
-      }
+      await deleteScreenshot(sessionId, fileName);
+      setShots((cur) => cur.filter((s) => s.fileName !== fileName));
+      setTotal((t) => Math.max(0, t - 1));
     },
     [sessionId],
   );
@@ -123,7 +121,7 @@ export function ScreenshotsPanel({ sessionId, onInsert }: ScreenshotsPanelProps)
                   <button type="button" className="linkbtn" title="Insert path into the composer" onClick={() => onInsert(s.path)}>
                     Insert
                   </button>
-                  <button type="button" className="linkbtn del" disabled={busy} onClick={() => void onDelete(s.fileName)}>
+                  <button type="button" className="linkbtn del" disabled={busy} onClick={() => setPendingDelete(s.fileName)}>
                     Del
                   </button>
                 </div>
@@ -143,6 +141,18 @@ export function ScreenshotsPanel({ sessionId, onInsert }: ScreenshotsPanelProps)
           )}
         </>
       )}
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="Delete this screenshot?"
+        message="This removes the image file from the Director's disk. This cannot be undone."
+        confirmLabel="Delete"
+        busyLabel="Deleting..."
+        onConfirm={async () => {
+          if (pendingDelete !== null) await performDelete(pendingDelete);
+        }}
+        onClose={() => setPendingDelete(null)}
+      />
     </div>
   );
 }

--- a/apps/cockpit/src/sessions/SessionActionBar.tsx
+++ b/apps/cockpit/src/sessions/SessionActionBar.tsx
@@ -6,6 +6,7 @@ import {
   sendInterrupt,
   gatewayErrorMessage,
 } from "@devthrottle/client-core/api/client";
+import { ConfirmDialog } from "../components";
 
 // The driver action bar (issue #972) - the React port of the Blazor Cockpit action bar / desktop
 // SessionActionBar. Each button is rendered from the SELECTED session's declared driver capabilities
@@ -27,6 +28,9 @@ export function SessionActionBar({ sessionId, capabilities }: SessionActionBarPr
   const [acting, setActing] = useState(false);
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Clear context resets the session's whole conversation in place; it is destructive, so it asks
+  // through the shared ConfirmDialog (issue #1244) instead of firing on the first click.
+  const [confirmClear, setConfirmClear] = useState(false);
   const statusTimer = useRef<number | null>(null);
 
   useEffect(() => {
@@ -89,7 +93,7 @@ export function SessionActionBar({ sessionId, capabilities }: SessionActionBarPr
           type="button"
           className="act-btn"
           disabled={acting}
-          onClick={() => sessionId && void act(() => sendClearContext(sessionId), "context cleared", "Clear context failed")}
+          onClick={() => setConfirmClear(true)}
           title="Reset the conversation in place (/clear) - the process keeps running"
         >
           Clear context
@@ -108,6 +112,24 @@ export function SessionActionBar({ sessionId, capabilities }: SessionActionBarPr
       )}
       {status !== null && <span className="action-status">{status}</span>}
       {error !== null && <span className="action-error">{error}</span>}
+
+      <ConfirmDialog
+        open={confirmClear}
+        title="Clear this session's context?"
+        message={
+          "This resets the conversation in place (/clear). The running process keeps going, but the " +
+          "agent loses the current conversation. This cannot be undone."
+        }
+        confirmLabel="Clear context"
+        busyLabel="Clearing..."
+        onConfirm={async () => {
+          if (sessionId === undefined) return;
+          // Let a failure throw so the dialog surfaces it (fail loudly); flash on success.
+          await sendClearContext(sessionId);
+          flash("context cleared");
+        }}
+        onClose={() => setConfirmClear(false)}
+      />
     </div>
   );
 }

--- a/apps/cockpit/src/transcripts/TranscriptsView.tsx
+++ b/apps/cockpit/src/transcripts/TranscriptsView.tsx
@@ -11,6 +11,7 @@ import {
   type RecordingListItem,
 } from "@devthrottle/client-core/recordings/recordingsClient";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
+import { ConfirmDialog, EmptyState, ErrorBanner, LoadingState } from "../components";
 
 // The Voice Recorder page (issue #977, epic #967) - the React port of the Blazor Cockpit
 // Transcripts.razor(.css) (#183). Recordings are uploaded from the phone and transcribed on the
@@ -22,6 +23,10 @@ import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 // Audio playback (the one thing a server-rendered Blazor page needed a JS shim for) is native here: a
 // single HTMLAudioElement plays segment 0, then 1, ... in order. It authenticates via the
 // cc-gateway-token cookie the shell mirrors at startup, exactly like the live terminal WebSocket.
+//
+// This is one of the first three pages to adopt the shared user-interface kit (issue #1244): Delete
+// asks through the shared ConfirmDialog instead of a browser window.confirm/alert, and the load and
+// empty states use the shared LoadingState / EmptyState / ErrorBanner.
 
 // Per-recording view state (open/transcript/edit fields/transient messages), keyed by id.
 interface CardState {
@@ -66,6 +71,9 @@ export function TranscriptsView() {
   // Single audio-playback label (the page plays one clip at a time, mirroring the Blazor single-audio
   // model that set nowPlaying on every open card).
   const [nowPlaying, setNowPlaying] = useState("");
+  // The recording awaiting delete confirmation. Deleting a recording removes its local transcript and
+  // audio, so it asks through the shared ConfirmDialog (issue #1244) instead of a browser window.confirm.
+  const [pendingDelete, setPendingDelete] = useState<RecordingListItem | null>(null);
 
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const msgTimers = useRef<number[]>([]);
@@ -165,24 +173,17 @@ export function TranscriptsView() {
   };
 
   // ---- delete ----
-  const deleteItem = async (item: RecordingListItem) => {
-    const vaultNote = item.inVault ? "\n\nThis recording is saved in the vault; that copy is kept." : "";
-    const ok = window.confirm(
-      `Delete "${item.title}"?\n\nThis removes the local transcript and its audio.${vaultNote}\n\nThis cannot be undone.`,
-    );
-    if (!ok) return;
+  // The actual delete, run once the ConfirmDialog is confirmed. A failure is left to throw so the
+  // dialog surfaces it (fail loudly) rather than a browser window.alert.
+  const performDelete = async (item: RecordingListItem) => {
     stopAudio();
-    try {
-      await deleteRecording(item.recordingId);
-      setItems((prev) => (prev === null ? prev : prev.filter((x) => x.recordingId !== item.recordingId)));
-      setState((s) => {
-        const copy = { ...s };
-        delete copy[item.recordingId];
-        return copy;
-      });
-    } catch (err) {
-      window.alert(`Delete failed: ${gatewayErrorMessage(err)}`);
-    }
+    await deleteRecording(item.recordingId);
+    setItems((prev) => (prev === null ? prev : prev.filter((x) => x.recordingId !== item.recordingId)));
+    setState((s) => {
+      const copy = { ...s };
+      delete copy[item.recordingId];
+      return copy;
+    });
   };
 
   // ---- promote to vault ----
@@ -263,9 +264,13 @@ export function TranscriptsView() {
         </p>
 
         {items === null ? (
-          <p className="ts-empty">{error ?? "Loading..."}</p>
+          error !== null ? (
+            <ErrorBanner message={error} />
+          ) : (
+            <LoadingState />
+          )
         ) : items.length === 0 ? (
-          <p className="ts-empty">No recordings yet. Record something on the phone and it will appear here.</p>
+          <EmptyState message="No recordings yet. Record something on the phone and it will appear here." />
         ) : (
           items.map((item) => {
             const s = cardOf(item.recordingId);
@@ -332,7 +337,7 @@ export function TranscriptsView() {
                         className="ts-danger"
                         onClick={(e) => {
                           e.stopPropagation();
-                          void deleteItem(item);
+                          setPendingDelete(item);
                         }}
                       >
                         Delete
@@ -388,6 +393,24 @@ export function TranscriptsView() {
           })
         )}
       </div>
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="Delete this recording?"
+        message={
+          pendingDelete === null
+            ? ""
+            : `Delete "${pendingDelete.title}"? This removes the local transcript and its audio.` +
+              (pendingDelete.inVault ? " This recording is saved in the vault; that copy is kept." : "") +
+              " This cannot be undone."
+        }
+        confirmLabel="Delete"
+        busyLabel="Deleting..."
+        onConfirm={async () => {
+          if (pendingDelete !== null) await performDelete(pendingDelete);
+        }}
+        onClose={() => setPendingDelete(null)}
+      />
     </div>
   );
 }

--- a/docs/CockpitVisualStyle.md
+++ b/docs/CockpitVisualStyle.md
@@ -1,0 +1,119 @@
+# Cockpit Visual Style Guide
+
+> **Scope:** the React web Cockpit (`apps/cockpit`), served by the Gateway. The desktop app has its
+> own, separate guide in [docs/VisualStyle.md](VisualStyle.md) (a charcoal, VS Code-inspired palette).
+> The web Cockpit uses a distinct dark navy palette; this document is its written standard, added with
+> the shared user-interface kit in issue 1244.
+
+The web Cockpit shares its palette with the mobile shell (`/m`) and the voice prototype so the three
+shells read as one product. Every colour is a design token defined in one place -
+`apps/cockpit/src/styles.css` (the `:root` block at the top) - and nothing in the app hard-codes a
+colour outside that block. The shared kit (`apps/cockpit/src/components`) styles itself only from these
+tokens (see `components/components.css`).
+
+---
+
+## 1. Colour palette (the navy tokens)
+
+These are the exact tokens declared in `apps/cockpit/src/styles.css`. This table is the written record
+of what the app actually uses; keep it in step with that file.
+
+| Token | Hex | Usage |
+|-------|-----|-------|
+| `--bg` | `#0b1020` | Page background (the deepest navy) |
+| `--surface` | `#141a2e` | Panels, rails, cards, modal bodies |
+| `--surface-2` | `#1b2238` | Raised surfaces: secondary buttons, list rows, inputs-on-panel |
+| `--border` | `#28304a` | Borders, separators, panel edges |
+| `--text` | `#e6e9f2` | Primary text |
+| `--text-dim` | `#99a0b8` | Secondary text: descriptions, meta, timestamps, hints |
+| `--accent` | `#3b82f6` | Primary action blue: primary buttons, active nav, focus ring |
+| `--attention` | `#f14c4c` | Attention / danger red: destructive buttons, error text, needs-you |
+| `--warn` | `#f59e0b` | Warning yellow (the Brief accents, issue 973) |
+| `--code-bg` | `#0a0f1e` | Inset code / monospace input surface |
+| `--needsyou-bg` | `#2a1d1f` | Tinted "needs you" panel background |
+| `--needsyou-text` | `#f1d8d8` | "needs you" panel text |
+| `--needsyou-fyi-bg` | `#262017` | Tinted "for your information" panel background |
+| `--needsyou-fyi-text` | `#e8dcc8` | "for your information" panel text |
+
+Non-colour token:
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--rail-left-width` | `220px` | Width of the left navigation rail |
+
+Two literal whites are used deliberately and are not tokens: `#ffffff` for text on top of the accent
+and danger fills (a token would only ever hold white here). Everything else is a token.
+
+---
+
+## 2. Typography
+
+- Font family (all text): the system UI stack -
+  `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif`.
+- Monospace (paths, session ids, code, cron expressions): `"Cascadia Mono", Consolas, Menlo, monospace`.
+- Common sizes: 22px page title, 15-16px section/modal headings, 13-14px body, 11-12px meta and hints.
+
+---
+
+## 3. The shared user-interface kit
+
+Every page imports its building blocks from `apps/cockpit/src/components` instead of hand-rolling a
+one-off class. Reach for these before writing a new button class or a new "Loading..." line.
+
+| Component | What it is |
+|-----------|------------|
+| `Button` | The one button, with four variants (below). Forwards every native button attribute. |
+| `PageHeader` | A page title, an optional one-line subtitle, and an optional right-aligned actions slot. |
+| `LoadingState` | The single "Loading..." indicator (`role="status"`). |
+| `EmptyState` | The "nothing here yet" message, with an optional title and an optional next-step action. |
+| `ErrorBanner` | The red failure banner (`role="alert"`), with an optional Retry button. |
+| `ConfirmDialog` | The one confirmation dialog every destructive action routes through (section 5). |
+| `StatusMessage` + `useFlash` | A small transient status line for action results (replaces `window.alert`). |
+
+### Button variants
+
+| Variant | Colour | Use for |
+|---------|--------|---------|
+| `primary` | Accent blue (`--accent`) | The main action on a surface. One per surface. |
+| `secondary` | Bordered navy (`--surface-2` + `--border`) | Supporting actions. The default. |
+| `danger` | Red (`--attention`) | Destructive actions. Always the confirm button of a `ConfirmDialog`. |
+| `ghost` | Borderless, accent text | A small, link-like inline control. |
+
+All buttons default to `type="button"` (an action, never an accidental form submit), dim to 0.5 opacity
+when disabled, and lighten slightly on hover.
+
+---
+
+## 4. Surfaces and shape
+
+- Page content lives in the padded main pane; full-bleed panes (the terminal, the Sessions screen)
+  cancel that padding with negative margins - see the comments in `styles.css`.
+- Cards and panels: `--surface` background, 1px `--border`, 8px corner radius.
+- Modals: `--surface` body, 1px `--border`, 12px corner radius, dimmed backdrop
+  (`rgba(0, 0, 0, 0.55)`), a soft drop shadow.
+- Buttons and inputs: 6-8px corner radius; inputs sit on `--code-bg` or `--bg` with a `--border` edge
+  that turns `--accent` on focus.
+
+---
+
+## 5. Destructive actions - MANDATORY
+
+Every destructive or irreversible action (delete, clear, kill, remove) must ask for confirmation through
+the shared `ConfirmDialog` before it fires. This rule has no exceptions.
+
+- Never use the browser's `window.confirm` or `window.alert`. They are blocking, unstyled, and cannot be
+  themed; the lint of this rule is simply that neither call appears anywhere in `apps/cockpit`.
+- The confirm button is the `danger` (red) variant for a destructive action; use `danger={false}` (the
+  accent-blue primary) only for a heavy-but-safe action such as a rebuild.
+- `ConfirmDialog` owns its own busy and error lifecycle. The confirmed action should let a failure throw:
+  the dialog stays open and shows exactly what went wrong (fail loudly), so the person can read it and
+  retry or cancel. Do not swallow the error into a fallback.
+- Report the result of an action with `StatusMessage` / `useFlash`, never a pop-up.
+
+---
+
+## 6. The one hard rule that outranks style
+
+The browser talks ONLY to the Gateway, through root-relative paths - never to a Director directly, never
+an absolute `http`/`https`/`ws`/`wss` URL in client code. This is enforced by `eslint.config.js` and is
+a correctness rule, not a style preference. See the Cockpit rebuild docs (epic 967) for the reasoning.


### PR DESCRIPTION
Closes thefrederiksen/devthrottle#1244. Foundation for the Cockpit improvement mission - issues 1245, 1246, 1254, and 1255 consume this kit.

## What this adds

A small shared user-interface kit under `apps/cockpit/src/components`, so no page hand-rolls a one-off button class again:

- **Button** - one button with four variants: primary, secondary, danger, ghost. Forwards every native button attribute.
- **PageHeader** - a title, an optional one-line subtitle, and an optional right-aligned actions slot.
- **LoadingState** / **EmptyState** / **ErrorBanner** - the shared load, empty, and failure states (ErrorBanner takes an optional Retry callback; both announce to screen readers).
- **ConfirmDialog** - the one in-app confirmation modal every destructive action routes through. It owns its own busy and error lifecycle: the confirmed action lets a failure throw, and the dialog stays open showing exactly what went wrong (fail loudly). Never `window.confirm`.
- **StatusMessage** + **useFlash** - a small transient status helper for action results, replacing `window.alert`.

Everything styles itself only from the shared navy tokens in `styles.css` (`components/components.css`); nothing hard-codes a colour.

## One confirmation dialog for every destructive action

- **Added** the missing confirmations: Schedule delete, Clear context, Clear queue, screenshot delete.
- **Replaced** the blocking browser `confirm`/`alert` in Exes (Kill / Delete slot / Build & start) and the Voice Recorder / Transcripts (Delete).
- No `window.confirm` or `window.alert` remains anywhere in `apps/cockpit`.

## Palette document

`docs/CockpitVisualStyle.md` records the navy tokens the web Cockpit actually uses (distinct from the desktop charcoal guide in `docs/VisualStyle.md`), plus the kit reference and the destructive-action rule. Every colour token matches `apps/cockpit/src/styles.css`.

## Kit adoption

Adopted on three pages this PR (Account, Exes, Transcripts). Full app-wide adoption of the loading/empty/error pieces is the separate follow-up issue thefrederiksen/devthrottle_internal#740.

## Verification

- `npm run build --workspace @devthrottle/cockpit` (tsc --noEmit + vite build): passes.
- `eslint` on the changed files: clean (no absolute-URL / Gateway-only-ingress violations).
- Acceptance grep - no real `window.confirm(` / `window.alert(` call site left in `apps/cockpit` (only mentions in explanatory comments).
- Palette check - every `#hex` token in `styles.css :root` is present in the palette doc with a matching value.
- Rendered proof - the kit built from the real `components.css` and the exact DOM the components emit, screenshotted: PageHeader, all four Button variants (incl. disabled), LoadingState / EmptyState / ErrorBanner / StatusMessage, and the ConfirmDialog with its inline error and red confirm button, all on the navy palette. (Attached to the mission report.)

Built from an isolated worktree off `origin/main`; small, focused diff (19 files, kit + doc + the destructive-action wiring).