### PR TITLE
fix(cockpit): confirm, re-sync, and image fallback for screenshot delete (#1254)

### DIFF
--- a/apps/cockpit/src/sessions/ScreenshotsPanel.tsx
+++ b/apps/cockpit/src/sessions/ScreenshotsPanel.tsx
@@ -6,6 +6,12 @@ import {
   gatewayErrorMessage,
   type ScreenshotInfo,
 } from "@devthrottle/client-core/api/client";
+import {
+  NO_BROKEN_IMAGES,
+  isImageBroken,
+  markImageBroken,
+  type BrokenImageSet,
+} from "@devthrottle/client-core/sessions/screenshotGallery";
 import { ConfirmDialog } from "../components";
 
 // The screenshots gallery panel (issue #972) - the React port of the Blazor Cockpit screenshots tab.
@@ -38,6 +44,10 @@ export function ScreenshotsPanel({ sessionId, onInsert }: ScreenshotsPanelProps)
   // Deleting a screenshot removes the file from the Director's disk, so it asks through the shared
   // ConfirmDialog (issue #1244); this holds the file name awaiting confirmation.
   const [pendingDelete, setPendingDelete] = useState<string | null>(null);
+  // Thumbnails whose bytes failed to load (the file vanished on disk). These render the "image
+  // unavailable" placeholder instead of the browser's broken-image glyph (issue #1254). A fresh
+  // list load clears this back to NO_BROKEN_IMAGES so a re-appeared file gets a fresh chance.
+  const [brokenImages, setBrokenImages] = useState<BrokenImageSet>(NO_BROKEN_IMAGES);
 
   const load = useCallback(
     async (signal?: AbortSignal) => {
@@ -49,6 +59,7 @@ export function ScreenshotsPanel({ sessionId, onInsert }: ScreenshotsPanelProps)
         setShots(result.items);
         setTotal(result.total > 0 ? result.total : result.items.length);
         setShown(INITIAL_SHOWN);
+        setBrokenImages(NO_BROKEN_IMAGES);
         setLoadedOnce(true);
       } catch (err) {
         if (signal?.aborted) return;
@@ -65,21 +76,23 @@ export function ScreenshotsPanel({ sessionId, onInsert }: ScreenshotsPanelProps)
     const controller = new AbortController();
     setShots([]);
     setTotal(0);
+    setBrokenImages(NO_BROKEN_IMAGES);
     setLoadedOnce(false);
     void load(controller.signal);
     return () => controller.abort();
   }, [load]);
 
   // The actual delete, run once the ConfirmDialog is confirmed. A failure is left to throw so the
-  // dialog surfaces it (fail loudly); on success the row drops from the gallery.
+  // dialog surfaces it (fail loudly) and the list is never touched. On success the gallery is
+  // re-synchronized from the Director's disk with a re-fetch rather than an optimistic local edit
+  // (issue #1254), so the count and thumbnails stay honest even if other files changed meanwhile.
   const performDelete = useCallback(
     async (fileName: string) => {
       if (!sessionId) return;
       await deleteScreenshot(sessionId, fileName);
-      setShots((cur) => cur.filter((s) => s.fileName !== fileName));
-      setTotal((t) => Math.max(0, t - 1));
+      await load();
     },
-    [sessionId],
+    [sessionId, load],
   );
 
   return (
@@ -111,11 +124,22 @@ export function ScreenshotsPanel({ sessionId, onInsert }: ScreenshotsPanelProps)
           <div className="gallery">
             {shots.slice(0, shown).map((s) => (
               <div className="shot-card" key={s.fileName}>
-                {sessionId && (
-                  <a href={screenshotFileUrl(sessionId, s.fileName)} target="_blank" rel="noreferrer" title="View full size">
-                    <img className="shot-thumb" src={screenshotFileUrl(sessionId, s.fileName)} alt={s.fileName} loading="lazy" />
-                  </a>
-                )}
+                {sessionId &&
+                  (isImageBroken(brokenImages, s.fileName) ? (
+                    <div className="shot-thumb-missing" role="img" aria-label={`${s.fileName} (image unavailable)`}>
+                      Image unavailable
+                    </div>
+                  ) : (
+                    <a href={screenshotFileUrl(sessionId, s.fileName)} target="_blank" rel="noreferrer" title="View full size">
+                      <img
+                        className="shot-thumb"
+                        src={screenshotFileUrl(sessionId, s.fileName)}
+                        alt={s.fileName}
+                        loading="lazy"
+                        onError={() => setBrokenImages((prev) => markImageBroken(prev, s.fileName))}
+                      />
+                    </a>
+                  ))}
                 <div className="shot-row">
                   <span className="shot-time">{s.timeLabel}</span>
                   <button type="button" className="linkbtn" title="Insert path into the composer" onClick={() => onInsert(s.path)}>

--- a/apps/cockpit/src/styles.css
+++ b/apps/cockpit/src/styles.css
@@ -1055,6 +1055,22 @@ body {
   cursor: pointer;
 }
 
+/* Shown in place of a thumbnail whose file vanished on disk (issue #1254), instead of the browser's
+   broken-image glyph. */
+.shot-thumb-missing {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 78px;
+  padding: 4px;
+  box-sizing: border-box;
+  font-size: 10px;
+  text-align: center;
+  color: var(--text-dim);
+  background: var(--surface-2);
+}
+
 .shot-row {
   display: flex;
   align-items: center;

--- a/packages/client-core/src/sessions/screenshotGallery.test.ts
+++ b/packages/client-core/src/sessions/screenshotGallery.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { NO_BROKEN_IMAGES, isImageBroken, markImageBroken } from "./screenshotGallery";
+
+// Regression coverage for issue #1254: a screenshot file removed on disk must render the "image
+// unavailable" placeholder, not the browser's broken-image glyph. That decision is driven by the
+// broken-image tracking here, so it is verified directly.
+describe("screenshots gallery broken-image tracking", () => {
+  it("starts with nothing broken", () => {
+    expect(isImageBroken(NO_BROKEN_IMAGES, "shot-1.png")).toBe(false);
+  });
+
+  it("marks a failed thumbnail so the panel can show the placeholder", () => {
+    const next = markImageBroken(NO_BROKEN_IMAGES, "shot-1.png");
+
+    expect(isImageBroken(next, "shot-1.png")).toBe(true);
+    expect(isImageBroken(next, "shot-2.png")).toBe(false);
+  });
+
+  it("never mutates the input set, so the shared constant and prior state stay clean", () => {
+    const first = markImageBroken(NO_BROKEN_IMAGES, "shot-1.png");
+    const second = markImageBroken(first, "shot-2.png");
+
+    // The shared starting constant is untouched by either call.
+    expect(NO_BROKEN_IMAGES.size).toBe(0);
+    // The earlier set is untouched by the later call.
+    expect(isImageBroken(first, "shot-2.png")).toBe(false);
+    expect(isImageBroken(second, "shot-1.png")).toBe(true);
+    expect(isImageBroken(second, "shot-2.png")).toBe(true);
+  });
+
+  it("returns the same set instance for a repeated failure, to avoid a needless re-render", () => {
+    const first = markImageBroken(NO_BROKEN_IMAGES, "shot-1.png");
+    const again = markImageBroken(first, "shot-1.png");
+
+    expect(again).toBe(first);
+  });
+});

--- a/packages/client-core/src/sessions/screenshotGallery.ts
+++ b/packages/client-core/src/sessions/screenshotGallery.ts
@@ -1,0 +1,35 @@
+// Pure view-state helpers for the Cockpit screenshots gallery (issue #1254).
+//
+// A gallery thumbnail loads its bytes from the owning Director's disk through the Gateway proxy. The
+// file can disappear between the moment the list was fetched and the moment the browser requests the
+// image - someone deleted it, or a delete elsewhere raced this view. When that happens the <img>
+// element fires its onError event and, left alone, the browser paints its built-in broken-image glyph
+// with no explanation. The panel instead tracks which thumbnails failed to load and renders a small
+// "image unavailable" placeholder in their place.
+//
+// The tracking lives here, in client-core, so it is pure and immutable: the decision is unit-tested
+// without a browser, and the React panel (apps/cockpit/src/sessions/ScreenshotsPanel.tsx) stays thin.
+
+/** The set of screenshot file names whose thumbnail failed to load. */
+export type BrokenImageSet = ReadonlySet<string>;
+
+/** The starting state: nothing is known to be broken. A fresh list load resets back to this. */
+export const NO_BROKEN_IMAGES: BrokenImageSet = new Set<string>();
+
+/**
+ * Record that a thumbnail failed to load. Returns a NEW set - the input is never mutated, so the
+ * shared NO_BROKEN_IMAGES constant and any prior React state can never be corrupted. When the file
+ * name is already known to be broken the SAME set instance is returned, so a repeated onError does
+ * not force a needless re-render.
+ */
+export function markImageBroken(current: BrokenImageSet, fileName: string): BrokenImageSet {
+  if (current.has(fileName)) return current;
+  const next = new Set(current);
+  next.add(fileName);
+  return next;
+}
+
+/** Whether a thumbnail is known to be broken and should render the placeholder instead of the <img>. */
+export function isImageBroken(current: BrokenImageSet, fileName: string): boolean {
+  return current.has(fileName);
+}


### PR DESCRIPTION
Fixes #1254.

## What changed

The screenshots dock (`apps/cockpit/src/sessions/ScreenshotsPanel.tsx`) had three related defects. #1244 already routed the delete through the shared `ConfirmDialog`. This change completes the fix, building on that confirmation:

1. **Re-sync after delete (was optimistic).** `performDelete` now awaits the server delete and then re-fetches the list from the Director (`await load()`) instead of editing the local array. The count and thumbnails stay honest even if other files changed. A failed delete still throws, so the `ConfirmDialog` surfaces the error and the list is never touched.
2. **Image error fallback.** Each thumbnail now has an `onError` handler. A file that vanished on disk renders a small "image unavailable" placeholder (`.shot-thumb-missing`) instead of the browser's broken-image glyph. The broken-image tracking is a new pure, immutable helper in `packages/client-core/src/sessions/screenshotGallery.ts` (a fresh list load clears it).
3. **Confirmation.** Preserved from #1244 (not undone).

## Acceptance criteria

- **Deleting asks first; a failed delete leaves the list correct and shows an error.** The `ConfirmDialog` from #1244 asks first; on delete failure the error throws out of `performDelete`, the dialog stays open showing it, and `load()` is never reached so the list is unchanged.
- **A screenshot file removed on disk renders the placeholder, not a broken-image glyph.** The `<img onError>` marks the file broken and the card renders the "image unavailable" placeholder.

## Proof

- New regression test `packages/client-core/src/sessions/screenshotGallery.test.ts` (4 cases: starts clean, marks failed, never mutates input, returns same instance on repeat) - passes.
- Full client-core suite: 167 tests pass (16 files).
- Cockpit `npm run build` (tsc --noEmit + vite build): clean.
- eslint on changed files: clean.

## Notes on working rules

Built from an isolated worktree off `origin/main`; the shared checkout was never branch-switched. Only the four changed files were staged by name (no `git add -A`, no lockfile churn). No fallback programming - failures throw and are surfaced; ASCII only.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)