### PR TITLE
Cockpit browser notifications reusing the existing web-push needs-you stack (#1257)

### DIFF
--- a/apps/cockpit/public/sw.js
+++ b/apps/cockpit/public/sw.js
@@ -1,0 +1,164 @@
+// Web Push service worker for the DevThrottle desktop Cockpit (issue #1257).
+//
+// The Cockpit reuses the SAME Gateway web-push plumbing the phone shipped with (#905): the Gateway
+// pushes a { "count": N } message to every subscribed device whenever the number of sessions that
+// "need you" is above zero and has changed, and pushes a single zero on the falling edge. There is NO
+// new Gateway code - this worker is only the desktop-browser end of that existing pipe. The mobile app
+// turns the push into an app-icon dot (public/push-sw.js); the Cockpit turns it into a real desktop
+// notification, because the point on a desktop is to be CALLED by a backgrounded tab, not just badged.
+//
+// This is a hand-written, push-only service worker: the Cockpit is a plain same-origin single-page app
+// with no offline/precache behavior, so this worker registers no fetch handler and owns nothing but the
+// three push-related listeners. Registered at "/sw.js" so its scope is the whole Cockpit ("/").
+//
+// The subscribe/unsubscribe flow itself lives in the shared client (packages/client-core/src/push/
+// register.ts); the shell-specific bits - the notification icon and the click-target URL - live here.
+
+'use strict';
+
+var NEEDS_YOU_TAG = 'devthrottle-needs-you';
+// The DevThrottle logo the Gateway already serves for the mobile app, reused so the desktop
+// notification carries the brand mark without shipping a second copy of the asset. Same-origin; if a
+// build has no mobile app the browser simply shows its default icon (a notification needs no icon).
+var NOTIFICATION_ICON = '/m/icon-192.png';
+
+self.addEventListener('push', function (event) {
+  var count = 0;
+  if (event.data) {
+    try {
+      var payload = event.data.json();
+      count = Number(payload && payload.count) || 0;
+    } catch (e) {
+      count = 0;
+    }
+  }
+  event.waitUntil(applyNeedsYou(count));
+});
+
+function applyNeedsYou(count) {
+  var tasks = [];
+
+  // App badge where the browser supports it (installed desktop PWA / some Chromium builds). Harmless
+  // and feature-detected everywhere else - the notification below is what actually calls the user.
+  if (self.navigator && 'setAppBadge' in self.navigator) {
+    if (count > 0) {
+      tasks.push(self.navigator.setAppBadge(count).catch(function () {}));
+    } else {
+      tasks.push(self.navigator.clearAppBadge().catch(function () {}));
+    }
+  }
+
+  if (count <= 0) {
+    // Falling edge: the Gateway pushes exactly one zero when the last waiting session is answered, so
+    // close the standing notification and clear the badge.
+    tasks.push(closeNeedsYou());
+    return Promise.all(tasks);
+  }
+
+  // Show one tagged notification for the current count. The Gateway only pushes when the count CHANGES
+  // (see WebPushNeedsYouNotifier.Decide), so renotify:true is correct here - each push is real news and
+  // should re-alert - while the shared tag REPLACES the previous notification rather than stacking a new
+  // one. Clicking it focuses the Cockpit and lands on the waiting session (see notificationclick).
+  var body = count === 1 ? '1 session needs you' : count + ' sessions need you';
+  tasks.push(
+    self.registration.showNotification('DevThrottle', {
+      tag: NEEDS_YOU_TAG,
+      body: body,
+      renotify: true,
+      icon: NOTIFICATION_ICON,
+      badge: NOTIFICATION_ICON,
+      data: { url: '/' }
+    })
+  );
+
+  return Promise.all(tasks);
+}
+
+function closeNeedsYou() {
+  return self.registration.getNotifications({ tag: NEEDS_YOU_TAG }).then(function (list) {
+    list.forEach(function (n) {
+      n.close();
+    });
+  });
+}
+
+self.addEventListener('notificationclick', function (event) {
+  event.notification.close();
+  event.waitUntil(
+    resolveTargetUrl().then(function (url) {
+      return focusOrOpen(url);
+    })
+  );
+});
+
+// Where the click should land. The push payload carries only the count (no session id - the Gateway
+// contract is unchanged), so we read the live roster to decide: exactly one session waiting -> land on
+// THAT session; several (or if the roster read fails / is ambiguous) -> land on the roster, which
+// surfaces the waiting sessions at the top. The /sessions read authenticates via the cc-gateway-token
+// cookie the shell sets at startup (credentials: 'include'); any failure falls back to the roster.
+function resolveTargetUrl() {
+  return fetch('/sessions', { credentials: 'include', headers: { Accept: 'application/json' } })
+    .then(function (res) {
+      return res.ok ? res.json() : null;
+    })
+    .then(function (body) {
+      var sessions = Array.isArray(body) ? body : [];
+      var needs = sessions.filter(function (s) {
+        return s && s.triageBucket === 'needsYou';
+      });
+      if (needs.length === 1 && needs[0].sessionId) {
+        return '/session/' + encodeURIComponent(needs[0].sessionId);
+      }
+      return '/';
+    })
+    .catch(function () {
+      return '/';
+    });
+}
+
+// Focus an existing Cockpit tab (and steer it to the target) or open a new one. A Cockpit window is any
+// same-origin window that is NOT the mobile app (its path starts with /m). Navigating the existing tab
+// is best-effort: if the browser will not let us navigate a controlled client we still focus it.
+function focusOrOpen(url) {
+  return self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(function (clients) {
+    for (var i = 0; i < clients.length; i++) {
+      var c = clients[i];
+      if (isCockpitWindow(c) && 'focus' in c) {
+        if ('navigate' in c) {
+          return c.navigate(url).then(function (nav) {
+            return (nav || c).focus();
+          }).catch(function () {
+            return c.focus();
+          });
+        }
+        return c.focus();
+      }
+    }
+    if (self.clients.openWindow) {
+      return self.clients.openWindow(url);
+    }
+    return undefined;
+  });
+}
+
+function isCockpitWindow(client) {
+  try {
+    var path = new URL(client.url).pathname;
+    return path.indexOf('/m/') !== 0 && path !== '/m';
+  } catch (e) {
+    return true;
+  }
+}
+
+// The page posts this when it is foregrounded and the live roster shows nothing waiting, so the
+// notification clears even though the Gateway only ever pushes non-zero counts (except the one falling
+// edge). Mirrors the mobile worker so reconcileBadge() clears both shells the same way.
+self.addEventListener('message', function (event) {
+  if (event.data && event.data.type === 'devthrottle-clear-needs-you') {
+    var tasks = [closeNeedsYou()];
+    if (self.navigator && 'clearAppBadge' in self.navigator) {
+      tasks.push(self.navigator.clearAppBadge().catch(function () {}));
+    }
+    event.waitUntil(Promise.all(tasks));
+  }
+});

--- a/apps/cockpit/src/main.tsx
+++ b/apps/cockpit/src/main.tsx
@@ -6,6 +6,8 @@ import { SignIn } from "@devthrottle/client-core/auth/SignIn";
 import { DeviceCallback } from "@devthrottle/client-core/auth/DeviceCallback";
 import { hasDeviceKey } from "@devthrottle/client-core/auth/deviceKey";
 import { configureEnrollment, COCKPIT_ENROLLMENT_PROFILE } from "@devthrottle/client-core/auth/enrollRequest";
+import { ensurePushSubscribed } from "@devthrottle/client-core/push/register";
+import { registerCockpitServiceWorker } from "./push/registerSw";
 import { AppShell } from "./AppShell";
 import { NotFound } from "./panes/NotFound";
 import { SessionsEmpty, SessionsView } from "./sessions/SessionsView";
@@ -64,6 +66,14 @@ ensureGatewayCookie();
 // instead of the retired /login token wall (issue #1088: a revoke returns the browser to the shared
 // sign-in flow, never to login.html).
 configureUnauthorizedRedirect(cockpitSignInRedirect);
+
+// Browser notifications (issue #1257): register the Cockpit's push service worker, then - only if the
+// user already granted notification permission on a previous visit - silently refresh this browser's
+// push subscription so the Gateway's record stays current across subscription rotations. Neither call
+// prompts (that needs a user gesture: the Settings > Notifications toggle). Both are fire-and-forget and
+// non-fatal - the Cockpit works fully without notifications. This reuses the exact plumbing the phone
+// shipped with (#905); there is no new Gateway code.
+void registerCockpitServiceWorker().then(() => ensurePushSubscribed());
 
 // The auth gate (issue #1088, the desktop analog of the mobile gate from #908): every real screen
 // requires an enrolled device key. Without one, the browser is sent to the shared Sign in screen with

--- a/apps/cockpit/src/push/registerSw.ts
+++ b/apps/cockpit/src/push/registerSw.ts
@@ -1,0 +1,17 @@
+// Registers the Cockpit's push service worker (issue #1257). The mobile app gets its service worker
+// auto-registered by vite-plugin-pwa; the Cockpit is a plain static single-page app with no PWA plugin,
+// so it registers its one hand-written worker (public/sw.js, served at "/sw.js" so its scope is the
+// whole Cockpit) here at startup. The worker only carries the Web Push listeners - it precaches nothing.
+//
+// Registration is idempotent (the browser reuses an existing registration and updates the script when
+// it changes) and non-fatal: a browser without service worker support, or a failed registration, simply
+// leaves the Cockpit without desktop notifications - every other feature works unchanged.
+
+export async function registerCockpitServiceWorker(): Promise<void> {
+  if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) return;
+  try {
+    await navigator.serviceWorker.register("/sw.js");
+  } catch (err) {
+    console.warn("[push] Cockpit service worker registration failed:", err);
+  }
+}

--- a/apps/cockpit/src/push/sw.test.ts
+++ b/apps/cockpit/src/push/sw.test.ts
@@ -1,0 +1,220 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Behavior test for the Cockpit push service worker (public/sw.js, issue #1257). The worker runs in the
+// service-worker global scope, so we load its source into a faked `self` (registration / clients /
+// navigator) plus a stubbed `fetch`, capture the listeners it registers, and drive them exactly as the
+// browser would. This proves the acceptance path without a live push service:
+//   - a "needs you" push draws one desktop notification with the right wording,
+//   - the falling-edge zero closes the standing notification instead of drawing another,
+//   - clicking the notification lands on the single waiting session (deep link) or the roster,
+//   - the foreground clear message closes the notification.
+
+const swSource = readFileSync(
+  fileURLToPath(new URL("../../public/sw.js", import.meta.url)),
+  "utf8",
+);
+
+interface ShownNotification {
+  title: string;
+  options: Record<string, unknown>;
+  close: () => void;
+  closed: boolean;
+}
+
+interface FakeWindowClient {
+  url: string;
+  focus: () => Promise<FakeWindowClient>;
+  navigate?: (url: string) => Promise<FakeWindowClient>;
+  focused: boolean;
+  navigatedTo?: string;
+}
+
+function loadWorker(options: {
+  sessions?: unknown;
+  fetchOk?: boolean;
+  fetchRejects?: boolean;
+  clients?: FakeWindowClient[];
+}) {
+  const listeners: Record<string, ((event: unknown) => void)[]> = {};
+  const shown: ShownNotification[] = [];
+  const openedWindows: string[] = [];
+
+  const fetchStub = vi.fn(async () => {
+    if (options.fetchRejects) throw new Error("network down");
+    return {
+      ok: options.fetchOk !== false,
+      json: async () => options.sessions ?? [],
+    } as unknown as Response;
+  });
+
+  const self = {
+    addEventListener(type: string, fn: (event: unknown) => void) {
+      (listeners[type] ??= []).push(fn);
+    },
+    registration: {
+      showNotification(title: string, opts: Record<string, unknown>) {
+        const entry: ShownNotification = {
+          title,
+          options: opts,
+          closed: false,
+          close() {
+            this.closed = true;
+          },
+        };
+        shown.push(entry);
+        return Promise.resolve();
+      },
+      getNotifications({ tag }: { tag: string }) {
+        return Promise.resolve(shown.filter((n) => !n.closed && n.options.tag === tag));
+      },
+    },
+    navigator: {
+      setAppBadge: vi.fn(async () => undefined),
+      clearAppBadge: vi.fn(async () => undefined),
+    },
+    clients: {
+      matchAll: async () => options.clients ?? [],
+      openWindow: async (url: string) => {
+        openedWindows.push(url);
+        return {} as FakeWindowClient;
+      },
+    },
+  };
+
+  // Run the worker source with `self` and `fetch` shadowing the globals it reaches for.
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  new Function("self", "fetch", swSource)(self, fetchStub);
+
+  async function dispatch(type: string, event: Record<string, unknown>) {
+    const waits: Promise<unknown>[] = [];
+    const withWait = { ...event, waitUntil: (p: Promise<unknown>) => waits.push(p) };
+    for (const fn of listeners[type] ?? []) fn(withWait);
+    await Promise.all(waits);
+  }
+
+  return { dispatch, shown, openedWindows, fetchStub, self };
+}
+
+function pushEvent(count: number) {
+  return { data: { json: () => ({ count }) } };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("cockpit push service worker", () => {
+  it("draws one notification naming the count when a session needs you", async () => {
+    const w = loadWorker({});
+    await w.dispatch("push", pushEvent(2));
+    expect(w.shown).toHaveLength(1);
+    expect(w.shown[0].title).toBe("DevThrottle");
+    expect(w.shown[0].options.body).toBe("2 sessions need you");
+    expect(w.shown[0].options.tag).toBe("devthrottle-needs-you");
+    expect((w.shown[0].options.data as { url: string }).url).toBe("/");
+  });
+
+  it("uses the singular wording for a single waiting session", async () => {
+    const w = loadWorker({});
+    await w.dispatch("push", pushEvent(1));
+    expect(w.shown[0].options.body).toBe("1 session needs you");
+  });
+
+  it("closes the standing notification on the falling-edge zero without drawing a new one", async () => {
+    const w = loadWorker({});
+    await w.dispatch("push", pushEvent(3));
+    expect(w.shown[0].closed).toBe(false);
+    await w.dispatch("push", pushEvent(0));
+    expect(w.shown).toHaveLength(1); // no second notification
+    expect(w.shown[0].closed).toBe(true);
+    expect(w.self.navigator.clearAppBadge).toHaveBeenCalled();
+  });
+
+  it("clicking deep-links to the one session that needs you", async () => {
+    const w = loadWorker({
+      sessions: [
+        { sessionId: "s-1", triageBucket: "active" },
+        { sessionId: "s-red", triageBucket: "needsYou" },
+      ],
+    });
+    await w.dispatch("notificationclick", {
+      notification: { close: () => undefined, data: { url: "/" } },
+    });
+    expect(w.fetchStub).toHaveBeenCalledWith("/sessions", expect.objectContaining({ credentials: "include" }));
+    expect(w.openedWindows).toEqual(["/session/s-red"]);
+  });
+
+  it("clicking lands on the roster when several sessions need you", async () => {
+    const w = loadWorker({
+      sessions: [
+        { sessionId: "a", triageBucket: "needsYou" },
+        { sessionId: "b", triageBucket: "needsYou" },
+      ],
+    });
+    await w.dispatch("notificationclick", {
+      notification: { close: () => undefined, data: { url: "/" } },
+    });
+    expect(w.openedWindows).toEqual(["/"]);
+  });
+
+  it("clicking falls back to the roster when the roster read fails", async () => {
+    const w = loadWorker({ fetchRejects: true });
+    await w.dispatch("notificationclick", {
+      notification: { close: () => undefined, data: { url: "/" } },
+    });
+    expect(w.openedWindows).toEqual(["/"]);
+  });
+
+  it("focuses an existing Cockpit tab instead of opening a new one", async () => {
+    const cockpitTab: FakeWindowClient = {
+      url: "https://gw.example/session/old",
+      focused: false,
+      focus() {
+        this.focused = true;
+        return Promise.resolve(this);
+      },
+      navigate(url: string) {
+        this.navigatedTo = url;
+        return Promise.resolve(this);
+      },
+    };
+    const w = loadWorker({
+      sessions: [{ sessionId: "s-red", triageBucket: "needsYou" }],
+      clients: [cockpitTab],
+    });
+    await w.dispatch("notificationclick", {
+      notification: { close: () => undefined, data: { url: "/" } },
+    });
+    expect(cockpitTab.focused).toBe(true);
+    expect(cockpitTab.navigatedTo).toBe("/session/s-red");
+    expect(w.openedWindows).toEqual([]); // reused the existing tab, did not open a second
+  });
+
+  it("does not treat the mobile app window as a Cockpit tab to reuse", async () => {
+    const mobileTab: FakeWindowClient = {
+      url: "https://gw.example/m/",
+      focused: false,
+      focus() {
+        this.focused = true;
+        return Promise.resolve(this);
+      },
+    };
+    const w = loadWorker({
+      sessions: [{ sessionId: "a", triageBucket: "needsYou" }, { sessionId: "b", triageBucket: "needsYou" }],
+      clients: [mobileTab],
+    });
+    await w.dispatch("notificationclick", {
+      notification: { close: () => undefined, data: { url: "/" } },
+    });
+    expect(mobileTab.focused).toBe(false);
+    expect(w.openedWindows).toEqual(["/"]); // opened a Cockpit window rather than hijacking the /m tab
+  });
+
+  it("the foreground clear message closes the notification", async () => {
+    const w = loadWorker({});
+    await w.dispatch("push", pushEvent(2));
+    await w.dispatch("message", { data: { type: "devthrottle-clear-needs-you" } });
+    expect(w.shown[0].closed).toBe(true);
+    expect(w.self.navigator.clearAppBadge).toHaveBeenCalled();
+  });
+});

--- a/apps/cockpit/src/sessions/SessionsView.tsx
+++ b/apps/cockpit/src/sessions/SessionsView.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Outlet, useMatch, useNavigate } from "react-router-dom";
 import { gatewayErrorMessage, type SessionDto } from "@devthrottle/client-core/api/client";
 import { getSessionsEnvelope, type DirectorReachability } from "@devthrottle/client-core/fleet/fleetClient";
+import { inBucket } from "@devthrottle/client-core/sessions/ordering";
+import { reconcileBadge } from "@devthrottle/client-core/push/register";
 import { SessionRoster, type RosterView } from "./SessionRoster";
 import { NewSessionDialog } from "./NewSessionDialog";
 
@@ -53,6 +55,11 @@ export function SessionsView() {
       setDirectors(env.directors);
       setError(null);
       loadedOnce.current = true;
+      // Keep the browser-notification state in sync while the Cockpit is open (issue #1257): when the
+      // roster shows nothing waiting, close any standing "needs you" desktop notification and clear the
+      // app badge. The Gateway pushes a single zero on the falling edge too, but this clears it the
+      // instant the user resolves the last session in the foreground, without waiting for that push.
+      void reconcileBadge(inBucket(env.sessions, "needsYou").length);
     } catch (err) {
       if (signal?.aborted) return;
       // Keep the last-known roster on screen; only raise the stale banner (the roster component

--- a/apps/cockpit/src/settings/SettingsView.tsx
+++ b/apps/cockpit/src/settings/SettingsView.tsx
@@ -21,6 +21,13 @@ import {
   ttsSample,
 } from "@devthrottle/client-core/api/ai";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
+import {
+  disablePush,
+  enablePush,
+  isPushSubscribed,
+  notificationPermission,
+  pushSupported,
+} from "@devthrottle/client-core/push/register";
 
 // The Cockpit Settings page (issue #1025, epic #967) - the React port of the retired Blazor
 // wwwroot/pages/settings.html. The left-rail "Settings" item used to be a dead full-load anchor to
@@ -236,6 +243,8 @@ function ThisMachineTab() {
         )}
       </section>
 
+      <NotificationsCard />
+
       <section className="settings-card">
         <h2 className="settings-h2">
           Training data <span className="settings-pill">improve the wingman</span>
@@ -264,6 +273,105 @@ function ThisMachineTab() {
 function cockpitLabel(settings: GatewaySettings): string {
   const state = settings.cockpit.up ? "up" : "down";
   return `port ${settings.cockpit.port} (${state})`;
+}
+
+// ---- Browser notifications (issue #1257) ----------------------------------------------------------
+//
+// Per-browser toggle that subscribes THIS browser to the Gateway's existing "needs you" web push (the
+// same pipe the phone uses, #905) so a backgrounded Cockpit tab raises a desktop notification when a
+// session turns red. The subscribe/unsubscribe flow is the shared client-core push module; this card is
+// only its on/off switch plus the browser permission prompt behind it. Self-contained state (support,
+// permission, subscribed) so it never depends on the Gateway settings load - notifications are a
+// property of this browser, not of the machine's Gateway config. Turning it off unsubscribes this
+// browser only; a phone or another browser stays subscribed.
+
+function NotificationsCard() {
+  const supported = pushSupported();
+  const [permission, setPermission] = useState<NotificationPermission | "unsupported">(
+    notificationPermission(),
+  );
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState("");
+
+  useEffect(() => {
+    if (!supported) {
+      setEnabled(false);
+      return;
+    }
+    let cancelled = false;
+    void isPushSubscribed().then((on) => {
+      if (!cancelled) setEnabled(on);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [supported]);
+
+  const onToggle = async (checked: boolean) => {
+    if (busy) return;
+    setBusy(true);
+    setMsg("Saving...");
+    try {
+      if (checked) {
+        const result = await enablePush();
+        setPermission(notificationPermission());
+        if (result === "granted") {
+          setEnabled(true);
+          setMsg("On. This browser will be notified when a session needs you, even in the background.");
+        } else if (result === "denied") {
+          setEnabled(false);
+          setMsg("This browser blocked notifications. Allow them in the browser's site settings, then try again.");
+        } else {
+          setEnabled(false);
+          setMsg("This browser does not support notifications.");
+        }
+      } else {
+        await disablePush();
+        setEnabled(false);
+        setMsg("Off. Notifications stopped for this browser only.");
+      }
+    } catch (e) {
+      setMsg(errText(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="settings-card">
+      <h2 className="settings-h2">
+        Notifications <span className="settings-pill">this browser</span>
+      </h2>
+      <p className="settings-hint">
+        Get a desktop notification when a session needs you, even when this tab is in the background or
+        the browser is minimized. Clicking the notification brings the Cockpit forward and opens the
+        session that is waiting. This is per-browser: turning it off here stops notifications for this
+        browser only, and your phone keeps its own alerts.
+      </p>
+      <label className="settings-check">
+        <input
+          type="checkbox"
+          checked={enabled === true}
+          disabled={!supported || busy || enabled === null || permission === "denied"}
+          onChange={(e) => void onToggle(e.target.checked)}
+        />
+        Notify me on this browser
+      </label>
+      {!supported && (
+        <p className="settings-hint settings-hint-inline">
+          This browser does not support web notifications.
+        </p>
+      )}
+      {supported && permission === "denied" && (
+        <p className="settings-hint settings-hint-inline">
+          Notifications are blocked for this site in the browser. Allow them in the browser&apos;s site
+          settings to turn this on.
+        </p>
+      )}
+      {msg !== "" && <div className="settings-msg">{msg}</div>}
+    </section>
+  );
 }
 
 // ---- "AI" tab: DevThrottle-hosted models + voice --------------------------------------------------

--- a/apps/cockpit/vite.config.ts
+++ b/apps/cockpit/vite.config.ts
@@ -37,6 +37,10 @@ const devProxy = proxyTarget
       "/dictation": { target: proxyTarget, changeOrigin: true },
       "/turnbriefs": { target: proxyTarget, changeOrigin: true },
       "/vault": { target: proxyTarget, changeOrigin: true },
+      // Web Push (issue #1257): the notifications toggle fetches the VAPID public key and registers /
+      // unregisters this browser's subscription at the Gateway's /push/* endpoints, so `npm run dev`
+      // reaches them against a live Gateway too.
+      "/push": { target: proxyTarget, changeOrigin: true },
       // Device enrollment (issue #1088): the shared client-core callback exchanges the cloud device
       // key at the Gateway's POST /m/enroll, so the enrollment flow works under `npm run dev` too.
       "/m": { target: proxyTarget, changeOrigin: true },

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -12,7 +12,7 @@ import { SignIn } from "@devthrottle/client-core/auth/SignIn";
 import { DeviceCallback } from "@devthrottle/client-core/auth/DeviceCallback";
 import { hasDeviceKey } from "@devthrottle/client-core/auth/deviceKey";
 import { ensureGatewayCookie, configureUnauthorizedRedirect, mobileSignInRedirect } from "@devthrottle/client-core/api/client";
-import { ensurePushSubscribed } from "./push/register";
+import { ensurePushSubscribed } from "@devthrottle/client-core/push/register";
 import { CreditsNotice } from "./components/CreditsNotice";
 import { useScreenWakeLock } from "./hooks/useScreenWakeLock";
 import { resumePendingDictations } from "@devthrottle/client-core/dictation/backgroundSend";

--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -6,7 +6,7 @@ import { useDictationStatusFor } from "@devthrottle/client-core/dictation/status
 import { useNow, waitingLabel } from "@devthrottle/client-core/sessions/waiting";
 import { getClipState, playClip, playingSid, stopPlayback, syncVoiceSessions, useVoiceClips } from "@devthrottle/client-core/voice/clips";
 import { NavDrawer } from "../components/NavDrawer";
-import { enablePush, notificationPermission, pushSupported, reconcileBadge } from "../push/register";
+import { enablePush, notificationPermission, pushSupported, reconcileBadge } from "@devthrottle/client-core/push/register";
 
 // Home / roster. A "needs you" group first (when any session wants attention), then an "other
 // sessions" group with everything that is NOT waiting on you - so a session appears in exactly one

--- a/packages/client-core/src/push/register.test.ts
+++ b/packages/client-core/src/push/register.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { notificationPermission, pushSupported, urlBase64ToUint8Array } from "./register";
+
+// The push client is shared by both shells (mobile PWA + desktop Cockpit, issue #1257). These tests
+// run in Node (no window / navigator / Notification), so they cover the pure VAPID-key conversion - the
+// one subtle correctness bit - and confirm the feature gates degrade to "off / unsupported" instead of
+// throwing when the browser APIs are absent (the same graceful path a non-supporting browser takes).
+
+describe("urlBase64ToUint8Array", () => {
+  it("decodes a base64url VAPID key to its exact raw bytes", () => {
+    // "hello" in standard base64 is "aGVsbG8=" -> bytes 104,101,108,108,111.
+    const out = urlBase64ToUint8Array("aGVsbG8");
+    expect(Array.from(out)).toEqual([104, 101, 108, 108, 111]);
+  });
+
+  it("treats - and _ as the base64url alphabet (+ and /)", () => {
+    // Byte sequence [255, 224] encodes to "/+A=" in standard base64 and "_-A" in base64url; both must
+    // decode to the same bytes, proving the -/_ -> +// substitution.
+    const fromUrl = urlBase64ToUint8Array("_-A");
+    const fromStd = urlBase64ToUint8Array("/+A=");
+    expect(Array.from(fromUrl)).toEqual([255, 224]);
+    expect(Array.from(fromUrl)).toEqual(Array.from(fromStd));
+  });
+
+  it("pads a length that is not a multiple of four", () => {
+    // A real 65-byte P-256 VAPID public key base64url-encodes to 87 chars (no padding); the decoder
+    // must re-add the missing "=" and yield exactly 65 bytes.
+    const key = "B".repeat(87);
+    expect(urlBase64ToUint8Array(key)).toHaveLength(65);
+  });
+});
+
+describe("feature gates without browser APIs", () => {
+  it("pushSupported is false when navigator/window are absent", () => {
+    expect(pushSupported()).toBe(false);
+  });
+
+  it("notificationPermission reports unsupported when Notification is absent", () => {
+    expect(notificationPermission()).toBe("unsupported");
+  });
+});

--- a/packages/client-core/src/push/register.ts
+++ b/packages/client-core/src/push/register.ts
@@ -1,14 +1,22 @@
-// Web Push subscription + app-icon badge control for the mobile PWA (the "needs you" dot).
+// Web Push subscription + app-icon badge control, shared by BOTH client shells (the mobile PWA and
+// the desktop Cockpit). One copy of the subscribe/unsubscribe contract so the two shells never drift
+// (issue #1257: the Cockpit reuses the exact plumbing the phone shipped with in #905).
 //
-// The flow: the user taps "Enable notifications" (a user gesture, required by iOS/Android to prompt),
-// we ask for Notification permission, subscribe the browser's push manager against the Gateway's VAPID
-// public key, and register that subscription with the Gateway. From then on the Gateway pushes the
-// current "needs you" count while the app is closed, and the service worker (public/push-sw.js) draws
-// the dot. While the app is OPEN, the roster page keeps the badge in sync directly via reconcileBadge()
-// and clears it when nothing is waiting - the Gateway never pushes a zero (a push must show a
-// notification), so clearing the dot is the client's job.
+// The flow: the user turns notifications on (a user gesture - a button tap or a settings checkbox,
+// required by the browser to prompt), we ask for Notification permission, subscribe the browser's
+// push manager against the Gateway's VAPID public key, and register that subscription with the
+// Gateway. From then on the Gateway pushes the current "needs you" count while the app is closed, and
+// each shell's own service worker draws the notification (mobile: public/push-sw.js -> the app-icon
+// dot; Cockpit: public/sw.js -> a desktop notification). While the app is OPEN, the roster keeps the
+// state in sync via reconcileBadge() and clears it when nothing is waiting - the Gateway never pushes
+// a zero except the single falling-edge clear, so foreground clearing is the client's job.
+//
+// This module is shell-neutral: it only talks to the root-relative /push/* endpoints and to
+// navigator.serviceWorker.ready (whichever service worker the shell registered). The shell-specific
+// bits - the notification icon and the click-target URL - live in each shell's service worker, never
+// here.
 
-import { authHeaders } from "@devthrottle/client-core/api/client";
+import { authHeaders } from "../api/client";
 
 // Kept in sync with the tag public/push-sw.js uses, so the page can close the same notification.
 const NEEDS_YOU_TAG = "devthrottle-needs-you";
@@ -66,6 +74,15 @@ async function postSubscription(subscription: PushSubscription): Promise<void> {
   if (!res.ok) throw new Error(`POST /push/subscribe failed: ${res.status}`);
 }
 
+async function postUnsubscribe(endpoint: string): Promise<void> {
+  const res = await fetch("/push/unsubscribe", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify({ endpoint }),
+  });
+  if (!res.ok) throw new Error(`POST /push/unsubscribe failed: ${res.status}`);
+}
+
 // Ensure the browser has a push subscription and the Gateway knows about it. Idempotent: reuses an
 // existing subscription and re-registers it (a cheap upsert on the Gateway).
 async function subscribeAndRegister(): Promise<void> {
@@ -91,6 +108,35 @@ export async function enablePush(): Promise<"granted" | "denied" | "unsupported"
   if (permission !== "granted") return "denied";
   await subscribeAndRegister();
   return "granted";
+}
+
+/**
+ * Turn notifications OFF for THIS browser only: drop the browser's push subscription and tell the
+ * Gateway to forget it, so the notifier stops pushing to this device. Per-device by construction -
+ * a phone or another browser stays subscribed and keeps getting the "needs you" push (issue #1257).
+ * A no-op when this browser has no subscription. Throws on a failed Gateway call so the caller can
+ * surface the real reason (no silent success).
+ */
+export async function disablePush(): Promise<void> {
+  if (!("serviceWorker" in navigator)) return;
+  const registration = await navigator.serviceWorker.ready;
+  const subscription = await registration.pushManager.getSubscription();
+  if (subscription === null) return;
+  const { endpoint } = subscription;
+  await subscription.unsubscribe();
+  await postUnsubscribe(endpoint);
+}
+
+/**
+ * Whether THIS browser currently has a live push subscription (permission granted AND a push manager
+ * subscription present). Used to render the notifications toggle in its true state on load, so the
+ * checkbox reflects reality rather than a guess. Returns false when push is unsupported.
+ */
+export async function isPushSubscribed(): Promise<boolean> {
+  if (!pushSupported()) return false;
+  if (Notification.permission !== "granted") return false;
+  const registration = await navigator.serviceWorker.ready;
+  return (await registration.pushManager.getSubscription()) !== null;
 }
 
 /**


### PR DESCRIPTION
Closes #1257.

## What this does

Gives the desktop Cockpit the same "needs you" alerting the phone already has (#905), by reusing the **exact** Gateway web-push plumbing. **There is no new Gateway push code** - this is only the desktop-browser end of the existing pipe (`/push/vapid-public-key`, `/push/subscribe`, `/push/unsubscribe`, and `WebPushNeedsYouNotifier`, which already fans out to every subscribed device and inherits the Cockpit's device-key auth).

- **Shared push client**: moved the mobile app's `push/register.ts` into `packages/client-core/src/push/` so both shells keep one copy of the subscribe/badge contract, and added `disablePush()` / `isPushSubscribed()` (per-browser off + true toggle state).
- **Cockpit service worker** (`apps/cockpit/public/sw.js`, served at `/sw.js`, scope `/`): turns the Gateway's `{ count }` push into a real desktop notification (re-alerts on each change), closes it on the falling-edge zero, and on click focuses an existing Cockpit tab (or opens one) and lands on the single waiting session - reading the live roster to deep-link it - or the roster when several are waiting.
- **Settings > Notifications toggle** (per browser) with the standard browser permission request behind it. Turning it off unsubscribes **this browser only**; a phone and a Cockpit browser both subscribed is normal, and each clears independently (falling-edge verified for both by construction - same notifier, same store).
- Registers the SW and silently re-subscribes on startup when permission was already granted; keeps the foreground state in sync from the roster poll (`reconcileBadge`) so the notification clears the instant the last session is answered.
- Dev-only: fronts `/push` in the Cockpit vite proxy.

## Proof

- **Typecheck** (all three workspaces), **lint**: clean.
- **Unit tests**: `client-core` 206 passed (incl. 5 new push tests: VAPID base64url->bytes conversion + support gates); `cockpit` 76 passed (incl. 9 new service-worker behavior tests: notification wording per count, falling-edge close, click deep-link to the one waiting session, roster fallback, existing-tab focus, ignoring the `/m` tab, foreground clear).
- **Cockpit build**: succeeds; `sw.js` is emitted to the dist root (so the Gateway serves it at `/sw.js`). **Mobile build**: succeeds (moved import).
- **Vite dev server + Playwright** end-to-end against the real shipped UI (Gateway mocked via routing; the only doubles are the OS permission prompt and the browser push service - FCM - both owner/infra, not our code): `/settings` renders the Notifications card, the **service worker registers with scope `http://localhost:5199/`** (whole Cockpit), toggling **on** fetches the VAPID key and sends `POST /push/subscribe` with the browser subscription, and toggling **off** sends `POST /push/unsubscribe` for the same endpoint. Screenshots captured off -> on -> off.

## Owner-only / not covered here

- The real OS "Allow notifications?" prompt and a real push delivered by the browser's push service need a human on a real machine; the Playwright run doubles exactly those two infra pieces and drives everything else for real.
- Not deployed to the live Gateway (sole-deployer rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)