### PR TITLE
Car Mode: default to the thinking model (GLM-5.2), evidence-based

### DIFF
--- a/docs/architecture/carmode-phase4-hardening.md
+++ b/docs/architecture/carmode-phase4-hardening.md
@@ -47,6 +47,17 @@ tools before answering (never guesses a count or a state), asks one short clarif
 unsure rather than guessing, and says briefly what it did after an act. This is enforced in the system
 prompt, not by post-processing the model's words.
 
+## Model choice - the thinking model, decided with evidence
+
+The Car Mode brain runs the THINKING hosted model (GLM-5.2), not the fast tier. The fast model
+(Qwen2.5-72B) was validated against the real fleet and rejected with evidence (see the QA report):
+it called the read tools and message/delete correctly but SKIPPED start_session entirely and
+hallucinated "I started a session" with no tool call and no session created. For a command-and-control
+agent a false "done" is broken, not merely slow, so this is the escalation the brief sanctioned. The
+`CC_CARMODE_MODEL` environment variable remains the switch; winning the latency back on the fast model
+(tool_choice=required, a stronger prompt, or routing read-only turns to the fast model and only action
+turns to GLM) is a deliberate later fast-follow, not a v1 blocker.
+
 ## Latency - the fold is a documented option, intentionally not taken in v1
 
 The v1 shape is three clear steps (decision 2): the browser captures audio, gets a transcript from

--- a/src/CcDirector.Gateway/CarMode/CarModeChat.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeChat.cs
@@ -128,17 +128,21 @@ public sealed class HostedCarModeChat : ICarModeChat
     }
 
     /// <summary>
-    /// Build the model resolver Car Mode uses: the DevThrottle base + vault key + the FAST wingman model
-    /// (the "decent but fast" tier the owner asked for), with an optional <c>CC_CARMODE_MODEL</c>
-    /// environment override so the model can be escalated to the thinking tier (GLM) without a code change
-    /// if the fast model cannot reliably choose tools (mission risk to validate with evidence).
+    /// Build the model resolver Car Mode uses: the DevThrottle base + vault key + the THINKING wingman
+    /// model (GLM). The fast tier was validated against the real fleet and REJECTED with evidence (mission
+    /// model risk, resolved 2026-07-11): the fast model called the read tools and message/delete correctly
+    /// but SKIPPED start_session entirely and hallucinated "I started a session" with no tool call and no
+    /// session created - unacceptable for a command-and-control agent, where a false "done" is broken, not
+    /// merely slow. The thinking model chooses tools reliably. The optional <c>CC_CARMODE_MODEL</c>
+    /// environment override remains the switch (e.g. to try the fast model again with tool_choice=required,
+    /// a stronger prompt, or a read-vs-act split - a deliberate later latency fast-follow, not a v1 blocker).
     /// </summary>
     public static Func<(string BaseUrl, string Model, string Key)> DefaultResolver(Func<string, string?> vaultGet)
     {
         return () =>
         {
             var mode = TranscriptionModeConfig.Get();
-            var ep = TranscriptionEndpointResolver.ResolveWingmanFast(mode);
+            var ep = TranscriptionEndpointResolver.ResolveWingman(mode);
             var overrideModel = Environment.GetEnvironmentVariable("CC_CARMODE_MODEL");
             var model = string.IsNullOrWhiteSpace(overrideModel) ? ep.Model : overrideModel.Trim();
             var key = vaultGet(ep.KeyName) ?? "";


### PR DESCRIPTION
Live-fleet validation of the Car Mode brain surfaced the mission's flagged model risk, and this is the sanctioned escalation.

## Evidence (from driving the deployed brain against the real fleet)
- Fast model (Qwen2.5-72B): called `list_sessions`, `message_session`, and `delete_session` correctly - but SKIPPED `start_session` entirely and hallucinated "I've started a session" with **no tool call and no session created**.
- Thinking model (GLM-5.2): called `start_session` reliably - created a real session (verified in `/sessions`) and returned the correct action record.

For a command-and-control agent, a false "done" is broken, not merely slow. The mission's model clause explicitly sanctions escalating to the thinking role with evidence.

## Change
- `HostedCarModeChat.DefaultResolver` now resolves the thinking wingman model (`ResolveWingman`, GLM-5.2) instead of the fast tier.
- The `CC_CARMODE_MODEL` environment override remains the switch. Winning the latency back on the fast model (`tool_choice=required`, a stronger prompt, or routing read-only turns to the fast model and only action turns to GLM) is a deliberate later fast-follow, not a v1 blocker.
- Both models' behavior recorded in the hardening doc; full detail in the QA report.

Gateway builds zero-warning; all Car Mode unit tests unaffected (they inject a scripted chat, model-agnostic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)