### PR TITLE
Desktop dictation: water-drop ready cue when the mic goes live

### DIFF
--- a/src/CcDirector.Avalonia.Tests/BatchDictationRecorderCaptureLiveTests.cs
+++ b/src/CcDirector.Avalonia.Tests/BatchDictationRecorderCaptureLiveTests.cs
@@ -1,0 +1,71 @@
+using CcDirector.Avalonia.Voice;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Dictation;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// Tests for the "microphone is now live" signal (<see cref="BatchDictationRecorder.OnCaptureLive"/>)
+/// that drives the desktop dialog's flip to RECORDING and the water-drop ready cue.
+///
+/// The whole point of the signal is honesty: it must fire only when REAL audio has
+/// actually been captured - not merely when the driver was asked to start - so the
+/// red state and the ready sound never precede audio. These tests drive that through
+/// the injected <see cref="IAudioSource"/> seam with a fake source, so there is no
+/// real microphone, no sound device, and no network.
+/// </summary>
+public sealed class BatchDictationRecorderCaptureLiveTests
+{
+    /// <summary>Minimal fake mic: emits captured chunks on demand via <see cref="Emit"/>.</summary>
+    private sealed class FakeMic : IAudioSource
+    {
+        public event Action<byte[]>? OnAudioChunk;
+        public string Description => "Fake Test Microphone";
+        public void Start() { }
+        public void Stop() { }
+        public Task StopAsync(TimeSpan drainTimeout) => Task.CompletedTask;
+        public void Emit(byte[] chunk) => OnAudioChunk?.Invoke(chunk);
+    }
+
+    private static BatchDictationRecorder NewRecorder(FakeMic fake) =>
+        new(new AgentOptions(), _ => fake,
+            (_, _, _) => Task.FromResult(new DictationResult("", "", 0)));
+
+    [Fact]
+    public async Task OnCaptureLive_FiresOnceOnFirstRealAudioChunk()
+    {
+        var fake = new FakeMic();
+        await using var recorder = NewRecorder(fake);
+
+        int liveCount = 0;
+        recorder.OnCaptureLive += () => liveCount++;
+
+        await recorder.StartAsync();
+        // StartRecording merely returning is NOT "live": no audio has been delivered.
+        Assert.Equal(0, liveCount);
+
+        fake.Emit(new byte[] { 1, 2, 3, 4 });
+        // The first real buffer is the honest "mic is capturing your voice" moment.
+        Assert.Equal(1, liveCount);
+
+        fake.Emit(new byte[] { 5, 6, 7, 8 });
+        // One-shot: subsequent buffers do not re-fire it.
+        Assert.Equal(1, liveCount);
+    }
+
+    [Fact]
+    public async Task OnCaptureLive_NotFiredForEmptyChunk()
+    {
+        var fake = new FakeMic();
+        await using var recorder = NewRecorder(fake);
+
+        int liveCount = 0;
+        recorder.OnCaptureLive += () => liveCount++;
+
+        await recorder.StartAsync();
+        fake.Emit(Array.Empty<byte>()); // a zero-length buffer is not real audio
+
+        Assert.Equal(0, liveCount);
+    }
+}

--- a/src/CcDirector.Avalonia/Voice/BatchDictationRecorder.cs
+++ b/src/CcDirector.Avalonia/Voice/BatchDictationRecorder.cs
@@ -22,7 +22,8 @@ namespace CcDirector.Avalonia.Voice;
 ///   var rec = new BatchDictationRecorder(options);
 ///   rec.OnAudioBands     += bands => /* drive equalizer */ ;
 ///   rec.OnInputRms       += rms   => /* low-level hint */ ;
-///   rec.OnCaptureStarted += ()    => /* flip the UI to RECORDING */ ;
+///   rec.OnCaptureStarted += ()    => /* driver asked to start (setup done) */ ;
+///   rec.OnCaptureLive    += ()    => /* first real audio in: flip to RECORDING + ready cue */ ;
 ///   await rec.StartAsync();   // mic opens, audio buffers locally
 ///   // user talks (no text appears - no live preview)
 ///   var result = await rec.TranscribeAsync();  // ONE batch transcription call
@@ -81,12 +82,28 @@ public sealed class BatchDictationRecorder : IAsyncDisposable
     public event Action<double>? OnInputRms;
 
     /// <summary>
-    /// Fires the instant the microphone actually starts capturing. The UI anchors
-    /// its recording timer to this and flips to the RECORDING state. There is no
-    /// separate "connected" event because there is no network connect before
-    /// capture - transcription happens once, after the user stops.
+    /// Fires the instant the microphone is asked to start capturing (right after
+    /// <c>StartRecording</c> returns). This is the SETUP moment, before any audio has
+    /// actually been delivered by the driver. There is no separate "connected" event
+    /// because there is no network connect before capture - transcription happens once,
+    /// after the user stops.
     /// </summary>
     public event Action? OnCaptureStarted;
+
+    /// <summary>
+    /// Fires exactly ONCE, when the first buffer of real audio actually lands in the
+    /// capture buffer - the honest "the microphone is now hearing your voice" moment,
+    /// as opposed to <see cref="OnCaptureStarted"/> which only means the driver was
+    /// asked to start. The desktop dialog holds its "GETTING READY" state until this
+    /// fires, then flips to RECORDING and plays the ready cue together, so neither the
+    /// red state nor the sound ever claims the mic is live before audio is flowing.
+    /// May fire on NAudio's worker thread, so a UI handler must marshal to the UI thread.
+    /// </summary>
+    public event Action? OnCaptureLive;
+
+    // One-shot latch for OnCaptureLive: set the first time a non-empty chunk is
+    // appended, so the "mic is live" signal is raised once per recorder, not per chunk.
+    private bool _captureLiveRaised;
 
     /// <summary>
     /// Fires as transcription progresses with (completedParts, totalParts). A long recording is split
@@ -335,6 +352,16 @@ public sealed class BatchDictationRecorder : IAsyncDisposable
         lock (_audioLock)
         {
             _audio.Write(chunk, 0, chunk.Length);
+        }
+
+        // The first non-empty chunk is the first real audio the driver delivered:
+        // the honest "microphone is now capturing your voice" moment. Raise it once,
+        // OUTSIDE the audio lock so a UI handler can never stall capture. AppendChunk
+        // runs on NAudio's single capture thread, so the latch needs no synchronization.
+        if (!_captureLiveRaised)
+        {
+            _captureLiveRaised = true;
+            OnCaptureLive?.Invoke();
         }
     }
 

--- a/src/CcDirector.Avalonia/Voice/DesktopAudioCue.cs
+++ b/src/CcDirector.Avalonia/Voice/DesktopAudioCue.cs
@@ -1,0 +1,111 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CcDirector.Core.Utilities;
+using NAudio.Wave;
+
+namespace CcDirector.Avalonia.Voice;
+
+/// <summary>
+/// Plays short user-interface sound cues on the desktop by SYNTHESIZING the
+/// waveform in code - there are no bundled audio files to ship or resolve. The
+/// only cue today is the dictation "ready" signal: a brief water-drop "bloop"
+/// played the instant the microphone is confirmed capturing real audio, so the
+/// user hears exactly when to start speaking (the same courtesy the Windows
+/// dictation panel gives with its ready beep).
+///
+/// The tone is generated as 16-bit mono PCM and played through NAudio's default
+/// output device, mirroring <see cref="DesktopTtsPlayer"/>'s playback pattern.
+/// Playback is fire-and-forget and best-effort by design: a cue is a courtesy,
+/// so a missing or busy output device must never disrupt the dictation turn - a
+/// failure is logged and swallowed, exactly as a missing text-to-speech voice is.
+/// </summary>
+public sealed class DesktopAudioCue
+{
+    private const int SampleRate = 44_100;
+
+    /// <summary>
+    /// Play the dictation "ready" water-drop bloop once. Returns immediately and
+    /// plays on a background thread. Never throws: a cue failure is logged and
+    /// swallowed so it can never take down the caller's dictation turn.
+    /// </summary>
+    public void PlayReady()
+    {
+        byte[] pcm;
+        try
+        {
+            pcm = BuildWaterDropBloop();
+        }
+        catch (Exception ex)
+        {
+            // Synthesis is pure arithmetic and should never fail; if it somehow does,
+            // the cue is skipped rather than propagating into the dictation flow.
+            FileLog.Write($"[DesktopAudioCue] bloop synthesis failed: {ex.Message}");
+            return;
+        }
+
+        _ = Task.Run(() =>
+        {
+            try
+            {
+                using var ms = new MemoryStream(pcm);
+                var source = new RawSourceWaveStream(ms, new WaveFormat(SampleRate, 16, 1));
+                using var output = new WaveOutEvent();
+                output.Init(source);
+                output.Play();
+                while (output.PlaybackState == PlaybackState.Playing)
+                    Thread.Sleep(20);
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[DesktopAudioCue] bloop playback failed: {ex.Message}");
+            }
+        });
+    }
+
+    /// <summary>
+    /// Synthesize a short water-drop "bloop": a sine tone whose pitch glides quickly
+    /// UPWARD while its amplitude decays exponentially. The rising-pitch glide paired
+    /// with a fast decay is the perceptual signature of a droplet (a "plink"), and the
+    /// whole cue is only ~200 ms so it reads as a single drop rather than a beep. A
+    /// short raised-cosine fade at each end removes the click a hard start/stop would
+    /// make. Returned as 16-bit little-endian mono PCM at <see cref="SampleRate"/>.
+    /// </summary>
+    private static byte[] BuildWaterDropBloop()
+    {
+        const double durationSeconds = 0.20;
+        const double startHz = 380.0;    // pitch glides up...
+        const double endHz = 1150.0;     // ...to give the droplet "bloop" chirp
+        const double decayRate = 26.0;   // exponential amplitude decay (higher = shorter tail)
+        const double amplitude = 0.55;   // peak level, with headroom below clipping
+        const double fadeSeconds = 0.006; // click-free attack/release
+
+        int sampleCount = (int)(SampleRate * durationSeconds);
+        var pcm = new byte[sampleCount * 2];
+
+        // Advance the phase per sample so the instantaneous frequency can rise without
+        // introducing a phase discontinuity (a naive sin(2*pi*f(t)*t) would click).
+        double phase = 0.0;
+        for (int i = 0; i < sampleCount; i++)
+        {
+            double t = (double)i / SampleRate;
+            double progress = (double)i / sampleCount;
+
+            double freq = startHz + (endHz - startHz) * progress;
+            phase += 2.0 * Math.PI * freq / SampleRate;
+
+            double envelope = Math.Exp(-decayRate * t);
+            double attack = t < fadeSeconds ? t / fadeSeconds : 1.0;
+            double remaining = durationSeconds - t;
+            double release = remaining < fadeSeconds ? remaining / fadeSeconds : 1.0;
+
+            double value = Math.Sin(phase) * envelope * attack * release * amplitude;
+            short sample = (short)Math.Clamp(value * short.MaxValue, short.MinValue, short.MaxValue);
+            pcm[i * 2] = (byte)(sample & 0xFF);
+            pcm[i * 2 + 1] = (byte)((sample >> 8) & 0xFF);
+        }
+
+        return pcm;
+    }
+}

--- a/src/CcDirector.Avalonia/Voice/SpeakDialog.axaml
+++ b/src/CcDirector.Avalonia/Voice/SpeakDialog.axaml
@@ -36,12 +36,13 @@
 
         <!-- Status row -->
         <Grid Grid.Row="1" ColumnDefinitions="Auto,*,Auto" Margin="0,0,0,12">
-            <!-- Opens in the CONNECTING state (yellow): the mic is already
-                 capturing (capture-first pipeline) but the transcription
-                 backend is not connected yet. SwitchToRecording flips these
-                 red once the session is live. -->
+            <!-- Opens in the GETTING READY state (yellow): the mic is warming up
+                 and has not delivered audio yet. SwitchToRecording flips these red -
+                 and plays the water-drop ready cue - only once the microphone
+                 actually starts capturing, so the red and the sound never precede
+                 real audio. -->
             <TextBlock x:Name="StatusLabel" Grid.Column="0"
-                       Text="CONNECTING"
+                       Text="GETTING READY"
                        FontFamily="Cascadia Mono,Consolas,monospace"
                        FontSize="20" FontWeight="Bold"
                        Foreground="#DCDCAA"

--- a/src/CcDirector.Avalonia/Voice/SpeakDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/Voice/SpeakDialog.axaml.cs
@@ -48,11 +48,21 @@ namespace CcDirector.Avalonia.Voice;
 /// </summary>
 public partial class SpeakDialog : Window
 {
-    private enum Stage { Recording, Transcribing, Paused, Failed }
+    private enum Stage { Connecting, Recording, Transcribing, Paused, Failed }
 
     private readonly AgentOptions _options;
     private readonly Border[] _bars;
     private readonly double[] _barTargets = new double[9];
+
+    // Plays the water-drop "ready" cue the instant the mic goes live. Best-effort:
+    // a failed sound never disrupts the dictation turn.
+    private readonly DesktopAudioCue _audioCue = new();
+
+    // Backstop for the GETTING READY state: if the selected mic never delivers a
+    // first audio buffer, we must not strand the user on "GETTING READY" forever.
+    // On expiry we fail loud with a clear "check your microphone" message instead of
+    // silently pretending to record. Cancelled the moment real audio arrives.
+    private readonly DispatcherTimer _readyTimeout;
 
     // Decaying peak of the raw int16 input RMS, tracked while recording.
     private double _recentPeakRms;
@@ -66,9 +76,11 @@ public partial class SpeakDialog : Window
     private DateTime _t0;
     private TimeSpan _elapsedBeforeSegment = TimeSpan.Zero;
 
-    // The dialog opens straight into recording: capture starts immediately
-    // (capture-first; no network connect precedes capture in the batch flow).
-    private Stage _stage = Stage.Recording;
+    // The dialog opens into GETTING READY and holds there until the microphone
+    // actually delivers its first audio buffer; only then does it flip to RECORDING
+    // (and play the ready cue). So neither the red state nor the sound ever claims
+    // the mic is live before audio is really flowing.
+    private Stage _stage = Stage.Connecting;
     private BatchDictationRecorder? _service;
 
     // The accumulated, dictionary-corrected transcript across every checkpointed
@@ -131,6 +143,13 @@ public partial class SpeakDialog : Window
         // OnAudioBands sets per-bar target heights; this timer animates toward them.
         _eqTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(33) };
         _eqTimer.Tick += (_, _) => StepEqualizer();
+
+        // One-shot backstop for the GETTING READY state (restarted on each entry).
+        // A healthy mic delivers its first buffer in well under 100 ms; six seconds
+        // with nothing means the device is not capturing, so fail loud rather than
+        // hang on GETTING READY.
+        _readyTimeout = new DispatcherTimer { Interval = TimeSpan.FromSeconds(6) };
+        _readyTimeout.Tick += (_, _) => OnReadyTimeout();
 
         Opened += async (_, _) => await OnDialogOpenedAsync();
         Closed += (_, _) => _ = OnDialogClosedAsync();
@@ -197,8 +216,10 @@ public partial class SpeakDialog : Window
             // very first frame. Then show the device list in the selector.
             _selectedDeviceNumber = MicDevices.ResolveByName(LoadPersistedMicName());
             PopulateMicSelector();
+            // Show GETTING READY immediately (responsive), then open the mic. The flip
+            // to RECORDING + ready cue happens later, when real audio actually arrives.
+            SwitchToConnecting();
             await StartNewServiceAsync();
-            SwitchToRecording();
         }
         catch (Exception ex)
         {
@@ -211,6 +232,7 @@ public partial class SpeakDialog : Window
     {
         _timer.Stop();
         _eqTimer.Stop();
+        _readyTimeout.Stop();
         await DisposeServiceAsync();
     }
 
@@ -220,6 +242,7 @@ public partial class SpeakDialog : Window
         svc.OnAudioBands += OnAudioBands;
         svc.OnInputRms += OnInputRms;
         svc.OnCaptureStarted += OnServiceCaptureStarted;
+        svc.OnCaptureLive += OnServiceCaptureLive;
         svc.OnTranscriptionProgress += OnServiceTranscriptionProgress;
         await svc.StartAsync("default");
         _service = svc;
@@ -284,10 +307,11 @@ public partial class SpeakDialog : Window
         _selectedDeviceNumber = deviceNumber;
         FileLog.Write($"[SpeakDialog] ChangeDevice: {deviceNumber} ({MicDevices.DescribeDevice(deviceNumber)})");
         await DisposeServiceAsync();
-        // Fresh device = fresh segment capture and fresh segment timer origin.
+        // Fresh device = fresh segment capture and fresh segment timer origin. Show
+        // GETTING READY until the new device delivers audio, then flip + cue.
         _t0 = DateTime.UtcNow;
+        SwitchToConnecting();
         await StartNewServiceAsync();
-        SwitchToRecording();
     }
 
     /// <summary>
@@ -296,6 +320,7 @@ public partial class SpeakDialog : Window
     /// </summary>
     private void SwitchToFailed(string message)
     {
+        _readyTimeout.Stop();
         _stage = Stage.Failed;
         TranscriptText.Text = message;
         TranscriptText.Foreground = new SolidColorBrush(Color.FromRgb(0xF4, 0x47, 0x47));
@@ -404,6 +429,42 @@ public partial class SpeakDialog : Window
     }
 
     /// <summary>
+    /// Fired the instant the microphone delivers its FIRST real audio buffer - the
+    /// honest "ready to speak" moment. This is where the dialog flips from GETTING
+    /// READY to RECORDING, anchors the timer to the true first-audio instant, and
+    /// plays the water-drop ready cue - all together, so neither the red state nor the
+    /// sound ever precedes real audio. Arrives on NAudio's worker thread. Guarded on
+    /// the Connecting stage so it is a no-op if the state has already moved on (e.g. a
+    /// mic switch mid-warmup) - and the recorder raises it only once regardless.
+    /// </summary>
+    private void OnServiceCaptureLive()
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (_stage != Stage.Connecting) return;
+            _readyTimeout.Stop();
+            _t0 = DateTime.UtcNow;
+            SwitchToRecording();
+            _audioCue.PlayReady();
+        });
+    }
+
+    /// <summary>
+    /// Backstop: the microphone never delivered a first audio buffer within the
+    /// GETTING READY window. Rather than strand the user on GETTING READY, fail loud
+    /// with a specific "check your microphone" message so they know what to fix. A
+    /// no-op if audio has since arrived and the stage moved on.
+    /// </summary>
+    private void OnReadyTimeout()
+    {
+        _readyTimeout.Stop();
+        if (_stage != Stage.Connecting) return;
+        FileLog.Write("[SpeakDialog] microphone delivered no audio within the ready window");
+        SwitchToFailed("The microphone did not start capturing. Check that it is connected, "
+            + "not muted, and that DevThrottle is allowed to use it, then try again.");
+    }
+
+    /// <summary>
     /// Fired as the segment transcribes. A long segment is split into several bounded transcription
     /// requests, so show which part is running instead of a silent "Transcribing..." wait. A short
     /// segment reports a single part and keeps the plain message. May arrive off the UI thread.
@@ -501,6 +562,7 @@ public partial class SpeakDialog : Window
         svc.OnAudioBands -= OnAudioBands;
         svc.OnInputRms -= OnInputRms;
         svc.OnCaptureStarted -= OnServiceCaptureStarted;
+        svc.OnCaptureLive -= OnServiceCaptureLive;
         svc.OnTranscriptionProgress -= OnServiceTranscriptionProgress;
         BackgroundRecorder = svc;
         BackgroundPrefix = _accumulatedText;
@@ -594,14 +656,15 @@ public partial class SpeakDialog : Window
         // speech appends onto the edited text rather than the pre-edit transcript.
         _accumulatedText = TranscriptText.Text ?? "";
 
-        // Anchor the new segment's origin BEFORE capture starts; OnServiceCaptureStarted
-        // re-anchors it to the real capture instant once the mic is live.
+        // Anchor the new segment's origin BEFORE capture starts; OnServiceCaptureLive
+        // re-anchors it to the real capture instant once the mic delivers audio.
         _t0 = DateTime.UtcNow;
 
         try
         {
+            // Hold GETTING READY until the resumed mic is actually capturing again.
+            SwitchToConnecting();
             await StartNewServiceAsync();
-            SwitchToRecording();
         }
         catch (Exception ex)
         {
@@ -646,6 +709,7 @@ public partial class SpeakDialog : Window
 
     private void SwitchToTranscribing()
     {
+        _readyTimeout.Stop();
         _stage = Stage.Transcribing;
         StatusLabel.Text = "TRANSCRIBING";
         StatusLabel.Foreground = new SolidColorBrush(Color.FromRgb(0xDC, 0xDC, 0xAA));
@@ -668,6 +732,7 @@ public partial class SpeakDialog : Window
 
     private void SwitchToPaused()
     {
+        _readyTimeout.Stop();
         _stage = Stage.Paused;
         StatusLabel.Text = "PAUSED - reviewing";
         StatusLabel.Foreground = new SolidColorBrush(Color.FromRgb(0xDC, 0xDC, 0xAA));
@@ -692,8 +757,43 @@ public partial class SpeakDialog : Window
         LevelHint.Text = "";
     }
 
+    /// <summary>
+    /// The warm-up state shown from the moment the dialog opens (or a segment resumes /
+    /// the mic is switched) until the microphone actually delivers audio. Yellow
+    /// "GETTING READY", a still timer at zero, and idle gray bars - deliberately NOT the
+    /// red RECORDING look and NO cue, because the mic is not confirmed live yet. Commit
+    /// actions are disabled (there is nothing captured to send); the mic selector stays
+    /// enabled so the user can pick a different device while it warms up. Starts the
+    /// no-audio backstop timer.
+    /// </summary>
+    private void SwitchToConnecting()
+    {
+        _stage = Stage.Connecting;
+        StatusLabel.Text = "GETTING READY";
+        StatusLabel.Foreground = new SolidColorBrush(Color.FromRgb(0xDC, 0xDC, 0xAA));
+        TimerLabel.Text = "0:00.0";
+        TimerLabel.Foreground = new SolidColorBrush(Color.FromRgb(0xDC, 0xDC, 0xAA));
+        TranscriptText.Text = "";
+        TranscriptText.IsReadOnly = true;
+        // Nothing is captured yet, so the commit/checkpoint actions are not actionable.
+        PrimaryButton.IsEnabled = false;
+        StopButton.IsEnabled = false;
+        PauseButton.Content = BuildPauseIcon();
+        PauseButton.IsEnabled = false;
+        MicSelector.IsEnabled = true;
+        // Idle gray bars: the meter must not dance before any audio is flowing.
+        for (int i = 0; i < _barTargets.Length; i++) _barTargets[i] = 8.0;
+        foreach (var bar in _bars) bar.Background = new SolidColorBrush(Color.FromRgb(0x6A, 0x6A, 0x6A));
+        LevelHint.Text = "";
+        _recentPeakRms = 0.0;
+        // Restart the backstop for this warm-up window.
+        _readyTimeout.Stop();
+        _readyTimeout.Start();
+    }
+
     private void SwitchToRecording()
     {
+        _readyTimeout.Stop();
         _stage = Stage.Recording;
         StatusLabel.Text = "RECORDING";
         StatusLabel.Foreground = new SolidColorBrush(Color.FromRgb(0xF4, 0x47, 0x47));


### PR DESCRIPTION
## What this does

Adds an audible + visual "ready" signal to desktop dictation, the way the Windows 11 dictation panel gives a beep and turns blue when it is actually listening. Requested by Soren.

Press Ctrl+H (or Speak). The dialog now opens in a calm yellow **GETTING READY** state and holds there until the microphone actually delivers its **first real audio buffer**. Only at that instant does it:

- flip to red **RECORDING**,
- anchor the timer to that true moment, and
- play a short synthesized **water-drop "bloop"**.

The critical requirement (Soren's): the sound and the red must **never fire before the mic is genuinely capturing**. Previously the dialog flipped to RECORDING the moment `WaveInEvent.StartRecording()` returned - before any audio was flowing. Now both the red and the cue are gated on the first captured audio buffer landing in the recorder, the same instant Windows' own beep lands on.

## How

- `BatchDictationRecorder` raises a new one-shot `OnCaptureLive` event on the first non-empty captured chunk - the honest "mic is live" moment - distinct from `OnCaptureStarted`, which only means the driver was asked to start.
- `DesktopAudioCue` synthesizes the bloop in code (a short rising-pitch sine with a fast exponential decay - the perceptual signature of a droplet) and plays it through NAudio. Best-effort: a missing/busy output device logs and is swallowed, never disrupting the dictation turn. No bundled audio files, so the mobile PWA can reuse the same character next.
- The cue plays on open, on Resume, and after a microphone switch. A six-second backstop fails loud with a "check your microphone" message rather than stranding on GETTING READY if a device never delivers audio.

## Tests

Two new tests assert `OnCaptureLive` fires exactly once on the first real audio buffer and never on an empty buffer, driven through the existing fake-audio-source seam (no real mic, no sound device, no network). Full solution builds with 0 warnings / 0 errors; the dictation recorder test class passes 6/6.

## Notes

Built and verified in an isolated worktree off `origin/main` (the shared working tree was being actively churned by other sessions). Desktop only - mobile PWA is the planned follow-up.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)