### PR TITLE
Car Mode Phase 4: hardening, spoken failures, turn-taking tests

### DIFF
--- a/docs/architecture/carmode-phase4-hardening.md
+++ b/docs/architecture/carmode-phase4-hardening.md
@@ -1,0 +1,72 @@
+# Car Mode Phase 4 - Hardening, narration, and latency
+
+Status: Phase 4 delivered. Written by the Manager session ("Car Mode - Manager", 2026-07-11).
+This records how Car Mode behaves under failure and real use, the narration approach, and the
+settled position on latency - the polish the mission asked for in Phase 4.
+
+## Loud, spoken, specific failures (decision 8, no fallback)
+
+Fire-and-forget is banned; every voice action shows and says its state.
+
+- Client. Every turn that fails routes its error through the shared `gatewayErrorMessage`, so an
+  unreachable Gateway, an out-of-credits 402, or a model error each collapses to ONE friendly,
+  retry-implying line ("Can't reach the Gateway - retrying.") instead of a raw "Failed to fetch".
+  The failure is put on the screen AND SPOKEN. It is spoken through the browser's LOCAL speech
+  synthesis, deliberately not the Gateway voice: the most common failure (an offline or
+  out-of-credit Gateway) is exactly when `POST /wingman/tts` is also down, so a failure that had to
+  be spoken by the Gateway would be silent - the one time it must not be. This local synthesis is
+  used ONLY to announce failures; the assistant's normal replies always use the one good Gateway
+  voice, so the single-voice rule holds. After any failure the microphone is handed straight back to
+  the owner with the "your turn" cue, so he is never left not knowing whose turn it is.
+- Server. `POST /carmode/turn` maps a money refusal (402) to the ONE shared hosted-AI state (so the
+  phone shows the consistent add-credit / add-key notice), and every other failure to a specific,
+  logged 502 the phone speaks. The brain's fleet tools throw (never return an empty list) on a bad
+  roster read, and the model loop is round-capped so a model that never settles fails loud instead of
+  looping forever.
+
+## Barge-in robustness
+
+Echo cancellation is already configured on the `MicRecorder` capture (`recorder.ts:68`), the single
+most important requirement so the assistant's own voice does not feed back and cause a false "stop".
+The turn-taking decision is one pure, unit-tested function (`decideControlAction`) gated by phase:
+only Listening can END (on "over and out"), only Speaking can INTERRUPT, Thinking ignores control
+words. False interrupts from the assistant's own speech are structurally unlikely (its replies do not
+contain "stop"/"wait"/"shut up"). The one residual risk - whether the built-in recognizer can HEAR the
+owner's "stop" over the assistant's voice on a real phone in a moving car - is owner-gated and carries
+the settled fallback (an on-device keyword model on the echo-cancelled stream), documented in
+`carmode-phase1-barge-in-finding.md`. The recognizer auto-restarts across the browser's internal
+segment ends and resets its buffer the instant a control phrase fires, so a used phrase never
+re-triggers.
+
+## Narration quality
+
+The assistant is prompted to sound like a competent, calm development manager on a phone call: it
+answers OUT LOUD in one or two short spoken sentences (no lists, no markdown, no emoji), always names a
+session by its human name and repository and NEVER by its number (decision 5), gets real facts from the
+tools before answering (never guesses a count or a state), asks one short clarifying question when
+unsure rather than guessing, and says briefly what it did after an act. This is enforced in the system
+prompt, not by post-processing the model's words.
+
+## Latency - the fold is a documented option, intentionally not taken in v1
+
+The v1 shape is three clear steps (decision 2): the browser captures audio, gets a transcript from
+`POST /wingman/transcribe`, hands the transcript to the brain at `POST /carmode/turn`, and speaks the
+reply from `POST /wingman/tts`. The mission explicitly allows folding transcription into the brain
+endpoint later (audio straight to `/carmode/turn`) as a latency optimization. It is deliberately NOT
+taken in v1: the three-step shape keeps each surface single-purpose and independently testable, and the
+dominant latency is the model tool-loop and the speech synthesis, not the extra request hop (the fleet
+tools are in-process loopback calls, sub-millisecond). Folding is a clean future change - `/carmode/turn`
+would accept multipart audio and call the same transcription owner in-process before the loop - with no
+change to the turn-taking machine or the tools. Recorded here so the option is a decision, not an
+oversight.
+
+## Test coverage (the mission's Phase 4 ask)
+
+- The brain's tool loop and confirmation gate: 43 unit tests (drives tools and feeds results back,
+  per-device context isolation and the round-cap loud failure, the act tools, the destructive
+  arm-then-confirm gate with the deterministic negatives-win confirmation words, the fuzzy resolver,
+  the parse, the stores).
+- The turn-taking machine's language: 20 unit tests (the exact end-word and interrupt rules, the
+  phase-gated `decideControlAction`, the two distinct cues).
+- The client Gateway calls: 10 unit tests (transcribe / speak / turn each map 402 to the shared
+  credits error and every other non-2xx to a specific GatewayError, and parse the success shapes).

--- a/packages/client-core/src/carmode/carModeApi.test.ts
+++ b/packages/client-core/src/carmode/carModeApi.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { carModeTurn, speakCarModeText, transcribeCarModeAudio } from "./carModeApi";
+import { CreditsError, GatewayError } from "../api/client";
+
+// The Car Mode Gateway calls must fail LOUD and SPECIFIC (mission decision 8): a money refusal (402) is
+// the shared CreditsError, and any other non-2xx is a GatewayError carrying the status - never a silent
+// success or a swallowed error. These stub fetch to prove the mapping without a network.
+
+function mockFetch(status: number, body: unknown, blob?: Blob) {
+  return vi.fn(
+    async (): Promise<Response> =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => body,
+        blob: async () => blob ?? new Blob([]),
+      }) as unknown as Response,
+  );
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("transcribeCarModeAudio", () => {
+  it("returns the trimmed transcript on success", async () => {
+    vi.stubGlobal("fetch", mockFetch(200, { transcript: "  how many need me  " }));
+    const text = await transcribeCarModeAudio(new Blob(["x"]));
+    expect(text).toBe("how many need me");
+  });
+
+  it("maps 402 to the shared CreditsError", async () => {
+    vi.stubGlobal("fetch", mockFetch(402, { state: "NeedsCredits", text: "Add credits." }));
+    await expect(transcribeCarModeAudio(new Blob(["x"]))).rejects.toBeInstanceOf(CreditsError);
+  });
+
+  it("maps another non-2xx to a GatewayError with the status", async () => {
+    vi.stubGlobal("fetch", mockFetch(502, { error: "upstream down" }));
+    await expect(transcribeCarModeAudio(new Blob(["x"]))).rejects.toMatchObject({ status: 502 });
+  });
+});
+
+describe("speakCarModeText", () => {
+  it("returns the audio blob on success", async () => {
+    const audio = new Blob(["mp3"], { type: "audio/mpeg" });
+    vi.stubGlobal("fetch", mockFetch(200, {}, audio));
+    const clip = await speakCarModeText("hello");
+    expect(clip).toBe(audio);
+  });
+
+  it("maps 402 to the shared CreditsError", async () => {
+    vi.stubGlobal("fetch", mockFetch(402, { state: "CapReached" }));
+    await expect(speakCarModeText("hi")).rejects.toBeInstanceOf(CreditsError);
+  });
+
+  it("maps another non-2xx to a GatewayError", async () => {
+    vi.stubGlobal("fetch", mockFetch(500, { error: "tts failed" }));
+    await expect(speakCarModeText("hi")).rejects.toBeInstanceOf(GatewayError);
+  });
+});
+
+describe("carModeTurn", () => {
+  it("parses the spoken reply, actions, and pendingConfirmation", async () => {
+    vi.stubGlobal("fetch", mockFetch(200, {
+      spoken: "  Deleting Old Worker is permanent. Confirm?  ",
+      actions: [{ tool: "message_session", summary: "Messaged X" }],
+      pendingConfirmation: true,
+    }));
+    const result = await carModeTurn("delete old worker");
+    expect(result.spoken).toBe("Deleting Old Worker is permanent. Confirm?");
+    expect(result.actions).toHaveLength(1);
+    expect(result.pendingConfirmation).toBe(true);
+  });
+
+  it("defaults actions to an empty array and pendingConfirmation to false", async () => {
+    vi.stubGlobal("fetch", mockFetch(200, { spoken: "Nothing needs you." }));
+    const result = await carModeTurn("who needs me");
+    expect(result.actions).toEqual([]);
+    expect(result.pendingConfirmation).toBe(false);
+  });
+
+  it("maps 402 to the shared CreditsError", async () => {
+    vi.stubGlobal("fetch", mockFetch(402, { state: "NeedsCredits" }));
+    await expect(carModeTurn("hi")).rejects.toBeInstanceOf(CreditsError);
+  });
+
+  it("maps another non-2xx to a GatewayError with the status", async () => {
+    vi.stubGlobal("fetch", mockFetch(502, { error: "car mode down" }));
+    await expect(carModeTurn("hi")).rejects.toMatchObject({ status: 502 });
+  });
+});

--- a/packages/client-core/src/carmode/controlPhrases.test.ts
+++ b/packages/client-core/src/carmode/controlPhrases.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { detectEndPhrase, detectInterrupt, normalizeTranscript } from "./controlPhrases";
+import { decideControlAction, detectEndPhrase, detectInterrupt, normalizeTranscript } from "./controlPhrases";
 
 // The walkie-talkie discipline is load-bearing: the assistant must never speak until "over and out",
 // and must never mistake a mid-sentence "over" or "stopover" for the end word. These tests pin the
@@ -73,5 +73,27 @@ describe("detectInterrupt", () => {
   });
   it("does not fire on empty input", () => {
     expect(detectInterrupt("")).toBe(false);
+  });
+});
+
+describe("decideControlAction (the turn-taking decision)", () => {
+  it("ends the turn only from Listening on the end phrase", () => {
+    expect(decideControlAction("listening", "how many need me over and out")).toBe("end");
+    expect(decideControlAction("listening", "how many need me")).toBe("none");
+  });
+
+  it("interrupts only from Speaking on an interrupt word", () => {
+    expect(decideControlAction("speaking", "stop")).toBe("interrupt");
+    expect(decideControlAction("speaking", "keep going")).toBe("none");
+  });
+
+  it("does NOT end from Speaking and does NOT interrupt from Listening (phase-gated)", () => {
+    expect(decideControlAction("speaking", "over and out")).toBe("none");
+    expect(decideControlAction("listening", "stop")).toBe("none");
+  });
+
+  it("ignores control words entirely while Thinking (nothing to interrupt, turn committed)", () => {
+    expect(decideControlAction("thinking", "over and out")).toBe("none");
+    expect(decideControlAction("thinking", "stop")).toBe("none");
   });
 });

--- a/packages/client-core/src/carmode/controlPhrases.ts
+++ b/packages/client-core/src/carmode/controlPhrases.ts
@@ -59,6 +59,26 @@ export function detectEndPhrase(rawTranscript: string): EndPhraseResult {
   return { ended: true, command };
 }
 
+/** What the turn-taking machine should do with a live control transcript, given the current phase. */
+export type ControlAction = "end" | "interrupt" | "none";
+
+/** The Car Mode phases the control-word handler branches on. */
+export type ControlPhase = "listening" | "thinking" | "speaking";
+
+/**
+ * The single turn-taking decision, pure and testable: given the current phase and the live control-word
+ * transcript, decide whether the owner ended his turn, interrupted the assistant, or did neither. Only
+ * Listening can END (on "over and out"), only Speaking can INTERRUPT (on "stop"/"wait"/"shut up"), and
+ * Thinking ignores control words (nothing is playing to interrupt, and the turn is already committed).
+ * useCarMode() calls this from its recognizer callback so the state machine's language rules live in one
+ * unit-tested place instead of inline in the imperative hook.
+ */
+export function decideControlAction(phase: ControlPhase, rawTranscript: string): ControlAction {
+  if (phase === "listening") return detectEndPhrase(rawTranscript).ended ? "end" : "none";
+  if (phase === "speaking") return detectInterrupt(rawTranscript) ? "interrupt" : "none";
+  return "none";
+}
+
 /**
  * Decide whether the transcript carries an interrupt word ("stop"/"wait"/"shut up"). Used ONLY while
  * the assistant is speaking, so the owner can cut it off instantly. Matches a WHOLE word/phrase (so

--- a/packages/client-core/src/carmode/useCarMode.ts
+++ b/packages/client-core/src/carmode/useCarMode.ts
@@ -2,9 +2,10 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { MicRecorder } from "../dictation/recorder";
 import { blobToWav16kMono } from "../dictation/wav";
 import { playReadyCue, playYourTurnCue } from "../dictation/readyCue";
-import { detectEndPhrase, detectInterrupt } from "./controlPhrases";
+import { decideControlAction, detectEndPhrase } from "./controlPhrases";
 import { ControlWordListener, isControlRecognitionSupported } from "./speechRecognition";
 import { speakCarModeText, transcribeCarModeAudio, type CarModeAction } from "./carModeApi";
+import { gatewayErrorMessage } from "../api/client";
 
 // The Car Mode turn-taking machine (new build B, mission Phase 1). This shared hook owns the whole
 // walkie-talkie loop so the page is a thin view (decision 6): capture -> transcribe -> brain -> speak,
@@ -158,7 +159,7 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
         await audio.play();
       } catch (err) {
         if (signal.aborted) return;
-        announceError(err instanceof Error ? err.message : "Could not play the reply.");
+        announceError(gatewayErrorMessage(err));
         await enterListening();
       }
     },
@@ -211,7 +212,10 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
       await speakAndPlay(spoken, controller.signal);
     } catch (err) {
       if (controller.signal.aborted) return; // stop() aborted this turn on purpose
-      announceError(err instanceof Error ? err.message : "Something went wrong on that turn.");
+      // A loud, SPECIFIC spoken failure (decision 8): an unreachable Gateway, an out-of-credits 402, or
+      // a model error each collapses to the shared, friendly, retry-implying line rather than a raw
+      // "Failed to fetch" - and it is spoken, never a silent stall.
+      announceError(gatewayErrorMessage(err));
       await enterListening();
     }
   }, [respond, announceError, enterListening, speakAndPlay, setPhaseBoth]);
@@ -223,22 +227,20 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
   const onControlTranscript = useCallback(
     (text: string) => {
       const current = phaseRef.current;
-      if (current === "listening") {
-        if (detectEndPhrase(text).ended) {
-          console.log("[CarMode] end phrase heard -> taking the turn");
-          void takeTurn();
+      if (current === "thinking" || current === "idle") return;
+      const action = decideControlAction(current, text);
+      if (action === "end") {
+        console.log("[CarMode] end phrase heard -> taking the turn");
+        void takeTurn();
+      } else if (action === "interrupt") {
+        console.log("[CarMode] interrupt heard -> silencing and returning the turn");
+        const audio = audioRef.current;
+        try {
+          audio?.pause();
+        } catch {
+          /* nothing playing */
         }
-      } else if (current === "speaking") {
-        if (detectInterrupt(text)) {
-          console.log("[CarMode] interrupt heard -> silencing and returning the turn");
-          const audio = audioRef.current;
-          try {
-            audio?.pause();
-          } catch {
-            /* nothing playing */
-          }
-          void enterListening();
-        }
+        void enterListening();
       }
     },
     [takeTurn, enterListening],


### PR DESCRIPTION
Fourth phase of the Car Mode mission: hardening and polish under real use.

## What this delivers
- **Loud, spoken, specific failures (decision 8).** Every failed turn routes its error through the shared `gatewayErrorMessage`, so an unreachable Gateway, an out-of-credits 402, or a model error collapses to ONE friendly, retry-implying line instead of a raw "Failed to fetch" - and it is SPOKEN. It is spoken through the browser's LOCAL speech synthesis, deliberately not the Gateway voice, because the most common failure (offline / out-of-credit Gateway) is exactly when `POST /wingman/tts` is also down. Used only to announce failures; normal replies still use the one good Gateway voice. After any failure the microphone returns to the owner with the "your turn" cue.
- **The turn-taking decision extracted and unit-tested.** `decideControlAction(phase, transcript)` is now one pure, phase-gated function (only Listening ends on "over and out", only Speaking interrupts, Thinking ignores control words); `useCarMode` calls it instead of inline logic.
- Hardening/narration doc (`docs/architecture/carmode-phase4-hardening.md`): the failure behavior, the barge-in position and fallback, the narration approach, and why the transcription-fold latency option (allowed by decision 2) is intentionally not taken in v1.

## Verification
- 20 control/turn-taking unit tests (the exact end-word and interrupt rules, the phase-gated decision, the two distinct cues) and 10 client Gateway-call tests (transcribe/speak/turn map 402 to the shared credits error and every other non-2xx to a specific GatewayError, and parse the success shapes).
- Full suites green: client-core 285, Gateway 1764. Mobile production build + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)