### PR TITLE
fix(gateway): back off wingman voice generation on 429 instead of storming the provider (#1324)

### DIFF
--- a/src/CcDirector.Gateway.Tests/HostedInferenceBrainTests.cs
+++ b/src/CcDirector.Gateway.Tests/HostedInferenceBrainTests.cs
@@ -95,6 +95,64 @@ public sealed class HostedInferenceBrainTests
         Assert.Contains(Core.HostedAi.HostedAiMessages.For(Core.HostedAi.HostedAiState.CapReached).Text, ex.Message);
     }
 
+    /// <summary>A stub that returns a status plus a Retry-After header, to drive the 429 path (issue #1324).</summary>
+    private sealed class RetryAfterStub : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly string _body;
+        private readonly TimeSpan? _retryAfter;
+        public RetryAfterStub(HttpStatusCode status, string body, TimeSpan? retryAfter)
+        { _status = status; _body = body; _retryAfter = retryAfter; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var resp = new HttpResponseMessage(_status) { Content = new StringContent(_body, Encoding.UTF8, "application/json") };
+            if (_retryAfter is { } ra)
+                resp.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(ra);
+            return Task.FromResult(resp);
+        }
+    }
+
+    [Fact]
+    public async Task AskAsync_429_ThrowsRateLimited_WithRetryAfterFromHeader()
+    {
+        // Issue #1324: a 429 surfaces as the typed rate-limit exception carrying the provider's
+        // Retry-After hint, so the caller can back off for exactly that long instead of guessing.
+        var stub = new RetryAfterStub(HttpStatusCode.TooManyRequests, "{\"error\":\"rate limited\"}", TimeSpan.FromSeconds(12));
+        using var http = new HttpClient(stub);
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "glm-5.2", http, _ => { });
+
+        var ex = await Assert.ThrowsAsync<WingmanModelRateLimitedException>(() => brain.AskAsync("hi"));
+        Assert.Equal(TimeSpan.FromSeconds(12), ex.RetryAfter);
+        Assert.Contains("429", ex.Message);
+    }
+
+    [Fact]
+    public async Task AskAsync_429_NoRetryAfter_ThrowsRateLimited_WithNullHint()
+    {
+        // No Retry-After header: still the typed exception, but with no hint - the caller then uses
+        // its own exponential backoff.
+        var stub = new RetryAfterStub(HttpStatusCode.TooManyRequests, "{\"error\":\"rate limited\"}", retryAfter: null);
+        using var http = new HttpClient(stub);
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "glm-5.2", http, _ => { });
+
+        var ex = await Assert.ThrowsAsync<WingmanModelRateLimitedException>(() => brain.AskAsync("hi"));
+        Assert.Null(ex.RetryAfter);
+    }
+
+    [Fact]
+    public async Task RateLimited429_IsStillAnInvalidOperationException_SoExistingCatchesHold()
+    {
+        // It extends InvalidOperationException, so every existing catch of the general wingman-call
+        // failure keeps catching a 429 unchanged (issue #1324).
+        var stub = new RetryAfterStub(HttpStatusCode.TooManyRequests, "{}", retryAfter: null);
+        using var http = new HttpClient(stub);
+        var brain = new HostedInferenceBrain("https://devthrottle.com/api/v1", "dt_live_abc", "glm-5.2", http, _ => { });
+
+        await Assert.ThrowsAsync<WingmanModelRateLimitedException>(() => brain.AskAsync("hi"));
+        var caught = await Record.ExceptionAsync(() => brain.AskAsync("hi"));
+        Assert.IsAssignableFrom<InvalidOperationException>(caught);
+    }
+
     [Fact]
     public async Task AskAsync_EmptyContent_Throws()
     {

--- a/src/CcDirector.Gateway.Tests/WingmanRateLimitGateTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanRateLimitGateTests.cs
@@ -1,0 +1,117 @@
+using CcDirector.Gateway.Wingman;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The shared wingman rate-limit cooldown (issue #1324): after a 429 the gate blocks further model
+/// calls until the backoff elapses - honoring the provider's Retry-After, else an exponential ramp
+/// capped to a ceiling - and a success resets it. A fake clock makes the timing deterministic.
+/// </summary>
+public sealed class WingmanRateLimitGateTests
+{
+    /// <summary>A hand-cranked clock so cooldown expiry is tested without any real waiting.</summary>
+    private sealed class FakeClock
+    {
+        public DateTime Now = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        public DateTime NowUtc() => Now;
+    }
+
+    [Fact]
+    public void FreshGate_IsNotInCooldown()
+    {
+        var gate = new WingmanRateLimitGate();
+        Assert.False(gate.InCooldown(out var remaining));
+        Assert.Equal(TimeSpan.Zero, remaining);
+    }
+
+    [Fact]
+    public void OnRateLimited_NoRetryAfter_ArmsBaseCooldown()
+    {
+        var clock = new FakeClock();
+        var gate = new WingmanRateLimitGate(clock.NowUtc, baseDelay: TimeSpan.FromSeconds(5), maxDelay: TimeSpan.FromSeconds(120));
+
+        var backoff = gate.OnRateLimited(null);
+
+        Assert.Equal(TimeSpan.FromSeconds(5), backoff);
+        Assert.True(gate.InCooldown(out var remaining));
+        Assert.Equal(TimeSpan.FromSeconds(5), remaining);
+    }
+
+    [Fact]
+    public void Cooldown_ExpiresAfterTheDelay()
+    {
+        var clock = new FakeClock();
+        var gate = new WingmanRateLimitGate(clock.NowUtc, baseDelay: TimeSpan.FromSeconds(5));
+        gate.OnRateLimited(null);
+
+        clock.Now = clock.Now.AddSeconds(4);
+        Assert.True(gate.InCooldown(out _));       // still inside the window
+
+        clock.Now = clock.Now.AddSeconds(1);       // now exactly at the boundary
+        Assert.False(gate.InCooldown(out _));       // elapsed
+    }
+
+    [Fact]
+    public void ConsecutiveRateLimits_BackOffExponentially_UpToCap()
+    {
+        var clock = new FakeClock();
+        var gate = new WingmanRateLimitGate(clock.NowUtc, baseDelay: TimeSpan.FromSeconds(5), maxDelay: TimeSpan.FromSeconds(120));
+
+        Assert.Equal(TimeSpan.FromSeconds(5), gate.OnRateLimited(null));    // 5 * 2^0
+        Assert.Equal(TimeSpan.FromSeconds(10), gate.OnRateLimited(null));   // 5 * 2^1
+        Assert.Equal(TimeSpan.FromSeconds(20), gate.OnRateLimited(null));   // 5 * 2^2
+        Assert.Equal(TimeSpan.FromSeconds(40), gate.OnRateLimited(null));   // 5 * 2^3
+        Assert.Equal(TimeSpan.FromSeconds(80), gate.OnRateLimited(null));   // 5 * 2^4
+        Assert.Equal(TimeSpan.FromSeconds(120), gate.OnRateLimited(null));  // 5 * 2^5 = 160 -> capped
+        Assert.Equal(TimeSpan.FromSeconds(120), gate.OnRateLimited(null));  // stays capped
+    }
+
+    [Fact]
+    public void OnRateLimited_HonorsProviderRetryAfter()
+    {
+        var clock = new FakeClock();
+        var gate = new WingmanRateLimitGate(clock.NowUtc, baseDelay: TimeSpan.FromSeconds(5), maxDelay: TimeSpan.FromSeconds(120));
+
+        var backoff = gate.OnRateLimited(TimeSpan.FromSeconds(30));
+
+        Assert.Equal(TimeSpan.FromSeconds(30), backoff);   // the provider's hint, not the 5s base
+        Assert.True(gate.InCooldown(out var remaining));
+        Assert.Equal(TimeSpan.FromSeconds(30), remaining);
+    }
+
+    [Fact]
+    public void RetryAfter_AboveCeiling_IsCapped()
+    {
+        var gate = new WingmanRateLimitGate(maxDelay: TimeSpan.FromSeconds(120));
+        Assert.Equal(TimeSpan.FromSeconds(120), gate.OnRateLimited(TimeSpan.FromSeconds(600)));
+    }
+
+    [Fact]
+    public void ANearerCooldown_DoesNotShortenALongerOneAlreadyArmed()
+    {
+        var clock = new FakeClock();
+        var gate = new WingmanRateLimitGate(clock.NowUtc, baseDelay: TimeSpan.FromSeconds(5));
+
+        gate.OnRateLimited(TimeSpan.FromSeconds(60));   // arm 60s
+        gate.OnRateLimited(TimeSpan.FromSeconds(5));     // a nearer 5s must not pull the cooldown in
+
+        Assert.True(gate.InCooldown(out var remaining));
+        Assert.Equal(TimeSpan.FromSeconds(60), remaining);
+    }
+
+    [Fact]
+    public void OnSuccess_ClearsCooldownAndResetsTheRamp()
+    {
+        var clock = new FakeClock();
+        var gate = new WingmanRateLimitGate(clock.NowUtc, baseDelay: TimeSpan.FromSeconds(5));
+        gate.OnRateLimited(null);
+        gate.OnRateLimited(null);    // ramp now at 10s
+
+        gate.OnSuccess();
+
+        Assert.False(gate.InCooldown(out _));
+        // The ramp is back to base: the next 429 is a 5s backoff again, not a continued 20s.
+        Assert.Equal(TimeSpan.FromSeconds(5), gate.OnRateLimited(null));
+    }
+}

--- a/src/CcDirector.Gateway/Wingman/HostedInferenceBrain.cs
+++ b/src/CcDirector.Gateway/Wingman/HostedInferenceBrain.cs
@@ -91,6 +91,13 @@ public sealed class HostedInferenceBrain : IAgentBrain
             var detail = resp.StatusCode == System.Net.HttpStatusCode.PaymentRequired
                 ? HostedAiMessages.For(HostedAiErrorMapper.Map402(text)).Text
                 : "Check the AI provider settings and that the account/key is valid.";
+            // Rate limited (issue #1324): surface a TYPED signal carrying the provider's Retry-After so
+            // the caller can back off for exactly as long as asked instead of hammering it into a 429
+            // storm. It extends InvalidOperationException, so every existing catch stays unchanged.
+            if ((int)resp.StatusCode == 429)
+                throw new WingmanModelRateLimitedException(
+                    $"The wingman model call failed: {(int)resp.StatusCode} {resp.StatusCode}. " + detail,
+                    ParseRetryAfter(resp.Headers.RetryAfter));
             throw new InvalidOperationException(
                 $"The wingman model call failed: {(int)resp.StatusCode} {resp.StatusCode}. " + detail);
         }
@@ -102,6 +109,23 @@ public sealed class HostedInferenceBrain : IAgentBrain
 
         _log($"[HostedInferenceBrain] chat/completions model={_model} OK: {content.Length} chars in {sw.Elapsed.TotalSeconds:F1}s");
         return new AskResult { Text = content, ReplySeconds = sw.Elapsed.TotalSeconds };
+    }
+
+    /// <summary>
+    /// Read the provider's Retry-After header into a positive wait, or null when it gave none
+    /// (issue #1324). Accepts both header forms: a delta in seconds and an absolute HTTP date. A
+    /// past date or non-positive delta is treated as "no hint" so the caller falls back to its own backoff.
+    /// </summary>
+    private static TimeSpan? ParseRetryAfter(RetryConditionHeaderValue? header)
+    {
+        if (header is null) return null;
+        if (header.Delta is { } delta && delta > TimeSpan.Zero) return delta;
+        if (header.Date is { } when)
+        {
+            var wait = when - DateTimeOffset.UtcNow;
+            if (wait > TimeSpan.Zero) return wait;
+        }
+        return null;
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Wingman/WingmanModelRateLimitedException.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanModelRateLimitedException.cs
@@ -1,0 +1,21 @@
+namespace CcDirector.Gateway.Wingman;
+
+/// <summary>
+/// The wingman model call was rejected with HTTP 429 (too many requests): the provider is rate
+/// limiting us (issue #1324). Calling it again immediately just earns another 429 - the storm that
+/// left every voice session showing "no narration". This carries the provider's Retry-After hint when
+/// it sent one, so the caller can back off for exactly as long as asked instead of guessing.
+///
+/// It extends <see cref="InvalidOperationException"/> so every existing catch of the general
+/// wingman-call failure keeps catching a 429 unchanged; only code that wants to treat a rate limit
+/// specially (the voice generator's cooldown) catches this exact type.
+/// </summary>
+public sealed class WingmanModelRateLimitedException : InvalidOperationException
+{
+    /// <summary>How long the provider asked us to wait before retrying (its Retry-After header), or
+    /// null when it gave no hint - the caller then uses its own exponential backoff.</summary>
+    public TimeSpan? RetryAfter { get; }
+
+    public WingmanModelRateLimitedException(string message, TimeSpan? retryAfter)
+        : base(message) => RetryAfter = retryAfter;
+}

--- a/src/CcDirector.Gateway/Wingman/WingmanRateLimitGate.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanRateLimitGate.cs
@@ -1,0 +1,84 @@
+namespace CcDirector.Gateway.Wingman;
+
+/// <summary>
+/// A shared, fleet-wide cooldown for the hosted wingman model call (issue #1324). When the provider
+/// rate limits us with HTTP 429, calling it again immediately just earns another 429 - the storm that
+/// blanked every voice session with "no narration is ready". This gate records a cooldown after a 429
+/// and reports it so <see cref="WingmanVoiceService.GenerateAsync"/> skips the model call until it
+/// elapses: it honors the provider's Retry-After when given, and otherwise backs off exponentially
+/// (5s, 10s, 20s ... capped) across consecutive hits. A success resets the ramp.
+///
+/// There is ONE gate per Gateway because every voice session shares the one provider, so a single
+/// cooldown calms the whole fleet at once. No per-caller jitter is needed here: jitter exists to
+/// de-synchronize a HERD of independent clients, but this is a single caller, so a plain shared
+/// cooldown is correct and simpler. Thread-safe; the clock is injectable so the backoff is unit-testable.
+/// </summary>
+internal sealed class WingmanRateLimitGate
+{
+    private readonly Func<DateTime> _nowUtc;
+    private readonly TimeSpan _baseDelay;
+    private readonly TimeSpan _maxDelay;
+    private readonly object _lock = new();
+    private DateTime _cooldownUntilUtc = DateTime.MinValue;
+    private int _consecutive;
+
+    /// <param name="nowUtc">Clock source; <see cref="DateTime.UtcNow"/> when null (tests inject a fake).</param>
+    /// <param name="baseDelay">The first backoff after a single 429 (default 5 seconds).</param>
+    /// <param name="maxDelay">The ceiling the exponential ramp and any Retry-After are capped to (default 120 seconds).</param>
+    public WingmanRateLimitGate(Func<DateTime>? nowUtc = null, TimeSpan? baseDelay = null, TimeSpan? maxDelay = null)
+    {
+        _nowUtc = nowUtc ?? (() => DateTime.UtcNow);
+        _baseDelay = baseDelay ?? TimeSpan.FromSeconds(5);
+        _maxDelay = maxDelay ?? TimeSpan.FromSeconds(120);
+    }
+
+    /// <summary>True while a cooldown is in effect; <paramref name="remaining"/> is how long is left.</summary>
+    public bool InCooldown(out TimeSpan remaining)
+    {
+        lock (_lock)
+        {
+            var left = _cooldownUntilUtc - _nowUtc();
+            if (left > TimeSpan.Zero) { remaining = left; return true; }
+            remaining = TimeSpan.Zero;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Record a 429 and (re)arm the cooldown; returns the backoff applied. Honors
+    /// <paramref name="retryAfter"/> when the provider sent one (capped to the ceiling); otherwise
+    /// doubles from the base delay for each consecutive hit up to the ceiling. A nearer cooldown never
+    /// shortens a longer one already armed.
+    /// </summary>
+    public TimeSpan OnRateLimited(TimeSpan? retryAfter)
+    {
+        lock (_lock)
+        {
+            if (_consecutive < int.MaxValue) _consecutive++;
+            TimeSpan backoff;
+            if (retryAfter is { } ra && ra > TimeSpan.Zero)
+            {
+                backoff = ra > _maxDelay ? _maxDelay : ra;
+            }
+            else
+            {
+                // 5 * 2^(n-1), capped. The exponent is clamped so the Pow never overflows on a long outage.
+                var seconds = _baseDelay.TotalSeconds * Math.Pow(2, Math.Min(_consecutive - 1, 20));
+                backoff = TimeSpan.FromSeconds(Math.Min(seconds, _maxDelay.TotalSeconds));
+            }
+            var until = _nowUtc() + backoff;
+            if (until > _cooldownUntilUtc) _cooldownUntilUtc = until;
+            return backoff;
+        }
+    }
+
+    /// <summary>A model call succeeded - clear the cooldown and reset the backoff ramp to base.</summary>
+    public void OnSuccess()
+    {
+        lock (_lock)
+        {
+            _consecutive = 0;
+            _cooldownUntilUtc = DateTime.MinValue;
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -46,6 +46,19 @@ public sealed class WingmanVoiceService
     private readonly string _audioDir;
     private readonly HttpClient? _ttsHttp;   // test seam for TtsAsync (issue #939); a per-call client when null
 
+    // Backpressure so a busy fleet cannot storm the hosted model into 429s (issue #1324). All
+    // generation - the turn-end hook AND the idle sweep - funnels through GenerateAsync, so gating
+    // it here bounds the whole fleet at once:
+    //  * _rateGate: a shared cooldown that skips the model call while the provider is rate limiting us.
+    //  * _genGate: caps how many generations run at once (ten sessions finishing together must not
+    //    fire ten simultaneous model calls).
+    //  * _inFlight: coalesces - never two generations for the same session at the same time.
+    private const int MaxConcurrentGenerations = 2;
+    private static readonly TimeSpan GateAcquireTimeout = TimeSpan.FromSeconds(15);
+    private readonly SemaphoreSlim _genGate = new(MaxConcurrentGenerations, MaxConcurrentGenerations);
+    private readonly ConcurrentDictionary<string, byte> _inFlight = new();   // sid -> a generation is running now
+    private readonly WingmanRateLimitGate _rateGate = new();
+
     /// <summary>On-disk shape of one ready session's metadata (the audio bytes live next to it as
     /// an .mp3). Persisted so the play triangle / playability survives a gateway restart (issue #553).</summary>
     private sealed record PersistedVoice(string Spoken, string Reply, DateTime AtUtc, string? ContentType = null);
@@ -289,39 +302,86 @@ public sealed class WingmanVoiceService
     /// </summary>
     public async Task GenerateAsync(string sid, string endpoint, CancellationToken ct = default)
     {
+        Mark(sid);
+
+        // Backpressure #1 (issue #1324) - respect a provider rate-limit cooldown. A 429 means "stop
+        // calling", so while the cooldown is in effect we skip the model call entirely. Both callers
+        // funnel through here, so one cooldown stops the WHOLE fleet from hammering a throttled provider.
+        if (_rateGate.InCooldown(out var cooldownLeft))
+        {
+            FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} SKIPPED: provider throttled, {cooldownLeft.TotalSeconds:F0}s cooldown left");
+            return;
+        }
+
+        // Backpressure #2 - coalesce. Never run two generations for the same session at once (a slow
+        // turn overlapping the idle sweep would otherwise double the spend). First caller wins.
+        if (!_inFlight.TryAdd(sid, 1))
+            return;
         try
         {
-            Mark(sid);
-            var turns = await _client.GetTurnsAsync(endpoint, sid, ct);
-            var widgets = turns?.Widgets ?? new List<TurnWidgetDto>();
-            var lastReply = widgets.LastOrDefault(w => w.Kind == "Text")?.Content;
-            if (string.IsNullOrWhiteSpace(lastReply)) return;  // nothing to say yet
-            // Recent conversation so the wingman can add context to a short/terse latest reply.
-            var recentContext = WingmanTranslator.BuildRecentContext(widgets);
-            // The wingman is now running for this session - show it yellow until the summary lands.
-            BeginGenerating(sid);
+            // Backpressure #3 - cap fleet-wide concurrency so a burst of simultaneous turn-ends does
+            // not fire a burst of simultaneous model calls. Bounded wait: if the gate stays saturated
+            // we DROP this cycle rather than queue unboundedly - the idle sweep or the next turn-end
+            // regenerates it.
+            if (!await _genGate.WaitAsync(GateAcquireTimeout, ct))
+            {
+                FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} SKIPPED: {MaxConcurrentGenerations} generations already in flight");
+                return;
+            }
             try
             {
-                var t = await _translator.TranslateAsync(recentContext, lastReply, ct);
-                await StoreSpokenAsync(sid, t.Spoken, lastReply, ct);
-                // Log the TRUE outcome: StoreSpokenAsync only makes the session playable when the
-                // text-to-speech synthesis actually returned audio. Logging "voice ready"
-                // unconditionally (the old behavior) hid every failed synthesis behind a success
-                // line, which made a text-to-speech outage look like it was working in the log.
-                if (HasVoice(sid))
-                    FileLog.Write($"[WingmanVoiceService] voice ready: sid={sid}, spokenLen={t.Spoken.Length}");
-                else
-                    FileLog.Write($"[WingmanVoiceService] voice NOT ready (text-to-speech produced no audio): sid={sid}, spokenLen={t.Spoken.Length}");
-                // Training capture (no-op unless the setting is on); fire-and-forget so it never
-                // delays the turn. CancellationToken.None so a captured turn is not lost on shutdown.
-                _ = _training.CaptureAsync(_client, endpoint, sid, "generate", lastReply, recentContext, t.Spoken, t.ReplySeconds, CancellationToken.None);
+                await GenerateOnceAsync(sid, endpoint, ct);
+                _rateGate.OnSuccess();   // reaching the provider clears any cooldown/backoff ramp
             }
-            finally { EndGenerating(sid); }
+            finally { _genGate.Release(); }
+        }
+        catch (WingmanModelRateLimitedException rl)
+        {
+            // The provider rate limited us - arm the cooldown so the next turn-end/sweep backs off
+            // instead of piling on. Honors its Retry-After when it sent one (issue #1324).
+            var backoff = _rateGate.OnRateLimited(rl.RetryAfter);
+            FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} rate limited (429); backing off {backoff.TotalSeconds:F0}s before the next generation");
         }
         catch (Exception ex)
         {
             FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} FAILED: {ex.Message}");
         }
+        finally { _inFlight.TryRemove(sid, out _); }
+    }
+
+    /// <summary>
+    /// One generation attempt: read the latest reply, translate it, synthesize and store the audio.
+    /// Split out of <see cref="GenerateAsync"/> so the backpressure wrapper (cooldown, concurrency cap,
+    /// coalescing) stays readable and this stays the pure "make the voice" step. A rate-limit surfaces
+    /// as <see cref="WingmanModelRateLimitedException"/> for the wrapper's cooldown to catch.
+    /// </summary>
+    private async Task GenerateOnceAsync(string sid, string endpoint, CancellationToken ct)
+    {
+        var turns = await _client.GetTurnsAsync(endpoint, sid, ct);
+        var widgets = turns?.Widgets ?? new List<TurnWidgetDto>();
+        var lastReply = widgets.LastOrDefault(w => w.Kind == "Text")?.Content;
+        if (string.IsNullOrWhiteSpace(lastReply)) return;  // nothing to say yet
+        // Recent conversation so the wingman can add context to a short/terse latest reply.
+        var recentContext = WingmanTranslator.BuildRecentContext(widgets);
+        // The wingman is now running for this session - show it yellow until the summary lands.
+        BeginGenerating(sid);
+        try
+        {
+            var t = await _translator.TranslateAsync(recentContext, lastReply, ct);
+            await StoreSpokenAsync(sid, t.Spoken, lastReply, ct);
+            // Log the TRUE outcome: StoreSpokenAsync only makes the session playable when the
+            // text-to-speech synthesis actually returned audio. Logging "voice ready"
+            // unconditionally (the old behavior) hid every failed synthesis behind a success
+            // line, which made a text-to-speech outage look like it was working in the log.
+            if (HasVoice(sid))
+                FileLog.Write($"[WingmanVoiceService] voice ready: sid={sid}, spokenLen={t.Spoken.Length}");
+            else
+                FileLog.Write($"[WingmanVoiceService] voice NOT ready (text-to-speech produced no audio): sid={sid}, spokenLen={t.Spoken.Length}");
+            // Training capture (no-op unless the setting is on); fire-and-forget so it never
+            // delays the turn. CancellationToken.None so a captured turn is not lost on shutdown.
+            _ = _training.CaptureAsync(_client, endpoint, sid, "generate", lastReply, recentContext, t.Spoken, t.ReplySeconds, CancellationToken.None);
+        }
+        finally { EndGenerating(sid); }
     }
 
     /// <summary>


### PR DESCRIPTION
## What this fixes

Fixes #1324. Mobile voice narration was going dead fleet-wide whenever the hosted wingman model got rate limited. The Gateway pre-builds narration for every voice session on every turn-end and again on a 15-second idle sweep, with no backpressure and no rate-limit handling. With about ten sessions in voice mode, that fan-out overran the provider, which answered `429 Too Many Requests`; the Gateway kept calling immediately, turning one 429 into a storm. While it lasted, every voice session showed "No narration is ready to play / Voice unavailable" - proven in the Gateway log for four local Windows sessions at once, so it was never Mac-specific.

## The change

All narration funnels through `WingmanVoiceService.GenerateAsync`, so the fix lives there plus the model client:

1. Typed rate-limit signal. `HostedInferenceBrain` now throws `WingmanModelRateLimitedException` on HTTP 429, carrying the provider's `Retry-After` (delta or HTTP-date form) when present. It extends `InvalidOperationException`, so every existing catch is unchanged.

2. Shared cooldown with backoff. A new `WingmanRateLimitGate` records a cooldown after a 429: it honors `Retry-After` when given, otherwise backs off exponentially (5s, 10s, 20s ... capped at 120s) across consecutive hits, and resets on the first success. One gate per Gateway, because all voice sessions share the one provider - a single cooldown calms the whole fleet. No jitter: there is a single caller here, not a herd, so a plain shared cooldown is correct.

3. Backpressure in `GenerateAsync`:
   - skip the model call entirely while the cooldown is in effect;
   - coalesce - never two generations for the same session at once;
   - cap fleet-wide concurrency at 2, and drop (not queue) a cycle when saturated - the idle sweep or the next turn-end regenerates it.

Net effect: a 429 now makes the fleet back off and recover instead of hammering the provider. When the provider is healthy, nothing changes except that at most two narrations build at a time.

## Scope

Server-side backpressure and 429 handling only (issue #1324 items 1 and 2). Item 3 (generate only for the actively-viewed session) and item 4 (distinguish a transient throttle from a hard outage in the phone UI) are follow-ups, left out to keep this focused and mergeable.

## Tests

- `WingmanRateLimitGateTests` (new, 8): base cooldown, expiry, exponential ramp to the cap, Retry-After honored and capped, a nearer cooldown not shortening a longer one, and success resetting the ramp - all on a fake clock, no real waiting.
- `HostedInferenceBrainTests` (+3): 429 throws the typed exception with Retry-After from the header, with a null hint when absent, and is still an `InvalidOperationException`.
- Full `CcDirector.Gateway.Tests` suite green.

## Verification note

The failure is a live provider rate limit, so it cannot be reproduced deterministically against the real endpoint on demand. The backoff/cooldown logic is proven by the unit tests on a fake clock; the wiring in `GenerateAsync` is a thin, reviewed wrapper over the existing generation step.
