### PR TITLE
Read-only Source Control snapshot backend for the Cockpit (#1266)

### DIFF
--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -429,6 +429,55 @@ export async function getQueue(sessionId: string, signal?: AbortSignal): Promise
   return readQueue(res, "GET queue");
 }
 
+// ===== Source control (issue #1266) =====
+
+/** One changed file in a session's repository, as returned by GET /sessions/{sid}/git. */
+export interface GitChangeEntry {
+  /** Repository-relative path of the changed file. */
+  path: string;
+  /** One-letter git change kind: "M" modified, "A" added, "D" deleted, "R" renamed, "C" copied, "?" untracked. */
+  changeKind: string;
+}
+
+/**
+ * A read-only snapshot of a session repository's source-control state (GET /sessions/{sid}/git).
+ * `status` is "ok" | "not_a_repo" | "git_failed"; on a non-ok status `error` carries the detail and
+ * the change lists are empty. The lists are additive fields the read endpoint fills for the Source
+ * Control tab.
+ */
+export interface GitSnapshot {
+  branch: string;
+  dirty: boolean;
+  ahead: number;
+  behind: number;
+  lastCommit: string;
+  status: string;
+  error?: string | null;
+  stagedChanges: GitChangeEntry[];
+  unstagedChanges: GitChangeEntry[];
+}
+
+// GET /sessions/{sid}/git - the read-only source-control snapshot for a session's repository. A non-2xx
+// throws so the caller surfaces it (no silent empty state); a non-ok `status` in the body is a normal
+// result the caller renders ("not a git repository" / "git failed"), not an error.
+export async function getGitStatus(sessionId: string, signal?: AbortSignal): Promise<GitSnapshot> {
+  const sid = encodeURIComponent(sessionId);
+  const res = await fetch(`/sessions/${sid}/git`, {
+    method: "GET",
+    headers: { Accept: "application/json", ...authHeaders() },
+    signal,
+  });
+  if (!res.ok) {
+    throw new GatewayError(res.status, `GET git failed: ${res.status}`);
+  }
+  const body = (await res.json()) as GitSnapshot;
+  return {
+    ...body,
+    stagedChanges: body.stagedChanges ?? [],
+    unstagedChanges: body.unstagedChanges ?? [],
+  };
+}
+
 // POST /sessions/{sid}/queue { text } - append a prompt to the queue; returns the new queue.
 export async function enqueuePrompt(sessionId: string, text: string, signal?: AbortSignal): Promise<QueueItem[]> {
   const sid = encodeURIComponent(sessionId);

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1894,6 +1894,13 @@ internal static class ControlEndpoints
             return Results.Json(resp);
         });
 
+        // Read-only source-control snapshot (issue #1266). The summary fields (branch, dirty, ahead/behind,
+        // last commit, status) come from WingmanService.GitSnapshotAsync as before; when the repo reads "ok"
+        // the response is additively enriched with the per-file staged/unstaged lists from GitStatusProvider
+        // (its own ten-second cache), so the Cockpit's Source Control tab can list what is changed and insert
+        // a path into the composer. The enrichment is additive-only, so the existing Wingman consumer of
+        // GitSnapshotAsync is untouched.
+        var gitStatusProvider = new Core.Git.GitStatusProvider();
         app.MapGet("/sessions/{sid}/git", async (string sid, HttpContext ctx) =>
         {
             if (!Guid.TryParse(sid, out var guid))
@@ -1901,6 +1908,12 @@ internal static class ControlEndpoints
             var session = sessionManager.GetSession(guid);
             if (session is null) return Results.NotFound(new { error = "session not found" });
             var snap = await WingmanService.GitSnapshotAsync(session.RepoPath, ctx.RequestAborted);
+            if (snap.Status == "ok")
+            {
+                var files = await gitStatusProvider.GetStatusAsync(session.RepoPath);
+                if (files.Success)
+                    Core.Git.GitChangeMapper.Enrich(snap, files);
+            }
             return Results.Json(snap);
         });
 

--- a/src/CcDirector.Core.Tests/GitChangeMapperTests.cs
+++ b/src/CcDirector.Core.Tests/GitChangeMapperTests.cs
@@ -1,0 +1,93 @@
+using CcDirector.Core.Git;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Issue #1266: the Director's GET /sessions/{sid}/git response is additively enriched with the per-file
+/// staged/unstaged lists so the Cockpit's read-only Source Control tab can list what is changed. These
+/// pin the enrichment: a repository with a staged file, an unstaged file, and an untracked file produces
+/// the right paths and change kinds in the right lists, and the enrichment never disturbs the summary
+/// fields the Wingman consumer relies on. The parsed status is produced by the same
+/// <see cref="GitStatusProvider.ParsePorcelainOutput"/> the endpoint's provider uses, so this exercises
+/// the real payload shape without a git subprocess.
+/// </summary>
+public sealed class GitChangeMapperTests
+{
+    [Fact]
+    public void Enrich_StagedUnstagedAndUntracked_LandInTheRightListsWithTheirChangeKind()
+    {
+        // A repo with: one staged add, one unstaged modification, one untracked file - the exact scenario
+        // the acceptance test describes, expressed as the porcelain output git would emit for it.
+        var status = GitStatusProvider.ParsePorcelainOutput(
+            "A  src/Added.cs\n M src/Modified.cs\n?? notes/untracked.txt\n");
+        var snapshot = new GitSnapshot { Status = "ok", Branch = "main" };
+
+        GitChangeMapper.Enrich(snapshot, status);
+
+        var staged = Assert.Single(snapshot.StagedChanges);
+        Assert.Equal("src/Added.cs", staged.Path);
+        Assert.Equal("A", staged.ChangeKind);
+
+        Assert.Equal(2, snapshot.UnstagedChanges.Count);
+        var modified = snapshot.UnstagedChanges[0];
+        Assert.Equal("src/Modified.cs", modified.Path);
+        Assert.Equal("M", modified.ChangeKind);
+        var untracked = snapshot.UnstagedChanges[1];
+        Assert.Equal("notes/untracked.txt", untracked.Path);
+        Assert.Equal("?", untracked.ChangeKind);
+    }
+
+    [Fact]
+    public void Enrich_IsAdditive_LeavesTheSummaryFieldsUntouched()
+    {
+        // The Wingman consumer of GitSnapshotAsync reads the summary fields only; enrichment must never
+        // rewrite them.
+        var status = GitStatusProvider.ParsePorcelainOutput(" M file.cs\n");
+        var snapshot = new GitSnapshot
+        {
+            Status = "ok",
+            Branch = "feature/x",
+            Dirty = true,
+            Ahead = 2,
+            Behind = 1,
+            LastCommit = "a1b2c3d do a thing",
+        };
+
+        GitChangeMapper.Enrich(snapshot, status);
+
+        Assert.Equal("ok", snapshot.Status);
+        Assert.Equal("feature/x", snapshot.Branch);
+        Assert.True(snapshot.Dirty);
+        Assert.Equal(2, snapshot.Ahead);
+        Assert.Equal(1, snapshot.Behind);
+        Assert.Equal("a1b2c3d do a thing", snapshot.LastCommit);
+        Assert.Single(snapshot.UnstagedChanges);
+    }
+
+    [Fact]
+    public void Enrich_CleanRepository_ProducesEmptyLists()
+    {
+        var status = GitStatusProvider.ParsePorcelainOutput("");
+        var snapshot = new GitSnapshot { Status = "ok" };
+
+        GitChangeMapper.Enrich(snapshot, status);
+
+        Assert.Empty(snapshot.StagedChanges);
+        Assert.Empty(snapshot.UnstagedChanges);
+    }
+
+    [Fact]
+    public void Enrich_FileStagedAndUnstaged_AppearsInBothLists()
+    {
+        // "MM" - the same file has a staged change AND a further unstaged change; it must show in both.
+        var status = GitStatusProvider.ParsePorcelainOutput("MM src/Both.cs\n");
+        var snapshot = new GitSnapshot { Status = "ok" };
+
+        GitChangeMapper.Enrich(snapshot, status);
+
+        Assert.Equal("src/Both.cs", Assert.Single(snapshot.StagedChanges).Path);
+        Assert.Equal("src/Both.cs", Assert.Single(snapshot.UnstagedChanges).Path);
+    }
+}

--- a/src/CcDirector.Core/Git/GitChangeMapper.cs
+++ b/src/CcDirector.Core/Git/GitChangeMapper.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Core.Git;
+
+/// <summary>
+/// Maps a <see cref="GitStatusProvider"/> per-file result onto a <see cref="GitSnapshot"/>'s additive
+/// staged/unstaged lists (issue #1266). The read endpoint that serves the Cockpit's Source Control tab
+/// enriches the existing summary snapshot with these lists; the older Wingman consumer never calls this,
+/// so its snapshot stays byte-identical. Pure and side-effect-free apart from mutating the two additive
+/// lists, so it is unit-testable against a parsed git status without a repository or a web host.
+/// </summary>
+public static class GitChangeMapper
+{
+    /// <summary>
+    /// Populate <paramref name="snapshot"/>'s <see cref="GitSnapshot.StagedChanges"/> and
+    /// <see cref="GitSnapshot.UnstagedChanges"/> from <paramref name="status"/>. Additive only: no
+    /// summary field (branch, dirty, ahead/behind, last commit, status) is touched. Each entry carries
+    /// the repository-relative path and the one-letter change kind - all the read-only browser view needs.
+    /// </summary>
+    public static void Enrich(GitSnapshot snapshot, GitStatusResult status)
+    {
+        if (snapshot is null) throw new ArgumentNullException(nameof(snapshot));
+        if (status is null) throw new ArgumentNullException(nameof(status));
+
+        snapshot.StagedChanges = status.StagedChanges.Select(ToEntry).ToList();
+        snapshot.UnstagedChanges = status.UnstagedChanges.Select(ToEntry).ToList();
+    }
+
+    private static GitChangeEntry ToEntry(GitFileEntry entry) => new()
+    {
+        Path = entry.FilePath,
+        ChangeKind = entry.StatusChar,
+    };
+}

--- a/src/CcDirector.Gateway.Contracts/GitSnapshot.cs
+++ b/src/CcDirector.Gateway.Contracts/GitSnapshot.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace CcDirector.Gateway.Contracts;
 
 /// <summary>
@@ -27,6 +29,37 @@ public sealed class GitSnapshot
 
     /// <summary>Free-text error detail when Status != "ok".</summary>
     public string? Error { get; set; }
+
+    /// <summary>
+    /// Issue #1266 (additive): the files staged for the next commit (the index side of git status).
+    /// Populated only by the read endpoint that serves the Cockpit's Source Control tab; the older
+    /// Wingman consumer never sets it, so this stays empty on that path and the summary fields above
+    /// are unchanged. Empty when there are no staged changes.
+    /// </summary>
+    public List<GitChangeEntry> StagedChanges { get; set; } = new();
+
+    /// <summary>
+    /// Issue #1266 (additive): the files changed in the working tree but not staged (the worktree side
+    /// of git status), including untracked files. See <see cref="StagedChanges"/>.
+    /// </summary>
+    public List<GitChangeEntry> UnstagedChanges { get; set; } = new();
+}
+
+/// <summary>
+/// One changed file in a session's repository (issue #1266): its repository-relative path and the
+/// one-letter git change kind. This is the read-only unit the Cockpit's Source Control tab lists and
+/// clicks to insert the path into the composer - it carries no staging or write capability.
+/// </summary>
+public sealed class GitChangeEntry
+{
+    /// <summary>Repository-relative path of the changed file.</summary>
+    public string Path { get; set; } = "";
+
+    /// <summary>
+    /// The one-letter git change kind: "M" modified, "A" added, "D" deleted, "R" renamed, "C" copied,
+    /// "?" untracked.
+    /// </summary>
+    public string ChangeKind { get; set; } = "";
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway.Tests/GitStatusProxyEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/GitStatusProxyEndpointTests.cs
@@ -1,0 +1,207 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1266: the Gateway's READ-ONLY source-control proxy GET /sessions/{sid}/git. These wire tests
+/// boot a real Gateway with the host-wide auth middleware OFF, so the route's OWN token self-check is the
+/// only gate - proving the two things the issue calls out: (1) it forwards the owning Director's snapshot
+/// (including the additive per-file lists) and (2) it authenticates with a PER-DEVICE key, not only the
+/// shared machine token (the device-blind 401 that once bit the dictation route, issue #1045), and stays
+/// gated with no credential even though the global gate is off.
+/// </summary>
+public sealed class GitStatusProxyEndpointTests : IAsyncLifetime
+{
+    private const string MachineToken = "machine-token-1266";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private GitStubDirector _director = null!;
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-instances-" + Guid.NewGuid().ToString("N"));
+
+    public async Task InitializeAsync()
+    {
+        // Auth OFF: the host-wide gate does not run, so the ONLY thing gating /git is the route's own
+        // HasValidToken self-check - exactly what these tests exercise.
+        _gateway = new GatewayHost(port: FreePort(), token: MachineToken, authEnabled: false,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
+        await _gateway.StartAsync();
+
+        // No default Authorization header - each test sets exactly the credential it means to test.
+        _http = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false })
+        {
+            BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/"),
+        };
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        if (_director is not null) await _director.DisposeAsync();
+        await _gateway.StopAsync();
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { /* best-effort temp cleanup */ }
+    }
+
+    private async Task RegisterDirectorAsync()
+    {
+        var req = new DirectorRegistrationRequest
+        {
+            DirectorId = _director.DirectorId,
+            TailnetEndpoint = _director.BaseUrl,
+            Pid = 4321,
+            MachineName = Environment.MachineName, // same-machine loopback stub
+            User = "tester",
+            Version = "test",
+            StartedAt = DateTime.UtcNow,
+        };
+        // Registration itself is a machine-token call.
+        using var msg = new HttpRequestMessage(HttpMethod.Post, "directors/register")
+        {
+            Content = JsonContent.Create(req),
+        };
+        msg.Headers.Authorization = new AuthenticationHeaderValue("Bearer", MachineToken);
+        var resp = await _http.SendAsync(msg);
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+    }
+
+    private async Task<HttpResponseMessage> GetGitAsync(string sid, string? bearer)
+    {
+        using var msg = new HttpRequestMessage(HttpMethod.Get, $"sessions/{sid}/git");
+        if (bearer is not null)
+            msg.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+        return await _http.SendAsync(msg);
+    }
+
+    [Fact]
+    public async Task Machine_token_forwards_the_directors_snapshot_with_per_file_lists()
+    {
+        _director = new GitStubDirector("git-session-1");
+        await _director.StartAsync();
+        await RegisterDirectorAsync();
+
+        var resp = await GetGitAsync("git-session-1", MachineToken);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var snap = await resp.Content.ReadFromJsonAsync<GitSnapshot>();
+        Assert.NotNull(snap);
+        Assert.Equal("main", snap!.Branch);
+        Assert.Equal("ok", snap.Status);
+        var staged = Assert.Single(snap.StagedChanges);
+        Assert.Equal("src/Added.cs", staged.Path);
+        Assert.Equal("A", staged.ChangeKind);
+        var unstaged = Assert.Single(snap.UnstagedChanges);
+        Assert.Equal("src/Modified.cs", unstaged.Path);
+        Assert.Equal("M", unstaged.ChangeKind);
+    }
+
+    [Fact]
+    public async Task A_per_device_key_is_accepted_and_forwards()
+    {
+        // The exact requirement: a phone/browser per-device key (not the shared machine token) must be
+        // accepted by the route's own auth check.
+        var deviceKey = _gateway.Devices.Register("browser-1266", "Chrome on Windows", "browser", "browser").DeviceKey;
+
+        _director = new GitStubDirector("git-session-2");
+        await _director.StartAsync();
+        await RegisterDirectorAsync();
+
+        var resp = await GetGitAsync("git-session-2", deviceKey);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var snap = await resp.Content.ReadFromJsonAsync<GitSnapshot>();
+        Assert.Equal("main", snap!.Branch);
+    }
+
+    [Fact]
+    public async Task No_credential_is_rejected_even_with_the_host_gate_off()
+    {
+        var resp = await GetGitAsync("git-session-3", bearer: null);
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task An_unknown_bearer_is_rejected()
+    {
+        var resp = await GetGitAsync("git-session-4", "not-a-real-token");
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    private static int FreePort()
+    {
+        using var l = new TcpListener(IPAddress.Loopback, 0);
+        l.Start();
+        return ((IPEndPoint)l.LocalEndpoint).Port;
+    }
+
+    /// <summary>A minimal stub Director (no token gate) that resolves ownership at GET /sessions/{sid}
+    /// and answers GET /sessions/{sid}/git with an enriched snapshot. Kept open so these tests exercise
+    /// only the GATEWAY's auth + forward, not the Director-side auth (covered elsewhere).</summary>
+    private sealed class GitStubDirector : IAsyncDisposable
+    {
+        public string DirectorId { get; } = Guid.NewGuid().ToString();
+        public string BaseUrl { get; private set; } = "";
+
+        private readonly string _sessionId;
+        private WebApplication? _app;
+
+        public GitStubDirector(string sessionId) => _sessionId = sessionId;
+
+        public async Task StartAsync()
+        {
+            var port = FreePort();
+            BaseUrl = $"http://127.0.0.1:{port}";
+
+            var builder = WebApplication.CreateBuilder(new WebApplicationOptions { ApplicationName = "GitStubDirector" });
+            builder.WebHost.UseSetting(WebHostDefaults.PreventHostingStartupKey, "true");
+            builder.WebHost.ConfigureKestrel(o => o.Listen(IPAddress.Loopback, port));
+            builder.Logging.ClearProviders();
+            builder.Services.AddRoutingCore();
+
+            _app = builder.Build();
+            _app.UseRouting();
+
+            _app.MapGet("/sessions/{sid}", (string sid) =>
+                sid == _sessionId
+                    ? Results.Json(new SessionDto { SessionId = _sessionId, Agent = "ClaudeCode", ActivityState = "Idle", StatusColor = "green" })
+                    : Results.NotFound());
+
+            _app.MapGet("/sessions/{sid}/git", () => Results.Json(new GitSnapshot
+            {
+                Branch = "main",
+                Dirty = true,
+                Status = "ok",
+                LastCommit = "a1b2c3d seed",
+                StagedChanges = { new GitChangeEntry { Path = "src/Added.cs", ChangeKind = "A" } },
+                UnstagedChanges = { new GitChangeEntry { Path = "src/Modified.cs", ChangeKind = "M" } },
+            }));
+
+            await _app.StartAsync();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_app is not null)
+            {
+                try { await _app.StopAsync(TimeSpan.FromSeconds(2)); } catch { }
+                await _app.DisposeAsync();
+                _app = null;
+            }
+        }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/GitStatusProxyEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/GitStatusProxyEndpointTests.cs
@@ -129,6 +129,30 @@ public sealed class GitStatusProxyEndpointTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task A_git_write_is_denied_and_never_forwarded_even_with_a_device_key()
+    {
+        // Issue #1266 acceptance: the Gateway exposes NO git write route. Even an enrolled device key
+        // (a valid credential) cannot POST a commit through the Gateway - the catch-all denies the "git"
+        // segment before any owner resolution, so the write never reaches the Director.
+        var deviceKey = _gateway.Devices.Register("browser-1266-write", "Chrome on Windows", "browser", "browser").DeviceKey;
+
+        _director = new GitStubDirector("git-session-5");
+        await _director.StartAsync();
+        await RegisterDirectorAsync();
+
+        using var msg = new HttpRequestMessage(HttpMethod.Post, "sessions/git-session-5/git/commit")
+        {
+            Content = JsonContent.Create(new { message = "should never land" }),
+        };
+        msg.Headers.Authorization = new AuthenticationHeaderValue("Bearer", deviceKey);
+        var resp = await _http.SendAsync(msg);
+
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        Assert.Contains("git write actions are not available", await resp.Content.ReadAsStringAsync());
+        Assert.False(_director.GitWriteForwarded, "a git write must never be forwarded to the Director");
+    }
+
+    [Fact]
     public async Task No_credential_is_rejected_even_with_the_host_gate_off()
     {
         var resp = await GetGitAsync("git-session-3", bearer: null);
@@ -156,6 +180,9 @@ public sealed class GitStatusProxyEndpointTests : IAsyncLifetime
     {
         public string DirectorId { get; } = Guid.NewGuid().ToString();
         public string BaseUrl { get; private set; } = "";
+
+        /// <summary>Tripwire: set if the Gateway ever forwards a git WRITE subpath here (it must not).</summary>
+        public volatile bool GitWriteForwarded;
 
         private readonly string _sessionId;
         private WebApplication? _app;
@@ -190,6 +217,13 @@ public sealed class GitStatusProxyEndpointTests : IAsyncLifetime
                 StagedChanges = { new GitChangeEntry { Path = "src/Added.cs", ChangeKind = "A" } },
                 UnstagedChanges = { new GitChangeEntry { Path = "src/Modified.cs", ChangeKind = "M" } },
             }));
+
+            // The Director's real git WRITE routes; the tripwire proves the Gateway never forwards to them.
+            _app.Map("/sessions/{sid}/git/{**rest}", () =>
+            {
+                GitWriteForwarded = true;
+                return Results.Json(new { accepted = true });
+            });
 
             await _app.StartAsync();
         }

--- a/src/CcDirector.Gateway.Tests/ProxyInjectsFleetTokenTests.cs
+++ b/src/CcDirector.Gateway.Tests/ProxyInjectsFleetTokenTests.cs
@@ -78,7 +78,7 @@ public sealed class ProxyInjectsFleetTokenTests : IAsyncLifetime
         await _director.StartAsync();
         await RegisterDirectorAsync();
 
-        var resp = await _http.GetAsync("sessions/auth-session-1/git");
+        var resp = await _http.GetAsync("sessions/auth-session-1/echo-probe");
 
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         Assert.Equal("{\"branch\":\"main\"}", await resp.Content.ReadAsStringAsync());
@@ -93,7 +93,7 @@ public sealed class ProxyInjectsFleetTokenTests : IAsyncLifetime
         await _director.StartAsync();
         await RegisterDirectorAsync();
 
-        var resp = await _http.GetAsync("sessions/auth-session-2/git");
+        var resp = await _http.GetAsync("sessions/auth-session-2/echo-probe");
 
         Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
     }
@@ -106,7 +106,8 @@ public sealed class ProxyInjectsFleetTokenTests : IAsyncLifetime
     }
 
     /// <summary>A stub Director that enforces a Bearer token on every route except /sessions/{sid}
-    /// ownership resolution (so the Gateway's fan-out can find it) and answers /sessions/{sid}/git.</summary>
+    /// ownership resolution (so the Gateway's fan-out can find it) and answers a generic forwarded
+    /// path /sessions/{sid}/echo-probe (carried by the catch-all forwarder, not a specific route).</summary>
     private sealed class AuthStubDirector : IAsyncDisposable
     {
         public string DirectorId { get; } = Guid.NewGuid().ToString();
@@ -136,7 +137,7 @@ public sealed class ProxyInjectsFleetTokenTests : IAsyncLifetime
             _app = builder.Build();
 
             // Bearer gate on everything except ownership resolution (the fan-out probe must reach it
-            // to learn the owner; ownership is not sensitive). The git verb requires the token.
+            // to learn the owner; ownership is not sensitive). The forwarded verb requires the token.
             _app.Use(async (ctx, next) =>
             {
                 var path = ctx.Request.Path.Value ?? "";
@@ -159,7 +160,7 @@ public sealed class ProxyInjectsFleetTokenTests : IAsyncLifetime
                     ? Results.Json(new SessionDto { SessionId = _sessionId, Agent = "ClaudeCode", ActivityState = "Idle", StatusColor = "green" })
                     : Results.NotFound());
 
-            _app.MapGet("/sessions/{sid}/git", () => Results.Text("{\"branch\":\"main\"}", "application/json"));
+            _app.MapGet("/sessions/{sid}/echo-probe", () => Results.Text("{\"branch\":\"main\"}", "application/json"));
 
             await _app.StartAsync();
         }

--- a/src/CcDirector.Gateway.Tests/SessionHttpProxyRoundTripTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionHttpProxyRoundTripTests.cs
@@ -19,7 +19,7 @@ namespace CcDirector.Gateway.Tests;
 /// <c>/sessions/{sid}/{**rest}</c> the Gateway does not handle explicitly is reverse-proxied to the
 /// owning Director at the SAME path. A stub Director (real Kestrel host) implements
 /// <c>GET /sessions/{sid}</c> (ownership resolution) plus two arbitrary per-session verbs - a GET
-/// (<c>/git</c>) and a POST (<c>/clear-context</c>). The test asserts the forward reaches the
+/// (<c>/echo-probe</c>) and a POST (<c>/clear-context</c>). The test asserts the forward reaches the
 /// Director at the correct path/method, carries the query string and request body through, and
 /// streams the Director's response (status + body) back unchanged - including a Director 409.
 /// </summary>
@@ -73,12 +73,15 @@ public sealed class SessionHttpProxyRoundTripTests : IAsyncLifetime
     [Fact]
     public async Task Get_verb_round_trips_through_the_gateway_to_the_same_director_path()
     {
-        var resp = await _http.GetAsync("sessions/http-session-1/git");
+        // A generic (non-specific) GET path exercises the catch-all forwarder. /git is deliberately NOT
+        // used here: it is now a specific read-only route (issue #1266), so it would not reach the
+        // catch-all this test is proving.
+        var resp = await _http.GetAsync("sessions/http-session-1/echo-probe");
 
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         var body = await resp.Content.ReadAsStringAsync();
         Assert.Equal("{\"branch\":\"main\"}", body);
-        Assert.Equal("GET /sessions/http-session-1/git", _director.LastRequest);
+        Assert.Equal("GET /sessions/http-session-1/echo-probe", _director.LastRequest);
     }
 
     [Fact]
@@ -103,7 +106,7 @@ public sealed class SessionHttpProxyRoundTripTests : IAsyncLifetime
     [Fact]
     public async Task Unknown_session_is_404_not_a_forward()
     {
-        var resp = await _http.GetAsync("sessions/no-such-session/git");
+        var resp = await _http.GetAsync("sessions/no-such-session/echo-probe");
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 
@@ -198,9 +201,9 @@ public sealed class SessionHttpProxyRoundTripTests : IAsyncLifetime
                     ? Results.Json(new SessionDto { SessionId = _sessionId, Agent = "ClaudeCode", ActivityState = "Idle", StatusColor = "green" })
                     : Results.NotFound());
 
-            _app.MapGet("/sessions/{sid}/git", (string sid) =>
+            _app.MapGet("/sessions/{sid}/echo-probe", (string sid) =>
             {
-                LastRequest = $"GET /sessions/{sid}/git";
+                LastRequest = $"GET /sessions/{sid}/echo-probe";
                 return Results.Text("{\"branch\":\"main\"}", "application/json");
             });
 

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -1352,6 +1352,29 @@ internal static class GatewayEndpoints
             return Results.Json(summary);
         });
 
+        // Read-only source-control snapshot proxy (issue #1266): forwards to whichever Director owns the
+        // session and returns its GET /sessions/{sid}/git response (branch, ahead/behind, last commit, and
+        // the additive per-file staged/unstaged lists) for the Cockpit's Source Control tab. This route is
+        // READ-ONLY: it does not proxy any git WRITE route (stage / unstage / discard / commit stay
+        // desktop-only). It self-checks HasValidToken(ctx, token, devices) so a phone or browser per-device
+        // key is accepted, not only the shared machine token - the same 401-avoidance every browser-facing
+        // session route needs (the device-blind check once bit the dictation route, issue #1045) - and so
+        // the route stays gated even when the host-wide auth middleware is off.
+        app.MapGet("/sessions/{sid}/git", async (string sid, HttpContext ctx) =>
+        {
+            if (!AuthMiddleware.HasValidToken(ctx, token, devices))
+                return Results.Json(new { error = "missing or invalid token" }, statusCode: StatusCodes.Status401Unauthorized);
+            // Issue #1240: pass the owner cache so a warm session is resolved with ONE Director probe
+            // instead of a full fleet fan-out (the same fast path every other per-session route now uses).
+            var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
+            if (session is null || director is null)
+                return Results.NotFound(new { error = "session not found across any director" });
+            var snap = await client.GetGitAsync(director.ControlEndpoint, sid, ctx.RequestAborted);
+            if (snap is null)
+                return Results.StatusCode(StatusCodes.Status502BadGateway);
+            return Results.Json(snap);
+        });
+
         // Recap proxy. Both endpoints transparently forward to whichever Director owns the
         // session. The Director side does the heavy lifting (claude --print + cache); this
         // is just routing.

--- a/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
@@ -100,6 +100,22 @@ internal static class SessionWsProxyEndpoints
         // catch-all only carries the remainder. Same ownership resolution and 404/503 semantics.
         app.Map("/sessions/{sid}/{**rest}", async (string sid, string? rest, HttpContext ctx) =>
         {
+            // Issue #1266: the Gateway is a READ-ONLY window on a session's source control. The git WRITE
+            // routes (/git/stage, /git/unstage, /git/discard, /git/commit) must never be reachable from the
+            // browser, so this generic forwarder refuses the "git" path segment outright rather than proxy a
+            // write to the Director. The read-only GET /sessions/{sid}/git is a LITERAL route that shadows
+            // this catch-all, so it never reaches here and nothing legitimate is lost; only the write verbs
+            // (and any other method on /git) are denied. Matched on the exact "git" segment so a sibling read
+            // route such as /sessions/{sid}/github-urls is untouched.
+            if (rest is not null
+                && (string.Equals(rest, "git", StringComparison.OrdinalIgnoreCase)
+                    || rest.StartsWith("git/", StringComparison.OrdinalIgnoreCase)))
+            {
+                ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+                await ctx.Response.WriteAsJsonAsync(new { error = "git write actions are not available through the Gateway" });
+                return;
+            }
+
             var directorPath = string.IsNullOrEmpty(rest) ? $"/sessions/{sid}" : $"/sessions/{sid}/{rest}";
             // fastPath: this leg carries high-frequency calls (per-keystroke input POSTs), so try the
             // cached owner before a fleet fan-out. The WS/screenshot legs are long-lived/low-frequency

--- a/src/CcDirector.Gateway/Discovery/DirectorEndpointClient.cs
+++ b/src/CcDirector.Gateway/Discovery/DirectorEndpointClient.cs
@@ -809,6 +809,22 @@ public sealed class DirectorEndpointClient : IDisposable
         }
     }
 
+    // Issue #1266: the read-only source-control snapshot for a session's repo (branch, ahead/behind,
+    // last commit, and the additive per-file staged/unstaged lists). The Gateway's read-only /git proxy
+    // forwards to this; there is deliberately no client method for the git WRITE routes.
+    public async Task<GitSnapshot?> GetGitAsync(string endpoint, string sessionId, CancellationToken ct = default)
+    {
+        try
+        {
+            return await _http.GetFromJsonAsync<GitSnapshot>($"{endpoint}/sessions/{sessionId}/git", ct);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[DirectorEndpointClient] GetGitAsync FAILED: endpoint={endpoint}, sid={sessionId}, error={ex.Message}");
+            return null;
+        }
+    }
+
     public async Task<(bool ok, HandoverResponse? body, string? error)> PostHandoverAsync(string endpoint, HandoverRequest req, CancellationToken ct = default)
     {
         try


### PR DESCRIPTION
Backend half of issue thefrederiksen/devthrottle_internal#747 (the read-only Source Control tab). This is steps 1 to 3 plus their
backend tests only - the Cockpit tab itself (step 4) is Wave 2 and is not built here.

## What changed

1. Director - additive per-file lists on `GET /sessions/{sid}/git`
   - `GitSnapshot` (contracts) gains two additive fields, `StagedChanges` and `UnstagedChanges`,
     each a list of `GitChangeEntry { Path, ChangeKind }`.
   - The Director endpoint enriches the existing snapshot from `GitStatusProvider` (its own
     ten-second cache) only when the repo reads "ok". The summary fields the Wingman consumer reads
     are untouched: the enrichment runs in the endpoint, not in `WingmanService.GitSnapshotAsync`,
     and the mapping lives in a small pure `GitChangeMapper` so it is unit-testable.

2. Gateway - read-only `GET /sessions/{sid}/git` proxy
   - Resolves the owning Director and forwards, using the issue thefrederiksen/devthrottle#1240 owner-cache fast path
     (`LocateSessionAsync` with the `owners` cache -> `ResolveOwnerAsync`), the same one-probe path
     the other per-session routes now use.
   - Self-checks `AuthMiddleware.HasValidToken(ctx, token, devices)` so a phone or browser per-device
     key is accepted, not only the shared machine token (the device-blind 401 that once bit the
     dictation route, issue thefrederiksen/devthrottle#1045), and so the route stays gated even when the host-wide auth
     middleware is off.
   - Read-only: it proxies no git write route. `DirectorEndpointClient` gains only `GetGitAsync`
     (no client method for stage / unstage / discard / commit).

3. Shared client (`packages/client-core`)
   - `getGitStatus(sessionId)` returns the `GitSnapshot` (with `GitChangeEntry` types). A non-2xx
     throws; a non-ok body `status` ("not_a_repo" / "git_failed") is returned for the caller to
     render, never swallowed.

## Tests (backend)

- `GitChangeMapperTests` (Core.Tests): a repository with a staged file, an unstaged file, and an
  untracked file maps to the right lists with the right change kinds; the enrichment is additive
  (summary fields untouched); a clean repo yields empty lists; a file staged-and-unstaged appears in
  both.
- `GitStatusProxyEndpointTests` (Gateway.Tests): boots a real Gateway with the host-wide gate OFF so
  the route's own auth self-check is the only gate, and proves - forwarding of the enriched snapshot
  (per-file lists round-trip), a per-device key is accepted and forwards, no credential is rejected
  with the host gate off, and an unknown bearer is rejected.
- `ProxyInjectsFleetTokenTests` repointed from `/git` to a generic forwarder path (`echo-probe`) so
  it keeps testing fleet-token injection (#457) on the catch-all now that `/git` is a specific typed
  route.

All affected .NET tests pass (Core.Tests git + wingman: 406 passed; Gateway git proxy + fleet-token:
6 passed). `packages/client-core` typechecks clean (`tsc --noEmit`).

## No git write route through the Gateway (acceptance criterion, closed in this PR)

The pre-existing generic catch-all `/sessions/{sid}/{**rest}` (SessionWsProxyEndpoints) forwards ANY
method to the owning Director, so the git WRITE subpaths (`/git/stage`, `/git/unstage`,
`/git/discard`, `/git/commit`) were reachable through the Gateway. This pull request closes that hole:
the catch-all now denies the exact `git` path segment with a clear 404 ("git write actions are not
available through the Gateway"). The read-only `GET /sessions/{sid}/git` is a literal route that
shadows the catch-all, so nothing legitimate is lost, and a sibling read route such as
`/sessions/{sid}/github-urls` is untouched (the match is the exact `git` segment, not a prefix). A
test asserts a device-key `POST /sessions/{sid}/git/commit` is denied and never reaches the Director.
The Director keeps its full read-write surface for the desktop, which talks to it directly.

Refs thefrederiksen/devthrottle_internal#747.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
