### PR TITLE
feat(mobile): show machine on session cards and add machine/repo filter

### DIFF
--- a/apps/mobile/src/components/SessionFilterPanel.tsx
+++ b/apps/mobile/src/components/SessionFilterPanel.tsx
@@ -1,0 +1,142 @@
+import { useState } from "react";
+import type { SessionDto } from "@devthrottle/client-core/api/client";
+import {
+  type FacetOption,
+  type SessionFilter,
+  EMPTY_FILTER,
+  filterIsActive,
+  machineFacet,
+  repoFacet,
+  toggleValue,
+} from "@devthrottle/client-core/sessions/filter";
+
+// The full-screen "Filter sessions" panel, opened by the app-bar funnel icon. It edits a DRAFT copy of
+// the active filter so the roster underneath does not reshuffle while you are still choosing; Apply
+// commits the draft, Clear resets it to nothing, and the back arrow / overlay tap discards it. The
+// facet lists (Machine, Repo) are built from the full, unfiltered roster so every machine and repo is
+// always offered with its live count. Within a facet, "All ..." is the no-selection state; picking one
+// or more specific values narrows the roster (union within a facet, AND across facets).
+export function SessionFilterPanel({
+  sessions,
+  filter,
+  onApply,
+  onClose,
+}: {
+  sessions: SessionDto[];
+  filter: SessionFilter;
+  onApply: (next: SessionFilter) => void;
+  onClose: () => void;
+}) {
+  const [draft, setDraft] = useState<SessionFilter>(filter);
+  const machines = machineFacet(sessions);
+  const repos = repoFacet(sessions);
+
+  const toggleMachine = (value: string) =>
+    setDraft((d) => ({ ...d, machines: toggleValue(d.machines, value) }));
+  const toggleRepo = (value: string) =>
+    setDraft((d) => ({ ...d, repos: toggleValue(d.repos, value) }));
+
+  return (
+    <div className="filter-overlay" role="presentation" onClick={onClose}>
+      <section
+        className="filter-panel"
+        role="dialog"
+        aria-label="Filter sessions"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="filter-head">
+          <button type="button" className="filter-back" aria-label="Close filter" onClick={onClose}>
+            {"<"}
+          </button>
+          <h2 className="filter-title">Filter sessions</h2>
+          <button
+            type="button"
+            className="filter-clear"
+            onClick={() => setDraft(EMPTY_FILTER)}
+            disabled={!filterIsActive(draft)}
+          >
+            Clear
+          </button>
+        </header>
+
+        <div className="filter-body">
+          <FilterFacet
+            heading="Machine"
+            options={machines}
+            selected={draft.machines}
+            onToggle={toggleMachine}
+            onAll={() => setDraft((d) => ({ ...d, machines: [] }))}
+            allLabel="All machines"
+          />
+          <FilterFacet
+            heading="Repo"
+            options={repos}
+            selected={draft.repos}
+            onToggle={toggleRepo}
+            onAll={() => setDraft((d) => ({ ...d, repos: [] }))}
+            allLabel="All repos"
+          />
+        </div>
+
+        <footer className="filter-foot">
+          <button type="button" className="filter-apply" onClick={() => onApply(draft)}>
+            Apply filter
+          </button>
+        </footer>
+      </section>
+    </div>
+  );
+}
+
+// One facet block: an "All ..." reset row (selected when nothing in this facet is picked) followed by a
+// checkbox row per value with its session count. Renders nothing when the roster has no values for the
+// facet (e.g. no machine names yet), so an empty section never shows.
+function FilterFacet({
+  heading,
+  options,
+  selected,
+  onToggle,
+  onAll,
+  allLabel,
+}: {
+  heading: string;
+  options: FacetOption[];
+  selected: string[];
+  onToggle: (value: string) => void;
+  onAll: () => void;
+  allLabel: string;
+}) {
+  if (options.length === 0) return null;
+  const allActive = selected.length === 0;
+  return (
+    <div className="filter-facet">
+      <h3 className="filter-facet-heading">{heading}</h3>
+      <button
+        type="button"
+        className={`filter-opt${allActive ? " filter-opt-on" : ""}`}
+        onClick={onAll}
+      >
+        <span className={`filter-radio${allActive ? " on" : ""}`} aria-hidden="true" />
+        <span className="filter-opt-label">{allLabel}</span>
+      </button>
+      {options.map((opt) => {
+        const on = selected.includes(opt.value);
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            className={`filter-opt${on ? " filter-opt-on" : ""}`}
+            onClick={() => onToggle(opt.value)}
+            aria-pressed={on}
+          >
+            <span className={`filter-check-box${on ? " on" : ""}`} aria-hidden="true">
+              {on ? "x" : ""}
+            </span>
+            <span className="filter-opt-label">{opt.value}</span>
+            <span className="filter-opt-count">{opt.count}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/mobile/src/hooks/useSessionFilter.ts
+++ b/apps/mobile/src/hooks/useSessionFilter.ts
@@ -1,0 +1,38 @@
+import { useCallback, useState } from "react";
+import { type SessionFilter, EMPTY_FILTER } from "@devthrottle/client-core/sessions/filter";
+
+// The roster filter, persisted to localStorage so a chosen machine/repo filter survives navigating into
+// a session and back, and app restarts. Stored under one key as JSON; a malformed or missing value
+// falls back to the empty (no) filter. The setter both updates React state and writes through to
+// storage in one call so the app bar, summary strip, and roster stay in lockstep.
+const STORAGE_KEY = "devthrottle.sessionFilter";
+
+function readStored(): SessionFilter {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return EMPTY_FILTER;
+    const parsed = JSON.parse(raw) as Partial<SessionFilter>;
+    return {
+      machines: Array.isArray(parsed.machines) ? parsed.machines.map(String) : [],
+      repos: Array.isArray(parsed.repos) ? parsed.repos.map(String) : [],
+    };
+  } catch {
+    return EMPTY_FILTER;
+  }
+}
+
+export function useSessionFilter(): [SessionFilter, (next: SessionFilter) => void] {
+  const [filter, setFilterState] = useState<SessionFilter>(readStored);
+
+  const setFilter = useCallback((next: SessionFilter) => {
+    setFilterState(next);
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    } catch {
+      // Storage can be unavailable (private mode / quota); the in-memory filter still applies for the
+      // session, so this is a non-fatal best-effort persistence, not a feature gate.
+    }
+  }, []);
+
+  return [filter, setFilter];
+}

--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -2,10 +2,13 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { listSessions, type SessionDto } from "@devthrottle/client-core/api/client";
 import { classify, contextLine, dotColor, effectiveColor, inBucket, inDesktopOrder, inWaitingOrder, isWorking, repoLeaf } from "@devthrottle/client-core/sessions/ordering";
+import { applyFilter, filterIsActive, filterSummary, machineName, pruneFilter } from "@devthrottle/client-core/sessions/filter";
 import { useDictationStatusFor } from "@devthrottle/client-core/dictation/status";
 import { useNow, waitingLabel } from "@devthrottle/client-core/sessions/waiting";
 import { getClipState, playClip, playingSid, stopPlayback, syncVoiceSessions, useVoiceClips } from "@devthrottle/client-core/voice/clips";
 import { NavDrawer } from "../components/NavDrawer";
+import { SessionFilterPanel } from "../components/SessionFilterPanel";
+import { useSessionFilter } from "../hooks/useSessionFilter";
 import { enablePush, notificationPermission, pushSupported, reconcileBadge } from "@devthrottle/client-core/push/register";
 
 // Home / roster. A "needs you" group first (when any session wants attention), then an "other
@@ -18,6 +21,10 @@ export function Home() {
   const [sessions, setSessions] = useState<SessionDto[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const loadedOnce = useRef(false);
+  // The roster filter (by machine and/or repo) and whether its full-screen panel is open. The filter
+  // is persisted across navigations and restarts by the hook; the panel is transient UI state.
+  const [filter, setFilter] = useSessionFilter();
+  const [showFilter, setShowFilter] = useState(false);
 
   // Re-render the roster when a voice clip finishes downloading (a card flips from the yellow
   // working state to the play-triangle the moment its audio is phone-ready).
@@ -54,15 +61,29 @@ export function Home() {
     };
   }, [load]);
 
+  // Drop any filter selection whose machine or repo is no longer in the live roster, so a filter pinned
+  // to a machine that went away cannot silently hide everything. pruneFilter returns the same reference
+  // when nothing changed, so this only writes through (and re-renders) on a real change.
+  useEffect(() => {
+    if (!sessions) return;
+    const pruned = pruneFilter(filter, sessions);
+    if (pruned !== filter) setFilter(pruned);
+  }, [sessions, filter, setFilter]);
+
+  // The roster narrowed to the active machine/repo filter. Facet lists in the panel and the total
+  // count in the app bar come from the FULL roster; only the displayed groups below are narrowed.
+  const filtered = sessions ? applyFilter(sessions, filter) : sessions;
   // The "Needs you" group is a waiting line: the session that has been waiting for you the longest
   // sits at the top, and a session that only just started needing you drops in at the bottom
   // (inWaitingOrder). This keeps the list from reshuffling under you as sessions change state, and
   // lets you work it top to bottom, dealing with the longest-neglected session first.
-  const needsYou = sessions ? inWaitingOrder(sessions) : [];
+  const needsYou = filtered ? inWaitingOrder(filtered) : [];
   // The bottom group is "the rest": every session that is NOT waiting on you, still in your manual
   // desktop order. A needs-you session shows only once, at the top - never duplicated down here.
-  const others = sessions ? inDesktopOrder(sessions.filter((s) => classify(s) !== "needsYou")) : [];
+  const others = filtered ? inDesktopOrder(filtered.filter((s) => classify(s) !== "needsYou")) : [];
   const total = sessions ? sessions.length : 0;
+  const shownTotal = filtered ? filtered.length : 0;
+  const active = filterIsActive(filter);
 
   return (
     <div className="screen">
@@ -70,12 +91,48 @@ export function Home() {
         <NavDrawer />
         <h1>DevThrottle</h1>
         <span className="app-bar-sub">Mission Control</span>
+        {/* The funnel opens the full-screen filter panel and doubles as the "filter active" indicator
+            (a dot appears when a machine/repo filter is applied), so it is both the one-tap entry point
+            and the status light - no separate menu item needed. */}
+        <button
+          type="button"
+          className={`filter-btn${active ? " filter-btn-on" : ""}`}
+          aria-label={active ? "Sessions filtered - edit filter" : "Filter sessions"}
+          onClick={() => setShowFilter(true)}
+        >
+          <span className="filter-funnel" aria-hidden="true" />
+        </button>
       </header>
+
+      {/* When a filter is applied, a thin strip under the app bar names it and offers a one-tap Clear,
+          so the filter can be seen and removed without reopening the panel. */}
+      {active && (
+        <div className="filter-strip" role="status">
+          <span className="filter-funnel filter-strip-icon" aria-hidden="true" />
+          <span className="filter-strip-text">{filterSummary(filter)}</span>
+          <span className="filter-strip-count">{shownTotal} of {total}</span>
+          <button type="button" className="filter-strip-clear" onClick={() => setFilter({ machines: [], repos: [] })}>
+            Clear
+          </button>
+        </div>
+      )}
 
       {error !== null && (
         <div className="banner banner-error" role="alert">
           {loadedOnce.current ? "Offline - showing last-known roster" : error}
         </div>
+      )}
+
+      {showFilter && sessions !== null && (
+        <SessionFilterPanel
+          sessions={sessions}
+          filter={filter}
+          onApply={(next) => {
+            setFilter(next);
+            setShowFilter(false);
+          }}
+          onClose={() => setShowFilter(false)}
+        />
       )}
 
       <EnableAlerts />
@@ -98,6 +155,17 @@ export function Home() {
 
       {sessions !== null && total === 0 && (
         <p className="status-line">No sessions running.</p>
+      )}
+
+      {/* Sessions exist but the active filter hides them all: say so plainly and offer a way back,
+          instead of an empty screen that reads like "no sessions running". */}
+      {sessions !== null && total > 0 && shownTotal === 0 && (
+        <p className="status-line">
+          No sessions match this filter.{" "}
+          <button type="button" className="link-btn" onClick={() => setFilter({ machines: [], repos: [] })}>
+            Clear filter
+          </button>
+        </p>
       )}
 
       {needsYou.length > 0 && (
@@ -169,6 +237,7 @@ function SessionRow({ session }: { session: SessionDto }) {
   const color = effectiveColor(session);
   const name = session.name && session.name.trim().length > 0 ? session.name : "(unnamed session)";
   const repo = repoLeaf(session);
+  const machine = machineName(session);
   const attention = classify(session) === "needsYou";
   // Issue #844: the session's short three-digit number (SessionDto.Number, #820) read from the
   // regenerated typed client. Null on sessions/Directors without a number - then no prefix shows.
@@ -192,15 +261,22 @@ function SessionRow({ session }: { session: SessionDto }) {
             {hasNum && <span className="row-num">{num}</span>}
             {name}
           </span>
-          {/* The status / what-is-happening text and the repo share one line BELOW the name,
-              separated by a thin divider, with the repo kept visually secondary. On a needs-you
+          {/* The status / what-is-happening text sits on its own line below the name. On a needs-you
               card the live "waiting <dur>" is pinned to the right of this same line (issue #844). */}
           <span className="row-meta">
             <span className="row-context">{contextLine(session)}</span>
-            {repo && <span className="row-divider" aria-hidden="true" />}
-            {repo && <span className="row-repo">{repo}</span>}
             {attention && session.needsYouSince && <WaitingTime since={String(session.needsYouSince)} />}
           </span>
+          {/* The facts you navigate and filter by - the machine the session runs on and its repo - are
+              a bottom row of small chips, so a fleet spread across several machines is legible at a
+              glance without crowding the status line. The machine chip is accent-tinted; the repo chip
+              is neutral. Either is omitted when the Gateway did not stamp it. */}
+          {(machine || repo) && (
+            <span className="row-chips">
+              {machine && <span className="row-chip row-chip-machine">{machine}</span>}
+              {repo && <span className="row-chip row-chip-repo">{repo}</span>}
+            </span>
+          )}
           {/* A dictation started on this session's screen keeps showing here once the user walks back
               to the roster (#1139): in-flight while it uploads/transcribes, a sticky red pill if it
               failed - so a dropped transcription is visible from the list, never silent. */}

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -243,13 +243,22 @@ a.banner-btn {
   overflow-wrap: anywhere;
 }
 
-/* Issue #844: the muted three-digit session-number prefix before the name, matching the desktop
-   SessionRail .sess-num (dimmed text, weight 600, a small gap before the name). It is an inline
-   span inside .row-name so the name keeps wrapping full-width after it. */
+/* Issue #844: the three-digit session-number prefix before the name. Rendered as a small, compact
+   badge (surface-2 chip) so it reads as the session's number at a glance and stays visually distinct
+   from the title. It is an inline span inside .row-name so the name keeps wrapping full-width after
+   it; the tabular figures and nowrap keep the badge from breaking across lines. */
 .row-num {
+  display: inline-block;
+  margin-right: 8px;
+  padding: 1px 6px;
+  border-radius: 6px;
+  background: var(--surface-2);
   color: var(--text-dim);
-  font-weight: 600;
-  margin-right: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  vertical-align: 1px;
 }
 
 /* The secondary line below the name: status text + thin divider + repo, wrapping as a group
@@ -295,6 +304,353 @@ a.banner-btn {
   font-size: 12px;
   color: var(--attention);
   white-space: nowrap;
+}
+
+/* The bottom "facts" row on a card: small chips for the machine and repo. It wraps if a phone is too
+   narrow to hold both. Kept a touch tighter to the status line above it than the name gap. */
+.row-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+/* A chip is a compact rounded label. The machine chip is accent-tinted (the primary "where does this
+   run" fact) with a small leading square standing in for a machine; the repo chip is neutral surface.
+   Both wrap their text rather than clipping, so a long machine or repo name stays fully readable. */
+.row-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11.5px;
+  font-weight: 600;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.row-chip::before {
+  content: "";
+  flex: 0 0 auto;
+  width: 7px;
+  height: 7px;
+}
+
+.row-chip-machine {
+  background: rgba(59, 130, 246, 0.14);
+  border: 1px solid rgba(59, 130, 246, 0.4);
+  color: #9cc2ff;
+}
+
+/* A small filled square as the machine glyph (a stand-in for a computer), no unicode. */
+.row-chip-machine::before {
+  background: currentColor;
+  border-radius: 2px;
+}
+
+.row-chip-repo {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+}
+
+/* A small open square (outline) as the repo glyph, distinct from the machine's filled square. */
+.row-chip-repo::before {
+  border: 1.5px solid currentColor;
+  border-radius: 2px;
+  width: 8px;
+  height: 8px;
+}
+
+/* An inline text button used inside status lines (e.g. "Clear filter"). Looks like an accent link,
+   not a chunky button, so it sits naturally mid-sentence. */
+.link-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent);
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+/* ===== Session filter (Filter sessions panel + app-bar funnel + summary strip) ===== */
+/* The app-bar funnel button, pushed to the right of the title. margin-left:auto floats it to the far
+   edge; it is a >=34px tap target with the same chrome as the hamburger for visual symmetry. */
+.filter-btn {
+  margin-left: auto;
+  align-self: center;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text-dim);
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+/* Active (a filter is applied): the funnel goes accent-colored and a small dot rides its top-right
+   corner, so the button is both the entry point and the "you are filtered" light. */
+.filter-btn-on {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.filter-btn-on::after {
+  content: "";
+  position: absolute;
+  top: -3px;
+  right: -3px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid var(--bg);
+}
+
+/* A CSS-only funnel silhouette (no unicode glyph): a wide top that tapers to a narrow stem. */
+.filter-funnel {
+  width: 17px;
+  height: 15px;
+  background: currentColor;
+  clip-path: polygon(0 0, 100% 0, 60% 46%, 60% 100%, 40% 84%, 40% 46%);
+}
+
+/* The summary strip below the app bar when a filter is applied: funnel + the selected values + a live
+   "shown of total" count + a one-tap Clear. */
+.filter-strip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 10px 0 0;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: rgba(59, 130, 246, 0.1);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  font-size: 13px;
+}
+
+.filter-strip-icon {
+  flex: 0 0 auto;
+  color: var(--accent);
+}
+
+.filter-strip-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  color: var(--text);
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.filter-strip-count {
+  flex: 0 0 auto;
+  color: var(--text-dim);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.filter-strip-clear {
+  flex: 0 0 auto;
+  background: transparent;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  border-radius: 7px;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+/* The full-screen filter panel: a dim overlay with a bottom-anchored sheet that can grow tall and
+   scroll its body. Sits above everything (z above the drawer). */
+.filter-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+
+.filter-panel {
+  display: flex;
+  flex-direction: column;
+  max-height: 92dvh;
+  background: var(--bg);
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+  border: 1px solid var(--border);
+  border-bottom: none;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+.filter-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.filter-back {
+  flex: 0 0 auto;
+  width: 36px;
+  height: 36px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  color: var(--text);
+  font-size: 18px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.filter-title {
+  flex: 1 1 auto;
+  margin: 0;
+  font-size: 17px;
+  font-weight: 700;
+}
+
+.filter-clear {
+  flex: 0 0 auto;
+  background: transparent;
+  border: none;
+  color: var(--accent);
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.filter-clear:disabled {
+  color: var(--text-dim);
+  opacity: 0.5;
+  cursor: default;
+}
+
+.filter-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: 8px 16px 16px;
+}
+
+.filter-facet {
+  margin-top: 16px;
+}
+
+.filter-facet-heading {
+  margin: 0 0 8px;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--text-dim);
+}
+
+/* One selectable row (All / a machine / a repo): full-width tap target with a leading check/radio, the
+   value, and a trailing count. Selected rows get an accent border + tint. */
+.filter-opt {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  text-align: left;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 12px;
+  margin: 0 0 8px;
+  min-height: 48px;
+  color: var(--text);
+  font-size: 14px;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.filter-opt-on {
+  border-color: var(--accent);
+  background: rgba(59, 130, 246, 0.12);
+}
+
+.filter-opt-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.filter-opt-count {
+  flex: 0 0 auto;
+  color: var(--text-dim);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* The square checkbox for a specific value; shows an "x" when selected. */
+.filter-check-box {
+  flex: 0 0 auto;
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--border);
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+  color: #ffffff;
+}
+
+.filter-check-box.on {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+/* The round radio for the "All ..." reset row (single-choice feel against the value checkboxes). */
+.filter-radio {
+  flex: 0 0 auto;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid var(--border);
+}
+
+.filter-radio.on {
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 4px var(--accent);
+}
+
+.filter-foot {
+  flex: 0 0 auto;
+  padding: 12px 16px calc(12px + env(safe-area-inset-bottom, 0px));
+  border-top: 1px solid var(--border);
+}
+
+.filter-apply {
+  display: block;
+  width: 100%;
+  border: none;
+  border-radius: 10px;
+  padding: 14px 0;
+  font-size: 15px;
+  font-weight: 700;
+  color: #ffffff;
+  background: var(--accent);
+  cursor: pointer;
+  touch-action: manipulation;
 }
 
 .detail {

--- a/packages/client-core/src/sessions/filter.test.ts
+++ b/packages/client-core/src/sessions/filter.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import type { SessionDto } from "../api/client";
+import {
+  EMPTY_FILTER,
+  applyFilter,
+  filterIsActive,
+  filterSummary,
+  machineFacet,
+  pruneFilter,
+  repoFacet,
+  sessionMatchesFilter,
+  toggleValue,
+} from "./filter";
+
+function session(fields: Partial<SessionDto> & { sessionId?: string } = {}): SessionDto {
+  return {
+    sessionId: "s1",
+    createdAt: "2026-07-08T00:00:00Z",
+    sortOrder: 0,
+    ...fields,
+  } as unknown as SessionDto;
+}
+
+const roster = [
+  session({ sessionId: "a", machineName: "SOREN_NORTH", repoPath: "D:/ReposFred/devthrottle" }),
+  session({ sessionId: "b", machineName: "SOREN_NORTH", repoPath: "D:/ReposFred/mindzieWeb" }),
+  session({ sessionId: "c", machineName: "SOREN_SOUTH", repoPath: "C:/repos/devthrottle" }),
+  session({ sessionId: "d", machineName: "BUILD_BOX", repoPath: "C:/repos/devthrottle" }),
+];
+
+describe("filterIsActive", () => {
+  it("is false for the empty filter", () => {
+    expect(filterIsActive(EMPTY_FILTER)).toBe(false);
+  });
+
+  it("is true when a machine or repo is selected", () => {
+    expect(filterIsActive({ machines: ["SOREN_NORTH"], repos: [] })).toBe(true);
+    expect(filterIsActive({ machines: [], repos: ["devthrottle"] })).toBe(true);
+  });
+});
+
+describe("applyFilter", () => {
+  it("returns the roster unchanged when inactive", () => {
+    expect(applyFilter(roster, EMPTY_FILTER)).toBe(roster);
+  });
+
+  it("filters by machine (union within the facet)", () => {
+    const out = applyFilter(roster, { machines: ["SOREN_NORTH", "BUILD_BOX"], repos: [] });
+    expect(out.map((s) => s.sessionId)).toEqual(["a", "b", "d"]);
+  });
+
+  it("filters by repo leaf", () => {
+    const out = applyFilter(roster, { machines: [], repos: ["devthrottle"] });
+    expect(out.map((s) => s.sessionId)).toEqual(["a", "c", "d"]);
+  });
+
+  it("combines machine AND repo", () => {
+    const out = applyFilter(roster, { machines: ["SOREN_NORTH"], repos: ["devthrottle"] });
+    expect(out.map((s) => s.sessionId)).toEqual(["a"]);
+  });
+
+  it("preserves the input ordering", () => {
+    const reversed = [...roster].reverse();
+    const out = applyFilter(reversed, { machines: [], repos: ["devthrottle"] });
+    expect(out.map((s) => s.sessionId)).toEqual(["d", "c", "a"]);
+  });
+});
+
+describe("sessionMatchesFilter", () => {
+  it("treats an empty facet as no restriction", () => {
+    expect(sessionMatchesFilter(roster[0], EMPTY_FILTER)).toBe(true);
+  });
+});
+
+describe("facets", () => {
+  it("counts machines, sorted by name", () => {
+    expect(machineFacet(roster)).toEqual([
+      { value: "BUILD_BOX", count: 1 },
+      { value: "SOREN_NORTH", count: 2 },
+      { value: "SOREN_SOUTH", count: 1 },
+    ]);
+  });
+
+  it("counts repo leaves, sorted by name", () => {
+    expect(repoFacet(roster)).toEqual([
+      { value: "devthrottle", count: 3 },
+      { value: "mindzieWeb", count: 1 },
+    ]);
+  });
+
+  it("ignores sessions with no machine name", () => {
+    expect(machineFacet([session({ machineName: "" }), session({ machineName: "X" })])).toEqual([
+      { value: "X", count: 1 },
+    ]);
+  });
+});
+
+describe("filterSummary", () => {
+  it("lists machines then repos", () => {
+    expect(filterSummary({ machines: ["SOREN_NORTH"], repos: ["devthrottle"] })).toBe("SOREN_NORTH, devthrottle");
+  });
+
+  it("is empty for the empty filter", () => {
+    expect(filterSummary(EMPTY_FILTER)).toBe("");
+  });
+});
+
+describe("toggleValue", () => {
+  it("adds a missing value and removes a present one", () => {
+    expect(toggleValue([], "a")).toEqual(["a"]);
+    expect(toggleValue(["a", "b"], "a")).toEqual(["b"]);
+  });
+});
+
+describe("pruneFilter", () => {
+  it("drops selections that no longer exist in the roster", () => {
+    const pruned = pruneFilter({ machines: ["SOREN_NORTH", "GONE"], repos: ["devthrottle", "old-repo"] }, roster);
+    expect(pruned).toEqual({ machines: ["SOREN_NORTH"], repos: ["devthrottle"] });
+  });
+
+  it("returns the same reference when nothing changed", () => {
+    const f = { machines: ["SOREN_NORTH"], repos: [] };
+    expect(pruneFilter(f, roster)).toBe(f);
+  });
+});

--- a/packages/client-core/src/sessions/filter.ts
+++ b/packages/client-core/src/sessions/filter.ts
@@ -1,0 +1,99 @@
+// Client-side roster filtering by machine and repo (the mobile "Filter sessions" panel). The roster
+// can grow large across a fleet of machines and repositories; this lets the phone narrow it to one
+// machine and/or one set of repositories. The model is deliberately simple and pure so it is fully
+// unit-tested and the UI (the full-screen panel) stays a thin renderer over it.
+import type { SessionDto } from "../api/client";
+import { repoLeaf } from "./ordering";
+
+// The active selection. An empty list for a facet means "all" - no restriction on that facet - so the
+// default (no filter) is two empty lists. Selections combine across facets (machine AND repo) and
+// union within a facet (machine A OR machine B).
+export interface SessionFilter {
+  machines: string[];
+  repos: string[];
+}
+
+export const EMPTY_FILTER: SessionFilter = { machines: [], repos: [] };
+
+// One selectable value in a facet, with the count of sessions that carry it in the full roster. The
+// count is always computed from the UNFILTERED roster so the panel shows every machine/repo you could
+// pick and how many sessions each holds, regardless of what is currently selected.
+export interface FacetOption {
+  value: string;
+  count: number;
+}
+
+// The machine a session runs on, trimmed. Empty string when the Gateway did not stamp a machine name
+// (older sessions); such a session is grouped under "(unknown)" in the panel so it stays selectable.
+export function machineName(s: SessionDto): string {
+  return (s.machineName ?? "").trim();
+}
+
+// True when the filter restricts the roster at all (either facet has a selection). The app bar shows
+// the "filter active" state and the summary strip appears only when this is true.
+export function filterIsActive(f: SessionFilter): boolean {
+  return f.machines.length > 0 || f.repos.length > 0;
+}
+
+// Keep a session when it matches EVERY active facet: its machine is among the selected machines (or no
+// machine is selected) AND its repo is among the selected repos (or no repo is selected).
+export function sessionMatchesFilter(s: SessionDto, f: SessionFilter): boolean {
+  if (f.machines.length > 0 && !f.machines.includes(machineName(s))) return false;
+  if (f.repos.length > 0 && !f.repos.includes(repoLeaf(s))) return false;
+  return true;
+}
+
+// The roster narrowed to the sessions that match the filter, preserving input order (the caller has
+// already ordered it). An inactive filter returns the roster unchanged.
+export function applyFilter(sessions: SessionDto[], f: SessionFilter): SessionDto[] {
+  if (!filterIsActive(f)) return sessions;
+  return sessions.filter((s) => sessionMatchesFilter(s, f));
+}
+
+// The distinct machine values in the roster with per-value counts, sorted by name. Built from the full
+// roster so the panel always offers every machine, whatever is selected.
+export function machineFacet(sessions: SessionDto[]): FacetOption[] {
+  return countBy(sessions, machineName);
+}
+
+// The distinct repo leaves in the roster with per-value counts, sorted by name.
+export function repoFacet(sessions: SessionDto[]): FacetOption[] {
+  return countBy(sessions, repoLeaf);
+}
+
+// A short human summary of what is selected, for the app-bar summary strip - e.g.
+// "SOREN_NORTH, devthrottle". Machines first, then repos, in selection order. Empty when inactive.
+export function filterSummary(f: SessionFilter): string {
+  return [...f.machines, ...f.repos].filter((v) => v.length > 0).join(", ");
+}
+
+// Toggle one value in a facet list immutably: add it if absent, remove it if present. Used by the
+// panel's checkboxes without the panel owning any set logic.
+export function toggleValue(values: string[], value: string): string[] {
+  return values.includes(value) ? values.filter((v) => v !== value) : [...values, value];
+}
+
+// Drop any selected value that no longer exists in the live roster, so a filter pinned to a machine or
+// repo that has gone away does not silently hide the whole list forever. Returns the same reference
+// when nothing changed so callers can skip a needless state update.
+export function pruneFilter(f: SessionFilter, sessions: SessionDto[]): SessionFilter {
+  const machines = new Set(sessions.map(machineName));
+  const repos = new Set(sessions.map(repoLeaf));
+  const keptMachines = f.machines.filter((m) => machines.has(m));
+  const keptRepos = f.repos.filter((r) => repos.has(r));
+  if (keptMachines.length === f.machines.length && keptRepos.length === f.repos.length) return f;
+  return { machines: keptMachines, repos: keptRepos };
+}
+
+// Count sessions by a string key, dropping empty keys, sorted alphabetically by value.
+function countBy(sessions: SessionDto[], key: (s: SessionDto) => string): FacetOption[] {
+  const counts = new Map<string, number>();
+  for (const s of sessions) {
+    const value = key(s);
+    if (value.length === 0) continue;
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([value, count]) => ({ value, count }))
+    .sort((a, b) => a.value.localeCompare(b.value));
+}


### PR DESCRIPTION
Improves the mobile roster so a fleet spread across several machines is legible and filterable.

## Session cards
- **Machine now shown.** Machine and repo are a bottom row of small chips (accent-tinted machine, neutral repo), so the status line is no longer crowded.
- Session **number** promoted to a compact badge before the wrapping full title.
- Full **title still wraps** over as many lines as needed (no truncation).

## Filter (by machine and/or repo)
- App-bar **funnel** opens a full-screen "Filter sessions" panel with **Machine** and **Repo** facets, each built from the live roster with per-value session counts.
- Multi-select within a facet (union), combined across facets (machine AND repo).
- Funnel **doubles as the active-filter indicator** (accent + dot when applied).
- **Summary strip** under the app bar names the active filter, shows a "shown of total" count, and offers one-tap Clear.
- Filter **persists** across navigation/restart (localStorage) and is **pruned** when a selected machine/repo leaves the roster, so it can never silently hide everything.

## Implementation
- Filtering logic is pure, fully unit-tested helpers in `packages/client-core/src/sessions/filter.ts` (16 new tests); the panel is a thin renderer over it.
- All 301 client-core tests pass; mobile typecheck + build + lint clean.

## Verification
- Deployed to the live Gateway `wwwroot/m` and confirmed the served bundle contains the new filter code and CSS.
- Visual render at phone width confirmed cards, chips, funnel, summary strip, and filter panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)