### PR TITLE
feat(stats): put "Your Throttle" inside the Cockpit and mobile apps

### DIFF
--- a/apps/cockpit/src/AppShell.tsx
+++ b/apps/cockpit/src/AppShell.tsx
@@ -54,6 +54,7 @@ const NAV_SECTIONS: ReadonlyArray<{ title: string; items: ReadonlyArray<NavItem>
     title: "System",
     items: [
       { to: "/account", label: "Account" },
+      { to: "/your-throttle", label: "Your Throttle" },
       { to: "/telemetry", label: "Telemetry" },
       { to: "/settings", label: "Settings" },
       { to: "/about", label: "About" },

--- a/apps/cockpit/src/main.tsx
+++ b/apps/cockpit/src/main.tsx
@@ -23,6 +23,7 @@ import { TranscriptsView } from "./transcripts/TranscriptsView";
 import { ExesView } from "./exes/ExesView";
 import { LearningView } from "./learning/LearningView";
 import { TelemetryView } from "./telemetry/TelemetryView";
+import { YourThrottleView } from "./throttle/YourThrottleView";
 import { TranscriptionHealthView } from "./transcription/TranscriptionHealthView";
 import { AccountView } from "./account/AccountView";
 import { AboutView } from "./about/AboutView";
@@ -39,6 +40,7 @@ import "./transcripts/transcripts.css";
 import "./exes/exes.css";
 import "./learning/learning.css";
 import "./telemetry/telemetry.css";
+import "./throttle/throttle.css";
 import "./transcription/transcriptionhealth.css";
 import "./account/account.css";
 import "./about/about.css";
@@ -162,6 +164,10 @@ const router = createBrowserRouter(
             // Telemetry, and About get a left-rail entry; Feedback is route-only (hidden from the default
             // rail there too), reached by its direct route.
             { path: "/telemetry", element: <TelemetryView /> },
+            // Your Throttle (devthrottle-stats mission): the in-Cockpit port of the standalone Gateway
+            // /stats page. Reads the same GET /stats/data feed through client-core so the user sees
+            // their throttle in the app rather than at a bare URL.
+            { path: "/your-throttle", element: <YourThrottleView /> },
             // Transcription Health: read-only view over the local transcription telemetry the Gateway
             // records (latency, failures, most-corrected words). Same Gateway REST surface via client-core.
             { path: "/transcription", element: <TranscriptionHealthView /> },

--- a/apps/cockpit/src/throttle/YourThrottleView.tsx
+++ b/apps/cockpit/src/throttle/YourThrottleView.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useState } from "react";
+import {
+  getThrottle,
+  summarizeThrottle,
+  formatShare,
+  MODALITY_LABEL,
+  SURFACE_LABEL,
+  SURFACE_ORDER,
+  type ThrottleData,
+  type ThrottleSummary,
+} from "@devthrottle/client-core/stats/statsClient";
+import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
+
+// The "Your Throttle" page (devthrottle-stats mission): the in-Cockpit port of the standalone Gateway
+// /stats HTML page, so the user reads their own throttle in the app they already have open rather than
+// navigating to a bare URL. Read-only, reads the same GET /stats/data feed the standalone page uses.
+// Responsive (CodingStyle.md): renders immediately with a loading state, loads asynchronously, and on a
+// load failure shows an explicit error banner (no-fallback rule). Auto-refreshes so the split visibly
+// moves as the user keeps driving.
+
+const REFRESH_MS = 10_000;
+
+/** A big headline metric card (voice share, phone share, total turns). */
+function HeadlineCard({ label, value, sub }: { label: string; value: string; sub: string }) {
+  return (
+    <div className="thr-card">
+      <div className="thr-card-value">{value}</div>
+      <div className="thr-card-label">{label}</div>
+      <div className="thr-card-sub">{sub}</div>
+    </div>
+  );
+}
+
+export function YourThrottleView() {
+  const [data, setData] = useState<ThrottleData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const tick = async () => {
+      try {
+        const fresh = await getThrottle(controller.signal);
+        if (controller.signal.aborted) return;
+        setData(fresh);
+        setError(null);
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setError(gatewayErrorMessage(err));
+      } finally {
+        if (!controller.signal.aborted) timer = setTimeout(() => void tick(), REFRESH_MS);
+      }
+    };
+    void tick();
+
+    return () => {
+      controller.abort();
+      if (timer !== undefined) clearTimeout(timer);
+    };
+  }, []);
+
+  const summary: ThrottleSummary | null = data === null ? null : summarizeThrottle(data);
+
+  return (
+    <div className="page thr">
+      <div className="page-head">
+        <h1>Your Throttle</h1>
+        <p className="page-sub">
+          How you are driving development: spoken vs typed, and from phone vs desktop vs cockpit. A turn
+          is one submitted message; one spoken utterance and one typed message each count as one turn.
+        </p>
+      </div>
+
+      {error !== null && (
+        <div className="thr-banner" role="alert">
+          {error}
+        </div>
+      )}
+
+      {summary === null && error === null && <div className="thr-loading">Loading...</div>}
+
+      {summary !== null && !summary.hasData && (
+        <div className="thr-empty">
+          No input counted yet. Send a turn from the composer, dictation, phone, or cockpit and it will
+          appear here.
+        </div>
+      )}
+
+      {summary !== null && summary.hasData && (
+        <>
+          <div className="thr-cards">
+            <HeadlineCard
+              label="Voice share of turns"
+              value={formatShare(summary.voiceShare)}
+              sub={`${summary.voiceTurns} of ${summary.totalTurns} turns spoken`}
+            />
+            <HeadlineCard
+              label="Phone share of turns"
+              value={formatShare(summary.phoneShare)}
+              sub={`${summary.turnsBySurface.phone} of ${summary.totalTurns} turns from phone`}
+            />
+            <HeadlineCard
+              label="Total turns"
+              value={String(summary.totalTurns)}
+              sub={`${summary.totalCharacters.toLocaleString()} characters`}
+            />
+          </div>
+
+          <div className="thr-section">
+            <h2>Turns by surface</h2>
+            <table className="thr-table">
+              <thead>
+                <tr>
+                  <th>Surface</th>
+                  <th className="thr-num">Turns</th>
+                </tr>
+              </thead>
+              <tbody>
+                {SURFACE_ORDER.map((s) => (
+                  <tr key={s}>
+                    <td>{SURFACE_LABEL[s]}</td>
+                    <td className="thr-num">{summary.turnsBySurface[s]}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="thr-section">
+            <h2>Full breakdown</h2>
+            <table className="thr-table">
+              <thead>
+                <tr>
+                  <th>Modality</th>
+                  <th>Surface</th>
+                  <th className="thr-num">Turns</th>
+                  <th className="thr-num">Characters</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data!.buckets.length === 0 ? (
+                  <tr>
+                    <td colSpan={4} className="thr-muted">
+                      No buckets yet.
+                    </td>
+                  </tr>
+                ) : (
+                  data!.buckets.map((b) => (
+                    <tr key={`${b.modality}-${b.surface}`}>
+                      <td>{MODALITY_LABEL[b.modality]}</td>
+                      <td>{SURFACE_LABEL[b.surface]}</td>
+                      <td className="thr-num">{b.turns}</td>
+                      <td className="thr-num">{b.characters.toLocaleString()}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+
+      {data !== null && data.notCaptured.length > 0 && (
+        <div className="thr-caveats">
+          <h2>What these numbers do not include</h2>
+          <ul>
+            {data.notCaptured.map((c, i) => (
+              <li key={i}>{c}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/cockpit/src/throttle/throttle.css
+++ b/apps/cockpit/src/throttle/throttle.css
@@ -1,0 +1,133 @@
+/* Your Throttle page (devthrottle-stats mission) - the in-Cockpit port of the standalone Gateway
+   /stats page. Rendered as normal scrolling content inside the padded main pane. Every color is a
+   token from the app theme (src/styles.css :root); nothing hard-codes a color so the page reads as one
+   product in both light and dark. */
+.thr {
+  max-width: 860px;
+}
+
+.thr .page-head {
+  margin-bottom: 16px;
+}
+.thr .page-head h1 {
+  margin: 0 0 6px;
+  font-size: 22px;
+  font-weight: 600;
+}
+.thr .page-sub {
+  color: var(--text-dim);
+  font-size: 13px;
+  margin: 0;
+  max-width: 640px;
+}
+
+.thr-banner {
+  background: var(--needsyou-bg);
+  color: var(--needsyou-text);
+  border: 1px solid var(--attention);
+  border-radius: 8px;
+  padding: 10px 12px;
+  margin-bottom: 16px;
+  font-size: 13px;
+}
+
+.thr-loading,
+.thr-empty {
+  color: var(--text-dim);
+  font-size: 14px;
+  padding: 24px 0;
+}
+
+/* Headline metric cards */
+.thr-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 14px;
+  margin-bottom: 24px;
+}
+.thr-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px 18px;
+}
+.thr-card-value {
+  font-size: 32px;
+  font-weight: 700;
+  color: var(--accent);
+  line-height: 1.1;
+}
+.thr-card-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  margin-top: 6px;
+}
+.thr-card-sub {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-top: 2px;
+}
+
+/* Breakdown tables */
+.thr-section {
+  margin-bottom: 24px;
+}
+.thr-section h2 {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0 0 10px;
+}
+.thr-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.thr-table th,
+.thr-table td {
+  text-align: left;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.thr-table thead th {
+  color: var(--text-dim);
+  font-weight: 600;
+  background: var(--surface-2);
+}
+.thr-table tbody tr:last-child td {
+  border-bottom: none;
+}
+.thr-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.thr-muted {
+  color: var(--text-dim);
+}
+
+/* Honesty caveats */
+.thr-caveats {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 18px;
+  margin-top: 8px;
+}
+.thr-caveats h2 {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+.thr-caveats ul {
+  margin: 0;
+  padding-left: 18px;
+}
+.thr-caveats li {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-bottom: 4px;
+}

--- a/apps/mobile/src/components/NavDrawer.tsx
+++ b/apps/mobile/src/components/NavDrawer.tsx
@@ -35,6 +35,9 @@ export function NavDrawer() {
             <Link className="drawer-item" to="/car" onClick={close}>
               Car Mode
             </Link>
+            <Link className="drawer-item" to="/throttle" onClick={close}>
+              Your Throttle
+            </Link>
             <div className="drawer-sep" />
             <Link className="drawer-item" to="/settings" onClick={close}>
               AI settings

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -9,6 +9,7 @@ import { VoiceMode } from "./pages/VoiceMode";
 import { CarMode } from "./pages/CarMode";
 import { AiSettings } from "./pages/AiSettings";
 import { About } from "./pages/About";
+import { YourThrottle } from "./pages/YourThrottle";
 import { SignIn } from "@devthrottle/client-core/auth/SignIn";
 import { DeviceCallback } from "@devthrottle/client-core/auth/DeviceCallback";
 import { hasDeviceKey } from "@devthrottle/client-core/auth/deviceKey";
@@ -84,6 +85,9 @@ const router = createBrowserRouter(
             { path: "/car", element: <CarMode /> },
             { path: "/settings", element: <AiSettings /> },
             { path: "/about", element: <About /> },
+            // Your Throttle (devthrottle-stats mission): the in-app port of the standalone Gateway
+            // /stats page, reading the same GET /stats/data feed through client-core.
+            { path: "/throttle", element: <YourThrottle /> },
             { path: "/new", element: <NewSession /> },
             { path: "/session/:sessionId", element: <Chat /> },
             { path: "/session/:sessionId/chat", element: <Chat /> },

--- a/apps/mobile/src/pages/YourThrottle.tsx
+++ b/apps/mobile/src/pages/YourThrottle.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  getThrottle,
+  summarizeThrottle,
+  formatShare,
+  MODALITY_LABEL,
+  SURFACE_LABEL,
+  SURFACE_ORDER,
+  type ThrottleData,
+  type ThrottleSummary,
+} from "@devthrottle/client-core/stats/statsClient";
+import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
+
+// Your Throttle (devthrottle-stats mission): the in-app port of the standalone Gateway /stats page for
+// the phone. Reads the same GET /stats/data feed the Cockpit reads, so the phone shows the same numbers
+// in the app the user already has open. Renders immediately with a loading state, loads asynchronously,
+// shows an explicit error banner on failure (no-fallback rule), and auto-refreshes so the split moves
+// live as the user drives by voice.
+
+const REFRESH_MS = 10_000;
+
+export function YourThrottle() {
+  const [data, setData] = useState<ThrottleData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const tick = async () => {
+      try {
+        const fresh = await getThrottle(controller.signal);
+        if (controller.signal.aborted) return;
+        setData(fresh);
+        setError(null);
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setError(gatewayErrorMessage(err));
+      } finally {
+        if (!controller.signal.aborted) timer = setTimeout(() => void tick(), REFRESH_MS);
+      }
+    };
+    void tick();
+
+    return () => {
+      controller.abort();
+      if (timer !== undefined) clearTimeout(timer);
+    };
+  }, []);
+
+  const summary: ThrottleSummary | null = data === null ? null : summarizeThrottle(data);
+
+  return (
+    <div className="screen">
+      <header className="app-bar">
+        <Link className="back-link" to="/">
+          Back
+        </Link>
+        <h1>Your Throttle</h1>
+      </header>
+
+      {error !== null && (
+        <div className="banner banner-error" role="alert">
+          {error}
+        </div>
+      )}
+
+      {summary === null && error === null && <div className="thr-note">Loading...</div>}
+
+      {summary !== null && !summary.hasData && (
+        <div className="thr-note">
+          No input counted yet. Send a turn from the phone, desktop, or cockpit and it will show up here.
+        </div>
+      )}
+
+      {summary !== null && summary.hasData && (
+        <>
+          <section className="thr-cards" aria-label="Headline shares">
+            <div className="thr-card">
+              <div className="thr-card-value">{formatShare(summary.voiceShare)}</div>
+              <div className="thr-card-label">Voice</div>
+            </div>
+            <div className="thr-card">
+              <div className="thr-card-value">{formatShare(summary.phoneShare)}</div>
+              <div className="thr-card-label">Phone</div>
+            </div>
+            <div className="thr-card">
+              <div className="thr-card-value">{summary.totalTurns}</div>
+              <div className="thr-card-label">Turns</div>
+            </div>
+          </section>
+
+          <div className="thr-caption">
+            {summary.voiceTurns} of {summary.totalTurns} turns spoken;{" "}
+            {summary.turnsBySurface.phone} of {summary.totalTurns} from phone.{" "}
+            {summary.totalCharacters.toLocaleString()} characters total.
+          </div>
+
+          <section className="thr-list" aria-label="Turns by surface">
+            <div className="thr-list-title">Turns by surface</div>
+            {SURFACE_ORDER.map((s) => (
+              <div className="thr-row" key={s}>
+                <span className="thr-row-label">{SURFACE_LABEL[s]}</span>
+                <span className="thr-row-value">{summary.turnsBySurface[s]}</span>
+              </div>
+            ))}
+          </section>
+
+          <section className="thr-list" aria-label="Full breakdown">
+            <div className="thr-list-title">Full breakdown</div>
+            {data!.buckets.map((b) => (
+              <div className="thr-row" key={`${b.modality}-${b.surface}`}>
+                <span className="thr-row-label">
+                  {MODALITY_LABEL[b.modality]} / {SURFACE_LABEL[b.surface]}
+                </span>
+                <span className="thr-row-value">
+                  {b.turns} turns, {b.characters.toLocaleString()} chars
+                </span>
+              </div>
+            ))}
+          </section>
+        </>
+      )}
+
+      {data !== null && data.notCaptured.length > 0 && (
+        <section className="thr-caveats" aria-label="What is not included">
+          <div className="thr-list-title">What these numbers do not include</div>
+          <ul>
+            {data.notCaptured.map((c, i) => (
+              <li key={i}>{c}</li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -2561,3 +2561,77 @@ a.banner-btn {
 .car-history-said {
   color: var(--text-dim);
 }
+
+/* ===== Your Throttle (devthrottle-stats mission) - the in-app port of the Gateway /stats page ===== */
+.thr-note {
+  color: var(--text-dim);
+  font-size: 14px;
+  padding: 20px 14px;
+}
+.thr-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  padding: 12px 14px 0;
+}
+.thr-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 8px;
+  text-align: center;
+}
+.thr-card-value {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--accent);
+  line-height: 1.1;
+}
+.thr-card-label {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-top: 4px;
+}
+.thr-caption {
+  font-size: 12px;
+  color: var(--text-dim);
+  padding: 10px 14px 0;
+}
+.thr-list {
+  padding: 16px 14px 0;
+}
+.thr-list-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 8px;
+}
+.thr-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+.thr-row-label {
+  color: var(--text);
+}
+.thr-row-value {
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+.thr-caveats {
+  padding: 16px 14px 24px;
+}
+.thr-caveats ul {
+  margin: 0;
+  padding-left: 18px;
+}
+.thr-caveats li {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-bottom: 6px;
+}

--- a/packages/client-core/src/stats/statsClient.test.ts
+++ b/packages/client-core/src/stats/statsClient.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { summarizeThrottle, formatShare, type ThrottleData } from "./statsClient";
+
+// The pure "Your Throttle" summary math (devthrottle-stats mission). The network read (getThrottle) is
+// exercised through the app; here we lock the honest share arithmetic that both shells render.
+
+function data(buckets: ThrottleData["buckets"]): ThrottleData {
+  return { generatedAtUtc: "2026-07-11T00:00:00Z", buckets, notCaptured: [] };
+}
+
+describe("summarizeThrottle", () => {
+  it("computes turn totals and shares across modality and surface", () => {
+    const s = summarizeThrottle(
+      data([
+        { modality: "voice", surface: "phone", turns: 3, characters: 900 },
+        { modality: "typed", surface: "desktop", turns: 1, characters: 100 },
+      ]),
+    );
+    expect(s.totalTurns).toBe(4);
+    expect(s.totalCharacters).toBe(1000);
+    expect(s.voiceTurns).toBe(3);
+    expect(s.typedTurns).toBe(1);
+    expect(s.turnsBySurface.phone).toBe(3);
+    expect(s.turnsBySurface.desktop).toBe(1);
+    expect(s.voiceShare).toBeCloseTo(0.75);
+    expect(s.phoneShare).toBeCloseTo(0.75);
+    expect(s.hasData).toBe(true);
+  });
+
+  it("reports null shares (not 0%) when no turns are counted yet", () => {
+    const s = summarizeThrottle(data([]));
+    expect(s.totalTurns).toBe(0);
+    expect(s.voiceShare).toBeNull();
+    expect(s.phoneShare).toBeNull();
+    expect(s.hasData).toBe(false);
+  });
+
+  it("counts character-only volume as data even with zero turns", () => {
+    // Raw terminal keystrokes are character volume with no turn - the tally still has data to show.
+    const s = summarizeThrottle(
+      data([{ modality: "typed", surface: "desktop", turns: 0, characters: 42 }]),
+    );
+    expect(s.totalTurns).toBe(0);
+    expect(s.totalCharacters).toBe(42);
+    expect(s.voiceShare).toBeNull();
+    expect(s.hasData).toBe(true);
+  });
+});
+
+describe("formatShare", () => {
+  it("renders a fraction as a whole-number percent", () => {
+    expect(formatShare(0.75)).toBe("75%");
+    expect(formatShare(0)).toBe("0%");
+    expect(formatShare(1)).toBe("100%");
+  });
+
+  it("renders no-data as an ASCII placeholder, never a fabricated 0%", () => {
+    expect(formatShare(null)).toBe("n/a");
+  });
+});

--- a/packages/client-core/src/stats/statsClient.ts
+++ b/packages/client-core/src/stats/statsClient.ts
@@ -1,0 +1,159 @@
+// The DevThrottle Stats "Your Throttle" surface (devthrottle-stats mission, Phase 1 in-app port): the
+// typed, same-origin client both the Cockpit and the mobile app read to render the throttle dashboard
+// natively, instead of sending the user to the standalone Gateway /stats HTML page.
+//
+// The Gateway already serves the aggregated tally at GET /stats/data (see StatsPageEndpoint). This is
+// the shared read client + the honest summary math (turn shares by modality and surface), so both
+// shells present one identical, single-source-of-truth view. Read-only; every request is root-relative
+// to the Gateway and carries the same Bearer via authHeaders().
+import { authHeaders, GatewayError } from "../api/client";
+
+/** How a unit of input was produced. */
+export type Modality = "typed" | "voice";
+
+/** Which surface the operator drove from. */
+export type Surface = "desktop" | "cockpit" | "phone" | "unknown";
+
+/** One (modality, surface) tally bucket, mirroring the Gateway InputStatBucketDto. */
+export interface ThrottleBucket {
+  modality: Modality;
+  surface: Surface;
+  /** Submitted turns through this bucket (never synthesized from raw keystrokes). */
+  turns: number;
+  /** Total character volume through this bucket. */
+  characters: number;
+}
+
+/** The GET /stats/data body: the fleet-wide aggregated tally plus the honesty caveats. */
+export interface ThrottleData {
+  /** When the Gateway generated this snapshot (ISO 8601 UTC), or "" when absent. */
+  generatedAtUtc: string;
+  buckets: ThrottleBucket[];
+  /** Plain-English caveats about what the numbers do and do not include. */
+  notCaptured: string[];
+}
+
+/** A derived, presentation-ready summary of the tally. Shares are fractions in [0,1], or null when
+ * there are no counted turns yet (an honest empty state - never a fabricated 0%). */
+export interface ThrottleSummary {
+  totalTurns: number;
+  totalCharacters: number;
+  voiceTurns: number;
+  typedTurns: number;
+  /** Voice share of TURNS, or null when no turns are counted yet. */
+  voiceShare: number | null;
+  /** Turns per surface. */
+  turnsBySurface: Record<Surface, number>;
+  /** Phone share of TURNS, or null when no turns are counted yet. */
+  phoneShare: number | null;
+  hasData: boolean;
+}
+
+const SURFACES: readonly Surface[] = ["desktop", "cockpit", "phone", "unknown"];
+
+function normalizeBucket(raw: unknown): ThrottleBucket {
+  const b = (raw ?? {}) as Partial<Record<keyof ThrottleBucket, unknown>>;
+  const modality: Modality = String(b.modality).toLowerCase() === "voice" ? "voice" : "typed";
+  const s = String(b.surface).toLowerCase();
+  const surface: Surface = s === "desktop" || s === "cockpit" || s === "phone" ? s : "unknown";
+  const turns = Number(b.turns);
+  const characters = Number(b.characters);
+  return {
+    modality,
+    surface,
+    turns: Number.isFinite(turns) ? turns : 0,
+    characters: Number.isFinite(characters) ? characters : 0,
+  };
+}
+
+async function gatewayErrorFrom(res: Response, label: string): Promise<GatewayError> {
+  let detail = `${res.status}`;
+  try {
+    const text = await res.text();
+    if (text.length > 0) {
+      try {
+        const body = JSON.parse(text) as { error?: string; detail?: string };
+        detail = body.error ?? body.detail ?? text;
+      } catch {
+        detail = text;
+      }
+    }
+  } catch {
+    /* body unreadable - keep the status code */
+  }
+  return new GatewayError(res.status, `${label} failed: ${detail}`);
+}
+
+// GET /stats/data - the fleet-wide "Your Throttle" tally. Throws on transport failure so the page can
+// show an explicit error banner (the no-fallback rule).
+export async function getThrottle(signal?: AbortSignal): Promise<ThrottleData> {
+  const res = await fetch("/stats/data", {
+    method: "GET",
+    headers: { Accept: "application/json", ...authHeaders() },
+    signal,
+  });
+  if (!res.ok) throw await gatewayErrorFrom(res, "GET /stats/data");
+  const body = (await res.json()) as {
+    generatedAtUtc?: unknown;
+    buckets?: unknown;
+    notCaptured?: unknown;
+  } | null;
+  const buckets = Array.isArray(body?.buckets) ? body!.buckets.map(normalizeBucket) : [];
+  const notCaptured = Array.isArray(body?.notCaptured)
+    ? body!.notCaptured.filter((x): x is string => typeof x === "string")
+    : [];
+  return {
+    generatedAtUtc: typeof body?.generatedAtUtc === "string" ? body.generatedAtUtc : "",
+    buckets,
+    notCaptured,
+  };
+}
+
+/** Derive the honest headline summary from a tally snapshot. Turn shares are over counted turns only;
+ * with zero turns the shares are null so the caller renders an empty state rather than "0%". */
+export function summarizeThrottle(data: ThrottleData): ThrottleSummary {
+  const turnsBySurface: Record<Surface, number> = { desktop: 0, cockpit: 0, phone: 0, unknown: 0 };
+  let totalTurns = 0;
+  let totalCharacters = 0;
+  let voiceTurns = 0;
+  let typedTurns = 0;
+
+  for (const b of data.buckets) {
+    totalTurns += b.turns;
+    totalCharacters += b.characters;
+    if (b.modality === "voice") voiceTurns += b.turns;
+    else typedTurns += b.turns;
+    turnsBySurface[b.surface] += b.turns;
+  }
+
+  const share = (part: number): number | null => (totalTurns > 0 ? part / totalTurns : null);
+
+  return {
+    totalTurns,
+    totalCharacters,
+    voiceTurns,
+    typedTurns,
+    voiceShare: share(voiceTurns),
+    turnsBySurface,
+    phoneShare: share(turnsBySurface.phone),
+    hasData: totalTurns > 0 || totalCharacters > 0,
+  };
+}
+
+/** Format a fraction share as a whole-number percent, or "n/a" when there is no data yet. ASCII only. */
+export function formatShare(fraction: number | null): string {
+  if (fraction === null) return "n/a";
+  return `${Math.round(fraction * 100)}%`;
+}
+
+/** Human labels for the wire tokens (ASCII only). */
+export const MODALITY_LABEL: Record<Modality, string> = { voice: "Voice", typed: "Typed" };
+export const SURFACE_LABEL: Record<Surface, string> = {
+  desktop: "Desktop",
+  cockpit: "Cockpit",
+  phone: "Phone",
+  unknown: "Unknown",
+};
+
+/** The surfaces in a stable presentation order. */
+export const SURFACE_ORDER = SURFACES;


### PR DESCRIPTION
## What

Ports the DevThrottle Stats "Your Throttle" dashboard from the standalone Gateway `/stats` HTML page into the two apps the user already uses, so it is one tap away instead of a bare URL.

- **Shared** `client-core/stats/statsClient.ts`: typed read of the same `GET /stats/data` feed the standalone page uses, plus the honest summary math (turn shares by modality and surface; `null` shares - never a fabricated 0% - when nothing is counted yet). One source of truth for both shells.
- **Cockpit**: a "Your Throttle" left-rail item (System section) and a native page with headline cards (voice share, phone share, total turns), turns-by-surface and full modality-by-surface breakdowns, and the honesty caveats.
- **Mobile `/m`**: a "Your Throttle" nav-drawer item and a phone-styled screen with the same content.
- Both auto-refresh every 10s so the split moves live while driving.

No new backend and no new counting - purely a front-end read of the existing aggregated feed.

## Verification

- `client-core`, `cockpit`, `mobile` typecheck clean (`tsc --noEmit`).
- `cockpit` and `mobile` production builds succeed.
- New vitest unit tests for `summarizeThrottle` / `formatShare` (5 tests, green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
