### PR TITLE
feat(stats): track fleet concurrency (live + actively-working) with hourly history

### DIFF
--- a/apps/cockpit/src/throttle/YourThrottleView.tsx
+++ b/apps/cockpit/src/throttle/YourThrottleView.tsx
@@ -87,6 +87,40 @@ export function YourThrottleView() {
         </div>
       )}
 
+      {data !== null && data.concurrency !== null && (
+        <div className="thr-section">
+          <h2>Fleet concurrency</h2>
+          <p className="thr-hint">
+            How many sessions run at once across every machine. Loaded/running is the parallel capacity in
+            flight; actively working is the subset whose agent is processing a turn this instant.
+          </p>
+          <table className="thr-table">
+            <thead>
+              <tr>
+                <th></th>
+                <th className="thr-num">Now</th>
+                <th className="thr-num">This week</th>
+                <th className="thr-num">All-time</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Loaded / running</td>
+                <td className="thr-num">{data.concurrency.live.current}</td>
+                <td className="thr-num">{data.concurrency.live.weeklyMax}</td>
+                <td className="thr-num">{data.concurrency.live.allTimeMax}</td>
+              </tr>
+              <tr>
+                <td>Actively working</td>
+                <td className="thr-num">{data.concurrency.working.current}</td>
+                <td className="thr-num">{data.concurrency.working.weeklyMax}</td>
+                <td className="thr-num">{data.concurrency.working.allTimeMax}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      )}
+
       {summary !== null && summary.hasData && (
         <>
           <div className="thr-cards">

--- a/apps/cockpit/src/throttle/throttle.css
+++ b/apps/cockpit/src/throttle/throttle.css
@@ -78,6 +78,12 @@
   font-weight: 600;
   margin: 0 0 10px;
 }
+.thr-hint {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin: 0 0 10px;
+  max-width: 600px;
+}
 .thr-table {
   width: 100%;
   border-collapse: collapse;

--- a/apps/mobile/src/pages/YourThrottle.tsx
+++ b/apps/mobile/src/pages/YourThrottle.tsx
@@ -74,6 +74,24 @@ export function YourThrottle() {
         </div>
       )}
 
+      {data !== null && data.concurrency !== null && (
+        <section className="thr-list" aria-label="Fleet concurrency">
+          <div className="thr-list-title">Fleet concurrency</div>
+          <div className="thr-row">
+            <span className="thr-row-label">Loaded / running</span>
+            <span className="thr-row-value">
+              {data.concurrency.live.current} now, {data.concurrency.live.allTimeMax} peak
+            </span>
+          </div>
+          <div className="thr-row">
+            <span className="thr-row-label">Actively working</span>
+            <span className="thr-row-value">
+              {data.concurrency.working.current} now, {data.concurrency.working.allTimeMax} peak
+            </span>
+          </div>
+        </section>
+      )}
+
       {summary !== null && summary.hasData && (
         <>
           <section className="thr-cards" aria-label="Headline shares">

--- a/packages/client-core/src/stats/statsClient.test.ts
+++ b/packages/client-core/src/stats/statsClient.test.ts
@@ -5,7 +5,7 @@ import { summarizeThrottle, formatShare, type ThrottleData } from "./statsClient
 // exercised through the app; here we lock the honest share arithmetic that both shells render.
 
 function data(buckets: ThrottleData["buckets"]): ThrottleData {
-  return { generatedAtUtc: "2026-07-11T00:00:00Z", buckets, notCaptured: [] };
+  return { generatedAtUtc: "2026-07-11T00:00:00Z", buckets, concurrency: null, notCaptured: [] };
 }
 
 describe("summarizeThrottle", () => {

--- a/packages/client-core/src/stats/statsClient.ts
+++ b/packages/client-core/src/stats/statsClient.ts
@@ -24,11 +24,34 @@ export interface ThrottleBucket {
   characters: number;
 }
 
+/** One tracked concurrency dimension (live loaded/running, or actively working). */
+export interface ConcurrencySeries {
+  /** Most recently observed count. */
+  current: number;
+  /** Highest count ever observed. */
+  allTimeMax: number;
+  /** When the all-time peak was observed (ISO 8601 UTC), or null if never. */
+  allTimeMaxAtUtc: string | null;
+  /** Highest count in the last 7 days, derived from the hourly history. */
+  weeklyMax: number;
+  /** Per-hour max history, oldest hour first (hour key "yyyy-MM-ddTHH" UTC). */
+  hourly: { hour: string; max: number }[];
+}
+
+/** Fleet concurrency: how many sessions are loaded/running at once (live) and how many are actively
+ * working at once (working). Null when the Gateway has not tracked any yet. */
+export interface ConcurrencyStats {
+  live: ConcurrencySeries;
+  working: ConcurrencySeries;
+}
+
 /** The GET /stats/data body: the fleet-wide aggregated tally plus the honesty caveats. */
 export interface ThrottleData {
   /** When the Gateway generated this snapshot (ISO 8601 UTC), or "" when absent. */
   generatedAtUtc: string;
   buckets: ThrottleBucket[];
+  /** Fleet concurrency (both series), or null when nothing tracked yet. */
+  concurrency: ConcurrencyStats | null;
   /** Plain-English caveats about what the numbers do and do not include. */
   notCaptured: string[];
 }
@@ -96,6 +119,7 @@ export async function getThrottle(signal?: AbortSignal): Promise<ThrottleData> {
   const body = (await res.json()) as {
     generatedAtUtc?: unknown;
     buckets?: unknown;
+    concurrency?: unknown;
     notCaptured?: unknown;
   } | null;
   const buckets = Array.isArray(body?.buckets) ? body!.buckets.map(normalizeBucket) : [];
@@ -105,8 +129,36 @@ export async function getThrottle(signal?: AbortSignal): Promise<ThrottleData> {
   return {
     generatedAtUtc: typeof body?.generatedAtUtc === "string" ? body.generatedAtUtc : "",
     buckets,
+    concurrency: normalizeConcurrency(body?.concurrency),
     notCaptured,
   };
+}
+
+function normalizeSeries(raw: unknown): ConcurrencySeries {
+  const s = (raw ?? {}) as Partial<Record<keyof ConcurrencySeries, unknown>>;
+  const num = (v: unknown): number => {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : 0;
+  };
+  const hourly = Array.isArray(s.hourly)
+    ? s.hourly.map((h) => {
+        const o = (h ?? {}) as { hour?: unknown; max?: unknown };
+        return { hour: String(o.hour ?? ""), max: num(o.max) };
+      })
+    : [];
+  return {
+    current: num(s.current),
+    allTimeMax: num(s.allTimeMax),
+    allTimeMaxAtUtc: typeof s.allTimeMaxAtUtc === "string" ? s.allTimeMaxAtUtc : null,
+    weeklyMax: num(s.weeklyMax),
+    hourly,
+  };
+}
+
+function normalizeConcurrency(raw: unknown): ConcurrencyStats | null {
+  if (raw === null || typeof raw !== "object") return null;
+  const c = raw as { live?: unknown; working?: unknown };
+  return { live: normalizeSeries(c.live), working: normalizeSeries(c.working) };
 }
 
 /** Derive the honest headline summary from a tally snapshot. Turn shares are over counted turns only;

--- a/src/CcDirector.Gateway.Tests/GatewaySessionConcurrencyStatsTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewaySessionConcurrencyStatsTests.cs
@@ -1,0 +1,93 @@
+using CcDirector.Gateway.Stats;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for the DevThrottle Stats fleet-concurrency tracker: both series (live + working), the
+/// all-time peak, the derived weekly max, restart durability, and hourly-history pruning.
+/// </summary>
+public sealed class GatewaySessionConcurrencyStatsTests : IDisposable
+{
+    private readonly string _path;
+
+    public GatewaySessionConcurrencyStatsTests()
+    {
+        _path = Path.Combine(Path.GetTempPath(), "cc-conc-" + Guid.NewGuid().ToString("N") + ".json");
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(_path); } catch (Exception) { /* best effort */ }
+    }
+
+    private static readonly DateTime T0 = new(2026, 7, 11, 20, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void Observe_TracksCurrentPeakAndHourly_ForBothSeries()
+    {
+        var s = new GatewaySessionConcurrencyStats(_path);
+        s.Observe(liveCount: 10, workingCount: 3, T0);
+        s.Observe(liveCount: 28, workingCount: 7, T0.AddMinutes(10));
+        s.Observe(liveCount: 20, workingCount: 5, T0.AddMinutes(20)); // lower - the peak must stand
+
+        var snap = s.Snapshot(T0.AddMinutes(21));
+        Assert.Equal(20, snap.Live.Current);
+        Assert.Equal(28, snap.Live.AllTimeMax);
+        Assert.Equal(5, snap.Working.Current);
+        Assert.Equal(7, snap.Working.AllTimeMax);
+        // A single clock hour holds that hour's max for each series.
+        Assert.Single(snap.Live.Hourly);
+        Assert.Equal("2026-07-11T20", snap.Live.Hourly[0].Hour);
+        Assert.Equal(28, snap.Live.Hourly[0].Max);
+        Assert.Equal(7, snap.Working.Hourly[0].Max);
+    }
+
+    [Fact]
+    public void Observe_CapsWorkingAtLive()
+    {
+        var s = new GatewaySessionConcurrencyStats(_path);
+        s.Observe(liveCount: 5, workingCount: 9, T0); // working can never exceed live
+        var snap = s.Snapshot(T0);
+        Assert.Equal(5, snap.Working.Current);
+        Assert.Equal(5, snap.Working.AllTimeMax);
+    }
+
+    [Fact]
+    public void WeeklyMax_IsMaxOverLast7Days_WhileAllTimeKeepsTheOlderPeak()
+    {
+        var s = new GatewaySessionConcurrencyStats(_path);
+        s.Observe(liveCount: 40, workingCount: 10, T0.AddDays(-10)); // older than a week
+        s.Observe(liveCount: 25, workingCount: 6, T0.AddDays(-2));   // within the week
+        s.Observe(liveCount: 22, workingCount: 5, T0);              // within the week
+
+        var snap = s.Snapshot(T0);
+        Assert.Equal(40, snap.Live.AllTimeMax); // all-time remembers the older peak
+        Assert.Equal(25, snap.Live.WeeklyMax);  // weekly only sees the last 7 days
+    }
+
+    [Fact]
+    public void PeaksAndHistory_SurviveRestart()
+    {
+        var a = new GatewaySessionConcurrencyStats(_path);
+        a.Observe(liveCount: 30, workingCount: 8, T0);
+
+        var b = new GatewaySessionConcurrencyStats(_path); // reload from disk
+        var snap = b.Snapshot(T0.AddMinutes(1));
+        Assert.Equal(30, snap.Live.AllTimeMax);
+        Assert.Equal(8, snap.Working.AllTimeMax);
+    }
+
+    [Fact]
+    public void OldHourlyBuckets_ArePruned_ButAllTimePeakRemains()
+    {
+        var s = new GatewaySessionConcurrencyStats(_path);
+        s.Observe(liveCount: 12, workingCount: 3, T0.AddDays(-120)); // beyond the 90-day retention
+        s.Observe(liveCount: 15, workingCount: 4, T0);              // triggers a prune at now = T0
+
+        var snap = s.Snapshot(T0);
+        Assert.Single(snap.Live.Hourly);                 // only the recent hour survives the history
+        Assert.Equal("2026-07-11T20", snap.Live.Hourly[0].Hour);
+        Assert.Equal(15, snap.Live.AllTimeMax);          // the peak is not history-derived, so it stands
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -80,7 +80,11 @@ internal static class GatewayEndpoints
         // /sessions roster (the path that carries SessionDto.InputStats whether stream mode is on or off),
         // so "Your Throttle" is fed by the same roster the fleet already reads, not only by the SignalR
         // push path (which is unmapped when stream mode is off). Null (old callers, tests) folds nothing.
-        Stats.GatewayInputStatsAggregator? inputStats = null)
+        Stats.GatewayInputStatsAggregator? inputStats = null,
+        // DevThrottle Stats: the durable fleet concurrency record. Observed from the same assembled roster
+        // (live count + actively-working count), so the peak is captured fleet-wide whether stream mode is
+        // on or off. Null (old callers, tests) records nothing.
+        Stats.GatewaySessionConcurrencyStats? concurrency = null)
     {
         // The old issue #1188 "session lock" (423 Locked on human input while a PENDING dictation record
         // existed) was removed deliberately (issue #1308). This is a single-operator tool: a collision
@@ -710,6 +714,20 @@ internal static class GatewayEndpoints
             // per-session high-water logic makes folding the full roster on every read idempotent - only a
             // genuine increase is added, so repeated /sessions polls never double-count.
             inputStats?.ObserveSnapshot(all);
+
+            // DevThrottle Stats: record fleet concurrency from the same assembled roster - how many
+            // sessions are loaded/running (live = non-exited) and how many are actively working right now
+            // (activityState = Working). Fleet-wide with no per-Director instrumentation, since the roster
+            // already sees every session on every machine. The tracker keeps only the higher value per
+            // hour, so folding on every /sessions read captures peaks without inflating anything.
+            if (concurrency is not null)
+            {
+                var liveCount = all.Count(s =>
+                    !string.Equals(s.ActivityState, "Exited", StringComparison.OrdinalIgnoreCase));
+                var workingCount = all.Count(s =>
+                    string.Equals(s.ActivityState, "Working", StringComparison.OrdinalIgnoreCase));
+                concurrency.Observe(liveCount, workingCount, DateTime.UtcNow);
+            }
 
             // Issue #1292: adopt every observed number into the fleet allocator's in-use set. This is how
             // the Gateway learns numbers it did not hand out - a number a Director assigned offline, or any

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -60,6 +60,14 @@ public sealed class GatewayHost : IAsyncDisposable
     public Stats.GatewayInputStatsAggregator InputStats { get; }
 
     /// <summary>
+    /// The durable fleet CONCURRENCY record (how many sessions run at once, and how many are actively
+    /// working at once) that the private Gateway dashboard and the agent API read. Fed from the same
+    /// assembled /sessions roster as <see cref="InputStats"/>, so it is fleet-wide with no per-Director
+    /// instrumentation - a session count is visible for every session on every machine, new build or old.
+    /// </summary>
+    public Stats.GatewaySessionConcurrencyStats SessionConcurrency { get; }
+
+    /// <summary>
     /// Issue #1215 (Cockpit plan phase 6): the last-known-good roster cache. The <c>/sessions</c>
     /// aggregation uses it so a single failed Director poll no longer drops that Director's sessions -
     /// they are served stale (Wobbly) through a short grace window and only dropped (Offline) once the
@@ -368,6 +376,7 @@ public sealed class GatewayHost : IAsyncDisposable
         Registry.OnDirectorRemoved += directorId => SessionNumbers.ReleaseForDirector(directorId);
         PushedSessions = new Streaming.PushedSessionStore();
         InputStats = new Stats.GatewayInputStatsAggregator(inputStatsPath);
+        SessionConcurrency = new Stats.GatewaySessionConcurrencyStats();
         RosterCache = new Discovery.FleetRosterCache();
         // Issue #1215: when a Director is unregistered or evicted from the registry, forget its cached
         // roster too so the cache does not grow without bound; a re-registering Director starts clean.
@@ -909,6 +918,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // DevThrottle Stats: the hub (constructed per-invocation by SignalR) folds each pushed session's
         // tally into this one aggregator instance, which the /stats dashboard reads.
         builder.Services.AddSingleton(InputStats);
+        builder.Services.AddSingleton(SessionConcurrency);
         builder.Services.AddSingleton(Registry);
         // launcher-persistent-join: the LauncherHub (constructed per-invocation by SignalR) and
         // SendLauncherCommandAsync share this one connection registry.
@@ -1118,7 +1128,10 @@ public sealed class GatewayHost : IAsyncDisposable
             // DevThrottle Stats: feed the input-tally aggregator from the assembled /sessions roster, so
             // "Your Throttle" is populated whether stream mode is on or off (the DirectorHub push fold only
             // runs in stream mode, which is off in production).
-            inputStats: InputStats);
+            inputStats: InputStats,
+            // DevThrottle Stats: record fleet concurrency (live + actively-working session counts) from the
+            // same assembled roster, so the peak is captured fleet-wide regardless of stream mode.
+            concurrency: SessionConcurrency);
 
         // Issue #268: the two raw per-session WebSocket legs (live Terminal stream + dictation)
         // proxied through the Gateway so a remote Cockpit talks same-origin to the Gateway and
@@ -1391,7 +1404,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // DevThrottle Stats: the always-available private dashboard (/stats) and its JSON (/stats/data).
         // A self-contained embedded page, so it works even on a plain dev build with no React wwwroot.
         // Mapped before the mobile/cockpit catch-alls so the explicit routes win.
-        Stats.StatsPageEndpoint.Map(_app, InputStats);
+        Stats.StatsPageEndpoint.Map(_app, InputStats, SessionConcurrency);
 
         Mobile.MobileApp.Map(_app, Token);
 

--- a/src/CcDirector.Gateway/Stats/GatewaySessionConcurrencyStats.cs
+++ b/src/CcDirector.Gateway/Stats/GatewaySessionConcurrencyStats.cs
@@ -1,0 +1,273 @@
+using System.Globalization;
+using System.Text.Json;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Stats;
+
+/// <summary>
+/// The Gateway's durable record of fleet CONCURRENCY - how many sessions run at once across every machine,
+/// and how many are actively working at once. Unlike the input tally, a session COUNT needs no per-Director
+/// instrumentation: the Gateway's assembled /sessions roster already sees every session on every machine
+/// (new build or old), so this is fleet-wide from day one. Observed from that same assembled roster on
+/// every read.
+///
+/// Two honest series are tracked so a public number is never overstated:
+///   - LIVE: sessions loaded/running (non-exited) - the parallel capacity in flight.
+///   - WORKING: sessions whose agent is processing a turn right now (activityState = Working) - the count
+///     actually churning at an instant, which is smaller and fluctuates.
+/// Each series keeps the current value, the all-time peak (and when it happened), and a per-hour max
+/// history keyed by UTC clock hour. Weekly max (or any window) is DERIVED from the hourly history - we
+/// store hourly once and compute the rest, so there is no separate weekly store to keep consistent.
+///
+/// Persisted (atomic temp-write + rename, corrupt file quarantined) so a Gateway restart keeps the peaks
+/// and the history. Hourly buckets past the retention window are pruned so the store stays bounded.
+/// </summary>
+public sealed class GatewaySessionConcurrencyStats
+{
+    private static readonly JsonSerializerOptions FileJsonOptions = new() { WriteIndented = true };
+    // ~90 days of hourly buckets: enough for weekly/monthly windows and a long chartable history, bounded
+    // so the store never grows without limit.
+    private const int RetentionDays = 90;
+    private const string HourFormat = "yyyy-MM-ddTHH";
+
+    private readonly string _path;
+    private readonly object _lock = new();
+    private readonly Series _live = new();
+    private readonly Series _working = new();
+
+    // One tracked dimension: current value, all-time peak (+when), and per-hour max history.
+    private sealed class Series
+    {
+        public int Current;
+        public int AllTimeMax;
+        public DateTime? AllTimeMaxAtUtc;
+        public readonly Dictionary<string, int> HourlyMax = new(StringComparer.Ordinal);
+
+        // Fold one observation. Returns true when the persisted state (peak or an hour's max) changed;
+        // a bare Current refresh is not persisted on its own.
+        public bool Observe(int count, DateTime nowUtc, string hourKey)
+        {
+            Current = count;
+            var changed = false;
+            if (count > AllTimeMax)
+            {
+                AllTimeMax = count;
+                AllTimeMaxAtUtc = nowUtc;
+                changed = true;
+            }
+            if (!HourlyMax.TryGetValue(hourKey, out var m) || count > m)
+            {
+                HourlyMax[hourKey] = count;
+                changed = true;
+            }
+            return changed;
+        }
+    }
+
+    /// <param name="path">The durable store file. Defaults to gateway-concurrency-stats.json under the
+    /// cc-director storage root, beside the other Gateway stores.</param>
+    public GatewaySessionConcurrencyStats(string? path = null)
+    {
+        _path = string.IsNullOrWhiteSpace(path)
+            ? Path.Combine(CcStorage.Root(), "gateway-concurrency-stats.json")
+            : path!;
+        Load();
+    }
+
+    private static string HourKey(DateTime utc) =>
+        utc.ToUniversalTime().ToString(HourFormat, CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Observe the current fleet counts at <paramref name="nowUtc"/>: <paramref name="liveCount"/> is the
+    /// non-exited session count, <paramref name="workingCount"/> the subset actively processing a turn.
+    /// Idempotent within an hour - only a value higher than this hour's max (or the all-time peak) is
+    /// persisted, so folding on every roster read never inflates anything.
+    /// </summary>
+    public void Observe(int liveCount, int workingCount, DateTime nowUtc)
+    {
+        if (liveCount < 0) liveCount = 0;
+        if (workingCount < 0) workingCount = 0;
+        if (workingCount > liveCount) workingCount = liveCount;
+
+        var key = HourKey(nowUtc);
+        lock (_lock)
+        {
+            var changed = _live.Observe(liveCount, nowUtc, key);
+            changed |= _working.Observe(workingCount, nowUtc, key);
+            if (changed)
+            {
+                PruneLocked(nowUtc);
+                Save();
+            }
+        }
+    }
+
+    /// <summary>A read-only snapshot for the dashboard / agent API: both series with current, all-time peak
+    /// (+when), the derived weekly max (max hourly bucket in the last 7 days), and the hourly history.</summary>
+    public ConcurrencySnapshot Snapshot(DateTime nowUtc)
+    {
+        lock (_lock)
+        {
+            return new ConcurrencySnapshot(SeriesSnapshot(_live, nowUtc), SeriesSnapshot(_working, nowUtc));
+        }
+    }
+
+    private static ConcurrencySeriesDto SeriesSnapshot(Series s, DateTime nowUtc)
+    {
+        var weeklyCutoff = nowUtc.AddDays(-7);
+        var weeklyMax = 0;
+        var hourly = new List<ConcurrencyHourDto>(s.HourlyMax.Count);
+        foreach (var kvp in s.HourlyMax)
+        {
+            if (TryParseHour(kvp.Key, out var dt) && dt >= weeklyCutoff && kvp.Value > weeklyMax)
+                weeklyMax = kvp.Value;
+            hourly.Add(new ConcurrencyHourDto { Hour = kvp.Key, Max = kvp.Value });
+        }
+        hourly.Sort((a, b) => string.CompareOrdinal(a.Hour, b.Hour));
+        return new ConcurrencySeriesDto
+        {
+            Current = s.Current,
+            AllTimeMax = s.AllTimeMax,
+            AllTimeMaxAtUtc = s.AllTimeMaxAtUtc,
+            WeeklyMax = weeklyMax,
+            Hourly = hourly,
+        };
+    }
+
+    private void PruneLocked(DateTime nowUtc)
+    {
+        var cutoff = nowUtc.AddDays(-RetentionDays);
+        Prune(_live, cutoff);
+        Prune(_working, cutoff);
+    }
+
+    private static void Prune(Series s, DateTime cutoff)
+    {
+        var stale = s.HourlyMax.Keys.Where(k => TryParseHour(k, out var dt) && dt < cutoff).ToList();
+        foreach (var k in stale) s.HourlyMax.Remove(k);
+    }
+
+    private static bool TryParseHour(string key, out DateTime utc) =>
+        DateTime.TryParseExact(key, HourFormat, CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out utc);
+
+    private sealed class SeriesStore
+    {
+        public int AllTimeMax { get; set; }
+        public DateTime? AllTimeMaxAtUtc { get; set; }
+        public Dictionary<string, int> HourlyMax { get; set; } = new();
+    }
+
+    private sealed class StoreFile
+    {
+        public SeriesStore Live { get; set; } = new();
+        public SeriesStore Working { get; set; } = new();
+    }
+
+    private void Load()
+    {
+        if (!File.Exists(_path))
+        {
+            FileLog.Write($"[GatewaySessionConcurrencyStats] Load: no store file at {_path}; starting empty");
+            return;
+        }
+
+        StoreFile? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize<StoreFile>(File.ReadAllText(_path), FileJsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            Quarantine(ex.Message);
+            return;
+        }
+        if (parsed is null)
+        {
+            Quarantine("file deserialized to null (no store document)");
+            return;
+        }
+
+        RestoreSeries(_live, parsed.Live);
+        RestoreSeries(_working, parsed.Working);
+        FileLog.Write($"[GatewaySessionConcurrencyStats] Load: live peak {_live.AllTimeMax}, working peak {_working.AllTimeMax}, {_live.HourlyMax.Count} live + {_working.HourlyMax.Count} working hourly bucket(s) from {_path}");
+    }
+
+    private static void RestoreSeries(Series s, SeriesStore? store)
+    {
+        if (store is null) return;
+        s.AllTimeMax = store.AllTimeMax;
+        s.AllTimeMaxAtUtc = store.AllTimeMaxAtUtc;
+        foreach (var (hour, max) in store.HourlyMax)
+            s.HourlyMax[hour] = max;
+    }
+
+    private void Quarantine(string reason)
+    {
+        var quarantinePath = $"{_path}.corrupt-{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}";
+        File.Move(_path, quarantinePath);
+        FileLog.Write($"[GatewaySessionConcurrencyStats] Load FAILED: store file at {_path} is corrupt ({reason}); quarantined to {quarantinePath}; starting empty.");
+    }
+
+    // Write-through under the lock: serialize the whole store and atomically replace the file (temp +
+    // rename) so a concurrent reader or a crash mid-write never sees a half-written store. A failed save is
+    // a LOGGED error that propagates - never a silent skip.
+    private void Save()
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(_path);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            var file = new StoreFile
+            {
+                Live = ToStore(_live),
+                Working = ToStore(_working),
+            };
+            var json = JsonSerializer.Serialize(file, FileJsonOptions);
+            var tmp = _path + ".tmp";
+            File.WriteAllText(tmp, json);
+            File.Move(tmp, _path, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewaySessionConcurrencyStats] Save FAILED: path={_path}: {ex.Message}");
+            throw;
+        }
+    }
+
+    private static SeriesStore ToStore(Series s) => new()
+    {
+        AllTimeMax = s.AllTimeMax,
+        AllTimeMaxAtUtc = s.AllTimeMaxAtUtc,
+        HourlyMax = new Dictionary<string, int>(s.HourlyMax, StringComparer.Ordinal),
+    };
+}
+
+/// <summary>One hour of the concurrency history: the UTC clock-hour key ("yyyy-MM-ddTHH") and the max
+/// concurrent count seen in that hour.</summary>
+public sealed class ConcurrencyHourDto
+{
+    public string Hour { get; set; } = "";
+    public int Max { get; set; }
+}
+
+/// <summary>One tracked concurrency dimension (live or working) for the dashboard / agent API.</summary>
+public sealed class ConcurrencySeriesDto
+{
+    /// <summary>The most recently observed count.</summary>
+    public int Current { get; set; }
+    /// <summary>The highest count ever observed.</summary>
+    public int AllTimeMax { get; set; }
+    /// <summary>When the all-time peak was observed (UTC), or null if never.</summary>
+    public DateTime? AllTimeMaxAtUtc { get; set; }
+    /// <summary>The highest count in the last 7 days, derived from the hourly history.</summary>
+    public int WeeklyMax { get; set; }
+    /// <summary>The per-hour max history, oldest hour first.</summary>
+    public List<ConcurrencyHourDto> Hourly { get; set; } = new();
+}
+
+/// <summary>Both concurrency dimensions: sessions loaded/running (live) and sessions actively working.</summary>
+public sealed record ConcurrencySnapshot(ConcurrencySeriesDto Live, ConcurrencySeriesDto Working);

--- a/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
+++ b/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
@@ -32,7 +32,8 @@ public static class StatsPageEndpoint
         "Surface (phone / cockpit) for remote input is read from the signed-in device. Remote input with no device identity (a shared-token or fleet call) is not counted as an operator surface.",
     };
 
-    public static void Map(IEndpointRouteBuilder app, GatewayInputStatsAggregator aggregator)
+    public static void Map(IEndpointRouteBuilder app, GatewayInputStatsAggregator aggregator,
+        GatewaySessionConcurrencyStats? concurrency = null)
     {
         FileLog.Write("[StatsPageEndpoint] serving /stats (embedded, always available)");
 
@@ -43,6 +44,9 @@ public static class StatsPageEndpoint
             {
                 generatedAtUtc = DateTime.UtcNow,
                 buckets = totals.Buckets,
+                // DevThrottle Stats: fleet concurrency (both series: live loaded/running, and actively
+                // working). Null until the aggregator is wired (old callers / tests).
+                concurrency = concurrency?.Snapshot(DateTime.UtcNow),
                 notCaptured = NotCaptured,
             });
         });


### PR DESCRIPTION
## What

Adds the **fleet concurrency** stat to "Your Throttle" - how many sessions run at once across every machine, tracked with an hourly history so peaks are captured, not just spot-read.

Two honest series (the point is the *distinction*, not one inflated number):
- **Live** = loaded/running sessions (non-exited) - the parallel capacity in flight.
- **Working** = the subset actively processing a turn right now (`activityState=Working`).

Each series keeps **current**, **all-time peak (+when)**, and a **per-hour max history**. Weekly max (and any window) is *derived* from the hourly history - store hourly once, compute the rest.

## Design

- `GatewaySessionConcurrencyStats`: persisted (atomic temp+rename, corrupt-quarantine, same pattern as the input aggregator); hourly buckets past a 90-day retention are pruned so the store stays bounded.
- Fed from the assembled `/sessions` roster in `GatewayEndpoints` (same fold point as the input tally), so it is **fleet-wide with no per-Director instrumentation** - visible for every session on every machine, new build or old, regardless of stream mode. Idempotent per hour: folding on every read captures peaks without inflating.
- Surfaced in `GET /stats/data` under `concurrency`, and shown on the cockpit + mobile "Your Throttle" pages as a "Fleet concurrency" section (now / this week / all-time).

## Verification

- Gateway compiles clean; **`GatewaySessionConcurrencyStatsTests` (5) green** (both series, working<=live cap, derived weekly max, restart durability, hourly pruning).
- client-core / cockpit / mobile typecheck clean; client-core stats tests green.
- Will be verified **live** after redeploy (captured peak on `/stats/data`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
