### PR TITLE
Car Mode: fast model + tool_choice=required + speak_answer, and a first-class Car Mode model setting

### DIFF
--- a/apps/cockpit/src/settings/SettingsView.tsx
+++ b/apps/cockpit/src/settings/SettingsView.tsx
@@ -13,6 +13,7 @@ import {
   type AiProviderSnapshot,
   getAiModels,
   getAiProvider,
+  setCarModeModel,
   setWingmanFastModel,
   setTtsModel,
   setTtsVoice,
@@ -456,6 +457,20 @@ function AiTab() {
     }
   };
 
+  const chooseCarMode = async (model: string) => {
+    setBusy(true);
+    setMsg("Saving...");
+    try {
+      await setCarModeModel(model);
+      setSnap({ ...snap, carModeModel: model });
+      setMsg("Car Mode model set.");
+    } catch (e) {
+      setMsg(errText(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const runFastTest = async () => {
     setBusy(true);
     setFastTestMsg("Testing " + snap.wingmanFastModel + "...");
@@ -583,6 +598,28 @@ function AiTab() {
           </button>
           <span className="settings-inline-msg">
             {fastTestMsg || "Used for spoken turn summaries, menus, and choice mapping."}
+          </span>
+        </div>
+      </div>
+
+      <div className="settings-field">
+        <label htmlFor="settings-ai-carmode-model">Car Mode model</label>
+        <select
+          id="settings-ai-carmode-model"
+          className="settings-select"
+          value={snap.carModeModel}
+          disabled={busy}
+          onChange={(e) => void chooseCarMode(e.target.value)}
+        >
+          {ensureIds(snap.carModeModel, chatModels).map((id) => (
+            <option key={id} value={id}>
+              {id}
+            </option>
+          ))}
+        </select>
+        <div className="settings-actions">
+          <span className="settings-inline-msg">
+            Hands-free fleet control from the phone. A fast model is recommended; GLM-5.2 is slower but a strong tool-caller.
           </span>
         </div>
       </div>

--- a/apps/mobile/src/pages/AiSettings.tsx
+++ b/apps/mobile/src/pages/AiSettings.tsx
@@ -5,6 +5,7 @@ import {
   type AiProviderSnapshot,
   getAiModels,
   getAiProvider,
+  setCarModeModel,
   setWingmanFastModel,
   setTtsModel,
   setTtsVoice,
@@ -115,6 +116,20 @@ export function AiSettings() {
     setBusy(false);
   };
 
+  const chooseCarMode = async (model: string) => {
+    setBusy(true);
+    setMsg("Saving...");
+    try {
+      await setCarModeModel(model);
+      setSnap({ ...snap, carModeModel: model });
+      setMsg("Car Mode model set.");
+    } catch (e) {
+      setMsg(errText(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const chooseSpeech = async (model: string) => {
     setBusy(true);
     setMsg("Saving...");
@@ -210,6 +225,18 @@ export function AiSettings() {
         <div className="setting-actions">
           <button type="button" className="setting-btn" disabled={busy} onClick={() => void runFastTest()}>Test</button>
           <span className="setting-msg">{fastTestMsg || "Spoken turn summaries and menus."}</span>
+        </div>
+      </div>
+
+      <div className="setting-block">
+        <label className="setting-label" htmlFor="ai-carmode-model">Car Mode model</label>
+        <select id="ai-carmode-model" className="setting-select" value={snap.carModeModel} disabled={busy} onChange={(e) => void chooseCarMode(e.target.value)}>
+          {ensure(snap.carModeModel, chatModels).map((id) => (
+            <option key={id} value={id}>{id}</option>
+          ))}
+        </select>
+        <div className="setting-actions">
+          <span className="setting-msg">Hands-free fleet control. Fast model recommended; GLM-5.2 is slower but a strong tool-caller.</span>
         </div>
       </div>
 

--- a/packages/client-core/src/api/ai.ts
+++ b/packages/client-core/src/api/ai.ts
@@ -10,6 +10,9 @@ export interface AiProviderSnapshot {
   provider: AiProviderId;
   wingmanModel: string;
   wingmanFastModel: string;
+  /** The model Car Mode's fleet brain runs on - its OWN setting, separate from the Wingman (Car Mode
+   *  runs a fast tier + tool_choice=required). The user's saved choice, or the Qwen2.5-72B default. */
+  carModeModel: string;
   transcriptionModel: string;
   ttsModel: string;
   ttsVoice: string;
@@ -88,6 +91,13 @@ export function setWingmanModel(model: string): Promise<{ model: string }> {
 
 export function setWingmanFastModel(model: string): Promise<{ model: string }> {
   return putJson<{ model: string }>("/gateway/ai/wingman-fast-model", { model });
+}
+
+// PUT /gateway/ai/car-mode-model { model } - persist the model Car Mode's fleet brain runs on (its own
+// setting, separate from the Wingman). The Gateway resolves the effective model at turn time as env
+// override, then this saved setting, then the Qwen2.5-72B default.
+export function setCarModeModel(model: string): Promise<{ model: string }> {
+  return putJson<{ model: string }>("/gateway/ai/car-mode-model", { model });
 }
 
 export function setTtsModel(model: string): Promise<{ model: string }> {

--- a/src/CcDirector.Core.Tests/CarModeModelConfigTests.cs
+++ b/src/CcDirector.Core.Tests/CarModeModelConfigTests.cs
@@ -1,0 +1,53 @@
+using CcDirector.Core.Configuration;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Car Mode runs its OWN model (a fast tier + tool_choice=required), separate from the Wingman. These
+/// pin the resolution precedence the Architect settled: the CC_CARMODE_MODEL env override wins, then the
+/// user's saved setting, then the Qwen2.5-72B default.
+/// </summary>
+public sealed class CarModeModelConfigTests
+{
+    [Fact]
+    public void Default_IsTheFastQwenTier()
+    {
+        Assert.Equal("Qwen/Qwen2.5-72B-Instruct", CarModeModelConfig.Default);
+        Assert.Equal(TranscriptionEndpointResolver.DevThrottleWingmanFastModel, CarModeModelConfig.Default);
+    }
+
+    [Fact]
+    public void Resolve_EnvOverride_Wins()
+    {
+        var original = Environment.GetEnvironmentVariable(CarModeModelConfig.EnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(CarModeModelConfig.EnvVar, "zai-org/GLM-5.2");
+            Assert.Equal("zai-org/GLM-5.2", CarModeModelConfig.Resolve());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(CarModeModelConfig.EnvVar, original);
+        }
+    }
+
+    [Fact]
+    public void Resolve_WithoutEnv_FallsBackToTheSavedSettingOrDefault()
+    {
+        var original = Environment.GetEnvironmentVariable(CarModeModelConfig.EnvVar);
+        try
+        {
+            Environment.SetEnvironmentVariable(CarModeModelConfig.EnvVar, null);
+            // With no env override the effective model is exactly the persisted user setting (Get()),
+            // which is the Qwen default when nothing is saved. Never empty.
+            var resolved = CarModeModelConfig.Resolve();
+            Assert.Equal(CarModeModelConfig.Get(), resolved);
+            Assert.False(string.IsNullOrWhiteSpace(resolved));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(CarModeModelConfig.EnvVar, original);
+        }
+    }
+}

--- a/src/CcDirector.Core/Configuration/CarModeModelConfig.cs
+++ b/src/CcDirector.Core/Configuration/CarModeModelConfig.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace CcDirector.Core.Configuration;
+
+/// <summary>
+/// The chat model Car Mode's fleet brain runs on. Car Mode deliberately runs a DIFFERENT model from the
+/// Wingman (validated 2026-07-11): a FAST hosted model paired with tool_choice=required + a speak_answer
+/// tool, which is fast AND reliably chooses tools - so Car Mode has its OWN first-class model setting,
+/// separate from any Wingman model, surfaced on the AI Settings screen.
+///
+/// Resolution precedence (settled with the Architect):
+///   1. the <c>CC_CARMODE_MODEL</c> environment variable (a per-install override / debug switch) - wins;
+///   2. the user's saved setting (config.json <c>car_mode_model</c>) - what the AI Settings dropdown writes;
+///   3. the default, <see cref="Default"/> (Qwen2.5-72B), the fast tier proven cleanest under the guardrail.
+/// GLM-5.2 remains a selectable option in the dropdown (slower but a strong tool-caller).
+/// </summary>
+public static class CarModeModelConfig
+{
+    /// <summary>The config.json key the chosen Car Mode model is stored under.</summary>
+    public const string ConfigKey = "car_mode_model";
+
+    /// <summary>The environment variable that overrides everything (per-install / debugging).</summary>
+    public const string EnvVar = "CC_CARMODE_MODEL";
+
+    /// <summary>The default Car Mode model: the fast tier (Qwen2.5-72B) proven cleanest under
+    /// tool_choice=required + speak_answer.</summary>
+    public const string Default = TranscriptionEndpointResolver.DevThrottleWingmanFastModel;
+
+    /// <summary>
+    /// The user's saved Car Mode model (config.json <c>car_mode_model</c>), or <see cref="Default"/> when
+    /// unset/blank. Does NOT consult the environment override - this is the persisted USER setting the AI
+    /// Settings screen shows. Use <see cref="Resolve"/> for the effective model the brain runs.
+    /// </summary>
+    public static string Get()
+    {
+        var node = CcDirectorConfigService.ReadRaw()[ConfigKey];
+        if (node is JsonValue v && v.GetValueKind() == JsonValueKind.String)
+        {
+            var model = v.GetValue<string>().Trim();
+            if (model.Length > 0) return model;
+        }
+        return Default;
+    }
+
+    /// <summary>
+    /// The EFFECTIVE Car Mode model the brain runs, applying the full precedence: the
+    /// <see cref="EnvVar"/> environment override wins, then the user's saved setting, then
+    /// <see cref="Default"/>. Read at call time so a settings change (or an env change on restart) is
+    /// honoured on the next turn.
+    /// </summary>
+    public static string Resolve()
+    {
+        var env = Environment.GetEnvironmentVariable(EnvVar);
+        if (!string.IsNullOrWhiteSpace(env)) return env.Trim();
+        return Get();
+    }
+
+    /// <summary>Persist the chosen Car Mode model to config.json (merge-patch).</summary>
+    public static void Set(string model)
+    {
+        CcDirectorConfigService.MergePatch(new JsonObject { [ConfigKey] = model.Trim() });
+    }
+}

--- a/src/CcDirector.Gateway.Tests/CarModeBrainTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeBrainTests.cs
@@ -206,8 +206,78 @@ public sealed class CarModeBrainTests
     [InlineData("{}", "session", null)]
     [InlineData("not json", "session", null)]
     [InlineData("{\"other\":1}", "session", null)]
+    // Defensive against the malformed shapes a model occasionally emits (must never crash the turn):
+    [InlineData("[{\"repo\":\"cc-consult\"}]", "repo", "cc-consult")] // arguments wrapped in a one-element array
+    [InlineData("{\"n\":5}", "n", "5")]                                // a number coerced to its text
+    [InlineData("[\"just a string\"]", "repo", null)]                 // array of non-objects -> null, no throw
+    [InlineData("[]", "repo", null)]                                   // empty array -> null, no throw
     public void ReadStringArg_ParsesOrDegradesToNull(string args, string name, string? expected)
         => Assert.Equal(expected, CarModeBrain.ReadStringArg(args, name));
+
+    // ---- speak_answer (tool_choice=required): the model says its final words by calling a tool ----
+
+    [Fact]
+    public async Task RunTurn_SpeakAnswerTool_IsTheFinalReply()
+    {
+        // A pure conversational turn under tool_choice=required: the model calls only speak_answer.
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"Nothing needs you right now.\"}") }));
+        var brain = new CarModeBrain(chat, new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+
+        var result = await brain.RunTurnAsync("device-a", "anything for me", CancellationToken.None);
+
+        Assert.Equal("Nothing needs you right now.", result.Spoken);
+        Assert.Empty(result.Actions);
+        Assert.False(result.PendingConfirmation);
+    }
+
+    [Fact]
+    public async Task RunTurn_ListThenSpeakAnswer_ExecutesToolThenSpeaks()
+    {
+        var fleet = new FakeFleet { Sessions = new[] { Session("Local Files Manager", true) } };
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("list_sessions") }),
+            new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"One session needs you: Local Files Manager.\"}") }));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+
+        var result = await brain.RunTurnAsync("device-a", "who needs me", CancellationToken.None);
+
+        Assert.Equal(1, fleet.ListCalls);
+        Assert.Contains("Local Files Manager", result.Spoken);
+    }
+
+    [Fact]
+    public async Task RunTurn_DeleteThenSpeakAnswer_ArmsAndSpeaksTheQuestion()
+    {
+        var fleet = new FakeFleet { ResolveResult = Info("Old Worker", "s-9") };
+        var pending = new CarModePendingStore(_ => { });
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("delete_session", "{\"session\":\"old worker\"}") }),
+            new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"Deleting Old Worker is permanent. Say confirm to proceed.\"}") }));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), pending, _ => { });
+
+        var result = await brain.RunTurnAsync("device-a", "delete old worker", CancellationToken.None);
+
+        Assert.Empty(fleet.Deleted);          // not deleted - only armed
+        Assert.True(result.PendingConfirmation);
+        Assert.Contains("permanent", result.Spoken);
+        Assert.NotNull(pending.Get("device-a"));
+    }
+
+    [Fact]
+    public async Task RunTurn_EmptySpeakAnswer_RetriesInLoopRatherThanFailing()
+    {
+        // A model occasionally calls speak_answer with no words. The loop must NOT fail the turn - it
+        // nudges the model, which speaks proper words on the next round.
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"  \"}") }),
+            new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"All set.\"}") }));
+        var brain = new CarModeBrain(chat, new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+
+        var result = await brain.RunTurnAsync("device-a", "hi", CancellationToken.None);
+
+        Assert.Equal("All set.", result.Spoken);
+    }
 
     // ---- Phase 3: the ordinary act tools run immediately ----
 

--- a/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
@@ -114,6 +114,21 @@ internal static class AiModelsEndpoint
             catch (JsonException) { return Results.BadRequest(new { error = "invalid JSON" }); }
         });
 
+        app.MapPut("/gateway/ai/car-mode-model", async (HttpContext ctx) =>
+        {
+            try
+            {
+                var body = await JsonSerializer.DeserializeAsync<ModelBody>(ctx.Request.Body, JsonOpts, ctx.RequestAborted);
+                if (body is null || string.IsNullOrWhiteSpace(body.Model))
+                    return Results.BadRequest(new { error = "body { \"model\": \"<id>\" } is required" });
+                var model = body.Model.Trim();
+                CarModeModelConfig.Set(model);
+                FileLog.Write($"[AiModelsEndpoint] car mode model set: {model}");
+                return Results.Json(new { model });
+            }
+            catch (JsonException) { return Results.BadRequest(new { error = "invalid JSON" }); }
+        });
+
         app.MapPut("/gateway/ai/tts-model", async (HttpContext ctx) =>
         {
             try

--- a/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
@@ -451,6 +451,10 @@ internal static class SettingsEndpoints
             // so models picked on the AI tab round-trip across a reload.
             wingmanModel = Core.Configuration.WingmanModelConfig.Resolve(mode),
             wingmanFastModel = Core.Configuration.WingmanModelConfig.ResolveFast(mode),
+            // Car Mode runs its OWN model, separate from the Wingman (a fast tier + tool_choice=required).
+            // The snapshot shows the user's saved setting (or the Qwen2.5-72B default); the env override
+            // is not reflected here because it is a per-install debug switch, not the user's choice.
+            carModeModel = Core.Configuration.CarModeModelConfig.Get(),
             transcriptionModel = Core.Configuration.TranscriptionEndpointResolver.Resolve(mode).Model,
             ttsModel = Core.Configuration.TtsModelConfig.Resolve(mode),
             ttsVoice = Core.Configuration.TtsVoiceConfig.Resolve(mode),

--- a/src/CcDirector.Gateway/CarMode/CarModeBrain.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeBrain.cs
@@ -93,13 +93,16 @@ public sealed class CarModeBrain
             var messagesJson = JsonSerializer.Serialize(messages);
             var turn = await _chat.CompleteAsync(messagesJson, ToolCatalogJson, ct);
 
+            // Under tool_choice=required the model normally calls a tool every turn, and says its final
+            // words by calling speak_answer. Defensive path: if a model still answers in plain content with
+            // no tool call, take that content as the final spoken reply so the loop degrades gracefully.
             if (turn.ToolCalls.Count == 0)
             {
                 var spoken = (turn.Content ?? "").Trim();
                 if (spoken.Length == 0)
                     throw new InvalidOperationException("The model returned an empty spoken reply.");
                 _conversations.Append(deviceKey, userText, spoken);
-                _log($"[CarModeBrain] turn done in {round + 1} round(s): actions={actions.Count}, pending={armedThisTurn}");
+                _log($"[CarModeBrain] turn done in {round + 1} round(s) via content: actions={actions.Count}, pending={armedThisTurn}");
                 return new CarModeTurnResponse { Spoken = spoken, Actions = actions, PendingConfirmation = armedThisTurn };
             }
 
@@ -117,12 +120,39 @@ public sealed class CarModeBrain
                 }).ToList(),
             });
 
+            string? finalSpoken = null;
             foreach (var call in turn.ToolCalls)
             {
+                if (string.Equals(call.Name, "speak_answer", StringComparison.Ordinal))
+                {
+                    // This is how the model says its final words under tool_choice=required.
+                    var words = (ReadStringArg(call.ArgumentsJson, "text") ?? "").Trim();
+                    if (words.Length > 0)
+                    {
+                        finalSpoken = words;
+                        messages.Add(new { role = "tool", tool_call_id = call.Id, content = "{\"status\":\"spoken\"}" });
+                    }
+                    else
+                    {
+                        // A model occasionally calls speak_answer with no words (a glitch under
+                        // tool_choice=required). Do NOT fail the whole turn - hand it back a nudge so it
+                        // speaks proper words on the next round; the round cap still bounds it.
+                        _log("[CarModeBrain] speak_answer called with no words; asking the model to retry");
+                        messages.Add(new { role = "tool", tool_call_id = call.Id, content = "{\"error\":\"speak_answer needs the exact words to say. Call it again with the words.\"}" });
+                    }
+                    continue;
+                }
                 var outcome = await ExecuteToolAsync(deviceKey, call, ct);
                 if (outcome.Action is not null) actions.Add(outcome.Action);
                 if (outcome.ArmedConfirmation) armedThisTurn = true;
                 messages.Add(new { role = "tool", tool_call_id = call.Id, content = outcome.ResultJson });
+            }
+
+            if (finalSpoken is not null)
+            {
+                _conversations.Append(deviceKey, userText, finalSpoken);
+                _log($"[CarModeBrain] turn done in {round + 1} round(s) via speak_answer: actions={actions.Count}, pending={armedThisTurn}");
+                return new CarModeTurnResponse { Spoken = finalSpoken, Actions = actions, PendingConfirmation = armedThisTurn };
             }
         }
 
@@ -247,20 +277,44 @@ public sealed class CarModeBrain
         }
     }
 
-    /// <summary>Read one string argument from a tool call's JSON arguments, tolerating an absent/garbled
-    ///  body (the model occasionally emits an empty object) by returning null.</summary>
+    /// <summary>
+    /// Read one string argument from a tool call's JSON arguments. Model output is a BOUNDARY, so this is
+    /// defensively tolerant of the malformed shapes a model occasionally emits under tool_choice=required:
+    /// an empty object, an argument that is a number/bool rather than a string, or the whole arguments body
+    /// wrapped in a one-element ARRAY (observed intermittently). It never throws - anything it cannot read
+    /// as the named string returns null, so the tool returns a "provide X" result the model can recover from
+    /// on the next round rather than crashing the turn.
+    /// </summary>
     internal static string? ReadStringArg(string argumentsJson, string name)
     {
         if (string.IsNullOrWhiteSpace(argumentsJson)) return null;
         try
         {
             using var doc = JsonDocument.Parse(argumentsJson);
-            return doc.RootElement.TryGetProperty(name, out var el) && el.ValueKind == JsonValueKind.String
-                ? el.GetString()
-                : null;
+            var root = doc.RootElement;
+            // Some models wrap the arguments object in a one-element array; unwrap to the first object.
+            if (root.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in root.EnumerateArray())
+                {
+                    if (item.ValueKind == JsonValueKind.Object) { root = item; break; }
+                }
+            }
+            if (root.ValueKind != JsonValueKind.Object) return null;
+            if (!root.TryGetProperty(name, out var el)) return null;
+            // Accept a string; coerce a number/bool to its text so a stray non-string value is still usable.
+            return el.ValueKind switch
+            {
+                JsonValueKind.String => el.GetString(),
+                JsonValueKind.Number => el.GetRawText(),
+                JsonValueKind.True => "true",
+                JsonValueKind.False => "false",
+                _ => null,
+            };
         }
-        catch (JsonException)
+        catch (Exception)
         {
+            // Any parse/type surprise from the model boundary degrades to null (no-crash), never propagates.
             return null;
         }
     }
@@ -291,7 +345,12 @@ public sealed class CarModeBrain
         + "confirmation_required result. Then tell him exactly what will be deleted and ask him to say "
         + "\"confirm\" to proceed or \"cancel\" to stop, and call no more tools. The system handles the "
         + "actual deletion once he confirms out loud - you never delete without that confirmation.\n"
-        + "- When you have the answer or have acted, reply with the final spoken sentence and call no more tools.";
+        + "\n\nHow you speak:\n"
+        + "- To SAY anything to the owner - an answer, a clarifying question, or an acknowledgement of what you "
+        + "did - you MUST call the speak_answer tool with the exact words to say out loud. Do not put your reply "
+        + "in the message content; only speak_answer is heard.\n"
+        + "- A normal turn is: call the tools you need to get facts or act, then call speak_answer once with the "
+        + "final spoken sentence. Keep it to one or two short spoken sentences.";
 
     // The tool catalog. Standard chat-completions function tools: reads, ordinary acts, and the
     // destructive delete (which the loop holds for a spoken confirmation - the model just requests it).
@@ -373,6 +432,20 @@ public sealed class CarModeBrain
                   "session": { "type": "string", "description": "The session to delete: a human name, a repository, or a number." }
                 },
                 "required": ["session"]
+              }
+            }
+          },
+          {
+            "type": "function",
+            "function": {
+              "name": "speak_answer",
+              "description": "Say words out loud to the owner. Call this for EVERY answer, clarifying question, or acknowledgement - it is the only thing the owner hears. Call it once, last, with the final spoken sentence.",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "text": { "type": "string", "description": "The exact words to say out loud, in one or two short spoken sentences." }
+                },
+                "required": ["text"]
               }
             }
           }

--- a/src/CcDirector.Gateway/CarMode/CarModeChat.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeChat.cs
@@ -131,20 +131,12 @@ public sealed class HostedCarModeChat : ICarModeChat
     }
 
     /// <summary>
-    /// The Car Mode model. A FAST hosted model, paired with <c>tool_choice=required</c> + the
-    /// <c>speak_answer</c> tool (see <see cref="CompleteAsync"/> and the brain's tool catalog). This is the
-    /// evidence-based resolution of the mission's model risk (2026-07-11): with plain <c>tool_choice=auto</c>
-    /// the fast model hallucinated actions it never took (it skipped start_session), which briefly forced an
-    /// escalation to the slow thinking model (GLM-5.2, 2-9s/turn). Live testing then showed the REAL fix is
-    /// forcing a tool call every turn: the same fast model then chose every tool reliably at ~1-2s per call.
-    /// So Car Mode runs fast + forced-tool-choice, winning both correctness and latency. The
-    /// <c>CC_CARMODE_MODEL</c> environment variable overrides this per install.
-    /// </summary>
-    public const string DefaultCarModeModel = "moonshotai/Kimi-K2.5";
-
-    /// <summary>
-    /// Build the model resolver Car Mode uses: the DevThrottle base + vault key + <see cref="DefaultCarModeModel"/>
-    /// (overridable by <c>CC_CARMODE_MODEL</c>). Paired with <c>tool_choice=required</c> + <c>speak_answer</c>.
+    /// Build the model resolver Car Mode uses: the DevThrottle base + vault key + the effective Car Mode
+    /// model from <see cref="CarModeModelConfig"/> (the <c>CC_CARMODE_MODEL</c> env override, then the user's
+    /// saved AI-Settings choice, then the Qwen2.5-72B default). Read fresh each call so a settings change is
+    /// honoured on the next turn. Paired with <c>tool_choice=required</c> + <c>speak_answer</c> (see
+    /// <see cref="CompleteAsync"/> and the brain's tool catalog), which is what makes a fast model choose
+    /// tools reliably.
     /// </summary>
     public static Func<(string BaseUrl, string Model, string Key)> DefaultResolver(Func<string, string?> vaultGet)
     {
@@ -153,10 +145,8 @@ public sealed class HostedCarModeChat : ICarModeChat
             var mode = TranscriptionModeConfig.Get();
             // Same base URL + vault key as the wingman endpoint; only the model differs for Car Mode.
             var ep = TranscriptionEndpointResolver.ResolveWingman(mode);
-            var overrideModel = Environment.GetEnvironmentVariable("CC_CARMODE_MODEL");
-            var model = string.IsNullOrWhiteSpace(overrideModel) ? DefaultCarModeModel : overrideModel.Trim();
             var key = vaultGet(ep.KeyName) ?? "";
-            return (ep.BaseUrl, model, key);
+            return (ep.BaseUrl, CarModeModelConfig.Resolve(), key);
         };
     }
 }

--- a/src/CcDirector.Gateway/CarMode/CarModeChat.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeChat.cs
@@ -68,8 +68,11 @@ public sealed class HostedCarModeChat : ICarModeChat
                 "No DevThrottle account key is configured. Sign in to DevThrottle so Car Mode can reach the model.");
 
         // Assemble the request with the messages + tools verbatim (the brain owns their shape) so this
-        // layer stays a thin transport.
-        var body = $"{{\"model\":{JsonSerializer.Serialize(model)},\"messages\":{messagesJson},\"tools\":{toolsJson},\"tool_choice\":\"auto\",\"stream\":false}}";
+        // layer stays a thin transport. tool_choice is "required" (validated 2026-07-11): forcing a tool
+        // call every turn is what makes a fast model choose tools RELIABLY instead of hallucinating an
+        // action it never took. Conversational turns still work because the tool catalog carries an
+        // explicit speak_answer tool the model calls to say anything - so "required" never traps it.
+        var body = $"{{\"model\":{JsonSerializer.Serialize(model)},\"messages\":{messagesJson},\"tools\":{toolsJson},\"tool_choice\":\"required\",\"stream\":false}}";
 
         var url = baseUrl.TrimEnd('/') + "/chat/completions";
         using var req = new HttpRequestMessage(HttpMethod.Post, url);
@@ -128,23 +131,30 @@ public sealed class HostedCarModeChat : ICarModeChat
     }
 
     /// <summary>
-    /// Build the model resolver Car Mode uses: the DevThrottle base + vault key + the THINKING wingman
-    /// model (GLM). The fast tier was validated against the real fleet and REJECTED with evidence (mission
-    /// model risk, resolved 2026-07-11): the fast model called the read tools and message/delete correctly
-    /// but SKIPPED start_session entirely and hallucinated "I started a session" with no tool call and no
-    /// session created - unacceptable for a command-and-control agent, where a false "done" is broken, not
-    /// merely slow. The thinking model chooses tools reliably. The optional <c>CC_CARMODE_MODEL</c>
-    /// environment override remains the switch (e.g. to try the fast model again with tool_choice=required,
-    /// a stronger prompt, or a read-vs-act split - a deliberate later latency fast-follow, not a v1 blocker).
+    /// The Car Mode model. A FAST hosted model, paired with <c>tool_choice=required</c> + the
+    /// <c>speak_answer</c> tool (see <see cref="CompleteAsync"/> and the brain's tool catalog). This is the
+    /// evidence-based resolution of the mission's model risk (2026-07-11): with plain <c>tool_choice=auto</c>
+    /// the fast model hallucinated actions it never took (it skipped start_session), which briefly forced an
+    /// escalation to the slow thinking model (GLM-5.2, 2-9s/turn). Live testing then showed the REAL fix is
+    /// forcing a tool call every turn: the same fast model then chose every tool reliably at ~1-2s per call.
+    /// So Car Mode runs fast + forced-tool-choice, winning both correctness and latency. The
+    /// <c>CC_CARMODE_MODEL</c> environment variable overrides this per install.
+    /// </summary>
+    public const string DefaultCarModeModel = "moonshotai/Kimi-K2.5";
+
+    /// <summary>
+    /// Build the model resolver Car Mode uses: the DevThrottle base + vault key + <see cref="DefaultCarModeModel"/>
+    /// (overridable by <c>CC_CARMODE_MODEL</c>). Paired with <c>tool_choice=required</c> + <c>speak_answer</c>.
     /// </summary>
     public static Func<(string BaseUrl, string Model, string Key)> DefaultResolver(Func<string, string?> vaultGet)
     {
         return () =>
         {
             var mode = TranscriptionModeConfig.Get();
+            // Same base URL + vault key as the wingman endpoint; only the model differs for Car Mode.
             var ep = TranscriptionEndpointResolver.ResolveWingman(mode);
             var overrideModel = Environment.GetEnvironmentVariable("CC_CARMODE_MODEL");
-            var model = string.IsNullOrWhiteSpace(overrideModel) ? ep.Model : overrideModel.Trim();
+            var model = string.IsNullOrWhiteSpace(overrideModel) ? DefaultCarModeModel : overrideModel.Trim();
             var key = vaultGet(ep.KeyName) ?? "";
             return (ep.BaseUrl, model, key);
         };


### PR DESCRIPTION
Resolves the Car Mode model story end to end (confirmed with the Architect + Soren).

## The guardrail (the real fix for the model risk)
Live-fleet testing showed the fix isn't the model, it's forcing a tool call every turn:
- `HostedCarModeChat` uses `tool_choice=required`; the brain adds an explicit `speak_answer` tool the model calls to say its final words, so conversational turns still work.
- Robustness at the model-output boundary (found live): `ReadStringArg` tolerates the malformed shapes a model intermittently emits under `required` (arguments wrapped in a one-element array, non-string values) and never throws; an empty `speak_answer` is nudged and retried in-loop.

## The Car Mode model, chosen with evidence
- Default is **Qwen2.5-72B** (fast + reliable under the guardrail). GLM-5.2 stays selectable (slower but a strong tool-caller). `CC_CARMODE_MODEL` env override wins.

## First-class Car Mode model setting (new requirement)
Car Mode runs its OWN model, so it gets its own persisted, user-facing setting - separate from the Wingman:
- `CarModeModelConfig` persists `config.json` `car_mode_model`; precedence: env override, then saved setting, then Qwen2.5-72B.
- `GET /gateway/ai-provider` returns `carModeModel`; `PUT /gateway/ai/car-mode-model` persists it (mirrors the wingman-model endpoints).
- A "Car Mode model" dropdown in **both** the mobile AiSettings and the cockpit SettingsView, populated from the hosted chat models, GLM-5.2 selectable.

## Verification
- 51 Car Mode brain tests (incl. speak_answer paths + defensive parse), CarModeModelConfig precedence tests, loopback guard green, client-core 285. Gateway zero-warning; all three shells typecheck; mobile build clean.
- Driven live via browser-harness against the real fleet on Qwen2.5-72B: who-needs-me, start (real session created), message (verified the text landed), delete held for spoken confirmation then executed (verified removed) - and the new Car Mode model setting rendered in AI Settings. (Full QA report emailed to Soren.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)