### PR TITLE
perf(carmode): per-turn timing telemetry, latency cuts, one-viewport polish

### DIFF
--- a/apps/mobile/src/pages/CarMode.tsx
+++ b/apps/mobile/src/pages/CarMode.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { useCarMode, type CarModeReply } from "@devthrottle/client-core/carmode/useCarMode";
 import { carModeTurn } from "@devthrottle/client-core/carmode/carModeApi";
-import { getGatewayHealth, gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 import { useScreenWakeLock } from "../hooks/useScreenWakeLock";
 
 // The client build id, inlined by Vite's `define` at build time (git short sha + build timestamp; see
@@ -33,26 +32,18 @@ export function CarMode() {
   // Phase 1: a standalone page under /m with a screen wake-lock).
   useScreenWakeLock();
 
-  // The live Gateway version, read once from /healthz, so the on-screen indicator pairs the CLIENT
-  // build id (which page bundle) with the SERVER version (which Gateway build) - together they tell the
-  // owner exactly what he is talking to. A read failure shows the specific reason, never a silent blank.
-  const [gatewayVersion, setGatewayVersion] = useState("loading...");
-  useEffect(() => {
-    const controller = new AbortController();
-    getGatewayHealth(controller.signal)
-      .then((h) => setGatewayVersion(h.version))
-      .catch((err) => {
-        if (!controller.signal.aborted) setGatewayVersion(gatewayErrorMessage(err));
-      });
-    return () => controller.abort();
-  }, []);
-
   // The injected brain responder. Phase 2+: the real fleet brain. The stand-in (below) just echoes the
   // heard command so Phase 1's barge-in proof needs no server and no credits.
   const respond = useCallback(async (command: string, signal: AbortSignal): Promise<CarModeReply> => {
     if (USE_FLEET_BRAIN) {
       const result = await carModeTurn(command, signal);
-      return { spoken: result.spoken, actions: result.actions, pendingConfirmation: result.pendingConfirmation };
+      return {
+        spoken: result.spoken,
+        actions: result.actions,
+        pendingConfirmation: result.pendingConfirmation,
+        turnId: result.turnId,
+        timing: result.timing,
+      };
     }
     // Phase 1 stand-in: a canned acknowledgement that repeats the command back, so the owner can hear
     // the whole loop (transcribe -> speak -> interrupt) working before the brain exists.
@@ -68,10 +59,6 @@ export function CarMode() {
     pendingConfirmation,
     error,
     unsupported,
-    history,
-    lastHeard,
-    captureState,
-    captureError,
     getMicLevel,
     endTurn,
     interrupt,
@@ -89,82 +76,74 @@ export function CarMode() {
         </Link>
         <span className="car-title">Car Mode</span>
         {/* The client build id in the corner: the owner glances here to confirm he is on the latest page,
-            not an old cached bundle. The full build id + Gateway version are in the debug readout below. */}
+            not an old cached bundle. The full build id is in the title tooltip. */}
         <span className="car-build" title={`Client build ${CLIENT_BUILD_ID}`}>
           {shortBuild(CLIENT_BUILD_ID)}
         </span>
       </header>
 
-      {error !== null && (
-        <div className="car-error" role="alert">
-          {error}
-        </div>
-      )}
+      {/* The scrollable middle: everything between the fixed header and the fixed control footer. It flexes
+          to fill the viewport and scrolls internally ONLY if its content is taller than the space, so the
+          End Car Mode button and the controls in the footer are ALWAYS visible with no page scroll. */}
+      <div className="car-middle">
+        {error !== null && (
+          <div className="car-error" role="alert">
+            {error}
+          </div>
+        )}
 
-      {unsupported && (
-        <div className="car-error" role="alert">
-          Car Mode needs Chrome or another Chromium browser for hands-free voice. Open this page in
-          Chrome.
-        </div>
-      )}
+        {unsupported && (
+          <div className="car-error" role="alert">
+            Car Mode needs Chrome or another Chromium browser for hands-free voice. Open this page in
+            Chrome.
+          </div>
+        )}
 
-      <main className="car-body">
-        {/* The one big status orb + word: whose turn it is, readable at a glance / audible by the two
-            cues. Its color is the whole state at a distance. */}
-        <div className={`car-orb car-orb-${phase}`} aria-hidden="true">
-          <span className="car-orb-pulse" />
-        </div>
-        <p className="car-status" aria-live="polite">
-          {started ? statusText : "Tap Start, then just talk."}
-        </p>
-
-        {/* Live microphone level meter (Architect direction): visibly shows the owner his voice is being
-            picked up. Reads the capture stream's AnalyserNode via getMicLevel on an animation frame. It
-            only moves while the microphone is actually capturing (the Listening phase); flat otherwise. */}
-        {started && <MicMeter getLevel={getMicLevel} active={phase === "listening"} />}
-
-        {pendingConfirmation && (
-          <p className="car-confirm" role="status">
-            Waiting for you to say "confirm" - or say "cancel".
+        <main className="car-body">
+          {/* The one big status orb + word: whose turn it is, readable at a glance / audible by the two
+              cues. Its color is the whole state at a distance. */}
+          <div className={`car-orb car-orb-${phase}`} aria-hidden="true">
+            <span className="car-orb-pulse" />
+          </div>
+          <p className="car-status" aria-live="polite">
+            {started ? statusText : "Tap Start, then just talk."}
           </p>
-        )}
 
-        {/* The heard command and the spoken reply. The interface is sound; this text is for eyes-on
-            confirmation and debugging over chrome://inspect (mission decision 9). */}
-        {transcript.length > 0 && (
-          <div className="car-heard">
-            <span className="car-label">You said</span>
-            <span className="car-heard-text">{transcript}</span>
-          </div>
-        )}
-        {reply.length > 0 && (
-          <div className="car-said">
-            <span className="car-label">Assistant</span>
-            <span className="car-said-text">{reply}</span>
-          </div>
-        )}
-        {actions.length > 0 && (
-          <ul className="car-actions">
-            {actions.map((a, i) => (
-              <li key={`${a.tool}-${i}`} className="car-action">
-                {a.summary}
-              </li>
-            ))}
-          </ul>
-        )}
-      </main>
+          {/* Live microphone level meter (Architect direction): visibly shows the owner his voice is being
+              picked up. Reads the capture stream's AnalyserNode via getMicLevel on an animation frame. It
+              only moves while the microphone is actually capturing (the Listening phase); flat otherwise. */}
+          {started && <MicMeter getLevel={getMicLevel} active={phase === "listening"} />}
 
-      {/* Diagnostic readout (always visible). This is the eyes-on channel for confirming, at a glance,
-          which page/Gateway is live and whether the phone is actually hearing the owner - the exact
-          things a cached-bundle or dead-microphone failure would hide. Kept compact and monospace. */}
-      <section className="car-debug" aria-label="Car Mode diagnostics">
-        <DebugRow label="Client build" value={CLIENT_BUILD_ID} />
-        <DebugRow label="Gateway" value={gatewayVersion} />
-        <DebugRow label="Audio capture" value={unsupported ? "NOT supported" : "supported"} />
-        <DebugRow label="State" value={started ? captureState : "not started"} />
-        <DebugRow label="Last transcribe error" value={captureError ?? "none"} />
-        <DebugRow label="Heard" value={lastHeard.length > 0 ? lastHeard : "(nothing yet)"} />
-      </section>
+          {pendingConfirmation && (
+            <p className="car-confirm" role="status">
+              Waiting for you to say "confirm" - or say "cancel".
+            </p>
+          )}
+
+          {/* The heard command and the spoken reply, for eyes-on confirmation. */}
+          {transcript.length > 0 && (
+            <div className="car-heard">
+              <span className="car-label">You said</span>
+              <span className="car-heard-text">{transcript}</span>
+            </div>
+          )}
+          {reply.length > 0 && (
+            <div className="car-said">
+              <span className="car-label">Assistant</span>
+              <span className="car-said-text">{reply}</span>
+            </div>
+          )}
+          {actions.length > 0 && (
+            <ul className="car-actions">
+              {actions.map((a, i) => (
+                <li key={`${a.tool}-${i}`} className="car-action">
+                  {a.summary}
+                </li>
+              ))}
+            </ul>
+          )}
+        </main>
+      </div>
 
       <footer className="car-foot">
         {!started ? (
@@ -205,20 +184,6 @@ export function CarMode() {
           </>
         )}
       </footer>
-
-      {history.length > 1 && (
-        <details className="car-history">
-          <summary>Recent turns ({history.length})</summary>
-          <ul>
-            {history.map((h, i) => (
-              <li key={i}>
-                <span className="car-history-you">{h.command}</span>
-                <span className="car-history-said">{h.spoken}</span>
-              </li>
-            ))}
-          </ul>
-        </details>
-      )}
     </div>
   );
 }
@@ -261,16 +226,6 @@ function MicMeter({ getLevel, active }: { getLevel: () => number; active: boolea
           <span className="car-meter-bar" style={{ height: `${8 + v * 84}%` }} />
         </span>
       ))}
-    </div>
-  );
-}
-
-// One label/value line in the diagnostic readout.
-function DebugRow({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="car-debug-row">
-      <span className="car-debug-label">{label}</span>
-      <span className="car-debug-value">{value}</span>
     </div>
   );
 }

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -2289,7 +2289,10 @@ a.banner-btn {
   font-size: 14px;
 }
 
-/* The full-screen Car Mode page. Chrome-less, high-contrast, thumb-reachable controls at the bottom. */
+/* The full-screen Car Mode page. Chrome-less, high-contrast, thumb-reachable controls at the bottom. It
+   fills exactly one viewport and never page-scrolls: the header and the control footer are pinned, and only
+   the middle scrolls if its content is taller than the space, so End Car Mode and the buttons are always
+   visible (docs/VisualStyle.md, the app-like session-screen rule). */
 .car-screen {
   position: fixed;
   inset: 0;
@@ -2297,7 +2300,25 @@ a.banner-btn {
   flex-direction: column;
   background: var(--bg);
   color: var(--text);
+  height: 100vh;
+  height: 100dvh;
+  max-height: 100dvh;
+  overflow: hidden;
+}
+.car-bar {
+  flex: 0 0 auto;
+}
+/* The flexible middle between the pinned header and the pinned footer: it takes the remaining height and
+   scrolls INTERNALLY only when its content does not fit, so the page itself never scrolls. */
+.car-middle {
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+.car-foot {
+  flex: 0 0 auto;
 }
 .car-bar {
   display: flex;
@@ -2335,34 +2356,6 @@ a.banner-btn {
   white-space: nowrap;
 }
 
-/* The always-visible diagnostic readout: which page/Gateway is live, and whether the phone is hearing
-   the owner. Compact and monospace so it stays out of the way but is legible at a glance. */
-.car-debug {
-  margin: 0 12px 8px;
-  padding: 8px 10px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--surface);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 12px;
-  line-height: 1.5;
-}
-.car-debug-row {
-  display: flex;
-  gap: 8px;
-  justify-content: space-between;
-  align-items: baseline;
-}
-.car-debug-label {
-  color: var(--text-dim);
-  white-space: nowrap;
-}
-.car-debug-value {
-  color: var(--text);
-  text-align: right;
-  word-break: break-word;
-  overflow-wrap: anywhere;
-}
 .car-error {
   margin: 12px 16px 0;
   padding: 12px 14px;
@@ -2596,34 +2589,6 @@ a.banner-btn {
   color: #6b7391;
   border-color: transparent;
   cursor: default;
-}
-
-.car-history {
-  margin: 0 16px 20px;
-  color: var(--text-dim);
-  font-size: 13px;
-}
-.car-history summary {
-  cursor: pointer;
-  padding: 6px 0;
-}
-.car-history ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-.car-history li {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: 6px 0;
-  border-top: 1px solid var(--border);
-}
-.car-history-you {
-  color: var(--text);
-}
-.car-history-said {
-  color: var(--text-dim);
 }
 
 /* ===== Your Throttle (devthrottle-stats mission) - the in-app port of the Gateway /stats page ===== */

--- a/packages/client-core/src/carmode/carModeApi.test.ts
+++ b/packages/client-core/src/carmode/carModeApi.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { carModeTurn, speakCarModeText, transcribeCarModeAudio } from "./carModeApi";
+import { carModeTurn, postCarModeTelemetry, speakCarModeText, transcribeCarModeAudio } from "./carModeApi";
 import { CreditsError, GatewayError } from "../api/client";
 
 // The Car Mode Gateway calls must fail LOUD and SPECIFIC (mission decision 8): a money refusal (402) is
@@ -75,6 +75,54 @@ describe("carModeTurn", () => {
     const result = await carModeTurn("who needs me");
     expect(result.actions).toEqual([]);
     expect(result.pendingConfirmation).toBe(false);
+  });
+
+  it("parses the server turnId and per-stage timing when present", async () => {
+    vi.stubGlobal("fetch", mockFetch(200, {
+      turnId: "abc123",
+      spoken: "You have two sessions waiting.",
+      timing: {
+        totalMs: 812.5,
+        modelCallCount: 2,
+        modelMsTotal: 760,
+        modelMs: [400, 360],
+        fleetReadCount: 1,
+        fleetReadMsTotal: 30,
+        rounds: 2,
+      },
+    }));
+    const result = await carModeTurn("who needs me");
+    expect(result.turnId).toBe("abc123");
+    expect(result.timing?.fleetReadCount).toBe(1);
+    expect(result.timing?.modelMs).toEqual([400, 360]);
+  });
+
+  it("defaults turnId to empty and timing to null when the server omits them", async () => {
+    vi.stubGlobal("fetch", mockFetch(200, { spoken: "Hi there." }));
+    const result = await carModeTurn("hello");
+    expect(result.turnId).toBe("");
+    expect(result.timing).toBeNull();
+  });
+});
+
+describe("postCarModeTelemetry", () => {
+  const record = {
+    turnId: "t1", pauseToTranscribeMs: 900, brainMs: 1200, ttsMs: 300, firstAudioMs: 350,
+    totalTurnMs: 2450, serverTotalMs: 1100, modelCallCount: 1, modelMsTotal: 1050,
+    modelMs: [1050], fleetReadCount: 0, fleetReadMsTotal: 0, rounds: 1, commandChars: 20,
+    replyChars: 40, actionsCount: 0, pendingConfirmation: false,
+  };
+
+  it("posts the record to /carmode/telemetry", async () => {
+    const fetchMock = mockFetch(200, { recorded: true, held: 1 });
+    vi.stubGlobal("fetch", fetchMock);
+    await postCarModeTelemetry(record);
+    expect(fetchMock).toHaveBeenCalledWith("/carmode/telemetry", expect.objectContaining({ method: "POST" }));
+  });
+
+  it("never throws when the post fails (best-effort observability)", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("network down"); }));
+    await expect(postCarModeTelemetry(record)).resolves.toBeUndefined();
   });
 
   it("maps 402 to the shared CreditsError", async () => {

--- a/packages/client-core/src/carmode/carModeApi.ts
+++ b/packages/client-core/src/carmode/carModeApi.ts
@@ -64,13 +64,29 @@ export interface CarModeAction {
   summary: string;
 }
 
+/** The per-stage SERVER timing the brain measured for one turn (performance round): every hosted-model
+ *  round trip and every fleet/roster read, plus the whole-turn server wall-clock. Milliseconds. The browser
+ *  echoes this back merged with its own client stamps as one telemetry record. */
+export interface CarModeServerTiming {
+  totalMs: number;
+  modelCallCount: number;
+  modelMsTotal: number;
+  modelMs: number[];
+  fleetReadCount: number;
+  fleetReadMsTotal: number;
+  rounds: number;
+}
+
 /** The brain's answer for one turn (POST /carmode/turn). `spoken` is what the assistant says out loud;
  *  `actions` is what it did this turn (empty for a pure question); `pendingConfirmation` is true when the
- *  assistant is holding a destructive action and is waiting for a spoken "confirm" next turn. */
+ *  assistant is holding a destructive action and is waiting for a spoken "confirm" next turn. `turnId` and
+ *  `timing` feed the telemetry record the browser posts back. */
 export interface CarModeTurnResult {
+  turnId: string;
   spoken: string;
   actions: CarModeAction[];
   pendingConfirmation: boolean;
+  timing: CarModeServerTiming | null;
 }
 
 /**
@@ -94,8 +110,53 @@ export async function carModeTurn(text: string, signal?: AbortSignal): Promise<C
   }
   const body = (await res.json().catch(() => ({}))) as Partial<CarModeTurnResult>;
   return {
+    turnId: typeof body.turnId === "string" ? body.turnId : "",
     spoken: (body.spoken ?? "").trim(),
     actions: Array.isArray(body.actions) ? body.actions : [],
     pendingConfirmation: Boolean(body.pendingConfirmation),
+    timing: body.timing ?? null,
   };
+}
+
+/** One merged per-turn timing record the browser posts to the Gateway telemetry store (performance round):
+ *  the client stamps it measured, plus the server timing it received in the turn response, plus small
+ *  non-text turn facts (character counts, action count). The server fills the received-at time, the device
+ *  hash, and the Gateway build from its own side. No command or reply text is ever included. */
+export interface CarModeTelemetryPost {
+  turnId: string;
+  pauseToTranscribeMs: number;
+  brainMs: number;
+  ttsMs: number;
+  firstAudioMs: number;
+  totalTurnMs: number;
+  serverTotalMs: number;
+  modelCallCount: number;
+  modelMsTotal: number;
+  modelMs: number[];
+  fleetReadCount: number;
+  fleetReadMsTotal: number;
+  rounds: number;
+  commandChars: number;
+  replyChars: number;
+  actionsCount: number;
+  pendingConfirmation: boolean;
+}
+
+/**
+ * Post one turn's merged timing record to the Gateway telemetry store (POST /carmode/telemetry). Best-effort
+ * observability: it never throws into the turn loop and never blocks the spoken reply - a failed post is
+ * logged and swallowed, because losing a timing record must never disrupt the drive. Same-origin, with the
+ * enrolled per-device key like every other Car Mode call.
+ */
+export async function postCarModeTelemetry(record: CarModeTelemetryPost): Promise<void> {
+  try {
+    await fetch("/carmode/telemetry", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...authHeaders() },
+      body: JSON.stringify(record),
+      keepalive: true,
+    });
+  } catch (err) {
+    console.log(`[CarMode] telemetry post failed (ignored): ${String(err)}`);
+  }
 }

--- a/packages/client-core/src/carmode/splitFirstSentence.test.ts
+++ b/packages/client-core/src/carmode/splitFirstSentence.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { splitFirstSentence } from "./useCarMode";
+
+// The first-sentence split lets Car Mode start speaking the first sentence while the rest is still being
+// synthesized (performance round). It must return exactly two parts (at most one extra synthesis), keep a
+// single-sentence reply whole, and never split off a tiny lead fragment that would only add a round trip.
+
+describe("splitFirstSentence", () => {
+  it("splits a two-sentence reply after the first sentence", () => {
+    const [first, rest] = splitFirstSentence("Two sessions need you. The newest is Local Files Manager.");
+    expect(first).toBe("Two sessions need you.");
+    expect(rest).toBe("The newest is Local Files Manager.");
+  });
+
+  it("keeps a single-sentence reply as one chunk with an empty remainder", () => {
+    const [first, rest] = splitFirstSentence("Nothing needs you right now.");
+    expect(first).toBe("Nothing needs you right now.");
+    expect(rest).toBe("");
+  });
+
+  it("does not split off a tiny lead fragment", () => {
+    const [first, rest] = splitFirstSentence("Okay. I left Old Worker alone.");
+    expect(first).toBe("Okay. I left Old Worker alone.");
+    expect(rest).toBe("");
+  });
+
+  it("puts everything after the first sentence into the remainder, not a third part", () => {
+    const [first, rest] = splitFirstSentence("I started a session. It is warming up now. I will let you know.");
+    expect(first).toBe("I started a session.");
+    expect(rest).toBe("It is warming up now. I will let you know.");
+  });
+
+  it("trims surrounding whitespace", () => {
+    const [first, rest] = splitFirstSentence("   Done deleting Old Worker.   Anything else?   ");
+    expect(first).toBe("Done deleting Old Worker.");
+    expect(rest).toBe("Anything else?");
+  });
+});

--- a/packages/client-core/src/carmode/useCarMode.ts
+++ b/packages/client-core/src/carmode/useCarMode.ts
@@ -3,7 +3,13 @@ import { MicRecorder } from "../dictation/recorder";
 import { blobToWav16kMono } from "../dictation/wav";
 import { playReadyCue, playYourTurnCue } from "../dictation/readyCue";
 import { detectEndPhrase, detectInterrupt } from "./controlPhrases";
-import { speakCarModeText, transcribeCarModeAudio, type CarModeAction } from "./carModeApi";
+import {
+  postCarModeTelemetry,
+  speakCarModeText,
+  transcribeCarModeAudio,
+  type CarModeAction,
+  type CarModeServerTiming,
+} from "./carModeApi";
 import { gatewayErrorMessage } from "../api/client";
 
 // The Car Mode turn-taking machine (new build B). This shared hook owns the whole walkie-talkie loop so
@@ -33,11 +39,35 @@ import { gatewayErrorMessage } from "../api/client";
 // turn is taken; the "your turn" double-blip (playYourTurnCue) fires whenever the microphone is the owner's
 // again. Two clearly distinct tones so he always knows whose turn it is without looking.
 
-/** The reply the injected brain produces for one turn: what to say, and (Phase 2+) what it did. */
+/** The reply the injected brain produces for one turn: what to say, and (Phase 2+) what it did. `turnId`
+ *  and `timing` are the server side of the performance-round telemetry: the browser merges them with its
+ *  own client stamps into one record it posts back. They are optional so the Phase 1 stand-in responder
+ *  (no server) still satisfies this shape. */
 export interface CarModeReply {
   spoken: string;
   actions?: CarModeAction[];
   pendingConfirmation?: boolean;
+  turnId?: string;
+  timing?: CarModeServerTiming | null;
+}
+
+/** One turn's client + server timing, gathered across the turn-taking machine and posted once first audio
+ *  plays. All times are milliseconds; only counts and lengths are kept, never any command or reply text. */
+interface TurnMetrics {
+  turnId: string;
+  pauseDetectedAt: number; // performance.now() when the ending pause was detected / "over and out" tapped
+  pauseToTranscribeMs: number; // that pause to the command transcript in hand
+  commandChars: number;
+  replyChars: number;
+  brainMs: number; // POST /carmode/turn round trip as the browser saw it
+  replyReadyAt: number; // performance.now() when the spoken reply text was in hand
+  server: CarModeServerTiming | null;
+  actionsCount: number;
+  pendingConfirmation: boolean;
+  ttsMs: number; // first-chunk text-to-speech round trip
+  firstAudioMs: number; // reply-in-hand to first audio playing
+  totalTurnMs: number; // pause detected to first audio playing (what the owner feels)
+  posted: boolean;
 }
 
 /** One command/answer exchange, kept for the on-screen scrollback. */
@@ -107,6 +137,23 @@ const SPEAKING_POLL_MS = 1500;
 // A snapshot smaller than this is just the container header with no real audio - skip transcribing it.
 const MIN_CLIP_BYTES = 2000;
 
+/**
+ * Split a reply into the first sentence and the remainder, so the browser can start synthesizing and
+ * PLAYING the first sentence while the rest is still being synthesized - the owner hears an answer sooner
+ * (performance round: begin playback on the first sentence, not the whole reply). Returns exactly two parts
+ * so at most one extra text-to-speech call is ever made; the remainder is an empty string when the reply is
+ * a single sentence (then it is one synthesis, unchanged). A very short lead fragment (for example "Okay.")
+ * is NOT split off on its own - it would just add a round trip for a word - so the whole reply stays as one.
+ */
+export function splitFirstSentence(text: string): [string, string] {
+  const trimmed = text.trim();
+  const match = trimmed.match(/^(.+?[.!?]+)\s+(\S.*)$/s);
+  if (match && match[1].trim().length >= 12 && match[2].trim().length > 0) {
+    return [match[1].trim(), match[2].trim()];
+  }
+  return [trimmed, ""];
+}
+
 /** Whether this browser can capture audio for Car Mode. Car Mode is Chromium-first (decision 7); elsewhere
  *  the page tells the owner plainly instead of silently degrading (no fallback, decision 8). */
 function isCaptureSupported(): boolean {
@@ -145,6 +192,13 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
   const busyRef = useRef(false); // a background transcription is in flight (do not start another)
   const speakingPollRef = useRef<number | null>(null); // setInterval id for the speaking rolling window
 
+  // Performance-round telemetry: the metrics for the turn in flight, filled across transcribe -> brain ->
+  // speak and posted once first audio plays. Null between turns.
+  const turnMetricsRef = useRef<TurnMetrics | null>(null);
+  // The chunked-playback "stop now" resolver: set while a clip is playing so an interrupt (voice "stop" or
+  // the Stop button) or End Car Mode can end the current clip's play promise and unblock the play loop.
+  const playbackStopRef = useRef<(() => void) | null>(null);
+
   // The phase, read synchronously inside the loop/timer callbacks (not a React render). A ref mirror
   // avoids a stale closure so the machine always branches on the CURRENT phase.
   const phaseRef = useRef<CarModePhase>("idle");
@@ -170,6 +224,72 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
       clearInterval(speakingPollRef.current);
       speakingPollRef.current = null;
     }
+  }, []);
+
+  // Post one turn's merged timing record ONCE (guards double-post). Only a real brain turn (with a server
+  // turnId and server timing) is posted; the canned "I didn't catch that" replies carry no server turn.
+  // Best-effort and fire-and-forget - it never blocks or disrupts the spoken reply.
+  const postTurnTelemetry = useCallback((m: TurnMetrics | null) => {
+    if (m === null || m.posted || m.turnId.length === 0 || m.server === null) return;
+    m.posted = true;
+    void postCarModeTelemetry({
+      turnId: m.turnId,
+      pauseToTranscribeMs: m.pauseToTranscribeMs,
+      brainMs: m.brainMs,
+      ttsMs: m.ttsMs,
+      firstAudioMs: m.firstAudioMs,
+      totalTurnMs: m.totalTurnMs,
+      serverTotalMs: m.server.totalMs,
+      modelCallCount: m.server.modelCallCount,
+      modelMsTotal: m.server.modelMsTotal,
+      modelMs: m.server.modelMs,
+      fleetReadCount: m.server.fleetReadCount,
+      fleetReadMsTotal: m.server.fleetReadMsTotal,
+      rounds: m.server.rounds,
+      commandChars: m.commandChars,
+      replyChars: m.replyChars,
+      actionsCount: m.actionsCount,
+      pendingConfirmation: m.pendingConfirmation,
+    });
+  }, []);
+
+  // Play one audio clip and resolve when it FINISHES ("ended") or is stopped early ("stopped" - an
+  // interrupt or End Car Mode). Used to play the reply's sentence chunks in order: the loop awaits each
+  // clip, so the next sentence starts the instant the previous one ends. A play() rejection (autoplay
+  // block) resolves "stopped" so the loop never hangs.
+  const playBlob = useCallback((url: string): Promise<"ended" | "stopped"> => {
+    return new Promise((resolve) => {
+      const audio = audioRef.current;
+      if (audio === null) {
+        resolve("stopped");
+        return;
+      }
+      let done = false;
+      const finish = (how: "ended" | "stopped") => {
+        if (done) return;
+        done = true;
+        audio.onended = null;
+        playbackStopRef.current = null;
+        resolve(how);
+      };
+      audio.onended = () => finish("ended");
+      playbackStopRef.current = () => finish("stopped");
+      audio.src = url;
+      void audio.play().catch(() => finish("stopped"));
+    });
+  }, []);
+
+  // Stop whatever clip is playing right now (pause the element and resolve its play promise), so the
+  // chunked-playback loop unwinds cleanly. Shared by the touch Stop button, the voice interrupt watch, and
+  // End Car Mode.
+  const haltPlayback = useCallback(() => {
+    const audio = audioRef.current;
+    try {
+      audio?.pause();
+    } catch {
+      /* nothing playing */
+    }
+    playbackStopRef.current?.();
   }, []);
 
   // Announce a failure LOUDLY (decision 8). The failure is put on screen AND spoken through the browser's
@@ -226,28 +346,72 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
   const speakAndPlay = useCallback(
     async (text: string, signal: AbortSignal) => {
       try {
-        const clip = await speakCarModeText(text, signal);
+        const metrics = turnMetricsRef.current;
+        // Begin on the FIRST sentence: synthesize and play it while the remainder is still synthesizing, so
+        // the owner hears an answer sooner (performance round). A single-sentence reply stays one synthesis.
+        const [first, rest] = splitFirstSentence(text);
+
+        const ttsStart = performance.now();
+        const firstBlob = await speakCarModeText(first, signal);
         if (signal.aborted) return;
+        if (metrics !== null) metrics.ttsMs = performance.now() - ttsStart;
+
+        // Prefetch the remainder in parallel so it is ready by the time the first sentence finishes.
+        const restPromise = rest.length > 0 ? speakCarModeText(rest, signal) : null;
+
         revokeClip();
-        const url = URL.createObjectURL(clip);
-        clipUrlRef.current = url;
+        const url0 = URL.createObjectURL(firstBlob);
+        clipUrlRef.current = url0;
         const audio = audioRef.current;
         if (audio === null) throw new Error("The audio player was not ready.");
-        audio.src = url;
+
         setPhaseBoth("speaking");
         setCaptureState("watching for stop");
-        await audio.play();
+
+        // Begin playing the first sentence; record when the owner first hears audio, then post the merged
+        // timing record for the turn (fire-and-forget - it never delays playback).
+        const firstPlayed = playBlob(url0);
+        if (metrics !== null && metrics.replyReadyAt > 0) {
+          const nowMs = performance.now();
+          metrics.firstAudioMs = nowMs - metrics.replyReadyAt;
+          metrics.totalTurnMs = metrics.pauseDetectedAt > 0 ? nowMs - metrics.pauseDetectedAt : 0;
+          postTurnTelemetry(metrics);
+        }
+
         // Barge-in: a fresh capture segment plus the rolling-window transcription watch for "stop".
         await restartCapture();
         stopSpeakingPoll();
         speakingPollRef.current = window.setInterval(() => onSpeakingTickRef.current(), SPEAKING_POLL_MS);
+
+        const how0 = await firstPlayed;
+        if (how0 === "stopped" || signal.aborted) return; // interrupted / ended session mid-reply
+
+        // Play the remainder (if any) right after the first sentence, back to back.
+        if (restPromise !== null) {
+          let restBlob: Blob;
+          try {
+            restBlob = await restPromise;
+          } catch (err) {
+            if (signal.aborted) return;
+            throw err;
+          }
+          if (signal.aborted) return;
+          revokeClip();
+          const url1 = URL.createObjectURL(restBlob);
+          clipUrlRef.current = url1;
+          const how1 = await playBlob(url1);
+          if (how1 === "stopped" || signal.aborted) return;
+        }
+
+        // The reply finished on its own: hand the microphone back to the owner.
+        await enterListening();
       } catch (err) {
         if (signal.aborted) return;
         announceError(gatewayErrorMessage(err));
         await enterListening();
       }
     },
-    [announceError, enterListening, restartCapture, revokeClip, setPhaseBoth, stopSpeakingPoll],
+    [announceError, enterListening, playBlob, postTurnTelemetry, restartCapture, revokeClip, setPhaseBoth, stopSpeakingPoll],
   );
 
   // Take the turn: the command (already stripped of "over and out") is answered by the brain and the reply
@@ -256,7 +420,6 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     async (command: string) => {
       if (phaseRef.current !== "listening") return;
       setPhaseBoth("thinking");
-      playReadyCue(); // "my turn" - the turn is taken
       stopSpeakingPoll();
       const rec = recorderRef.current;
       try {
@@ -275,11 +438,25 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
 
       try {
         if (trimmed.length === 0) {
+          // A forced turn with nothing heard: a canned nudge, no server turn, so no telemetry record.
+          turnMetricsRef.current = null;
           await speakAndPlay("I didn't catch a request. Go ahead when you're ready.", controller.signal);
           return;
         }
+        const brainStart = performance.now();
         const answer = await respond(trimmed, controller.signal);
         const spoken = answer.spoken.trim();
+        // Fill the turn metrics the transcribe step started (same object via the ref), for telemetry.
+        const metrics = turnMetricsRef.current;
+        if (metrics !== null) {
+          metrics.brainMs = performance.now() - brainStart;
+          metrics.replyReadyAt = performance.now();
+          metrics.turnId = answer.turnId ?? "";
+          metrics.server = answer.timing ?? null;
+          metrics.replyChars = spoken.length;
+          metrics.actionsCount = (answer.actions ?? []).length;
+          metrics.pendingConfirmation = Boolean(answer.pendingConfirmation);
+        }
         setReply(spoken);
         setActions(answer.actions ?? []);
         setPendingConfirmation(Boolean(answer.pendingConfirmation));
@@ -311,6 +488,9 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
         if (busyRef.current) return;
         busyRef.current = true;
       }
+      // The pause was detected (or "over and out" tapped) now; time the command transcription from here so
+      // the telemetry record shows how long the owner waits between finishing and the brain starting.
+      const pauseDetectedAt = performance.now();
       try {
         const clip = rec.snapshot();
         if (clip.size < MIN_CLIP_BYTES) {
@@ -320,16 +500,42 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
         if (!force) setCaptureState("pause - transcribing");
         const { wav } = await blobToWav16kMono(clip);
         const transcript = (await transcribeCarModeAudio(wav)).trim();
+        const pauseToTranscribeMs = performance.now() - pauseDetectedAt;
         setLastHeard(transcript);
         setCaptureError(null);
         const parsed = detectEndPhrase(transcript);
         setCaptureState(`heard: "${transcript}"`);
+
+        // Confirm the turn: fire the "my turn" cue the INSTANT the transcript confirms (before the brain
+        // responds), so the owner gets an immediate audible acknowledgement, then seed the turn metrics the
+        // brain + speak steps fill, then take the turn.
+        const confirmAndTake = (command: string) => {
+          playReadyCue();
+          turnMetricsRef.current = {
+            turnId: "",
+            pauseDetectedAt,
+            pauseToTranscribeMs,
+            commandChars: command.trim().length,
+            replyChars: 0,
+            brainMs: 0,
+            replyReadyAt: 0,
+            server: null,
+            actionsCount: 0,
+            pendingConfirmation: false,
+            ttsMs: 0,
+            firstAudioMs: 0,
+            totalTurnMs: 0,
+            posted: false,
+          };
+          void takeTurn(command);
+        };
+
         if (parsed.ended) {
           console.log("[CarMode] end phrase heard -> taking the turn");
-          void takeTurn(parsed.command);
+          confirmAndTake(parsed.command);
         } else if (force) {
           console.log('[CarMode] "over and out" tapped -> taking the turn with the heard command');
-          void takeTurn(transcript);
+          confirmAndTake(transcript);
         } else {
           // A mid-thought pause: keep the turn. Wait for fresh speech before probing again.
           heardSpeechRef.current = false;
@@ -369,12 +575,7 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
       setCaptureError(null);
       if (phaseRef.current === "speaking" && detectInterrupt(transcript)) {
         console.log("[CarMode] interrupt heard -> silencing and returning the turn");
-        const audio = audioRef.current;
-        try {
-          audio?.pause();
-        } catch {
-          /* nothing playing */
-        }
+        haltPlayback();
         setCaptureState("interrupt");
         await enterListening();
       }
@@ -383,7 +584,7 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     } finally {
       busyRef.current = false;
     }
-  }, [enterListening]);
+  }, [enterListening, haltPlayback]);
 
   // Keep the "latest" refs the long-lived loop/interval call pointed at the current implementations.
   onPauseRef.current = () => void transcribeAndDecide(false);
@@ -399,15 +600,10 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
   const interrupt = useCallback(() => {
     if (phaseRef.current !== "speaking") return;
     console.log('[CarMode] "stop" tapped -> silencing and returning the turn');
-    const audio = audioRef.current;
-    try {
-      audio?.pause();
-    } catch {
-      /* nothing playing */
-    }
+    haltPlayback();
     setCaptureState("interrupt");
     void enterListening();
-  }, [enterListening]);
+  }, [enterListening, haltPlayback]);
 
   // The live microphone level for the on-screen meter, polled by the page on an animation frame. Reads the
   // capture stream's AnalyserNode (display only) and returns 0 when the microphone is not capturing.
@@ -423,11 +619,9 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     setStarted(true);
     setError(null);
     recorderRef.current = new MicRecorder();
+    // The reply's sentence chunks are played by playBlob, which sets onended per clip; the speak loop hands
+    // the microphone back after the LAST chunk, so no global onended handler is needed here.
     audioRef.current = new Audio();
-    audioRef.current.onended = () => {
-      // The reply finished on its own: hand the microphone back to the owner.
-      if (phaseRef.current === "speaking") void enterListening();
-    };
 
     // The single silence-detector loop, live for the whole session; it only acts while Listening. When the
     // level drops below the threshold for PAUSE_MS AFTER speech was heard, it fires a pause probe.
@@ -457,6 +651,9 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
   const stop = useCallback(() => {
     console.log("[CarMode] stop");
     abortRef.current?.abort();
+    // Unblock any in-flight chunked playback so the speak loop unwinds instead of awaiting an ended event
+    // that will never fire.
+    playbackStopRef.current?.();
     if (rafRef.current !== 0) {
       window.cancelAnimationFrame(rafRef.current);
       rafRef.current = 0;
@@ -488,6 +685,7 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
   useEffect(() => {
     return () => {
       abortRef.current?.abort();
+      playbackStopRef.current?.();
       if (rafRef.current !== 0) window.cancelAnimationFrame(rafRef.current);
       if (speakingPollRef.current !== null) clearInterval(speakingPollRef.current);
       try {

--- a/src/CcDirector.Gateway.Tests/CarModeBrainTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeBrainTests.cs
@@ -117,6 +117,46 @@ public sealed class CarModeBrainTests
     }
 
     [Fact]
+    public async Task RunTurn_MeasuresPerStageTiming_ModelCallsAndFleetReads()
+    {
+        // Performance round: the turn response carries a per-stage timing breakdown. A list-then-answer turn
+        // is two model round trips and one fleet read; the timing must reflect exactly that.
+        var fleet = new FakeFleet { Sessions = new[] { Session("Local Files Manager", true) } };
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("list_sessions") }),
+            new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"One session needs you.\"}") }));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+
+        var result = await brain.RunTurnAsync("device-a", "who needs me over", CancellationToken.None);
+
+        Assert.NotNull(result.Timing);
+        Assert.Equal(2, result.Timing!.ModelCallCount);
+        Assert.Equal(2, result.Timing.ModelMs.Count);
+        Assert.Equal(2, result.Timing.Rounds);
+        Assert.Equal(1, result.Timing.FleetReadCount); // exactly one roster read for list_sessions
+        Assert.True(result.Timing.TotalMs >= 0);
+    }
+
+    [Fact]
+    public async Task RunTurn_GeneralQuestion_AnswersDirectly_WithNoFleetRead()
+    {
+        // The fleet-read suppression: a general question the model answers directly by calling speak_answer
+        // makes NO fleet read, so the roster aggregation never runs and the turn is fast.
+        var fleet = new FakeFleet { Sessions = new[] { Session("Local Files Manager", true) } };
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"I can run your fleet by voice.\"}") }));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+
+        var result = await brain.RunTurnAsync("device-a", "what can you help me with over", CancellationToken.None);
+
+        Assert.Equal("I can run your fleet by voice.", result.Spoken);
+        Assert.Equal(0, fleet.ListCalls);
+        Assert.NotNull(result.Timing);
+        Assert.Equal(0, result.Timing!.FleetReadCount);
+        Assert.Equal(1, result.Timing.ModelCallCount);
+    }
+
+    [Fact]
     public async Task RunTurn_ModelCallsActivityTool_PassesReferenceThrough()
     {
         var fleet = new FakeFleet

--- a/src/CcDirector.Gateway.Tests/CarModeTelemetryStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeTelemetryStoreTests.cs
@@ -1,0 +1,128 @@
+using CcDirector.Gateway.CarMode;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The Car Mode telemetry store (performance round) keeps per-turn timing records, retained by AGE
+/// (90 days) with a growth-guard cap only. These tests drive it against a temp file to prove it records,
+/// hands back newest-first, prunes records older than the retention window, keeps records with an
+/// unparseable stamp, survives a corrupt file, and never stores any text.
+/// </summary>
+public sealed class CarModeTelemetryStoreTests : IDisposable
+{
+    private readonly string _path = Path.Combine(Path.GetTempPath(), $"carmode-telemetry-{Guid.NewGuid():N}.json");
+
+    public void Dispose()
+    {
+        if (File.Exists(_path)) File.Delete(_path);
+        foreach (var f in Directory.GetFiles(Path.GetDirectoryName(_path)!, Path.GetFileName(_path) + ".corrupt-*"))
+            File.Delete(f);
+    }
+
+    private static CarModeTelemetryRecord Record(string turnId, string receivedAtUtc, double totalTurnMs = 2500) => new()
+    {
+        TurnId = turnId,
+        ReceivedAtUtc = receivedAtUtc,
+        DeviceHash = "abc123def456",
+        GatewayVersion = "1.0.0+test",
+        TotalTurnMs = totalTurnMs,
+        BrainMs = 1200,
+        FleetReadCount = 0,
+        ModelCallCount = 1,
+    };
+
+    [Fact]
+    public void Add_ThenRecent_ReturnsNewestFirst()
+    {
+        var store = new CarModeTelemetryStore(_path, _ => { });
+        store.Add(Record("t1", DateTime.UtcNow.AddMinutes(-2).ToString("o")));
+        store.Add(Record("t2", DateTime.UtcNow.AddMinutes(-1).ToString("o")));
+
+        var recent = store.Recent(10);
+
+        Assert.Equal(2, recent.Count);
+        Assert.Equal("t2", recent[0].TurnId); // newest first
+        Assert.Equal("t1", recent[1].TurnId);
+        Assert.Equal(2, store.Count());
+    }
+
+    [Fact]
+    public void Prune_DropsRecordsOlderThanNinetyDays_KeepsRecent()
+    {
+        var store = new CarModeTelemetryStore(_path, _ => { });
+        store.Add(Record("old", DateTime.UtcNow.AddDays(-120).ToString("o")));
+        store.Add(Record("fresh", DateTime.UtcNow.AddDays(-1).ToString("o")));
+
+        var recent = store.Recent(10);
+
+        Assert.Single(recent);
+        Assert.Equal("fresh", recent[0].TurnId);
+    }
+
+    [Fact]
+    public void Prune_KeepsRecordWithUnparseableStamp_RatherThanDiscardIt()
+    {
+        var store = new CarModeTelemetryStore(_path, _ => { });
+        store.Add(Record("weird", "not-a-date"));
+
+        Assert.Equal(1, store.Count());
+    }
+
+    [Fact]
+    public void Load_RestoresPersistedRecords_AcrossInstances()
+    {
+        var first = new CarModeTelemetryStore(_path, _ => { });
+        first.Add(Record("t1", DateTime.UtcNow.ToString("o")));
+
+        var second = new CarModeTelemetryStore(_path, _ => { });
+
+        Assert.Equal(1, second.Count());
+        Assert.Equal("t1", second.Recent(1)[0].TurnId);
+    }
+
+    [Fact]
+    public void Load_QuarantinesCorruptFile_AndStartsEmpty()
+    {
+        File.WriteAllText(_path, "{ this is not valid json ][");
+
+        var store = new CarModeTelemetryStore(_path, _ => { });
+
+        Assert.Equal(0, store.Count());
+        var corrupt = Directory.GetFiles(Path.GetDirectoryName(_path)!, Path.GetFileName(_path) + ".corrupt-*");
+        Assert.Single(corrupt);
+    }
+}
+
+/// <summary>The device hash (DT-05): a device's turns must group by a stable one-way hash that never
+/// contains the raw credential, and a blank credential maps to a fixed anonymous bucket.</summary>
+public sealed class CarModeDeviceHashTests
+{
+    [Fact]
+    public void Of_IsStableForTheSameCredential_ButNeverContainsIt()
+    {
+        var secret = "super-secret-device-key-1234567890";
+        var a = CarModeDeviceHash.Of(secret);
+        var b = CarModeDeviceHash.Of(secret);
+
+        Assert.Equal(a, b);
+        Assert.DoesNotContain(secret, a, StringComparison.Ordinal);
+        Assert.DoesNotContain("secret", a, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(12, a.Length); // 6 bytes rendered as hex
+    }
+
+    [Fact]
+    public void Of_DifferentCredentials_HashDifferently()
+    {
+        Assert.NotEqual(CarModeDeviceHash.Of("device-one"), CarModeDeviceHash.Of("device-two"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Of_BlankCredential_MapsToAnonymous(string? credential)
+    {
+        Assert.Equal("anonymous", CarModeDeviceHash.Of(credential));
+    }
+}

--- a/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
@@ -15,14 +15,22 @@ namespace CcDirector.Gateway.Api;
 /// action for confirmation. The browser stays thin (decision 2): it never sees the model key or the fleet
 /// logic.
 ///
-/// Auth: the route is not on the public allow-list and is not under /m/, so the host-wide auth gate already
-/// requires the caller's per-device key (or the shared token), per the Gateway auth rule. The caller's own
-/// credential also keys the server-side conversation context, so multi-turn works per device without any
-/// history crossing the wire. The credential is used only as an opaque key and is never logged (DT-05).
+/// Performance round: the turn response also carries a server-minted turnId and a per-stage server timing
+/// block so the browser can merge its own client stamps and post ONE compact timing record to the
+/// telemetry store below. Two more routes serve that store:
+///   POST /carmode/telemetry       - the browser posts one merged record per turn.
+///   GET  /carmode/telemetry       - a self-contained HTML dashboard of recent turns and aggregates.
+///   GET  /carmode/telemetry/data  - the raw records as JSON, which the dashboard fetches.
+///
+/// Auth: the routes are not on the public allow-list and are not under /m/, so the host-wide auth gate
+/// already requires the caller's per-device key (or the shared token), per the Gateway auth rule. The
+/// caller's own credential also keys the server-side conversation context, so multi-turn works per device
+/// without any history crossing the wire. The credential is used only as an opaque key and a one-way
+/// device hash, and is never logged (DT-05).
 /// </summary>
 internal static class CarModeEndpoint
 {
-    public static void Map(IEndpointRouteBuilder app, CarModeBrain brain)
+    public static void Map(IEndpointRouteBuilder app, CarModeBrain brain, CarModeTelemetryStore telemetry)
     {
         app.MapPost("/carmode/turn", async (HttpContext ctx, CarModeTurnRequest? req, CancellationToken ct) =>
         {
@@ -31,14 +39,29 @@ internal static class CarModeEndpoint
                 return Results.Json(new { error = "text is required" }, statusCode: StatusCodes.Status400BadRequest);
 
             var deviceKey = ExtractCallerCredential(ctx);
+            // A server-minted turn id ties the browser's posted timing record back to this turn's log line.
+            var turnId = Guid.NewGuid().ToString("N");
             try
             {
                 var result = await brain.RunTurnAsync(deviceKey, req.Text.Trim(), ct);
                 return Results.Json(new
                 {
+                    turnId,
                     spoken = result.Spoken,
                     actions = result.Actions.Select(a => new { tool = a.Tool, summary = a.Summary }),
                     pendingConfirmation = result.PendingConfirmation,
+                    // The per-stage server timing, inline, so the browser posts it back merged with its
+                    // own client stamps as one telemetry record (performance round).
+                    timing = result.Timing is null ? null : new
+                    {
+                        totalMs = result.Timing.TotalMs,
+                        modelCallCount = result.Timing.ModelCallCount,
+                        modelMsTotal = result.Timing.ModelMsTotal,
+                        modelMs = result.Timing.ModelMs,
+                        fleetReadCount = result.Timing.FleetReadCount,
+                        fleetReadMsTotal = result.Timing.FleetReadMsTotal,
+                        rounds = result.Timing.Rounds,
+                    },
                 });
             }
             catch (CarModeUnavailableException ex)
@@ -61,11 +84,66 @@ internal static class CarModeEndpoint
                     statusCode: StatusCodes.Status502BadGateway);
             }
         });
+
+        // The browser posts ONE merged timing record per turn here. It fills the client stamps and echoes
+        // the server timing it received in the turn response; the SERVER fills the received-at time, the
+        // device hash (from its own credential extraction, never trusting the client), and the Gateway
+        // build, so those cannot be spoofed. A malformed body is a clear 400, never a silent drop.
+        app.MapPost("/carmode/telemetry", (HttpContext ctx, CarModeTelemetryPost? req) =>
+        {
+            if (req is null || string.IsNullOrWhiteSpace(req.TurnId))
+                return Results.Json(new { error = "turnId is required" }, statusCode: StatusCodes.Status400BadRequest);
+
+            var record = new CarModeTelemetryRecord
+            {
+                TurnId = req.TurnId,
+                ReceivedAtUtc = DateTime.UtcNow.ToString("o"),
+                DeviceHash = CarModeDeviceHash.Of(ExtractCallerCredential(ctx)),
+                GatewayVersion = AppVersion.Full,
+                PauseToTranscribeMs = req.PauseToTranscribeMs,
+                BrainMs = req.BrainMs,
+                TtsMs = req.TtsMs,
+                FirstAudioMs = req.FirstAudioMs,
+                TotalTurnMs = req.TotalTurnMs,
+                ServerTotalMs = req.ServerTotalMs,
+                ModelCallCount = req.ModelCallCount,
+                ModelMsTotal = req.ModelMsTotal,
+                ModelMs = req.ModelMs ?? Array.Empty<double>(),
+                FleetReadCount = req.FleetReadCount,
+                FleetReadMsTotal = req.FleetReadMsTotal,
+                Rounds = req.Rounds,
+                CommandChars = req.CommandChars,
+                ReplyChars = req.ReplyChars,
+                ActionsCount = req.ActionsCount,
+                PendingConfirmation = req.PendingConfirmation,
+            };
+            var held = telemetry.Add(record);
+            return Results.Json(new { recorded = true, held });
+        });
+
+        app.MapGet("/carmode/telemetry/data", (HttpContext ctx) =>
+        {
+            var limit = 200;
+            if (int.TryParse(ctx.Request.Query["limit"], out var q) && q > 0) limit = Math.Min(q, 2000);
+            return Results.Json(new
+            {
+                generatedAtUtc = DateTime.UtcNow,
+                held = telemetry.Count(),
+                records = telemetry.Recent(limit),
+            });
+        });
+
+        app.MapGet("/carmode/telemetry", (HttpContext ctx) =>
+        {
+            ctx.Response.Headers.CacheControl = "no-cache";
+            ctx.Response.ContentType = "text/html; charset=utf-8";
+            return ctx.Response.WriteAsync(CarModeTelemetryPage.Html);
+        });
     }
 
     /// <summary>The caller's own credential (Bearer header, else the cc-gateway-token cookie), used only as
-    ///  the opaque per-device conversation key. Empty when the auth gate is off (debug), which the store
-    ///  maps to one shared anonymous context. Never logged.</summary>
+    ///  the opaque per-device conversation key and the one-way device hash. Empty when the auth gate is off
+    ///  (debug), which the store maps to one shared anonymous context. Never logged.</summary>
     private static string ExtractCallerCredential(HttpContext ctx)
     {
         if (ctx.Request.Headers.TryGetValue("Authorization", out var header))
@@ -79,4 +157,28 @@ internal static class CarModeEndpoint
             return cookie;
         return "";
     }
+}
+
+/// <summary>Body of POST /carmode/telemetry: the browser's client stamps plus the server timing it echoes
+/// back from the turn response, and small non-text turn facts. The server overrides the identity/build
+/// fields from its own side, so those are not part of this body.</summary>
+public sealed class CarModeTelemetryPost
+{
+    public string TurnId { get; set; } = "";
+    public double PauseToTranscribeMs { get; set; }
+    public double BrainMs { get; set; }
+    public double TtsMs { get; set; }
+    public double FirstAudioMs { get; set; }
+    public double TotalTurnMs { get; set; }
+    public double ServerTotalMs { get; set; }
+    public int ModelCallCount { get; set; }
+    public double ModelMsTotal { get; set; }
+    public double[]? ModelMs { get; set; }
+    public int FleetReadCount { get; set; }
+    public double FleetReadMsTotal { get; set; }
+    public int Rounds { get; set; }
+    public int CommandChars { get; set; }
+    public int ReplyChars { get; set; }
+    public int ActionsCount { get; set; }
+    public bool PendingConfirmation { get; set; }
 }

--- a/src/CcDirector.Gateway/CarMode/CarModeBrain.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeBrain.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using CcDirector.Core.Utilities;
 
@@ -46,6 +47,66 @@ public sealed class CarModeBrain
     /// </summary>
     public async Task<CarModeTurnResponse> RunTurnAsync(string deviceKey, string userText, CancellationToken ct)
     {
+        // Time the WHOLE turn from here, and collect per-model-call and per-fleet-read timings inside the
+        // core loop, so the endpoint returns a real per-stage breakdown to the browser (performance round).
+        var timer = new TurnTimer();
+        var response = await RunTurnCoreAsync(deviceKey, userText, timer, ct);
+        timer.Total.Stop();
+        var timing = timer.ToTiming();
+        _log($"[CarModeBrain] turn timing: total={timing.TotalMs:F0}ms, models={timing.ModelCallCount} ({timing.ModelMsTotal:F0}ms), "
+            + $"fleetReads={timing.FleetReadCount} ({timing.FleetReadMsTotal:F0}ms), rounds={timing.Rounds}");
+        return response with { Timing = timing };
+    }
+
+    /// <summary>Collects the per-stage server timing for one turn: the whole-turn stopwatch, each hosted-model
+    ///  round trip, and each fleet/roster read. Mutated in-place by the core loop, then frozen to a
+    ///  <see cref="CarModeTurnTiming"/>.</summary>
+    private sealed class TurnTimer
+    {
+        public readonly Stopwatch Total = Stopwatch.StartNew();
+        public readonly List<double> ModelMs = new();
+        public int FleetReadCount;
+        public double FleetReadMs;
+        public int Rounds;
+
+        /// <summary>Time one hosted-model round trip.</summary>
+        public async Task<T> TimeModelAsync<T>(Func<Task<T>> call)
+        {
+            var sw = Stopwatch.StartNew();
+            try { return await call(); }
+            finally { sw.Stop(); ModelMs.Add(sw.Elapsed.TotalMilliseconds); }
+        }
+
+        /// <summary>Time one fleet/roster read (or directors/repos read).</summary>
+        public async Task<T> TimeFleetAsync<T>(Func<Task<T>> call)
+        {
+            var sw = Stopwatch.StartNew();
+            try { return await call(); }
+            finally { sw.Stop(); FleetReadCount++; FleetReadMs += sw.Elapsed.TotalMilliseconds; }
+        }
+
+        /// <summary>Time one fleet act (start/message/approve/delete) as a fleet read for accounting.</summary>
+        public async Task TimeFleetAsync(Func<Task> call)
+        {
+            var sw = Stopwatch.StartNew();
+            try { await call(); }
+            finally { sw.Stop(); FleetReadCount++; FleetReadMs += sw.Elapsed.TotalMilliseconds; }
+        }
+
+        public CarModeTurnTiming ToTiming() => new()
+        {
+            TotalMs = Total.Elapsed.TotalMilliseconds,
+            ModelCallCount = ModelMs.Count,
+            ModelMsTotal = ModelMs.Sum(),
+            ModelMs = ModelMs.ToArray(),
+            FleetReadCount = FleetReadCount,
+            FleetReadMsTotal = FleetReadMs,
+            Rounds = Rounds,
+        };
+    }
+
+    private async Task<CarModeTurnResponse> RunTurnCoreAsync(string deviceKey, string userText, TurnTimer timer, CancellationToken ct)
+    {
         if (string.IsNullOrWhiteSpace(userText))
             throw new ArgumentException("The command text is required.", nameof(userText));
 
@@ -62,7 +123,7 @@ public sealed class CarModeBrain
             _pending.Clear(deviceKey);
             if (CarModeConfirm.IsAffirmative(userText))
             {
-                var (spokenDone, action) = await ExecuteConfirmedAsync(armed, ct);
+                var (spokenDone, action) = await ExecuteConfirmedAsync(armed, timer, ct);
                 _conversations.Append(deviceKey, userText, spokenDone);
                 _log($"[CarModeBrain] confirmed {armed.Tool} for {armed.TargetName}");
                 return new CarModeTurnResponse { Spoken = spokenDone, Actions = new[] { action } };
@@ -90,8 +151,9 @@ public sealed class CarModeBrain
 
         for (var round = 0; round < MaxRounds; round++)
         {
+            timer.Rounds = round + 1;
             var messagesJson = JsonSerializer.Serialize(messages);
-            var turn = await _chat.CompleteAsync(messagesJson, ToolCatalogJson, ct);
+            var turn = await timer.TimeModelAsync(() => _chat.CompleteAsync(messagesJson, ToolCatalogJson, ct));
 
             // Under tool_choice=required the model normally calls a tool every turn, and says its final
             // words by calling speak_answer. Defensive path: if a model still answers in plain content with
@@ -142,7 +204,7 @@ public sealed class CarModeBrain
                     }
                     continue;
                 }
-                var outcome = await ExecuteToolAsync(deviceKey, call, ct);
+                var outcome = await ExecuteToolAsync(deviceKey, call, timer, ct);
                 if (outcome.Action is not null) actions.Add(outcome.Action);
                 if (outcome.ArmedConfirmation) armedThisTurn = true;
                 messages.Add(new { role = "tool", tool_call_id = call.Id, content = outcome.ResultJson });
@@ -175,14 +237,14 @@ public sealed class CarModeBrain
     ///  a tool error (the model can recover next round); a genuine fleet failure throws (a loud, specific,
     ///  spoken failure). Ordinary acts (start / message / approve) run immediately; the destructive act
     ///  (delete) is NOT run - it arms a confirmation the owner must speak next turn (decision 3).</summary>
-    private async Task<ToolOutcome> ExecuteToolAsync(string deviceKey, CarModeToolCall call, CancellationToken ct)
+    private async Task<ToolOutcome> ExecuteToolAsync(string deviceKey, CarModeToolCall call, TurnTimer timer, CancellationToken ct)
     {
         _log($"[CarModeBrain] tool: {call.Name}");
         switch (call.Name)
         {
             case "list_sessions":
             {
-                var sessions = await _fleet.ListSessionsAsync(ct);
+                var sessions = await timer.TimeFleetAsync(() => _fleet.ListSessionsAsync(ct));
                 return Result(new
                 {
                     needsYouCount = sessions.Count(s => s.NeedsYou),
@@ -199,7 +261,7 @@ public sealed class CarModeBrain
                 var reference = ReadStringArg(call.ArgumentsJson, "session");
                 if (string.IsNullOrWhiteSpace(reference))
                     return Result(new { error = "Provide a session name, repo, or number." });
-                var activity = await _fleet.GetSessionActivityAsync(reference, ct);
+                var activity = await timer.TimeFleetAsync(() => _fleet.GetSessionActivityAsync(reference, ct));
                 if (activity is null)
                     return Result(new { error = $"No session matched \"{reference}\"." });
                 return Result(new { activity.Name, activity.Repo, activity.State, activity.NeedsYou, activity.Summary });
@@ -209,7 +271,7 @@ public sealed class CarModeBrain
                 var repo = ReadStringArg(call.ArgumentsJson, "repo");
                 if (string.IsNullOrWhiteSpace(repo))
                     return Result(new { error = "Provide the repository name to start a session in." });
-                var summary = await _fleet.StartSessionAsync(repo, ct);
+                var summary = await timer.TimeFleetAsync(() => _fleet.StartSessionAsync(repo, ct));
                 return Acted(new { status = "started", summary }, new CarModeActionRecord("start_session", summary));
             }
             case "message_session":
@@ -218,10 +280,10 @@ public sealed class CarModeBrain
                 var message = ReadStringArg(call.ArgumentsJson, "message");
                 if (string.IsNullOrWhiteSpace(reference) || string.IsNullOrWhiteSpace(message))
                     return Result(new { error = "Provide both the session and the message to send." });
-                var target = await _fleet.ResolveSessionAsync(reference, ct);
+                var target = await timer.TimeFleetAsync(() => _fleet.ResolveSessionAsync(reference, ct));
                 if (target is null)
                     return Result(new { error = $"No session matched \"{reference}\"." });
-                await _fleet.MessageSessionAsync(target.SessionId, message, ct);
+                await timer.TimeFleetAsync(() => _fleet.MessageSessionAsync(target.SessionId, message, ct));
                 var summary = $"Messaged {target.Name}.";
                 return Acted(new { status = "sent", session = target.Name }, new CarModeActionRecord("message_session", summary));
             }
@@ -230,10 +292,10 @@ public sealed class CarModeBrain
                 var reference = ReadStringArg(call.ArgumentsJson, "session");
                 if (string.IsNullOrWhiteSpace(reference))
                     return Result(new { error = "Provide the session to approve." });
-                var target = await _fleet.ResolveSessionAsync(reference, ct);
+                var target = await timer.TimeFleetAsync(() => _fleet.ResolveSessionAsync(reference, ct));
                 if (target is null)
                     return Result(new { error = $"No session matched \"{reference}\"." });
-                await _fleet.ApproveSessionAsync(target.SessionId, ct);
+                await timer.TimeFleetAsync(() => _fleet.ApproveSessionAsync(target.SessionId, ct));
                 var summary = $"Approved {target.Name}.";
                 return Acted(new { status = "approved", session = target.Name }, new CarModeActionRecord("approve_session", summary));
             }
@@ -242,7 +304,7 @@ public sealed class CarModeBrain
                 var reference = ReadStringArg(call.ArgumentsJson, "session");
                 if (string.IsNullOrWhiteSpace(reference))
                     return Result(new { error = "Provide the session to delete." });
-                var target = await _fleet.ResolveSessionAsync(reference, ct);
+                var target = await timer.TimeFleetAsync(() => _fleet.ResolveSessionAsync(reference, ct));
                 if (target is null)
                     return Result(new { error = $"No session matched \"{reference}\"." });
                 // Destructive: do NOT delete. Arm a confirmation the owner must speak next turn.
@@ -265,12 +327,12 @@ public sealed class CarModeBrain
 
     /// <summary>Execute a destructive action the owner has just confirmed out loud, returning the spoken
     ///  acknowledgement and the action record. A fleet failure throws (a loud, specific, spoken failure).</summary>
-    private async Task<(string Spoken, CarModeActionRecord Action)> ExecuteConfirmedAsync(CarModePendingAction pending, CancellationToken ct)
+    private async Task<(string Spoken, CarModeActionRecord Action)> ExecuteConfirmedAsync(CarModePendingAction pending, TurnTimer timer, CancellationToken ct)
     {
         switch (pending.Tool)
         {
             case "delete":
-                await _fleet.DeleteSessionAsync(pending.SessionId, ct);
+                await timer.TimeFleetAsync(() => _fleet.DeleteSessionAsync(pending.SessionId, ct));
                 return ($"Done. I deleted {pending.TargetName}.", new CarModeActionRecord("delete_session", $"Deleted {pending.TargetName}."));
             default:
                 throw new InvalidOperationException($"Unknown pending action \"{pending.Tool}\".");
@@ -331,7 +393,13 @@ public sealed class CarModeBrain
         + "- Always refer to a session by its human NAME and its repository, never by its number "
         + "(for example: \"Local Files Manager, in the devthrottle repo\"). Only use a number if the owner "
         + "used one.\n"
-        + "- Use the tools to get REAL facts before you answer. Never guess a count, a name, or a state.\n"
+        + "- When a question is ABOUT THE FLEET - how many sessions there are, which need you, what a session "
+        + "is doing, the latest one, or an action on a session - use the tools to get REAL facts first. Never "
+        + "guess a count, a name, or a state.\n"
+        + "- But when a question is GENERAL and is NOT about the fleet - a greeting, \"what can you do\", "
+        + "\"what can you help me with\", how Car Mode works, a thank-you, or small talk - answer it "
+        + "DIRECTLY by calling speak_answer. Do NOT call list_sessions or any fleet tool for these. Reading "
+        + "the fleet you do not need only makes the owner wait longer, so skip it.\n"
         + "- \"need me\", \"need you\", \"waiting\", and \"who wants me\" all mean sessions whose needsYou is "
         + "true. \"The latest one\" is the first session in the list (it is ordered newest first).\n"
         + "- If a request is ambiguous or you cannot tell which session is meant, ask one short clarifying "

--- a/src/CcDirector.Gateway/CarMode/CarModeModels.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeModels.cs
@@ -51,6 +51,12 @@ public sealed record CarModeTurnResponse
     public required string Spoken { get; init; }
     public IReadOnlyList<CarModeActionRecord> Actions { get; init; } = Array.Empty<CarModeActionRecord>();
     public bool PendingConfirmation { get; init; }
+
+    /// <summary>The per-stage server timing for this turn (Car Mode performance round): every hosted-model
+    ///  round trip and every fleet/roster read, plus the whole-turn wall-clock. Null only on a path that did
+    ///  not measure (it always measures in production). The endpoint returns it inline so the browser merges
+    ///  it with its own client stamps into one telemetry record.</summary>
+    public CarModeTurnTiming? Timing { get; init; }
 }
 
 /// <summary>Request body of POST /carmode/turn: the owner's transcribed command for this turn.</summary>

--- a/src/CcDirector.Gateway/CarMode/CarModeTelemetry.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeTelemetry.cs
@@ -1,0 +1,124 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace CcDirector.Gateway.CarMode;
+
+/// <summary>
+/// The per-stage timing the Car Mode brain measures while it answers one turn (Car Mode performance round).
+/// These are the SERVER stamps: the whole /carmode/turn wall-clock, every hosted-model round trip, and the
+/// fleet/roster reads the tools made. They are returned inline in the turn response so the browser can
+/// merge them with its own CLIENT stamps (pause-to-transcribe, the brain round trip, text-to-speech, and
+/// first-audio) into ONE compact record it posts back to the telemetry store. Milliseconds throughout.
+/// </summary>
+public sealed record CarModeTurnTiming
+{
+    /// <summary>The whole brain turn, server side: the first line of RunTurnAsync to the final answer.</summary>
+    public double TotalMs { get; init; }
+
+    /// <summary>How many hosted-model round trips this turn took (one per tool-calling round).</summary>
+    public int ModelCallCount { get; init; }
+
+    /// <summary>The sum of every model round trip's duration.</summary>
+    public double ModelMsTotal { get; init; }
+
+    /// <summary>Each model round trip's duration, in call order, so a slow single call is visible.</summary>
+    public IReadOnlyList<double> ModelMs { get; init; } = Array.Empty<double>();
+
+    /// <summary>How many times the tools read the fleet roster (or the directors/repos) this turn. Zero for
+    ///  a general question that never touched the fleet - the whole point of the fleet-read suppression.</summary>
+    public int FleetReadCount { get; init; }
+
+    /// <summary>The sum of every fleet/roster read's duration this turn.</summary>
+    public double FleetReadMsTotal { get; init; }
+
+    /// <summary>How many tool-calling rounds the loop ran before it settled on a final spoken answer.</summary>
+    public int Rounds { get; init; }
+}
+
+/// <summary>
+/// One compact Car Mode turn timing record, the unit the telemetry store keeps. It carries ONLY timings
+/// and small counts - never the text of what was said or heard (the command and reply are recorded as
+/// character counts only, mirroring the Stats dashboard's counts-only rule). The device is identified by a
+/// short one-way hash of its credential, never the raw credential (security rule DT-05).
+///
+/// The browser fills the client stamps and echoes back the server timing it received in the turn response;
+/// the server fills <see cref="ReceivedAtUtc"/>, <see cref="DeviceHash"/>, and <see cref="GatewayVersion"/>
+/// from its own side so those cannot be spoofed by the client.
+/// </summary>
+public sealed record CarModeTelemetryRecord
+{
+    /// <summary>The turn id the server minted and returned in the turn response, so the client record and
+    ///  the server's own log line for the same turn can be lined up.</summary>
+    public string TurnId { get; init; } = "";
+
+    /// <summary>When the server received this record (server-stamped, ISO-8601 UTC). The retention sweep
+    ///  ages records off by this.</summary>
+    public string ReceivedAtUtc { get; init; } = "";
+
+    /// <summary>A short, one-way hash of the caller's device credential (server-stamped). Groups a device's
+    ///  turns without ever storing the credential (DT-05).</summary>
+    public string DeviceHash { get; init; } = "";
+
+    /// <summary>The Gateway build that served the turn (server-stamped), so a record is tied to a build.</summary>
+    public string GatewayVersion { get; init; } = "";
+
+    // ----- Client stamps (milliseconds), measured in the browser turn-taking machine -----
+
+    /// <summary>Pause detected (or "over and out" tapped) to the command transcript in hand: the Gateway
+    ///  transcription round trip for the command.</summary>
+    public double PauseToTranscribeMs { get; init; }
+
+    /// <summary>The brain round trip as the browser saw it: POST /carmode/turn request to response, network
+    ///  included (so it is >= the server TotalMs by the network cost).</summary>
+    public double BrainMs { get; init; }
+
+    /// <summary>The text-to-speech round trip for the FIRST spoken chunk (POST /wingman/tts).</summary>
+    public double TtsMs { get; init; }
+
+    /// <summary>Reply text in hand to audio actually playing: the time the owner waits after the brain
+    ///  answers before he hears anything (first-chunk synthesis plus the play call).</summary>
+    public double FirstAudioMs { get; init; }
+
+    /// <summary>The whole turn as the owner feels it: pause detected to first audio playing.</summary>
+    public double TotalTurnMs { get; init; }
+
+    // ----- Server stamps (from CarModeTurnTiming, echoed back by the client) -----
+
+    public double ServerTotalMs { get; init; }
+    public int ModelCallCount { get; init; }
+    public double ModelMsTotal { get; init; }
+    public IReadOnlyList<double> ModelMs { get; init; } = Array.Empty<double>();
+    public int FleetReadCount { get; init; }
+    public double FleetReadMsTotal { get; init; }
+    public int Rounds { get; init; }
+
+    // ----- Small, non-text turn facts -----
+
+    /// <summary>The owner's command length in characters (never the text itself).</summary>
+    public int CommandChars { get; init; }
+
+    /// <summary>The spoken reply length in characters (never the text itself).</summary>
+    public int ReplyChars { get; init; }
+
+    /// <summary>How many fleet actions the brain took this turn.</summary>
+    public int ActionsCount { get; init; }
+
+    /// <summary>True when the turn ended holding a destructive action for a spoken confirmation.</summary>
+    public bool PendingConfirmation { get; init; }
+}
+
+/// <summary>Helpers for the caller-credential hash used as <see cref="CarModeTelemetryRecord.DeviceHash"/>.</summary>
+public static class CarModeDeviceHash
+{
+    /// <summary>A short, stable, one-way hash of a device credential (first 12 hex of its SHA-256), so a
+    ///  device's turns group together without the raw credential ever being stored or logged (DT-05). A
+    ///  blank credential (auth-off debug) maps to a fixed "anonymous" bucket.</summary>
+    public static string Of(string? credential)
+    {
+        if (string.IsNullOrWhiteSpace(credential)) return "anonymous";
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(credential));
+        var sb = new StringBuilder(12);
+        for (var i = 0; i < 6; i++) sb.Append(bytes[i].ToString("x2"));
+        return sb.ToString();
+    }
+}

--- a/src/CcDirector.Gateway/CarMode/CarModeTelemetryPage.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeTelemetryPage.cs
@@ -1,0 +1,189 @@
+namespace CcDirector.Gateway.CarMode;
+
+/// <summary>
+/// The self-contained HTML for GET /carmode/telemetry (Car Mode performance round): a private dashboard the
+/// owner opens on the Gateway to see, per turn, exactly where a Car Mode turn spent its time - the client
+/// stamps (pause to transcribe, the brain round trip, first audio) and the server stamps (each model call,
+/// the fleet reads, the whole-turn wall-clock). It reads the Gateway's own telemetry store with no cloud
+/// round trip. Embedded in the binary (not a wwwroot React route) so it works even on a plain dev build,
+/// exactly like the Stats page. All CSS and JavaScript inline, no external requests, ASCII only,
+/// light/dark aware.
+/// </summary>
+internal static class CarModeTelemetryPage
+{
+    public const string Html = """
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Car Mode Timing</title>
+<style>
+  :root {
+    --bg: #f5f6f8; --card: #ffffff; --ink: #1b1f24; --muted: #5b636d; --line: #e2e5ea;
+    --accent: #2f6feb; --good: #0b8f5a; --warn: #8a6d1a; --bad: #c0392b;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #12151a; --card: #1b1f26; --ink: #e8ebef; --muted: #9aa3ad; --line: #2a2f38;
+      --accent: #5b8def; --good: #3fbf86; --warn: #d8b451; --bad: #e06c5b;
+    }
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--ink);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    line-height: 1.5; }
+  .wrap { max-width: 1100px; margin: 0 auto; padding: 24px 16px 64px; }
+  h1 { font-size: 20px; margin: 0 0 2px; }
+  .sub { color: var(--muted); font-size: 13px; margin: 0 0 20px; }
+  .cards { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 22px; }
+  @media (max-width: 720px) { .cards { grid-template-columns: 1fr 1fr; } }
+  .card { background: var(--card); border: 1px solid var(--line); border-radius: 12px; padding: 16px; }
+  .card .big { font-size: 30px; font-weight: 700; letter-spacing: -0.5px; line-height: 1; }
+  .card .lbl { color: var(--muted); font-size: 12.5px; margin-top: 6px; }
+  .card .sm { color: var(--muted); font-size: 11.5px; margin-top: 2px; }
+  .section { background: var(--card); border: 1px solid var(--line); border-radius: 12px;
+    padding: 12px 14px; margin-bottom: 16px; overflow-x: auto; }
+  .section h2 { font-size: 14px; margin: 4px 2px 10px; text-transform: uppercase; letter-spacing: 0.04em;
+    color: var(--muted); }
+  table { width: 100%; border-collapse: collapse; font-size: 12.5px; white-space: nowrap; }
+  th, td { text-align: right; padding: 6px 8px; border-bottom: 1px solid var(--line);
+    font-variant-numeric: tabular-nums; }
+  th:first-child, td:first-child { text-align: left; }
+  th { color: var(--muted); font-weight: 600; position: sticky; top: 0; background: var(--card); }
+  td.slow { color: var(--bad); font-weight: 600; }
+  td.zero { color: var(--good); }
+  .empty { color: var(--muted); font-size: 14px; padding: 12px 4px; }
+  .foot { color: var(--muted); font-size: 12px; margin-top: 18px; }
+  .err { color: var(--bad); }
+  .pill { display: inline-block; font-size: 11px; padding: 1px 7px; border-radius: 20px;
+    border: 1px solid var(--line); color: var(--muted); margin-left: 6px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Car Mode Timing</h1>
+  <p class="sub">Per-turn, per-stage latency for hands-free Car Mode - measured end to end, client and server. All numbers are milliseconds. Counts and timings only; no command or reply text is ever recorded.</p>
+
+  <div class="cards" id="cards"></div>
+
+  <div class="section">
+    <h2>Recent turns <span class="pill" id="heldPill"></span></h2>
+    <table id="tbl">
+      <thead>
+        <tr>
+          <th>When</th>
+          <th>Total<br>(felt)</th>
+          <th>Pause-&gt;<br>transcribe</th>
+          <th>Brain<br>(round trip)</th>
+          <th>First<br>audio</th>
+          <th>TTS<br>(1st)</th>
+          <th>Server<br>total</th>
+          <th>Model<br>calls</th>
+          <th>Model<br>ms</th>
+          <th>Fleet<br>reads</th>
+          <th>Fleet<br>ms</th>
+          <th>Rounds</th>
+          <th>Cmd<br>chars</th>
+          <th>Reply<br>chars</th>
+        </tr>
+      </thead>
+      <tbody id="rows"></tbody>
+    </table>
+  </div>
+
+  <div class="foot" id="foot"></div>
+</div>
+
+<script>
+(function () {
+  function ms(n) { return (n == null) ? "-" : Math.round(n).toLocaleString(); }
+  function median(arr) {
+    if (!arr.length) return null;
+    var a = arr.slice().sort(function (x, y) { return x - y; });
+    var m = Math.floor(a.length / 2);
+    return a.length % 2 ? a[m] : (a[m - 1] + a[m]) / 2;
+  }
+  function pctile(arr, p) {
+    if (!arr.length) return null;
+    var a = arr.slice().sort(function (x, y) { return x - y; });
+    var idx = Math.min(a.length - 1, Math.floor((p / 100) * a.length));
+    return a[idx];
+  }
+  function card(big, lbl, sm) {
+    var d = document.createElement("div"); d.className = "card";
+    var b = document.createElement("div"); b.className = "big"; b.textContent = big;
+    var l = document.createElement("div"); l.className = "lbl"; l.textContent = lbl;
+    d.appendChild(b); d.appendChild(l);
+    if (sm) { var s = document.createElement("div"); s.className = "sm"; s.textContent = sm; d.appendChild(s); }
+    return d;
+  }
+
+  function render(data) {
+    var recs = data.records || [];
+    var cards = document.getElementById("cards"); cards.innerHTML = "";
+    document.getElementById("heldPill").textContent = (data.held || 0) + " stored";
+
+    if (!recs.length) {
+      cards.appendChild(card("-", "No turns recorded yet", "Take a turn in Car Mode on the phone"));
+      document.getElementById("rows").innerHTML = '<tr><td colspan="14" class="empty">No turns recorded yet. Open Car Mode on the phone, say something and "over and out", and it will appear here.</td></tr>';
+      document.getElementById("foot").textContent = "";
+      return;
+    }
+
+    var totals = recs.map(function (r) { return r.totalTurnMs; }).filter(function (n) { return n > 0; });
+    var brains = recs.map(function (r) { return r.brainMs; }).filter(function (n) { return n > 0; });
+    var firsts = recs.map(function (r) { return r.firstAudioMs; }).filter(function (n) { return n > 0; });
+    var fleetHit = recs.filter(function (r) { return (r.fleetReadCount || 0) > 0; }).length;
+
+    cards.appendChild(card(ms(median(totals)), "Median total (felt)", "p90 " + ms(pctile(totals, 90))));
+    cards.appendChild(card(ms(median(brains)), "Median brain round trip", "p90 " + ms(pctile(brains, 90))));
+    cards.appendChild(card(ms(median(firsts)), "Median time to first audio", "p90 " + ms(pctile(firsts, 90))));
+    cards.appendChild(card(fleetHit + " / " + recs.length, "Turns that read the fleet", "the rest answered without it"));
+
+    var body = document.getElementById("rows"); body.innerHTML = "";
+    recs.forEach(function (r) {
+      var tr = document.createElement("tr");
+      function td(v, cls) {
+        var c = document.createElement("td");
+        if (cls) c.className = cls;
+        c.textContent = v;
+        return c;
+      }
+      var when = r.receivedAtUtc ? new Date(r.receivedAtUtc).toLocaleTimeString() : "-";
+      tr.appendChild(td(when));
+      tr.appendChild(td(ms(r.totalTurnMs), r.totalTurnMs > 6000 ? "slow" : ""));
+      tr.appendChild(td(ms(r.pauseToTranscribeMs)));
+      tr.appendChild(td(ms(r.brainMs), r.brainMs > 5000 ? "slow" : ""));
+      tr.appendChild(td(ms(r.firstAudioMs)));
+      tr.appendChild(td(ms(r.ttsMs)));
+      tr.appendChild(td(ms(r.serverTotalMs)));
+      tr.appendChild(td(r.modelCallCount == null ? "-" : r.modelCallCount));
+      tr.appendChild(td(ms(r.modelMsTotal)));
+      tr.appendChild(td(r.fleetReadCount == null ? "-" : r.fleetReadCount, (r.fleetReadCount || 0) === 0 ? "zero" : ""));
+      tr.appendChild(td(ms(r.fleetReadMsTotal)));
+      tr.appendChild(td(r.rounds == null ? "-" : r.rounds));
+      tr.appendChild(td(r.commandChars == null ? "-" : r.commandChars));
+      tr.appendChild(td(r.replyChars == null ? "-" : r.replyChars));
+      body.appendChild(tr);
+    });
+
+    var when = data.generatedAtUtc ? new Date(data.generatedAtUtc).toLocaleString() : "";
+    document.getElementById("foot").textContent = "Updated " + when + " - refreshes every 5 seconds. Retained about 90 days. Counts and timings only; no message text.";
+  }
+
+  function load() {
+    fetch("/carmode/telemetry/data?limit=200", { credentials: "same-origin" })
+      .then(function (r) { if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); })
+      .then(render)
+      .catch(function (e) { document.getElementById("foot").innerHTML = '<span class="err">Could not load telemetry: ' + e.message + "</span>"; });
+  }
+
+  load();
+  setInterval(load, 5000);
+})();
+</script>
+</body>
+</html>
+""";
+}

--- a/src/CcDirector.Gateway/CarMode/CarModeTelemetryStore.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeTelemetryStore.cs
@@ -1,0 +1,171 @@
+using System.Text.Json;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.CarMode;
+
+/// <summary>
+/// The durable, Gateway-local store of Car Mode turn timing records (Car Mode performance round). Every
+/// turn the browser posts ONE compact <see cref="CarModeTelemetryRecord"/> here; the private
+/// GET /carmode/telemetry dashboard reads them back with no cloud round trip. This is the observability
+/// foundation the owner asked for - a real per-stage breakdown of where a Car Mode turn spends its time.
+///
+/// Retention is by AGE (drop records older than <see cref="RetentionDays"/> days, the owner's stated
+/// 90-day intent), with a generous hard cap (<see cref="MaxRecords"/>) ONLY as an unbounded-growth guard so
+/// the file can never grow without bound if the owner walks-and-talks far more than expected in a window.
+/// Persisted as a single JSON document with an atomic temp-write + rename (a concurrent reader or a crash
+/// mid-write never sees a half-written store); a corrupt file is quarantined and the store starts empty,
+/// exactly like <see cref="Stats.GatewayInputStatsAggregator"/>.
+///
+/// Only timings and small counts are ever kept - never the text of what was said or heard.
+/// </summary>
+public sealed class CarModeTelemetryStore
+{
+    private static readonly JsonSerializerOptions FileJsonOptions = new() { WriteIndented = false };
+
+    /// <summary>Keep records for this many days (the owner asked specifically for 90 days).</summary>
+    private const int RetentionDays = 90;
+
+    /// <summary>An unbounded-growth guard only - far above any realistic 90-day volume. When the store
+    ///  somehow exceeds this, the oldest records are dropped first so the newest are always kept.</summary>
+    private const int MaxRecords = 10000;
+
+    private readonly string _path;
+    private readonly object _lock = new();
+    private readonly Action<string> _log;
+
+    // Newest last (append order). Reads hand back a newest-first copy for the dashboard.
+    private readonly List<CarModeTelemetryRecord> _records = new();
+
+    /// <param name="path">The durable store file. Defaults to carmode-telemetry.json under the cc-director
+    ///  storage root, beside the other Gateway stores.</param>
+    /// <param name="log">Log sink; <see cref="FileLog.Write"/> when null.</param>
+    public CarModeTelemetryStore(string? path = null, Action<string>? log = null)
+    {
+        _path = string.IsNullOrWhiteSpace(path)
+            ? Path.Combine(CcStorage.Root(), "carmode-telemetry.json")
+            : path!;
+        _log = log ?? FileLog.Write;
+        Load();
+    }
+
+    /// <summary>Record one turn's timing, then prune by age (and the growth-guard cap) and persist. A null
+    ///  record is ignored. The stored count after the add is returned so the endpoint can log it.</summary>
+    public int Add(CarModeTelemetryRecord? record)
+    {
+        if (record is null) return Count();
+        lock (_lock)
+        {
+            _records.Add(record);
+            PruneLocked(DateTime.UtcNow);
+            Save();
+            _log($"[CarModeTelemetry] recorded turn {record.TurnId}: total={record.TotalTurnMs:F0}ms, brain={record.BrainMs:F0}ms, "
+                + $"fleetReads={record.FleetReadCount}, models={record.ModelCallCount}; store now holds {_records.Count}");
+            return _records.Count;
+        }
+    }
+
+    /// <summary>The most recent <paramref name="limit"/> records, newest first, for the dashboard.</summary>
+    public IReadOnlyList<CarModeTelemetryRecord> Recent(int limit)
+    {
+        if (limit <= 0) limit = 100;
+        lock (_lock)
+        {
+            var start = Math.Max(0, _records.Count - limit);
+            var slice = _records.GetRange(start, _records.Count - start);
+            slice.Reverse();
+            return slice;
+        }
+    }
+
+    /// <summary>How many records are held right now.</summary>
+    public int Count()
+    {
+        lock (_lock) return _records.Count;
+    }
+
+    // Drop records older than the retention window, then, only if still over the growth-guard cap, drop the
+    // oldest until under it. Caller holds the lock.
+    private void PruneLocked(DateTime nowUtc)
+    {
+        var cutoff = nowUtc.AddDays(-RetentionDays);
+        var removedByAge = _records.RemoveAll(r => !WithinRetention(r.ReceivedAtUtc, cutoff));
+        if (removedByAge > 0)
+            _log($"[CarModeTelemetry] pruned {removedByAge} record(s) older than {RetentionDays} days");
+
+        if (_records.Count > MaxRecords)
+        {
+            var overflow = _records.Count - MaxRecords;
+            _records.RemoveRange(0, overflow);
+            _log($"[CarModeTelemetry] growth guard: dropped {overflow} oldest record(s) to stay at {MaxRecords}");
+        }
+    }
+
+    /// <summary>True when a record's received-at stamp is at or after the cutoff. A record with an
+    ///  unparseable stamp is KEPT (treated as fresh) rather than silently discarded.</summary>
+    private static bool WithinRetention(string receivedAtUtc, DateTime cutoff)
+    {
+        if (!DateTime.TryParse(receivedAtUtc, null, System.Globalization.DateTimeStyles.AdjustToUniversal | System.Globalization.DateTimeStyles.AssumeUniversal, out var when))
+            return true;
+        return when >= cutoff;
+    }
+
+    private void Load()
+    {
+        if (!File.Exists(_path))
+        {
+            _log($"[CarModeTelemetry] Load: no store file at {_path}; starting empty");
+            return;
+        }
+
+        List<CarModeTelemetryRecord>? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize<List<CarModeTelemetryRecord>>(File.ReadAllText(_path), FileJsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            Quarantine(ex.Message);
+            return;
+        }
+        if (parsed is null)
+        {
+            Quarantine("file deserialized to null (no store document)");
+            return;
+        }
+
+        _records.AddRange(parsed);
+        PruneLocked(DateTime.UtcNow);
+        _log($"[CarModeTelemetry] Load: restored {_records.Count} record(s) from {_path}");
+    }
+
+    private void Quarantine(string reason)
+    {
+        var quarantinePath = $"{_path}.corrupt-{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}";
+        File.Move(_path, quarantinePath);
+        _log($"[CarModeTelemetry] Load FAILED: store file at {_path} is corrupt ({reason}); quarantined to {quarantinePath}; starting empty.");
+    }
+
+    // Write-through under the lock: serialize the whole store and atomically replace the file (temp +
+    // rename) so a concurrent reader or a crash mid-write never sees a half-written store. A failed save is
+    // a LOGGED error that propagates - never a silent skip (no-fallback).
+    private void Save()
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(_path);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            var json = JsonSerializer.Serialize(_records, FileJsonOptions);
+            var tmp = _path + ".tmp";
+            File.WriteAllText(tmp, json);
+            File.Move(tmp, _path, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            _log($"[CarModeTelemetry] Save FAILED: path={_path}: {ex.Message}");
+            throw;
+        }
+    }
+}

--- a/src/CcDirector.Gateway/CarMode/LoopbackCarModeFleet.cs
+++ b/src/CcDirector.Gateway/CarMode/LoopbackCarModeFleet.cs
@@ -20,10 +20,22 @@ public sealed class LoopbackCarModeFleet : ICarModeFleet
 {
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
+    /// <summary>How long a roster read is reused before a fresh loopback GET. A single Car Mode turn often
+    ///  reads the roster more than once (list_sessions, then resolve a target), and several turns come in
+    ///  quick succession; a tiny cache collapses those into one aggregation without ever showing stale
+    ///  state a person would notice (Car Mode performance round).</summary>
+    private static readonly TimeSpan RosterCacheTtl = TimeSpan.FromSeconds(2);
+
     private readonly HttpClient _http;
     private readonly string _baseUrl;
     private readonly string _token;
     private readonly Action<string> _log;
+
+    // The short-lived roster cache (2s TTL). Guarded by _rosterLock; a hit returns the cached list, a miss
+    // does one loopback GET and refills. Kept deliberately tiny so nothing a person would notice goes stale.
+    private readonly object _rosterLock = new();
+    private IReadOnlyList<SessionDto>? _rosterCache;
+    private DateTime _rosterCachedAtUtc = DateTime.MinValue;
 
     /// <param name="port">This Gateway's own listening port (loopback).</param>
     /// <param name="token">The per-machine Gateway token, attached as the Bearer so the call works
@@ -145,9 +157,30 @@ public sealed class LoopbackCarModeFleet : ICarModeFleet
         _log($"[CarModeFleet] deleted session {sessionId}");
     }
 
-    /// <summary>Read THIS Gateway's aggregated roster over loopback. A non-success status throws with the
-    ///  code named (no-fallback) so the brain surfaces a loud, specific failure instead of an empty list.</summary>
+    /// <summary>Read THIS Gateway's aggregated roster, reusing a read taken within the last
+    ///  <see cref="RosterCacheTtl"/> so one turn's several roster reads (and back-to-back turns) collapse to
+    ///  a single loopback aggregation. A cache miss does one real GET and refills the cache.</summary>
     private async Task<IReadOnlyList<SessionDto>> GetSessionsAsync(CancellationToken ct)
+    {
+        lock (_rosterLock)
+        {
+            if (_rosterCache is not null && DateTime.UtcNow - _rosterCachedAtUtc < RosterCacheTtl)
+                return _rosterCache;
+        }
+
+        var fresh = await GetSessionsFreshAsync(ct);
+
+        lock (_rosterLock)
+        {
+            _rosterCache = fresh;
+            _rosterCachedAtUtc = DateTime.UtcNow;
+        }
+        return fresh;
+    }
+
+    /// <summary>One real loopback read of the aggregated roster. A non-success status throws with the code
+    ///  named (no-fallback) so the brain surfaces a loud, specific failure instead of an empty list.</summary>
+    private async Task<IReadOnlyList<SessionDto>> GetSessionsFreshAsync(CancellationToken ct)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"{_baseUrl}/sessions");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -279,6 +279,9 @@ public sealed class GatewayHost : IAsyncDisposable
     // Car Mode (decision 3): the per-device store of a destructive action armed and awaiting the owner's
     // spoken confirmation, so a delete never runs without a clear spoken "confirm".
     private readonly CarMode.CarModePendingStore _carModePending = new();
+    // Car Mode performance round: the durable, Gateway-local store of per-turn timing records. The browser
+    // posts ONE record per turn; GET /carmode/telemetry reads them back. Retained about 90 days by age.
+    private readonly CarMode.CarModeTelemetryStore _carModeTelemetry = new();
     // Gateway-owned set of sessions whose dictated utterance is being transcribed in the background
     // (the phone released the Speak dialog and the audio is uploading/transcribing). Stamps the
     // orange "Transcribing..." roster color so nobody else grabs the session mid-dictation.
@@ -1149,7 +1152,7 @@ public sealed class GatewayHost : IAsyncDisposable
         var carModeChat = new CarMode.HostedCarModeChat(CarMode.HostedCarModeChat.DefaultResolver(_keyVault.Get));
         var carModeFleet = new CarMode.LoopbackCarModeFleet(Port, Token);
         var carModeBrain = new CarMode.CarModeBrain(carModeChat, carModeFleet, _carModeConversations, _carModePending);
-        Api.CarModeEndpoint.Map(_app, carModeBrain);
+        Api.CarModeEndpoint.Map(_app, carModeBrain, _carModeTelemetry);
         // Editable/versioned wingman instructions settings surface (issue #537), incl. A/B test
         // over saved training sessions (reads the shared training store; uses the hosted wingman brain).
         WingmanInstructionsEndpoint.Map(_app, _instructionsStore, _trainingStore, WingmanBrainAsync);


### PR DESCRIPTION
## What and why

Car Mode was slow (the owner reported a simple question taking ~30 seconds) and only transcription was timed - the brain (model tool-loop + fleet read) and text-to-speech were not measured at all. This round adds the observability to see exactly where a turn spends its time, cuts the clear latency wins guided by it, and cleans up the screen. Built, deployed to the production Gateway, and measured.

## Timing telemetry (the reusable foundation)

- **`CarModeTurnTiming`**: the brain now measures every hosted-model round trip and every fleet/roster read, plus the whole-turn wall-clock, and returns it inline in the `POST /carmode/turn` response with a server-minted `turnId`.
- The browser merges its own client stamps (pause-to-transcribe, brain round trip, text-to-speech, first-audio, whole turn) with the server timing and posts **one** compact record to `POST /carmode/telemetry`.
- **`CarModeTelemetryStore`**: durable, Gateway-local, atomic temp-write + rename; retained by **age (90 days)** with a 10000-record growth-guard cap only; corrupt file quarantined - same pattern as `GatewayInputStatsAggregator`.
- **`GET /carmode/telemetry`**: a self-contained dashboard of recent turns and aggregates (median/p90 total, brain, first-audio; how many turns read the fleet).
- Counts and timings only - **never** any command or reply text. The device is a one-way hash of its credential, never the raw credential (security rule DT-05, verified live: `deviceHash=21b694e9...`).

## Latency cuts

- **Fleet-read suppression (prompt-only, no regex)**: a general/help/greeting question now answers directly via `speak_answer` and never reads the fleet roster; the fleet tools are used only when the question is actually about sessions.
- **2-second roster-read cache** in `LoopbackCarModeFleet` so one turn's several reads (and back-to-back turns) collapse to a single loopback aggregation.
- **First-sentence playback**: the browser begins text-to-speech and playback on the first sentence while the remainder synthesizes in parallel.

## UI polish (docs/VisualStyle.md)

- Removed the debug readout box entirely.
- `/m/car` fits one viewport (`100dvh`, `overflow: hidden`); only the middle scrolls, so **End Car Mode** and the controls are always visible - no page scroll.
- The "my turn" cue now fires the instant the transcript confirms "over and out" (before the brain responds).
- Kept the colour-changing status orb (bubbles).

## Proof (measured on the production Gateway, build 1.0.7+7a5c1c8c)

Real per-stage server numbers (inline in the turn response):

| Turn | Model calls | Fleet reads | Rounds | Server total |
|---|---|---|---|---|
| "what can you help me with" (general) | 1 (~2735ms) | **0** | 1 | 2741ms |
| "what can you do" (general, warm) | 1 (~1673ms) | **0** | 1 | 1674ms |
| "how many sessions need me" (fleet) | 2 (946+1091ms) | 1 (43ms) | 2 | 2086ms |

- **Key finding**: the fleet roster read is only ~43ms now - it was never the 30s culprit; the model round trips dominate. The structural win is that general questions now do **one** model round with **zero** fleet reads (was two rounds plus a fleet read).
- **Before** (old build, same infra): the same general question took 9.15s cold / 1.5s warm and read the fleet.
- Text-to-speech measured 1.3s warm / 4.7s cold; first-sentence playback starts after the first sentence while the tail synthesizes.

## Tests

- Server: brain per-stage timing + fleet-read suppression (no fleet read on a general question); telemetry store record / prune-by-age / quarantine; device-hash never contains the credential. 63 Car Mode server tests green.
- Client: timing parse, telemetry post best-effort (never throws), and the sentence splitter. 320 client-core tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)