### PR TITLE
fix(carmode): build/version indicator and live recognizer debug readout

### DIFF
--- a/apps/mobile/src/pages/CarMode.tsx
+++ b/apps/mobile/src/pages/CarMode.tsx
@@ -1,8 +1,16 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useCarMode, type CarModeReply } from "@devthrottle/client-core/carmode/useCarMode";
 import { carModeTurn } from "@devthrottle/client-core/carmode/carModeApi";
+import { getGatewayHealth, gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 import { useScreenWakeLock } from "../hooks/useScreenWakeLock";
+
+// The client build id, inlined by Vite's `define` at build time (git short sha + build timestamp; see
+// vite.config.ts). Shown on the screen so the owner can confirm at a glance he is on the latest page,
+// not an old cached bundle. Vite substitutes this constant in both dev and production builds, so it is
+// always a real string in the app; the typeof guard only prevents a ReferenceError if this module is
+// ever imported outside a Vite build (for example a unit test), and is not a build-time fallback.
+const CLIENT_BUILD_ID = typeof __CLIENT_BUILD_ID__ === "string" ? __CLIENT_BUILD_ID__ : "no-build-id";
 
 // Car Mode (Car Mode mission): the standalone, chrome-less, full-screen page the owner opens to run
 // the whole fleet by voice, hands-free, phone in his pocket. It is a THIN view over the shared
@@ -24,6 +32,20 @@ export function CarMode() {
   // Car Mode is eyes-free with the phone in a pocket: keep the screen awake the whole time (mission
   // Phase 1: a standalone page under /m with a screen wake-lock).
   useScreenWakeLock();
+
+  // The live Gateway version, read once from /healthz, so the on-screen indicator pairs the CLIENT
+  // build id (which page bundle) with the SERVER version (which Gateway build) - together they tell the
+  // owner exactly what he is talking to. A read failure shows the specific reason, never a silent blank.
+  const [gatewayVersion, setGatewayVersion] = useState("loading...");
+  useEffect(() => {
+    const controller = new AbortController();
+    getGatewayHealth(controller.signal)
+      .then((h) => setGatewayVersion(h.version))
+      .catch((err) => {
+        if (!controller.signal.aborted) setGatewayVersion(gatewayErrorMessage(err));
+      });
+    return () => controller.abort();
+  }, []);
 
   // The injected brain responder. Phase 2+: the real fleet brain. The stand-in (below) just echoes the
   // heard command so Phase 1's barge-in proof needs no server and no credits.
@@ -47,6 +69,9 @@ export function CarMode() {
     error,
     unsupported,
     history,
+    liveTranscript,
+    recognizerState,
+    recognizerError,
     start,
     stop,
   } = useCarMode({ respond });
@@ -60,7 +85,11 @@ export function CarMode() {
           Exit
         </Link>
         <span className="car-title">Car Mode</span>
-        <span className="car-bar-spacer" aria-hidden="true" />
+        {/* The client build id in the corner: the owner glances here to confirm he is on the latest page,
+            not an old cached bundle. The full build id + Gateway version are in the debug readout below. */}
+        <span className="car-build" title={`Client build ${CLIENT_BUILD_ID}`}>
+          {shortBuild(CLIENT_BUILD_ID)}
+        </span>
       </header>
 
       {error !== null && (
@@ -117,6 +146,18 @@ export function CarMode() {
         )}
       </main>
 
+      {/* Diagnostic readout (always visible). This is the eyes-on channel for confirming, at a glance,
+          which page/Gateway is live and whether the phone is actually hearing the owner - the exact
+          things a cached-bundle or dead-microphone failure would hide. Kept compact and monospace. */}
+      <section className="car-debug" aria-label="Car Mode diagnostics">
+        <DebugRow label="Client build" value={CLIENT_BUILD_ID} />
+        <DebugRow label="Gateway" value={gatewayVersion} />
+        <DebugRow label="Speech recognition" value={unsupported ? "NOT supported" : "supported"} />
+        <DebugRow label="Recognizer" value={started ? recognizerState : "not started"} />
+        <DebugRow label="Last recognizer error" value={recognizerError ?? "none"} />
+        <DebugRow label="Hearing now" value={liveTranscript.length > 0 ? liveTranscript : "(silence)"} />
+      </section>
+
       <footer className="car-foot">
         {!started ? (
           <button type="button" className="car-start" onClick={() => void start()} disabled={unsupported}>
@@ -149,6 +190,23 @@ export function CarMode() {
       )}
     </div>
   );
+}
+
+// One label/value line in the diagnostic readout.
+function DebugRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="car-debug-row">
+      <span className="car-debug-label">{label}</span>
+      <span className="car-debug-value">{value}</span>
+    </div>
+  );
+}
+
+// The short form of the build id for the header corner: just the git short sha (the first token), so
+// the badge stays tiny. The full "sha timestamp" is in the title tooltip and the debug readout.
+function shortBuild(buildId: string): string {
+  const firstSpace = buildId.indexOf(" ");
+  return firstSpace < 0 ? buildId : buildId.substring(0, firstSpace);
 }
 
 // The plain-English status line for each phase, the words that pair with the color orb and the cues.

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -2320,6 +2320,49 @@ a.banner-btn {
 .car-bar-spacer {
   width: 34px;
 }
+/* The build-id badge in the header corner: tiny, monospace, dim - a glance confirms the live page. */
+.car-build {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px;
+  color: var(--text-dim);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 3px 6px;
+  max-width: 40vw;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The always-visible diagnostic readout: which page/Gateway is live, and whether the phone is hearing
+   the owner. Compact and monospace so it stays out of the way but is legible at a glance. */
+.car-debug {
+  margin: 0 12px 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+}
+.car-debug-row {
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.car-debug-label {
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+.car-debug-value {
+  color: var(--text);
+  text-align: right;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
 .car-error {
   margin: 12px 16px 0;
   padding: 12px 14px;

--- a/apps/mobile/src/vite-env.d.ts
+++ b/apps/mobile/src/vite-env.d.ts
@@ -1,2 +1,7 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/client" />
+
+// The client build id, inlined by Vite's `define` at build time (see vite.config.ts). It is the git
+// short commit sha plus the build timestamp, shown on the Car Mode screen so the owner can confirm at a
+// glance he is on the latest page, not an old cached bundle.
+declare const __CLIENT_BUILD_ID__: string;

--- a/apps/mobile/vite.config.ts
+++ b/apps/mobile/vite.config.ts
@@ -1,6 +1,22 @@
+import { execSync } from "node:child_process";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
+
+// The client build id, injected at build time so a page can show at a glance which bundle it is
+// running (Car Mode diagnostic: the owner must be able to tell a fresh page from an old cached one).
+// The build timestamp alone proves a fresh build (it changes every time); the git short commit sha
+// pins the bundle to an exact commit so it can be matched against the Gateway version from /healthz.
+//
+// No fallback (CLAUDE.md): the mobile app is only ever built from a git checkout - the redeploy
+// script builds from an isolated git worktree, and the release builds from a git clone - so reading
+// the commit sha MUST succeed. A missing git is a broken build environment, surfaced loudly here
+// rather than shipping an "unknown" marker that would defeat the whole point of the indicator.
+function resolveClientBuildId(): string {
+  const sha = execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim();
+  const builtAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  return `${sha} ${builtAt}`;
+}
 
 // The app is served by the Gateway under /m, so every asset URL must be /m-rooted.
 // The PWA service worker caches the app shell (Issue 1, AC7) so the roster opens offline
@@ -8,6 +24,11 @@ import { VitePWA } from "vite-plugin-pwa";
 // MSBuild target copies into wwwroot/m/.
 export default defineConfig({
   base: "/m/",
+  // Compile-time constant read by the app (see apps/mobile/src/vite-env.d.ts for its type). Stringified
+  // so it is inlined as a literal, exactly like Vite's own import.meta.env values.
+  define: {
+    __CLIENT_BUILD_ID__: JSON.stringify(resolveClientBuildId()),
+  },
   plugins: [
     react(),
     VitePWA({
@@ -39,6 +60,16 @@ export default defineConfig({
         ],
       },
       workbox: {
+        // Update promptly on reload (Car Mode diagnostic): a new service worker takes control of the
+        // page as soon as it installs (skipWaiting) and claims the already-open clients (clientsClaim),
+        // and the stale precache from the previous build is deleted (cleanupOutdatedCaches). Combined
+        // with registerType "autoUpdate" above, this means a single refresh actually replaces the cached
+        // bundle instead of serving the old one until every tab is closed. These are the autoUpdate
+        // defaults; they are set explicitly here so the update behavior is visible and cannot silently
+        // regress.
+        skipWaiting: true,
+        clientsClaim: true,
+        cleanupOutdatedCaches: true,
         // Web Push (app-icon "needs you" dot): import the hand-written push handler into the
         // generated service worker. It only adds push/notificationclick/message listeners and does
         // not touch Workbox's precache/offline behavior. The file ships verbatim from public/ and is

--- a/packages/client-core/src/carmode/speechRecognition.ts
+++ b/packages/client-core/src/carmode/speechRecognition.ts
@@ -75,10 +75,24 @@ export class ControlWordListener {
   private active = false;
   private onTranscript: (text: string) => void = () => {};
   private onError: (message: string) => void = () => {};
+  private onLifecycle: (state: string) => void = () => {};
 
   /** True while the listener is meant to be running (survives the browser's internal segment restarts). */
   get isActive(): boolean {
     return this.active;
+  }
+
+  /** Log a lifecycle transition AND surface it to the caller so Car Mode can show the recognizer's live
+   *  state on screen (Car Mode diagnostic: the owner must be able to SEE whether the phone is hearing
+   *  him). The console line stays for chrome://inspect (mission decision 9); the on-screen readout is the
+   *  eyes-free-when-parked equivalent. */
+  private note(state: string): void {
+    console.log(`[CarMode.recognizer] ${state}`);
+    try {
+      this.onLifecycle(state);
+    } catch {
+      // The lifecycle sink is a diagnostic courtesy; never let it throw back into the recognizer loop.
+    }
   }
 
   /**
@@ -86,7 +100,11 @@ export class ControlWordListener {
    * caller surfaces the reason (no silent fallback). Safe to call once; call stop() before start()
    * to restart cleanly.
    */
-  start(onTranscript: (text: string) => void, onError: (message: string) => void): void {
+  start(
+    onTranscript: (text: string) => void,
+    onError: (message: string) => void,
+    onLifecycle?: (state: string) => void,
+  ): void {
     const Ctor = resolveConstructor();
     if (Ctor === null) {
       throw new Error("This browser does not support speech recognition. Car Mode needs Chrome/Chromium.");
@@ -94,9 +112,10 @@ export class ControlWordListener {
     if (this.active) return;
     this.onTranscript = onTranscript;
     this.onError = onError;
+    this.onLifecycle = onLifecycle ?? (() => {});
     this.active = true;
     this.spawn(Ctor);
-    console.log("[CarMode.recognizer] started");
+    this.note("started");
   }
 
   /**
@@ -114,7 +133,7 @@ export class ControlWordListener {
     } catch {
       // already ending; onend will still restart while active
     }
-    console.log("[CarMode.recognizer] reset");
+    this.note("reset");
   }
 
   /** Stop spotting and release the recognizer. Idempotent. */
@@ -132,7 +151,7 @@ export class ControlWordListener {
         // already stopping; nothing to release beyond clearing handlers above
       }
     }
-    console.log("[CarMode.recognizer] stopped");
+    this.note("stopped");
   }
 
   private spawn(Ctor: SpeechRecognitionCtor): void {
@@ -158,16 +177,16 @@ export class ControlWordListener {
       // as he likes - decision, no silence timer), so they are NOT surfaced as failures; onend restarts
       // the segment. A "not-allowed" (microphone permission) is fatal and must be spoken.
       if (e.error === "no-speech" || e.error === "aborted") {
-        console.log(`[CarMode.recognizer] transient: ${e.error}`);
+        this.note(`transient: ${e.error}`);
         return;
       }
       if (e.error === "not-allowed" || e.error === "service-not-allowed") {
-        console.log(`[CarMode.recognizer] FATAL: ${e.error}`);
+        this.note(`FATAL: ${e.error}`);
         this.active = false;
         this.onError("Microphone access is blocked. Allow the microphone for Car Mode and try again.");
         return;
       }
-      console.log(`[CarMode.recognizer] error (will retry): ${e.error}`);
+      this.note(`error (will retry): ${e.error}`);
     };
 
     r.onend = () => {
@@ -176,15 +195,17 @@ export class ControlWordListener {
       if (!this.active) return;
       const Again = resolveConstructor();
       if (Again === null) return;
+      this.note("segment restart");
       this.spawn(Again);
     };
 
     this.recognition = r;
     try {
       r.start();
+      this.note("listening");
     } catch (err) {
       // start() throws if called too soon after the previous segment; the onend restart loop recovers.
-      console.log(`[CarMode.recognizer] start deferred: ${err instanceof Error ? err.message : String(err)}`);
+      this.note(`start deferred: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 }

--- a/packages/client-core/src/carmode/useCarMode.ts
+++ b/packages/client-core/src/carmode/useCarMode.ts
@@ -62,6 +62,16 @@ export interface CarModeView {
   unsupported: boolean;
   /** Recent exchanges, newest last, for the on-screen scrollback. */
   history: CarModeExchange[];
+  /** The raw live transcript the control-word recognizer is emitting right now, before any phrase
+   *  parsing (Car Mode diagnostic: lets the owner SEE whether the phone is hearing him and what it
+   *  thinks he said). Empty until the recognizer emits its first result. */
+  liveTranscript: string;
+  /** The recognizer's last lifecycle state ("started", "listening", "reset", "segment restart",
+   *  "transient: no-speech", ...) surfaced for the on-screen debug readout. */
+  recognizerState: string;
+  /** The recognizer's last error line, or null when it has not errored. Distinct from `error` (which is
+   *  the loud, user-facing failure); this is the raw diagnostic detail. */
+  recognizerError: string | null;
   start: () => Promise<void>;
   stop: () => void;
 }
@@ -83,6 +93,11 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
   const [pendingConfirmation, setPendingConfirmation] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [history, setHistory] = useState<CarModeExchange[]>([]);
+  // Diagnostic surface (Car Mode diagnostic): the raw live transcript, the recognizer's last lifecycle
+  // state, and its last error - shown on screen so the owner can SEE whether the phone is hearing him.
+  const [liveTranscript, setLiveTranscript] = useState("");
+  const [recognizerState, setRecognizerState] = useState("not started");
+  const [recognizerError, setRecognizerError] = useState<string | null>(null);
   const unsupported = !isControlRecognitionSupported();
 
   // Long-lived collaborators, held in refs so the effect wiring never re-creates them mid-session.
@@ -226,6 +241,10 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
   // the turn is already committed).
   const onControlTranscript = useCallback(
     (text: string) => {
+      // Diagnostic: mirror every raw recognizer emission to the on-screen readout, in EVERY phase, so
+      // the owner can watch what the phone is hearing even while it thinks or speaks. This is display
+      // only; the control decision below still branches on the live phase.
+      setLiveTranscript(text);
       const current = phaseRef.current;
       if (current === "thinking" || current === "idle") return;
       const action = decideControlAction(current, text);
@@ -264,7 +283,16 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     const listener = new ControlWordListener();
     listenerRef.current = listener;
     try {
-      listener.start(onControlTranscript, (message) => announceError(message));
+      listener.start(
+        onControlTranscript,
+        (message) => announceError(message),
+        (state) => {
+          // Surface the recognizer's lifecycle for the on-screen debug readout. A line beginning with
+          // "FATAL" or "error" is also mirrored to recognizerError as the last raw diagnostic detail.
+          setRecognizerState(state);
+          if (state.startsWith("FATAL") || state.startsWith("error")) setRecognizerError(state);
+        },
+      );
     } catch (err) {
       announceError(err instanceof Error ? err.message : "Could not start the recognizer.");
       setStarted(false);
@@ -332,6 +360,9 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     error,
     unsupported,
     history,
+    liveTranscript,
+    recognizerState,
+    recognizerError,
     start,
     stop,
   };


### PR DESCRIPTION
## Why

Car Mode is deployed to the production Gateway (version 1.0.7), but the owner reports on his phone that "over and out" does not end the turn at all. The pure phrase-detection code (`packages/client-core/src/carmode/controlPhrases.ts`) is sound, so this is diagnostic-first: make the two most likely real causes visible instead of guessing at a recognizer fix.

The two suspects:
1. The phone is still serving the OLD service-worker-cached bundle.
2. The live recognizer is not receiving audio on the phone.

## What this adds (diagnostics only - no turn-taking behavior change)

### Task A - confirm which page/Gateway is live
- Client build id (git short commit sha + build timestamp) injected at build time via a Vite `define`, shown in the header corner and the debug readout.
- Gateway version read from `/healthz`, shown beside it.
- Service worker updates promptly on reload: `skipWaiting`, `clientsClaim`, `cleanupOutdatedCaches` set explicitly alongside `registerType: autoUpdate`, so one refresh replaces the cached bundle.

### Task B - see whether the phone is hearing the owner
- The control-word recognizer's lifecycle state and last error surfaced on screen (it already logged them to the console; now also via an `onLifecycle` callback that `useCarMode` exposes).
- The live raw transcript the recognizer emits (before phrase parsing), so the owner can watch what the phone thinks he said.
- Whether browser speech recognition is supported at all.

## Verification
- `npm run typecheck --workspaces` clean.
- `npm run build --workspace @devthrottle/mobile` succeeds; confirmed the build id string and all three SW update flags are present in the output bundle and `sw.js`.
- `npm run test --workspace @devthrottle/client-core`: 301 tests pass.

Next: deploy to the production Gateway so the owner can reload `/m/car` and report what the readout shows.

Standards: enterprise logging, no fallback, plain English, ASCII only.