### PR TITLE
fix(installer): pre-release setup executable installs its matching pre-release (#1294)

### DIFF
--- a/tools/cc-director-setup-avalonia/Services/EngineInstallRunner.cs
+++ b/tools/cc-director-setup-avalonia/Services/EngineInstallRunner.cs
@@ -27,8 +27,10 @@ public sealed class EngineInstallRunner
     /// <summary>Fetch the latest release and build the two UI rows (Director + the Python tools bundle).</summary>
     public async Task<Prep> PrepareAsync(CancellationToken ct = default)
     {
-        SetupLog.Write("[EngineInstallRunner] PrepareAsync: fetching latest release");
-        var release = await _source.FetchLatestAsync(ct);
+        SetupLog.Write("[EngineInstallRunner] PrepareAsync: resolving the release for this setup executable");
+        // Install the release this setup exe was built for: a pre-release build installs its
+        // matching pre-release, a stable build installs the latest stable (issue #1294).
+        var release = await _source.FetchReleaseForSetupAsync(ct);
         var version = release.Manifest.Version;
 
         var items = new List<ToolDownloadItem>();

--- a/tools/cc-director-setup-cli/Commands.cs
+++ b/tools/cc-director-setup-cli/Commands.cs
@@ -414,7 +414,10 @@ internal static class Commands
 
         var manifest = args.Option("manifest", "latest");
         if (manifest.Equals("latest", StringComparison.OrdinalIgnoreCase))
-            return await new ReleaseSource().FetchLatestAsync(CancellationToken.None);
+            // The CLI ships inside the setup bundle and does the real install work, so it resolves
+            // the release its OWN stamped version was built for: a pre-release CLI installs its
+            // matching pre-release, a stable CLI installs the latest stable (issue #1294).
+            return await new ReleaseSource().FetchReleaseForSetupAsync(CancellationToken.None);
         return ReleaseSource.LoadLocalManifest(manifest);
     }
 

--- a/tools/cc-director-setup-engine.Tests/ReleaseSourceSetupVersionTests.cs
+++ b/tools/cc-director-setup-engine.Tests/ReleaseSourceSetupVersionTests.cs
@@ -1,0 +1,162 @@
+using System.Net;
+using System.Net.Http;
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+/// <summary>
+/// Issue #1294: a pre-release setup executable must install its matching pre-release, resolved in
+/// memory from the setup exe's own stamped version - never the latest stable (which /releases/latest
+/// would hand it). A stable setup exe still installs the latest stable, unchanged.
+/// </summary>
+public class ReleaseSourceSetupVersionTests
+{
+    private static readonly string Slug = GitHubRepositoryDefaults.Slug;
+    private static string LatestUrl => $"https://api.github.com/repos/{Slug}/releases/latest";
+    private static string ListUrl => $"https://api.github.com/repos/{Slug}/releases";
+
+    private const string Rc4ManifestUrl = "https://release.test/rc4/release-manifest.json";
+    private const string Rc3ManifestUrl = "https://release.test/rc3/release-manifest.json";
+    private const string StableManifestUrl = "https://release.test/stable/release-manifest.json";
+
+    /// <summary>A minimal valid release-manifest.json whose only asset is the manifest itself.</summary>
+    private static string ManifestJson(string version) =>
+        $$"""
+        { "version": "{{version}}", "assets": {
+            "release-manifest.json": { "version": "{{version}}", "sha256": "", "platform": "any", "size": 0 }
+        } }
+        """;
+
+    /// <summary>One GitHub release object carrying a single release-manifest.json asset.</summary>
+    private static string ReleaseObj(string tag, bool prerelease, string manifestUrl) =>
+        $$"""
+        { "tag_name": "{{tag}}", "prerelease": {{(prerelease ? "true" : "false")}}, "assets": [
+            { "name": "release-manifest.json", "browser_download_url": "{{manifestUrl}}" }
+        ] }
+        """;
+
+    /// <summary>The /releases list, newest-first: rc4, rc3, then the 1.0.7 stable.</summary>
+    private static string ReleaseListJson() =>
+        "[" +
+        ReleaseObj("v1.1.0-rc4", prerelease: true, Rc4ManifestUrl) + "," +
+        ReleaseObj("v1.1.0-rc3", prerelease: true, Rc3ManifestUrl) + "," +
+        ReleaseObj("v1.0.7", prerelease: false, StableManifestUrl) +
+        "]";
+
+    /// <summary>Serves a fixed body per exact URL and records every requested URL.</summary>
+    private sealed class UrlRouter(Dictionary<string, string> bodies) : HttpMessageHandler
+    {
+        public List<string> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var url = request.RequestUri!.ToString();
+            Requests.Add(url);
+            return Task.FromResult(bodies.TryGetValue(url, out var body)
+                ? new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body) }
+                : new HttpResponseMessage(HttpStatusCode.NotFound) { Content = new StringContent($"no stub for {url}") });
+        }
+    }
+
+    private static ReleaseInfoCache TempCache() =>
+        new(Path.Combine(Path.GetTempPath(), "cc-relcache-" + Guid.NewGuid().ToString("N") + ".json"));
+
+    private static ReleaseSource NewSource(UrlRouter router) =>
+        new(new HttpClient(router), TempCache(), (_, _) => Task.CompletedTask);
+
+    [Fact]
+    public async Task FetchReleaseForSetup_StableSetupVersion_InstallsLatestStableViaLatestEndpoint()
+    {
+        // A stable setup exe resolves the latest stable release - identical to today's behavior.
+        var router = new UrlRouter(new()
+        {
+            [LatestUrl] = ReleaseObj("v1.0.7", prerelease: false, StableManifestUrl),
+            [StableManifestUrl] = ManifestJson("1.0.7"),
+        });
+        var source = NewSource(router);
+
+        var release = await source.FetchReleaseForSetupAsync(CancellationToken.None, setupVersion: "1.0.7");
+
+        Assert.Equal("1.0.7", release.Manifest.Version);
+        Assert.Contains(LatestUrl, router.Requests);
+        Assert.DoesNotContain(ListUrl, router.Requests);
+    }
+
+    [Fact]
+    public async Task FetchReleaseForSetup_PreReleaseSetupVersion_InstallsMatchingPreReleaseFromList()
+    {
+        // The rc4 setup exe must resolve rc4 from the FULL list, not the stable /releases/latest.
+        var router = new UrlRouter(new()
+        {
+            [ListUrl] = ReleaseListJson(),
+            [Rc4ManifestUrl] = ManifestJson("1.1.0-rc4"),
+            [Rc3ManifestUrl] = ManifestJson("1.1.0-rc3"),
+            [StableManifestUrl] = ManifestJson("1.0.7"),
+            // Present but must NOT be consulted on the pre-release path.
+            [LatestUrl] = ReleaseObj("v1.0.7", prerelease: false, StableManifestUrl),
+        });
+        var source = NewSource(router);
+
+        var release = await source.FetchReleaseForSetupAsync(CancellationToken.None, setupVersion: "1.1.0-rc4");
+
+        Assert.Equal("1.1.0-rc4", release.Manifest.Version);
+        Assert.Contains(ListUrl, router.Requests);
+        Assert.Contains(Rc4ManifestUrl, router.Requests);
+        Assert.DoesNotContain(LatestUrl, router.Requests);
+        Assert.DoesNotContain(StableManifestUrl, router.Requests);
+    }
+
+    [Fact]
+    public async Task FetchReleaseForSetup_PreReleaseWithLeadingVAndBuildMetadata_StillMatches()
+    {
+        // The stamped version carries "+commit"; the tag carries a leading "v". Both must normalize.
+        var router = new UrlRouter(new()
+        {
+            [ListUrl] = ReleaseListJson(),
+            [Rc4ManifestUrl] = ManifestJson("1.1.0-rc4"),
+            [Rc3ManifestUrl] = ManifestJson("1.1.0-rc3"),
+            [StableManifestUrl] = ManifestJson("1.0.7"),
+        });
+        var source = NewSource(router);
+
+        var release = await source.FetchReleaseForSetupAsync(CancellationToken.None, setupVersion: "1.1.0-rc3+deadbeef");
+
+        Assert.Equal("1.1.0-rc3", release.Manifest.Version);
+    }
+
+    [Fact]
+    public async Task FetchReleaseForSetup_PreReleaseNotInList_FallsBackToNewestPreRelease()
+    {
+        // rc9 was never published; the newest pre-release (rc4, first in the newest-first list) is used.
+        var router = new UrlRouter(new()
+        {
+            [ListUrl] = ReleaseListJson(),
+            [Rc4ManifestUrl] = ManifestJson("1.1.0-rc4"),
+            [Rc3ManifestUrl] = ManifestJson("1.1.0-rc3"),
+            [StableManifestUrl] = ManifestJson("1.0.7"),
+        });
+        var source = NewSource(router);
+
+        var release = await source.FetchReleaseForSetupAsync(CancellationToken.None, setupVersion: "1.1.0-rc9");
+
+        Assert.Equal("1.1.0-rc4", release.Manifest.Version);
+    }
+
+    [Fact]
+    public async Task FetchReleaseForSetup_PreReleaseButListHasNoPreRelease_Throws()
+    {
+        // The list carries only stable releases; a pre-release installer has nothing to install and
+        // must fail loudly rather than silently downgrade to stable.
+        var listWithNoPreRelease = "[" + ReleaseObj("v1.0.7", prerelease: false, StableManifestUrl) + "]";
+        var router = new UrlRouter(new()
+        {
+            [ListUrl] = listWithNoPreRelease,
+            [StableManifestUrl] = ManifestJson("1.0.7"),
+        });
+        var source = NewSource(router);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            source.FetchReleaseForSetupAsync(CancellationToken.None, setupVersion: "1.1.0-rc4"));
+    }
+}

--- a/tools/cc-director-setup-engine.Tests/SetupExecutableVersionTests.cs
+++ b/tools/cc-director-setup-engine.Tests/SetupExecutableVersionTests.cs
@@ -1,0 +1,27 @@
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+public class SetupExecutableVersionTests
+{
+    [Theory]
+    [InlineData("1.1.0-rc4+abc1234", "1.1.0-rc4")]
+    [InlineData("1.1.0-rc4", "1.1.0-rc4")]
+    [InlineData("1.0.7+deadbeef", "1.0.7")]
+    [InlineData("1.0.7", "1.0.7")]
+    [InlineData("  1.0.7+abc  ", "1.0.7")]
+    public void Strip_RemovesSourceLinkMetadata(string input, string expected)
+    {
+        Assert.Equal(expected, SetupExecutableVersion.Strip(input));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void Strip_EmptyOrNull_ReturnsEmpty(string? input)
+    {
+        Assert.Equal("", SetupExecutableVersion.Strip(input));
+    }
+}

--- a/tools/cc-director-setup-engine.Tests/VersionUtilTests.cs
+++ b/tools/cc-director-setup-engine.Tests/VersionUtilTests.cs
@@ -46,4 +46,40 @@ public class VersionUtilTests
         Assert.False(VersionUtil.IsNewer(null, "0.3.0"));
         Assert.False(VersionUtil.IsNewer("garbage", "0.3.0"));
     }
+
+    [Theory]
+    [InlineData("1.1.0-rc4", true)]
+    [InlineData("v1.1.0-rc4", true)]
+    [InlineData("1.1.0-rc4+abc123", true)]
+    [InlineData("1.1.0", false)]
+    [InlineData("v1.1.0", false)]
+    [InlineData("1.1.0+abc123", false)]
+    [InlineData("", false)]
+    [InlineData("   ", false)]
+    [InlineData(null, false)]
+    public void HasPreReleaseSuffix_DetectsSuffixAfterStrippingDecoration(string? input, bool expected)
+    {
+        Assert.Equal(expected, VersionUtil.HasPreReleaseSuffix(input));
+    }
+
+    [Theory]
+    [InlineData("v1.1.0-rc4", "1.1.0-rc4")]
+    [InlineData("1.1.0-rc4", "1.1.0-rc4")]
+    [InlineData("1.1.0-RC4+abc123", "1.1.0-rc4")]
+    [InlineData("V1.0.7", "1.0.7")]
+    [InlineData("1.0.7", "1.0.7")]
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    public void CanonicalTag_KeepsSuffixDropsDecorationAndLowercases(string? input, string expected)
+    {
+        Assert.Equal(expected, VersionUtil.CanonicalTag(input));
+    }
+
+    [Fact]
+    public void CanonicalTag_PreReleaseAndStableDoNotCollide()
+    {
+        // The pre-release suffix must survive so an rc build never compares equal to its stable line.
+        Assert.NotEqual(VersionUtil.CanonicalTag("1.1.0-rc4"), VersionUtil.CanonicalTag("1.1.0"));
+        Assert.Equal(VersionUtil.CanonicalTag("v1.1.0-rc4"), VersionUtil.CanonicalTag("1.1.0-rc4"));
+    }
 }

--- a/tools/cc-director-setup-engine/ReleaseSource.cs
+++ b/tools/cc-director-setup-engine/ReleaseSource.cs
@@ -9,11 +9,15 @@ public sealed record ResolvedRelease(ReleaseManifest Manifest, IReadOnlyDictiona
 
 /// <summary>
 /// Resolves the release a plan is computed against. Shared by both front-ends
-/// (the WPF installer UI and the CLI). Three modes:
+/// (the WPF installer UI and the CLI). Modes:
 ///   - a local manifest file (LoadLocalManifest): plan/dry-run only, no URLs.
 ///   - a local release directory (LoadLocalReleaseDir): offline install/update.
-///   - "latest" (FetchLatestAsync): the GitHub latest release, mapping asset
-///     download URLs and parsing release-manifest.json.
+///   - "latest" (FetchLatestAsync): the GitHub latest STABLE release, mapping asset
+///     download URLs and parsing release-manifest.json. Used by the silent auto-updater.
+///   - "for this setup exe" (FetchReleaseForSetupAsync): the release the running setup
+///     executable was BUILT for. A stable setup exe resolves the latest stable (identical to
+///     FetchLatestAsync); a pre-release setup exe resolves its matching pre-release from the
+///     full release list, which /releases/latest hides (issue #1294).
 /// </summary>
 public sealed class ReleaseSource
 {
@@ -75,21 +79,69 @@ public sealed class ReleaseSource
     }
 
     /// <summary>
-    /// Fetch the GitHub latest release, hardened against the shared-network-address
-    /// rate limit that dead-ended first-run installs (issue #266):
-    ///   - sends a conditional request (If-None-Match) when a cached entity tag exists;
-    ///     a 304 Not Modified serves the cached body and does NOT consume the rate-limit
-    ///     budget;
-    ///   - on a 403/429 rate-limit response, retries with bounded backoff that honours
-    ///     GitHub's reset hint (Retry-After or X-RateLimit-Reset) within a sane cap, then
-    ///     raises a classified <see cref="GitHubRateLimitException"/> rather than a raw
-    ///     "status code does not indicate success: 403".
+    /// Fetch the GitHub latest STABLE release (the /releases/latest endpoint, which excludes
+    /// pre-releases and drafts). Used by the silent auto-updater and by a stable setup exe.
+    /// The request is hardened against the shared-network-address rate limit (issue #266) - see
+    /// <see cref="GetReleaseBodyAsync"/>.
     /// </summary>
     /// <exception cref="GitHubRateLimitException">The fetch was rate-limited and retries were exhausted.</exception>
     public async Task<ResolvedRelease> FetchLatestAsync(CancellationToken ct)
     {
         var url = $"https://api.github.com/repos/{GitHubRepositoryDefaults.Slug}/releases/latest";
-        var cached = _cache.Read();
+        var body = await GetReleaseBodyAsync(url, useCache: true, ct);
+        return await BuildResolvedReleaseAsync(body, ct);
+    }
+
+    /// <summary>
+    /// Resolve the release the running setup executable was BUILT for, decided in memory from the
+    /// setup exe's own stamped version - nothing is written to disk and no channel file is used
+    /// (issue #1294).
+    ///
+    /// A stable setup exe (version with no pre-release suffix, or an unreadable stamp) resolves the
+    /// latest stable release - identical to <see cref="FetchLatestAsync"/> and unchanged for stable
+    /// users. A pre-release setup exe (for example "1.1.0-rc4") resolves its MATCHING pre-release
+    /// from the full <c>/releases</c> list, because GitHub's <c>/releases/latest</c> hides
+    /// pre-releases and would otherwise hand a pre-release installer the newest stable build.
+    /// </summary>
+    /// <param name="setupVersion">
+    /// The setup exe's stamped version. Null reads it from the entry assembly
+    /// (<see cref="SetupExecutableVersion.Read"/>); tests pass it explicitly.
+    /// </param>
+    /// <exception cref="GitHubRateLimitException">The fetch was rate-limited and retries were exhausted.</exception>
+    public async Task<ResolvedRelease> FetchReleaseForSetupAsync(CancellationToken ct, string? setupVersion = null)
+    {
+        setupVersion ??= SetupExecutableVersion.Read();
+
+        if (!VersionUtil.HasPreReleaseSuffix(setupVersion))
+        {
+            EngineLog.Write($"[ReleaseSource] Setup version '{setupVersion}' is stable; installing the latest stable release.");
+            return await FetchLatestAsync(ct);
+        }
+
+        EngineLog.Write($"[ReleaseSource] Setup version '{setupVersion}' is a pre-release; resolving from the full release list.");
+        var url = $"https://api.github.com/repos/{GitHubRepositoryDefaults.Slug}/releases";
+        // The list body is not cached: the ETag cache is keyed to the single /releases/latest entity,
+        // and the list is only consulted on the rare pre-release install path.
+        var listBody = await GetReleaseBodyAsync(url, useCache: false, ct);
+        var releaseJson = SelectPreRelease(listBody, setupVersion);
+        return await BuildResolvedReleaseAsync(releaseJson, ct);
+    }
+
+    /// <summary>
+    /// GET a GitHub release resource, hardened against the shared-network-address rate limit that
+    /// dead-ended first-run installs (issue #266):
+    ///   - when <paramref name="useCache"/> and a cached entity tag exists, sends a conditional
+    ///     request (If-None-Match); a 304 Not Modified serves the cached body and does NOT consume
+    ///     the rate-limit budget;
+    ///   - on a 403/429 rate-limit response, retries with bounded backoff that honours GitHub's
+    ///     reset hint (Retry-After or X-RateLimit-Reset) within a sane cap, then raises a classified
+    ///     <see cref="GitHubRateLimitException"/> rather than a raw
+    ///     "status code does not indicate success: 403".
+    /// Returns the raw response body; the caller parses it (a single release object or a list).
+    /// </summary>
+    private async Task<string> GetReleaseBodyAsync(string url, bool useCache, CancellationToken ct)
+    {
+        var cached = useCache ? _cache.Read() : null;
         DateTimeOffset? lastResetHint = null;
 
         for (var attempt = 1; attempt <= MaxAttempts; attempt++)
@@ -107,17 +159,20 @@ public sealed class ReleaseSource
                 if (cached is not { } hit)
                     throw new InvalidOperationException(
                         "GitHub returned 304 Not Modified but no cached release info is available.");
-                EngineLog.Write("[ReleaseSource] FetchLatest: 304 Not Modified, serving cached release info");
-                return await BuildResolvedReleaseAsync(hit.Body, ct);
+                EngineLog.Write("[ReleaseSource] Fetch: 304 Not Modified, serving cached release info");
+                return hit.Body;
             }
 
             if (resp.IsSuccessStatusCode)
             {
                 var body = await resp.Content.ReadAsStringAsync(ct);
-                var etag = resp.Headers.ETag?.ToString();
-                if (!string.IsNullOrEmpty(etag))
-                    _cache.Write(etag, body);
-                return await BuildResolvedReleaseAsync(body, ct);
+                if (useCache)
+                {
+                    var etag = resp.Headers.ETag?.ToString();
+                    if (!string.IsNullOrEmpty(etag))
+                        _cache.Write(etag, body);
+                }
+                return body;
             }
 
             if (IsRateLimited(resp))
@@ -128,7 +183,7 @@ public sealed class ReleaseSource
 
                 var wait = ComputeBackoff(attempt, lastResetHint);
                 EngineLog.Write(
-                    $"[ReleaseSource] FetchLatest: 403 rate-limit, retry {attempt}/{MaxAttempts - 1} after {wait.TotalSeconds:0}s");
+                    $"[ReleaseSource] Fetch: 403 rate-limit, retry {attempt}/{MaxAttempts - 1} after {wait.TotalSeconds:0}s");
                 await _delay(wait, ct);
                 continue;
             }
@@ -141,9 +196,52 @@ public sealed class ReleaseSource
             ? $" GitHub says the limit resets at {r.UtcDateTime:u}."
             : "";
         EngineLog.Write(
-            $"[ReleaseSource] FetchLatest: rate-limit retries exhausted after {MaxAttempts} attempts.{hint}");
+            $"[ReleaseSource] Fetch: rate-limit retries exhausted after {MaxAttempts} attempts.{hint}");
         throw new GitHubRateLimitException(
             "GitHub rate limit exceeded while fetching release info." + hint, MaxAttempts, lastResetHint);
+    }
+
+    /// <summary>
+    /// From a GitHub <c>/releases</c> list body, pick the release a pre-release setup exe should
+    /// install: the release whose tag matches the setup exe's own version exactly, else the newest
+    /// pre-release in the list (GitHub returns releases newest-first). Returns that release's JSON,
+    /// ready for <see cref="BuildResolvedReleaseAsync"/>. Throws when the list carries no pre-release.
+    /// </summary>
+    private static string SelectPreRelease(string listJson, string setupVersion)
+    {
+        using var doc = JsonDocument.Parse(listJson);
+        if (doc.RootElement.ValueKind != JsonValueKind.Array)
+            throw new InvalidOperationException("GitHub /releases did not return a JSON array.");
+
+        var wanted = VersionUtil.CanonicalTag(setupVersion);
+        JsonElement? newestPreRelease = null;
+
+        foreach (var rel in doc.RootElement.EnumerateArray())
+        {
+            var tag = rel.TryGetProperty("tag_name", out var t) ? t.GetString() : null;
+
+            // An exact version match is exactly what this setup exe is, so it wins outright -
+            // the rc4 installer installs rc4 even when a newer rc5 exists.
+            if (!string.IsNullOrEmpty(tag) && VersionUtil.CanonicalTag(tag) == wanted)
+            {
+                EngineLog.Write($"[ReleaseSource] SelectPreRelease: matched release tagged '{tag}'.");
+                return rel.GetRawText();
+            }
+
+            var isPreRelease = rel.TryGetProperty("prerelease", out var p) && p.ValueKind == JsonValueKind.True;
+            if (isPreRelease)
+                newestPreRelease ??= rel.Clone(); // first pre-release seen == newest (list is newest-first)
+        }
+
+        if (newestPreRelease is { } fallback)
+        {
+            var tag = fallback.TryGetProperty("tag_name", out var t) ? t.GetString() : "(untagged)";
+            EngineLog.Write($"[ReleaseSource] SelectPreRelease: no release tagged '{setupVersion}'; using newest pre-release '{tag}'.");
+            return fallback.GetRawText();
+        }
+
+        throw new InvalidOperationException(
+            $"Setup executable is a pre-release ({setupVersion}) but the GitHub release list contains no pre-release to install.");
     }
 
     /// <summary>Parse a release JSON body into the resolved release (asset URLs + manifest).</summary>

--- a/tools/cc-director-setup-engine/SetupExecutableVersion.cs
+++ b/tools/cc-director-setup-engine/SetupExecutableVersion.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+
+namespace CcDirector.Setup.Engine;
+
+/// <summary>
+/// Reads the version stamped onto the running setup executable at build time. Every binary
+/// - including the setup wizard and the setup CLI - is stamped from Directory.Build.props via
+/// AssemblyInformationalVersion, and the setup exe is the process entry assembly, so a
+/// v1.1.0-rc4 setup build self-identifies as "1.1.0-rc4". The SDK appends "+commit" SourceLink
+/// metadata to that string; this strips it, leaving the plain version.
+///
+/// The setup engine uses this to install the release the setup exe was BUILT for: a pre-release
+/// setup exe installs its matching pre-release rather than the latest stable (issue #1294).
+/// </summary>
+public static class SetupExecutableVersion
+{
+    /// <summary>
+    /// The running setup executable's stamped version (for example "1.1.0-rc4" or "1.1.0").
+    /// Returns "" when the entry assembly or its version stamp cannot be read; the caller
+    /// treats an unknown version as stable (the latest-stable install path).
+    /// </summary>
+    public static string Read()
+    {
+        var info = Assembly.GetEntryAssembly()?
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        return Strip(info);
+    }
+
+    /// <summary>Drop the "+commit" SourceLink metadata, leaving "1.1.0-rc4" (or "1.1.0", or "").</summary>
+    internal static string Strip(string? informationalVersion)
+    {
+        if (string.IsNullOrWhiteSpace(informationalVersion)) return "";
+        var plus = informationalVersion.IndexOf('+');
+        return (plus >= 0 ? informationalVersion[..plus] : informationalVersion).Trim();
+    }
+}

--- a/tools/cc-director-setup-engine/VersionUtil.cs
+++ b/tools/cc-director-setup-engine/VersionUtil.cs
@@ -25,6 +25,37 @@ public static class VersionUtil
     public static Version Normalize(Version v) => new(v.Major, v.Minor, Math.Max(v.Build, 0));
 
     /// <summary>
+    /// True when the version carries a pre-release suffix (for example "1.1.0-rc4").
+    /// After dropping a leading 'v'/'V' and any "+build" metadata, a '-' segment remains.
+    /// A plain "1.1.0" (or "v1.1.0+abc123") is NOT a pre-release.
+    /// </summary>
+    public static bool HasPreReleaseSuffix(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return false;
+        var t = text.Trim();
+        if (t.StartsWith('v') || t.StartsWith('V')) t = t[1..];
+        var plus = t.IndexOf('+');
+        if (plus >= 0) t = t[..plus];
+        return t.IndexOf('-') >= 0;
+    }
+
+    /// <summary>
+    /// Canonical form for comparing a version to a release tag: drop a leading 'v'/'V'
+    /// and any "+build" metadata, then trim and lowercase. The "-rc4" pre-release suffix
+    /// is KEPT (unlike <see cref="TryParse"/>), so "v1.1.0-rc4" and "1.1.0-rc4" compare
+    /// equal while "1.1.0" does not. An empty or whitespace input yields "".
+    /// </summary>
+    public static string CanonicalTag(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return "";
+        var t = text.Trim();
+        if (t.StartsWith('v') || t.StartsWith('V')) t = t[1..];
+        var plus = t.IndexOf('+');
+        if (plus >= 0) t = t[..plus];
+        return t.ToLowerInvariant();
+    }
+
+    /// <summary>
     /// True when <paramref name="candidate"/> is strictly newer than
     /// <paramref name="installed"/>. Either side being unparseable returns false
     /// (we never "update" on the basis of a version we cannot read).

--- a/tools/cc-director-setup/MainWindow.xaml.cs
+++ b/tools/cc-director-setup/MainWindow.xaml.cs
@@ -193,11 +193,13 @@ public partial class MainWindow : Window
 
     private async Task FetchLatestVersionAsync()
     {
-        SetupLog.Write("[MainWindow] FetchLatestVersionAsync: checking for latest release");
+        SetupLog.Write("[MainWindow] FetchLatestVersionAsync: checking the release for this setup executable");
 
         try
         {
-            var release = await new ReleaseSource().FetchLatestAsync(CancellationToken.None);
+            // Show the version this setup exe will actually install (its matching pre-release when
+            // this is a pre-release build), so the welcome screen is not misleading (issue #1294).
+            var release = await new ReleaseSource().FetchReleaseForSetupAsync(CancellationToken.None);
             _latestVersion = release.Manifest.Version;
             SetupLog.Write($"[MainWindow] FetchLatestVersionAsync: latestVersion={_latestVersion}");
             _welcomeStep?.UpdateVersionInfo(_installedVersion, _latestVersion);

--- a/tools/cc-director-setup/Services/EngineInstallRunner.cs
+++ b/tools/cc-director-setup/Services/EngineInstallRunner.cs
@@ -57,8 +57,10 @@ public sealed class EngineInstallRunner
     /// <summary>Fetch the latest release, resolve the in-scope components, and build the UI item list.</summary>
     public async Task<Prep> PrepareAsync(CancellationToken ct = default)
     {
-        SetupLog.Write("[EngineInstallRunner] PrepareAsync: fetching latest release");
-        var release = await _source.FetchLatestAsync(ct);
+        SetupLog.Write("[EngineInstallRunner] PrepareAsync: resolving the release for this setup executable");
+        // Install the release this setup exe was built for: a pre-release build installs its
+        // matching pre-release, a stable build installs the latest stable (issue #1294).
+        var release = await _source.FetchReleaseForSetupAsync(ct);
         var version = release.Manifest.Version;
 
         // The engine places the Director here. The Gateway tray app + Cockpit are installed by the


### PR DESCRIPTION
Closes #1294.

## Problem

Running a pre-release setup executable did not install that pre-release - it installed the latest **stable** release. Proven on 2026-07-11: the `v1.1.0-rc4` setup executable installed **v1.0.7**, so the feature under test (pull request #1272) was absent.

## Root cause

The setup engine resolved which release to install by calling GitHub's `/releases/latest`, which deliberately excludes pre-releases and drafts. Every `v1.1.0-rcN` is published as a pre-release, so that call could only ever return the newest stable.

## The fix (installer only, in memory, no config file)

Every binary - including the setup executable - is stamped at build time with the version from `Directory.Build.props`, so a `v1.1.0-rc4` setup exe self-identifies as `1.1.0-rc4`. The engine now reads its own stamped version and:

- **Stable setup exe** (no pre-release suffix, or an unreadable stamp): resolves the newest stable via `/releases/latest` - identical to today.
- **Pre-release setup exe** (e.g. `1.1.0-rc4`): resolves the release from the full `GET /releases` list (which **includes** pre-releases), selecting the release whose tag matches its own version exactly, or the newest pre-release as a fallback.

The choice lives entirely within the single install run; nothing is written to disk. No channel configuration file is introduced.

## Explicitly out of scope

- **The auto-updater (`UpdateService.cs`) is unchanged.** It normalizes away the `-rcN` suffix, so a machine on `1.1.0-rc4` is seen as `1.1.0` and is never downgraded to the latest stable `1.0.7`.
- The `ToolUpdater` auto-update path keeps using `FetchLatestAsync`; only the installer front-ends (WPF wizard, Avalonia wizard, and the setup CLI) now use the new `FetchReleaseForSetupAsync`.

## Changes

- `ReleaseSource`: add `FetchReleaseForSetupAsync` and `SelectPreRelease`; extract the rate-limit-hardened GET (issue #266) into `GetReleaseBodyAsync` so both the latest-stable and full-list paths reuse it.
- `SetupExecutableVersion` (new): read the entry assembly's stamped version, minus the SourceLink `+commit` metadata.
- `VersionUtil`: `HasPreReleaseSuffix` and `CanonicalTag` helpers.
- Point the WPF wizard, Avalonia wizard, and setup CLI at the new method.

## Tests

Added to the existing `cc-director-setup-engine.Tests` project:
- `ReleaseSourceSetupVersionTests`: stable exe -> `/releases/latest`; pre-release exe -> full list + exact match; `+commit`/leading-`v` normalization; fallback to newest pre-release; throws when the list has no pre-release.
- `VersionUtilTests` and `SetupExecutableVersionTests` for the new helpers.

Full engine suite: **265 passed, 0 failed.** All four setup front-ends build clean.

## Acceptance criteria

- [x] A `v1.1.0-rcN` setup exe installs the `1.1.0-rcN` components, not the latest stable.
- [x] A stable setup exe still installs the latest stable, unchanged.
- [x] The release is resolved from the full `/releases` list on the pre-release path.
- [x] No persistent channel configuration; the choice is made in memory from the stamped version.
- [x] The auto-updater is unchanged; a pre-release machine is not downgraded to stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)