### PR TITLE
feat(carmode): live mic meter + touch Over-and-out/Stop buttons

### DIFF
--- a/apps/mobile/src/pages/CarMode.tsx
+++ b/apps/mobile/src/pages/CarMode.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { useCarMode, type CarModeReply } from "@devthrottle/client-core/carmode/useCarMode";
 import { carModeTurn } from "@devthrottle/client-core/carmode/carModeApi";
@@ -72,6 +72,9 @@ export function CarMode() {
     liveTranscript,
     recognizerState,
     recognizerError,
+    getMicLevel,
+    endTurn,
+    interrupt,
     start,
     stop,
   } = useCarMode({ respond });
@@ -114,6 +117,11 @@ export function CarMode() {
         <p className="car-status" aria-live="polite">
           {started ? statusText : "Tap Start, then just talk."}
         </p>
+
+        {/* Live microphone level meter (Architect direction): visibly shows the owner his voice is being
+            picked up. Reads the capture stream's AnalyserNode via getMicLevel on an animation frame. It
+            only moves while the microphone is actually capturing (the Listening phase); flat otherwise. */}
+        {started && <MicMeter getLevel={getMicLevel} active={phase === "listening"} />}
 
         {pendingConfirmation && (
           <p className="car-confirm" role="status">
@@ -167,7 +175,30 @@ export function CarMode() {
           <>
             <p className="car-hint">
               Say <strong>"over and out"</strong> to send. Say <strong>"stop"</strong> to cut me off.
+              Or use the buttons below.
             </p>
+            {/* Touch equivalents of the two spoken control phrases (Architect direction: the app must be
+                fully usable by touch, so testing is never blocked by the spoken "over and out"). Each
+                runs the EXACT same code path as the phrase. "Over and out" is the primary action, live
+                only while Listening; "Stop" only cuts off while Speaking - matching the voice rules. */}
+            <div className="car-touch">
+              <button
+                type="button"
+                className="car-overandout"
+                onClick={endTurn}
+                disabled={phase !== "listening"}
+              >
+                Over and out
+              </button>
+              <button
+                type="button"
+                className="car-interrupt"
+                onClick={interrupt}
+                disabled={phase !== "speaking"}
+              >
+                Stop
+              </button>
+            </div>
             <button type="button" className="car-stop" onClick={stop}>
               End Car Mode
             </button>
@@ -188,6 +219,48 @@ export function CarMode() {
           </ul>
         </details>
       )}
+    </div>
+  );
+}
+
+// The live microphone level meter: a row of bars whose heights follow the input level, so the owner can
+// SEE his voice is picked up (Architect direction). It runs its own animation-frame loop reading the
+// polled level getter and holds the bar heights in local state, so only the meter re-renders each frame,
+// never the whole Car Mode page. The centre bars react most, so it reads as an equalizer (the same shape
+// as the dictation meter). When not capturing (getLevel returns 0, or between turns) the bars rest flat.
+const METER_BAR_COUNT = 11;
+
+function MicMeter({ getLevel, active }: { getLevel: () => number; active: boolean }) {
+  const [levels, setLevels] = useState<number[]>(() => new Array(METER_BAR_COUNT).fill(0));
+  // Read `active` from a ref inside the animation loop so the long-lived loop is not re-created each time
+  // the phase flips; the loop itself is started once and torn down on unmount.
+  const activeRef = useRef(active);
+  activeRef.current = active;
+
+  useEffect(() => {
+    let raf = 0;
+    const tick = () => {
+      const level = activeRef.current ? getLevel() : 0;
+      const centre = (METER_BAR_COUNT - 1) / 2;
+      setLevels(
+        new Array(METER_BAR_COUNT).fill(0).map((_, i) => {
+          const falloff = 1 - Math.abs(i - centre) / (centre + 1);
+          return Math.min(1, level * (0.55 + falloff));
+        }),
+      );
+      raf = window.requestAnimationFrame(tick);
+    };
+    raf = window.requestAnimationFrame(tick);
+    return () => window.cancelAnimationFrame(raf);
+  }, [getLevel]);
+
+  return (
+    <div className={`car-meter ${active ? "car-meter-active" : ""}`} aria-hidden="true">
+      {levels.map((v, i) => (
+        <span key={i} className="car-meter-well">
+          <span className="car-meter-bar" style={{ height: `${8 + v * 84}%` }} />
+        </span>
+      ))}
     </div>
   );
 }

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -2534,6 +2534,70 @@ a.banner-btn {
   border: 1px solid var(--attention);
 }
 
+/* Live microphone level meter: an equalizer of bars that rise with the input level, so the owner can
+   SEE his voice is picked up. Green while capturing (active), dim otherwise. */
+.car-meter {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 4px;
+  height: 56px;
+  width: 100%;
+  max-width: 26ch;
+}
+.car-meter-well {
+  flex: 1 1 0;
+  height: 100%;
+  display: flex;
+  align-items: flex-end;
+  max-width: 12px;
+}
+.car-meter-bar {
+  width: 100%;
+  border-radius: 3px;
+  background: var(--text-dim);
+  transition: height 0.06s linear;
+}
+.car-meter-active .car-meter-bar {
+  background: #22c55e;
+}
+
+/* Touch equivalents of the two spoken control phrases. "Over and out" is the primary (green) action;
+   "Stop" is the interrupt. Both grey out when their phase rule makes them a no-op, matching the voice. */
+.car-touch {
+  display: flex;
+  gap: 10px;
+  width: 100%;
+  max-width: 420px;
+}
+.car-overandout,
+.car-interrupt {
+  flex: 1 1 0;
+  padding: 18px 12px;
+  font-size: 18px;
+  font-weight: 700;
+  border-radius: 12px;
+  border: none;
+  cursor: pointer;
+}
+.car-overandout {
+  flex: 2 1 0;
+  background: #22c55e;
+  color: #06210f;
+}
+.car-interrupt {
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+.car-overandout:disabled,
+.car-interrupt:disabled {
+  background: #26314e;
+  color: #6b7391;
+  border-color: transparent;
+  cursor: default;
+}
+
 .car-history {
   margin: 0 16px 20px;
   color: var(--text-dim);

--- a/packages/client-core/src/carmode/useCarMode.ts
+++ b/packages/client-core/src/carmode/useCarMode.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { MicRecorder } from "../dictation/recorder";
 import { blobToWav16kMono } from "../dictation/wav";
 import { playReadyCue, playYourTurnCue } from "../dictation/readyCue";
-import { decideControlAction, detectEndPhrase } from "./controlPhrases";
+import { decideControlAction, detectEndPhrase, END_PHRASE, INTERRUPT_WORDS } from "./controlPhrases";
 import { ControlWordListener, isControlRecognitionSupported } from "./speechRecognition";
 import { speakCarModeText, transcribeCarModeAudio, type CarModeAction } from "./carModeApi";
 import { gatewayErrorMessage } from "../api/client";
@@ -72,6 +72,16 @@ export interface CarModeView {
   /** The recognizer's last error line, or null when it has not errored. Distinct from `error` (which is
    *  the loud, user-facing failure); this is the raw diagnostic detail. */
   recognizerError: string | null;
+  /** The current microphone input level in 0..1, sampled live from the capture stream's AnalyserNode,
+   *  for the on-screen level meter. Read on an animation frame; returns 0 when not capturing. This is a
+   *  polled getter (not React state) so the meter can animate without re-rendering the whole page. */
+  getMicLevel: () => number;
+  /** End the current turn by TOUCH, through the EXACT same path as the spoken "over and out" (the button
+   *  feeds the phrase into the same control handler). A no-op outside Listening, matching the voice rule. */
+  endTurn: () => void;
+  /** Interrupt the assistant by TOUCH, through the EXACT same path as the spoken "stop". A no-op unless
+   *  the assistant is Speaking, matching the voice rule. */
+  interrupt: () => void;
   start: () => Promise<void>;
   stop: () => void;
 }
@@ -265,6 +275,25 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     [takeTurn, enterListening],
   );
 
+  // Touch controls (Architect direction: the app must be fully usable by touch so testing the rest is
+  // not blocked by spoken "over and out"). Both feed the phrase text into the SAME control handler the
+  // recognizer uses, so a tap and the spoken phrase are literally the same code path - the button cannot
+  // drift from the voice behavior.
+  const endTurn = useCallback(() => {
+    console.log('[CarMode] "over and out" tapped -> same path as the spoken phrase');
+    onControlTranscript(END_PHRASE);
+  }, [onControlTranscript]);
+
+  const interrupt = useCallback(() => {
+    console.log('[CarMode] "stop" tapped -> same path as the spoken interrupt');
+    onControlTranscript(INTERRUPT_WORDS[0]);
+  }, [onControlTranscript]);
+
+  // The live microphone level for the on-screen meter, polled by the page on an animation frame. Reads
+  // the capture stream's AnalyserNode (display only; it never touches the captured audio) and returns 0
+  // when the microphone is not currently capturing.
+  const getMicLevel = useCallback(() => recorderRef.current?.level() ?? 0, []);
+
   const start = useCallback(async () => {
     if (started) return;
     if (unsupported) {
@@ -363,6 +392,9 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     liveTranscript,
     recognizerState,
     recognizerError,
+    getMicLevel,
+    endTurn,
+    interrupt,
     start,
     stop,
   };


### PR DESCRIPTION
## Why

Architect direction (Car Mode mission): we own the testing now. Two things make that possible and are independently valuable to the owner:
1. A **live microphone level meter** so he can SEE his voice is picked up (the diagnostic he needs when voice seems dead).
2. **Touch buttons** for "Over and out" and "Stop" so the app is fully usable by touch and testing the rest is never blocked by the spoken phrase.

## What

- Live mic meter on `/m/car`: an equalizer of bars driven by the capture stream's `AnalyserNode`, via a new polled `getMicLevel()` getter on `useCarMode`. Green while capturing (Listening), flat otherwise. Same meter shape as the dictation dialog; display-only.
- "Over and out" and "Stop" touch buttons. Each runs the **exact same code path** as the spoken phrase — the button feeds the phrase text into the same control handler the recognizer uses (`endTurn -> onControlTranscript("over and out")`, `interrupt -> onControlTranscript("stop")`), so a tap and the phrase can never drift. "Over and out" is live only while Listening; "Stop" only while Speaking.
- Keeps the build id + debug readout from the prior change.

## Verified automatically (no Soren)

A Playwright harness driving **real Chrome** loads `/m/car`, renders the meter + both buttons (screenshot attached in the mission notes), and clicking "Over and out" ends the turn: `[CarMode] end phrase heard -> taking the turn`, phase → thinking, command transcribed, full loop runs.

Typecheck clean across all workspaces; 301 client-core tests pass.

## Note on the fake-audio recognizer harness (for the follow-up)

The same harness proved that Chrome's `--use-file-for-fake-audio-capture` reaches `getUserMedia` (analyser peak 255) but is **not** consumed by `webkitSpeechRecognition` (it reports `no-speech` even as the sole mic consumer). So the *spoken* over-and-out cannot be driven by fake audio; the touch button is the automatable end-of-turn proof. Details go to the Architect.

Standards: enterprise logging, no fallback, plain English, ASCII only.