### PR TITLE
[Cockpit] Read-only Source Control tab on the session page (#1266)

### DIFF
--- a/apps/cockpit/src/sessions/SessionComposer.tsx
+++ b/apps/cockpit/src/sessions/SessionComposer.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { MutableRefObject } from "react";
 import {
   enqueuePrompt,
   sendPrompt,
@@ -34,9 +35,15 @@ export interface SessionComposerProps {
   onChange: (value: string) => void;
   /** Replace the queue with the server's authoritative list after a Queue action. */
   onQueued: (items: QueueItem[]) => void;
+  /**
+   * When set, the composer publishes a function into this ref that focuses its textarea. The Source
+   * Control tab (issue #1266) calls it after inserting a clicked file's path so the reader can type the
+   * matching instruction straight away. Cleared on unmount so a stale focuser is never called.
+   */
+  focusHandleRef?: MutableRefObject<(() => void) | null>;
 }
 
-export function SessionComposer({ sessionId, value, onChange, onQueued }: SessionComposerProps) {
+export function SessionComposer({ sessionId, value, onChange, onQueued, focusHandleRef }: SessionComposerProps) {
   const [busy, setBusy] = useState(false);
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -48,6 +55,16 @@ export function SessionComposer({ sessionId, value, onChange, onQueued }: Sessio
   // change while it is open). Dictation is inserted here, exactly like the desktop Insert button and
   // the mobile SessionControls, instead of always at the end.
   const caretRef = useRef(0);
+
+  // Publish a focuser for the composer textarea into the parent-owned ref (issue #1266), and clear it on
+  // unmount so the Source Control tab never calls into a torn-down composer.
+  useEffect(() => {
+    if (!focusHandleRef) return;
+    focusHandleRef.current = () => textareaRef.current?.focus();
+    return () => {
+      focusHandleRef.current = null;
+    };
+  }, [focusHandleRef]);
 
   const send = useCallback(async () => {
     if (!sessionId || busy) return;

--- a/apps/cockpit/src/sessions/SessionDetail.tsx
+++ b/apps/cockpit/src/sessions/SessionDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router-dom";
 import { getQueue, type QueueItem } from "@devthrottle/client-core/api/client";
 import { TerminalPane } from "../panes/TerminalPane";
@@ -8,8 +8,10 @@ import { SessionComposer } from "./SessionComposer";
 import { SessionMenu } from "./SessionMenu";
 import { ChatTab } from "./ChatTab";
 import { VoiceTab } from "./VoiceTab";
+import { SourceControlTab } from "./SourceControlTab";
 import { QueuePanel } from "./QueuePanel";
 import { ScreenshotsPanel } from "./ScreenshotsPanel";
+import { appendToCompose } from "./composerInsert";
 
 // The selected session's detail region (issue #972): the live terminal (issue #971's TerminalPane,
 // reused verbatim) stacked over the driver action bar and the composer, with a tabbed dock for the
@@ -18,10 +20,12 @@ import { ScreenshotsPanel } from "./ScreenshotsPanel";
 // the composer text, and the queue are all per-session).
 
 type DockTab = "queue" | "shots";
-// The session-main view (issue #1213): Terminal, Chat, Voice. Terminal is the live PTY mirror (issue
-// #971); Chat is the cleaned conversation history and Voice is the hands-free narration - both ported
-// from the mobile pages through the shared client-core code, not rewritten.
-type MainTab = "terminal" | "chat" | "voice";
+// The session-main view (issues #1213, #1266): Terminal, Chat, Voice, Source Control. Terminal is the
+// live PTY mirror (issue #971); Chat is the cleaned conversation history and Voice is the hands-free
+// narration - both ported from the mobile pages through the shared client-core code, not rewritten.
+// Source Control is the read-only repository view (issue #1266) - click a file to insert its path into
+// the composer.
+type MainTab = "terminal" | "chat" | "voice" | "sourceControl";
 
 export function SessionDetail() {
   const { sessionId } = useParams<{ sessionId: string }>();
@@ -33,6 +37,9 @@ export function SessionDetail() {
   const [queue, setQueue] = useState<QueueItem[]>([]);
   const [tab, setTab] = useState<DockTab>("queue");
   const [mainTab, setMainTab] = useState<MainTab>("terminal");
+  // Set by the composer to a function that focuses its textarea, so the Source Control tab can focus the
+  // composer after inserting a clicked file's path (issue #1266).
+  const composerFocusRef = useRef<(() => void) | null>(null);
 
   // Load the queue for the selected session (and reset the composer) whenever the session changes, so
   // the composer and the queue never carry over from a previously-selected session.
@@ -50,9 +57,19 @@ export function SessionDetail() {
   }, [sessionId]);
 
   // Append text (a popped queue item, or a screenshot path) into the composer, separated by a space.
-  const appendToCompose = useCallback((text: string) => {
-    setCompose((cur) => (cur.length > 0 && !cur.endsWith(" ") ? `${cur} ${text}` : `${cur}${text}`));
+  const appendCompose = useCallback((text: string) => {
+    setCompose((cur) => appendToCompose(cur, text));
   }, []);
+
+  // The Source Control tab's click-a-file: insert the repository-relative path AND focus the composer,
+  // so the reader can immediately type the instruction that goes with the file (issue #1266).
+  const insertPathAndFocus = useCallback(
+    (path: string) => {
+      appendCompose(path);
+      composerFocusRef.current?.();
+    },
+    [appendCompose],
+  );
 
   return (
     <div className="session-detail">
@@ -85,6 +102,15 @@ export function SessionDetail() {
           >
             Voice
           </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mainTab === "sourceControl"}
+            className={`session-tab ${mainTab === "sourceControl" ? "on" : ""}`}
+            onClick={() => setMainTab("sourceControl")}
+          >
+            Source Control
+          </button>
           {/* The session menu (issue #1214): Rename, Hold/Resume, Handover info, Close - top right of
               the session header, driving the shared Gateway calls. */}
           {selected && <SessionMenu session={selected} variant="page" onClosed={() => navigate("/")} />}
@@ -106,10 +132,21 @@ export function SessionDetail() {
               <VoiceTab sessionId={sessionId} />
             </div>
           )}
+          {mainTab === "sourceControl" && (
+            <div className="session-pane">
+              <SourceControlTab sessionId={sessionId} onInsertPath={insertPathAndFocus} />
+            </div>
+          )}
         </div>
 
         <SessionActionBar sessionId={sessionId} capabilities={selected?.driverCapabilities} />
-        <SessionComposer sessionId={sessionId} value={compose} onChange={setCompose} onQueued={setQueue} />
+        <SessionComposer
+          sessionId={sessionId}
+          value={compose}
+          onChange={setCompose}
+          onQueued={setQueue}
+          focusHandleRef={composerFocusRef}
+        />
       </div>
 
       <aside className="session-dock">
@@ -123,9 +160,9 @@ export function SessionDetail() {
         </div>
         <div className="dock-body">
           {tab === "queue" ? (
-            <QueuePanel sessionId={sessionId} queue={queue} onQueue={setQueue} onPop={appendToCompose} />
+            <QueuePanel sessionId={sessionId} queue={queue} onQueue={setQueue} onPop={appendCompose} />
           ) : (
-            <ScreenshotsPanel sessionId={sessionId} onInsert={appendToCompose} />
+            <ScreenshotsPanel sessionId={sessionId} onInsert={appendCompose} />
           )}
         </div>
       </aside>

--- a/apps/cockpit/src/sessions/SourceControlTab.tsx
+++ b/apps/cockpit/src/sessions/SourceControlTab.tsx
@@ -1,0 +1,250 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  getGitStatus,
+  gatewayErrorMessage,
+  type GitSnapshot,
+  type GitChangeEntry,
+} from "@devthrottle/client-core/api/client";
+
+// The Cockpit Source Control tab (issue #1266): a READ-ONLY view of the selected session's repository -
+// branch, ahead/behind, last commit, and the staged / unstaged file lists - so a browser driver can see
+// what is or is not committed on that machine. Clicking a file inserts its repository-relative path into
+// the composer (append + focus), so acting happens through the agent via the prompt, never here. There
+// are deliberately NO stage / unstage / discard / commit controls; the Gateway exposes no write route.
+//
+// Data source: the shared client-core getGitStatus (GET /sessions/{sid}/git), which the Gateway proxies
+// to the owning Director. The Director enriches its ten-second-cached snapshot with the per-file lists.
+//
+// Refresh: fetch on tab open, a manual Refresh control, and light polling (~10s). The tab is only
+// mounted while it is the active tab (SessionDetail unmounts it on a tab switch), and the polling also
+// pauses while the browser page is hidden (issue #1239), so it never polls when nobody is looking.
+
+const POLL_MS = 10_000;
+
+// The one-letter git change kinds (GitChangeEntry.changeKind) spelled out for the reader, matching the
+// desktop Source Control tab's wording.
+const CHANGE_KIND_LABEL: Record<string, string> = {
+  M: "modified",
+  A: "added",
+  D: "deleted",
+  R: "renamed",
+  C: "copied",
+  "?": "untracked",
+  U: "unmerged",
+  T: "type changed",
+};
+
+function changeKindLabel(kind: string): string {
+  return CHANGE_KIND_LABEL[kind] ?? "changed";
+}
+
+export interface SourceControlTabProps {
+  sessionId: string | undefined;
+  /** Insert a clicked file's repository-relative path into the composer (append + focus). */
+  onInsertPath: (path: string) => void;
+}
+
+export function SourceControlTab({ sessionId, onInsertPath }: SourceControlTabProps) {
+  const [snapshot, setSnapshot] = useState<GitSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  // Guards against overlapping fetches (a manual Refresh landing on top of a poll tick).
+  const busyRef = useRef(false);
+
+  const refresh = useCallback(
+    async (signal?: AbortSignal) => {
+      if (!sessionId || busyRef.current) return;
+      busyRef.current = true;
+      try {
+        const snap = await getGitStatus(sessionId, signal);
+        setSnapshot(snap);
+        // A non-ok status ("not a git repository" / "git failed") is a normal rendered result, not a
+        // transport error; clear the transport error so a recovered fetch stops showing the old banner.
+        setError(null);
+      } catch (err) {
+        if (signal?.aborted === true) return;
+        // No silent failure: surface the transport error so the reader knows the state is not shown.
+        setError(gatewayErrorMessage(err));
+      } finally {
+        busyRef.current = false;
+        setLoading(false);
+      }
+    },
+    [sessionId],
+  );
+
+  // Fetch on tab open, then poll ~10s while the browser page is visible; pause polling when hidden and
+  // refresh once on becoming visible again (issue #1239). The interval is torn down on unmount (tab
+  // switch) so the terminal-first session view never keeps a background git poll running.
+  useEffect(() => {
+    if (!sessionId) return;
+    const controller = new AbortController();
+    // Release the overlap guard for this fresh lifecycle: a previous run's in-flight fetch was aborted by
+    // its cleanup, but its `finally` (which clears the guard) has not run yet, so without this reset the
+    // very first fetch of the new session/mount would be swallowed and the snapshot would stay empty.
+    busyRef.current = false;
+    setLoading(true);
+    setSnapshot(null);
+    setError(null);
+    void refresh(controller.signal);
+
+    let timer: number | undefined;
+    const start = () => {
+      if (timer === undefined) {
+        timer = window.setInterval(() => void refresh(controller.signal), POLL_MS);
+      }
+    };
+    const stop = () => {
+      if (timer !== undefined) {
+        window.clearInterval(timer);
+        timer = undefined;
+      }
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") {
+        void refresh(controller.signal);
+        start();
+      } else {
+        stop();
+      }
+    };
+    if (document.visibilityState === "visible") start();
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      controller.abort();
+      stop();
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [sessionId, refresh]);
+
+  const manualRefresh = useCallback(() => void refresh(), [refresh]);
+
+  return (
+    <div className="scm-tab">
+      <div className="scm-header">
+        <ScmHeaderBody snapshot={snapshot} error={error} loading={loading} />
+        <button type="button" className="scm-refresh" onClick={manualRefresh} disabled={loading}>
+          Refresh
+        </button>
+      </div>
+
+      {error === null && snapshot !== null && snapshot.status === "ok" && (
+        <div className="scm-lists">
+          <ScmSection title="Staged" entries={snapshot.stagedChanges} onInsertPath={onInsertPath} />
+          <ScmSection title="Changes" entries={snapshot.unstagedChanges} onInsertPath={onInsertPath} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// The header line: branch, ahead/behind, last commit for an ok snapshot; a plain explanation for a
+// non-repository or a git failure; the transport error when the fetch itself failed; "Loading..." until
+// the first result lands. Never blank.
+function ScmHeaderBody({
+  snapshot,
+  error,
+  loading,
+}: {
+  snapshot: GitSnapshot | null;
+  error: string | null;
+  loading: boolean;
+}) {
+  if (error !== null) {
+    return (
+      <div className="scm-state scm-state-error" role="alert">
+        <span className="scm-state-title">Could not load source control</span>
+        <span className="scm-state-detail">{error}</span>
+      </div>
+    );
+  }
+  if (snapshot === null) {
+    return <div className="scm-state">{loading ? "Loading..." : "No source-control data yet."}</div>;
+  }
+  if (snapshot.status === "not_a_repo") {
+    return (
+      <div className="scm-state">
+        <span className="scm-state-title">Not a git repository</span>
+        <span className="scm-state-detail">This session's working directory is not tracked by git.</span>
+      </div>
+    );
+  }
+  if (snapshot.status !== "ok") {
+    // "git_failed" (or any future non-ok status): show the error detail, never a silent blank.
+    return (
+      <div className="scm-state scm-state-error" role="alert">
+        <span className="scm-state-title">git failed</span>
+        <span className="scm-state-detail">{snapshot.error ?? "git could not read this repository."}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="scm-repo">
+      <span className="scm-branch" title="Current branch">
+        {snapshot.branch.length > 0 ? snapshot.branch : "(detached)"}
+      </span>
+      <span className="scm-sync">
+        {snapshot.ahead > 0 && <span className="scm-ahead">{snapshot.ahead} ahead</span>}
+        {snapshot.behind > 0 && <span className="scm-behind">{snapshot.behind} behind</span>}
+        {snapshot.ahead === 0 && snapshot.behind === 0 && (
+          <span className="scm-insync">up to date</span>
+        )}
+      </span>
+      {snapshot.lastCommit.length > 0 && (
+        <span className="scm-commit" title="Last commit">
+          {snapshot.lastCommit}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// One of the two file sections (Staged / Changes). Each row is the change kind plus the repository-
+// relative path; the WHOLE row inserts the path into the composer, with a small insert affordance too.
+function ScmSection({
+  title,
+  entries,
+  onInsertPath,
+}: {
+  title: string;
+  entries: GitChangeEntry[];
+  onInsertPath: (path: string) => void;
+}) {
+  return (
+    <section className="scm-section">
+      <div className="scm-section-title">
+        {title}
+        <span className="scm-count">{entries.length}</span>
+      </div>
+      {entries.length === 0 ? (
+        <div className="scm-section-empty">No files</div>
+      ) : (
+        <ul className="scm-files">
+          {entries.map((entry, i) => (
+            <li key={`${entry.path}-${i}`}>
+              <button
+                type="button"
+                className="scm-file"
+                onClick={() => onInsertPath(entry.path)}
+                title={`Insert ${entry.path} into the composer`}
+              >
+                <span
+                  className={`scm-kind scm-kind-${entry.changeKind === "?" ? "untracked" : entry.changeKind.toLowerCase()}`}
+                  title={changeKindLabel(entry.changeKind)}
+                >
+                  {entry.changeKind}
+                </span>
+                <span className="scm-path">{entry.path}</span>
+                <span className="scm-insert" aria-hidden="true">
+                  insert
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/cockpit/src/sessions/composerInsert.test.ts
+++ b/apps/cockpit/src/sessions/composerInsert.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { appendToCompose } from "./composerInsert";
+
+// Issue #1266: clicking a changed file in the Source Control tab must INSERT its repository-relative
+// path into the composer text box - appended at the end, separated from any existing text by a single
+// space. These tests pin that behaviour (the exact rule the Source Control row's onClick relies on).
+describe("appendToCompose", () => {
+  it("inserts the clicked file's path into an empty composer with no leading space", () => {
+    expect(appendToCompose("", "src/App.tsx")).toBe("src/App.tsx");
+  });
+
+  it("appends the path after existing text with a single separating space", () => {
+    expect(appendToCompose("roll back", "src/App.tsx")).toBe("roll back src/App.tsx");
+  });
+
+  it("does not double the space when the composer already ends with one", () => {
+    expect(appendToCompose("roll back ", "src/App.tsx")).toBe("roll back src/App.tsx");
+  });
+
+  it("appends a second clicked path with exactly one space between the two paths", () => {
+    const afterFirst = appendToCompose("", "src/App.tsx");
+    expect(appendToCompose(afterFirst, "docs/README.md")).toBe("src/App.tsx docs/README.md");
+  });
+
+  it("leaves the composer unchanged when there is nothing to insert", () => {
+    expect(appendToCompose("roll back", "")).toBe("roll back");
+  });
+});

--- a/apps/cockpit/src/sessions/composerInsert.ts
+++ b/apps/cockpit/src/sessions/composerInsert.ts
@@ -1,0 +1,16 @@
+// Appending text into the session composer (issues #972, #1266).
+//
+// The composer text is owned by SessionDetail, and several surfaces drop text into it: the queue's Pop,
+// the screenshot gallery's Insert, and the Source Control tab's click-a-file-to-insert-its-path. They
+// all share this one rule so the separating space is applied identically everywhere: keep exactly one
+// space between the existing text and the appended text, and never prepend a leading space when the box
+// is empty. Kept pure and side-effect-free so the Source Control insert behaviour is unit-testable.
+
+/**
+ * Append `insert` to `current`, separated by a single space unless `current` is empty or already ends
+ * with a space. An empty `insert` leaves `current` unchanged.
+ */
+export function appendToCompose(current: string, insert: string): string {
+  if (insert.length === 0) return current;
+  return current.length > 0 && !current.endsWith(" ") ? `${current} ${insert}` : `${current}${insert}`;
+}

--- a/apps/cockpit/src/styles.css
+++ b/apps/cockpit/src/styles.css
@@ -1793,6 +1793,240 @@ body {
   cursor: pointer;
 }
 
+/* ===== Source Control tab (issue #1266): read-only repository view; click a file to insert its path == */
+.scm-tab {
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.scm-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  flex: 0 0 auto;
+}
+
+.scm-repo {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px 14px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.scm-branch {
+  font-weight: 600;
+  color: var(--text);
+  font-family: "Cascadia Mono", Consolas, Menlo, monospace;
+}
+
+.scm-sync {
+  display: inline-flex;
+  gap: 10px;
+  font-size: 12px;
+}
+
+.scm-ahead {
+  color: var(--accent);
+}
+
+.scm-behind {
+  color: var(--warn);
+}
+
+.scm-insync {
+  color: var(--text-dim);
+}
+
+.scm-commit {
+  color: var(--text-dim);
+  font-size: 12px;
+  font-family: "Cascadia Mono", Consolas, Menlo, monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.scm-state {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  flex: 1 1 auto;
+  min-width: 0;
+  color: var(--text-dim);
+  font-size: 13px;
+}
+
+.scm-state-title {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.scm-state-detail {
+  font-size: 12px;
+}
+
+.scm-state-error .scm-state-title {
+  color: var(--attention);
+}
+
+.scm-refresh {
+  flex: 0 0 auto;
+  padding: 5px 12px;
+  font-size: 12px;
+  color: var(--text);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.scm-refresh:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+
+.scm-refresh:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.scm-lists {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.scm-section-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-dim);
+  margin-bottom: 4px;
+}
+
+.scm-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-dim);
+  background: var(--surface-2);
+  border-radius: 9px;
+}
+
+.scm-section-empty {
+  color: var(--text-dim);
+  font-size: 12px;
+  padding: 2px 0 4px;
+}
+
+.scm-files {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.scm-file {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  text-align: left;
+  padding: 4px 8px;
+  background: transparent;
+  border: none;
+  border-radius: 5px;
+  color: var(--text);
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.scm-file:hover {
+  background: var(--surface-2);
+}
+
+.scm-kind {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  font-family: "Cascadia Mono", Consolas, Menlo, monospace;
+  font-size: 12px;
+  font-weight: 700;
+  border-radius: 4px;
+  color: var(--text-dim);
+  background: var(--surface-2);
+}
+
+.scm-kind-m {
+  color: var(--warn);
+}
+
+.scm-kind-a {
+  color: #4ec9b0;
+}
+
+.scm-kind-d {
+  color: var(--attention);
+}
+
+.scm-kind-r,
+.scm-kind-c {
+  color: var(--accent);
+}
+
+.scm-kind-untracked {
+  color: var(--text-dim);
+}
+
+.scm-path {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: "Cascadia Mono", Consolas, Menlo, monospace;
+  font-size: 12px;
+}
+
+.scm-insert {
+  flex: 0 0 auto;
+  font-size: 11px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0;
+}
+
+.scm-file:hover .scm-insert {
+  opacity: 1;
+}
+
 /* ===== Session menu (issue #1214): Rename / Hold-Resume / Handover info / Close ===== */
 .session-menu {
   position: relative;


### PR DESCRIPTION
Implements **step 4** of issue thefrederiksen/devthrottle_internal#747: the read-only Source Control tab on the Cockpit session page. Steps 1-3 (the Director payload, the Gateway proxy, and the shared client-core `getGitStatus`) merged earlier in PR thefrederiksen/devthrottle#1274; this builds the browser tab on top of them.

## What it does
A **Source Control** tab now sits beside Terminal / Chat / Voice on the session page. It is strictly read-only in the browser - seeing the repository state happens here; acting happens through the agent via the composer.

- **Header:** branch, ahead / behind, last commit. Clear `Not a git repository` and loud `git failed` (with the error detail) states, plus a transport-error banner - never a silent blank.
- **Two sections, Staged and Changes,** matching the desktop grouping. Each file shows its git change-kind letter (M / A / D / R / C / ?) and its repository-relative path.
- **Click a file** (the whole row, with a hover `insert` affordance) to insert its repository-relative path into the composer - appended with a single separating space - and focus the composer, so you can immediately type the instruction ("roll this back please") and send.
- **Refresh:** fetch on tab open, a manual Refresh control, and light ~10s polling that pauses while the browser page is hidden (issue thefrederiksen/devthrottle#1239). The tab is unmounted on a tab switch, so the poll never runs unseen; the **terminal pane stays mounted-hidden** so its live socket is never dropped.
- **Read-only:** no stage / unstage / discard / commit control of any kind. The Gateway exposes no git write route.

## Notable
- Extracted the composer-append rule into a pure `appendToCompose` helper shared by the queue Pop, the screenshot Insert, and the new file-click; unit-tested (the client-side composer-insert test, per the issue's test requirement).
- Fixed a remount race in the tab's fetch guard so the first fetch after a mount / session change is never swallowed by a still-in-flight aborted fetch.

## Proof
- `npm run typecheck` clean; `npm test` 72/72 pass (5 new composer-insert tests); `npm run build` clean.
- Drove the real cockpit app (Vite dev server) with the Gateway REST surface stubbed via Playwright - **13/13 checks pass** across the ok / not-a-repo / git-failed states, click-to-insert, composer focus, single-space second insert, no-write-verbs, and terminal-stays-mounted. Screenshots captured for all four states.

## Not deployed
The `/git` end-to-end path needs Directors running the new build; verified at the Gateway boundary via the merged client-core call. **Not deployed to the live Gateway** (sole-deployer owns that).

Refs thefrederiksen/devthrottle_internal#747. Part of the Cockpit Improvement mission, Wave 2.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>