### PR TITLE
fix(gateway): stop re-narration from interrupting an active voice listener (#1322)

### DIFF
--- a/src/CcDirector.Gateway.Tests/TurnEndWatcherVoiceRefreshTests.cs
+++ b/src/CcDirector.Gateway.Tests/TurnEndWatcherVoiceRefreshTests.cs
@@ -24,13 +24,16 @@ public sealed class TurnEndWatcherVoiceRefreshTests
     private sealed class RecordingVoice
     {
         private readonly HashSet<string> _voiceSessions;
-        public readonly List<(string Sid, string Endpoint)> Generated = new();
+        public readonly List<(string Sid, string Endpoint, bool IsNewTurn)> Generated = new();
         public readonly List<string> Cleared = new();
 
         public RecordingVoice(params string[] voiceSessions) => _voiceSessions = new(voiceSessions);
 
         public bool IsVoiceSession(string sid) => _voiceSessions.Contains(sid);
-        public void GenerateAsync(string sid, string endpoint) => Generated.Add((sid, endpoint));
+        // Mirrors WingmanVoiceService.GenerateAsync(sid, endpoint, ct, showReadingWindow): the host
+        // passes signal.IsNewTurn as showReadingWindow, so the yellow "wingman reading" hold shows
+        // only for a genuinely new turn and a catch-up refresh stays quiet (issue #1322).
+        public void GenerateAsync(string sid, string endpoint, bool isNewTurn) => Generated.Add((sid, endpoint, isNewTurn));
         public void OnSessionWorking(string sid) => Cleared.Add(sid);
     }
 
@@ -45,7 +48,7 @@ public sealed class TurnEndWatcherVoiceRefreshTests
             onTurnEnd: signal =>
             {
                 if (voice.IsVoiceSession(signal.SessionId))
-                    voice.GenerateAsync(signal.SessionId, signal.DirectorEndpoint);
+                    voice.GenerateAsync(signal.SessionId, signal.DirectorEndpoint, signal.IsNewTurn);
             },
             onSessionWorking: sid => voice.OnSessionWorking(sid));
     }
@@ -65,6 +68,26 @@ public sealed class TurnEndWatcherVoiceRefreshTests
         var generated = Assert.Single(voice.Generated);
         Assert.Equal("voice-sid", generated.Sid);
         Assert.Equal("http://d1", generated.Endpoint);
+        // A live Working -> Waiting boundary is a genuinely new turn: show the yellow reading window.
+        Assert.True(generated.IsNewTurn);
+    }
+
+    [Fact]
+    public void FirstSightingAlreadyWaiting_FiresQuietRefresh_NotANewTurn()
+    {
+        // Issue #1322: a session first seen ALREADY waiting (the startup catch-up of a turn that
+        // ended earlier) still gets a voice refresh, but it is NOT a new turn - so it must generate
+        // quietly (showReadingWindow false), never flipping a session a phone may be listening to
+        // into the yellow "wingman reading" state mid-play.
+        var voice = new RecordingVoice("voice-sid");
+        using var watcher = BuildWatcher(voice);
+
+        // No prior Working observation - the very first sighting is the waiting state.
+        watcher.Observe("voice-sid", "WaitingForInput", "http://d1");
+
+        var generated = Assert.Single(voice.Generated);
+        Assert.Equal("voice-sid", generated.Sid);
+        Assert.False(generated.IsNewTurn);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Sockets;
 using System.Text;
 using CcDirector.AgentBrain;
 using CcDirector.Core;
@@ -182,6 +183,66 @@ public sealed class WingmanVoiceServiceTests
             Assert.False(reloaded.HasVoice("sid-1"));
         }
         finally { Cleanup(persistPath); }
+    }
+
+    // ---------- Do not re-narrate an already-narrated turn (issue #1322) ----------
+
+    [Fact]
+    public async Task GenerateAsync_WhenSessionAlreadyHasVoice_SkipsWithoutFetchingTurns()
+    {
+        // Issue #1322: a re-narration must never disturb a turn that already has a fresh, playable
+        // narration - a client may be actively listening to it. The guard short-circuits BEFORE the
+        // Director turn fetch, so an already-ready session is not re-generated (which would flip it
+        // yellow again and mint a new generatedAt, restarting the listener's clip). Proven with a
+        // loopback "Director" that records whether its /turns endpoint was ever hit.
+        var hits = 0;
+        // Grab a free loopback port, then release it for the HttpListener.
+        var probe = new TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+        probe.Stop();
+
+        using var listener = new HttpListener();
+        var prefix = $"http://127.0.0.1:{port}/";
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+        var serve = Task.Run(async () =>
+        {
+            while (listener.IsListening)
+            {
+                HttpListenerContext ctx;
+                try { ctx = await listener.GetContextAsync(); }
+                catch { break; }   // listener stopped
+                Interlocked.Increment(ref hits);
+                ctx.Response.StatusCode = 200;
+                var body = Encoding.UTF8.GetBytes("{\"widgets\":[]}");
+                await ctx.Response.OutputStream.WriteAsync(body);
+                ctx.Response.Close();
+            }
+        });
+
+        // Own an isolated audio directory so the durable clip this test seeds never leaks into the
+        // shared temp voice-audio folder other tests load from (StoreReadyAudioForTest persists).
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-guard-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
+        {
+            var svc = ServiceAt(persistPath);
+            svc.StoreReadyAudioForTest("sid-1", "spoken", "reply", new byte[] { 1, 2, 3 });
+            Assert.True(svc.HasVoice("sid-1"));
+
+            await svc.GenerateAsync("sid-1", prefix.TrimEnd('/'), CancellationToken.None);
+
+            Assert.Equal(0, hits);                    // the guard skipped before any turn fetch
+            Assert.True(svc.HasVoice("sid-1"));       // the existing clip is untouched
+            Assert.False(svc.IsGenerating("sid-1"));  // and it never flipped the session yellow
+        }
+        finally
+        {
+            listener.Stop();
+            await serve;
+            try { Directory.Delete(dir, recursive: true); } catch { /* best-effort cleanup */ }
+        }
     }
 
     // ---------- Turn voice off / Unmark (issue #859) ----------

--- a/src/CcDirector.Gateway/Briefing/TurnEndWatcher.cs
+++ b/src/CcDirector.Gateway/Briefing/TurnEndWatcher.cs
@@ -5,8 +5,12 @@ using CcDirector.Gateway.Discovery;
 
 namespace CcDirector.Gateway.Briefing;
 
-/// <summary>One observed turn boundary: the session and the Director that owns it.</summary>
-public sealed record TurnEndSignal(string SessionId, string DirectorEndpoint);
+/// <summary>One observed turn boundary: the session and the Director that owns it. <paramref
+/// name="IsNewTurn"/> is true only for a live Working -> Waiting boundary (a genuinely new turn the
+/// user is now waiting on); it is false when a session is FIRST seen already waiting (a startup
+/// catch-up of a turn that ended earlier). Voice generation uses it to show the yellow "wingman
+/// reading" hold only for a new turn and stay quiet on a catch-up refresh (issue #1322).</summary>
+public sealed record TurnEndSignal(string SessionId, string DirectorEndpoint, bool IsNewTurn = false);
 
 /// <summary>
 /// The brief agent's turn-boundary tracker (issues #185/#186). PUSH-fed since #186:
@@ -102,7 +106,12 @@ public sealed class TurnEndWatcher : IDisposable
         }
 
         if (IsTurnEnd(hadPrev ? prev : null, activityState))
-            _onTurnEnd(new TurnEndSignal(sessionId, directorEndpoint));
+        {
+            // A live boundary (previous state was Working) is a genuinely new turn; a first sighting
+            // of an already-waiting session (no previous state) is a catch-up of an earlier turn.
+            var isNewTurn = hadPrev && prev == "Working";
+            _onTurnEnd(new TurnEndSignal(sessionId, directorEndpoint, isNewTurn));
+        }
     }
 
     // Timer callbacks must never overlap (a slow Director would stack) and never throw.

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -734,7 +734,9 @@ public sealed class GatewayHost : IAsyncDisposable
                     if (st is "Idle" or "WaitingForInput" or "WaitingForPerm")
                     {
                         FileLog.Write($"[GatewayHost] voice sweep: pre-building voice for idle session {sid}");
-                        await vs.GenerateAsync(sid, ep, CancellationToken.None);
+                        // A pre-build is not a new turn - generate quietly so an idle session a client
+                        // may be listening to is never flipped yellow mid-play (issue #1322).
+                        await vs.GenerateAsync(sid, ep, CancellationToken.None, showReadingWindow: false);
                         generated++;
                     }
                     break;  // found the owning Director
@@ -840,8 +842,11 @@ public sealed class GatewayHost : IAsyncDisposable
                 // list with no wait. Non-voice sessions do nothing here - the watcher is voice-only.
                 if (_voiceService is { } vs && vs.IsVoiceSession(signal.SessionId))
                 {
-                    FileLog.Write($"[GatewayHost] turn-end -> voice auto-refresh: sid={signal.SessionId}");
-                    _ = vs.GenerateAsync(signal.SessionId, signal.DirectorEndpoint, CancellationToken.None);
+                    FileLog.Write($"[GatewayHost] turn-end -> voice auto-refresh: sid={signal.SessionId} newTurn={signal.IsNewTurn}");
+                    // Show the yellow "wingman reading" hold only for a genuinely new turn; a startup
+                    // catch-up of an earlier turn refreshes quietly so a listening client is not
+                    // dropped out of the speaking screen (issue #1322).
+                    _ = vs.GenerateAsync(signal.SessionId, signal.DirectorEndpoint, CancellationToken.None, showReadingWindow: signal.IsNewTurn);
                 }
             },
             onSessionWorking: sid =>

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -299,10 +299,34 @@ public sealed class WingmanVoiceService
     /// Regenerate the voice for a session from its latest turn: read the last reply, translate it,
     /// synthesize audio, store. Called on every turn-end for voice sessions (background, best-effort
     /// - it swallows its own failures so a turn is never blocked on voice).
+    ///
+    /// Issue #1322: a re-narration must never interrupt a client that is already listening to this
+    /// turn's narration. Two guards make it "prepare quietly": it does nothing when the current turn
+    /// already has a fresh, playable narration (regenerating it would only mint a new clip and pull
+    /// the rug on an active listener), and it shows the yellow "wingman reading" window ONLY for a
+    /// brand-new turn (<paramref name="showReadingWindow"/>). A background refresh / catch-up of an
+    /// already-ended turn stays quiet, because a phone may be playing this turn from its own local
+    /// cache and flipping the session yellow would drop it out of the speaking screen mid-play.
     /// </summary>
-    public async Task GenerateAsync(string sid, string endpoint, CancellationToken ct = default)
+    /// <param name="showReadingWindow">True for a genuinely new turn (a live Working -> Waiting
+    /// boundary): show the yellow "wingman reading" hold until the summary lands. False for a
+    /// background refresh, a startup catch-up, or an idle pre-build sweep: generate silently so a
+    /// session a client is already listening to is never flipped yellow.</param>
+    public async Task GenerateAsync(string sid, string endpoint, CancellationToken ct = default, bool showReadingWindow = true)
     {
         Mark(sid);
+
+        // Do not re-narrate a turn that already has a fresh, current narration. A genuinely new turn
+        // clears this cache first (OnSessionWorking on the Working transition), so a cache that is
+        // still present means the current turn is already narrated - regenerating it would only flip
+        // the session yellow again and mint a new generatedAt, restarting the clip a listening client
+        // is already playing (issue #1322). The idle sweep already skips cached sessions this way; the
+        // turn-end path must too. Checked before the backpressure gates - a no-op costs nothing.
+        if (HasVoice(sid))
+        {
+            FileLog.Write($"[WingmanVoiceService] GenerateAsync skip (current turn already narrated): sid={sid}");
+            return;
+        }
 
         // Backpressure #1 (issue #1324) - respect a provider rate-limit cooldown. A 429 means "stop
         // calling", so while the cooldown is in effect we skip the model call entirely. Both callers
@@ -330,7 +354,7 @@ public sealed class WingmanVoiceService
             }
             try
             {
-                await GenerateOnceAsync(sid, endpoint, ct);
+                await GenerateOnceAsync(sid, endpoint, ct, showReadingWindow);
                 _rateGate.OnSuccess();   // reaching the provider clears any cooldown/backoff ramp
             }
             finally { _genGate.Release(); }
@@ -355,7 +379,7 @@ public sealed class WingmanVoiceService
     /// coalescing) stays readable and this stays the pure "make the voice" step. A rate-limit surfaces
     /// as <see cref="WingmanModelRateLimitedException"/> for the wrapper's cooldown to catch.
     /// </summary>
-    private async Task GenerateOnceAsync(string sid, string endpoint, CancellationToken ct)
+    private async Task GenerateOnceAsync(string sid, string endpoint, CancellationToken ct, bool showReadingWindow)
     {
         var turns = await _client.GetTurnsAsync(endpoint, sid, ct);
         var widgets = turns?.Widgets ?? new List<TurnWidgetDto>();
@@ -363,8 +387,10 @@ public sealed class WingmanVoiceService
         if (string.IsNullOrWhiteSpace(lastReply)) return;  // nothing to say yet
         // Recent conversation so the wingman can add context to a short/terse latest reply.
         var recentContext = WingmanTranslator.BuildRecentContext(widgets);
-        // The wingman is now running for this session - show it yellow until the summary lands.
-        BeginGenerating(sid);
+        // The wingman is now running for this session - show it yellow until the summary lands, but
+        // only for a brand-new turn. A background refresh / catch-up stays quiet so a session a phone
+        // may be listening to is never flipped yellow mid-play (issue #1322).
+        if (showReadingWindow) BeginGenerating(sid);
         try
         {
             var t = await _translator.TranslateAsync(recentContext, lastReply, ct);
@@ -381,7 +407,7 @@ public sealed class WingmanVoiceService
             // delays the turn. CancellationToken.None so a captured turn is not lost on shutdown.
             _ = _training.CaptureAsync(_client, endpoint, sid, "generate", lastReply, recentContext, t.Spoken, t.ReplySeconds, CancellationToken.None);
         }
-        finally { EndGenerating(sid); }
+        finally { if (showReadingWindow) EndGenerating(sid); }
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes thefrederiksen/devthrottle#1322 (the Gateway-side primary fix).

## The problem

On the mobile app, entering Voice mode (or just listening) jitters: the narration restarts from 0:00 and the screen blinks between Speaking and the working/preparing card. Live Gateway state captured while it was happening on a real phone showed the interruption is **Gateway-driven**, not just client poll jitter:

- Re-narration runs through `WingmanVoiceService.GenerateAsync`, fired by the turn-end watcher. Its startup catch-up path fires for every session already waiting when the Gateway or watcher restarts - which is why every voice session was seen flipping to generating at once.
- The moment generation starts, `BeginGenerating` sets `voiceGenerating`, which the `/sessions` fold turns into the amber "Wingman reading" state for a red/parked session - dropping a listening phone out of the Speaking screen.
- When it finishes, `StoreReady` mints a new `generatedAt`, which the phone treats as a brand-new clip and restarts from 0:00.
- The Gateway has **no signal that a phone is actively listening**, so the fix cannot be "don't regenerate while listening" - it has to be "don't do a needless, disruptive regeneration at all."

## The fix - "prepare quietly"

1. **`GenerateAsync` skips entirely when the current turn already has a fresh narration** (`HasVoice`). A genuinely new turn always clears the cache first (`OnSessionWorking` on the Working transition), so this only ever skips redundant re-narration. Checked before the thefrederiksen/devthrottle#1324 backpressure gates - a no-op costs nothing.
2. **The yellow "reading" window shows only for a genuinely new turn.** `TurnEndSignal` now carries `IsNewTurn` (true only for a live Working -> Waiting boundary). A startup catch-up refresh and the idle pre-build sweep generate quietly (`showReadingWindow: false`), so a session a phone may be listening to is never flipped yellow mid-play.

## Behavior change to note

The amber "Wingman reading" cue no longer appears on the roster while the Gateway merely *refreshes* an already-narrated turn - only for genuinely new turns. This is the interruption the issue is about, so removing it for refreshes is intended.

## Tests

- `WingmanVoiceServiceTests.GenerateAsync_WhenSessionAlreadyHasVoice_SkipsWithoutFetchingTurns` - a loopback "Director" proves the guard short-circuits before any turn fetch.
- `TurnEndWatcherVoiceRefreshTests` - `IsNewTurn` is true for a live Working -> Waiting boundary and false for a first-sighting catch-up.
- Affected classes green (26/26 in isolation). Gateway builds with 0 warnings. Rebased onto current `origin/main` (integrates cleanly with the thefrederiksen/devthrottle#1324 backpressure refactor of `GenerateAsync`).

## Follow-ups (filed separately)

- thefrederiksen/devthrottle_internal#755 - the Gateway should stamp one authoritative voice phase; the phone must stop re-deriving its own state machine.
- thefrederiksen/devthrottle_internal#756 - client hardening: don't restart active playback on a same-turn replacement clip; hysteresis on the transient "Working" tick.

Co-Authored-By: Claude Opus 4.8 (1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)