### PR TITLE
Fix inventory drift: drop the deleted Voice Tab from the feature inventory

### DIFF
--- a/docs/features/feature-inventory.yaml
+++ b/docs/features/feature-inventory.yaml
@@ -197,17 +197,6 @@ features:
     screenshot: wingman-tab.png
     summary: Clean structured briefing of what Claude wants you to do next - verbatim validation, synthesized actions, tap-to-answer buttons, a voice preview, and the final reply rendered as markdown.
 
-  - id: voice-tab
-    title: Voice Tab
-    category: voice-wingman
-    status: implemented
-    screen: main-window
-    source:
-      - src/CcDirector.Avalonia/Controls/VoiceView.axaml
-      - src/CcDirector.Avalonia/Controls/VoiceView.axaml.cs
-    screenshot: voice-tab.png
-    summary: Eyes-free panel with Ask Agent / Ask Wingman buttons and transcript-plus-reply display.
-
   - id: fifo-window
     title: FIFO Full-Screen Mode
     category: voice-wingman


### PR DESCRIPTION
The `Inventory drift check` has been red on every pull request because `docs/features/feature-inventory.yaml` still listed the desktop **Voice Tab**, whose files (`VoiceView.axaml` / `VoiceView.axaml.cs`) were removed when the Voice and History tabs were deleted. The check fails on any documented `source:` path that no longer exists.

This removes the stale `voice-tab` entry. `scripts/check-inventory-drift.ps1` now exits 0 ("inventory is consistent with the source tree"). The remaining informational notes (views not in the inventory) do not fail the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)