### PR TITLE
fix(cockpit): stop the prompt queue losing text on a failed Pop or Save (#1252)

### DIFF
--- a/apps/cockpit/package.json
+++ b/apps/cockpit/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@devthrottle/client-core": "*",
@@ -22,6 +23,7 @@
     "@types/react-dom": "18.3.1",
     "@vitejs/plugin-react": "4.3.4",
     "typescript": "5.7.2",
-    "vite": "6.0.3"
+    "vite": "6.0.3",
+    "vitest": "2.1.8"
   }
 }

--- a/apps/cockpit/src/sessions/QueuePanel.tsx
+++ b/apps/cockpit/src/sessions/QueuePanel.tsx
@@ -10,6 +10,7 @@ import {
   type QueueItem,
 } from "@devthrottle/client-core/api/client";
 import { ConfirmDialog } from "../components";
+import { confirmThenApply } from "./queueActions";
 
 // The prompt queue panel (issue #972) - the React port of the Blazor Cockpit queue tab. Every verb
 // goes to the owning Director through the Gateway and returns the authoritative queue, so the list is
@@ -33,15 +34,20 @@ export function QueuePanel({ sessionId, queue, onQueue, onPop }: QueuePanelProps
   // (issue #1244) rather than firing on the first click.
   const [confirmClear, setConfirmClear] = useState(false);
 
+  // Runs a queue verb and replaces the list from the authoritative response. Returns true on success,
+  // false on failure (the guard, a caught error) so callers can gate a local side effect on the server
+  // actually having confirmed the change (issue #1252).
   const run = useCallback(
-    async (verb: () => Promise<QueueItem[]>) => {
-      if (!sessionId || busy) return;
+    async (verb: () => Promise<QueueItem[]>): Promise<boolean> => {
+      if (!sessionId || busy) return false;
       setBusy(true);
       setError(null);
       try {
         onQueue(await verb());
+        return true;
       } catch (err) {
         setError(gatewayErrorMessage(err));
+        return false;
       } finally {
         setBusy(false);
       }
@@ -51,18 +57,29 @@ export function QueuePanel({ sessionId, queue, onQueue, onPop }: QueuePanelProps
 
   const saveEdit = useCallback(
     async (itemId: string) => {
-      const text = editingText;
-      setEditingId(null);
-      setEditingText("");
-      if (sessionId) await run(() => editQueueItem(sessionId, itemId, text));
+      if (!sessionId) return;
+      // Keep the edit box open with the typed text until the server confirms the save; only then tear
+      // it down. A failed save leaves the text in the box with an error shown - it is never discarded.
+      await confirmThenApply(
+        () => run(() => editQueueItem(sessionId, itemId, editingText)),
+        () => {
+          setEditingId(null);
+          setEditingText("");
+        },
+      );
     },
     [sessionId, editingText, run],
   );
 
   const pop = useCallback(
     async (itemId: string, text: string) => {
-      onPop(text);
-      if (sessionId) await run(() => deleteQueueItem(sessionId, itemId));
+      if (!sessionId) return;
+      // Delete on the server first; only paste the text into the composer once the item is actually
+      // gone from the queue. A failed delete leaves the queue untouched and pastes nothing.
+      await confirmThenApply(
+        () => run(() => deleteQueueItem(sessionId, itemId)),
+        () => onPop(text),
+      );
     },
     [sessionId, onPop, run],
   );

--- a/apps/cockpit/src/sessions/queueActions.test.ts
+++ b/apps/cockpit/src/sessions/queueActions.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { confirmThenApply } from "./queueActions";
+
+// Regression tests for issue #1252: the prompt queue lost user text when the server call failed because
+// the local side effect (Pop pasting into the composer, Save tearing down the edit box) ran BEFORE the
+// server verb confirmed. confirmThenApply pins the fixed order: the side effect fires only after, and
+// only if, the server verb succeeds.
+describe("confirmThenApply", () => {
+  it("applies the side effect when the verb succeeds", async () => {
+    const applyOnSuccess = vi.fn();
+
+    const result = await confirmThenApply(() => Promise.resolve(true), applyOnSuccess);
+
+    expect(result).toBe(true);
+    expect(applyOnSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT apply the side effect when the verb fails - text is never lost", async () => {
+    const applyOnSuccess = vi.fn();
+
+    const result = await confirmThenApply(() => Promise.resolve(false), applyOnSuccess);
+
+    expect(result).toBe(false);
+    expect(applyOnSuccess).not.toHaveBeenCalled();
+  });
+
+  it("waits for the verb to resolve before applying the side effect (never optimistic)", async () => {
+    const order: string[] = [];
+    const runVerb = () =>
+      new Promise<boolean>((resolve) => {
+        order.push("verb-start");
+        // Resolve on a later microtask so an optimistic (pre-await) side effect would be observable.
+        Promise.resolve().then(() => {
+          order.push("verb-resolved");
+          resolve(true);
+        });
+      });
+    const applyOnSuccess = () => order.push("apply");
+
+    await confirmThenApply(runVerb, applyOnSuccess);
+
+    expect(order).toEqual(["verb-start", "verb-resolved", "apply"]);
+  });
+});

--- a/apps/cockpit/src/sessions/queueActions.ts
+++ b/apps/cockpit/src/sessions/queueActions.ts
@@ -1,0 +1,23 @@
+// Server-confirm-then-apply sequencing for the prompt queue (issue #1252).
+//
+// The prompt queue must never lose user text when the server call fails. The rule is: run the server
+// verb first, and apply the local side effect (paste-into-composer for Pop, tear-down-the-edit-box for
+// Save) ONLY after the verb has confirmed success. The old code applied the side effect first and then
+// called the server, so a failed call left the item both pasted into the composer AND still queued
+// (Pop), or discarded the typed edit while only showing an error banner (Save).
+
+/**
+ * Run a server verb, then apply a local side effect only when the verb succeeded.
+ *
+ * `runVerb` must resolve to true on success and false on failure (it reports its own errors and never
+ * throws). `applyOnSuccess` runs after, and only if, the verb resolved true. Returns the verb's result
+ * so callers can branch further if they need to.
+ */
+export async function confirmThenApply(
+  runVerb: () => Promise<boolean>,
+  applyOnSuccess: () => void,
+): Promise<boolean> {
+  const ok = await runVerb();
+  if (ok) applyOnSuccess();
+  return ok;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "@types/react-dom": "18.3.1",
         "@vitejs/plugin-react": "4.3.4",
         "typescript": "5.7.2",
-        "vite": "6.0.3"
+        "vite": "6.0.3",
+        "vitest": "2.1.8"
       }
     },
     "apps/mobile": {


### PR DESCRIPTION
Fixes #1252.

## Problem

The prompt queue applied changes locally before the server confirmed, so a failed Gateway call lost the user's text (`apps/cockpit/src/sessions/QueuePanel.tsx`):

1. **Pop** pasted the item into the composer BEFORE the delete round-tripped. A failed delete left the item both pasted into the composer and still in the queue - the next Pop duplicated it.
2. **Save** tore down the edit box BEFORE the save resolved. A failed save discarded the typed edit with only an error banner - the user's text was gone.

## Fix - server-confirm-then-apply, in both places

- `run()` now reports success (returns `true`/`false`) instead of swallowing the outcome.
- A new pure helper `confirmThenApply(runVerb, applyOnSuccess)` runs the local side effect only after, and only if, the server verb resolves successfully.
- **Pop** awaits the delete first; it pastes into the composer only on success. On failure the queue is left untouched and nothing is pasted.
- **Save** keeps the edit box open with the typed text; it tears the box down only on a successful save. On failure the text stays in the box with an error shown.

The #1244 shared `ConfirmDialog` routing for Clear queue is preserved untouched.

## Tests

New `apps/cockpit/src/sessions/queueActions.test.ts` pins the fixed ordering with three regression tests:
- side effect applied when the verb succeeds,
- side effect NOT applied when the verb fails (text never lost),
- side effect waits for the verb to resolve (never optimistic).

A `test` script (`vitest run`) is added to the cockpit workspace.

## Proof (matches acceptance criteria)

Run in an isolated worktree off `origin/main`:

```
> @devthrottle/cockpit typecheck  (tsc --noEmit)   -> clean
> @devthrottle/cockpit test       (vitest run)     -> 1 file, 3 passed
> @devthrottle/cockpit build      (tsc && vite)    -> built in 1.60s
```

Acceptance:
- Gateway down, Pop: `run()` returns `false`, so `onPop` is never called - the composer does not receive the text, the item stays queued, the error banner shows.
- Gateway down, Save: `run()` returns `false`, so the teardown never fires - the typed text stays in the edit box, the error banner shows.
- Gateway healthy: both verbs resolve `true`, so behaviour is exactly as before.