### PR TITLE
fix(mobile): keep session tab screens within the window - no page scroll

### DIFF
--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -708,9 +708,30 @@ a.banner-btn {
   display: flex;
   flex-direction: column;
   height: 100dvh;
+  /* Clip to the viewport so the PAGE can never scroll - the session screens behave like an app: the
+     top chrome (title, tabs, manage bar, status) and the bottom input + key rows stay pinned on
+     screen, and only the terminal/chat body in the middle scrolls. Without this, anything that pushes
+     the column past 100dvh (a large device font scale, safe-area insets) spills out and the whole page
+     scrolls, hiding the bottom keys until you scroll the screen (issue: mobile session tabs). */
+  max-height: 100dvh;
+  overflow: hidden;
   max-width: 680px;
   margin: 0 auto;
   padding: 0 12px calc(10px + env(safe-area-inset-bottom));
+}
+
+/* Every direct child of a session screen holds its natural size; ONLY the terminal/chat stage flexes
+   and scrolls internally. This makes the stage the single give-point, so the input row and the key
+   rows can never be pushed off the bottom edge no matter how tall the chrome gets. The stage override
+   has higher specificity than the blanket rule, so it wins regardless of source order. */
+.terminal-screen > * {
+  flex: 0 0 auto;
+}
+
+.terminal-screen > .term-stage,
+.terminal-screen > .chat-stage {
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .term-title {


### PR DESCRIPTION
The Terminal and Chat session screens could grow taller than the viewport (most visibly with the **Keys panel open**, or under a large device font scale / safe-area insets), so the **whole page scrolled** and the bottom input + key rows (Send/Speak/Attach, Enter/Esc/Stop, arrows) fell below the fold — you had to scroll the entire screen to reach them. Not app behavior.

**Fix:** clip the shared `.terminal-screen` shell to the viewport (`max-height:100dvh` + `overflow:hidden`) so the page can never scroll, and lock every direct child to `flex:0 0 auto` so **only** the terminal/chat body flexes and scrolls internally. Top chrome (title, tabs, manage bar, status) and the bottom input + key rows stay pinned; the middle body gives up height and scrolls in its own window.

Covers **Terminal and Chat** (shared shell); **Voice** was fixed in #1349.

**Verified** at a 598px viewport with the Keys panel open: page does not scroll, every row (including the arrow keys) stays visible, and the terminal body scrolls in its own window. Deployed to the live Gateway and confirmed the served CSS carries the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)