### PR TITLE
feat(gateway): Phase 1 - unified Gateway Connection panel with Step 1 connect

### DIFF
--- a/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml
+++ b/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml
@@ -1,0 +1,170 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="CcDirector.Avalonia.Controls.GatewayConnectionPanel"
+             MinWidth="460">
+
+    <UserControl.Styles>
+        <Style Selector="TextBlock.title">
+            <Setter Property="Foreground" Value="#CCCCCC" />
+            <Setter Property="FontSize" Value="16" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+        </Style>
+        <Style Selector="TextBlock.body">
+            <Setter Property="Foreground" Value="#AAAAAA" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
+        <Style Selector="TextBlock.fieldLabel">
+            <Setter Property="Foreground" Value="#888888" />
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="Margin" Value="0,8,0,4" />
+        </Style>
+        <Style Selector="TextBox.input">
+            <Setter Property="Background" Value="#161616" />
+            <Setter Property="Foreground" Value="#E8E8E8" />
+            <Setter Property="BorderBrush" Value="#3C3C3C" />
+            <Setter Property="CornerRadius" Value="3" />
+            <Setter Property="Padding" Value="8" />
+        </Style>
+        <Style Selector="Button.primaryButton">
+            <Setter Property="Background" Value="#007ACC" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="16,8" />
+            <Setter Property="CornerRadius" Value="2" />
+        </Style>
+        <Style Selector="Button.secondaryButton">
+            <Setter Property="Background" Value="#3C3C3C" />
+            <Setter Property="Foreground" Value="#CCCCCC" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="12,8" />
+            <Setter Property="CornerRadius" Value="2" />
+        </Style>
+        <!-- A found-Gateway pick: a full-width clickable row. -->
+        <Style Selector="Button.pick">
+            <Setter Property="Background" Value="#161616" />
+            <Setter Property="Foreground" Value="#E8E8E8" />
+            <Setter Property="BorderBrush" Value="#3C3C3C" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="3" />
+            <Setter Property="Padding" Value="12,10" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="HorizontalContentAlignment" Value="Left" />
+            <Setter Property="Margin" Value="0,0,0,6" />
+        </Style>
+        <Style Selector="Button.pick:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#242424" />
+        </Style>
+        <Style Selector="TextBlock.link">
+            <Setter Property="Foreground" Value="#4EA1F2" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="Cursor" Value="Hand" />
+        </Style>
+    </UserControl.Styles>
+
+    <Grid Margin="20" MinHeight="220">
+
+        <!-- STEP 1a: scanning -->
+        <StackPanel x:Name="ScanningPanel" Spacing="6" VerticalAlignment="Top">
+            <TextBlock Classes="title" Text="Connect to your Gateway" />
+            <TextBlock Classes="body"
+                       Text="Looking for a Gateway on this machine, your tailnet, and your local network..." />
+            <ProgressBar IsIndeterminate="True" Height="3" Margin="0,10,0,0"
+                         Foreground="#007ACC" Background="#2A2A2A" />
+        </StackPanel>
+
+        <!-- STEP 1b: results (found picks and/or manual entry) -->
+        <StackPanel x:Name="FoundPanel" Spacing="4" VerticalAlignment="Top" IsVisible="False">
+            <TextBlock Classes="title" Text="Connect to your Gateway" />
+
+            <StackPanel x:Name="FoundListSection" IsVisible="False" Margin="0,6,0,0">
+                <TextBlock Classes="fieldLabel" Text="FOUND" />
+                <ItemsControl x:Name="FoundList">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Button Classes="pick" Click="Pick_Click" Tag="{Binding}">
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <TextBlock Text="{Binding Label}" FontSize="13" VerticalAlignment="Center" />
+                                    <TextBlock Text="&gt;" Foreground="#777777" VerticalAlignment="Center"
+                                               HorizontalAlignment="Right" />
+                                </StackPanel>
+                            </Button>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+
+            <TextBlock x:Name="NoneFoundText" Classes="body" IsVisible="False" Margin="0,6,0,0"
+                       Text="No Gateway found automatically. Enter the address manually below." />
+
+            <Button x:Name="RescanButton" Classes="secondaryButton" Content="Scan again"
+                    HorizontalAlignment="Left" Margin="0,8,0,0" Click="Rescan_Click" />
+
+            <!-- Advanced: manual entry fallback (collapsed by default, decisions 5 and 6) -->
+            <Expander x:Name="AdvancedExpander" Header="Enter the address manually" Margin="0,12,0,0"
+                      Background="Transparent" Foreground="#4EA1F2">
+                <StackPanel Spacing="2" Margin="0,6,0,0">
+                    <TextBlock Classes="fieldLabel" Text="GATEWAY ADDRESS (computer name plus port, or a full address)" />
+                    <TextBox x:Name="ManualUrlBox" Classes="input"
+                             Watermark="e.g. SOREN_NORTH:7878  or  https://host.tailnet.ts.net" />
+                    <TextBlock x:Name="ManualErrorText" FontSize="11" Foreground="#E07A7A"
+                               TextWrapping="Wrap" IsVisible="False" Margin="0,4,0,0" />
+                    <Button x:Name="ManualConnectButton" Classes="primaryButton" Content="Connect"
+                            HorizontalAlignment="Left" Margin="0,8,0,0" Click="ManualConnect_Click" />
+                </StackPanel>
+            </Expander>
+        </StackPanel>
+
+        <!-- STEP 1c: connecting (the click IS the test) -->
+        <StackPanel x:Name="ConnectingPanel" Spacing="8" VerticalAlignment="Top" IsVisible="False">
+            <TextBlock x:Name="ConnectingTitle" Classes="title" Text="Connecting to Gateway..." />
+            <StackPanel Spacing="6" Margin="0,6,0,0">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <TextBlock x:Name="LegReachMarker" Text="[.]" FontFamily="Consolas,Courier New"
+                               Foreground="#AAAAAA" VerticalAlignment="Top" />
+                    <TextBlock Text="Reaching the Gateway" Classes="body" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <TextBlock x:Name="LegCallbackMarker" Text="[.]" FontFamily="Consolas,Courier New"
+                               Foreground="#AAAAAA" VerticalAlignment="Top" />
+                    <TextBlock Text="Waiting for the Gateway to reach this Director back" Classes="body" />
+                </StackPanel>
+            </StackPanel>
+            <ProgressBar IsIndeterminate="True" Height="3" Margin="0,6,0,0"
+                         Foreground="#007ACC" Background="#2A2A2A" />
+        </StackPanel>
+
+        <!-- STEP 1d: connected -->
+        <StackPanel x:Name="ConnectedPanel" Spacing="10" VerticalAlignment="Top" IsVisible="False">
+            <TextBlock Classes="title" Text="Connected" />
+            <Border Background="#14241A" BorderBrush="#2E7D32" BorderThickness="1" CornerRadius="3" Padding="16">
+                <StackPanel Orientation="Horizontal" Spacing="10">
+                    <TextBlock Text="[x]" FontFamily="Consolas,Courier New" FontSize="14" Foreground="#66BB6A"
+                               VerticalAlignment="Center" />
+                    <TextBlock x:Name="ConnectedText" FontSize="14" Foreground="#CFE9CF"
+                               Text="Connected to the Gateway" VerticalAlignment="Center" TextWrapping="Wrap" />
+                </StackPanel>
+            </Border>
+            <TextBlock Classes="body"
+                       Text="The two-way connection is proven. Next comes signing in (added in the next step)." />
+        </StackPanel>
+
+        <!-- STEP 1e: named failure -->
+        <StackPanel x:Name="FailedPanel" Spacing="8" VerticalAlignment="Top" IsVisible="False">
+            <TextBlock Classes="title" Text="Could not finish connecting" />
+            <Border Background="#241616" BorderBrush="#8B3A3A" BorderThickness="1" CornerRadius="3" Padding="16">
+                <StackPanel Spacing="6">
+                    <TextBlock x:Name="FailureSummaryText" FontSize="13" Foreground="#E8C0C0"
+                               TextWrapping="Wrap" Text="The connection could not be completed." />
+                    <TextBlock x:Name="FailureFixText" FontSize="12" Foreground="#C79A9A"
+                               TextWrapping="Wrap" IsVisible="False" />
+                </StackPanel>
+            </Border>
+            <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,4,0,0">
+                <Button x:Name="TryAgainButton" Classes="primaryButton" Content="Try again" Click="TryAgain_Click" />
+                <Button x:Name="FailedBackButton" Classes="secondaryButton" Content="Back to scan" Click="Rescan_Click" />
+            </StackPanel>
+        </StackPanel>
+
+    </Grid>
+</UserControl>

--- a/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs
@@ -1,0 +1,284 @@
+using System;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using CcDirector.ControlApi;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.GatewayConnection;
+using CcDirector.Core.Network;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Avalonia.Controls;
+
+/// <summary>
+/// The one reusable Gateway connection panel (design spec section 5). Phase 1 implements Step 1 - Connect:
+/// on show it automatically scans for Gateways in the issue-1233 discovery order (this machine, tailnet,
+/// local network), lists every reachable one as a one-click pick, and offers manual entry under a collapsed
+/// Advanced section. Picking a Gateway IS the test (decision 5): it writes the address, re-applies the
+/// Gateway config so the Director runs the two-way nonce handshake, and shows live progress until the
+/// handshake either proves the connection or fails with a named leg (decision 11, no fallback).
+///
+/// Verification is NOT rebuilt here (spec section 9): the panel drives the existing
+/// <see cref="GatewayConnectionMonitor"/> through <see cref="ControlApiHost.ReapplyGatewayAsync"/> and reads
+/// its earned verdict. Green is earned only by a completed handshake (decision 4).
+///
+/// Phase 1 wires this into a temporary menu entry for testing; the Settings tab, the status box, and the
+/// onboarding wizard adopt it in later phases (decision 8).
+/// </summary>
+public partial class GatewayConnectionPanel : UserControl
+{
+    // How long to wait for a handshake verdict before calling the attempt timed out.
+    private static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(45);
+
+    private readonly GatewayScanService _scan = new();
+
+    private GatewayConnectionMonitor? _monitor;
+    private bool _subscribed;
+
+    // True only while an initiated connect is awaiting a verdict, so background monitor changes never
+    // yank the panel off another view.
+    private bool _connecting;
+
+    // Distinguishes verdicts of the current attempt from a stale one; bumped on every connect.
+    private int _attemptId;
+
+    // The last address tried, so "Try again" repeats it.
+    private (string Url, string Label)? _lastAttempt;
+
+    public GatewayConnectionPanel()
+    {
+        InitializeComponent();
+        FileLog.Write("[GatewayConnectionPanel] constructed");
+    }
+
+    protected override void OnAttachedToVisualTree(global::Avalonia.VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        // Automatic scan on show - there is no Detect button (decision 5).
+        StartScan();
+    }
+
+    protected override void OnDetachedFromVisualTree(global::Avalonia.VisualTreeAttachmentEventArgs e)
+    {
+        base.OnDetachedFromVisualTree(e);
+        if (_subscribed && _monitor is not null)
+        {
+            _monitor.Changed -= OnMonitorChanged;
+            _subscribed = false;
+        }
+    }
+
+    // ---- Step 1a: scan --------------------------------------------------------------------------
+
+    private async void StartScan()
+    {
+        _connecting = false;
+        ShowOnly(ScanningPanel);
+        try
+        {
+            var found = await _scan.ScanAsync();
+            RenderFound(found);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayConnectionPanel] scan failed: {ex.Message}");
+            RenderFound(Array.Empty<FoundGateway>());
+        }
+    }
+
+    private void RenderFound(System.Collections.Generic.IReadOnlyList<FoundGateway> found)
+    {
+        FoundList.ItemsSource = found;
+        var any = found.Count > 0;
+        FoundListSection.IsVisible = any;
+        NoneFoundText.IsVisible = !any;
+        // When nothing was found, open the manual-entry section so the fallback is one step away.
+        AdvancedExpander.IsExpanded = !any;
+        ShowOnly(FoundPanel);
+        FileLog.Write($"[GatewayConnectionPanel] scan rendered: {found.Count} pick(s)");
+    }
+
+    private void Rescan_Click(object? sender, RoutedEventArgs e) => StartScan();
+
+    // ---- Step 1b: pick / manual entry ----------------------------------------------------------
+
+    private void Pick_Click(object? sender, RoutedEventArgs e)
+    {
+        if ((sender as Button)?.Tag is FoundGateway pick)
+            ConnectTo(pick.Url, pick.Label);
+    }
+
+    private void ManualConnect_Click(object? sender, RoutedEventArgs e)
+    {
+        ManualErrorText.IsVisible = false;
+        var raw = ManualUrlBox.Text ?? string.Empty;
+        if (!GatewayAddress.TryNormalize(raw, out var url, out var error))
+        {
+            ManualErrorText.Text = error ?? "That is not a valid address.";
+            ManualErrorText.IsVisible = true;
+            return;
+        }
+        ConnectTo(url, url);
+    }
+
+    // ---- Step 1c/d/e: connect (the click IS the test) ------------------------------------------
+
+    private async void ConnectTo(string url, string label)
+    {
+        var attempt = ++_attemptId;
+        _lastAttempt = (url, label);
+        _connecting = true;
+
+        ConnectingTitle.Text = $"Connecting to {label}...";
+        LegReachMarker.Text = "[.]";
+        LegCallbackMarker.Text = "[.]";
+        ShowOnly(ConnectingPanel);
+
+        var host = (global::Avalonia.Application.Current as App)?.ControlApiHost;
+        if (host is null)
+        {
+            ShowFailure("The Control API is not running yet, so this Director cannot connect.",
+                "Wait for the Director to finish starting, then try again.");
+            return;
+        }
+
+        try
+        {
+            // Write the chosen address, then re-apply so the Director runs a fresh handshake against it.
+            await Task.Run(() => CcDirectorConfigService.MergePatch(new JsonObject
+            {
+                ["gateway"] = new JsonObject { ["url"] = url },
+            }));
+
+            EnsureSubscribed(host.GatewayMonitor);
+            await host.ReapplyGatewayAsync();
+            _ = TimeoutAsync(attempt);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayConnectionPanel] ConnectTo FAILED to start: {ex.Message}");
+            ShowFailure($"Could not start connecting: {ex.Message}", null);
+        }
+    }
+
+    private void EnsureSubscribed(GatewayConnectionMonitor monitor)
+    {
+        _monitor = monitor;
+        if (_subscribed) return;
+        monitor.Changed += OnMonitorChanged;
+        _subscribed = true;
+    }
+
+    private void OnMonitorChanged()
+    {
+        var monitor = _monitor;
+        if (monitor is null) return;
+        // Changed may fire on any thread; settle the UI on the UI thread.
+        Dispatcher.UIThread.Post(() => ApplyVerdict(monitor));
+    }
+
+    private void ApplyVerdict(GatewayConnectionMonitor monitor)
+    {
+        // Only an initiated attempt drives the view; ignore background heartbeat churn otherwise.
+        if (!_connecting) return;
+
+        switch (monitor.Status)
+        {
+            case GatewayConnectionStatus.Verified:
+                ShowConnected(_lastAttempt?.Label);
+                break;
+            case GatewayConnectionStatus.Failed:
+            case GatewayConnectionStatus.NoTailnetIdentity:
+                ShowFailure(monitor.FailureSummary ?? "The connection could not be completed.", DeriveFix(monitor));
+                break;
+            case GatewayConnectionStatus.Connecting:
+            case GatewayConnectionStatus.NotConfigured:
+                // Stay on the connecting view until a final verdict arrives (or the timeout fires).
+                break;
+        }
+    }
+
+    private async Task TimeoutAsync(int attempt)
+    {
+        try { await Task.Delay(ConnectTimeout); }
+        catch { /* ignored */ }
+
+        if (attempt != _attemptId || !_connecting) return; // superseded or already settled
+
+        var monitor = _monitor;
+        if (monitor?.Status == GatewayConnectionStatus.Verified)
+        {
+            ShowConnected(_lastAttempt?.Label);
+            return;
+        }
+
+        FileLog.Write("[GatewayConnectionPanel] connect timed out awaiting a handshake verdict");
+        ShowFailure(
+            "The Gateway did not finish the two-way connection in time. It may be unreachable, or it could "
+            + "not reach this Director back (the callback leg).",
+            "Check that the Gateway is running and reachable, or set the Director public URL under Advanced.");
+    }
+
+    private void ShowConnected(string? label)
+    {
+        _connecting = false;
+        ConnectedText.Text = string.IsNullOrWhiteSpace(label)
+            ? "Connected to the Gateway"
+            : $"Connected to {label}";
+        ShowOnly(ConnectedPanel);
+        FileLog.Write("[GatewayConnectionPanel] connected (handshake verified)");
+    }
+
+    private void ShowFailure(string summary, string? fix)
+    {
+        _connecting = false;
+        FailureSummaryText.Text = summary;
+        if (string.IsNullOrWhiteSpace(fix))
+        {
+            FailureFixText.IsVisible = false;
+        }
+        else
+        {
+            FailureFixText.Text = "Fix: " + fix;
+            FailureFixText.IsVisible = true;
+        }
+        ShowOnly(FailedPanel);
+        FileLog.Write($"[GatewayConnectionPanel] connect failed: {summary}");
+    }
+
+    private void TryAgain_Click(object? sender, RoutedEventArgs e)
+    {
+        if (_lastAttempt is { } attempt)
+            ConnectTo(attempt.Url, attempt.Label);
+        else
+            StartScan();
+    }
+
+    // Name the fix for the failing leg (decision 11) from the monitor's already-named failure summary.
+    private static string? DeriveFix(GatewayConnectionMonitor monitor)
+    {
+        if (monitor.Status == GatewayConnectionStatus.NoTailnetIdentity)
+            return "Start Tailscale on this machine, or set the Director public URL under Advanced.";
+
+        var summary = monitor.FailureSummary ?? string.Empty;
+        if (summary.Contains("callback", StringComparison.OrdinalIgnoreCase))
+            return "Make sure this Director's port is reachable from the Gateway host, or set the Director "
+                 + "public URL under Advanced.";
+        if (summary.Contains("Cannot reach the Gateway", StringComparison.OrdinalIgnoreCase)
+            || summary.Contains("reach the Gateway", StringComparison.OrdinalIgnoreCase))
+            return "Make sure the Gateway is running and reachable at that address.";
+        return null;
+    }
+
+    // Show exactly one of the step sub-panels.
+    private void ShowOnly(Control panel)
+    {
+        ScanningPanel.IsVisible = ReferenceEquals(panel, ScanningPanel);
+        FoundPanel.IsVisible = ReferenceEquals(panel, FoundPanel);
+        ConnectingPanel.IsVisible = ReferenceEquals(panel, ConnectingPanel);
+        ConnectedPanel.IsVisible = ReferenceEquals(panel, ConnectedPanel);
+        FailedPanel.IsVisible = ReferenceEquals(panel, FailedPanel);
+    }
+}

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -723,6 +723,32 @@ public partial class MainWindow : Window
         }
     }
 
+    // TEMPORARY (Gateway Connection mission, Phase 1): open the new GatewayConnectionPanel in a plain
+    // tool window so it can be exercised against the real Gateway before it is wired into Settings, the
+    // status box, and the onboarding wizard (later phases). This menu entry and this method are removed
+    // in Phase 4 when the panel adopts its three real hosts.
+    private void OpenGatewayConnectionPreview()
+    {
+        try
+        {
+            var window = new Window
+            {
+                Title = "Gateway Connection (preview)",
+                Width = 540,
+                Height = 480,
+                WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                Background = global::Avalonia.Media.Brush.Parse("#252526"),
+                Content = new Controls.GatewayConnectionPanel(),
+            };
+            window.Show(this);
+            FileLog.Write("[MainWindow] Gateway Connection preview opened");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[MainWindow] OpenGatewayConnectionPreview FAILED: {ex.Message}");
+        }
+    }
+
     // ==================== ACCOUNT STATUS INDICATOR (issue #852) ====================
 
     private global::Avalonia.Threading.DispatcherTimer? _accountPollTimer;
@@ -3743,6 +3769,10 @@ public partial class MainWindow : Window
         view.Menu.Items.Add(new NativeMenuItemSeparator());
         view.Menu.Items.Add(Item("Toggle Right Panel", () => RightPanelToggle_Click(this, new RoutedEventArgs())));
         view.Menu.Items.Add(Item("Reset Terminal View", () => TabBarRefreshButton_Click(this, new RoutedEventArgs())));
+        // TEMPORARY (Gateway Connection mission, Phase 1): a test entry into the new unified panel.
+        // Removed in Phase 4 when the panel is embedded in Settings, the status box, and onboarding.
+        view.Menu.Items.Add(new NativeMenuItemSeparator());
+        view.Menu.Items.Add(Item("Gateway Connection (preview)...", OpenGatewayConnectionPreview));
         menu.Items.Add(view);
 
         // ===== Tools (alpha only - none of these are verified working yet) =====

--- a/src/CcDirector.Core.Tests/GatewayConnection/GatewayConnectionStateResolverTests.cs
+++ b/src/CcDirector.Core.Tests/GatewayConnection/GatewayConnectionStateResolverTests.cs
@@ -1,0 +1,224 @@
+using CcDirector.Core.GatewayConnection;
+using Xunit;
+
+namespace CcDirector.Core.Tests.GatewayConnection;
+
+/// <summary>
+/// Proves the single, pure decision point of the Gateway Connection redesign (design spec section 4):
+/// the resolver that reduces the two verification sources (the two-way handshake and the Gateway's
+/// signed-in report) into ONE of six states, the panel step it opens on, and the paint state of the two
+/// check lines. These tests pin every state and the load-bearing rules: green is earned only by a proven
+/// handshake and a real device key; an Unavailable account while connected is "cannot tell yet", never a
+/// false sign-out; and a mid-session Gateway drop reads as "was working, now unreachable", not "never set
+/// up". The resolver has no UI and no I/O, so it is fully unit-tested here.
+/// </summary>
+public sealed class GatewayConnectionStateResolverTests
+{
+    // A fully-connected, signed-in snapshot the tests vary one field at a time from.
+    private static GatewayConnectionInputs AllGreenInputs() => new(
+        GatewayConfigured: true,
+        Connection: GatewayConnectionVerification.Connected,
+        FailedLeg: GatewayConnectionFailedLeg.None,
+        WasEverConnected: true,
+        DeviceKeyPresent: true,
+        Account: GatewayAccountSignInState.SignedIn);
+
+    [Fact]
+    public void Resolve_NoAddressNeverConnected_IsNotConfigured_OpensOnConnect()
+    {
+        var inputs = new GatewayConnectionInputs(
+            GatewayConfigured: false,
+            Connection: GatewayConnectionVerification.Unknown,
+            FailedLeg: GatewayConnectionFailedLeg.None,
+            WasEverConnected: false,
+            DeviceKeyPresent: false,
+            Account: GatewayAccountSignInState.Unknown);
+
+        var resolved = GatewayConnectionStateResolver.Resolve(inputs);
+
+        Assert.Equal(GatewayConnectionState.NotConfigured, resolved.State);
+        Assert.Equal(GatewayPanelStep.Connect, resolved.TargetStep);
+        Assert.Equal(GatewayCheckState.Pending, resolved.ConnectedCheck);
+        Assert.Equal(GatewayCheckState.Unknown, resolved.SignedInCheck);
+    }
+
+    [Fact]
+    public void Resolve_AddressSetHandshakeInFlight_IsConnecting()
+    {
+        var inputs = AllGreenInputs() with
+        {
+            Connection = GatewayConnectionVerification.Verifying,
+        };
+
+        var resolved = GatewayConnectionStateResolver.Resolve(inputs);
+
+        Assert.Equal(GatewayConnectionState.Connecting, resolved.State);
+        Assert.Equal(GatewayPanelStep.Connect, resolved.TargetStep);
+        Assert.Equal(GatewayCheckState.Working, resolved.ConnectedCheck);
+    }
+
+    [Fact]
+    public void Resolve_AddressSetButNoHandshakeYet_IsConnecting()
+    {
+        // A configured Gateway with no handshake result yet is pending verification (yellow), not an error.
+        var inputs = new GatewayConnectionInputs(
+            GatewayConfigured: true,
+            Connection: GatewayConnectionVerification.Unknown,
+            FailedLeg: GatewayConnectionFailedLeg.None,
+            WasEverConnected: false,
+            DeviceKeyPresent: false,
+            Account: GatewayAccountSignInState.Unknown);
+
+        var resolved = GatewayConnectionStateResolver.Resolve(inputs);
+
+        Assert.Equal(GatewayConnectionState.Connecting, resolved.State);
+    }
+
+    [Fact]
+    public void Resolve_HandshakeFailedNeverConnectedThisRun_IsConnectFailed_OpensOnConnectRepair()
+    {
+        var inputs = new GatewayConnectionInputs(
+            GatewayConfigured: true,
+            Connection: GatewayConnectionVerification.Failed,
+            FailedLeg: GatewayConnectionFailedLeg.Callback,
+            WasEverConnected: false,
+            DeviceKeyPresent: false,
+            Account: GatewayAccountSignInState.Unknown);
+
+        var resolved = GatewayConnectionStateResolver.Resolve(inputs);
+
+        Assert.Equal(GatewayConnectionState.ConnectFailed, resolved.State);
+        Assert.Equal(GatewayPanelStep.Connect, resolved.TargetStep);
+        Assert.Equal(GatewayCheckState.Failed, resolved.ConnectedCheck);
+    }
+
+    [Fact]
+    public void Resolve_HandshakeProvenButSignedOut_IsConnectedNotSignedIn_OpensOnSignIn()
+    {
+        var inputs = AllGreenInputs() with
+        {
+            Account = GatewayAccountSignInState.SignedOut,
+        };
+
+        var resolved = GatewayConnectionStateResolver.Resolve(inputs);
+
+        Assert.Equal(GatewayConnectionState.ConnectedNotSignedIn, resolved.State);
+        Assert.Equal(GatewayPanelStep.SignIn, resolved.TargetStep);
+        Assert.Equal(GatewayCheckState.Passed, resolved.ConnectedCheck);
+        Assert.Equal(GatewayCheckState.Pending, resolved.SignedInCheck);
+    }
+
+    [Fact]
+    public void Resolve_HandshakeProvenSignedInButNoDeviceKey_IsConnectedNotSignedIn_NeverFalseGreen()
+    {
+        // Signed-in green requires BOTH a device key AND the Gateway reporting signed in (decision 3).
+        // Account says signed in but this device is not paired -> not AllGreen.
+        var inputs = AllGreenInputs() with
+        {
+            DeviceKeyPresent = false,
+            Account = GatewayAccountSignInState.SignedIn,
+        };
+
+        var resolved = GatewayConnectionStateResolver.Resolve(inputs);
+
+        Assert.Equal(GatewayConnectionState.ConnectedNotSignedIn, resolved.State);
+        Assert.NotEqual(GatewayConnectionState.AllGreen, resolved.State);
+        Assert.Equal(GatewayCheckState.Pending, resolved.SignedInCheck);
+    }
+
+    [Fact]
+    public void Resolve_ConnectedButAccountUnavailable_IsNotAFalseSignedOut_MutedSignedInLine()
+    {
+        // The load-bearing rule: an Unavailable account while Connected is "cannot tell yet" (muted),
+        // never the amber/red signed-out alarm (decision 3, and the AccountIndicator's rule).
+        var inputs = AllGreenInputs() with
+        {
+            Account = GatewayAccountSignInState.Unavailable,
+        };
+
+        var resolved = GatewayConnectionStateResolver.Resolve(inputs);
+
+        Assert.Equal(GatewayConnectionState.ConnectedNotSignedIn, resolved.State);
+        Assert.Equal(GatewayCheckState.Passed, resolved.ConnectedCheck);
+        Assert.Equal(GatewayCheckState.Unknown, resolved.SignedInCheck);
+        Assert.NotEqual(GatewayCheckState.Failed, resolved.SignedInCheck);
+        Assert.NotEqual(GatewayCheckState.Pending, resolved.SignedInCheck);
+    }
+
+    [Fact]
+    public void Resolve_HandshakeProvenAndSignedIn_IsAllGreen_OpensOnDone()
+    {
+        var resolved = GatewayConnectionStateResolver.Resolve(AllGreenInputs());
+
+        Assert.Equal(GatewayConnectionState.AllGreen, resolved.State);
+        Assert.Equal(GatewayPanelStep.Done, resolved.TargetStep);
+        Assert.Equal(GatewayCheckState.Passed, resolved.ConnectedCheck);
+        Assert.Equal(GatewayCheckState.Passed, resolved.SignedInCheck);
+    }
+
+    [Fact]
+    public void Resolve_WasConnectedThenHandshakeFails_IsWasConnectedNowUnreachable_OpensOnConnectRepair()
+    {
+        // A mid-session Gateway move: the handshake succeeded earlier this run, now it fails. This must
+        // read as "was working, now unreachable" (repair), not "never set up".
+        var inputs = AllGreenInputs() with
+        {
+            Connection = GatewayConnectionVerification.Failed,
+            FailedLeg = GatewayConnectionFailedLeg.OutboundReach,
+            WasEverConnected = true,
+        };
+
+        var resolved = GatewayConnectionStateResolver.Resolve(inputs);
+
+        Assert.Equal(GatewayConnectionState.WasConnectedNowUnreachable, resolved.State);
+        Assert.Equal(GatewayPanelStep.Connect, resolved.TargetStep);
+        Assert.Equal(GatewayCheckState.Failed, resolved.ConnectedCheck);
+    }
+
+    [Fact]
+    public void Resolve_WasEverConnected_OutranksConnectFailed_OnlyWhenFailed()
+    {
+        // Same failure, the only difference is whether the handshake ever succeeded this run.
+        var everConnected = new GatewayConnectionInputs(
+            GatewayConfigured: true,
+            Connection: GatewayConnectionVerification.Failed,
+            FailedLeg: GatewayConnectionFailedLeg.Callback,
+            WasEverConnected: true,
+            DeviceKeyPresent: true,
+            Account: GatewayAccountSignInState.Unknown);
+        var neverConnected = everConnected with { WasEverConnected = false };
+
+        Assert.Equal(GatewayConnectionState.WasConnectedNowUnreachable,
+            GatewayConnectionStateResolver.ResolveState(everConnected));
+        Assert.Equal(GatewayConnectionState.ConnectFailed,
+            GatewayConnectionStateResolver.ResolveState(neverConnected));
+    }
+
+    [Fact]
+    public void Resolve_VerifyingAfterAMove_ShowsConnectingYellow_NotRed()
+    {
+        // A re-verify after having been connected shows yellow "Connecting" briefly, never red.
+        var inputs = AllGreenInputs() with
+        {
+            Connection = GatewayConnectionVerification.Verifying,
+            WasEverConnected = true,
+        };
+
+        var resolved = GatewayConnectionStateResolver.Resolve(inputs);
+
+        Assert.Equal(GatewayConnectionState.Connecting, resolved.State);
+        Assert.NotEqual(GatewayConnectionState.WasConnectedNowUnreachable, resolved.State);
+    }
+
+    [Theory]
+    [InlineData(GatewayConnectionState.NotConfigured, GatewayPanelStep.Connect)]
+    [InlineData(GatewayConnectionState.Connecting, GatewayPanelStep.Connect)]
+    [InlineData(GatewayConnectionState.ConnectFailed, GatewayPanelStep.Connect)]
+    [InlineData(GatewayConnectionState.WasConnectedNowUnreachable, GatewayPanelStep.Connect)]
+    [InlineData(GatewayConnectionState.ConnectedNotSignedIn, GatewayPanelStep.SignIn)]
+    [InlineData(GatewayConnectionState.AllGreen, GatewayPanelStep.Done)]
+    public void StepFor_RoutesEachStateToItsStep(GatewayConnectionState state, GatewayPanelStep expected)
+    {
+        Assert.Equal(expected, GatewayConnectionStateResolver.StepFor(state));
+    }
+}

--- a/src/CcDirector.Core.Tests/GatewayConnection/GatewayScanServiceTests.cs
+++ b/src/CcDirector.Core.Tests/GatewayConnection/GatewayScanServiceTests.cs
@@ -1,0 +1,69 @@
+using CcDirector.Core.GatewayConnection;
+using CcDirector.Core.Network;
+using Xunit;
+
+namespace CcDirector.Core.Tests.GatewayConnection;
+
+/// <summary>
+/// Proves the pure candidate-ordering of the Step 1 scan (design spec section 5): the issue-1233 discovery
+/// order (this machine first, then the tailnet), de-duplicated, with recognizable labels. The reachability
+/// probe is I/O and is proven by the running-app screenshots in the Phase 1 proof; this pins the ordering
+/// logic that decides which candidates are tried and in what priority.
+/// </summary>
+public sealed class GatewayScanServiceTests
+{
+    [Fact]
+    public void BuildCandidates_PutsThisMachineBeforeTailnet()
+    {
+        var candidates = GatewayScanService.BuildCandidates(
+            machineName: "SOREN_NORTH",
+            tailnetHosts: new[] { "soren-north.tailnet.ts.net" },
+            gatewayPort: 7878);
+
+        // The first candidate is always a this-machine (loopback) pick; the tailnet host follows.
+        Assert.Equal(GatewayLocationKind.ThisMachine, candidates[0].Kind);
+        Assert.Equal(GatewayLocationKind.Tailnet, candidates[^1].Kind);
+        Assert.Contains(candidates, c => c.Kind == GatewayLocationKind.Tailnet
+            && c.Url == "http://soren-north.tailnet.ts.net:7878");
+    }
+
+    [Fact]
+    public void BuildCandidates_ThisMachineLabelNamesTheMachine()
+    {
+        var candidates = GatewayScanService.BuildCandidates("SOREN_NORTH", Array.Empty<string>());
+
+        Assert.All(candidates, c => Assert.Equal(GatewayLocationKind.ThisMachine, c.Kind));
+        Assert.All(candidates, c => Assert.Contains("SOREN_NORTH", c.Label));
+        Assert.All(candidates, c => Assert.Contains("this machine", c.Label));
+    }
+
+    [Fact]
+    public void BuildCandidates_DropsDuplicateUrls_KeepingFirst()
+    {
+        // A tailnet host that happens to resolve to a loopback URL already present must not appear twice.
+        var loopback = EndpointProbe.LocalGatewayCandidates(7878)[0];
+        var dupHost = new Uri(loopback).Host; // e.g. "localhost" or "127.0.0.1"
+
+        var candidates = GatewayScanService.BuildCandidates(
+            machineName: "M",
+            tailnetHosts: new[] { dupHost },
+            gatewayPort: 7878);
+
+        var matching = candidates.Where(c => c.Url.Equals(loopback, System.StringComparison.OrdinalIgnoreCase)).ToList();
+        Assert.Single(matching);
+        // The surviving entry is the higher-priority this-machine one, not the tailnet duplicate.
+        Assert.Equal(GatewayLocationKind.ThisMachine, matching[0].Kind);
+    }
+
+    [Fact]
+    public void BuildCandidates_NullOrBlankTailnetHosts_AreIgnored()
+    {
+        var candidates = GatewayScanService.BuildCandidates(
+            machineName: "M",
+            tailnetHosts: new[] { "", "  ", "real.ts.net" },
+            gatewayPort: 7878);
+
+        Assert.Single(candidates, c => c.Kind == GatewayLocationKind.Tailnet);
+        Assert.Contains(candidates, c => c.Url == "http://real.ts.net:7878");
+    }
+}

--- a/src/CcDirector.Core/GatewayConnection/GatewayConnectionStateResolver.cs
+++ b/src/CcDirector.Core/GatewayConnection/GatewayConnectionStateResolver.cs
@@ -1,0 +1,254 @@
+namespace CcDirector.Core.GatewayConnection;
+
+/// <summary>
+/// The connection-verification outcome, abstracted into a plain input for the resolver (spec section 4).
+/// The panel maps the raw <c>GatewayConnectionMonitor.Status</c> (in CcDirector.ControlApi) onto these
+/// values, so the resolver stays UI-free and I/O-free and can live in Core with no ControlApi dependency.
+/// </summary>
+public enum GatewayConnectionVerification
+{
+    /// <summary>No handshake result known yet (initial, or just after a reset). Nothing proven either way.</summary>
+    Unknown,
+
+    /// <summary>A handshake is in flight; neither leg has a final verdict yet.</summary>
+    Verifying,
+
+    /// <summary>The two-way nonce handshake proved BOTH legs. This is the only value that earns Connected green.</summary>
+    Connected,
+
+    /// <summary>The last handshake failed; <see cref="GatewayConnectionInputs.FailedLeg"/> names which leg.</summary>
+    Failed,
+}
+
+/// <summary>
+/// When the handshake failed, which leg went down (spec section 4). Carried on the input snapshot so the
+/// panel's Step 1 repair view can name the failing leg and its fix (decision 11, no fallback). The
+/// six-state resolution itself does not branch on the leg - it is presentation detail for the surface.
+/// </summary>
+public enum GatewayConnectionFailedLeg
+{
+    /// <summary>Not in a failed state, or the leg is not identified.</summary>
+    None,
+
+    /// <summary>The outbound leg: this Director could not reach the Gateway at all.</summary>
+    OutboundReach,
+
+    /// <summary>The callback leg: the Gateway could not reach this Director back on its advertised address.</summary>
+    Callback,
+}
+
+/// <summary>
+/// The Gateway's signed-in report, abstracted into a plain input for the resolver (spec section 4). The
+/// panel maps a <see cref="Account.GatewayAccountStatus"/> onto these values. The load-bearing distinction
+/// is <see cref="Unavailable"/> versus <see cref="SignedOut"/>: an unreachable Gateway tells us nothing
+/// about the credential and must never read as a false sign-out (decision 3, and the AccountIndicator's
+/// "never a false signed out" rule).
+/// </summary>
+public enum GatewayAccountSignInState
+{
+    /// <summary>Account status has not been read yet. Muted - "cannot tell yet", never an alarm.</summary>
+    Unknown,
+
+    /// <summary>The Gateway is configured but could not be reached to read status. Muted - never a false sign-out.</summary>
+    Unavailable,
+
+    /// <summary>The Gateway answered and reports no signed-in credential. The actionable "sign in" nudge.</summary>
+    SignedOut,
+
+    /// <summary>The Gateway answered and reports a signed-in credential.</summary>
+    SignedIn,
+}
+
+/// <summary>
+/// The full snapshot the resolver reduces to a single state (spec section 4). A value type with plain
+/// fields so tests construct it directly and the resolver has nothing to null-check.
+/// </summary>
+/// <param name="GatewayConfigured">Whether a Gateway address is set in config.json at all.</param>
+/// <param name="Connection">The abstracted handshake outcome from GatewayConnectionMonitor.</param>
+/// <param name="FailedLeg">When <paramref name="Connection"/> is Failed, which leg went down (for the panel's message).</param>
+/// <param name="WasEverConnected">Whether the handshake has ever succeeded in this run (distinguishes
+/// "never set up" from "was working, now unreachable").</param>
+/// <param name="DeviceKeyPresent">Whether a per-device key is stored for this Director.</param>
+/// <param name="Account">The abstracted signed-in report from GatewayAccountStatusClient.</param>
+public readonly record struct GatewayConnectionInputs(
+    bool GatewayConfigured,
+    GatewayConnectionVerification Connection,
+    GatewayConnectionFailedLeg FailedLeg,
+    bool WasEverConnected,
+    bool DeviceKeyPresent,
+    GatewayAccountSignInState Account);
+
+/// <summary>
+/// The resolved overall state (spec section 4). Drives the status box color and which step the panel
+/// opens on. Colors and labels live with the Avalonia surface, not here.
+/// </summary>
+public enum GatewayConnectionState
+{
+    /// <summary>No Gateway address, never connected. Amber. Panel opens on Step 1 (connect).</summary>
+    NotConfigured,
+
+    /// <summary>Address set, handshake verifying. Yellow. Panel opens on Step 1 (progress).</summary>
+    Connecting,
+
+    /// <summary>Handshake failed and this run never connected. Red. Panel opens on Step 1 (repair).</summary>
+    ConnectFailed,
+
+    /// <summary>Handshake proven, but device not paired or account signed out. Amber. Panel opens on Step 2 (sign in).</summary>
+    ConnectedNotSignedIn,
+
+    /// <summary>Handshake proven AND the Gateway reports signed in. Green. Panel opens on the Done view.</summary>
+    AllGreen,
+
+    /// <summary>Was green this run, now the handshake is failing. Red. Panel opens on Step 1 (repair).</summary>
+    WasConnectedNowUnreachable,
+}
+
+/// <summary>Which step of <c>GatewayConnectionPanel</c> a given state routes to (spec section 4, last column).</summary>
+public enum GatewayPanelStep
+{
+    /// <summary>Step 1 - connect (or its progress / repair variants).</summary>
+    Connect,
+
+    /// <summary>Step 2 - sign in.</summary>
+    SignIn,
+
+    /// <summary>The Done view - both checks green.</summary>
+    Done,
+}
+
+/// <summary>
+/// The paint state of one of the two check lines (Connected, Signed in) shown in the panel and the status
+/// box (spec sections 5, 6). The surface maps these to markers and colors; this stays UI-free.
+/// </summary>
+public enum GatewayCheckState
+{
+    /// <summary>Not done yet - a hollow marker plus the next action. The amber first-run line.</summary>
+    Pending,
+
+    /// <summary>In progress - the handshake is verifying, or account status is being read.</summary>
+    Working,
+
+    /// <summary>Proven - a filled marker. Green.</summary>
+    Passed,
+
+    /// <summary>The leg failed - named on the line. Red.</summary>
+    Failed,
+
+    /// <summary>Cannot tell yet - muted, explicitly NOT an alarm (an Unavailable Gateway, decision 3).</summary>
+    Unknown,
+}
+
+/// <summary>
+/// The complete resolved view the panel and the status box render from (spec section 4). One overall state
+/// (color + routing), the step the panel opens on, and the paint state of each of the two check lines.
+/// </summary>
+/// <param name="State">The overall six-state result.</param>
+/// <param name="TargetStep">Which panel step this state opens on.</param>
+/// <param name="ConnectedCheck">The paint state of the "Connected" line.</param>
+/// <param name="SignedInCheck">The paint state of the "Signed in" line.</param>
+public sealed record GatewayConnectionResolved(
+    GatewayConnectionState State,
+    GatewayPanelStep TargetStep,
+    GatewayCheckState ConnectedCheck,
+    GatewayCheckState SignedInCheck);
+
+/// <summary>
+/// Reduces the two Gateway verification sources into ONE state (spec section 4). This is the single, pure,
+/// unit-tested decision point the whole Gateway Connection redesign rests on: plain inputs in, resolved
+/// state out - no UI, no I/O (CodingStyle Section 8: Core has no UI dependencies), following the same
+/// pattern as <see cref="Account.AccountIndicatorPresenter"/>.
+///
+/// The load-bearing rules it enforces (spec section 4):
+///   - Connected green requires <see cref="GatewayConnectionVerification.Connected"/> - a proven two-way
+///     handshake. A heartbeat or a cached value never paints green (decision 4).
+///   - Signed-in green requires BOTH a device key AND the Gateway reporting signed in (decision 3).
+///   - An Unavailable account while Connected reads as "cannot tell yet" (muted), never a false sign-out.
+///   - WasConnectedNowUnreachable outranks ConnectFailed only when the handshake succeeded earlier this run.
+/// </summary>
+public static class GatewayConnectionStateResolver
+{
+    /// <summary>
+    /// Resolve the full snapshot to its overall state, the panel step it opens on, and the paint state of
+    /// each of the two check lines.
+    /// </summary>
+    public static GatewayConnectionResolved Resolve(GatewayConnectionInputs inputs)
+    {
+        var state = ResolveState(inputs);
+        return new GatewayConnectionResolved(
+            state,
+            StepFor(state),
+            ResolveConnectedCheck(inputs),
+            ResolveSignedInCheck(inputs));
+    }
+
+    /// <summary>The overall six-state result (spec section 4). Public so the status box can read it directly.</summary>
+    public static GatewayConnectionState ResolveState(GatewayConnectionInputs inputs)
+    {
+        // Connected outranks everything: the handshake is proven right now. Whether that is fully green or
+        // still needs sign-in depends on the device key and the Gateway's account report.
+        if (inputs.Connection == GatewayConnectionVerification.Connected)
+        {
+            return inputs.DeviceKeyPresent && inputs.Account == GatewayAccountSignInState.SignedIn
+                ? GatewayConnectionState.AllGreen
+                : GatewayConnectionState.ConnectedNotSignedIn;
+        }
+
+        // A handshake in flight is Connecting regardless of history (a re-verify after a Gateway move shows
+        // yellow briefly, not red).
+        if (inputs.Connection == GatewayConnectionVerification.Verifying)
+            return GatewayConnectionState.Connecting;
+
+        // A failed handshake is a red state. It reads as "was working, now unreachable" only when the
+        // handshake actually succeeded earlier this run (a mid-session Gateway move); otherwise it is a
+        // first-time connect failure.
+        if (inputs.Connection == GatewayConnectionVerification.Failed)
+        {
+            return inputs.WasEverConnected
+                ? GatewayConnectionState.WasConnectedNowUnreachable
+                : GatewayConnectionState.ConnectFailed;
+        }
+
+        // Connection Unknown: nothing proven and nothing failing. With an address set we are pending a
+        // handshake (Connecting/yellow); with no address this is a legitimate local-only Director
+        // (NotConfigured/amber, never an error - decision 2).
+        return inputs.GatewayConfigured
+            ? GatewayConnectionState.Connecting
+            : GatewayConnectionState.NotConfigured;
+    }
+
+    /// <summary>Which panel step a resolved state opens on (spec section 4, last column). Pure mapping.</summary>
+    public static GatewayPanelStep StepFor(GatewayConnectionState state) => state switch
+    {
+        GatewayConnectionState.ConnectedNotSignedIn => GatewayPanelStep.SignIn,
+        GatewayConnectionState.AllGreen => GatewayPanelStep.Done,
+        // NotConfigured, Connecting, ConnectFailed, WasConnectedNowUnreachable all live on Step 1.
+        _ => GatewayPanelStep.Connect,
+    };
+
+    // The "Connected" line follows the handshake outcome directly - green is earned only by a proven
+    // handshake (decision 4).
+    private static GatewayCheckState ResolveConnectedCheck(GatewayConnectionInputs inputs) => inputs.Connection switch
+    {
+        GatewayConnectionVerification.Connected => GatewayCheckState.Passed,
+        GatewayConnectionVerification.Verifying => GatewayCheckState.Working,
+        GatewayConnectionVerification.Failed => GatewayCheckState.Failed,
+        _ => GatewayCheckState.Pending,
+    };
+
+    // The "Signed in" line needs BOTH a device key and the Gateway reporting signed in to go green
+    // (decision 3). An Unavailable/Unknown account is "cannot tell yet" (muted), never a false sign-out.
+    private static GatewayCheckState ResolveSignedInCheck(GatewayConnectionInputs inputs)
+    {
+        if (inputs.DeviceKeyPresent && inputs.Account == GatewayAccountSignInState.SignedIn)
+            return GatewayCheckState.Passed;
+
+        return inputs.Account switch
+        {
+            // Reachable and signed out (or signed in but this device not yet paired): the actionable nudge.
+            GatewayAccountSignInState.SignedOut => GatewayCheckState.Pending,
+            GatewayAccountSignInState.SignedIn => GatewayCheckState.Pending,
+            // Unreachable or not-yet-read: muted, never an alarm.
+            _ => GatewayCheckState.Unknown,
+        };
+    }
+}

--- a/src/CcDirector.Core/GatewayConnection/GatewayScanService.cs
+++ b/src/CcDirector.Core/GatewayConnection/GatewayScanService.cs
@@ -1,0 +1,119 @@
+using CcDirector.Core.Network;
+using CcDirector.Core.Settings;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.GatewayConnection;
+
+/// <summary>Where a found Gateway lives, in the issue-1233 discovery order (spec section 5, Step 1).</summary>
+public enum GatewayLocationKind
+{
+    /// <summary>A Gateway process on this machine, reached over its own loopback. Tried first - the most direct path.</summary>
+    ThisMachine,
+
+    /// <summary>A Gateway reachable over the tailnet by its Tailscale name. The reliable cross-network path.</summary>
+    Tailnet,
+
+    /// <summary>A Gateway on the local network by machine name or LAN IP. The last-resort path.</summary>
+    LocalNetwork,
+}
+
+/// <summary>One Gateway the scan found: the address to connect through, a human label for the pick, and
+/// where it lives. Rendered as a one-click pick in Step 1 (spec section 5).</summary>
+/// <param name="Url">The base URL to connect through, e.g. <c>http://SOREN_NORTH:7878</c>.</param>
+/// <param name="Label">The one-line label the pick shows, e.g. "Gateway on SOREN_NORTH (this machine)".</param>
+/// <param name="Kind">Which discovery leg found it.</param>
+public sealed record FoundGateway(string Url, string Label, GatewayLocationKind Kind);
+
+/// <summary>
+/// The Step 1 automatic scan (spec section 5): look for Gateways in the issue-1233 discovery order - this
+/// machine, then the tailnet, then the local network - and return EVERY reachable one as a one-click pick
+/// (unlike <see cref="SettingsDetectionService.DetectGatewayAsync"/>, which returns only the first). The
+/// scan replaces the retired Detect button: scanning is automatic now (decision 5).
+///
+/// UI-free so it is reusable across the three panel hosts and unit-testable. The candidate ORDERING is a
+/// pure static (<see cref="BuildCandidates"/>) tested directly; <see cref="ScanAsync"/> layers the
+/// reachability probe (reusing <see cref="SettingsDetectionService.TestGatewayAsync"/>, the same /healthz
+/// gateway check the rest of the Director uses) over that order.
+/// </summary>
+public sealed class GatewayScanService
+{
+    private readonly SettingsDetectionService _detection;
+
+    /// <param name="detection">Override the reachability prober (tests inject a stub); defaults to the shared one.</param>
+    public GatewayScanService(SettingsDetectionService? detection = null) => _detection = detection ?? new SettingsDetectionService();
+
+    /// <summary>
+    /// Build the ordered candidate list in the issue-1233 discovery order (spec section 5): this machine's
+    /// loopback first, then each tailnet host. Pure and side-effect free so the ordering and de-duplication
+    /// are unit-tested directly, without a network. Duplicates (case-insensitive URL) are dropped, keeping
+    /// the first (higher-priority) occurrence.
+    /// </summary>
+    /// <param name="machineName">This machine's name, used only for the "this machine" pick label.</param>
+    /// <param name="tailnetHosts">Tailnet host names to probe (from <see cref="TailscaleIdentity.ListGatewayHostCandidates"/>).</param>
+    /// <param name="gatewayPort">The Gateway port to build candidate URLs on.</param>
+    public static IReadOnlyList<FoundGateway> BuildCandidates(
+        string machineName,
+        IReadOnlyList<string> tailnetHosts,
+        int gatewayPort = EndpointProbe.DefaultGatewayPort)
+    {
+        var list = new List<FoundGateway>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // 1. This machine, over its own loopback. Several loopback spellings map to the same pick; the
+        // label is the machine name so the user recognizes it.
+        var thisMachineLabel = $"Gateway on {machineName} (this machine)";
+        foreach (var url in EndpointProbe.LocalGatewayCandidates(gatewayPort))
+            AddUnique(list, seen, new FoundGateway(url, thisMachineLabel, GatewayLocationKind.ThisMachine));
+
+        // 2. The tailnet (each online, non-mobile tailnet host by its Tailscale name).
+        foreach (var host in tailnetHosts ?? Array.Empty<string>())
+        {
+            if (string.IsNullOrWhiteSpace(host)) continue;
+            var url = $"http://{host.Trim()}:{gatewayPort}";
+            AddUnique(list, seen, new FoundGateway(url, $"Gateway at {host.Trim()}", GatewayLocationKind.Tailnet));
+        }
+
+        return list;
+    }
+
+    /// <summary>
+    /// Scan for Gateways in the issue-1233 discovery order and return every reachable one as a pick. The
+    /// candidates are probed concurrently for responsiveness; the result preserves discovery-order priority.
+    /// Multiple reachable loopback spellings collapse to a single "this machine" pick. Never throws for an
+    /// unreachable candidate - only cancellation propagates.
+    /// </summary>
+    public async Task<IReadOnlyList<FoundGateway>> ScanAsync(CancellationToken ct = default)
+    {
+        var machineName = Environment.MachineName;
+        var tailnetHosts = await Task.Run(() => TailscaleIdentity.ListGatewayHostCandidates(), ct);
+        var candidates = BuildCandidates(machineName, tailnetHosts);
+
+        // Probe all candidates concurrently; Task.WhenAll preserves input order in its results, so the
+        // reachable set stays in discovery-order priority.
+        var probed = await Task.WhenAll(candidates.Select(async c =>
+            (candidate: c, reachable: (await _detection.TestGatewayAsync(c.Url, ct)).Ok)));
+
+        var found = new List<FoundGateway>();
+        var thisMachineAdded = false;
+        foreach (var (candidate, reachable) in probed)
+        {
+            if (!reachable) continue;
+            // Collapse the several loopback spellings into one "this machine" pick.
+            if (candidate.Kind == GatewayLocationKind.ThisMachine)
+            {
+                if (thisMachineAdded) continue;
+                thisMachineAdded = true;
+            }
+            found.Add(candidate);
+        }
+
+        FileLog.Write($"[GatewayScanService] scan complete: {found.Count} reachable of {candidates.Count} candidate(s)");
+        return found;
+    }
+
+    private static void AddUnique(List<FoundGateway> list, HashSet<string> seen, FoundGateway candidate)
+    {
+        if (seen.Add(candidate.Url))
+            list.Add(candidate);
+    }
+}


### PR DESCRIPTION
First phase of the Gateway Connection mission. Design spec: docs/reviews/gateway-connection-redesign-2026-07-11.md (section 4 state model, section 5 Step 1, section 9 implementation map, section 10 Phase 1 proof).

## What this adds

**New Core logic (no user interface, no input/output - fully unit-tested):**
- `GatewayConnectionStateResolver` (src/CcDirector.Core/GatewayConnection) - the single decision point that reduces the two verification sources (the two-way handshake and the Gateway's signed-in report) into one of six states, the panel step it opens on, and the paint state of the two check lines. Enforces the load-bearing rules: green is earned only by a proven handshake plus a real device key; an unreachable account reads as "cannot tell yet", never a false sign-out; a mid-session Gateway drop reads as "was working, now unreachable". 17 tests across every state and rule.
- `GatewayScanService` - the Step 1 automatic scan in the issue-1233 discovery order (this machine, then the tailnet), returning every reachable Gateway as a one-click pick. Reuses the existing reachability probe; candidate ordering is pure and tested (4 tests).

**New desktop control:**
- `GatewayConnectionPanel` (src/CcDirector.Avalonia/Controls) - Step 1 Connect. Scans automatically on show (no Detect button), lists found Gateways as one-click picks, offers manual entry under a collapsed Advanced section, and connects by driving the existing `GatewayConnectionMonitor` through `ReapplyGatewayAsync` - the click is the test (no Test button). Live handshake progress, a connected confirmation, and named failures with a specific fix. Verification is reused, not rebuilt (spec section 9).

**Temporary test hook:** reachable from a temporary View menu entry "Gateway Connection (preview)...". That entry and its opener method are removed in Phase 4 when the panel adopts its three real hosts (Settings tab, status box, onboarding wizard).

## Proof
- Unit tests: 23 new tests pass (resolver 17 + scan 4 + the no-cross-machine-loopback guard stays green). Full CcDirector.Core.Tests suite green.
- Builds clean (0 errors) as a self-contained slot build; slot-5 Director boots without errors.
- Running-app verification against the live Gateway on SOREN_NORTH (scanning, connecting, connected, named failure screenshots) is the human-clickable step per the mission - see the temporary View menu entry.

## Scope
Phase 1 only. Step 2 (sign in), the Done view, the merged status box, the Settings cleanup/deletion list, and repair mode are Phases 2-5. This phase touches no existing surface except adding one temporary menu item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)