### PR TITLE
Car Mode Phase 2: the fleet tool-calling brain (read-only)

### DIFF
--- a/src/CcDirector.Gateway.Tests/CarModeBrainTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeBrainTests.cs
@@ -1,0 +1,276 @@
+using CcDirector.Gateway.CarMode;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The Car Mode brain (Car Mode mission, New build A) is a hand-rolled tool-calling loop. These tests
+/// drive the loop with a scripted fake chat and a fake fleet (no network, no model), proving it executes
+/// the tools the model calls, feeds the results back, returns the final spoken reply, keeps per-device
+/// context, and fails loud rather than looping forever - plus the fuzzy session resolver and the parse.
+/// </summary>
+public sealed class CarModeBrainTests
+{
+    /// <summary>A chat that returns pre-scripted assistant turns in order, and records the messages it saw.</summary>
+    private sealed class ScriptedChat : ICarModeChat
+    {
+        private readonly Queue<CarModeAssistantTurn> _turns;
+        public List<string> SeenMessages { get; } = new();
+        public ScriptedChat(params CarModeAssistantTurn[] turns) => _turns = new Queue<CarModeAssistantTurn>(turns);
+        public Task<CarModeAssistantTurn> CompleteAsync(string messagesJson, string toolsJson, CancellationToken ct)
+        {
+            SeenMessages.Add(messagesJson);
+            if (_turns.Count == 0) throw new InvalidOperationException("script exhausted");
+            return Task.FromResult(_turns.Dequeue());
+        }
+    }
+
+    private sealed class FakeFleet : ICarModeFleet
+    {
+        public int ListCalls;
+        public List<string> ActivityRefs { get; } = new();
+        public IReadOnlyList<CarModeSessionInfo> Sessions { get; set; } = new List<CarModeSessionInfo>();
+        public CarModeActivity? Activity { get; set; }
+        public Task<IReadOnlyList<CarModeSessionInfo>> ListSessionsAsync(CancellationToken ct)
+        {
+            ListCalls++;
+            return Task.FromResult(Sessions);
+        }
+        public Task<CarModeActivity?> GetSessionActivityAsync(string sessionReference, CancellationToken ct)
+        {
+            ActivityRefs.Add(sessionReference);
+            return Task.FromResult(Activity);
+        }
+    }
+
+    private static CarModeToolCall Call(string name, string args = "{}") => new("call_1", name, args);
+
+    private static CarModeSessionInfo Session(string name, bool needsYou) => new()
+    {
+        SessionId = Guid.NewGuid().ToString(),
+        Name = name,
+        Repo = "devthrottle",
+        MachineName = "SOREN_NORTH",
+        State = needsYou ? "Needs you" : "Working",
+        NeedsYou = needsYou,
+        Summary = needsYou ? "waiting for your answer" : "running the tests",
+    };
+
+    [Fact]
+    public async Task RunTurn_ModelCallsListTool_ThenAnswers_ExecutesToolAndReturnsSpoken()
+    {
+        var fleet = new FakeFleet { Sessions = new[] { Session("Local Files Manager", true), Session("Car Mode Worker", false) } };
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("list_sessions") }),
+            new CarModeAssistantTurn("One session needs you: Local Files Manager, in the devthrottle repo.", Array.Empty<CarModeToolCall>()));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), _ => { });
+
+        var result = await brain.RunTurnAsync("device-a", "how many need me over", CancellationToken.None);
+
+        Assert.Equal(1, fleet.ListCalls);
+        Assert.Contains("Local Files Manager", result.Spoken);
+        Assert.Empty(result.Actions); // a read produces no action record
+        // The second round's message list must carry the tool result back to the model.
+        Assert.Equal(2, chat.SeenMessages.Count);
+        Assert.Contains("needsYouCount", chat.SeenMessages[1]);
+    }
+
+    [Fact]
+    public async Task RunTurn_ModelCallsActivityTool_PassesReferenceThrough()
+    {
+        var fleet = new FakeFleet
+        {
+            Activity = new CarModeActivity
+            {
+                SessionId = "s1", Name = "Car Mode Manager", Repo = "devthrottle",
+                State = "Working", Summary = "building the fleet brain", NeedsYou = false,
+            },
+        };
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("get_session_activity", "{\"session\":\"car mode\"}") }),
+            new CarModeAssistantTurn("Car Mode Manager, in the devthrottle repo, is building the fleet brain.", Array.Empty<CarModeToolCall>()));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), _ => { });
+
+        var result = await brain.RunTurnAsync("device-a", "what is the car mode session doing", CancellationToken.None);
+
+        Assert.Single(fleet.ActivityRefs);
+        Assert.Equal("car mode", fleet.ActivityRefs[0]);
+        Assert.Contains("building the fleet brain", result.Spoken);
+    }
+
+    [Fact]
+    public async Task RunTurn_KeepsPerDeviceContext_AcrossTurns()
+    {
+        var fleet = new FakeFleet();
+        var store = new CarModeConversationStore();
+        var chat1 = new ScriptedChat(new CarModeAssistantTurn("Nothing needs you right now.", Array.Empty<CarModeToolCall>()));
+        var brain1 = new CarModeBrain(chat1, fleet, store, _ => { });
+        await brain1.RunTurnAsync("device-a", "who needs me", CancellationToken.None);
+
+        // The next turn on the SAME device must carry the prior exchange into the model's messages.
+        var chat2 = new ScriptedChat(new CarModeAssistantTurn("Still nothing.", Array.Empty<CarModeToolCall>()));
+        var brain2 = new CarModeBrain(chat2, fleet, store, _ => { });
+        await brain2.RunTurnAsync("device-a", "and now", CancellationToken.None);
+
+        Assert.Contains("who needs me", chat2.SeenMessages[0]);
+        Assert.Contains("Nothing needs you right now.", chat2.SeenMessages[0]);
+    }
+
+    [Fact]
+    public async Task RunTurn_ContextIsIsolatedPerDevice()
+    {
+        var fleet = new FakeFleet();
+        var store = new CarModeConversationStore();
+        var brainA = new CarModeBrain(new ScriptedChat(new CarModeAssistantTurn("A reply", Array.Empty<CarModeToolCall>())), fleet, store, _ => { });
+        await brainA.RunTurnAsync("device-a", "secret A question", CancellationToken.None);
+
+        var chatB = new ScriptedChat(new CarModeAssistantTurn("B reply", Array.Empty<CarModeToolCall>()));
+        var brainB = new CarModeBrain(chatB, fleet, store, _ => { });
+        await brainB.RunTurnAsync("device-b", "question B", CancellationToken.None);
+
+        Assert.DoesNotContain("secret A question", chatB.SeenMessages[0]);
+    }
+
+    [Fact]
+    public async Task RunTurn_EmptyText_Throws()
+    {
+        var brain = new CarModeBrain(new ScriptedChat(), new FakeFleet(), new CarModeConversationStore(), _ => { });
+        await Assert.ThrowsAsync<ArgumentException>(() => brain.RunTurnAsync("device-a", "   ", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task RunTurn_ModelLoopsToolsForever_HitsRoundCap_ReturnsLoudFailure()
+    {
+        var fleet = new FakeFleet { Sessions = Array.Empty<CarModeSessionInfo>() };
+        // Every round asks for a tool and never answers - the loop must stop and speak a failure.
+        var turns = Enumerable.Range(0, 10).Select(_ => new CarModeAssistantTurn(null, new[] { Call("list_sessions") })).ToArray();
+        var brain = new CarModeBrain(new ScriptedChat(turns), fleet, new CarModeConversationStore(), _ => { });
+
+        var result = await brain.RunTurnAsync("device-a", "who needs me", CancellationToken.None);
+
+        Assert.Contains("trouble", result.Spoken, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task RunTurn_EmptyFinalReply_Throws()
+    {
+        var brain = new CarModeBrain(
+            new ScriptedChat(new CarModeAssistantTurn("   ", Array.Empty<CarModeToolCall>())),
+            new FakeFleet(), new CarModeConversationStore(), _ => { });
+        await Assert.ThrowsAsync<InvalidOperationException>(() => brain.RunTurnAsync("device-a", "hi", CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData("{\"session\":\"devthrottle\"}", "session", "devthrottle")]
+    [InlineData("{}", "session", null)]
+    [InlineData("not json", "session", null)]
+    [InlineData("{\"other\":1}", "session", null)]
+    public void ReadStringArg_ParsesOrDegradesToNull(string args, string name, string? expected)
+        => Assert.Equal(expected, CarModeBrain.ReadStringArg(args, name));
+
+    // ---- The chat transport parse ----
+
+    [Fact]
+    public void ParseAssistantTurn_ContentOnly_NoToolCalls()
+    {
+        var body = "{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"hello there\"}}]}";
+        var turn = HostedCarModeChat.ParseAssistantTurn(body);
+        Assert.Equal("hello there", turn.Content);
+        Assert.Empty(turn.ToolCalls);
+    }
+
+    [Fact]
+    public void ParseAssistantTurn_ToolCalls_ExtractsNameAndArguments()
+    {
+        var body = "{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":null,\"tool_calls\":["
+            + "{\"id\":\"c1\",\"type\":\"function\",\"function\":{\"name\":\"list_sessions\",\"arguments\":\"{}\"}}]}}]}";
+        var turn = HostedCarModeChat.ParseAssistantTurn(body);
+        Assert.Null(turn.Content);
+        Assert.Single(turn.ToolCalls);
+        Assert.Equal("list_sessions", turn.ToolCalls[0].Name);
+        Assert.Equal("c1", turn.ToolCalls[0].Id);
+    }
+
+    [Fact]
+    public void ParseAssistantTurn_NoChoices_Throws()
+        => Assert.Throws<InvalidOperationException>(() => HostedCarModeChat.ParseAssistantTurn("{\"choices\":[]}"));
+
+    // ---- The fuzzy session resolver ----
+
+    private static SessionDto Dto(string name, int? number, string repoPath, int createdMinutesAgo) => new()
+    {
+        SessionId = Guid.NewGuid().ToString(),
+        Name = name,
+        Number = number,
+        RepoPath = repoPath,
+        CreatedAt = DateTime.UtcNow.AddMinutes(-createdMinutesAgo),
+    };
+
+    [Fact]
+    public void ResolveSession_ByExactNumber()
+    {
+        var sessions = new[] { Dto("Alpha", 101, "C:/repos/one", 10), Dto("Beta", 104, "C:/repos/two", 5) };
+        var match = LoopbackCarModeFleet.ResolveSession(sessions, "session 104");
+        Assert.NotNull(match);
+        Assert.Equal("Beta", match!.Name);
+    }
+
+    [Fact]
+    public void ResolveSession_ByNameSubstring()
+    {
+        var sessions = new[] { Dto("Local Files Manager", 101, "C:/repos/devthrottle", 10), Dto("Car Mode Worker", 102, "C:/repos/devthrottle", 5) };
+        var match = LoopbackCarModeFleet.ResolveSession(sessions, "car mode");
+        Assert.NotNull(match);
+        Assert.Equal("Car Mode Worker", match!.Name);
+    }
+
+    [Fact]
+    public void ResolveSession_ByRepoLeaf()
+    {
+        var sessions = new[] { Dto("Alpha", 101, "C:/repos/website", 10), Dto("Beta", 102, "C:/repos/devthrottle", 5) };
+        var match = LoopbackCarModeFleet.ResolveSession(sessions, "devthrottle");
+        Assert.NotNull(match);
+        Assert.Equal("Beta", match!.Name);
+    }
+
+    [Fact]
+    public void ResolveSession_NoMatch_ReturnsNull()
+    {
+        var sessions = new[] { Dto("Alpha", 101, "C:/repos/one", 10) };
+        Assert.Null(LoopbackCarModeFleet.ResolveSession(sessions, "nonexistent zebra"));
+    }
+
+    [Theory]
+    [InlineData("C:/repos/devthrottle", "devthrottle")]
+    [InlineData("C:\\repos\\devthrottle", "devthrottle")]
+    [InlineData("C:/repos/devthrottle/", "devthrottle")]
+    [InlineData("", "")]
+    public void RepoLeaf_TakesLastSegment(string path, string expected)
+        => Assert.Equal(expected, LoopbackCarModeFleet.RepoLeaf(path));
+
+    // ---- The per-device conversation store ----
+
+    [Fact]
+    public void ConversationStore_AppendAndGet_RoundTrips()
+    {
+        var store = new CarModeConversationStore(_ => { });
+        store.Append("dev", "hi", "hello");
+        var history = store.GetHistory("dev");
+        Assert.Equal(2, history.Count);
+        Assert.Equal("user", history[0].Role);
+        Assert.Equal("hi", history[0].Content);
+        Assert.Equal("assistant", history[1].Role);
+    }
+
+    [Fact]
+    public void ConversationStore_TrimsToBoundedHistory()
+    {
+        var store = new CarModeConversationStore(_ => { });
+        for (var i = 0; i < 20; i++) store.Append("dev", $"q{i}", $"a{i}");
+        var history = store.GetHistory("dev");
+        Assert.True(history.Count <= 16);
+        // The most recent exchange is kept.
+        Assert.Equal("a19", history[^1].Content);
+    }
+}

--- a/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
@@ -1,0 +1,82 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.CarMode;
+using CcDirector.Gateway.HostedAi;
+using CcDirector.Gateway.Util;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The Car Mode brain front door (Car Mode mission, Phase 2): POST /carmode/turn. The phone hands the
+/// owner's transcribed command here; the <see cref="CarModeBrain"/> runs its tool-calling loop against the
+/// fleet and returns the final spoken reply, any actions taken, and whether it is holding a destructive
+/// action for confirmation. The browser stays thin (decision 2): it never sees the model key or the fleet
+/// logic.
+///
+/// Auth: the route is not on the public allow-list and is not under /m/, so the host-wide auth gate already
+/// requires the caller's per-device key (or the shared token), per the Gateway auth rule. The caller's own
+/// credential also keys the server-side conversation context, so multi-turn works per device without any
+/// history crossing the wire. The credential is used only as an opaque key and is never logged (DT-05).
+/// </summary>
+internal static class CarModeEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app, CarModeBrain brain)
+    {
+        app.MapPost("/carmode/turn", async (HttpContext ctx, CarModeTurnRequest? req, CancellationToken ct) =>
+        {
+            FileLog.Write($"[CarModeEndpoint] turn: len={req?.Text?.Length ?? 0}");
+            if (req is null || string.IsNullOrWhiteSpace(req.Text))
+                return Results.Json(new { error = "text is required" }, statusCode: StatusCodes.Status400BadRequest);
+
+            var deviceKey = ExtractCallerCredential(ctx);
+            try
+            {
+                var result = await brain.RunTurnAsync(deviceKey, req.Text.Trim(), ct);
+                return Results.Json(new
+                {
+                    spoken = result.Spoken,
+                    actions = result.Actions.Select(a => new { tool = a.Tool, summary = a.Summary }),
+                    pendingConfirmation = result.PendingConfirmation,
+                });
+            }
+            catch (CarModeUnavailableException ex)
+            {
+                // A money refusal (out of credits / cap / no key): the ONE shared 402 state, so the phone
+                // shows the consistent add-credit / add-key notice instead of a generic error.
+                FileLog.Write($"[CarModeEndpoint] turn unavailable: {ex.State}");
+                return HostedAiHttp.PaymentRequiredResult(ex.State);
+            }
+            catch (OperationCanceledException)
+            {
+                // The client navigated away / aborted the turn; nothing to report (499 = client closed).
+                return Results.Json(new { error = "cancelled" }, statusCode: 499);
+            }
+            catch (Exception ex)
+            {
+                // A loud, specific failure the phone speaks (decision 8), never a silent stall.
+                FileLog.Write($"[CarModeEndpoint] turn FAILED: {ex.Message}");
+                return Results.Json(new { error = "Car Mode could not complete that: " + ex.Message },
+                    statusCode: StatusCodes.Status502BadGateway);
+            }
+        });
+    }
+
+    /// <summary>The caller's own credential (Bearer header, else the cc-gateway-token cookie), used only as
+    ///  the opaque per-device conversation key. Empty when the auth gate is off (debug), which the store
+    ///  maps to one shared anonymous context. Never logged.</summary>
+    private static string ExtractCallerCredential(HttpContext ctx)
+    {
+        if (ctx.Request.Headers.TryGetValue("Authorization", out var header))
+        {
+            var raw = header.ToString();
+            const string prefix = "Bearer ";
+            if (raw.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                return raw[prefix.Length..].Trim();
+        }
+        if (ctx.Request.Cookies.TryGetValue(AuthMiddleware.CookieName, out var cookie) && !string.IsNullOrWhiteSpace(cookie))
+            return cookie;
+        return "";
+    }
+}

--- a/src/CcDirector.Gateway/CarMode/CarModeBrain.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeBrain.cs
@@ -1,0 +1,221 @@
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.CarMode;
+
+/// <summary>
+/// The Car Mode fleet-manager brain (Car Mode mission, New build A): a hand-rolled C# tool-calling loop
+/// against the hosted model (decision 10 - not an agent framework, not the OpenAI Agents SDK). It sends
+/// the owner's transcript plus the tool catalog, executes any tool the model calls in-process against the
+/// fleet, feeds the results back, and repeats until the model returns a final spoken message. Conversation
+/// context is kept server-side per device so multi-turn references ("show me the latest one") resolve.
+///
+/// Phase 2 wires the READ tools only (list + activity). Phase 3 adds the act tools (start / message /
+/// approve) and the confirmed-destructive tools (delete), extending the tool catalog, the system prompt,
+/// and the dispatch below - the loop itself does not change.
+/// </summary>
+public sealed class CarModeBrain
+{
+    /// <summary>Hard cap on model round trips per turn so a model that keeps calling tools without
+    ///  answering fails loud (no silent infinite loop). Each round may carry several tool calls.</summary>
+    private const int MaxRounds = 6;
+
+    private static readonly JsonSerializerOptions ToolResultJson = new() { WriteIndented = false };
+
+    private readonly ICarModeChat _chat;
+    private readonly ICarModeFleet _fleet;
+    private readonly CarModeConversationStore _conversations;
+    private readonly Action<string> _log;
+
+    public CarModeBrain(ICarModeChat chat, ICarModeFleet fleet, CarModeConversationStore conversations, Action<string>? log = null)
+    {
+        _chat = chat ?? throw new ArgumentNullException(nameof(chat));
+        _fleet = fleet ?? throw new ArgumentNullException(nameof(fleet));
+        _conversations = conversations ?? throw new ArgumentNullException(nameof(conversations));
+        _log = log ?? FileLog.Write;
+    }
+
+    /// <summary>
+    /// Run one turn: send the owner's command plus prior context to the model, drive the tool-calling
+    /// loop, and return the final spoken reply and any actions taken. Throws
+    /// <see cref="CarModeUnavailableException"/> on a money refusal (the endpoint maps it to a 402) and a
+    /// specific exception on any other model/fleet failure, so the browser speaks a loud, specific failure
+    /// - never a silent stall or a guess.
+    /// </summary>
+    public async Task<CarModeTurnResponse> RunTurnAsync(string deviceKey, string userText, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(userText))
+            throw new ArgumentException("The command text is required.", nameof(userText));
+
+        _log($"[CarModeBrain] turn: len={userText.Length}");
+
+        var messages = new List<object>();
+        messages.Add(new { role = "system", content = SystemPrompt });
+        foreach (var m in _conversations.GetHistory(deviceKey))
+            messages.Add(new { role = m.Role, content = m.Content });
+        messages.Add(new { role = "user", content = userText });
+
+        var actions = new List<CarModeActionRecord>();
+
+        for (var round = 0; round < MaxRounds; round++)
+        {
+            var messagesJson = JsonSerializer.Serialize(messages);
+            var turn = await _chat.CompleteAsync(messagesJson, ToolCatalogJson, ct);
+
+            if (turn.ToolCalls.Count == 0)
+            {
+                var spoken = (turn.Content ?? "").Trim();
+                if (spoken.Length == 0)
+                    throw new InvalidOperationException("The model returned an empty spoken reply.");
+                _conversations.Append(deviceKey, userText, spoken);
+                _log($"[CarModeBrain] turn done in {round + 1} round(s): actions={actions.Count}");
+                return new CarModeTurnResponse { Spoken = spoken, Actions = actions };
+            }
+
+            // The model wants tools this round: echo its assistant message (with the tool_calls) back,
+            // then run each tool and append its result, so the next round sees the outcomes.
+            messages.Add(new
+            {
+                role = "assistant",
+                content = turn.Content,
+                tool_calls = turn.ToolCalls.Select(tc => new
+                {
+                    id = tc.Id,
+                    type = "function",
+                    function = new { name = tc.Name, arguments = tc.ArgumentsJson },
+                }).ToList(),
+            });
+
+            foreach (var call in turn.ToolCalls)
+            {
+                var (resultJson, action) = await ExecuteToolAsync(call, ct);
+                if (action is not null) actions.Add(action);
+                messages.Add(new { role = "tool", tool_call_id = call.Id, content = resultJson });
+            }
+        }
+
+        // The model never settled on an answer within the round cap: a loud, specific failure, not a guess.
+        _log("[CarModeBrain] round cap reached without a final answer");
+        var giveUp = "I'm having trouble answering that right now. Please try again.";
+        _conversations.Append(deviceKey, userText, giveUp);
+        return new CarModeTurnResponse { Spoken = giveUp, Actions = actions };
+    }
+
+    /// <summary>Run one tool the model called and return its result JSON (for the tool message) and an
+    ///  optional action record (Phase 3 acts; reads have none). An unknown tool or bad arguments is
+    ///  returned to the model as a tool error, not thrown - the model can recover on the next round.</summary>
+    private async Task<(string ResultJson, CarModeActionRecord? Action)> ExecuteToolAsync(CarModeToolCall call, CancellationToken ct)
+    {
+        _log($"[CarModeBrain] tool: {call.Name}");
+        switch (call.Name)
+        {
+            case "list_sessions":
+            {
+                var sessions = await _fleet.ListSessionsAsync(ct);
+                var payload = new
+                {
+                    needsYouCount = sessions.Count(s => s.NeedsYou),
+                    total = sessions.Count,
+                    sessions = sessions.Select(s => new
+                    {
+                        s.Name,
+                        s.Number,
+                        s.Repo,
+                        s.MachineName,
+                        mission = s.MissionName,
+                        s.State,
+                        s.NeedsYou,
+                        s.WaitingMinutes,
+                        s.Summary,
+                    }),
+                };
+                return (JsonSerializer.Serialize(payload, ToolResultJson), null);
+            }
+            case "get_session_activity":
+            {
+                var reference = ReadStringArg(call.ArgumentsJson, "session");
+                if (string.IsNullOrWhiteSpace(reference))
+                    return (JsonSerializer.Serialize(new { error = "Provide a session name, repo, or number." }, ToolResultJson), null);
+                var activity = await _fleet.GetSessionActivityAsync(reference, ct);
+                if (activity is null)
+                    return (JsonSerializer.Serialize(new { error = $"No session matched \"{reference}\"." }, ToolResultJson), null);
+                var payload = new
+                {
+                    activity.Name,
+                    activity.Repo,
+                    activity.State,
+                    activity.NeedsYou,
+                    activity.Summary,
+                };
+                return (JsonSerializer.Serialize(payload, ToolResultJson), null);
+            }
+            default:
+                return (JsonSerializer.Serialize(new { error = $"Unknown tool \"{call.Name}\"." }, ToolResultJson), null);
+        }
+    }
+
+    /// <summary>Read one string argument from a tool call's JSON arguments, tolerating an absent/garbled
+    ///  body (the model occasionally emits an empty object) by returning null.</summary>
+    internal static string? ReadStringArg(string argumentsJson, string name)
+    {
+        if (string.IsNullOrWhiteSpace(argumentsJson)) return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(argumentsJson);
+            return doc.RootElement.TryGetProperty(name, out var el) && el.ValueKind == JsonValueKind.String
+                ? el.GetString()
+                : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    // The system prompt: a competent, concise development manager the owner talks to hands-free. Spoken
+    // output, human names never numbers, real facts from tools, ask when unsure (mission decisions 5 + 3).
+    private const string SystemPrompt =
+        "You are the voice of DevThrottle Car Mode. The owner is driving and talks to you hands-free to run "
+        + "his fleet of coding-agent sessions. Behave like a competent, calm development manager on a phone "
+        + "call.\n\n"
+        + "Rules:\n"
+        + "- Answer OUT LOUD in one or two short spoken sentences. No lists, no markdown, no headings, no "
+        + "emoji. It will be read aloud, so write it the way you would say it.\n"
+        + "- Always refer to a session by its human NAME and its repository, never by its number "
+        + "(for example: \"Local Files Manager, in the devthrottle repo\"). Only use a number if the owner "
+        + "used one.\n"
+        + "- Use the tools to get REAL facts before you answer. Never guess a count, a name, or a state.\n"
+        + "- \"need me\", \"need you\", \"waiting\", and \"who wants me\" all mean sessions whose needsYou is "
+        + "true. \"The latest one\" is the first session in the list (it is ordered newest first).\n"
+        + "- If a request is ambiguous or you cannot tell which session is meant, ask one short clarifying "
+        + "question instead of guessing.\n"
+        + "- When you have the answer, reply with the final spoken sentence and call no more tools.";
+
+    // The tool catalog (Phase 2: read-only). Standard chat-completions function tools.
+    private const string ToolCatalogJson = """
+        [
+          {
+            "type": "function",
+            "function": {
+              "name": "list_sessions",
+              "description": "List the whole fleet of sessions with their human name, repository, state, whether each needs the owner, how long it has been waiting, and a short summary of what it is doing. Use this to answer how many need the owner, to list sessions, or to find the latest one.",
+              "parameters": { "type": "object", "properties": {}, "required": [] }
+            }
+          },
+          {
+            "type": "function",
+            "function": {
+              "name": "get_session_activity",
+              "description": "Get what one specific session is doing right now. Resolve a fuzzy reference (a name, a repository, or a number) to one session.",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "session": { "type": "string", "description": "The session to read: a human name, a repository name, or a number." }
+                },
+                "required": ["session"]
+              }
+            }
+          }
+        ]
+        """;
+}

--- a/src/CcDirector.Gateway/CarMode/CarModeChat.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeChat.cs
@@ -1,0 +1,148 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.HostedAi;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.CarMode;
+
+/// <summary>One function the model asked to call this step: its id (echoed back on the tool result),
+/// the tool name, and the raw JSON-string arguments the model produced.</summary>
+public sealed record CarModeToolCall(string Id, string Name, string ArgumentsJson);
+
+/// <summary>The assistant's turn from one chat-completions round: its spoken text (null/empty while it is
+/// still calling tools) and the tools it wants run this step (empty on the final answer).</summary>
+public sealed record CarModeAssistantTurn(string? Content, IReadOnlyList<CarModeToolCall> ToolCalls);
+
+/// <summary>Raised when the hosted model call is refused for a money reason (HTTP 402): out of credits,
+/// monthly cap reached, or no key. Carries the shared hosted-AI state so the endpoint returns the one
+/// consistent add-credit / add-key message (issue #939), never a hand-written string.</summary>
+public sealed class CarModeUnavailableException : Exception
+{
+    public HostedAiState State { get; }
+    public CarModeUnavailableException(HostedAiState state, string message) : base(message) => State = state;
+}
+
+/// <summary>
+/// The transport seam for the Car Mode tool-calling loop. Given the serialized messages and tool catalog,
+/// it does ONE chat-completions round trip and returns the assistant's turn (content or tool calls). It is
+/// an interface so the brain's loop is unit-tested with scripted turns and no network.
+/// </summary>
+public interface ICarModeChat
+{
+    Task<CarModeAssistantTurn> CompleteAsync(string messagesJson, string toolsJson, CancellationToken ct);
+}
+
+/// <summary>
+/// The production <see cref="ICarModeChat"/>: a standard provider-compatible
+/// <c>POST {base}/chat/completions</c> with a <c>tools</c> array and <c>tool_choice: auto</c>, against the
+/// DevThrottle inference proxy. The base URL, credential, and model are resolved at CALL time (a settings
+/// change is honoured on the next turn without a Gateway restart), mirroring the wingman brain. The
+/// credential is Bearer-presented and NEVER logged (security rule DT-05): only outcomes are logged.
+/// </summary>
+public sealed class HostedCarModeChat : ICarModeChat
+{
+    private static readonly HttpClient SharedHttp = new() { Timeout = TimeSpan.FromMinutes(2) };
+
+    private readonly Func<(string BaseUrl, string Model, string Key)> _resolve;
+    private readonly HttpClient _http;
+    private readonly Action<string> _log;
+
+    /// <param name="resolve">Resolves the base URL, model, and credential for the current settings, read
+    ///  fresh each call.</param>
+    /// <param name="http">HTTP client (tests inject a stub handler); a shared 2-minute client when null.</param>
+    /// <param name="log">Log sink; <see cref="FileLog.Write"/> when null.</param>
+    public HostedCarModeChat(Func<(string BaseUrl, string Model, string Key)> resolve, HttpClient? http = null, Action<string>? log = null)
+    {
+        _resolve = resolve ?? throw new ArgumentNullException(nameof(resolve));
+        _http = http ?? SharedHttp;
+        _log = log ?? FileLog.Write;
+    }
+
+    public async Task<CarModeAssistantTurn> CompleteAsync(string messagesJson, string toolsJson, CancellationToken ct)
+    {
+        var (baseUrl, model, key) = _resolve();
+        if (string.IsNullOrWhiteSpace(key))
+            throw new CarModeUnavailableException(HostedAiState.NeedsKey,
+                "No DevThrottle account key is configured. Sign in to DevThrottle so Car Mode can reach the model.");
+
+        // Assemble the request with the messages + tools verbatim (the brain owns their shape) so this
+        // layer stays a thin transport.
+        var body = $"{{\"model\":{JsonSerializer.Serialize(model)},\"messages\":{messagesJson},\"tools\":{toolsJson},\"tool_choice\":\"auto\",\"stream\":false}}";
+
+        var url = baseUrl.TrimEnd('/') + "/chat/completions";
+        using var req = new HttpRequestMessage(HttpMethod.Post, url);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", key);
+        req.Content = new StringContent(body, Encoding.UTF8, "application/json");
+
+        using var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseContentRead, ct);
+        var text = await resp.Content.ReadAsStringAsync(ct);
+
+        if (!resp.IsSuccessStatusCode)
+        {
+            _log($"[CarModeChat] chat/completions model={model} -> {(int)resp.StatusCode} ({text.Length} bytes)");
+            if (resp.StatusCode == System.Net.HttpStatusCode.PaymentRequired)
+            {
+                var state = HostedAiErrorMapper.Map402(text);
+                throw new CarModeUnavailableException(state, HostedAiMessages.For(state).Text);
+            }
+            throw new InvalidOperationException(
+                $"The Car Mode model call failed: {(int)resp.StatusCode} {resp.StatusCode}.");
+        }
+
+        return ParseAssistantTurn(text);
+    }
+
+    /// <summary>Parse <c>choices[0].message</c> into an assistant turn: its content and any tool_calls.
+    ///  Internal + static so a test asserts the parse without a network. Throws on an unusable body
+    ///  (no-fallback: the caller must not proceed on a shape it could not read).</summary>
+    internal static CarModeAssistantTurn ParseAssistantTurn(string body)
+    {
+        using var doc = JsonDocument.Parse(body);
+        if (!doc.RootElement.TryGetProperty("choices", out var choices)
+            || choices.ValueKind != JsonValueKind.Array
+            || choices.GetArrayLength() == 0)
+            throw new InvalidOperationException("The model response had no choices.");
+
+        var message = choices[0].GetProperty("message");
+        string? content = message.TryGetProperty("content", out var c) && c.ValueKind == JsonValueKind.String
+            ? c.GetString()
+            : null;
+
+        var toolCalls = new List<CarModeToolCall>();
+        if (message.TryGetProperty("tool_calls", out var tcs) && tcs.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var tc in tcs.EnumerateArray())
+            {
+                var id = tc.TryGetProperty("id", out var idEl) ? idEl.GetString() ?? "" : "";
+                if (!tc.TryGetProperty("function", out var fn)) continue;
+                var name = fn.TryGetProperty("name", out var nameEl) ? nameEl.GetString() ?? "" : "";
+                var args = fn.TryGetProperty("arguments", out var argEl) ? argEl.GetString() ?? "{}" : "{}";
+                if (name.Length > 0)
+                    toolCalls.Add(new CarModeToolCall(id, name, string.IsNullOrWhiteSpace(args) ? "{}" : args));
+            }
+        }
+
+        return new CarModeAssistantTurn(content, toolCalls);
+    }
+
+    /// <summary>
+    /// Build the model resolver Car Mode uses: the DevThrottle base + vault key + the FAST wingman model
+    /// (the "decent but fast" tier the owner asked for), with an optional <c>CC_CARMODE_MODEL</c>
+    /// environment override so the model can be escalated to the thinking tier (GLM) without a code change
+    /// if the fast model cannot reliably choose tools (mission risk to validate with evidence).
+    /// </summary>
+    public static Func<(string BaseUrl, string Model, string Key)> DefaultResolver(Func<string, string?> vaultGet)
+    {
+        return () =>
+        {
+            var mode = TranscriptionModeConfig.Get();
+            var ep = TranscriptionEndpointResolver.ResolveWingmanFast(mode);
+            var overrideModel = Environment.GetEnvironmentVariable("CC_CARMODE_MODEL");
+            var model = string.IsNullOrWhiteSpace(overrideModel) ? ep.Model : overrideModel.Trim();
+            var key = vaultGet(ep.KeyName) ?? "";
+            return (ep.BaseUrl, model, key);
+        };
+    }
+}

--- a/src/CcDirector.Gateway/CarMode/CarModeConversationStore.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeConversationStore.cs
@@ -1,0 +1,90 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.CarMode;
+
+/// <summary>One stored turn of a Car Mode conversation: a plain text message with its role
+/// ("user" or "assistant"). Only clean final text is kept - never the intermediate tool_calls / tool
+/// results - so the stored history can never break the strict tool-call/tool-result pairing the model
+/// API requires, and a fresh tool call re-reads live fleet state each turn rather than replaying a stale
+/// roster.</summary>
+public sealed record CarModeMessage(string Role, string Content);
+
+/// <summary>
+/// Server-side, per-device Car Mode conversation context (Car Mode mission: "conversation context is
+/// kept server-side, keyed by the caller's device, so multi-turn works"). The device's own credential
+/// keys the history so "how many need me" then "show me the latest one" resolve, and no history ever
+/// crosses the wire. In-memory by design (a Gateway restart simply starts a fresh conversation), bounded
+/// per device, and swept by idle age so a device that stops talking does not retain context forever.
+/// Thread-safe: turns can arrive concurrently from the same device.
+/// </summary>
+public sealed class CarModeConversationStore
+{
+    private sealed class Conversation
+    {
+        public readonly List<CarModeMessage> Messages = new();
+        public DateTime LastUsedUtc = DateTime.UtcNow;
+    }
+
+    /// <summary>Keep the last N messages (roughly N/2 exchanges) so context stays useful without growing
+    ///  unbounded; older turns fall off the front.</summary>
+    private const int MaxMessages = 16;
+
+    /// <summary>Drop a device's context after this much idle time.</summary>
+    private static readonly TimeSpan IdleTtl = TimeSpan.FromMinutes(30);
+
+    private readonly ConcurrentDictionary<string, Conversation> _byDevice = new(StringComparer.Ordinal);
+    private readonly Action<string> _log;
+
+    public CarModeConversationStore(Action<string>? log = null) => _log = log ?? FileLog.Write;
+
+    /// <summary>The prior messages for a device, oldest first, for prepending to this turn's request.
+    ///  Returns an empty list for an unknown or expired device.</summary>
+    public IReadOnlyList<CarModeMessage> GetHistory(string deviceKey)
+    {
+        SweepExpired();
+        if (_byDevice.TryGetValue(Normalize(deviceKey), out var convo))
+        {
+            lock (convo)
+            {
+                convo.LastUsedUtc = DateTime.UtcNow;
+                return convo.Messages.ToList();
+            }
+        }
+        return Array.Empty<CarModeMessage>();
+    }
+
+    /// <summary>Record a completed exchange (the owner's command and the assistant's final spoken reply)
+    ///  for a device, trimming to the most recent <see cref="MaxMessages"/>.</summary>
+    public void Append(string deviceKey, string userText, string assistantText)
+    {
+        var key = Normalize(deviceKey);
+        var convo = _byDevice.GetOrAdd(key, _ => new Conversation());
+        lock (convo)
+        {
+            convo.Messages.Add(new CarModeMessage("user", userText));
+            convo.Messages.Add(new CarModeMessage("assistant", assistantText));
+            if (convo.Messages.Count > MaxMessages)
+                convo.Messages.RemoveRange(0, convo.Messages.Count - MaxMessages);
+            convo.LastUsedUtc = DateTime.UtcNow;
+        }
+    }
+
+    /// <summary>Forget a device's context (used by a "start over" request, and available for tests).</summary>
+    public void Clear(string deviceKey) => _byDevice.TryRemove(Normalize(deviceKey), out _);
+
+    private void SweepExpired()
+    {
+        var cutoff = DateTime.UtcNow - IdleTtl;
+        foreach (var kv in _byDevice)
+        {
+            bool expired;
+            lock (kv.Value) expired = kv.Value.LastUsedUtc < cutoff;
+            if (expired && _byDevice.TryRemove(kv.Key, out _))
+                _log($"[CarModeConversation] expired idle context for a device");
+        }
+    }
+
+    // A blank credential (auth-off debug mode) keys one shared anonymous context rather than throwing.
+    private static string Normalize(string? deviceKey) => string.IsNullOrWhiteSpace(deviceKey) ? "anonymous" : deviceKey;
+}

--- a/src/CcDirector.Gateway/CarMode/CarModeModels.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeModels.cs
@@ -1,0 +1,60 @@
+namespace CcDirector.Gateway.CarMode;
+
+/// <summary>
+/// The compact, speakable view of one fleet session the Car Mode brain reasons over (Car Mode mission,
+/// New build A read tools). Deliberately small: the human NAME and repository the assistant must speak,
+/// the state and "needs you" facts, the short one-line summary of what it is doing, and the id the act
+/// tools (Phase 3) address - never the raw SessionDto. Sessions are referred to by name and what they
+/// are doing, never by number, in every spoken line (decision 5), but the number is carried so the
+/// brain can resolve a spoken "session one-oh-four" if the owner uses one.
+/// </summary>
+public sealed record CarModeSessionInfo
+{
+    public required string SessionId { get; init; }
+    public required string Name { get; init; }
+    public int? Number { get; init; }
+    public required string Repo { get; init; }
+    public required string MachineName { get; init; }
+    public string? MissionName { get; init; }
+    /// <summary>Human-readable state label, e.g. "Needs you" / "Working" / "Ready" (SessionDto.StateLabel).</summary>
+    public required string State { get; init; }
+    /// <summary>True when this session is waiting on the owner (TriageBucket == "needsYou").</summary>
+    public bool NeedsYou { get; init; }
+    /// <summary>How long it has been waiting on the owner, in whole minutes; 0 when not waiting.</summary>
+    public int WaitingMinutes { get; init; }
+    /// <summary>The &lt;=8-word one-line summary of what it is doing (SessionDto.RailLine), or the short
+    ///  status reason when there is no rail line. Empty when neither is available.</summary>
+    public required string Summary { get; init; }
+}
+
+/// <summary>What one session is doing, for the "read me that one" / "what is X doing" read tool. For v1
+/// this is the roster's own summary fields (name + repo + short line), which already answer the mission's
+/// Phase 2 proof; a richer transcript read can be layered on later without changing the tool contract.</summary>
+public sealed record CarModeActivity
+{
+    public required string SessionId { get; init; }
+    public required string Name { get; init; }
+    public required string Repo { get; init; }
+    public required string State { get; init; }
+    public required string Summary { get; init; }
+    public bool NeedsYou { get; init; }
+}
+
+/// <summary>One action the brain took during a turn (Phase 3+), surfaced to the page for on-screen
+/// confirmation alongside the spoken reply. The act already happened server-side.</summary>
+public sealed record CarModeActionRecord(string Tool, string Summary);
+
+/// <summary>The brain's result for one turn: what to say out loud, what it did, and whether it is holding
+/// a destructive action for a spoken confirmation on the next turn (Phase 3).</summary>
+public sealed record CarModeTurnResponse
+{
+    public required string Spoken { get; init; }
+    public IReadOnlyList<CarModeActionRecord> Actions { get; init; } = Array.Empty<CarModeActionRecord>();
+    public bool PendingConfirmation { get; init; }
+}
+
+/// <summary>Request body of POST /carmode/turn: the owner's transcribed command for this turn.</summary>
+public sealed class CarModeTurnRequest
+{
+    public string Text { get; set; } = "";
+}

--- a/src/CcDirector.Gateway/CarMode/ICarModeFleet.cs
+++ b/src/CcDirector.Gateway/CarMode/ICarModeFleet.cs
@@ -1,0 +1,22 @@
+namespace CcDirector.Gateway.CarMode;
+
+/// <summary>
+/// The fleet operations the Car Mode brain's tools call (Car Mode mission, New build A). Each method is
+/// backed by an existing Gateway or Director endpoint - no new fleet mechanics, just a wrapper the model
+/// can call in the tool-calling loop. Phase 2 is read-only (list + activity); Phase 3 adds the act tools
+/// (start / message / approve) and the confirmed-destructive tools (delete).
+///
+/// This is an interface so the brain's tool loop is unit-tested against a fake fleet (no network), and
+/// the production implementation talks to the Gateway's own endpoints.
+/// </summary>
+public interface ICarModeFleet
+{
+    /// <summary>The whole fleet roster as compact, speakable session views. Answers count / list /
+    ///  "who needs me" / "the latest one". Ordered newest-created first so "the latest one" is index 0.</summary>
+    Task<IReadOnlyList<CarModeSessionInfo>> ListSessionsAsync(CancellationToken ct);
+
+    /// <summary>Resolve a fuzzy human reference (a name, a repo, or a number) to one session and return
+    ///  what it is doing. Returns null when nothing matches, so the brain can say it plainly rather than
+    ///  guess.</summary>
+    Task<CarModeActivity?> GetSessionActivityAsync(string sessionReference, CancellationToken ct);
+}

--- a/src/CcDirector.Gateway/CarMode/LoopbackCarModeFleet.cs
+++ b/src/CcDirector.Gateway/CarMode/LoopbackCarModeFleet.cs
@@ -1,0 +1,185 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.CarMode;
+
+/// <summary>
+/// The production <see cref="ICarModeFleet"/>: the brain's tools reach the fleet by calling THIS
+/// Gateway's own HTTP endpoints over loopback with the per-machine token, exactly the way the Web Push
+/// needs-you notifier reads its own <c>/sessions</c> (GatewayHost.GetNeedsYouCountAsync). Going through
+/// the real endpoints means the brain sees the identical aggregated roster - the same names, states, and
+/// effective "needs you" fold - that every client sees, with zero re-implementation of the aggregation.
+/// The loopback hop is to this process on 127.0.0.1, so it adds no meaningful latency to the voice loop.
+///
+/// Phase 2 is read-only. Phase 3 adds the act tools (message / start / approve) and the confirmed
+/// destructive tools (delete) as more methods that POST/DELETE the same endpoints the buttons call.
+/// </summary>
+public sealed class LoopbackCarModeFleet : ICarModeFleet
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    private readonly HttpClient _http;
+    private readonly string _baseUrl;
+    private readonly string _token;
+    private readonly Action<string> _log;
+
+    /// <param name="port">This Gateway's own listening port (loopback).</param>
+    /// <param name="token">The per-machine Gateway token, attached as the Bearer so the call works
+    ///  whether or not the host-wide auth gate is on.</param>
+    /// <param name="http">HTTP client; a short-timeout loopback client when null.</param>
+    /// <param name="log">Log sink; <see cref="FileLog.Write"/> when null.</param>
+    public LoopbackCarModeFleet(int port, string token, HttpClient? http = null, Action<string>? log = null)
+    {
+        _http = http ?? new HttpClient { Timeout = TimeSpan.FromSeconds(20) };
+        _baseUrl = $"http://127.0.0.1:{port}";
+        _token = token ?? "";
+        _log = log ?? FileLog.Write;
+    }
+
+    public async Task<IReadOnlyList<CarModeSessionInfo>> ListSessionsAsync(CancellationToken ct)
+    {
+        var sessions = await GetSessionsAsync(ct);
+        // Newest-created first so "the latest one" is a stable, obvious reference (index 0).
+        var ordered = sessions
+            .OrderByDescending(s => s.CreatedAt)
+            .Select(ToInfo)
+            .ToList();
+        _log($"[CarModeFleet] list -> {ordered.Count} sessions ({ordered.Count(i => i.NeedsYou)} need you)");
+        return ordered;
+    }
+
+    public async Task<CarModeActivity?> GetSessionActivityAsync(string sessionReference, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(sessionReference))
+            throw new ArgumentException("A session reference is required.", nameof(sessionReference));
+
+        var sessions = await GetSessionsAsync(ct);
+        var match = ResolveSession(sessions, sessionReference);
+        if (match is null)
+        {
+            _log($"[CarModeFleet] activity: no session matched \"{sessionReference}\"");
+            return null;
+        }
+        var info = ToInfo(match);
+        return new CarModeActivity
+        {
+            SessionId = info.SessionId,
+            Name = info.Name,
+            Repo = info.Repo,
+            State = info.State,
+            Summary = info.Summary,
+            NeedsYou = info.NeedsYou,
+        };
+    }
+
+    /// <summary>Read THIS Gateway's aggregated roster over loopback. A non-success status throws with the
+    ///  code named (no-fallback) so the brain surfaces a loud, specific failure instead of an empty list.</summary>
+    private async Task<IReadOnlyList<SessionDto>> GetSessionsAsync(CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"{_baseUrl}/sessions");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+        using var response = await _http.SendAsync(request, HttpCompletionOption.ResponseContentRead, ct);
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException($"The fleet roster call failed: {(int)response.StatusCode} {response.StatusCode}.");
+        var json = await response.Content.ReadAsStringAsync(ct);
+        var sessions = JsonSerializer.Deserialize<List<SessionDto>>(json, JsonOptions);
+        return sessions ?? new List<SessionDto>();
+    }
+
+    /// <summary>Resolve a fuzzy reference to one session: exact number, then exact name, then a name/repo
+    ///  substring, then the newest match. Static and pure so it is unit-tested directly.</summary>
+    internal static SessionDto? ResolveSession(IReadOnlyList<SessionDto> sessions, string reference)
+    {
+        var reff = reference.Trim().ToLowerInvariant();
+        if (reff.Length == 0) return null;
+
+        // A number reference ("session 104", "one hundred four" already digitized by the model).
+        var digits = new string(reff.Where(char.IsDigit).ToArray());
+        if (digits.Length > 0 && int.TryParse(digits, out var num))
+        {
+            var byNumber = sessions.FirstOrDefault(s => s.Number == num);
+            if (byNumber is not null) return byNumber;
+        }
+
+        // Exact (case-insensitive) name.
+        var exact = sessions.FirstOrDefault(s => (s.Name ?? "").Trim().ToLowerInvariant() == reff);
+        if (exact is not null) return exact;
+
+        // Match by name or repo, newest first so a tie picks the latest. A session matches when the
+        // reference is a substring of its name (the owner spoke a fragment of the name), or when its
+        // name or repo appears as WHOLE WORDS inside the reference (the owner said the name/repo within
+        // a longer phrase). Whole-word matching on the reverse direction avoids a short repo leaf like
+        // "one" spuriously matching inside an unrelated word like "nonexistent".
+        var candidates = sessions
+            .OrderByDescending(s => s.CreatedAt)
+            .Where(s =>
+            {
+                var name = (s.Name ?? "").Trim().ToLowerInvariant();
+                var repo = RepoLeaf(s.RepoPath).ToLowerInvariant();
+                if (name.Length > 0 && (name.Contains(reff) || ContainsAsWords(reff, name))) return true;
+                if (repo.Length > 0 && ContainsAsWords(reff, repo)) return true;
+                return false;
+            })
+            .ToList();
+        return candidates.FirstOrDefault();
+    }
+
+    /// <summary>True when <paramref name="needle"/>'s words appear as a contiguous run of whole words in
+    ///  <paramref name="haystack"/>. Whole-word, so "one" matches "the one repo" but not "nonexistent".</summary>
+    internal static bool ContainsAsWords(string haystack, string needle)
+    {
+        var hay = haystack.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var need = needle.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (need.Length == 0 || need.Length > hay.Length) return false;
+        for (var i = 0; i + need.Length <= hay.Length; i++)
+        {
+            var all = true;
+            for (var j = 0; j < need.Length; j++)
+            {
+                if (!string.Equals(hay[i + j], need[j], StringComparison.Ordinal)) { all = false; break; }
+            }
+            if (all) return true;
+        }
+        return false;
+    }
+
+    private static CarModeSessionInfo ToInfo(SessionDto s)
+    {
+        var needsYou = string.Equals(s.TriageBucket, "needsYou", StringComparison.OrdinalIgnoreCase);
+        var summary = !string.IsNullOrWhiteSpace(s.RailLine) ? s.RailLine!
+            : !string.IsNullOrWhiteSpace(s.LastStatusReason) ? s.LastStatusReason
+            : "";
+        return new CarModeSessionInfo
+        {
+            SessionId = s.SessionId,
+            Name = string.IsNullOrWhiteSpace(s.Name) ? "(unnamed session)" : s.Name!.Trim(),
+            Number = s.Number,
+            Repo = RepoLeaf(s.RepoPath),
+            MachineName = s.MachineName ?? "",
+            MissionName = string.IsNullOrWhiteSpace(s.MissionName) ? null : s.MissionName,
+            State = string.IsNullOrWhiteSpace(s.StateLabel) ? (s.EffectiveColor ?? s.StatusColor) : s.StateLabel!,
+            NeedsYou = needsYou,
+            WaitingMinutes = WaitingMinutes(s.NeedsYouSince),
+            Summary = summary,
+        };
+    }
+
+    /// <summary>The last path segment of a repository path (the human name a person calls a repo), for
+    ///  both directory separators.</summary>
+    internal static string RepoLeaf(string? repoPath)
+    {
+        if (string.IsNullOrWhiteSpace(repoPath)) return "";
+        var trimmed = repoPath.TrimEnd('/', '\\');
+        var idx = trimmed.LastIndexOfAny(new[] { '/', '\\' });
+        return idx >= 0 && idx < trimmed.Length - 1 ? trimmed[(idx + 1)..] : trimmed;
+    }
+
+    private static int WaitingMinutes(DateTime? since)
+    {
+        if (since is not { } t) return 0;
+        var minutes = (DateTime.UtcNow - t).TotalMinutes;
+        return minutes <= 0 ? 0 : (int)Math.Round(minutes);
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -264,6 +264,10 @@ public sealed class GatewayHost : IAsyncDisposable
     private readonly Running.WorkListRunnerManager _runnerManager = new();
     // Issue #218: Gateway-owned clock for when each session entered the red / NEEDS-YOU state.
     private readonly NeedsYouClock _needsYouClock = new();
+    // Car Mode (Car Mode mission): the server-side, per-device conversation context behind the fleet
+    // tool-calling brain (POST /carmode/turn), so multi-turn references ("the latest one") resolve.
+    // In-memory by design; one instance for the whole Gateway.
+    private readonly CarMode.CarModeConversationStore _carModeConversations = new();
     // Gateway-owned set of sessions whose dictated utterance is being transcribed in the background
     // (the phone released the Speak dialog and the audio is uploading/transcribing). Stamps the
     // orange "Transcribing..." roster color so nobody else grabs the session mid-dictation.
@@ -1116,6 +1120,17 @@ public sealed class GatewayHost : IAsyncDisposable
         // plus the direct-to-wingman path. Backed by the same warm Brain the brief agent uses.
         _voiceService ??= new Wingman.WingmanVoiceService(WingmanBrainAsync, _keyVault, _client, training: _trainingStore, instructionsProvider: () => _instructionsStore.ActiveContent);
         GatewayWingmanVoiceEndpoint.Map(_app, Registry, _client, WingmanBrainAsync, _keyVault, _voiceService, instructionsProvider: () => _instructionsStore.ActiveContent);
+
+        // Car Mode brain (Car Mode mission, New build A): the fleet tool-calling loop behind
+        // POST /carmode/turn. The chat transport resolves the fast wingman model + the vault key at CALL
+        // time (a settings change applies on the next turn, no restart); the fleet tools reach THIS
+        // Gateway's own endpoints over loopback (the same aggregated roster every client sees); the
+        // conversation context is kept server-side per device. Inherits the host-wide auth gate (the
+        // caller's per-device key), like every other data route.
+        var carModeChat = new CarMode.HostedCarModeChat(CarMode.HostedCarModeChat.DefaultResolver(_keyVault.Get));
+        var carModeFleet = new CarMode.LoopbackCarModeFleet(Port, Token);
+        var carModeBrain = new CarMode.CarModeBrain(carModeChat, carModeFleet, _carModeConversations);
+        Api.CarModeEndpoint.Map(_app, carModeBrain);
         // Editable/versioned wingman instructions settings surface (issue #537), incl. A/B test
         // over saved training sessions (reads the shared training store; uses the hosted wingman brain).
         WingmanInstructionsEndpoint.Map(_app, _instructionsStore, _trainingStore, WingmanBrainAsync);


### PR DESCRIPTION
Second phase of the Car Mode mission: New build A, the read-only fleet brain behind `POST /carmode/turn`.

## What this delivers
- `CarModeBrain` - a hand-rolled C# tool-calling loop (mission decision 10: not an agent framework, not the OpenAI Agents SDK). It sends the owner's transcript plus the tool catalog, executes the tools the model calls in-process, feeds the results back, and repeats until a final spoken message. Round-capped so a model that never settles fails loud.
- `HostedCarModeChat` - the standard chat-completions transport with a `tools` array and `tool_choice: auto`, resolving the fast wingman model (`Qwen2.5-72B-Instruct`) and vault key at call time. `CC_CARMODE_MODEL` env override escalates to the thinking model with no code change if the fast model cannot reliably choose tools.
- `LoopbackCarModeFleet` - the read tools (`list_sessions`, `get_session_activity`) reach THIS Gateway's own `/sessions` over loopback with the machine token, so the brain sees the identical aggregated roster (names, states, effective needs-you fold) every client sees - zero re-implementation. Whole-word fuzzy session resolution by name, repo, or number.
- `CarModeConversationStore` - bounded, idle-swept, per-device conversation context so multi-turn references ("the latest one") resolve; no history ever crosses the wire.
- `CarModeEndpoint` - `POST /carmode/turn` behind the host-wide auth gate (per-device key). Maps a money refusal to the shared 402 state and every other failure to a loud, specific error the phone speaks.
- System prompt: a competent, concise development manager - spoken output, sessions by human name never number, real facts from tools, ask when unsure.

## Verification
- 24 new unit tests: the loop drives tools and feeds results back, per-device context isolation, the round-cap loud failure, the fuzzy resolver (number / name / repo / no-match), the response parse, and the store.
- Gateway builds zero-warning; full Gateway test project compiles and the Car Mode suite is green.
- The client `carModeTurn` + the `/m/car` page already call this endpoint (wired in Phase 1); the live end-to-end drive against the running Gateway is in the final QA report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)