### PR TITLE
Car Mode Phase 3: full control + spoken-confirmation policy

### DIFF
--- a/src/CcDirector.Gateway.Tests/CarModeBrainTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeBrainTests.cs
@@ -32,6 +32,14 @@ public sealed class CarModeBrainTests
         public List<string> ActivityRefs { get; } = new();
         public IReadOnlyList<CarModeSessionInfo> Sessions { get; set; } = new List<CarModeSessionInfo>();
         public CarModeActivity? Activity { get; set; }
+
+        // Phase 3 act tools: record what was called so tests can assert the loop reached the fleet.
+        public CarModeSessionInfo? ResolveResult { get; set; }
+        public List<string> StartedRepos { get; } = new();
+        public List<(string SessionId, string Message)> Messaged { get; } = new();
+        public List<string> Approved { get; } = new();
+        public List<string> Deleted { get; } = new();
+
         public Task<IReadOnlyList<CarModeSessionInfo>> ListSessionsAsync(CancellationToken ct)
         {
             ListCalls++;
@@ -42,9 +50,41 @@ public sealed class CarModeBrainTests
             ActivityRefs.Add(sessionReference);
             return Task.FromResult(Activity);
         }
+        public Task<CarModeSessionInfo?> ResolveSessionAsync(string sessionReference, CancellationToken ct)
+            => Task.FromResult(ResolveResult);
+        public Task<string> StartSessionAsync(string repo, CancellationToken ct)
+        {
+            StartedRepos.Add(repo);
+            return Task.FromResult($"Started a session in the {repo} repository on TESTBOX.");
+        }
+        public Task MessageSessionAsync(string sessionId, string message, CancellationToken ct)
+        {
+            Messaged.Add((sessionId, message));
+            return Task.CompletedTask;
+        }
+        public Task ApproveSessionAsync(string sessionId, CancellationToken ct)
+        {
+            Approved.Add(sessionId);
+            return Task.CompletedTask;
+        }
+        public Task DeleteSessionAsync(string sessionId, CancellationToken ct)
+        {
+            Deleted.Add(sessionId);
+            return Task.CompletedTask;
+        }
     }
 
     private static CarModeToolCall Call(string name, string args = "{}") => new("call_1", name, args);
+
+    private static CarModeSessionInfo Info(string name, string id) => new()
+    {
+        SessionId = id,
+        Name = name,
+        Repo = "devthrottle",
+        MachineName = "TESTBOX",
+        State = "Working",
+        Summary = "",
+    };
 
     private static CarModeSessionInfo Session(string name, bool needsYou) => new()
     {
@@ -64,7 +104,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("list_sessions") }),
             new CarModeAssistantTurn("One session needs you: Local Files Manager, in the devthrottle repo.", Array.Empty<CarModeToolCall>()));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), _ => { });
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync("device-a", "how many need me over", CancellationToken.None);
 
@@ -90,7 +130,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("get_session_activity", "{\"session\":\"car mode\"}") }),
             new CarModeAssistantTurn("Car Mode Manager, in the devthrottle repo, is building the fleet brain.", Array.Empty<CarModeToolCall>()));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), _ => { });
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync("device-a", "what is the car mode session doing", CancellationToken.None);
 
@@ -105,12 +145,12 @@ public sealed class CarModeBrainTests
         var fleet = new FakeFleet();
         var store = new CarModeConversationStore();
         var chat1 = new ScriptedChat(new CarModeAssistantTurn("Nothing needs you right now.", Array.Empty<CarModeToolCall>()));
-        var brain1 = new CarModeBrain(chat1, fleet, store, _ => { });
+        var brain1 = new CarModeBrain(chat1, fleet, store, new CarModePendingStore(_ => { }), _ => { });
         await brain1.RunTurnAsync("device-a", "who needs me", CancellationToken.None);
 
         // The next turn on the SAME device must carry the prior exchange into the model's messages.
         var chat2 = new ScriptedChat(new CarModeAssistantTurn("Still nothing.", Array.Empty<CarModeToolCall>()));
-        var brain2 = new CarModeBrain(chat2, fleet, store, _ => { });
+        var brain2 = new CarModeBrain(chat2, fleet, store, new CarModePendingStore(_ => { }), _ => { });
         await brain2.RunTurnAsync("device-a", "and now", CancellationToken.None);
 
         Assert.Contains("who needs me", chat2.SeenMessages[0]);
@@ -122,11 +162,11 @@ public sealed class CarModeBrainTests
     {
         var fleet = new FakeFleet();
         var store = new CarModeConversationStore();
-        var brainA = new CarModeBrain(new ScriptedChat(new CarModeAssistantTurn("A reply", Array.Empty<CarModeToolCall>())), fleet, store, _ => { });
+        var brainA = new CarModeBrain(new ScriptedChat(new CarModeAssistantTurn("A reply", Array.Empty<CarModeToolCall>())), fleet, store, new CarModePendingStore(_ => { }), _ => { });
         await brainA.RunTurnAsync("device-a", "secret A question", CancellationToken.None);
 
         var chatB = new ScriptedChat(new CarModeAssistantTurn("B reply", Array.Empty<CarModeToolCall>()));
-        var brainB = new CarModeBrain(chatB, fleet, store, _ => { });
+        var brainB = new CarModeBrain(chatB, fleet, store, new CarModePendingStore(_ => { }), _ => { });
         await brainB.RunTurnAsync("device-b", "question B", CancellationToken.None);
 
         Assert.DoesNotContain("secret A question", chatB.SeenMessages[0]);
@@ -135,7 +175,7 @@ public sealed class CarModeBrainTests
     [Fact]
     public async Task RunTurn_EmptyText_Throws()
     {
-        var brain = new CarModeBrain(new ScriptedChat(), new FakeFleet(), new CarModeConversationStore(), _ => { });
+        var brain = new CarModeBrain(new ScriptedChat(), new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
         await Assert.ThrowsAsync<ArgumentException>(() => brain.RunTurnAsync("device-a", "   ", CancellationToken.None));
     }
 
@@ -145,7 +185,7 @@ public sealed class CarModeBrainTests
         var fleet = new FakeFleet { Sessions = Array.Empty<CarModeSessionInfo>() };
         // Every round asks for a tool and never answers - the loop must stop and speak a failure.
         var turns = Enumerable.Range(0, 10).Select(_ => new CarModeAssistantTurn(null, new[] { Call("list_sessions") })).ToArray();
-        var brain = new CarModeBrain(new ScriptedChat(turns), fleet, new CarModeConversationStore(), _ => { });
+        var brain = new CarModeBrain(new ScriptedChat(turns), fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync("device-a", "who needs me", CancellationToken.None);
 
@@ -157,7 +197,7 @@ public sealed class CarModeBrainTests
     {
         var brain = new CarModeBrain(
             new ScriptedChat(new CarModeAssistantTurn("   ", Array.Empty<CarModeToolCall>())),
-            new FakeFleet(), new CarModeConversationStore(), _ => { });
+            new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
         await Assert.ThrowsAsync<InvalidOperationException>(() => brain.RunTurnAsync("device-a", "hi", CancellationToken.None));
     }
 
@@ -168,6 +208,169 @@ public sealed class CarModeBrainTests
     [InlineData("{\"other\":1}", "session", null)]
     public void ReadStringArg_ParsesOrDegradesToNull(string args, string name, string? expected)
         => Assert.Equal(expected, CarModeBrain.ReadStringArg(args, name));
+
+    // ---- Phase 3: the ordinary act tools run immediately ----
+
+    [Fact]
+    public async Task RunTurn_StartSession_CallsFleetAndRecordsAction()
+    {
+        var fleet = new FakeFleet();
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("start_session", "{\"repo\":\"devthrottle\"}") }),
+            new CarModeAssistantTurn("Started a session in the devthrottle repo.", Array.Empty<CarModeToolCall>()));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+
+        var result = await brain.RunTurnAsync("device-a", "start a session in devthrottle", CancellationToken.None);
+
+        Assert.Single(fleet.StartedRepos);
+        Assert.Equal("devthrottle", fleet.StartedRepos[0]);
+        Assert.Contains(result.Actions, a => a.Tool == "start_session");
+        Assert.False(result.PendingConfirmation);
+    }
+
+    [Fact]
+    public async Task RunTurn_MessageSession_ResolvesThenSends()
+    {
+        var fleet = new FakeFleet { ResolveResult = Info("Car Mode Worker", "s-42") };
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("message_session", "{\"session\":\"car mode worker\",\"message\":\"run the tests\"}") }),
+            new CarModeAssistantTurn("Told Car Mode Worker to run the tests.", Array.Empty<CarModeToolCall>()));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+
+        var result = await brain.RunTurnAsync("device-a", "message the worker", CancellationToken.None);
+
+        Assert.Single(fleet.Messaged);
+        Assert.Equal("s-42", fleet.Messaged[0].SessionId);
+        Assert.Equal("run the tests", fleet.Messaged[0].Message);
+        Assert.Contains(result.Actions, a => a.Tool == "message_session");
+    }
+
+    [Fact]
+    public async Task RunTurn_MessageSession_UnresolvedReference_DoesNotSend()
+    {
+        var fleet = new FakeFleet { ResolveResult = null };
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("message_session", "{\"session\":\"ghost\",\"message\":\"hi\"}") }),
+            new CarModeAssistantTurn("I couldn't find a session called ghost.", Array.Empty<CarModeToolCall>()));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+
+        await brain.RunTurnAsync("device-a", "message ghost", CancellationToken.None);
+
+        Assert.Empty(fleet.Messaged);
+    }
+
+    // ---- Phase 3: the destructive tool is HELD for a spoken confirmation ----
+
+    [Fact]
+    public async Task RunTurn_DeleteSession_ArmsConfirmation_DoesNotDelete()
+    {
+        var fleet = new FakeFleet { ResolveResult = Info("Old Worker", "s-9") };
+        var pending = new CarModePendingStore(_ => { });
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("delete_session", "{\"session\":\"old worker\"}") }),
+            new CarModeAssistantTurn("Deleting Old Worker is permanent. Say confirm to proceed, or cancel.", Array.Empty<CarModeToolCall>()));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), pending, _ => { });
+
+        var result = await brain.RunTurnAsync("device-a", "delete the old worker", CancellationToken.None);
+
+        Assert.Empty(fleet.Deleted); // NOT deleted yet
+        Assert.True(result.PendingConfirmation);
+        Assert.NotNull(pending.Get("device-a"));
+        Assert.Equal("s-9", pending.Get("device-a")!.SessionId);
+    }
+
+    [Fact]
+    public async Task RunTurn_ConfirmAfterArmedDelete_ExecutesDelete()
+    {
+        var fleet = new FakeFleet { ResolveResult = Info("Old Worker", "s-9") };
+        var pending = new CarModePendingStore(_ => { });
+        var store = new CarModeConversationStore();
+
+        // Turn 1: arm.
+        var brain1 = new CarModeBrain(
+            new ScriptedChat(
+                new CarModeAssistantTurn(null, new[] { Call("delete_session", "{\"session\":\"old worker\"}") }),
+                new CarModeAssistantTurn("Say confirm to delete Old Worker.", Array.Empty<CarModeToolCall>())),
+            fleet, store, pending, _ => { });
+        await brain1.RunTurnAsync("device-a", "delete old worker", CancellationToken.None);
+        Assert.Empty(fleet.Deleted);
+
+        // Turn 2: the owner confirms. The model is NOT consulted - the gate executes deterministically.
+        var chat2 = new ScriptedChat(); // must not be called
+        var brain2 = new CarModeBrain(chat2, fleet, store, pending, _ => { });
+        var result = await brain2.RunTurnAsync("device-a", "confirm", CancellationToken.None);
+
+        Assert.Single(fleet.Deleted);
+        Assert.Equal("s-9", fleet.Deleted[0]);
+        Assert.Empty(chat2.SeenMessages); // no model call on the confirmation turn
+        Assert.False(result.PendingConfirmation);
+        Assert.Contains(result.Actions, a => a.Tool == "delete_session");
+        Assert.Null(pending.Get("device-a")); // disarmed
+    }
+
+    [Fact]
+    public async Task RunTurn_CancelAfterArmedDelete_DoesNotDelete()
+    {
+        var fleet = new FakeFleet { ResolveResult = Info("Old Worker", "s-9") };
+        var pending = new CarModePendingStore(_ => { });
+        pending.Arm("device-a", new CarModePendingAction("delete", "s-9", "Old Worker"));
+
+        var chat = new ScriptedChat(); // must not be called
+        var brain = new CarModeBrain(chat, new FakeFleet(), new CarModeConversationStore(), pending, _ => { });
+        var result = await brain.RunTurnAsync("device-a", "no cancel that", CancellationToken.None);
+
+        Assert.Empty(fleet.Deleted);
+        Assert.Contains("Old Worker", result.Spoken);
+        Assert.Null(pending.Get("device-a"));
+    }
+
+    [Fact]
+    public async Task RunTurn_UnrelatedCommandAfterArmedDelete_DisarmsAndProceeds()
+    {
+        var pending = new CarModePendingStore(_ => { });
+        pending.Arm("device-a", new CarModePendingAction("delete", "s-9", "Old Worker"));
+        var fleet = new FakeFleet { Sessions = Array.Empty<CarModeSessionInfo>() };
+        var chat = new ScriptedChat(new CarModeAssistantTurn("Nothing needs you.", Array.Empty<CarModeToolCall>()));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), pending, _ => { });
+
+        var result = await brain.RunTurnAsync("device-a", "who needs me", CancellationToken.None);
+
+        // The armed delete is dropped (safe) and the new command is processed normally.
+        Assert.Null(pending.Get("device-a"));
+        Assert.Equal("Nothing needs you.", result.Spoken);
+    }
+
+    // ---- The spoken-confirmation words ----
+
+    [Theory]
+    [InlineData("confirm")]
+    [InlineData("yes")]
+    [InlineData("yes do it")]
+    [InlineData("go ahead")]
+    [InlineData("confirmed")]
+    public void CarModeConfirm_Affirmatives(string text) => Assert.True(CarModeConfirm.IsAffirmative(text));
+
+    [Theory]
+    [InlineData("no")]
+    [InlineData("cancel")]
+    [InlineData("cancel that")]
+    [InlineData("don't")]
+    [InlineData("never mind")]
+    public void CarModeConfirm_NotAffirmative(string text) => Assert.False(CarModeConfirm.IsAffirmative(text));
+
+    [Fact]
+    public void CarModeConfirm_MixedIsNotAffirmative_NegativesWin()
+    {
+        // "yes but no" or "confirm... no wait" must NOT delete - negatives win for safety.
+        Assert.False(CarModeConfirm.IsAffirmative("yes no wait"));
+    }
+
+    [Fact]
+    public void CarModeConfirm_NoInsideNorthDoesNotFire()
+    {
+        // Whole-word: "north" must not read as "no".
+        Assert.False(CarModeConfirm.IsNegative("soren north"));
+    }
 
     // ---- The chat transport parse ----
 

--- a/src/CcDirector.Gateway/CarMode/CarModeBrain.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeBrain.cs
@@ -25,13 +25,15 @@ public sealed class CarModeBrain
     private readonly ICarModeChat _chat;
     private readonly ICarModeFleet _fleet;
     private readonly CarModeConversationStore _conversations;
+    private readonly CarModePendingStore _pending;
     private readonly Action<string> _log;
 
-    public CarModeBrain(ICarModeChat chat, ICarModeFleet fleet, CarModeConversationStore conversations, Action<string>? log = null)
+    public CarModeBrain(ICarModeChat chat, ICarModeFleet fleet, CarModeConversationStore conversations, CarModePendingStore pending, Action<string>? log = null)
     {
         _chat = chat ?? throw new ArgumentNullException(nameof(chat));
         _fleet = fleet ?? throw new ArgumentNullException(nameof(fleet));
         _conversations = conversations ?? throw new ArgumentNullException(nameof(conversations));
+        _pending = pending ?? throw new ArgumentNullException(nameof(pending));
         _log = log ?? FileLog.Write;
     }
 
@@ -49,6 +51,34 @@ public sealed class CarModeBrain
 
         _log($"[CarModeBrain] turn: len={userText.Length}");
 
+        // The confirmation gate (decision 3): if a destructive action is armed for this device, THIS turn
+        // is the spoken confirmation. A clear affirmative executes it; a cancel drops it; anything else
+        // disarms it (safe default - the delete never runs) and is processed as a fresh command. This is
+        // deterministic C#, not left to the model, so a destructive action can never run without a clear
+        // spoken "confirm".
+        var armed = _pending.Get(deviceKey);
+        if (armed is not null)
+        {
+            _pending.Clear(deviceKey);
+            if (CarModeConfirm.IsAffirmative(userText))
+            {
+                var (spokenDone, action) = await ExecuteConfirmedAsync(armed, ct);
+                _conversations.Append(deviceKey, userText, spokenDone);
+                _log($"[CarModeBrain] confirmed {armed.Tool} for {armed.TargetName}");
+                return new CarModeTurnResponse { Spoken = spokenDone, Actions = new[] { action } };
+            }
+            if (CarModeConfirm.IsNegative(userText))
+            {
+                var spokenCancel = $"Okay, I left {armed.TargetName} alone.";
+                _conversations.Append(deviceKey, userText, spokenCancel);
+                _log($"[CarModeBrain] cancelled {armed.Tool} for {armed.TargetName}");
+                return new CarModeTurnResponse { Spoken = spokenCancel };
+            }
+            // Neither confirm nor cancel: the armed delete is dropped (safe) and this utterance is treated
+            // as a new command below.
+            _log($"[CarModeBrain] pending {armed.Tool} disarmed by an unrelated command");
+        }
+
         var messages = new List<object>();
         messages.Add(new { role = "system", content = SystemPrompt });
         foreach (var m in _conversations.GetHistory(deviceKey))
@@ -56,6 +86,7 @@ public sealed class CarModeBrain
         messages.Add(new { role = "user", content = userText });
 
         var actions = new List<CarModeActionRecord>();
+        var armedThisTurn = false;
 
         for (var round = 0; round < MaxRounds; round++)
         {
@@ -68,8 +99,8 @@ public sealed class CarModeBrain
                 if (spoken.Length == 0)
                     throw new InvalidOperationException("The model returned an empty spoken reply.");
                 _conversations.Append(deviceKey, userText, spoken);
-                _log($"[CarModeBrain] turn done in {round + 1} round(s): actions={actions.Count}");
-                return new CarModeTurnResponse { Spoken = spoken, Actions = actions };
+                _log($"[CarModeBrain] turn done in {round + 1} round(s): actions={actions.Count}, pending={armedThisTurn}");
+                return new CarModeTurnResponse { Spoken = spoken, Actions = actions, PendingConfirmation = armedThisTurn };
             }
 
             // The model wants tools this round: echo its assistant message (with the tool_calls) back,
@@ -88,9 +119,10 @@ public sealed class CarModeBrain
 
             foreach (var call in turn.ToolCalls)
             {
-                var (resultJson, action) = await ExecuteToolAsync(call, ct);
-                if (action is not null) actions.Add(action);
-                messages.Add(new { role = "tool", tool_call_id = call.Id, content = resultJson });
+                var outcome = await ExecuteToolAsync(deviceKey, call, ct);
+                if (outcome.Action is not null) actions.Add(outcome.Action);
+                if (outcome.ArmedConfirmation) armedThisTurn = true;
+                messages.Add(new { role = "tool", tool_call_id = call.Id, content = outcome.ResultJson });
             }
         }
 
@@ -98,13 +130,22 @@ public sealed class CarModeBrain
         _log("[CarModeBrain] round cap reached without a final answer");
         var giveUp = "I'm having trouble answering that right now. Please try again.";
         _conversations.Append(deviceKey, userText, giveUp);
-        return new CarModeTurnResponse { Spoken = giveUp, Actions = actions };
+        return new CarModeTurnResponse { Spoken = giveUp, Actions = actions, PendingConfirmation = armedThisTurn };
     }
 
-    /// <summary>Run one tool the model called and return its result JSON (for the tool message) and an
-    ///  optional action record (Phase 3 acts; reads have none). An unknown tool or bad arguments is
-    ///  returned to the model as a tool error, not thrown - the model can recover on the next round.</summary>
-    private async Task<(string ResultJson, CarModeActionRecord? Action)> ExecuteToolAsync(CarModeToolCall call, CancellationToken ct)
+    /// <summary>The outcome of one tool call: the JSON handed back to the model, an optional action record
+    ///  (for the ordinary acts; reads produce none), and whether it ARMED a destructive action awaiting a
+    ///  spoken confirmation (which was NOT executed).</summary>
+    private sealed record ToolOutcome(string ResultJson, CarModeActionRecord? Action, bool ArmedConfirmation);
+
+    private static ToolOutcome Result(object payload) => new(JsonSerializer.Serialize(payload, ToolResultJson), null, false);
+    private static ToolOutcome Acted(object payload, CarModeActionRecord action) => new(JsonSerializer.Serialize(payload, ToolResultJson), action, false);
+
+    /// <summary>Run one tool the model called. An unknown tool or bad arguments is returned to the model as
+    ///  a tool error (the model can recover next round); a genuine fleet failure throws (a loud, specific,
+    ///  spoken failure). Ordinary acts (start / message / approve) run immediately; the destructive act
+    ///  (delete) is NOT run - it arms a confirmation the owner must speak next turn (decision 3).</summary>
+    private async Task<ToolOutcome> ExecuteToolAsync(string deviceKey, CarModeToolCall call, CancellationToken ct)
     {
         _log($"[CarModeBrain] tool: {call.Name}");
         switch (call.Name)
@@ -112,45 +153,97 @@ public sealed class CarModeBrain
             case "list_sessions":
             {
                 var sessions = await _fleet.ListSessionsAsync(ct);
-                var payload = new
+                return Result(new
                 {
                     needsYouCount = sessions.Count(s => s.NeedsYou),
                     total = sessions.Count,
                     sessions = sessions.Select(s => new
                     {
-                        s.Name,
-                        s.Number,
-                        s.Repo,
-                        s.MachineName,
-                        mission = s.MissionName,
-                        s.State,
-                        s.NeedsYou,
-                        s.WaitingMinutes,
-                        s.Summary,
+                        s.Name, s.Number, s.Repo, s.MachineName, mission = s.MissionName,
+                        s.State, s.NeedsYou, s.WaitingMinutes, s.Summary,
                     }),
-                };
-                return (JsonSerializer.Serialize(payload, ToolResultJson), null);
+                });
             }
             case "get_session_activity":
             {
                 var reference = ReadStringArg(call.ArgumentsJson, "session");
                 if (string.IsNullOrWhiteSpace(reference))
-                    return (JsonSerializer.Serialize(new { error = "Provide a session name, repo, or number." }, ToolResultJson), null);
+                    return Result(new { error = "Provide a session name, repo, or number." });
                 var activity = await _fleet.GetSessionActivityAsync(reference, ct);
                 if (activity is null)
-                    return (JsonSerializer.Serialize(new { error = $"No session matched \"{reference}\"." }, ToolResultJson), null);
-                var payload = new
-                {
-                    activity.Name,
-                    activity.Repo,
-                    activity.State,
-                    activity.NeedsYou,
-                    activity.Summary,
-                };
-                return (JsonSerializer.Serialize(payload, ToolResultJson), null);
+                    return Result(new { error = $"No session matched \"{reference}\"." });
+                return Result(new { activity.Name, activity.Repo, activity.State, activity.NeedsYou, activity.Summary });
+            }
+            case "start_session":
+            {
+                var repo = ReadStringArg(call.ArgumentsJson, "repo");
+                if (string.IsNullOrWhiteSpace(repo))
+                    return Result(new { error = "Provide the repository name to start a session in." });
+                var summary = await _fleet.StartSessionAsync(repo, ct);
+                return Acted(new { status = "started", summary }, new CarModeActionRecord("start_session", summary));
+            }
+            case "message_session":
+            {
+                var reference = ReadStringArg(call.ArgumentsJson, "session");
+                var message = ReadStringArg(call.ArgumentsJson, "message");
+                if (string.IsNullOrWhiteSpace(reference) || string.IsNullOrWhiteSpace(message))
+                    return Result(new { error = "Provide both the session and the message to send." });
+                var target = await _fleet.ResolveSessionAsync(reference, ct);
+                if (target is null)
+                    return Result(new { error = $"No session matched \"{reference}\"." });
+                await _fleet.MessageSessionAsync(target.SessionId, message, ct);
+                var summary = $"Messaged {target.Name}.";
+                return Acted(new { status = "sent", session = target.Name }, new CarModeActionRecord("message_session", summary));
+            }
+            case "approve_session":
+            {
+                var reference = ReadStringArg(call.ArgumentsJson, "session");
+                if (string.IsNullOrWhiteSpace(reference))
+                    return Result(new { error = "Provide the session to approve." });
+                var target = await _fleet.ResolveSessionAsync(reference, ct);
+                if (target is null)
+                    return Result(new { error = $"No session matched \"{reference}\"." });
+                await _fleet.ApproveSessionAsync(target.SessionId, ct);
+                var summary = $"Approved {target.Name}.";
+                return Acted(new { status = "approved", session = target.Name }, new CarModeActionRecord("approve_session", summary));
+            }
+            case "delete_session":
+            {
+                var reference = ReadStringArg(call.ArgumentsJson, "session");
+                if (string.IsNullOrWhiteSpace(reference))
+                    return Result(new { error = "Provide the session to delete." });
+                var target = await _fleet.ResolveSessionAsync(reference, ct);
+                if (target is null)
+                    return Result(new { error = $"No session matched \"{reference}\"." });
+                // Destructive: do NOT delete. Arm a confirmation the owner must speak next turn.
+                _pending.Arm(deviceKey, new CarModePendingAction("delete", target.SessionId, target.Name));
+                return new ToolOutcome(
+                    JsonSerializer.Serialize(new
+                    {
+                        status = "confirmation_required",
+                        session = target.Name,
+                        repo = target.Repo,
+                        message = $"Deleting {target.Name} in the {target.Repo} repo is permanent. Ask the owner to say \"confirm\" to proceed, or \"cancel\" to stop. Do not call any more tools.",
+                    }, ToolResultJson),
+                    Action: null,
+                    ArmedConfirmation: true);
             }
             default:
-                return (JsonSerializer.Serialize(new { error = $"Unknown tool \"{call.Name}\"." }, ToolResultJson), null);
+                return Result(new { error = $"Unknown tool \"{call.Name}\"." });
+        }
+    }
+
+    /// <summary>Execute a destructive action the owner has just confirmed out loud, returning the spoken
+    ///  acknowledgement and the action record. A fleet failure throws (a loud, specific, spoken failure).</summary>
+    private async Task<(string Spoken, CarModeActionRecord Action)> ExecuteConfirmedAsync(CarModePendingAction pending, CancellationToken ct)
+    {
+        switch (pending.Tool)
+        {
+            case "delete":
+                await _fleet.DeleteSessionAsync(pending.SessionId, ct);
+                return ($"Done. I deleted {pending.TargetName}.", new CarModeActionRecord("delete_session", $"Deleted {pending.TargetName}."));
+            default:
+                throw new InvalidOperationException($"Unknown pending action \"{pending.Tool}\".");
         }
     }
 
@@ -188,10 +281,20 @@ public sealed class CarModeBrain
         + "- \"need me\", \"need you\", \"waiting\", and \"who wants me\" all mean sessions whose needsYou is "
         + "true. \"The latest one\" is the first session in the list (it is ordered newest first).\n"
         + "- If a request is ambiguous or you cannot tell which session is meant, ask one short clarifying "
-        + "question instead of guessing.\n"
-        + "- When you have the answer, reply with the final spoken sentence and call no more tools.";
+        + "question instead of guessing.\n\n"
+        + "Taking action (you have full control):\n"
+        + "- Ordinary actions just happen - do not ask permission for them. To start a session, call "
+        + "start_session with the repository name. To message a session, call message_session. To approve "
+        + "a session that is waiting, call approve_session. After an act, say briefly what you did.\n"
+        + "- Deleting or killing a session is DESTRUCTIVE and always needs the owner's spoken confirmation. "
+        + "When he asks to delete or kill a session, call delete_session; you will get a "
+        + "confirmation_required result. Then tell him exactly what will be deleted and ask him to say "
+        + "\"confirm\" to proceed or \"cancel\" to stop, and call no more tools. The system handles the "
+        + "actual deletion once he confirms out loud - you never delete without that confirmation.\n"
+        + "- When you have the answer or have acted, reply with the final spoken sentence and call no more tools.";
 
-    // The tool catalog (Phase 2: read-only). Standard chat-completions function tools.
+    // The tool catalog. Standard chat-completions function tools: reads, ordinary acts, and the
+    // destructive delete (which the loop holds for a spoken confirmation - the model just requests it).
     private const string ToolCatalogJson = """
         [
           {
@@ -211,6 +314,63 @@ public sealed class CarModeBrain
                 "type": "object",
                 "properties": {
                   "session": { "type": "string", "description": "The session to read: a human name, a repository name, or a number." }
+                },
+                "required": ["session"]
+              }
+            }
+          },
+          {
+            "type": "function",
+            "function": {
+              "name": "start_session",
+              "description": "Start a brand-new agent session in a repository the owner names. Give the repository's short name (its folder leaf), for example \"devthrottle\".",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "repo": { "type": "string", "description": "The repository to start the session in, by its short name." }
+                },
+                "required": ["repo"]
+              }
+            }
+          },
+          {
+            "type": "function",
+            "function": {
+              "name": "message_session",
+              "description": "Send a message (a prompt) into a running session, the same as typing to it. Use this to tell a session to do something, for example run the tests.",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "session": { "type": "string", "description": "The session to message: a human name, a repository, or a number." },
+                  "message": { "type": "string", "description": "The message to send into the session." }
+                },
+                "required": ["session", "message"]
+              }
+            }
+          },
+          {
+            "type": "function",
+            "function": {
+              "name": "approve_session",
+              "description": "Approve a session that is waiting for the owner by accepting its highlighted default (presses Enter). Use this when the owner says to approve, allow, or continue a waiting session.",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "session": { "type": "string", "description": "The session to approve: a human name, a repository, or a number." }
+                },
+                "required": ["session"]
+              }
+            }
+          },
+          {
+            "type": "function",
+            "function": {
+              "name": "delete_session",
+              "description": "Request to delete (kill and remove) a session. This is DESTRUCTIVE: it does not delete immediately - it returns confirmation_required, and the owner must confirm out loud before it happens.",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "session": { "type": "string", "description": "The session to delete: a human name, a repository, or a number." }
                 },
                 "required": ["session"]
               }

--- a/src/CcDirector.Gateway/CarMode/CarModeConfirm.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeConfirm.cs
@@ -1,0 +1,53 @@
+namespace CcDirector.Gateway.CarMode;
+
+/// <summary>
+/// The spoken-confirmation words for a destructive Car Mode action (Car Mode mission, decision 3:
+/// deleting or killing a session always requires a spoken confirmation). Pure and exhaustively tested,
+/// because it gates an irreversible action: a delete only proceeds on a clear affirmative, and anything
+/// ambiguous is treated as NOT confirmed (negatives win), so an accidental word never destroys a session.
+/// </summary>
+public static class CarModeConfirm
+{
+    private static readonly string[] Affirmatives =
+    {
+        "yes", "yeah", "yep", "yup", "confirm", "confirmed", "do it", "go ahead", "affirmative",
+        "correct", "sure", "please do", "proceed", "okay do it", "ok do it",
+    };
+
+    private static readonly string[] Negatives =
+    {
+        "no", "nope", "cancel", "stop", "wait", "don't", "do not", "dont", "never mind", "nevermind",
+        "negative", "forget it", "abort", "leave it",
+    };
+
+    private static string Normalize(string raw) =>
+        System.Text.RegularExpressions.Regex.Replace(raw.ToLowerInvariant(), "[^a-z0-9\\s]", " ")
+            .Replace("  ", " ").Trim();
+
+    /// <summary>True when the text is a clear affirmative AND carries no negative (negatives win, so a
+    ///  destructive action never proceeds on a mixed or ambiguous answer).</summary>
+    public static bool IsAffirmative(string text)
+    {
+        var t = " " + Normalize(text) + " ";
+        if (t.Trim().Length == 0) return false;
+        if (ContainsAny(t, Negatives)) return false;
+        return ContainsAny(t, Affirmatives);
+    }
+
+    /// <summary>True when the text carries a negative / cancel word.</summary>
+    public static bool IsNegative(string text)
+    {
+        var t = " " + Normalize(text) + " ";
+        return ContainsAny(t, Negatives);
+    }
+
+    // Whole-word/phrase match: the padded text contains " phrase " so "no" does not match inside "north".
+    private static bool ContainsAny(string paddedText, string[] phrases)
+    {
+        foreach (var phrase in phrases)
+        {
+            if (paddedText.Contains(" " + phrase + " ", StringComparison.Ordinal)) return true;
+        }
+        return false;
+    }
+}

--- a/src/CcDirector.Gateway/CarMode/CarModePendingStore.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModePendingStore.cs
@@ -1,0 +1,55 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.CarMode;
+
+/// <summary>A destructive action armed and waiting for the owner's spoken confirmation: which tool, the
+/// resolved session id it will act on, and the human name to say back. Addressed by id (not re-resolved)
+/// so the confirmation deletes exactly the session the owner was told about.</summary>
+public sealed record CarModePendingAction(string Tool, string SessionId, string TargetName);
+
+/// <summary>
+/// Per-device store of the ONE destructive action currently held for a spoken confirmation (Car Mode
+/// mission, decision 3). The brain arms it when the model calls a destructive tool and does not execute;
+/// the next turn either confirms (execute) or does not (drop). In-memory, keyed by the device credential,
+/// with a short TTL so a forgotten confirmation disarms itself rather than lingering as a live delete.
+/// </summary>
+public sealed class CarModePendingStore
+{
+    private sealed record Entry(CarModePendingAction Action, DateTime ArmedUtc);
+
+    /// <summary>A held confirmation older than this is treated as disarmed (the owner moved on). Short,
+    ///  because an armed destructive action must not survive a conversation.</summary>
+    private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(5);
+
+    private readonly ConcurrentDictionary<string, Entry> _byDevice = new(StringComparer.Ordinal);
+    private readonly Action<string> _log;
+
+    public CarModePendingStore(Action<string>? log = null) => _log = log ?? FileLog.Write;
+
+    /// <summary>Arm a destructive action for a device, replacing any prior one.</summary>
+    public void Arm(string deviceKey, CarModePendingAction action)
+    {
+        _byDevice[Normalize(deviceKey)] = new Entry(action, DateTime.UtcNow);
+        _log($"[CarModePending] armed {action.Tool} for {action.TargetName}");
+    }
+
+    /// <summary>The armed action for a device, or null when none is armed or it has expired (a fresh,
+    ///  bounded TTL check on read - no timer).</summary>
+    public CarModePendingAction? Get(string deviceKey)
+    {
+        var key = Normalize(deviceKey);
+        if (!_byDevice.TryGetValue(key, out var entry)) return null;
+        if (DateTime.UtcNow - entry.ArmedUtc > Ttl)
+        {
+            _byDevice.TryRemove(key, out _);
+            return null;
+        }
+        return entry.Action;
+    }
+
+    /// <summary>Disarm a device's held action (after it is confirmed, cancelled, or superseded).</summary>
+    public void Clear(string deviceKey) => _byDevice.TryRemove(Normalize(deviceKey), out _);
+
+    private static string Normalize(string? deviceKey) => string.IsNullOrWhiteSpace(deviceKey) ? "anonymous" : deviceKey;
+}

--- a/src/CcDirector.Gateway/CarMode/ICarModeFleet.cs
+++ b/src/CcDirector.Gateway/CarMode/ICarModeFleet.cs
@@ -19,4 +19,26 @@ public interface ICarModeFleet
     ///  what it is doing. Returns null when nothing matches, so the brain can say it plainly rather than
     ///  guess.</summary>
     Task<CarModeActivity?> GetSessionActivityAsync(string sessionReference, CancellationToken ct);
+
+    /// <summary>Resolve a fuzzy human reference to one session's identity (id + name + repo), or null when
+    ///  nothing matches. Used by the act tools to name what they are about to do and to address it by id.</summary>
+    Task<CarModeSessionInfo?> ResolveSessionAsync(string sessionReference, CancellationToken ct);
+
+    /// <summary>Start a new session in a repository named by the owner (its leaf name). Resolves the repo
+    ///  to a real path on a machine and creates the session the same way the "+ New session" button does.
+    ///  Returns a short spoken-ready summary of what was started. Throws with a clear reason when no
+    ///  repository of that name exists on any machine (no silent guess).</summary>
+    Task<string> StartSessionAsync(string repo, CancellationToken ct);
+
+    /// <summary>Send a message (a prompt) into a session, exactly the way the Send button does
+    ///  (POST /prompt, appendEnter). Addressed by session id (already resolved).</summary>
+    Task MessageSessionAsync(string sessionId, string message, CancellationToken ct);
+
+    /// <summary>Approve a waiting session by pressing Enter to accept its highlighted default, exactly the
+    ///  way the Enter button does (POST /prompt "\r", appendEnter false). Addressed by session id.</summary>
+    Task ApproveSessionAsync(string sessionId, CancellationToken ct);
+
+    /// <summary>Delete (kill) a session, exactly the way the remove button does (DELETE /sessions/{id}).
+    ///  Destructive: the brain only calls this AFTER a spoken confirmation. Addressed by session id.</summary>
+    Task DeleteSessionAsync(string sessionId, CancellationToken ct);
 }

--- a/src/CcDirector.Gateway/CarMode/LoopbackCarModeFleet.cs
+++ b/src/CcDirector.Gateway/CarMode/LoopbackCarModeFleet.cs
@@ -74,6 +74,77 @@ public sealed class LoopbackCarModeFleet : ICarModeFleet
         };
     }
 
+    public async Task<CarModeSessionInfo?> ResolveSessionAsync(string sessionReference, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(sessionReference))
+            throw new ArgumentException("A session reference is required.", nameof(sessionReference));
+        var sessions = await GetSessionsAsync(ct);
+        var match = ResolveSession(sessions, sessionReference);
+        return match is null ? null : ToInfo(match);
+    }
+
+    public async Task<string> StartSessionAsync(string repo, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(repo))
+            throw new ArgumentException("A repository name is required.", nameof(repo));
+        var wanted = repo.Trim();
+
+        // Find a machine that knows a repository by this leaf name, then create the session there the
+        // same way the "+ New session" button does (POST /directors/{id}/sessions). No repository of that
+        // name anywhere is a clear, spoken failure - never a silent guess at some other repo.
+        var directors = await GetJsonArrayAsync("/directors", ct);
+        foreach (var d in directors)
+        {
+            var directorId = GetString(d, "directorId");
+            var machineName = GetString(d, "machineName");
+            if (string.IsNullOrWhiteSpace(directorId)) continue;
+
+            var repos = await GetJsonArrayAsync($"/directors/{Uri.EscapeDataString(directorId)}/repos", ct);
+            foreach (var r in repos)
+            {
+                var path = GetString(r, "path");
+                if (string.IsNullOrWhiteSpace(path)) continue;
+                var leaf = RepoLeaf(path);
+                if (!string.Equals(leaf, wanted, StringComparison.OrdinalIgnoreCase)
+                    && !leaf.Contains(wanted, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var created = await CreateSessionAsync(directorId, path, ct);
+                var createdName = string.IsNullOrWhiteSpace(created?.Name) ? "a new session" : created!.Name!.Trim();
+                _log($"[CarModeFleet] started session in {leaf} on {machineName}");
+                return $"Started {createdName} in the {leaf} repository on {machineName}.";
+            }
+        }
+        throw new InvalidOperationException($"I couldn't find a repository called \"{wanted}\" on any machine.");
+    }
+
+    public async Task MessageSessionAsync(string sessionId, string message, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId)) throw new ArgumentException("A session id is required.", nameof(sessionId));
+        if (string.IsNullOrWhiteSpace(message)) throw new ArgumentException("A message is required.", nameof(message));
+        await PostJsonAsync($"/sessions/{Uri.EscapeDataString(sessionId)}/prompt", new { text = message, appendEnter = true }, ct);
+        _log($"[CarModeFleet] messaged session {sessionId}");
+    }
+
+    public async Task ApproveSessionAsync(string sessionId, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId)) throw new ArgumentException("A session id is required.", nameof(sessionId));
+        // Press Enter to accept the highlighted default, exactly the Enter button's payload.
+        await PostJsonAsync($"/sessions/{Uri.EscapeDataString(sessionId)}/prompt", new { text = "\r", appendEnter = false }, ct);
+        _log($"[CarModeFleet] approved (Enter) session {sessionId}");
+    }
+
+    public async Task DeleteSessionAsync(string sessionId, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId)) throw new ArgumentException("A session id is required.", nameof(sessionId));
+        using var request = new HttpRequestMessage(HttpMethod.Delete, $"{_baseUrl}/sessions/{Uri.EscapeDataString(sessionId)}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+        using var response = await _http.SendAsync(request, ct);
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException($"The delete-session call failed: {(int)response.StatusCode} {response.StatusCode}.");
+        _log($"[CarModeFleet] deleted session {sessionId}");
+    }
+
     /// <summary>Read THIS Gateway's aggregated roster over loopback. A non-success status throws with the
     ///  code named (no-fallback) so the brain surfaces a loud, specific failure instead of an empty list.</summary>
     private async Task<IReadOnlyList<SessionDto>> GetSessionsAsync(CancellationToken ct)
@@ -87,6 +158,57 @@ public sealed class LoopbackCarModeFleet : ICarModeFleet
         var sessions = JsonSerializer.Deserialize<List<SessionDto>>(json, JsonOptions);
         return sessions ?? new List<SessionDto>();
     }
+
+    /// <summary>GET a loopback endpoint that returns a JSON array and hand back its elements. Throws on a
+    ///  non-success status (no silent empty list).</summary>
+    private async Task<IReadOnlyList<JsonElement>> GetJsonArrayAsync(string path, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"{_baseUrl}{path}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+        using var response = await _http.SendAsync(request, HttpCompletionOption.ResponseContentRead, ct);
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException($"GET {path} failed: {(int)response.StatusCode} {response.StatusCode}.");
+        var json = await response.Content.ReadAsStringAsync(ct);
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.ValueKind == JsonValueKind.Array
+            ? doc.RootElement.EnumerateArray().Select(e => e.Clone()).ToList()
+            : new List<JsonElement>();
+    }
+
+    /// <summary>POST a JSON body to a loopback endpoint with the Bearer, throwing on a non-success status
+    ///  so the brain surfaces a loud, specific failure.</summary>
+    private async Task PostJsonAsync(string path, object body, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{_baseUrl}{path}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+        request.Content = new StringContent(JsonSerializer.Serialize(body), System.Text.Encoding.UTF8, "application/json");
+        using var response = await _http.SendAsync(request, ct);
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException($"POST {path} failed: {(int)response.StatusCode} {response.StatusCode}.");
+    }
+
+    /// <summary>Create a session on a Director (POST /directors/{id}/sessions), the same call the
+    ///  "+ New session" button makes, and return the created session.</summary>
+    private async Task<SessionDto?> CreateSessionAsync(string directorId, string repoPath, CancellationToken ct)
+    {
+        var body = new { repoPath = repoPath.Trim(), agent = "ClaudeCode", wingmanEnabled = false };
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{_baseUrl}/directors/{Uri.EscapeDataString(directorId)}/sessions");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+        request.Content = new StringContent(JsonSerializer.Serialize(body), System.Text.Encoding.UTF8, "application/json");
+        using var response = await _http.SendAsync(request, HttpCompletionOption.ResponseContentRead, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            var detail = await response.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException($"Creating the session failed: {(int)response.StatusCode} {response.StatusCode}. {detail}");
+        }
+        var json = await response.Content.ReadAsStringAsync(ct);
+        return JsonSerializer.Deserialize<SessionDto>(json, JsonOptions);
+    }
+
+    private static string GetString(JsonElement el, string name) =>
+        el.ValueKind == JsonValueKind.Object && el.TryGetProperty(name, out var p) && p.ValueKind == JsonValueKind.String
+            ? p.GetString() ?? ""
+            : "";
 
     /// <summary>Resolve a fuzzy reference to one session: exact number, then exact name, then a name/repo
     ///  substring, then the newest match. Static and pure so it is unit-tested directly.</summary>

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -268,6 +268,9 @@ public sealed class GatewayHost : IAsyncDisposable
     // tool-calling brain (POST /carmode/turn), so multi-turn references ("the latest one") resolve.
     // In-memory by design; one instance for the whole Gateway.
     private readonly CarMode.CarModeConversationStore _carModeConversations = new();
+    // Car Mode (decision 3): the per-device store of a destructive action armed and awaiting the owner's
+    // spoken confirmation, so a delete never runs without a clear spoken "confirm".
+    private readonly CarMode.CarModePendingStore _carModePending = new();
     // Gateway-owned set of sessions whose dictated utterance is being transcribed in the background
     // (the phone released the Speak dialog and the audio is uploading/transcribing). Stamps the
     // orange "Transcribing..." roster color so nobody else grabs the session mid-dictation.
@@ -1129,7 +1132,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // caller's per-device key), like every other data route.
         var carModeChat = new CarMode.HostedCarModeChat(CarMode.HostedCarModeChat.DefaultResolver(_keyVault.Get));
         var carModeFleet = new CarMode.LoopbackCarModeFleet(Port, Token);
-        var carModeBrain = new CarMode.CarModeBrain(carModeChat, carModeFleet, _carModeConversations);
+        var carModeBrain = new CarMode.CarModeBrain(carModeChat, carModeFleet, _carModeConversations, _carModePending);
         Api.CarModeEndpoint.Map(_app, carModeBrain);
         // Editable/versioned wingman instructions settings surface (issue #537), incl. A/B test
         // over saved training sessions (reads the shared training store; uses the hosted wingman brain).


### PR DESCRIPTION
Third phase of the Car Mode mission: full command-and-control with the agreed confirmation policy (mission decision 3).

## What this delivers
- **Ordinary acts just happen** (no per-action nagging):
  - `start_session` - resolves a repo name (its folder leaf) to a real path on a machine and creates the session exactly the way the "+ New session" button does (`POST /directors/{id}/sessions`).
  - `message_session` - resolves a fuzzy session reference and sends a prompt (`POST /prompt`, the Send button's payload).
  - `approve_session` - presses Enter to accept the highlighted default (the Enter button's exact payload).
  Each records an on-screen action and the assistant says briefly what it did.
- **Deleting is destructive and always needs a spoken confirmation.** `delete_session` never deletes: the loop arms a per-device pending confirmation and returns a spoken question. The next turn is gated in **deterministic C#** (`CarModeConfirm`, negatives-win), so a delete runs ONLY on a clear spoken "confirm". A "cancel" or any unrelated command disarms it safely - nothing is deleted, and the deletion never depends on the model.
- `CarModePendingStore` - the per-device armed-action store with a short TTL so a forgotten confirmation disarms itself.
- System prompt + tool catalog extended with the full-control and confirmation rules.

The `/m/car` page already renders `pendingConfirmation` ("say confirm or cancel") and the action list, so no client change was needed.

## Verification
- 19 new unit tests: act tools call the fleet and record actions; an unresolved reference does not act; `delete_session` arms without deleting; a spoken "confirm" executes the delete with NO model call on the confirmation turn; "cancel" and unrelated commands disarm; the negatives-win confirmation words (including "yes no wait" -> not affirmative, "north" not read as "no").
- 43 Car Mode tests total green; Gateway builds zero-warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)