### PR TITLE
docs(gateway): Step 1 guidance, recommendation, and dictation-style visuals

### DIFF
--- a/docs/reviews/gateway-connection-redesign-2026-07-11.md
+++ b/docs/reviews/gateway-connection-redesign-2026-07-11.md
@@ -151,20 +151,76 @@ Found Gateways appear as one-click picks. Picking one runs the connect - which I
 (decision 5): it fires the two-way handshake and shows live progress. There is no separate Test
 button and no separate Detect button.
 
-ASCII wireframe - scanning, then found:
+This is the ONLY screen a brand-new user sees, so it must teach as well as work. It carries a
+plain-English intro, a clearly-marked recommendation, and a one-line "when to use this" on every
+option. Approved by Soren 2026-07-11; the rendered reference is
+docs/reviews/gateway-connection-step1-mockup-2026-07-11.html.
+
+Copy (use these words - decision 12, plain English):
+
+- Title: "Connect to your Gateway", with a small state pill in the header showing the count
+  ("2 FOUND" while found, "SCANNING..." while the scan runs).
+- Intro paragraph: "Your Gateway is the hub this Director connects to for voice, the fleet view,
+  cross-machine sessions, and shared keys. Pick how this Director should reach it - we looked on
+  this computer and over Tailscale. Not sure? Start with the one marked Recommended."
+- Section label above the list: "FOUND ON YOUR NETWORK".
+
+Each found option is a framed row: an icon, a name plus its address, a "when to use this" line, and
+a chevron. The per-kind copy:
+
+- This computer (Gateway on localhost): name "This computer", address = the machine name; when:
+  "The Gateway runs on this machine. Fastest and always available - the computer name does not
+  change, so this keeps working."
+- On your network (Gateway found by machine-name / LAN IP): name "On your network", address = the
+  machine name; when: "The Gateway is on another computer on your network. The computer name rarely
+  changes, so this keeps working - best when you are on the same network."
+- Over Tailscale: name "Over Tailscale", address = the ts.net name; when: "Reaches the Gateway from
+  any network. Use this on a laptop you travel with, or from a remote office - anywhere you are not
+  on the same network as the Gateway."
+
+The Recommended rule (decides which ONE row gets the badge): recommend the most stable LOCAL name
+that is reachable, in priority order This computer > On your network > Over Tailscale. Tailscale is
+recommended ONLY when it is the sole option found. When more than one is found, exactly one row
+carries a "Recommended" badge and a green left-accent; the rest are plain. This encodes Soren's
+rule: the local machine name rarely changes, so it is the default; Tailscale is the off-network
+fallback for travel or a remote office.
+
+A footnote under the list states the no-hidden-test rule: "Picking an option connects right away
+and checks the two-way connection - there is no separate Test step." A subtle "Scan again" link
+sits below the list.
+
+Visual direction (match the dictation card, TranscriptionComponent.axaml, and docs/VisualStyle.md;
+single dark theme, ASCII only): card surface #252526 on the #1E1E1E panel, 1px #3C3C3C borders,
+9-10px corner radius; the header count pill tinted blue (background #16283F, text #5AA9F0); the
+Recommended row uses a green left-accent bar (#34D06E) and badge (background #1B3A2A, text #34D06E)
+with a faint green wash; option icons in small tinted tiles (a monitor glyph for local, a globe for
+Tailscale); guidance/intro text in muted blue #6C79A0; the "when to use" lines in #888888 with the
+key phrase emphasized in #AAAAAA. No new accent colors beyond the app palette.
+
+ASCII wireframe - scanning, then found (two options, the local one recommended):
 
 ```
-+--------------------------------------------------+
-|  Connect to your Gateway                         |
-|  Looking for a Gateway on this machine, your     |
-|  tailnet, and your local network...              |
-|                                                  |
-|  Found:                                          |
-|   [ Gateway on SOREN_NORTH (this machine)   > ]  |
-|   [ Gateway at soren-north.tailnet.ts.net   > ]  |
-|                                                  |
-|  Not listed?  Enter the address manually         |  <- link, not a box
-+--------------------------------------------------+
++----------------------------------------------------------+
+|  Connect to your Gateway                       [ 2 FOUND ]|
+|  Your Gateway is the hub this Director connects to for    |
+|  voice, the fleet view, cross-machine sessions, and       |
+|  shared keys. Pick how this Director should reach it -     |
+|  we looked on this computer and over Tailscale. Not sure? |
+|  Start with the one marked Recommended.                   |
+|                                                          |
+|  FOUND ON YOUR NETWORK                                    |
+|  | []  This computer  SOREN_NORTH   [Recommended]     > | |  <- green accent
+|  |     The Gateway runs on this machine. Fastest and    | |
+|  |     always available - the name does not change.     | |
+|  | ()  Over Tailscale  soren-north....ts.net           > | |
+|  |     Reaches the Gateway from any network. Use this   | |
+|  |     on a laptop you travel with or a remote office.  | |
+|                                                          |
+|  Scan again                                              |
+|  [ v Enter the address manually - name+port or full URL ]|  <- collapsed Advanced
+|  (check) Picking an option connects right away and checks |
+|          the two-way connection - no separate Test step.  |
++----------------------------------------------------------+
 ```
 
 ASCII wireframe - connecting (live progress), the click IS the test:

--- a/docs/reviews/gateway-connection-step1-mockup-2026-07-11.html
+++ b/docs/reviews/gateway-connection-step1-mockup-2026-07-11.html
@@ -1,0 +1,345 @@
+<title>Gateway Connection - redesigned Step 1</title>
+<style>
+  :root {
+    --window: #333333;
+    --panel: #1E1E1E;
+    --card: #252526;
+    --card-hover: #2E2E30;
+    --border: #3C3C3C;
+    --border-strong: #4A4A4A;
+    --text: #CCCCCC;
+    --text-2: #AAAAAA;
+    --text-3: #888888;
+    --muted: #666666;
+    --accent: #007ACC;
+    --hint: #6C79A0;
+    --green-bg: #1B3A2A;
+    --green-fg: #34D06E;
+    --green-accent: #2E7D50;
+    --blue-bg: #16283F;
+    --blue-fg: #5AA9F0;
+    --inner: #1A1A1A;
+    --font: "Segoe UI", system-ui, sans-serif;
+    --mono: "Cascadia Mono", Consolas, monospace;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background:
+      radial-gradient(1200px 600px at 50% -10%, #262a30 0%, #1a1c1f 55%, #141517 100%);
+    font-family: var(--font);
+    color: var(--text);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 26px;
+    padding: 40px 20px 60px;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .caption {
+    max-width: 640px;
+    text-align: center;
+    color: var(--text-3);
+    font-size: 13px;
+    line-height: 1.5;
+  }
+  .caption strong { color: var(--text-2); font-weight: 600; }
+
+  /* ---- app window ---- */
+  .window {
+    width: 620px;
+    max-width: 100%;
+    border-radius: 10px;
+    overflow: hidden;
+    background: var(--panel);
+    border: 1px solid #2a2a2a;
+    box-shadow: 0 24px 60px rgba(0,0,0,0.55), 0 2px 0 rgba(255,255,255,0.02) inset;
+  }
+
+  .titlebar {
+    height: 40px;
+    background: var(--window);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 0 12px;
+    border-bottom: 1px solid #262626;
+  }
+  .titlebar .logo {
+    font-family: var(--mono);
+    font-weight: 700;
+    font-size: 12px;
+    color: #6fb3e0;
+    letter-spacing: 0.5px;
+  }
+  .titlebar .title { font-size: 12.5px; color: var(--text-2); }
+  .titlebar .win-btns { margin-left: auto; display: flex; gap: 16px; color: var(--muted); font-size: 13px; }
+
+  /* ---- panel body ---- */
+  .body { padding: 22px 22px 24px; }
+
+  .head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 6px;
+  }
+  .head h1 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: #E4E4E4;
+    letter-spacing: 0.2px;
+  }
+  .pill {
+    margin-left: auto;
+    font-size: 10.5px;
+    font-weight: 700;
+    letter-spacing: 0.6px;
+    padding: 4px 9px;
+    border-radius: 11px;
+    background: var(--blue-bg);
+    color: var(--blue-fg);
+    white-space: nowrap;
+  }
+
+  .intro {
+    color: var(--hint);
+    font-size: 12.5px;
+    line-height: 1.55;
+    margin: 4px 0 18px;
+    max-width: 540px;
+  }
+  .intro b { color: #9fb0d6; font-weight: 600; }
+
+  .section-label {
+    font-size: 10.5px;
+    font-weight: 700;
+    letter-spacing: 1.1px;
+    color: var(--text-3);
+    margin: 0 0 10px 2px;
+  }
+
+  .options { display: flex; flex-direction: column; gap: 10px; }
+
+  .opt {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 14px 15px;
+    border-radius: 9px;
+    background: var(--card);
+    border: 1px solid var(--border);
+    cursor: pointer;
+    transition: background 120ms ease, border-color 120ms ease;
+  }
+  .opt:hover { background: var(--card-hover); border-color: var(--border-strong); }
+
+  .opt.recommended {
+    border-color: var(--green-accent);
+    background: linear-gradient(90deg, rgba(46,125,80,0.14) 0%, rgba(37,37,38,0.9) 34%);
+  }
+  .opt.recommended::before {
+    content: "";
+    position: absolute;
+    left: 0; top: 8px; bottom: 8px;
+    width: 3px;
+    border-radius: 3px;
+    background: var(--green-fg);
+  }
+
+  .opt .ico {
+    flex: 0 0 auto;
+    width: 38px; height: 38px;
+    border-radius: 8px;
+    background: #1F2A22;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .opt.net .ico { background: #172433; }
+  .opt .ico svg { width: 20px; height: 20px; display: block; }
+
+  .opt .info { flex: 1 1 auto; min-width: 0; }
+  .opt .name-row { display: flex; align-items: center; gap: 8px; margin-bottom: 3px; }
+  .opt .name {
+    font-size: 14px;
+    font-weight: 600;
+    color: #E6E6E6;
+  }
+  .opt .addr { font-family: var(--mono); font-weight: 500; color: var(--text-3); font-size: 12.5px; }
+  .badge-rec {
+    font-size: 9.5px;
+    font-weight: 700;
+    letter-spacing: 0.7px;
+    padding: 2px 7px;
+    border-radius: 9px;
+    background: var(--green-bg);
+    color: var(--green-fg);
+    text-transform: uppercase;
+  }
+  .opt .when {
+    font-size: 12px;
+    line-height: 1.45;
+    color: var(--text-3);
+  }
+  .opt .when b { color: var(--text-2); font-weight: 600; }
+
+  .opt .chev { flex: 0 0 auto; color: var(--muted); font-size: 18px; }
+  .opt.recommended .chev { color: var(--green-fg); }
+
+  .subrow {
+    display: flex;
+    align-items: center;
+    margin-top: 14px;
+  }
+  .link {
+    background: none; border: none;
+    color: var(--hint);
+    font-size: 12px;
+    font-family: var(--font);
+    cursor: pointer;
+    padding: 4px 2px;
+    display: inline-flex; align-items: center; gap: 6px;
+  }
+  .link:hover { color: #9fb0d6; text-decoration: underline; }
+  .link svg { width: 13px; height: 13px; }
+
+  .divider { height: 1px; background: var(--border); margin: 16px 0 0; opacity: 0.6; }
+
+  /* ---- advanced disclosure (collapsed) ---- */
+  .advanced {
+    margin-top: 14px;
+    border: 1px solid var(--border);
+    border-radius: 9px;
+    background: #202021;
+  }
+  .adv-head {
+    display: flex; align-items: center; gap: 10px;
+    padding: 12px 14px;
+    cursor: pointer;
+  }
+  .adv-head .adv-ico { color: var(--text-3); }
+  .adv-head .adv-title { font-size: 13px; font-weight: 600; color: var(--text-2); }
+  .adv-head .adv-sub { font-size: 11.5px; color: var(--muted); margin-left: 2px; }
+  .adv-head .caret { margin-left: auto; color: var(--muted); }
+
+  .footnote {
+    margin-top: 16px;
+    display: flex; gap: 8px; align-items: flex-start;
+    font-size: 11.5px;
+    color: var(--hint);
+    line-height: 1.5;
+  }
+  .footnote svg { width: 14px; height: 14px; flex: 0 0 auto; margin-top: 1px; color: var(--green-accent); }
+</style>
+
+<p class="caption">
+  Redesigned <strong>Step 1 - Connect</strong> for the Gateway Connection panel. Adds a plain-English
+  explanation, a clearly marked recommendation, a short "when to use this" line on each option, and the
+  dictation screen's card styling with color and depth. Mockup only - not the running build.
+</p>
+
+<div class="window">
+  <div class="titlebar">
+    <span class="logo">cc</span>
+    <span class="title">Gateway Connection (preview)</span>
+    <span class="win-btns"><span>&minus;</span><span>&#9723;</span><span>&times;</span></span>
+  </div>
+
+  <div class="body">
+    <div class="head">
+      <h1>Connect to your Gateway</h1>
+      <span class="pill">2 FOUND</span>
+    </div>
+
+    <p class="intro">
+      Your Gateway is the hub this Director connects to for voice, the fleet view, cross-machine
+      sessions, and shared keys. Pick <b>how this Director should reach it</b> - we looked on this
+      computer and over Tailscale. Not sure? Start with the one marked
+      <b>Recommended</b>.
+    </p>
+
+    <div class="section-label">FOUND ON YOUR NETWORK</div>
+    <div class="options">
+
+      <!-- Recommended: this machine / local name -->
+      <div class="opt recommended local">
+        <div class="ico">
+          <svg viewBox="0 0 24 24" fill="none" stroke="#34D06E" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="4" width="18" height="12" rx="1.5"></rect>
+            <path d="M8 20h8M12 16v4"></path>
+          </svg>
+        </div>
+        <div class="info">
+          <div class="name-row">
+            <span class="name">This computer</span>
+            <span class="addr">SOREN_NORTH</span>
+            <span class="badge-rec">Recommended</span>
+          </div>
+          <div class="when">
+            The Gateway runs on this machine. <b>Fastest and always available</b> - the computer name
+            does not change, so this keeps working.
+          </div>
+        </div>
+        <div class="chev">&rsaquo;</div>
+      </div>
+
+      <!-- Tailscale / any network -->
+      <div class="opt net">
+        <div class="ico">
+          <svg viewBox="0 0 24 24" fill="none" stroke="#5AA9F0" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="9"></circle>
+            <path d="M3 12h18M12 3c2.6 2.5 2.6 15.5 0 18M12 3c-2.6 2.5-2.6 15.5 0 18"></path>
+          </svg>
+        </div>
+        <div class="info">
+          <div class="name-row">
+            <span class="name">Over Tailscale</span>
+            <span class="addr">soren-north.taildb08ed.ts.net</span>
+          </div>
+          <div class="when">
+            Reaches the Gateway <b>from any network</b>. Use this on a laptop you travel with, or from
+            a remote office - anywhere you are not on the same network as the Gateway.
+          </div>
+        </div>
+        <div class="chev">&rsaquo;</div>
+      </div>
+
+    </div>
+
+    <div class="subrow">
+      <button class="link">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 12a9 9 0 1 1-3-6.7L21 8"></path><path d="M21 3v5h-5"></path>
+        </svg>
+        Scan again
+      </button>
+    </div>
+
+    <div class="advanced">
+      <div class="adv-head">
+        <span class="adv-ico">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"></path>
+            <path d="M19.4 15a1.6 1.6 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.6 1.6 0 0 0-2.7 1.1V21a2 2 0 1 1-4 0v-.1A1.6 1.6 0 0 0 6.6 19l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1A1.6 1.6 0 0 0 4 13.6H4a2 2 0 1 1 0-4h.1A1.6 1.6 0 0 0 5.6 7L5.5 6.9a2 2 0 1 1 2.8-2.8l.1.1A1.6 1.6 0 0 0 11 4.6V4a2 2 0 1 1 4 0v.1a1.6 1.6 0 0 0 2.7 1.1l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.6 1.6 0 0 0-.3 1.8v.1a1.6 1.6 0 0 0 1.4 1H23a2 2 0 1 1 0 4h-.1a1.6 1.6 0 0 0-1.5 1z"></path>
+          </svg>
+        </span>
+        <span class="adv-title">Enter the address manually</span>
+        <span class="adv-sub">- computer name plus port, or a full address</span>
+        <span class="caret">&#9662;</span>
+      </div>
+    </div>
+
+    <div class="footnote">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M20 6 9 17l-5-5"></path>
+      </svg>
+      <span>Picking an option connects right away and checks the two-way connection - there is no
+      separate Test step.</span>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Soren-approved refinement of the Connect step (the only screen a brand-new user sees).

- Plain-English intro explaining what the Gateway is and how to choose.
- Exactly one found option marked **Recommended** by the rule **This computer > On your network > Over Tailscale** (the local machine name rarely changes, so it is the default; Tailscale is the off-network fallback for travel or a remote office). Each option carries a one-line when-to-use.
- Restyled to the dictation card language: framed rows, header count pill, green recommendation accent, tinted option icons, muted-blue guidance.

Includes the rendered reference mockup (`docs/reviews/gateway-connection-step1-mockup-2026-07-11.html`) approved 2026-07-11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)