### PR TITLE
feat(gateway): Step 1 polish - teaching intro, recommendation, dictation-card styling

### DIFF
--- a/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml
+++ b/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml
@@ -1,12 +1,12 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="CcDirector.Avalonia.Controls.GatewayConnectionPanel"
-             MinWidth="460">
+             MinWidth="480">
 
     <UserControl.Styles>
         <Style Selector="TextBlock.title">
-            <Setter Property="Foreground" Value="#CCCCCC" />
-            <Setter Property="FontSize" Value="16" />
+            <Setter Property="Foreground" Value="#E4E4E4" />
+            <Setter Property="FontSize" Value="18" />
             <Setter Property="FontWeight" Value="SemiBold" />
         </Style>
         <Style Selector="TextBlock.body">
@@ -40,79 +40,105 @@
             <Setter Property="Padding" Value="12,8" />
             <Setter Property="CornerRadius" Value="2" />
         </Style>
-        <!-- A found-Gateway pick: a full-width clickable row. -->
-        <Style Selector="Button.pick">
-            <Setter Property="Background" Value="#161616" />
-            <Setter Property="Foreground" Value="#E8E8E8" />
-            <Setter Property="BorderBrush" Value="#3C3C3C" />
-            <Setter Property="BorderThickness" Value="1" />
-            <Setter Property="CornerRadius" Value="3" />
-            <Setter Property="Padding" Value="12,10" />
-            <Setter Property="HorizontalAlignment" Value="Stretch" />
-            <Setter Property="HorizontalContentAlignment" Value="Left" />
-            <Setter Property="Margin" Value="0,0,0,6" />
-        </Style>
-        <Style Selector="Button.pick:pointerover /template/ ContentPresenter">
-            <Setter Property="Background" Value="#242424" />
-        </Style>
-        <Style Selector="TextBlock.link">
-            <Setter Property="Foreground" Value="#4EA1F2" />
+        <!-- A borderless link-style button (Scan again). -->
+        <Style Selector="Button.link">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Foreground" Value="#6C79A0" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="2,4" />
             <Setter Property="FontSize" Value="12" />
             <Setter Property="Cursor" Value="Hand" />
         </Style>
+        <Style Selector="Button.link:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="TextBlock.Foreground" Value="#9FB0D6" />
+        </Style>
     </UserControl.Styles>
 
-    <Grid Margin="20" MinHeight="220">
+    <!-- Scrolls so the panel never clips when a host (Settings tab, status-box window, onboarding) is
+         shorter than the content. -->
+    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+    <Grid Margin="22" MinHeight="240">
 
-        <!-- STEP 1a: scanning -->
-        <StackPanel x:Name="ScanningPanel" Spacing="6" VerticalAlignment="Top">
-            <TextBlock Classes="title" Text="Connect to your Gateway" />
-            <TextBlock Classes="body"
-                       Text="Looking for a Gateway on this machine, your tailnet, and your local network..." />
-            <ProgressBar IsIndeterminate="True" Height="3" Margin="0,10,0,0"
-                         Foreground="#007ACC" Background="#2A2A2A" />
-        </StackPanel>
+        <!-- STEP 1: Connect (scanning and found share one header; the pill and body swap) -->
+        <StackPanel x:Name="ConnectPanel" Spacing="0" VerticalAlignment="Top">
 
-        <!-- STEP 1b: results (found picks and/or manual entry) -->
-        <StackPanel x:Name="FoundPanel" Spacing="4" VerticalAlignment="Top" IsVisible="False">
-            <TextBlock Classes="title" Text="Connect to your Gateway" />
+            <!-- Header: title + count pill -->
+            <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,6">
+                <TextBlock Grid.Column="0" Classes="title" Text="Connect to your Gateway"
+                           VerticalAlignment="Center" />
+                <Border Grid.Column="1" x:Name="CountPill" Background="#16283F" CornerRadius="11"
+                        Padding="9,4" VerticalAlignment="Center">
+                    <TextBlock x:Name="CountPillText" Text="SCANNING..." Foreground="#5AA9F0"
+                               FontSize="10.5" FontWeight="Bold" />
+                </Border>
+            </Grid>
 
-            <StackPanel x:Name="FoundListSection" IsVisible="False" Margin="0,6,0,0">
-                <TextBlock Classes="fieldLabel" Text="FOUND" />
-                <ItemsControl x:Name="FoundList">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                            <Button Classes="pick" Click="Pick_Click" Tag="{Binding}">
-                                <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <TextBlock Text="{Binding Label}" FontSize="13" VerticalAlignment="Center" />
-                                    <TextBlock Text="&gt;" Foreground="#777777" VerticalAlignment="Center"
-                                               HorizontalAlignment="Right" />
-                                </StackPanel>
-                            </Button>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
+            <!-- Teaching intro (muted blue, key phrases emphasized) -->
+            <TextBlock x:Name="IntroText" Foreground="#6C79A0" FontSize="12.5" TextWrapping="Wrap"
+                       Margin="0,4,0,18" MaxWidth="540" HorizontalAlignment="Left">
+                <Run Text="Your Gateway is the hub this Director connects to for voice, the fleet view, cross-machine sessions, and shared keys. Pick " />
+                <Run Text="how this Director should reach it" Foreground="#9FB0D6" FontWeight="SemiBold" />
+                <Run Text=" - we looked on this computer and over Tailscale. Not sure? Start with the one marked " />
+                <Run Text="Recommended" Foreground="#9FB0D6" FontWeight="SemiBold" />
+                <Run Text="." />
+            </TextBlock>
 
-            <TextBlock x:Name="NoneFoundText" Classes="body" IsVisible="False" Margin="0,6,0,0"
-                       Text="No Gateway found automatically. Enter the address manually below." />
+            <!-- While scanning -->
+            <ProgressBar x:Name="ScanningProgress" IsIndeterminate="True" Height="3"
+                         Foreground="#007ACC" Background="#2A2A2A" Margin="0,2,0,0" />
 
-            <Button x:Name="RescanButton" Classes="secondaryButton" Content="Scan again"
-                    HorizontalAlignment="Left" Margin="0,8,0,0" Click="Rescan_Click" />
+            <!-- After scanning -->
+            <StackPanel x:Name="ResultsArea" Spacing="0" IsVisible="False">
+                <TextBlock x:Name="SectionLabel" Text="FOUND ON YOUR NETWORK" Foreground="#888888"
+                           FontSize="10.5" FontWeight="Bold" Margin="2,0,0,10" />
 
-            <!-- Advanced: manual entry fallback (collapsed by default, decisions 5 and 6) -->
-            <Expander x:Name="AdvancedExpander" Header="Enter the address manually" Margin="0,12,0,0"
-                      Background="Transparent" Foreground="#4EA1F2">
-                <StackPanel Spacing="2" Margin="0,6,0,0">
-                    <TextBlock Classes="fieldLabel" Text="GATEWAY ADDRESS (computer name plus port, or a full address)" />
-                    <TextBox x:Name="ManualUrlBox" Classes="input"
-                             Watermark="e.g. SOREN_NORTH:7878  or  https://host.tailnet.ts.net" />
-                    <TextBlock x:Name="ManualErrorText" FontSize="11" Foreground="#E07A7A"
-                               TextWrapping="Wrap" IsVisible="False" Margin="0,4,0,0" />
-                    <Button x:Name="ManualConnectButton" Classes="primaryButton" Content="Connect"
-                            HorizontalAlignment="Left" Margin="0,8,0,0" Click="ManualConnect_Click" />
+                <!-- Found option rows are built in code to match the mockup exactly. -->
+                <StackPanel x:Name="OptionsHost" Spacing="10" />
+
+                <TextBlock x:Name="NoneFoundText" Classes="body" IsVisible="False"
+                           Text="No Gateway found automatically. Enter the address manually below."
+                           Margin="0,2,0,0" />
+
+                <StackPanel Orientation="Horizontal" Margin="0,14,0,0">
+                    <Button x:Name="RescanButton" Classes="link" Click="Rescan_Click" Content="Scan again" />
                 </StackPanel>
-            </Expander>
+
+                <!-- Advanced: manual entry fallback, collapsed by default (decisions 5, 6) -->
+                <Border Margin="0,14,0,0" Background="#202021" BorderBrush="#3C3C3C" BorderThickness="1"
+                        CornerRadius="9">
+                    <Expander x:Name="AdvancedExpander" Background="Transparent" BorderThickness="0"
+                              Padding="4,0">
+                        <Expander.Header>
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <TextBlock Text="Enter the address manually" Foreground="#AAAAAA"
+                                           FontSize="13" FontWeight="SemiBold" VerticalAlignment="Center" />
+                                <TextBlock Text="- computer name plus port, or a full address"
+                                           Foreground="#666666" FontSize="11.5" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Expander.Header>
+                        <StackPanel Spacing="2" Margin="0,6,4,10">
+                            <TextBlock Classes="fieldLabel"
+                                       Text="GATEWAY ADDRESS (computer name plus port, or a full address)" />
+                            <TextBox x:Name="ManualUrlBox" Classes="input"
+                                     Watermark="e.g. SOREN_NORTH:7878  or  https://host.tailnet.ts.net" />
+                            <TextBlock x:Name="ManualErrorText" FontSize="11" Foreground="#E07A7A"
+                                       TextWrapping="Wrap" IsVisible="False" Margin="0,4,0,0" />
+                            <Button x:Name="ManualConnectButton" Classes="primaryButton" Content="Connect"
+                                    HorizontalAlignment="Left" Margin="0,8,0,0" Click="ManualConnect_Click" />
+                        </StackPanel>
+                    </Expander>
+                </Border>
+
+                <!-- Footnote: the no-hidden-test rule -->
+                <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,16,0,0">
+                    <Path Data="M20,6 L9,17 L4,12" Stroke="#2E7D50" StrokeThickness="2"
+                          StrokeLineCap="Round" StrokeJoin="Round" Width="14" Height="14"
+                          Stretch="Uniform" VerticalAlignment="Top" Margin="0,2,0,0" />
+                    <TextBlock Foreground="#6C79A0" FontSize="11.5" TextWrapping="Wrap" MaxWidth="500"
+                               Text="Picking an option connects right away and checks the two-way connection - there is no separate Test step." />
+                </StackPanel>
+            </StackPanel>
         </StackPanel>
 
         <!-- STEP 1c: connecting (the click IS the test) -->
@@ -167,4 +193,5 @@
         </StackPanel>
 
     </Grid>
+    </ScrollViewer>
 </UserControl>

--- a/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Collections.Generic;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Media;
 using Avalonia.Threading;
 using CcDirector.ControlApi;
 using CcDirector.Core.Configuration;
@@ -15,14 +21,18 @@ namespace CcDirector.Avalonia.Controls;
 /// <summary>
 /// The one reusable Gateway connection panel (design spec section 5). Phase 1 implements Step 1 - Connect:
 /// on show it automatically scans for Gateways in the issue-1233 discovery order (this machine, tailnet,
-/// local network), lists every reachable one as a one-click pick, and offers manual entry under a collapsed
-/// Advanced section. Picking a Gateway IS the test (decision 5): it writes the address, re-applies the
-/// Gateway config so the Director runs the two-way nonce handshake, and shows live progress until the
-/// handshake either proves the connection or fails with a named leg (decision 11, no fallback).
+/// local network), teaches with a plain-English intro, and lists every reachable one as a framed one-click
+/// pick with a per-kind "when to use this" line. Exactly one pick carries a Recommended badge by the rule
+/// This computer &gt; On your network &gt; Over Tailscale (Tailscale only when it is the sole find). Picking a
+/// Gateway IS the test (decision 5): it writes the address, re-applies the Gateway config so the Director
+/// runs the two-way nonce handshake, and shows live progress until the handshake either proves the
+/// connection or fails with a named leg (decision 11, no fallback).
 ///
 /// Verification is NOT rebuilt here (spec section 9): the panel drives the existing
 /// <see cref="GatewayConnectionMonitor"/> through <see cref="ControlApiHost.ReapplyGatewayAsync"/> and reads
-/// its earned verdict. Green is earned only by a completed handshake (decision 4).
+/// its earned verdict. Green is earned only by a completed handshake (decision 4). The visual language
+/// matches the dictation card (spec section 5 visual direction): a #252526 card, a blue count pill, a green
+/// Recommended accent, tinted icon tiles, and muted-blue guidance.
 ///
 /// Phase 1 wires this into a temporary menu entry for testing; the Settings tab, the status box, and the
 /// onboarding wizard adopt it in later phases (decision 8).
@@ -31,6 +41,17 @@ public partial class GatewayConnectionPanel : UserControl
 {
     // How long to wait for a handshake verdict before calling the attempt timed out.
     private static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(45);
+
+    private static readonly FontFamily MonoFont = new("Cascadia Mono,Consolas,Courier New");
+
+    // Icon geometries (24-unit viewbox, stretched into the 38px tile). A monitor for a local machine, a
+    // globe for Tailscale (spec section 5 visual direction).
+    private const string MonitorGeometry =
+        "M4.5,4 H19.5 A1.5,1.5 0 0 1 21,5.5 V14.5 A1.5,1.5 0 0 1 19.5,16 H4.5 A1.5,1.5 0 0 1 3,14.5 "
+        + "V5.5 A1.5,1.5 0 0 1 4.5,4 Z M8,20 H16 M12,16 V20";
+    private const string GlobeGeometry =
+        "M3,12 A9,9 0 1 1 21,12 A9,9 0 1 1 3,12 Z M3,12 H21 M12,3 C14.6,5.5 14.6,18.5 12,21 "
+        + "M12,3 C9.4,5.5 9.4,18.5 12,21";
 
     private readonly GatewayScanService _scan = new();
 
@@ -53,14 +74,14 @@ public partial class GatewayConnectionPanel : UserControl
         FileLog.Write("[GatewayConnectionPanel] constructed");
     }
 
-    protected override void OnAttachedToVisualTree(global::Avalonia.VisualTreeAttachmentEventArgs e)
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnAttachedToVisualTree(e);
         // Automatic scan on show - there is no Detect button (decision 5).
         StartScan();
     }
 
-    protected override void OnDetachedFromVisualTree(global::Avalonia.VisualTreeAttachmentEventArgs e)
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnDetachedFromVisualTree(e);
         if (_subscribed && _monitor is not null)
@@ -75,7 +96,10 @@ public partial class GatewayConnectionPanel : UserControl
     private async void StartScan()
     {
         _connecting = false;
-        ShowOnly(ScanningPanel);
+        CountPillText.Text = "SCANNING...";
+        ScanningProgress.IsVisible = true;
+        ResultsArea.IsVisible = false;
+        ShowOnly(ConnectPanel);
         try
         {
             var found = await _scan.ScanAsync();
@@ -88,25 +112,260 @@ public partial class GatewayConnectionPanel : UserControl
         }
     }
 
-    private void RenderFound(System.Collections.Generic.IReadOnlyList<FoundGateway> found)
+    private void RenderFound(IReadOnlyList<FoundGateway> found)
     {
-        FoundList.ItemsSource = found;
+        ScanningProgress.IsVisible = false;
+        CountPillText.Text = $"{found.Count} FOUND";
+
+        OptionsHost.Children.Clear();
+        var recommended = RecommendedIndex(found);
+        for (var i = 0; i < found.Count; i++)
+            OptionsHost.Children.Add(BuildOptionRow(found[i], recommended == i));
+
         var any = found.Count > 0;
-        FoundListSection.IsVisible = any;
         NoneFoundText.IsVisible = !any;
         // When nothing was found, open the manual-entry section so the fallback is one step away.
         AdvancedExpander.IsExpanded = !any;
-        ShowOnly(FoundPanel);
-        FileLog.Write($"[GatewayConnectionPanel] scan rendered: {found.Count} pick(s)");
+        ResultsArea.IsVisible = true;
+        ShowOnly(ConnectPanel);
+        FileLog.Write($"[GatewayConnectionPanel] scan rendered: {found.Count} pick(s), recommended index {recommended}");
     }
 
     private void Rescan_Click(object? sender, RoutedEventArgs e) => StartScan();
 
+    // The Recommended rule (spec section 5): the most stable LOCAL name reachable, in priority order This
+    // computer > On your network > Over Tailscale. Tailscale wins only when it is the sole find, which the
+    // priority ranking already yields (a local kind, if present, always outranks it).
+    private static int RecommendedIndex(IReadOnlyList<FoundGateway> found)
+    {
+        var best = -1;
+        var bestRank = int.MaxValue;
+        for (var i = 0; i < found.Count; i++)
+        {
+            var rank = KindRank(found[i].Kind);
+            if (rank < bestRank)
+            {
+                bestRank = rank;
+                best = i;
+            }
+        }
+        return best;
+    }
+
+    private static int KindRank(GatewayLocationKind kind) => kind switch
+    {
+        GatewayLocationKind.ThisMachine => 0,
+        GatewayLocationKind.LocalNetwork => 1,
+        GatewayLocationKind.Tailnet => 2,
+        _ => 3,
+    };
+
+    // ---- Option row construction (built in code to match the mockup's mixed-emphasis copy) ------
+
+    private Control BuildOptionRow(FoundGateway gateway, bool recommended)
+    {
+        var copy = CopyFor(gateway);
+
+        var icon = new global::Avalonia.Controls.Shapes.Path
+        {
+            Data = Geometry.Parse(copy.IconGeometry),
+            Stroke = Brush(copy.StrokeColor),
+            StrokeThickness = 1.6,
+            StrokeLineCap = PenLineCap.Round,
+            StrokeJoin = PenLineJoin.Round,
+            Width = 20,
+            Height = 20,
+            Stretch = Stretch.Uniform,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        var iconTile = new Border
+        {
+            Width = 38,
+            Height = 38,
+            CornerRadius = new CornerRadius(8),
+            Background = Brush(copy.TileColor),
+            Child = icon,
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(0, 0, 14, 0),
+        };
+        Grid.SetColumn(iconTile, 0);
+
+        var nameRow = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Margin = new Thickness(0, 0, 0, 3),
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        nameRow.Children.Add(new TextBlock
+        {
+            Text = copy.Name,
+            Foreground = Brush("#E6E6E6"),
+            FontSize = 14,
+            FontWeight = FontWeight.SemiBold,
+            VerticalAlignment = VerticalAlignment.Center,
+        });
+        nameRow.Children.Add(new TextBlock
+        {
+            Text = copy.Address,
+            FontFamily = MonoFont,
+            Foreground = Brush("#888888"),
+            FontSize = 12.5,
+            VerticalAlignment = VerticalAlignment.Center,
+        });
+        if (recommended)
+            nameRow.Children.Add(BuildRecommendedBadge());
+
+        var when = new TextBlock { FontSize = 12, TextWrapping = TextWrapping.Wrap, Foreground = Brush("#888888") };
+        when.Inlines!.Add(new Run(copy.WhenPrefix));
+        when.Inlines.Add(new Run(copy.WhenBold) { Foreground = Brush("#AAAAAA"), FontWeight = FontWeight.SemiBold });
+        when.Inlines.Add(new Run(copy.WhenSuffix));
+
+        var info = new StackPanel { Spacing = 0, VerticalAlignment = VerticalAlignment.Center };
+        info.Children.Add(nameRow);
+        info.Children.Add(when);
+        Grid.SetColumn(info, 1);
+
+        var chevron = new TextBlock
+        {
+            Text = ">",
+            FontSize = 18,
+            Foreground = Brush(recommended ? "#34D06E" : "#666666"),
+            VerticalAlignment = VerticalAlignment.Center,
+            Margin = new Thickness(10, 0, 0, 0),
+        };
+        Grid.SetColumn(chevron, 2);
+
+        var inner = new Grid { ColumnDefinitions = new ColumnDefinitions("Auto,*,Auto") };
+        inner.Children.Add(iconTile);
+        inner.Children.Add(info);
+        inner.Children.Add(chevron);
+
+        var card = new Border
+        {
+            CornerRadius = new CornerRadius(9),
+            BorderThickness = new Thickness(1),
+            BorderBrush = Brush(recommended ? "#2E7D50" : "#3C3C3C"),
+            Background = recommended ? RecommendedBackground() : Brush("#252526"),
+            Padding = new Thickness(15, 14),
+            Cursor = new Cursor(StandardCursorType.Hand),
+            Child = inner,
+            Tag = gateway,
+        };
+        card.PointerPressed += Pick_PointerPressed;
+        WireHover(card, recommended);
+
+        // A green left-accent bar for the recommended row, overlaid on the card's left edge.
+        var outer = new Grid();
+        outer.Children.Add(card);
+        if (recommended)
+        {
+            outer.Children.Add(new Border
+            {
+                Width = 3,
+                CornerRadius = new CornerRadius(3),
+                Background = Brush("#34D06E"),
+                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment = VerticalAlignment.Stretch,
+                Margin = new Thickness(0, 8, 0, 8),
+                IsHitTestVisible = false,
+            });
+        }
+        return outer;
+    }
+
+    private static Border BuildRecommendedBadge() => new()
+    {
+        Background = Brush("#1B3A2A"),
+        CornerRadius = new CornerRadius(9),
+        Padding = new Thickness(7, 2),
+        VerticalAlignment = VerticalAlignment.Center,
+        Child = new TextBlock
+        {
+            Text = "RECOMMENDED",
+            Foreground = Brush("#34D06E"),
+            FontSize = 9.5,
+            FontWeight = FontWeight.Bold,
+        },
+    };
+
+    // Non-recommended cards get a subtle hover; the recommended card keeps its green wash.
+    private static void WireHover(Border card, bool recommended)
+    {
+        if (recommended) return;
+        card.PointerEntered += (_, _) =>
+        {
+            card.Background = Brush("#2E2E30");
+            card.BorderBrush = Brush("#4A4A4A");
+        };
+        card.PointerExited += (_, _) =>
+        {
+            card.Background = Brush("#252526");
+            card.BorderBrush = Brush("#3C3C3C");
+        };
+    }
+
+    private static IBrush RecommendedBackground() => new LinearGradientBrush
+    {
+        StartPoint = new RelativePoint(0, 0, RelativeUnit.Relative),
+        EndPoint = new RelativePoint(1, 0, RelativeUnit.Relative),
+        GradientStops =
+        {
+            new GradientStop(Color.Parse("#242E7D50"), 0),
+            new GradientStop(Color.Parse("#E6252526"), 0.34),
+            new GradientStop(Color.Parse("#FF252526"), 1),
+        },
+    };
+
+    // The per-kind name, address, and "when to use this" copy (spec section 5 - exact strings).
+    private static OptionCopy CopyFor(FoundGateway gateway) => gateway.Kind switch
+    {
+        GatewayLocationKind.ThisMachine => new OptionCopy(
+            Name: "This computer",
+            Address: Environment.MachineName,
+            WhenPrefix: "The Gateway runs on this machine. ",
+            WhenBold: "Fastest and always available",
+            WhenSuffix: " - the computer name does not change, so this keeps working.",
+            TileColor: "#1F2A22",
+            StrokeColor: "#34D06E",
+            IconGeometry: MonitorGeometry),
+
+        GatewayLocationKind.LocalNetwork => new OptionCopy(
+            Name: "On your network",
+            Address: SafeHost(gateway.Url),
+            WhenPrefix: "The Gateway is on another computer on your network. The computer name rarely changes, so this keeps working - ",
+            WhenBold: "best when you are on the same network",
+            WhenSuffix: ".",
+            TileColor: "#172433",
+            StrokeColor: "#5AA9F0",
+            IconGeometry: MonitorGeometry),
+
+        _ => new OptionCopy(
+            Name: "Over Tailscale",
+            Address: SafeHost(gateway.Url),
+            WhenPrefix: "Reaches the Gateway ",
+            WhenBold: "from any network",
+            WhenSuffix: ". Use this on a laptop you travel with, or from a remote office - anywhere you are not on the same network as the Gateway.",
+            TileColor: "#172433",
+            StrokeColor: "#5AA9F0",
+            IconGeometry: GlobeGeometry),
+    };
+
+    private static string SafeHost(string url)
+        => Uri.TryCreate(url, UriKind.Absolute, out var uri) ? uri.Host : url;
+
+    private static SolidColorBrush Brush(string hex) => new(Color.Parse(hex));
+
+    private readonly record struct OptionCopy(
+        string Name, string Address, string WhenPrefix, string WhenBold, string WhenSuffix,
+        string TileColor, string StrokeColor, string IconGeometry);
+
     // ---- Step 1b: pick / manual entry ----------------------------------------------------------
 
-    private void Pick_Click(object? sender, RoutedEventArgs e)
+    private void Pick_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
-        if ((sender as Button)?.Tag is FoundGateway pick)
+        if ((sender as Border)?.Tag is FoundGateway pick)
             ConnectTo(pick.Url, pick.Label);
     }
 
@@ -275,8 +534,7 @@ public partial class GatewayConnectionPanel : UserControl
     // Show exactly one of the step sub-panels.
     private void ShowOnly(Control panel)
     {
-        ScanningPanel.IsVisible = ReferenceEquals(panel, ScanningPanel);
-        FoundPanel.IsVisible = ReferenceEquals(panel, FoundPanel);
+        ConnectPanel.IsVisible = ReferenceEquals(panel, ConnectPanel);
         ConnectingPanel.IsVisible = ReferenceEquals(panel, ConnectingPanel);
         ConnectedPanel.IsVisible = ReferenceEquals(panel, ConnectedPanel);
         FailedPanel.IsVisible = ReferenceEquals(panel, FailedPanel);

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -734,8 +734,8 @@ public partial class MainWindow : Window
             var window = new Window
             {
                 Title = "Gateway Connection (preview)",
-                Width = 540,
-                Height = 480,
+                Width = 560,
+                Height = 660,
                 WindowStartupLocation = WindowStartupLocation.CenterOwner,
                 Background = global::Avalonia.Media.Brush.Parse("#252526"),
                 Content = new Controls.GatewayConnectionPanel(),


### PR DESCRIPTION
Refines the Phase 1 GatewayConnectionPanel Step 1 (Connect) view to the approved Step 1 design (docs/reviews/gateway-connection-redesign-2026-07-11.md section 5 + the rendered reference gateway-connection-step1-mockup-2026-07-11.html). Presentation only - no resolver or scan logic changes.

## Changes
- Header count pill: "SCANNING..." then "N FOUND".
- Plain-English teaching intro (exact strings from the spec), key phrases emphasized.
- Each found Gateway is a framed row: tinted icon tile (monitor for local, globe for Tailscale), name plus address, and a per-kind "when to use this" line with the key phrase emphasized.
- Exactly one row gets a Recommended badge + green left-accent, by the rule This computer > On your network > Over Tailscale (Tailscale only when it is the sole find). The kind comes from the scan; the panel only surfaces it.
- Dictation-card styling: #252526 card, blue count pill, green accent/badge, tinted icon tiles, muted-blue guidance.
- Manual entry stays under the collapsed Advanced; the no-separate-Test footnote stays under the list.
- Panel body scrolls so it never clips in a shorter host; preview window is a little taller.

## Proof
Verified in the running slot-5 build against the live Gateway on SOREN_NORTH: the scan found this machine (recommended) and the Tailscale address; the rendered panel matches the mockup with the footnote fully visible. Builds clean (0 errors). No Core logic touched, so the 23 Phase 1 unit tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)