### PR TITLE
fix(mobile): voice screen - fixed audio controls, only narrative scrolls

### DIFF
--- a/apps/mobile/src/pages/VoiceMode.tsx
+++ b/apps/mobile/src/pages/VoiceMode.tsx
@@ -85,7 +85,10 @@ export function VoiceMode() {
         style={{ display: "none" }}
       />
 
-      <div className="voice-body">
+      {/* In the speaking state the audio controls are a FIXED header and only the narrative text
+          scrolls, in its own window below them (voice-body-speaking). In the other states the body
+          scrolls normally. */}
+      <div className={`voice-body${speaking ? " voice-body-speaking" : ""}`}>
         {error !== null && (
           <div className="banner banner-error" role="alert">{error}</div>
         )}
@@ -159,10 +162,11 @@ export function VoiceMode() {
           </>
         )}
 
-        {/* C. SPEAKING - the audio bar and Respond are pinned at the TOP (the controls you actually
-            use in voice mode); the response text sits BELOW and scrolls. In voice mode the text is a
-            nice-to-have, so a long response must never push the controls off-screen - the top block
-            is sticky (issue #1003, voice-mode screen layout). */}
+        {/* C. SPEAKING - the audio bar and Respond are a FIXED header at the TOP (the controls you
+            actually use in voice mode); the response text sits BELOW and scrolls inside its own window.
+            In voice mode the text is a nice-to-have, so a long response must never push the controls
+            off-screen and must never scroll up behind them - the body is a fixed-header + scrolling
+            narrative column, not one big scroll (issue #1003, voice-mode screen layout). */}
         {speaking && (
           <>
             <div className="voice-top">

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -1129,18 +1129,41 @@ a.banner-btn {
   }
 }
 
-/* The pinned top controls on the voice screen: the audio bar + Respond stay reachable at the TOP
-   even when the response text below is long (issue #1003, voice-mode layout). Sticky so it stays put
-   while the narrative scrolls beneath it inside .voice-body. */
+/* The top controls on the voice screen: the audio bar + Respond stay reachable at the TOP even when
+   the response text below is long (issue #1003, voice-mode layout). In the speaking state the body is
+   a fixed-header + scrolling-narrative column (see .voice-body-speaking), so this block is a fixed
+   header that never shrinks and the narrative scrolls in its own window below it - the text can no
+   longer scroll up behind the controls. */
 .voice-top {
-  position: sticky;
-  top: 0;
-  z-index: 3;
-  background: var(--bg);
+  flex: 0 0 auto;
   padding-top: 2px;
   padding-bottom: 10px;
   margin-bottom: 10px;
   border-bottom: 1px solid var(--border);
+}
+
+/* Speaking state only: turn .voice-body into a non-scrolling column so the controls stay put and only
+   the narrative card scrolls. voice-body keeps its padding and bounded height (flex:1 in the
+   100dvh .terminal-screen); here it just stops being one big scroll. */
+.voice-body-speaking {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* The narrative card becomes the single scroll window, filling the space left under the fixed controls
+   down to the bottom of the screen. min-height:0 lets it shrink below its content so the inner
+   overflow (not the page) does the scrolling. */
+.voice-body-speaking .voice-narr-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* "Turn voice off" stays a fixed strip at the very bottom, below the scrolling narrative. */
+.voice-body-speaking .voice-off-toggle {
+  flex: 0 0 auto;
 }
 
 /* C. Speaking: the player row (play/pause + restart + seek slider + clock). */


### PR DESCRIPTION
The mobile Voice mode screen scrolled as one big page, so a long narrative slid up **behind** the pinned audio controls (status pill, player, Respond).

Fix: make the controls a **fixed header** and give the narrative its **own scroll window** that fills the space beneath them to the bottom of the screen. "Turn voice off" stays fixed at the very bottom. The page no longer scrolls - only the text does, inside its window - so nothing renders behind the controls.

Implementation: replace the sticky `.voice-top` with a fixed-header + scrolling-narrative flex column, scoped to the speaking state via `.voice-body-speaking` so the other voice states (off/working/unavailable) are unchanged.

Verified with a phone-height render: narrative scrolls internally to its max, the body does not overflow the page. Deployed to the live Gateway `wwwroot/m` and confirmed the served bundle contains `.voice-body-speaking` and no longer has the sticky rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)