### PR TITLE
fix(terminal): replay history at the width it was written for (fixes wide-line shatter, #1304)

### DIFF
--- a/src/CcDirector.Core.Tests/CircularTerminalBufferResizeMarkTests.cs
+++ b/src/CcDirector.Core.Tests/CircularTerminalBufferResizeMarkTests.cs
@@ -1,0 +1,135 @@
+using CcDirector.Core.Memory;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Resize marks record the terminal geometry against byte positions in the ring buffer, so a
+/// replay can parse every byte at the width it was originally emitted for (issue #1304).
+/// </summary>
+public class CircularTerminalBufferResizeMarkTests
+{
+    [Fact]
+    public void GetResizeMarksSince_NoMarksRecorded_ReturnsZeroGeometry()
+    {
+        var buffer = new CircularTerminalBuffer(1024);
+        buffer.Write(new byte[50]);
+
+        var (startCols, startRows, marks) = buffer.GetResizeMarksSince(0);
+
+        Assert.Equal(0, startCols);
+        Assert.Equal(0, startRows);
+        Assert.Empty(marks);
+    }
+
+    [Fact]
+    public void GetResizeMarksSince_ReturnsGeometryInEffectAndLaterMarks()
+    {
+        var buffer = new CircularTerminalBuffer(1024);
+        buffer.RecordResize(150, 40);          // position 0
+        buffer.Write(new byte[100]);
+        buffer.RecordResize(129, 40);          // position 100
+        buffer.Write(new byte[50]);
+
+        var (startCols, startRows, marks) = buffer.GetResizeMarksSince(0);
+
+        Assert.Equal(150, startCols);
+        Assert.Equal(40, startRows);
+        var mark = Assert.Single(marks);
+        Assert.Equal(100, mark.Position);
+        Assert.Equal(129, mark.Cols);
+        Assert.Equal(40, mark.Rows);
+    }
+
+    [Fact]
+    public void GetResizeMarksSince_MarkExactlyAtPosition_CountsAsStartGeometry()
+    {
+        var buffer = new CircularTerminalBuffer(1024);
+        buffer.RecordResize(150, 40);          // position 0
+        buffer.Write(new byte[100]);
+        buffer.RecordResize(129, 40);          // position 100
+
+        var (startCols, startRows, marks) = buffer.GetResizeMarksSince(100);
+
+        Assert.Equal(129, startCols);
+        Assert.Equal(40, startRows);
+        Assert.Empty(marks);
+    }
+
+    [Fact]
+    public void RecordResize_SameGeometryAsNewestMark_IsCollapsed()
+    {
+        var buffer = new CircularTerminalBuffer(1024);
+        buffer.RecordResize(150, 40);
+        buffer.Write(new byte[10]);
+        buffer.RecordResize(150, 40);          // duplicate geometry, no information gained
+
+        var (_, _, marks) = buffer.GetResizeMarksSince(-1);
+
+        Assert.Single(marks);
+    }
+
+    [Fact]
+    public void RecordResize_InvalidGeometry_IsIgnored()
+    {
+        var buffer = new CircularTerminalBuffer(1024);
+        buffer.RecordResize(0, 40);
+        buffer.RecordResize(150, -1);
+
+        var (startCols, startRows, marks) = buffer.GetResizeMarksSince(0);
+
+        Assert.Equal(0, startCols);
+        Assert.Equal(0, startRows);
+        Assert.Empty(marks);
+    }
+
+    [Fact]
+    public void RecordResize_PrunesMarksTheRingRolledPast_KeepingTheBaseline()
+    {
+        // Capacity 100: after writing 250 bytes the ring starts at position 150.
+        var buffer = new CircularTerminalBuffer(100);
+        buffer.RecordResize(80, 24);           // position 0   - rolled past, prunable
+        buffer.Write(new byte[50]);
+        buffer.RecordResize(100, 30);          // position 50  - rolled past, but newest before
+                                               //                ring start: the baseline, kept
+        buffer.Write(new byte[200]);           // total 250, ring start 150
+        buffer.RecordResize(120, 40);          // position 250 - triggers pruning
+
+        var (startCols, startRows, marks) = buffer.GetResizeMarksSince(150);
+
+        Assert.Equal(100, startCols);
+        Assert.Equal(30, startRows);
+        var mark = Assert.Single(marks);
+        Assert.Equal(250, mark.Position);
+        Assert.Equal(120, mark.Cols);
+        Assert.Equal(40, mark.Rows);
+    }
+
+    [Fact]
+    public void Clear_DropsRecordedMarks()
+    {
+        var buffer = new CircularTerminalBuffer(1024);
+        buffer.RecordResize(150, 40);
+        buffer.Write(new byte[10]);
+
+        buffer.Clear();
+
+        var (startCols, startRows, marks) = buffer.GetResizeMarksSince(0);
+        Assert.Equal(0, startCols);
+        Assert.Equal(0, startRows);
+        Assert.Empty(marks);
+    }
+
+    [Fact]
+    public void RecordResize_AfterDispose_DoesNotThrow()
+    {
+        var buffer = new CircularTerminalBuffer(64);
+        buffer.Dispose();
+
+        var exRecord = Record.Exception(() => buffer.RecordResize(150, 40));
+        var exGet = Record.Exception(() => _ = buffer.GetResizeMarksSince(0));
+
+        Assert.Null(exRecord);
+        Assert.Null(exGet);
+    }
+}

--- a/src/CcDirector.Core.Tests/SegmentedReplayTests.cs
+++ b/src/CcDirector.Core.Tests/SegmentedReplayTests.cs
@@ -1,0 +1,241 @@
+using System.Text;
+using CcDirector.Terminal.Core;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// SegmentedReplay parses raw terminal bytes at the geometry each byte was originally emitted
+/// for, applying recorded resizes at their byte positions (issue #1304). The invariant under
+/// test: a segmented replay produces exactly the grid and scrollback that a live parser
+/// produced when it was resized at the same points - and therefore wide committed history is
+/// never falsely re-wrapped at a narrower later width.
+/// </summary>
+public class SegmentedReplayTests
+{
+    private const int MaxScrollback = 1000;
+
+    // ---------------------------------------------------------------- helpers
+
+    private static byte[] Lines(string prefix, int count, int width)
+    {
+        var sb = new StringBuilder();
+        for (int i = 0; i < count; i++)
+        {
+            string label = $"{prefix}{i:D2}";
+            sb.Append(label).Append('=', width - label.Length).Append("\r\n");
+        }
+        return Encoding.ASCII.GetBytes(sb.ToString());
+    }
+
+    private static string RowText(TerminalCell[] row)
+    {
+        var chars = new char[row.Length];
+        for (int i = 0; i < row.Length; i++)
+            chars[i] = row[i].Character == '\0' ? ' ' : row[i].Character;
+        return new string(chars).TrimEnd();
+    }
+
+    private static string GridText(TerminalCell[,] cells)
+    {
+        int cols = cells.GetLength(0), rows = cells.GetLength(1);
+        var sb = new StringBuilder();
+        for (int r = 0; r < rows; r++)
+        {
+            for (int c = 0; c < cols; c++)
+                sb.Append(cells[c, r].Character == '\0' ? ' ' : cells[c, r].Character);
+            sb.Append('\n');
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>The live resize path: truncate-copy into a new grid, then UpdateGrid.</summary>
+    private static TerminalCell[,] LiveResize(AnsiParser parser, TerminalCell[,] cells, int newCols, int newRows)
+    {
+        var next = new TerminalCell[newCols, newRows];
+        int copyCols = Math.Min(cells.GetLength(0), newCols);
+        int copyRows = Math.Min(cells.GetLength(1), newRows);
+        for (int r = 0; r < copyRows; r++)
+            for (int c = 0; c < copyCols; c++)
+                next[c, r] = cells[c, r];
+        parser.UpdateGrid(next, newCols, newRows);
+        return next;
+    }
+
+    // ------------------------------------------------------------------ tests
+
+    [Fact]
+    public void Replay_NoResizes_MatchesSinglePassParse()
+    {
+        byte[] data = Lines("line", 30, 70);
+
+        var singleScrollback = new List<TerminalCell[]>();
+        var singleCells = new TerminalCell[80, 10];
+        var singleParser = new AnsiParser(singleCells, 80, 10, singleScrollback, MaxScrollback);
+        singleParser.Parse(data);
+
+        var replayScrollback = new List<TerminalCell[]>();
+        var (replayCells, _) = SegmentedReplay.Replay(
+            data, 80, 10, Array.Empty<ReplayResize>(), 80, 10, replayScrollback, MaxScrollback);
+
+        Assert.Equal(GridText(singleCells), GridText(replayCells));
+        Assert.Equal(singleScrollback.Count, replayScrollback.Count);
+        for (int i = 0; i < singleScrollback.Count; i++)
+            Assert.Equal(RowText(singleScrollback[i]), RowText(replayScrollback[i]));
+    }
+
+    [Fact]
+    public void Replay_MatchesLiveParserAcrossResize()
+    {
+        // Live history: 20 wide lines at 150 columns, then a shrink to 129, then 10 more lines.
+        byte[] chunk1 = Lines("WIDE", 20, 142);
+        byte[] chunk2 = Lines("post", 10, 100);
+        byte[] all = chunk1.Concat(chunk2).ToArray();
+
+        // The live parser saw: parse chunk1 at 150x8, resize to 129x8, parse chunk2.
+        var liveScrollback = new List<TerminalCell[]>();
+        var liveCells = new TerminalCell[150, 8];
+        var liveParser = new AnsiParser(liveCells, 150, 8, liveScrollback, MaxScrollback);
+        liveParser.Parse(chunk1);
+        liveCells = LiveResize(liveParser, liveCells, 129, 8);
+        liveParser.Parse(chunk2);
+
+        // The segmented replay of the recorded bytes plus the recorded resize.
+        var replayScrollback = new List<TerminalCell[]>();
+        var (replayCells, _) = SegmentedReplay.Replay(
+            all, 150, 8,
+            new[] { new ReplayResize(chunk1.Length, 129, 8) },
+            129, 8, replayScrollback, MaxScrollback);
+
+        Assert.Equal(GridText(liveCells), GridText(replayCells));
+        Assert.Equal(liveScrollback.Count, replayScrollback.Count);
+        for (int i = 0; i < liveScrollback.Count; i++)
+        {
+            Assert.Equal(liveScrollback[i].Length, replayScrollback[i].Length);
+            Assert.Equal(RowText(liveScrollback[i]), RowText(replayScrollback[i]));
+        }
+    }
+
+    [Fact]
+    public void Replay_WideHistoryShrunkLater_KeepsOriginalWidthIntact()
+    {
+        // The bug in issue #1304: 142-column content written at 150 columns, replayed after
+        // the pane shrank to 129, was falsely wrapped into a full row plus a remainder row.
+        byte[] chunk1 = Lines("WIDE", 20, 142);
+        byte[] chunk2 = Lines("post", 10, 100);
+        byte[] all = chunk1.Concat(chunk2).ToArray();
+
+        var scrollback = new List<TerminalCell[]>();
+        SegmentedReplay.Replay(
+            all, 150, 8,
+            new[] { new ReplayResize(chunk1.Length, 129, 8) },
+            129, 8, scrollback, MaxScrollback);
+
+        // Rows that reached scrollback BEFORE the shrink keep their full emission
+        // width. (Rows still on screen at the shrink are truncated by the live
+        // truncate-copy - faithful to what the live parser did - and the real
+        // application repaints those; a synthetic stream has no repaint.)
+        var intactWideRows = scrollback.Where(row => RowText(row).Length == 142).ToList();
+        Assert.NotEmpty(intactWideRows);
+        foreach (var row in intactWideRows)
+        {
+            Assert.StartsWith("WIDE", RowText(row));
+            Assert.Equal(150, row.Length); // stored at its emission width, not re-wrapped
+        }
+
+        // The defining symptom of the bug is absent: no shattered remainder rows,
+        // which a 142-column line falsely wrapped at 129 columns would leave as a
+        // bare run of the padding character.
+        Assert.DoesNotContain(scrollback, row =>
+        {
+            string text = RowText(row);
+            return text.Length > 0 && text.Length <= 142 - 129 && text.All(ch => ch == '=');
+        });
+    }
+
+    [Fact]
+    public void Replay_GrowingBackAfterShrink_RestoresWideHistory()
+    {
+        // Shrink to 129 then widen back to 150: wide rows stay intact throughout,
+        // which the old parse-everything-at-current-width rebuild could not do.
+        byte[] chunk1 = Lines("WIDE", 20, 142);
+        byte[] chunk2 = Lines("post", 10, 100);
+        byte[] all = chunk1.Concat(chunk2).ToArray();
+
+        var scrollback = new List<TerminalCell[]>();
+        var (cells, _) = SegmentedReplay.Replay(
+            all, 150, 8,
+            new[] { new ReplayResize(chunk1.Length, 129, 8) },
+            150, 8, scrollback, MaxScrollback);
+
+        Assert.Equal(150, cells.GetLength(0));
+        // The rows that reached scrollback before the shrink survived it at full
+        // width and are fully visible again at 150 columns.
+        var intactWideRows = scrollback.Where(row => RowText(row).Length == 142).ToList();
+        Assert.NotEmpty(intactWideRows);
+        foreach (var row in intactWideRows)
+            Assert.Equal(150, row.Length);
+    }
+
+    [Fact]
+    public void Replay_FinalGeometryIsAlwaysApplied()
+    {
+        byte[] data = Lines("line", 5, 40);
+
+        var (cells, parser) = SegmentedReplay.Replay(
+            data, 150, 40, Array.Empty<ReplayResize>(), 129, 41,
+            new List<TerminalCell[]>(), MaxScrollback);
+
+        Assert.Equal(129, cells.GetLength(0));
+        Assert.Equal(41, cells.GetLength(1));
+        // The parser was resized along with the grid, ready for live continuation.
+        var (cursorCol, cursorRow) = parser.GetCursorPosition();
+        Assert.InRange(cursorCol, 0, 128);
+        Assert.InRange(cursorRow, 0, 40);
+    }
+
+    [Fact]
+    public void Replay_EmptyData_ReturnsGridAtFinalGeometry()
+    {
+        var (cells, _) = SegmentedReplay.Replay(
+            Array.Empty<byte>(), 150, 40, Array.Empty<ReplayResize>(), 129, 41,
+            new List<TerminalCell[]>(), MaxScrollback);
+
+        Assert.Equal(129, cells.GetLength(0));
+        Assert.Equal(41, cells.GetLength(1));
+    }
+
+    [Fact]
+    public void Replay_MultipleResizes_AppliedInOrder()
+    {
+        // Three eras: 150, 133, 129 - the exact sequence observed in issue #1304.
+        byte[] chunk1 = Lines("era1", 10, 142);
+        byte[] chunk2 = Lines("era2", 10, 120);
+        byte[] chunk3 = Lines("era3", 10, 100);
+        byte[] all = chunk1.Concat(chunk2).Concat(chunk3).ToArray();
+
+        var scrollback = new List<TerminalCell[]>();
+        SegmentedReplay.Replay(
+            all, 150, 8,
+            new[]
+            {
+                new ReplayResize(chunk1.Length, 133, 8),
+                new ReplayResize(chunk1.Length + chunk2.Length, 129, 8),
+            },
+            129, 8, scrollback, MaxScrollback);
+
+        // Rows that reached scrollback within their own era keep that era's width.
+        var era1Intact = scrollback.Where(r => RowText(r).StartsWith("era1") && RowText(r).Length == 142).ToList();
+        Assert.NotEmpty(era1Intact);
+        foreach (var row in era1Intact)
+            Assert.Equal(150, row.Length);
+
+        // Every era2 row's 120-character content is intact (120 fits both later widths,
+        // so none may wrap). Rows scrolled out during their own era are stored at 133;
+        // rows still on screen at the era3 shrink are stored at 129 - both unharmed.
+        var era2Intact = scrollback.Where(r => RowText(r).StartsWith("era2") && RowText(r).Length == 120).ToList();
+        Assert.NotEmpty(era2Intact);
+        Assert.All(era2Intact, row => Assert.True(row.Length >= 120));
+        Assert.Contains(era2Intact, row => row.Length == 133);
+    }
+}

--- a/src/CcDirector.Core/Backends/ConPtyBackend.cs
+++ b/src/CcDirector.Core/Backends/ConPtyBackend.cs
@@ -50,6 +50,10 @@ public sealed class ConPtyBackend : ISessionBackend
         // Create ConPTY with terminal dimensions
         _console = PseudoConsole.Create(cols, rows);
 
+        // Record the spawn geometry before any output lands, so a replay knows the
+        // width the very first bytes were emitted for (issue #1304).
+        _buffer!.RecordResize(cols, rows);
+
         // Create process host
         _processHost = new ProcessHost(_console);
         _processHost.OnExited += OnProcessExited;
@@ -88,6 +92,10 @@ public sealed class ConPtyBackend : ISessionBackend
     public void Resize(short cols, short rows)
     {
         if (_disposed || _console == null) return;
+        // Mark the geometry change at the current byte position BEFORE the console
+        // resizes, so the repaint bytes the resize triggers fall after the mark and
+        // are replayed at the new width (issue #1304).
+        _buffer?.RecordResize(cols, rows);
         try
         {
             _console.Resize(cols, rows);

--- a/src/CcDirector.Core/Backends/UnixPtyBackend.cs
+++ b/src/CcDirector.Core/Backends/UnixPtyBackend.cs
@@ -56,6 +56,10 @@ public sealed class UnixPtyBackend : ISessionBackend
         // Create Unix PTY with terminal dimensions
         _console = UnixPseudoConsole.Create(cols, rows);
 
+        // Record the spawn geometry before any output lands, so a replay knows the
+        // width the very first bytes were emitted for (issue #1304).
+        _buffer!.RecordResize(cols, rows);
+
         // Create process host
         _processHost = new UnixProcessHost(_console);
         _processHost.OnExited += OnProcessExited;
@@ -94,6 +98,10 @@ public sealed class UnixPtyBackend : ISessionBackend
     public void Resize(short cols, short rows)
     {
         if (_disposed || _console == null) return;
+        // Mark the geometry change at the current byte position BEFORE the console
+        // resizes, so the repaint bytes the resize triggers fall after the mark and
+        // are replayed at the new width (issue #1304).
+        _buffer?.RecordResize(cols, rows);
         try
         {
             _console.Resize(cols, rows);

--- a/src/CcDirector.Core/Memory/CircularTerminalBuffer.cs
+++ b/src/CcDirector.Core/Memory/CircularTerminalBuffer.cs
@@ -3,6 +3,14 @@ using CcDirector.Core.Utilities;
 namespace CcDirector.Core.Memory;
 
 /// <summary>
+/// A terminal geometry change recorded against the raw byte stream: every byte written at or
+/// after <see cref="Position"/> (and before the next mark) was emitted by an application that
+/// believed the terminal was <see cref="Cols"/> x <see cref="Rows"/>. Replaying those bytes at
+/// any other width falsely re-wraps them (issue #1304).
+/// </summary>
+public readonly record struct TerminalResizeMark(long Position, short Cols, short Rows);
+
+/// <summary>
 /// Thread-safe circular byte buffer for raw terminal output.
 /// Stores raw ANSI bytes with no line parsing.
 /// </summary>
@@ -16,6 +24,10 @@ public sealed class CircularTerminalBuffer : IDisposable
     private long _totalWritten;   // Monotonic counter - never wraps
     private DateTime _lastWriteAtUtc = DateTime.MinValue;
     private volatile bool _disposed;
+
+    // Terminal geometry history for faithful replay (issue #1304). Small: one entry
+    // per real resize, pruned as the ring rolls past them. Guarded by _lock.
+    private readonly List<TerminalResizeMark> _resizeMarks = new();
 
     // Lock contention tracking
     private int _writeLockWaitCount;
@@ -250,6 +262,89 @@ public sealed class CircularTerminalBuffer : IDisposable
         }
     }
 
+    /// <summary>
+    /// Record that the terminal was resized to <paramref name="cols"/> x <paramref name="rows"/>
+    /// at the current write position. Bytes written from this point on were emitted for the new
+    /// geometry; <see cref="GetResizeMarksSince"/> lets a replay apply each recorded size at the
+    /// right byte, so history is never re-wrapped at a width it was not written for (issue #1304).
+    /// A call with the same geometry as the newest mark is collapsed (no information gained).
+    /// </summary>
+    public void RecordResize(short cols, short rows)
+    {
+        if (_disposed) return;
+        if (cols <= 0 || rows <= 0) return;
+
+        try { _lock.EnterWriteLock(); }
+        catch (ObjectDisposedException) { return; } // raced with Dispose
+        try
+        {
+            if (_resizeMarks.Count > 0)
+            {
+                var newest = _resizeMarks[^1];
+                if (newest.Cols == cols && newest.Rows == rows)
+                    return;
+            }
+
+            _resizeMarks.Add(new TerminalResizeMark(_totalWritten, cols, rows));
+            PruneStaleResizeMarks();
+        }
+        finally
+        {
+            _lock.ExitWriteLock();
+        }
+    }
+
+    /// <summary>
+    /// Return the geometry in effect at <paramref name="position"/> plus every mark after it,
+    /// in order. StartCols/StartRows are (0, 0) when no mark at or before the position exists
+    /// (a buffer from before marks were recorded); the caller must then choose its own
+    /// starting geometry.
+    /// </summary>
+    public (short StartCols, short StartRows, IReadOnlyList<TerminalResizeMark> Marks) GetResizeMarksSince(long position)
+    {
+        if (!TryEnterReadLock()) return (0, 0, Array.Empty<TerminalResizeMark>());
+        try
+        {
+            short startCols = 0, startRows = 0;
+            var later = new List<TerminalResizeMark>();
+            foreach (var mark in _resizeMarks)
+            {
+                if (mark.Position <= position)
+                {
+                    startCols = mark.Cols;
+                    startRows = mark.Rows;
+                }
+                else
+                {
+                    later.Add(mark);
+                }
+            }
+            return (startCols, startRows, later);
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+    }
+
+    /// <summary>
+    /// Drop marks the ring has rolled past, keeping the newest mark at or before the ring
+    /// start: that one defines the geometry of the oldest replayable byte. Caller must hold
+    /// the write lock.
+    /// </summary>
+    private void PruneStaleResizeMarks()
+    {
+        long ringStart = Math.Max(0, _totalWritten - _capacity);
+        int newestAtOrBefore = -1;
+        for (int i = 0; i < _resizeMarks.Count; i++)
+        {
+            if (_resizeMarks[i].Position <= ringStart) newestAtOrBefore = i;
+            else break;
+        }
+        if (newestAtOrBefore > 0)
+            _resizeMarks.RemoveRange(0, newestAtOrBefore);
+    }
+
     /// <summary>Reset the buffer.</summary>
     public void Clear()
     {
@@ -261,6 +356,7 @@ public sealed class CircularTerminalBuffer : IDisposable
             Array.Clear(_buffer);
             _writeHead = 0;
             _totalWritten = 0;
+            _resizeMarks.Clear();
         }
         finally
         {

--- a/src/CcDirector.Terminal.Avalonia/TerminalControl.cs
+++ b/src/CcDirector.Terminal.Avalonia/TerminalControl.cs
@@ -386,9 +386,12 @@ public class TerminalControl : Control
 
     /// <summary>
     /// Rebuild the cell grid and scrollback by replaying the entire PTY ring
-    /// buffer through a fresh ANSI parser at the current dimensions. The ring
-    /// holds the last ~2 MB of raw output, so this gives back scrollback that
-    /// survives any dimension change without juggling cached cell grids.
+    /// buffer through a fresh ANSI parser. The ring holds the last ~2 MB of raw
+    /// output plus the resize marks recorded when it was written, so the replay
+    /// parses every byte at the geometry it was originally emitted for (issue
+    /// #1304): committed history keeps its original width instead of being
+    /// falsely re-wrapped at today's width, and rows wider than the viewport
+    /// clip at the right edge, which the renderers already handle.
     /// Caller must guarantee Bounds and _session.Buffer are valid.
     /// </summary>
     private void RebuildFromBuffer()
@@ -400,16 +403,35 @@ public class TerminalControl : Control
         _lastScrollTotal = 0;
         _pathExistsCache.Clear();
 
-        _parser = new AnsiParser(_cells, _cols, _rows, _scrollback, ScrollbackLines, FileLog.Write);
-
         long replayedBytes = 0;
+        int replaySegments = 0;
         if (_session?.Buffer != null)
         {
             var (data, newPos) = _session.Buffer.GetWrittenSince(0);
-            if (data.Length > 0)
-                _parser.Parse(data);
+            long dataStart = newPos - data.Length;
+            var (startCols, startRows, marks) = _session.Buffer.GetResizeMarksSince(dataStart);
+
+            // A buffer from before resize marks were recorded reports (0, 0):
+            // parse at the current dimensions, which is the pre-#1304 behavior.
+            int firstCols = startCols > 0 ? startCols : _cols;
+            int firstRows = startRows > 0 ? startRows : _rows;
+
+            var resizes = new List<ReplayResize>(marks.Count);
+            foreach (var mark in marks)
+                resizes.Add(new ReplayResize((int)(mark.Position - dataStart), mark.Cols, mark.Rows));
+
+            var (cells, parser) = SegmentedReplay.Replay(
+                data, firstCols, firstRows, resizes, _cols, _rows,
+                _scrollback, ScrollbackLines, FileLog.Write);
+            _cells = cells;
+            _parser = parser;
             _bufferPosition = newPos;
             replayedBytes = data.Length;
+            replaySegments = resizes.Count + 1;
+        }
+        else
+        {
+            _parser = new AnsiParser(_cells, _cols, _rows, _scrollback, ScrollbackLines, FileLog.Write);
         }
 
         // After replay the parser may be on the alternate screen, drawing into its own buffer;
@@ -420,7 +442,7 @@ public class TerminalControl : Control
         // first live poll computes a delta of zero, not the whole replayed history (issue #761).
         _lastScrollTotal = _parser?.TotalLinesScrolled ?? 0;
 
-        FileLog.Write($"[TerminalControl] RebuildFromBuffer: cols={_cols}, rows={_rows}, replayedBytes={replayedBytes}, scrollback={_scrollback.Count}");
+        FileLog.Write($"[TerminalControl] RebuildFromBuffer: cols={_cols}, rows={_rows}, replayedBytes={replayedBytes}, segments={replaySegments}, scrollback={_scrollback.Count}");
     }
 
     /// <summary>

--- a/src/CcDirector.Terminal.Core/SegmentedReplay.cs
+++ b/src/CcDirector.Terminal.Core/SegmentedReplay.cs
@@ -1,0 +1,86 @@
+namespace CcDirector.Terminal.Core;
+
+/// <summary>
+/// A resize boundary inside a raw replay byte stream: at byte offset <see cref="Offset"/>
+/// (relative to the start of the replay data), the terminal became
+/// <see cref="Cols"/> x <see cref="Rows"/>.
+/// </summary>
+public readonly record struct ReplayResize(int Offset, int Cols, int Rows);
+
+/// <summary>
+/// Replays raw terminal bytes through a fresh <see cref="AnsiParser"/>, applying recorded
+/// resizes at their byte positions so every byte is parsed at the geometry that was in effect
+/// when it was originally written (issue #1304).
+///
+/// Parsing history at any other width is unfaithful: bytes emitted for a 150-column terminal
+/// replayed at 129 columns falsely auto-wrap, shattering wide content (box-drawing tables,
+/// long paths) into a full row plus a detached remainder row. A segmented replay reproduces
+/// exactly what the live parser saw at the time, so committed history keeps its original
+/// width; rows wider than the current viewport clip at the right edge, which the renderers
+/// already handle.
+/// </summary>
+public static class SegmentedReplay
+{
+    /// <summary>
+    /// Replay <paramref name="data"/> starting at <paramref name="startCols"/> x
+    /// <paramref name="startRows"/>, applying each entry of <paramref name="resizes"/> (ordered
+    /// by offset) at its byte position, then resizing to <paramref name="finalCols"/> x
+    /// <paramref name="finalRows"/> so the returned grid matches the caller's current viewport.
+    /// Scrollback rows accumulate into <paramref name="scrollback"/> at the width they were
+    /// emitted for. Returns the final grid and the parser, ready for live continuation.
+    /// </summary>
+    public static (TerminalCell[,] Cells, AnsiParser Parser) Replay(
+        byte[] data,
+        int startCols, int startRows,
+        IReadOnlyList<ReplayResize> resizes,
+        int finalCols, int finalRows,
+        List<TerminalCell[]> scrollback, int maxScrollback,
+        Action<string>? logCallback = null)
+    {
+        int cols = Math.Max(1, startCols);
+        int rows = Math.Max(1, startRows);
+        var cells = new TerminalCell[cols, rows];
+        var parser = new AnsiParser(cells, cols, rows, scrollback, maxScrollback, logCallback);
+
+        int position = 0;
+        foreach (var resize in resizes)
+        {
+            int end = Math.Clamp(resize.Offset, position, data.Length);
+            if (end > position)
+            {
+                parser.Parse(data[position..end]);
+                position = end;
+            }
+            (cells, cols, rows) = ApplyResize(parser, cells, cols, rows, resize.Cols, resize.Rows);
+        }
+
+        if (position < data.Length)
+            parser.Parse(data[position..]);
+
+        (cells, cols, rows) = ApplyResize(parser, cells, cols, rows, finalCols, finalRows);
+        return (cells, parser);
+    }
+
+    /// <summary>
+    /// The same truncate-copy the live resize path uses (TerminalControl.HandleSizeChanged),
+    /// so a segmented replay reproduces exactly what the live parser saw at each resize.
+    /// </summary>
+    private static (TerminalCell[,] Cells, int Cols, int Rows) ApplyResize(
+        AnsiParser parser, TerminalCell[,] cells, int oldCols, int oldRows, int newCols, int newRows)
+    {
+        newCols = Math.Max(1, newCols);
+        newRows = Math.Max(1, newRows);
+        if (newCols == oldCols && newRows == oldRows)
+            return (cells, oldCols, oldRows);
+
+        var next = new TerminalCell[newCols, newRows];
+        int copyCols = Math.Min(oldCols, newCols);
+        int copyRows = Math.Min(oldRows, newRows);
+        for (int r = 0; r < copyRows; r++)
+            for (int c = 0; c < copyCols; c++)
+                next[c, r] = cells[c, r];
+
+        parser.UpdateGrid(next, newCols, newRows);
+        return (next, newCols, newRows);
+    }
+}


### PR DESCRIPTION
Fixes #1304.

## What this does

Makes the terminal's rebuild-on-attach replay faithful to history: every byte of recorded output is parsed at the geometry that was in effect when it was written, instead of at today's width. That removes the false re-wrapping that shattered wide content (box-drawing tables, long paths) whenever the pane was narrower than the content had been written for.

## How

- **CircularTerminalBuffer** now records a small resize mark (byte position, cols, rows) on every pseudo-terminal resize, pruned as the ring rolls past. Duplicate geometries collapse; positions are taken under the buffer's existing write lock.
- **ConPtyBackend / UnixPtyBackend** record the spawn geometry in Start (before any output lands) and every geometry change in Resize (before the console resizes, so the triggered repaint bytes fall after the mark). Recording at the backend covers every caller, including LaunchPreviewDialog's direct resize.
- **SegmentedReplay** (new, Terminal.Core) replays the bytes segment by segment, applying each recorded size at its byte position using the same truncate-copy plus UpdateGrid the live resize path uses - so the replay reproduces exactly what the live parser saw at the time.
- **TerminalControl.RebuildFromBuffer** uses the segmented replay. Buffers with no recorded marks (from before this change) report no geometry and keep the old parse-at-current-width behavior, byte for byte.

No renderer changes: OriginalRenderer already reads scrollback cells with a per-row length guard, so history rows wider than the viewport clip at the right edge and reappear in full when the pane widens.

## What stays the same

- The live terminal path is untouched: agents are resized and auto-wrap exactly as before.
- Alternate-screen agents self-heal on resize as before; their recovered history rows get the same clip-at-right rendering.
- A session that was never resized replays identically to today.

## Visible behavior change

Committed history no longer re-wraps to a narrower pane; it keeps its original width and clips at the right edge (the classic console model). Widening the pane restores full visibility. This is the intended fix: aligned tables clipped at the edge instead of shattered rows.

## Tests

- New CircularTerminalBufferResizeMarkTests: recording, duplicate collapse, invalid-geometry rejection, ring-roll pruning with baseline retention, clear, disposed-safety.
- New SegmentedReplayTests: byte-for-byte fidelity against a live parser resized at the same points; wide-history width preservation across shrink and regrow; the exact 150 -> 133 -> 129 sequence observed in the issue; empty-data and final-geometry cases.
- Full CcDirector.Core.Tests suite: 2874 passed, 0 failed.
- CcDirector.Terminal.Avalonia.Tests: 7 passed, 0 failed.
- Full desktop app builds with 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
