### PR TITLE
docs: trunk-based development rules + restore CenCon method contract

### DIFF
--- a/.claude/skills/commit/skill.md
+++ b/.claude/skills/commit/skill.md
@@ -5,7 +5,31 @@ description: Create a git commit following the project's commit standards. Trigg
 
 # Commit Skill
 
-Commit workflow: review code, list files, get approval, commit, push.
+Commit workflow: review code, list files, get approval, then drive ALL THE WAY to a merged
+pull request on origin/main and park the checkout back on main.
+
+## Trunk-based development - "done" means merged to main
+
+This repo (like every repo here) does trunk-based development. There are three states of
+work and only one counts:
+
+1. **Committed / pushed to a side branch** - still IN PROGRESS. A backup, not a delivery.
+2. **An open pull request** - still IN PROGRESS.
+3. **Merged to origin/main** - DONE. Tracked, visible to every agent, carries its pull
+   request record so it can be QA'd or reverted later.
+
+So a commit request is NOT finished at `git push`. Committing still requires the user's
+explicit ask (per CLAUDE.md) - but ONCE the user approves the commit, that authorizes driving
+it the rest of the way: push, open a pull request, merge on green, delete the branch, and park
+the checkout back on main. "I committed and pushed" is an unfinished job. Merge first, QA
+after - main is GitHub, not a public release.
+
+The four supporting rules (see the TRUNK DEVELOPMENT section of the global CLAUDE.md):
+- A branch lives less than a day - merge the day it is born.
+- Soft cap of 3 open pull requests at once - finish one before opening a fourth.
+- One checkout per concurrent activity - never build two workstreams from one tree; a
+  concurrent agent uses its own worktree off origin/main.
+- Never commit directly on main. If the checkout is on main, create a branch first.
 
 ## Triggers
 
@@ -72,7 +96,20 @@ DO NOT PROCEED until user says yes, ok, approved, go ahead, or proceed.
 
 If user says no or requests changes, update the plan and re-present.
 
-STEP 5: Execute commit
+STEP 5: Put the work on a branch (never commit directly on main)
+
+Check the current branch: git branch --show-current.
+
+If the checkout is already on a short-lived feature branch, commit there.
+
+If the checkout is on main, create a branch FIRST - never commit on main:
+- If no other session shares this checkout: git checkout -b <type>/<short-desc>
+- If this checkout is shared with other live sessions (a fleet checkout), do NOT move its
+  HEAD. Create an isolated worktree off origin/main and work there:
+  git worktree add ../<repo>-wt-<short-desc> -b <type>/<short-desc> origin/main
+  then cd into it. (See the "Shared checkout" rules in the global CLAUDE.md.)
+
+STEP 6: Commit and push
 
 Stage the specific files using git add with each filename.
 Never use git add . or git add -A.
@@ -85,17 +122,34 @@ EOF
 
 Run git status to verify commit succeeded.
 
-Push with git push.
+Push with: git push -u origin HEAD.
 
 If push fails due to remote changes, run git pull --rebase then git push.
 
-STEP 6: Report completion
+STEP 7: Open the pull request, merge on green, and park back on main
+
+The job is not done until the work is MERGED to origin/main. Once the user approved the
+commit (Step 4), drive it home:
+
+1. Open the pull request: gh pr create --fill (or with a title/body matching recent PRs).
+2. Wait for checks to go green: gh pr checks <number> --watch.
+   - If checks fail, fix the failure and push a NEW commit (never amend, never --no-verify),
+     then re-watch. Report the failure to the user if it is not quick and mechanical.
+3. Merge with squash once green: gh pr merge <number> --squash --delete-branch.
+   (delete_branch_on_merge is ON, but --delete-branch is explicit and harmless.)
+4. Park the checkout back on main:
+   git checkout main && git pull
+   If you worked in a worktree, remove it: git worktree remove ../<repo>-wt-<short-desc>.
+5. Verify the resting state: git status --short is empty, git branch --show-current is main,
+   and the feature branch is gone (git branch --list <type>/<short-desc> prints nothing).
+
+STEP 8: Report completion
 
 Tell the user:
-- Commit hash
+- Pull request number and merge commit on main
 - Number of files changed
-- Branch name
-- Push status
+- That the branch was deleted and the checkout is parked back on main, clean
+- Any exception (e.g. left open because checks are still running) WITH the reason
 
 ## Handling bypass requests
 
@@ -117,11 +171,16 @@ NEVER do these:
 
 ALWAYS do these:
 - Use HEREDOC for commit messages
-- Push after committing
+- Drive an approved commit all the way to merged-on-main, then park the checkout on main
 - Create NEW commit after hook failures, never amend
 
 ---
 
-**Skill Version:** 1.0
-**Last Updated:** 2026-02-14
+**Skill Version:** 2.0 - trunk-based development (2026-07-11)
+**Changed from 1.0:** The workflow no longer stops at `git push`. Once the user approves the
+commit it drives all the way to a merged pull request on origin/main and parks the checkout
+back on main: branch-if-on-main (or isolated worktree on a shared checkout), push, open the
+pull request, merge on green (squash + delete branch), park on main, verify clean. Added the
+trunk-based-development framing (merged-to-main is the only "done") aligned with the global
+CLAUDE.md TRUNK DEVELOPMENT section and the /repo-hygiene skill.
 **Adapted from:** sampleWeb commit skill

--- a/docs/CodingStyle.md
+++ b/docs/CodingStyle.md
@@ -849,6 +849,48 @@ In voice-**conversation** mode, summarizing the **agent's reply** for text-to-sp
 
 ---
 
+## 17. Git workflow - trunk-based development
+
+We do **trunk-based development**: the industry norm for high-performing teams, calibrated
+for a one-person shop driving a fleet of agents (no required reviews, no release trains, no
+ceremony - just five hard rules and merge-on-green).
+
+There are three states of work and only one counts as **done**:
+
+1. Committed or pushed to a side branch - still IN PROGRESS.
+2. An open pull request - still IN PROGRESS.
+3. **Merged to origin/main - DONE.** Tracked, visible to every agent, carrying its pull
+   request record so it can be QA'd or reverted later.
+
+### The five rules
+
+1. **Merged to origin/main is the only "done."** Committing still requires the user's
+   explicit ask, but once approved the commit drives ALL THE WAY to a merged pull request,
+   then the branch is deleted and the checkout is parked back on main. "I committed and
+   pushed" is an unfinished job. Merge first, QA after.
+2. **A branch lives less than a day.** The limit is AGE, not count. If it cannot merge
+   today, the work is too big - split it. Nothing sits unmerged overnight without a written
+   reason on the pull request.
+3. **Soft cap of 3 open pull requests at once.** A habit, not a git rule: at 3, finish one
+   before opening a fourth.
+4. **One checkout per concurrent activity.** Never two workstreams - two agents, two builds -
+   in one working tree. Each concurrent activity uses its own worktree off origin/main,
+   removed the moment its pull request merges. Never commit directly on main.
+5. **Converge daily.** The repo returns to its resting state (checkout on main = origin/main,
+   clean tree, zero side branches, zero worktrees, zero aging pull requests) several times a
+   day. The `/repo-hygiene` skill drives a repo back to this state.
+
+### How it is enforced
+
+- The **`/commit` skill** carries rules 1 and 4 end to end: it branches (or uses an isolated
+  worktree on a shared checkout), commits the named files, opens the pull request, merges on
+  green (squash + delete branch), and parks the checkout on main.
+- The **`/repo-hygiene` skill** is the daily backstop and audits GIT STATE (branches, trees,
+  worktrees, pull requests), converging drift back to main.
+- The **CenCon Development Method** (`docs/cencon/DEVELOPMENT_METHOD.md`) requires each
+  change to be an isolated worktree off main that ends merged to main.
+- `delete_branch_on_merge` is ON so merged pull requests self-clean.
+
 ## When in Doubt
 
 1. Log more, not less

--- a/docs/cencon/DEVELOPMENT_METHOD.md
+++ b/docs/cencon/DEVELOPMENT_METHOD.md
@@ -1,0 +1,582 @@
+# CC Director - CenCon Development Method
+
+**Schema:** CenCon Method v1.0 (Development Governance)
+**Status:** Active
+**Last Updated:** 2026-07-11
+**Owner:** Support Agent (maintains this document)
+**Adapted from:** an internal CenCon method variant (same method, GitHub-Issues tracker)
+
+---
+
+## 1. Purpose
+
+CenCon already governs how this repository is **documented** (architecture_manifest.yaml,
+security_profile.yaml, INDEX.md). This document extends CenCon to govern how this repository is
+**changed**.
+
+It defines a four-agent development process and one hard rule:
+
+> **No code is written without a clearly-defined work item.**
+
+When you sit down at cc-director, you do not start editing files. You start a work item, you make
+it clearly defined, and then you let the Developer Agent and QA Agent carry it the rest of the way.
+This is not optional guidance - it is the method the repository enforces.
+
+The four agents are not hypothetical, but they no longer map one-to-one onto running sessions
+(issue #259): the **Developer and QA roles run inside a single Implementation session** that loops
+build&lt;-&gt;verify, alongside a **Product** session and a **Support** session. The four roles and
+the `flow:*` labels are unchanged; what changed is the session topology. cc-director is the runtime
+of its own development method.
+
+---
+
+## 2. The Hard Gate
+
+Every code change traces back to exactly one **GitHub issue** (in `example-org/devthrottle`)
+that has passed the **Definition of Ready** (Section 5). There are no exceptions for "small"
+changes.
+
+Rationale (consistent with CLAUDE.md proof-based verification):
+
+- The issue is the durable, auditable handoff artifact between agents.
+- A change with no issue has no spec, no acceptance criteria, and no proof target.
+- Labels on the issue are the bus: they overlap cleanly with a normal GitHub flow and let any
+  agent (or human) pick up where another left off.
+
+The only work that may happen without an issue:
+
+- Drafting/refining an issue (Product Agent's own job).
+- Answering questions (Support Agent - read-only, never edits code).
+
+---
+
+## 3. The Four Agents
+
+Each agent is a single-purpose role. Product and Support are their own Claude Code sessions; the
+Developer and QA roles run together inside one **Implementation** session (issue #259) that loops
+build&lt;-&gt;verify in place rather than handing off between two sessions. Roles hand work down the
+line by changing the `flow:*` label on the issue - between separate sessions explicitly, and within
+the Implementation session as an internal `flow:ready-dev` -&gt; `flow:ready-qa` loop. Between work
+items, an agent's memory is cleared so no context bleeds from the last ticket into the next
+(Section 7).
+
+### 3.1 Product Agent
+
+- **Job:** Own issues. Create them and sharpen them until they meet the Definition of Ready. The
+  only way work enters the system.
+- **Never:** Writes implementation code.
+- **Input:** A raw request, idea, bug report, or an issue bounced back with `flow:rejected`.
+- **Output:** An issue labeled `flow:ready-dev` that satisfies the Definition of Ready.
+- **Tracker surface:** the `enter-issue` skill (create) and `gh` CLI; issue kinds map to the
+  existing `bug` / `enhancement` labels (plus area labels such as `cockpit`, `installation`).
+
+### 3.2 Developer Agent
+
+- **Job:** Implement one ready issue end to end.
+- **Reject path:** If the item does not meet the Definition of Ready, the Developer Agent labels
+  it `flow:rejected`, writes WHY in a comment, and returns it to Product. It does not "do its best"
+  with a weak spec.
+- **Definition of Done it must satisfy before handing off:** Section 6.
+- **Proof:** On completion, commits a screenshot and an HTML report to the PR branch under
+  `docs/cencon/proof/issue-<n>/` and links them repo-relative in an issue comment (Section 6a).
+- **Input:** An issue labeled `flow:ready-dev`.
+- **Output:** Either `flow:rejected` (back to Product) or `flow:ready-qa` with proof linked.
+
+### 3.3 QA Agent
+
+- **Job:** Loop over `flow:ready-qa` issues, verify each independently with proof, pass or fail.
+- **Independence:** Verifies actual behavior in the running app - it does not trust the Developer
+  Agent's report. (SOC 2 separation of duties is preserved as ROLE separation: when Developer and QA
+  run inside one Implementation session (#259), the QA pass is still performed deliberately and
+  independently against what was asked - verify, fix, re-verify - never a rubber-stamp of the code
+  just written.)
+- **Fail path:** Labels `flow:qa-failed`, writes WHY, returns to Developer.
+- **Pass path:** Labels `flow:done`, links the QA proof report, and - when running inside the
+  Implementation session (the `implementation-loop` skill) - **squash-merges the PR to main** on a
+  clean build, then closes the issue (DECIDED D5). Standalone QA does not merge.
+- **Never stops on its own** - it takes the next QA item until the queue is empty.
+- **Input:** An issue labeled `flow:ready-qa`.
+- **Output:** `flow:qa-failed` (back to Developer) or `flow:done`.
+
+### 3.4 Support Agent
+
+- **Job:** The idle seat. Answers questions about the codebase and about what the other three
+  agents are doing. Owns and maintains the CenCon documents (this file and `docs/cencon/`).
+- **Never:** Touches issues or implementation code. Read-only with respect to product code.
+- **Input:** Questions.
+- **Output:** Answers, and CenCon doc updates when the architecture/method drifts.
+
+---
+
+## 4. The Label State Machine
+
+State lives as a `flow:*` **label** on the GitHub issue. One agent watches for one trigger label.
+
+```
+  (raw request / idea / bug)
+            |
+            v
+      [ Product Agent ]
+            |
+            |  meets Definition of Ready
+            v
+      flow:ready-dev ----------------------------+
+            |                                     |
+            |  a loop SELECTS it (claim, 4a)      |
+            v                                     |
+      flow:in-progress                            |
+            |   (invisible to other loops)        |
+            |   stale-claim sweep --> back to flow:ready-dev
+            v                                     |
+      [ Developer Agent ]                         |
+            |                                     |
+     +------+-------------------------+           |
+     |                                |           |
+ weak spec                      implemented       |
+     |                          + proof linked     |
+     v                                |           |
+ flow:rejected --> [ Product Agent ]--+ (re-sharpen, re-label ready-dev)
+                                      ^
+            +-------------------------+
+            |
+            v
+      flow:ready-qa
+            |
+            v
+      [ QA Agent ]
+            |
+     +------+----------------+
+     |                       |
+  defect found          verified
+     |                       |
+     v                       v
+ flow:qa-failed         flow:done
+     |                  (issue closed)
+     v
+ [ Developer Agent ] (fix, re-label ready-qa)
+```
+
+Label vocabulary (single source of truth - these labels exist in the repo):
+
+| Label | Meaning | Owner who sets it | Next agent |
+|-------|---------|-------------------|------------|
+| `flow:ready-dev` | Spec is ready to implement (and unclaimed) | Product Agent | Developer Agent |
+| `flow:in-progress` | Claimed by ONE implementation-loop run; excluded from selection | Implementation loop (claim) | the same loop |
+| `flow:rejected` | Spec too weak; see comment | Developer Agent | Product Agent |
+| `flow:ready-qa` | Implemented + proof linked | Developer Agent | QA Agent |
+| `flow:qa-failed` | Defect found; see comment | QA Agent | Developer Agent |
+| `flow:done` | Verified with proof | QA Agent | (closed) |
+| `flow:needs-human` | 3-strike escalation | Product Agent | the human |
+
+Only one `flow:*` label is present at a time. Changing the label IS the handoff:
+
+```bash
+gh issue edit <N> --repo example-org/devthrottle --add-label flow:ready-qa --remove-label flow:ready-dev
+```
+
+DECIDED (D1): the `flow:*` labels are authoritative. GitHub's open/closed state is cosmetic and is
+not required to track these states; an issue is only closed when it reaches `flow:done`.
+
+DECIDED (D6): an issue is **claimed at the moment a loop selects it** by transitioning
+`flow:ready-dev` -> `flow:in-progress` (Section 4a), so two concurrent loops cannot both implement
+it. The selection query reads `flow:ready-dev` ONLY, so a claimed (`flow:in-progress`) issue is
+invisible to every other loop. The claim is released on every terminal path (it becomes
+`flow:ready-qa` once the Developer hands off, and from there `flow:done` / `flow:qa-failed` /
+`flow:needs-human` as usual), and a crashed claim is reclaimable by a stale-claim sweep so an issue
+is never stranded invisible forever.
+
+DECIDED (D3): the reject round-trip is fully autonomous. When the Developer Agent labels
+`flow:rejected`, the Product Agent re-sharpens and re-submits with no human in the loop. (Guard
+against ping-pong: see Section 5a.)
+
+---
+
+## 4a. Issue-Level Claim (duplicate-prevention)
+
+The selection guard at the LIST level (one consumer per list, epic #270 AC4) does not guard at the
+ISSUE level. On 2026-06-10 two concurrent implementation-loops both selected the oldest
+`flow:ready-dev` issue (#199) and both implemented it, producing duplicate PRs (#294, #296) and a
+near-collision pushing the same branch. The claim mechanism (issue #298) closes that gap.
+
+### The claim, in one move
+
+The instant a loop **selects** an issue (implementation-loop Step 0), it claims it by transitioning
+the label so it leaves every other loop's selection set:
+
+```bash
+# claim: ready-dev -> in-progress, in a single edit, then record WHO claimed it
+gh issue edit <N> --repo example-org/devthrottle \
+   --add-label flow:in-progress --remove-label flow:ready-dev
+gh issue comment <N> --repo example-org/devthrottle \
+   --body "CLAIM flow:in-progress by <director-id>/<session-id> at <UTC-ISO8601>"
+```
+
+The selection query reads `flow:ready-dev` **only**, so a `flow:in-progress` issue is invisible to
+every other loop:
+
+```bash
+gh issue list --repo example-org/devthrottle --label flow:ready-dev --state open \
+  --json number,title,updatedAt --jq 'sort_by(.updatedAt) | .[0]'
+```
+
+The GitHub **label set is the lock** - the single source of truth that already carries flow state.
+No new store is introduced.
+
+### Honest about atomicity (the residual race window)
+
+GitHub label operations are NOT an atomic compare-and-swap. Two loops can both read
+`flow:ready-dev` and both run the claim edit in a small window. The mechanism handles this with a
+**verify-after-claim re-read**, not a false promise of atomicity:
+
+1. **Best-effort claim** (the single `gh issue edit` above) removes `flow:ready-dev` and adds
+   `flow:in-progress` in one call, and the loop records a timestamped `CLAIM ...` comment. This
+   alone shrinks the wide window we hit on #199: the label flips the instant work starts, so any
+   loop that selects *after* this edit indexes simply never sees the issue.
+2. **Verify-after-claim** (closes the remaining narrow window): immediately after claiming, the loop
+   re-reads the issue's `CLAIM ...` comments and confirms its OWN claim comment is the **oldest**
+   one. If another loop's claim comment is older, this loop **LOST the race and backs off** -
+   it relabels `flow:in-progress` -> `flow:ready-dev` only if it was the sole claimant (otherwise it
+   leaves the winner's claim intact) and selects a different issue (or reports none). The winner
+   (oldest claim comment) keeps the issue. Comment `createdAt` ordering is the tie-break.
+
+   The comment ordering is the deterministic arbiter even when both label edits "succeed", because
+   GitHub serializes comment creation and exposes a stable `createdAt`. This is **best-effort with a
+   deterministic loser-back-off**, not lock-free atomicity - stated plainly so no one over-trusts it.
+   The residual exposure is only the sub-second window between two loops selecting the same issue at
+   the same instant, and the verify-after-claim re-read resolves even that by comment order. If a
+   future need demands true mutual exclusion, an external lock (e.g. a Gateway-held lease) would be
+   required - out of scope here.
+
+   Note on index lag: `gh issue list --label` is backed by GitHub's eventually-consistent search
+   index, so a freshly relabeled issue may take a few seconds to enter/leave the selection set. Both
+   the loop and the proof harness tolerate this with a bounded settle-wait rather than asserting on
+   the first read.
+
+### Release (every terminal path frees the claim)
+
+`flow:in-progress` is a transient working state, never a terminal one. It is released the moment the
+issue advances:
+
+- **Developer hands off:** `flow:in-progress` -> `flow:ready-qa` (the Developer's normal hand-off
+  edit also removes `flow:in-progress`). From there the issue rides the existing QA cycle
+  (`flow:ready-qa` <-> `flow:qa-failed`) - those states are themselves "claimed" by the running loop
+  and likewise excluded from a fresh `flow:ready-dev` selection.
+- **PASS:** ends `flow:done` (claim already gone).
+- **Weak spec / 3-strike / merge conflict / dirty build:** ends `flow:needs-human` (claim removed).
+- A bounce (`flow:qa-failed`) is handled in-loop by the same run that holds the claim; it does not
+  return to the `flow:ready-dev` pool, so no other loop can grab it mid-flight.
+
+### Stale-claim recovery (never stranded invisible forever)
+
+A loop that crashes after claiming would leave an issue `flow:in-progress` with no live owner -
+invisible to selection forever. To prevent a permanent strand, a **stale-claim sweep** reclaims it:
+
+- An issue is **stale** if it is `flow:in-progress` AND its most-recent `CLAIM ...` comment is older
+  than the stale threshold (default **60 minutes** - longer than any healthy DEV+QA cycle) AND it is
+  not the issue the current run itself just claimed.
+- A stale issue is reclaimed `flow:in-progress` -> `flow:ready-dev` with a `STALE-CLAIM SWEEP ...`
+  comment, returning it to the selection set so the next loop picks it up cleanly.
+- The sweep runs at the top of issue selection (implementation-loop Step 0) and may also be invoked
+  manually. A **fresh** claim (age < threshold) is protected and never swept - that is what keeps the
+  sweep from stealing an issue out from under a healthy run.
+
+DECIDED (D6): the `flow:in-progress` claim + verify-after-claim + stale-claim sweep is the
+duplicate-prevention mechanism. It is best-effort (honest about the sub-second residual window),
+deterministically resolves a race by claim-comment order, releases on every terminal path, and is
+self-healing on a crashed claim.
+
+---
+
+## 5. Definition of Ready (Product Agent's bar)
+
+An issue is `flow:ready-dev` only when ALL of the following are true. The Developer Agent rejects
+anything that fails this list.
+
+1. **Title** is a single, specific outcome, with an area prefix (see Area Prefixes below).
+2. **Problem / value:** one paragraph - what is wrong or wanted, and why it matters.
+3. **Scope:** explicitly states what is IN and what is OUT.
+4. **Acceptance criteria:** a checklist of observable, testable conditions. Each must be verifiable
+   by the QA Agent with a screenshot, a Control API response, or a log/command - no "should feel
+   faster".
+5. **Affected area:** which projects/containers (per `architecture_manifest.yaml`) are expected to
+   change - e.g. `CcDirector.Core`, `CcDirector.Avalonia`, `CcDirector.ControlApi`,
+   `CcDirector.Gateway`, `CcDirector.GatewayApp`, `CcDirector.Engine`, a `cc-*` tool.
+6. **Proof target:** what the success screenshot/report must show.
+7. **No invented design intent:** any assumption about intended behavior is flagged as an
+   assumption inside the issue, not stated as fact.
+
+If a request cannot be made to satisfy this list, it is not ready - the Product Agent keeps working
+it (or asks the human), it does not pass it down.
+
+### 5a. Ping-pong guard (autonomous reject loop)
+
+Because the reject round-trip is fully autonomous (D3), a spec must not bounce forever between
+Product and Developer:
+
+- Each `flow:rejected` -> re-sharpen -> `flow:ready-dev` cycle increments a reject count recorded in
+  an issue comment.
+- On the **third** rejection of the same issue, the agents stop the autonomous loop, label the
+  issue `flow:needs-human`, and leave a comment summarizing the disagreement for the human to
+  resolve.
+- The Developer Agent's rejection comment must be specific (which DoR item failed and why) so
+  Product can act on it rather than re-submitting the same spec.
+
+---
+
+## 6. Definition of Done (Developer Agent's bar)
+
+Before labeling `flow:ready-qa`, the Developer Agent must have ALL of:
+
+1. Code implemented against every acceptance criterion in the issue.
+2. `review-code` skill invoked and `docs/CodingStyle.md` + `docs/VisualStyle.md` honored before/while
+   writing code (per CLAUDE.md). UI changes must comply with `docs/VisualStyle.md`.
+3. Solution builds clean: `dotnet build cc-director.sln`, run inside the session's OWN git
+   worktree (per-session build isolation, issue #299). For a runnable test binary, allocate a
+   per-session dev slot with `scripts\agent-session-isolation.ps1 allocate` (slots are taken
+   dynamically from 6 upward; slot 5 is the legacy/manual default and may be in use by a human -
+   never assume it is free; never use the main build or slots 1-4 - CLAUDE.md rule 0b), then build
+   it with `scripts\local-build-avalonia.ps1 -Slot <N>` from the worktree root so bin/obj and
+   local_builds stay inside the worktree.
+4. **Proof-based verification** performed (per CLAUDE.md): the change exercised in the running app.
+   Launch the test Director via the session's OWN per-slot scheduled task -
+   `scripts\agent-session-isolation.ps1 launch` registers and starts `cc-director<N>-launch`
+   (NEVER spawn cc-director.exe from inside the agent's own process tree - CLAUDE.md rule 0b) and
+   resolves the Director's self-allocated Control API port from its log. Drive it via the Control
+   API (loopback REST) and/or screenshots, and capture a screenshot showing the expected result.
+   State Expected vs Actual for each acceptance criterion. Afterward,
+   `scripts\agent-session-isolation.ps1 teardown` stops only the session's own exact-path process
+   and unregisters the session's task - concurrent sessions on one machine never collide on slot,
+   build output, or port.
+5. **CenCon not drifted:** if the change altered architecture or security posture, the relevant
+   `docs/cencon/` files are updated in the same change, and no blocking security rule
+   (DT-01..DT-NN in `security_profile.yaml`) is violated.
+6. An **HTML report** committed and linked (Section 6a): what was implemented, which acceptance
+   criteria are met, screenshots, and an explicit "I believe this is finished" statement.
+
+A missing proof report is itself a Definition-of-Done failure - the issue does not advance.
+
+### 6a. Proof on GitHub (the adaptation that differs from the Azure DevOps variant)
+
+GitHub's `gh` CLI cannot attach arbitrary files/images to an issue the way Azure DevOps work items
+can. Therefore proof travels on the **pull request branch**:
+
+1. The Developer Agent works on a branch and opens a PR. Commits to the **PR branch** are authorized
+   by adoption of this method.
+2. The screenshot(s) and the HTML report are committed under `docs/cencon/proof/issue-<n>/`
+   (e.g. `report.html`, `before.png`, `after.png`).
+3. The Developer Agent links them **repo-relative** in an issue comment, alongside the PR link:
+
+   ```
+   Proof: docs/cencon/proof/issue-123/report.html  (PR #124)
+   ```
+
+4. **Merging the PR to `main`:** the Developer Agent never merges - branch commits are authorized, a
+   merge is not. Inside the `implementation-loop`, the **QA role** squash-merges to main on a clean
+   pass as part of `flow:done` (DECIDED D5; user-granted authority scoped to the loop; clean-build
+   gate, never forced through a conflict). A **standalone** QA session does not merge - it stops at
+   `flow:done` and leaves the merge to the human. Either way, the Developer Agent's handoff artifact
+   to QA is the issue + the proof on the branch, not a merged change.
+
+The QA Agent's proof report follows the same path: committed under `docs/cencon/proof/issue-<n>/`
+(e.g. `qa-report.html`) and linked from the `flow:done` (or `flow:qa-failed`) comment.
+
+### 6b. Trunk-based development - merged to main is the only "done"
+
+The method runs on **trunk-based development** - the industry norm for high-performing teams,
+calibrated for a one-person shop driving a fleet of agents. The full rules live in the TRUNK
+DEVELOPMENT section of the repo's CLAUDE.md and in `docs/CodingStyle.md` Section 17; they bind every
+agent in this method:
+
+- **Merged to origin/main is the only "done."** A commit, a pushed branch, or an open pull request
+  are all still IN PROGRESS. An issue is finished only when its change is squash-merged to main
+  (the QA role's authority inside the `implementation-loop`, D5) and the branch is deleted. Merge
+  first, QA-after only applies to already-merged main; within the method QA verifies BEFORE the
+  merge - the point is that nothing "done" sits unmerged on a side branch.
+- **One checkout per activity.** Each change is built in its OWN isolated git worktree off
+  origin/main (the Developer Agent's Step 4.0). Never two workstreams in one working tree, never
+  build in the shared primary checkout, never two test Directors from one tree.
+- **A branch lives less than a day.** If a change cannot merge today, the issue is too big - split
+  it. Nothing sits unmerged overnight without a written reason on the pull request.
+- **Soft cap of 3 open pull requests at once.** A habit, not a git rule: finish one before opening a
+  fourth. It preserves legitimate parallel work while forbidding the pile-up.
+- **After merge, park the checkout back on main, clean**, and remove the worktree. The
+  `/repo-hygiene` skill is the daily backstop that converges any drift back to this resting state.
+
+This is what makes the proof trail (Section 6a) durable: the merged pull request is the permanent,
+tracked record that QA and audit read from - not a branch that rots as main moves on.
+
+---
+
+## 7. Memory Reset Between Work Items
+
+Each agent processes exactly one issue per fresh context. When an item leaves an agent (handed
+down or bounced back), that agent's session memory is cleared before it picks up the next item.
+This prevents spec, code, or assumptions from one ticket leaking into another.
+
+DECIDED (D2): the `implementation-loop` skill is the supervisor of the Implementation session, and
+the memory reset is achieved by **running each phase in a fresh sub-agent**. The supervisor stays
+thin - it holds only the issue number, the current `flow:*` label, the bounce counter, and a
+one-line result ledger. Each DEV phase (following `developer-agent`) and each QA phase (following
+`qa-agent`) is spawned as a separate sub-agent with a throwaway context; the sub-agent does all the
+file reads, builds, and proof work in isolation and returns only a compact structured result. This
+is why no spec, build log, or fixture bleeds between phases or between issues, and why `--all` can
+drive many items without the supervisor's context filling up. The handoff between fresh sub-agents
+relies on the method's existing durable state (the `flow:*` label, issue comments, and the PR
+branch), not on shared memory - so a fresh QA sub-agent is also a more honestly independent verifier.
+The 3-strike `flow:qa-failed` guard and the weak-spec `flow:needs-human` escalation live in the
+supervisor; one phase runs at a time (DEV then QA) within a loop, and across loops each session's
+test Director is isolated per-session (own worktree, own slot >= 6, own self-allocated Control API
+port - issue #299), so sub-agents never collide on a test Director.
+
+---
+
+## 7a. Terminal Signal Contract (machine-readable loop outcome)
+
+The `implementation-loop` skill (the supervisor of the Implementation session, Section 7 / D2)
+reaches exactly one terminal outcome per issue per run. So that an external watcher - specifically
+the autonomous work-item queue runner (epic #270) - can know when one loop run has finished without
+parsing prose, the loop emits a single **machine-readable terminal signal** as the last thing it
+prints to the session transcript on EVERY terminal path. This is a contract, not a feature: child 3
+of #270 (the Gateway queue runner) is built against the spec recorded here.
+
+### The three signal values
+
+There are exactly three terminal-signal values:
+
+| Signal | Meaning | Loop outcomes that map to it |
+|--------|---------|------------------------------|
+| `done` | The issue was verified and squash-merged to main; the run is fully complete. | MERGED (`flow:done`) |
+| `needs-human` | The run stopped cleanly and a human must act; work is committed/parked, nothing is lost. | PARKED (3-strike `flow:needs-human`), ESCALATED (weak-spec `flow:needs-human`), merge conflict / dirty post-merge build (`flow:needs-human`) |
+| `failed` | The run could not complete - it stopped abnormally and produced no usable result. | Pre-flight dirty-tree / leftover-stash stop (Step 0a), wrong-base stop, build-tool failure, crash, or any abnormal exit |
+
+`done` and `needs-human` correspond to the loop's existing clean terminal outcomes (the work is
+preserved either as a merge or as a parked PR). `failed` is the catch-all for any path on which the
+loop cannot reach one of those two - the repository state is whatever it was, and a human should
+look at why the run aborted.
+
+### The sentinel block (transport = session transcript)
+
+The signal travels on the **session transcript** (the surface the Gateway/Wingman already capture -
+no new transport is introduced). The loop prints, as its final transcript output for the issue, a
+single fenced sentinel block in this exact shape:
+
+```
+IMPL-LOOP-TERMINAL
+issue: <N>
+signal: done | needs-human | failed
+pr: <pr number or none>
+merged: yes | no
+reason: <one line - why this terminal state>
+```
+
+- `issue` identifies the work item (so a watcher can correlate the signal with the item it started).
+- `signal` carries exactly one of the three values above.
+- `pr` is the PR number on `done`/`needs-human` paths that have one, or `none`.
+- `merged` is `yes` only on the `done` signal; `no` on `needs-human` and `failed`.
+- `reason` is a single human-readable line explaining the terminal state.
+
+### Rules
+
+- The sentinel block is emitted **in addition to** the loop's existing human-readable one-line
+  report (Step 4 of the `implementation-loop` skill), never instead of it. The two coexist; the
+  human report is unchanged.
+- **Exactly one** sentinel block is emitted per issue per run, as the loop's final action on that
+  issue, so a watcher reading the last sentinel block gets an unambiguous answer.
+- The block is the loop's last transcript output for the issue (in single-issue mode) or for that
+  issue's slot (in `--all` mode, one block per issue as each finishes).
+
+This contract is the keystone of #270: every other child of that epic depends on the three values
+and the block format defined here.
+
+## 7b. Per-Source Adapter Contract (multi-source work lists)
+
+A work-list item is a structured `{ source, id, area? }` ref (epic #270, Option B), so the board
+can hold items from more than one tracker. Issue #300 made runnability **per-source adapter
+dispatch** instead of a hard-coded github gate. The contract has two halves, deliberately split
+(decision D-2 on #300) so the Gateway stays thin and the seeded Claude session keeps doing the
+tracker operations (the same shape as the original github path, where `gh` runs inside the session,
+not inside the Gateway):
+
+### The Gateway half: `ISourceAdapter` (C#, `CcDirector.Gateway.Running`)
+
+One adapter per RUNNABLE source, registered in the `SourceAdapters` registry. Dispatch IS
+runnability: a source with a registered adapter is runnable; a source without one is **skipped with
+a note and left in the list** (the runner never writes status into the list - #273). The adapter
+owns exactly the three per-source concerns the queue runner has:
+
+| Member | Concern |
+|--------|---------|
+| `Source` | The source name it serves (matches `WorkListItemRef.Source`, case-insensitive). |
+| `BuildSeedPrompt(item)` | The seed prompt that starts the `implementation-loop` in that source's mode (github: `/implementation-loop <id>`; devops: `/implementation-loop --source devops <id>`). |
+| `TryGetCorrelationKey(item, out key)` | The integer the `IMPL-LOOP-TERMINAL` block's `issue:` field must carry for this item (Section 7a is source-agnostic; for github it is the issue number, for devops the work item id). |
+
+v1 registry: `github` and `devops` are runnable; `jira` has no adapter and skips with the existing
+note. Status write-back (claim / done / needs-human / failed) is NOT an adapter member - it is the
+seeded session's job, driven by the source mode of the `implementation-loop` skill (the second
+half, below).
+
+### The skill half: a source mode in `implementation-loop`
+
+Each runnable source has a mode in the `implementation-loop` skill defining who carries the claim
+and where terminal status is written back. Everything code-side (branch, PR, squash-merge, proof
+under `docs/cencon/proof/`) stays GitHub PR-based in the code repo the work item names (default
+`example-org/devthrottle`).
+
+- **github mode** (the original): claim and write-back are the `flow:*` labels (Section 4/4a).
+- **devops mode** (issue #300): claim and write-back are the Azure DevOps work item State plus
+  discussion comments, via the `az boards` CLI (host prerequisite: az CLI + `azure-devops`
+  extension, authenticated; no PAT handling in v1). The status mapping (decision D-3):
+
+  | Loop outcome | Work item State | Plus |
+  |--------------|-----------------|------|
+  | CLAIM (selection) | the template's in-progress state | discussion comment `CLAIM by <director>/<session> at <utc>`; verify-after-claim re-read - oldest CLAIM comment wins, loser backs off (same shape as #298) |
+  | `done` | the template's done state | discussion comment with the merged PR URL |
+  | `needs-human` | STAYS in-progress | tag `needs-human` + discussion comment saying what a human must do |
+  | `failed` | back to the initial/proposed state | discussion comment with the failure reason |
+
+  State names are pinned static for the common process templates, chosen by probing the work item
+  TYPE's allowed state list (`az devops invoke --area wit --resource workitemtypestates` - one
+  static lookup, no dynamic state-graph discovery; the current state name alone is ambiguous,
+  `To Do` opens both Basic and Scrum). An unrecognized state set escalates `needs-human` (never
+  guess a transition):
+
+  | Template | initial / proposed | in-progress | done |
+  |----------|--------------------|-------------|------|
+  | Basic    | `To Do`            | `Doing`     | `Done` |
+  | Scrum    | `To Do`            | `In Progress` | `Done` |
+  | Agile    | `New`              | `Active`    | `Closed` |
+
+### Adding a future source (e.g. jira)
+
+Adding a source = (1) register its `ISourceAdapter` (seed prompt + correlation key), (2) add its
+mode to the `implementation-loop` skill (claim + write-back mapping against that tracker's CLI),
+(3) document the host prerequisite. The sentinel contract (Section 7a) needs no change - `issue:
+<id>` already carries any numeric item id. Until then, refs for that source are accepted, stored,
+ordered, and displayed, and the runner skips them with a note.
+
+## 8. Relationship to the Rest of CenCon
+
+- **architecture_manifest.yaml** tells the Product Agent which containers an item will touch
+  (DoR item 5) and tells the Developer Agent where to update docs (DoD item 5).
+- **security_profile.yaml** (OWASP Desktop DT-01..DT-NN + SOC 2 control mappings) is a checklist
+  the Developer Agent must not violate and the QA Agent re-checks. A drift here can bounce an item.
+- **INDEX.md** is the human entry point; this file is linked from it under Related Documentation.
+- **Drift rule:** the 30-day documentation drift rule (enforced by `/review-code`) applies to this
+  method document too - the Support Agent keeps it current as the process evolves.
+
+---
+
+## 9. Open Decisions (to resolve as we build)
+
+| ID | Decision | Status |
+|----|----------|--------|
+| D1 | Labels vs GitHub open/closed state as authoritative | DECIDED: labels authoritative |
+| D2 | Memory-reset + loop mechanism (who restarts agents) | DECIDED: the `implementation-loop` skill is the supervisor; it sequences DEV->QA->DEV until pass and `/clear`s (or re-seeds) between issues in `--all` mode (Section 7) |
+| D3 | Reject round-trip: human pause or fully autonomous | DECIDED: fully autonomous, 3-strike human escalation (Section 5a) |
+| D4 | Proof transport on GitHub | DECIDED: committed to PR branch under docs/cencon/proof/issue-<n>/, linked repo-relative; branch commits authorized (Section 6a) |
+| D5 | Whether merged-to-main is part of `flow:done` or a separate human step | DECIDED: inside the `implementation-loop`, QA squash-merges to main on a clean pass as part of `flow:done` (user-granted authority, scoped to the loop); a standalone QA session still leaves the merge to the human |
+| D6 | Issue-level claim to stop two loops implementing the same issue | DECIDED: claim `flow:ready-dev` -> `flow:in-progress` at selection (Section 4a) + verify-after-claim re-read (oldest claim comment wins, loser backs off) + stale-claim sweep (>60min) for crash recovery; label set is the lock, best-effort with an honest residual sub-second window |
+
+---
+
+*Extends CenCon Method v1.0. Source of truth for how cc-director is changed.*


### PR DESCRIPTION
## What

Turns the doctrine we converged on today (trunk-based development, merged-to-main is the only "done") into written, enforced rules, and restores the CenCon method's missing contract document.

## Changes

- **`/commit` skill (v2.0)** - no longer stops at `git push`. Once the user approves a commit it branches (or uses an isolated worktree on a shared checkout), pushes, opens the pull request, merges on green (squash + delete branch), and parks the checkout back on main.
- **`docs/CodingStyle.md`** - new Section 17 "Git workflow - trunk-based development": the five rules and how they are enforced.
- **`docs/cencon/DEVELOPMENT_METHOD.md`** - restored. This is the contract all four CenCon agent skills (`product-agent`, `developer-agent`, `qa-agent`, `support-agent`) tell you to "read first", but it was deleted by the public-repo scrub, leaving those references dangling. Restored de-personalized (private repo slug -> the `example-org/devthrottle` placeholder the skills already use) with a new Section 6b giving it a merged-to-main Definition of Done.

## Why

Today's cleanup removed 41+ dirty files, 12 stale pull requests, 45 local branches, and 31 worktrees from a shared checkout. These rules are the mechanism that keeps that from rebuilding. The global CLAUDE.md TRUNK DEVELOPMENT section and the `/repo-hygiene` skill (v2.1) carry the same rules on the config side; this pull request carries them in the repo.

Docs only - no code paths touched.