### PR TITLE
docs: Cockpit Improvement Wave 1 quality-assurance report

### DIFF
--- a/docs/architecture/cockpit-improvement-mission-2026-07-10.md
+++ b/docs/architecture/cockpit-improvement-mission-2026-07-10.md
@@ -1,0 +1,159 @@
+# Mission Brief: Cockpit Improvement
+
+Status: active mission. Written 2026-07-10 by the Architect session ("Architect: Cockpit Improvement",
+session 0c9d28b7, machine SOREN_NORTH). This document is the Architect's handover to the Manager
+session. The Manager owns execution from here; the Architect does not gate the Manager.
+
+## The mission
+
+Upgrade the React Cockpit (apps/cockpit, served by the Gateway) plus the small set of desktop and
+Gateway fixes around it, per the reviewed and verified improvement work filed as GitHub issues
+number 1238 through 1261. The mission ends with every in-scope issue implemented, verified, and a
+nicely formatted HTML quality-assurance report that shows and explains every improvement.
+
+Source documents (read them before starting):
+
+- docs/reviews/cockpit-improvement-report-2026-07-10.html - the improvement report (what and why).
+- docs/architecture/cockpit-review-2026-07-10.md - the deep review with file-and-line evidence.
+- docs/architecture/cockpit-improvement-plan.md - the approved plan behind issues 1210 to 1215.
+- docs/architecture/gateway-owns-session-presentation.md - the presentation-ownership plan (issue 1241).
+
+Every claim in the issues was re-verified against the working tree on 2026-07-10 by the Architect,
+including corrections (the orange-rail bug is desktop-only; the Gateway already produces the
+machine-errors envelope; effective color and triage bucket are already stamped on the wire).
+
+## Roles and rules of the mission
+
+- The Architect (this document's author) settled the design and filed the issues. Do not re-open
+  design questions that an issue already answers; the issue text is the specification.
+- The Manager (you) owns execution: sequencing, spawning workers, reviewing their work, merging,
+  and the final quality-assurance report. You are allowed to spawn agent sessions yourself
+  (cc-devthrottle session spawn <repo> --controlled-by self ...) - that is the DevThrottle rule.
+- Escalate to Soren only for product decisions an issue does not answer. Do not stop the whole
+  mission to wait; keep working everything that is not blocked.
+- Work fully autonomously otherwise.
+
+## Decisions already made - do not re-litigate
+
+1. The issue bodies are the specification. Each has evidence, steps, and acceptance criteria.
+2. The Fleet page dies into the Fleet Map (issue 1212); the terminal stays a plain terminal;
+   Chat and Voice arrive as literal ports (issue 1213). These belong to the existing stack, not you.
+3. The Gateway owns session presentation; clients render server fields (issue 1241 direction).
+4. Manual rail order is sacred; only the opt-in attention grouping changes (issue 1249).
+5. The browser talks ONLY to the Gateway with relative addresses.
+6. No fallback programming; fail loudly with a clear message.
+7. Plain English everywhere - no abbreviations, no jargon. ASCII only in code and output.
+
+## The one open dependency: the pull-request stack 1217 to 1226
+
+Issues 1210 to 1215 are already implemented in an open, stacked set of pull requests (1217, 1219,
+1220, 1223, 1225, 1226), deployed for testing and awaiting merge. That stack is NOT yours to merge -
+it belongs to its author and to Soren's click-through. Rules:
+
+- Do NOT merge or rebase that stack yourself.
+- Work the Wave 1 issues below first; none of them depend on the stack.
+- Surface the stack plainly in your status reporting ("Wave 2 is waiting on the 1217-1226 stack").
+  When the stack merges, start Wave 2.
+- If the stack is still unmerged when Wave 1 is done, say so loudly (go red / needs-you) rather
+  than starting Wave 2 into guaranteed conflicts.
+
+## The work, in waves
+
+Wave 1 - independent of the stack (start immediately, safe to parallelize across workers):
+
+- 1238 [Desktop, bug] Parked dictation clips keep the rail orange and mask red. Highest value
+  per line in the mission. Touches MainWindow.axaml.cs counting + a regression test.
+- 1243 [Cockpit] New-session dialog: model and permission mode (client-only; Args field exists).
+- 1240 [Gateway] Per-session actions use the session-owner cache, not a full fleet scan.
+- 1244 [Cockpit] The shared user-interface kit + one confirmation dialog + palette document.
+  This is a foundation: 1245, 1248, 1254, 1255 consume it. Do it early, with one strong worker.
+- 1250 [Cockpit, bug] Learning page silent failure + full-reload link.
+- 1252 [Cockpit, bug] Prompt queue loses text on failed pop/edit.
+- 1253 [Cockpit, bug] Transcription Health failure count single-sourced.
+- 1254 [Cockpit, bug] Screenshots dock: confirm + re-sync + image error fallback (dialog part
+  after 1244).
+- 1255 [Cockpit, bug] Dirty tracking: Director settings editor + Dictionary duplicates
+  (dialog part after 1244).
+- 1261 [Cockpit, maintenance] De-duplicate formatting helpers; names instead of identifier prefixes.
+- 1245 [Cockpit] Schedule page rebuild on the reusable sortable/searchable table (after 1244).
+- 1246 [Cockpit] Directors page adopts the shared table (after 1245).
+
+Wave 2 - after the 1217-1226 stack merges (files conflict before then):
+
+- 1239 [Cockpit] One shared roster store, visibility-aware polling.
+- 1242 [Cockpit] Terminal room: collapsible rails, full-screen, session name in the header.
+- 1247 [Cockpit] Navigation cleanup (sections, expose pages, narration remnants, one home name).
+- 1248 [Cockpit] Loading/empty/error states everywhere + keyboard + announcements + auth screens
+  (after 1244).
+- 1249 [Cockpit] Attention view needs-you group in wait-time order.
+- 1251 [Cockpit, bug] Rename box must not freeze polling (fix on the post-stack surface).
+- 1241 [Gateway plus clients] Finish Gateway-owns-presentation (phased; each phase shippable).
+- 1256 [Cockpit] Command-center home (after 1239 and 1244).
+- 1257 [Cockpit] Browser notifications via the existing web-push stack.
+- 1259 [Cockpit] Jump to a session by number.
+- 1266 [Cockpit] Read-only Source Control tab on the session page (added by Soren 2026-07-10).
+  The Director and Gateway halves (extend GET /sessions/{sid}/git with per-file lists; read-only
+  Gateway proxy with device-key authentication) are stack-independent and MAY be built during
+  Wave 1; only the Cockpit tab itself waits for the stack (pull request 1223 rebuilds the tab strip).
+
+Parked - NOT in this mission's implementation scope (good-idea label):
+
+- 1258 (triage from the rail) and 1260 (fleet content search). Leave them parked.
+
+## Working rules for you and every worker
+
+- This is a SHARED working tree with other live sessions. Stage only your own files by name,
+  never git add -A. Build every pull request from an isolated worktree off origin/main
+  (git worktree add), cherry-pick or re-apply, push HEAD to a branch - never switch the shared
+  checkout's branch.
+- One issue = one branch = one pull request, referencing the issue. Squash-merge after review and
+  verification, then close the issue. Small pull requests.
+- Tests are required: every bug fix gets a regression test; every public method change follows
+  docs/CodingStyle.md. Run the affected test projects before any merge.
+- NEVER kill running cc-director processes. If you need a live Director for testing, build to
+  slot 5 or higher (scripts/local-build-avalonia.ps1 -Slot 5) and launch via the
+  cc-director-launch scheduled task; shut it down via POST /shutdown on its Control API.
+- Gateway testing: build with -p:IncludeNativeLibrariesForSelfExtract=true, swap only the
+  executable, relaunch via the devthrottle-gateway-launch scheduled task. Never redeploy-gateway.ps1
+  on uncommitted work (it is HEAD-only and reverts the tree).
+- Cockpit verification is in a real browser against a running Gateway. Every completed issue needs
+  proof: a screenshot or a short observable check matching the issue's acceptance criteria.
+- Fleet messages are one line only (newlines truncate). Message only sessions on this mission.
+- Do not broadcast to the fleet.
+
+## How to run the workers
+
+- Spawn one worker per issue (or per small coherent group), controlled by you:
+  cc-devthrottle session spawn D:\ReposFred\devthrottle --controlled-by self
+  --name "Worker: issue NNNN" --purpose "implement issue NNNN"
+  --args "--dangerously-skip-permissions --model opus"
+  --prompt "Implement GitHub issue NNNN in this repo. The issue body is the full specification.
+  Follow docs/architecture/cockpit-improvement-mission-2026-07-10.md working rules. Report back
+  to your manager session when the pull request is open with proof."
+  (Write the prompt as ONE line when passing it on the command line.)
+- Keep a small number of workers running in parallel (three or four), grouped so they do not touch
+  the same files. The kit (1244) blocks 1245/1246/1248 and parts of 1254/1255 - sequence around it.
+- Review every worker's pull request yourself before merging: does it match the issue's acceptance
+  criteria, does it carry the test, is the diff free of unrelated files.
+- When a worker is done and its work is merged, have it flag itself finished
+  (cc-devthrottle session done).
+
+## The final deliverable: the quality-assurance report
+
+When the in-scope issues are done (or when everything not blocked by the stack is done and the
+stack is still unmerged - report what is true), produce:
+
+- docs/reviews/cockpit-improvement-qa-report-<date>.html
+- A nicely formatted, self-contained HTML report in the same visual style as
+  docs/reviews/cockpit-improvement-report-2026-07-10.html (dark, clean, ASCII text).
+- For EVERY improvement: the issue number and title, what was wrong (one plain-English paragraph),
+  what changed (files touched, the approach), how it was verified (the acceptance check that was
+  actually performed, with the observed result), and its pull request number.
+- A verification section: quality assurance means independently CHECKING, not trusting the
+  worker's word. Spawn a fresh QA worker session that re-verifies each acceptance criterion in the
+  running application and records pass or fail with evidence. Failed items go back to a worker
+  before the report calls them done.
+- An honest status table at the top: done and verified / done awaiting verification / blocked and
+  why / parked.
+
+When the report exists, message the Architect session (0c9d28b7) with its path, one line.

--- a/docs/architecture/cockpit-review-2026-07-10.md
+++ b/docs/architecture/cockpit-review-2026-07-10.md
@@ -1,0 +1,718 @@
+# Cockpit Review and Top Recommendations
+
+Date: 2026-07-10
+Author: review session (devthrottle - codex review)
+Scope: the React Cockpit web app (apps/cockpit, served by the Gateway at /c), the shared
+packages/client-core it runs on, and the Gateway remote-control path behind it.
+Method: full read of the Cockpit source, the shared client, and the Gateway session/stream
+endpoints, plus three focused deep-dive passes (UI and front-end quality, the remote-control
+mechanism end to end, and the most recent code changes).
+
+---
+
+## Why the Cockpit exists (the yardstick for every recommendation)
+
+The Cockpit is the remote control room for the whole fleet. From any browser - a laptop, a
+second machine, a phone on the couch - one person needs to see every agent session running on
+every machine, know which ones are stuck and waiting for a human, and drive any one of them
+(type into it, stop it, queue work, hand it an image) without ever touching that machine
+directly. The browser only ever talks to one central Gateway; the Gateway reaches out to each
+machine's Director on the browser's behalf.
+
+So the two questions that judge the Cockpit are: (1) can I trust what it shows me about ten
+machines at once, and (2) when I pick a session, is driving it fast, clear, and safe. The
+review is organized around those two questions, then around the product surface that surrounds
+them.
+
+## What most likely frustrated you in the cockpit-UI session
+
+Reading the code against how you actually use it, these are the friction points that stack up
+in a normal driving session, and every one of them shows up in the recommendations below:
+
+- The live terminal - the whole point - is boxed into the smallest part of the screen, and on
+  a laptop it is narrow enough that the agent's output overflows and needs sideways scrolling.
+- The session you are driving is labelled by a raw identifier (a long code), not the friendly
+  name you gave it, so the header never confirms which session you are typing into.
+- Machines and sessions flicker in and out of the list when one machine has a single slow
+  moment, which reads as "did it crash?" when nothing is wrong.
+- There is a row of tabs above the terminal with only one tab in it, an empty button row when
+  a session is still loading, and pages that exist but cannot be found from the menu - all of
+  which read as "this is half-built."
+- Starting a new session from the Cockpit gives you no control over the agent's model or
+  permission mode, so the session comes up blocked on a permission prompt and running the
+  wrong model.
+- The session rail can get stuck showing orange ("transcribing / dictation queued") on a
+  session that is actually red and needs you - so the one signal you rely on lies to you.
+
+---
+
+## The recommendations
+
+Ranked by impact. Each says what is wrong, where it lives, what to do, and a rough size.
+The first five make the Cockpit trustworthy and pleasant for its core job; the next set
+raise the whole product's polish; the last set are new capabilities worth building.
+
+### 1. Stop the fleet list from blinking, and never silently drop a machine
+
+**Problem.** When one machine has a single slow poll, its sessions can vanish from the list
+for up to 30 seconds and then reappear. Worse, the two main views disagree: the Fleet page
+shows unreachable machines as an explicit warning, but the Sessions page (the one you live in)
+silently drops them - a whole machine's sessions just disappear with no explanation. The
+Gateway probes each machine with a 2-second timeout and, after three misses, benches that
+machine for a 30-second cooldown; a healthy-but-briefly-slow machine (common over a relayed
+tail-network hop) gets benched and its sessions disappear.
+
+**Where.** Gateway fan-out and cooldown: `src/CcDirector.Gateway/Api/GatewayEndpoints.cs:406-456`;
+timeouts `src/CcDirector.Gateway/Discovery/DirectorRegistry.cs:44-53`, `DirectorEndpointClient.cs:28`.
+Silent-drop on the Sessions page: `SessionsView` consumes the plain `GET /sessions` array
+(`apps/cockpit/src/sessions/SessionsView.tsx:45-59`), which skips failed machines
+(`GatewayEndpoints.cs:456` `if (sessions is null) continue;`), while the Fleet/Fleet-Map pages
+use the richer envelope with `machineErrors` (`packages/client-core/src/fleet/fleetClient.ts:89-100`).
+
+**Do.** Give the Gateway a last-known-good session snapshot per machine and keep serving it for
+a short grace window (two or three failed polls), marking that machine as "wobbly" instead of
+removing its rows. Present three states, not two: Online, Wobbly (dimmed, "last seen 20s ago"),
+Offline - and only repeated consecutive failures reach Offline. Never let the list reflow or
+collapse on a transient miss; rows change appearance in place. Make the Sessions page consume
+the same envelope so it shows the wobbly/offline state instead of silently dropping machines.
+Raise the roster probe timeout for known cross-machine hops (the action path already does this),
+and require more than one miss before the 30-second bench.
+
+**Size.** Medium. This is Phase 6 of the existing improvement plan (issue #1215); this review
+raises its priority to number one because it is the thing that makes the whole control room feel
+untrustworthy.
+
+### 2. Give the terminal room, and label it with the session's name
+
+**Problem.** The terminal - the load-bearing surface - is the most cramped thing on the screen.
+Fixed chrome eats roughly 780 pixels before the terminal starts: the 220px nav rail, the 264px
+session rail, and the 300px right-hand dock. On a 1366-wide laptop the agent's terminal gets
+about 580px, narrow enough that output overflows and the code carries a sideways-scroll
+work-around to cope. There is no way to collapse the rails or go full-screen. And the terminal's
+header shows a raw session identifier, not the friendly name you gave the session, so nothing on
+the driving surface confirms which session you are in.
+
+**Where.** Fixed columns: `apps/cockpit/src/styles.css:47` (shell), `:227` (roster 264px),
+`:667` (`.session-detail: 1fr 300px`). Overflow work-around: `:198-208`. GUID header:
+`apps/cockpit/src/panes/TerminalPane.tsx:47`. The session's real name, repo, machine, and status
+are all already in hand at `apps/cockpit/src/sessions/SessionDetail.tsx:25` and are simply not shown.
+
+**Do.** Add a collapse control for the session rail and for the right-hand dock, plus a
+full-screen ("zen") toggle for the terminal, so you can hand the driving surface the whole
+window when you want it. Replace the identifier in the terminal header with the session name,
+its repository, its machine, and a status dot - the same identity you see in the rail - so the
+header always confirms what you are typing into.
+
+**Size.** Small-to-medium, and the single biggest day-to-day quality-of-life win.
+
+### 3. Fix the orange rail that hides a session that needs you
+
+**Problem (a real bug).** A dictation clip that is permanently parked - blocked because you are
+out of credits, or because the composer is busy - still counts toward the session's
+"pending dictation" tally, and that tally paints the rail orange ("dictation queued")
+indefinitely. Because the orange state is resolved before the red "needs you" state, a session
+that genuinely needs you can be masked as orange forever and never drain on its own. The one
+signal you steer by is showing the wrong colour.
+
+**Where.** The count is taken over every stored record with no status filter:
+`src/CcDirector.Avalonia/MainWindow.axaml.cs:3246-3248` (`store.LoadAll()`); the orange overlay
+wins over red in `src/CcDirector.Core/.../SessionStatusWingman.cs:413-414`; parked statuses
+(`NeedsAttention`, `ComposerBlocked`) are explicitly not retry-eligible in
+`PendingDictation.cs`.
+
+**Do.** Count only genuinely deliverable (still-pending) clips toward the orange state; parked
+clips are already surfaced through the notification banner, so they must not colour the rail.
+Add a test that a parked clip leaves a red session red - the current Wingman tests set the count
+directly and would not catch this.
+
+**Size.** Small. High value because it corrupts the primary attention signal.
+
+### 4. Let a browser-created session choose its model and permission mode
+
+**Problem.** Starting a session from the Cockpit gives it no arguments: it is hard-coded to the
+default agent with no model and no permission flags. In practice that means a Cockpit-created
+session comes up blocked on a permission prompt and running the default (smaller-context) model
+rather than the one you want - so the first thing you have to do after creating it is fix it by
+hand, or it silently runs under-powered.
+
+**Where.** `packages/client-core/src/api/client.ts:688` (`createSession` sends only
+`{ repoPath, agent:"ClaudeCode", wingmanEnabled:false }`, no launch arguments); the dialog that
+calls it has no such controls: `apps/cockpit/src/sessions/NewSessionDialog.tsx:124`. This matches
+the known behaviour that session creation applies no default permission or model - the arguments
+must be passed explicitly or the session blocks and runs at the default.
+
+**Do.** Add model and permission-mode choices to the New-session dialog (with your usual
+defaults pre-selected), thread them through `createSession` as launch arguments, and remember
+the last choice per machine. This is the difference between "create and immediately babysit" and
+"create and it just runs."
+
+**Size.** Small-to-medium.
+
+### 5. Poll the fleet once, share it everywhere, and pause when the tab is hidden
+
+**Problem.** Three different pages each poll the full fleet roster independently every two to
+three seconds, with no shared cache and no push. Open the Sessions, Fleet, and Fleet-Map pages
+and the Gateway runs three overlapping full fan-outs to every machine. Nothing pauses when the
+browser tab is in the background, so a parked Cockpit tab hammers the Gateway - and every machine
+behind it - forever. And because each keystroke you type is routed by re-scanning every machine
+to find the session's owner (rather than using the owner cache the stream path already keeps),
+typing latency and Gateway load both grow with the size of the fleet.
+
+**Where.** Independent polls: `SessionsView.tsx:12` (3s), `FleetView.tsx:28` (2s),
+`FleetMapView.tsx:22` (2s), plus Directors/Schedule/Wingman/Exes on their own timers - the same
+`AbortController + setInterval + keep-last-on-error` block is copy-pasted about nine times.
+Keystroke fan-out: `POST /sessions/{sid}/prompt` resolves the owner with a full fleet scan
+(`GatewayEndpoints.cs:909`, `LocateSessionAsync` at `:1530`) instead of the owner fast-path cache
+used by `SessionWsProxyEndpoints.cs:192-203`.
+
+**Do.** Three moves. (a) Consolidate the roster into one shared client-core store with a single
+poll and a `usePolling` hook, so every fleet view reads one cached roster and stays in sync.
+(b) Gate polling on tab visibility so a hidden tab goes quiet, and prefer pushing roster changes
+over the existing channel rather than re-pulling the whole thing. (c) Route the prompt, interrupt,
+and escape calls through the owner fast-path cache so a keystroke no longer scans the whole fleet.
+Together these make the control room scale to ten-plus machines without feeling heavy or laggy.
+
+**Size.** Medium. High leverage for a many-machine control room.
+
+### 6. Adopt one small web UI kit and one documented palette
+
+**Problem.** The desktop app and the web Cockpit are two different-looking products. The style
+guide the project mandates describes a charcoal, editor-style palette for the desktop app; the
+Cockpit invented its own navy palette and is held to no written web standard. Inside the Cockpit,
+roughly twenty near-duplicate button classes, a hand-rolled header on every page, and a different
+wording for "loading" and "error" on every page guarantee drift. Destructive actions are handled
+three different ways - some pop a blocking browser dialog, some confirm inline, some delete with
+no confirmation at all.
+
+**Where.** Divergent palettes: `docs/VisualStyle.md` (charcoal/editor tokens) vs
+`apps/cockpit/src/styles.css:4-23` (navy tokens). Confirmation drift: inline confirm in
+`account/AccountView.tsx` (the good pattern); blocking browser dialogs in `exes/ExesView.tsx`
+and `transcripts/TranscriptsView.tsx`; no confirmation at all on Schedule delete
+(`schedule/ScheduleView.tsx:272`) or Clear-context (`sessions/SessionActionBar.tsx:87`).
+
+**Do.** Build a tiny shared kit - one Button (with variants), PageHeader, LoadingState,
+EmptyState, ErrorBanner, and a single ConfirmDialog/toast - and write a short "Cockpit visual
+style" section (or a companion doc) that documents the navy tokens the web app actually uses.
+Route every destructive action through the one ConfirmDialog, and add confirmation to the two
+that currently have none (Schedule delete, Clear-context). This collapses the drift and makes the
+whole app feel like one product.
+
+**Size.** Medium. Pays for itself across every future page.
+
+### 7. Make every real page reachable, and remove the half-built ones
+
+**Problem.** Five fully-built pages have no menu entry and can only be reached by typing a URL:
+the Wingman pipeline, the voice recordings/transcripts, the executables/slot manager, the
+feedback corpus, and the (being-retired) work lists. Meanwhile there are dead surfaces on show:
+a tab strip above the terminal with only one tab, an empty action-bar row while a session loads,
+a Fleet-Map legend and card label still advertising a "Wingman narration" feature that is turned
+off, and CSS classes that style states that never render. All of this reads as "unfinished."
+
+**Where.** Undiscoverable but built: routes at `apps/cockpit/src/main.tsx:136-166` with no entry
+in `AppShell.tsx:19-35`. Single-tab strip: `sessions/SessionDetail.tsx:55-66`. Empty action bar
+on a cold deep link: `sessions/SessionActionBar.tsx:61` (capabilities undefined). Retired-but-shown
+narration: `fleet/FleetMapView.tsx:58,177,181,417`. Home-route is even named three different
+things across pages ("Sessions", "Dashboard", "Cockpit").
+
+**Do.** Group the nav into sections (Fleet / Data / System) and add entries for the built pages
+worth keeping; decide the fate of Lists and delete it if it is truly retired. Remove the
+single-tab strip until Chat/Voice land, show a "loading session..." state instead of an empty
+action bar, and finish retiring the narration overlay (legend, label, and dead CSS). Standardise
+the home-route name. Small individually; together they move the app from "beta" to "finished."
+
+**Size.** Small per item.
+
+### 8. Standardise loading, empty, and error states - and announce actions
+
+**Problem.** Every page shows "Loading..." as italic text with different wording, many pages have
+no retry on failure, and several destructive results are reported with un-styled browser pop-ups.
+There are no skeletons or spinners anywhere, so the app feels slower than it is. And action
+results ("turn stopped", "sent") are plain text with no accessible announcement, and several
+clickable table rows cannot be reached by keyboard at all.
+
+**Where.** Italic loading text and inconsistent copy across nearly every view; no retry on Fleet,
+Fleet-Map, Directors, Schedule, Wingman, Dictionary, About. Keyboard-inaccessible rows:
+`fleet/DirectorsView.tsx:115`, `fleet/DirectorDetailView.tsx:171`, `schedule/ScheduleView.tsx:381`
+(Fleet-Map's `NodeCard` does it correctly and is the model). Un-announced action status:
+`sessions/SessionActionBar.tsx:109-110`.
+
+**Do.** Use the shared LoadingState/EmptyState/ErrorBanner from recommendation 6 everywhere,
+with skeleton rows for lists and a consistent Retry. Wrap clickable rows so the whole row is a
+real keyboard target. Add a live-region announcement to action and composer status. This is the
+polish layer that makes the app feel trustworthy.
+
+**Size.** Small-to-medium (mostly mechanical once the kit exists).
+
+### 9. Reconcile the two clients: one "needs you" order, one behaviour
+
+**Problem.** The same "Needs you" group is ordered differently on the phone and in the Cockpit.
+The phone shows it as a wait-time queue (longest wait on top), which is the agreed behaviour; the
+Cockpit still shows it in your manual drag order. The shared helper for the queue order exists but
+was only wired into the phone. So the same fleet reads differently depending on which screen you
+pick it up on.
+
+**Where.** Phone uses the queue order (`apps/mobile/src/pages/Home.tsx:59`, `inWaitingOrder`);
+the Cockpit attention view still uses manual order (`apps/cockpit/src/sessions/SessionRoster.tsx:101`,
+`inBucket`). The shared helper is `packages/client-core/src/sessions/ordering.ts:71`.
+
+**Do.** Decide the intended behaviour once and wire both clients to it. If "oldest-waiting first"
+is the rule (the phone's behaviour, and what the team already recorded as intended), switch the
+Cockpit attention group to the same shared helper. Add the missing tie-break tests while there.
+
+**Size.** Small.
+
+### 10. A real command-center home instead of "pick a session"
+
+**Problem.** The Cockpit's front door, before you select anything, is a single line of text that
+says "pick a session." For a control room that is a wasted screen - the moment you most want an
+at-a-glance read of the whole fleet, you get nothing.
+
+**Do (new page).** Make the landing screen a fleet command center: the "needs you" queue front
+and center (who has been waiting longest, and a one-line reason), a strip of fleet vitals (how
+many machines online / wobbly / offline, how many sessions working / idle / on hold), any
+unreachable machines called out, and the most recent activity across the fleet. Every item links
+straight into the session or machine. This turns dead space into the single most useful screen in
+the product and directly answers "what needs me right now, across everything."
+
+**Size.** Medium. High-visibility new capability that reuses data the roster already returns.
+
+### 11. The Schedule page is the worst grid in the app - redesign it (case study)
+
+This one is worth a full worked example, because it is the clearest instance of a pattern that
+hurts the whole app: putting a big block of free text into a grid cell, and mislabelling the
+column while doing it.
+
+**What is wrong today.**
+
+- The grid has a column headed **"Runs"**, but the cell renders the whole skill/prompt text -
+  the code is literally `` `skill ${seed}` `` (`apps/cockpit/src/schedule/ScheduleView.tsx:775-778`,
+  rendered at `:387` under `<th>Runs</th>` at `:368`). So a column whose name promises a run
+  count or run history is filled with hundreds of words of instructions.
+- The word **"skill" is glued onto the front of the prompt** with a bare space, so it reads as
+  the first word of the instruction rather than a type label. It is a raw internal kind-tag
+  leaking into the UI.
+- Each row grows to whatever height the instruction text needs, so the grid is a wall of prose
+  you have to read past. You cannot scan it. You cannot compare two jobs. The thing a schedule
+  grid is *for* - "what runs, where, when next, did the last one work" - is buried.
+- When you open one job's editor, the **"Skill / prompt" field is a single-line input**
+  (`:541`), so the same multi-paragraph instruction you could not read in the grid is now edited
+  through a one-line slot. The two places that touch this text get it exactly backwards: the
+  grid shows too much, the editor shows too little.
+- The grid cannot be **sorted** or **searched**. For a schedule - which is inherently "things
+  ordered in time" - you cannot even sort by what fires next.
+
+```
+  WHAT IT LOOKS LIKE NOW  (the "Runs" column is the whole prompt)
+
+  Name                  Target        Runs                                     Schedule     Next run
+  ----------------------------------------------------------------------------------------------------
+  Shorts stats          SOREN_NORTH   skill You are a DevThrottle marketing    once @       2026-06-28
+  analysis (48h                       analytics run (fresh session, no prior   2026-06-28   22:00 UTC
+  after batch)                        context). It is about 48 hours after the 18:00:00
+                                      full week's batch of animated YouTube
+                                      Shorts finished publishing. Do this: 1)
+                                      cd into marketing/shorts and run `py
+                                      -3.11 youtube_stats.py` to pull the
+                                      latest per-video views/likes/comments
+                                      ... [hundreds of words, pushing every
+                                      other column off to the right] ...
+  ----------------------------------------------------------------------------------------------------
+        ^ column says "Runs"          ^ but it is the instructions, with the raw word "skill"
+          (should be a count/history)   pretending to be the first word of the sentence
+```
+
+**The principle.** A grid cell holds one short, scannable scalar - a name, a state, a time, a
+count. Long free text (an instruction, a description, a log) is *detail*: it belongs in a
+row-detail panel, a drawer, or the editor, never spilled into the grid. The grid answers "which
+one and is it healthy"; the detail answers "what exactly does it do." This same rule fixes the
+Schedule page and prevents the next person from doing it again elsewhere.
+
+**How it should look - the grid.** One fixed-height row per job. A leading status light. A short
+"what it runs" cell that is a *type chip plus a one-line title* (the job's name-derived summary
+or the first line of the prompt, truncated), never the body. Human-readable schedule and next/last
+run. Sortable headers (default: next run, soonest first). A search box that matches name, machine,
+repo, and the prompt text.
+
+```
+  HOW IT SHOULD LOOK  (scannable grid; the prompt is NOT in it)
+
+  Search [ youtube________ ]                        Sort: Next run v         [ + New schedule ]
+
+   *  Name                       Runs                Target             Schedule          Next run    Last run
+  -----------------------------------------------------------------------------------------------------------
+   o  Shorts stats analysis      Skill  youtube-     SOREN_NORTH        Once              --          --
+      (48h after batch)          stats rollup        cc-consult         Jun 28  6:00pm    disabled
+   *  Inbound Watch (daily)      Skill  inbound-     SOREN_NORTH        Daily  8:00am ET  in 3h       2h ago  OK
+                                 watch               devthrottle
+   *  Upwork auto-run            Skill  jobs-auto    SOREN_NORTH        Mon-Fri           in 46m      6h ago  OK
+      (twice daily)                                  cc-consult         8:14a & 2:14p ET
+   *  LOT baggage - check reply  Skill  reminder     SOREN_NORTH        Mon-Fri 1:00pm    in 1d       never
+                                                     private            ET
+  -----------------------------------------------------------------------------------------------------------
+    ^ status   ^ short name       ^ type chip +      ^ machine +        ^ plain English   ^ relative, absolute
+      light                         short label        repo               (cron on hover)   on hover
+```
+
+Notes on the columns:
+- **Runs** becomes a real column again: a small type chip (Skill / Work list / Prompt) and a
+  short label, not the body. If you want a number, this is also the natural home for a run count
+  ("42 runs, 2 failed").
+- **Schedule** is rendered in plain English ("Mon-Fri 8:14a & 2:14p ET"), with the raw cron
+  (`13 8,14 * * *`) available on hover - not the reverse.
+- **Next run / Last run** are relative ("in 46m", "2h ago") with the absolute UTC on hover, and
+  the last run carries its outcome badge (OK / FAILED + reason).
+- Every header is sortable; the whole row is one keyboard target; Run now / Edit / Delete live in
+  a hover action set or a kebab menu so they do not clutter the default scan.
+
+**How it should look - the detail (click a row).** The full instructions live here, read-only and
+scrollable, next to the plain-English schedule, the resolved next run, and the recent run history
+with outcomes. This is where you actually read what a job does.
+
+```
+  ROW DETAIL / DRAWER  (opens when you click a row)
+
+  +- Upwork auto-run (twice daily) --------------------- [Run now] [Edit] [x] -+
+  |  Enabled - SOREN_NORTH - D:/ReposFred/cc-consult - Claude Code             |
+  |                                                                            |
+  |  Schedule    Every Mon-Fri at 8:14 AM and 2:14 PM Eastern  (13 8,14 * * *) |
+  |  Next run    in 46 minutes   (2026-07-11 12:14 UTC)                        |
+  |  Notify      Always (success or failure)                                   |
+  |                                                                            |
+  |  Instructions -----------------------------------------------------------  |
+  |  | Run the jobs-auto skill for Center Consulting's Upwork account. In    | |
+  |  | the morning, once in the afternoon, check open/message/hire status    | |
+  |  | for proposals submitted via ... [full text, scrollable, monospace]    | |
+  |  |______________________________________________________________________| |
+  |                                                                            |
+  |  Recent runs                                                               |
+  |    2026-07-11 12:14 UTC   OK       42s                                     |
+  |    2026-07-10 20:14 UTC   OK       1m03s                                   |
+  |    2026-07-10 12:14 UTC   FAILED   gateway timeout                         |
+  +----------------------------------------------------------------------------+
+```
+
+**How it should look - the editor.** The prompt becomes a real multi-line, resizable, monospace
+text area (it is a multi-paragraph instruction, so give it room), and the schedule shows a live
+plain-English preview so you know what the cron string actually means before you save.
+
+```
+  EDITOR  (the prompt is a real text area; the schedule explains itself)
+
+  Skill / prompt
+  +--------------------------------------------------------------+
+  | Run the jobs-auto skill for Center Consulting's Upwork       |
+  | account. In the morning, once in the afternoon, check        |
+  | open/message/hire status for proposals submitted via ...     |
+  |                                                      ( ^ )    |  <- grows / drag to resize
+  +--------------------------------------------------------------+
+
+  Schedule  [ Recurring (cron) v ]   Cron [ 13 8,14 * * * ]
+     -> Runs every Mon-Fri at 8:14 AM and 2:14 PM Eastern. Next run: in 46 minutes.
+```
+
+**What this looks like normally, and the broader take.** Every mature scheduler - a continuous-
+integration schedules table, a task scheduler, a hosting provider's cron dashboard - follows the
+same shape: a dense sortable/searchable table of *scalars* (name, state, what-it-runs summary,
+next/last run, outcome) with the long definition tucked into a detail view or an editor. The
+Schedule page is the loudest violation, but the same "big text in a grid cell" and "grid cannot
+be sorted or searched" pattern shows up wherever the Cockpit lists things (the Directors table,
+the Lists page, the Wingman queue). So the fix here should be built as a reusable table with three
+capabilities every list in the app then inherits: **column sort, a search/filter box, and a
+row-detail panel** for the long content. Do it once for Schedule, and it becomes the pattern that
+retires the wall-of-text grid everywhere.
+
+**Do (summary).** (1) Rename the "Runs" column and stop rendering the prompt body in it - show a
+type chip plus a short one-line label. (2) Strip the raw "skill" kind-tag out of the visible text.
+(3) Add column sorting (default: next run) and a search box over name/machine/repo/prompt. (4) Add
+a row-detail panel that shows the full instructions, plain-English schedule, resolved next run, and
+recent run history. (5) Make the editor's prompt a proper multi-line resizable text area, and add a
+plain-English schedule preview. (6) Build 3 and 4 as a shared sortable/searchable table so the rest
+of the app's grids can adopt it.
+
+**Size.** Medium for the Schedule page; the shared table it produces pays back across the app.
+
+### 12. Grid and list audit - apply the same standard everywhere
+
+Having found the Schedule grid, I audited every other list and table in the Cockpit against the
+same standard. The standard, stated once so it can be reused as a checklist:
+
+- **A cell holds one short scalar.** Long free text (instructions, descriptions, transcripts,
+  endpoints) belongs in a row-detail panel or an expander, never spilled into a cell.
+- **Rows are a fixed, scannable height.** No row grows to fit prose.
+- **People and sessions are named, not shown as an identifier.** A raw code fragment is not a
+  label.
+- **Columns are sortable**, with a sensible default (usually "what matters next").
+- **There is a search/filter box** over the fields you would actually look something up by.
+- **The whole row is a keyboard target**, and destructive actions confirm consistently.
+
+The headline finding: **no list in the entire Cockpit is user-sortable or searchable.** Not one
+grid has a clickable column sort; not one has a search box (the Fleet Map title-search is only
+planned, not built). For a control room whose whole job is finding the right thing among many,
+that is a systemic gap, not a per-page nit. The good news is the app already contains the right
+pattern to copy - the Voice Recorder page - so this is about spreading an existing good idea, not
+inventing one.
+
+**Per-surface verdict:**
+
+| Surface | File | Verdict | What it needs |
+|---|---|---|---|
+| Schedule cron jobs | `schedule/ScheduleView.tsx:363` | Broken (see rec 11) | Prompt out of the grid; sort; search; row detail; multi-line editor |
+| Directors table | `fleet/DirectorsView.tsx:96` | Poor | 9 columns force horizontal scroll on a laptop; fixed sort by machine name only; no search. Add column sort + a search box; collapse low-value columns into the detail page |
+| Wingman recent briefs | `wingman/WingmanQueueView.tsx:155` | Minor (dead page) | Sessions shown by an 8-character identifier prefix (`shortId`), not their name - the recurring "drive a code, not a name" problem again |
+| Lists items | `lists/ListsView.tsx:390` | Being removed | Manual drag-priority (sort intentionally off), but no search within a long list; the page is slated for removal regardless |
+| Session roster (rail) | `sessions/SessionRoster.tsx:84` | OK, but no search | Has ordering toggles; has no way to type a word and find a session (Fleet Map search is planned, the rail has none) |
+| Voice Recorder (Transcripts) | `transcripts/TranscriptsView.tsx:270` | Good - the model to copy | A card list where each card shows a short summary and expands to the full transcript. This is exactly "scalar in the list, long text in the detail." Reuse this shape |
+| Exes | `exes/ExesView.tsx:146` | Separate concern | Card-based, fine structurally; uses blocking browser confirm/alert and an all-caps header inconsistent with every other page |
+
+**The two reusable pieces this produces:**
+
+1. **A sortable, searchable data table** with an optional row-detail drawer - for surfaces whose
+   rows are scalars (Schedule, Directors, and any future fleet/data grid). Column sort, a search
+   box, fixed-height rows, keyboard-reachable rows, one confirm dialog. Build it for Schedule
+   (rec 11), then adopt it in Directors.
+
+2. **The card-with-expander** the Voice Recorder page already uses - for surfaces whose items are
+   inherently long (a transcript, a brief, an instruction you sometimes want to read in full).
+
+Between these two patterns, every list in the app has a correct home, and the "wall of text in a
+grid cell, and you can't sort or search it" problem stops recurring.
+
+**Also worth fixing while in these files (recurring across the audited grids):**
+
+- **Identity by name, not code.** The Wingman briefs table (`WingmanQueueView.tsx:168`) and
+  several other surfaces show an 8-character identifier where the session's name belongs. Same
+  root issue as the terminal header in recommendation 2 - show the name.
+- **Consistent confirm.** Exes and Voice Recorder use blocking browser `confirm`/`alert`
+  (`ExesView.tsx:62,69`; `TranscriptsView.tsx:170,184`); Schedule deletes with no confirm at all.
+  Route all of them through the one in-app confirm dialog (recommendation 6).
+- **De-duplicate the helpers.** `repoBasename`, `relativeTime`, `humanizeState`, `portOf`, and
+  `shortId` are re-implemented inside `ExesView.tsx:252-313` and `WingmanQueueView.tsx:220`
+  despite already existing in `fleet/format.ts`. One shared formatting module.
+
+**Size.** The audit is done (this section). The shared table is the medium item from rec 11;
+adopting it in Directors and fixing the name/confirm/helper nits are small follow-ups.
+
+### 13. Audit of the remaining screens - the long tail of correctness and consistency
+
+Every remaining Cockpit screen was read in full (the Fleet page, Director detail, Settings,
+Account, Telemetry, Transcription Health, About, Dictionary, Learning, Feedback, the two session
+dock panels, the sign-in and device-callback screens, and the placeholder/404 panes). Most are
+competently built; the value here is a list of concrete, ticket-sized defects plus the systemic
+consistency gaps that a shared UI kit (recommendation 6) would close.
+
+**Per-screen quality:**
+
+| Screen | Quality | One-line |
+|---|---|---|
+| Account (`account/AccountView.tsx`) | Good - the model | Inline confirm, distinct signed-in / loading / error / empty / signed-out states. Copy its confirm pattern everywhere |
+| Settings (`settings/SettingsView.tsx`) | Good | Immediate render, loading line, explicit error, no fabricated values; one global `busy` disables every field during any one save |
+| Telemetry (`telemetry/TelemetryView.tsx`) | Good | Careful load-vs-save error split; toggle is a plain button (not a real switch); "Saved" banner never auto-dismisses |
+| Transcription Health (`transcription/TranscriptionHealthView.tsx`) | Good | Full state matrix; but recomputes a server value client-side (see bugs); no refresh affordance |
+| About (`about/AboutView.tsx`) | Good | Correct states; no refresh, so "Gateway time" freezes at page load |
+| Director detail (`fleet/DirectorDetailView.tsx`) | Good | Best states of the fleet screens; raw-JSON settings editor has no dirty tracking; mouse-only rows |
+| Fleet page (`fleet/FleetView.tsx`) | Good | Solid, but the rename guard can freeze the whole dashboard (see bugs) |
+| Screenshots dock (`sessions/ScreenshotsPanel.tsx`) | Good | Well-bounded; optimistic delete with no re-sync, no image-error fallback, Del has no confirm |
+| Queue dock (`sessions/QueuePanel.tsx`) | Ok | Server-authoritative, but optimistic Pop and edit-teardown lose data on failure (see bugs) |
+| Dictionary (`dictionary/DictionaryView.tsx`) | Ok | Silently drops duplicate entries; load failure is terminal (no retry); no unsaved-edit guard |
+| Learning (`learning/LearningView.tsx`) | Ok, one real bug | Ask-Wingman fails silently on a thrown error (see bugs); one hard-reload link |
+| Feedback (`feedback/FeedbackView.tsx`) | Good but orphaned | Not in the nav; reimplements `shortId`/`formatTime` instead of reusing `format.ts` |
+| Sign-in / Device-callback (`packages/client-core/src/auth/*.tsx`) | Poor styling | Inline-styled, background-less buttons with no theme/focus/hover; callback has no enrollment timeout |
+| Placeholder / 404 (`panes/*.tsx`) | Mixed | 404 is fine; PlaceholderPane still ships "ported in a later issue" developer copy and uses a second page-shell vocabulary (`.pane` vs `.page`) |
+
+**Correctness defects worth a ticket each (found in the read):**
+
+- **Ask-Wingman fails silently.** `LearningView.tsx:31-42` has a `try/finally` with no `catch`, so
+  if the request throws (Gateway down), the page shows nothing - directly contradicting its own
+  header comment about the no-silent-failure rule.
+- **The Fleet dashboard freezes while you rename.** `FleetView.tsx:68` bails the 2-second roster
+  poll whenever any name input is focused, so every machine's colours/states/new sessions stop
+  updating until you blur that one field. A focused input left alone stalls the whole page.
+- **The prompt queue loses text on a failed action.** Pop pastes into the composer *before* the
+  delete round-trips (`QueuePanel.tsx:59-63`), so a failed delete leaves the item both pasted and
+  still queued (a duplicate); and edit-save tears down the edit box before the async save resolves
+  (`:50-53`), so a failed save discards the typed edit with only an error banner.
+- **Transcription Health can contradict itself.** `failures` is derived as `total - successful`
+  client-side (`TranscriptionHealthView.tsx:66-67`), which can disagree with the authoritative
+  `byOutcome` map the same page renders; the "all N succeeded" banner trusts the subtraction.
+- **Screenshot delete drifts from disk.** Optimistic local delete with no re-sync
+  (`ScreenshotsPanel.tsx:76-77`), no image `onError` fallback (`:118`), and no confirm on Del.
+- **Director settings editor has no dirty tracking.** "Reload" silently discards unsaved edits and
+  "Save" is always enabled even when unchanged (`DirectorDetailView.tsx:344-347`); Dictionary
+  likewise drops edits on navigate and silently swallows duplicate entries
+  (`DictionaryView.tsx:58,75,106`).
+
+**Systemic consistency gaps (these are what recommendation 6 fixes):**
+
+- **The home screen is named three different ways.** The nav calls it "Sessions"
+  (`AppShell.tsx:20`), the Dictionary back-link calls it "Dashboard" (`DictionaryView.tsx:156`),
+  and Learning calls it "Cockpit" (`LearningView.tsx:92`). Same destination, three words.
+- **Eighteen distinct page-header classes** across the app; only eight uses share `page-head`, and
+  the panes use a second, incompatible `.pane` shell vocabulary. No shared PageHeader.
+- **Confirmation is chaotic** (restating rec 6 with the full evidence): no confirm at all on
+  Schedule delete (`ScheduleView.tsx:272`), Clear-context (`SessionActionBar.tsx:87`), Clear-queue
+  (`QueuePanel.tsx:71`), and Screenshot Del (`ScreenshotsPanel.tsx:126`); blocking browser
+  `confirm`/`alert` in Exes (`ExesView.tsx:62`) and Voice Recorder (`TranscriptsView.tsx:170`);
+  and one good inline confirm in Account. Route them all through one dialog.
+- **The auth screens do not match the app.** Sign-in and device-callback are inline-styled with
+  background-less buttons and no focus/hover/theme (`SignIn.tsx:49`, `DeviceCallback.tsx:80`) - the
+  first screen a new user sees looks unfinished. Give them the app's real button and surface tokens.
+
+**The polling census (reinforces recommendation 5).** Twelve `setInterval` timers across nine
+files, and **not one of them checks whether the tab is visible** - a backgrounded Cockpit keeps
+polling forever:
+
+| File:line | Interval | Polls |
+|---|---|---|
+| `fleet/FleetView.tsx:102` | 2s | fleet roster |
+| `fleet/FleetView.tsx:112` | 15s | interrupted sessions |
+| `fleet/FleetMapView.tsx:76` | 2s | fleet-map roster |
+| `sessions/SessionsView.tsx:64` | 3s | sessions roster |
+| `fleet/DirectorsView.tsx:53` | 5s | directors list |
+| `fleet/DirectorsView.tsx:54` | 1s | clock re-render only |
+| `fleet/DirectorDetailView.tsx:77` | 5s | director detail |
+| `fleet/DirectorDetailView.tsx:78` | 1s | clock re-render only |
+| `schedule/ScheduleView.tsx:147` | 5s | schedule |
+| `wingman/WingmanQueueView.tsx:40` | 3s | wingman queue |
+| `exes/ExesView.tsx:46` | 3s | executables |
+| `lists/ListsView.tsx:161` | 10s | lists |
+
+Three different pages poll the same fleet roster (2s / 2s / 3s), and the two Director views each
+run a *second* one-second interval purely to re-render relative-time labels. A single
+visibility-aware `usePolling` hook and one shared roster store (recommendation 5) would collapse
+all of this.
+
+**Size.** The audit is done (this section). The correctness defects are small individual tickets;
+the consistency gaps are absorbed by recommendations 5 and 6.
+
+---
+
+## Bigger new capabilities worth building next
+
+These go beyond fixing what exists. Listed roughly in order of value.
+
+- **Cockpit notifications.** The phone already gets a "needs you" badge via web push; the Cockpit
+  has none, so you must keep the tab in view. Reuse that push work so a browser tab (even
+  backgrounded) can tell you a session needs you. This is the difference between watching the
+  Cockpit and being called by it.
+
+- **Triage from the rail.** For a "needs you" session, let a common answer - approve, deny, or a
+  one-line reply - happen right on the rail card without opening the session. When you are
+  shepherding ten agents, most interactions are one word; opening each one is the slow path.
+
+- **Jump to a session by number.** Sessions already carry a short number ("102", "104"). Let you
+  press a key, type the number, and land on that session - a fast keyboard address for the fleet,
+  the way you would switch tabs.
+
+- **Chat and Voice tabs on the session page.** Bring the phone's chat and voice-mode surfaces to
+  the Cockpit session page as tabs beside Terminal, sharing the same code (this is Phase 4 of the
+  existing plan). Not everyone wants to read a raw terminal to drive an agent.
+
+- **Search what the fleet is doing.** Today you can filter sessions by title. The higher-value
+  version is "which agent is touching X" by searching recent terminal output or transcripts across
+  the fleet, through the Gateway. That is how you find the right session when you do not remember
+  its name.
+
+---
+
+## Quick wins (a day or less each)
+
+- Replace the terminal's identifier header with the session name (part of recommendation 2).
+- Remove the single-tab tab strip above the terminal (`SessionDetail.tsx:55`).
+- Add confirmation to Schedule delete and Clear-context (`ScheduleView.tsx:272`,
+  `SessionActionBar.tsx:87`).
+- Fix the one full-page-reload link on the Learning page (it should be an in-app link, not an
+  anchor that reloads the whole app) - `learning/LearningView.tsx:98`.
+- Delete the dead CSS and the retired narration legend/label on the Fleet Map
+  (`FleetMapView.tsx:177,181,417`).
+- De-duplicate the copy-pasted date/time and repo-name helpers into one shared client-core module
+  (re-implemented verbatim in `exes/ExesView.tsx:252-313` and several other views).
+
+---
+
+## Root causes - the handful of patterns behind most findings
+
+Thirteen recommendations and a page of bugs sound like thirteen problems. They are not. Almost
+everything above traces back to six underlying patterns. Fix the pattern and a whole column of
+findings closes at once.
+
+1. **The Gateway is pulled, not pushed, from three places at once.** The browser re-fetches the
+   entire fleet roster every two to three seconds from several pages independently, the Gateway
+   re-scans every machine on every fetch, and even a single keystroke re-scans the fleet to find
+   its owner. This one pattern produces the blinking list (rec 1), the load-and-latency problem
+   (rec 5), and half the polling census (rec 13). Root fix: one shared roster store, pushed and
+   cached, visibility-aware.
+
+2. **There is no shared web UI kit.** Every page reinvents its header, its buttons, its loading
+   line, its empty state, its error banner, and its idea of confirmation. That single absence
+   produces the eighteen header classes, the twenty button classes, the "loading..." wording drift,
+   the four different confirm behaviours, and the un-themed auth screens (recs 6, 8, 12, 13). Root
+   fix: build the small kit once.
+
+3. **Long free text keeps landing in grid cells.** The Schedule "Runs" column is the loudest case,
+   but the same instinct shows up wherever the app lists things. It produces rec 11 and half of
+   rec 12. Root fix: the two reusable patterns - a sortable/searchable table with a detail drawer,
+   and the card-with-expander the Voice Recorder already uses.
+
+4. **Sessions are shown as identifiers, not names.** The terminal header, the Wingman briefs table,
+   and other surfaces show a code where the name belongs. It produces part of rec 2, rec 12, and
+   the general "which one am I looking at" friction. Root fix: always render the name the roster
+   already carries.
+
+5. **State is recomputed on the client instead of trusted from the Gateway.** Transcription Health
+   subtracts to get a failure count, several pages re-derive times and colours, and the desktop
+   rail re-tallies dictation state - each a place where the client can drift from the server. It
+   produces the orange-rail bug (rec 3), the transcription contradiction (rec 13), and a class of
+   latent inconsistencies. Root fix: the Gateway owns presentation state; the client renders it.
+
+6. **Optimistic actions with no rollback, and destructive actions with no guard.** Pop and delete
+   apply locally before the server confirms and lose data on failure; several destructive buttons
+   fire with no confirmation. It produces the queue and screenshot bugs (rec 13) and the confirm
+   chaos (rec 6). Root fix: confirm through one dialog, and either wait for the server or roll back
+   on failure.
+
+If you only internalize one thing from this review: the Cockpit is not thirteen broken things, it
+is six missing foundations. The recommendations are ranked for impact, but the cheapest path is to
+lay foundations 1 and 2 first, because they retire the most findings per unit of work.
+
+## A suggested sequence
+
+The recommendations are ranked by impact individually; this is how to actually stage the work so
+each step ships something and the later steps get cheaper.
+
+- **First - earn trust (make the room reliable).** Recommendation 1 (stop the fleet blinking; never
+  silently drop a machine) and recommendation 3 (the orange-rail bug that hides a red session).
+  These are the two things that make the control room lie to you; nothing else matters until the
+  screen can be believed. Recommendation 4 (model/permission on session creation) rides along here
+  because it is small and removes a daily annoyance.
+
+- **Second - lay the two foundations.** Recommendation 5 (one shared, pushed, visibility-aware
+  roster store) and recommendation 6 (the small UI kit: Button, PageHeader, LoadingState,
+  EmptyState, ErrorBanner, one ConfirmDialog). Everything after this is faster and more consistent
+  because these exist. Sweep the ticket-sized correctness bugs from recommendation 13 in here too -
+  most are a few lines once the kit's confirm/rollback helpers exist.
+
+- **Third - make the driving surface and the grids right.** Recommendation 2 (give the terminal
+  room and a real name), recommendation 11 (rebuild the Schedule page on a sortable/searchable
+  table with a detail drawer), then recommendation 12 (adopt that table in Directors). Recommendation
+  7 (reachable, consistently-named navigation) and recommendation 8 (standardised loading/empty/error
+  and accessibility) fall out cheaply now that the kit exists.
+
+- **Fourth - the new capabilities.** The command-center home (rec 10), then the bigger items -
+  Cockpit notifications, triage from the rail, jump-to-session-by-number, Chat and Voice tabs,
+  fleet content search - in whatever order matches how you actually work the fleet.
+
+Recommendation 9 (reconcile the two clients' "needs you" order) is a small independent fix that can
+land any time. The quick-wins list can be picked off opportunistically whenever someone is already
+in the relevant file.
+
+## Relationship to the existing improvement plan
+
+The approved plan at `docs/architecture/cockpit-improvement-plan.md` already covers the composer
+Speak button, rail/Fleet-Map polish, folding the Fleet page into the Fleet Map, Chat/Voice tabs,
+the session menu, and fleet-sweep stability. This review agrees with that direction and adds the
+things the plan does not yet cover or under-weights: the terminal getting real room and a real
+identity (recommendation 2), the model/permission gap on session creation (recommendation 4),
+the shared UI kit and single palette (recommendation 6), the orange-rail masking bug
+(recommendation 3), and the command-center home (recommendation 10). It also raises fleet-sweep
+stability (plan Phase 6) to the top of the list, because it is the issue that most undermines
+trust in the whole control room.

--- a/docs/reviews/cockpit-improvement-qa-report-2026-07-10.html
+++ b/docs/reviews/cockpit-improvement-qa-report-2026-07-10.html
@@ -1,0 +1,372 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Cockpit Improvement - Quality Assurance Report - 2026-07-10</title>
+<style>
+  :root {
+    --bg: #0b1020;
+    --panel: #121a30;
+    --panel-2: #17203a;
+    --line: #24304f;
+    --text: #dbe4f5;
+    --muted: #8fa0c2;
+    --accent: #4da3ff;
+    --red: #ff5d6c;
+    --orange: #ffb45d;
+    --green: #4ecf8d;
+    --blue: #5da8ff;
+    --yellow: #ffd75d;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: "Segoe UI", system-ui, Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.6;
+  }
+  .wrap { max-width: 980px; margin: 0 auto; padding: 40px 28px 80px; }
+  header.masthead {
+    border-bottom: 1px solid var(--line);
+    padding-bottom: 24px;
+    margin-bottom: 32px;
+  }
+  .kicker {
+    color: var(--accent);
+    font-size: 13px;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    margin: 0 0 8px;
+  }
+  h1 { font-size: 34px; margin: 0 0 10px; line-height: 1.2; }
+  .meta { color: var(--muted); font-size: 14px; }
+  .meta span { margin-right: 18px; }
+  h2 {
+    font-size: 24px;
+    margin: 48px 0 14px;
+    padding-top: 18px;
+    border-top: 1px solid var(--line);
+  }
+  h3 { font-size: 18px; margin: 26px 0 8px; }
+  p { margin: 10px 0; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code {
+    background: var(--panel-2);
+    border: 1px solid var(--line);
+    border-radius: 4px;
+    padding: 1px 6px;
+    font-family: Consolas, "Courier New", monospace;
+    font-size: 13.5px;
+    color: #cfe0ff;
+  }
+  pre {
+    background: #0d1428;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 14px 16px;
+    overflow-x: auto;
+    font-family: Consolas, "Courier New", monospace;
+    font-size: 13px;
+    line-height: 1.45;
+    color: #b9c8e6;
+  }
+  .lead { font-size: 18px; color: #eaf0fb; }
+  .callout {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-left: 4px solid var(--accent);
+    border-radius: 8px;
+    padding: 14px 18px;
+    margin: 18px 0;
+  }
+  .callout.warn { border-left-color: var(--orange); }
+  .callout.good { border-left-color: var(--green); }
+  .callout.bad { border-left-color: var(--red); }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 16px 0;
+    font-size: 14.5px;
+  }
+  th, td {
+    text-align: left;
+    padding: 9px 12px;
+    border-bottom: 1px solid var(--line);
+    vertical-align: top;
+  }
+  th {
+    color: var(--muted);
+    font-weight: 600;
+    font-size: 12.5px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    border-bottom: 2px solid var(--line);
+  }
+  tr:hover td { background: rgba(77, 163, 255, 0.05); }
+  .tablewrap { overflow-x: auto; }
+  .tag {
+    display: inline-block;
+    border-radius: 20px;
+    padding: 1px 10px;
+    font-size: 12px;
+    font-weight: 600;
+    white-space: nowrap;
+    border: 1px solid transparent;
+  }
+  .tag.done    { background: rgba(78, 207, 141, 0.12); color: var(--green);  border-color: rgba(78, 207, 141, 0.35); }
+  .tag.small   { background: rgba(143, 160, 194, 0.12); color: var(--muted); border-color: rgba(143, 160, 194, 0.3); }
+  .tag.pass    { background: rgba(78, 207, 141, 0.16); color: var(--green);  border-color: rgba(78, 207, 141, 0.45); }
+  .tag.blocked { background: rgba(255, 93, 108, 0.12); color: var(--red);    border-color: rgba(255, 93, 108, 0.35); }
+  .card {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 18px 22px;
+    margin: 16px 0;
+  }
+  .card h3 { margin-top: 0; }
+  .card .fields { margin-top: 10px; }
+  .field { margin: 8px 0; }
+  .field .label {
+    color: var(--muted);
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    display: block;
+    margin-bottom: 2px;
+  }
+  .field.verify { border-left: 3px solid var(--green); padding-left: 12px; }
+  .prnum { color: var(--muted); font-size: 13px; }
+  .muted { color: var(--muted); }
+  .pillrow { margin: 14px 0 4px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+<header class="masthead">
+  <p class="kicker">Cockpit Improvement Mission - Quality Assurance</p>
+  <h1>What we fixed in the Cockpit, and how we checked it</h1>
+  <p class="meta">
+    <span>Date: 2026-07-10</span>
+    <span>Prepared by: Manager session (Cockpit Improvement)</span>
+    <span>Scope: Wave 1 (GitHub issues 1238-1266)</span>
+  </p>
+</header>
+
+<p class="lead">
+  The Cockpit is the web page you open in a browser to watch and drive every Claude session across
+  every machine. This mission made it more trustworthy: it stops quietly losing your work, tells you
+  plainly when something fails, and gives it a consistent look and a shared set of parts to build on.
+  This report lists every improvement, what was wrong before, what changed, and how it was independently
+  verified.
+</p>
+
+<div class="callout good">
+  <strong>Headline:</strong> Wave 1 is complete. Eleven improvements were implemented, reviewed, and
+  merged, and one original item was correctly retired as already-fixed. A fresh, independent
+  quality-assurance session - which wrote none of the code - re-verified every acceptance test against the
+  running application and the merged main line: <strong>all twelve pass, with zero failures</strong>
+  (299 automated tests green across the client, Cockpit, Gateway, and core; both typechecks clean).
+  Wave 2 cannot start yet because it depends on a separate batch of pull requests (1217 to 1226) that is
+  not ours to merge and is still open.
+</div>
+
+<h2>Status at a glance</h2>
+<div class="tablewrap">
+<table>
+  <thead>
+    <tr><th>Issue</th><th>Improvement</th><th>Pull request</th><th>State</th><th>Verified</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>1240</td><td>Gateway: per-session actions use the session-owner cache, not a full fleet scan</td><td>#1263</td><td><span class="tag done">merged</span></td><td><span class="tag pass">PASS</span></td></tr>
+    <tr><td>1243</td><td>New-session dialog: choose model and permission mode, remembered</td><td>#1264</td><td><span class="tag done">merged</span></td><td><span class="tag pass">PASS</span></td></tr>
+    <tr><td>1244</td><td>Shared user-interface kit, one confirmation dialog, written palette</td><td>#1269</td><td><span class="tag done">merged</span></td><td><span class="tag pass">PASS</span></td></tr>
+    <tr><td>1250</td><td>Learning page: no more silent failure; Settings link no full reload</td><td>#1270</td><td><span class="tag done">merged</span></td><td><span class="tag pass">PASS</span></td></tr>
+    <tr><td>1252</td><td>Prompt queue no longer loses text on a failed pop or edit</td><td>#1275</td><td><span class="tag done">merged</span></td><td><span class="tag pass">PASS</span></td></tr>
+    <tr><td>1253</td><td>Transcription Health failure count single-sourced</td><td>#1267</td><td><span class="tag done">merged</span></td><td><span class="tag pass">PASS</span></td></tr>
+    <tr><td>1254</td><td>Screenshots dock: confirm, re-sync, image error fallback</td><td>#1276</td><td><span class="tag done">merged</span></td><td><span class="tag pass">PASS</span></td></tr>
+    <tr><td>1255</td><td>Stop silently losing unsaved settings and dictionary edits</td><td>#1278</td><td><span class="tag done">merged</span></td><td><span class="tag pass">PASS</span></td></tr>
+    <tr><td>1245</td><td>Schedule page on a reusable sortable, searchable table</td><td>#1277</td><td><span class="tag done">merged</span></td><td><span class="tag pass">PASS</span></td></tr>
+    <tr><td>1246</td><td>Directors page adopts the shared table</td><td>#1279</td><td><span class="tag done">merged</span></td><td><span class="tag pass">PASS</span></td></tr>
+    <tr><td>1261</td><td>De-duplicate the copy-pasted formatting helpers</td><td>#1280</td><td><span class="tag done">merged</span></td><td><span class="tag pass">PASS</span></td></tr>
+    <tr><td>1266</td><td>Source Control: Director and Gateway backend (read-only)</td><td>#1274</td><td><span class="tag done">merged (backend)</span></td><td><span class="tag pass">PASS</span></td></tr>
+    <tr><td>1238</td><td>Parked dictation kept the desktop rail orange - retired as already-fixed</td><td>n/a</td><td><span class="tag small">closed obsolete</span></td><td class="muted">see notes</td></tr>
+    <tr><td>Wave 2</td><td>Roster store, terminal room, navigation, attention view, Source Control tab, and more</td><td>-</td><td><span class="tag blocked">blocked</span></td><td class="muted">on stack 1217-1226</td></tr>
+  </tbody>
+</table>
+</div>
+
+<h2>The improvements in detail</h2>
+
+<div class="card">
+  <h3>1240 - Gateway per-session actions use the session-owner cache <span class="prnum">(pull request #1263)</span></h3>
+  <div class="fields">
+    <div class="field"><span class="label">What was wrong</span>Every time the Gateway acted on one session (read it, close it, ask its status), it asked every Director in the fleet, in parallel, on every single call. With many machines that is a lot of wasted network traffic for something the Gateway already knew: which Director owns that session.</div>
+    <div class="field"><span class="label">What changed</span>A small resolver, <code>ResolveOwnerAsync</code>, now checks a session-owner cache first: on a hit it asks only the owning Director (one lookup). If the cached owner has since lost the session it falls back to the full scan and re-remembers the new owner; a cold cache behaves exactly as before. Five focused tests cover cache-hit, stale, cold, no-cache, and unknown-session.</div>
+    <div class="field verify"><span class="label">How it was verified - PASS</span>Independently confirmed that the resolver probes only the cached owner on a hit, falls back to a self-correcting fleet scan when the cache is stale, and logs each path. The five owner-resolution unit tests and 25 Gateway tests pass.</div>
+  </div>
+</div>
+
+<div class="card">
+  <h3>1243 - New-session dialog: model and permission mode, remembered <span class="prnum">(pull request #1264)</span></h3>
+  <div class="fields">
+    <div class="field"><span class="label">What was wrong</span>Starting a session from the browser gave no way to pick the model or the permission mode; you got the defaults and had to fix it afterwards.</div>
+    <div class="field"><span class="label">What changed</span>The dialog gained two clearly labelled choices - model (Default, Opus, Sonnet) and permission mode (Ask, or Skip prompts) - that assemble the exact command-line arguments and are remembered in the browser so the next session pre-selects your last choice. It deliberately does not steer you toward either permission mode.</div>
+    <div class="field verify"><span class="label">How it was verified - PASS</span>Confirmed in the running dialog that the model and permission choices are present, remembered across a reopen, and build the exact argument string (for example, <code>--model opus --dangerously-skip-permissions</code>), which the create call passes through. Screenshot captured.</div>
+  </div>
+</div>
+
+<div class="card">
+  <h3>1244 - Shared user-interface kit, one confirmation dialog, written palette <span class="prnum">(pull request #1269)</span></h3>
+  <div class="fields">
+    <div class="field"><span class="label">What was wrong</span>The Cockpit had no shared components at all - every page hand-rolled its own buttons and wording. Destructive actions were handled three different ways, including blocking browser pop-ups, and some had no confirmation at all. The web app was held to no written visual standard.</div>
+    <div class="field"><span class="label">What changed</span>A small kit now lives in one place (Button, PageHeader, LoadingState, EmptyState, ErrorBanner, a StatusMessage helper, and one ConfirmDialog). Every destructive action - schedule delete, clear context, clear queue, screenshot delete, and the old browser pop-ups on Exes and Voice Recorder - now asks through that one in-app dialog, which fails loudly and never swallows an error. A new palette document records the web app colours. No <code>window.confirm</code> or <code>window.alert</code> remains.</div>
+    <div class="field verify"><span class="label">How it was verified - PASS</span>Confirmed no <code>window.confirm</code> or <code>window.alert</code> remains anywhere in the Cockpit (only inside explanatory comments), the shared components directory and its ConfirmDialog are present and used by the destructive actions, and <code>docs/CockpitVisualStyle.md</code> exists.</div>
+  </div>
+</div>
+
+<div class="card">
+  <h3>1250 - Learning page: silent failure fixed, Settings link no reload <span class="prnum">(pull request #1270)</span></h3>
+  <div class="fields">
+    <div class="field"><span class="label">What was wrong</span>When "Ask Wingman" failed (Gateway down, transport error) the page showed nothing at all - the request was thrown away silently. The Settings link was a plain anchor that reloaded the entire app.</div>
+    <div class="field"><span class="label">What changed</span>The ask now catches a failure and shows a clear error banner, and the logic was pulled into a testable mapper that always resolves to exactly one of answer or error. The Settings link became a router link, so it navigates without a full reload.</div>
+    <div class="field verify"><span class="label">How it was verified - PASS</span>Confirmed in the running page that a failed ask shows a clear error banner ("Gateway is unreachable") instead of nothing, and the Settings link navigates in place as a router link with no full reload.</div>
+  </div>
+</div>
+
+<div class="card">
+  <h3>1252 - Prompt queue no longer loses text on a failed pop or edit <span class="prnum">(pull request #1275)</span></h3>
+  <div class="fields">
+    <div class="field"><span class="label">What was wrong</span>Popping a queued prompt pasted its text into the composer before the server confirmed the delete, and saving an edit tore down the edit box before the save was confirmed. If the server call then failed, the typed text was gone.</div>
+    <div class="field"><span class="label">What changed</span>A small helper, <code>confirmThenApply</code>, pins the order: run the server action first, apply the local change (paste, or tear down the edit box) only after it confirms. A failed pop pastes nothing and leaves the queue untouched; a failed save keeps the text in the box with an error shown.</div>
+    <div class="field verify"><span class="label">How it was verified - PASS</span>Confirmed that <code>confirmThenApply</code> runs the server action first and applies the local side effect only on success; the three ordering tests pass.</div>
+  </div>
+</div>
+
+<div class="card">
+  <h3>1253 - Transcription Health failure count single-sourced <span class="prnum">(pull request #1267)</span></h3>
+  <div class="fields">
+    <div class="field"><span class="label">What was wrong</span>The failure count was computed by subtraction (total turns minus successful turns), a second number that could drift from and contradict the outcome breakdown shown right below it.</div>
+    <div class="field"><span class="label">What changed</span>The count now comes from the same outcome map the breakdown renders, so the number, the healthy banner, and the breakdown can never disagree. A Refresh control was added so the page can be brought up to date without a full reload.</div>
+    <div class="field verify"><span class="label">How it was verified - PASS</span>Confirmed in the running page that the failure count is summed from the non-success outcomes and the banner ("8 of 128") matches the outcome breakdown exactly, and the Refresh control is present and works.</div>
+  </div>
+</div>
+
+<div class="card">
+  <h3>1254 - Screenshots dock: confirm, re-sync, image fallback <span class="prnum">(pull request #1276)</span></h3>
+  <div class="fields">
+    <div class="field"><span class="label">What was wrong</span>Deleting a screenshot updated the view optimistically with no re-check against the machine's disk, there was no confirmation, and a thumbnail whose file had vanished showed the browser's broken-image glyph with no explanation.</div>
+    <div class="field"><span class="label">What changed</span>Delete now asks through the shared confirmation dialog and then re-fetches the list from the owning machine's disk. A thumbnail that fails to load renders a small "image unavailable" placeholder instead of the broken-image glyph, and a fresh load clears that state.</div>
+    <div class="field verify"><span class="label">How it was verified - PASS</span>Confirmed in the running dock that delete asks through the shared dialog and then re-fetches the list, and a missing thumbnail shows the "Image unavailable" placeholder rather than the broken-image glyph.</div>
+  </div>
+</div>
+
+<div class="card">
+  <h3>1255 - Stop silently losing unsaved settings and dictionary edits <span class="prnum">(pull request #1278)</span></h3>
+  <div class="fields">
+    <div class="field"><span class="label">What was wrong</span>The Director settings editor had no dirty tracking, so navigating away silently discarded unsaved edits. The Dictionary swallowed duplicate entries without a word and dropped edits on navigation.</div>
+    <div class="field"><span class="label">What changed</span>Both pages now guard unsaved edits: an in-app navigation is intercepted and asks "leave with unsaved edits?" through the shared dialog, and the browser's own close/reload is covered too. Duplicate dictionary entries are now surfaced with a notice next to the box instead of vanishing.</div>
+    <div class="field verify"><span class="label">How it was verified - PASS</span>Confirmed in the running pages that Save is disabled when clean and enabled when dirty, that navigating away with unsaved edits pops the "Discard unsaved changes?" dialog, and that a duplicate dictionary entry shows "already in the vocabulary".</div>
+  </div>
+</div>
+
+<div class="card">
+  <h3>1245 - Schedule page on a reusable sortable, searchable table <span class="prnum">(pull request #1277)</span></h3>
+  <div class="fields">
+    <div class="field"><span class="label">What was wrong</span>The Schedule page was hand-rolled with no sorting or searching and no proper prompt editor.</div>
+    <div class="field"><span class="label">What changed</span>It was rebuilt on a new reusable DataTable (sortable columns, a search box, fixed row heights) with a row-detail drawer and a real multiline prompt editor. The table itself is a shared component, built so the Directors page could adopt it next.</div>
+    <div class="field verify"><span class="label">How it was verified - PASS</span>Confirmed in the running page: type chips and one-line labels (no prompt body crammed into the grid), uniform rows, working search and column sort, a row-click detail drawer with the full instructions and a plain-English schedule, and a multiline prompt editor.</div>
+  </div>
+</div>
+
+<div class="card">
+  <h3>1246 - Directors page adopts the shared table <span class="prnum">(pull request #1279)</span></h3>
+  <div class="fields">
+    <div class="field"><span class="label">What was wrong</span>The Directors page did not use the shared table and carried low-value columns.</div>
+    <div class="field"><span class="label">What changed</span>It now uses the same DataTable with five meaningful columns, sorting, and a repository search, and fits a standard 1366-wide screen without horizontal scrolling. No extension to the shared table was needed - it was reused as-is.</div>
+    <div class="field verify"><span class="label">How it was verified - PASS</span>Confirmed in the running page: exactly five columns (Machine, Status, Sessions, Version, Last seen) with search and sort, and no horizontal scroll at 1366 wide (measured scroll width equal to client width).</div>
+  </div>
+</div>
+
+<div class="card">
+  <h3>1261 - De-duplicate the copy-pasted formatting helpers <span class="prnum">(pull request #1280)</span></h3>
+  <div class="fields">
+    <div class="field"><span class="label">What was wrong</span>Small formatting helpers (repository name, port, uptime, short identifier) were copy-pasted across several pages.</div>
+    <div class="field"><span class="label">What changed</span>The copies were removed and the pages now import one shared set of helpers, with the Exes page time format preserved exactly. Where a page's data already carries a session name it is shown; two payloads carry only an identifier and no name, so the short identifier stays there, with the proper name lookup deferred to the shared roster store planned for Wave 2 (issue 1239).</div>
+    <div class="field verify"><span class="label">How it was verified - PASS</span>Confirmed that each helper now has a single definition in the shared format module, imported by the Exes, Wingman, and Feedback pages, and that where the data carries no session name the short identifier is correctly retained.</div>
+  </div>
+</div>
+
+<div class="card">
+  <h3>1266 - Source Control backend: Director and Gateway (read-only) <span class="prnum">(pull request #1274)</span></h3>
+  <div class="fields">
+    <div class="field"><span class="label">What was wrong</span>From a browser you could not see a session's repository state, and the Gateway had no git endpoint at all. This mission builds the backend half; the browser tab itself belongs to Wave 2.</div>
+    <div class="field"><span class="label">What changed</span>The Director's existing git endpoint now also returns the per-file staged and unstaged lists (added without disturbing existing consumers, keeping the ten-second cache). The Gateway gained a read-only git proxy that authenticates per-device keys and resolves the owning Director through the new owner cache. Crucially, git write actions are denied at the Gateway: any write sub-path returns a clear 404 and is never forwarded, proven by a Director-side tripwire test. The shared client gained a getGitStatus call.</div>
+    <div class="field verify"><span class="label">How it was verified - PASS</span>Confirmed the git snapshot additively carries the per-file staged and unstaged lists enriched from the status provider (ten-second cache kept); the Gateway read-only proxy authenticates per-device keys and denies git writes; the client getGitStatus is present. Five Gateway proxy tests and 24 core git tests pass. The Wave 2 browser tab is correctly not built (out of scope).</div>
+  </div>
+</div>
+
+<h2>One item retired, and a real bug found in its place</h2>
+<div class="callout warn">
+  <p><strong>Issue 1238 was closed as already-fixed.</strong> It described parked dictation clips keeping the
+  desktop session rail orange forever and masking a red "needs you". On checking, the desktop dictation
+  queue those parked clips lived in had already been removed on the main line by pull request #1208
+  (dictation now delivers immediately or fails loudly, with no queue). Re-adding the queue to "fix" 1238
+  would have reversed that settled decision, so 1238 was retired. The Architect confirmed this.</p>
+  <p><strong>A genuine related bug was found and filed as issue #1268.</strong> A quick sanity check of the
+  live desktop rail found that an orphaned dictation-lock marker (a phone that starts an upload then dies
+  before finishing) can still keep the rail orange indefinitely and hide a real red "needs you". This is a
+  real, separate defect; it is filed with full evidence for a later fix and is not part of this mission's
+  implementation scope.</p>
+</div>
+
+<h2>What is blocked, and why</h2>
+<div class="callout bad">
+  <p><strong>Wave 2 cannot start.</strong> The second half of the mission (a shared roster store, the terminal
+  room, navigation cleanup, the attention view, the Source Control tab, and more) sits on top of a separate,
+  already-built batch of six pull requests - 1217, 1219, 1220, 1223, 1225, 1226 - that is deployed for
+  testing and awaiting merge. That batch is not ours to merge; it belongs to its author and to your
+  click-through. As of this report all six are still open. Starting Wave 2 before they merge would run
+  straight into guaranteed file conflicts, so it is deliberately held.</p>
+  <p class="muted">This is the one thing that needs a human: merging that batch is what unblocks the rest.</p>
+</div>
+
+<h2>How the verification was done</h2>
+<p>
+  Quality assurance here means independently checking, not taking the implementer's word. Each improvement
+  was reviewed against its issue's acceptance criteria before merge, and then a separate, fresh
+  quality-assurance session - which wrote none of the code - re-verified every acceptance test against the
+  running application and the test suites on the merged main line, recording pass or fail with evidence.
+  Every one of the twelve passed; nothing needed to be sent back.
+</p>
+<p>
+  Across the four test suites the run was clean: <strong>183 client tests, 67 Cockpit tests, 25 Gateway
+  tests, and 24 core tests passed with zero failures</strong>, and both TypeScript typechecks were clean.
+  User-interface criteria were checked in a real browser with screenshots; backend criteria were checked
+  against the endpoints and their tests.
+</p>
+<div class="callout">
+  <span class="label muted">A note on the automated test runs.</span>
+  <p>Two integration tests, <code>StreamModeOff_DoesNotMapTheHub</code> and its launcher twin, fail intermittently
+  on the shared build - including on the main line itself, roughly half the time - regardless of the change under
+  test. They are unrelated SignalR hub-mapping tests. Every pull request in this mission was confirmed green on a
+  re-run, except the final formatting-only cleanup (1261), which was merged with an administrator override after
+  three re-runs hit only that same unrelated flaky pair while its own frontend tests passed. Recommendation:
+  file a separate issue to stabilize those two flaky tests, since they are making the main line red about half
+  the time for the whole repository.</p>
+</div>
+
+<p class="muted" style="margin-top:40px; font-size:13px;">
+  Prepared by the Cockpit Improvement Manager session on 2026-07-10. Independent verification performed by a
+  separate quality-assurance session against the merged main line. Source review documents for this mission
+  were recovered from an insurance snapshot after a shared working-tree cleanup removed the untracked originals;
+  this report is committed to the repository so it cannot be lost the same way.
+</p>
+
+</div>
+</body>
+</html>

--- a/docs/reviews/cockpit-improvement-report-2026-07-10.html
+++ b/docs/reviews/cockpit-improvement-report-2026-07-10.html
@@ -1,0 +1,694 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Cockpit Improvement Report - 2026-07-10</title>
+<style>
+  :root {
+    --bg: #0b1020;
+    --panel: #121a30;
+    --panel-2: #17203a;
+    --line: #24304f;
+    --text: #dbe4f5;
+    --muted: #8fa0c2;
+    --accent: #4da3ff;
+    --red: #ff5d6c;
+    --orange: #ffb45d;
+    --green: #4ecf8d;
+    --blue: #5da8ff;
+    --yellow: #ffd75d;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: "Segoe UI", system-ui, Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.6;
+  }
+  .wrap { max-width: 980px; margin: 0 auto; padding: 40px 28px 80px; }
+  header.masthead {
+    border-bottom: 1px solid var(--line);
+    padding-bottom: 24px;
+    margin-bottom: 32px;
+  }
+  .kicker {
+    color: var(--accent);
+    font-size: 13px;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    margin: 0 0 8px;
+  }
+  h1 { font-size: 34px; margin: 0 0 10px; line-height: 1.2; }
+  .meta { color: var(--muted); font-size: 14px; }
+  .meta span { margin-right: 18px; }
+  h2 {
+    font-size: 24px;
+    margin: 48px 0 14px;
+    padding-top: 18px;
+    border-top: 1px solid var(--line);
+  }
+  h3 { font-size: 18px; margin: 26px 0 8px; }
+  p { margin: 10px 0; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code {
+    background: var(--panel-2);
+    border: 1px solid var(--line);
+    border-radius: 4px;
+    padding: 1px 6px;
+    font-family: Consolas, "Courier New", monospace;
+    font-size: 13.5px;
+    color: #cfe0ff;
+  }
+  pre {
+    background: #0d1428;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 14px 16px;
+    overflow-x: auto;
+    font-family: Consolas, "Courier New", monospace;
+    font-size: 13px;
+    line-height: 1.45;
+    color: #b9c8e6;
+  }
+  .lead { font-size: 18px; color: #eaf0fb; }
+  .callout {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-left: 4px solid var(--accent);
+    border-radius: 8px;
+    padding: 14px 18px;
+    margin: 18px 0;
+  }
+  .callout.warn { border-left-color: var(--orange); }
+  .callout.good { border-left-color: var(--green); }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 16px 0;
+    font-size: 14.5px;
+  }
+  th, td {
+    text-align: left;
+    padding: 9px 12px;
+    border-bottom: 1px solid var(--line);
+    vertical-align: top;
+  }
+  th {
+    color: var(--muted);
+    font-weight: 600;
+    font-size: 12.5px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    border-bottom: 2px solid var(--line);
+  }
+  tr:hover td { background: rgba(77, 163, 255, 0.05); }
+  .tablewrap { overflow-x: auto; }
+  .tag {
+    display: inline-block;
+    border-radius: 20px;
+    padding: 1px 10px;
+    font-size: 12px;
+    font-weight: 600;
+    white-space: nowrap;
+    border: 1px solid transparent;
+  }
+  .tag.bug     { background: rgba(255, 93, 108, 0.14); color: var(--red);    border-color: rgba(255, 93, 108, 0.4); }
+  .tag.planned { background: rgba(78, 207, 141, 0.12); color: var(--green);  border-color: rgba(78, 207, 141, 0.35); }
+  .tag.new     { background: rgba(93, 168, 255, 0.12); color: var(--blue);   border-color: rgba(93, 168, 255, 0.35); }
+  .tag.arch    { background: rgba(255, 215, 93, 0.12); color: var(--yellow); border-color: rgba(255, 215, 93, 0.35); }
+  .tag.small   { background: rgba(143, 160, 194, 0.12); color: var(--muted); border-color: rgba(143, 160, 194, 0.3); }
+  .card {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 18px 22px;
+    margin: 16px 0;
+  }
+  .card h3 { margin-top: 0; }
+  .card .who { color: var(--muted); font-size: 13px; margin-top: 10px; }
+  .num {
+    display: inline-block;
+    background: var(--panel-2);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    color: var(--accent);
+    font-weight: 700;
+    font-size: 14px;
+    padding: 0 8px;
+    margin-right: 8px;
+  }
+  ul { margin: 8px 0 8px 4px; padding-left: 22px; }
+  li { margin: 5px 0; }
+  .toc {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 16px 22px;
+    margin: 22px 0;
+  }
+  .toc ol { margin: 6px 0; padding-left: 24px; }
+  .footnote { color: var(--muted); font-size: 13.5px; }
+  .dot {
+    display: inline-block; width: 10px; height: 10px; border-radius: 50%;
+    margin-right: 6px; vertical-align: baseline;
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="masthead">
+  <p class="kicker">DevThrottle Cockpit</p>
+  <h1>Improving the Cockpit: the remote control room for the fleet</h1>
+  <p class="meta">
+    <span>Date: 2026-07-10</span>
+    <span>Prepared by: Claude session cbf4c725 (devthrottle)</span>
+    <span>Status: proposal only - nothing has been implemented</span>
+  </p>
+</header>
+
+<p class="lead">
+The Cockpit exists so one person can stand anywhere in the world, open a browser through
+port 443 to the Gateway, and run the whole fleet: see every agent session on every machine,
+know instantly which ones are stuck waiting for a human, and drive any one of them - type into
+it, stop it, queue work, hand it an image - without ever touching that machine directly.
+This report is the combined result of a full read of the Cockpit code and a second, independent
+deep review that ran today. It says what to improve and why, ranked and staged, so you can
+decide before anything is built.
+</p>
+
+<div class="toc">
+  <strong>Contents</strong>
+  <ol>
+    <li><a href="#what">What the Cockpit is today</a></li>
+    <li><a href="#verdict">The overall verdict</a></li>
+    <li><a href="#roots">Six root causes behind almost everything</a></li>
+    <li><a href="#trust">Theme A - Make the picture trustworthy</a></li>
+    <li><a href="#drive">Theme B - Make driving a session excellent</a></li>
+    <li><a href="#finish">Theme C - Make it feel like one finished product</a></li>
+    <li><a href="#new">Theme D - New capabilities worth building</a></li>
+    <li><a href="#quick">Quick wins (a day or less each)</a></li>
+    <li><a href="#staging">Suggested order of work</a></li>
+    <li><a href="#sources">Sources and relationship to existing plans</a></li>
+  </ol>
+</div>
+
+<h2 id="what">1. What the Cockpit is today</h2>
+<p>
+The Cockpit is a React single-page application at <code>apps/cockpit</code>, served by the
+Gateway at the site root. It is a thin shell over the shared <code>packages/client-core</code>
+library (the same library the phone app uses), and the browser talks <em>only</em> to the
+Gateway with relative addresses - no client ever learns a Director's address. The browser
+enrolls as a device on your account, exactly like the phone.
+</p>
+<p>Its main surfaces:</p>
+<ul>
+  <li><strong>Sessions</strong> - the driving loop: a rail listing every session across every
+      machine (with the shared status colors), and for the selected session a live terminal,
+      an action bar (Stop, Interrupt, Clear context, History), a composer (Send, Queue, Attach),
+      a prompt queue, and a screenshots dock.</li>
+  <li><strong>Fleet Map</strong> - the screen in your screenshot: a spatial node canvas of the
+      whole fleet, pivotable by machine, repository, or agent, with one status dot per session.</li>
+  <li><strong>Directors, Schedule, Dictionary, Learning, Telemetry, Transcription Health,
+      Account, Settings, About</strong> - the management and data pages around the core.</li>
+</ul>
+<div class="callout">
+<strong>Note on versions.</strong> The build you screenshotted already shows the "Fleet list"
+pivot and the title search box - those come from the improvement-plan pull-request stack
+(pull requests 1217 through 1226) which is deployed but not yet merged into the checkout this
+report was read from. Everything below accounts for that stack being in flight.
+</div>
+
+<h2 id="verdict">2. The overall verdict</h2>
+<p>
+The architecture is right and the product is close. The one-library-two-shells design, the
+Gateway-only ingress, the device enrollment, and the shared status-color rule are all the
+correct foundations, and the day-to-day core (see the fleet, click a session, answer it) works.
+What holds it back is a layer of trust and finish issues:
+</p>
+<ul>
+  <li>The fleet picture <strong>blinks</strong>: one slow machine and its sessions vanish for
+      up to thirty seconds, and the Sessions page (the one you live in) drops them silently
+      while the Fleet pages at least show a warning.</li>
+  <li>The <strong>terminal - the whole point - is the most cramped thing on the screen</strong>,
+      and it is labeled with a raw identifier instead of the session's name.</li>
+  <li>A real bug lets a <strong>stuck orange "transcribing" state mask a red "needs you"</strong> -
+      the one signal you steer by can lie.</li>
+  <li>A session created from the browser gets <strong>no model and no permission mode</strong>,
+      so it comes up blocked and under-powered.</li>
+  <li>Not one list in the app can be <strong>sorted or searched</strong>, and every page invents
+      its own header, buttons, loading text, and confirmation behavior - it reads as beta.</li>
+</ul>
+<p>
+None of these are deep flaws. They are a finite set of fixes, most of which share six root
+causes - fix the cause and a whole column of symptoms closes at once.
+</p>
+
+<h2 id="roots">3. Six root causes behind almost everything</h2>
+<div class="tablewrap">
+<table>
+  <tr><th style="width:44%">Root cause</th><th>What it produces</th></tr>
+  <tr>
+    <td>1. The Gateway is <strong>pulled, not pushed</strong>, from many pages at once - twelve
+        independent poll timers in nine files, none of which pause when the tab is hidden, and
+        every keystroke re-scans the fleet to find its owner.</td>
+    <td>The blinking list, Gateway and machine load that grows with fleet size, typing latency.</td>
+  </tr>
+  <tr>
+    <td>2. There is <strong>no shared web user-interface kit</strong> - every page reinvents its
+        header, buttons, loading text, empty state, error banner, and confirmation.</td>
+    <td>Eighteen header classes, about twenty button classes, four different confirmation
+        behaviors, unstyled sign-in screens.</td>
+  </tr>
+  <tr>
+    <td>3. <strong>Long free text keeps landing in grid cells</strong> - the Schedule page renders
+        entire multi-paragraph prompts inside a column labeled "Runs".</td>
+    <td>Unscannable walls of text; grids that cannot be compared, sorted, or searched.</td>
+  </tr>
+  <tr>
+    <td>4. <strong>Sessions are shown as codes, not names</strong> - the terminal header, the
+        Wingman briefs table, and other surfaces show an identifier where the name belongs.</td>
+    <td>"Which session am I typing into?" is never confirmed on the driving surface.</td>
+  </tr>
+  <tr>
+    <td>5. <strong>State is recomputed on the client instead of trusted from the Gateway</strong> -
+        the status-color fold exists in both C-sharp and TypeScript, and several pages re-derive
+        values the server already knows.</td>
+    <td>The orange-rail bug, a self-contradicting Transcription Health page, and every future fix
+        having to be applied twice.</td>
+  </tr>
+  <tr>
+    <td>6. <strong>Optimistic actions with no rollback, destructive actions with no guard</strong> -
+        several buttons apply locally before the server confirms, or delete with no confirmation.</td>
+    <td>The prompt queue can lose typed text on a failed save; Schedule delete and Clear-context
+        fire with no confirmation at all.</td>
+  </tr>
+</table>
+</div>
+<p class="footnote">
+This framing comes from the independent review and I agree with it fully: the Cockpit is not
+thirteen broken things, it is six missing foundations.
+</p>
+
+<h2 id="trust">4. Theme A - Make the picture trustworthy</h2>
+<p>Nothing else matters until the screen can be believed. These four items earn that trust.</p>
+
+<div class="card">
+  <h3><span class="num">A1</span>Stop the fleet from blinking; never silently drop a machine
+      <span class="tag planned">planned - issue 1215, priority raised</span></h3>
+  <p><strong>Today:</strong> one slow poll benches a healthy machine for thirty seconds and its
+  sessions vanish. The Sessions page silently drops unreachable machines; the Fleet pages show
+  a warning - the two views disagree about reality.</p>
+  <p><strong>Proposed:</strong> the Gateway keeps a last-known-good snapshot per machine and
+  serves it through a short grace window. Three visible states, not two:
+  <span class="dot" style="background:#4ecf8d"></span>Online,
+  <span class="dot" style="background:#8fa0c2"></span>Wobbly (dimmed, "last seen 20 seconds ago"),
+  <span class="dot" style="background:#556"></span>Offline. Rows change appearance in place and
+  the list never reflows on a transient miss. The Sessions page consumes the same envelope as
+  the Fleet pages so every surface tells the same story. A genuinely down machine still reads
+  as down within the existing eviction times - this is a defined presentation state, not a
+  fallback that hides outages.</p>
+  <p class="who">Effort: medium. This is Phase 6 of the approved plan; both the review and I
+  raise it to number one because it is the single thing that makes the control room feel
+  untrustworthy.</p>
+</div>
+
+<div class="card">
+  <h3><span class="num">A2</span>Fix the orange state that hides a session that needs you
+      <span class="tag bug">real bug</span></h3>
+  <p><strong>Today:</strong> a permanently parked dictation clip (out of credits, composer
+  blocked) still counts toward the "pending dictation" tally, which paints the rail orange
+  forever - and orange is resolved before red, so a session that genuinely needs you can be
+  masked indefinitely.</p>
+  <p><strong>Proposed:</strong> count only genuinely deliverable clips toward the orange state;
+  parked clips already surface through the notification banner. Add a regression test that a
+  parked clip leaves a red session red.</p>
+  <p class="who">Effort: small. Highest value per line of code in this report - it repairs the
+  primary attention signal.</p>
+</div>
+
+<div class="card">
+  <h3><span class="num">A3</span>Poll the fleet once, share it everywhere, pause when hidden
+      <span class="tag new">new</span></h3>
+  <p><strong>Today:</strong> twelve poll timers across nine files; three pages poll the same
+  roster every two to three seconds; a backgrounded tab hammers the Gateway forever; every
+  keystroke you type is routed by re-scanning every machine.</p>
+  <p><strong>Proposed:</strong> one shared roster store in client-core with a single
+  visibility-aware polling hook; every fleet view reads the same cached roster and stays in
+  sync. Prefer pushing roster changes over the existing stream instead of re-pulling. Route
+  prompt, interrupt, and escape through the owner cache the streaming path already keeps, so a
+  keystroke stops scanning the fleet.</p>
+  <p class="who">Effort: medium. This is what lets the control room scale to ten-plus machines
+  without feeling heavy.</p>
+</div>
+
+<div class="card">
+  <h3><span class="num">A4</span>Let the Gateway own presentation state, once
+      <span class="tag arch">architecture</span></h3>
+  <p><strong>Today:</strong> the status-color and ordering policy lives twice - in C-sharp on
+  the Gateway and in a line-by-line TypeScript port - and several pages bypass even the shared
+  module and re-derive state inline. The recent stuck-orange fix had to be applied in both
+  languages.</p>
+  <p><strong>Proposed:</strong> follow the already-written plan (<code>docs/architecture/
+  gateway-owns-session-presentation.md</code>): the Gateway stamps effective color, triage
+  bucket, state label, and ordering onto the session data it already serves; clients render the
+  fields and delete their local copies; a lint rule keeps policy from creeping back into the
+  browser. This is the permanent fix for root cause 5 - bugs like A2 become impossible to
+  have in two places.</p>
+  <p class="who">Effort: medium, in phases that are each independently shippable.</p>
+</div>
+
+<h2 id="drive">5. Theme B - Make driving a session excellent</h2>
+<p>Once the picture is honest, this is where you spend your time - the "answer it" half.</p>
+
+<div class="card">
+  <h3><span class="num">B1</span>Give the terminal room, and label it with the session's name
+      <span class="tag new">new</span></h3>
+  <p><strong>Today:</strong> fixed chrome eats roughly 780 pixels before the terminal starts
+  (navigation rail, session rail, right dock). On a laptop the agent's output overflows into a
+  sideways scroll. The terminal header shows a raw identifier, not the name you gave the session.</p>
+  <p><strong>Proposed:</strong> collapse controls for the session rail and the right dock, plus a
+  full-screen toggle that hands the terminal the whole window. Replace the identifier header with
+  the session's name, repository, machine, and status dot - the same identity the rail shows -
+  so the header always confirms what you are typing into.</p>
+  <p class="who">Effort: small to medium. The single biggest day-to-day quality-of-life win.</p>
+</div>
+
+<div class="card">
+  <h3><span class="num">B2</span>Let a browser-created session choose model and permission mode
+      <span class="tag new">new</span></h3>
+  <p><strong>Today:</strong> the New-session dialog sends no launch arguments, so a
+  Cockpit-created session comes up blocked on a permission prompt and running the default
+  smaller-context model. The first thing you do after creating it is fix it by hand.</p>
+  <p><strong>Proposed:</strong> model and permission-mode choices in the dialog with your usual
+  defaults pre-selected, threaded through as launch arguments, remembering the last choice.
+  "Create and it just runs" instead of "create and immediately babysit".</p>
+  <p class="who">Effort: small to medium.</p>
+</div>
+
+<div class="card">
+  <h3><span class="num">B3</span>Finish the composer: Speak, paste, drag-and-drop
+      <span class="tag planned">planned - issue 1210</span></h3>
+  <p><strong>Today:</strong> the composer has Send, Queue, and Attach. There is no dictation
+  button, no clipboard paste of images, no drag-and-drop - all things you reach for constantly
+  when remote.</p>
+  <p><strong>Proposed:</strong> mount the shared dictation dialog (the exact component the phone
+  uses - one transcription path through the Gateway, no new code), and add clipboard paste and
+  drag-and-drop that call the same upload as Attach. Verify Attach end to end from a remote
+  browser.</p>
+  <p class="who">Effort: small. Already specified as Phase 1 of the approved plan.</p>
+</div>
+
+<div class="card">
+  <h3><span class="num">B4</span>Session management from the browser: rename, hold, handover, close
+      <span class="tag planned">planned - issue 1214</span></h3>
+  <p><strong>Today:</strong> the Gateway calls for rename, hold or resume, and close already
+  exist in the shared library - the Cockpit simply never surfaces them. Managing a session still
+  requires walking to the desktop application.</p>
+  <p><strong>Proposed:</strong> a session menu on the session page and on rail cards: Rename,
+  Put on hold / Resume, Handover info, Close (with confirmation). Any per-agent capability
+  differences expressed as data on the session, never as client-side special cases.</p>
+  <p class="who">Effort: small to medium. Phase 5 of the approved plan.</p>
+</div>
+
+<h2 id="finish">6. Theme C - Make it feel like one finished product</h2>
+
+<div class="card">
+  <h3><span class="num">C1</span>One small user-interface kit, one documented palette, one confirmation
+      <span class="tag new">new</span></h3>
+  <p><strong>Today:</strong> the desktop application and the web Cockpit look like two different
+  products; the written style guide describes the desktop charcoal palette while the Cockpit
+  invented an undocumented navy one. Inside the Cockpit: eighteen distinct page-header classes,
+  about twenty near-duplicate button classes, different loading and error wording on every page,
+  and destructive actions handled three different ways (inline confirmation, blocking browser
+  pop-ups, and - on Schedule delete and Clear-context - no confirmation at all).</p>
+  <p><strong>Proposed:</strong> a tiny shared kit - Button with variants, PageHeader,
+  LoadingState, EmptyState, ErrorBanner, one ConfirmDialog - plus a short written "Cockpit visual
+  style" documenting the navy tokens the web app actually uses. Every destructive action routes
+  through the one dialog. The unstyled sign-in and device-callback screens (the first thing a
+  new user sees) get the app's real buttons and surfaces.</p>
+  <p class="who">Effort: medium, then it pays for itself on every page that follows.</p>
+</div>
+
+<div class="card">
+  <h3><span class="num">C2</span>Grids you can actually scan, sort, and search
+      <span class="tag new">new</span></h3>
+  <p><strong>Today:</strong> not one list in the entire Cockpit is sortable or searchable. The
+  Schedule page is the worst case: a column labeled "Runs" renders the entire multi-paragraph
+  prompt of each job, with the raw word "skill" glued onto the front, while the editor offers the
+  same text back through a single-line input box.</p>
+  <p><strong>Proposed:</strong> the rule is simple - a grid cell holds one short scannable value;
+  long text lives in a row-detail panel or the editor, never in the grid. Rebuild the Schedule
+  page on that rule (fixed-height rows, a type chip and one-line label under "Runs", plain-English
+  schedule with the raw cron on hover, sortable columns defaulting to next run, a search box, a
+  detail drawer with the full instructions and recent run history, a real multi-line prompt
+  editor). Build it as a reusable table so Directors and every future grid inherit sort, search,
+  and the detail drawer for free. The Voice Recorder page already demonstrates the right
+  card-with-expander shape for long content - copy it, do not invent.</p>
+  <p class="who">Effort: medium for Schedule; small follow-ups to adopt elsewhere.</p>
+</div>
+
+<div class="card">
+  <h3><span class="num">C3</span>Navigation cleanup: every real page reachable, no half-built surfaces
+      <span class="tag new">new</span></h3>
+  <p><strong>Today:</strong> five fully-built pages have no menu entry and are reachable only by
+  typing an address. Meanwhile a tab strip with a single tab sits above the terminal, an empty
+  action bar shows while a session loads, the Fleet Map legend still advertises the retired
+  narration overlay, and the home screen is called three different names ("Sessions",
+  "Dashboard", "Cockpit") depending on which page links to it.</p>
+  <p><strong>Proposed:</strong> group the navigation into sections (Fleet / Data / System), add
+  entries for the built pages worth keeping, delete the pages that are truly retired, remove the
+  single-tab strip until Chat and Voice land, show a loading state instead of an empty action
+  bar, finish retiring the narration remnants, and pick one name for home.</p>
+  <p class="who">Effort: small per item; together they move the app from "beta" to "finished".</p>
+</div>
+
+<div class="card">
+  <h3><span class="num">C4</span>Standard loading, empty, and error states - and keyboard access
+      <span class="tag new">new</span></h3>
+  <p><strong>Today:</strong> "Loading..." appears as italic text with different wording
+  everywhere, many pages have no retry after a failure, several clickable table rows cannot be
+  reached by keyboard, and action results ("turn stopped", "sent") are silent to screen readers.</p>
+  <p><strong>Proposed:</strong> the kit from C1 applied everywhere: skeleton rows, a consistent
+  Retry, whole-row keyboard targets (the Fleet Map card already does this correctly and is the
+  model), and live-region announcements for action results.</p>
+  <p class="who">Effort: small to medium, mostly mechanical once the kit exists.</p>
+</div>
+
+<div class="card">
+  <h3><span class="num">C5</span>One "needs you" order on every screen
+      <span class="tag small">small fix</span></h3>
+  <p><strong>Today:</strong> the phone orders the "needs you" group as a wait-time queue (longest
+  wait on top - the agreed and recorded behavior), but the Cockpit's attention view still shows
+  manual drag order. The same fleet reads differently depending on the screen.</p>
+  <p><strong>Proposed:</strong> wire the Cockpit's attention view to the same shared queue-order
+  helper the phone uses. The default "My order" view stays exactly as it is - manual order is
+  sacred there; only the opt-in attention grouping changes.</p>
+  <p class="who">Effort: small. Can land any time.</p>
+</div>
+
+<div class="card">
+  <h3><span class="num">C6</span>Sweep the ticket-sized correctness bugs
+      <span class="tag bug">bugs</span></h3>
+  <p>The deep review surfaced a set of small, real defects, each worth one ticket:</p>
+  <ul>
+    <li>Ask-Wingman on the Learning page fails silently when the request throws (a try/finally
+        with no catch).</li>
+    <li>The Fleet dashboard stops all polling while any rename box has focus - one focused input
+        freezes the whole page's updates.</li>
+    <li>The prompt queue pastes into the composer before the server confirms the pop, so a failed
+        delete duplicates the item; a failed edit-save discards the typed text.</li>
+    <li>Transcription Health derives its failure count by subtraction client-side and can
+        contradict the authoritative outcome map on the same page.</li>
+    <li>Screenshot delete is optimistic with no re-synchronization and no confirmation.</li>
+    <li>The Director settings editor has no dirty tracking - Reload silently discards unsaved
+        edits; Dictionary drops edits on navigation and silently swallows duplicate entries.</li>
+  </ul>
+  <p class="who">Effort: small each; most become a few lines once the kit's confirm and rollback
+  helpers exist.</p>
+</div>
+
+<h2 id="new">7. Theme D - New capabilities worth building</h2>
+
+<div class="card">
+  <h3><span class="num">D1</span>A command-center home instead of "pick a session"
+      <span class="tag new">new page</span></h3>
+  <p><strong>Today:</strong> the front door of the control room, before you select anything, is a
+  line of text that says "pick a session" - a wasted screen at the exact moment you most want an
+  at-a-glance read of everything.</p>
+  <p><strong>Proposed:</strong> a fleet command center as the landing screen, built entirely from
+  data the roster already returns:</p>
+  <pre>
++--------------------------------------------------------------------------+
+|  FLEET   2 machines online   0 wobbly   0 offline    12 sessions         |
+|          1 working   9 need you   2 idle                                 |
++--------------------------------------------------------------------------+
+|  NEEDS YOU (oldest first)                    |  FLEET ACTIVITY           |
+|  [102] test offline m...   waiting 26m  ->   |  116 went red        1m   |
+|  [110] mindzieWeb ...      waiting 29s  ->   |  118 finished turn   2m   |
+|  [116] devthrottle - ...   waiting 1m   ->   |  102 started         26m  |
+|  ... every row links straight into the session ...                       |
++--------------------------------------------------------------------------+</pre>
+  <p>The "needs you" queue front and center with wait times and a one-line reason, fleet vitals,
+  unreachable machines called out, and recent activity - each row one click from the session.</p>
+  <p class="who">Effort: medium. The highest-visibility new capability; it directly answers
+  "what needs me right now, across everything".</p>
+</div>
+
+<div class="card">
+  <h3><span class="num">D2</span>Browser notifications - be called by the Cockpit, not watch it
+      <span class="tag new">new</span></h3>
+  <p>The phone already gets a "needs you" badge through web push. The Cockpit has nothing, so a
+  browser tab must be kept in view. Reuse the existing push work so a backgrounded tab can tell
+  you a session needs you. For a product whose pitch is "run the fleet from anywhere", this is
+  the difference between watching and being called.</p>
+  <p class="who">Effort: small to medium - the push plumbing already exists for the phone.</p>
+</div>
+
+<div class="card">
+  <h3><span class="num">D3</span>Triage from the rail
+      <span class="tag new">new</span></h3>
+  <p>When you shepherd ten agents, most interactions are one word - approve, deny, a one-line
+  answer. Let those happen directly on a "needs you" rail card without opening the session.
+  Opening each session is the slow path.</p>
+  <p class="who">Effort: medium.</p>
+</div>
+
+<div class="card">
+  <h3><span class="num">D4</span>Jump to a session by number
+      <span class="tag new">new</span></h3>
+  <p>Sessions already carry a short number (102, 104...). Press a key, type the number, land on
+  the session - a keyboard address for the fleet, the way you switch tabs in a browser.</p>
+  <p class="who">Effort: small.</p>
+</div>
+
+<div class="card">
+  <h3><span class="num">D5</span>Chat and Voice tabs on the session page
+      <span class="tag planned">planned - issue 1213</span></h3>
+  <p>Bring the phone's Chat and Voice surfaces to the session page as tabs beside Terminal,
+  sharing the same client-core code (hoist any logic still living in the phone pages down into
+  the shared library first, so nothing forks). Not everyone wants to read a raw terminal to
+  drive an agent - especially on the couch.</p>
+  <p class="who">Effort: medium. Phase 4 of the approved plan.</p>
+</div>
+
+<div class="card">
+  <h3><span class="num">D6</span>Search what the fleet is doing
+      <span class="tag new">follow-on</span></h3>
+  <p>Title search (already in flight) finds a session you can name. The higher-value version is
+  "which agent is touching X" - searching recent terminal output or transcripts across the
+  fleet, through the Gateway. That is how you find the right session when you do not remember
+  what you called it.</p>
+  <p class="who">Effort: medium to large. Deliberately a follow-on, as the approved plan notes.</p>
+</div>
+
+<div class="card">
+  <h3><span class="num">D7</span>Show missions on the Fleet Map: workers nested under their manager
+      <span class="tag planned">designed - issues 1227 and 1228</span></h3>
+  <p>Already designed in <code>docs/architecture/cockpit-fleet-map-hierarchy.md</code>: sessions
+  that run workers appear with the workers indented inside the manager's cluster box, driven by
+  the real controller relationship (not the old free-form group labels). The rail stays flat and
+  hand-ordered - it only gains the same small grey role letters the desktop rail already has. As
+  multi-agent missions become the normal way of working, this is how the map stays readable.</p>
+  <p class="who">Effort: medium. Sequenced after the current improvement stack merges, since it
+  edits the same Fleet Map file.</p>
+</div>
+
+<h2 id="quick">8. Quick wins (a day or less each)</h2>
+<div class="tablewrap">
+<table>
+  <tr><th>Win</th><th>Where</th></tr>
+  <tr><td>Show the session name in the terminal header instead of the identifier</td>
+      <td><code>panes/TerminalPane.tsx</code></td></tr>
+  <tr><td>Remove the single-tab strip above the terminal until Chat and Voice land</td>
+      <td><code>sessions/SessionDetail.tsx</code></td></tr>
+  <tr><td>Add confirmation to Schedule delete and Clear-context</td>
+      <td><code>schedule/ScheduleView.tsx</code>, <code>sessions/SessionActionBar.tsx</code></td></tr>
+  <tr><td>Fix the full-page-reload link on the Learning page</td>
+      <td><code>learning/LearningView.tsx</code></td></tr>
+  <tr><td>Delete the retired narration legend, label, and dead styles on the Fleet Map</td>
+      <td><code>fleet/FleetMapView.tsx</code></td></tr>
+  <tr><td>De-duplicate the copy-pasted date, time, and repository-name helpers into one shared module</td>
+      <td><code>exes/ExesView.tsx</code>, <code>wingman/WingmanQueueView.tsx</code>, others</td></tr>
+  <tr><td>Pick one name for the home screen (currently "Sessions", "Dashboard", and "Cockpit")</td>
+      <td><code>AppShell.tsx</code>, <code>dictionary/DictionaryView.tsx</code>, <code>learning/LearningView.tsx</code></td></tr>
+</table>
+</div>
+
+<h2 id="staging">9. Suggested order of work</h2>
+<p>
+Each stage ships deployed and clickable before the next starts, in keeping with how this
+project works. The current improvement-plan pull-request stack (1217 through 1226: composer
+Speak and paste, rail polish, Fleet Map numbers and search, the Fleet list pivot) merges first -
+it is already built and deployed for testing.
+</p>
+<div class="tablewrap">
+<table>
+  <tr><th style="width:20%">Stage</th><th>What ships</th><th>Why this order</th></tr>
+  <tr>
+    <td><strong>1. Earn trust</strong></td>
+    <td>A1 fleet stability, A2 orange-rail bug, B2 model and permission on creation</td>
+    <td>The two things that make the screen lie to you, plus the small daily annoyance that
+        rides along cheaply.</td>
+  </tr>
+  <tr>
+    <td><strong>2. Lay the foundations</strong></td>
+    <td>A3 one shared roster store, C1 the user-interface kit; sweep the C6 bug list alongside</td>
+    <td>Everything after this is faster and more consistent because these exist.</td>
+  </tr>
+  <tr>
+    <td><strong>3. The driving surface and the grids</strong></td>
+    <td>B1 terminal room and identity, B4 session menu, C2 Schedule rebuild and the shared
+        table, C3 navigation cleanup, C4 states and keyboard access</td>
+    <td>The kit makes these cheap; this is where the product starts feeling finished.</td>
+  </tr>
+  <tr>
+    <td><strong>4. New capabilities</strong></td>
+    <td>D1 command-center home, D2 notifications, D4 jump-by-number, D5 Chat and Voice,
+        D7 mission nesting, then D3 triage and D6 content search</td>
+    <td>Built on an honest, fast, consistent base instead of on sand.</td>
+  </tr>
+  <tr>
+    <td><strong>Any time</strong></td>
+    <td>C5 needs-you ordering, A4 Gateway-owns-presentation phases, the quick wins</td>
+    <td>Independent; pick them off when someone is already in the relevant file.</td>
+  </tr>
+</table>
+</div>
+
+<h2 id="sources">10. Sources and relationship to existing plans</h2>
+<ul>
+  <li><strong>My own read of the code</strong> (today): the Cockpit application, the shared
+      client library, the session and fleet views, and the routing and shell.</li>
+  <li><strong>The independent deep review</strong> (session "codex review - cockpit", finished
+      today): <code>docs/architecture/cockpit-review-2026-07-10.md</code> - thirteen ranked
+      recommendations, a full grid audit, a screen-by-screen audit with concrete defects, the
+      polling census, and the root-cause analysis. This report adopts its findings; where I
+      weigh in, I agree with its ranking, including raising fleet stability to number one.</li>
+  <li><strong>The approved improvement plan</strong>:
+      <code>docs/architecture/cockpit-improvement-plan.md</code> - phases 1 through 6
+      (issues 1210 through 1215), whose pull-request stack is deployed and awaiting merge.
+      This report does not re-litigate its settled decisions (the Fleet page folds into the
+      Fleet Map; the terminal stays a plain terminal; Chat and Voice arrive as literal ports).</li>
+  <li><strong>The Fleet Map hierarchy design</strong>:
+      <code>docs/architecture/cockpit-fleet-map-hierarchy.md</code> (issues 1227 and 1228).</li>
+  <li><strong>The presentation-ownership plan</strong>:
+      <code>docs/architecture/gateway-owns-session-presentation.md</code>.</li>
+</ul>
+
+<div class="callout good">
+<strong>Bottom line.</strong> The Cockpit's bones are right. Stage 1 makes it honest, stage 2
+makes it cheap to improve, stage 3 makes it pleasant, and stage 4 makes it powerful. Nothing in
+this report has been implemented - it is a proposal for you to read and react to.
+</div>
+
+<p class="footnote">Prepared 2026-07-10 by the devthrottle Claude session (cbf4c725), combining
+a direct code read with the independent review document. No code was changed.</p>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
Final deliverable of the Cockpit Improvement mission (Wave 1). A self-contained, dark-themed HTML report at docs/reviews/cockpit-improvement-qa-report-2026-07-10.html.

For every improvement it gives: the issue and title, what was wrong (plain English), what changed (approach), how it was independently verified (the acceptance check actually performed, with the observed result), and the pull request number.

Coverage:
- 11 merged Wave 1 improvements plus the issue 1266 backend half: 1240, 1243, 1244, 1250, 1252, 1253, 1254, 1255, 1245, 1246, 1261, 1266 (backend).
- Independent quality-assurance re-verification (a fresh session that wrote none of the code): all 12 PASS, zero failures; 299 automated tests green (183 client-core, 67 Cockpit, 25 Gateway, 24 core); both typechecks clean.
- Issue 1238 retired as already-fixed (superseded by thefrederiksen/devthrottle#1208); the real successor bug filed as thefrederiksen/devthrottle_internal#748.
- Wave 2 blocked on the still-open 1217-1226 stack (not ours to merge).
- Recommendation: stabilize the flaky StreamModeOff tests (red on main ~half the time).

Not self-merged - presenting for your review and merge.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>