### PR TITLE
feat(ui): rename the session "hold" button to Snooze / Unsnooze

### DIFF
--- a/apps/cockpit/src/fleet/DirectorDetailView.tsx
+++ b/apps/cockpit/src/fleet/DirectorDetailView.tsx
@@ -184,7 +184,7 @@ export function DirectorDetailView() {
                           <td>
                             <span className="dcell-dot" style={{ background: dotColor(effectiveColor(s)) }} title={s.lastStatusReason ?? undefined} />
                             <span className="dcell-name">{(s.name ?? "").trim().length === 0 ? repoBasename(s.repoPath) : s.name}</span>
-                            {s.onHold && <span className="dtag dtag-hold">HOLD</span>}
+                            {s.onHold && <span className="dtag dtag-hold">SNOOZED</span>}
                             {briefing ? (
                               <div className="dcell-sub dcell-briefing">wingman reading...</div>
                             ) : (s.railLine ?? "").trim().length > 0 ? (

--- a/apps/cockpit/src/fleet/FleetMapView.tsx
+++ b/apps/cockpit/src/fleet/FleetMapView.tsx
@@ -237,7 +237,7 @@ export function FleetMapView() {
         <LegendDot color="yellow" label="Wingman reading" />
         <LegendDot color="orange" label="Transcribing" />
         <LegendDot color="supporting" label="Sub-agent" />
-        <LegendDot color="grey" label="On hold" />
+        <LegendDot color="grey" label="Snoozed" />
       </div>
     </div>
     </ReachabilityContext.Provider>

--- a/apps/cockpit/src/sessions/SessionMenu.tsx
+++ b/apps/cockpit/src/sessions/SessionMenu.tsx
@@ -10,7 +10,7 @@ import {
 } from "@devthrottle/client-core/api/client";
 import { renameSession } from "@devthrottle/client-core/fleet/fleetClient";
 
-// The session menu (issue #1214): a three-dot control with Rename, Put on hold / Resume, Handover info,
+// The session menu (issue #1214): a three-dot control with Rename, Snooze / Unsnooze, Handover info,
 // and Close session. It is the SAME component on the session page and on every rail card. Every action
 // goes Cockpit -> Gateway with relative URLs through the shared client (renameSession, holdSession,
 // killSession, getHandover) - the browser never learns a Director address. Close asks for confirmation
@@ -204,7 +204,7 @@ export function SessionMenu({ session, onClosed, variant = "page" }: SessionMenu
               Rename
             </button>
             <button type="button" role="menuitem" className="session-menu-item" onClick={() => void doHold()}>
-              {session.onHold ? "Resume" : "Put on hold"}
+              {session.onHold ? "Unsnooze" : "Snooze"}
             </button>
             <button type="button" role="menuitem" className="session-menu-item" onClick={openHandover}>
               Handover info

--- a/apps/cockpit/src/sessions/SessionRoster.tsx
+++ b/apps/cockpit/src/sessions/SessionRoster.tsx
@@ -136,7 +136,7 @@ function AttentionGroups({
         </Bucket>
       )}
       {held.length > 0 && (
-        <Bucket title="On hold" tone="hold" count={held.length}>
+        <Bucket title="Snoozed" tone="hold" count={held.length}>
           {held.map((s) => (
             <RosterRow key={`hold-${s.sessionId}`} session={s} directors={directors} selectedId={selectedId} />
           ))}
@@ -206,7 +206,7 @@ function RosterRow({
           </span>
           <span className="roster-meta">
             <span className="roster-state">{contextLine(session)}</span>
-            {session.onHold && <span className="roster-tag">hold</span>}
+            {session.onHold && <span className="roster-tag">snoozed</span>}
             {session.voiceMode && <span className="roster-tag voice">voice</span>}
             {machine && <span className="roster-machine" title={session.directorId ?? undefined}>{machine}</span>}
             {lastSeen && <span className="roster-lastseen">{lastSeen}</span>}

--- a/apps/mobile/src/components/SessionManageBar.tsx
+++ b/apps/mobile/src/components/SessionManageBar.tsx
@@ -111,7 +111,7 @@ export function SessionManageBar({ sessionId }: SessionManageBarProps) {
           onClick={toggleHold}
           disabled={busy || onHold === null}
         >
-          {held ? "Resume" : "Hold"}
+          {held ? "Unsnooze" : "Snooze"}
         </button>
         <button
           type="button"
@@ -122,7 +122,7 @@ export function SessionManageBar({ sessionId }: SessionManageBarProps) {
           Remove
         </button>
       </div>
-      {held && <span className="manage-held-pill">On hold</span>}
+      {held && <span className="manage-held-pill">Snoozed</span>}
 
       {confirming && (
         <div className="confirm-overlay" role="dialog" aria-modal="true" aria-label="Remove session">

--- a/packages/client-core/src/sessions/ordering.ts
+++ b/packages/client-core/src/sessions/ordering.ts
@@ -123,7 +123,7 @@ export function dotColor(color: string): string {
 // One short context line per row: the on-hold note, else the latest status reason, else the
 // activity state. Never empty so every row reads cleanly.
 export function contextLine(s: SessionDto): string {
-  if (s.onHold) return "On hold";
+  if (s.onHold) return "Snoozed";
   // Issue #1181, Task 4: the honest phase - "Uploading from phone" while the phone is still sending the
   // audio up, "Transcribing" while the server turns it into text. Falls back to the old blanket flag.
   if (s.dictationStatus) return s.dictationStatus;

--- a/src/CcDirector.Avalonia/FifoWindow.axaml
+++ b/src/CcDirector.Avalonia/FifoWindow.axaml
@@ -107,7 +107,7 @@
                 <Button Grid.Column="2" x:Name="SkipButton" Content="Skip"
                         Click="OnSkipClick" Background="#2B6CB0" Foreground="White"
                         Height="64" Width="92" HorizontalContentAlignment="Center" Cursor="Hand" />
-                <Button Grid.Column="3" x:Name="HoldButton" Content="Hold"
+                <Button Grid.Column="3" x:Name="HoldButton" Content="Snooze"
                         Click="OnHoldClick" Background="#8A5A1A" Foreground="White"
                         Height="64" Width="92" HorizontalContentAlignment="Center" Cursor="Hand" />
                 <Button Grid.Column="4" x:Name="NextButton" Content="Next &gt;"

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -2168,10 +2168,10 @@ public partial class MainWindow : Window
 
         // On-hold toggle: parks the session out of the FIFO rotation and paints its
         // list strip dark blue so you can see at a glance which sessions you've set aside.
-        var hold = new MenuItem { Header = vm.IsOnHold ? "Take Off Hold" : "Hold" };
+        var hold = new MenuItem { Header = vm.IsOnHold ? "Unsnooze" : "Snooze" };
         ToolTip.SetTip(hold, vm.IsOnHold
-            ? "Return this session to the \"Your Turn\" rotation."
-            : "Park this session out of the \"Your Turn\" rotation and mark it dark blue.");
+            ? "Unsnooze this session and return it to the \"Your Turn\" rotation."
+            : "Snooze this session so it drops out of the \"Your Turn\" rotation and is marked dark blue.");
         hold.Click += (_, _) => ToggleSessionHold(vm);
 
         // Wingman toggle is an alpha-only feature (issue #559): the Voice/Wingman tabs are

--- a/src/CcDirector.Avalonia/SessionViewModel.cs
+++ b/src/CcDirector.Avalonia/SessionViewModel.cs
@@ -156,7 +156,7 @@ public class SessionViewModel : INotifyPropertyChanged
     /// <summary>Tooltip-ready reason for the current strip color. Reflects the on-hold
     /// override when set, otherwise the wingman's reason for <see cref="Session.StatusColor"/>.</summary>
     public string StatusReason => Session.OnHold
-        ? "On hold (set aside by you)"
+        ? "Snoozed (set aside by you)"
         : Session.IsReceivingDictation
             ? "Receiving a dictation from your phone"
             : Session.LastStatusReason ?? "";

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -171,7 +171,7 @@ public sealed class SessionDto
     /// <summary>
     /// Gateway-owned human-readable state label after the same fold (issue #1177, Phase 2):
     /// e.g. "Needs you" | "Working" | "Ready" | "Wingman reading" | "Preparing voice" |
-    /// "Transcribing" | "Explaining" | "Sub-agent" | "Background" | "On hold" | "Exited".
+    /// "Transcribing" | "Explaining" | "Sub-agent" | "Background" | "Snoozed" | "Exited".
     /// Computed by <see cref="SessionOrdering.StateLabel"/> from the same raw facts + overlays as
     /// <see cref="EffectiveColor"/>, so every client renders ONE consistent label instead of each
     /// hand-rolling its own. Stamped by the Gateway aggregator; Director-local responses may leave it null.

--- a/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
@@ -184,7 +184,7 @@ public static class SessionOrdering
     /// </summary>
     public static string StateLabel(SessionDto s)
     {
-        if (s.OnHold) return "On hold";
+        if (s.OnHold) return "Snoozed";
         // Issue #1181, Task 4: the honest phase label wins - "Uploading from phone" while the phone is still
         // sending the audio, "Transcribing" while the server turns it into text. Falls back to the blanket
         // "Transcribing" for the legacy flag / the desktop's own dictation.

--- a/src/CcDirector.Gateway.Tests/SessionOrderingTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionOrderingTests.cs
@@ -486,11 +486,11 @@ public sealed class SessionOrderingTests
     // ----- StateLabel: one per color / overlay (issue #1177, Phase 2) -----
 
     [Fact]
-    public void StateLabel_OnHold_IsOnHold()
+    public void StateLabel_OnHold_IsSnoozed()
     {
         var s = Raw("WaitingForInput");
         s.OnHold = true;
-        Assert.Equal("On hold", SessionOrdering.StateLabel(s));
+        Assert.Equal("Snoozed", SessionOrdering.StateLabel(s));
     }
 
     [Fact]


### PR DESCRIPTION
## What

Renames the user-visible **"hold"** wording on a session to **Snooze** (park it) and **Unsnooze** (bring it back). Read-only state displays now read **Snoozed**.

"Snooze" is the word people already know from Gmail, Slack, and phone alarms - "make this go away for now, I'll deal with it later" - which is exactly what parking a session out of the "your turn" rotation does. The old wording was also inconsistent (Hold / Put on hold / Resume / Take Off Hold).

## Scope

**Visible text only.** The internal state stays named `hold` - `Session.OnHold`, `POST /sessions/{sid}/hold`, `holdSession()`, and the CSS classes are all untouched. No contract or storage change.

**Toggles (Snooze / Unsnooze):**
- `apps/mobile/.../SessionManageBar.tsx`
- `apps/cockpit/src/sessions/SessionMenu.tsx`
- `src/CcDirector.Avalonia/MainWindow.axaml.cs` (right-click menu + tooltips)
- `src/CcDirector.Avalonia/FifoWindow.axaml`

**Read-only labels (Snoozed):**
- `src/CcDirector.Gateway.Contracts/SessionOrdering.cs` - the authoritative Gateway `StateLabel` every client renders
- `packages/client-core/src/sessions/ordering.ts` - roster row context line
- cockpit roster bucket + tag, fleet-map legend, director-detail badge, mobile pill, desktop status tooltip

**Deliberately left alone:** the dictation "Hold" button and the retired Communication Manager "Hold" (different features), and the retired native phone app.

## Verification
- Frontend `npm run typecheck` passes across client-core, cockpit, mobile.
- Gateway `SessionOrderingTests.StateLabel` pass 12/12 (updated the on-hold case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)