### PR TITLE
feat(stats): Phase 1 - honest voice-vs-typed and phone-vs-desktop-vs-cockpit instrumentation with an always-available Gateway dashboard

### DIFF
--- a/src/CcDirector.Avalonia/FifoWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/FifoWindow.axaml.cs
@@ -398,7 +398,8 @@ public partial class FifoWindow : Window
         if (!_terminalVisible) { _terminalVisible = true; ApplyTerminalVisibility(); }
         SetStatus("Sending to agent...", Yellow);
         // Desktop voice FIFO injection is framework-mediated; exempt from the dictation lock (issue #1181, Task 3b).
-        await _current.SendTextAsync(transcript, SendSource.Internal);
+        // DevThrottle Stats: this is spoken input from the desktop - count it as one voice turn.
+        await _current.SendTextAsync(transcript, SendSource.Internal, InputOrigin.DesktopVoice);
         SetText(ReplyText, $"Sent to {DisplayName(_current)}. Watch the terminal, then Next.");
         SetStatus("Sent - watch the terminal, then Next", Green);
     }

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -3077,7 +3077,8 @@ public partial class MainWindow : Window
         if (_activeSession?.Session == target)
             CleanView.InjectUserPrompt(text);
 
-        await target.SendTextAsync(text);
+        // DevThrottle Stats: desktop dictation - spoken input from the local machine.
+        await target.SendTextAsync(text, origin: InputOrigin.DesktopVoice);
     }
 
     // ===== Fire-and-forget dictation delivery =====
@@ -4321,7 +4322,9 @@ public partial class MainWindow : Window
         FileLog.Write($"[MainWindow] SendWingmanBriefOption: sid={_activeSession.Session.Id}, key=\"{o.Key}\", answerVia={answerVia}");
         if (string.Equals(answerVia, "keys", StringComparison.OrdinalIgnoreCase))
         {
-            try { await _activeSession.Session.SendTextAsync(o.Send); }
+            // DevThrottle Stats: a desktop wingman menu answer is a non-voice desktop action. Count it as
+            // typed (never voice) so answering menus from the desktop cannot inflate the published voice share.
+            try { await _activeSession.Session.SendTextAsync(o.Send, origin: InputOrigin.DesktopTyped); }
             catch (Exception ex) { FileLog.Write($"[MainWindow] SendWingmanBriefOption keys FAILED: {ex.Message}"); }
         }
         else
@@ -4950,7 +4953,8 @@ public partial class MainWindow : Window
         // Backends send Enter (CR/LF) explicitly after the text -- don't append a submit
         // newline here. Appending one used to trip LargeInputHandler's multi-line check
         // and route short single-line prompts through a temp file.
-        await _activeSession.Session.SendTextAsync(text);
+        // DevThrottle Stats: the desktop composer is typed input from the local machine, by construction.
+        await _activeSession.Session.SendTextAsync(text, origin: InputOrigin.DesktopTyped);
 
         if (isInteractiveCommand)
         {

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -3580,6 +3580,9 @@ internal static class ControlEndpoints
             // them (desktop-dictation orange, legacy auto-explain yellow) without reading StatusColor.
             IsTranscribing = s.IsTranscribing,
             IsAutoExplaining = s.IsExplaining,
+            // DevThrottle Stats: the per-session input tally, taken at the choke point. Null when empty so a
+            // fresh session does not bloat every snapshot; the Gateway aggregates the non-null tallies.
+            InputStats = s.InputStats.IsEmpty ? null : s.InputStats.Snapshot(),
             RemoteRepo = s.RemoteRepo ?? "",
             RemoteThreadUrl = s.RemoteThreadUrl ?? "",
             RemoteRunUrl = s.RemoteRunUrl ?? "",

--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -119,10 +119,25 @@ internal static class SessionCommandExecutor
 
         var bufferCursor = session.Buffer?.TotalBytesWritten ?? 0;
 
+        // DevThrottle Stats: build the origin for the Director's choke-point tally. Modality is voice for a
+        // dictation delivery (SendSource.Delivery, set from the X-Dictation-Delivery marker) and typed
+        // otherwise. Surface comes from the Gateway-authoritative request.Surface. Count when this is an
+        // operator prompt - marked by a NON-NULL request.Surface, which the operator front doors (the
+        // Gateway prompt handler and the dictation delivery) always set, stamping "unknown" when the device
+        // key did not resolve. A phone/cockpit key maps to that surface; "unknown" maps to the Unknown
+        // bucket the dashboard shows (decision 9: excluded volume is surfaced, never silently dropped).
+        // A framework send (SendSource.Internal) and machine-to-machine traffic (fanout/broadcast, which
+        // never sets Surface, so it is null) are correctly NOT counted.
+        InputOrigin? origin = (source != SendSource.Internal && request.Surface is not null)
+            ? new InputOrigin(
+                source == SendSource.Delivery ? InputModality.Voice : InputModality.Typed,
+                InputOrigin.RemoteSurfaceFromDeviceType(request.Surface))
+            : null;
+
         if (request.AppendEnter)
-            await session.SendTextAsync(request.Text, source);
+            await session.SendTextAsync(request.Text, source, origin);
         else
-            session.SendInput(Encoding.UTF8.GetBytes(request.Text));
+            session.SendInput(Encoding.UTF8.GetBytes(request.Text), origin);
 
         var response = new PromptResponse
         {

--- a/src/CcDirector.ControlApi/TerminalStreamEndpoint.cs
+++ b/src/CcDirector.ControlApi/TerminalStreamEndpoint.cs
@@ -214,7 +214,12 @@ internal static class TerminalStreamEndpoint
                 var bytes = message.ToArray();
                 message.SetLength(0);
 
-                sessionManager.GetSession(guid)?.SendInput(bytes);
+                // DevThrottle Stats: raw keystrokes over the live terminal stream are real operator typing,
+                // but the Director cannot resolve which surface the stream came from (the device registry is
+                // Gateway-side). Count them as typed CHARACTER volume with an Unknown surface - surfaced on
+                // the dashboard, never silently dropped (decision 9) - and never as turns (raw keystrokes are
+                // composing, not a submitted turn).
+                sessionManager.GetSession(guid)?.SendInput(bytes, InputOrigin.Typed(InputSurface.Unknown));
             }
         }
         catch

--- a/src/CcDirector.Core.Tests/SessionInputStatsTests.cs
+++ b/src/CcDirector.Core.Tests/SessionInputStatsTests.cs
@@ -1,0 +1,149 @@
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// The DevThrottle Stats tally math: one submitted turn is one turn (never inflated by mechanics), raw
+/// keystrokes are character volume with no turn, buckets split by (modality, surface), and a snapshot
+/// round-trips through the wire DTO so a persisted tally restores exactly after a Director restart.
+/// </summary>
+public sealed class SessionInputStatsTests
+{
+    private static long Turns(InputStatsDtoView v, string modality, string surface) =>
+        v.Get(modality, surface).Turns;
+
+    private static long Chars(InputStatsDtoView v, string modality, string surface) =>
+        v.Get(modality, surface).Characters;
+
+    [Fact]
+    public void RecordTurn_CountsOneTurnAndCharacters_PerBucket()
+    {
+        var stats = new SessionInputStats();
+
+        stats.RecordTurn(InputOrigin.Voice(InputSurface.Phone), characters: 40);
+        stats.RecordTurn(InputOrigin.Voice(InputSurface.Phone), characters: 60);
+        stats.RecordTurn(InputOrigin.DesktopTyped, characters: 10);
+
+        var v = new InputStatsDtoView(stats.Snapshot());
+
+        Assert.Equal(2, Turns(v, "voice", "phone"));
+        Assert.Equal(100, Chars(v, "voice", "phone"));
+        Assert.Equal(1, Turns(v, "typed", "desktop"));
+        Assert.Equal(10, Chars(v, "typed", "desktop"));
+    }
+
+    [Fact]
+    public void RecordCharacters_AddsVolumeButNeverATurn()
+    {
+        var stats = new SessionInputStats();
+
+        stats.RecordCharacters(InputOrigin.DesktopTyped, characters: 5);
+        stats.RecordCharacters(InputOrigin.DesktopTyped, characters: 7);
+
+        var v = new InputStatsDtoView(stats.Snapshot());
+
+        Assert.Equal(0, Turns(v, "typed", "desktop"));
+        Assert.Equal(12, Chars(v, "typed", "desktop"));
+    }
+
+    [Fact]
+    public void OneSpokenTurnAndOneTypedTurn_EachCountAsExactlyOneTurn()
+    {
+        // The fairness property the mission's headline unit rests on: a long dictated utterance and a
+        // short typed message are each ONE turn, so neither modality is inflated by its mechanics.
+        var stats = new SessionInputStats();
+
+        stats.RecordTurn(InputOrigin.Voice(InputSurface.Phone), characters: 500);
+        stats.RecordTurn(InputOrigin.Typed(InputSurface.Desktop), characters: 4);
+
+        var v = new InputStatsDtoView(stats.Snapshot());
+
+        Assert.Equal(1, Turns(v, "voice", "phone"));
+        Assert.Equal(1, Turns(v, "typed", "desktop"));
+    }
+
+    [Fact]
+    public void RecordCharacters_IgnoresNonPositiveVolume()
+    {
+        var stats = new SessionInputStats();
+
+        stats.RecordCharacters(InputOrigin.DesktopTyped, characters: 0);
+        stats.RecordCharacters(InputOrigin.DesktopTyped, characters: -3);
+
+        Assert.True(stats.IsEmpty);
+        Assert.Empty(stats.Snapshot().Buckets);
+    }
+
+    [Fact]
+    public void Snapshot_RoundTripsThroughSeed_RestoresExactCounts()
+    {
+        var original = new SessionInputStats();
+        original.RecordTurn(InputOrigin.Voice(InputSurface.Phone), 100);
+        original.RecordTurn(InputOrigin.Typed(InputSurface.Cockpit), 20);
+        original.RecordCharacters(InputOrigin.Typed(InputSurface.Desktop), 33);
+
+        var persisted = original.Snapshot();
+
+        var restored = new SessionInputStats();
+        restored.Seed(persisted);
+        var v = new InputStatsDtoView(restored.Snapshot());
+
+        Assert.Equal(1, Turns(v, "voice", "phone"));
+        Assert.Equal(100, Chars(v, "voice", "phone"));
+        Assert.Equal(1, Turns(v, "typed", "cockpit"));
+        Assert.Equal(20, Chars(v, "typed", "cockpit"));
+        Assert.Equal(0, Turns(v, "typed", "desktop"));
+        Assert.Equal(33, Chars(v, "typed", "desktop"));
+    }
+
+    [Fact]
+    public void Seed_ClearsBucketsNotInSnapshot()
+    {
+        var stats = new SessionInputStats();
+        stats.RecordTurn(InputOrigin.Voice(InputSurface.Phone), 10);
+
+        stats.Seed(new InputStatsDto()); // empty snapshot
+
+        Assert.True(stats.IsEmpty);
+    }
+
+    [Fact]
+    public void UnknownSurface_IsRecordedHonestly_NotFoldedAway()
+    {
+        var stats = new SessionInputStats();
+        stats.RecordTurn(InputOrigin.Typed(InputSurface.Unknown), 5);
+
+        var v = new InputStatsDtoView(stats.Snapshot());
+        Assert.Equal(1, Turns(v, "typed", "unknown"));
+    }
+
+    [Theory]
+    [InlineData("phone", InputSurface.Phone)]
+    [InlineData("browser", InputSurface.Cockpit)]
+    [InlineData("BROWSER", InputSurface.Cockpit)]
+    [InlineData("workstation", InputSurface.Unknown)]
+    [InlineData("unknown", InputSurface.Unknown)]
+    [InlineData("", InputSurface.Unknown)]
+    [InlineData(null, InputSurface.Unknown)]
+    public void RemoteSurfaceFromDeviceType_MapsKnownDevices_AndDoesNotGuessTheRest(string? deviceType, InputSurface expected)
+    {
+        // A remote operator prompt with an unresolved surface ("unknown"/null) resolves to Unknown - which is
+        // COUNTED into the Unknown bucket (surfaced on the dashboard), never dropped or guessed (decision 9).
+        Assert.Equal(expected, InputOrigin.RemoteSurfaceFromDeviceType(deviceType));
+    }
+
+    /// <summary>Tiny read helper: look up a bucket by its wire tokens, defaulting to zeroes when absent.</summary>
+    private sealed class InputStatsDtoView
+    {
+        private readonly InputStatsDto _dto;
+        public InputStatsDtoView(InputStatsDto dto) => _dto = dto;
+
+        public InputStatBucketDto Get(string modality, string surface) =>
+            _dto.Buckets.FirstOrDefault(b =>
+                string.Equals(b.Modality, modality, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(b.Surface, surface, StringComparison.OrdinalIgnoreCase))
+            ?? new InputStatBucketDto { Modality = modality, Surface = surface };
+    }
+}

--- a/src/CcDirector.Core.Tests/TerminalPromptInjectionChokepointTests.cs
+++ b/src/CcDirector.Core.Tests/TerminalPromptInjectionChokepointTests.cs
@@ -13,11 +13,15 @@ public sealed class TerminalPromptInjectionChokepointTests
         var fifo = File.ReadAllText(Path.Combine(root, "src", "CcDirector.Avalonia", "FifoWindow.axaml.cs"));
         var voiceMode = File.ReadAllText(Path.Combine(root, "src", "CcDirector.Core", "Voice", "Controllers", "VoiceModeController.cs"));
 
-        Assert.Contains("await _activeSession.Session.SendTextAsync(text);", main);
-        Assert.Contains("await target.SendTextAsync(text);", main);
+        // DevThrottle Stats threaded an InputOrigin through the desktop choke-point calls: the composer is
+        // typed-desktop, the background dictation submit and the FIFO/voice-mode injections are voice-desktop.
+        // The chokepoint (SendTextAsync only, no Enter-retry, no raw SendInput) is unchanged - the calls still
+        // funnel here; they now also carry the honest origin tag.
+        Assert.Contains("await _activeSession.Session.SendTextAsync(text, origin: InputOrigin.DesktopTyped);", main);
+        Assert.Contains("await target.SendTextAsync(text, origin: InputOrigin.DesktopVoice);", main);
         Assert.Contains("await _activeSession.Session.SendTextAsync(\"/handover\", SendSource.Internal);", main);
-        Assert.Contains("await _current.SendTextAsync(transcript, SendSource.Internal);", fifo);
-        Assert.Contains("await _activeSession.SendTextAsync(transcription, SendSource.Internal);", voiceMode);
+        Assert.Contains("await _current.SendTextAsync(transcript, SendSource.Internal, InputOrigin.DesktopVoice);", fifo);
+        Assert.Contains("await _activeSession.SendTextAsync(transcription, SendSource.Internal, InputOrigin.DesktopVoice);", voiceMode);
 
         Assert.DoesNotContain("ScheduleEnterRetry", main);
         Assert.DoesNotContain("RetryEnterAfterDelay", main);
@@ -38,7 +42,7 @@ public sealed class TerminalPromptInjectionChokepointTests
 
         Assert.Contains("Verb = \"prompt\"", control);
         Assert.Contains("SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command, source: source);", control);
-        Assert.Contains("await session.SendTextAsync(request.Text, source);", executor);
+        Assert.Contains("await session.SendTextAsync(request.Text, source, origin);", executor);
         Assert.Contains("await local.SendTextAsync(framed, SendSource.Internal);", control);
         Assert.Contains("await s.SendTextAsync(framed, SendSource.Internal);", control);
         Assert.Contains("await session.SendTextAsync(text, SendSource.Internal);", control);
@@ -48,7 +52,7 @@ public sealed class TerminalPromptInjectionChokepointTests
         // Raw SendInput is still allowed when the caller explicitly asked not to append Enter; that is
         // terminal typing, not prompt submission.
         Assert.Contains("if (request.AppendEnter)", executor);
-        Assert.Contains("session.SendInput(Encoding.UTF8.GetBytes(request.Text));", executor);
+        Assert.Contains("session.SendInput(Encoding.UTF8.GetBytes(request.Text), origin);", executor);
     }
 
     [Fact]
@@ -73,7 +77,7 @@ public sealed class TerminalPromptInjectionChokepointTests
         Assert.Contains("await sendPrompt(sid, trimmed, true);", mobileVoice);
 
         Assert.Contains("await sendPrompt(this.sessionId, chunk, false);", interactive);
-        Assert.Contains("sessionManager.GetSession(guid)?.SendInput(bytes);", stream);
+        Assert.Contains("sessionManager.GetSession(guid)?.SendInput(bytes, InputOrigin.Typed(InputSurface.Unknown));", stream);
 
         Assert.Contains("await client.PostPromptAsync(director.ControlEndpoint, sid, req);", gateway);
         Assert.Contains("new HttpRequestMessage(HttpMethod.Post, $\"{endpoint}/sessions/{sessionId}/prompt\")", directorClient);

--- a/src/CcDirector.Core/Sessions/InputOrigin.cs
+++ b/src/CcDirector.Core/Sessions/InputOrigin.cs
@@ -1,0 +1,80 @@
+namespace CcDirector.Core.Sessions;
+
+/// <summary>How a unit of user input was produced (the DevThrottle Stats modality axis).</summary>
+public enum InputModality
+{
+    /// <summary>Typed on a keyboard.</summary>
+    Typed,
+
+    /// <summary>Spoken and transcribed (desktop dictation / voice mode, or phone durable dictation).</summary>
+    Voice,
+}
+
+/// <summary>Which surface the operator drove from (the DevThrottle Stats surface axis).</summary>
+public enum InputSurface
+{
+    /// <summary>Surface could not be determined. Recorded honestly, but never presented as a real surface
+    /// share - the dashboard shows it as its own "unknown" slice rather than folding it into a lie.</summary>
+    Unknown,
+
+    /// <summary>The cc-director desktop app on the local machine (input never leaves the machine).</summary>
+    Desktop,
+
+    /// <summary>The cockpit web app in a browser.</summary>
+    Cockpit,
+
+    /// <summary>The mobile /m app on a phone.</summary>
+    Phone,
+}
+
+/// <summary>
+/// The origin of one unit of user input: its <see cref="InputModality"/> (typed vs voice) and its
+/// <see cref="InputSurface"/> (desktop / cockpit / phone). Threaded from each entry point into the two
+/// Session choke points (<see cref="Session.SendInput(byte[], InputOrigin?)"/> and
+/// <see cref="Session.SendTextAsync(string, SendSource, InputOrigin?)"/>) so the Director can tally, at
+/// the ONE place that sees desktop-local input too, how the operator is actually driving development.
+///
+/// A <c>null</c> origin at a choke point means the caller is framework-internal (handover text, queue
+/// drain, framing) and is deliberately NOT counted - it carries no human keystrokes and no spoken words.
+/// </summary>
+public readonly record struct InputOrigin(InputModality Modality, InputSurface Surface)
+{
+    /// <summary>Typed at the desktop app - the by-construction origin of local desktop input.</summary>
+    public static InputOrigin DesktopTyped => new(InputModality.Typed, InputSurface.Desktop);
+
+    /// <summary>Spoken at the desktop app (desktop dictation / voice mode).</summary>
+    public static InputOrigin DesktopVoice => new(InputModality.Voice, InputSurface.Desktop);
+
+    /// <summary>Typed input from the given surface.</summary>
+    public static InputOrigin Typed(InputSurface surface) => new(InputModality.Typed, surface);
+
+    /// <summary>Spoken input from the given surface.</summary>
+    public static InputOrigin Voice(InputSurface surface) => new(InputModality.Voice, surface);
+
+    /// <summary>
+    /// Map a device registry <c>DeviceType</c> (resolved from a verified per-device key) to the REMOTE
+    /// surface it represents. Remote input reaching a Director through the Gateway is a phone or a
+    /// cockpit browser; anything else is honestly <see cref="InputSurface.Unknown"/> rather than guessed.
+    /// Desktop is never resolved this way - local desktop input is <see cref="InputSurface.Desktop"/> by
+    /// construction and carries no device header.
+    /// </summary>
+    public static InputSurface RemoteSurfaceFromDeviceType(string? deviceType) =>
+        (deviceType ?? "").Trim().ToLowerInvariant() switch
+        {
+            "phone" => InputSurface.Phone,
+            "browser" => InputSurface.Cockpit,
+            _ => InputSurface.Unknown,
+        };
+
+    /// <summary>The stable lowercase wire token for this modality ("typed" / "voice").</summary>
+    public string ModalityToken => Modality == InputModality.Voice ? "voice" : "typed";
+
+    /// <summary>The stable lowercase wire token for this surface ("desktop" / "cockpit" / "phone" / "unknown").</summary>
+    public string SurfaceToken => Surface switch
+    {
+        InputSurface.Desktop => "desktop",
+        InputSurface.Cockpit => "cockpit",
+        InputSurface.Phone => "phone",
+        _ => "unknown",
+    };
+}

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -1528,12 +1528,24 @@ public sealed class Session : IDisposable
         return result;
     }
 
-    /// <summary>Send raw bytes to the backend.</summary>
-    public void SendInput(byte[] data)
+    /// <summary>
+    /// The DevThrottle Stats per-session input tally (submitted turns + character volume by modality and
+    /// surface). Recorded at THIS choke point so desktop-local input is counted too; read by the Director
+    /// mapper for flow-up and by the Director stats store for persistence. Always present; empty until the
+    /// first counted input.
+    /// </summary>
+    public SessionInputStats InputStats { get; } = new();
+
+    /// <summary>Send raw bytes to the backend. <paramref name="origin"/> tags this input for the
+    /// DevThrottle Stats tally as typed CHARACTER volume for its surface (never a turn - a bare keystroke
+    /// is the user composing, not a submitted turn). Null origin = framework-internal, not counted.</summary>
+    public void SendInput(byte[] data, InputOrigin? origin = null)
     {
         if (_disposed || Status is SessionStatus.Exited or SessionStatus.Failed) return;
         FileLog.Write($"[Session] SendInput: session={Id}, bytes={data.Length}, firstByte=0x{(data.Length > 0 ? data[0].ToString("X2") : "00")}");
         _backend.Write(data);
+        if (origin is InputOrigin o)
+            InputStats.RecordCharacters(o, CountPrintable(data));
         // Only promote to Working when the write contains an actual submission
         // (CR or LF). A bare keystroke is the user composing at the prompt --
         // Claude Code hasn't received a turn yet. Treating every byte as Working
@@ -1554,6 +1566,21 @@ public sealed class Session : IDisposable
         for (int i = 0; i < data.Length; i++)
             if (data[i] == 0x0D || data[i] == 0x0A) return true;
         return false;
+    }
+
+    /// <summary>
+    /// Count the printable bytes in a raw keystroke buffer for the DevThrottle Stats character tally:
+    /// every byte at or above 0x20 except DEL (0x7F). Control bytes (Enter, arrows' leading ESC, Backspace)
+    /// do not count. This is an honest approximation of typed character volume - an escape sequence's
+    /// trailing letters (e.g. "[A" from an arrow key) count as a couple of characters of navigation
+    /// activity, which the secondary character metric tolerates; the headline metric is TURNS, not chars.
+    /// </summary>
+    private static int CountPrintable(byte[] data)
+    {
+        int n = 0;
+        for (int i = 0; i < data.Length; i++)
+            if (data[i] >= 0x20 && data[i] != 0x7F) n++;
+        return n;
     }
 
     /// <summary>
@@ -1616,7 +1643,7 @@ public sealed class Session : IDisposable
     /// single-operator tool, and a collision between the operator's own phone dictation and their
     /// own typed send is theirs to make, not the Director's to police.
     /// </summary>
-    public async Task SendTextAsync(string text, SendSource source = SendSource.UserInput)
+    public async Task SendTextAsync(string text, SendSource source = SendSource.UserInput, InputOrigin? origin = null)
     {
         if (_disposed || Status is SessionStatus.Exited or SessionStatus.Failed) return;
 
@@ -1641,15 +1668,21 @@ public sealed class Session : IDisposable
         // setter no-ops + skips OnHoldChanged when already false.
         OnHold = false;
         SetActivityState(ActivityState.Working);
+        // DevThrottle Stats: a SendTextAsync is exactly one submitted turn. Count it (plus its character
+        // volume) for the tagged origin. Null origin = framework-internal (handover, queue drain) - not
+        // counted, even though it still submits a turn to the agent.
+        if (origin is InputOrigin o)
+            InputStats.RecordTurn(o, text?.Length ?? 0);
     }
 
     /// <summary>Send text followed by Enter (sync wrapper). See
-    /// <see cref="SendTextAsync(string, SendSource)"/> for what <paramref name="source"/> means.</summary>
-    public void SendText(string text, SendSource source = SendSource.UserInput)
+    /// <see cref="SendTextAsync(string, SendSource, InputOrigin?)"/> for what <paramref name="source"/> and
+    /// <paramref name="origin"/> mean.</summary>
+    public void SendText(string text, SendSource source = SendSource.UserInput, InputOrigin? origin = null)
     {
         if (_disposed || Status is SessionStatus.Exited or SessionStatus.Failed) return;
         // Fire and forget for sync API
-        _ = SendTextAsync(text, source);
+        _ = SendTextAsync(text, source, origin);
     }
 
     /// <summary>Send just an Enter keystroke to the backend.</summary>

--- a/src/CcDirector.Core/Sessions/SessionInputStats.cs
+++ b/src/CcDirector.Core/Sessions/SessionInputStats.cs
@@ -1,0 +1,112 @@
+using System.Collections.Concurrent;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Core.Sessions;
+
+/// <summary>
+/// Per-session tally of how the operator drove this session: submitted TURNS and CHARACTER volume, split
+/// by (<see cref="InputModality"/>, <see cref="InputSurface"/>). This is the honest instrumentation heart
+/// of the DevThrottle Stats mission: the count is taken at the Session choke point
+/// (<see cref="Session.SendInput(byte[], InputOrigin?)"/> / <see cref="Session.SendTextAsync(string, SendSource, InputOrigin?)"/>),
+/// the one place that sees desktop-local input too, so a published phone/voice share is never silently
+/// inflated by a surface the Gateway cannot see.
+///
+/// Counting rules (mission "unit of how much"):
+/// - A submitted turn (a whole message that ends with Enter, or a dictation/voice-turn delivery) is one
+///   turn via <see cref="RecordTurn"/>. One spoken utterance and one typed message each count as one turn,
+///   so neither modality is inflated by its mechanics.
+/// - Raw keystrokes (a <see cref="Session.SendInput(byte[], InputOrigin?)"/> that is terminal typing, not a
+///   prompt submission) are counted as typed CHARACTER volume only via <see cref="RecordCharacters"/> -
+///   NEVER synthesized into turns.
+///
+/// Thread-safe: several PTY/stream callers can record concurrently.
+/// </summary>
+public sealed class SessionInputStats
+{
+    private sealed class Counters
+    {
+        public long Turns;
+        public long Characters;
+    }
+
+    private readonly ConcurrentDictionary<(InputModality Modality, InputSurface Surface), Counters> _buckets = new();
+
+    /// <summary>Raised after any recorded change, so the host can persist and push a delta (debounced by
+    /// the host - this fires per keystroke). Carries no data; readers call <see cref="Snapshot"/>.</summary>
+    public event Action? Changed;
+
+    /// <summary>
+    /// Record one submitted turn from <paramref name="origin"/>, plus its <paramref name="characters"/> of
+    /// text volume. Used by <see cref="Session.SendTextAsync(string, SendSource, InputOrigin?)"/> and by a
+    /// dictation/voice-turn delivery.
+    /// </summary>
+    public void RecordTurn(InputOrigin origin, int characters)
+    {
+        var c = _buckets.GetOrAdd((origin.Modality, origin.Surface), static _ => new Counters());
+        Interlocked.Increment(ref c.Turns);
+        if (characters > 0)
+            Interlocked.Add(ref c.Characters, characters);
+        Changed?.Invoke();
+    }
+
+    /// <summary>
+    /// Record <paramref name="characters"/> of raw typed keystrokes from <paramref name="origin"/> with NO
+    /// turn (mission rule: a bare keystroke is the user composing, not a submitted turn). Used by
+    /// <see cref="Session.SendInput(byte[], InputOrigin?)"/> for terminal typing.
+    /// </summary>
+    public void RecordCharacters(InputOrigin origin, int characters)
+    {
+        if (characters <= 0) return;
+        var c = _buckets.GetOrAdd((origin.Modality, origin.Surface), static _ => new Counters());
+        Interlocked.Add(ref c.Characters, characters);
+        Changed?.Invoke();
+    }
+
+    /// <summary>An immutable snapshot of the tally as the shared wire DTO, buckets in a stable order.</summary>
+    public InputStatsDto Snapshot()
+    {
+        var dto = new InputStatsDto();
+        foreach (var kvp in _buckets
+                     .OrderBy(b => b.Key.Modality)
+                     .ThenBy(b => b.Key.Surface))
+        {
+            var origin = new InputOrigin(kvp.Key.Modality, kvp.Key.Surface);
+            dto.Buckets.Add(new InputStatBucketDto
+            {
+                Modality = origin.ModalityToken,
+                Surface = origin.SurfaceToken,
+                Turns = Interlocked.Read(ref kvp.Value.Turns),
+                Characters = Interlocked.Read(ref kvp.Value.Characters),
+            });
+        }
+        return dto;
+    }
+
+    /// <summary>True when nothing has been counted yet (used to skip pushing an empty tally).</summary>
+    public bool IsEmpty => _buckets.IsEmpty;
+
+    /// <summary>
+    /// Replace the tally with a persisted snapshot (Director restart restore). Buckets not present in
+    /// <paramref name="dto"/> are cleared; a null or empty dto leaves the tally empty. Does NOT raise
+    /// <see cref="Changed"/> - seeding is a load, not new user activity.
+    /// </summary>
+    public void Seed(InputStatsDto? dto)
+    {
+        _buckets.Clear();
+        if (dto?.Buckets is null) return;
+        foreach (var b in dto.Buckets)
+        {
+            var modality = string.Equals(b.Modality, "voice", StringComparison.OrdinalIgnoreCase)
+                ? InputModality.Voice
+                : InputModality.Typed;
+            var surface = (b.Surface ?? "").Trim().ToLowerInvariant() switch
+            {
+                "desktop" => InputSurface.Desktop,
+                "cockpit" => InputSurface.Cockpit,
+                "phone" => InputSurface.Phone,
+                _ => InputSurface.Unknown,
+            };
+            _buckets[(modality, surface)] = new Counters { Turns = b.Turns, Characters = b.Characters };
+        }
+    }
+}

--- a/src/CcDirector.Core/Voice/Controllers/VoiceModeController.cs
+++ b/src/CcDirector.Core/Voice/Controllers/VoiceModeController.cs
@@ -267,7 +267,8 @@ public class VoiceModeController : IDisposable
 
             State = VoiceState.WaitingForClaude;
             // Voice-mode injection is framework-mediated; exempt from the dictation lock (issue #1181, Task 3b).
-            await _activeSession.SendTextAsync(transcription, SendSource.Internal);
+            // DevThrottle Stats: desktop voice-mode is spoken input from the desktop - count it as one voice turn.
+            await _activeSession.SendTextAsync(transcription, SendSource.Internal, InputOrigin.DesktopVoice);
 
             // Wait for Claude to finish (ActivityState becomes WaitingForInput)
             await WaitForClaudeResponseAsync(ct);

--- a/src/CcDirector.Gateway.Contracts/InputStatsDto.cs
+++ b/src/CcDirector.Gateway.Contracts/InputStatsDto.cs
@@ -1,0 +1,35 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// One (modality, surface) bucket of the DevThrottle Stats input tally: how many submitted TURNS and
+/// how many CHARACTERS of user input arrived through this modality/surface pair. A turn is one
+/// submitted message; character volume counts every typed or spoken character. The pair is the honest
+/// unit the mission measures - "how much of development is spoken vs typed, and from phone vs desktop
+/// vs cockpit".
+/// </summary>
+public sealed class InputStatBucketDto
+{
+    /// <summary>How the input was produced: "typed" or "voice".</summary>
+    public string Modality { get; set; } = "";
+
+    /// <summary>Which surface the input came from: "desktop", "cockpit", "phone", or "unknown".</summary>
+    public string Surface { get; set; } = "";
+
+    /// <summary>Count of submitted turns through this bucket (never synthesized from raw keystrokes).</summary>
+    public long Turns { get; set; }
+
+    /// <summary>Total character volume of input through this bucket.</summary>
+    public long Characters { get; set; }
+}
+
+/// <summary>
+/// A snapshot of a session's (or an aggregate's) input tally, as a flat list of
+/// <see cref="InputStatBucketDto"/> buckets. Additive wire type: rides the existing snapshot/delta path
+/// on <see cref="SessionDto.InputStats"/> and defaults to null on Directors that predate it. Only counts
+/// and ratios ever travel; the text of what was said or typed never does (mission decision 5).
+/// </summary>
+public sealed class InputStatsDto
+{
+    /// <summary>The per-bucket tallies. Empty when the session has taken no counted input yet.</summary>
+    public List<InputStatBucketDto> Buckets { get; set; } = new();
+}

--- a/src/CcDirector.Gateway.Contracts/PromptRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/PromptRequest.cs
@@ -19,6 +19,17 @@ public sealed class PromptRequest
 
     /// <summary>Wait timeout in milliseconds. Default 120000 (2 min). Only used when WaitForIdle=true.</summary>
     public int TimeoutMs { get; set; } = 120_000;
+
+    /// <summary>
+    /// DevThrottle Stats surface tag: which surface this remote prompt came from - "phone", "cockpit",
+    /// or null when unknown. GATEWAY-AUTHORITATIVE: the Gateway resolves it from the verified per-device
+    /// key and OVERWRITES any client-supplied value before forwarding, so it cannot be forged from a
+    /// client. Null on a direct Director call (there is no device key to resolve). Rides both prompt
+    /// delivery paths (the HTTP body and the SignalR command payload), so the Director's choke-point tally
+    /// gets the surface without a separate header. The modality (typed vs voice) is NOT carried here - it
+    /// comes from the existing X-Dictation-Delivery marker (a voice delivery) via <c>SendSource</c>.
+    /// </summary>
+    public string? Surface { get; set; }
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -458,6 +458,16 @@ public sealed class SessionDto
     public string RemoteRunStatus { get; set; } = "";
 
     /// <summary>
+    /// DevThrottle Stats: this session's input tally (submitted turns + character volume by modality and
+    /// surface), taken at the Director's SendInput/SendTextAsync choke point so desktop-local input is
+    /// counted too. Rides the existing snapshot/delta path up to the Gateway, which aggregates every
+    /// session's tally into the always-available stats page. Null when the session has taken no counted
+    /// input yet, or on Directors that predate this field. Only counts ever travel - never the text of
+    /// anything typed or said (mission decision 5).
+    /// </summary>
+    public InputStatsDto? InputStats { get; set; }
+
+    /// <summary>
     /// Issue #1176 (Phase 1a): a copy safe to hand out from the Gateway's pushed-session cache. The
     /// <c>/sessions</c> aggregation stamps scalar fields (EffectiveColor, DirectorId, MachineName,
     /// voice/transcription overlays, etc.) on the object it serves, so callers must never receive the

--- a/src/CcDirector.Gateway.Tests/DirectorHubTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorHubTests.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Stats;
 using CcDirector.Gateway.Streaming;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.SignalR;
@@ -19,6 +20,7 @@ public sealed class DirectorHubTests : IDisposable
     private readonly string _tempDir;
     private readonly DirectorRegistry _registry;
     private readonly PushedSessionStore _store;
+    private readonly GatewayInputStatsAggregator _inputStats;
     private DateTime _now = new(2026, 7, 9, 12, 0, 0, DateTimeKind.Utc);
 
     public DirectorHubTests()
@@ -27,6 +29,7 @@ public sealed class DirectorHubTests : IDisposable
         Directory.CreateDirectory(_tempDir);
         _registry = new DirectorRegistry(_tempDir);
         _store = new PushedSessionStore(() => _now);
+        _inputStats = new GatewayInputStatsAggregator(Path.Combine(_tempDir, "input-stats.json"));
     }
 
     public void Dispose()
@@ -39,7 +42,7 @@ public sealed class DirectorHubTests : IDisposable
     private (DirectorHub hub, FakeHubCallerContext ctx) NewHub(string connectionId)
     {
         var ctx = new FakeHubCallerContext(connectionId);
-        var hub = new DirectorHub(_store, _registry) { Context = ctx };
+        var hub = new DirectorHub(_store, _registry, _inputStats) { Context = ctx };
         return (hub, ctx);
     }
 

--- a/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
@@ -1,0 +1,128 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Stats;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The Gateway aggregation math (DevThrottle Stats): folding per-session tallies into all-time totals via
+/// a high-water increment must never double-count a repeated snapshot, must add only the increase, must
+/// keep a removed session's contribution, must treat a dropped count (a Director restart of the same
+/// session id) as fresh activity, and must survive a Gateway restart with both the totals and the live
+/// high-water intact.
+/// </summary>
+public sealed class GatewayInputStatsAggregatorTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _path;
+
+    public GatewayInputStatsAggregatorTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cc-stats-agg-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+        _path = Path.Combine(_dir, "input-stats.json");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch (Exception) { /* best effort */ }
+    }
+
+    private static SessionDto Session(string id, params (string modality, string surface, long turns, long chars)[] buckets)
+    {
+        var dto = new SessionDto { SessionId = id, InputStats = new InputStatsDto() };
+        foreach (var b in buckets)
+            dto.InputStats!.Buckets.Add(new InputStatBucketDto { Modality = b.modality, Surface = b.surface, Turns = b.turns, Characters = b.chars });
+        return dto;
+    }
+
+    private static long Turns(InputStatsDto dto, string modality, string surface) =>
+        dto.Buckets.FirstOrDefault(b => b.Modality == modality && b.Surface == surface)?.Turns ?? 0;
+
+    private static long Chars(InputStatsDto dto, string modality, string surface) =>
+        dto.Buckets.FirstOrDefault(b => b.Modality == modality && b.Surface == surface)?.Characters ?? 0;
+
+    [Fact]
+    public void RepeatedSnapshot_DoesNotDoubleCount()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        var s = Session("s1", ("voice", "phone", 3, 120));
+
+        agg.Observe(s);
+        agg.Observe(s); // same counts again - a periodic re-push, must not double-count
+        agg.Observe(s);
+
+        var t = agg.CurrentTotals();
+        Assert.Equal(3, Turns(t, "voice", "phone"));
+        Assert.Equal(120, Chars(t, "voice", "phone"));
+    }
+
+    [Fact]
+    public void GrowingSnapshot_AddsOnlyTheIncrease()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        agg.Observe(Session("s1", ("typed", "desktop", 2, 40)));
+        agg.Observe(Session("s1", ("typed", "desktop", 5, 100))); // grew by 3 turns / 60 chars
+
+        var t = agg.CurrentTotals();
+        Assert.Equal(5, Turns(t, "typed", "desktop"));
+        Assert.Equal(100, Chars(t, "typed", "desktop"));
+    }
+
+    [Fact]
+    public void TwoSessions_SumIntoTotals()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        agg.Observe(Session("s1", ("voice", "phone", 4, 200)));
+        agg.Observe(Session("s2", ("voice", "phone", 1, 50)));
+
+        Assert.Equal(5, Turns(agg.CurrentTotals(), "voice", "phone"));
+    }
+
+    [Fact]
+    public void Forget_KeepsContributionInTotals()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        agg.Observe(Session("s1", ("voice", "phone", 4, 200)));
+
+        agg.Forget("s1");
+
+        Assert.Equal(4, Turns(agg.CurrentTotals(), "voice", "phone"));
+        // A late duplicate push for the forgotten session starts a fresh high-water and would add again;
+        // that is acceptable because RemoveSession is terminal - the session will not push after removal.
+    }
+
+    [Fact]
+    public void DroppedCount_SameSessionId_CountsAsFreshActivity()
+    {
+        // A Director restarts and session s1 begins a NEW tally from zero (its reported count drops). The
+        // new activity must be added, not ignored because it is below the old high-water.
+        var agg = new GatewayInputStatsAggregator(_path);
+        agg.Observe(Session("s1", ("typed", "cockpit", 10, 300)));
+        agg.Observe(Session("s1", ("typed", "cockpit", 2, 40)));   // reset: 2 new turns of fresh activity
+
+        Assert.Equal(12, Turns(agg.CurrentTotals(), "typed", "cockpit"));
+        Assert.Equal(340, Chars(agg.CurrentTotals(), "typed", "cockpit"));
+    }
+
+    [Fact]
+    public void Persistence_RestoresTotals_AndDoesNotDoubleCountLiveSession()
+    {
+        var agg1 = new GatewayInputStatsAggregator(_path);
+        agg1.Observe(Session("s1", ("voice", "phone", 3, 120)));
+
+        // Gateway restart: a new aggregator on the same path reloads totals AND the live high-water.
+        var agg2 = new GatewayInputStatsAggregator(_path);
+        Assert.Equal(3, Turns(agg2.CurrentTotals(), "voice", "phone"));
+
+        // The same still-live session re-pushes its current snapshot after reconnect - must NOT be re-added.
+        agg2.Observe(Session("s1", ("voice", "phone", 3, 120)));
+        Assert.Equal(3, Turns(agg2.CurrentTotals(), "voice", "phone"));
+
+        // ...and further growth adds only the increase.
+        agg2.Observe(Session("s1", ("voice", "phone", 4, 160)));
+        Assert.Equal(4, Turns(agg2.CurrentTotals(), "voice", "phone"));
+        Assert.Equal(160, Chars(agg2.CurrentTotals(), "voice", "phone"));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/StatsPageEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/StatsPageEndpointTests.cs
@@ -1,0 +1,142 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Stats;
+using CcDirector.Gateway.Util;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// HTTP wire tests for the DevThrottle Stats private dashboard (<c>GET /stats</c> and <c>/stats/data</c>).
+/// Boots ONLY <see cref="StatsPageEndpoint"/> on an ephemeral port over a real aggregator seeded with a few
+/// sessions, so it proves the always-available page and its JSON serve end-to-end - including under the
+/// same host-wide <see cref="AuthMiddleware"/> the real Gateway applies.
+/// </summary>
+public sealed class StatsPageEndpointTests : IDisposable
+{
+    private const string GatewayToken = "test-gateway-token-for-stats";
+    private readonly string _dir;
+
+    public StatsPageEndpointTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "cc-stats-ep-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch (Exception) { /* best effort */ }
+    }
+
+    private static SessionDto Session(string id, params (string modality, string surface, long turns, long chars)[] buckets)
+    {
+        var dto = new SessionDto { SessionId = id, InputStats = new InputStatsDto() };
+        foreach (var b in buckets)
+            dto.InputStats!.Buckets.Add(new InputStatBucketDto { Modality = b.modality, Surface = b.surface, Turns = b.turns, Characters = b.chars });
+        return dto;
+    }
+
+    private async Task<(WebApplication app, HttpClient http)> StartAsync(GatewayInputStatsAggregator agg, bool authEnabled)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        if (authEnabled)
+        {
+            var requireToken = new AuthMiddleware.RequireToken
+            {
+                Token = GatewayToken,
+                Devices = new DeviceRegistry(Path.Combine(_dir, "devices-" + Guid.NewGuid().ToString("N") + ".json")),
+            };
+            app.Use(async (ctx, next) => await AuthMiddleware.Run(ctx, requireToken, next));
+        }
+
+        StatsPageEndpoint.Map(app, agg);
+        await app.StartAsync();
+        var http = new HttpClient { BaseAddress = new Uri(app.Urls.First()) };
+        return (app, http);
+    }
+
+    [Fact]
+    public async Task StatsPage_Serves_SelfContainedHtml()
+    {
+        var agg = new GatewayInputStatsAggregator(Path.Combine(_dir, "s.json"));
+        var (app, http) = await StartAsync(agg, authEnabled: false);
+        try
+        {
+            var resp = await http.GetAsync("/stats");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.StartsWith("text/html", resp.Content.Headers.ContentType!.ToString());
+
+            var html = await resp.Content.ReadAsStringAsync();
+            Assert.Contains("Your Throttle", html); // private per-person view name (owner decision)
+            Assert.Contains("/stats/data", html); // the page fetches its own data endpoint
+            // Self-contained: no external resource references.
+            Assert.DoesNotContain("http://", html);
+            Assert.DoesNotContain("https://", html);
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    [Fact]
+    public async Task StatsData_ReturnsAggregatedTotals_AndCaveats()
+    {
+        var agg = new GatewayInputStatsAggregator(Path.Combine(_dir, "s.json"));
+        agg.Observe(Session("s1", ("voice", "phone", 3, 300)));
+        agg.Observe(Session("s2", ("typed", "desktop", 1, 20)));
+
+        var (app, http) = await StartAsync(agg, authEnabled: false);
+        try
+        {
+            var resp = await http.GetAsync("/stats/data");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            var root = doc.RootElement;
+
+            var buckets = root.GetProperty("buckets");
+            long voicePhoneTurns = 0, typedDesktopTurns = 0;
+            foreach (var b in buckets.EnumerateArray())
+            {
+                var mod = b.GetProperty("modality").GetString();
+                var surf = b.GetProperty("surface").GetString();
+                var turns = b.GetProperty("turns").GetInt64();
+                if (mod == "voice" && surf == "phone") voicePhoneTurns = turns;
+                if (mod == "typed" && surf == "desktop") typedDesktopTurns = turns;
+            }
+            Assert.Equal(3, voicePhoneTurns);
+            Assert.Equal(1, typedDesktopTurns);
+
+            // The honesty caveats are always present so a published share is never quietly flattered.
+            Assert.True(root.GetProperty("notCaptured").GetArrayLength() > 0);
+            // No message text ever leaves the machine for this page - only counts.
+            var raw = root.GetRawText();
+            Assert.DoesNotContain("\"text\"", raw, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    [Fact]
+    public async Task AuthEnabled_NoToken_Returns401_AndWithToken_Returns200()
+    {
+        var agg = new GatewayInputStatsAggregator(Path.Combine(_dir, "s.json"));
+        var (app, http) = await StartAsync(agg, authEnabled: true);
+        try
+        {
+            var noToken = await http.GetAsync("/stats/data");
+            Assert.Equal(HttpStatusCode.Unauthorized, noToken.StatusCode);
+
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", GatewayToken);
+            var withToken = await http.GetAsync("/stats/data");
+            Assert.Equal(HttpStatusCode.OK, withToken.StatusCode);
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -139,6 +139,13 @@ internal static class GatewayDictationEndpoint
             // transcribe so a slow transcribe cannot let it age out mid-flight (issue #1126).
             transcribingSessions.Refresh(req.SessionId!);
 
+            // DevThrottle Stats: this dictation is a VOICE turn; resolve WHICH surface recorded it from the
+            // verified device key that authenticated this complete (the phone that recorded it, or the
+            // cockpit browser for a cockpit Speak) so the tally does not mislabel cockpit voice as phone.
+            // Captured here (in request context) and threaded into the cached single-flight run; all completes
+            // for one upload id come from the same device, so the value is stable across retries.
+            var deliverySurface = ctx.Items.TryGetValue(AuthMiddleware.DeviceTypeItemKey, out var dt) ? dt as string : null;
+
             // Durable de-dupe (issue #1183): a DELIVERED or ABANDONED upload id has a terminal tombstone on
             // disk. Return its cached outcome and NEVER inject a second turn - even past the old one-hour
             // window and even after a Gateway restart (the record and this check both live on disk). This
@@ -168,7 +175,7 @@ internal static class GatewayDictationEndpoint
             // from then on, so there is no age-swept cache window.
             var entry = _completes.GetOrAdd(uploadId, id => new CompleteEntry(
                 new Lazy<Task<DictationOutcome>>(() => RunCompleteCoreAsync(
-                    id, req, uploads, registry, client, owners, transcription, transcribingSessions))));
+                    id, req, uploads, registry, client, owners, transcription, transcribingSessions, deliverySurface))));
 
             DictationOutcome outcome;
             try
@@ -304,7 +311,7 @@ internal static class GatewayDictationEndpoint
     private static async Task<DictationOutcome> RunCompleteCoreAsync(
         string uploadId, DictationCompleteRequest req, VoiceUploadStore uploads, DirectorRegistry registry,
         DirectorEndpointClient client, SessionOwnerCache? owners, GatewayTranscriptionService transcription,
-        TranscribingSessions transcribingSessions)
+        TranscribingSessions transcribingSessions, string? deliverySurface)
     {
         var sid = req.SessionId!;
         // Issue #1181, Task 4: this run assembles + transcribes + delivers, so mark the session ACTIVELY
@@ -381,7 +388,12 @@ internal static class GatewayDictationEndpoint
             // exempt there: it names its upload id via the X-Dictation-Delivery header (deliveryUploadId), and
             // the Director exempts exactly this send - the dictation's own arrival, which is what the lock is
             // held for. The header rides the fleet-authenticated call, so it cannot be forged from outside.
-            var (ok, _, err) = await client.PostPromptAsync(endpoint, sid, new PromptRequest { Text = message, AppendEnter = true }, deliveryUploadId: uploadId);
+            // DevThrottle Stats: Surface tags which surface recorded this voice turn (phone / cockpit);
+            // deliveryUploadId marks it a voice Delivery at the Director. Together the Director counts it as
+            // one voice turn from the resolved surface. A dictation is always a real operator turn, so when
+            // the device key did not resolve we stamp "unknown" (never null) - it is counted into the honest
+            // "unknown" surface bucket, never silently dropped (decision 9).
+            var (ok, _, err) = await client.PostPromptAsync(endpoint, sid, new PromptRequest { Text = message, AppendEnter = true, Surface = deliverySurface ?? "unknown" }, deliveryUploadId: uploadId);
             if (!ok)
                 return DictationOutcome.Error(StatusCodes.Status502BadGateway, err ?? "submit to session failed");
 

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -1119,10 +1119,20 @@ internal static class GatewayEndpoints
             return Results.Json(buffer);
         });
 
-        app.MapPost("/sessions/{sid}/prompt", async (string sid, PromptRequest req) =>
+        app.MapPost("/sessions/{sid}/prompt", async (string sid, PromptRequest req, HttpContext httpCtx) =>
         {
             if (req is null || string.IsNullOrEmpty(req.Text))
                 return Results.BadRequest(new { error = "text is required" });
+
+            // DevThrottle Stats: stamp the surface from the VERIFIED device key (stashed by AuthMiddleware),
+            // overwriting any client-supplied value so it cannot be forged. Rides both the SignalR command
+            // and the HTTP fallback below to the Director's choke-point tally. This IS the operator front
+            // door, so it is ALWAYS a real turn: when no device key resolved (a shared-machine-token call) we
+            // stamp "unknown" - NOT null - so the Director still counts it, into the honest "unknown" surface
+            // bucket the dashboard shows (decision 9: surface excluded volume, never silently drop it).
+            // Machine-to-machine traffic (fanout/broadcast) never reaches this handler and never sets Surface,
+            // so it stays null and is correctly excluded.
+            req.Surface = (httpCtx.Items.TryGetValue(AuthMiddleware.DeviceTypeItemKey, out var dt) ? dt as string : null) ?? "unknown";
 
             var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -52,6 +52,14 @@ public sealed class GatewayHost : IAsyncDisposable
     public Streaming.PushedSessionStore PushedSessions { get; }
 
     /// <summary>
+    /// DevThrottle Stats: the always-available aggregate of every session's input tally (turns + character
+    /// volume by modality and surface). Fed by the director-stream hub from the pushed
+    /// <see cref="Contracts.SessionDto.InputStats"/> and read by the private Gateway dashboard at
+    /// <c>/stats</c> with no cloud round-trip.
+    /// </summary>
+    public Stats.GatewayInputStatsAggregator InputStats { get; }
+
+    /// <summary>
     /// Issue #1215 (Cockpit plan phase 6): the last-known-good roster cache. The <c>/sessions</c>
     /// aggregation uses it so a single failed Director poll no longer drops that Director's sessions -
     /// they are served stale (Wobbly) through a short grace window and only dropped (Offline) once the
@@ -349,7 +357,7 @@ public sealed class GatewayHost : IAsyncDisposable
     /// <see cref="Account"/> null on a non-Windows host, where the operating-system credential store is
     /// not yet implemented).
     /// </param>
-    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null)
+    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null)
     {
         Port = port;
         Token = token ?? GatewayAuth.LoadOrCreate();
@@ -359,6 +367,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // own stale/unreachable sweep, so this never fires for a merely momentarily-unreachable Director.
         Registry.OnDirectorRemoved += directorId => SessionNumbers.ReleaseForDirector(directorId);
         PushedSessions = new Streaming.PushedSessionStore();
+        InputStats = new Stats.GatewayInputStatsAggregator(inputStatsPath);
         RosterCache = new Discovery.FleetRosterCache();
         // Issue #1215: when a Director is unregistered or evicted from the registry, forget its cached
         // roster too so the cache does not grow without bound; a re-registering Director starts clean.
@@ -897,6 +906,9 @@ public sealed class GatewayHost : IAsyncDisposable
         // /sessions aggregation (wired explicitly below) share the one PushedSessionStore instance.
         builder.Services.AddSignalR();
         builder.Services.AddSingleton(PushedSessions);
+        // DevThrottle Stats: the hub (constructed per-invocation by SignalR) folds each pushed session's
+        // tally into this one aggregator instance, which the /stats dashboard reads.
+        builder.Services.AddSingleton(InputStats);
         builder.Services.AddSingleton(Registry);
         // launcher-persistent-join: the LauncherHub (constructed per-invocation by SignalR) and
         // SendLauncherCommandAsync share this one connection registry.
@@ -1369,6 +1381,11 @@ public sealed class GatewayHost : IAsyncDisposable
         // before the mobile shell so the explicit POST route wins over the shell's GET catch-all.
         var mobileEnrollmentClient = new Core.Account.DeviceRegistryClient(new HttpClient { Timeout = TimeSpan.FromSeconds(10) });
         Api.MobileEnrollmentEndpoint.Map(_app, new Account.MobileDeviceEnrollmentService(Account, mobileEnrollmentClient, Devices));
+
+        // DevThrottle Stats: the always-available private dashboard (/stats) and its JSON (/stats/data).
+        // A self-contained embedded page, so it works even on a plain dev build with no React wwwroot.
+        // Mapped before the mobile/cockpit catch-alls so the explicit routes win.
+        Stats.StatsPageEndpoint.Map(_app, InputStats);
 
         Mobile.MobileApp.Map(_app, Token);
 

--- a/src/CcDirector.Gateway/Pairing/DeviceRegistry.cs
+++ b/src/CcDirector.Gateway/Pairing/DeviceRegistry.cs
@@ -168,6 +168,29 @@ public sealed class DeviceRegistry
         return false;
     }
 
+    /// <summary>
+    /// The <c>DeviceType</c> ("phone" / "browser" / "workstation" / ...) of the active device whose
+    /// per-device key matches <paramref name="key"/>, or null when no active device matches. Used by the
+    /// DevThrottle Stats surface resolution to tag a remote prompt with the surface it came from, from the
+    /// SAME verified key that already authenticated the call (no client change, no forgeable header). The
+    /// compare is constant-time, mirroring <see cref="IsValidDeviceKey"/>, so a near-miss reveals nothing
+    /// through timing.
+    /// </summary>
+    public string? DeviceTypeForKey(string? key)
+    {
+        if (string.IsNullOrEmpty(key)) return null;
+        var supplied = System.Text.Encoding.ASCII.GetBytes(key);
+        foreach (var record in _byDeviceId.Values)
+        {
+            if (!string.Equals(record.Status, StatusActive, StringComparison.Ordinal)) continue;
+            var stored = System.Text.Encoding.ASCII.GetBytes(record.DeviceKey);
+            if (stored.Length == supplied.Length &&
+                CryptographicOperations.FixedTimeEquals(stored, supplied))
+                return record.DeviceType;
+        }
+        return null;
+    }
+
     /// <summary>The host-readable list of registered devices, newest first. Keys are never included.</summary>
     public IReadOnlyList<RegisteredDeviceDto> List()
     {

--- a/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
+++ b/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
@@ -1,0 +1,233 @@
+using System.Text.Json;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Stats;
+
+/// <summary>
+/// The Gateway's durable, always-available aggregate of the DevThrottle Stats input tally. Every session's
+/// per-session tally (submitted turns + character volume by modality and surface) rides up the existing
+/// director-stream snapshot/delta path on <see cref="SessionDto.InputStats"/>; this aggregator folds them
+/// into all-time totals the private Gateway dashboard reads with no cloud round-trip.
+///
+/// Correct across BOTH a Director restart and a Gateway restart, with no double-counting, via a high-water
+/// increment: for each live session it remembers the last per-bucket counts it saw, and adds only the
+/// increase to the totals. A session that ends (RemoveSession) leaves its contribution in the totals and
+/// its high-water entry is pruned. A session whose reported counts DROP (a Director restarted and the
+/// session began a fresh tally) is treated as new activity from zero. Both the totals and the high-water
+/// map are persisted (atomic temp-write + rename, corrupt file quarantined) so a Gateway restart neither
+/// loses the totals nor re-adds live sessions' current counts.
+///
+/// Only counts ever pass through here - never the text of anything typed or said (mission decision 5).
+/// </summary>
+public sealed class GatewayInputStatsAggregator
+{
+    private static readonly JsonSerializerOptions FileJsonOptions = new() { WriteIndented = true };
+
+    private readonly string _path;
+    private readonly object _lock = new();
+
+    // All-time totals, keyed by (modality token, surface token).
+    private readonly Dictionary<(string Modality, string Surface), Counters> _totals = new();
+
+    // Per-live-session last-seen counts, so only the INCREASE is folded into the totals.
+    private readonly Dictionary<string, Dictionary<(string Modality, string Surface), Counters>> _highWater = new();
+
+    private sealed class Counters
+    {
+        public long Turns { get; set; }
+        public long Characters { get; set; }
+    }
+
+    /// <param name="path">The durable store file. Defaults to gateway-input-stats.json under the cc-director
+    /// storage root, beside the other Gateway stores.</param>
+    public GatewayInputStatsAggregator(string? path = null)
+    {
+        _path = string.IsNullOrWhiteSpace(path)
+            ? Path.Combine(CcStorage.Root(), "gateway-input-stats.json")
+            : path!;
+        Load();
+    }
+
+    /// <summary>Fold every session in a full snapshot into the totals.</summary>
+    public void ObserveSnapshot(IEnumerable<SessionDto>? sessions)
+    {
+        if (sessions is null) return;
+        lock (_lock)
+        {
+            var changed = false;
+            foreach (var s in sessions)
+                changed |= FoldLocked(s);
+            if (changed) Save();
+        }
+    }
+
+    /// <summary>Fold one session (a delta) into the totals.</summary>
+    public void Observe(SessionDto? session)
+    {
+        if (session is null) return;
+        lock (_lock)
+        {
+            if (FoldLocked(session)) Save();
+        }
+    }
+
+    /// <summary>
+    /// Forget a removed session's high-water entry. Its contribution stays in the totals (it was folded in
+    /// as it happened); dropping the high-water entry just stops the map growing without bound.
+    /// </summary>
+    public void Forget(string? sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId)) return;
+        lock (_lock)
+        {
+            if (_highWater.Remove(sessionId)) Save();
+        }
+    }
+
+    /// <summary>An immutable snapshot of the all-time totals for the dashboard, buckets in a stable order.</summary>
+    public InputStatsDto CurrentTotals()
+    {
+        lock (_lock)
+        {
+            return ToDtoLocked(_totals);
+        }
+    }
+
+    // Fold one session's tally into the totals via the high-water increment. Returns true when the totals
+    // changed. Caller holds the lock.
+    private bool FoldLocked(SessionDto s)
+    {
+        if (string.IsNullOrEmpty(s.SessionId) || s.InputStats?.Buckets is null || s.InputStats.Buckets.Count == 0)
+            return false;
+
+        if (!_highWater.TryGetValue(s.SessionId, out var hw))
+        {
+            hw = new Dictionary<(string, string), Counters>();
+            _highWater[s.SessionId] = hw;
+        }
+
+        var changed = false;
+        foreach (var b in s.InputStats.Buckets)
+        {
+            var key = (b.Modality ?? "", b.Surface ?? "");
+            hw.TryGetValue(key, out var prev);
+            var prevTurns = prev?.Turns ?? 0;
+            var prevChars = prev?.Characters ?? 0;
+
+            // Normal case: counts only grow, so add the increase. Reset case (a Director restarted this
+            // session id with a fresh tally): the reported count is LOWER than last seen, so the whole
+            // current count is new activity from zero.
+            var deltaTurns = b.Turns >= prevTurns ? b.Turns - prevTurns : b.Turns;
+            var deltaChars = b.Characters >= prevChars ? b.Characters - prevChars : b.Characters;
+
+            if (deltaTurns > 0 || deltaChars > 0)
+            {
+                if (!_totals.TryGetValue(key, out var total))
+                {
+                    total = new Counters();
+                    _totals[key] = total;
+                }
+                total.Turns += deltaTurns;
+                total.Characters += deltaChars;
+                changed = true;
+            }
+
+            hw[key] = new Counters { Turns = b.Turns, Characters = b.Characters };
+        }
+        return changed;
+    }
+
+    private static InputStatsDto ToDtoLocked(Dictionary<(string Modality, string Surface), Counters> src)
+    {
+        var dto = new InputStatsDto();
+        foreach (var kvp in src.OrderBy(k => k.Key.Modality, StringComparer.Ordinal).ThenBy(k => k.Key.Surface, StringComparer.Ordinal))
+        {
+            dto.Buckets.Add(new InputStatBucketDto
+            {
+                Modality = kvp.Key.Modality,
+                Surface = kvp.Key.Surface,
+                Turns = kvp.Value.Turns,
+                Characters = kvp.Value.Characters,
+            });
+        }
+        return dto;
+    }
+
+    private sealed class StoreFile
+    {
+        public List<InputStatBucketDto> Totals { get; set; } = new();
+        public Dictionary<string, List<InputStatBucketDto>> HighWater { get; set; } = new();
+    }
+
+    private void Load()
+    {
+        if (!File.Exists(_path))
+        {
+            FileLog.Write($"[GatewayInputStatsAggregator] Load: no store file at {_path}; starting empty");
+            return;
+        }
+
+        StoreFile? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize<StoreFile>(File.ReadAllText(_path), FileJsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            Quarantine(ex.Message);
+            return;
+        }
+        if (parsed is null)
+        {
+            Quarantine("file deserialized to null (no store document)");
+            return;
+        }
+
+        foreach (var b in parsed.Totals)
+            _totals[(b.Modality ?? "", b.Surface ?? "")] = new Counters { Turns = b.Turns, Characters = b.Characters };
+        foreach (var (sid, buckets) in parsed.HighWater)
+        {
+            var hw = new Dictionary<(string, string), Counters>();
+            foreach (var b in buckets)
+                hw[(b.Modality ?? "", b.Surface ?? "")] = new Counters { Turns = b.Turns, Characters = b.Characters };
+            _highWater[sid] = hw;
+        }
+        FileLog.Write($"[GatewayInputStatsAggregator] Load: restored {_totals.Count} total bucket(s), {_highWater.Count} live session(s) from {_path}");
+    }
+
+    private void Quarantine(string reason)
+    {
+        var quarantinePath = $"{_path}.corrupt-{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}";
+        File.Move(_path, quarantinePath);
+        FileLog.Write($"[GatewayInputStatsAggregator] Load FAILED: store file at {_path} is corrupt ({reason}); quarantined to {quarantinePath}; starting empty.");
+    }
+
+    // Write-through under the lock: serialize the whole store and atomically replace the file (temp +
+    // rename) so a concurrent reader or a crash mid-write never sees a half-written store. A failed save is
+    // a LOGGED error that propagates - never a silent skip.
+    private void Save()
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(_path);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            var file = new StoreFile { Totals = ToDtoLocked(_totals).Buckets };
+            foreach (var (sid, hw) in _highWater)
+                file.HighWater[sid] = ToDtoLocked(hw).Buckets;
+
+            var json = JsonSerializer.Serialize(file, FileJsonOptions);
+            var tmp = _path + ".tmp";
+            File.WriteAllText(tmp, json);
+            File.Move(tmp, _path, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayInputStatsAggregator] Save FAILED: path={_path}: {ex.Message}");
+            throw;
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
+++ b/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
@@ -1,0 +1,264 @@
+using CcDirector.Core.Utilities;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Stats;
+
+/// <summary>
+/// The DevThrottle Stats private dashboard: the always-available page the owner opens on the Gateway to
+/// see, from real usage, how much of his development is spoken vs typed and how much comes from the phone,
+/// the desktop, or the cockpit. Served as a SELF-CONTAINED page embedded in this binary (not a wwwroot
+/// React route), so it works even on a plain dev build where the React apps are not built (mission
+/// New build B, core finding 8). It reads the Gateway's own aggregated totals with no cloud round-trip.
+///
+/// Two routes, both behind the normal Gateway auth (the owner's signed-in browser reaches them):
+///   GET /stats       - the HTML dashboard (this embedded page).
+///   GET /stats/data  - the aggregated totals as JSON, which the page fetches and refreshes.
+///
+/// Only counts and ratios are ever served - never the text of anything typed or said (mission decision 5).
+/// The page states plainly which input paths are counted and which are not-captured (no-fallback rule).
+/// </summary>
+public static class StatsPageEndpoint
+{
+    /// <summary>
+    /// Honesty caveats shown on the page and returned in the JSON: exactly which input paths are counted
+    /// and which are not-captured, so a share the owner might publish is never quietly flattered.
+    /// </summary>
+    private static readonly string[] NotCaptured =
+    {
+        "Your main phone voice (the Speak button / durable dictation) is counted as voice. If you pause a voice-mode reply and then send the already-typed transcript, that one is counted as typed.",
+        "Raw keystrokes typed directly into a browser's live terminal stream are not attributed to a surface, so they are not counted. The message composer, and terminal typing on the desktop app, are counted.",
+        "Surface (phone / cockpit) for remote input is read from the signed-in device. Remote input with no device identity (a shared-token or fleet call) is not counted as an operator surface.",
+    };
+
+    public static void Map(IEndpointRouteBuilder app, GatewayInputStatsAggregator aggregator)
+    {
+        FileLog.Write("[StatsPageEndpoint] serving /stats (embedded, always available)");
+
+        app.MapGet("/stats/data", () =>
+        {
+            var totals = aggregator.CurrentTotals();
+            return Results.Json(new
+            {
+                generatedAtUtc = DateTime.UtcNow,
+                buckets = totals.Buckets,
+                notCaptured = NotCaptured,
+            });
+        });
+
+        app.MapGet("/stats", (HttpContext ctx) =>
+        {
+            ctx.Response.Headers.CacheControl = "no-cache";
+            ctx.Response.ContentType = "text/html; charset=utf-8";
+            return ctx.Response.WriteAsync(PageHtml);
+        });
+    }
+
+    // Self-contained: all CSS and JavaScript inline, no external requests, ASCII only. Light/dark aware.
+    private const string PageHtml = """
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Your Throttle</title>
+<style>
+  :root {
+    --bg: #f5f6f8; --card: #ffffff; --ink: #1b1f24; --muted: #5b636d; --line: #e2e5ea;
+    --voice: #2f6feb; --typed: #8a94a3; --accent: #0b8f5a; --warn: #8a6d1a; --warnbg: #fdf6e3;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #12151a; --card: #1b1f26; --ink: #e8ebef; --muted: #9aa3ad; --line: #2a2f38;
+      --voice: #5b8def; --typed: #6b7480; --accent: #3fbf86; --warn: #d8b451; --warnbg: #211d10;
+    }
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--ink);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    line-height: 1.5; }
+  .wrap { max-width: 820px; margin: 0 auto; padding: 24px 16px 64px; }
+  h1 { font-size: 20px; margin: 0 0 2px; }
+  .sub { color: var(--muted); font-size: 13px; margin: 0 0 20px; }
+  .cards { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-bottom: 22px; }
+  @media (max-width: 560px) { .cards { grid-template-columns: 1fr; } }
+  .card { background: var(--card); border: 1px solid var(--line); border-radius: 12px; padding: 18px; }
+  .headline .big { font-size: 44px; font-weight: 700; letter-spacing: -1px; line-height: 1; }
+  .headline .lbl { color: var(--muted); font-size: 13px; margin-top: 6px; }
+  .headline .of { color: var(--muted); font-size: 12px; margin-top: 2px; }
+  .section { background: var(--card); border: 1px solid var(--line); border-radius: 12px;
+    padding: 18px; margin-bottom: 16px; }
+  .section h2 { font-size: 14px; margin: 0 0 12px; text-transform: uppercase; letter-spacing: 0.04em;
+    color: var(--muted); }
+  .row { margin: 10px 0; }
+  .row .top { display: flex; justify-content: space-between; font-size: 13px; margin-bottom: 4px; }
+  .row .top .n { color: var(--muted); }
+  .bar { height: 12px; border-radius: 6px; background: var(--line); overflow: hidden; }
+  .bar > span { display: block; height: 100%; border-radius: 6px; }
+  .fill-voice { background: var(--voice); }
+  .fill-typed { background: var(--typed); }
+  .fill-accent { background: var(--accent); }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  th, td { text-align: left; padding: 7px 6px; border-bottom: 1px solid var(--line); }
+  th { color: var(--muted); font-weight: 600; }
+  td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+  .notes { font-size: 12.5px; color: var(--ink); background: var(--warnbg);
+    border: 1px solid var(--line); border-left: 3px solid var(--warn); border-radius: 8px;
+    padding: 12px 14px; }
+  .notes h2 { color: var(--warn); }
+  .notes ul { margin: 8px 0 0; padding-left: 18px; }
+  .notes li { margin: 6px 0; }
+  .empty { color: var(--muted); font-size: 14px; padding: 8px 0; }
+  .foot { color: var(--muted); font-size: 12px; margin-top: 18px; }
+  .err { color: #c0392b; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Your Throttle</h1>
+  <p class="sub">Where your development actually happens - counted at the Director, so desktop typing is included, not just what reaches the Gateway.</p>
+
+  <div class="cards">
+    <div class="card headline">
+      <div class="big" id="voiceShare">-</div>
+      <div class="lbl">of your turns are spoken</div>
+      <div class="of" id="voiceOf"></div>
+    </div>
+    <div class="card headline">
+      <div class="big" id="phoneShare">-</div>
+      <div class="lbl">of your turns are from the phone</div>
+      <div class="of" id="phoneOf"></div>
+    </div>
+  </div>
+
+  <p class="sub" id="denom"></p>
+
+  <div class="section">
+    <h2>Turns by input - voice vs typed</h2>
+    <div id="modalityRows"></div>
+  </div>
+
+  <div class="section">
+    <h2>Turns by surface - phone vs desktop vs cockpit</h2>
+    <div id="surfaceRows"></div>
+  </div>
+
+  <div class="section">
+    <h2>Character volume (secondary cross-check)</h2>
+    <table>
+      <thead><tr><th>Modality</th><th>Surface</th><th class="num">Turns</th><th class="num">Characters</th></tr></thead>
+      <tbody id="bucketTable"></tbody>
+    </table>
+  </div>
+
+  <div class="notes section">
+    <h2>What is counted, and what is not-captured</h2>
+    <ul id="notCaptured"></ul>
+  </div>
+
+  <div class="foot" id="foot"></div>
+</div>
+
+<script>
+(function () {
+  var TITLE = { voice: "Voice", typed: "Typed", phone: "Phone", desktop: "Desktop", cockpit: "Cockpit", unknown: "Unknown" };
+
+  function pct(part, whole) { return whole > 0 ? Math.round((part / whole) * 100) : 0; }
+  function fmt(n) { return (n || 0).toLocaleString(); }
+
+  function sumBy(buckets, field, keyName, keyVal) {
+    var t = 0;
+    for (var i = 0; i < buckets.length; i++) {
+      if (buckets[i][keyName] === keyVal) t += (buckets[i][field] || 0);
+    }
+    return t;
+  }
+  function total(buckets, field) {
+    var t = 0; for (var i = 0; i < buckets.length; i++) t += (buckets[i][field] || 0); return t;
+  }
+
+  function row(label, value, whole, fillClass) {
+    var p = pct(value, whole);
+    var div = document.createElement("div");
+    div.className = "row";
+    var top = document.createElement("div"); top.className = "top";
+    var l = document.createElement("span"); l.textContent = label;
+    var n = document.createElement("span"); n.className = "n"; n.textContent = fmt(value) + " turns (" + p + "%)";
+    top.appendChild(l); top.appendChild(n);
+    var bar = document.createElement("div"); bar.className = "bar";
+    var span = document.createElement("span"); span.className = fillClass; span.style.width = p + "%";
+    bar.appendChild(span);
+    div.appendChild(top); div.appendChild(bar);
+    return div;
+  }
+
+  function render(data) {
+    var buckets = data.buckets || [];
+    var turns = total(buckets, "turns");
+
+    var voiceTurns = sumBy(buckets, "turns", "modality", "voice");
+    var phoneTurns = sumBy(buckets, "turns", "surface", "phone");
+
+    document.getElementById("voiceShare").textContent = turns > 0 ? pct(voiceTurns, turns) + "%" : "--";
+    document.getElementById("phoneShare").textContent = turns > 0 ? pct(phoneTurns, turns) + "%" : "--";
+    document.getElementById("voiceOf").textContent = turns > 0 ? fmt(voiceTurns) + " of " + fmt(turns) + " turns" : "";
+    document.getElementById("phoneOf").textContent = turns > 0 ? fmt(phoneTurns) + " of " + fmt(turns) + " turns" : "";
+
+    // The denominator behind the shares, and the excluded/unknown-surface count, so the shares are always
+    // inspectable and you can see the unknown slice is small (decision 9: surface it, never hide it).
+    var unknownTurns = sumBy(buckets, "turns", "surface", "unknown");
+    document.getElementById("denom").textContent = turns > 0
+      ? ("Shares are over " + fmt(turns) + " counted turns. Unknown surface: " + fmt(unknownTurns) + " turn" + (unknownTurns === 1 ? "" : "s") + ".")
+      : "";
+
+    var mod = document.getElementById("modalityRows"); mod.innerHTML = "";
+    var surf = document.getElementById("surfaceRows"); surf.innerHTML = "";
+    if (turns === 0) {
+      mod.innerHTML = '<div class="empty">No turns counted yet. Send a message by voice from your phone, or type one from the desktop, and it will appear here.</div>';
+      surf.innerHTML = '<div class="empty">No turns counted yet.</div>';
+    } else {
+      mod.appendChild(row(TITLE.voice, voiceTurns, turns, "fill-voice"));
+      mod.appendChild(row(TITLE.typed, sumBy(buckets, "turns", "modality", "typed"), turns, "fill-typed"));
+      ["phone", "desktop", "cockpit", "unknown"].forEach(function (s) {
+        var v = sumBy(buckets, "turns", "surface", s);
+        if (v > 0 || s !== "unknown") surf.appendChild(row(TITLE[s], v, turns, "fill-accent"));
+      });
+    }
+
+    var tb = document.getElementById("bucketTable"); tb.innerHTML = "";
+    if (buckets.length === 0) {
+      tb.innerHTML = '<tr><td colspan="4" class="empty">Nothing counted yet.</td></tr>';
+    } else {
+      buckets.slice().sort(function (a, b) { return (b.characters || 0) - (a.characters || 0); }).forEach(function (b) {
+        var tr = document.createElement("tr");
+        tr.innerHTML = "<td>" + (TITLE[b.modality] || b.modality) + "</td><td>" + (TITLE[b.surface] || b.surface) +
+          "</td><td class='num'>" + fmt(b.turns) + "</td><td class='num'>" + fmt(b.characters) + "</td>";
+        tb.appendChild(tr);
+      });
+    }
+
+    var nc = document.getElementById("notCaptured"); nc.innerHTML = "";
+    (data.notCaptured || []).forEach(function (m) {
+      var li = document.createElement("li"); li.textContent = m; nc.appendChild(li);
+    });
+
+    var when = data.generatedAtUtc ? new Date(data.generatedAtUtc).toLocaleString() : "";
+    document.getElementById("foot").textContent = "Updated " + when + " - refreshes every few seconds. Counts only; no message text ever leaves your machine for this page.";
+  }
+
+  function load() {
+    fetch("/stats/data", { credentials: "same-origin" })
+      .then(function (r) { if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); })
+      .then(render)
+      .catch(function (e) { document.getElementById("foot").innerHTML = '<span class="err">Could not load stats: ' + e.message + "</span>"; });
+  }
+
+  load();
+  setInterval(load, 4000);
+})();
+</script>
+</body>
+</html>
+""";
+}

--- a/src/CcDirector.Gateway/Streaming/DirectorHub.cs
+++ b/src/CcDirector.Gateway/Streaming/DirectorHub.cs
@@ -1,6 +1,7 @@
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Stats;
 using Microsoft.AspNetCore.SignalR;
 
 namespace CcDirector.Gateway.Streaming;
@@ -28,11 +29,13 @@ public sealed class DirectorHub : Hub
 
     private readonly PushedSessionStore _store;
     private readonly DirectorRegistry _registry;
+    private readonly GatewayInputStatsAggregator _inputStats;
 
-    public DirectorHub(PushedSessionStore store, DirectorRegistry registry)
+    public DirectorHub(PushedSessionStore store, DirectorRegistry registry, GatewayInputStatsAggregator inputStats)
     {
         _store = store;
         _registry = registry;
+        _inputStats = inputStats;
     }
 
     /// <summary>Bind this connection to a Director. Must be the first message; aborts the connection on a bad id.</summary>
@@ -64,7 +67,10 @@ public sealed class DirectorHub : Hub
     public void PushSnapshot(long sequence, SessionDto[] sessions)
     {
         var directorId = RequireBoundDirector();
-        _store.ApplySnapshot(directorId, Context.ConnectionId, sequence, sessions ?? Array.Empty<SessionDto>());
+        var set = sessions ?? Array.Empty<SessionDto>();
+        _store.ApplySnapshot(directorId, Context.ConnectionId, sequence, set);
+        // DevThrottle Stats: fold each session's input tally into the always-available aggregate.
+        _inputStats.ObserveSnapshot(set);
     }
 
     /// <summary>A single-session delta: upserts one session for the bound Director.</summary>
@@ -77,6 +83,8 @@ public sealed class DirectorHub : Hub
             return;
         }
         _store.ApplyDelta(directorId, Context.ConnectionId, sequence, session);
+        // DevThrottle Stats: fold this session's tally into the always-available aggregate.
+        _inputStats.Observe(session);
     }
 
     /// <summary>A remove/tombstone: drops one session from the bound Director's set.</summary>
@@ -89,6 +97,8 @@ public sealed class DirectorHub : Hub
             return;
         }
         _store.ApplyRemove(directorId, Context.ConnectionId, sequence, sessionId);
+        // DevThrottle Stats: its contribution stays in the totals; drop only its high-water entry.
+        _inputStats.Forget(sessionId);
     }
 
     public override Task OnConnectedAsync()

--- a/src/CcDirector.Gateway/Util/AuthMiddleware.cs
+++ b/src/CcDirector.Gateway/Util/AuthMiddleware.cs
@@ -48,6 +48,14 @@ internal static class AuthMiddleware
     public const string CookieName = "cc-gateway-token";
 
     /// <summary>
+    /// HttpContext.Items key under which <see cref="HasValidToken"/> stashes the <c>DeviceType</c> of the
+    /// per-device key that authenticated the request ("phone" / "browser" / ...), or leaves absent when the
+    /// caller used the shared machine token (no device). The DevThrottle Stats surface resolution reads it
+    /// to tag a remote prompt with its surface, from the SAME verified key that authenticated the call.
+    /// </summary>
+    public const string DeviceTypeItemKey = "cc.stats.DeviceType";
+
+    /// <summary>
     /// The desktop Cockpit's sign-in route (issue #1088): the shared client-core enrollment screen a
     /// signed-out browser navigation is redirected to. Must match the route in apps/cockpit/src/main.tsx.
     /// </summary>
@@ -190,9 +198,14 @@ internal static class AuthMiddleware
                 var provided = raw.Substring(prefix.Length).Trim();
                 if (string.Equals(provided, token, StringComparison.Ordinal))
                     return true;
-                // Issue #469: a unique per-device key issued at enrollment is equally valid.
-                if (devices is not null && devices.IsValidDeviceKey(provided))
+                // Issue #469: a unique per-device key issued at enrollment is equally valid. DevThrottle
+                // Stats: stash the matched device's type so a remote prompt can be tagged with its surface.
+                var deviceType = devices?.DeviceTypeForKey(provided);
+                if (deviceType is not null)
+                {
+                    ctx.Items[DeviceTypeItemKey] = deviceType;
                     return true;
+                }
             }
         }
 
@@ -209,8 +222,14 @@ internal static class AuthMiddleware
         {
             if (string.Equals(cookieValue, token, StringComparison.Ordinal))
                 return true;
-            if (devices is not null && devices.IsValidDeviceKey(cookieValue))
+            // DevThrottle Stats: same device-key surface stash as the Bearer branch (the live terminal
+            // stream authenticates via this cookie).
+            var cookieDeviceType = devices?.DeviceTypeForKey(cookieValue);
+            if (cookieDeviceType is not null)
+            {
+                ctx.Items[DeviceTypeItemKey] = cookieDeviceType;
                 return true;
+            }
         }
 
         return false;

--- a/src/CcDirector.Terminal.Avalonia/TerminalControl.cs
+++ b/src/CcDirector.Terminal.Avalonia/TerminalControl.cs
@@ -1285,7 +1285,8 @@ public class TerminalControl : Control
             byte[]? data = MapKeyToBytes(e.Key, e.KeyModifiers);
             if (data != null)
             {
-                _session.SendInput(data);
+                // DevThrottle Stats: raw desktop terminal typing - typed character volume, local by construction.
+                _session.SendInput(data, InputOrigin.DesktopTyped);
                 e.Handled = true;
             }
         }
@@ -1302,7 +1303,8 @@ public class TerminalControl : Control
             if (_session == null || string.IsNullOrEmpty(e.Text)) return;
 
             var bytes = Encoding.UTF8.GetBytes(e.Text);
-            _session.SendInput(bytes);
+            // DevThrottle Stats: raw desktop terminal typing - typed character volume, local by construction.
+            _session.SendInput(bytes, InputOrigin.DesktopTyped);
             e.Handled = true;
         }
         catch (Exception ex)


### PR DESCRIPTION
## DevThrottle Stats - Phase 1

Instrument, honestly, how development is actually driven - spoken vs typed, and phone vs desktop vs cockpit - and show it on an always-available private Gateway dashboard. This is the proof half of the DevThrottle Stats mission (the leaderboards come later); the point is a phone/voice share the owner can trust because the measurement does not quietly flatter the phone.

Brief: `docs/architecture/devthrottle-stats-mission-2026-07-11.md`.

### The honest counting seam

Counting happens at the Director choke point - the two methods every input funnels through (`Session.SendInput` / `Session.SendTextAsync`) - NOT at the Gateway. Desktop-local typing never reaches the Gateway, so a Gateway-only count would miss it entirely and inflate the phone/voice share. Each turn is tagged with a modality (voice or typed) and a surface (phone, cockpit, desktop, or unknown):

- **Desktop** input is tagged by construction (the local app calls the session in-process): the composer and terminal typing are typed-desktop; dictation, voice mode, and the FIFO are voice-desktop.
- **Remote** surface is resolved from the verified per-device key and carried on `PromptRequest.Surface`, which the Gateway sets authoritatively so a client cannot forge it. Phone voice is counted from the durable dictation delivery (the operator's real drive-safe path).
- Operator input whose surface does not resolve is counted into a **visible "unknown" bucket** (surfaced on the dashboard, never silently dropped). Genuine machine-to-machine traffic (fanout, framework sends) is excluded, because only the operator front doors set the surface.

### The unit

Headline is **turns**: one spoken utterance and one typed message each count as exactly one turn, so neither modality is inflated by its mechanics. Character volume is reported alongside as an honest cross-check. Raw keystrokes are character volume only - never synthesized into turns.

### Flow-up, durability, and the dashboard

The per-session tally rides the existing director-stream on `SessionDto.InputStats`. The Gateway folds it into a durable all-time aggregate with a high-water increment, so it survives both a Director and a Gateway restart with no double-counting. The private dashboard at **`/stats` ("Your Throttle")** is a self-contained embedded page (works even on a plain dev build with no React build), showing the voice and phone shares, the breakdown by modality and surface, the character cross-check, the inspectable denominator and unknown count, and the plain not-captured caveats. Only counts ever leave the machine - never the text of anything typed or said.

### Tests

- Tally math (one turn is one turn; raw keystrokes are chars-only; snapshot round-trips for restart restore).
- Gateway aggregation (no double-count across Director and Gateway restarts; reset handling; persistence).
- Choke-point wiring pinned by the existing injection-chokepoint guard, updated for the new signatures.
- The `/stats` page and `/stats/data` served end-to-end through the real authentication gate.

Full solution builds; the entire Gateway suite passes with zero regressions.

### Not in this phase

Opt-in publishing and the public "Throttle Boards" leaderboards (Phase 2+), and any seed/demo data (deferred by the owner - the boards will render real opted-in data with clean empty states).

Manual verification to follow on the live Gateway: drive a session by voice from the phone and by keyboard from the desktop, open Your Throttle, and watch the split move.

Co-Authored-By: Claude Opus 4.8 (1M context)
