### PR TITLE
feat(local-files): Phase 1 - session-scoped file endpoint, client helpers, classifier

### DIFF
--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -597,6 +597,38 @@ export function screenshotFileUrl(sessionId: string, fileName: string): string {
   return `/sessions/${sid}/screenshots/file?name=${encodeURIComponent(fileName)}`;
 }
 
+// ===== Local Files (remote file viewer): any local file on the owning Director's disk =====
+// Same request shape as the screenshot bytes above, generalized from "one screenshot" to "any file
+// by absolute path". The client viewing a session always has the session id, so it asks the Gateway
+// same-origin at /sessions/{sid}/file?path=... ; the Gateway's per-session catch-all resolves the
+// owning Director and forwards the request there, and the Director streams the bytes off its own
+// disk. The session id is purely the routing vehicle that reaches the right machine (the path is
+// always a path on that machine), not a sandbox. Root-relative to the Gateway, so a browser <img>
+// or <iframe> src carries the cc-gateway-token cookie exactly as the screenshot viewer does.
+
+/** The same-origin URL for a local file's bytes on the owning Director, used as an <img>/<iframe>
+ *  src and as the target of a Download link. `path` is an absolute path on the session's machine. */
+export function sessionFileUrl(sessionId: string, path: string): string {
+  const sid = encodeURIComponent(sessionId);
+  return `/sessions/${sid}/file?path=${encodeURIComponent(path)}`;
+}
+
+// Fetch a local file's TEXT content through the Gateway (for the Markdown and text/code viewers,
+// which need the string, not an <img>/<iframe> src). A non-OK response is thrown as a GatewayError
+// so the viewer can show the real reason - 404 for a missing file, 503 for an offline Director -
+// never a silent blank.
+export async function fetchSessionFileText(sessionId: string, path: string, signal?: AbortSignal): Promise<string> {
+  const res = await fetch(sessionFileUrl(sessionId, path), {
+    method: "GET",
+    headers: { ...authHeaders() },
+    signal,
+  });
+  if (!res.ok) {
+    throw new GatewayError(res.status, `GET file failed: ${res.status}`);
+  }
+  return res.text();
+}
+
 // GET /sessions/{sid}/screenshots[?count=N] - the newest screenshots' metadata (not the bytes).
 // count <= 0 fetches everything (the folder can hold thousands, so callers pass a cap). A 503 means
 // the owning Director is offline (the Gateway could not reach it for this leg, issue #412); it is

--- a/packages/client-core/src/history/fileTypes.test.ts
+++ b/packages/client-core/src/history/fileTypes.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { classifyFile, fileExtension } from "./fileTypes";
+
+// Local Files mission (Phase 1): classifyFile maps a detected absolute path to exactly one viewer
+// type by extension. Full coverage is formally Phase 4; this basic set locks the contract from the
+// brief's decision 4 (image / pdf / html / markdown / text / download) so a later change cannot
+// silently reclassify a type.
+
+describe("classifyFile", () => {
+  it.each([
+    ["C:\\shots\\out.png", "image"],
+    ["C:\\shots\\out.PNG", "image"],
+    ["/c/shots/photo.jpg", "image"],
+    ["D:\\a\\b.jpeg", "image"],
+    ["D:\\a\\b.gif", "image"],
+    ["D:\\a\\b.svg", "image"],
+    ["D:\\a\\b.webp", "image"],
+    ["D:\\a\\b.bmp", "image"],
+  ])("classifies %s as image", (path, expected) => {
+    expect(classifyFile(path)).toBe(expected);
+  });
+
+  it("classifies a pdf", () => {
+    expect(classifyFile("D:\\reports\\Q3.pdf")).toBe("pdf");
+  });
+
+  it.each([
+    ["D:\\site\\index.html", "html"],
+    ["D:\\site\\page.htm", "html"],
+  ])("classifies %s as html", (path, expected) => {
+    expect(classifyFile(path)).toBe(expected);
+  });
+
+  it.each([
+    ["D:\\docs\\README.md", "markdown"],
+    ["D:\\docs\\notes.markdown", "markdown"],
+  ])("classifies %s as markdown", (path, expected) => {
+    expect(classifyFile(path)).toBe(expected);
+  });
+
+  it.each([
+    ["D:\\logs\\run.log", "text"],
+    ["D:\\a\\b.txt", "text"],
+    ["D:\\a\\data.json", "text"],
+    ["D:\\a\\data.csv", "text"],
+    ["D:\\src\\app.ts", "text"],
+    ["D:\\src\\app.py", "text"],
+    ["D:\\src\\Program.cs", "text"],
+    ["D:\\src\\build.gradle", "text"],
+    ["D:\\src\\config.yaml", "text"],
+    ["D:\\src\\style.css", "text"],
+  ])("classifies %s as text", (path, expected) => {
+    expect(classifyFile(path)).toBe(expected);
+  });
+
+  it.each([
+    ["D:\\bin\\app.exe", "download"],
+    ["D:\\data\\archive.zip", "download"],
+    ["D:\\media\\clip.mp4", "download"],
+    ["D:\\data\\model.bin", "download"],
+    ["D:\\no-extension-here", "download"],
+  ])("classifies unknown/binary %s as download", (path, expected) => {
+    expect(classifyFile(path)).toBe(expected);
+  });
+
+  it.each([
+    ["D:\\repo\\Dockerfile", "text"],
+    ["D:\\repo\\Makefile", "text"],
+  ])("classifies bare textual filename %s as text", (path, expected) => {
+    expect(classifyFile(path)).toBe(expected);
+  });
+
+  it("treats a dotfile like .gitignore as having no extension (falls to basename rule)", () => {
+    expect(classifyFile("D:\\repo\\.gitignore")).toBe("text");
+  });
+});
+
+describe("fileExtension", () => {
+  it.each([
+    ["C:\\a\\b.PNG", "png"],
+    ["/c/a/b.tar.gz", "gz"],
+    ["D:\\dir.with.dot\\file", ""],
+    ["D:\\repo\\.gitignore", ""],
+    ["", ""],
+  ])("extracts the extension of %s", (path, expected) => {
+    expect(fileExtension(path)).toBe(expected);
+  });
+});

--- a/packages/client-core/src/history/fileTypes.ts
+++ b/packages/client-core/src/history/fileTypes.ts
@@ -1,0 +1,96 @@
+// Local Files mission (Phase 1): classify a detected file path into ONE viewer type, purely by its
+// extension, so a click knows which render mode to open. This is app-agnostic (no UI imports): the
+// cockpit and the mobile /m shells both call it and then open their own viewer for the returned type.
+//
+// The type maps exactly to the render modes in the mission brief (decision 4):
+//   image    -> <img src=fileUrl>
+//   pdf      -> <iframe src=fileUrl> (browser native PDF viewer)
+//   html     -> SANDBOXED <iframe src=fileUrl>
+//   markdown -> fetch the text, render with markdownToHtml()
+//   text     -> fetch the text, show in <pre> (covers code files too)
+//   download -> unknown / binary: do not guess, offer a Download button
+//
+// We cannot sniff bytes on the client, so classification is extension-driven with a textual
+// allowlist: a known-textual extension is 'text', and everything else unknown is 'download'
+// (fail loud, no guessing) - matching the brief's "do not guess" rule for unknown/binary files.
+
+export type FileViewerType = "image" | "pdf" | "html" | "markdown" | "text" | "download";
+
+// Images the browser renders directly with <img>.
+const IMAGE_EXTENSIONS = new Set([
+  "png", "jpg", "jpeg", "gif", "svg", "webp", "bmp",
+]);
+
+// Markdown, rendered through the shared sanitized markdownToHtml().
+const MARKDOWN_EXTENSIONS = new Set([
+  "md", "markdown",
+]);
+
+// HTML, rendered in a sandboxed iframe (decision 3).
+const HTML_EXTENSIONS = new Set([
+  "html", "htm",
+]);
+
+// Textual / code extensions shown as plain text in a <pre>. The base set from the brief (txt, log,
+// json, csv) plus the common code and config extensions so a source or config file a session
+// produced opens as readable text rather than an opaque download.
+const TEXT_EXTENSIONS = new Set([
+  // Plain text and data.
+  "txt", "text", "log", "json", "csv", "tsv", "xml", "yaml", "yml", "toml", "ini", "cfg", "conf",
+  "properties", "env", "rst", "tex",
+  // Web and stylesheets.
+  "js", "jsx", "ts", "tsx", "mjs", "cjs", "css", "scss", "sass", "less",
+  // General-purpose languages.
+  "py", "cs", "java", "kt", "kts", "scala", "go", "rs", "rb", "php", "swift", "dart", "lua",
+  "pl", "r", "vb", "fs", "clj", "ex", "exs", "erl",
+  // C / C++ family.
+  "c", "h", "cpp", "cc", "cxx", "hpp", "hh", "m", "mm",
+  // Shell and build scripts.
+  "sh", "bash", "zsh", "ps1", "psm1", "bat", "cmd", "sql", "gradle",
+]);
+
+// A few common EXTENSIONLESS textual files. Classification is extension-first, but these bare names
+// are text often enough that treating them as a download would surprise the user.
+const TEXT_BASENAMES = new Set([
+  "dockerfile", "makefile", "readme", "license", "licence", "changelog", "gitignore",
+  "gitattributes", "editorconfig", "npmrc", "env",
+]);
+
+/** The lower-cased extension WITHOUT the dot (e.g. "PNG" -> "png"), or "" when there is none. */
+export function fileExtension(path: string): string {
+  if (!path) return "";
+  // Take the last path segment so a dot in a parent directory name is never mistaken for the ext.
+  const segments = path.replace(/\\/g, "/").split("/");
+  const name = segments[segments.length - 1] ?? "";
+  const dot = name.lastIndexOf(".");
+  // dot <= 0 means no dot, or a dotfile like ".gitignore" (no real extension).
+  if (dot <= 0) return "";
+  return name.slice(dot + 1).toLowerCase();
+}
+
+/** The lower-cased final path segment, dots stripped for a dotfile (".gitignore" -> "gitignore"). */
+function fileBaseName(path: string): string {
+  if (!path) return "";
+  const segments = path.replace(/\\/g, "/").split("/");
+  const name = (segments[segments.length - 1] ?? "").toLowerCase();
+  return name.startsWith(".") ? name.slice(1) : name;
+}
+
+/**
+ * Classify an absolute file path into the viewer type that should render it. Unknown or binary
+ * extensions return "download" - the caller offers a Download button rather than guessing a render.
+ */
+export function classifyFile(path: string): FileViewerType {
+  const ext = fileExtension(path);
+  if (ext) {
+    if (IMAGE_EXTENSIONS.has(ext)) return "image";
+    if (ext === "pdf") return "pdf";
+    if (HTML_EXTENSIONS.has(ext)) return "html";
+    if (MARKDOWN_EXTENSIONS.has(ext)) return "markdown";
+    if (TEXT_EXTENSIONS.has(ext)) return "text";
+    return "download";
+  }
+  // No extension: a small set of well-known bare textual filenames reads as text; all else download.
+  if (TEXT_BASENAMES.has(fileBaseName(path))) return "text";
+  return "download";
+}

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1014,25 +1014,35 @@ internal static class ControlEndpoints
             if (!System.IO.File.Exists(path))
                 return Results.NotFound(new { error = "file not found: " + path });
 
-            var ext = System.IO.Path.GetExtension(path).ToLowerInvariant();
-            var ctype = ext switch
-            {
-                ".html" or ".htm" => "text/html; charset=utf-8",
-                ".pdf"            => "application/pdf",
-                ".png"            => "image/png",
-                ".jpg" or ".jpeg" => "image/jpeg",
-                ".gif"            => "image/gif",
-                ".svg"            => "image/svg+xml",
-                ".css"            => "text/css; charset=utf-8",
-                ".js"             => "text/javascript; charset=utf-8",
-                ".json"           => "application/json; charset=utf-8",
-                ".csv"            => "text/csv; charset=utf-8",
-                ".md" or ".txt" or ".log" => "text/plain; charset=utf-8",
-                _                 => "application/octet-stream",
-            };
+            var ctype = FileContentType(path);
             FileLog.Write($"[ControlEndpoints] GET /file: {path} ({ctype})");
             // No fileDownloadName -> served inline, so the browser renders it (not a download).
             return Results.File(path, ctype);
+        });
+
+        // Local Files mission (Phase 1): the session-scoped sibling of the top-level /file above.
+        // The client viewing a session always has the session id, so it asks the Gateway for
+        // GET /sessions/{sid}/file?path=... ; the Gateway's per-session catch-all
+        // (/sessions/{sid}/{**rest}) uses the sid ONLY to resolve the owning Director, then forwards
+        // the request here unchanged. Because the session lives on this machine, any absolute path
+        // its terminal or chat emitted is a path on this machine - correct by construction. The sid
+        // is the routing vehicle, NOT a sandbox: like /file above, any existing absolute path is
+        // served (per the solo-tailnet decision), 404 if it does not exist. Two things this route
+        // adds over the top-level /file: enableRangeProcessing (large PDFs/images seek and resume)
+        // and X-Content-Type-Options: nosniff (the browser must honor the content type we set, so an
+        // HTML file cannot be re-sniffed into something that executes with different authority).
+        app.MapGet("/sessions/{sid}/file", (HttpContext ctx, string sid, string? path) =>
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                return Results.BadRequest(new { error = "path is required" });
+            if (!System.IO.File.Exists(path))
+                return Results.NotFound(new { error = "file not found: " + path });
+
+            var ctype = FileContentType(path);
+            FileLog.Write($"[ControlEndpoints] GET /sessions/{sid}/file: {path} ({ctype})");
+            ctx.Response.Headers["X-Content-Type-Options"] = "nosniff";
+            // No fileDownloadName -> served inline, so the browser renders it (not a download).
+            return Results.File(path, ctype, enableRangeProcessing: true);
         });
 
         // Phase 4b: observability into the wingman. Returns current color + reason,
@@ -3752,5 +3762,27 @@ internal static class ControlEndpoints
         ".bmp" => "image/bmp",
         ".webp" => "image/webp",
         _ => "application/octet-stream",
+    };
+
+    /// <summary>
+    /// The single extension -> HTTP content-type map shared by the top-level <c>GET /file</c> and the
+    /// session-scoped <c>GET /sessions/{sid}/file</c> (Local Files mission). One map, two routes, so a
+    /// new type is added in exactly one place. The octet-stream fallback means an unknown extension is
+    /// served as an opaque download, never guessed as text or an image.
+    /// </summary>
+    private static string FileContentType(string path) => Path.GetExtension(path).ToLowerInvariant() switch
+    {
+        ".html" or ".htm" => "text/html; charset=utf-8",
+        ".pdf"            => "application/pdf",
+        ".png"            => "image/png",
+        ".jpg" or ".jpeg" => "image/jpeg",
+        ".gif"            => "image/gif",
+        ".svg"            => "image/svg+xml",
+        ".css"            => "text/css; charset=utf-8",
+        ".js"             => "text/javascript; charset=utf-8",
+        ".json"           => "application/json; charset=utf-8",
+        ".csv"            => "text/csv; charset=utf-8",
+        ".md" or ".txt" or ".log" => "text/plain; charset=utf-8",
+        _                 => "application/octet-stream",
     };
 }

--- a/src/CcDirector.Gateway.Tests/SessionFileProxyRoundTripTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionFileProxyRoundTripTests.cs
@@ -1,0 +1,228 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using CcDirector.Gateway;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Local Files mission (Phase 1) round-trip proof, modeled on
+/// <see cref="ScreenshotProxyRoundTripTests"/>: a remote
+/// <c>GET /sessions/{sid}/file?path=&lt;absolute path&gt;</c> on the Gateway is carried by the
+/// generic per-session catch-all to the owning Director's <c>GET /sessions/{sid}/file</c> at the
+/// same path, and the Director streams the file's bytes + content type back through unchanged. A
+/// stub Director (real Kestrel host) implements just the two endpoints the proxy touches:
+/// <c>GET /sessions/{sid}</c> (ownership resolution) and <c>GET /sessions/{sid}/file</c> (the bytes),
+/// the latter replicating the real Director handler (content-type map, nosniff, range support). The
+/// test proves an image and a text file BOTH come back byte-identical with the right content type,
+/// that the URL-escaped path arrives decoded, and that a missing path passes the Director 404 through.
+/// </summary>
+public sealed class SessionFileProxyRoundTripTests : IAsyncLifetime
+{
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private StubDirector _director = null!;
+
+    // A tiny but real PNG header + payload and a text file. Byte-identity is what matters.
+    private static readonly byte[] PngBytes =
+    {
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+        0xDE, 0xAD, 0xBE, 0xEF, 0x13, 0x37, 0x42, 0x42,
+    };
+    private const string TextContent = "line one\nline two\nthe quick brown fox\n";
+
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-instances-" + Guid.NewGuid().ToString("N"));
+    private readonly string _filesDir =
+        Path.Combine(Path.GetTempPath(), "cc-localfiles-" + Guid.NewGuid().ToString("N"));
+
+    private string _pngPath = "";
+    private string _textPath = "";
+
+    public async Task InitializeAsync()
+    {
+        // Real files on disk with a SPACE in the name, so the ?path= URL-escaping is exercised.
+        Directory.CreateDirectory(_filesDir);
+        _pngPath = Path.Combine(_filesDir, "a report.png");
+        _textPath = Path.Combine(_filesDir, "notes 1.txt");
+        await File.WriteAllBytesAsync(_pngPath, PngBytes);
+        await File.WriteAllTextAsync(_textPath, TextContent);
+
+        _gateway = new GatewayHost(port: FreePort(), token: "test-token", authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
+        await _gateway.StartAsync();
+
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "test-token");
+
+        _director = new StubDirector(sessionId: "file-session-1");
+        await _director.StartAsync();
+
+        var req = new DirectorRegistrationRequest
+        {
+            DirectorId = _director.DirectorId,
+            TailnetEndpoint = _director.BaseUrl,
+            Pid = 4243,
+            // Loopback stub on THIS machine -> register as same-machine (issue #457 refuses a
+            // loopback endpoint advertised for a different machine).
+            MachineName = Environment.MachineName,
+            User = "tester",
+            Version = "test",
+            StartedAt = DateTime.UtcNow,
+        };
+        var resp = await _http.PostAsJsonAsync("directors/register", req);
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _director.DisposeAsync();
+        await _gateway.StopAsync();
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); }
+        catch { }
+        try { if (Directory.Exists(_filesDir)) Directory.Delete(_filesDir, true); }
+        catch { }
+    }
+
+    [Fact]
+    public async Task Image_bytes_round_trip_through_the_gateway_with_content_type()
+    {
+        var resp = await _http.GetAsync(
+            $"sessions/file-session-1/file?path={Uri.EscapeDataString(_pngPath)}");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.NotNull(resp.Content.Headers.ContentType);
+        Assert.Equal("image/png", resp.Content.Headers.ContentType!.MediaType);
+
+        var bytes = await resp.Content.ReadAsByteArrayAsync();
+        Assert.Equal(PngBytes, bytes);
+
+        // The escaped path (it has a space) reached the Director decoded, intact.
+        Assert.Equal(_pngPath, _director.LastRequestedPath);
+        // The safety header set by the Director survives the proxy.
+        Assert.True(resp.Headers.Contains("X-Content-Type-Options"));
+        Assert.Equal("nosniff", string.Join("", resp.Headers.GetValues("X-Content-Type-Options")));
+    }
+
+    [Fact]
+    public async Task Text_bytes_round_trip_through_the_gateway_with_content_type()
+    {
+        var resp = await _http.GetAsync(
+            $"sessions/file-session-1/file?path={Uri.EscapeDataString(_textPath)}");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.NotNull(resp.Content.Headers.ContentType);
+        Assert.Equal("text/plain", resp.Content.Headers.ContentType!.MediaType);
+
+        var text = await resp.Content.ReadAsStringAsync();
+        Assert.Equal(TextContent, text);
+        Assert.Equal(_textPath, _director.LastRequestedPath);
+    }
+
+    [Fact]
+    public async Task Missing_file_on_a_live_owner_passes_the_director_404_through()
+    {
+        var missing = Path.Combine(_filesDir, "does-not-exist.png");
+        var resp = await _http.GetAsync(
+            $"sessions/file-session-1/file?path={Uri.EscapeDataString(missing)}");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    private static int FreePort()
+    {
+        using var l = new TcpListener(IPAddress.Loopback, 0);
+        l.Start();
+        return ((IPEndPoint)l.LocalEndpoint).Port;
+    }
+
+    /// <summary>
+    /// Minimal Kestrel host pretending to be a Director's Control API: owns exactly one session (so
+    /// the Gateway's ownership fan-out resolves it) and serves any local file by absolute path,
+    /// replicating the real <c>GET /sessions/{sid}/file</c> handler - the shared content-type map,
+    /// the nosniff header, and range support - so the test proves the real behavior end to end.
+    /// </summary>
+    private sealed class StubDirector : IAsyncDisposable
+    {
+        public string DirectorId { get; } = Guid.NewGuid().ToString();
+        public string BaseUrl { get; private set; } = "";
+        public string? LastRequestedPath { get; private set; }
+
+        private readonly string _sessionId;
+        private WebApplication? _app;
+
+        public StubDirector(string sessionId) => _sessionId = sessionId;
+
+        public async Task StartAsync()
+        {
+            var port = FreePort();
+            BaseUrl = $"http://127.0.0.1:{port}";
+
+            var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+            {
+                ApplicationName = "StubDirector",
+            });
+            builder.WebHost.UseSetting(WebHostDefaults.PreventHostingStartupKey, "true");
+            builder.WebHost.ConfigureKestrel(o => o.Listen(IPAddress.Loopback, port));
+            builder.Logging.ClearProviders();
+            builder.Services.AddRoutingCore();
+
+            _app = builder.Build();
+            _app.UseRouting();
+            _app.MapGet("/sessions/{sid}", (string sid) =>
+                sid == _sessionId
+                    ? Results.Json(new SessionDto { SessionId = _sessionId, Agent = "ClaudeCode", ActivityState = "Idle", StatusColor = "green" })
+                    : Results.NotFound());
+            _app.MapGet("/sessions/{sid}/file", (HttpContext ctx, string sid, string? path) =>
+            {
+                LastRequestedPath = path;
+                if (string.IsNullOrWhiteSpace(path))
+                    return Results.BadRequest(new { error = "path is required" });
+                if (!File.Exists(path))
+                    return Results.NotFound(new { error = "file not found: " + path });
+                ctx.Response.Headers["X-Content-Type-Options"] = "nosniff";
+                return Results.File(path, ContentType(path), enableRangeProcessing: true);
+            });
+
+            await _app.StartAsync();
+        }
+
+        // The same extension -> content-type map the real Director uses (kept in step for the proof).
+        private static string ContentType(string path) => Path.GetExtension(path).ToLowerInvariant() switch
+        {
+            ".html" or ".htm" => "text/html; charset=utf-8",
+            ".pdf"            => "application/pdf",
+            ".png"            => "image/png",
+            ".jpg" or ".jpeg" => "image/jpeg",
+            ".gif"            => "image/gif",
+            ".svg"            => "image/svg+xml",
+            ".css"            => "text/css; charset=utf-8",
+            ".js"             => "text/javascript; charset=utf-8",
+            ".json"           => "application/json; charset=utf-8",
+            ".csv"            => "text/csv; charset=utf-8",
+            ".md" or ".txt" or ".log" => "text/plain; charset=utf-8",
+            _                 => "application/octet-stream",
+        };
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_app is not null)
+            {
+                try { await _app.StopAsync(TimeSpan.FromSeconds(2)); } catch { }
+                await _app.DisposeAsync();
+                _app = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Local Files mission - Phase 1 (server and API foundation)

Server and API foundation only. No viewer or UI (those are Phases 2-4). Brief: `docs/architecture/local-files-mission-2026-07-11.md`.

### What this adds

**Director** - `GET /sessions/{sid}/file` in `ControlEndpoints.cs`, a session-scoped sibling of the existing top-level `GET /file`:
- 400 when the path is missing, 404 when the file does not exist, otherwise the bytes inline with the correct content type.
- `enableRangeProcessing: true` so large PDFs and images seek and resume.
- `X-Content-Type-Options: nosniff` so the browser honors the content type we set.
- No path sandbox: the session id is only the routing vehicle the Gateway uses to reach the owning Director (the settled solo-tailnet decision).
- The extension to content-type switch is extracted into one shared `FileContentType` helper used by both `/file` and the new route - one map, not two copies.

**Gateway** - no new code. The existing per-session catch-all `/sessions/{sid}/{**rest}` forwards `/sessions/{sid}/file` to the owning Director at the same path, and "file" is not caught by the git-write refusal (which matches only the "git" segment). Verified by reading the code and by the round-trip test.

**client-core**:
- `sessionFileUrl(sessionId, path)` and `fetchSessionFileText(sessionId, path)` next to `screenshotFileUrl` in `api/client.ts`.
- New app-agnostic `classifyFile(path)` in `history/fileTypes.ts` mapping an extension to one viewer type (`image` / `pdf` / `html` / `markdown` / `text` / `download`) per brief decision 4. Known textual/code extensions are `text`; unknown or binary is `download` (no guessing).

**Tests**:
- `SessionFileProxyRoundTripTests` (modeled on `ScreenshotProxyRoundTripTests`): an image and a text file both come back byte-identical with the right content type and the nosniff header through the Gateway; a missing file passes the Director 404 through.
- Unit tests for `classifyFile` and `fileExtension`.

### Proof
- `dotnet build` succeeds for the touched projects.
- Round-trip test passes (3 of 3).
- client-core typecheck, build, and vitest pass (40 of 40).
- Exercised against a real built Director (slot 5): image and text bytes, `image/png` and `text/plain` content types, the nosniff header, a `206 Partial Content` range response, and the 404 and 400 error cases all confirmed by direct loopback GET.

The one combination not exercised live is a GET through the running production Gateway to a slot-5 session, because standalone session-create on the test Director returns an unrelated model-binding 400 (nothing this change touches). The in-process Gateway round-trip test covers that exact routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)