### PR TITLE
fix(mobile): keep the Voice screen alive when the session briefly drops out of /sessions (#1333)

### DIFF
--- a/packages/client-core/src/voice/useVoiceMode.ts
+++ b/packages/client-core/src/voice/useVoiceMode.ts
@@ -196,13 +196,26 @@ export function useVoiceMode(sessionId: string | undefined, opts?: { seededVoice
     async (signal: AbortSignal) => {
       try {
         const all = await listSessions(signal);
-        const match = all.find((s) => s.sessionId === sid) ?? null;
+        const match = all.find((s) => s.sessionId === sid);
+
+        if (!match) {
+          // The session is momentarily ABSENT from /sessions - almost always the owning computer is
+          // briefly unreachable, not a real "voice off" (issue #1333). Keep the last-known session and
+          // whatever is playing instead of nulling it, which would collapse the Voice screen to the off
+          // card mid-listen. A successful poll whose list simply omits this session is a transient gap,
+          // NOT authority to turn voice off - only the branch below (the session IS reported, with
+          // voiceMode=false) does that. Surface a soft reconnecting note; the next good poll clears it.
+          setPollDone(true);
+          setError("Reconnecting to this session's computer...");
+          return;
+        }
+
         // Only re-render when a field the screen uses actually changed (issue #951).
         setSession((prev) => (sameSessionForVoice(prev, match) ? prev : match));
-        if (match?.name && match.name.trim()) setName(match.name.trim());
+        if (match.name && match.name.trim()) setName(match.name.trim());
         setPollDone(true); // the true state is now known - OFF may render from here on if applicable
 
-        const on = localEnabledRef.current || Boolean(match?.voiceMode);
+        const on = localEnabledRef.current || Boolean(match.voiceMode);
         if (!on) {
           setVoice(null);
           setError(null);


### PR DESCRIPTION
Fixes thefrederiksen/devthrottle#1333. First step of the broader mobile bad-connection resilience work.

## Problem

On a bad connection (the owning computer briefly unreachable) a session drops out of the Gateway's `/sessions` list for a poll or two. `useVoiceMode` treated that absence as authority to turn voice off: `all.find(...) ?? null` nulled the session, `voiceOn` flipped false, and the Voice screen collapsed to the "Switch to voice mode" off card mid-listen. The audio and screen came back on the next good poll - the jitter Soren saw driving through bad coverage.

A *failed* poll was already handled (the catch keeps last-known). The gap was a *successful* poll whose list simply omits this session.

## Fix

The poll now splits the two cases:
- **Session present** in the list -> authoritative: adopt its state, including `voiceMode = false` which still correctly returns to the off card.
- **Session absent** -> transient gap: keep the last-known session and whatever is playing, show a soft "Reconnecting..." note, and let the next good poll clear it.

6-line change in `packages/client-core/src/voice/useVoiceMode.ts`.

## Proof

- client-core typechecks clean; the mobile PWA builds clean.
- Behavioral verification will be done live on the deployed `/m` with offline emulation (the shared hook has no unit-test harness in the repo, and the authentic test is a real dropped connection).

## Note

The "Reconnecting..." note renders through the existing `error` banner (the only message channel the shared hook has). A proper soft-styled indicator belongs with the global connection banner in the mobile-resilience epic (and thefrederiksen/devthrottle_internal#755).

Co-Authored-By: Claude Opus 4.8 (1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)