### PR TITLE
fix(dictation): stop wrapped desktop dictations from being typed in twice (#1308)

### DIFF
--- a/src/CcDirector.Core.Tests/Drivers/TerminalSubmitTests.cs
+++ b/src/CcDirector.Core.Tests/Drivers/TerminalSubmitTests.cs
@@ -224,6 +224,65 @@ public sealed class TerminalSubmitTests
         Assert.Equal(new byte[] { 0x0D }, backend.WrittenBytes[1]);
     }
 
+    // ===== screen-grid fallback (issue #1308) ======================================================
+    // A long dictation that WRAPS across composer rows is repainted interleaved with box borders and
+    // footer hints, so the byte stream may never carry the typed text as one contiguous run even
+    // though it is sitting in the composer. The rendered screen is consulted as a second opinion
+    // before Escape/retype/throw.
+
+    [Fact]
+    public async Task EchoVerifiedSubmit_EchoTornInByteStream_ScreenSnapshotRescuesAndPressesEnter()
+    {
+        var backend = new RecordingSessionBackend { Buffer = new CircularTerminalBuffer() };
+        var text = "Do you understand what it is I am talking about? And can you please also rename this session";
+        // The byte stream only ever shows torn fragments interleaved with the footer hint.
+        backend.EchoScript.UseDefault(RecordingEchoStep.CustomEcho("bypasspermissionson esc again to clear"));
+        // The rendered screen shows the text wrapped across two composer rows, with borders and padding.
+        var screen = new[]
+        {
+            "| Do you understand what it is I am talking       |",
+            "| about? And can you please also rename this      |",
+            "| session                                         |",
+            "  bypass permissions on (shift+tab to cycle)",
+        };
+
+        await TerminalSubmit.EchoVerifiedSubmitAsync(
+            backend,
+            text,
+            "Test",
+            echoTimeout: TimeSpan.FromMilliseconds(30),
+            pollInterval: TimeSpan.FromMilliseconds(5),
+            enterSettleDelay: TimeSpan.FromMilliseconds(1),
+            screenSnapshot: () => screen);
+
+        // Rescued on attempt 1: text typed once, Enter pressed, and no Escape ever disturbed the composer.
+        Assert.Equal(1, backend.EnterCount);
+        Assert.Equal(new byte[] { 0x0D }, backend.WrittenBytes[^1]);
+        Assert.DoesNotContain(backend.WrittenBytes, b => b.Length == 1 && b[0] == 0x1B);
+        Assert.Equal([text], backend.SubmittedTexts);
+    }
+
+    [Fact]
+    public async Task EchoVerifiedSubmit_ScreenSnapshotWithoutTheText_StillFailsLoudly()
+    {
+        var backend = new RecordingSessionBackend { Buffer = new CircularTerminalBuffer() };
+        backend.EchoScript.UseDefault(RecordingEchoStep.Withheld());
+        var screen = new[] { "Some unrelated conversation output", "> ", "esc to interrupt" };
+
+        var error = await Assert.ThrowsAsync<ComposerNotAcceptingInputException>(
+            () => TerminalSubmit.EchoVerifiedSubmitAsync(
+                backend,
+                "these words never reached the composer",
+                "Test",
+                echoTimeout: TimeSpan.FromMilliseconds(20),
+                pollInterval: TimeSpan.FromMilliseconds(5),
+                enterSettleDelay: TimeSpan.FromMilliseconds(1),
+                screenSnapshot: () => screen));
+
+        Assert.Contains("never echoed", error.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, backend.EnterCount);
+    }
+
     [Fact]
     public void StripAnsi_RemovesCsiSequences()
     {

--- a/src/CcDirector.Core/Drivers/TerminalSubmit.cs
+++ b/src/CcDirector.Core/Drivers/TerminalSubmit.cs
@@ -26,6 +26,9 @@ public static class TerminalSubmit
     /// The single ConPTY submit protocol: trim caller submit newlines, use bracketed paste for
     /// large or multi-line blocks when the target TUI requested it, fall back to an @-temp-file
     /// reference when needed, and otherwise echo-verify before pressing Enter.
+    /// <paramref name="screenSnapshot"/>, when provided, returns the CURRENT rendered screen rows
+    /// and is consulted as a second opinion whenever the byte-stream echo check misses (see
+    /// <see cref="ScreenShowsText"/>).
     /// </summary>
     public static async Task SharedSubmitAsync(
         ISessionBackend backend,
@@ -35,7 +38,8 @@ public static class TerminalSubmit
         bool requireEcho = true,
         TimeSpan? echoTimeout = null,
         TimeSpan? pollInterval = null,
-        TimeSpan? enterSettleDelay = null)
+        TimeSpan? enterSettleDelay = null,
+        Func<string[]>? screenSnapshot = null)
     {
         ArgumentNullException.ThrowIfNull(backend);
 
@@ -51,7 +55,8 @@ public static class TerminalSubmit
                 requireEcho,
                 echoTimeout,
                 pollInterval,
-                enterSettleDelay);
+                enterSettleDelay,
+                screenSnapshot);
             return;
         }
 
@@ -65,7 +70,7 @@ public static class TerminalSubmit
 
             if (!string.IsNullOrWhiteSpace(backend.WorkingDirectory))
             {
-                await SubmitViaAtReferenceAsync(backend, textForCheck, driverTag, echoTimeout, pollInterval, enterSettleDelay);
+                await SubmitViaAtReferenceAsync(backend, textForCheck, driverTag, echoTimeout, pollInterval, enterSettleDelay, screenSnapshot);
                 return;
             }
         }
@@ -78,7 +83,8 @@ public static class TerminalSubmit
                 driverTag,
                 echoTimeout,
                 pollInterval,
-                enterSettleDelay);
+                enterSettleDelay,
+                screenSnapshot);
         }
         else
         {
@@ -98,7 +104,8 @@ public static class TerminalSubmit
         string driverTag,
         TimeSpan? echoTimeout = null,
         TimeSpan? pollInterval = null,
-        TimeSpan? enterSettleDelay = null)
+        TimeSpan? enterSettleDelay = null,
+        Func<string[]>? screenSnapshot = null)
         => await SharedSubmitAsync(
             backend,
             text,
@@ -107,7 +114,8 @@ public static class TerminalSubmit
             requireEcho: true,
             echoTimeout,
             pollInterval,
-            enterSettleDelay);
+            enterSettleDelay,
+            screenSnapshot);
 
     private static async Task EchoVerifiedInlineSubmitAsync(
         ISessionBackend backend,
@@ -115,7 +123,8 @@ public static class TerminalSubmit
         string driverTag,
         TimeSpan? echoTimeout = null,
         TimeSpan? pollInterval = null,
-        TimeSpan? enterSettleDelay = null)
+        TimeSpan? enterSettleDelay = null,
+        Func<string[]>? screenSnapshot = null)
     {
         ArgumentNullException.ThrowIfNull(backend);
 
@@ -141,6 +150,21 @@ public static class TerminalSubmit
 
             if (needle.Length == 0 || await WaitForEchoAsync(buffer, cursor, needle, visibleTailNeedle, to, poll))
             {
+                await Task.Delay(settle);
+                backend.Write(EnterByte);
+                return;
+            }
+
+            // The byte stream missed the echo, but that stream is a poor witness for input that
+            // WRAPPED across composer rows: the TUI repaints wrapped text interleaved with box
+            // borders, footer hints ("esc again to clear") and cursor moves, so the typed text may
+            // never appear in the bytes as one contiguous run even though it is sitting in the
+            // composer. Ask the rendered screen - the final visual state, free of interleaving -
+            // before treating the attempt as a failure and disturbing the composer with Escape.
+            if (ScreenShowsText(screenSnapshot, needle, visibleTailNeedle))
+            {
+                FileLog.Write($"[{driverTag}] EchoVerifiedSubmit: byte-stream echo missed on attempt {attempt} " +
+                              $"but the rendered screen shows the typed text (len={text.Length}) - pressing Enter");
                 await Task.Delay(settle);
                 backend.Write(EnterByte);
                 return;
@@ -201,7 +225,8 @@ public static class TerminalSubmit
         string driverTag,
         TimeSpan? echoTimeout = null,
         TimeSpan? pollInterval = null,
-        TimeSpan? enterSettleDelay = null)
+        TimeSpan? enterSettleDelay = null,
+        Func<string[]>? screenSnapshot = null)
     {
         var tempPath = LargeInputHandler.CreateTempFile(text, backend.WorkingDirectory);
         var relRef = LargeInputHandler.MakeAtReference(tempPath, backend.WorkingDirectory);
@@ -214,7 +239,8 @@ public static class TerminalSubmit
             driverTag,
             echoTimeout,
             pollInterval,
-            enterSettleDelay);
+            enterSettleDelay,
+            screenSnapshot);
 
         await AtReferenceSubmitVerifier.EnsureSubmittedAsync(backend.Buffer, backend.Write, atReference);
     }
@@ -227,7 +253,8 @@ public static class TerminalSubmit
         bool requireEcho,
         TimeSpan? echoTimeout = null,
         TimeSpan? pollInterval = null,
-        TimeSpan? enterSettleDelay = null)
+        TimeSpan? enterSettleDelay = null,
+        Func<string[]>? screenSnapshot = null)
     {
         var tempPath = LargeInputHandler.CreateTempFile(text, backend.WorkingDirectory);
         var relRef = LargeInputHandler.MakeAtReference(tempPath, backend.WorkingDirectory);
@@ -246,12 +273,33 @@ public static class TerminalSubmit
                 driverTag,
                 echoTimeout,
                 pollInterval,
-                enterSettleDelay);
+                enterSettleDelay,
+                screenSnapshot);
         }
         else
         {
             await TypeSettleEnterSubmitAsync(backend, instruction, driverTag, enterSettleDelay);
         }
+    }
+
+    /// <summary>
+    /// Second-opinion echo check against the RENDERED screen instead of the raw byte stream. Wrapped
+    /// composer rows reconstruct into the original text when the rows are concatenated and normalized
+    /// (the wrap points, borders and padding all fall outside <see cref="NormalizeForEcho"/>'s
+    /// alphabet), so finding the needle here is proof the composer holds the typed text even when the
+    /// byte stream only ever carried it as interleaved fragments. Also accepts the visible-tail
+    /// needle for composers that truncate the display of long input.
+    /// </summary>
+    private static bool ScreenShowsText(Func<string[]>? screenSnapshot, string needle, string? visibleTailNeedle)
+    {
+        if (screenSnapshot is null || needle.Length == 0)
+            return false;
+
+        var hay = NormalizeForEcho(string.Concat(screenSnapshot()));
+        if (hay.Contains(needle, StringComparison.Ordinal))
+            return true;
+
+        return visibleTailNeedle is not null && hay.Contains(visibleTailNeedle, StringComparison.Ordinal);
     }
 
     private static bool ShouldUseInstructionFile(string driverTag, string text)

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -1634,7 +1634,8 @@ public sealed class Session : IDisposable
                 text,
                 Driver.Kind.ToString(),
                 BracketedPasteEnabled,
-                requireEcho: Driver.Kind != Agents.AgentKind.Copilot);
+                requireEcho: Driver.Kind != Agents.AgentKind.Copilot,
+                screenSnapshot: SnapshotScreenRows);
         }
         else
         {


### PR DESCRIPTION
## The problem

A long desktop dictation that wraps across the composer's rows is injected into the session **twice, back to back**, then submitted once - the whole spoken message duplicated. Reproduced live in two sessions (one was even named "devthrottle - double text").

## Root cause

Desktop dictation delivers through the shared echo-verified submit (`TerminalSubmit.SharedSubmitAsync`), which watches the terminal's raw byte stream to confirm the composer echoed the typed text before pressing Enter. When the text **wraps** across composer rows, the terminal repaints it interleaved with box borders, the "esc again to clear" footer hint and cursor moves, so the typed text never appears in the byte stream as one contiguous run - even though it is sitting in the composer.

The echo check gets a **false negative**, so the code presses Escape to clear the composer and retypes the whole message. But a **single Escape does not clear Claude's composer** (it needs Escape twice - hence the "esc again to clear" hint), so the second type lands on top of the first, and the doubled text is submitted.

This code is already on `main`, so running latest code does **not** fix it - this pull request does.

## The fix

Consult the **rendered screen** as a second opinion. When the byte-stream echo check misses, concatenate and normalize the current screen rows (wrap points, borders and padding all fall outside the echo alphabet, so wrapped text reconstructs into the original) and, if the typed text is present, press Enter instead of disturbing the composer with an Escape-and-retype.

- `TerminalSubmit.cs` - threads an optional `screenSnapshot` through the submit path and adds `ScreenShowsText`.
- `Session.cs` - one line, passes `screenSnapshot: SnapshotScreenRows` (already exists on `main`).
- The dictation lock on `main` is left fully untouched - this change only adds the screen-snapshot second opinion.

## Tests

Two regression tests (all 14 `TerminalSubmit` tests pass):
- A torn-byte-stream wrapped dictation is rescued by the screen snapshot and submits **once**, with no stray Escape.
- A composer that genuinely never received the text still fails loudly.

## Not yet done

Unit-verified only. Recommend a live check in the running app (dictate a long message that wraps, confirm it lands once) before merge, since the bug is fundamentally a rendering-timing issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)