### PR TITLE
feat(cockpit): open on the Fleet Map by default and remember the grouping

### DIFF
--- a/apps/cockpit/src/AppShell.tsx
+++ b/apps/cockpit/src/AppShell.tsx
@@ -11,14 +11,16 @@ import { NavLink, Outlet, useLocation } from "react-router-dom";
 // themselves - see SessionsView - not to this frame.
 
 // The left-rail destinations. Each maps to a real routed page (the epic ported them in one at a time).
+// The Fleet Map is first and is the default landing: a fresh boot at "/" redirects to it, so the
+// Cockpit opens on the whole-fleet picture (main.tsx). Sessions lives at its own /sessions home.
 // `subtree` marks a destination active for a route family that does NOT share its path prefix: the
-// Sessions index lives at "/" (matched with `end`, so it does not light up on every route), but the
-// session detail routes into "/session/:id" - a different first segment - so it needs an explicit
-// subtree so Sessions stays highlighted while a session is being driven (the Directors item does not,
-// because "/directors/:id" already shares the "/directors" prefix NavLink matches by default).
+// Sessions home lives at "/sessions", but the session detail routes into "/session/:id" - a different
+// path - so it needs an explicit subtree so Sessions stays highlighted while a session is being driven
+// (the Directors item does not, because "/directors/:id" already shares the "/directors" prefix NavLink
+// matches by default).
 const NAV_ITEMS: ReadonlyArray<{ to: string; label: string; subtree?: string }> = [
-  { to: "/", label: "Sessions", subtree: "/session" },
   { to: "/fleet-map", label: "Fleet Map" },
+  { to: "/sessions", label: "Sessions", subtree: "/session" },
   { to: "/directors", label: "Directors" },
   { to: "/schedule", label: "Schedule" },
   // "Lists" (work lists) is hidden from the rail for now - GitHub issues already are the queue, so

--- a/apps/cockpit/src/exes/ExesView.tsx
+++ b/apps/cockpit/src/exes/ExesView.tsx
@@ -113,7 +113,7 @@ export function ExesView() {
         <span className="ex-stats">{statsText}</span>
         <StatusMessage flash={result.flash} />
         <span className="ex-spacer" />
-        <Link className="ex-link ex-link-accent" to="/">
+        <Link className="ex-link ex-link-accent" to="/sessions">
           sessions
         </Link>
         <Link className="ex-link ex-link-accent" to="/transcripts">

--- a/apps/cockpit/src/fleet/FleetMapView.tsx
+++ b/apps/cockpit/src/fleet/FleetMapView.tsx
@@ -44,6 +44,21 @@ const PIVOTS: ReadonlyArray<{ key: Pivot; label: string; kindLabel: string }> = 
   { key: "list", label: "Fleet list", kindLabel: "Session" },
 ];
 
+// The grouping is sticky per browser: the map opens on whatever the user last chose (rather than a
+// "smart" default that guesses from the fleet shape), so returning to the map lands them exactly where
+// they left off. Defaults to "By machine" the first time, or when storage is unavailable.
+const PIVOT_STORAGE_KEY = "cockpit.fleetMapPivot";
+
+function initialPivot(): Pivot {
+  try {
+    const saved = window.localStorage.getItem(PIVOT_STORAGE_KEY);
+    if (saved === "machine" || saved === "repo" || saved === "agent" || saved === "list") return saved;
+  } catch {
+    /* storage unavailable (private mode) - fall through to the default */
+  }
+  return "machine";
+}
+
 // A group of sessions that share a team (SessionDto.groupId), rendered as a lead/worker cluster.
 interface Team {
   groupId: string;
@@ -66,7 +81,17 @@ export function FleetMapView() {
   const [machineErrors, setMachineErrors] = useState<MachineError[]>([]);
   const [directors, setDirectors] = useState<DirectorReachability[]>([]);
   const [lastError, setLastError] = useState<string | null>(null);
-  const [pivot, setPivot] = useState<Pivot>("machine");
+  const [pivot, setPivotState] = useState<Pivot>(initialPivot);
+  // Persist the choice so the map reopens on it (see initialPivot). Wraps the raw setter so every
+  // pivot change - from any button - writes through to storage.
+  const setPivot = useCallback((next: Pivot) => {
+    setPivotState(next);
+    try {
+      window.localStorage.setItem(PIVOT_STORAGE_KEY, next);
+    } catch {
+      /* storage unavailable (private mode) - the selection still applies this session */
+    }
+  }, []);
   // Title search (issue #1211): a case-insensitive substring filter over the session name. It hides
   // non-matches and NEVER reorders what remains (see the lanes memo below). Not persisted across
   // reloads.

--- a/apps/cockpit/src/main.tsx
+++ b/apps/cockpit/src/main.tsx
@@ -96,26 +96,28 @@ const router = createBrowserRouter(
         {
           element: <AppShell />,
           children: [
+            // The default landing is the Fleet Map: a fresh boot at "/" redirects there so the Cockpit
+            // opens on the whole-fleet picture (the first rail item), not an empty session prompt.
+            { index: true, element: <Navigate to="/fleet-map" replace /> },
             // The Sessions experience (issue #972): the fleet roster stays mounted on the left while the
             // selected session's detail (the interactive terminal from #971, the action bar, the composer,
-            // the queue, and the screenshots) routes into the right region. The index route ("/") shows a
+            // the queue, and the screenshots) routes into the right region. The /sessions home shows a
             // "pick a session" prompt; /session/{sid} drives that session.
             {
               element: <SessionsView />,
               children: [
-                { index: true, element: <SessionsEmpty /> },
+                { path: "sessions", element: <SessionsEmpty /> },
                 { path: "session/:sessionId", element: <SessionDetail /> },
               ],
             },
             // Roster/detail entry-page alignment (issue #978): the Blazor Cockpit reached the one session
-            // experience through several paths - /cockpit and /sessions (the list/home) and /cockpit/{sid}
-            // and /sessions/{sid} (drive / read-mostly detail). The React shell has ONE rail-plus-terminal
+            // experience through several paths - /cockpit (the list/home) and /cockpit/{sid} and
+            // /sessions/{sid} (drive / read-mostly detail). The React shell has ONE rail-plus-terminal
             // core (the routes above), so those Blazor paths redirect into it rather than duplicating the
             // session view. This keeps every Blazor entry path reaching a page for the cutover (#979): the
-            // list/home paths land on the roster index, the id paths on that session in the core.
-            { path: "/cockpit", element: <Navigate to="/" replace /> },
+            // list/home paths land on the /sessions home, the id paths on that session in the core.
+            { path: "/cockpit", element: <Navigate to="/sessions" replace /> },
             { path: "/cockpit/:sessionId", element: <SessionRedirect /> },
-            { path: "/sessions", element: <Navigate to="/" replace /> },
             { path: "/sessions/:sessionId", element: <SessionRedirect /> },
             // The fleet + machine views (issue #975): the Fleet cards dashboard, the Directors registry
             // table, and the standalone Director-detail page. Ported one-to-one from the Blazor

--- a/apps/cockpit/src/panes/NotFound.tsx
+++ b/apps/cockpit/src/panes/NotFound.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 
 // The real 404 page for the desktop Cockpit. A hard navigation to a client-side route the router
 // does not know (a stale bookmark, a mistyped path) lands here instead of a developer placeholder.
-// It states plainly that the page does not exist and offers the way back to Sessions (the "/" index).
+// It states plainly that the page does not exist and offers the way back to Sessions (the /sessions home).
 export function NotFound() {
   return (
     <section className="pane">
@@ -11,7 +11,7 @@ export function NotFound() {
         The page you were looking for does not exist. It may have moved, or the link may be out of
         date.
       </p>
-      <Link className="pane-link" to="/">
+      <Link className="pane-link" to="/sessions">
         Go to Sessions
       </Link>
     </section>

--- a/apps/cockpit/src/sessions/SessionDetail.tsx
+++ b/apps/cockpit/src/sessions/SessionDetail.tsx
@@ -87,7 +87,7 @@ export function SessionDetail() {
           </button>
           {/* The session menu (issue #1214): Rename, Hold/Resume, Handover info, Close - top right of
               the session header, driving the shared Gateway calls. */}
-          {selected && <SessionMenu session={selected} variant="page" onClosed={() => navigate("/")} />}
+          {selected && <SessionMenu session={selected} variant="page" onClosed={() => navigate("/sessions")} />}
         </div>
 
         <div className="session-content">

--- a/apps/cockpit/src/sessions/SessionRedirect.tsx
+++ b/apps/cockpit/src/sessions/SessionRedirect.tsx
@@ -5,12 +5,12 @@ import { Navigate, useParams } from "react-router-dom";
 // page). The React shell has ONE session experience: the rail-plus-terminal core at /session/{sid}
 // (the roster on the left, the live terminal + brief + history + action bar on the right). To keep
 // every Blazor entry path reaching a page after the cutover (#979) WITHOUT standing up a duplicate
-// session view, those id-carrying paths redirect into that one core. The bare list/home paths
-// (/cockpit, /sessions) redirect to the index (the roster is the sessions list), wired in main.tsx.
+// session view, those id-carrying paths redirect into that one core. The bare list/home path
+// (/cockpit) redirects to the /sessions home (the roster is the sessions list), wired in main.tsx.
 export function SessionRedirect() {
   const { sessionId } = useParams();
   if (sessionId === undefined || sessionId.length === 0) {
-    return <Navigate to="/" replace />;
+    return <Navigate to="/sessions" replace />;
   }
   return <Navigate to={`/session/${encodeURIComponent(sessionId)}`} replace />;
 }


### PR DESCRIPTION
## What

Make the **Fleet Map** the Cockpit's default view, and let it remember how the user last grouped it.

### Fleet Map is the default landing and the first rail item
- The left rail now lists **Fleet Map** first, then Sessions.
- A fresh boot at `/` redirects to `/fleet-map`, so the Cockpit opens on the whole-fleet picture instead of an empty "pick a session" prompt.
- The Sessions experience moves to its own `/sessions` home. The roster + terminal core at `/session/:id` is unchanged.
- Everything that used to return to the Sessions home now points at `/sessions`: the `/cockpit` and `/sessions/:id` entry redirects, the `SessionRedirect` fallback, the close-session return in `SessionDetail`, and the "sessions" / "Go to Sessions" links in Exes and the Not-found page. The `/fleet` bookmark redirect to `/fleet-map` is unchanged.

### Remember the grouping instead of guessing it
- The by-machine / by-repository / by-agent / Fleet-list pivot is now **sticky per browser** (localStorage `cockpit.fleetMapPivot`). Returning to the map lands on whatever the user last chose.
- This replaces the idea of an "intelligent" default that guesses from the fleet shape. It defaults to **By machine** the first time, or when storage is unavailable.

## Notes
- Cockpit-only change (`apps/cockpit`), 7 files, no backend surface touched.
- Built from a clean worktree off `origin/main` (this branch was based on a stale main, so the edits were redone against current file contents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
