### PR TITLE
docs(gateway): drop last 'paired' wording from the resolver state table

### DIFF
--- a/docs/reviews/gateway-connection-redesign-2026-07-11.md
+++ b/docs/reviews/gateway-connection-redesign-2026-07-11.md
@@ -118,7 +118,7 @@ Output - the resolved overall state (drives both colors and which step the panel
 | NotConfigured | No Gateway address, never connected | Amber | Step 1 (connect) |
 | Connecting | Address set, handshake verifying | Yellow | Step 1 (progress) |
 | ConnectFailed | Handshake failed, a named leg is down | Red | Step 1 (repair) |
-| ConnectedNotSignedIn | Handshake proven, device not paired or account signed out | Amber | Step 2 (sign in) |
+| ConnectedNotSignedIn | Handshake proven, device has no token yet or account signed out | Amber | Step 2 (sign in) |
 | AllGreen | Handshake proven AND Gateway reports signed in | Green | Done view |
 | WasConnectedNowUnreachable | Was green this run, now the handshake is failing | Red | Step 1 (repair) |
 


### PR DESCRIPTION
Follow-up consistency fix after PR thefrederiksen/devthrottle#1330. The resolver state table's ConnectedNotSignedIn row still read 'device not paired'; device trust is sign-in-issued (epic thefrederiksen/devthrottle_internal#675, MOBILE_DEVICE_AUTH.md), so this changes it to 'device has no token yet or account signed out'. Behavior unchanged - deviceKeyPresent stays (the token is the device key, now DevThrottle-sign-in-issued).

🤖 Generated with [Claude Code](https://claude.com/claude-code)