### PR TITLE
Inject the signed-in user identity into every session preamble (#1357)

### DIFF
--- a/.claude/skills/dev-throttle/SKILL.md
+++ b/.claude/skills/dev-throttle/SKILL.md
@@ -162,6 +162,14 @@ Two related endpoints:
 Do not self-close while something still needs the user (a pending decision, an approval, an
 unanswered question). Reap only when the queue is truly empty.
 
+## Who the user is
+
+Every session is started for one signed-in DevThrottle user. The session-start preamble names that
+user - both their email and, when they set one, their chosen nickname. Treat that named person as the
+user of this session: unless they explicitly say otherwise, "me", "my account", and "email me" mean
+that user. Do NOT guess who the user is from usage patterns or by searching the database for a name -
+use the identity the preamble gave you. If no user is named (nobody signed in), do not invent one.
+
 ## When this skill is the right thing to consult
 
 - "What cc-* tools do I have for X?" - look in the tool list above; run the tool with `--help` for syntax.
@@ -175,7 +183,8 @@ unanswered question). Reap only when the queue is truly empty.
 
 ---
 
-**Skill Version:** 4.2 (end-user, DevThrottle rebrand)
+**Skill Version:** 4.3 (end-user, DevThrottle rebrand)
 **Last Updated:** 2026-07-11
+**Changes in 4.3:** Added "Who the user is" - the session-start preamble names the signed-in DevThrottle user (email + nickname); "me / my account / email me" means that user unless they say otherwise, and identity must not be guessed from usage or the database (issue #1357).
 **Changes in 4.2:** Added "Closing a session (including closing yourself)" - a session can reap itself with `POST /sessions/{sid}/request-deletion` against its own Director (`CC_DIRECTOR_API` + `CC_SESSION_ID`), the graceful self-delete that does not kill the process mid-turn. Documented the Gateway forward of the same call, the cancel-during-grace endpoint, and that immediate `DELETE /sessions/{sid}` must not be used on yourself. Added these three endpoints to the Control API table.
 **Changes in 4.1:** Added "Creating a session correctly (always name it)" - a created session MUST carry a meaningful Name, the normal permission preset + model in Args (--dangerously-skip-permissions --model opus[1m]), a PrePrompt for its first task, and a verify/PATCH of the name afterwards (the Control API applies no defaults; some running builds do not honor create-time Name).

--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -400,7 +400,13 @@ public sealed class ControlApiHost : IAsyncDisposable
         // and control-API send paths. Idempotent to set on each start.
         Core.Sessions.Session.DictationLockCheck = id => Core.Sessions.DictationLockReader.IsSessionLocked(id);
 
-        ControlEndpoints.Map(_app, _sessionManager, DirectorId, _version, _requestShutdownAsync, _authEnabled, _repositoryRegistry, _turnSummaryCache, gatewayUrl, _proactiveExplain, GatewayMonitor, resolveTailnetEndpoint, () => _gatewayClient, messageSteward, _missionStore);
+        // Issue #1357: the signed-in DevThrottle user for a session's preamble. The account credential
+        // lives on the Gateway (issue #651), so this reads GET /account/status (email + provider +
+        // nickname) through a short-lived cache. GatewayConfig.Load is re-read each resolve so a settings
+        // change is picked up without a restart. Standalone/no-Gateway resolves to null (line omitted).
+        var signedInUserProvider = new Core.Account.SignedInUserProvider(Core.Configuration.GatewayConfig.Load);
+
+        ControlEndpoints.Map(_app, _sessionManager, DirectorId, _version, _requestShutdownAsync, _authEnabled, _repositoryRegistry, _turnSummaryCache, gatewayUrl, _proactiveExplain, GatewayMonitor, resolveTailnetEndpoint, () => _gatewayClient, messageSteward, _missionStore, ct => signedInUserProvider.ResolveAsync(ct));
         // Dictation glossary resolution mirrors the key resolver (#253): the Gateway's shared
         // dictionary when attached, the local cache when standalone. GatewayConfig.Load (not the
         // snapshot) is passed so the resolver re-reads config.json each dictation and self-heals
@@ -470,6 +476,16 @@ public sealed class ControlApiHost : IAsyncDisposable
         // (e.g. GET $CC_DIRECTOR_API/sessions/$CC_SESSION_ID to find themselves).
         _sessionManager.ControlApiBaseUrl = $"http://127.0.0.1:{Port}";
         _sessionManager.DirectorId = DirectorId;
+
+        // Issue #1357: let the (synchronous, non-blocking) Pi launch path name the signed-in user from
+        // the provider's cached snapshot. Warm the cache once now so the first Pi session started right
+        // after boot already has it; failures inside ResolveAsync are swallowed (best-effort context).
+        _sessionManager.SignedInUserAccessor = () => signedInUserProvider.CurrentSnapshot;
+        _ = Task.Run(async () =>
+        {
+            try { await signedInUserProvider.ResolveAsync(CancellationToken.None); }
+            catch (Exception ex) { FileLog.Write($"[ControlApiHost] signed-in user warm-up failed (best-effort): {ex.Message}"); }
+        });
 
         // Issue #1292: the Gateway is the authority for the fleet-unique session number. Wire the
         // SessionManager to ask the CURRENT GatewayClient (read the FIELD lazily so a settings change

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -3,6 +3,7 @@ using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
 using CcDirector.ControlApi.Chat;
+using CcDirector.Core.Account;
 using CcDirector.Core.AgentPlugins;
 using CcDirector.Core.Agents;
 using CcDirector.Core.Backends;
@@ -29,7 +30,7 @@ namespace CcDirector.ControlApi;
 /// </summary>
 internal static class ControlEndpoints
 {
-    public static void Map(IEndpointRouteBuilder app, SessionManager sessionManager, string directorId, string version, Func<Task> requestShutdownAsync, bool authEnabled = false, RepositoryRegistry? repositoryRegistry = null, TurnSummaryCache? turnSummaryCache = null, string? gatewayUrl = null, ProactiveExplainService? proactiveExplain = null, GatewayConnectionMonitor? gatewayMonitor = null, Func<TailnetEndpointResolution>? resolveTailnetEndpoint = null, Func<GatewayClient?>? gatewayClientProvider = null, MessageSteward? messageSteward = null, MissionStore? missionStore = null)
+    public static void Map(IEndpointRouteBuilder app, SessionManager sessionManager, string directorId, string version, Func<Task> requestShutdownAsync, bool authEnabled = false, RepositoryRegistry? repositoryRegistry = null, TurnSummaryCache? turnSummaryCache = null, string? gatewayUrl = null, ProactiveExplainService? proactiveExplain = null, GatewayConnectionMonitor? gatewayMonitor = null, Func<TailnetEndpointResolution>? resolveTailnetEndpoint = null, Func<GatewayClient?>? gatewayClientProvider = null, MessageSteward? messageSteward = null, MissionStore? missionStore = null, Func<CancellationToken, Task<SignedInUser?>>? signedInUserResolver = null)
     {
         var logoutVisibility = authEnabled ? "" : "style=\"display:none\"";
         // URL of the Gateway this Director is registered with, for the "Gateway" nav
@@ -252,7 +253,7 @@ internal static class ControlEndpoints
         // cc-devthrottle commands to reach the rest of the fleet. The Claude SessionStart hook fetches this
         // and injects it as additionalContext so the agent knows the fleet instantly, with no
         // skill lookup. Plain text (not JSON) so a hook can drop it straight into a context field.
-        app.MapGet("/sessions/{sid}/fleet-preamble", (string sid) =>
+        app.MapGet("/sessions/{sid}/fleet-preamble", async (string sid, CancellationToken ct) =>
         {
             if (!Guid.TryParse(sid, out var guid))
                 return Results.BadRequest(new { error = "invalid session id format" });
@@ -267,9 +268,14 @@ internal static class ControlEndpoints
                 SessionName.FolderName(session.RepoPath),
                 SessionName.Disambiguator(session.Id));
 
+            // Issue #1357: name the signed-in DevThrottle user so the agent binds "me / my account /
+            // email me" to that account. Resolved (cached) from the Gateway; null when no one is signed
+            // in or no resolver is wired (tests, standalone) - the preamble then omits the identity line.
+            SignedInUser? user = signedInUserResolver is null ? null : await signedInUserResolver(ct);
+
             // A session only ever calls its OWN Director, so this Director's machine name is the
             // session's machine.
-            var text = FleetPreamble.Build(session.Id.ToString(), name, Environment.MachineName, session.RepoPath);
+            var text = FleetPreamble.Build(session.Id.ToString(), name, Environment.MachineName, session.RepoPath, user);
             return Results.Text(text, "text/plain");
         });
 

--- a/src/CcDirector.Core.Tests/Account/AccountNicknameClientTests.cs
+++ b/src/CcDirector.Core.Tests/Account/AccountNicknameClientTests.cs
@@ -1,0 +1,93 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using CcDirector.Core.Account;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Account;
+
+/// <summary>
+/// Issue #1357: the account nickname client reads <c>GET /api/v1/account/nickname</c> with the account
+/// JWT and parses the nickname out of the response. It accepts both the <c>{ data: { nickname } }</c>
+/// envelope the account API uses for its other reads and a bare top-level <c>{ nickname }</c> shape, and
+/// returns null when the account has no nickname set (the caller falls back to the email). These tests
+/// prove the parse and the HTTP call without a network.
+/// </summary>
+public sealed class AccountNicknameClientTests
+{
+    [Fact]
+    public void Parse_DataEnvelope_ReadsNickname()
+        => Assert.Equal("Starlord", AccountNicknameClient.Parse("{\"data\":{\"nickname\":\"Starlord\"}}"));
+
+    [Fact]
+    public void Parse_TopLevel_ReadsNickname()
+        => Assert.Equal("Starlord", AccountNicknameClient.Parse("{\"nickname\":\"Starlord\"}"));
+
+    [Fact]
+    public void Parse_TrimsWhitespace()
+        => Assert.Equal("Ace", AccountNicknameClient.Parse("{\"data\":{\"nickname\":\"  Ace  \"}}"));
+
+    [Theory]
+    [InlineData("{}")]                                   // no nickname anywhere
+    [InlineData("{\"data\":{}}")]                        // envelope present, no nickname
+    [InlineData("{\"data\":{\"nickname\":null}}")]       // explicit null
+    [InlineData("{\"nickname\":\"\"}")]                  // empty string
+    [InlineData("{\"nickname\":\"   \"}")]               // whitespace only
+    public void Parse_Unset_ReturnsNull(string body)
+        => Assert.Null(AccountNicknameClient.Parse(body));
+
+    [Theory]
+    [InlineData("[]")]                                   // not an object
+    [InlineData("\"just-a-string\"")]                    // not an object
+    public void Parse_NotAnObject_Throws(string body)
+        => Assert.Throws<InvalidOperationException>(() => AccountNicknameClient.Parse(body));
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly string _body;
+        public string? SeenAuth { get; private set; }
+        public string? SeenUrl { get; private set; }
+        public StubHandler(HttpStatusCode status, string body) { _status = status; _body = body; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            SeenAuth = request.Headers.Authorization?.ToString();
+            SeenUrl = request.RequestUri?.ToString();
+            return Task.FromResult(new HttpResponseMessage(_status) { Content = new StringContent(_body, Encoding.UTF8, "application/json") });
+        }
+    }
+
+    [Fact]
+    public async Task GetNicknameAsync_Success_ReturnsNickname_AndBearsTheJwt()
+    {
+        var handler = new StubHandler(HttpStatusCode.OK, "{\"data\":{\"nickname\":\"Starlord\"}}");
+        var client = new AccountNicknameClient(new HttpClient(handler), baseUrl: "https://example.test");
+
+        var nickname = await client.GetNicknameAsync("the.jwt");
+
+        Assert.Equal("Starlord", nickname);
+        Assert.Equal("Bearer the.jwt", handler.SeenAuth);
+        Assert.Equal("https://example.test/api/v1/account/nickname", handler.SeenUrl);
+    }
+
+    [Fact]
+    public async Task GetNicknameAsync_Unset_ReturnsNull()
+    {
+        var client = new AccountNicknameClient(new HttpClient(new StubHandler(HttpStatusCode.OK, "{\"data\":{}}")), baseUrl: "https://example.test");
+        Assert.Null(await client.GetNicknameAsync("jwt"));
+    }
+
+    [Fact]
+    public async Task GetNicknameAsync_Non2xx_Throws()
+    {
+        var client = new AccountNicknameClient(new HttpClient(new StubHandler(HttpStatusCode.Unauthorized, "{}")), baseUrl: "https://example.test");
+        await Assert.ThrowsAnyAsync<HttpRequestException>(() => client.GetNicknameAsync("jwt"));
+    }
+
+    [Fact]
+    public async Task GetNicknameAsync_NoToken_Throws()
+    {
+        var client = new AccountNicknameClient(new HttpClient(new StubHandler(HttpStatusCode.OK, "{}")), baseUrl: "https://example.test");
+        await Assert.ThrowsAsync<ArgumentException>(() => client.GetNicknameAsync(""));
+    }
+}

--- a/src/CcDirector.Core.Tests/Account/GatewayAccountStatusClientTests.cs
+++ b/src/CcDirector.Core.Tests/Account/GatewayAccountStatusClientTests.cs
@@ -54,6 +54,35 @@ public sealed class GatewayAccountStatusClientTests
         Assert.Equal("tok-123", handler.Request.Headers.Authorization.Parameter);
     }
 
+    // Issue #1357: the client surfaces the nickname when the Gateway includes it.
+    [Fact]
+    public async Task GetStatusAsync_SignedInWithNickname_ReadsNickname()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK,
+            "{\"signedIn\":true,\"email\":\"person@example.com\",\"provider\":\"google\",\"nickname\":\"Starlord\"}");
+        var client = new GatewayAccountStatusClient(new HttpClient(handler));
+
+        var status = await client.GetStatusAsync(new GatewayConfig { Url = GatewayUrl });
+
+        Assert.True(status.SignedIn);
+        Assert.Equal("person@example.com", status.Email);
+        Assert.Equal("Starlord", status.Nickname);
+    }
+
+    // Issue #1357: when the Gateway omits nickname, the client leaves it null (email fallback happens downstream).
+    [Fact]
+    public async Task GetStatusAsync_SignedInNoNickname_NicknameIsNull()
+    {
+        var handler = new CapturingHandler(HttpStatusCode.OK,
+            "{\"signedIn\":true,\"email\":\"person@example.com\",\"provider\":\"google\"}");
+        var client = new GatewayAccountStatusClient(new HttpClient(handler));
+
+        var status = await client.GetStatusAsync(new GatewayConfig { Url = GatewayUrl });
+
+        Assert.True(status.SignedIn);
+        Assert.Null(status.Nickname);
+    }
+
     [Fact]
     public async Task GetStatusAsync_NoToken_SendsNoAuthorizationHeader()
     {

--- a/src/CcDirector.Core.Tests/Account/SignedInUserProviderTests.cs
+++ b/src/CcDirector.Core.Tests/Account/SignedInUserProviderTests.cs
@@ -1,0 +1,116 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using CcDirector.Core.Account;
+using CcDirector.Core.Configuration;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Account;
+
+/// <summary>
+/// Issue #1357: the Director-side provider resolves the signed-in user (email + nickname) from the
+/// Gateway's <c>GET /account/status</c>, caches it for a TTL so the hot preamble path does not re-hit the
+/// Gateway, and exposes a synchronous last-known snapshot for the (non-blocking) Pi launch path. A fake
+/// HTTP handler stands in for the Gateway so no real network call is made.
+/// </summary>
+public sealed class SignedInUserProviderTests
+{
+    private const string GatewayUrl = "http://127.0.0.1:7878";
+
+    private sealed class CountingHandler : HttpMessageHandler
+    {
+        private readonly string _body;
+        public int Calls { get; private set; }
+        public CountingHandler(string body) { _body = body; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Calls++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_body, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    /// <summary>A test clock the tests advance to cross the cache TTL boundary deterministically.</summary>
+    private sealed class MutableTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now = new(2026, 07, 11, 0, 0, 0, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan by) => _now += by;
+    }
+
+    private static SignedInUserProvider Make(CountingHandler handler, TimeProvider time)
+        => new(
+            () => new GatewayConfig { Url = GatewayUrl },
+            new GatewayAccountStatusClient(new HttpClient(handler)),
+            ttl: TimeSpan.FromMinutes(5),
+            timeProvider: time);
+
+    [Fact]
+    public async Task ResolveAsync_SignedInWithNickname_MapsEmailAndNickname()
+    {
+        var handler = new CountingHandler("{\"signedIn\":true,\"email\":\"soren@example.com\",\"provider\":\"google\",\"nickname\":\"Starlord\"}");
+        var provider = Make(handler, new MutableTimeProvider());
+
+        var user = await provider.ResolveAsync();
+
+        Assert.NotNull(user);
+        Assert.Equal("soren@example.com", user!.Email);
+        Assert.Equal("Starlord", user.Nickname);
+        Assert.Equal("Starlord", user.DisplayName);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_SignedInNoNickname_EmailIsDisplayName()
+    {
+        var handler = new CountingHandler("{\"signedIn\":true,\"email\":\"soren@example.com\",\"provider\":\"google\"}");
+        var provider = Make(handler, new MutableTimeProvider());
+
+        var user = await provider.ResolveAsync();
+
+        Assert.NotNull(user);
+        Assert.Null(user!.Nickname);
+        Assert.Equal("soren@example.com", user.DisplayName);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_SignedOut_ReturnsNull()
+    {
+        var handler = new CountingHandler("{\"signedIn\":false}");
+        var provider = Make(handler, new MutableTimeProvider());
+
+        Assert.Null(await provider.ResolveAsync());
+    }
+
+    [Fact]
+    public async Task ResolveAsync_CachesWithinTtl_ThenRefreshesAfter()
+    {
+        var handler = new CountingHandler("{\"signedIn\":true,\"email\":\"soren@example.com\",\"provider\":\"google\",\"nickname\":\"Starlord\"}");
+        var time = new MutableTimeProvider();
+        var provider = Make(handler, time);
+
+        await provider.ResolveAsync();
+        await provider.ResolveAsync();
+        Assert.Equal(1, handler.Calls); // second call served from cache
+
+        time.Advance(TimeSpan.FromMinutes(6)); // past the 5-minute TTL
+        await provider.ResolveAsync();
+        Assert.Equal(2, handler.Calls); // stale -> one more fetch
+    }
+
+    [Fact]
+    public async Task CurrentSnapshot_IsNullBeforeResolve_ThenLastResolved()
+    {
+        var handler = new CountingHandler("{\"signedIn\":true,\"email\":\"soren@example.com\",\"provider\":\"google\",\"nickname\":\"Starlord\"}");
+        var provider = Make(handler, new MutableTimeProvider());
+
+        Assert.Null(provider.CurrentSnapshot); // no network before a resolve
+        Assert.Equal(0, handler.Calls);
+
+        await provider.ResolveAsync();
+
+        Assert.NotNull(provider.CurrentSnapshot);
+        Assert.Equal("Starlord", provider.CurrentSnapshot!.Nickname);
+    }
+}

--- a/src/CcDirector.Core.Tests/Pi/PiPreambleWriterTests.cs
+++ b/src/CcDirector.Core.Tests/Pi/PiPreambleWriterTests.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Account;
 using CcDirector.Core.Pi;
 using Xunit;
 
@@ -5,6 +6,28 @@ namespace CcDirector.Core.Tests.Pi;
 
 public class PiPreambleWriterTests
 {
+    // Issue #1357: when a signed-in user is supplied, the Pi preamble file names that user.
+    [Fact]
+    public void WriteForSession_WithSignedInUser_WritesIdentityLine()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "pi-preamble-test-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var sid = "abc12345-1111-2222-3333-444455556666";
+            var path = PiPreambleWriter.WriteForSession(
+                sid, "myrepo", "MACHINE_A", @"D:\repo\myrepo", dir,
+                new SignedInUser("soren@example.com", "Starlord"));
+
+            var text = File.ReadAllText(path);
+            Assert.Contains("The user of this session is Starlord (soren@example.com).", text);
+            Assert.Contains("do not guess identity from usage or the database", text);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     [Fact]
     public void WriteForSession_WritesPreambleFile_WithIdentityAndCommands()
     {

--- a/src/CcDirector.Core.Tests/Sessions/FleetPreambleTests.cs
+++ b/src/CcDirector.Core.Tests/Sessions/FleetPreambleTests.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Account;
 using CcDirector.Core.Sessions;
 using Xunit;
 
@@ -5,6 +6,66 @@ namespace CcDirector.Core.Tests.Sessions;
 
 public class FleetPreambleTests
 {
+    // Issue #1357: with a nickname set, the identity line names the user by the nickname and still
+    // carries the email, and binds "me / my account / email me" to that user.
+    [Fact]
+    public void Build_SignedInUserWithNickname_ShowsNicknameAndEmailAndRule()
+    {
+        var text = FleetPreamble.Build(
+            "a3dfb85e-49dd-442a-9e36-40fc44838783",
+            "devthrottle",
+            "MACHINE_A",
+            @"C:\repos\devthrottle",
+            new SignedInUser("soren@example.com", "Starlord"));
+
+        Assert.Contains("The user of this session is Starlord (soren@example.com).", text);
+        Assert.Contains("\"me / my account / email me\" means this user", text);
+        Assert.Contains("do not guess identity from usage or the database", text);
+    }
+
+    // Issue #1357: with no nickname set, the line falls back to the email as the display name.
+    [Fact]
+    public void Build_SignedInUserWithoutNickname_ShowsEmailAsName()
+    {
+        var text = FleetPreamble.Build(
+            "a3dfb85e-49dd-442a-9e36-40fc44838783",
+            "devthrottle",
+            "MACHINE_A",
+            @"C:\repos\devthrottle",
+            new SignedInUser("soren@example.com", Nickname: null));
+
+        Assert.Contains("The user of this session is soren@example.com (soren@example.com).", text);
+    }
+
+    // Issue #1357: no signed-in user -> the identity line is omitted entirely (no blank line, no "null").
+    [Fact]
+    public void Build_NoSignedInUser_OmitsIdentityLine()
+    {
+        var text = FleetPreamble.Build(
+            "a3dfb85e-49dd-442a-9e36-40fc44838783",
+            "devthrottle",
+            "MACHINE_A",
+            @"C:\repos\devthrottle",
+            user: null);
+
+        Assert.DoesNotContain("The user of this session is", text);
+        Assert.DoesNotContain("null", text);
+    }
+
+    // Issue #1357: the identity line stays ASCII when the user's values are ASCII.
+    [Fact]
+    public void Build_SignedInUser_IsAsciiOnly()
+    {
+        var text = FleetPreamble.Build(
+            "603b2066-d587-40f2-a37c-a308cebb8038",
+            "frontend",
+            "MACHINE_A",
+            @"C:\repos\devthrottle",
+            new SignedInUser("person@example.com", "Ace"));
+
+        Assert.All(text, ch => Assert.True(ch < 128, $"non-ASCII character U+{(int)ch:X4} in preamble"));
+    }
+
     [Fact]
     public void Build_NamedSession_IncludesIdentityAndFleetCommands()
     {

--- a/src/CcDirector.Core/Account/AccountNicknameClient.cs
+++ b/src/CcDirector.Core/Account/AccountNicknameClient.cs
@@ -1,0 +1,119 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Account;
+
+/// <summary>
+/// A small HTTP client for the signed-in account's chosen nickname (issue #1357, cloud contract
+/// <c>GET /api/v1/account/nickname</c>; the same value is also returned on <c>/auth/me</c>). The
+/// nickname lives server-side in the website/account repo (<c>members.nickname</c>); this client reads
+/// it so a session's preamble can name the human by the nickname they chose.
+///
+/// It mirrors <see cref="AccountCreditsClient"/>: it authenticates with the Bearer access token the
+/// Gateway already holds for cloud egress (the SAME credential
+/// <see cref="DevThrottleAccountService.GetAccessTokenForForwarding"/> returns - the nickname endpoint
+/// is JWT-authed, NOT dt_-key-authed), the base URL resolves the same way the rest of the account egress
+/// does (<see cref="AccountTelemetryClient.ApiBaseUrlEnvVar"/> override, else the production default), so
+/// this client introduces no new hard-coded host, and the access token is sent only as the
+/// Authorization header and is NEVER written to the log (DT-05). The <see cref="HttpClient"/> is
+/// injectable so tests drive it against an in-process stub.
+///
+/// When the account has no nickname set, the endpoint returns it as null/absent and this client returns
+/// null - the caller (the preamble) then falls back to the email, which is the documented behaviour.
+/// </summary>
+public sealed class AccountNicknameClient
+{
+    /// <summary>The path that returns the signed-in account's chosen nickname.</summary>
+    public const string NicknamePath = "/api/v1/account/nickname";
+
+    private readonly HttpClient _client;
+    private readonly string _baseUrl;
+
+    /// <param name="client">HTTP client (tests inject a stub); defaults to a short-timeout client.</param>
+    /// <param name="baseUrl">API base URL; defaults to the shared account-egress base resolution.</param>
+    public AccountNicknameClient(HttpClient? client = null, string? baseUrl = null)
+    {
+        _client = client ?? new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        _baseUrl = ResolveBaseUrl(baseUrl);
+    }
+
+    private static string ResolveBaseUrl(string? baseUrl)
+    {
+        if (!string.IsNullOrWhiteSpace(baseUrl))
+            return baseUrl.Trim().TrimEnd('/');
+        var fromEnv = Environment.GetEnvironmentVariable(AccountTelemetryClient.ApiBaseUrlEnvVar);
+        if (!string.IsNullOrWhiteSpace(fromEnv))
+            return fromEnv.Trim().TrimEnd('/');
+        return AccountTelemetryClient.DefaultApiBaseUrl;
+    }
+
+    /// <summary>
+    /// Reads the account's nickname via <c>GET /api/v1/account/nickname</c>. Returns the trimmed nickname
+    /// when the account has one set, or null when the account has no nickname (the caller falls back to
+    /// the email). Throws on a non-success response (so an unreachable or erroring cloud surfaces as a
+    /// clear failure the caller reports, never a fabricated value) or a malformed body. No token is ever
+    /// returned or logged.
+    /// </summary>
+    /// <param name="accessToken">The Bearer access token the Gateway holds. Never logged.</param>
+    /// <param name="ct">Cancels the request.</param>
+    public async Task<string?> GetNicknameAsync(string accessToken, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(accessToken))
+            throw new ArgumentException("Access token is required", nameof(accessToken));
+
+        var endpoint = $"{_baseUrl}{NicknamePath}";
+        FileLog.Write($"[AccountNicknameClient] GetNicknameAsync: GET {endpoint}");
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        using var response = await _client.SendAsync(request, ct).ConfigureAwait(false);
+        FileLog.Write($"[AccountNicknameClient] GetNicknameAsync: response status={(int)response.StatusCode}");
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        var nickname = Parse(json);
+        FileLog.Write($"[AccountNicknameClient] GetNicknameAsync: nickname={(nickname is null ? "<unset>" : "resolved")}");
+        return nickname;
+    }
+
+    /// <summary>
+    /// Parses the nickname out of the cloud response. Accepts the <c>{ "data": { "nickname": "..." } }</c>
+    /// envelope the account API uses for its other reads (see <see cref="AccountCreditsClient"/>) AND a
+    /// bare top-level <c>{ "nickname": "..." }</c> shape (as returned inline on <c>/auth/me</c>). Returns
+    /// the trimmed nickname when present and non-empty, or null when the field is absent, null, or blank -
+    /// an unset nickname is a normal state, not an error. Internal so the parse is unit-testable without a
+    /// network. Throws only when the body is not a JSON object at all.
+    /// </summary>
+    internal static string? Parse(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        if (root.ValueKind != JsonValueKind.Object)
+            throw new InvalidOperationException("account nickname response was not a JSON object");
+
+        // Prefer the { data: { nickname } } envelope; fall back to a top-level { nickname }.
+        if (root.TryGetProperty("data", out var data) && data.ValueKind == JsonValueKind.Object)
+        {
+            var fromEnvelope = ReadNickname(data);
+            if (fromEnvelope is not null)
+                return fromEnvelope;
+        }
+
+        return ReadNickname(root);
+    }
+
+    /// <summary>Reads a non-empty, trimmed <c>nickname</c> string from an object, or null when absent/blank.</summary>
+    private static string? ReadNickname(JsonElement obj)
+    {
+        if (obj.TryGetProperty("nickname", out var nick) && nick.ValueKind == JsonValueKind.String)
+        {
+            var value = nick.GetString();
+            if (!string.IsNullOrWhiteSpace(value))
+                return value.Trim();
+        }
+        return null;
+    }
+}

--- a/src/CcDirector.Core/Account/GatewayAccountStatusClient.cs
+++ b/src/CcDirector.Core/Account/GatewayAccountStatusClient.cs
@@ -26,6 +26,13 @@ public sealed record GatewayAccountStatus(
     string? Provider,
     string? Error)
 {
+    /// <summary>
+    /// The signed-in user's chosen account nickname (issue #1357), or null when not signed in, when the
+    /// user has not set one, or when the Gateway did not resolve it. An <c>init</c> property (not a
+    /// positional parameter) so every existing construction of this record stays source-compatible.
+    /// </summary>
+    public string? Nickname { get; init; }
+
     /// <summary>The state for a Director that has no Gateway URL configured.</summary>
     public static GatewayAccountStatus NotConfigured() =>
         new(GatewayConfigured: false, Reachable: false, SignedIn: false, Email: null, Provider: null, Error: null);
@@ -102,9 +109,9 @@ public sealed class GatewayAccountStatusClient
                 return new GatewayAccountStatus(GatewayConfigured: true, Reachable: false, SignedIn: false,
                     Email: null, Provider: null, Error: "The Gateway returned an empty status response.");
 
-            FileLog.Write($"[GatewayAccountStatusClient] GetStatusAsync: signedIn={dto.SignedIn} (identity {(dto.Email is null ? "unavailable" : "resolved")})");
+            FileLog.Write($"[GatewayAccountStatusClient] GetStatusAsync: signedIn={dto.SignedIn} (identity {(dto.Email is null ? "unavailable" : "resolved")}, nickname {(dto.Nickname is null ? "unset" : "resolved")})");
             return new GatewayAccountStatus(GatewayConfigured: true, Reachable: true, SignedIn: dto.SignedIn,
-                Email: dto.Email, Provider: dto.Provider, Error: null);
+                Email: dto.Email, Provider: dto.Provider, Error: null) { Nickname = dto.Nickname };
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {

--- a/src/CcDirector.Core/Account/SignedInUser.cs
+++ b/src/CcDirector.Core/Account/SignedInUser.cs
@@ -1,0 +1,21 @@
+namespace CcDirector.Core.Account;
+
+/// <summary>
+/// The signed-in DevThrottle user surfaced INTO a session so the agent knows who the human is
+/// (issue #1357). This is the identity the fleet preamble binds "me / my account / email me" to.
+///
+/// It carries the always-present <see cref="Email"/> (from the account token's claims) and the
+/// optional <see cref="Nickname"/> the user set on their account. <see cref="DisplayName"/> is the
+/// name to show: the nickname when the user set one, otherwise the email - so a user who never chose
+/// a nickname is still named by their email rather than by nothing.
+/// </summary>
+/// <param name="Email">The signed-in user's email address (always present for a signed-in user).</param>
+/// <param name="Nickname">The account nickname, or null when the user has not set one.</param>
+public sealed record SignedInUser(string Email, string? Nickname)
+{
+    /// <summary>
+    /// The name to display for this user: the nickname when set, otherwise the email. Never empty
+    /// for a signed-in user, because <see cref="Email"/> is always present.
+    /// </summary>
+    public string DisplayName => string.IsNullOrWhiteSpace(Nickname) ? Email : Nickname!;
+}

--- a/src/CcDirector.Core/Account/SignedInUserProvider.cs
+++ b/src/CcDirector.Core/Account/SignedInUserProvider.cs
@@ -1,0 +1,100 @@
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Account;
+
+/// <summary>
+/// Resolves the signed-in DevThrottle user (email + nickname) for a session's fleet preamble (issue
+/// #1357), reading it from the Gateway's <c>GET /account/status</c> through
+/// <see cref="GatewayAccountStatusClient"/>. The account credential lives on the Gateway (issue #651),
+/// so the Director never holds a token of its own - it asks the Gateway.
+///
+/// A short-lived in-memory cache keeps this off the hot path: the preamble endpoint is fetched at
+/// session start (and re-fetched by some agents on /clear), and the Pi launch path reads the cached
+/// snapshot synchronously so session creation never blocks on the network. On a cold or stale cache
+/// <see cref="ResolveAsync"/> makes one Gateway call and stores the result; <see cref="CurrentSnapshot"/>
+/// returns the last resolved value without any network call.
+///
+/// When the Gateway is not configured, is unreachable, or reports signed-out, the resolved user is null
+/// and the preamble omits the identity line - the caller never fabricates an identity.
+/// </summary>
+public sealed class SignedInUserProvider
+{
+    /// <summary>How long a resolved snapshot is reused before the next resolve re-reads the Gateway.</summary>
+    public static readonly TimeSpan DefaultCacheTtl = TimeSpan.FromMinutes(5);
+
+    private readonly Func<GatewayConfig> _configLoader;
+    private readonly GatewayAccountStatusClient _client;
+    private readonly TimeSpan _ttl;
+    private readonly TimeProvider _timeProvider;
+
+    private readonly object _gate = new();
+    private SignedInUser? _snapshot;
+    private DateTimeOffset _fetchedAt = DateTimeOffset.MinValue;
+    private bool _haveSnapshot;
+
+    /// <param name="configLoader">
+    /// Re-reads the Gateway connection config each resolve (pass <c>GatewayConfig.Load</c>) so a
+    /// settings change is picked up without a restart.
+    /// </param>
+    /// <param name="client">The Gateway account-status client; a default one is created when null.</param>
+    /// <param name="ttl">Cache lifetime; defaults to <see cref="DefaultCacheTtl"/>.</param>
+    /// <param name="timeProvider">Time source for the cache clock; defaults to the system clock (tests inject one).</param>
+    public SignedInUserProvider(
+        Func<GatewayConfig> configLoader,
+        GatewayAccountStatusClient? client = null,
+        TimeSpan? ttl = null,
+        TimeProvider? timeProvider = null)
+    {
+        _configLoader = configLoader ?? throw new ArgumentNullException(nameof(configLoader));
+        _client = client ?? new GatewayAccountStatusClient();
+        _ttl = ttl ?? DefaultCacheTtl;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <summary>
+    /// The last resolved signed-in user, WITHOUT a network call - null until the first successful
+    /// resolve, or when the last resolve found no signed-in user. Used by the synchronous Pi launch path
+    /// so session creation never blocks on the Gateway.
+    /// </summary>
+    public SignedInUser? CurrentSnapshot
+    {
+        get { lock (_gate) return _snapshot; }
+    }
+
+    /// <summary>
+    /// Returns the signed-in user, serving a fresh cached snapshot when one exists and otherwise reading
+    /// the Gateway once and caching the result. Never throws for a Gateway problem - the underlying
+    /// client reports an unreachable/erroring Gateway as a not-signed-in result value, which resolves to
+    /// a null user (identity line omitted).
+    /// </summary>
+    public async Task<SignedInUser?> ResolveAsync(CancellationToken ct = default)
+    {
+        lock (_gate)
+        {
+            if (_haveSnapshot && _timeProvider.GetUtcNow() - _fetchedAt < _ttl)
+                return _snapshot;
+        }
+
+        var status = await _client.GetStatusAsync(_configLoader(), ct).ConfigureAwait(false);
+        var user = ToUser(status);
+
+        lock (_gate)
+        {
+            _snapshot = user;
+            _fetchedAt = _timeProvider.GetUtcNow();
+            _haveSnapshot = true;
+        }
+
+        FileLog.Write($"[SignedInUserProvider] ResolveAsync: user={(user is null ? "<none>" : "resolved")}");
+        return user;
+    }
+
+    /// <summary>Maps a Gateway status to a <see cref="SignedInUser"/>, or null when not usably signed in.</summary>
+    internal static SignedInUser? ToUser(GatewayAccountStatus status)
+    {
+        if (status is null || !status.SignedIn || string.IsNullOrWhiteSpace(status.Email))
+            return null;
+        return new SignedInUser(status.Email!, status.Nickname);
+    }
+}

--- a/src/CcDirector.Core/Pi/PiPreambleWriter.cs
+++ b/src/CcDirector.Core/Pi/PiPreambleWriter.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Account;
 using CcDirector.Core.Sessions;
 using CcDirector.Core.Utilities;
 
@@ -11,19 +12,31 @@ namespace CcDirector.Core.Pi;
 /// "knows the fleet, and still knows it after a reset" behaviour without any in-process extension.
 ///
 /// The Director already knows the session's identity at launch, so the preamble is built locally
-/// (no endpoint fetch needed) and is correct for this exact session.
+/// (no endpoint fetch needed) and is correct for this exact session. The signed-in user (issue #1357)
+/// is passed in from the Director's cached snapshot so the preamble names the human too.
 /// </summary>
 public static class PiPreambleWriter
 {
     /// <summary>Write the preamble for one session under the default per-user directory; returns the path.</summary>
     public static string WriteForSession(string sessionId, string? name, string machine, string repoPath)
-        => WriteForSession(sessionId, name, machine, repoPath, DefaultDirectory());
+        => WriteForSession(sessionId, name, machine, repoPath, DefaultDirectory(), user: null);
+
+    /// <summary>
+    /// Write the preamble for one session under the default per-user directory, naming the signed-in
+    /// DevThrottle user (issue #1357); returns the path.
+    /// </summary>
+    public static string WriteForSession(string sessionId, string? name, string machine, string repoPath, SignedInUser? user)
+        => WriteForSession(sessionId, name, machine, repoPath, DefaultDirectory(), user);
 
     /// <summary>Testable overload that writes under an explicit directory.</summary>
     public static string WriteForSession(string sessionId, string? name, string machine, string repoPath, string directory)
+        => WriteForSession(sessionId, name, machine, repoPath, directory, user: null);
+
+    /// <summary>Testable overload that writes under an explicit directory and names the signed-in user.</summary>
+    public static string WriteForSession(string sessionId, string? name, string machine, string repoPath, string directory, SignedInUser? user)
     {
         Directory.CreateDirectory(directory);
-        var text = FleetPreamble.Build(sessionId, name, machine, repoPath);
+        var text = FleetPreamble.Build(sessionId, name, machine, repoPath, user);
         var path = Path.Combine(directory, $"{sessionId}.txt");
         File.WriteAllText(path, text);
         FileLog.Write($"[PiPreambleWriter] wrote fleet preamble for {sessionId} to {path}");

--- a/src/CcDirector.Core/Sessions/FleetPreamble.cs
+++ b/src/CcDirector.Core/Sessions/FleetPreamble.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using CcDirector.Core.Account;
+
 namespace CcDirector.Core.Sessions;
 
 /// <summary>
@@ -18,16 +21,32 @@ public static class FleetPreamble
     /// <summary>
     /// Render the preamble for one session. <paramref name="name"/> may be null/empty
     /// (an unnamed session); the other values are always present on a live session.
+    /// <paramref name="user"/> is the signed-in DevThrottle user (issue #1357); when null (no one
+    /// signed in) the user-identity line is omitted cleanly - no blank line, no "null" artifact.
     /// </summary>
-    public static string Build(string sessionId, string? name, string machine, string repoPath)
+    public static string Build(string sessionId, string? name, string machine, string repoPath, SignedInUser? user = null)
     {
         var shortId = sessionId.Length >= 8 ? sessionId.Substring(0, 8) : sessionId;
         var displayName = string.IsNullOrWhiteSpace(name) ? "(unnamed)" : name;
 
-        var lines = new[]
+        var lines = new List<string>
         {
             $"[CC Director fleet] You are session {shortId} \"{displayName}\" on machine {machine}, repo {repoPath}.",
             $"Your full session id is {sessionId}.",
+        };
+
+        // Issue #1357: tell the agent WHO the human is, so "me / my account / email me" binds to the
+        // signed-in account instead of being guessed from usage or the database. Only emitted when a
+        // user is actually signed in with an email; otherwise the line is omitted entirely.
+        if (user is not null && !string.IsNullOrWhiteSpace(user.Email))
+        {
+            lines.Add(
+                $"The user of this session is {user.DisplayName} ({user.Email}). Unless they say otherwise, " +
+                "\"me / my account / email me\" means this user; do not guess identity from usage or the database.");
+        }
+
+        lines.AddRange(new[]
+        {
             "You can talk to other sessions across the fleet. This command is already on your PATH:",
             "  cc-devthrottle actions --json        list agent-discoverable DevThrottle actions",
             "  cc-devthrottle session list          list every session in the fleet",
@@ -47,7 +66,7 @@ public static class FleetPreamble
             "Every message you send interrupts the receiving agent. 'message send all' reaches only your own",
             "team, which is what you want. Do NOT try to reach the WHOLE fleet ('--everyone') - it freezes",
             "every session on every machine and repo; the Gateway Hub refuses it without a human grant (issue #1229).",
-        };
+        });
 
         return string.Join("\n", lines);
     }

--- a/src/CcDirector.Core/Sessions/SessionManager.cs
+++ b/src/CcDirector.Core/Sessions/SessionManager.cs
@@ -74,6 +74,14 @@ public sealed class SessionManager : IDisposable
     public string? DirectorId { get; set; }
 
     /// <summary>
+    /// Issue #1357: returns the signed-in DevThrottle user (email + nickname) to name in a Pi session's
+    /// launch-time preamble, or null when no one is signed in. Set by ControlApiHost.StartAsync to read
+    /// the host's cached snapshot SYNCHRONOUSLY (no network) so session creation never blocks. Null
+    /// (tests, no host wiring) omits the user-identity line, exactly as when nobody is signed in.
+    /// </summary>
+    public Func<Account.SignedInUser?>? SignedInUserAccessor { get; set; }
+
+    /// <summary>
     /// Fired immediately after a session is added to the manager's internal dictionary,
     /// for EVERY session - whether created via the Avalonia UI, the web Control API,
     /// or restored from persistence at startup. Handlers must be idempotent: the
@@ -578,8 +586,11 @@ public sealed class SessionManager : IDisposable
                     session.CustomName,
                     SessionName.FolderName(repoPath),
                     SessionName.Disambiguator(id));
+                // Issue #1357: name the signed-in user in Pi's preamble too, read synchronously from the
+                // host's cached snapshot (no network) so launch never blocks; null omits the line.
+                var signedInUser = SignedInUserAccessor?.Invoke();
                 var preambleFile = CcDirector.Core.Pi.PiPreambleWriter.WriteForSession(
-                    id.ToString(), piName, Environment.MachineName, repoPath);
+                    id.ToString(), piName, Environment.MachineName, repoPath, signedInUser);
                 args = $"{args} --append-system-prompt \"{preambleFile}\"".Trim();
                 _log?.Invoke("Wrote Pi fleet preamble and passed it via --append-system-prompt.");
             }

--- a/src/CcDirector.Gateway.Contracts/AccountStatusDto.cs
+++ b/src/CcDirector.Gateway.Contracts/AccountStatusDto.cs
@@ -21,4 +21,11 @@ public sealed class AccountStatusDto
 
     /// <summary>The authentication provider, or null when not signed in / unavailable.</summary>
     public string? Provider { get; set; }
+
+    /// <summary>
+    /// The signed-in user's chosen account nickname (issue #1357), or null when not signed in, when the
+    /// user has not set one, or when it could not be resolved. Present so a session preamble can name the
+    /// human by their nickname; consumers fall back to <see cref="Email"/> when this is null.
+    /// </summary>
+    public string? Nickname { get; set; }
 }

--- a/src/CcDirector.Gateway.Tests/Account/AccountStatusEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/Account/AccountStatusEndpointTests.cs
@@ -77,7 +77,7 @@ public sealed class AccountStatusEndpointTests
     /// <see cref="AuthMiddleware"/> the real Gateway uses is applied, so the 401 path is exercised
     /// against the production gate, not a stand-in.
     /// </summary>
-    private static async Task<(WebApplication app, HttpClient http)> StartAsync(DevThrottleAccountService? account, bool authEnabled)
+    private static async Task<(WebApplication app, HttpClient http)> StartAsync(DevThrottleAccountService? account, bool authEnabled, AccountNicknameClient? nickname = null)
     {
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
@@ -90,7 +90,7 @@ public sealed class AccountStatusEndpointTests
             app.Use(async (ctx, next) => await AuthMiddleware.Run(ctx, requireToken, next));
         }
 
-        AccountStatusEndpoint.Map(app, account);
+        AccountStatusEndpoint.Map(app, account, nickname);
         await app.StartAsync();
 
         var baseUrl = app.Urls.First();
@@ -131,6 +131,72 @@ public sealed class AccountStatusEndpointTests
             http.Dispose();
             await app.DisposeAsync();
         }
+    }
+
+    // Issue #1357: when a nickname client is wired and the signed-in account has a nickname, the status
+    // response carries it (resolved via the cloud client, cached). The token is never in the body.
+    [Fact]
+    public async Task SignedIn_WithNicknameClient_Returns200_WithNickname()
+    {
+        var jwt = GatewayTestJwt.CreateWithIdentity(DateTime.UtcNow.AddHours(1), "star@example.com", "google");
+        var account = MakeAccount(new DevThrottleTokens(jwt, "refresh-1"));
+        var nickname = new AccountNicknameClient(
+            new HttpClient(new StubNicknameHandler("{\"data\":{\"nickname\":\"Starlord\"}}")), baseUrl: "https://example.test");
+
+        var (app, http) = await StartAsync(account, authEnabled: false, nickname: nickname);
+        try
+        {
+            var resp = await http.GetAsync("/account/status");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+            var body = await resp.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+
+            Assert.True(root.GetProperty("signedIn").GetBoolean());
+            Assert.Equal("star@example.com", root.GetProperty("email").GetString());
+            Assert.Equal("Starlord", root.GetProperty("nickname").GetString());
+            Assert.DoesNotContain(jwt, body, StringComparison.Ordinal);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    // Issue #1357: no nickname client wired -> the response simply omits nickname (identity path unchanged).
+    [Fact]
+    public async Task SignedIn_NoNicknameClient_OmitsNickname()
+    {
+        var jwt = GatewayTestJwt.CreateWithIdentity(DateTime.UtcNow.AddHours(1), "star@example.com", "google");
+        var account = MakeAccount(new DevThrottleTokens(jwt, "refresh-1"));
+
+        var (app, http) = await StartAsync(account, authEnabled: false);
+        try
+        {
+            var resp = await http.GetAsync("/account/status");
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            Assert.True(doc.RootElement.GetProperty("signedIn").GetBoolean());
+            Assert.False(doc.RootElement.TryGetProperty("nickname", out _), "nickname omitted when no client is wired");
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    /// <summary>Returns a fixed body for the cloud nickname endpoint so no real network call is made.</summary>
+    private sealed class StubNicknameHandler : HttpMessageHandler
+    {
+        private readonly string _body;
+        public StubNicknameHandler(string body) { _body = body; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new System.Net.Http.StringContent(_body, System.Text.Encoding.UTF8, "application/json"),
+            });
     }
 
     // Acceptance criterion 2: no stored credential -> 200, signedIn:false, and NO identity fields present.

--- a/src/CcDirector.Gateway.Tests/FleetPreambleEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetPreambleEndpointTests.cs
@@ -1,0 +1,125 @@
+using System.Net;
+using CcDirector.ControlApi;
+using CcDirector.Core.Account;
+using CcDirector.Core.Backends;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Memory;
+using CcDirector.Core.Sessions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1357: HTTP-level proof of the Director's <c>GET /sessions/{sid}/fleet-preamble</c> endpoint.
+/// It maps the real <see cref="ControlEndpoints"/> over a minimal Kestrel host with an adopted idle
+/// session and a stub signed-in-user resolver, then reads the preamble over the wire - proving the
+/// resolver is wired into the endpoint and the identity line appears (or is omitted) exactly as built.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class FleetPreambleEndpointTests
+{
+    private static Session MakeIdleSession()
+    {
+        var session = new Session(
+            Guid.NewGuid(),
+            repoPath: @"C:\test\preamble-endpoint-test",
+            workingDirectory: @"C:\test\preamble-endpoint-test",
+            claudeArgs: null,
+            backend: new StubBackend(),
+            claudeSessionId: null,
+            activityState: ActivityState.Idle,
+            createdAt: DateTimeOffset.UtcNow,
+            customName: "preamble-endpoint-test",
+            customColor: null);
+        session.MarkRunning();
+        return session;
+    }
+
+    private static async Task<(WebApplication app, HttpClient http, Guid sessionId)> StartAsync(
+        Func<CancellationToken, Task<SignedInUser?>>? resolver)
+    {
+        var sm = new SessionManager(new AgentOptions());
+        var session = MakeIdleSession();
+        sm.AdoptSession(session);
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        ControlEndpoints.Map(app, sm, "dir-preamble-test", "1.0.0-test", () => Task.CompletedTask,
+            signedInUserResolver: resolver);
+        await app.StartAsync();
+
+        var http = new HttpClient { BaseAddress = new Uri(app.Urls.First()) };
+        return (app, http, session.Id);
+    }
+
+    [Fact]
+    public async Task Preamble_WithSignedInUser_ContainsIdentityLine()
+    {
+        var (app, http, sid) = await StartAsync(
+            _ => Task.FromResult<SignedInUser?>(new SignedInUser("star@example.com", "Starlord")));
+        try
+        {
+            var resp = await http.GetAsync($"/sessions/{sid}/fleet-preamble");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+            var text = await resp.Content.ReadAsStringAsync();
+            Assert.Contains("The user of this session is Starlord (star@example.com).", text);
+            Assert.Contains("do not guess identity from usage or the database", text);
+            // The base preamble is still present.
+            Assert.Contains("cc-devthrottle", text);
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Preamble_NoResolver_OmitsIdentityLine()
+    {
+        var (app, http, sid) = await StartAsync(resolver: null);
+        try
+        {
+            var resp = await http.GetAsync($"/sessions/{sid}/fleet-preamble");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+            var text = await resp.Content.ReadAsStringAsync();
+            Assert.DoesNotContain("The user of this session is", text);
+            Assert.Contains("cc-devthrottle", text); // base preamble intact
+        }
+        finally
+        {
+            http.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+
+    private sealed class StubBackend : ISessionBackend
+    {
+        public int ProcessId => 1;
+        public string Status => "Stub";
+        public bool IsRunning => true;
+        public bool HasExited => false;
+        public CircularTerminalBuffer? Buffer => null;
+
+#pragma warning disable CS0067
+        public event Action<string>? StatusChanged;
+        public event Action<int>? ProcessExited;
+#pragma warning restore CS0067
+
+        public void Start(string executable, string args, string workingDir, short cols, short rows,
+            Dictionary<string, string>? environmentVars = null) { }
+        public void Write(byte[] data) { }
+        public Task SendTextAsync(string text) => Task.CompletedTask;
+        public Task SendEnterAsync() => Task.CompletedTask;
+        public void Resize(short cols, short rows) { }
+        public Task GracefulShutdownAsync(int timeoutMs = 5000) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+}

--- a/src/CcDirector.Gateway/Api/AccountStatusEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AccountStatusEndpoint.cs
@@ -8,18 +8,21 @@ namespace CcDirector.Gateway.Api;
 
 /// <summary>
 /// Gateway Centralization Phase 2 (issue #638): the read-only <c>GET /account/status</c> endpoint that
-/// answers "is the Gateway signed in to DevThrottle, and as whom?". The answer is computed ENTIRELY
-/// LOCALLY from the Gateway-hosted credential service (issue #636, the reused
-/// <see cref="DevThrottleAccountService"/> exposed as <c>GatewayHost.Account</c>) - there is NO cloud or
-/// network call. A Director's future startup gate (a separate issue) reads this to decide whether its
-/// Gateway is signed in.
+/// answers "is the Gateway signed in to DevThrottle, and as whom?". The signed-in boolean and the
+/// email/provider identity are computed ENTIRELY LOCALLY from the Gateway-hosted credential service
+/// (issue #636, the reused <see cref="DevThrottleAccountService"/> exposed as <c>GatewayHost.Account</c>)
+/// - no cloud call on that path. A Director's startup gate (issue #651) reads this. Issue #1357 adds the
+/// user's chosen <c>nickname</c>, which DOES require a cloud read (the nickname lives server-side); that
+/// read is best-effort and cached per account (see <c>NicknameCacheTtl</c>), so this hard-polled endpoint
+/// hits the cloud at most once per TTL and a nickname failure never breaks the status read.
 ///
 /// Wire contract: the response body is
-/// <c>{ "signedIn": bool, "email"?: string, "provider"?: string }</c>. When the Gateway holds a valid
-/// credential, <c>signedIn</c> is true and the <c>email</c>/<c>provider</c> identity fields are present
-/// (the same two values <see cref="JwtIdentityReader"/> extracts, surfaced through
-/// <see cref="DevThrottleAccountService.GetIdentity"/>). When the Gateway holds no credential,
-/// <c>signedIn</c> is false and the identity fields are OMITTED - never present, never fabricated.
+/// <c>{ "signedIn": bool, "email"?: string, "provider"?: string, "nickname"?: string }</c>. When the
+/// Gateway holds a valid credential, <c>signedIn</c> is true and the <c>email</c>/<c>provider</c> identity
+/// fields are present (the same two values <see cref="JwtIdentityReader"/> extracts, surfaced through
+/// <see cref="DevThrottleAccountService.GetIdentity"/>); <c>nickname</c> is present only when the account
+/// has one set and it resolved. When the Gateway holds no credential, <c>signedIn</c> is false and the
+/// identity fields are OMITTED - never present, never fabricated.
 ///
 /// Security (carries DT-05 from #636): the response NEVER includes the access or refresh token - only
 /// the boolean and the identity. The tokens are never written to the log on any path either; the log
@@ -41,9 +44,19 @@ internal static class AccountStatusEndpoint
     /// credential service (a non-Windows host, where the operating-system credential store is not yet
     /// implemented); the endpoint then truthfully reports not-signed-in.
     /// </param>
-    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account)
+    /// <param name="nickname">
+    /// The cloud nickname client (issue #1357), used to resolve the signed-in user's chosen nickname for
+    /// the session preamble. Null disables nickname resolution (the response then omits it); the identity
+    /// email/provider path is unchanged and stays entirely local. Resolution is cached per account so the
+    /// hard-polled status read makes at most one cloud call per <see cref="NicknameCacheTtl"/>.
+    /// </param>
+    public static void Map(IEndpointRouteBuilder app, DevThrottleAccountService? account, AccountNicknameClient? nickname = null)
     {
-        app.MapGet("/account/status", () =>
+        // Per-account nickname cache so this hard-polled endpoint hits the cloud at most once per TTL.
+        // Captured in the closure (Map runs once per host) and guarded by its own lock.
+        var cache = new NicknameCache();
+
+        app.MapGet("/account/status", async (HttpContext ctx) =>
         {
             // No credential service on this host (a non-Windows host where the operating-system
             // credential store is not yet implemented): the Gateway holds no account credential, so the
@@ -51,7 +64,7 @@ internal static class AccountStatusEndpoint
             if (account is null)
             {
                 FileLog.Write("[AccountStatusEndpoint] GET /account/status: no credential service on this host -> signedIn=false");
-                return Results.Json(new AccountStatusResponse(false, null, null));
+                return Results.Json(new AccountStatusResponse(false, null, null, null));
             }
 
             // Both reads are entirely local (no network call): IsLoggedIn validates the cached token's
@@ -60,15 +73,80 @@ internal static class AccountStatusEndpoint
             if (!signedIn)
             {
                 FileLog.Write("[AccountStatusEndpoint] GET /account/status: signedIn=false (no valid credential)");
-                return Results.Json(new AccountStatusResponse(false, null, null));
+                return Results.Json(new AccountStatusResponse(false, null, null, null));
             }
 
             var identity = account.GetIdentity();
+            var resolvedNickname = await ResolveNicknameAsync(account, nickname, cache, ctx.RequestAborted).ConfigureAwait(false);
             // The identity is only logged as resolved / unavailable - the email itself is user identity,
             // not a token, but we keep the log minimal and never log any credential material.
-            FileLog.Write($"[AccountStatusEndpoint] GET /account/status: signedIn=true (identity {(identity is null ? "unavailable" : "resolved")})");
-            return Results.Json(new AccountStatusResponse(true, identity?.Email, identity?.Provider));
+            FileLog.Write($"[AccountStatusEndpoint] GET /account/status: signedIn=true (identity {(identity is null ? "unavailable" : "resolved")}, nickname {(resolvedNickname is null ? "unset" : "resolved")})");
+            return Results.Json(new AccountStatusResponse(true, identity?.Email, identity?.Provider, resolvedNickname));
         });
+    }
+
+    /// <summary>How long a resolved nickname is reused before the next status read re-reads the cloud.</summary>
+    private static readonly TimeSpan NicknameCacheTtl = TimeSpan.FromMinutes(15);
+
+    /// <summary>Per-account nickname cache, one instance per mapped endpoint (captured in the closure).</summary>
+    private sealed class NicknameCache
+    {
+        public readonly object Gate = new();
+        public string? Subject;
+        public string? Nickname;
+        public DateTime AtUtc = DateTime.MinValue;
+    }
+
+    /// <summary>
+    /// Resolves the signed-in account's nickname, serving a fresh per-account cached value without a
+    /// cloud call and reading the cloud (once) only on a cold or stale cache or when the account changed.
+    /// Returns null when nickname resolution is disabled (no client), when there is no forwarding token,
+    /// when the account has no nickname set, or when the cloud call fails - in every one of those cases
+    /// the caller falls back to the email, so a nickname problem never breaks the status read.
+    /// </summary>
+    private static async Task<string?> ResolveNicknameAsync(
+        DevThrottleAccountService account,
+        AccountNicknameClient? nickname,
+        NicknameCache cache,
+        CancellationToken ct)
+    {
+        if (nickname is null)
+            return null;
+
+        var subject = account.GetAccountSubject();
+        if (string.IsNullOrEmpty(subject))
+            return null;
+
+        lock (cache.Gate)
+        {
+            if (cache.Subject == subject && DateTime.UtcNow - cache.AtUtc < NicknameCacheTtl)
+                return cache.Nickname;
+        }
+
+        var token = account.GetAccessTokenForForwarding();
+        if (string.IsNullOrEmpty(token))
+            return null;
+
+        string? resolved;
+        try
+        {
+            resolved = await nickname.GetNicknameAsync(token, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // A nickname read is best-effort context, never a gate: a cloud failure logs and yields null
+            // (the preamble falls back to the email). We do NOT cache a failure, so the next read retries.
+            FileLog.Write($"[AccountStatusEndpoint] nickname resolve failed (falling back to email): {ex.Message}");
+            return null;
+        }
+
+        lock (cache.Gate)
+        {
+            cache.Subject = subject;
+            cache.Nickname = resolved;
+            cache.AtUtc = DateTime.UtcNow;
+        }
+        return resolved;
     }
 
     /// <summary>
@@ -81,6 +159,7 @@ internal static class AccountStatusEndpoint
     /// <param name="SignedIn">Whether the Gateway holds a valid DevThrottle credential.</param>
     /// <param name="Email">The signed-in user's email, or null (omitted) when not signed in / unavailable.</param>
     /// <param name="Provider">The authentication provider, or null (omitted) when not signed in / unavailable.</param>
+    /// <param name="Nickname">The chosen account nickname (issue #1357), or null (omitted) when not signed in / unset / unresolved.</param>
     private sealed record AccountStatusResponse(
         [property: System.Text.Json.Serialization.JsonPropertyName("signedIn")]
         bool SignedIn,
@@ -89,5 +168,8 @@ internal static class AccountStatusEndpoint
         string? Email,
         [property: System.Text.Json.Serialization.JsonPropertyName("provider")]
         [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
-        string? Provider);
+        string? Provider,
+        [property: System.Text.Json.Serialization.JsonPropertyName("nickname")]
+        [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        string? Nickname);
 }

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1207,8 +1207,10 @@ public sealed class GatewayHost : IAsyncDisposable
         // carries only the boolean + identity, never the access/refresh token (security rule DT-05).
         // Inherits the host-wide token middleware above (the existing gateway.token convention). On a
         // host with no credential service (a non-Windows host, Account null) it truthfully reports
-        // not-signed-in.
-        AccountStatusEndpoint.Map(_app, Account);
+        // not-signed-in. Issue #1357: it also resolves the signed-in user's chosen nickname (cached,
+        // best-effort) through the cloud nickname client, so a session's preamble can name the human;
+        // the identity email/provider path stays entirely local.
+        AccountStatusEndpoint.Map(_app, Account, new Core.Account.AccountNicknameClient(new HttpClient { Timeout = TimeSpan.FromSeconds(10) }));
 
         // Gateway Centralization Phase 3 (issue #648): POST /account/logout CLEARS the Gateway-hosted
         // DevThrottle credential through the same reused DevThrottleAccountService (Account). The account


### PR DESCRIPTION
Closes #1357.

## Problem
The session-start fleet preamble told the agent which **session / machine / repo** it is, but never **who the human is**. So "email me", "my account", "talk about me" fell back to guessing (searching the database by name, picking an account by login count). It should just *know*.

## What changed
- **Preamble names the user.** `FleetPreamble.Build` takes an optional signed-in user and emits: `The user of this session is <nickname or email> (<email>). Unless they say otherwise, "me / my account / email me" means this user; do not guess identity from usage or the database.` The line is omitted cleanly when no one is signed in (no blank line, no "null").
- **Nickname.** New `SignedInUser` type. `AccountNicknameClient` reads `GET /api/v1/account/nickname` (mirrors `AccountCreditsClient`) and falls back to the email when unset. The Gateway resolves it best-effort and cached per account, and surfaces it on `GET /account/status` next to email/provider.
- **Director side.** The account credential lives on the Gateway (issue #651), so the Director reads the identity from the Gateway through `SignedInUserProvider` (short-lived cache; a synchronous last-known snapshot for the non-blocking Pi launch path). Wired into both preamble callers named in the issue: the `GET /sessions/{sid}/fleet-preamble` endpoint (Claude/Codex) and `PiPreambleWriter` (Pi).
- **Skill.** The `dev-throttle` skill gains a short "Who the user is" note stating the same rule (reinforcement; the preamble is the always-on primary).

## Acceptance criteria
- [x] A fresh session's preamble contains a user-identity line with the signed-in email.
- [x] Nickname shown when set (e.g. "Starlord"); email shown when unset.
- [x] The `dev-throttle` skill states the "this is the user unless they say otherwise" rule.
- [x] With no user signed in, the preamble renders without the line (no blank/"null" artifact).

## Proof
- Unit: preamble line/omit/ASCII, Pi writer, `AccountNicknameClient` parse (both `{data:{nickname}}` and top-level shapes) + HTTP + bearer, `SignedInUserProvider` map/cache/snapshot, `GatewayAccountStatusClient` nickname.
- Integration (real Kestrel): `GET /account/status` returns the nickname via a stubbed cloud client and still carries no token; the Director `GET /sessions/{sid}/fleet-preamble` endpoint returns the identity line with a signed-in user and omits it without one.
- Builds clean (0 warnings/0 errors) across Core, Contracts, Gateway, ControlApi, and the Avalonia desktop app. New/changed tests all pass; the touched Director endpoint suites (ControlApiHost, DirectorSurface, CockpitParity, FleetMessaging, StreamCommand = 78) stay green.

Reference: the nickname column + `GET/PATCH /api/v1/account/nickname` shipped in `devthrottle_internal` PR #341; `/auth/me` also returns it. This is the consumer side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)