### PR TITLE
docs(gateway): device auth is DevThrottle sign-in only - remove the pairing-code model

### DIFF
--- a/docs/architecture/gateway-connection-mission-2026-07-11.md
+++ b/docs/architecture/gateway-connection-mission-2026-07-11.md
@@ -12,14 +12,16 @@ Detect button, a Test button, another Detect button, a plain-text token box, a s
 flow in ONE place, built on a hard split between two separately-verified states:
 
 - CONNECTED: this Director can reach the Gateway, proven by the existing two-way nonce handshake.
-- SIGNED IN: this device is trusted by the Gateway (device key valid) and the Gateway reports a
-  signed-in account.
+- SIGNED IN: this device holds a valid per-device token and the Gateway reports a signed-in account.
+  The device gets that token the one and only way any device does - mobile or Director - by signing
+  in to DevThrottle. There is no pairing code, no QR code, and nothing shown on the Gateway host to
+  read off or type in.
 
 The flow must be reachable both from the Settings dialog and from a single status box in the
 bottom-left corner of the main window, where one click always takes the user to the next
 unfinished step. First-time setup and re-sign-in are the same flow. The result must be so simple
 that a brand-new user on a brand-new machine gets from first launch to fully connected by doing
-three things: click the amber box, click Connect, type the pairing code.
+three things: click the amber box, click Connect, sign in with DevThrottle.
 
 Source document (read it before starting):
 
@@ -50,12 +52,13 @@ duplicates the URL-plus-Detect-plus-Test controls in OnboardingWizardDialog.axam
 
 ## Decisions already made - do not re-litigate
 
-1. Two user-visible checkpoints, no more: Connected and Signed In. Device pairing is the
-   Director-side half of "signed in", not a third checkbox.
+1. Two user-visible checkpoints, no more: Connected and Signed In. Signing in to DevThrottle is the
+   Director-side half of "signed in" (it issues this device its token), not a separate pairing step.
 2. The Director never gates on any of this (issues 641 and 664 removed the Director login;
    the app always boots and works locally). The status box is a nudge, never a wall.
 3. The Director never holds account credentials (epic 1069: the account lives at the Gateway).
-   The Director's part is device pairing plus watching GET /account/status.
+   The Director's part is holding a valid per-device token - issued when the user signs in to
+   DevThrottle - plus watching GET /account/status.
 4. Green is earned, never assumed: the Connected check comes only from the proven two-way
    handshake; the Signed-in check only from the Gateway's own report.
 5. Scanning is automatic (the Detect button dies); connecting is the test (the Test button dies).
@@ -85,15 +88,15 @@ the full detail and proof requirement for each.
   resolver and Step 1: automatic scan (this machine, tailnet, local network - the issue 1233
   discovery order), found Gateways as one-click picks, manual entry fallback, live handshake
   progress, named failures. Reachable from a temporary menu entry for testing.
-- Phase 2 - Sign-in step. Step 2: pairing-code entry (absorbing the register-device dialog) and
-  the open-the-account-page path that polls account status and auto-advances. Done view with the
-  collapsed Advanced section.
+- Phase 2 - Sign-in step. Step 2: sign in with DevThrottle - open the browser sign-in that issues
+  this device its token, poll account status, and auto-advance. Done view with the collapsed
+  Advanced section. The old pairing-code dialog is deleted, not reused.
 - Phase 3 - One status box. Merge the two bottom-left boxes into one GatewayStatusBox with two
   check lines and four visual states (not connected, connected only, all green, was-working-now-
   unreachable red). Click opens the panel on the current step.
 - Phase 4 - Settings cleanup. Gateway tab becomes the embedded panel; Account tab becomes a
-  status summary plus one button; delete Detect, Test, the plain-text token box, the register
-  button, and the re-run-wizard button; the onboarding wizard embeds the panel.
+  status summary plus one button; delete Detect, Test, the plain-text token box, the pairing-code
+  "Connect to Gateway..." dialog, and the re-run-wizard button; the onboarding wizard embeds the panel.
 - Phase 5 - Repair mode. Troubleshooter diagnostics inline in Step 1; changed-address
   rediscovery offered as a one-click fix; red-state routing; re-sign-in lands directly on Step 2.
 
@@ -104,7 +107,7 @@ the full detail and proof requirement for each.
 2. The deletion list from the design document is fully executed - none of the removed buttons,
    boxes, or dialogs are reachable from the user interface.
 3. The end-to-end success test passes on a fresh profile: from clean start to two green checks
-   without typing a URL - click the amber box, click Connect, type the pairing code.
+   without typing a URL - click the amber box, click Connect, sign in with DevThrottle.
 4. The Mac verification pass is explicitly scheduled as the final step (network discovery,
    browser launch, and device-key storage path are the three platform-sensitive spots).
 5. A final verification report (HTML, in docs/reviews/) showing every state and step with

--- a/docs/architecture/security/REGISTER_DIRECTOR_MOCKUP.html
+++ b/docs/architecture/security/REGISTER_DIRECTOR_MOCKUP.html
@@ -114,6 +114,15 @@
 
 <header class="top">
   <h1>Register a Director - UI Mockup (Anchor B)</h1>
+  <div style="border:2px solid #b00; background:#3a1414; color:#f4c7c7; padding:12px 16px; border-radius:6px; margin:12px 0; font-size:14px; line-height:1.5;">
+    <strong>SUPERSEDED - this entire mockup is obsolete.</strong>
+    There is NO pairing code, NO QR code, and nothing shown on the Gateway host to read off or type in, and
+    you do NOT need to be in front of the gateway machine. A device (mobile or cc-director Director) gets
+    onto the Gateway exactly one way: by signing in to DevThrottle, which issues that device its per-device
+    token. The "Connect to Gateway" pairing-code dialog shown here is being deleted. See
+    <code>docs/architecture/mobile/MOBILE_DEVICE_AUTH.md</code> (the current device-auth spec) and
+    <code>docs/reviews/gateway-connection-redesign-2026-07-11.md</code> Step 2 for the actual sign-in flow.
+  </div>
   <div class="sub">The pairing code is shown in the Gateway's own local app window on the host machine - never over the network. You must be in front of the gateway machine to enroll a device.</div>
   <div class="meta">Mockup / design only. Per-device-key model, local-presence root of trust. Companion to SECURITY_FLOWS.html.</div>
 </header>

--- a/docs/architecture/security/SECURITY_FLOWS.html
+++ b/docs/architecture/security/SECURITY_FLOWS.html
@@ -56,8 +56,19 @@
 
 <header class="top">
   <h1>CC Director - Security Flows</h1>
+  <div style="border:2px solid #b00; background:#3a1414; color:#f4c7c7; padding:12px 16px; border-radius:6px; margin:12px 0; font-size:14px; line-height:1.5;">
+    <strong>SUPERSEDED - the enrollment model in this document is obsolete.</strong>
+    The "pairing code shown on the Gateway host / you must be in front of the gateway machine" enrollment
+    flow described below is NOT how devices are authenticated. A device (mobile or cc-director Director)
+    gets onto the Gateway exactly one way: by signing in to DevThrottle, which issues that device its
+    per-device token. There is no pairing code, no QR code, and nothing shown on the Gateway host to read
+    off or type in. See <code>docs/architecture/mobile/MOBILE_DEVICE_AUTH.md</code> (the current device-auth
+    spec, generalized to the desktop in epic #1069/#1088) and
+    <code>docs/reviews/gateway-connection-redesign-2026-07-11.md</code>. The per-device-key and
+    revoke-only principles below remain accurate; only the pairing-code enrollment mechanism is obsolete.
+  </div>
   <div class="sub">How every machine, agent, and client gets authorized access to a REST API. Target model: per-device keys issued by the Gateway.</div>
-  <div class="meta">Design / explainer doc - diagrams and flows only, not the implementation plan. Status: PROPOSED (per-device-key model approved).</div>
+  <div class="meta">Design / explainer doc - diagrams and flows only, not the implementation plan. Status: SUPERSEDED for enrollment (see banner); per-device-key model still current.</div>
 </header>
 
 <h2>1. The trust model in one paragraph</h2>

--- a/docs/reviews/gateway-connection-redesign-2026-07-11.md
+++ b/docs/reviews/gateway-connection-redesign-2026-07-11.md
@@ -43,21 +43,24 @@ brand-new machine reaches "fully connected" by doing exactly three things:
 
 1. click the amber status box,
 2. click Connect,
-3. type the pairing code.
+3. sign in with DevThrottle.
 
-No URL typed. No Detect. No Test. No separate dialogs.
+No URL typed. No Detect. No Test. No pairing codes. No separate dialogs.
 
 The whole design rests on a hard split between two states that are verified separately and never
 conflated:
 
 - **CONNECTED** - this Director can reach the Gateway, proven by the existing two-way nonce
   handshake (GatewayConnectionMonitor). Heartbeats alone never prove it; both legs must complete.
-- **SIGNED IN** - this device is trusted by the Gateway (a valid per-device key) AND the Gateway
-  reports a signed-in account (GatewayAccountStatusClient reading GET /account/status).
+- **SIGNED IN** - this device holds a valid per-device token AND the Gateway reports a signed-in
+  account (GatewayAccountStatusClient reading GET /account/status). A device gets that token exactly
+  one way: by signing in to DevThrottle. Signing in is what authenticates the device (Director or
+  mobile) and puts the per-device token on it - there is no pairing code, no QR code, and nothing
+  shown on the Gateway host to read off or type in.
 
 Green is earned, never assumed. Connected green comes only from the proven handshake; Signed-in
-green comes only from the Gateway's own report. Device pairing is the Director-side half of
-"signed in", not a third checkbox.
+green comes only from the Gateway's own report. Signing in to DevThrottle is the single way this
+device becomes trusted, not a separate pairing step.
 
 ---
 
@@ -69,7 +72,8 @@ These thirteen are fixed. They are restated from the mission brief so this spec 
 2. The Director never gates on any of this (issues 641 and 664 removed the Director login; the app
    always boots and works locally). The status box is a nudge, never a wall.
 3. The Director never holds account credentials (epic 1069: the account lives at the Gateway). The
-   Director's part is device pairing plus watching GET /account/status.
+   Director's part is holding a valid per-device token - issued when the user signs in to DevThrottle -
+   plus watching GET /account/status.
 4. Green is earned: Connected only from the proven two-way handshake; Signed-in only from the
    Gateway's own report.
 5. Scanning is automatic (the Detect button dies); connecting is the test (the Test button dies).
@@ -257,17 +261,17 @@ question when the callback leg fails and auto-detection cannot resolve it (decis
 
 ### Step 2 - Sign in (Phase 2)
 
-Once CONNECTED, Step 2 gets the device paired and the account signed in. It absorbs the current
-ConnectToGatewayDialog pairing flow.
+Once CONNECTED, Step 2 makes this device trusted the ONE way a device ever becomes trusted:
+signing in to DevThrottle. There is no pairing code, no QR code, and nothing shown on the Gateway
+host - signing in is what authenticates the device (Director or mobile) and puts a per-device token
+on it.
 
-Two paths, shown together:
+One path:
 
-- **Pairing code** - the user reads a one-time code off the Gateway host's own screen and types it
-  here. On success the Gateway issues this device a unique key, saved locally (this is exactly what
-  ConnectToGatewayDialog does today; the field moves into the panel).
-- **Open the account page** - a button that opens the Cockpit Account page in the browser; the
-  panel then polls GET /account/status and auto-advances to the Done view the moment the Gateway
-  reports signed in.
+- **Sign in with DevThrottle** - a button that opens the DevThrottle sign-in in the browser. When
+  the user signs in, the per-device token is issued to this Director and stored locally, and the
+  Gateway reports the account signed in. The panel polls GET /account/status and auto-advances to
+  the Done view the moment the Gateway reports signed in.
 
 ASCII wireframe:
 
@@ -275,13 +279,9 @@ ASCII wireframe:
 +--------------------------------------------------+
 |  Sign in                                         |
 |  Connected to the Gateway. One more step to make  |
-|  this device trusted.                            |
+|  this device trusted: sign in with DevThrottle.  |
 |                                                  |
-|  Pairing code (shown on the Gateway host screen): |
-|   [ _ _ _ - _ _ _ ]        [ Pair this device ]   |
-|                                                  |
-|  or                                              |
-|   [ Open the account page ]                       |
+|   [ Sign in with DevThrottle ]                    |
 |   Waiting for you to sign in...                   |  <- appears after click, polls status
 +--------------------------------------------------+
 ```
@@ -335,12 +335,12 @@ the same flow into the same panel.
 ## 7. The three flows
 
 - **First-time (brand-new machine).** Box is amber -> click -> panel Step 1 auto-scans -> user
-  clicks the found Gateway -> handshake proves Connected -> panel advances to Step 2 -> user types
-  the pairing code -> both checks green -> Done. Three user actions total: click box, click
-  Connect, type code.
-- **Re-sign-in (device known, signed out at the Gateway).** Box is amber on line 2 only (Connected
-  is already green) -> click -> panel opens directly on Step 2 -> "Open the account page" or pair ->
-  green. It never sends the user back through Step 1.
+  clicks the found Gateway -> handshake proves Connected -> panel advances to Step 2 -> user signs
+  in with DevThrottle -> both checks green -> Done. Three user actions total: click box, click
+  Connect, sign in.
+- **Re-sign-in (device signed out at the Gateway).** Box is amber on line 2 only (Connected is
+  already green) -> click -> panel opens directly on Step 2 -> Sign in with DevThrottle -> green.
+  It never sends the user back through Step 1.
 - **Gateway moved (was connected, address changed).** Box goes red as WasConnectedNowUnreachable ->
   click -> panel opens Step 1 in repair mode -> the rediscovery scan runs automatically and offers
   the Gateway's new address as a one-click fix (Phase 5).
@@ -359,7 +359,8 @@ From SettingsDialog.axaml Gateway tab (lines 150 to 205):
 - `DetectPublicUrlButton` "Detect" for the public URL (line 174) - auto-detected under Advanced.
 - `GatewayTokenBox` plain-text token box (line 185) - never shown in the clear; masked under
   Advanced.
-- `ConnectToGatewayButton` "Connect to Gateway..." (line 190) - pairing moves into panel Step 2.
+- `ConnectToGatewayButton` "Connect to Gateway..." (line 190) - the whole pairing-code dialog
+  (ConnectToGatewayDialog) is deleted; signing in with DevThrottle in panel Step 2 replaces it.
 - `RerunOnboardingButton` "Re-run setup wizard..." (line 198) - the panel is the flow; no re-run
   button.
 - The bare `GatewayUrlBox` / `GatewayAdvertisedBox` as primary controls (lines 158, 172) - they
@@ -389,7 +390,7 @@ Reuse what exists; do not rebuild verification.
 |---------|------------------------|-------------------------|
 | Connected verification | `GatewayConnectionMonitor` (src/CcDirector.ControlApi) | resolver consumes its result |
 | Account/signed-in status | `GatewayAccountStatusClient` + `AccountIndicatorPresenter` (src/CcDirector.Core/Account) | resolver consumes its result |
-| Device pairing | `ConnectToGatewayDialog` + `DeviceRegistryClient.Register` | pairing UI moves into panel Step 2 |
+| Device trust (sign-in) | the DevThrottle browser sign-in that issues this device its token (see the account sign-in start/callback path and the loopback sign-in hand-back) | Step 2 opens that sign-in and polls status; the ConnectToGatewayDialog pairing-code dialog is deleted, not reused |
 | Diagnostics | `GatewayTroubleshootDialog.axaml.cs` logic | rendered inline in Step 1 repair mode |
 | Settings Gateway tab | `SettingsDialog.axaml` 150-205 + `.axaml.cs` handlers | tab embeds the panel; handlers deleted |
 | Two status boxes | `MainWindow.axaml` 251 + 286, presenters in `MainWindow.axaml.cs` | merged into GatewayStatusBox |
@@ -414,9 +415,9 @@ SOREN_NORTH, and clickable by Soren before the next phase begins.
   Proof: unit tests for the resolver across all six states; screenshots of scanning, connecting,
   connected, and a named failure, from the running app against the real Gateway on SOREN_NORTH.
 
-- **Phase 2 - Sign-in step.** Step 2 pairing-code entry (absorbing ConnectToGatewayDialog) and the
-  open-the-account-page path that polls account status and auto-advances. The Done view with the
-  collapsed Advanced section (masked key, public URL, manual address).
+- **Phase 2 - Sign-in step.** Step 2 sign in with DevThrottle: open the browser sign-in that issues
+  this device its token, then poll account status and auto-advance. The Done view with the collapsed
+  Advanced section (masked token, public URL, manual address). The old pairing-code dialog is deleted.
   Proof: unit tests for the resolver's signed-in transitions; screenshots of Step 2, the polling
   wait, and the green Done view, from the running app.
 
@@ -445,8 +446,8 @@ SOREN_NORTH, and clickable by Soren before the next phase begins.
 2. The section 8 deletion list is fully executed - none of the removed buttons, boxes, or dialogs
    are reachable from the user interface.
 3. The end-to-end success test passes on a fresh profile: from clean start to two green checks
-   without typing a URL - click the amber box, click Connect, type the pairing code.
+   without typing a URL - click the amber box, click Connect, sign in with DevThrottle.
 4. The Mac verification pass is explicitly scheduled as the final step (network discovery, browser
-   launch, and device-key storage path are the three platform-sensitive spots).
+   launch, and the per-device token storage path are the three platform-sensitive spots).
 5. A final verification report in docs/reviews/ showing every state and step with screenshots from
    the running app.


### PR DESCRIPTION
Owner correction (Soren, 2026-07-11): the only way any device - mobile or the cc-director Director - gets onto the Gateway is by **signing in to DevThrottle**, which issues that device its per-device token. There is **no pairing code, no QR code, and nothing shown on the Gateway host** to read off or type in.

This matches the current authoritative device-auth spec (`docs/architecture/mobile/MOBILE_DEVICE_AUTH.md`), which already states exactly this and was generalized to the desktop Cockpit in epic thefrederiksen/devthrottle_internal#675/#1088. The pairing-code idea in the mission docs was a regression to the legacy desktop `ConnectToGatewayDialog` (#469), which is being deleted.

## Cleaned
- **gateway-connection-redesign-2026-07-11.md** (mission design spec): Step 2 is now a single "Sign in with DevThrottle" path (open browser sign-in, issue the device its token, poll `GET /account/status`, auto-advance). Removed the pairing-code entry, the "code shown on the Gateway host screen" wireframe, and the two-path model. Updated the two-state definition, settled decisions, three flows, deletion list, implementation map, phase plan, and definition of done.
- **gateway-connection-mission-2026-07-11.md** (mission brief): same correction throughout.
- **security/SECURITY_FLOWS.html** and **security/REGISTER_DIRECTOR_MOCKUP.html**: marked SUPERSEDED with a banner - their "pairing code / you must be in front of the gateway machine" enrollment model is obsolete. (SECURITY_FLOWS's per-device-key + revoke-only principles remain accurate.)

Doc-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)