### PR TITLE
fix(cockpit): stop silently losing unsaved settings and dictionary edits (#1255)

### DIFF
--- a/apps/cockpit/src/dictionary/DictionaryView.tsx
+++ b/apps/cockpit/src/dictionary/DictionaryView.tsx
@@ -1,11 +1,17 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useBlocker } from "react-router-dom";
 import {
   getDictionary,
   saveDictionary,
   type Dictionary,
 } from "@devthrottle/client-core/dictation/dictionaryClient";
+import {
+  addMistranscriptionTerm,
+  addMistranscriptionVariant,
+  addVocabularyWord,
+} from "@devthrottle/client-core/dictation/dictionaryEdits";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
+import { ConfirmDialog } from "../components";
 
 // The dictation Dictionary editor (issue #977, epic #967) - the React port of the Blazor Cockpit
 // Dictionary.razor (#183). The human edits the vocabulary chips biased into speech-to-text and the
@@ -27,7 +33,34 @@ export function DictionaryView() {
   // Per-term draft text for the "+ wrong spelling" inputs, keyed by term.
   const [variantDrafts, setVariantDrafts] = useState<Record<string, string>>({});
 
+  // Rejection notices shown next to each add box (issue #1255): a duplicate no longer silently clears
+  // the input - it says so here, and the notice clears the moment the person edits that box again.
+  const [vocabNotice, setVocabNotice] = useState("");
+  const [termNotice, setTermNotice] = useState("");
+  const [variantNotices, setVariantNotices] = useState<Record<string, string>>({});
+
   const clearMsgTimer = useRef<number | null>(null);
+
+  // Guard against losing unsaved edits on navigation (issue #1255). useBlocker intercepts in-app route
+  // changes (for example the "Dashboard" link) while there are unsaved edits, so the person is asked
+  // before the page unmounts and the edits vanish. The browser's own beforeunload covers a tab close or
+  // refresh, which React Router cannot intercept.
+  const blocker = useBlocker(dirty);
+  // ConfirmDialog calls onClose right after a successful (synchronous) onConfirm. For the navigation
+  // guard that would fire blocker.reset() immediately after blocker.proceed() and cancel the very
+  // navigation we just allowed. This flag lets that trailing onClose no-op when we are proceeding, so
+  // only a real cancel/dismiss resets the blocker.
+  const proceedingRef = useRef(false);
+  useEffect(() => {
+    if (!dirty) return;
+    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      // A non-empty returnValue is what triggers the browser's native "leave site?" prompt.
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, [dirty]);
 
   useEffect(() => {
     let cancelled = false;
@@ -52,12 +85,20 @@ export function DictionaryView() {
 
   // ---- vocabulary ----
   const addVocab = () => {
-    const v = newVocab.trim();
-    setNewVocab("");
-    if (v.length === 0 || dict === null) return;
-    if (!dict.vocabulary.includes(v)) {
-      setDict({ ...dict, vocabulary: [...dict.vocabulary, v] });
+    if (dict === null) return;
+    const result = addVocabularyWord(dict, newVocab);
+    if (result.status === "added") {
+      setDict(result.dict);
+      setNewVocab("");
+      setVocabNotice("");
       markDirty();
+    } else if (result.status === "duplicate") {
+      // Keep the text so the person sees exactly what was rejected, and say why.
+      setVocabNotice(`"${result.word}" is already in the vocabulary.`);
+    } else {
+      // Empty input - nothing to add and nothing to announce; just clear the box.
+      setNewVocab("");
+      setVocabNotice("");
     }
   };
 
@@ -69,15 +110,18 @@ export function DictionaryView() {
 
   // ---- mistranscriptions ----
   const addTerm = () => {
-    const name = newTerm.trim();
-    setNewTerm("");
-    if (name.length === 0 || dict === null) return;
-    if (!(name in dict.commonMistranscriptions)) {
-      setDict({
-        ...dict,
-        commonMistranscriptions: { ...dict.commonMistranscriptions, [name]: [] },
-      });
+    if (dict === null) return;
+    const result = addMistranscriptionTerm(dict, newTerm);
+    if (result.status === "added") {
+      setDict(result.dict);
+      setNewTerm("");
+      setTermNotice("");
       markDirty();
+    } else if (result.status === "duplicate") {
+      setTermNotice(`"${result.word}" is already a term.`);
+    } else {
+      setNewTerm("");
+      setTermNotice("");
     }
   };
 
@@ -91,24 +135,38 @@ export function DictionaryView() {
       delete copy[term];
       return copy;
     });
+    setVariantNotices((n) => {
+      const copy = { ...n };
+      delete copy[term];
+      return copy;
+    });
     markDirty();
   };
 
-  const setVariantDraft = (term: string, value: string) =>
+  const setVariantNotice = (term: string, value: string) =>
+    setVariantNotices((n) => ({ ...n, [term]: value }));
+
+  const setVariantDraft = (term: string, value: string) => {
     setVariantDrafts((d) => ({ ...d, [term]: value }));
+    // Editing the box clears any stale duplicate notice for that term.
+    setVariantNotices((n) => (n[term] ? { ...n, [term]: "" } : n));
+  };
 
   const addVariant = (term: string) => {
     if (dict === null) return;
-    const v = (variantDrafts[term] ?? "").trim();
-    setVariantDrafts((d) => ({ ...d, [term]: "" }));
-    if (v.length === 0) return;
-    const variants = dict.commonMistranscriptions[term];
-    if (variants === undefined || variants.includes(v)) return;
-    setDict({
-      ...dict,
-      commonMistranscriptions: { ...dict.commonMistranscriptions, [term]: [...variants, v] },
-    });
-    markDirty();
+    const result = addMistranscriptionVariant(dict, term, variantDrafts[term] ?? "");
+    if (result.status === "added") {
+      setDict(result.dict);
+      setVariantDrafts((d) => ({ ...d, [term]: "" }));
+      setVariantNotice(term, "");
+      markDirty();
+    } else if (result.status === "duplicate") {
+      setVariantNotice(term, `"${result.variant}" is already listed.`);
+    } else {
+      // Empty input or a term that vanished under the page - clear the box, nothing to announce.
+      setVariantDrafts((d) => ({ ...d, [term]: "" }));
+      setVariantNotice(term, "");
+    }
   };
 
   const removeVariant = (term: string, vi: number) => {
@@ -194,12 +252,20 @@ export function DictionaryView() {
                   className="dc-addbox"
                   placeholder="+ add term"
                   value={newVocab}
-                  onChange={(e) => setNewVocab(e.target.value)}
+                  onChange={(e) => {
+                    setNewVocab(e.target.value);
+                    if (vocabNotice !== "") setVocabNotice("");
+                  }}
                   onKeyDown={(e) => {
                     if (e.key === "Enter") addVocab();
                   }}
                 />
               </div>
+              {vocabNotice !== "" && (
+                <p className="dc-notice" role="status">
+                  {vocabNotice}
+                </p>
+              )}
             </div>
 
             {/* ---- Common mistranscriptions ---- */}
@@ -246,6 +312,11 @@ export function DictionaryView() {
                             }}
                           />
                         </div>
+                        {(variantNotices[term] ?? "") !== "" && (
+                          <p className="dc-notice" role="status">
+                            {variantNotices[term]}
+                          </p>
+                        )}
                       </div>
                     </div>
                   ))
@@ -256,16 +327,45 @@ export function DictionaryView() {
                   className="dc-addbox dc-addterm"
                   placeholder="+ add a term to correct"
                   value={newTerm}
-                  onChange={(e) => setNewTerm(e.target.value)}
+                  onChange={(e) => {
+                    setNewTerm(e.target.value);
+                    if (termNotice !== "") setTermNotice("");
+                  }}
                   onKeyDown={(e) => {
                     if (e.key === "Enter") addTerm();
                   }}
                 />
+                {termNotice !== "" && (
+                  <p className="dc-notice" role="status">
+                    {termNotice}
+                  </p>
+                )}
               </div>
             </div>
           </>
         )}
       </div>
+
+      {/* Warn before navigating away from unsaved dictionary edits (issue #1255). The blocker is armed
+          only while `dirty` is true; confirming lets the pending navigation through, cancelling stays. */}
+      <ConfirmDialog
+        open={blocker.state === "blocked"}
+        title="Leave with unsaved edits?"
+        message="Your dictionary changes have not been saved. If you leave now they will be lost."
+        confirmLabel="Leave without saving"
+        cancelLabel="Stay on this page"
+        onConfirm={() => {
+          proceedingRef.current = true;
+          blocker.proceed?.();
+        }}
+        onClose={() => {
+          if (proceedingRef.current) {
+            proceedingRef.current = false;
+            return;
+          }
+          blocker.reset?.();
+        }}
+      />
     </div>
   );
 }

--- a/apps/cockpit/src/dictionary/dictionary.css
+++ b/apps/cockpit/src/dictionary/dictionary.css
@@ -191,3 +191,11 @@
   font-size: 13px;
   padding: 6px 0;
 }
+
+/* Duplicate-rejection notice next to an add box (issue #1255): a duplicate no longer silently clears
+   the input - it says so here, in amber so it reads as "not added". */
+.dc-notice {
+  color: var(--attention);
+  font-size: 12.5px;
+  margin: 8px 0 0;
+}

--- a/apps/cockpit/src/fleet/DirectorDetailView.tsx
+++ b/apps/cockpit/src/fleet/DirectorDetailView.tsx
@@ -10,6 +10,8 @@ import {
   type FleetDirector,
   type MachineError,
 } from "@devthrottle/client-core/fleet/fleetClient";
+import { isSettingsDirty, prettyPrintSettings } from "@devthrottle/client-core/fleet/settingsEditor";
+import { ConfirmDialog } from "../components";
 import { clockLabel, humanizeState, portLabel, relativeTime, repoBasename, uptime } from "./format";
 
 // The standalone Director page (issue #975) - the React port of the Blazor DirectorDetail.razor:
@@ -271,10 +273,17 @@ export function DirectorDetailView() {
 // reaches the wire, and the Director re-applies live.
 function DirectorSettings({ directorId, reachable }: { directorId: string; reachable: boolean }) {
   const [text, setText] = useState<string>("");
+  // The last-loaded (or last-saved) text: the baseline the current text is compared against for dirty
+  // tracking (issue #1255). Save is disabled while the text matches it, and Reload asks before
+  // discarding when the text differs.
+  const [baseline, setBaseline] = useState<string>("");
   const [loaded, setLoaded] = useState(false);
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [confirmReload, setConfirmReload] = useState(false);
+
+  const dirty = loaded && isSettingsDirty(text, baseline);
 
   const load = useCallback(async () => {
     setBusy(true);
@@ -282,14 +291,11 @@ function DirectorSettings({ directorId, reachable }: { directorId: string; reach
     setStatus(null);
     try {
       const raw = await getDirectorSettings(directorId);
-      // Pretty-print for editing; keep the raw text if it is not valid JSON so nothing is lost.
-      let pretty = raw;
-      try {
-        pretty = JSON.stringify(JSON.parse(raw), null, 2);
-      } catch {
-        pretty = raw;
-      }
+      // Pretty-print for editing; keep the raw text if it is not valid JSON so nothing is lost. The
+      // same value becomes the dirty-tracking baseline, so a freshly-loaded editor reads as clean.
+      const pretty = prettyPrintSettings(raw);
       setText(pretty);
+      setBaseline(pretty);
       setLoaded(true);
       setStatus("Loaded");
     } catch (err) {
@@ -313,11 +319,23 @@ function DirectorSettings({ directorId, reachable }: { directorId: string; reach
     setBusy(true);
     try {
       await putDirectorSettings(directorId, normalized);
+      // The saved text is now the clean baseline, so the editor goes clean and Save disables again.
+      setBaseline(text);
       setStatus("Saved - the Director re-applied it live.");
     } catch (err) {
       setError(gatewayErrorMessage(err));
     } finally {
       setBusy(false);
+    }
+  };
+
+  // Reload replaces the current text with the Director's stored settings. When there are unsaved edits,
+  // route it through the shared confirmation so a stray Reload can never silently drop them (#1255).
+  const requestReload = () => {
+    if (dirty) {
+      setConfirmReload(true);
+    } else {
+      void load();
     }
   };
 
@@ -344,15 +362,30 @@ function DirectorSettings({ directorId, reachable }: { directorId: string; reach
             onChange={(e) => setText(e.target.value)}
           />
           <div className="ddet-settings-actions">
-            <button type="button" className="ddet-btn ddet-btn-primary" onClick={() => void save()} disabled={busy}>
+            <button
+              type="button"
+              className="ddet-btn ddet-btn-primary"
+              onClick={() => void save()}
+              disabled={busy || !dirty}
+            >
               {busy ? "Saving..." : "Save"}
             </button>
-            <button type="button" className="ddet-btn" onClick={() => void load()} disabled={busy}>Reload</button>
-            {status !== null && <span className="ddet-settings-status">{status}</span>}
+            <button type="button" className="ddet-btn" onClick={requestReload} disabled={busy}>Reload</button>
+            {dirty && <span className="ddet-settings-dirty">Unsaved changes</span>}
+            {status !== null && !dirty && <span className="ddet-settings-status">{status}</span>}
           </div>
         </div>
       )}
       {error !== null && <div className="ddet-settings-error">{error}</div>}
+      <ConfirmDialog
+        open={confirmReload}
+        title="Discard unsaved changes?"
+        message="Reloading replaces your edits with the Director's stored settings. This cannot be undone."
+        confirmLabel="Discard and reload"
+        cancelLabel="Keep editing"
+        onConfirm={() => void load()}
+        onClose={() => setConfirmReload(false)}
+      />
     </section>
   );
 }

--- a/apps/cockpit/src/fleet/fleet.css
+++ b/apps/cockpit/src/fleet/fleet.css
@@ -830,6 +830,13 @@
   font-size: 12px;
 }
 
+/* The unsaved-edits cue on the settings editor (issue #1255): amber, so it reads as "action pending"
+   next to the enabled Save button. */
+.ddet-settings-dirty {
+  color: var(--warn);
+  font-size: 12px;
+}
+
 .ddet-settings-error {
   margin-top: 8px;
   color: var(--attention);

--- a/packages/client-core/src/dictation/dictionaryEdits.test.ts
+++ b/packages/client-core/src/dictation/dictionaryEdits.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  addMistranscriptionTerm,
+  addMistranscriptionVariant,
+  addVocabularyWord,
+} from "./dictionaryEdits";
+import type { Dictionary } from "./dictionaryClient";
+
+// Regression tests for the Dictionary duplicate-swallowing bug (issue #1255): before the fix, adding
+// an entry that already existed silently no-oped. These lock the explicit outcomes the page relies on
+// to announce duplicates and to keep an unchanged Dictionary reference when nothing was added.
+
+function base(): Dictionary {
+  return {
+    vocabulary: ["devthrottle", "gateway"],
+    commonMistranscriptions: { throttle: ["throddle"], director: [] },
+    profiles: {},
+  };
+}
+
+describe("addVocabularyWord", () => {
+  it("adds a new, trimmed word", () => {
+    const dict = base();
+    const r = addVocabularyWord(dict, "  cockpit  ");
+    expect(r.status).toBe("added");
+    if (r.status !== "added") throw new Error("expected added");
+    expect(r.word).toBe("cockpit");
+    expect(r.dict.vocabulary).toEqual(["devthrottle", "gateway", "cockpit"]);
+    // The input Dictionary is not mutated.
+    expect(dict.vocabulary).toEqual(["devthrottle", "gateway"]);
+  });
+
+  it("reports a duplicate instead of silently swallowing it", () => {
+    const r = addVocabularyWord(base(), "gateway");
+    expect(r).toEqual({ status: "duplicate", word: "gateway" });
+  });
+
+  it("treats whitespace-only input as empty", () => {
+    expect(addVocabularyWord(base(), "   ").status).toBe("empty");
+  });
+});
+
+describe("addMistranscriptionTerm", () => {
+  it("adds a new term with an empty variant list", () => {
+    const r = addMistranscriptionTerm(base(), "wingman");
+    expect(r.status).toBe("added");
+    if (r.status !== "added") throw new Error("expected added");
+    expect(r.dict.commonMistranscriptions.wingman).toEqual([]);
+  });
+
+  it("reports a duplicate term (including one whose variant list is empty)", () => {
+    // "director" already exists with an empty variant list - this is exactly the case that used to be
+    // indistinguishable from a fresh add.
+    expect(addMistranscriptionTerm(base(), "director")).toEqual({ status: "duplicate", word: "director" });
+    expect(addMistranscriptionTerm(base(), "throttle")).toEqual({ status: "duplicate", word: "throttle" });
+  });
+
+  it("treats empty input as empty", () => {
+    expect(addMistranscriptionTerm(base(), "").status).toBe("empty");
+  });
+});
+
+describe("addMistranscriptionVariant", () => {
+  it("adds a new, trimmed variant under an existing term", () => {
+    const r = addMistranscriptionVariant(base(), "director", "  dyrector  ");
+    expect(r.status).toBe("added");
+    if (r.status !== "added") throw new Error("expected added");
+    expect(r.dict.commonMistranscriptions.director).toEqual(["dyrector"]);
+  });
+
+  it("reports a duplicate variant instead of swallowing it", () => {
+    expect(addMistranscriptionVariant(base(), "throttle", "throddle")).toEqual({
+      status: "duplicate",
+      term: "throttle",
+      variant: "throddle",
+    });
+  });
+
+  it("reports a missing term rather than crashing", () => {
+    expect(addMistranscriptionVariant(base(), "nope", "x")).toEqual({ status: "missing-term", term: "nope" });
+  });
+
+  it("treats whitespace-only input as empty", () => {
+    expect(addMistranscriptionVariant(base(), "throttle", "  ").status).toBe("empty");
+  });
+});

--- a/packages/client-core/src/dictation/dictionaryEdits.ts
+++ b/packages/client-core/src/dictation/dictionaryEdits.ts
@@ -1,0 +1,73 @@
+// Pure edit operations for the dictation Dictionary editor (issue #1255). The Cockpit Dictionary page
+// used to fold "the word is already there" into the same silent no-op as "the box is empty" - it
+// cleared the input and did nothing, so a person who re-typed an existing word got no sign their edit
+// was rejected. These functions make the outcome explicit: an add either produces a new Dictionary, or
+// reports exactly why it did not (empty input, or a duplicate the page must announce). The page reads
+// the status and shows the duplicate case instead of swallowing it.
+//
+// Every function is a pure transform over the immutable Dictionary shape (it returns a fresh object and
+// never mutates its argument), so the page can drive React state from the result and these rules can be
+// unit-tested without a browser.
+import type { Dictionary } from "./dictionaryClient";
+
+/** Outcome of trying to add a single string entry (a vocabulary word, or a term to correct). */
+export type AddEntryResult =
+  // The trimmed input was empty - there is nothing to add, and nothing to announce.
+  | { status: "empty" }
+  // The entry already exists - the page must say so rather than silently clearing the input.
+  | { status: "duplicate"; word: string }
+  // The entry was added - `dict` is the new Dictionary the page should adopt.
+  | { status: "added"; word: string; dict: Dictionary };
+
+/** Add a word to the vocabulary biased into speech-to-text. Trims first; rejects empty and duplicates. */
+export function addVocabularyWord(dict: Dictionary, raw: string): AddEntryResult {
+  const word = raw.trim();
+  if (word.length === 0) return { status: "empty" };
+  if (dict.vocabulary.includes(word)) return { status: "duplicate", word };
+  return { status: "added", word, dict: { ...dict, vocabulary: [...dict.vocabulary, word] } };
+}
+
+/** Add a correct-term key to the common-mistranscriptions map (with an empty variant list). Trims
+ *  first; rejects empty and a term already present in the map. */
+export function addMistranscriptionTerm(dict: Dictionary, raw: string): AddEntryResult {
+  const word = raw.trim();
+  if (word.length === 0) return { status: "empty" };
+  if (Object.prototype.hasOwnProperty.call(dict.commonMistranscriptions, word)) {
+    return { status: "duplicate", word };
+  }
+  return {
+    status: "added",
+    word,
+    dict: { ...dict, commonMistranscriptions: { ...dict.commonMistranscriptions, [word]: [] } },
+  };
+}
+
+/** Outcome of trying to add a wrong-spelling variant under an existing correct term. */
+export type AddVariantResult =
+  // The trimmed input was empty - nothing to add.
+  | { status: "empty" }
+  // The term is not in the map (it was removed under the page's feet) - the page cannot add to it.
+  | { status: "missing-term"; term: string }
+  // The variant is already listed for this term - the page must say so, not silently clear the input.
+  | { status: "duplicate"; term: string; variant: string }
+  // The variant was added - `dict` is the new Dictionary the page should adopt.
+  | { status: "added"; term: string; variant: string; dict: Dictionary };
+
+/** Add a wrong-spelling variant under a correct term. Trims first; rejects empty, a missing term, and
+ *  a duplicate variant already listed for that term. */
+export function addMistranscriptionVariant(dict: Dictionary, term: string, raw: string): AddVariantResult {
+  const variant = raw.trim();
+  if (variant.length === 0) return { status: "empty" };
+  const variants = dict.commonMistranscriptions[term];
+  if (variants === undefined) return { status: "missing-term", term };
+  if (variants.includes(variant)) return { status: "duplicate", term, variant };
+  return {
+    status: "added",
+    term,
+    variant,
+    dict: {
+      ...dict,
+      commonMistranscriptions: { ...dict.commonMistranscriptions, [term]: [...variants, variant] },
+    },
+  };
+}

--- a/packages/client-core/src/fleet/settingsEditor.test.ts
+++ b/packages/client-core/src/fleet/settingsEditor.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { isSettingsDirty, prettyPrintSettings } from "./settingsEditor";
+
+// Regression tests for the Director settings editor dirty tracking (issue #1255): Save must be disabled
+// until the text actually differs from what was loaded, and Reload must know when there are edits to
+// warn about.
+
+describe("prettyPrintSettings", () => {
+  it("pretty-prints valid JSON with two-space indentation", () => {
+    expect(prettyPrintSettings('{"a":1,"b":2}')).toBe('{\n  "a": 1,\n  "b": 2\n}');
+  });
+
+  it("keeps invalid JSON verbatim so nothing is lost", () => {
+    expect(prettyPrintSettings("not json {")).toBe("not json {");
+  });
+
+  it("is idempotent - re-printing already-pretty text leaves a clean editor", () => {
+    const once = prettyPrintSettings('{"a":1}');
+    expect(prettyPrintSettings(once)).toBe(once);
+    // A freshly-loaded, untouched editor is therefore clean against its own baseline.
+    expect(isSettingsDirty(once, once)).toBe(false);
+  });
+});
+
+describe("isSettingsDirty", () => {
+  it("is clean when the text equals the baseline", () => {
+    expect(isSettingsDirty('{\n  "a": 1\n}', '{\n  "a": 1\n}')).toBe(false);
+  });
+
+  it("is dirty on any content change", () => {
+    expect(isSettingsDirty('{\n  "a": 2\n}', '{\n  "a": 1\n}')).toBe(true);
+  });
+
+  it("is dirty on a whitespace-only change (a real edit the person may want to keep)", () => {
+    expect(isSettingsDirty('{"a":1} ', '{"a":1}')).toBe(true);
+  });
+});

--- a/packages/client-core/src/fleet/settingsEditor.ts
+++ b/packages/client-core/src/fleet/settingsEditor.ts
@@ -1,0 +1,22 @@
+// Pure helpers for the Director settings editor's dirty tracking (issue #1255). The editor is a raw
+// JSON text area; before the fix it had no notion of "unsaved edits", so Reload silently discarded them
+// and Save was always enabled. These two helpers give the page the exact baseline it compares against:
+// what the text looks like right after a load, and whether the current text differs from it.
+
+/** Pretty-print raw settings JSON for editing. If the body is not valid JSON, keep it verbatim so the
+ *  person can still see and fix it - this preserves the text, it does not hide a failure. The load
+ *  baseline and the dirty check both use this so a freshly-loaded, untouched editor reads as clean. */
+export function prettyPrintSettings(raw: string): string {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}
+
+/** True when the current text differs from the last-loaded (or last-saved) baseline. Compared exactly,
+ *  including whitespace: a whitespace-only change is still an edit the person may want to keep, so it
+ *  must enable Save and arm the discard-on-reload confirmation. */
+export function isSettingsDirty(current: string, baseline: string): boolean {
+  return current !== baseline;
+}


### PR DESCRIPTION
Fixes #1255.

Two Cockpit surfaces silently lost the person's unsaved edits. Both now guard them.

## What changed

### Director settings editor (`apps/cockpit/src/fleet/DirectorDetailView.tsx`)
- Tracks the current text against the last-loaded (or last-saved) baseline.
- **Save is disabled until the text actually differs** from what was loaded (was `disabled={busy}` only).
- An amber **"Unsaved changes"** cue shows while dirty.
- **Reload routes through the shared `ConfirmDialog` (#1244)** ("Discard unsaved changes?") when there are edits to lose; when clean it reloads directly.

### Dictionary (`apps/cockpit/src/dictionary/DictionaryView.tsx`)
- Adding a duplicate **vocabulary word / term / variant** now shows a visible **"... is already in the dictionary"** notice and keeps the input, instead of silently clearing it and doing nothing.
- **Navigation is guarded while unsaved:** an in-app route change (for example the Dashboard link) routes through `ConfirmDialog` ("Leave with unsaved edits?"); a tab close/refresh triggers the browser's own leave prompt.

### Pure, unit-tested logic (`packages/client-core`)
The add rules and the dirty check are extracted into pure helpers so the regressions are locked by tests:
- `dictation/dictionaryEdits.ts` - `addVocabularyWord`, `addMistranscriptionTerm`, `addMistranscriptionVariant` return an explicit `added` / `duplicate` / `empty` outcome (no more silent swallow).
- `fleet/settingsEditor.ts` - `prettyPrintSettings`, `isSettingsDirty`.

## Proof

**Automated tests** - `npm --prefix packages/client-core test`: **179 passed** (17 files), including the 16 new tests in `dictionaryEdits.test.ts` (10) and `settingsEditor.test.ts` (6). Cockpit `npm run build` (tsc --noEmit && vite build) passes; eslint clean.

**End-to-end in the running app** (Vite dev server + Playwright, Gateway calls stubbed):

```
[1] Dictionary loaded; Save disabled: True
[2] Duplicate notice: '"gateway" is already in the vocabulary.' | input kept: 'gateway'
[3] After adding new word, Save enabled: True
[4] Leave-guard dialog title: 'Leave with unsaved edits?' | still on /dictionary: True
[5] After cancel, still on /dictionary: True | chip 'cockpit' present: True
[6] Settings loaded; Save disabled when clean: True
[7] After edit, 'Unsaved changes' shown: True | Save enabled: True
[8] Reload discard dialog: 'Discard unsaved changes?'
[9] After cancel Reload, still dirty: True
PROOF OK
```

### Acceptance criteria
- [x] Type into the settings box and press Reload: a confirmation appears; cancel keeps the text. (steps 7-9)
- [x] Save is disabled until the settings text actually differs from what was loaded. (steps 6-7)
- [x] Adding a duplicate dictionary word produces a visible message; navigating away with unsaved dictionary edits warns or loses nothing. (steps 2, 4-5)

Depends on: #1244 (shared `ConfirmDialog`), which is merged to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)