### PR TITLE
Fix SPA fallback returning 200 shell for non-GET unknown routes (the StreamModeOff 'flaky' failures)

### DIFF
--- a/src/CcDirector.Gateway.Tests/SpaFallbackNonGetTests.cs
+++ b/src/CcDirector.Gateway.Tests/SpaFallbackNonGetTests.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Regression for the Cockpit SPA fallback swallowing non-GET 404s. The site-root fallback
+/// (CockpitReactApp) serves index.html for unmatched client-side routes so browser deep links work.
+/// It must do so ONLY for GET/HEAD navigations: a POST that falls through to the fallback is an
+/// unmatched API/hub call - e.g. POSTing a SignalR <c>/negotiate</c> to a hub that is not mapped
+/// (stream mode off) - and must answer 404, NOT a 200 index.html shell.
+///
+/// Before the fix the fallback matched every HTTP method, so such a POST was served the shell (200)
+/// WHENEVER the Cockpit assets (wwwroot/c/index.html) were present in the build output. That is
+/// exactly why the StreamModeOff hub-not-mapped tests failed on CI (assets present) but passed
+/// locally (assets absent) - the "flake" was really environment-dependent behavior. This test forces
+/// the assets to be present so the assertion is deterministic in every environment.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class SpaFallbackNonGetTests : IAsyncLifetime
+{
+    private const string Token = "test-token-spa-fallback";
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _instancesDir = Path.Combine(Path.GetTempPath(), "cc-spa-fallback-" + Guid.NewGuid().ToString("N"));
+    private readonly string _webRoot = Path.Combine(AppContext.BaseDirectory, "wwwroot", "c");
+    private bool _createdWebRoot;
+
+    private GatewayHost _gateway = null!;   // set in InitializeAsync
+    private HttpClient _http = null!;       // set in InitializeAsync
+
+    public SpaFallbackNonGetTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-spa-fallback-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        // Force the Cockpit shell to be present so the fallback WOULD serve it - the CI condition that
+        // exposed the bug. Only write index.html if a real built host has not already put one there.
+        var indexPath = Path.Combine(_webRoot, "index.html");
+        if (!File.Exists(indexPath))
+        {
+            Directory.CreateDirectory(_webRoot);
+            await File.WriteAllTextAsync(indexPath, "<!doctype html><title>cockpit shell</title>");
+            _createdWebRoot = true;
+        }
+
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            streamMode: false);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        // Remove ONLY the shell we created, so other tests see the original wwwroot/c state.
+        if (_createdWebRoot)
+        {
+            try { Directory.Delete(_webRoot, true); } catch (Exception) { /* best effort */ }
+        }
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch (Exception) { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch (Exception) { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task Post_ToUnmatchedRoute_Answers404_NotTheShell()
+    {
+        // A POST to a route no endpoint claims (here a hub negotiate with the hub not mapped) must be a
+        // 404 even though the Cockpit shell is present - the fallback must not serve it a 200.
+        var resp = await _http.PostAsync("director-stream/negotiate?negotiateVersion=1", content: null);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ToClientSideRoute_StillServesTheShell()
+    {
+        // A browser deep-link (GET, extensionless) STILL falls back to index.html - proving the fix
+        // narrowed the fallback to navigations only, without breaking SPA client-side routing.
+        var resp = await _http.GetAsync("some/client/route");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal("text/html", resp.Content.Headers.ContentType?.MediaType);
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/src/CcDirector.Gateway/Cockpit/CockpitReactApp.cs
+++ b/src/CcDirector.Gateway/Cockpit/CockpitReactApp.cs
@@ -135,6 +135,19 @@ public static class CockpitReactApp
     /// </summary>
     private static async Task ServeAsync(HttpContext ctx, string relativePath)
     {
+        // The SPA shell (and its client-side routes and static assets) is only ever reached by a
+        // browser NAVIGATION or asset load, which is always GET (or HEAD). A NON-GET request that fell
+        // through to this fallback is by definition an unmatched API/hub call - e.g. a POST to a hub's
+        // /negotiate path when that hub is not mapped (stream mode off) - and MUST answer 404. Serving
+        // the 200 index.html shell for such a POST masks "this route does not exist" as success: it is
+        // both wrong for API clients and the reason the StreamModeOff hub-not-mapped tests saw 200 OK
+        // instead of 404 whenever the Cockpit assets happened to be present in the build output.
+        if (!HttpMethods.IsGet(ctx.Request.Method) && !HttpMethods.IsHead(ctx.Request.Method))
+        {
+            await WriteNotFoundAsync(ctx, $"Not found: {ctx.Request.Method} /{relativePath}");
+            return;
+        }
+
         var webRoot = WebRoot;
         if (!Directory.Exists(webRoot))
         {


### PR DESCRIPTION
## The real problem (not flaky, not the test)

The two `StreamModeOff_DoesNotMapThe(Launcher)Hub` tests were failing CI with `Expected: NotFound, Actual: OK`. Root cause is a genuine Gateway bug, not test flakiness:

- The Cockpit site-root fallback `app.MapFallback("{*path}", ServeAsync)` matched **every HTTP method**.
- A `POST director-stream/negotiate` when the hub is not mapped (stream mode off) has no matching endpoint, so it fell through to the fallback. `negotiate` has no file extension, so it was treated as a client-side route and served the **200 `index.html` shell** instead of a 404 — but only when the Cockpit assets (`wwwroot/c/index.html`) were present in the build output.
- That is why it passed locally (assets absent → 404) and failed on CI (assets present → 200). Environment-dependent determinism, mislabeled "flaky."

Beyond the test, this is a correctness bug: any POST/PUT/DELETE to an unknown route returned `200 text/html` instead of `404`.

## The fix

The SPA shell and its client-side routes are only ever reached by a browser navigation, which is always GET (or HEAD). Restrict the fallback to GET/HEAD; a non-GET request that reaches it is an unmatched API/hub call and answers 404. One guard in `ServeAsync`.

## Proof (verified locally, not asserted)

Added `SpaFallbackNonGetTests` — a **deterministic** regression that forces the Cockpit shell to be present (the exact CI condition), then asserts:
- `POST` to an unmatched route → **404** (the bug)
- `GET` deep-link to an extensionless client route → **200 text/html** (proves SPA routing still works)

I verified the test **fails without the guard** (`Expected: NotFound, Actual: OK`) and **passes with it**. The two previously-failing `StreamModeOff` tests now pass regardless of whether the assets are present. The **full Gateway.Tests suite (1669 tests) passes, 0 failures**.

Fixes #1283