### PR TITLE
fix(stats): feed Your Throttle from the /sessions roster, not only the SignalR push

### DIFF
--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -75,7 +75,12 @@ internal static class GatewayEndpoints
         // /session-numbers/* endpoints are mapped and the /sessions aggregation adopts every observed
         // number so the in-use set survives a Gateway restart. Null (old callers, tests) maps nothing
         // and leaves each Director to number locally.
-        Discovery.FleetSessionNumberAllocator? sessionNumbers = null)
+        Discovery.FleetSessionNumberAllocator? sessionNumbers = null,
+        // DevThrottle Stats: the always-available input-tally aggregator. Folded from the assembled
+        // /sessions roster (the path that carries SessionDto.InputStats whether stream mode is on or off),
+        // so "Your Throttle" is fed by the same roster the fleet already reads, not only by the SignalR
+        // push path (which is unmapped when stream mode is off). Null (old callers, tests) folds nothing.
+        Stats.GatewayInputStatsAggregator? inputStats = null)
     {
         // The old issue #1188 "session lock" (423 Locked on human input while a PENDING dictation record
         // existed) was removed deliberately (issue #1308). This is a single-operator tool: a collision
@@ -697,6 +702,14 @@ internal static class GatewayEndpoints
             // stamp the presentation fold (which reads the role to suppress a live Worker's red toward the
             // human). Done here, once, because the role needs the full fleet view.
             StampFleetRolesAndFold(all, needsYouStampFor);
+
+            // DevThrottle Stats: fold the assembled roster's per-session input tallies into the always-
+            // available aggregate that backs "Your Throttle". This is the ONE path that carries
+            // SessionDto.InputStats on the live Gateway regardless of stream mode (the SignalR DirectorHub
+            // fold only runs when stream mode is on, which it is not in production). The aggregator's
+            // per-session high-water logic makes folding the full roster on every read idempotent - only a
+            // genuine increase is added, so repeated /sessions polls never double-count.
+            inputStats?.ObserveSnapshot(all);
 
             // Issue #1292: adopt every observed number into the fleet allocator's in-use set. This is how
             // the Gateway learns numbers it did not hand out - a number a Director assigned offline, or any

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1114,7 +1114,11 @@ public sealed class GatewayHost : IAsyncDisposable
             rosterCache: RosterCache,
             // Issue #1292: the fleet-wide session-number authority backs POST /session-numbers/allocate
             // (Directors ask here at session creation) and the /sessions adopt-reconcile.
-            sessionNumbers: SessionNumbers);
+            sessionNumbers: SessionNumbers,
+            // DevThrottle Stats: feed the input-tally aggregator from the assembled /sessions roster, so
+            // "Your Throttle" is populated whether stream mode is on or off (the DirectorHub push fold only
+            // runs in stream mode, which is off in production).
+            inputStats: InputStats);
 
         // Issue #268: the two raw per-session WebSocket legs (live Terminal stream + dictation)
         // proxied through the Gateway so a remote Cockpit talks same-origin to the Gateway and


### PR DESCRIPTION
## Bug

"Your Throttle" showed **no data** on the live Gateway even though input counts exist end-to-end on the Director (verified: sessions carry voice/phone turns) and even reach the Gateway's `/sessions` roster.

## Root cause

Phase 1 wired `GatewayInputStatsAggregator` to feed **only** through the SignalR `DirectorHub` push path (`PushSnapshot`/`PushDelta` -> `ObserveSnapshot`/`Observe`). But stream mode is **off** in production (the thefrederiksen/devthrottle_internal#721 kill-switch; `StreamMode` defaults false), so `DirectorHub` is never mapped (`POST /director-stream/negotiate` -> 404) and no Director ever pushes. The aggregator was never fed, so `GET /stats/data` stayed empty and the persist file was never written. The roster shows the counts because it is served over the **REST** path (`ControlEndpoints.Map` populates `SessionDto.InputStats`), which never folded into the aggregator.

## Fix

Fold the assembled `/sessions` roster into the aggregator in `GatewayEndpoints`, right after `StampFleetRolesAndFold`. That roster carries `InputStats` on every read regardless of stream mode, so Your Throttle is fed by the same roster the fleet already polls. The aggregator's per-session high-water logic makes folding the full roster on every read idempotent - only a genuine increase is added, so repeated polls never double-count. The SignalR fold stays in place for when stream mode is on; this simply adds the always-live path.

## Verification

- Gateway compiles clean (Release, 0 warnings).
- **Verified live** on the deployed Gateway: `/stats/data` populates after redeploy.
- Fold logic is unit-tested (`GatewayInputStatsAggregatorTests`).
- Fast-follow: an endpoint-level regression test needs a fake-director HTTP harness that does not exist yet (`DirectorEndpointClient` is sealed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
