### PR TITLE
Car Mode Phase 1: standalone page + walkie-talkie turn-taking core

### DIFF
--- a/apps/mobile/src/components/NavDrawer.tsx
+++ b/apps/mobile/src/components/NavDrawer.tsx
@@ -32,6 +32,9 @@ export function NavDrawer() {
             <Link className="drawer-item" to="/new" onClick={close}>
               New session
             </Link>
+            <Link className="drawer-item" to="/car" onClick={close}>
+              Car Mode
+            </Link>
             <div className="drawer-sep" />
             <Link className="drawer-item" to="/settings" onClick={close}>
               AI settings

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -6,6 +6,7 @@ import { NewSession } from "./pages/NewSession";
 import { Terminal } from "./pages/Terminal";
 import { Chat } from "./pages/Chat";
 import { VoiceMode } from "./pages/VoiceMode";
+import { CarMode } from "./pages/CarMode";
 import { AiSettings } from "./pages/AiSettings";
 import { About } from "./pages/About";
 import { SignIn } from "@devthrottle/client-core/auth/SignIn";
@@ -78,6 +79,9 @@ const router = createBrowserRouter(
           element: <RequireDeviceKey />,
           children: [
             { path: "/", element: <Home /> },
+            // Car Mode (Car Mode mission): its own chrome-less, full-screen route, NOT nested in any
+            // tabbed session view. Hands-free voice control of the whole fleet with a screen wake-lock.
+            { path: "/car", element: <CarMode /> },
             { path: "/settings", element: <AiSettings /> },
             { path: "/about", element: <About /> },
             { path: "/new", element: <NewSession /> },

--- a/apps/mobile/src/pages/CarMode.tsx
+++ b/apps/mobile/src/pages/CarMode.tsx
@@ -1,0 +1,166 @@
+import { useCallback } from "react";
+import { Link } from "react-router-dom";
+import { useCarMode, type CarModeReply } from "@devthrottle/client-core/carmode/useCarMode";
+import { carModeTurn } from "@devthrottle/client-core/carmode/carModeApi";
+import { useScreenWakeLock } from "../hooks/useScreenWakeLock";
+
+// Car Mode (Car Mode mission): the standalone, chrome-less, full-screen page the owner opens to run
+// the whole fleet by voice, hands-free, phone in his pocket. It is a THIN view over the shared
+// useCarMode() turn-taking machine (decision 6) - all the state, capture, transcription, playback, and
+// the two audible cues live in client-core; this page owns only the route, a big eyes-free layout, and
+// the choice of brain responder.
+//
+// Phase 1 wires the turn-taking end to end with a STAND-IN reply so the hardest unknown - the
+// walkie-talkie discipline and barge-in - is proven before the fleet brain is built on top of it. From
+// Phase 2 the responder is the real POST /carmode/turn brain. The page picks which by the flag below;
+// nothing else changes.
+
+// Phase 2 is merged, so Car Mode talks to the real fleet brain (POST /carmode/turn). The Phase 1
+// stand-in responder is kept just below, guarded by this flag, purely so the turn-taking machine can be
+// exercised with no brain (and no credits) when diagnosing barge-in in isolation.
+const USE_FLEET_BRAIN = true;
+
+export function CarMode() {
+  // Car Mode is eyes-free with the phone in a pocket: keep the screen awake the whole time (mission
+  // Phase 1: a standalone page under /m with a screen wake-lock).
+  useScreenWakeLock();
+
+  // The injected brain responder. Phase 2+: the real fleet brain. The stand-in (below) just echoes the
+  // heard command so Phase 1's barge-in proof needs no server and no credits.
+  const respond = useCallback(async (command: string, signal: AbortSignal): Promise<CarModeReply> => {
+    if (USE_FLEET_BRAIN) {
+      const result = await carModeTurn(command, signal);
+      return { spoken: result.spoken, actions: result.actions, pendingConfirmation: result.pendingConfirmation };
+    }
+    // Phase 1 stand-in: a canned acknowledgement that repeats the command back, so the owner can hear
+    // the whole loop (transcribe -> speak -> interrupt) working before the brain exists.
+    return { spoken: `You said: ${command}. Go ahead when you're ready.` };
+  }, []);
+
+  const {
+    phase,
+    started,
+    transcript,
+    reply,
+    actions,
+    pendingConfirmation,
+    error,
+    unsupported,
+    history,
+    start,
+    stop,
+  } = useCarMode({ respond });
+
+  const statusText = phaseStatus(phase);
+
+  return (
+    <div className="car-screen">
+      <header className="car-bar">
+        <Link className="car-exit" to="/" onClick={stop} aria-label="Leave Car Mode">
+          Exit
+        </Link>
+        <span className="car-title">Car Mode</span>
+        <span className="car-bar-spacer" aria-hidden="true" />
+      </header>
+
+      {error !== null && (
+        <div className="car-error" role="alert">
+          {error}
+        </div>
+      )}
+
+      {unsupported && (
+        <div className="car-error" role="alert">
+          Car Mode needs Chrome or another Chromium browser for hands-free voice. Open this page in
+          Chrome.
+        </div>
+      )}
+
+      <main className="car-body">
+        {/* The one big status orb + word: whose turn it is, readable at a glance / audible by the two
+            cues. Its color is the whole state at a distance. */}
+        <div className={`car-orb car-orb-${phase}`} aria-hidden="true">
+          <span className="car-orb-pulse" />
+        </div>
+        <p className="car-status" aria-live="polite">
+          {started ? statusText : "Tap Start, then just talk."}
+        </p>
+
+        {pendingConfirmation && (
+          <p className="car-confirm" role="status">
+            Waiting for you to say "confirm" - or say "cancel".
+          </p>
+        )}
+
+        {/* The heard command and the spoken reply. The interface is sound; this text is for eyes-on
+            confirmation and debugging over chrome://inspect (mission decision 9). */}
+        {transcript.length > 0 && (
+          <div className="car-heard">
+            <span className="car-label">You said</span>
+            <span className="car-heard-text">{transcript}</span>
+          </div>
+        )}
+        {reply.length > 0 && (
+          <div className="car-said">
+            <span className="car-label">Assistant</span>
+            <span className="car-said-text">{reply}</span>
+          </div>
+        )}
+        {actions.length > 0 && (
+          <ul className="car-actions">
+            {actions.map((a, i) => (
+              <li key={`${a.tool}-${i}`} className="car-action">
+                {a.summary}
+              </li>
+            ))}
+          </ul>
+        )}
+      </main>
+
+      <footer className="car-foot">
+        {!started ? (
+          <button type="button" className="car-start" onClick={() => void start()} disabled={unsupported}>
+            Start Car Mode
+          </button>
+        ) : (
+          <>
+            <p className="car-hint">
+              Say <strong>"over and out"</strong> to send. Say <strong>"stop"</strong> to cut me off.
+            </p>
+            <button type="button" className="car-stop" onClick={stop}>
+              End Car Mode
+            </button>
+          </>
+        )}
+      </footer>
+
+      {history.length > 1 && (
+        <details className="car-history">
+          <summary>Recent turns ({history.length})</summary>
+          <ul>
+            {history.map((h, i) => (
+              <li key={i}>
+                <span className="car-history-you">{h.command}</span>
+                <span className="car-history-said">{h.spoken}</span>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  );
+}
+
+// The plain-English status line for each phase, the words that pair with the color orb and the cues.
+function phaseStatus(phase: string): string {
+  switch (phase) {
+    case "listening":
+      return "Listening - go ahead. I stay quiet until you say 'over and out'.";
+    case "thinking":
+      return "Got it. Working on that...";
+    case "speaking":
+      return "Speaking. Say 'stop' to cut me off.";
+    default:
+      return "Ready.";
+  }
+}

--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -87,6 +87,13 @@ export function Home() {
         New session
       </Link>
 
+      {/* Car Mode (Car Mode mission): the hands-free, eyes-free voice channel to the whole fleet. Its
+          own full-screen page; one tap in, then just talk. */}
+      <Link className="car-entry" to="/car">
+        <span className="car-entry-icon" aria-hidden="true">&#9679;</span>
+        Car Mode - drive the fleet by voice
+      </Link>
+
       {sessions === null && error === null && <p className="status-line">Loading sessions...</p>}
 
       {sessions !== null && total === 0 && (

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -1867,3 +1867,254 @@ a.banner-btn {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-weight: 600;
 }
+
+/* ===== Car Mode (Car Mode mission) ============================================================ */
+/* The roster entry point to Car Mode - a big, unmistakable tap target above the session groups. */
+.car-entry {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 0 14px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--accent);
+  background: linear-gradient(180deg, var(--surface-2), var(--surface));
+  color: var(--text);
+  font-size: 16px;
+  font-weight: 600;
+  text-decoration: none;
+}
+.car-entry-icon {
+  color: var(--accent);
+  font-size: 14px;
+}
+
+/* The full-screen Car Mode page. Chrome-less, high-contrast, thumb-reachable controls at the bottom. */
+.car-screen {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+  color: var(--text);
+  overflow-y: auto;
+}
+.car-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+.car-exit {
+  color: var(--text-dim);
+  text-decoration: none;
+  font-size: 15px;
+  padding: 6px 4px;
+}
+.car-title {
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+.car-bar-spacer {
+  width: 34px;
+}
+.car-error {
+  margin: 12px 16px 0;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: #3a1c1c;
+  border: 1px solid var(--attention);
+  color: #ffd7d7;
+  font-size: 15px;
+}
+
+.car-body {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 24px 20px;
+  text-align: center;
+}
+
+/* The one big status orb: its color IS the state at a distance (paired with the two audible cues). */
+.car-orb {
+  position: relative;
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface-2);
+  border: 3px solid var(--border);
+  transition: background 0.2s, border-color 0.2s;
+}
+.car-orb-pulse {
+  width: 60%;
+  height: 60%;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.85;
+}
+.car-orb-idle {
+  color: var(--text-dim);
+  border-color: var(--border);
+}
+.car-orb-listening {
+  color: #22c55e;
+  border-color: #22c55e;
+}
+.car-orb-listening .car-orb-pulse {
+  animation: carPulse 1.6s ease-in-out infinite;
+}
+.car-orb-thinking {
+  color: #f59e0b;
+  border-color: #f59e0b;
+}
+.car-orb-thinking .car-orb-pulse {
+  animation: carSpin 1s linear infinite;
+  border-radius: 40%;
+}
+.car-orb-speaking {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.car-orb-speaking .car-orb-pulse {
+  animation: carPulse 0.9s ease-in-out infinite;
+}
+@keyframes carPulse {
+  0%, 100% { transform: scale(0.8); opacity: 0.6; }
+  50% { transform: scale(1.05); opacity: 0.95; }
+}
+@keyframes carSpin {
+  from { transform: rotate(0deg) scale(0.85); }
+  to { transform: rotate(360deg) scale(0.85); }
+}
+
+.car-status {
+  font-size: 19px;
+  line-height: 1.4;
+  max-width: 22ch;
+  color: var(--text);
+}
+.car-confirm {
+  font-size: 17px;
+  font-weight: 600;
+  color: #ffd7d7;
+  background: #3a1c1c;
+  border: 1px solid var(--attention);
+  border-radius: 10px;
+  padding: 10px 14px;
+}
+.car-label {
+  display: block;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+  margin-bottom: 2px;
+}
+.car-heard,
+.car-said {
+  width: 100%;
+  max-width: 34ch;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+}
+.car-heard-text {
+  font-size: 17px;
+}
+.car-said-text {
+  font-size: 17px;
+  color: var(--text);
+}
+.car-actions {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  max-width: 34ch;
+}
+.car-action {
+  font-size: 14px;
+  color: #9be7a8;
+  padding: 4px 0;
+}
+
+.car-foot {
+  padding: 16px 20px calc(20px + env(safe-area-inset-bottom, 0px));
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+.car-hint {
+  font-size: 15px;
+  color: var(--text-dim);
+  margin: 0;
+  text-align: center;
+}
+.car-hint strong {
+  color: var(--text);
+}
+.car-start,
+.car-stop {
+  width: 100%;
+  max-width: 420px;
+  padding: 18px;
+  font-size: 19px;
+  font-weight: 700;
+  border-radius: 12px;
+  border: none;
+  cursor: pointer;
+}
+.car-start {
+  background: var(--accent);
+  color: #fff;
+}
+.car-start:disabled {
+  background: #26314e;
+  color: #6b7391;
+  cursor: default;
+}
+.car-stop {
+  background: #3a1c1c;
+  color: #ffd7d7;
+  border: 1px solid var(--attention);
+}
+
+.car-history {
+  margin: 0 16px 20px;
+  color: var(--text-dim);
+  font-size: 13px;
+}
+.car-history summary {
+  cursor: pointer;
+  padding: 6px 0;
+}
+.car-history ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.car-history li {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px 0;
+  border-top: 1px solid var(--border);
+}
+.car-history-you {
+  color: var(--text);
+}
+.car-history-said {
+  color: var(--text-dim);
+}

--- a/docs/architecture/car-mode-mission-2026-07-11.md
+++ b/docs/architecture/car-mode-mission-2026-07-11.md
@@ -1,0 +1,303 @@
+# Mission Brief: Car Mode (hands-free voice control of the whole fleet)
+
+Status: active mission. Written 2026-07-11 by the Architect session ("Car Mode - Architect",
+session a240f4bf, machine SOREN_NORTH). This document is the Architect's handover to the Manager
+session. The Manager owns execution from here; the Architect settles the design and then lets the
+Manager drive.
+
+## The mission
+
+The owner wants to grab his phone, put it in his pocket, and run the entire fleet of agents by
+voice while walking or driving - no screen, no typing. He opens one page, called Car Mode, taps
+into voice mode once, and from then on it just listens. He speaks a request about the fleet ("how
+many sessions need me right now", "show me the latest one", "start a new session in the
+devthrottle repo", "message that session and tell it to run the tests") and it answers out loud
+and does the work. The bar is a competent human development manager on the other end of a phone
+call: he is travelling, his developers are in the office, and this page is the one channel he has
+to direct them.
+
+The interaction is deliberately a walkie-talkie, not a chat bot. The owner rejected silence-based
+turn detection outright: he pauses to think mid-sentence and will not tolerate the assistant
+guessing he is done and cutting him off, nor the pause-then-talk lag. Instead:
+
+- He finishes a turn by saying the phrase **"over and out"**. Nothing the assistant does happens
+  until it hears that phrase. He can stop and think for as long as he likes and it stays silent.
+- He can cut the assistant off at any time by saying **"stop"** (also "wait", "shut up"). It goes
+  silent instantly and returns to listening. The assistant can never talk over him - it only
+  begins speaking after "over and out".
+- Because the screen is in his pocket, sound is the interface. Every turn boundary has an audible
+  cue (see "The audible handshake" below) so he always knows, without looking, whose turn it is
+  and that his "over and out" was heard.
+
+Full command-and-control is in scope. Starting a session by voice should feel exactly like tapping
+the button himself - the assistant just does it. The assistant only comes back to ask when it is
+genuinely unsure. Destructive or irreversible actions (deleting or killing a session) always ask
+for a spoken confirmation. There is no per-action nagging beyond that; the assistant decides when
+a confirmation is warranted.
+
+## The core finding - most of the plumbing already exists
+
+Verified against the working tree on 2026-07-11. Read this before starting; it is why the new
+work is two focused pieces, not a from-scratch voice stack.
+
+1. Microphone capture with echo cancellation already exists and is shared by both apps.
+   `MicRecorder` in `packages/client-core/src/dictation/recorder.ts` opens the microphone via
+   `getUserMedia` with `{ echoCancellation: true, noiseSuppression: true, channelCount: 1 }`
+   already set (line 68), records Opus-in-WebM in 100 ms slices, and latches a "first real audio
+   frame" event (lines 87-96). Echo cancellation is the single most important requirement for
+   barge-in (so the assistant's own voice does not feed back into the microphone and trigger a
+   false "stop") - and it is already configured. Reuse this recorder; do not write a new one.
+
+2. There is one transcription path, through the Gateway, and it already has HTTP front doors.
+   `GatewayTranscriptionService.TranscribeAsync(...)`
+   (`src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs:98`) is the single owner
+   of speech-to-text: one provider, one validated dictionary. The simplest front door is
+   `POST /wingman/transcribe` (`src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs:339`):
+   send a `multipart/form-data` audio file, get back `{ transcript }`. Client-side transcode to
+   16 kHz mono WAV already exists in `packages/client-core/src/dictation/wav.ts`. Reuse both.
+
+3. There is one good voice, through the Gateway, and it returns raw audio, never base64.
+   `POST /wingman/tts` (`GatewayWingmanVoiceEndpoint.cs:201`) takes `{ text, voice?, model? }`
+   and returns raw audio bytes (`audio/mpeg`); the voice defaults to the owner's configured
+   text-to-speech voice. The client-core sample player at `packages/client-core/src/api/ai.ts`
+   `ttsSample()` (line 102) shows the fetch-to-Blob-to-`<audio>` pattern. Reuse this to speak
+   every reply. (Note: the "/api/tts" name in early conversation was a conflation; the real
+   Gateway route is `POST /wingman/tts`, which proxies the hosted `.../api/v1/audio/speech`.)
+
+4. The water-drop "ready" cue is already synthesized in the browser and is the seed for the
+   audible handshake. `playReadyCue()` in `packages/client-core/src/dictation/readyCue.ts:15`
+   synthesizes the ~380 Hz to 1150 Hz water-drop with the Web Audio API (no bundled asset). Car
+   Mode reuses it for one of the two turn cues and adds a second, clearly distinguishable tone in
+   the same file for the other (see decision 4).
+
+5. The whole fleet roster - names, summaries, and "needs you" - is already one call.
+   `GET /sessions` on the Gateway (`src/CcDirector.Gateway/Api/GatewayEndpoints.cs:438`) returns
+   `SessionDto[]` (`src/CcDirector.Gateway.Contracts/SessionDto.cs`) already carrying everything
+   the assistant needs to talk like a human: `Name` (friendly name), `Number`, `MissionName`,
+   `StateLabel` ("Needs you" / "Working" / "Ready"), `LastStatusReason` (short reason),
+   `RailLine` (the <=8-word one-line summary of what it is doing), `TriageBucket`
+   ("needsYou" / "active" / "onHold"), and `NeedsYouSince` (how long it has been waiting).
+   "How many need me" and "show me the latest one" are answerable directly from this.
+
+6. The "now talking about session X" narration - full name plus a short summary, never a number -
+   already exists as a pattern to copy. The (now retired) phone app composed it in
+   `phone/CcDirectorClient/Voice/VoiceConversation.cs`: `BuildSpokenIntro(session)` (line 375)
+   returns "{name}, in the {repo} repo." and it is prefixed to the model's short spoken summary
+   (`PrepareExplainAsync`, line 331). Reuse the prose shape, not the code (that app is dead; Car
+   Mode is React over client-core).
+
+7. The apps already know how to host a new full-screen page over shared logic. Car Mode ships as a
+   standalone, separately-deployable page on the phone (decision 9), served under `/m` behind the
+   HTTPS front door. The mobile routing model is in `apps/mobile/src/main.tsx`
+   (`createBrowserRouter`, `basename: "/m"`, gated routes under `<RequireDeviceKey>`, lines 77-89);
+   `apps/mobile/src/pages/VoiceMode.tsx` is the closest model page. Register Car Mode as its own
+   chrome-less full-screen route (for example `/m/car`) under `<RequireDeviceKey>`, not nested in
+   any tabbed session view, with a screen wake-lock so the phone does not sleep. Shared logic lives
+   in a new `packages/client-core/src/carmode/` folder with a `useCarMode()` hook, mirroring the
+   existing `voice/useVoiceMode.ts` turn-taking hook; the page itself only wires the route plus
+   JSX. The cockpit uses the same client-core hook if we ever want it there (its routing is in
+   `apps/cockpit/src/main.tsx` with the rail in `AppShell.tsx`), but the phone is the target and
+   the cockpit is not required for this mission.
+
+## The two things that are genuinely new - build these, everything else is reuse
+
+The research found the two gaps clearly. Neither is small; both are the heart of Car Mode.
+
+### New build A - a tool-calling brain on the Gateway (the fleet manager)
+
+Today's hosted-model helper, `HostedInferenceBrain`
+(`src/CcDirector.Gateway/Wingman/HostedInferenceBrain.cs:26`), is single-shot: one user message
+in, one assistant text out, over `POST {base}/chat/completions`. It has NO tool use, no
+tool-result loop, no multi-step reasoning. Car Mode needs the opposite: a model that can call
+fleet tools, read their results, and keep going until it has answered or acted.
+
+- Build a new Gateway component (for example `src/CcDirector.Gateway/CarMode/CarModeBrain.cs`)
+  that runs a proper tool-calling loop against the hosted model using the standard
+  chat-completions `tools` / `tool_calls` shape: send the user's transcript plus the tool
+  catalog, execute any tool the model calls (in-process, by calling the Gateway's own session
+  endpoints), feed the results back, and repeat until the model returns a final spoken message.
+- The harness is a hand-rolled loop in C#, not an agent framework and not the OpenAI Agents
+  Software Development Kit. Reason (settled 2026-07-11): the brain lives inside the .NET Gateway,
+  where the model key, the fleet endpoints, and all the plumbing already are, and where a
+  latency-sensitive voice loop wants its tools called in-process with no network hop. The OpenAI
+  Agents Software Development Kit can drive an open-source, OpenAI-compatible model (via a custom
+  base address or its built-in adapter), so the model is not the issue - but it is Python-first
+  with no C# version, so adopting it would force a separate non-.NET service that calls back into
+  the Gateway over HTTP for every tool. That is the wrong shape for one small in-Gateway agent.
+  For v1's small fixed toolset the loop is about a hundred lines and extends the single-shot
+  `HostedInferenceBrain` we already have; zero new dependency, full control over latency and the
+  enterprise logging the project requires. If the toolset or the reasoning later grows, adopt the
+  Microsoft Agent Framework (the .NET-native successor to Semantic Kernel, which does support
+  OpenAI-compatible endpoints) in-process - still C#, still in the Gateway. Do not reach for the
+  OpenAI Agents Software Development Kit unless we deliberately want a polyglot brain as its own
+  service.
+- The model is the fast hosted role, which is the "decent but fast" tier the owner asked for
+  (currently `Qwen/Qwen2.5-72B-Instruct`, resolved by
+  `TranscriptionEndpointResolver.ResolveWingmanFast()`,
+  `src/CcDirector.Core/Configuration/TranscriptionEndpoint.cs:134`; base
+  `https://devthrottle.com/api/v1`, key `DEVTHROTTLE_API_KEY`). Tool-calling quality on this model
+  is an early risk to validate; if it cannot reliably choose tools, escalate to the thinking role
+  (`ResolveWingman()`, `GLM-5.2`) and accept the extra latency - decide with evidence, not a guess.
+- Conversation context is kept server-side, keyed by the caller's device, so multi-turn works
+  ("how many need me" then "show me the latest one" - the second turn knows what "the latest one"
+  means).
+
+The fleet tools (v1), each backed by an existing Gateway or Director endpoint - no new fleet
+mechanics, just a tool wrapper the model can call:
+
+- Read tools: count/list sessions and their state, focus a session (resolve a fuzzy human
+  reference to one session and set it as the current subject), read what a session is doing - all
+  from `GET /sessions` and the per-session history endpoints.
+- Act tools: start a session in a named repo, send a message to a session, approve a waiting
+  session - each calling the same endpoint the buttons already call.
+- Destructive tools (delete/kill a session): marked as requiring confirmation. When the model
+  invokes one, the loop does not execute it; it returns a spoken confirmation question and waits
+  for the next turn to carry a "yes"/"confirm" before acting.
+
+Note: the `cc-devthrottle actions --json` registry (`tools/cc-devthrottle/src/cli.py`, `_ACTIONS`)
+is a good human-readable inventory of what an agent can do, but it is command-line only - there is
+no HTTP endpoint that lists or invokes "actions". Do not try to route the brain through the
+command line. The brain's tools call the Gateway's HTTP endpoints in-process.
+
+### New build B - the client turn-taking machine with reliable end-word and interrupt detection
+
+This is the highest-risk unknown and must be proven first (see Phase 1). The design:
+
+- A two-state machine in `useCarMode()`: Listening (the owner is talking) and Speaking (the
+  assistant is talking). Plus a brief Thinking state while the brain works.
+- In Listening: `MicRecorder` buffers the full utterance for accurate Gateway transcription, while
+  a lightweight, continuous recognizer watches only for the control phrase "over and out". When it
+  fires, stop the recording, play the "my turn" cue, and send the buffered audio to be transcribed
+  and answered. There is no silence timer anywhere.
+- In Speaking: play the reply through `<audio>` from `POST /wingman/tts`, while the same
+  lightweight recognizer watches only for "stop"/"wait"/"shut up". On a hit, pause the audio
+  instantly, play the "your turn" cue, and return to Listening.
+- The lightweight recognizer for the control words: start with the browser's built-in speech
+  recognition (available in the Chromium web view Car Mode runs in) because it is zero-dependency.
+  The open question - and the reason Phase 1 exists - is whether it stays reliable while the
+  assistant's own voice is playing (barge-in) and whether it can run alongside `MicRecorder`
+  cleanly. If it cannot, fall back to a small on-device keyword-spotting model running on the
+  echo-cancelled microphone stream. Prove this on a real phone with the assistant's voice playing
+  before building anything else on top of it. Do not assume it works; measure it.
+
+## The audible handshake (first-class, not an afterthought)
+
+Because Car Mode is used eyes-free, the turn boundaries must be audible. Two short, clearly
+distinct tones, both synthesized in `readyCue.ts`:
+
+- "My turn" cue: fires the instant "over and out" is recognized. This is the owner's confirmation
+  that his sign-off was heard and the assistant is now taking the turn. Reuse the existing
+  water-drop for this.
+- "Your turn" cue: fires when the assistant finishes speaking (or is interrupted) and the
+  microphone is live again for the owner. A different, unmistakable tone.
+
+The owner must be able to tell the two apart without looking. Keep them short and unambiguous.
+
+## Decisions already made - do not re-litigate
+
+1. The sending phrase is "over and out", required as the complete phrase and only as the last
+   thing said; plain "over" or plain "out" alone never triggers. Strip the phrase before the
+   command text reaches the brain. Interrupt words are "stop", "wait", "shut up".
+2. The brain runs server-side on the Gateway, not in the browser. The browser stays thin: capture
+   audio, get a transcript, hand the transcript to the brain, speak the reply. This keeps the
+   model key and the fleet tools server-side and matches the rule that clients talk only to the
+   Gateway. A latency optimization - folding transcription into the brain endpoint so audio goes
+   straight to it - is allowed later, but the v1 shape is three clear steps.
+3. Full control, agent-decides-confirmation. The assistant acts without asking for ordinary
+   actions (start a session, send a message, approve). It asks only when genuinely unsure.
+   Destructive actions (delete/kill) always require a spoken confirmation. No per-action nagging.
+4. Two distinct audible cues at the turn boundaries, both from `readyCue.ts` (above).
+5. Sessions are referred to by human name and what they are doing, never by number, in every
+   spoken line. Reuse the "{name}, in the {repo} repo" plus short-summary prose shape from the old
+   phone narration. Resolving a fuzzy reference ("the latest one", "the one that needs me") to a
+   specific session is the brain's job, using the `GET /sessions` roster.
+6. Reuse, do not rebuild: `MicRecorder` (with its echo cancellation) for capture, `wav.ts` for
+   transcode, `POST /wingman/transcribe` for speech-to-text, `POST /wingman/tts` for the voice,
+   `GET /sessions` for the roster, `readyCue.ts` for the cues. The shared turn-taking logic lives
+   in `packages/client-core/src/carmode/useCarMode()`; each app mounts a thin page.
+7. Chromium only. Echo cancellation and the built-in recognizer are solid in the Chromium web view
+   both apps use and weak elsewhere; Car Mode does not support Firefox. State this, do not work
+   around it.
+8. Plain English everywhere, ASCII only in code and output. No fallback programming: a failed
+   transcription, an offline Gateway, or a model error is a loud, spoken, specific failure, never
+   a silent stall or a guess. Fire-and-forget is banned - every voice action shows and says its
+   state.
+9. Phone-first, as a standalone separately-deployable page (owner decision 2026-07-11). Car Mode is
+   just a web page, so there is no reason to prove it in the cockpit first; build and iterate
+   directly against the phone. It is its own page and its own deploy, overriding whatever is on the
+   phone when we push. Debugging is not lost: Chrome on Android exposes full developer tools to the
+   desktop over `chrome://inspect` with the phone on the wireless debugger (the test Z Flip is
+   already paired), so console, network, and breakpoints all work against the page running on the
+   phone.
+10. The brain harness is a hand-rolled C# tool-calling loop in the Gateway, not the OpenAI Agents
+    Software Development Kit and not (for v1) an agent framework. See New build A for the full
+    reasoning: the deciding factor is that the brain lives in the .NET Gateway and wants its tools
+    in-process, and the OpenAI Agents Software Development Kit has no C# version (it would force a
+    separate Python service). Model compatibility is not the constraint - that Software Development
+    Kit can drive open-source OpenAI-compatible models fine. If a framework is later wanted, it is
+    the .NET-native Microsoft Agent Framework, in-process, not the OpenAI one.
+
+## The work, in phases
+
+Each phase ships alone: implemented, merged to origin/main per the trunk rule, deployed to the
+phone, and exercised by the owner on the phone before the next phase begins. Every phase is built
+and proven directly on the phone (decision 9) - it is just a web page, deployed as its own
+standalone page under `/m`, and debugged over `chrome://inspect`. The standalone page exists from
+Phase 1, so there is no separate "ship on the phone" phase; every phase is on the phone.
+
+- Phase 1 - Turn-taking core and the audible handshake, no fleet brain yet. Stand up the standalone
+  Car Mode page under `/m` with a screen wake-lock, and the two-state machine in `useCarMode()`:
+  "over and out" ends the turn; "stop" interrupts; both audible cues fire. Wire it end to end with
+  a stand-in reply - transcribe the command through `POST /wingman/transcribe`, show the text on
+  screen, and speak a canned acknowledgement through `POST /wingman/tts` that the owner can
+  interrupt. This phase exists to prove new build B - the hardest unknown - before anything is
+  built on it. Proof, on the phone: speak a sentence, pause mid-thought without it jumping in, say
+  "over and out", hear the "my turn" cue and see the transcript; while it speaks, say "stop" and
+  confirm it goes silent and gives the "your turn" cue. A written finding on whether the phone's
+  built-in speech recognition survives barge-in (the assistant's own voice playing), or whether we
+  moved to an on-device keyword model on the echo-cancelled microphone stream.
+
+- Phase 2 - The fleet brain, read-only. New build A with read-only tools only: `CarModeBrain` and
+  `POST /carmode/turn` on the Gateway (a hand-rolled C# tool-calling loop per decision 10,
+  authenticated by the caller's device key per the Gateway auth rule), with tools backed by
+  `GET /sessions` and the history endpoints. Wire the phone page to it. Proof, on the phone, by
+  voice: "how many sessions need me" answered with a count and the human names; "show me the latest
+  one" / "what is the devthrottle session doing" answered aloud, naming the session and repo and its
+  short summary, never a number.
+
+- Phase 3 - Full control and the confirmation policy. Add the acting tools (start a session in a
+  named repo, message a session, approve) and the destructive tools (delete/kill) gated behind a
+  spoken confirmation, with the assistant free to ask when unsure. Proof, on the phone, by voice:
+  start a session in the devthrottle repo and confirm it appears; message a running session and
+  confirm it arrives; ask to delete a session and confirm the assistant requires a spoken "confirm"
+  before doing it.
+
+- Phase 4 - The real-world walk. Hardening and polish under real use: barge-in robustness in noise
+  and while moving; loud, spoken error and offline states (Gateway unreachable, out of credits,
+  model failure); latency tuning (the option to fold transcription into `POST /carmode/turn`); a
+  narration-quality pass so the assistant sounds like a competent development manager, not a form
+  reader; unit tests for the turn-taking machine and the brain's tool loop. Proof: the owner walks
+  outside with the phone in his pocket and runs the fleet by voice, hands-free, for a real stretch -
+  who needs him, read me that one, start a session, message an agent - with the audible handshakes
+  carrying the whole interaction and nothing failing silently.
+
+## Definition of done for the mission
+
+1. All phases merged to origin/main, each verified by the owner on the real phone against the real
+   Gateway (the standalone `/m` Car Mode page), and Phase 4 verified on the phone while walking.
+2. From the phone, hands-free, the owner runs the whole fleet by voice: he can ask who needs him
+   and get human names, have a session read to him (named, never numbered), start a session in a
+   repo, and message an agent - and it feels like directing a competent development manager on a
+   phone call.
+3. The walkie-talkie discipline holds: it never speaks until "over and out"; he can pause to think
+   as long as he likes; "stop" cuts it off instantly; and both turn boundaries are audible so he
+   always knows whose turn it is without looking.
+4. Full control works with the agreed confirmation policy: ordinary actions just happen; deleting
+   or killing a session requires a spoken confirmation.
+5. The two new builds are real and tested: the Gateway tool-calling brain (with the read, act, and
+   confirmed-destructive tools) and the client turn-taking machine (with proven end-word and
+   interrupt detection over the echo-cancelled microphone). Everything else is the reused plumbing
+   listed in the core finding.
+6. A final verification report (HTML, in docs/reviews/) with screenshots and a phone recording
+   showing a full hands-free session: who-needs-me, read-me-that-one, start-a-session,
+   message-an-agent, and a destructive action being held for confirmation.

--- a/docs/architecture/carmode-phase1-barge-in-finding.md
+++ b/docs/architecture/carmode-phase1-barge-in-finding.md
@@ -1,0 +1,83 @@
+# Car Mode Phase 1 - Turn-taking core and the barge-in finding
+
+Status: Phase 1 delivered. Written by the Manager session ("Car Mode - Manager", 2026-07-11).
+This is the written finding the mission requires from Phase 1 ("New build B" and the Phase 1
+proof): does the walkie-talkie discipline hold, and does control-word detection survive the
+assistant's own voice playing (barge-in)?
+
+## What Phase 1 built
+
+The standalone, chrome-less Car Mode page under `/m/car` (route registered in
+`apps/mobile/src/main.tsx`, gated behind `<RequireDeviceKey>`, with a screen wake-lock), plus the
+shared two-state turn-taking machine in `packages/client-core/src/carmode/`:
+
+- `controlPhrases.ts` - the pure, exhaustively-tested language rules: "over and out" ends a turn ONLY
+  as the complete phrase and only as the last thing said (plain "over" or "out" never triggers, and a
+  mid-sentence "stopover and outages" never triggers); "stop"/"wait"/"shut up" are whole-word
+  interrupts. The end phrase is stripped before the command reaches the brain (decision 1).
+- `speechRecognition.ts` - `ControlWordListener`, a continuous wrapper over the browser's built-in
+  speech recognition (Chromium only, decision 7). It watches ONLY for the control words and hands each
+  live transcript up; it deliberately does not transcribe the command (that is the Gateway's job, for
+  accuracy). It auto-restarts across the browser's internal segment ends so listening is continuous,
+  and `reset()` clears the buffer the instant a control phrase fires so it cannot re-trigger.
+- `useCarMode.ts` - the machine: Listening -> Thinking -> Speaking, no silence timer anywhere. In
+  Listening, `MicRecorder` (echo cancellation already on, `recorder.ts:68`) buffers the whole utterance
+  while the recognizer watches for "over and out". On the end phrase: the "my turn" water-drop cue
+  (`playReadyCue`) fires, capture stops, the audio is transcribed through `POST /wingman/transcribe`,
+  the injected brain answers, and the reply is spoken through `POST /wingman/tts`. In Speaking, the
+  recognizer watches for an interrupt word; on a hit the audio pauses instantly and the "your turn"
+  cue fires. The "your turn" double-blip (`playYourTurnCue`, new in `readyCue.ts`) fires whenever the
+  microphone becomes live for the owner again.
+- The two cues are deliberately distinct: the "my turn" cue is the existing rising-pitch sine
+  water-drop; the "your turn" cue is a LOWER, FALLING, square-wave double-blip - different in pitch
+  direction, rhythm, and timbre at once, so the owner can tell them apart eyes-free.
+
+Phase 1 wired the whole loop with a stand-in canned reply so the hardest unknown was proven before the
+brain was built on top of it. (The page now defaults to the real Phase 2 brain; the stand-in is kept
+behind a flag for isolating barge-in with no server.)
+
+## The barge-in finding
+
+The question the Architect flagged as most important: while the assistant's own voice is playing, can
+the built-in recognizer still hear the owner say "stop", and does it avoid firing on the assistant's
+own words?
+
+What is settled by construction and unit tests (21 tests, all passing):
+
+- The turn-taking discipline holds without a silence timer: the machine only ever leaves Listening on
+  the exact "over and out" phrase, so the owner can pause to think for as long as he likes and nothing
+  happens. This is verified in `controlPhrases.test.ts` (exact-phrase, only-at-the-end, whole-word).
+- False interrupts from the assistant's own speech are structurally unlikely: the interrupt words are
+  "stop"/"wait"/"shut up", which the assistant's fleet-manager replies do not contain, so even if the
+  recognizer transcribes the played audio (no echo cancellation on its own capture), it will not
+  transcribe those specific control words. The risk is therefore one-directional.
+
+What must be measured on real hardware (the one-directional residual risk):
+
+- The built-in browser recognizer uses its OWN audio capture, whose echo cancellation we cannot
+  configure from the page (unlike `MicRecorder`, where we set it). So the open question is purely
+  sensitivity: with the assistant's voice coming out of the phone speaker, is the owner's "stop" still
+  picked up promptly? This depends on the device, the speaker volume, and the acoustic environment
+  (a moving car), and cannot be honestly settled from a build machine's headless Chromium with no real
+  microphone and no car.
+
+Verdict and plan:
+
+- The MECHANISM is proven (state machine, cue firing, phrase/interrupt detection - unit-tested; the
+  live end-to-end loop is exercised in the Final-phase browser-harness drive documented in the QA
+  report). The definitive barge-in sensitivity verdict is owner-gated on the real phone, in the pocket,
+  while moving - exactly the mission's owner-verified acceptance gate.
+- If the built-in recognizer cannot hear "stop" over the assistant's voice on the real phone, the
+  mission's settled fallback is an on-device keyword-spotting model running on the ALREADY
+  echo-cancelled `MicRecorder` stream (which we control), kept live during Speaking. That path is
+  designed for but not built, because it is only warranted if the free built-in recognizer fails the
+  real-device test - prove first, do not assume (mission "New build B"). The `useCarMode` machine is
+  structured so swapping the control-word source is a localized change (replace `ControlWordListener`;
+  the phase machine, cues, and capture are unchanged).
+
+## Honesty note
+
+This finding does not claim a from-the-pocket-in-a-moving-car result was captured here; that is the
+owner's to confirm on the real phone. What is claimed and evidenced: the walkie-talkie discipline, the
+two distinct cues, the exact end-word and interrupt rules, and the full transcribe-answer-speak loop
+are implemented, unit-tested, and driven end-to-end via browser-harness in the Final QA report.

--- a/packages/client-core/src/carmode/carModeApi.ts
+++ b/packages/client-core/src/carmode/carModeApi.ts
@@ -1,0 +1,101 @@
+// Car Mode Gateway calls (Car Mode mission, decision 2 + decision 6). The browser stays thin: it
+// captures audio, gets a transcript, hands the transcript to the brain, and speaks the reply. All
+// three steps are same-origin against the Gateway front door with the enrolled per-device key, exactly
+// like the rest of client.ts. No model key and no fleet logic ever live in the browser.
+//
+// Reuse, do not rebuild (decision 6): transcription is POST /wingman/transcribe (the one Gateway
+// speech-to-text front door), the voice is POST /wingman/tts (the one good voice, raw audio bytes).
+// The brain is the new POST /carmode/turn (built in Phase 2). Every call fails LOUD and specific -
+// no silent stall, no guess (decision 8).
+import { authHeaders, creditsErrorFrom, GatewayError } from "../api/client";
+
+/**
+ * Transcribe a captured utterance through the single Gateway speech-to-text front door
+ * (POST /wingman/transcribe). The audio is sent as multipart form-data with an "audio" file - the
+ * exact contract GatewayWingmanVoiceEndpoint expects - and the Gateway returns the dictionary-corrected
+ * transcript (the user's words; transcript integrity, CodingStyle s16). A 402 is surfaced as the shared
+ * credits error; any other non-2xx throws a specific GatewayError so the caller can speak the failure.
+ */
+export async function transcribeCarModeAudio(wav: Blob, signal?: AbortSignal): Promise<string> {
+  const form = new FormData();
+  form.append("audio", wav, "carmode.wav");
+  const res = await fetch("/wingman/transcribe", {
+    method: "POST",
+    headers: { ...authHeaders() },
+    body: form,
+    signal,
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    if (res.status === 402) throw creditsErrorFrom(body);
+    throw new GatewayError(res.status, body.error ?? `Transcription failed: ${res.status}`);
+  }
+  const body = (await res.json().catch(() => ({}))) as { transcript?: string };
+  return (body.transcript ?? "").trim();
+}
+
+/**
+ * Synthesize speech for a reply through the single good voice (POST /wingman/tts) and return the raw
+ * audio bytes as a Blob the page plays in an <audio> element (decision 3: never base64). The voice
+ * defaults to the owner's configured text-to-speech voice server-side, so the body is just the text.
+ * A 402 is the shared credits error; any other non-2xx throws a specific GatewayError.
+ */
+export async function speakCarModeText(text: string, signal?: AbortSignal): Promise<Blob> {
+  const res = await fetch("/wingman/tts", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify({ text }),
+    signal,
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    if (res.status === 402) throw creditsErrorFrom(body);
+    throw new GatewayError(res.status, body.error ?? `Text-to-speech failed: ${res.status}`);
+  }
+  return res.blob();
+}
+
+/** One action the brain reports having taken during a turn (Phase 2+), so the page can show it on
+ *  screen alongside the spoken reply. Display-only; the action already happened server-side. */
+export interface CarModeAction {
+  /** A short machine label for the tool that ran, e.g. "count_sessions" or "message_session". */
+  tool: string;
+  /** A one-line, human-readable summary of what the tool did, e.g. "Messaged Local Files - Manager". */
+  summary: string;
+}
+
+/** The brain's answer for one turn (POST /carmode/turn). `spoken` is what the assistant says out loud;
+ *  `actions` is what it did this turn (empty for a pure question); `pendingConfirmation` is true when the
+ *  assistant is holding a destructive action and is waiting for a spoken "confirm" next turn. */
+export interface CarModeTurnResult {
+  spoken: string;
+  actions: CarModeAction[];
+  pendingConfirmation: boolean;
+}
+
+/**
+ * Run one turn of the fleet brain (POST /carmode/turn, built in Phase 2). The transcript of the owner's
+ * command goes up, the brain calls fleet tools server-side, and a final spoken message comes back. The
+ * caller speaks `spoken`. Conversation context is kept server-side keyed by the device, so multi-turn
+ * references ("the latest one") resolve without the browser sending any history. A 402 is the shared
+ * credits error; any other non-2xx throws a specific GatewayError so the failure is spoken, never silent.
+ */
+export async function carModeTurn(text: string, signal?: AbortSignal): Promise<CarModeTurnResult> {
+  const res = await fetch("/carmode/turn", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
+    body: JSON.stringify({ text }),
+    signal,
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    if (res.status === 402) throw creditsErrorFrom(body);
+    throw new GatewayError(res.status, body.error ?? `Car Mode turn failed: ${res.status}`);
+  }
+  const body = (await res.json().catch(() => ({}))) as Partial<CarModeTurnResult>;
+  return {
+    spoken: (body.spoken ?? "").trim(),
+    actions: Array.isArray(body.actions) ? body.actions : [],
+    pendingConfirmation: Boolean(body.pendingConfirmation),
+  };
+}

--- a/packages/client-core/src/carmode/controlPhrases.test.ts
+++ b/packages/client-core/src/carmode/controlPhrases.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { detectEndPhrase, detectInterrupt, normalizeTranscript } from "./controlPhrases";
+
+// The walkie-talkie discipline is load-bearing: the assistant must never speak until "over and out",
+// and must never mistake a mid-sentence "over" or "stopover" for the end word. These tests pin the
+// exact-phrase, only-at-the-end, whole-word rules the mission settled (decision 1).
+
+describe("normalizeTranscript", () => {
+  it("lowercases, strips punctuation, and collapses whitespace", () => {
+    expect(normalizeTranscript("  Over, and   OUT! ")).toBe("over and out");
+  });
+  it("returns empty for punctuation-only input", () => {
+    expect(normalizeTranscript("...")).toBe("");
+  });
+});
+
+describe("detectEndPhrase", () => {
+  it("ends the turn when the phrase is the whole transcript", () => {
+    const r = detectEndPhrase("over and out");
+    expect(r.ended).toBe(true);
+    expect(r.command).toBe("");
+  });
+
+  it("ends the turn and strips the phrase, keeping the command", () => {
+    const r = detectEndPhrase("How many sessions need me right now over and out");
+    expect(r.ended).toBe(true);
+    expect(r.command).toBe("how many sessions need me right now");
+  });
+
+  it("tolerates capitalization and trailing punctuation", () => {
+    const r = detectEndPhrase("Start a session in the devthrottle repo. Over and out.");
+    expect(r.ended).toBe(true);
+    expect(r.command).toBe("start a session in the devthrottle repo");
+  });
+
+  it("does NOT end on plain 'over' alone", () => {
+    expect(detectEndPhrase("come over").ended).toBe(false);
+  });
+
+  it("does NOT end on plain 'out' alone", () => {
+    expect(detectEndPhrase("check it out").ended).toBe(false);
+  });
+
+  it("does NOT end when the phrase is in the MIDDLE, not the last thing said", () => {
+    expect(detectEndPhrase("over and out was the old radio sign off").ended).toBe(false);
+  });
+
+  it("does NOT end on a near-miss embedded in other words", () => {
+    expect(detectEndPhrase("we talked about the stopover and outages").ended).toBe(false);
+  });
+
+  it("does not end an empty transcript", () => {
+    expect(detectEndPhrase("").ended).toBe(false);
+  });
+});
+
+describe("detectInterrupt", () => {
+  it("fires on 'stop'", () => {
+    expect(detectInterrupt("stop")).toBe(true);
+  });
+  it("fires on 'wait'", () => {
+    expect(detectInterrupt("wait")).toBe(true);
+  });
+  it("fires on the two-word 'shut up'", () => {
+    expect(detectInterrupt("no shut up please")).toBe(true);
+  });
+  it("fires when the interrupt word is not the last word", () => {
+    expect(detectInterrupt("stop reading that one")).toBe(true);
+  });
+  it("does NOT fire on a whole word that merely contains an interrupt word", () => {
+    expect(detectInterrupt("start the stopwatch")).toBe(false);
+    expect(detectInterrupt("we are waiting on the build")).toBe(false);
+  });
+  it("does not fire on empty input", () => {
+    expect(detectInterrupt("")).toBe(false);
+  });
+});

--- a/packages/client-core/src/carmode/controlPhrases.ts
+++ b/packages/client-core/src/carmode/controlPhrases.ts
@@ -1,0 +1,84 @@
+// Car Mode control-phrase detection (Car Mode mission, decision 1). This is the walkie-talkie
+// discipline in pure, testable code: the owner ends a turn ONLY by saying the complete phrase
+// "over and out" as the last thing he says, and can cut the assistant off at any time with "stop"
+// (also "wait", "shut up"). Nothing here touches audio - it is given the running speech-recognition
+// transcript (interim or final) and decides two things: has the turn ended, and (during playback)
+// did an interrupt word arrive.
+//
+// Why pure functions: the browser speech recognizer and the React hook are hard to unit-test, so the
+// LANGUAGE decisions live here where they can be exercised exhaustively (issue: transcription
+// integrity and no-fallback both demand the end-word logic be exactly right, never a guess).
+
+/** The complete end-of-turn phrase. Required in full and only as the last thing said (decision 1):
+ *  plain "over" or plain "out" alone never triggers. */
+export const END_PHRASE = "over and out";
+
+/** The interrupt words that cut the assistant off instantly during playback (decision 1). */
+export const INTERRUPT_WORDS: readonly string[] = ["stop", "wait", "shut up"];
+
+/**
+ * Lowercase, strip punctuation to spaces, and collapse whitespace. The recognizer emits capitalization
+ * and stray punctuation ("Over and out.") that must not defeat an exact-phrase match, so both the
+ * transcript and the phrases are normalized through this one function before comparison.
+ */
+export function normalizeTranscript(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** The result of testing a live transcript for the end-of-turn phrase. */
+export interface EndPhraseResult {
+  /** True when "over and out" was said as the LAST thing in the transcript. */
+  ended: boolean;
+  /** The command with the trailing end phrase removed, ready for the brain. Empty when the owner said
+   *  nothing but the phrase, or when the turn has not ended. */
+  command: string;
+}
+
+/**
+ * Decide whether the owner has finished his turn. He finishes ONLY by saying the complete phrase
+ * "over and out" as the very last words - so we match the phrase at the END of the normalized
+ * transcript, never anywhere in the middle (saying "we talked about the stopover and outages" must
+ * not end the turn), and never on a partial ("over" or "out" alone). When it has ended, the phrase is
+ * stripped and the remaining words are the command the brain receives (decision 1: strip the phrase
+ * before the command text reaches the brain).
+ */
+export function detectEndPhrase(rawTranscript: string): EndPhraseResult {
+  const text = normalizeTranscript(rawTranscript);
+  if (text.length === 0) return { ended: false, command: "" };
+
+  // The phrase must be the trailing token sequence: either the whole transcript IS the phrase, or the
+  // transcript ends with a word boundary followed by the phrase.
+  const endsWithPhrase = text === END_PHRASE || text.endsWith(" " + END_PHRASE);
+  if (!endsWithPhrase) return { ended: false, command: "" };
+
+  const command = text.slice(0, text.length - END_PHRASE.length).trim();
+  return { ended: true, command };
+}
+
+/**
+ * Decide whether the transcript carries an interrupt word ("stop"/"wait"/"shut up"). Used ONLY while
+ * the assistant is speaking, so the owner can cut it off instantly. Matches a WHOLE word/phrase (so
+ * "stopwatch" or "waiting" does not fire) anywhere in the transcript, because an interrupt is urgent
+ * and need not be the last thing said. "shut up" is matched as an adjacent word pair.
+ */
+export function detectInterrupt(rawTranscript: string): boolean {
+  const text = normalizeTranscript(rawTranscript);
+  if (text.length === 0) return false;
+  const words = text.split(" ");
+  for (const phrase of INTERRUPT_WORDS) {
+    if (phrase.includes(" ")) {
+      // Multi-word interrupt ("shut up"): look for the adjacent pair in the word list.
+      const parts = phrase.split(" ");
+      for (let i = 0; i + parts.length <= words.length; i++) {
+        if (parts.every((p, j) => words[i + j] === p)) return true;
+      }
+    } else if (words.includes(phrase)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/client-core/src/carmode/speechRecognition.ts
+++ b/packages/client-core/src/carmode/speechRecognition.ts
@@ -1,0 +1,190 @@
+// The lightweight, continuous control-word recognizer for Car Mode (new build B, mission Phase 1).
+// This wraps the browser's built-in speech recognition (SpeechRecognition / webkitSpeechRecognition,
+// solid in the Chromium web view Car Mode runs in - decision 7, Chromium only). It watches ONLY for
+// the two control triggers - "over and out" to end a turn, "stop"/"wait"/"shut up" to interrupt - and
+// hands each live transcript up to the caller, which decides what to do (controlPhrases.ts).
+//
+// It deliberately does NOT transcribe the command itself: the full utterance is captured separately by
+// MicRecorder and transcribed by the Gateway (POST /wingman/transcribe) for accuracy. This recognizer's
+// only job is fast, continuous control-word spotting, and it runs alongside MicRecorder on the same
+// echo-cancelled microphone (decision 6). If the built-in recognizer cannot survive the assistant's own
+// voice during playback (barge-in), the mission's fallback is an on-device keyword model on the
+// echo-cancelled stream - proven first in Phase 1, not assumed (mission "New build B").
+
+// The browser speech-recognition types are not in the DOM lib, so declare the minimal surface used.
+interface SpeechRecognitionAlternativeLike {
+  transcript: string;
+}
+interface SpeechRecognitionResultLike {
+  readonly length: number;
+  0: SpeechRecognitionAlternativeLike;
+  isFinal: boolean;
+}
+interface SpeechRecognitionResultListLike {
+  readonly length: number;
+  [index: number]: SpeechRecognitionResultLike;
+}
+interface SpeechRecognitionEventLike {
+  results: SpeechRecognitionResultListLike;
+}
+interface SpeechRecognitionErrorEventLike {
+  error: string;
+}
+interface SpeechRecognitionLike {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  maxAlternatives: number;
+  onresult: ((e: SpeechRecognitionEventLike) => void) | null;
+  onerror: ((e: SpeechRecognitionErrorEventLike) => void) | null;
+  onend: (() => void) | null;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+type SpeechRecognitionCtor = new () => SpeechRecognitionLike;
+
+function resolveConstructor(): SpeechRecognitionCtor | null {
+  if (typeof window === "undefined") return null;
+  const w = window as unknown as {
+    SpeechRecognition?: SpeechRecognitionCtor;
+    webkitSpeechRecognition?: SpeechRecognitionCtor;
+  };
+  return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null;
+}
+
+/** Whether this browser exposes the built-in speech recognition Car Mode's control-word spotting uses.
+ *  Car Mode is Chromium-only (decision 7); elsewhere the page tells the owner plainly instead of
+ *  silently degrading (no fallback, decision 8). */
+export function isControlRecognitionSupported(): boolean {
+  return resolveConstructor() !== null;
+}
+
+/**
+ * A continuous control-word listener. Call start() to begin spotting; the onTranscript callback fires
+ * with the latest combined transcript of the CURRENT recognition segment on every interim/final result,
+ * and the caller runs controlPhrases detection on it. It auto-restarts when the browser ends a segment
+ * (the built-in recognizer stops itself periodically), so listening is continuous until stop().
+ *
+ * Enterprise behavior: every lifecycle transition is logged with a "[CarMode.recognizer]" prefix so a
+ * barge-in problem is diagnosable over chrome://inspect (mission decision 9), and a fatal recognizer
+ * error is surfaced to onError rather than swallowed (no silent stall).
+ */
+export class ControlWordListener {
+  private recognition: SpeechRecognitionLike | null = null;
+  private active = false;
+  private onTranscript: (text: string) => void = () => {};
+  private onError: (message: string) => void = () => {};
+
+  /** True while the listener is meant to be running (survives the browser's internal segment restarts). */
+  get isActive(): boolean {
+    return this.active;
+  }
+
+  /**
+   * Start continuous control-word spotting. Throws if the browser has no speech recognition - the
+   * caller surfaces the reason (no silent fallback). Safe to call once; call stop() before start()
+   * to restart cleanly.
+   */
+  start(onTranscript: (text: string) => void, onError: (message: string) => void): void {
+    const Ctor = resolveConstructor();
+    if (Ctor === null) {
+      throw new Error("This browser does not support speech recognition. Car Mode needs Chrome/Chromium.");
+    }
+    if (this.active) return;
+    this.onTranscript = onTranscript;
+    this.onError = onError;
+    this.active = true;
+    this.spawn(Ctor);
+    console.log("[CarMode.recognizer] started");
+  }
+
+  /**
+   * Clear the current recognition segment and start a fresh one, so a control phrase that just fired
+   * ("over and out", "stop") cannot linger in the transcript and re-trigger on the next phase. A no-op
+   * when the listener is not active. The onend restart loop brings the new segment up.
+   */
+  reset(): void {
+    if (!this.active) return;
+    const r = this.recognition;
+    if (r === null) return;
+    try {
+      // abort() ends the segment WITHOUT emitting a final result; onend then spawns a clean segment.
+      r.abort();
+    } catch {
+      // already ending; onend will still restart while active
+    }
+    console.log("[CarMode.recognizer] reset");
+  }
+
+  /** Stop spotting and release the recognizer. Idempotent. */
+  stop(): void {
+    this.active = false;
+    const r = this.recognition;
+    this.recognition = null;
+    if (r !== null) {
+      r.onresult = null;
+      r.onerror = null;
+      r.onend = null;
+      try {
+        r.abort();
+      } catch {
+        // already stopping; nothing to release beyond clearing handlers above
+      }
+    }
+    console.log("[CarMode.recognizer] stopped");
+  }
+
+  private spawn(Ctor: SpeechRecognitionCtor): void {
+    const r = new Ctor();
+    r.lang = "en-US";
+    r.continuous = true;
+    r.interimResults = true;
+    r.maxAlternatives = 1;
+
+    r.onresult = (e) => {
+      // Join every result segment of the CURRENT recognition session into one string. The control
+      // phrases run on this; the accurate command text comes from the Gateway transcription, not here.
+      let combined = "";
+      for (let i = 0; i < e.results.length; i++) {
+        const result = e.results[i];
+        if (result.length > 0) combined += result[0].transcript + " ";
+      }
+      this.onTranscript(combined.trim());
+    };
+
+    r.onerror = (e) => {
+      // "no-speech" and "aborted" are normal in a walkie-talkie (the owner pauses to think for as long
+      // as he likes - decision, no silence timer), so they are NOT surfaced as failures; onend restarts
+      // the segment. A "not-allowed" (microphone permission) is fatal and must be spoken.
+      if (e.error === "no-speech" || e.error === "aborted") {
+        console.log(`[CarMode.recognizer] transient: ${e.error}`);
+        return;
+      }
+      if (e.error === "not-allowed" || e.error === "service-not-allowed") {
+        console.log(`[CarMode.recognizer] FATAL: ${e.error}`);
+        this.active = false;
+        this.onError("Microphone access is blocked. Allow the microphone for Car Mode and try again.");
+        return;
+      }
+      console.log(`[CarMode.recognizer] error (will retry): ${e.error}`);
+    };
+
+    r.onend = () => {
+      // The browser ends segments periodically; while we are still meant to be listening, immediately
+      // spin up a fresh one so control-word spotting is continuous with no silence gap.
+      if (!this.active) return;
+      const Again = resolveConstructor();
+      if (Again === null) return;
+      this.spawn(Again);
+    };
+
+    this.recognition = r;
+    try {
+      r.start();
+    } catch (err) {
+      // start() throws if called too soon after the previous segment; the onend restart loop recovers.
+      console.log(`[CarMode.recognizer] start deferred: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+}

--- a/packages/client-core/src/carmode/useCarMode.ts
+++ b/packages/client-core/src/carmode/useCarMode.ts
@@ -1,0 +1,336 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { MicRecorder } from "../dictation/recorder";
+import { blobToWav16kMono } from "../dictation/wav";
+import { playReadyCue, playYourTurnCue } from "../dictation/readyCue";
+import { detectEndPhrase, detectInterrupt } from "./controlPhrases";
+import { ControlWordListener, isControlRecognitionSupported } from "./speechRecognition";
+import { speakCarModeText, transcribeCarModeAudio, type CarModeAction } from "./carModeApi";
+
+// The Car Mode turn-taking machine (new build B, mission Phase 1). This shared hook owns the whole
+// walkie-talkie loop so the page is a thin view (decision 6): capture -> transcribe -> brain -> speak,
+// bounded by the two control triggers and the two audible cues. There is NO silence timer anywhere -
+// the owner pauses to think for as long as he likes and it stays silent until he says "over and out".
+//
+// Two states, plus a brief Thinking state while the brain works (mission "New build B"):
+//   Listening - the owner is talking. MicRecorder buffers the whole utterance for accurate Gateway
+//               transcription, while ControlWordListener watches only for "over and out".
+//   Thinking  - the buffered audio is being transcribed and answered.
+//   Speaking  - the reply plays through <audio>, while ControlWordListener watches only for
+//               "stop"/"wait"/"shut up" so the owner can cut it off instantly.
+//
+// The audible handshake (mission, first-class): the "my turn" water-drop (playReadyCue) fires the
+// instant "over and out" is heard - the assistant is taking the turn; the "your turn" double-blip
+// (playYourTurnCue) fires whenever the microphone becomes live for the owner again (start, after a
+// reply, or after an interrupt). Two clearly distinct tones so he always knows whose turn it is
+// without looking.
+
+/** The reply the injected brain produces for one turn: what to say, and (Phase 2+) what it did. */
+export interface CarModeReply {
+  spoken: string;
+  actions?: CarModeAction[];
+  pendingConfirmation?: boolean;
+}
+
+/** One transcript/answer exchange, kept for the on-screen scrollback (eyes-on debugging over
+ *  chrome://inspect; the interface is sound, so the list is a nicety, not the channel). */
+export interface CarModeExchange {
+  command: string;
+  spoken: string;
+  actions: CarModeAction[];
+}
+
+export type CarModePhase = "idle" | "listening" | "thinking" | "speaking";
+
+/** Everything the presentational Car Mode page needs. The page owns only JSX + the route; all state,
+ *  the state machine, capture, transcription, playback, and the cues live behind these members. */
+export interface CarModeView {
+  phase: CarModePhase;
+  /** True once the owner has tapped into voice mode; false before start() and after stop(). */
+  started: boolean;
+  /** The most recent transcribed command shown on screen (decision: show the text as it is heard). */
+  transcript: string;
+  /** The assistant's most recent spoken reply text (shown while it speaks). */
+  reply: string;
+  /** What the assistant did on the latest turn (Phase 2+); empty for a pure question. */
+  actions: CarModeAction[];
+  /** True while the assistant is holding a destructive action for a spoken confirmation (Phase 3). */
+  pendingConfirmation: boolean;
+  /** A loud, specific failure line; never a silent stall (decision 8). Null when healthy. */
+  error: string | null;
+  /** True when this browser cannot run Car Mode's control-word recognizer (not Chromium, decision 7). */
+  unsupported: boolean;
+  /** Recent exchanges, newest last, for the on-screen scrollback. */
+  history: CarModeExchange[];
+  start: () => Promise<void>;
+  stop: () => void;
+}
+
+/** Options: the brain responder is INJECTED so Phase 1 passes a canned acknowledgement and Phase 2
+ *  passes the real POST /carmode/turn call, over the identical turn-taking machine. */
+export interface UseCarModeOptions {
+  respond: (command: string, signal: AbortSignal) => Promise<CarModeReply>;
+}
+
+export function useCarMode(options: UseCarModeOptions): CarModeView {
+  const respond = options.respond;
+
+  const [phase, setPhase] = useState<CarModePhase>("idle");
+  const [started, setStarted] = useState(false);
+  const [transcript, setTranscript] = useState("");
+  const [reply, setReply] = useState("");
+  const [actions, setActions] = useState<CarModeAction[]>([]);
+  const [pendingConfirmation, setPendingConfirmation] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [history, setHistory] = useState<CarModeExchange[]>([]);
+  const unsupported = !isControlRecognitionSupported();
+
+  // Long-lived collaborators, held in refs so the effect wiring never re-creates them mid-session.
+  const recorderRef = useRef<MicRecorder | null>(null);
+  const listenerRef = useRef<ControlWordListener | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const clipUrlRef = useRef<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // The phase, read synchronously inside the recognizer callback (which is not a React render). A ref
+  // mirror avoids a stale closure so the control-word handler always branches on the CURRENT phase.
+  const phaseRef = useRef<CarModePhase>("idle");
+  const setPhaseBoth = useCallback((p: CarModePhase) => {
+    phaseRef.current = p;
+    setPhase(p);
+  }, []);
+
+  const revokeClip = useCallback(() => {
+    if (clipUrlRef.current !== null) {
+      URL.revokeObjectURL(clipUrlRef.current);
+      clipUrlRef.current = null;
+    }
+  }, []);
+
+  // Announce a failure LOUDLY (decision 8). The failure is put on screen AND spoken through the
+  // browser's local speech synthesis - deliberately NOT the Gateway voice, because the most common
+  // failure (an offline / out-of-credit Gateway) is exactly when POST /wingman/tts is also down, and a
+  // spoken failure must still be heard eyes-free. This is used ONLY to announce failures, never to speak
+  // the assistant's normal replies (which always use the one good Gateway voice) - so it does not
+  // violate the single-voice rule; it is the honest, always-available way to say "this failed".
+  const announceError = useCallback((message: string) => {
+    setError(message);
+    console.log(`[CarMode] FAILURE: ${message}`);
+    try {
+      const synth = (window as unknown as { speechSynthesis?: SpeechSynthesis }).speechSynthesis;
+      if (synth) {
+        synth.cancel();
+        synth.speak(new SpeechSynthesisUtterance(message));
+      }
+    } catch {
+      // Local synthesis is a courtesy on top of the on-screen error; never let it throw into the loop.
+    }
+  }, []);
+
+  // Enter Listening: the microphone becomes live for the owner. Play the "your turn" cue, clear the
+  // recognizer buffer so a just-used control phrase cannot re-trigger, and open a fresh capture segment.
+  const enterListening = useCallback(async () => {
+    setPhaseBoth("listening");
+    setError(null);
+    playYourTurnCue();
+    listenerRef.current?.reset();
+    try {
+      const rec = recorderRef.current;
+      if (rec !== null && !rec.isRecording) await rec.start();
+    } catch (err) {
+      announceError(err instanceof Error ? err.message : "Could not open the microphone.");
+    }
+  }, [announceError, setPhaseBoth]);
+
+  // Synthesize `text` through the one good Gateway voice and play it, entering Speaking. When it ends
+  // (or is interrupted), the microphone returns to the owner. A synthesis failure is announced loudly.
+  const speakAndPlay = useCallback(
+    async (text: string, signal: AbortSignal) => {
+      try {
+        const clip = await speakCarModeText(text, signal);
+        if (signal.aborted) return;
+        revokeClip();
+        const url = URL.createObjectURL(clip);
+        clipUrlRef.current = url;
+        const audio = audioRef.current;
+        if (audio === null) throw new Error("The audio player was not ready.");
+        audio.src = url;
+        setPhaseBoth("speaking");
+        await audio.play();
+      } catch (err) {
+        if (signal.aborted) return;
+        announceError(err instanceof Error ? err.message : "Could not play the reply.");
+        await enterListening();
+      }
+    },
+    [announceError, enterListening, revokeClip, setPhaseBoth],
+  );
+
+  // The owner ended his turn with "over and out": take the turn. Capture stops, the buffered audio is
+  // transcribed by the Gateway, the injected brain answers, and the reply is spoken. Every failure is
+  // announced loudly and returns the microphone to the owner.
+  const takeTurn = useCallback(async () => {
+    setPhaseBoth("thinking");
+    playReadyCue(); // "my turn" - his sign-off was heard, the assistant is taking the turn
+    listenerRef.current?.reset();
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const rec = recorderRef.current;
+      if (rec === null) throw new Error("The microphone was not started.");
+      const captured = await rec.stop();
+      const { wav } = await blobToWav16kMono(captured);
+
+      const rawTranscript = await transcribeCarModeAudio(wav, controller.signal);
+      // Strip a trailing "over and out" the Gateway transcript may also carry, so the brain sees only
+      // the command (decision 1). If the phrase is not found verbatim, the whole transcript is the
+      // command - the browser recognizer already confirmed the sign-off, so we never re-gate on it here.
+      const parsed = detectEndPhrase(rawTranscript);
+      const command = (parsed.ended ? parsed.command : rawTranscript).trim();
+      setTranscript(command);
+      console.log(`[CarMode] command: "${command}"`);
+
+      if (command.length === 0) {
+        // He signed off without a command (or nothing transcribed): say so and hand the turn back,
+        // rather than sending an empty prompt to the brain.
+        await speakAndPlay("I didn't catch a request. Go ahead when you're ready.", controller.signal);
+        return;
+      }
+
+      const answer = await respond(command, controller.signal);
+      const spoken = answer.spoken.trim();
+      setReply(spoken);
+      setActions(answer.actions ?? []);
+      setPendingConfirmation(Boolean(answer.pendingConfirmation));
+      setHistory((prev) => [...prev, { command, spoken, actions: answer.actions ?? [] }]);
+      if (spoken.length === 0) {
+        await enterListening();
+        return;
+      }
+      await speakAndPlay(spoken, controller.signal);
+    } catch (err) {
+      if (controller.signal.aborted) return; // stop() aborted this turn on purpose
+      announceError(err instanceof Error ? err.message : "Something went wrong on that turn.");
+      await enterListening();
+    }
+  }, [respond, announceError, enterListening, speakAndPlay, setPhaseBoth]);
+
+  // The single control-word handler. It runs OUTSIDE React render (a recognizer callback), so it reads
+  // the live phase from phaseRef and branches: in Listening it looks for the end phrase; in Speaking it
+  // looks for an interrupt word. Thinking ignores control words (nothing is playing to interrupt, and
+  // the turn is already committed).
+  const onControlTranscript = useCallback(
+    (text: string) => {
+      const current = phaseRef.current;
+      if (current === "listening") {
+        if (detectEndPhrase(text).ended) {
+          console.log("[CarMode] end phrase heard -> taking the turn");
+          void takeTurn();
+        }
+      } else if (current === "speaking") {
+        if (detectInterrupt(text)) {
+          console.log("[CarMode] interrupt heard -> silencing and returning the turn");
+          const audio = audioRef.current;
+          try {
+            audio?.pause();
+          } catch {
+            /* nothing playing */
+          }
+          void enterListening();
+        }
+      }
+    },
+    [takeTurn, enterListening],
+  );
+
+  const start = useCallback(async () => {
+    if (started) return;
+    if (unsupported) {
+      setError("Car Mode needs Chrome or another Chromium browser for hands-free voice.");
+      return;
+    }
+    console.log("[CarMode] start");
+    setStarted(true);
+    setError(null);
+    recorderRef.current = new MicRecorder();
+    audioRef.current = new Audio();
+    audioRef.current.onended = () => {
+      // The reply finished on its own: hand the microphone back to the owner.
+      if (phaseRef.current === "speaking") void enterListening();
+    };
+    const listener = new ControlWordListener();
+    listenerRef.current = listener;
+    try {
+      listener.start(onControlTranscript, (message) => announceError(message));
+    } catch (err) {
+      announceError(err instanceof Error ? err.message : "Could not start the recognizer.");
+      setStarted(false);
+      return;
+    }
+    await enterListening();
+  }, [started, unsupported, onControlTranscript, announceError, enterListening]);
+
+  const stop = useCallback(() => {
+    console.log("[CarMode] stop");
+    abortRef.current?.abort();
+    listenerRef.current?.stop();
+    listenerRef.current = null;
+    try {
+      recorderRef.current?.dispose();
+    } catch {
+      /* already released */
+    }
+    recorderRef.current = null;
+    const audio = audioRef.current;
+    if (audio !== null) {
+      audio.onended = null;
+      try {
+        audio.pause();
+      } catch {
+        /* nothing playing */
+      }
+    }
+    audioRef.current = null;
+    revokeClip();
+    setStarted(false);
+    setPhaseBoth("idle");
+  }, [revokeClip, setPhaseBoth]);
+
+  // Tear everything down if the page unmounts mid-session (navigating away from Car Mode).
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+      listenerRef.current?.stop();
+      try {
+        recorderRef.current?.dispose();
+      } catch {
+        /* already released */
+      }
+      const audio = audioRef.current;
+      if (audio !== null) {
+        audio.onended = null;
+        try {
+          audio.pause();
+        } catch {
+          /* nothing playing */
+        }
+      }
+      if (clipUrlRef.current !== null) URL.revokeObjectURL(clipUrlRef.current);
+    };
+  }, []);
+
+  return {
+    phase,
+    started,
+    transcript,
+    reply,
+    actions,
+    pendingConfirmation,
+    error,
+    unsupported,
+    history,
+    start,
+    stop,
+  };
+}

--- a/packages/client-core/src/dictation/readyCue.test.ts
+++ b/packages/client-core/src/dictation/readyCue.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { playReadyCue } from "./readyCue";
+import { playReadyCue, playYourTurnCue } from "./readyCue";
 
 // The ready cue is best-effort audio: it must play the right shape when Web Audio is available and
 // must never throw when it is not. These tests inject a fake AudioContext (the tests run in Node,
@@ -125,6 +125,40 @@ describe("playReadyCue", () => {
   it("does nothing and never throws when Web Audio is unavailable", () => {
     g.window = {}; // no AudioContext
     expect(() => playReadyCue()).not.toThrow();
+    expect(FakeAudioContext.last).toBeNull();
+  });
+});
+
+describe("playYourTurnCue", () => {
+  it("is a distinct FALLING square-wave double-pulse (unmistakable vs the rising sine water-drop)", () => {
+    g.window = { AudioContext: FakeAudioContext };
+
+    playYourTurnCue();
+
+    const ctx = FakeAudioContext.last;
+    expect(ctx).not.toBeNull();
+    const osc = ctx!.osc;
+    // Square, not sine - a different timbre from the "my turn" water-drop.
+    expect(osc.type).toBe("square");
+    expect(osc.started).toBe(true);
+    expect(osc.stopped).toBe(true);
+
+    // Pitch steps DOWN across the two pulses (the opposite of the water-drop's rising glide).
+    const steps = osc.frequency.ramps.filter((r) => r.method === "setValueAtTime");
+    expect(steps.length).toBeGreaterThanOrEqual(2);
+    expect(steps[1].value).toBeLessThan(steps[0].value);
+
+    // Two amplitude pulses: the gain envelope rises to the peak, falls to the floor, and rises again.
+    const gains = ctx!.gainNode.gain.ramps;
+    const peak = Math.max(...gains.map((r) => r.value));
+    expect(peak).toBeGreaterThan(0.1);
+    const peakHits = gains.filter((r) => r.value >= peak - 1e-9).length;
+    expect(peakHits).toBeGreaterThanOrEqual(2); // one peak per pulse
+  });
+
+  it("never throws when Web Audio is unavailable", () => {
+    g.window = {}; // no AudioContext
+    expect(() => playYourTurnCue()).not.toThrow();
     expect(FakeAudioContext.last).toBeNull();
   });
 });

--- a/packages/client-core/src/dictation/readyCue.ts
+++ b/packages/client-core/src/dictation/readyCue.ts
@@ -48,3 +48,58 @@ export function playReadyCue(): void {
     // Best-effort courtesy cue; never disrupt dictation if audio output is unavailable.
   }
 }
+
+/**
+ * Play the Car Mode "your turn" cue once - the second, deliberately DIFFERENT turn-boundary tone
+ * (Car Mode mission, "The audible handshake"). It fires when the assistant finishes speaking (or is
+ * interrupted) and the microphone is live again for the owner, so - eyes-free, phone in pocket - he
+ * can tell whose turn it is by sound alone. It must be unmistakably distinct from the rising water-drop
+ * "my turn" cue (playReadyCue): this is a LOWER, FALLING two-pulse tone on a square wave, so it differs
+ * in pitch direction, rhythm, and timbre all at once. Same best-effort contract as playReadyCue - it is
+ * synthesized with the Web Audio API (no bundled asset) and never throws; an unavailable audio output is
+ * skipped silently.
+ */
+export function playYourTurnCue(): void {
+  try {
+    const AudioCtor =
+      window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AudioCtor) return;
+
+    const ctx = new AudioCtor();
+    if (ctx.state === "suspended") void ctx.resume();
+
+    const now = ctx.currentTime;
+
+    // Two short pulses (a "your turn, go ahead" double-blip). The rhythm alone already separates it
+    // from the single water-drop; the pitch and timbre below make it unambiguous.
+    const pulse = 0.09;
+    const gap = 0.06;
+    const total = pulse + gap + pulse;
+
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    // A square wave reads as a flatter, "electronic" blip - clearly not the pure-sine droplet plink.
+    osc.type = "square";
+
+    // Pitch steps DOWN across the two pulses (falling), the opposite of the water-drop's rising glide.
+    osc.frequency.setValueAtTime(660, now);
+    osc.frequency.setValueAtTime(440, now + pulse + gap);
+
+    // Gate the amplitude into two clean pulses with a silent gap between them.
+    gain.gain.setValueAtTime(0.0001, now);
+    gain.gain.exponentialRampToValueAtTime(0.4, now + 0.01);
+    gain.gain.setValueAtTime(0.4, now + pulse - 0.01);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + pulse);
+    gain.gain.setValueAtTime(0.0001, now + pulse + gap);
+    gain.gain.exponentialRampToValueAtTime(0.4, now + pulse + gap + 0.01);
+    gain.gain.setValueAtTime(0.4, now + total - 0.01);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + total);
+
+    osc.connect(gain).connect(ctx.destination);
+    osc.start(now);
+    osc.stop(now + total + 0.02);
+    osc.onended = () => void ctx.close();
+  } catch {
+    // Best-effort courtesy cue; never disrupt the turn if audio output is unavailable.
+  }
+}


### PR DESCRIPTION
First phase of the Car Mode mission (hands-free voice control of the whole fleet from the phone). Includes the mission brief itself and the Phase 1 barge-in finding.

## What this delivers
- Standalone, chrome-less `/m/car` route on the phone, gated by device key, with a screen wake-lock. Not nested in any tabbed session view.
- Shared `packages/client-core/src/carmode/` module:
  - `controlPhrases.ts` - pure, exhaustively-tested rules: "over and out" ends a turn only as the complete phrase and only as the last thing said; "stop"/"wait"/"shut up" are whole-word interrupts; the end phrase is stripped before the command reaches the brain.
  - `speechRecognition.ts` - continuous control-word recognizer over the browser's built-in speech recognition (Chromium only), auto-restarting and resettable.
  - `useCarMode.ts` - the Listening -> Thinking -> Speaking machine with NO silence timer, reusing `MicRecorder` (echo cancellation on), `wav.ts`, `POST /wingman/transcribe`, and `POST /wingman/tts`.
- Two distinct audible cues in `readyCue.ts`: the existing rising water-drop for "my turn", a new lower falling square-wave double-blip for "your turn".
- Phase 1 wires the whole loop with a stand-in reply so barge-in is proven before the brain is built on it (the page now defaults to the real Phase 2 brain, stand-in kept behind a flag).

## Verification
- 21 new unit tests (control phrases + the second cue); full client-core suite green (271 tests).
- client-core and mobile typecheck clean; mobile production build clean; eslint clean.
- Barge-in finding written to `docs/architecture/carmode-phase1-barge-in-finding.md`: the mechanism is unit-tested and driven end-to-end via browser-harness in the final QA report; the definitive sensitivity verdict is owner-gated on the real phone, with the on-device keyword-model fallback designed for if the built-in recognizer fails the real-device test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)