### PR TITLE
[Cockpit] Rebuild Schedule page on a reusable sortable, searchable DataTable (#1245)

### DIFF
--- a/apps/cockpit/package.json
+++ b/apps/cockpit/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@devthrottle/client-core": "*",
@@ -22,6 +23,7 @@
     "@types/react-dom": "18.3.1",
     "@vitejs/plugin-react": "4.3.4",
     "typescript": "5.7.2",
-    "vite": "6.0.3"
+    "vite": "6.0.3",
+    "vitest": "2.1.8"
   }
 }

--- a/apps/cockpit/src/components/DataTable.tsx
+++ b/apps/cockpit/src/components/DataTable.tsx
@@ -1,0 +1,260 @@
+import { useMemo, useState } from "react";
+import type { KeyboardEvent, ReactNode } from "react";
+import {
+  filterAndSortRows,
+  nextSort,
+  type SortDirection,
+  type SortState,
+} from "./dataTableCore";
+
+// The shared Cockpit data table (issue #1245). Every list in the app used to be a bespoke <table>: no
+// sort, no search, and - at its worst on the Schedule page - a whole multi-paragraph prompt crammed
+// into one grid cell so the rows became a wall of prose you could not scan. This one component gives a
+// list three capabilities the rest of the app then inherits: sortable columns, a search box, and an
+// optional row-detail drawer for the long content a grid cell must never hold. A grid cell holds one
+// short scannable value; the drawer holds the detail. The Schedule page is the first adopter; the
+// Directors page (issue #1246) is next.
+//
+// It is generic over the row type T. A page describes its columns (how to render and, when sortable,
+// how to derive a sort value), hands the table its rows and a function that flattens each row to the
+// text the search box matches, and - if a row has detail worth reading - a renderer for the drawer.
+// The table owns the search text, the sort state, and which row's drawer is open; the page owns the
+// data and the meaning of every cell.
+
+/** One column of the table. */
+export interface DataTableColumn<T> {
+  /** A stable key for this column (used for the sort state and React keys). */
+  key: string;
+  /** The column heading. */
+  header: string;
+  /** Renders this column's cell for a row. Keep it to one short scannable value - never a body of text. */
+  render: (row: T) => ReactNode;
+  /** When true, the header is clickable and sorts by `sortValue`. */
+  sortable?: boolean;
+  /** The value this row sorts by for this column. Return a number for times/counts so they order
+   *  numerically rather than by their display text. Required to make a column meaningfully sortable. */
+  sortValue?: (row: T) => string | number;
+  /** Optional extra class on every cell in this column (for example "mono" or "dim"). */
+  className?: string;
+  /** Cell text alignment; defaults to left. */
+  align?: "left" | "right";
+  /** Optional hover title on the header cell (for example, to explain the column). */
+  headerTitle?: string;
+  /** Optional fixed column width (a CSS length, for example "180px"). The table uses a fixed layout,
+   *  so widths keep the columns steady and let long cells truncate rather than reflow. */
+  width?: string;
+}
+
+export interface DataTableProps<T> {
+  /** The columns, left to right. */
+  columns: DataTableColumn<T>[];
+  /** The rows to show (already loaded by the page). */
+  rows: T[];
+  /** A stable unique key for a row (its id). Also identifies which row's drawer is open. */
+  rowKey: (row: T) => string;
+  /** Flattens a row to the single string the search box matches (name, machine, repository, prompt, ...). */
+  searchableText: (row: T) => string;
+  /** The search box placeholder. */
+  searchPlaceholder?: string;
+  /** The initial sort (column key + direction). Omit for the rows' natural order. */
+  defaultSort?: SortState;
+  /** Shown in place of the table when there are no rows at all. */
+  emptyMessage?: ReactNode;
+  /** Shown when there are rows but the search query matches none of them. */
+  noMatchMessage?: ReactNode;
+  /** Extra toolbar content pinned to the right of the search box (for example, a "New" button). */
+  toolbarExtra?: ReactNode;
+  /** Renders the drawer body for a row. When provided, activating a row opens the drawer. */
+  renderDetail?: (row: T) => ReactNode;
+  /** The drawer's title for a row (defaults to nothing). */
+  detailTitle?: (row: T) => ReactNode;
+  /** Optional actions pinned to the drawer header (for example, Run now / Edit). */
+  detailActions?: (row: T) => ReactNode;
+  /** Called when a row is activated (clicked, or Enter/Space with the row focused), before the drawer
+   *  opens. A page uses this to load the row's detail data (for example, its run history). */
+  onRowActivate?: (row: T) => void;
+}
+
+export function DataTable<T>({
+  columns,
+  rows,
+  rowKey,
+  searchableText,
+  searchPlaceholder = "Search",
+  defaultSort,
+  emptyMessage,
+  noMatchMessage,
+  toolbarExtra,
+  renderDetail,
+  detailTitle,
+  detailActions,
+  onRowActivate,
+}: DataTableProps<T>) {
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<SortState | null>(defaultSort ?? null);
+  // The open drawer is tracked by row key, not by a row object, so it stays pinned to the same job as
+  // polling replaces the row array. When the keyed row disappears (deleted), the drawer closes itself.
+  const [detailKey, setDetailKey] = useState<string | null>(null);
+
+  const sortValueFor = useMemo(() => {
+    const byKey = new Map(columns.map((column) => [column.key, column] as const));
+    return (row: T, columnKey: string): string | number | null => {
+      const column = byKey.get(columnKey);
+      if (column === undefined || column.sortValue === undefined) return null;
+      return column.sortValue(row);
+    };
+  }, [columns]);
+
+  const visibleRows = useMemo(
+    () => filterAndSortRows(rows, query, searchableText, sort, sortValueFor),
+    [rows, query, searchableText, sort, sortValueFor],
+  );
+
+  const detailRow = detailKey === null ? null : rows.find((row) => rowKey(row) === detailKey) ?? null;
+
+  const activate = (row: T) => {
+    if (onRowActivate !== undefined) onRowActivate(row);
+    if (renderDetail !== undefined) setDetailKey(rowKey(row));
+  };
+
+  const onRowKeyDown = (event: KeyboardEvent<HTMLTableRowElement>, row: T) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      activate(row);
+    }
+  };
+
+  const rowsAreActivatable = onRowActivate !== undefined || renderDetail !== undefined;
+
+  return (
+    <div className="ui-table-wrap">
+      <div className="ui-table-toolbar">
+        <input
+          className="ui-table-search"
+          type="search"
+          value={query}
+          placeholder={searchPlaceholder}
+          aria-label={searchPlaceholder}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+        {toolbarExtra !== undefined && <div className="ui-table-toolbar-extra">{toolbarExtra}</div>}
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="ui-table-empty">{emptyMessage}</div>
+      ) : visibleRows.length === 0 ? (
+        <div className="ui-table-empty">
+          {noMatchMessage ?? `No rows match "${query.trim()}".`}
+        </div>
+      ) : (
+        <table className="ui-table">
+          <thead>
+            <tr>
+              {columns.map((column) => {
+                const active = sort !== null && sort.columnKey === column.key;
+                const indicator = !active ? "" : sort.direction === "asc" ? " ^" : " v";
+                return (
+                  <th
+                    key={column.key}
+                    className={headerClass(column, active)}
+                    style={column.width !== undefined ? { width: column.width } : undefined}
+                    title={column.headerTitle}
+                    aria-sort={active ? ariaSort(sort.direction) : undefined}
+                    onClick={
+                      column.sortable === true && column.sortValue !== undefined
+                        ? () => setSort((current) => nextSort(current, column.key))
+                        : undefined
+                    }
+                  >
+                    {column.header}
+                    {active && <span className="ui-table-sort-mark">{indicator}</span>}
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {visibleRows.map((row) => {
+              const key = rowKey(row);
+              return (
+                <tr
+                  key={key}
+                  className={`ui-table-row${rowsAreActivatable ? " activatable" : ""}${
+                    key === detailKey ? " open" : ""
+                  }`}
+                  tabIndex={rowsAreActivatable ? 0 : undefined}
+                  role={rowsAreActivatable ? "button" : undefined}
+                  onClick={rowsAreActivatable ? () => activate(row) : undefined}
+                  onKeyDown={rowsAreActivatable ? (event) => onRowKeyDown(event, row) : undefined}
+                >
+                  {columns.map((column) => (
+                    <td
+                      key={column.key}
+                      className={cellClass(column)}
+                      onClick={
+                        // A cell may host its own controls (buttons, toggles); stop those clicks from
+                        // also activating the row's drawer. Cells opt in via the "ui-table-cell-stop"
+                        // class, marked through the column className.
+                        column.className !== undefined && column.className.includes("ui-table-cell-stop")
+                          ? (event) => event.stopPropagation()
+                          : undefined
+                      }
+                    >
+                      {column.render(row)}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+
+      {detailRow !== null && renderDetail !== undefined && (
+        <div className="ui-drawer-backdrop" onClick={() => setDetailKey(null)}>
+          <aside
+            className="ui-drawer"
+            role="dialog"
+            aria-modal="true"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <header className="ui-drawer-head">
+              <div className="ui-drawer-title">{detailTitle !== undefined ? detailTitle(detailRow) : null}</div>
+              <div className="ui-drawer-head-actions">
+                {detailActions !== undefined && detailActions(detailRow)}
+                <button
+                  type="button"
+                  className="ui-drawer-close"
+                  aria-label="Close"
+                  onClick={() => setDetailKey(null)}
+                >
+                  x
+                </button>
+              </div>
+            </header>
+            <div className="ui-drawer-body">{renderDetail(detailRow)}</div>
+          </aside>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function headerClass<T>(column: DataTableColumn<T>, active: boolean): string {
+  const classes = ["ui-table-th"];
+  if (column.sortable === true && column.sortValue !== undefined) classes.push("sortable");
+  if (active) classes.push("active");
+  if (column.align === "right") classes.push("right");
+  return classes.join(" ");
+}
+
+function cellClass<T>(column: DataTableColumn<T>): string {
+  const classes = ["ui-table-td"];
+  if (column.className !== undefined && column.className.length > 0) classes.push(column.className);
+  if (column.align === "right") classes.push("right");
+  return classes.join(" ");
+}
+
+function ariaSort(direction: SortDirection): "ascending" | "descending" {
+  return direction === "asc" ? "ascending" : "descending";
+}

--- a/apps/cockpit/src/components/components.css
+++ b/apps/cockpit/src/components/components.css
@@ -226,3 +226,189 @@
 .ui-status-error {
   color: var(--attention);
 }
+
+/* ===== DataTable (issue #1245) ================================================================ */
+/* The shared sortable, searchable table with an optional row-detail drawer. Fixed-height rows and
+   single-line cells are the point: a grid cell holds one short scannable value, never a body of text. */
+.ui-table-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ui-table-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.ui-table-search {
+  flex: 1;
+  min-width: 0;
+  max-width: 360px;
+  background: var(--code-bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 7px 12px;
+  font: inherit;
+  font-size: 13px;
+}
+.ui-table-search:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.ui-table-toolbar-extra {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ui-table-empty {
+  padding: 24px;
+  text-align: center;
+  color: var(--text-dim);
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+  font-size: 13px;
+}
+
+.ui-table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 13px;
+  table-layout: fixed;
+}
+
+.ui-table-th {
+  color: var(--text-dim);
+  font-weight: 600;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ui-table-th.right {
+  text-align: right;
+}
+.ui-table-th.sortable {
+  cursor: pointer;
+  user-select: none;
+}
+.ui-table-th.sortable:hover {
+  color: var(--text);
+}
+.ui-table-th.active {
+  color: var(--accent);
+}
+.ui-table-sort-mark {
+  font-weight: 700;
+}
+
+.ui-table-row {
+  height: 44px;
+}
+.ui-table-row.activatable {
+  cursor: pointer;
+}
+.ui-table-row.activatable:hover td,
+.ui-table-row.open td {
+  background: var(--surface-2);
+}
+.ui-table-row.activatable:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.ui-table-td {
+  border-bottom: 1px solid var(--border);
+  padding: 6px 10px;
+  text-align: left;
+  vertical-align: middle;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ui-table-td.right {
+  text-align: right;
+}
+.ui-table-td.mono {
+  font-family: "Cascadia Mono", Consolas, Menlo, monospace;
+}
+.ui-table-td.dim {
+  color: var(--text-dim);
+}
+
+/* ===== DataTable row-detail drawer ============================================================ */
+.ui-drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  justify-content: flex-end;
+  z-index: 90;
+}
+
+.ui-drawer {
+  width: 560px;
+  max-width: 94vw;
+  height: 100%;
+  background: var(--surface);
+  border-left: 1px solid var(--border);
+  box-shadow: -18px 0 48px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+}
+
+.ui-drawer-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.ui-drawer-title {
+  flex: 1;
+  min-width: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.ui-drawer-head-actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ui-drawer-close {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-dim);
+  cursor: pointer;
+  width: 28px;
+  height: 28px;
+  font-size: 14px;
+  line-height: 1;
+}
+.ui-drawer-close:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.ui-drawer-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 18px;
+}

--- a/apps/cockpit/src/components/dataTableCore.test.ts
+++ b/apps/cockpit/src/components/dataTableCore.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareSortValues,
+  filterAndSortRows,
+  matchesQuery,
+  nextSort,
+  type SortState,
+} from "./dataTableCore";
+
+interface Row {
+  id: string;
+  name: string;
+  next: number;
+}
+
+const rows: Row[] = [
+  { id: "a", name: "Alpha", next: 300 },
+  { id: "b", name: "bravo", next: 100 },
+  { id: "c", name: "Charlie", next: 200 },
+];
+
+const searchableText = (row: Row) => `${row.name} ${row.id}`;
+const sortValueFor = (row: Row, columnKey: string): string | number | null => {
+  if (columnKey === "name") return row.name.toLowerCase();
+  if (columnKey === "next") return row.next;
+  return null;
+};
+
+describe("matchesQuery", () => {
+  it("matches every row on an empty query", () => {
+    expect(matchesQuery("anything", "")).toBe(true);
+    expect(matchesQuery("anything", "   ")).toBe(true);
+  });
+
+  it("matches case-insensitively on a substring", () => {
+    expect(matchesQuery("SOREN_NORTH devthrottle", "north")).toBe(true);
+  });
+
+  it("does not match when the substring is absent", () => {
+    expect(matchesQuery("SOREN_NORTH", "laptop")).toBe(false);
+  });
+});
+
+describe("compareSortValues", () => {
+  it("orders numbers numerically ascending", () => {
+    expect(compareSortValues(100, 300, "asc")).toBeLessThan(0);
+  });
+
+  it("flips the order for descending", () => {
+    expect(compareSortValues(100, 300, "desc")).toBeGreaterThan(0);
+  });
+
+  it("orders strings case-insensitively", () => {
+    expect(compareSortValues("bravo", "Charlie", "asc")).toBeLessThan(0);
+  });
+});
+
+describe("filterAndSortRows", () => {
+  it("sorts by a numeric column ascending (soonest first)", () => {
+    const sort: SortState = { columnKey: "next", direction: "asc" };
+    const result = filterAndSortRows(rows, "", searchableText, sort, sortValueFor);
+    expect(result.map((r) => r.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("sorts by a string column ascending, ignoring case", () => {
+    const sort: SortState = { columnKey: "name", direction: "asc" };
+    const result = filterAndSortRows(rows, "", searchableText, sort, sortValueFor);
+    expect(result.map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("filters by the search query before sorting", () => {
+    const sort: SortState = { columnKey: "next", direction: "asc" };
+    const result = filterAndSortRows(rows, "bravo", searchableText, sort, sortValueFor);
+    expect(result.map((r) => r.id)).toEqual(["b"]);
+  });
+
+  it("leaves the filtered order untouched when the active column is not sortable", () => {
+    const sort: SortState = { columnKey: "unknown", direction: "asc" };
+    const result = filterAndSortRows(rows, "", searchableText, sort, sortValueFor);
+    expect(result.map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("is stable: equal rows keep their input order", () => {
+    const tied = [
+      { id: "x", name: "same", next: 1 },
+      { id: "y", name: "same", next: 1 },
+      { id: "z", name: "same", next: 1 },
+    ];
+    const sort: SortState = { columnKey: "name", direction: "asc" };
+    const result = filterAndSortRows(tied, "", searchableText, sort, sortValueFor);
+    expect(result.map((r) => r.id)).toEqual(["x", "y", "z"]);
+  });
+});
+
+describe("nextSort", () => {
+  it("sorts a new column ascending", () => {
+    expect(nextSort(null, "name")).toEqual({ columnKey: "name", direction: "asc" });
+  });
+
+  it("flips the direction of the already-sorted column", () => {
+    expect(nextSort({ columnKey: "name", direction: "asc" }, "name")).toEqual({
+      columnKey: "name",
+      direction: "desc",
+    });
+  });
+
+  it("switches to a different column ascending", () => {
+    expect(nextSort({ columnKey: "name", direction: "desc" }, "next")).toEqual({
+      columnKey: "next",
+      direction: "asc",
+    });
+  });
+});

--- a/apps/cockpit/src/components/dataTableCore.ts
+++ b/apps/cockpit/src/components/dataTableCore.ts
@@ -1,0 +1,76 @@
+// The pure sort-and-filter core of the shared DataTable (issue #1245). These functions hold no React
+// state and touch no DOM, so the table's behaviour - "typing in the search box filters", "clicking a
+// header sorts" - is unit-tested here directly (dataTableCore.test.ts) without rendering anything. The
+// DataTable component (DataTable.tsx) is a thin view over exactly these two operations.
+
+/** Ascending or descending sort on a column. */
+export type SortDirection = "asc" | "desc";
+
+/** The active sort: which column, and which way. */
+export interface SortState {
+  columnKey: string;
+  direction: SortDirection;
+}
+
+// Does one row's searchable text contain the query? The query is trimmed and compared
+// case-insensitively; an empty query matches every row (the search box is not yet narrowing).
+export function matchesQuery(searchableText: string, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (q.length === 0) return true;
+  return searchableText.toLowerCase().includes(q);
+}
+
+// Compare two sort values for one column. Numbers compare numerically (so "in 46m" sorts before
+// "in 3h" when both are backed by an epoch number, not by their display text); anything else compares
+// as a case-insensitive string. The result is negated for a descending sort. This is a pure total
+// order, so callers get a stable, predictable arrangement.
+export function compareSortValues(
+  a: string | number,
+  b: string | number,
+  direction: SortDirection,
+): number {
+  let comparison: number;
+  if (typeof a === "number" && typeof b === "number") {
+    comparison = a - b;
+  } else {
+    comparison = String(a).localeCompare(String(b), undefined, { sensitivity: "base" });
+  }
+  return direction === "asc" ? comparison : -comparison;
+}
+
+// Filter rows by the search query using each row's searchable text, then sort by the active column's
+// sort value. The sort is stable: rows that compare equal keep their input order (a plain index
+// tie-breaker), so a second sort key never scrambles the first. `sortValueFor` returns the value to
+// sort a row by for the active column, or null when the active column is not sortable (in which case
+// the rows keep their filtered order).
+export function filterAndSortRows<T>(
+  rows: readonly T[],
+  query: string,
+  searchableText: (row: T) => string,
+  sort: SortState | null,
+  sortValueFor: (row: T, columnKey: string) => string | number | null,
+): T[] {
+  const filtered = rows.filter((row) => matchesQuery(searchableText(row), query));
+  if (sort === null) return filtered;
+
+  // Decorate with the original index so equal rows keep their relative order (a stable sort).
+  const decorated = filtered.map((row, index) => ({ row, index }));
+  decorated.sort((left, right) => {
+    const a = sortValueFor(left.row, sort.columnKey);
+    const b = sortValueFor(right.row, sort.columnKey);
+    if (a === null || b === null) return left.index - right.index;
+    const comparison = compareSortValues(a, b, sort.direction);
+    return comparison !== 0 ? comparison : left.index - right.index;
+  });
+  return decorated.map((entry) => entry.row);
+}
+
+// The next sort state when a header is clicked. Clicking a new column sorts it ascending; clicking the
+// already-sorted column flips its direction. This is the one place the header-click rule lives, so the
+// component and its tests agree on it.
+export function nextSort(current: SortState | null, columnKey: string): SortState {
+  if (current !== null && current.columnKey === columnKey) {
+    return { columnKey, direction: current.direction === "asc" ? "desc" : "asc" };
+  }
+  return { columnKey, direction: "asc" };
+}

--- a/apps/cockpit/src/components/index.ts
+++ b/apps/cockpit/src/components/index.ts
@@ -24,5 +24,16 @@ export type { ConfirmDialogProps } from "./ConfirmDialog";
 export { StatusMessage } from "./StatusMessage";
 export type { StatusMessageProps } from "./StatusMessage";
 
+export { DataTable } from "./DataTable";
+export type { DataTableColumn, DataTableProps } from "./DataTable";
+
+export {
+  matchesQuery,
+  compareSortValues,
+  filterAndSortRows,
+  nextSort,
+} from "./dataTableCore";
+export type { SortDirection, SortState } from "./dataTableCore";
+
 export { useFlash } from "./useFlash";
 export type { Flash, FlashController } from "./useFlash";

--- a/apps/cockpit/src/schedule/ScheduleView.tsx
+++ b/apps/cockpit/src/schedule/ScheduleView.tsx
@@ -18,8 +18,18 @@ import {
 } from "@devthrottle/client-core/fleet/fleetClient";
 import type { SessionDto } from "@devthrottle/client-core/api/client";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
-import { clockLabel } from "../fleet/format";
-import { ConfirmDialog } from "../components";
+import { clockLabel, relativeTime, repoBasename } from "../fleet/format";
+import { Button, ConfirmDialog, DataTable, PageHeader, type DataTableColumn } from "../components";
+import {
+  absoluteUtc,
+  actionShortLabel,
+  actionType,
+  cronToEnglish,
+  epochOrMax,
+  lastOutcome,
+  promptBody,
+  relativeUntil,
+} from "./scheduleFormat";
 
 // The Schedule page (issue #976, epic #967) - the React port of the Blazor Cockpit Schedule.razor
 // (issue #488). The human's window into cron jobs: a pure CLIENT of the Gateway's /cron/jobs surface
@@ -335,124 +345,206 @@ export function ScheduleView() {
     [machineErrors],
   );
 
-  const selectedName = jobs.find((j) => j.id === selectedId)?.name ?? "";
+  // The searchable text of a job: name, machine, repository, and the prompt text - so the search box
+  // finds a job by any of them (issue #1245), including a word buried in the instructions.
+  const searchableText = useCallback(
+    (job: CronJob): string =>
+      [job.name, job.target.machine, job.action.repoPath, job.action.seed, job.action.workListName ?? ""].join(" "),
+    [],
+  );
 
-  return (
-    <div className="sched">
-      <header className="sched-head">
-        <h1 className="sched-title">Schedule</h1>
-        <span className="sched-sub">
-          {jobs.length} cron job{jobs.length === 1 ? "" : "s"}
-        </span>
-        <span className="sched-refreshed">
-          {lastRefresh === null ? "connecting..." : `updated ${clockLabel(lastRefresh)}`}
-        </span>
-        <span className="sched-spacer" />
-        <button className="sched-btn primary" onClick={openCreate}>
-          New cron job
-        </button>
-      </header>
-
-      {lastError !== null && <div className="sched-banner-error">Gateway error: {lastError}</div>}
-
-      {jobs.length === 0 && lastError === null && lastRefresh !== null && (
-        <div className="sched-empty">
-          No cron jobs yet. Create one to schedule a session or a work-list drain on a machine.
-        </div>
-      )}
-
-      {jobs.length > 0 && (
-        <>
-          <table className="sched-tbl">
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Target</th>
-                <th>Runs</th>
-                <th>Schedule</th>
-                <th>Next run</th>
-                <th>Last run</th>
-                <th>Status</th>
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              {jobs.map((job) => (
-                <tr
-                  key={job.id}
-                  className={`sched-row${job.id === selectedId ? " sel" : ""}`}
-                  onClick={() => void selectJob(job.id)}
-                >
-                  <td>
-                    <span className="sched-cell-name">{job.name}</span>
-                  </td>
-                  <td className="mono">{job.target.machine}</td>
-                  <td>{runsLabel(job)}</td>
-                  <td>
-                    {scheduleLabel(job)}
-                    {notifyEnabled(job) && (
-                      <span className="sched-notify-badge" title={notifyTitle(job)}>
-                        {notifyLabel(job)}
-                      </span>
-                    )}
-                  </td>
-                  <td className="mono">{fmtUtc(job.nextRunUtc)}</td>
-                  <td className="dim">
-                    {job.lastFiredUtc ? fmtUtc(job.lastFiredUtc) : "never"}{" "}
-                    {job.lastStatus && job.lastStatus.length > 0 ? `(${job.lastStatus})` : ""}
-                  </td>
-                  <td>
-                    <button
-                      className={`sched-chip ${job.enabled ? "enabled" : "disabled"}`}
-                      title="Toggle enabled"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        void toggleEnabled(job);
-                      }}
-                    >
-                      {job.enabled ? "Enabled" : "Disabled"}
-                    </button>
-                  </td>
-                  <td className="sched-actions" onClick={(e) => e.stopPropagation()}>
-                    <button className="sched-linkbtn" onClick={() => void runNow(job)}>
-                      Run now
-                    </button>
-                    <button className="sched-linkbtn" onClick={() => openEdit(job)}>
-                      Edit
-                    </button>
-                    <button className="sched-linkbtn del" onClick={() => setPendingDelete(job)}>
-                      Delete
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-
-          {actionError !== null && <div className="sched-banner-error">{actionError}</div>}
-        </>
-      )}
-
-      {selectedId !== null && (
-        <>
-          <div className="sched-sec-head">
-            <h2>Run history</h2>
-            <span className="sched-hint">
-              {selectedName} - newest first. Infra status (did it start) is separate from task status
-              (did it finish).
+  // The grid columns: one short scannable value each. The prompt body is never here - it lives in the
+  // drawer. Default sort is next run, soonest first (epochOrMax sinks "no next run" to the bottom).
+  const columns = useMemo<DataTableColumn<CronJob>[]>(
+    () => [
+      {
+        key: "state",
+        header: "",
+        width: "30px",
+        render: (job) => (
+          <span
+            className={`sched-dot2 ${job.enabled ? "on" : "off"}`}
+            title={job.enabled ? "Enabled" : "Disabled"}
+          />
+        ),
+      },
+      {
+        key: "name",
+        header: "Name",
+        width: "200px",
+        sortable: true,
+        sortValue: (job) => job.name.toLowerCase(),
+        render: (job) => <span className="sched-cell-name">{job.name}</span>,
+      },
+      {
+        key: "runs",
+        header: "Runs",
+        width: "220px",
+        sortable: true,
+        sortValue: (job) => actionShortLabel(job).toLowerCase(),
+        render: (job) => (
+          <span className="sched-runs">
+            <span className={`sched-typechip ${actionType(job).toLowerCase().replace(/\s+/g, "-")}`}>
+              {actionType(job)}
             </span>
+            <span className="sched-runs-label" title={actionShortLabel(job)}>
+              {actionShortLabel(job)}
+            </span>
+          </span>
+        ),
+      },
+      {
+        key: "target",
+        header: "Target",
+        width: "150px",
+        sortable: true,
+        sortValue: (job) => job.target.machine.toLowerCase(),
+        render: (job) => (
+          <span className="sched-target">
+            <span className="mono">{job.target.machine}</span>
+            <span className="sched-target-repo">{repoBasename(job.action.repoPath)}</span>
+          </span>
+        ),
+      },
+      {
+        key: "schedule",
+        header: "Schedule",
+        width: "195px",
+        sortable: true,
+        sortValue: (job) => cronToEnglish(scheduleCron(job)).toLowerCase(),
+        render: (job) => (
+          <span className="sched-schedule" title={scheduleCron(job) ?? undefined}>
+            {scheduleEnglish(job)}
+            {notifyEnabled(job) && (
+              <span className="sched-notify-badge" title={notifyTitle(job)}>
+                {notifyLabel(job)}
+              </span>
+            )}
+          </span>
+        ),
+      },
+      {
+        key: "next",
+        header: "Next run",
+        width: "90px",
+        sortable: true,
+        sortValue: (job) => epochOrMax(job.nextRunUtc),
+        render: (job) => (
+          <span className="mono" title={absoluteUtc(job.nextRunUtc)}>
+            {relativeUntil(job.nextRunUtc)}
+          </span>
+        ),
+      },
+      {
+        key: "last",
+        header: "Last run",
+        width: "135px",
+        sortable: true,
+        sortValue: (job) => epochOrMax(job.lastFiredUtc),
+        render: (job) => {
+          const outcome = lastOutcome(job.lastStatus);
+          return (
+            <span className="sched-lastrun" title={absoluteUtc(job.lastFiredUtc)}>
+              <span className="dim">
+                {job.lastFiredUtc ? relativeTime(job.lastFiredUtc, { withAgo: true }) : "never"}
+              </span>
+              {outcome.kind !== "none" && (
+                <span className={`sched-outcome ${outcome.kind}`}>{outcome.label}</span>
+              )}
+            </span>
+          );
+        },
+      },
+      {
+        key: "enabled",
+        header: "Status",
+        width: "90px",
+        className: "ui-table-cell-stop",
+        sortable: true,
+        sortValue: (job) => (job.enabled ? 0 : 1),
+        render: (job) => (
+          <button
+            className={`sched-chip ${job.enabled ? "enabled" : "disabled"}`}
+            title="Toggle enabled"
+            onClick={() => void toggleEnabled(job)}
+          >
+            {job.enabled ? "Enabled" : "Disabled"}
+          </button>
+        ),
+      },
+      {
+        key: "actions",
+        header: "",
+        width: "165px",
+        align: "right",
+        className: "ui-table-cell-stop",
+        render: (job) => (
+          <span className="sched-actions">
+            <button className="sched-linkbtn" onClick={() => void runNow(job)}>
+              Run now
+            </button>
+            <button className="sched-linkbtn" onClick={() => openEdit(job)}>
+              Edit
+            </button>
+            <button className="sched-linkbtn del" onClick={() => setPendingDelete(job)}>
+              Delete
+            </button>
+          </span>
+        ),
+      },
+    ],
+    [toggleEnabled, runNow, openEdit],
+  );
+
+  // The drawer body for a job: what it does, in full. The prompt lives here (read-only, scrollable,
+  // monospace) alongside the plain-English schedule, the resolved next run, and recent run history.
+  const renderDetail = useCallback(
+    (job: CronJob) => {
+      const showRuns = job.id === selectedId;
+      return (
+        <div className="sched-detail">
+          <div className="sched-detail-summary">
+            <span className={`sched-dot2 ${job.enabled ? "on" : "off"}`} />
+            {job.enabled ? "Enabled" : "Disabled"} - <span className="mono">{job.target.machine}</span> -{" "}
+            <span className="mono">{job.action.repoPath}</span>
           </div>
 
-          {runs.length === 0 ? (
-            <div className="sched-empty">No runs recorded yet for this job.</div>
+          <dl className="sched-detail-facts">
+            <dt>Schedule</dt>
+            <dd>
+              {scheduleEnglish(job)}
+              {scheduleCron(job) !== null && <span className="sched-detail-cron">({scheduleCron(job)})</span>}
+            </dd>
+            <dt>Next run</dt>
+            <dd>
+              {relativeUntil(job.nextRunUtc)}{" "}
+              <span className="dim">({absoluteUtc(job.nextRunUtc)})</span>
+            </dd>
+            <dt>Last run</dt>
+            <dd>
+              {job.lastFiredUtc ? relativeTime(job.lastFiredUtc, { withAgo: true }) : "never"}{" "}
+              <span className="dim">({absoluteUtc(job.lastFiredUtc)})</span>
+            </dd>
+            <dt>Notify</dt>
+            <dd>{notifyDescription(job)}</dd>
+          </dl>
+
+          <div className="sched-detail-label">
+            {actionType(job)} - instructions
+          </div>
+          <pre className="sched-detail-prompt">{promptBody(job)}</pre>
+
+          <div className="sched-detail-label">Recent runs</div>
+          {!showRuns ? (
+            <div className="sched-detail-note">Loading run history...</div>
+          ) : runs.length === 0 ? (
+            <div className="sched-detail-note">No runs recorded yet for this job.</div>
           ) : (
-            <table className="sched-tbl">
+            <table className="sched-runtbl">
               <thead>
                 <tr>
                   <th>Scheduled</th>
                   <th>Fired</th>
-                  <th>Target</th>
-                  <th>Session</th>
                   <th>Infra</th>
                   <th>Task</th>
                 </tr>
@@ -462,8 +554,6 @@ export function ScheduleView() {
                   <tr key={`${r.scheduledUtc}/${r.firedUtc}/${i}`}>
                     <td className="mono">{fmtUtc(r.scheduledUtc)}</td>
                     <td className="mono">{fmtUtc(r.firedUtc)}</td>
-                    <td className="mono">{r.targetDirectorId}</td>
-                    <td className="mono dim">{r.sessionId && r.sessionId.length > 0 ? r.sessionId : "-"}</td>
                     <td>
                       <span className={`sched-st ${infraClass(r.infraStatus)}`}>{r.infraStatus}</span>
                     </td>
@@ -473,7 +563,55 @@ export function ScheduleView() {
               </tbody>
             </table>
           )}
-        </>
+        </div>
+      );
+    },
+    [runs, selectedId],
+  );
+
+  return (
+    <div className="sched">
+      <PageHeader
+        title="Schedule"
+        subtitle={`${jobs.length} cron job${jobs.length === 1 ? "" : "s"} across the fleet.`}
+        actions={
+          <Button variant="primary" onClick={openCreate}>
+            New cron job
+          </Button>
+        }
+      />
+
+      {lastError !== null && <div className="sched-banner-error">Gateway error: {lastError}</div>}
+      {actionError !== null && <div className="sched-banner-error">{actionError}</div>}
+
+      {lastRefresh !== null && (
+        <DataTable<CronJob>
+          columns={columns}
+          rows={jobs}
+          rowKey={(job) => job.id}
+          searchableText={searchableText}
+          searchPlaceholder="Search name, machine, repository, or prompt"
+          defaultSort={{ columnKey: "next", direction: "asc" }}
+          emptyMessage="No cron jobs yet. Create one to schedule a session or a work-list drain on a machine."
+          toolbarExtra={
+            <span className="sched-refreshed">
+              {lastRefresh === null ? "connecting..." : `updated ${clockLabel(lastRefresh)}`}
+            </span>
+          }
+          onRowActivate={(job) => void selectJob(job.id)}
+          renderDetail={renderDetail}
+          detailTitle={(job) => job.name}
+          detailActions={(job) => (
+            <>
+              <Button variant="secondary" onClick={() => void runNow(job)}>
+                Run now
+              </Button>
+              <Button variant="secondary" onClick={() => openEdit(job)}>
+                Edit
+              </Button>
+            </>
+          )}
+        />
       )}
 
       {showForm && (
@@ -541,12 +679,17 @@ export function ScheduleView() {
               ) : (
                 <div className="sched-fld">
                   <label className="sched-fld-label">Skill / prompt</label>
-                  <input
-                    className="mono"
+                  <textarea
+                    className="sched-prompt mono"
                     value={form.seed}
-                    placeholder="/implementation-loop 312"
+                    rows={6}
+                    placeholder={"/implementation-loop 312\n\nor a full multi-paragraph instruction..."}
                     onChange={(e) => setForm((f) => ({ ...f, seed: e.target.value }))}
                   />
+                  <div className="sched-fld-help">
+                    A skill invocation (begins with a slash) or a full multi-paragraph instruction. This
+                    box grows and can be dragged taller.
+                  </div>
                 </div>
               )}
 
@@ -570,6 +713,9 @@ export function ScheduleView() {
                     placeholder="0 0 * * *"
                     onChange={(e) => setForm((f) => ({ ...f, cron: e.target.value }))}
                   />
+                  {form.cron.trim().length > 0 && (
+                    <div className="sched-cron-preview">Runs {cronToEnglish(form.cron)}.</div>
+                  )}
                   {formErrors.schedule && <div className="sched-fld-err">{formErrors.schedule}</div>}
                 </div>
               ) : (
@@ -786,16 +932,33 @@ function notifyTitle(j: CronJob): string {
     : `Run-complete notification + webhook: ${j.notifyWebhookUrl}`;
 }
 
-function scheduleLabel(j: CronJob): string {
-  return j.scheduleKind.toLowerCase() === "recurring"
-    ? j.cronExpression ?? "(no cron)"
-    : `once @ ${j.runAt ?? ""}`;
+// The raw cron string when the job is recurring, otherwise null. Used for the "on hover" title and the
+// drawer's parenthetical, and as the input to the plain-English schedule.
+function scheduleCron(j: CronJob): string | null {
+  if (j.scheduleKind.toLowerCase() !== "recurring") return null;
+  const cron = (j.cronExpression ?? "").trim();
+  return cron.length > 0 ? cron : null;
 }
 
-function runsLabel(j: CronJob): string {
-  return !j.action.workListName || j.action.workListName.length === 0
-    ? `skill ${j.action.seed}`
-    : `work list ${j.action.workListName}`;
+// The schedule in plain English: a recurring job reads its cron ("At 8:14 AM and 2:14 PM, Monday
+// through Friday"); a one-off reads its run-at instant ("Once at ...").
+function scheduleEnglish(j: CronJob): string {
+  if (j.scheduleKind.toLowerCase() === "recurring") return cronToEnglish(j.cronExpression);
+  const runAt = (j.runAt ?? "").trim();
+  return runAt.length > 0 ? `Once at ${runAt}` : "Once (no time set)";
+}
+
+// The run-complete notification policy, spelled out for the drawer.
+function notifyDescription(j: CronJob): string {
+  const policy = j.notifyOn.toLowerCase();
+  const base =
+    policy === "always"
+      ? "Always (success or failure)"
+      : policy === "failure"
+        ? "Only on failure"
+        : "Off";
+  const hook = j.notifyWebhookUrl && j.notifyWebhookUrl.length > 0 ? ` - webhook: ${j.notifyWebhookUrl}` : "";
+  return base + hook;
 }
 
 // "yyyy-MM-dd HH:mm 'UTC'" from an ISO UTC timestamp, matching the Blazor FmtUtc. "-" when absent.

--- a/apps/cockpit/src/schedule/schedule.css
+++ b/apps/cockpit/src/schedule/schedule.css
@@ -134,6 +134,114 @@
 .sched-cell-name {
   font-weight: 600;
   color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+}
+
+/* ---- new table cells (issue #1245): the "Runs" column is a type chip + short label, never the body ---- */
+.sched-dot2 {
+  display: inline-block;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  vertical-align: middle;
+}
+.sched-dot2.on {
+  background: var(--sched-green);
+}
+.sched-dot2.off {
+  background: var(--text-dim);
+  opacity: 0.6;
+}
+
+.sched-runs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.sched-typechip {
+  flex: none;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-radius: 3px;
+  padding: 2px 7px;
+  border: 1px solid;
+}
+.sched-typechip.skill {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.sched-typechip.prompt {
+  color: var(--warn);
+  border-color: var(--warn);
+}
+.sched-typechip.work-list {
+  color: var(--sched-green);
+  border-color: var(--sched-green);
+}
+
+.sched-runs-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-dim);
+  font-family: "Cascadia Mono", Consolas, Menlo, monospace;
+  font-size: 12px;
+}
+
+.sched-target {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+.sched-target-repo {
+  font-size: 11px;
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sched-schedule {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+}
+
+.sched-lastrun {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sched-outcome {
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  padding: 1px 6px;
+  border-radius: 3px;
+  border: 1px solid;
+}
+.sched-outcome.ok {
+  color: var(--sched-green);
+  border-color: var(--sched-green);
+}
+.sched-outcome.err {
+  color: var(--attention);
+  border-color: var(--attention);
+}
+.sched-outcome.warn {
+  color: var(--warn);
+  border-color: var(--warn);
 }
 
 .sched-actions {
@@ -320,9 +428,133 @@
 }
 
 .sched-fld input:focus,
-.sched-fld select:focus {
+.sched-fld select:focus,
+.sched-fld textarea:focus {
   outline: none;
   border-color: var(--accent);
+}
+
+/* ---- multi-line prompt editor (issue #1245): a real resizable monospace text area ---- */
+.sched-prompt {
+  width: 100%;
+  background: var(--code-bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 12.5px;
+  line-height: 1.5;
+  font-family: "Cascadia Mono", Consolas, Menlo, monospace;
+  resize: vertical;
+  min-height: 96px;
+}
+
+.sched-fld-help {
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--text-dim);
+  line-height: 1.45;
+}
+
+/* live plain-English preview of the cron string, so the person knows what it means before saving */
+.sched-cron-preview {
+  margin-top: 6px;
+  padding: 6px 9px;
+  background: var(--surface-2);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--accent);
+}
+
+/* ---- row-detail drawer content (issue #1245) ---- */
+.sched-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  font-size: 13px;
+}
+
+.sched-detail-summary {
+  color: var(--text-dim);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.sched-detail-facts {
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  gap: 6px 12px;
+  margin: 0;
+}
+.sched-detail-facts dt {
+  color: var(--text-dim);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding-top: 2px;
+}
+.sched-detail-facts dd {
+  margin: 0;
+  color: var(--text);
+}
+.sched-detail-cron {
+  margin-left: 8px;
+  color: var(--text-dim);
+  font-family: "Cascadia Mono", Consolas, Menlo, monospace;
+  font-size: 12px;
+}
+
+.sched-detail-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-dim);
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 4px;
+}
+
+.sched-detail-prompt {
+  margin: 0;
+  max-height: 320px;
+  overflow: auto;
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+  font-family: "Cascadia Mono", Consolas, Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.sched-detail-note {
+  color: var(--text-dim);
+  font-style: italic;
+  font-size: 12.5px;
+}
+
+.sched-runtbl {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 12px;
+}
+.sched-runtbl th,
+.sched-runtbl td {
+  border-bottom: 1px solid var(--border);
+  padding: 6px 8px;
+  text-align: left;
+}
+.sched-runtbl th {
+  color: var(--text-dim);
+  font-weight: 600;
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 /* per-field validation guidance (issue #1027) */

--- a/apps/cockpit/src/schedule/scheduleFormat.test.ts
+++ b/apps/cockpit/src/schedule/scheduleFormat.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import type { CronJob } from "@devthrottle/client-core/schedule/scheduleClient";
+import {
+  absoluteUtc,
+  actionShortLabel,
+  actionType,
+  cronToEnglish,
+  epochOrMax,
+  lastOutcome,
+  promptBody,
+  relativeUntil,
+} from "./scheduleFormat";
+
+// A minimal CronJob builder for the display tests - only the fields these pure helpers read.
+function job(
+  overrides: Omit<Partial<CronJob>, "action"> & { action?: Partial<CronJob["action"]> } = {},
+): CronJob {
+  const { action: actionOverrides, ...rest } = overrides;
+  return {
+    id: "job-1",
+    name: "Test job",
+    enabled: true,
+    scheduleKind: "recurring",
+    cronExpression: "0 0 * * *",
+    runAt: null,
+    timeZoneId: "America/Chicago",
+    target: { machine: "SOREN_NORTH" },
+    preventOverlap: true,
+    notifyOn: "none",
+    notifyWebhookUrl: null,
+    nextRunUtc: null,
+    lastFiredUtc: null,
+    lastStatus: null,
+    ...rest,
+    action: {
+      repoPath: "C:\\repos\\devthrottle",
+      seed: "",
+      workListName: null,
+      ...(actionOverrides ?? {}),
+    },
+  };
+}
+
+describe("actionType", () => {
+  it("classifies a slash command as a Skill", () => {
+    expect(actionType(job({ action: { seed: "/inbound-watch" } }))).toBe("Skill");
+  });
+
+  it("classifies free text as a Prompt", () => {
+    expect(actionType(job({ action: { seed: "You are a marketing analyst..." } }))).toBe("Prompt");
+  });
+
+  it("classifies a named work list as a Work list", () => {
+    expect(actionType(job({ action: { seed: "", workListName: "Tonight" } }))).toBe("Work list");
+  });
+});
+
+describe("actionShortLabel", () => {
+  it("never glues the raw word 'skill' onto the prompt", () => {
+    const label = actionShortLabel(job({ action: { seed: "/implementation-loop 312" } }));
+    expect(label).toBe("/implementation-loop 312");
+    expect(label.startsWith("skill ")).toBe(false);
+  });
+
+  it("uses only the first line of a multi-paragraph prompt", () => {
+    const label = actionShortLabel(
+      job({ action: { seed: "First line summary\n\nSecond paragraph with detail." } }),
+    );
+    expect(label).toBe("First line summary");
+  });
+
+  it("truncates a long single line to the maximum length with an ellipsis", () => {
+    const long = "a".repeat(200);
+    const label = actionShortLabel(job({ action: { seed: long } }), 60);
+    expect(label.length).toBe(60);
+    expect(label.endsWith("...")).toBe(true);
+  });
+
+  it("uses the work list name for a work-list job", () => {
+    expect(actionShortLabel(job({ action: { seed: "", workListName: "Tonight" } }))).toBe("Tonight");
+  });
+});
+
+describe("promptBody", () => {
+  it("returns the full prompt untouched, with no type prefix", () => {
+    const body = "You are a run.\n\nStep 1: do the thing.";
+    expect(promptBody(job({ action: { seed: body } }))).toBe(body);
+  });
+});
+
+describe("cronToEnglish", () => {
+  it("reads a daily midnight schedule", () => {
+    expect(cronToEnglish("0 0 * * *")).toBe("At 12:00 AM");
+  });
+
+  it("reads twice-daily on weekdays", () => {
+    expect(cronToEnglish("13 8,14 * * 1-5")).toBe("At 8:13 AM and 2:13 PM, Monday through Friday");
+  });
+
+  it("reads a step-minute schedule", () => {
+    expect(cronToEnglish("*/15 * * * *")).toBe("Every 15 minutes");
+  });
+
+  it("reads a day-of-month schedule", () => {
+    expect(cronToEnglish("0 0 1 * *")).toBe("At 12:00 AM, on the 1st of the month");
+  });
+
+  it("falls back to a spelled-out field description when there are too many times to list", () => {
+    expect(cronToEnglish("0,30 8,12,16,20 * * *")).toBe("At minute 0 and 30, hour 8 and 12 and 16 and 20");
+  });
+
+  it("returns the raw string when it is not five fields", () => {
+    expect(cronToEnglish("not a cron")).toBe("not a cron");
+  });
+
+  it("names an empty schedule plainly", () => {
+    expect(cronToEnglish("")).toBe("(no schedule)");
+    expect(cronToEnglish(null)).toBe("(no schedule)");
+  });
+});
+
+describe("relativeUntil", () => {
+  const now = Date.parse("2026-07-11T12:00:00Z");
+
+  it("phrases a time 46 minutes out", () => {
+    expect(relativeUntil("2026-07-11T12:46:00Z", now)).toBe("in 46m");
+  });
+
+  it("phrases a time hours out", () => {
+    expect(relativeUntil("2026-07-11T15:00:00Z", now)).toBe("in 3h");
+  });
+
+  it("phrases a time days out", () => {
+    expect(relativeUntil("2026-07-13T12:00:00Z", now)).toBe("in 2d");
+  });
+
+  it("says a past time is overdue", () => {
+    expect(relativeUntil("2026-07-11T11:00:00Z", now)).toBe("overdue");
+  });
+
+  it("returns a dash for an absent or unparseable time", () => {
+    expect(relativeUntil(null, now)).toBe("-");
+    expect(relativeUntil("nonsense", now)).toBe("-");
+  });
+});
+
+describe("epochOrMax", () => {
+  it("parses a valid time to its epoch", () => {
+    expect(epochOrMax("2026-07-11T12:00:00Z")).toBe(Date.parse("2026-07-11T12:00:00Z"));
+  });
+
+  it("sinks an absent time to the maximum so it sorts last, not first", () => {
+    expect(epochOrMax(null)).toBe(Number.MAX_SAFE_INTEGER);
+    expect(epochOrMax("")).toBe(Number.MAX_SAFE_INTEGER);
+  });
+});
+
+describe("lastOutcome", () => {
+  it("marks a success", () => {
+    expect(lastOutcome("OK")).toEqual({ kind: "ok", label: "OK" });
+  });
+
+  it("marks a failure and keeps the reason", () => {
+    expect(lastOutcome("failed: gateway timeout")).toEqual({
+      kind: "err",
+      label: "failed: gateway timeout",
+    });
+  });
+
+  it("shows an unknown status verbatim as a neutral badge", () => {
+    expect(lastOutcome("started")).toEqual({ kind: "warn", label: "started" });
+  });
+
+  it("reports no badge when nothing ran", () => {
+    expect(lastOutcome(null)).toEqual({ kind: "none", label: "" });
+  });
+});
+
+describe("absoluteUtc", () => {
+  it("formats a UTC instant", () => {
+    expect(absoluteUtc("2026-07-11T12:14:00Z")).toBe("2026-07-11 12:14 UTC");
+  });
+
+  it("returns a dash when absent", () => {
+    expect(absoluteUtc(null)).toBe("-");
+  });
+});

--- a/apps/cockpit/src/schedule/scheduleFormat.ts
+++ b/apps/cockpit/src/schedule/scheduleFormat.ts
@@ -1,0 +1,347 @@
+// The pure display logic of the Schedule page (issue #1245). Turning a cron string into plain English,
+// deciding a job's type chip and one-line label, and phrasing a next/last run as a relative time are
+// all pure functions with no React and no DOM, so they are unit-tested directly (scheduleFormat.test.ts).
+// The grid and drawer (ScheduleView.tsx) only render what these return. Everything here is ASCII and
+// spelled out in full words - no abbreviations leak into the interface.
+
+import type { CronJob } from "@devthrottle/client-core/schedule/scheduleClient";
+
+/** The three kinds of thing a scheduled job runs, shown as a small type chip in the grid. */
+export type ActionType = "Skill" | "Work list" | "Prompt";
+
+// Which type chip a job wears. A named work list drains that list; a seed that begins with a slash is a
+// skill invocation (for example "/inbound-watch"); anything else is a free-text prompt. This replaces
+// the old code that glued the raw internal word "skill" onto the front of the prompt body.
+export function actionType(job: CronJob): ActionType {
+  const workList = job.action.workListName ?? "";
+  if (workList.trim().length > 0) return "Work list";
+  return job.action.seed.trim().startsWith("/") ? "Skill" : "Prompt";
+}
+
+// The short, single-line label shown beside the type chip - never the prompt body. For a work list it
+// is the list name. For a skill it is the command and its arguments from the first line. For a prompt
+// it is the first non-empty line, whitespace-collapsed and truncated so the row stays one line high.
+export function actionShortLabel(job: CronJob, maxLength = 60): string {
+  const workList = job.action.workListName ?? "";
+  if (workList.trim().length > 0) return workList.trim();
+
+  const firstLine = firstNonEmptyLine(job.action.seed);
+  if (firstLine.length === 0) return "(no prompt)";
+  return truncate(firstLine, maxLength);
+}
+
+// The full prompt body for the drawer, exactly as stored (no truncation, no "skill" prefix). The drawer
+// shows this read-only in a scrollable monospace block. A work-list job has no prompt body.
+export function promptBody(job: CronJob): string {
+  const workList = job.action.workListName ?? "";
+  if (workList.trim().length > 0) return `Drains the work list "${workList.trim()}".`;
+  return job.action.seed;
+}
+
+function firstNonEmptyLine(text: string): string {
+  for (const line of text.split(/\r?\n/)) {
+    const collapsed = line.trim().replace(/\s+/g, " ");
+    if (collapsed.length > 0) return collapsed;
+  }
+  return "";
+}
+
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
+}
+
+// ===== Relative times =========================================================================
+
+// A future instant phrased as "in 46m" / "in 3h" / "in 2d", with "now" for the current minute and
+// "overdue" for a time already past. `now` is injectable so a ticking page renders consistently and so
+// the tests are deterministic. Returns "-" when the instant is absent or unparseable (fail visibly, do
+// not invent a time).
+export function relativeUntil(iso: string | null | undefined, now: number = Date.now()): string {
+  if (iso === null || iso === undefined || iso.length === 0) return "-";
+  const target = Date.parse(iso);
+  if (Number.isNaN(target)) return "-";
+  const seconds = Math.floor((target - now) / 1000);
+  if (seconds < 0) return "overdue";
+  if (seconds < 60) return "now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `in ${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `in ${hours}h`;
+  return `in ${Math.floor(hours / 24)}d`;
+}
+
+// The absolute wall-clock form shown on hover: "yyyy-MM-dd HH:mm UTC", or "-" when absent. Kept in UTC
+// (matching the rest of the Schedule page) so a job's time reads the same on every machine.
+export function absoluteUtc(iso: string | null | undefined): string {
+  if (iso === null || iso === undefined || iso.length === 0) return "-";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "-";
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())} ${pad(
+    date.getUTCHours(),
+  )}:${pad(date.getUTCMinutes())} UTC`;
+}
+
+// A sortable epoch for a run time: the parsed milliseconds, or a very large number when absent so
+// "never / no next run" rows sink to the bottom of an ascending (soonest-first) sort rather than
+// pretending to be the earliest.
+export function epochOrMax(iso: string | null | undefined): number {
+  if (iso === null || iso === undefined || iso.length === 0) return Number.MAX_SAFE_INTEGER;
+  const parsed = Date.parse(iso);
+  return Number.isNaN(parsed) ? Number.MAX_SAFE_INTEGER : parsed;
+}
+
+// ===== Last-run outcome badge =================================================================
+
+/** How a last-run outcome is coloured: a success, a failure, an in-between, or none recorded. */
+export type OutcomeKind = "ok" | "err" | "warn" | "none";
+
+export interface Outcome {
+  kind: OutcomeKind;
+  label: string;
+}
+
+// Classify a job's last-run status string into a badge. The Gateway's status vocabulary is small; an
+// unknown value is shown verbatim as a neutral badge rather than being dropped, so nothing is hidden.
+export function lastOutcome(status: string | null | undefined): Outcome {
+  const value = (status ?? "").trim();
+  if (value.length === 0) return { kind: "none", label: "" };
+  const lower = value.toLowerCase();
+  if (lower === "ok" || lower === "success" || lower === "succeeded" || lower === "completed") {
+    return { kind: "ok", label: "OK" };
+  }
+  if (lower.includes("fail") || lower === "error" || lower.includes("timeout")) {
+    return { kind: "err", label: value };
+  }
+  return { kind: "warn", label: value };
+}
+
+// ===== Cron to plain English ==================================================================
+
+const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+// Turn a 5-field cron expression (minute hour day-of-month month day-of-week) into a plain-English
+// sentence, for example "13 8,14 * * 1-5" -> "At 8:13 AM and 2:13 PM, Monday through Friday". This
+// never throws: an expression it cannot fully phrase falls back to a spelled-out field description
+// ("At minute 13, hour 8 and 14, ...") rather than an error, and a malformed expression is returned as
+// the raw string so the person still sees exactly what is stored. It phrases the common shapes the
+// Cockpit's schedules actually use; the raw cron is always available on hover for the rest.
+export function cronToEnglish(cron: string | null | undefined): string {
+  const raw = (cron ?? "").trim();
+  if (raw.length === 0) return "(no schedule)";
+  const fields = raw.split(/\s+/);
+  if (fields.length !== 5) return raw;
+
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = fields;
+  const timeText = describeTime(minute, hour);
+  if (timeText === null) return describeFieldsFallback(fields);
+
+  const dayText = describeDays(dayOfMonth, dayOfWeek);
+  const monthText = describeMonths(month);
+
+  const parts = [timeText];
+  if (dayText !== null) parts.push(dayText);
+  if (monthText !== null) parts.push(monthText);
+  return parts.join(", ");
+}
+
+// Phrase the minute+hour fields as a list of clock times ("8:13 AM and 2:13 PM"), or a per-minute /
+// per-hour phrase, or null when the fields are too complex to render as clock times (the caller then
+// uses the spelled-out fallback).
+function describeTime(minute: string, hour: string): string | null {
+  const minuteEveryStep = stepOf(minute, 60);
+  if (minute === "*" && hour === "*") return "Every minute";
+  if (minuteEveryStep !== null && hour === "*") return `Every ${minuteEveryStep} minutes`;
+
+  const minutes = expandList(minute, 0, 59);
+  const hours = expandList(hour, 0, 23);
+  if (minutes === null || hours === null) return null;
+  if (minutes.length === 0 || hours.length === 0) return null;
+  // Only render explicit clock times when the count stays small enough to read as a list.
+  if (minutes.length * hours.length > 6) return null;
+
+  const times: string[] = [];
+  for (const h of hours) {
+    for (const m of minutes) {
+      times.push(clockTime(h, m));
+    }
+  }
+  return `At ${joinList(times)}`;
+}
+
+// Phrase the day-of-week and day-of-month fields. Day-of-week is preferred when present because that is
+// how the Cockpit's schedules are written ("Monday through Friday"). Returns null when both are the
+// wildcard (a daily job has no day clause).
+function describeDays(dayOfMonth: string, dayOfWeek: string): string | null {
+  if (dayOfWeek !== "*") {
+    const range = rangeOf(dayOfWeek);
+    if (range !== null) {
+      return `${DAY_NAMES[range.start % 7]} through ${DAY_NAMES[range.end % 7]}`;
+    }
+    const days = expandList(dayOfWeek, 0, 7);
+    if (days !== null && days.length > 0) {
+      const names = days.map((d) => DAY_NAMES[d % 7]);
+      return joinList(dedupeInOrder(names));
+    }
+  }
+  if (dayOfMonth !== "*") {
+    const days = expandList(dayOfMonth, 1, 31);
+    if (days !== null && days.length > 0) {
+      return `on the ${joinList(days.map(ordinal))} of the month`;
+    }
+  }
+  return null;
+}
+
+function describeMonths(month: string): string | null {
+  if (month === "*") return null;
+  const months = expandList(month, 1, 12);
+  if (months === null || months.length === 0) return null;
+  return `in ${joinList(months.map((m) => MONTH_NAMES[(m - 1) % 12]))}`;
+}
+
+// The last-resort readable rendering: spell out each field. Still plain English, never an error.
+function describeFieldsFallback(fields: string[]): string {
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = fields;
+  const labels = [
+    `minute ${fieldWords(minute)}`,
+    `hour ${fieldWords(hour)}`,
+    dayOfMonth === "*" ? null : `day-of-month ${fieldWords(dayOfMonth)}`,
+    month === "*" ? null : `month ${fieldWords(month)}`,
+    dayOfWeek === "*" ? null : `day-of-week ${fieldWords(dayOfWeek)}`,
+  ].filter((label): label is string => label !== null);
+  return `At ${labels.join(", ")}`;
+}
+
+function fieldWords(field: string): string {
+  return field === "*" ? "every" : field.replace(/,/g, " and ");
+}
+
+// ===== small numeric helpers for the cron parser =============================================
+
+// Expand a single cron field into the explicit sorted list of values it names, within [min, max].
+// Handles "*", a single number, a comma list, a range "a-b", and a step "*/n" or "a-b/n". Returns null
+// for anything outside this grammar so the caller can fall back rather than guess.
+function expandList(field: string, min: number, max: number): number[] | null {
+  if (field === "*") {
+    const all: number[] = [];
+    for (let value = min; value <= max; value++) all.push(value);
+    return all;
+  }
+  const values = new Set<number>();
+  for (const part of field.split(",")) {
+    const expanded = expandPart(part, min, max);
+    if (expanded === null) return null;
+    for (const value of expanded) values.add(value);
+  }
+  return Array.from(values).sort((a, b) => a - b);
+}
+
+function expandPart(part: string, min: number, max: number): number[] | null {
+  const stepMatch = /^(.+)\/(\d+)$/.exec(part);
+  let base = part;
+  let step = 1;
+  if (stepMatch !== null) {
+    base = stepMatch[1];
+    step = Number(stepMatch[2]);
+    if (step <= 0) return null;
+  }
+
+  let start: number;
+  let end: number;
+  if (base === "*") {
+    start = min;
+    end = max;
+  } else {
+    const rangeMatch = /^(\d+)-(\d+)$/.exec(base);
+    if (rangeMatch !== null) {
+      start = Number(rangeMatch[1]);
+      end = Number(rangeMatch[2]);
+    } else if (/^\d+$/.test(base)) {
+      start = Number(base);
+      end = stepMatch !== null ? max : start;
+    } else {
+      return null;
+    }
+  }
+  if (start < min || end > max || start > end) return null;
+
+  const result: number[] = [];
+  for (let value = start; value <= end; value += step) result.push(value);
+  return result;
+}
+
+// The step of a "*/n" field, or null when the field is not a simple step over the whole range.
+function stepOf(field: string, wholeRangeSize: number): number | null {
+  const match = /^\*\/(\d+)$/.exec(field);
+  if (match === null) return null;
+  const step = Number(match[1]);
+  return step > 0 && step < wholeRangeSize ? step : null;
+}
+
+// A simple "a-b" range as start/end numbers, or null when the field is not exactly one range.
+function rangeOf(field: string): { start: number; end: number } | null {
+  const match = /^(\d+)-(\d+)$/.exec(field);
+  if (match === null) return null;
+  const start = Number(match[1]);
+  const end = Number(match[2]);
+  return start <= end ? { start, end } : null;
+}
+
+// A 24-hour (hour, minute) as a 12-hour clock time, for example (14, 5) -> "2:05 PM".
+function clockTime(hour24: number, minute: number): string {
+  const period = hour24 < 12 ? "AM" : "PM";
+  let hour12 = hour24 % 12;
+  if (hour12 === 0) hour12 = 12;
+  return `${hour12}:${String(minute).padStart(2, "0")} ${period}`;
+}
+
+function ordinal(value: number): string {
+  const tens = value % 100;
+  if (tens >= 11 && tens <= 13) return `${value}th`;
+  switch (value % 10) {
+    case 1:
+      return `${value}st`;
+    case 2:
+      return `${value}nd`;
+    case 3:
+      return `${value}rd`;
+    default:
+      return `${value}th`;
+  }
+}
+
+// Join a list into an English series: "a", "a and b", "a, b and c".
+function joinList(items: string[]): string {
+  if (items.length === 0) return "";
+  if (items.length === 1) return items[0];
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")} and ${items[items.length - 1]}`;
+}
+
+function dedupeInOrder(items: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const item of items) {
+    if (!seen.has(item)) {
+      seen.add(item);
+      result.push(item);
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
Closes #1245.

## What changed

A new shared **DataTable** component (`apps/cockpit/src/components/`) built on the issue #1244 kit, then the Schedule page rebuilt on it.

**DataTable** (`DataTable.tsx` + pure `dataTableCore.ts`): sortable columns, a search box, fixed-height single-line rows, whole-row keyboard target, and an optional row-detail drawer. This is the reusable deliverable the Directors page (issue #1246) adopts next. The sort/filter logic is a pure, unit-tested module.

**Schedule grid** (`ScheduleView.tsx` + `scheduleFormat.ts`):
- The "Runs" column is now a **type chip** (Skill / Work list / Prompt) plus a one-line truncated label - never the prompt body, and never the raw word "skill" glued onto the instruction.
- **Schedule** reads in plain English ("At 8:14 AM and 2:14 PM, Monday through Friday") with the raw cron on hover.
- **Next run / Last run** are relative ("in 46m", "6h ago") with the absolute time on hover; the last run carries its outcome badge (OK / FAILED).
- **Default sort** is next run, soonest first (no-next-run rows sink to the bottom); every header sorts; the **search box** matches name, machine, repository, and prompt text.

**Row-detail drawer** (click a row): the full instructions read-only in a scrollable monospace block, the plain-English schedule with raw cron, the resolved next run, the notify policy, and recent run history with infra/task outcomes.

**Editor**: the prompt is now a real multi-line, resizable, monospace text area, and the cron field shows a live plain-English preview so you know what the expression means before saving.

## Acceptance criteria

- [x] No prompt body is visible anywhere in the grid; every row is the same height.
- [x] Clicking a column header sorts; typing in the search box filters; clicking a row opens the drawer with the full instructions.
- [x] The editor prompt area accepts and shows a multi-paragraph instruction comfortably.

## Tests

`npm run test --workspace @devthrottle/cockpit` - 42 tests pass:
- `dataTableCore.test.ts`: sort (numeric/string, ascending/descending, stable), search filtering, header-click sort cycling.
- `scheduleFormat.test.ts`: cron-to-plain-English (daily, weekday twice-daily, step-minute, day-of-month, fallback, malformed), type chip, short label (strips the "skill" prefix, truncates, first-line-only), relative times, sort epoch, outcome badge.

`npm run build --workspace @devthrottle/cockpit` passes (tsc + vite). ESLint clean.

## Proof

Verified in a real browser by rendering the real `ScheduleView` against a stubbed Gateway. The scannable grid (type chips, plain-English schedule, relative times with outcome badges, sortable Next-run default), the row-detail drawer (full instructions + run history), the multi-line prompt editor with live cron preview, and search filtering were all captured. Screenshots attached in the mission QA report.

Built from an isolated worktree off origin/main; only the ten Schedule/DataTable files are touched.