### PR TITLE
docs(mac): running a Mac unattended - the never-lock setup guide, script, and security tradeoffs

### DIFF
--- a/docs/public/getting-started/05-running-on-mac-unattended.md
+++ b/docs/public/getting-started/05-running-on-mac-unattended.md
@@ -1,0 +1,137 @@
+# Running DevThrottle on a Mac Unattended
+
+A Mac mini makes a great always-on fleet machine -- but macOS ships tuned for a person sitting in front of it, not for an agent host nobody touches for weeks. This page is the checklist that turns a Mac into an unattended DevThrottle Workstation: what to change, the exact commands, and the tradeoffs stated plainly. It assumes DevThrottle is already installed ([Installation](installation.md)) and the machine is reachable over Tailscale ([Multi-Machine Setup](installation.md#multi-machine-setup-remote-access)).
+
+> **The one rule that matters:** never let the screen lock. Turn the display off instead. Everything else on this page is detail.
+
+## Why the screen lock is the enemy
+
+macOS cannot launch a new graphical application while the screen is locked. When the lock engages, the login window takes ownership of the displays. Your session keeps running -- applications that are already open keep working, and background processes are unaffected -- but any **new** graphical launch cannot bind display resources at startup and fails. The Director is a graphical application, so on a locked Mac the fleet cannot start new Directors, and the Director itself cannot be restarted after an update or crash until a human unlocks the screen.
+
+This is architectural, not a bug, and there is no setting, entitlement, or launchd trick that gets around it. We proved it on our own hardware (a Director launched into a locked session dies instantly with a render-timer error, even from a launch agent placed directly in the graphical user domain), and it matches what Apple's own engineers say on the developer forums: the only third-party code that can put an interface on the lock screen is an authorization plug-in that replaces login screens -- there is no mechanism for launching an application behind the lock. Windows is genuinely different by design: locking a Windows machine just switches which desktop is visible, while the session and its window objects stay fully active underneath -- new processes can still create windows there. That is why CC Director on Windows launches sessions on locked machines without any special setup, and no equivalent exists on macOS.
+
+The industry already solved this. Every commercial Mac build farm -- GitHub's hosted macOS runners, Cirrus Labs images, Buildkite's Amazon EC2 Mac guide, GitLab's MacStadium images -- ships the identical configuration: automatic login, screen lock disabled, screen saver disabled, system sleep disabled, FileVault off. The display may sleep; the session never locks. That is exactly the configuration below.
+
+## The security tradeoff, stated plainly
+
+After this setup, the machine logs itself in at boot, never locks, and its disk is not encrypted. **Anyone with physical access owns the machine and everything on it.** This is the right trade for a Mac in a locked home or office that only you can touch. It is the wrong trade for a laptop, a shared space, or anywhere the hardware could walk away. Compensating controls that still work: keep the machine reachable only over Tailscale, keep Screen Sharing and Remote Login password-protected, and remember that Find My can remotely lock a stolen machine after the fact.
+
+## The checklist
+
+Everything scriptable is collected in `scripts/mac-unattended-setup.sh` in the repository -- it shows current values and asks per section. The same steps, in order, for doing it by hand:
+
+### 1. Turn FileVault off
+
+Automatic login does not exist while FileVault is on: the encrypted disk needs a typed password before macOS can even start. Decryption runs in the background; the machine stays usable.
+
+    sudo fdesetup disable
+
+*System Settings path:* Privacy & Security > FileVault.
+*Tradeoff:* the disk is readable if the hardware is stolen. If that risk is unacceptable, keep FileVault on and accept that every reboot needs a person (for a planned reboot, `sudo fdesetup authrestart` skips the unlock screen exactly once -- it does not help with power failures).
+
+### 2. Enable automatic login
+
+Every restart -- planned, power failure, or crash -- lands on the logged-in desktop where the Director can start.
+
+    sudo sysadminctl -autologin set -userName <user> -password -
+
+*System Settings path:* Users & Groups > Automatically log in as.
+*Tradeoff:* the account password is stored obfuscated (not encrypted) in `/etc/kcpassword`.
+
+### 3. Set "require password after sleep or screen saver" to Never
+
+This is the setting that actually prevents locking. With it off, the display turning off no longer locks the session, and new graphical launches keep working around the clock.
+
+    sysadminctl -screenLock off -password -
+
+*System Settings path:* Lock Screen > "Require password after screen saver begins or display is turned off" > Never.
+*Gotcha:* if the control is grayed out, open the iPhone Mirroring app and set it to "Ask every time" first.
+*Note:* the old `defaults write com.apple.screensaver askForPassword 0` trick stopped working around macOS 13 -- `sysadminctl` is the supported command, and it requires the account password by design.
+
+### 4. Disable the screen saver
+
+    defaults -currentHost write com.apple.screensaver idleTime -int 0
+    sudo defaults write /Library/Preferences/com.apple.screensaver loginWindowIdleTime -int 0
+
+*System Settings path:* Lock Screen > "Start Screen Saver when inactive" > Never.
+
+### 5. Power settings: never sleep the machine, let the display sleep
+
+    sudo pmset -a sleep 0            # the machine never sleeps
+    sudo pmset -a disksleep 0        # disks never spin down
+    sudo pmset -a displaysleep 10    # the display MAY turn off -- harmless once the lock is off
+    sudo pmset -a womp 1             # wake on network access
+    sudo pmset -a autorestart 1      # start up again after a power failure
+
+*System Settings path:* Energy.
+*Gotcha:* some Apple Silicon minis honor "start up after power failure" inconsistently after a hard power cut. Test yours (pull the plug); if it fails, a smart plug that cycles power is the community workaround.
+
+### 6. Software updates: security automatic, reboots manual
+
+Keep the invisible security pieces automatic, but stop macOS from installing full operating-system updates on its own -- those reboot the machine and kill every running session.
+
+    sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -bool true
+    sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticDownload -bool true
+    sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -bool true
+    sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall -bool true
+    sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticallyInstallMacOSUpdates -bool false
+
+Then install operating-system updates yourself, on your schedule: `sudo softwareupdate -ia` during a maintenance window.
+*Tradeoff:* you own the patch schedule now -- put a recurring reminder somewhere.
+
+### 7. Quiet-machine settings
+
+    defaults write com.apple.CrashReporter DialogType none                # no crash dialogs (crashes still logged)
+    defaults write NSGlobalDomain NSAppSleepDisabled -bool YES            # no App Nap throttling of background apps
+    sudo defaults write /Library/Preferences/com.apple.TimeMachine DoNotOfferNewDisksForBackup -bool true
+
+### 8. Enable Remote Login for recovery
+
+When the graphical session is unreachable, `ssh` over Tailscale is how you fix the machine without walking to it. Screen Sharing is the second door -- keep both.
+
+    sudo systemsetup -setremotelogin on
+
+### 9. Privacy permissions: the one-time clicks
+
+The high-value privacy permissions live in a database protected by System Integrity Protection. **No script, no command line, no setting can grant them** on a normal machine -- only a human clicking in System Settings (or mobile device management on a supervised fleet). The good news: a grant is inherited by every process the granted application launches, so granting the Director covers all the agent processes it spawns. Grant once, done forever -- with one caveat: the grant is tied to the application's code signature, so it sticks for the installed app but a rebuilt ad-hoc-signed test slot counts as a new application.
+
+| Permission | Grant it to | Needed for |
+|------------|-------------|------------|
+| Full Disk Access | CC Director (and your terminal, if you launch Directors from one) | agents reading anywhere on disk without per-folder prompts |
+| Screen Recording | CC Director | the screenshot features |
+| Automation | approve prompts as they appear | controlling other applications |
+
+*System Settings path:* Privacy & Security > (each category) > add the app with the + button.
+
+### What you do NOT need to change
+
+- **Gatekeeper** -- locally built binaries never get the quarantine flag, so Gatekeeper never prompts for them. Leave Gatekeeper on; do not use `spctl --global-disable`.
+- **The application firewall** -- if it is off, there are no "accept incoming connections?" prompts. If you turn it on, know that ad-hoc-signed binaries get a fresh signature every rebuild, so each rebuild re-prompts; the fix is signing test builds with a stable self-signed certificate, or scripting `socketfilterfw --add --unblockapp` into the build.
+- **Notifications** -- banners never block a background process; they only matter to a person looking at the screen.
+
+## Verify the setup
+
+1. Restart the Mac. It must land on the desktop with nobody touching it.
+2. Turn the display off (`pmset displaysleepnow`), wait a minute, then start a new session on this machine from the fleet. It must launch cleanly.
+3. Pull the power cord for ten seconds. The Mac should boot itself back to the desktop.
+4. From another machine: `ssh` works and Screen Sharing connects, both over Tailscale.
+
+## How the rest of the community handles this
+
+You are not alone in this configuration -- it is what everyone running unattended Macs converges on:
+
+- **Mac build farms** (GitHub's hosted macOS runners, Cirrus Labs images, GitLab's MacStadium images, Buildkite's Amazon EC2 Mac guide) all ship automatic login with the lock, screen saver, and sleep disabled. Their provisioning scripts run the same commands listed above.
+- **The OpenClaw community** -- thousands of people hosting the open-source agent on dedicated Mac minis -- independently arrived at the identical recipe: automatic login, sleep off, lock and screen saver set to Never, "start up after power failure" on, and the FileVault tradeoff documented just as bluntly as here. Their guides add one more trick for Macs with no monitor: an HDMI dummy plug, because macOS graphical rendering and screen capture misbehave with no display attached at all. If your Mac mini has no monitor, buy the dummy plug.
+
+Browsers deserve a special note, because agents drive them constantly:
+
+- **Headless browsers are immune.** Headless Chromium (Playwright, Puppeteer) never talks to the display, so it launches and runs fine regardless of lock state or missing monitors. OpenClaw's browser tool falls back to headless with a structured error when no display is available.
+- **Headed browsers degrade rather than crash.** A visible Chrome window on a locked or backgrounded Mac gets its rendering and timers throttled -- automation pauses and resumes on unlock. Browser-automation people work around it with launch flags (`--disable-background-timer-throttling --disable-renderer-backgrounding`), but on a never-locked machine the problem does not arise.
+- **Attaching to an already-running browser keeps working while locked**, because the remote-debugging protocol is a plain network interface and its screenshots come from the browser's own compositor, not the physical screen. This matches the general rule: existing graphical processes survive a lock; only new display-bound launches fail.
+- There is **no virtual-display server for macOS** the way Linux has one for X11 -- a dummy plug or virtual-display utility is the closest substitute, and neither bypasses the lock screen.
+
+## Next Steps
+
+- [Installation](installation.md) -- installing DevThrottle on macOS
+- [Multi-Machine Setup](installation.md#multi-machine-setup-remote-access) -- joining the fleet over Tailscale
+- [Quick Start](quick-start.md) -- your first session

--- a/docs/public/index.json
+++ b/docs/public/index.json
@@ -16,7 +16,8 @@
         { "id": "introduction", "title": "Introduction", "file": "getting-started/01-introduction.md" },
         { "id": "installation", "title": "Installation", "file": "getting-started/02-installation.md" },
         { "id": "setup-wizard", "title": "Setup Wizard Walkthrough", "file": "getting-started/04-setup-wizard-walkthrough.md" },
-        { "id": "quick-start", "title": "Quick Start", "file": "getting-started/03-quick-start.md" }
+        { "id": "quick-start", "title": "Quick Start", "file": "getting-started/03-quick-start.md" },
+        { "id": "mac-unattended", "title": "Running DevThrottle on a Mac Unattended", "file": "getting-started/05-running-on-mac-unattended.md" }
       ]
     },
     {

--- a/scripts/mac-unattended-setup.sh
+++ b/scripts/mac-unattended-setup.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+#
+# mac-unattended-setup.sh — Configure a Mac mini as an unattended DevThrottle fleet machine.
+#
+# WHY THIS SCRIPT EXISTS
+#   macOS cannot launch a NEW graphical application while the screen is locked. The session
+#   keeps running, but the login window owns the displays, and any app that needs a
+#   display link at startup (our Avalonia Director does) dies immediately — we measured
+#   "RenderTimer error -6661" (a CoreVideo "invalid argument" from display-link creation),
+#   even when launched through a launchd agent in the graphical user domain. Every Mac
+#   build farm in the industry (GitHub's hosted runners, Cirrus Labs images, Buildkite,
+#   Amazon EC2 Mac) solves this the same way: never let the machine lock. The display is
+#   allowed to turn off — that is harmless — but the session stays logged in and unlocked.
+#
+# WHAT THIS SCRIPT DOES (each section asks before changing anything)
+#   1. Turn FileVault off                  (required for automatic login; decrypts in background)
+#   2. Enable automatic login              (machine boots straight to the desktop after any restart)
+#   3. Never require a password after sleep or screen saver  (the "do not lock" setting)
+#   4. Never start the screen saver        (both in-session and at the login window)
+#   5. Power settings                      (never system-sleep, display may sleep, restart after power failure)
+#   6. Software updates                    (keep security data automatic, stop surprise operating-system reboots)
+#   7. Quiet-machine settings              (no crash dialogs, no App Nap throttling, no Time Machine disk prompts)
+#   8. Enable Remote Login (ssh)           (recovery path when the graphical session is unreachable)
+#
+# WHAT IT CANNOT DO (one-time clicks in System Settings, listed again at the end)
+#   - Grant Full Disk Access / Screen Recording / Accessibility. Those live in the
+#     System-Integrity-Protection-protected privacy database and can only be granted by a
+#     human in System Settings (or by mobile device management on a supervised machine).
+#
+# SECURITY TRADEOFF, STATED PLAINLY
+#   After this script the disk is unencrypted, the machine logs itself in, and the screen
+#   never locks. Anyone with physical access owns the machine and everything on it. This
+#   is the accepted posture for a fleet Mac in the owner's own house; do not use this
+#   script on a portable machine or in a shared space.
+#
+# Usage:  bash scripts/mac-unattended-setup.sh          (answers y/n per section; sudo will prompt)
+# Re-running is safe — every step is idempotent.
+#
+set -uo pipefail
+
+bold() { printf '\033[1m%s\033[0m\n' "$*"; }
+
+confirm() {
+    # confirm "question" — returns 0 on yes
+    local reply
+    read -r -p "$1 [y/N] " reply
+    [[ "$reply" == "y" || "$reply" == "Y" ]]
+}
+
+section() {
+    echo
+    bold "== $1 =="
+}
+
+FLEET_USER="${SUDO_USER:-$USER}"
+
+echo "This script configures THIS Mac as an unattended DevThrottle fleet machine."
+echo "Fleet user: $FLEET_USER"
+echo "Every section shows the current value and asks before changing it."
+echo
+
+# ---------------------------------------------------------------------------
+section "1. FileVault off (required for automatic login)"
+# ---------------------------------------------------------------------------
+fdesetup status
+if fdesetup status | grep -q "FileVault is On"; then
+    echo "FileVault must be OFF for automatic login to exist at all — macOS disables the"
+    echo "automatic-login option while the disk is encrypted, because the pre-boot unlock"
+    echo "needs a typed password. Decryption starts now and finishes in the background;"
+    echo "the machine stays usable meanwhile."
+    if confirm "Turn FileVault OFF now?"; then
+        sudo fdesetup disable
+        echo "Decryption running in the background. Check progress later with: fdesetup status"
+    fi
+else
+    echo "FileVault is already off — nothing to do."
+fi
+
+# ---------------------------------------------------------------------------
+section "2. Automatic login (boots straight to the desktop)"
+# ---------------------------------------------------------------------------
+sudo sysadminctl -autologin status 2>&1 || true
+echo "Automatic login means every restart — planned, power failure, or update — lands on"
+echo "the logged-in desktop where the Director's launch agent can start it. Without it,"
+echo "the machine parks at the login window and someone must type a password."
+echo "You will be prompted for $FLEET_USER's account password (stored obfuscated, not"
+echo "encrypted, in /etc/kcpassword — recoverable by anyone with root on this machine)."
+if confirm "Enable automatic login for $FLEET_USER?"; then
+    sudo sysadminctl -autologin set -userName "$FLEET_USER" -password -
+    sudo sysadminctl -autologin status
+fi
+
+# ---------------------------------------------------------------------------
+section "3. Never require a password after sleep or screen saver (the no-lock setting)"
+# ---------------------------------------------------------------------------
+sysadminctl -screenLock status 2>&1
+echo "This is THE setting that fixes graphical launches: with it off, the display turning"
+echo "off no longer locks the session, so new applications keep launching normally."
+echo "You will be prompted for $FLEET_USER's account password (macOS requires it to weaken"
+echo "the lock — this cannot be done silently, by design)."
+echo "Note: if System Settings shows this control grayed out, open the iPhone Mirroring"
+echo "app and set it to 'Ask every time' first — a known macOS quirk."
+if confirm "Set the screen-lock password requirement to Never?"; then
+    sysadminctl -screenLock off -password -
+    sysadminctl -screenLock status
+fi
+
+# ---------------------------------------------------------------------------
+section "4. Never start the screen saver"
+# ---------------------------------------------------------------------------
+echo "Current in-session idle time (missing key means system default):"
+defaults -currentHost read com.apple.screensaver idleTime 2>&1 || true
+echo "The screen saver serves no purpose on an unattended machine, and on a machine that"
+echo "still had locking enabled it would be a lock trigger. Belt and braces: disable it."
+if confirm "Disable the screen saver (in-session and at the login window)?"; then
+    defaults -currentHost write com.apple.screensaver idleTime -int 0
+    sudo defaults write /Library/Preferences/com.apple.screensaver loginWindowIdleTime -int 0
+    echo "Screen saver disabled."
+fi
+
+# ---------------------------------------------------------------------------
+section "5. Power settings (always-on Mac mini)"
+# ---------------------------------------------------------------------------
+pmset -g custom
+echo "Target: the machine never sleeps (sleep 0), disks never spin down (disksleep 0),"
+echo "the display is ALLOWED to turn off after 10 minutes (displaysleep 10 — harmless once"
+echo "the lock is off, and the owner prefers the panel dark), wake-on-network stays on"
+echo "(womp 1), and the machine restarts itself after a power failure (autorestart 1)."
+echo "Note: some Apple Silicon minis honor autorestart inconsistently after a hard power"
+echo "cut — the verification list at the end includes a pull-the-plug test."
+if confirm "Apply these power settings?"; then
+    sudo pmset -a sleep 0
+    sudo pmset -a disksleep 0
+    sudo pmset -a displaysleep 10
+    sudo pmset -a womp 1
+    sudo pmset -a autorestart 1
+    echo "Applied. New values:"
+    pmset -g custom
+fi
+
+# ---------------------------------------------------------------------------
+section "6. Software updates (no surprise reboots)"
+# ---------------------------------------------------------------------------
+defaults read /Library/Preferences/com.apple.SoftwareUpdate AutomaticallyInstallMacOSUpdates 2>&1 || true
+echo "Keep the invisible security pieces automatic (malware definitions, rapid security"
+echo "responses, background downloads) but STOP macOS from installing full operating-system"
+echo "updates on its own — those reboot the machine and kill every running session."
+echo "Operating-system updates then happen only when you run them during a maintenance window."
+if confirm "Apply the update policy (security automatic, operating-system installs manual)?"; then
+    sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -bool true
+    sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticDownload -bool true
+    sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate CriticalUpdateInstall -bool true
+    sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate ConfigDataInstall -bool true
+    sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticallyInstallMacOSUpdates -bool false
+    sudo defaults write /Library/Preferences/com.apple.commerce AutoUpdate -bool false
+    echo "Applied."
+fi
+
+# ---------------------------------------------------------------------------
+section "7. Quiet-machine settings"
+# ---------------------------------------------------------------------------
+echo "Three small things that otherwise interrupt an unattended machine:"
+echo "  - Crash-report dialogs pile up on screen (crashes still go to the log files)."
+echo "  - App Nap throttles applications whose windows are not frontmost."
+echo "  - Time Machine asks about every newly attached disk."
+if confirm "Apply the quiet-machine settings?"; then
+    defaults write com.apple.CrashReporter DialogType none
+    defaults write NSGlobalDomain NSAppSleepDisabled -bool YES
+    sudo defaults write /Library/Preferences/com.apple.TimeMachine DoNotOfferNewDisksForBackup -bool true
+    echo "Applied."
+fi
+
+# ---------------------------------------------------------------------------
+section "8. Remote Login (ssh) — the recovery path"
+# ---------------------------------------------------------------------------
+sudo systemsetup -getremotelogin 2>/dev/null || true
+echo "When the graphical session is wedged, ssh over Tailscale is how you fix the machine"
+echo "without walking to it. Screen Sharing is already enabled on this machine; ssh is the"
+echo "second, independent door."
+if confirm "Enable Remote Login (ssh)?"; then
+    sudo systemsetup -setremotelogin on
+    sudo systemsetup -getremotelogin
+fi
+
+# ---------------------------------------------------------------------------
+section "Done — manual steps that need System Settings clicks"
+# ---------------------------------------------------------------------------
+cat <<'EOF'
+The privacy permissions below live in a System-Integrity-Protection-protected database
+and CANNOT be granted from any script. Grant them once; they persist and are inherited
+by every process the granted application launches (so the claude processes the Director
+spawns are covered by the Director's own grant).
+
+  A. System Settings > Privacy & Security > Full Disk Access
+       add "CC Director" (and your terminal application if you run Directors from it).
+  B. System Settings > Privacy & Security > Screen Recording
+       add "CC Director" — only needed if you use the screenshot features on this Mac.
+  C. If any Automation prompt appears later ("CC Director wants to control ..."),
+       click Allow once; it is remembered per application pair.
+
+VERIFY THE SETUP (five minutes):
+  1. Restart the Mac. It should land on the desktop with nobody touching it.
+  2. Turn the display off (or run: pmset displaysleepnow), wait a minute, then launch a
+     test-slot Director remotely. It must start cleanly — no RenderTimer error.
+  3. Pull the power cord, wait ten seconds, plug it back in. The Mac should boot itself
+     and land on the desktop. (Some Apple Silicon minis fail this — if yours does, put it
+     on a smart plug or accept a manual power button press after outages.)
+  4. From another machine: ssh over Tailscale works, and Screen Sharing still connects.
+
+REBUILD NOTE for slot binaries: the slots are ad-hoc signed, so every rebuild is a "new"
+application to macOS. Locally built binaries carry no quarantine flag, so Gatekeeper never
+prompts for them — but if the application firewall is ever turned ON, each rebuild will
+re-trigger the "accept incoming connections?" prompt until the slots are signed with a
+stable self-signed certificate. The firewall is currently off, so nothing to do today.
+EOF


### PR DESCRIPTION
## What this adds

Today's research session verified that macOS cannot launch a NEW graphical application while the screen is locked - no setting or vendor mechanism changes that. The answer everyone running unattended Macs converges on: never lock the screen, let the display turn off instead.

This pull request preserves that research output in the repository:

- `docs/public/getting-started/05-running-on-mac-unattended.md` - the guide page: the limitation, the never-lock checklist, and the security tradeoffs stated plainly.
- `scripts/mac-unattended-setup.sh` - the interactive, idempotent one-visit setup script (8 sections, asks before each change, lists the manual privacy-permission clicks it cannot do).
- `docs/public/index.json` - registers the new page in the getting-started section.

The DevThrottle website documentation page (devthrottle_internal) links to `scripts/mac-unattended-setup.sh` on `main`, so that link goes live when this merges.

Tracked by issue thefrederiksen/devthrottle_internal#585 in the internal repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)