### PR TITLE
fix(terminal): fixed 14px scrollbar gutter so bar visibility never resizes the terminal (#1307)

### DIFF
--- a/src/CcDirector.Avalonia/MainWindow.axaml
+++ b/src/CcDirector.Avalonia/MainWindow.axaml
@@ -929,7 +929,12 @@
                             <Grid x:Name="TerminalGrid">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
+                                    <!-- Fixed gutter, NOT Auto: hiding/showing the scrollbar must
+                                         never change the terminal's width. With Auto, the bar
+                                         becoming visible when scrollback first appeared stole
+                                         columns mid-session and forced the agent to re-wrap
+                                         (issue #1307). -->
+                                    <ColumnDefinition Width="14" />
                                 </Grid.ColumnDefinitions>
                                 <terminal:TerminalControl x:Name="TerminalHost"
                                                           Grid.Column="0" />


### PR DESCRIPTION
Fixes #1307. Follow-up to #1304 / #1306.

## What this does

Changes the terminal scrollbar's grid column from `Width="Auto"` to a fixed `Width="14"` in MainWindow.axaml, so hiding or showing the scrollbar never changes the terminal's width.

## Why

The bar's `IsVisible` is toggled off while a full-screen agent has no recovered scrollback and back on when history first appears (MainWindow.axaml.cs, UpdateTerminalScrollBar). With an Auto column, that toggle collapsed and restored the 14-pixel gutter mid-session: the terminal silently lost columns the moment output started accumulating, the pseudo-terminal was resized, and the agent re-wrapped its entire display. This self-inflicted width oscillation was the trigger for the #1304 wide-history shattering.

With a fixed column, the hide/show logic keeps working exactly as today for looks (a dead bar still does not read as broken scrolling), but layout no longer moves. Cost: 14 pixels of dark gutter during the brief period before any scrollback exists.

## Verification

- Full desktop app builds with 0 warnings, 0 errors.
- This is a layout-only change with no unit-test surface; the acceptance steps are on #1307: start a Claude Code session, watch `Attach complete: cols=N` in the Director log, let scrollback appear, and confirm `cols` does not change when the bar becomes visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
