### PR TITLE
Mobile PWA dictation: water-drop ready cue when the mic goes live

### DIFF
--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -585,6 +585,7 @@ a.banner-btn {
   color: var(--attention);
 }
 
+.dictate-status-connecting,
 .dictate-status-transcribing,
 .dictate-status-paused {
   color: #dcdcaa;

--- a/packages/client-core/src/dictation/DictationDialog.tsx
+++ b/packages/client-core/src/dictation/DictationDialog.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { transcribeUtterance } from "../api/client";
 import type { CapturedUtterance } from "./backgroundSend";
 import { logCaptureHealth } from "./captureHealth";
+import { playReadyCue } from "./readyCue";
 import { MicRecorder } from "./recorder";
 import { joinText } from "./transcript";
 import { blobToWav16kMono } from "./wav";
@@ -22,7 +23,15 @@ import { blobToWav16kMono } from "./wav";
 // by the single dictionary-correction engine; this component only displays them, lets the user
 // hand-edit, and joins segments with a single space. It never rewrites the words.
 
-type Stage = "recording" | "transcribing" | "paused" | "error";
+// "connecting" = the GETTING READY warm-up: the mic is opening but has not delivered audio yet, so
+// the dialog is deliberately NOT in the red RECORDING look and plays no cue. It flips to "recording"
+// (and plays the ready bloop) only when the first real audio chunk arrives, so neither the red state
+// nor the sound ever precedes real audio - the desktop SpeakDialog does the same.
+type Stage = "connecting" | "recording" | "transcribing" | "paused" | "error";
+
+// Backstop for the GETTING READY state: if the mic never delivers a first chunk, fail loud with a
+// "check your microphone" message rather than stranding the user on GETTING READY forever.
+const READY_TIMEOUT_MS = 6000;
 
 export interface DictationDialogProps {
   /** Commit the transcript WITHOUT submitting (drop into the view's text box for editing). Required
@@ -64,12 +73,52 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
   const segmentStartRef = useRef<number>(0);
   const elapsedBeforeRef = useRef<number>(0);
 
-  const [stage, setStage] = useState<Stage>("recording");
+  const [stage, setStage] = useState<Stage>("connecting");
+  // Mirror of the current stage for use inside timers/callbacks without stale closures.
+  const stageRef = useRef<Stage>("connecting");
+  useEffect(() => {
+    stageRef.current = stage;
+  }, [stage]);
+
+  // Pending GETTING READY backstop timer (window.setTimeout handle), or null when disarmed.
+  const readyTimeoutRef = useRef<number | null>(null);
+
   const [transcript, setTranscript] = useState<string>("");
   const [hint, setHint] = useState<string>("");
   const [errorText, setErrorText] = useState<string>("");
   const [elapsed, setElapsed] = useState<number>(0);
   const [levels, setLevels] = useState<number[]>(() => new Array(BAR_COUNT).fill(0));
+
+  const clearReadyBackstop = useCallback(() => {
+    if (readyTimeoutRef.current !== null) {
+      window.clearTimeout(readyTimeoutRef.current);
+      readyTimeoutRef.current = null;
+    }
+  }, []);
+
+  const armReadyBackstop = useCallback(() => {
+    clearReadyBackstop();
+    readyTimeoutRef.current = window.setTimeout(() => {
+      readyTimeoutRef.current = null;
+      if (stageRef.current !== "connecting") return;
+      setErrorText(
+        "The microphone did not start capturing. Check that it is connected, not muted, and that this site is allowed to use it, then try again.",
+      );
+      setStage("error");
+    }, READY_TIMEOUT_MS);
+  }, [clearReadyBackstop]);
+
+  // The honest "mic is now capturing your voice" moment (first real audio chunk). Anchor the
+  // segment timer here, flip to RECORDING, and play the ready cue together - so the red and the
+  // sound land exactly when audio starts flowing, never before. elapsedBeforeRef is left untouched
+  // so a Resume keeps its accumulated time; only a fresh open resets it (in the mount effect).
+  const onCaptureLive = useCallback(() => {
+    clearReadyBackstop();
+    if (stageRef.current !== "connecting") return;
+    segmentStartRef.current = performance.now();
+    setStage("recording");
+    playReadyCue();
+  }, [clearReadyBackstop]);
 
   // ----- equalizer + timer animation (display only) -----
   useEffect(() => {
@@ -97,24 +146,32 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
   useEffect(() => {
     const recorder = recorderRef.current;
     let cancelled = false;
+    // Flip to RECORDING + play the cue only when the first real audio chunk arrives (not merely
+    // when start() returns). The same handler serves every segment on this recorder instance.
+    recorder.onCaptureLive = () => {
+      if (cancelled) return;
+      onCaptureLive();
+    };
     (async () => {
       try {
-        await recorder.start();
-        if (cancelled) return;
-        segmentStartRef.current = performance.now();
+        // A fresh open starts the running total from zero; hold GETTING READY until audio flows.
         elapsedBeforeRef.current = 0;
-        setStage("recording");
+        armReadyBackstop();
+        await recorder.start();
+        // Intentionally do NOT flip to RECORDING here - onCaptureLive does, once audio is real.
       } catch (err) {
         if (cancelled) return;
+        clearReadyBackstop();
         setErrorText(err instanceof Error ? err.message : "Could not start the microphone.");
         setStage("error");
       }
     })();
     return () => {
       cancelled = true;
+      clearReadyBackstop();
       recorder.dispose();
     };
-  }, []);
+  }, [onCaptureLive, armReadyBackstop, clearReadyBackstop]);
 
   // Stop the current segment, transcode to WAV, and transcribe it. Returns the segment text, or
   // null when there was no audio / transcription failed (the reason is shown). The recorder is
@@ -170,18 +227,21 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
       busyRef.current = false;
     } else if (stage === "paused") {
       // Resume: re-seed from the (possibly edited) box so edits survive, start a fresh segment.
+      // Hold GETTING READY until the mic delivers audio again; onCaptureLive flips to RECORDING
+      // (and re-cues), keeping the accumulated elapsed time.
       accumulatedRef.current = transcript;
+      setHint("");
+      setStage("connecting");
+      armReadyBackstop();
       try {
         await recorderRef.current.start();
-        segmentStartRef.current = performance.now();
-        setHint("");
-        setStage("recording");
       } catch (err) {
+        clearReadyBackstop();
         setHint("Could not resume - your text is kept. " + (err instanceof Error ? err.message : ""));
         setStage("paused");
       }
     }
-  }, [stage, transcript, transcribeCurrentSegment]);
+  }, [stage, transcript, transcribeCurrentSegment, armReadyBackstop, clearReadyBackstop]);
 
   const commit = useCallback(
     async (action: (text: string) => void) => {
@@ -271,8 +331,20 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
   const isError = stage === "error";
   const isPaused = stage === "paused";
   const isTranscribing = stage === "transcribing";
+  const isConnecting = stage === "connecting";
+  // Nothing is captured yet while GETTING READY (and nothing is mid-transcription), so the
+  // commit/checkpoint actions are not actionable then.
+  const actionsDisabled = isTranscribing || isConnecting;
   const statusLabel =
-    stage === "recording" ? "RECORDING" : stage === "transcribing" ? "TRANSCRIBING" : stage === "paused" ? "PAUSED" : "ERROR";
+    stage === "connecting"
+      ? "GETTING READY"
+      : stage === "recording"
+        ? "RECORDING"
+        : stage === "transcribing"
+          ? "TRANSCRIBING"
+          : stage === "paused"
+            ? "PAUSED"
+            : "ERROR";
 
   return (
     <div className="dictate-overlay" role="dialog" aria-modal="true" aria-label="Dictate">
@@ -318,7 +390,7 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
               type="button"
               className="dictate-btn dictate-pause"
               onClick={onPauseResume}
-              disabled={isTranscribing}
+              disabled={actionsDisabled}
             >
               {isPaused ? "Resume" : <span className="dictate-pause-glyph"><i /><i /></span>}
             </button>
@@ -331,7 +403,7 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
                   type="button"
                   className="dictate-btn dictate-insert"
                   onClick={() => commit(onInsert)}
-                  disabled={isTranscribing}
+                  disabled={actionsDisabled}
                 >
                   Insert
                 </button>
@@ -340,7 +412,7 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
                 type="button"
                 className="dictate-btn dictate-send"
                 onClick={onSendClick}
-                disabled={isTranscribing}
+                disabled={actionsDisabled}
               >
                 Send
               </button>

--- a/packages/client-core/src/dictation/readyCue.test.ts
+++ b/packages/client-core/src/dictation/readyCue.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { playReadyCue } from "./readyCue";
+
+// The ready cue is best-effort audio: it must play the right shape when Web Audio is available and
+// must never throw when it is not. These tests inject a fake AudioContext (the tests run in Node,
+// where window/AudioContext do not exist) to verify the bloop wiring without a real sound device.
+
+interface Ramp {
+  method: "setValueAtTime" | "exponentialRampToValueAtTime";
+  value: number;
+  time: number;
+}
+
+class FakeParam {
+  ramps: Ramp[] = [];
+  setValueAtTime(value: number, time: number) {
+    this.ramps.push({ method: "setValueAtTime", value, time });
+  }
+  exponentialRampToValueAtTime(value: number, time: number) {
+    this.ramps.push({ method: "exponentialRampToValueAtTime", value, time });
+  }
+}
+
+class FakeNode {
+  connect(target: FakeNode) {
+    return target;
+  }
+}
+
+class FakeOscillator extends FakeNode {
+  type = "";
+  frequency = new FakeParam();
+  started = false;
+  stopped = false;
+  onended: (() => void) | null = null;
+  start() {
+    this.started = true;
+  }
+  stop() {
+    this.stopped = true;
+  }
+}
+
+class FakeGain extends FakeNode {
+  gain = new FakeParam();
+}
+
+class FakeAudioContext {
+  static last: FakeAudioContext | null = null;
+  state = "running";
+  currentTime = 0;
+  destination = new FakeNode();
+  osc = new FakeOscillator();
+  gainNode = new FakeGain();
+  closed = false;
+  resumed = false;
+  constructor() {
+    FakeAudioContext.last = this;
+  }
+  createOscillator() {
+    return this.osc;
+  }
+  createGain() {
+    return this.gainNode;
+  }
+  resume() {
+    this.resumed = true;
+    return Promise.resolve();
+  }
+  close() {
+    this.closed = true;
+    return Promise.resolve();
+  }
+}
+
+const g = globalThis as unknown as { window?: unknown };
+
+afterEach(() => {
+  delete g.window;
+  FakeAudioContext.last = null;
+});
+
+describe("playReadyCue", () => {
+  it("synthesizes a rising-pitch decaying bloop through Web Audio", () => {
+    g.window = { AudioContext: FakeAudioContext };
+
+    playReadyCue();
+
+    const ctx = FakeAudioContext.last;
+    expect(ctx).not.toBeNull();
+    const osc = ctx!.osc;
+    expect(osc.type).toBe("sine");
+    expect(osc.started).toBe(true);
+    expect(osc.stopped).toBe(true);
+
+    // Pitch glides UP (the droplet "plink"): start low, ramp to a higher target.
+    const start = osc.frequency.ramps.find((r) => r.method === "setValueAtTime");
+    const rampUp = osc.frequency.ramps.find((r) => r.method === "exponentialRampToValueAtTime");
+    expect(start).toBeDefined();
+    expect(rampUp).toBeDefined();
+    expect(rampUp!.value).toBeGreaterThan(start!.value);
+
+    // Gain: fast attack then a decay back down to a near-silent floor.
+    const gainRamps = ctx!.gainNode.gain.ramps;
+    const peak = Math.max(...gainRamps.map((r) => r.value));
+    const last = gainRamps[gainRamps.length - 1];
+    expect(peak).toBeGreaterThan(0.1);
+    expect(last.value).toBeLessThan(peak);
+  });
+
+  it("resumes a suspended context so the cue is audible", () => {
+    class SuspendedCtx extends FakeAudioContext {
+      constructor() {
+        super();
+        this.state = "suspended";
+      }
+    }
+    g.window = { AudioContext: SuspendedCtx };
+
+    playReadyCue();
+
+    expect((FakeAudioContext.last as SuspendedCtx).resumed).toBe(true);
+  });
+
+  it("does nothing and never throws when Web Audio is unavailable", () => {
+    g.window = {}; // no AudioContext
+    expect(() => playReadyCue()).not.toThrow();
+    expect(FakeAudioContext.last).toBeNull();
+  });
+});

--- a/packages/client-core/src/dictation/readyCue.ts
+++ b/packages/client-core/src/dictation/readyCue.ts
@@ -1,0 +1,50 @@
+// The dictation "ready" cue: a short water-drop "bloop" played the instant the microphone is
+// confirmed capturing real audio, so the user hears exactly when to start speaking - the same
+// courtesy the Windows dictation panel gives with its ready beep, and the web twin of the desktop
+// DesktopAudioCue. The tone is SYNTHESIZED with the Web Audio API (no bundled audio files), so it
+// sounds the same character as the desktop cue.
+//
+// Best-effort by design: a cue is a courtesy, so a browser without Web Audio, or an autoplay block,
+// must never disrupt the dictation turn - it is skipped silently.
+
+/**
+ * Play the dictation "ready" water-drop bloop once. Returns immediately; the sound plays on the
+ * Web Audio clock. Never throws. Should be called from within/just after a user gesture (the Speak
+ * tap that opened dictation) so the browser permits playback.
+ */
+export function playReadyCue(): void {
+  try {
+    const AudioCtor =
+      window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AudioCtor) return;
+
+    const ctx = new AudioCtor();
+    // A context created outside a gesture can start "suspended"; resume so the cue is audible.
+    if (ctx.state === "suspended") void ctx.resume();
+
+    const now = ctx.currentTime;
+    const duration = 0.2;
+
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = "sine";
+
+    // Pitch glides UP over the cue; paired with the fast decay below this is the perceptual
+    // signature of a droplet (a "plink") rather than a flat beep. Matches the desktop cue's shape.
+    osc.frequency.setValueAtTime(380, now);
+    osc.frequency.exponentialRampToValueAtTime(1150, now + duration * 0.9);
+
+    // Fast click-free attack, then an exponential decay to near-silence. exponentialRamp cannot
+    // target exactly 0, so ramp to a tiny floor and stop the oscillator right after.
+    gain.gain.setValueAtTime(0.0001, now);
+    gain.gain.exponentialRampToValueAtTime(0.5, now + 0.01);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+
+    osc.connect(gain).connect(ctx.destination);
+    osc.start(now);
+    osc.stop(now + duration + 0.02);
+    osc.onended = () => void ctx.close();
+  } catch {
+    // Best-effort courtesy cue; never disrupt dictation if audio output is unavailable.
+  }
+}

--- a/packages/client-core/src/dictation/recorder.ts
+++ b/packages/client-core/src/dictation/recorder.ts
@@ -18,6 +18,12 @@ function pickMimeType(): string {
   return "";
 }
 
+// How often MediaRecorder flushes a chunk while recording. A timeslice makes the recorder deliver
+// encoded audio DURING capture (not only on stop), which gives us a genuine "first real audio
+// arrived" event - the web twin of the desktop recorder's first captured PCM buffer. It does not
+// change the captured clip: the chunks are concatenated in order on stop exactly as before.
+const CHUNK_MS = 100;
+
 export class MicRecorder {
   private stream: MediaStream | null = null;
   private recorder: MediaRecorder | null = null;
@@ -26,6 +32,12 @@ export class MicRecorder {
   private audioCtx: AudioContext | null = null;
   private analyser: AnalyserNode | null = null;
   private levelData: Uint8Array | null = null;
+
+  // One-shot latch + callback for the honest "the microphone is now capturing your voice" moment:
+  // fired when the FIRST real audio chunk lands, not merely when start() returned. The dialog uses
+  // it to flip to RECORDING and play the ready cue only once audio is actually flowing.
+  private captureLiveFired = false;
+  onCaptureLive: (() => void) | null = null;
 
   // Capture-health (issue #863): wall-clock of the segment the mic was actually open.
   // Compared against the DECODED audio duration of the captured blob (in wav.ts) to detect
@@ -71,10 +83,19 @@ export class MicRecorder {
       ? new MediaRecorder(this.stream, { mimeType: this.mimeType })
       : new MediaRecorder(this.stream);
     this.chunks = [];
+    this.captureLiveFired = false;
     this.recorder.ondataavailable = (e) => {
-      if (e.data && e.data.size > 0) this.chunks.push(e.data);
+      if (e.data && e.data.size > 0) {
+        this.chunks.push(e.data);
+        // The first real chunk is the honest "mic is capturing your voice" moment. Fire once.
+        if (!this.captureLiveFired) {
+          this.captureLiveFired = true;
+          this.onCaptureLive?.();
+        }
+      }
     };
-    this.recorder.start();
+    // Start WITH a timeslice so chunks (and the first-audio signal) arrive during capture.
+    this.recorder.start(CHUNK_MS);
     this.startedAt = performance.now();
   }
 


### PR DESCRIPTION
## What this does

Brings the desktop dictation "ready" cue to the mobile PWA Speak dialog (Terminal, Chat, and Voice-mode Respond all share this one dialog). It is the follow-up to the desktop change in #1272.

The dialog now opens in a yellow **GETTING READY** state and holds there until the microphone actually delivers its **first real audio chunk**. Only then does it flip to red **RECORDING**, anchor the timer, and play a short synthesized **water-drop "bloop"** - together, so neither the red nor the sound ever precedes real audio.

This is the requirement Soren emphasized: the cue must not fire until the mic is genuinely capturing. Previously the dialog showed RECORDING optimistically the moment it mounted, before `getUserMedia` had even resolved.

## How

- `MicRecorder` starts `MediaRecorder` with a 100 ms timeslice so encoded audio arrives *during* capture, and fires a one-shot `onCaptureLive` callback on the first real chunk - the web twin of the desktop recorder's first captured PCM buffer. The captured clip is unchanged (chunks concatenate on stop exactly as before).
- `readyCue.ts` synthesizes the bloop with the Web Audio API (a short rising-pitch sine with a fast decay - the same character as the desktop `DesktopAudioCue`). No bundled audio files. Best-effort: a browser without Web Audio, or with autoplay blocked, simply skips it.
- `DictationDialog` gains a `connecting` stage shown on open, Resume, and microphone restart; commit actions are disabled until audio flows; a six-second backstop fails loud with a "check your microphone" message rather than stranding on GETTING READY.

## Tests

New `readyCue.test.ts` (3 tests) covers the synthesis shape (rising pitch, decaying gain envelope), that a suspended `AudioContext` is resumed, and that it never throws when Web Audio is unavailable. Both workspaces typecheck clean; the full client-core suite passes (147 tests).

## Notes

Built and verified in an isolated worktree off `origin/main` (the shared working tree is being actively churned by other sessions). Pairs with #1272 (desktop). Cockpit has no dictation, so there is nothing to change there.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)