### PR TITLE
fix(cockpit): recover lost QA fixes - menu flip-up, show-through, Fleet Map edge clipping (#1296)

### DIFF
--- a/apps/cockpit/src/about/AboutView.tsx
+++ b/apps/cockpit/src/about/AboutView.tsx
@@ -61,6 +61,12 @@ export function AboutView() {
         <h1>About DevThrottle</h1>
       </div>
       <p className="abt-lede">What this Gateway is running and what&apos;s installed.</p>
+      {/* The cockpit's own build identity, stamped into the static bundle at build time (see
+          vite.config.ts). Always shown - even if the Gateway /about call fails - so you can always
+          confirm which cockpit is deployed, independently of the Gateway version below. */}
+      <p className="abt-cockpit-build">
+        Cockpit build: <strong>{__COCKPIT_COMMIT__}</strong> (built {formatServerTime(__COCKPIT_BUILD_TIME__)} UTC)
+      </p>
 
       {error !== null ? (
         <div className="abt-error">Could not load About info from the Gateway: {error}</div>
@@ -70,7 +76,8 @@ export function AboutView() {
         <>
           <div className="abt-card">
             <Row label="Product" value={about.product} />
-            <Row label="Version" value={about.version} />
+            <Row label="Gateway version" value={about.version} />
+            <Row label="Cockpit build" value={`${__COCKPIT_COMMIT__} (${formatServerTime(__COCKPIT_BUILD_TIME__)} UTC)`} />
             <Row label="Build date" value={about.buildDate ?? "(unknown)"} />
             <Row label="Machine" value={about.machineName} />
             <Row label="Install root" value={about.installRoot} />

--- a/apps/cockpit/src/about/about.css
+++ b/apps/cockpit/src/about/about.css
@@ -23,6 +23,17 @@
   margin: 0 0 16px;
 }
 
+.abt-cockpit-build {
+  color: var(--text-dim);
+  font-size: 13px;
+  margin: -8px 0 16px;
+}
+
+.abt-cockpit-build strong {
+  color: var(--text);
+  font-family: "Cascadia Mono", Consolas, Menlo, monospace;
+}
+
 .abt-error {
   background: #3a1b1b;
   color: #f1a0a0;

--- a/apps/cockpit/src/fleet/fleetmap.css
+++ b/apps/cockpit/src/fleet/fleetmap.css
@@ -238,8 +238,13 @@
   display: flex;
   gap: 20px;
   align-items: flex-start;
-  justify-content: center;
+  /* "safe" keeps the lanes centred while they fit, but falls back to start-alignment when the row is
+     wider than the scroll viewport. Plain "center" clips the overflow equally on BOTH sides and makes
+     the first lane unreachable by scrolling - which cut off the edge repository columns. */
+  justify-content: safe center;
   flex-wrap: nowrap;
+  /* Match the canvas padding so the first and last lanes are not flush against the scroll edges. */
+  padding-inline: 2px;
 }
 
 .fmap-lane {

--- a/apps/cockpit/src/sessions/SessionMenu.tsx
+++ b/apps/cockpit/src/sessions/SessionMenu.tsx
@@ -38,14 +38,26 @@ export function SessionMenu({ session, onClosed, variant = "page" }: SessionMenu
   const btnRef = useRef<HTMLButtonElement | null>(null);
   const popRef = useRef<HTMLDivElement | null>(null);
   // The dropdown is rendered in a portal on document.body so it can never be clipped by the scrolling
-  // rail or covered by a later card; its position tracks the button (issue #1214).
-  const [popPos, setPopPos] = useState<{ top: number; right: number } | null>(null);
+  // rail or covered by a later card; its position tracks the button (issue #1214). It anchors from
+  // the top (opening downward) when there is room below, and flips to anchor from the bottom (opening
+  // upward) for a button near the bottom of the window, so it never runs off the bottom of the screen.
+  const [popPos, setPopPos] = useState<{ top?: number; bottom?: number; right: number } | null>(null);
 
   useLayoutEffect(() => {
     if (!open) return;
     const place = () => {
       const r = btnRef.current?.getBoundingClientRect();
-      if (r) setPopPos({ top: r.bottom + 4, right: Math.max(8, window.innerWidth - r.right) });
+      if (!r) return;
+      const right = Math.max(8, window.innerWidth - r.right);
+      // The menu holds a fixed set of items; this height covers all of them plus padding. If the
+      // space below the button cannot fit it, open upward from the button's top instead.
+      const MENU_HEIGHT = 184;
+      const spaceBelow = window.innerHeight - r.bottom;
+      if (spaceBelow < MENU_HEIGHT + 8) {
+        setPopPos({ bottom: Math.max(8, window.innerHeight - r.top + 4), right });
+      } else {
+        setPopPos({ top: r.bottom + 4, right });
+      }
     };
     place();
     window.addEventListener("resize", place);
@@ -178,7 +190,15 @@ export function SessionMenu({ session, onClosed, variant = "page" }: SessionMenu
             ref={popRef}
             className="session-menu-pop"
             role="menu"
-            style={{ position: "fixed", top: popPos.top, right: popPos.right }}
+            style={{
+              position: "fixed",
+              right: popPos.right,
+              // Always set BOTH top and bottom (one to a value, the other to "auto") so that when the
+              // menu flips upward (bottom-anchored) no stray top from CSS can leave both set at once,
+              // which would break the menu's position.
+              top: popPos.top ?? "auto",
+              bottom: popPos.bottom ?? "auto",
+            }}
           >
             <button type="button" role="menuitem" className="session-menu-item" onClick={openRename}>
               Rename

--- a/apps/cockpit/src/styles.css
+++ b/apps/cockpit/src/styles.css
@@ -2074,11 +2074,11 @@ body {
   position: relative;
 }
 
-/* When a rail card's menu is open, lift the WHOLE card above its siblings so the dropdown is not
-   painted under the next card (a later positioned sibling would otherwise cover it). */
-.roster-li:has(.session-menu.open) {
-  z-index: 50;
-}
+/* The dropdown is portaled to document.body and self-positioned with a high z-index (see
+   .session-menu-pop), so the row no longer needs to be lifted for the menu to sit on top. Lifting the
+   row here was in fact harmful: .roster-li is positioned, so raising it to z-index 50 painted the
+   row's own TEXT above the portaled popover (z-index 40), and the text showed through the menu. Do
+   not re-add a z-index raise on the open row. */
 
 .session-menu.rail {
   position: absolute;
@@ -2087,10 +2087,8 @@ body {
   z-index: 2;
 }
 
-/* An open menu lifts above every other rail card so its dropdown is never covered by a lower card. */
-.session-menu.open {
-  z-index: 50;
-}
+/* The open menu no longer needs a z-index raise: the dropdown is portaled to document.body and sits
+   above the app through .session-menu-pop's own z-index, not by lifting this in-row container. */
 
 .session-menu-btn {
   display: inline-flex;
@@ -2126,11 +2124,17 @@ body {
 }
 
 .session-menu-pop {
-  position: absolute;
-  top: calc(100% + 4px);
-  right: 0;
-  z-index: 40;
+  /* Position is set entirely inline by SessionMenu (position: fixed, plus top OR bottom + right), so
+     the menu can open downward or flip upward. Do NOT set top/right here: a leftover top would leak
+     into the flip-up case (which sets only bottom), leaving both top and bottom set and breaking the
+     menu's position - that is what stopped the bottom rows' menus from appearing at all. */
+  /* Sits above app content (roster rows, fleet cards, the dock) but below the modal dialog overlay
+     (z-index 80). Must exceed any raised in-flow element, or that element's text shows through the
+     portaled menu. */
+  z-index: 70;
   min-width: 168px;
+  max-height: calc(100vh - 16px);
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   padding: 5px;

--- a/apps/cockpit/src/vite-env.d.ts
+++ b/apps/cockpit/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+// Build-time constants stamped by vite.config.ts (define) so the About page can show the cockpit's
+// own build identity. Replaced with string literals at build time.
+declare const __COCKPIT_COMMIT__: string;
+declare const __COCKPIT_BUILD_TIME__: string;

--- a/apps/cockpit/vite.config.ts
+++ b/apps/cockpit/vite.config.ts
@@ -1,5 +1,15 @@
+import { execSync } from "node:child_process";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+
+// Stamp the cockpit's OWN build identity at build time so the About page can show exactly which
+// cockpit is deployed, independently of the Gateway's version. The two can diverge when only the
+// static cockpit files are refreshed (a cockpit-only redeploy), so the Gateway version alone cannot
+// tell you which cockpit you are looking at. The commit is the repo HEAD at build time; the time is
+// the build time. git is present in every build path (dev and the release MSBuild), so this is not
+// wrapped in a fallback - if it cannot read the commit the build fails loudly.
+const cockpitCommit = execSync("git rev-parse --short HEAD").toString().trim();
+const cockpitBuildTime = new Date().toISOString();
 
 // The desktop Cockpit is the Gateway's canonical front door: it is served at the site root "/"
 // (epic #967 cutover, issue #979 - the Blazor Server Cockpit is retired). Every asset URL is
@@ -49,6 +59,10 @@ const devProxy = proxyTarget
 
 export default defineConfig({
   base: "/",
+  define: {
+    __COCKPIT_COMMIT__: JSON.stringify(cockpitCommit),
+    __COCKPIT_BUILD_TIME__: JSON.stringify(cockpitBuildTime),
+  },
   plugins: [react()],
   server: {
     proxy: devProxy,


### PR DESCRIPTION
## What

Re-lands three cockpit QA fixes that were made on branch `feat/recover-cockpit-qa-fixes-1296` (commit 8fecaf43). The original pull request thefrederiksen/devthrottle_internal#752 never merged and the branch was lost during the branch pile-up that repository-hygiene convergence is cleaning up. Verified against current `main`: all three fixes are genuinely absent.

## Fixes

- **Session menu flip-up**: the dropdown now flips to open upward when its button sits near the bottom of the window, so it never runs off the bottom of the screen (`SessionMenu.tsx`).
- **Session menu show-through**: portal / z-order fix so the menu no longer shows content behind it (`styles.css`, `about.css`).
- **Fleet Map edge clipping**: `justify-content: safe center` plus canvas-matched inline padding, so the edge repository columns are no longer clipped and stay reachable by scrolling (`fleetmap.css`).

## Also

Stamps the cockpit's own build identity (`__COCKPIT_COMMIT__` / `__COCKPIT_BUILD_TIME__`) at build time so the About page shows exactly which cockpit is deployed, independent of the Gateway version (`vite.config.ts`, `vite-env.d.ts`, `AboutView.tsx`).

## Provenance

Recovered during repository hygiene convergence (2026-07-11). Cherry-picked cleanly onto current `main` with no conflicts.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)