### PR TITLE
feat(gateway): email the account owner from a session/scheduled run (#1318 consumer)

### DIFF
--- a/docs/cencon/proof/issue-1318/report.html
+++ b/docs/cencon/proof/issue-1318/report.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Proof - issue #1318 consumer - email the account owner (Gateway relay + CLI)</title>
+<style>
+  body { font-family: system-ui, Arial, sans-serif; margin: 2rem; color: #1a1a1a; max-width: 60rem; }
+  h1 { font-size: 1.4rem; } h2 { font-size: 1.1rem; margin-top: 1.6rem; }
+  table { border-collapse: collapse; margin-top: .6rem; width: 100%; }
+  td, th { border: 1px solid #ccc; padding: .4rem .7rem; text-align: left; vertical-align: top; }
+  th { background: #f3f4f6; } code { background: #f3f4f6; padding: .1rem .3rem; border-radius: 3px; }
+  .ok { color: #0e8a16; font-weight: 600; }
+</style>
+</head>
+<body>
+<h1>Proof - issue #1318 (consumer): email the account owner from a session/scheduled run</h1>
+<p>The escalation channel for Auto Daily Runs. The cloud send primitive shipped as devthrottle_internal
+#338; this is the DevThrottle-side consumer that calls it. The Gateway holds NO Resend key - it only
+relays the account's own token.</p>
+
+<h2>What was implemented</h2>
+<ul>
+  <li><code>CcDirector.Core/Account/AccountNotifyClient.cs</code> - cloud client for
+    <code>POST /api/v1/account/notify-owner</code>, Bearer account token, body carries
+    subject/text/html/attachments and NO recipient (single-recipient by construction). Token never
+    logged; base URL resolved via the shared account-egress resolution.</li>
+  <li><code>CcDirector.Gateway/Api/AccountEmailEndpoint.cs</code> - <code>POST /account/email</code> relay:
+    injects <code>GetAccessTokenForForwarding()</code> and forwards to the cloud. Signed-out -> 401,
+    cloud failure -> 502, never a fabricated success. Token-gated like the other /account routes.</li>
+  <li><code>cc-devthrottle email owner --subject --body [--html] [--attach &lt;file&gt;]</code> - the CLI
+    verb; <code>--attach</code> is repeatable, reads the file and base64-encodes it with a guessed MIME
+    type (e.g. an HTML report to read offline).</li>
+</ul>
+
+<h2>Acceptance criteria - expected vs actual</h2>
+<table>
+  <tr><th>Criterion</th><th>Actual</th></tr>
+  <tr><td>A session can email the owner with one command</td>
+      <td class="ok">PASS - <code>cc-devthrottle email owner</code> -> Gateway relay -> cloud</td></tr>
+  <tr><td>Recipient is always the owner; caller cannot address anyone else</td>
+      <td class="ok">PASS - no recipient field anywhere; unit test asserts the wire body has no to/recipient</td></tr>
+  <tr><td>Attachments delivered (HTML report offline)</td>
+      <td class="ok">PASS - CLI reads + base64-encodes files; unit test round-trips report.html</td></tr>
+  <tr><td>Gateway holds no Resend key</td>
+      <td class="ok">PASS - relay only injects the account token; no email/Resend code on the Gateway</td></tr>
+  <tr><td>Signed-out / cloud failure fails loud</td>
+      <td class="ok">PASS - 401 signed-out, 502 cloud failure, never a fake success</td></tr>
+</table>
+
+<h2>Tests + build</h2>
+<ul>
+  <li><code>AccountNotifyClientTests</code> - 6/6 pass (wire body has no recipient, Bearer token sent,
+    cloud rejection surfaced with status, empty token throws).</li>
+  <li><code>test_email_cli.py</code> - 6/6 pass (subject/body forwarded, no recipient option, body-or-attachment
+    required, html-only, attachment base64 round-trip, missing-file fails clearly); 66/66 CLI suite.</li>
+  <li>CcDirector.Core.Tests and CcDirector.Gateway.Tests build clean (0 warnings / 0 errors).</li>
+  <li>Cloud endpoint confirmed deployed and gated (unauthenticated POST -> 401).</li>
+</ul>
+
+<p><b>I believe this is finished.</b> Next: #1319 (Auto Daily Runs scheduling: self-reap when clean,
+email-on-drift, per-schedule email-when-clean) wires this verb as the escalation step.</p>
+</body>
+</html>

--- a/src/CcDirector.Core.Tests/Account/AccountNotifyClientTests.cs
+++ b/src/CcDirector.Core.Tests/Account/AccountNotifyClientTests.cs
@@ -1,0 +1,117 @@
+using System.Net;
+using System.Text;
+using System.Text.Json.Nodes;
+using CcDirector.Core.Account;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Account;
+
+/// <summary>
+/// Unit coverage for the owner-email cloud client (issue #1318 consumer). Proves the wire body carries
+/// the subject/body/attachments and NO recipient (single-recipient by construction lives at the cloud,
+/// which resolves the owner from the token), that the Bearer token is sent, and that a cloud failure
+/// surfaces as a clear error rather than a fabricated success. A stub handler stands in for the cloud.
+/// </summary>
+public sealed class AccountNotifyClientTests
+{
+    [Fact]
+    public void BuildBody_CarriesSubjectBodyAttachments_AndNoRecipient()
+    {
+        var body = AccountNotifyClient.BuildBody(
+            "Nightly report", "plain", "<p>html</p>",
+            new[] { new NotifyAttachment("report.html", "YWJj", "text/html") });
+
+        var root = (JsonObject)JsonNode.Parse(body)!;
+        Assert.Equal("Nightly report", (string?)root["subject"]);
+        Assert.Equal("plain", (string?)root["text"]);
+        Assert.Equal("<p>html</p>", (string?)root["html"]);
+        // No recipient field of any kind is ever emitted.
+        Assert.False(root.ContainsKey("to"));
+        Assert.False(root.ContainsKey("recipient"));
+
+        var att = (JsonArray)root["attachments"]!;
+        Assert.Single(att);
+        var a0 = (JsonObject)att[0]!;
+        Assert.Equal("report.html", (string?)a0["filename"]);
+        Assert.Equal("YWJj", (string?)a0["content"]);
+        Assert.Equal("text/html", (string?)a0["contentType"]);
+    }
+
+    [Fact]
+    public void BuildBody_OmitsEmptyBodyAndContentType()
+    {
+        var body = AccountNotifyClient.BuildBody(
+            "Subj", null, null, new[] { new NotifyAttachment("x.bin", "YWJj", null) });
+
+        var root = (JsonObject)JsonNode.Parse(body)!;
+        Assert.False(root.ContainsKey("text"));
+        Assert.False(root.ContainsKey("html"));
+        var a0 = (JsonObject)((JsonArray)root["attachments"]!)[0]!;
+        Assert.False(a0.ContainsKey("contentType"));
+    }
+
+    [Fact]
+    public async Task SendOwnerAsync_SendsBearerToken_AndPostsToNotifyPath()
+    {
+        HttpRequestMessage? seen = null;
+        var handler = new StubHandler(req => { seen = req; return Json(HttpStatusCode.OK, """{ "data": { "sent": true, "id": "resend-1" } }"""); });
+        var client = NewClient(handler);
+
+        var result = await client.SendOwnerAsync("tok-123", "Subj", "body", null, null);
+
+        Assert.True(result.Sent);
+        Assert.Equal("resend-1", result.ProviderId);
+        Assert.NotNull(seen);
+        Assert.EndsWith(AccountNotifyClient.NotifyOwnerPath, seen!.RequestUri!.AbsolutePath);
+        Assert.Equal("Bearer", seen.Headers.Authorization?.Scheme);
+        Assert.Equal("tok-123", seen.Headers.Authorization?.Parameter);
+    }
+
+    [Fact]
+    public async Task SendOwnerAsync_CloudRejects_ReturnsErrorWithStatus_NotSent()
+    {
+        var handler = new StubHandler(_ => Json(HttpStatusCode.BadRequest, """{ "error": { "message": "subject is required" } }"""));
+        var client = NewClient(handler);
+
+        var result = await client.SendOwnerAsync("tok", "s", "b", null, null);
+
+        Assert.False(result.Sent);
+        Assert.Equal(400, result.StatusCode);
+        Assert.Equal("subject is required", result.Error);
+    }
+
+    [Fact]
+    public async Task SendOwnerAsync_CloudErrorWithoutMessage_HasGenericReason()
+    {
+        var handler = new StubHandler(_ => Json(HttpStatusCode.BadGateway, "not json"));
+        var client = NewClient(handler);
+
+        var result = await client.SendOwnerAsync("tok", "s", "b", null, null);
+
+        Assert.False(result.Sent);
+        Assert.Equal(502, result.StatusCode);
+        Assert.Contains("502", result.Error);
+    }
+
+    [Fact]
+    public async Task SendOwnerAsync_EmptyToken_Throws()
+    {
+        var client = NewClient(new StubHandler(_ => Json(HttpStatusCode.OK, "{}")));
+        await Assert.ThrowsAsync<ArgumentException>(() => client.SendOwnerAsync("", "s", "b", null, null));
+    }
+
+    private static AccountNotifyClient NewClient(StubHandler handler)
+        => new(new HttpClient(handler), baseUrl: "https://cloud.example.com");
+
+    private static HttpResponseMessage Json(HttpStatusCode code, string body)
+        => new(code) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _respond;
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) => _respond = respond;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(_respond(request));
+    }
+}

--- a/src/CcDirector.Core/Account/AccountNotifyClient.cs
+++ b/src/CcDirector.Core/Account/AccountNotifyClient.cs
@@ -1,0 +1,143 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Account;
+
+/// <summary>One attachment for an owner email (issue #1318 consumer). <see cref="ContentBase64"/> is the
+/// file's bytes base64-encoded; the cloud decodes it and hands it to Resend.</summary>
+/// <param name="Filename">The attachment's file name as it appears in the email.</param>
+/// <param name="ContentBase64">The file bytes, base64-encoded.</param>
+/// <param name="ContentType">Optional MIME type (e.g. text/html); null lets the provider infer it.</param>
+public sealed record NotifyAttachment(string Filename, string ContentBase64, string? ContentType);
+
+/// <summary>The outcome of an owner-email send through the cloud (issue #1318 consumer).</summary>
+/// <param name="Sent">True when the cloud accepted and sent the email.</param>
+/// <param name="ProviderId">The provider (Resend) message id when the cloud returned one.</param>
+/// <param name="Error">A clear, fixable failure reason when <see cref="Sent"/> is false; else null.</param>
+/// <param name="StatusCode">The cloud HTTP status (0 when the request never got a response).</param>
+public sealed record CloudNotifyResult(bool Sent, string? ProviderId, string? Error, int StatusCode);
+
+/// <summary>
+/// A small HTTP client for the DevThrottle "email the account owner" primitive (issue #1318 consumer,
+/// cloud contract <c>POST /api/v1/account/notify-owner</c> shipped in devthrottle_internal #338). It sends
+/// the signed-in account owner an email (subject + text/html + optional attachments), authenticated with
+/// the Bearer access token the Gateway already holds for cloud egress (the SAME credential
+/// <see cref="DevThrottleAccountService.GetAccessTokenForForwarding"/> returns). The recipient is resolved
+/// SERVER-SIDE from the token - this client never sends a recipient, so it is single-recipient by
+/// construction, matching the endpoint.
+///
+/// The base URL resolves the same way the rest of the account egress does
+/// (<see cref="AccountTelemetryClient.ApiBaseUrlEnvVar"/> override, else the production default), so this
+/// client introduces no new hard-coded host. The access token is sent only as the Authorization header and
+/// is NEVER written to the log (DT-05); the subject/body/attachment content is never logged either. The
+/// <see cref="HttpClient"/> is injectable so tests drive it against an in-process stub.
+/// </summary>
+public sealed class AccountNotifyClient
+{
+    /// <summary>The path that emails the signed-in account owner (single recipient, resolved server-side).</summary>
+    public const string NotifyOwnerPath = "/api/v1/account/notify-owner";
+
+    private readonly HttpClient _client;
+    private readonly string _baseUrl;
+
+    /// <param name="client">HTTP client (tests inject a stub); defaults to a short-timeout client.</param>
+    /// <param name="baseUrl">API base URL; defaults to the shared account-egress base resolution.</param>
+    public AccountNotifyClient(HttpClient? client = null, string? baseUrl = null)
+    {
+        _client = client ?? new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        _baseUrl = ResolveBaseUrl(baseUrl);
+    }
+
+    private static string ResolveBaseUrl(string? baseUrl)
+    {
+        if (!string.IsNullOrWhiteSpace(baseUrl))
+            return baseUrl.Trim().TrimEnd('/');
+        var fromEnv = Environment.GetEnvironmentVariable(AccountTelemetryClient.ApiBaseUrlEnvVar);
+        if (!string.IsNullOrWhiteSpace(fromEnv))
+            return fromEnv.Trim().TrimEnd('/');
+        return AccountTelemetryClient.DefaultApiBaseUrl;
+    }
+
+    /// <summary>
+    /// Emails the signed-in account owner via <c>POST /api/v1/account/notify-owner</c>. Returns a result:
+    /// <see cref="CloudNotifyResult.Sent"/> true on a 2xx, otherwise a clear error carrying the cloud's
+    /// status + message (never a fabricated success - no-fallback rule). Throws only for a transport
+    /// failure the caller reports as unreachable. No token, subject, body, or attachment content is logged.
+    /// </summary>
+    /// <param name="accessToken">The Bearer access token the Gateway holds. Never logged.</param>
+    public async Task<CloudNotifyResult> SendOwnerAsync(
+        string accessToken, string subject, string? text, string? html,
+        IReadOnlyList<NotifyAttachment>? attachments, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(accessToken))
+            throw new ArgumentException("Access token is required", nameof(accessToken));
+
+        var endpoint = $"{_baseUrl}{NotifyOwnerPath}";
+        var json = BuildBody(subject, text, html, attachments);
+        FileLog.Write($"[AccountNotifyClient] SendOwnerAsync: POST {endpoint} (attachments={attachments?.Count ?? 0})");
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        using var response = await _client.SendAsync(request, ct).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        FileLog.Write($"[AccountNotifyClient] SendOwnerAsync: response status={(int)response.StatusCode}");
+
+        if (response.IsSuccessStatusCode)
+            return ParseSuccess(body);
+
+        return new CloudNotifyResult(false, null, ParseError(body, (int)response.StatusCode), (int)response.StatusCode);
+    }
+
+    /// <summary>Build the cloud request body. Internal for unit testing the wire shape (recipient never appears).</summary>
+    internal static string BuildBody(string subject, string? text, string? html, IReadOnlyList<NotifyAttachment>? attachments)
+    {
+        var payload = new JsonObject { ["subject"] = subject };
+        if (!string.IsNullOrEmpty(text)) payload["text"] = text;
+        if (!string.IsNullOrEmpty(html)) payload["html"] = html;
+        if (attachments is { Count: > 0 })
+        {
+            var arr = new JsonArray();
+            foreach (var a in attachments)
+            {
+                var obj = new JsonObject { ["filename"] = a.Filename, ["content"] = a.ContentBase64 };
+                if (!string.IsNullOrEmpty(a.ContentType)) obj["contentType"] = a.ContentType;
+                arr.Add(obj);
+            }
+            payload["attachments"] = arr;
+        }
+        return payload.ToJsonString();
+    }
+
+    /// <summary>Parse the cloud <c>{ "data": { "sent": true, "id": "..." } }</c> success envelope.</summary>
+    internal static CloudNotifyResult ParseSuccess(string json)
+    {
+        var data = (JsonNode.Parse(json) as JsonObject)?["data"] as JsonObject;
+        var providerId = (data?["id"] as JsonValue)?.GetValue<string>();
+        return new CloudNotifyResult(true, providerId, null, 200);
+    }
+
+    /// <summary>Extract a human-readable message from the cloud <c>{ "error": { "message": ... } }</c> body.</summary>
+    internal static string ParseError(string json, int statusCode)
+    {
+        try
+        {
+            var error = (JsonNode.Parse(json) as JsonObject)?["error"] as JsonObject;
+            var message = (error?["message"] as JsonValue)?.GetValue<string>();
+            if (!string.IsNullOrWhiteSpace(message))
+                return message!;
+        }
+        catch (JsonException)
+        {
+            // fall through to a generic message below
+        }
+        return $"the DevThrottle account service returned {statusCode}.";
+    }
+}

--- a/src/CcDirector.Gateway/Api/AccountEmailEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AccountEmailEndpoint.cs
@@ -1,0 +1,116 @@
+using System.Text.Json.Serialization;
+using CcDirector.Core.Account;
+using CcDirector.Core.Utilities;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The Gateway relay for "DevThrottle emails me" (issue #1318 consumer). A session or scheduled run on any
+/// Director calls <c>POST /account/email</c> with a subject + body (+ optional attachments); the Gateway
+/// injects the account access token it already holds (<see cref="DevThrottleAccountService.GetAccessTokenForForwarding"/>,
+/// the SAME egress credential it uses for credits/telemetry) and forwards to the cloud primitive
+/// (<c>POST /api/v1/account/notify-owner</c>, devthrottle_internal #338) via <see cref="AccountNotifyClient"/>.
+///
+/// The Gateway holds NO Resend key and runs NO email code - the send happens entirely in the cloud, which
+/// resolves the recipient from the token. The request has no recipient field, so it is single-recipient by
+/// construction end to end. Wire contract:
+///   POST /account/email  { "subject": string, "bodyText"?: string, "bodyHtml"?: string,
+///                          "attachments"?: [ { "filename": string, "content": base64, "contentType"?: string } ] }
+///        200 -> { "sent": true, "providerId"?: string }
+///        4xx -> { "sent": false, "error": string }   (bad input, forwarded from the cloud)
+///        401 -> { "sent": false, "error": string }   (Gateway not signed in - no account to send from)
+///        502 -> { "sent": false, "error": string }   (cloud unreachable / send failure - never a fake success)
+///
+/// Inherits the host-wide Gateway token middleware like the other <c>/account/*</c> endpoints (not on the
+/// public-paths allow-list). The account token is never returned or logged (DT-05).
+/// </summary>
+internal static class AccountEmailEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account, AccountNotifyClient notify)
+    {
+        if (notify is null) throw new ArgumentNullException(nameof(notify));
+
+        app.MapPost("/account/email", async (AccountEmailRequest? request, HttpContext http) =>
+        {
+            // Entry point: the delegate is the boundary, so the only try-catch lives here.
+            if (request is null || string.IsNullOrWhiteSpace(request.Subject))
+                return Results.BadRequest(new AccountEmailResponse(false, "subject is required.", null));
+
+            var token = account?.GetAccessTokenForForwarding();
+            if (string.IsNullOrEmpty(token))
+            {
+                FileLog.Write("[AccountEmailEndpoint] POST /account/email: no account credential -> not signed in");
+                return Results.Json(
+                    new AccountEmailResponse(false,
+                        "not signed in to DevThrottle - there is no account to email from. Sign in from the Gateway tray, then retry.",
+                        null),
+                    statusCode: StatusCodes.Status401Unauthorized);
+            }
+
+            try
+            {
+                var attachments = request.Attachments?
+                    .Select(a => new NotifyAttachment(a.Filename ?? "", a.Content ?? "", a.ContentType))
+                    .ToList();
+
+                var result = await notify
+                    .SendOwnerAsync(token, request.Subject!, request.BodyText, request.BodyHtml, attachments, http.RequestAborted)
+                    .ConfigureAwait(false);
+
+                if (!result.Sent)
+                {
+                    // A 4xx from the cloud is a caller input problem (forward it as a 400); anything else is
+                    // an upstream/send failure (502). Never a fabricated success.
+                    var status = result.StatusCode is >= 400 and < 500
+                        ? StatusCodes.Status400BadRequest
+                        : StatusCodes.Status502BadGateway;
+                    FileLog.Write($"[AccountEmailEndpoint] POST /account/email: not sent (cloud status {result.StatusCode})");
+                    return Results.Json(new AccountEmailResponse(false, result.Error, null), statusCode: status);
+                }
+
+                FileLog.Write("[AccountEmailEndpoint] POST /account/email: sent to owner.");
+                return Results.Json(new AccountEmailResponse(true, null, result.ProviderId));
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[AccountEmailEndpoint] POST /account/email FAILED: {ex.Message}");
+                return Results.Json(
+                    new AccountEmailResponse(false,
+                        "Could not reach the DevThrottle account service to send the email. Try again shortly.", null),
+                    statusCode: StatusCodes.Status502BadGateway);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The relay request body. Subject + body + optional attachments - deliberately NO recipient field, so
+    /// the send can only ever reach the account owner (single-recipient by construction, issue #1318).
+    /// </summary>
+    internal sealed class AccountEmailRequest
+    {
+        [JsonPropertyName("subject")] public string? Subject { get; set; }
+        [JsonPropertyName("bodyText")] public string? BodyText { get; set; }
+        [JsonPropertyName("bodyHtml")] public string? BodyHtml { get; set; }
+        [JsonPropertyName("attachments")] public List<AccountEmailAttachment>? Attachments { get; set; }
+    }
+
+    /// <summary>One attachment: a file name plus its base64-encoded bytes and an optional MIME type.</summary>
+    internal sealed class AccountEmailAttachment
+    {
+        [JsonPropertyName("filename")] public string? Filename { get; set; }
+        [JsonPropertyName("content")] public string? Content { get; set; }
+        [JsonPropertyName("contentType")] public string? ContentType { get; set; }
+    }
+
+    private sealed record AccountEmailResponse(
+        [property: JsonPropertyName("sent")] bool Sent,
+        [property: JsonPropertyName("error")]
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        string? Error,
+        [property: JsonPropertyName("providerId")]
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        string? ProviderId);
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1214,6 +1214,15 @@ public sealed class GatewayHost : IAsyncDisposable
         // ever holding the token. Signed-out -> explicit signedIn:false; unreachable cloud -> clear 502.
         AccountCreditsEndpoint.Map(_app, Account, new Core.Account.AccountCreditsClient(new HttpClient { Timeout = TimeSpan.FromSeconds(10) }));
 
+        // "DevThrottle emails me" relay (issue #1318 consumer): POST /account/email. A session or scheduled
+        // run passes a subject + body (+ optional attachments); the Gateway injects its own stored account
+        // token and forwards to the cloud primitive (POST /api/v1/account/notify-owner, devthrottle_internal
+        // #338), which resolves the recipient from the token and sends via Resend. The Gateway holds NO
+        // Resend key and runs no email code - it only relays the account's own token. Single-recipient by
+        // construction (no recipient field). Signed-out -> 401; cloud failure -> clear 502. Inherits the
+        // host-wide token middleware above like the other /account routes.
+        AccountEmailEndpoint.Map(_app, Account, new Core.Account.AccountNotifyClient(new HttpClient { Timeout = TimeSpan.FromSeconds(30) }));
+
         // Start the browser loopback sign-in from a web request (issue #853): POST /account/sign-in. The
         // Cockpit Account page's signed-out state needs a real "Sign in" action, but the loopback flow that
         // captures the credential lives here on the Gateway (issue #637, GatewaySignInService = SignIn). So

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import json
-from typing import Optional
+from typing import List, Optional
 
 import typer
 from rich.console import Console
 from rich.table import Table
 
 from . import __version__
+from . import email_ops
 from . import mission_ops
 from . import schedule_ops
 from . import settings_ops
@@ -47,12 +48,16 @@ schedule_app = typer.Typer(
 setup_app = typer.Typer(
     help="Install, update, and repair DevThrottle.", add_completion=False, no_args_is_help=True
 )
+email_app = typer.Typer(
+    help="Send email to the account owner.", add_completion=False, no_args_is_help=True
+)
 app.add_typer(session_app, name="session")
 app.add_typer(mission_app, name="mission")
 app.add_typer(message_app, name="message")
 app.add_typer(settings_app, name="settings")
 app.add_typer(schedule_app, name="schedule")
 app.add_typer(setup_app, name="setup")
+app.add_typer(email_app, name="email")
 console = Console()
 
 _ACTIONS = [
@@ -228,6 +233,18 @@ _ACTIONS = [
         "command": "cc-devthrottle schedule endpoint",
         "mutatesState": False,
         "args": [],
+    },
+    {
+        "id": "email-owner",
+        "description": "Email the account owner (single recipient); optional file attachments. The escalation channel for unattended runs.",
+        "command": 'cc-devthrottle email owner --subject "<subject>" --body "<text>" [--attach <file>]',
+        "mutatesState": True,
+        "args": [
+            {"name": "subject", "required": True},
+            {"name": "body", "required": False},
+            {"name": "html", "required": False},
+            {"name": "attach", "required": False},
+        ],
     },
     {
         "id": "setup-status",
@@ -699,6 +716,41 @@ def setup_doctor(
 ) -> None:
     """Show setup diagnostics."""
     setup_ops.doctor(json_output)
+
+
+@email_app.callback()
+def email_main(
+    gateway: Optional[str] = typer.Option(
+        None,
+        "--gateway",
+        help="Override the Gateway base URL.",
+    ),
+) -> None:
+    """Send email to the account owner."""
+    email_ops.set_gateway_override(gateway)
+
+
+@email_app.command("owner")
+def email_owner(
+    subject: str = typer.Option(..., "--subject", help="The email subject line."),
+    body: Optional[str] = typer.Option(
+        None, "--body", help="Plain-text body. Provide --body, --html, and/or --attach."
+    ),
+    html: Optional[str] = typer.Option(
+        None, "--html", help="HTML body. Provide --body, --html, and/or --attach."
+    ),
+    attach: Optional[List[str]] = typer.Option(
+        None, "--attach", help="Attach a file (repeatable), e.g. an HTML report to read offline."
+    ),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output the send result as JSON."),
+) -> None:
+    """Send ONE email to the account owner (single recipient - no way to address anyone else).
+
+    Passes only a subject, body, and any attachments to the Gateway, which relays it to the cloud
+    with your account token; the cloud resolves the owner and sends. Use it to escalate from an
+    unattended or scheduled run, or to send yourself a report to read offline.
+    """
+    email_ops.send_owner(subject, body, html, attach, json_output)
 
 
 if __name__ == "__main__":

--- a/tools/cc-devthrottle/src/email_ops.py
+++ b/tools/cc-devthrottle/src/email_ops.py
@@ -1,0 +1,182 @@
+"""Owner-email operations for cc-devthrottle (issue #1318 consumer).
+
+'cc-devthrottle email owner' sends ONE email to the account owner on file. It passes only a subject,
+body, and optional attachments - there is no recipient argument, so the send is single-recipient by
+construction. The escalation channel an unattended or scheduled run uses to reach the human before it
+self-reaps, and the way to send yourself a report (e.g. an HTML file) to read offline.
+
+The send is server-side: this verb POSTs to the local Gateway's /account/email relay, which injects the
+account token it holds and forwards to the cloud primitive (POST /api/v1/account/notify-owner). No Resend
+key ever touches this machine.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import mimetypes
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+import requests
+import typer
+from rich.console import Console
+
+_tools_dir = str(Path(__file__).resolve().parent.parent.parent)
+if _tools_dir not in sys.path:
+    sys.path.insert(0, _tools_dir)
+
+from cc_shared.config import CCDirectorConfig  # noqa: E402
+
+LOOPBACK_DEFAULT = "http://127.0.0.1:7878"
+TIMEOUT_SECONDS = 45
+
+console = Console()
+err_console = Console(stderr=True)
+gateway_override: Optional[str] = None
+
+
+class GatewayError(Exception):
+    """A handled, user-facing failure talking to the Gateway."""
+
+
+def set_gateway_override(value: Optional[str]) -> None:
+    global gateway_override
+    gateway_override = value.rstrip("/") if value else None
+
+
+def resolve_base_url() -> str:
+    config = CCDirectorConfig().load()
+    url = (config.gateway.url or "").strip()
+    return url.rstrip("/") if url else LOOPBACK_DEFAULT
+
+
+def _auth_token() -> str:
+    config = CCDirectorConfig().load()
+    return (config.gateway.token or "").strip()
+
+
+def _is_loopback(url: str) -> bool:
+    host = (urlparse(url).hostname or "").lower()
+    return host in ("127.0.0.1", "localhost", "::1")
+
+
+def _read_attachment(path_text: str) -> Dict[str, str]:
+    """Read one file into the wire shape { filename, content(base64), contentType }."""
+    path = Path(path_text).expanduser()
+    if not path.is_file():
+        raise GatewayError(f"attachment not found: {path}")
+    data = path.read_bytes()
+    content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+    return {
+        "filename": path.name,
+        "content": base64.b64encode(data).decode("ascii"),
+        "contentType": content_type,
+    }
+
+
+class EmailClient:
+    """Talks to one Gateway's owner-email relay (POST /account/email)."""
+
+    def __init__(self, base_url: Optional[str] = None) -> None:
+        self.base_url = (base_url or resolve_base_url()).rstrip("/")
+        self._token = _auth_token()
+        if not self._token and not _is_loopback(self.base_url):
+            raise GatewayError(
+                f"Gateway URL {self.base_url} is remote but gateway.token is not set. "
+                "Set it with 'cc-devthrottle settings set gateway.token <token>' "
+                "(a loopback Gateway on this machine needs no token)."
+            )
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Accept": "application/json"}
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
+        return headers
+
+    def send_owner(
+        self,
+        subject: str,
+        body_text: Optional[str],
+        body_html: Optional[str],
+        attachments: List[Dict[str, str]],
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"subject": subject}
+        if body_text:
+            payload["bodyText"] = body_text
+        if body_html:
+            payload["bodyHtml"] = body_html
+        if attachments:
+            payload["attachments"] = attachments
+
+        url = f"{self.base_url}/account/email"
+        try:
+            resp = requests.post(url, json=payload, headers=self._headers(), timeout=TIMEOUT_SECONDS)
+        except requests.exceptions.ConnectionError as exc:
+            raise GatewayError(
+                f"Gateway not reachable at {self.base_url}. "
+                "Is the Gateway tray app running on this machine? "
+                "If you target a remote Gateway, set gateway.url with "
+                "'cc-devthrottle settings set gateway.url <url>'."
+            ) from exc
+        except requests.exceptions.Timeout as exc:
+            raise GatewayError(
+                f"Gateway at {self.base_url} did not respond within {TIMEOUT_SECONDS}s."
+            ) from exc
+
+        if 200 <= resp.status_code < 300:
+            return resp.json() if resp.content else {}
+        raise GatewayError(_gateway_message(resp))
+
+
+def _gateway_message(resp: requests.Response) -> str:
+    try:
+        data = resp.json()
+        if isinstance(data, dict) and data.get("error"):
+            return str(data["error"])
+    except ValueError:
+        pass
+    text = (resp.text or "").strip()
+    return text if text else f"Gateway returned HTTP {resp.status_code}"
+
+
+def _fail(message: str) -> None:
+    err_console.print(f"[red]Error:[/red] {message}")
+    raise typer.Exit(1)
+
+
+def send_owner(
+    subject: str,
+    body: Optional[str],
+    html: Optional[str],
+    attach: Optional[List[str]],
+    json_output: bool,
+) -> None:
+    """Send one email to the account owner via the Gateway relay."""
+    if not subject or not subject.strip():
+        _fail("--subject is required.")
+        return
+    if not (body and body.strip()) and not (html and html.strip()) and not attach:
+        _fail("provide a body: --body <text>, --html <html>, and/or --attach <file>.")
+        return
+
+    try:
+        attachments = [_read_attachment(p) for p in (attach or [])]
+        result = EmailClient(base_url=gateway_override).send_owner(subject.strip(), body, html, attachments)
+    except GatewayError as ex:
+        _fail(str(ex))
+        return
+
+    if json_output:
+        print(json.dumps(result, indent=2))
+        return
+
+    provider_id = result.get("providerId")
+    count = len(attach or [])
+    suffix = f" with {count} attachment(s)" if count else ""
+    if provider_id:
+        console.print(f"[green]Sent[/green] email to the account owner{suffix} (id {provider_id}).")
+    else:
+        console.print(f"[green]Sent[/green] email to the account owner{suffix}.")

--- a/tools/cc-devthrottle/tests/test_email_cli.py
+++ b/tools/cc-devthrottle/tests/test_email_cli.py
@@ -1,0 +1,82 @@
+"""Tests for the cc-devthrottle email owner verb (issue #1318 consumer)."""
+
+import base64
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src.cli import app  # noqa: E402
+
+runner = CliRunner()
+
+
+def _run_owner(extra_args, send_return=None):
+    with patch("src.email_ops.EmailClient") as client_cls:
+        instance = client_cls.return_value
+        instance.send_owner.return_value = send_return if send_return is not None else {"sent": True}
+        result = runner.invoke(app, ["email", "owner"] + extra_args)
+        call = instance.send_owner.call_args
+    return result, call
+
+
+def test_owner_send_passes_subject_and_body():
+    result, call = _run_owner(
+        ["--subject", "Nightly drift", "--body", "2 aging PRs"],
+        send_return={"sent": True, "providerId": "resend-1"},
+    )
+    assert result.exit_code == 0
+    # send_owner(subject, body_text, body_html, attachments)
+    assert call.args[0] == "Nightly drift"
+    assert call.args[1] == "2 aging PRs"
+    assert call.args[3] == []  # no attachments
+    assert "Sent" in result.output
+
+
+def test_owner_has_no_recipient_option():
+    result = runner.invoke(app, ["email", "owner", "--help"])
+    assert result.exit_code == 0
+    assert "--subject" in result.output
+    assert "--attach" in result.output
+    assert "--to" not in result.output
+    assert "--recipient" not in result.output
+
+
+def test_owner_requires_a_body_or_attachment():
+    result, call = _run_owner(["--subject", "Only a subject"])
+    assert result.exit_code != 0
+    assert call is None
+    assert "body" in result.output.lower()
+
+
+def test_owner_html_body_is_forwarded():
+    result, call = _run_owner(["--subject", "Report", "--html", "<p>drift</p>"])
+    assert result.exit_code == 0
+    assert call.args[1] is None       # no plain text
+    assert call.args[2] == "<p>drift</p>"
+
+
+def test_owner_attaches_file_as_base64(tmp_path):
+    report = tmp_path / "report.html"
+    report.write_text("<html><body>offline report</body></html>", encoding="utf-8")
+
+    result, call = _run_owner(["--subject", "Report", "--attach", str(report)])
+    assert result.exit_code == 0
+    attachments = call.args[3]
+    assert len(attachments) == 1
+    a = attachments[0]
+    assert a["filename"] == "report.html"
+    assert a["contentType"] == "text/html"
+    decoded = base64.b64decode(a["content"]).decode("utf-8")
+    assert decoded == "<html><body>offline report</body></html>"
+
+
+def test_owner_missing_attachment_fails_clearly(tmp_path):
+    missing = tmp_path / "nope.html"
+    result, call = _run_owner(["--subject", "Report", "--attach", str(missing)])
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()


### PR DESCRIPTION
Part of #1318 (Auto Daily Runs escalation channel). The cloud send primitive shipped as devthrottle_internal #338 (PR #339); this is the DevThrottle-side consumer that calls it.

## What
- `AccountNotifyClient` (Core) - cloud client for `POST /api/v1/account/notify-owner`, Bearer account token, body carries subject/text/html/attachments and NO recipient (single-recipient by construction). Token never logged.
- `POST /account/email` (Gateway relay) - injects `GetAccessTokenForForwarding()` and forwards to the cloud. Signed-out -> 401, cloud failure -> 502, never a fake success. **Holds no Resend key** - it only relays the account's own token.
- `cc-devthrottle email owner --subject --body [--html] [--attach <file>]` - repeatable `--attach` reads files and base64-encodes them (e.g. an HTML report to read offline).

## Proof
- `AccountNotifyClient` 6/6 unit tests (wire body has no recipient, Bearer sent, cloud rejection surfaced, empty token throws).
- `email owner` CLI 6/6 (66/66 suite): no recipient option, body-or-attachment required, attachment base64 round-trip, missing-file fails clearly.
- Core.Tests + Gateway.Tests build clean; cloud endpoint confirmed deployed (401-gated).
- `docs/cencon/proof/issue-1318/report.html`.

## Next
#1319 (Auto Daily Runs scheduling) wires this verb as the escalation step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)