### PR TITLE
feat(local-files): Phase 4 hardening - download size, range fix, tests, report

### DIFF
--- a/apps/cockpit/src/components/FileViewerModal.tsx
+++ b/apps/cockpit/src/components/FileViewerModal.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
-import { classifyFile } from "@devthrottle/client-core/history/fileTypes";
+import { classifyFile, formatFileSize } from "@devthrottle/client-core/history/fileTypes";
 import type { FileViewerType } from "@devthrottle/client-core/history/fileTypes";
 import {
   GatewayError,
+  fetchSessionFileSize,
   fetchSessionFileText,
   sessionFileUrl,
 } from "@devthrottle/client-core/api/client";
@@ -114,14 +115,54 @@ function FileViewerContent(props: {
       return <TextFile sessionId={sessionId} path={path} render="text" />;
     case "download":
     default:
-      return (
-        <div className="file-viewer-download-panel">
-          <p className="file-viewer-download-note">This file type has no in-app preview.</p>
-          <p className="file-viewer-download-name">{name}</p>
-          <a className="file-viewer-download-btn" href={url} download={name}>Download</a>
-        </div>
-      );
+      return <DownloadPanel sessionId={sessionId} path={path} url={url} name={name} />;
   }
+}
+
+// The unknown/binary case: no guessed render (brief decision 4), just the file NAME, its SIZE, and a
+// Download button. The size is probed through the Gateway (a one-byte ranged GET; fetchSessionFileSize).
+// While it loads the button is already usable. A 404/503 during the probe means the file is genuinely
+// missing or the machine is offline, so the panel shows that specific reason instead of offering a
+// Download that would only fail - keeping the fail-loud contract for this mode too. A size that cannot
+// be determined simply shows the name with no size (never a fake one).
+function DownloadPanel({
+  sessionId,
+  path,
+  url,
+  name,
+}: {
+  sessionId: string;
+  path: string;
+  url: string;
+  name: string;
+}) {
+  const [size, setSize] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setSize(null);
+    setError(null);
+    fetchSessionFileSize(sessionId, path, controller.signal)
+      .then((bytes) => setSize(bytes))
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        setError(fileLoadMessage(err));
+      });
+    return () => controller.abort();
+  }, [sessionId, path]);
+
+  if (error !== null) return <div className="file-viewer-error">{error}</div>;
+
+  const sizeLabel = size === null ? "" : formatFileSize(size);
+  return (
+    <div className="file-viewer-download-panel">
+      <p className="file-viewer-download-note">This file type has no in-app preview.</p>
+      <p className="file-viewer-download-name">{name}</p>
+      {sizeLabel ? <p className="file-viewer-download-size">{sizeLabel}</p> : null}
+      <a className="file-viewer-download-btn" href={url} download={name}>Download</a>
+    </div>
+  );
 }
 
 // An image renders directly from the Gateway URL. A failed load (missing file / offline machine) shows

--- a/apps/cockpit/src/components/components.css
+++ b/apps/cockpit/src/components/components.css
@@ -349,6 +349,11 @@
   word-break: break-all;
 }
 
+.file-viewer-download-size {
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
 /* The Download control appears both in the head (small) and in the download-mode body (button). */
 .file-viewer-download,
 .file-viewer-download-btn {

--- a/apps/mobile/src/pages/FileView.tsx
+++ b/apps/mobile/src/pages/FileView.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { classifyFile } from "@devthrottle/client-core/history/fileTypes";
+import { classifyFile, formatFileSize } from "@devthrottle/client-core/history/fileTypes";
 import type { FileViewerType } from "@devthrottle/client-core/history/fileTypes";
 import {
   GatewayError,
+  fetchSessionFileSize,
   fetchSessionFileText,
   sessionFileUrl,
 } from "@devthrottle/client-core/api/client";
@@ -111,14 +112,54 @@ function FileViewContent(props: {
       return <TextFile sessionId={sessionId} path={path} render="text" />;
     case "download":
     default:
-      return (
-        <div className="file-view-download-panel">
-          <p className="file-view-download-note">This file type has no in-app preview.</p>
-          <p className="file-view-download-name">{name}</p>
-          <a className="file-view-download-btn" href={url} download={name}>Download</a>
-        </div>
-      );
+      return <DownloadPanel sessionId={sessionId} path={path} url={url} name={name} />;
   }
+}
+
+// The unknown/binary case: no guessed render (brief decision 4), just the file NAME, its SIZE, and a
+// Download button. The size is probed through the Gateway (a one-byte ranged GET; fetchSessionFileSize).
+// While it loads the button is already usable. A 404/503 during the probe means the file is genuinely
+// missing or the machine is offline, so the panel shows that specific reason instead of offering a
+// Download that would only fail - keeping the fail-loud contract for this mode too. A size that cannot
+// be determined simply shows the name with no size (never a fake one). Mirrors the Cockpit DownloadPanel.
+function DownloadPanel({
+  sessionId,
+  path,
+  url,
+  name,
+}: {
+  sessionId: string;
+  path: string;
+  url: string;
+  name: string;
+}) {
+  const [size, setSize] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setSize(null);
+    setError(null);
+    fetchSessionFileSize(sessionId, path, controller.signal)
+      .then((bytes) => setSize(bytes))
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        setError(fileLoadMessage(err));
+      });
+    return () => controller.abort();
+  }, [sessionId, path]);
+
+  if (error !== null) return <div className="file-view-error">{error}</div>;
+
+  const sizeLabel = size === null ? "" : formatFileSize(size);
+  return (
+    <div className="file-view-download-panel">
+      <p className="file-view-download-note">This file type has no in-app preview.</p>
+      <p className="file-view-download-name">{name}</p>
+      {sizeLabel ? <p className="file-view-download-size">{sizeLabel}</p> : null}
+      <a className="file-view-download-btn" href={url} download={name}>Download</a>
+    </div>
+  );
 }
 
 // An image renders directly from the Gateway URL. A failed load (missing file / offline machine) shows

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -1828,6 +1828,10 @@ a.banner-btn {
   font-weight: 600;
   word-break: break-all;
 }
+.file-view-download-size {
+  color: var(--text-dim);
+  font-size: 12px;
+}
 .file-view-download-btn {
   display: inline-block;
   padding: 9px 16px;

--- a/docs/reviews/local-files-verification.md
+++ b/docs/reviews/local-files-verification.md
@@ -1,0 +1,135 @@
+# Local Files mission - verification report (DRAFT)
+
+Status: DRAFT scaffold, written by the Phase 4 worker on 2026-07-11. The code, tests, and the
+screenshot evidence gathered during Phases 2 and 3 are in place. The one remaining section -
+real-machine and real-phone sign-off against the LIVE Gateway - is marked PENDING below and is a
+Manager-owned closeout step gated on the deployment decision. Do not treat this document as the final
+sign-off until that section is filled in.
+
+## The mission, in one paragraph
+
+When a local file path appears in a session's terminal output or its chat - an image, a PDF, an HTML
+page, a Markdown file, a text or code file - the remote clients (the cockpit React app and the mobile
+phone app at `/m`) show it as a clickable link, and clicking it opens that file rendered in place,
+streamed from the machine the session runs on. The request rides the Gateway to the owning session's
+Director, which reads the bytes off its own disk and streams them back - the same path the screenshot
+viewer already uses, generalized from "one screenshot image" to "any local file, rendered by type."
+Full brief: `docs/architecture/local-files-mission-2026-07-11.md`.
+
+## How the request flows (proven in Phase 1)
+
+Client viewer issues a same-origin `GET /sessions/{sid}/file?path=<url-encoded absolute path>` to the
+Gateway. The Gateway's per-session catch-all proxy resolves the owning Director and forwards the
+request unchanged; the Director reads the file off its own disk and streams the bytes back with the
+right content type, range support, and `X-Content-Type-Options: nosniff`. The session id is purely the
+routing vehicle that reaches the right machine (the path is always a path on that machine) - it is NOT
+a sandbox (brief decision 2). HTML is rendered in a sandboxed iframe without `allow-same-origin` so a
+report's own script runs in a null origin with none of the Gateway's cookie authority (brief decision
+3).
+
+## Evidence by client x surface x file type
+
+Every file type was opened from BOTH the chat and the terminal, on BOTH clients, during Phases 2 and 3.
+The screenshots were captured against a fresh slot-5 Director built from the mission branch (the live
+fleet Gateway/Director still predate Phase 1; deploying to the live Gateway is the closeout step). See
+each proof folder's `README.md` for the exact capture method.
+
+### Cockpit (React desktop) - Phase 2, `docs/reviews/phase2-proof/`
+
+| File type | Chat click | Terminal click |
+|-----------|------------|----------------|
+| Image (`proof.png`) | [chat-1-image.png](phase2-proof/chat-1-image.png) | [term-1-image.png](phase2-proof/term-1-image.png) |
+| PDF (`report.pdf`) | [chat-2-pdf.png](phase2-proof/chat-2-pdf.png) | [term-2-pdf.png](phase2-proof/term-2-pdf.png) |
+| HTML (`report.html`, self-contained cc-html) | [chat-3-html.png](phase2-proof/chat-3-html.png) | [term-3-html.png](phase2-proof/term-3-html.png) |
+| Markdown (`report.md`) | [chat-4-markdown.png](phase2-proof/chat-4-markdown.png) | [term-4-markdown.png](phase2-proof/term-4-markdown.png) |
+| Text / code (`sample.py`) | [chat-5-text.png](phase2-proof/chat-5-text.png) | [term-5-text.png](phase2-proof/term-5-text.png) |
+
+### Mobile (`/m` PWA) - Phase 3, `docs/reviews/phase3-proof/`
+
+| File type | Chat click | Terminal click |
+|-----------|------------|----------------|
+| Image | [chat-1-image.png](phase3-proof/chat-1-image.png) | [term-1-image.png](phase3-proof/term-1-image.png) |
+| PDF | [chat-2-pdf.png](phase3-proof/chat-2-pdf.png) | [term-2-pdf.png](phase3-proof/term-2-pdf.png) |
+| HTML | [chat-3-html.png](phase3-proof/chat-3-html.png) | [term-3-html.png](phase3-proof/term-3-html.png) |
+| Markdown | [chat-4-markdown.png](phase3-proof/chat-4-markdown.png) | [term-4-markdown.png](phase3-proof/term-4-markdown.png) |
+| Text / code | [chat-5-text.png](phase3-proof/chat-5-text.png) | [term-5-text.png](phase3-proof/term-5-text.png) |
+
+## Phase 4 hardening (this slice)
+
+- **Download / unknown-binary polish.** The `download` render mode (unknown or binary extensions -
+  no guessed render, per brief decision 4) now shows the file NAME, its human-readable SIZE, and a
+  Download button, in both viewers (`apps/cockpit/src/components/FileViewerModal.tsx`,
+  `apps/mobile/src/pages/FileView.tsx`). The size is read WITHOUT downloading the file: a one-byte
+  ranged request (`Range: bytes=0-0`) makes the Director answer `206 Partial Content` with a
+  `Content-Range: bytes 0-0/<total>` header, and the total is the full size
+  (`fetchSessionFileSize` in `packages/client-core/src/api/client.ts`; `formatFileSize` in
+  `packages/client-core/src/history/fileTypes.ts`). This reuses the range support the endpoint already
+  has - no HEAD verb and no new Gateway route were needed. If the size cannot be read, the panel shows
+  the name and Download with NO guessed size (the brief's "no fake size" rule).
+
+- **Loud, specific error and permission states.** Both viewers surface distinct, plain-English
+  messages, never a blank or a hung spinner: a missing file shows "not found (404)"; an offline owning
+  machine shows "the session's machine is offline (503)" (the Gateway returns 503 when the owning
+  Director is unreachable, surfaced as a `GatewayError`, the same contract `getScreenshots` uses); an
+  image that fails to load shows a specific message instead of a broken-image icon. The download
+  panel's size probe now participates in the same contract: a 404/503 during the probe shows the
+  specific reason rather than offering a Download that would only fail.
+
+- **Large-file / range behavior.** The Director serves `/sessions/{sid}/file` with
+  `enableRangeProcessing: true`, so a big PDF or image can seek and resume. Phase 4 found and closed a
+  real gap on the way to proving this: the Gateway's HTTP forwarder did not carry the client's `Range`
+  / `If-Range` request header across to the Director, so a ranged request always came back as a full
+  `200`. The forwarder now forwards those two conditional headers
+  (`src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs`), and the round-trip test proves a Range
+  request returns `206 Partial Content` with the exact slice AND the correct total in `Content-Range`,
+  through the Gateway proxy (`src/CcDirector.Gateway.Tests/SessionFileProxyRoundTripTests.cs`).
+
+## Known limitation (stated, not solved in v1)
+
+HTML files that reference sibling assets by relative path - a separate `.css`, an external image -
+will NOT resolve those assets, because the viewer loads a single file by query string, not a directory.
+Self-contained HTML, which is what the repo's own document tooling (`cc-html`) emits by inlining
+CSS/JS/images, renders correctly, and that is the primary case (generated reports). Building a
+directory-serving or asset-rewriting proxy is deliberately out of scope for v1; if it proves needed it
+is a follow-up. The Phase 2/3 HTML screenshots use self-contained cc-html output, which renders fully.
+
+## Tests
+
+All of the following pass on the mission branch (numbers recorded by the Phase 4 worker on 2026-07-11):
+
+- `packages/client-core` (vitest): 349 tests across 32 files pass. This includes the thorough
+  `classifyFile` coverage (every viewer type, case-insensitive extensions and basenames, extensionless
+  textual basenames, unknown -> download), `formatFileSize`, `fetchSessionFileSize` (Range header sent,
+  size read from `Content-Range`, 404/503 -> `GatewayError`), and the terminal link-provider routing
+  tests for BOTH engines (`interactive.test.ts` for the cockpit, `stream.test.ts` for mobile): a
+  detected FILE path click calls `onFileLink(path)`, an http/https URL does NOT (it opens as a URL),
+  and the xterm column ranges line up with the on-screen text.
+- `apps/cockpit` (vitest): 81 tests across 7 files pass. Both apps typecheck clean (`tsc --noEmit`)
+  and build clean (`vite build`).
+- `src/CcDirector.Gateway.Tests` (.NET): 1802 tests pass, including the extended
+  `SessionFileProxyRoundTripTests` (image + text byte-identity, `nosniff` survives the proxy, missing
+  file 404, the new `206` slice test, and the one-byte size-probe test).
+
+## macOS
+
+The macOS verification pass (embedded-WebView file viewing) is tracked in issue #125 and is handled in
+mission closeout, not here. One React/Avalonia codebase, no porting step; #125 is the place that pass
+is recorded.
+
+## PENDING: real-machine + real-phone sign-off against the LIVE Gateway (post-deploy)
+
+This section is intentionally left for the Manager to fill in AFTER the deployment decision. It must
+record, against the LIVE Gateway (not a slot-5 dev build):
+
+- [ ] Each of the five file types opened from the cockpit chat and cockpit terminal on this Windows
+      machine, with fresh screenshots.
+- [ ] Each of the five file types opened from the phone `/m` chat and phone terminal, with screenshots
+      taken from the real phone.
+- [ ] The download/unknown-binary panel showing a real file name + size + working Download.
+- [ ] A deliberately-missing file showing the "not found (404)" message, and (if reproducible) an
+      offline owning Director showing the "machine is offline (503)" message.
+- [ ] A large PDF or image that visibly seeks/resumes in the viewer (the range path end to end).
+- [ ] The macOS pass recorded on issue #125.
+
+No real-device screenshots have been fabricated for this draft; the tables above are the slot-build
+proof from Phases 2 and 3, clearly labelled as such.

--- a/packages/client-core/src/api/client.test.ts
+++ b/packages/client-core/src/api/client.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import {
   configureUnauthorizedRedirect,
   cockpitSignInRedirect,
   mobileSignInRedirect,
   resolveSignInTarget,
+  fetchSessionFileSize,
+  GatewayError,
 } from "./client";
 
 // The shell-aware mid-session 401 redirect (issue #1024, retargeted by issue #1088). A 401 on the
@@ -53,5 +55,73 @@ describe("shell-aware unauthorized redirect", () => {
   it("defaults to the mobile route when a shell installs nothing", () => {
     // The mobile shell historically owned client-core, so the unconfigured default stays /m/signin.
     expect(resolveSignInTarget({ pathname: "/m", search: "" })).toBe("/m/signin");
+  });
+});
+
+// fetchSessionFileSize (Local Files, Phase 4): the download panel's size probe. It issues a one-byte
+// ranged GET (Range: bytes=0-0) so the Director answers 206 with Content-Range "bytes 0-0/<total>", and
+// reads the FULL size from that total - without downloading the file. A missing file / offline machine
+// (404 / 503) throws a GatewayError so the panel fails loud; a response with no readable total returns
+// null so the panel shows the name with NO guessed size.
+describe("fetchSessionFileSize", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  // A minimal fetch Response stand-in: status, a header bag, and a cancelable body.
+  function fakeResponse(status: number, headers: Record<string, string>): Response {
+    const map = new Map(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]));
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      headers: { get: (name: string) => map.get(name.toLowerCase()) ?? null },
+      body: { cancel: () => Promise.resolve() },
+    } as unknown as Response;
+  }
+
+  it("sends a Range: bytes=0-0 header to the session file URL", async () => {
+    const fetchMock = vi.fn(async () =>
+      fakeResponse(206, { "Content-Range": "bytes 0-0/2048" }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await fetchSessionFileSize("sess-1", "D:\\out\\big.pdf");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe(`/sessions/sess-1/file?path=${encodeURIComponent("D:\\out\\big.pdf")}`);
+    expect((init.headers as Record<string, string>).Range).toBe("bytes=0-0");
+  });
+
+  it("reads the full size from the Content-Range total on a 206", async () => {
+    globalThis.fetch = (async () =>
+      fakeResponse(206, { "Content-Range": "bytes 0-0/1500000" })) as unknown as typeof fetch;
+
+    expect(await fetchSessionFileSize("s", "D:\\a\\b.bin")).toBe(1500000);
+  });
+
+  it("returns null when the server ignored the range (200, no Content-Range)", async () => {
+    globalThis.fetch = (async () =>
+      fakeResponse(200, { "Content-Length": "42" })) as unknown as typeof fetch;
+
+    expect(await fetchSessionFileSize("s", "D:\\a\\b.bin")).toBeNull();
+  });
+
+  it("throws a GatewayError with the status for a missing file (404)", async () => {
+    globalThis.fetch = (async () => fakeResponse(404, {})) as unknown as typeof fetch;
+
+    await expect(fetchSessionFileSize("s", "D:\\gone.bin")).rejects.toMatchObject({
+      status: 404,
+    });
+    await expect(fetchSessionFileSize("s", "D:\\gone.bin")).rejects.toBeInstanceOf(GatewayError);
+  });
+
+  it("throws a GatewayError with the status when the machine is offline (503)", async () => {
+    globalThis.fetch = (async () => fakeResponse(503, {})) as unknown as typeof fetch;
+
+    await expect(fetchSessionFileSize("s", "D:\\a\\b.bin")).rejects.toMatchObject({
+      status: 503,
+    });
   });
 });

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -629,6 +629,39 @@ export async function fetchSessionFileText(sessionId: string, path: string, sign
   return res.text();
 }
 
+// The on-disk SIZE of a file on the owning Director, for the download panel's "name - size" display
+// (Local Files, Phase 4). We do NOT download the file to weigh it: a Range: bytes=0-0 request makes the
+// Director - which already serves this route with enableRangeProcessing on - answer 206 Partial Content
+// with a Content-Range header ("bytes 0-0/<total>") whose total is the full size, transferring a single
+// byte. This reuses the existing range support and needs no new server or Gateway route (the per-session
+// catch-all proxy forwards any verb/headers unchanged). A missing file or offline machine is thrown as a
+// GatewayError (404 / 503) so the panel can fail loud. When the total cannot be read - an old or odd
+// server that ignored the range and returned 200 - null is returned and the caller shows the name and
+// Download with NO guessed size (the brief's "no fake size" rule; no fallback programming).
+export async function fetchSessionFileSize(sessionId: string, path: string, signal?: AbortSignal): Promise<number | null> {
+  const res = await fetch(sessionFileUrl(sessionId, path), {
+    method: "GET",
+    headers: { ...authHeaders(), Range: "bytes=0-0" },
+    signal,
+  });
+  // 206 (range honored) and 200 (range ignored, full body) are both "ok"; anything else is a real error.
+  if (!res.ok) {
+    throw new GatewayError(res.status, `GET file size failed: ${res.status}`);
+  }
+  // We never read the body - drop it so a 200 (full-file) response does not stream needlessly.
+  void res.body?.cancel();
+  const contentRange = res.headers.get("Content-Range");
+  if (contentRange) {
+    // "bytes 0-0/<total>" - the number after the last slash is the full file size.
+    const slash = contentRange.lastIndexOf("/");
+    if (slash >= 0) {
+      const total = Number(contentRange.slice(slash + 1).trim());
+      if (Number.isFinite(total) && total >= 0) return total;
+    }
+  }
+  return null;
+}
+
 // GET /sessions/{sid}/screenshots[?count=N] - the newest screenshots' metadata (not the bytes).
 // count <= 0 fetches everything (the folder can hold thousands, so callers pass a cap). A 503 means
 // the owning Director is offline (the Gateway could not reach it for this leg, issue #412); it is

--- a/packages/client-core/src/history/fileTypes.test.ts
+++ b/packages/client-core/src/history/fileTypes.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { classifyFile, fileExtension } from "./fileTypes";
+import { classifyFile, fileExtension, formatFileSize } from "./fileTypes";
 
-// Local Files mission (Phase 1): classifyFile maps a detected absolute path to exactly one viewer
-// type by extension. Full coverage is formally Phase 4; this basic set locks the contract from the
-// brief's decision 4 (image / pdf / html / markdown / text / download) so a later change cannot
-// silently reclassify a type.
+// Local Files mission (Phase 1, hardened in Phase 4): classifyFile maps a detected absolute path to
+// exactly one viewer type by extension. This set locks the contract from the brief's decision 4
+// (image / pdf / html / markdown / text / download) so a later change cannot silently reclassify a
+// type - every viewer type, case-insensitivity, extensionless textual basenames, and unknown ->
+// download are all covered.
 
 describe("classifyFile", () => {
   it.each([
@@ -20,13 +21,18 @@ describe("classifyFile", () => {
     expect(classifyFile(path)).toBe(expected);
   });
 
-  it("classifies a pdf", () => {
-    expect(classifyFile("D:\\reports\\Q3.pdf")).toBe("pdf");
+  it.each([
+    ["D:\\reports\\Q3.pdf", "pdf"],
+    ["D:\\reports\\Q3.PDF", "pdf"],
+  ])("classifies %s as pdf", (path, expected) => {
+    expect(classifyFile(path)).toBe(expected);
   });
 
   it.each([
     ["D:\\site\\index.html", "html"],
     ["D:\\site\\page.htm", "html"],
+    ["D:\\site\\INDEX.HTML", "html"],
+    ["D:\\site\\PAGE.HTM", "html"],
   ])("classifies %s as html", (path, expected) => {
     expect(classifyFile(path)).toBe(expected);
   });
@@ -34,6 +40,8 @@ describe("classifyFile", () => {
   it.each([
     ["D:\\docs\\README.md", "markdown"],
     ["D:\\docs\\notes.markdown", "markdown"],
+    ["D:\\docs\\NOTES.MARKDOWN", "markdown"],
+    ["/c/docs/spec.MD", "markdown"],
   ])("classifies %s as markdown", (path, expected) => {
     expect(classifyFile(path)).toBe(expected);
   });
@@ -66,12 +74,52 @@ describe("classifyFile", () => {
   it.each([
     ["D:\\repo\\Dockerfile", "text"],
     ["D:\\repo\\Makefile", "text"],
-  ])("classifies bare textual filename %s as text", (path, expected) => {
+    ["D:\\repo\\MAKEFILE", "text"],
+    ["/c/repo/dockerfile", "text"],
+    ["D:\\repo\\README", "text"],
+    ["D:\\repo\\LICENSE", "text"],
+    ["D:\\repo\\CHANGELOG", "text"],
+  ])("classifies bare textual filename %s as text (case-insensitive)", (path, expected) => {
     expect(classifyFile(path)).toBe(expected);
   });
 
-  it("treats a dotfile like .gitignore as having no extension (falls to basename rule)", () => {
-    expect(classifyFile("D:\\repo\\.gitignore")).toBe("text");
+  it.each([
+    ["D:\\repo\\.gitignore", "text"],
+    ["D:\\repo\\.editorconfig", "text"],
+  ])("treats dotfile %s as extensionless and applies the basename rule", (path, expected) => {
+    expect(classifyFile(path)).toBe(expected);
+  });
+
+  it("classifies a bare unknown extensionless name as download (not guessed as text)", () => {
+    expect(classifyFile("D:\\bin\\mysteryblob")).toBe("download");
+  });
+});
+
+// formatFileSize (Phase 4): the human-readable size shown in the download panel. Binary units, bytes
+// whole, KB and up with one decimal; a non-finite/negative value yields "" so the panel shows the name
+// with NO size rather than a fake one.
+describe("formatFileSize", () => {
+  it.each([
+    [0, "0 B"],
+    [1, "1 B"],
+    [820, "820 B"],
+    [1023, "1023 B"],
+    [1024, "1.0 KB"],
+    [15360, "15.0 KB"],
+    [1_048_576, "1.0 MB"],
+    [1_500_000, "1.4 MB"],
+    [1_073_741_824, "1.0 GB"],
+    [1_099_511_627_776, "1.0 TB"],
+  ])("formats %d bytes as %s", (bytes, expected) => {
+    expect(formatFileSize(bytes)).toBe(expected);
+  });
+
+  it.each([
+    [-1],
+    [Number.NaN],
+    [Number.POSITIVE_INFINITY],
+  ])("returns an empty string for the non-representable value %d", (bytes) => {
+    expect(formatFileSize(bytes)).toBe("");
   });
 });
 

--- a/packages/client-core/src/history/fileTypes.ts
+++ b/packages/client-core/src/history/fileTypes.ts
@@ -77,6 +77,25 @@ function fileBaseName(path: string): string {
 }
 
 /**
+ * A human-readable file size for the download panel (Local Files, Phase 4). Binary units (1 KB =
+ * 1024 B): bytes are shown whole, KB and up carry one decimal - e.g. 820 -> "820 B", 15360 ->
+ * "15.0 KB", 1500000 -> "1.4 MB". A non-finite or negative value returns "" so the caller shows the
+ * file name with NO size rather than a nonsense value (the brief's "no fake size" rule).
+ */
+export function formatFileSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(1)} ${units[unit]}`;
+}
+
+/**
  * Classify an absolute file path into the viewer type that should render it. Unknown or binary
  * extensions return "download" - the caller offers a Download button rather than guessing a render.
  */

--- a/packages/client-core/src/terminal/interactive.test.ts
+++ b/packages/client-core/src/terminal/interactive.test.ts
@@ -53,7 +53,22 @@ const hoisted = vi.hoisted(() => {
     disposed = false;
     // getLine backs the Local Files link provider's per-line lookup; the existing tests never trigger a
     // hover, so returning null is enough to satisfy the shape.
-    buffer = { active: { viewportY: 0, baseY: 0, getLine: (_y: number) => null } };
+    // getLine backs the Local Files link provider's per-line lookup. lineText is set by the link tests
+    // to the rendered text of buffer row 1; every other row returns null (no links).
+    lineText = "";
+    buffer = {
+      active: {
+        viewportY: 0,
+        baseY: 0,
+        getLine: (y: number) =>
+          y === 0 && this.lineText
+            ? { translateToString: (_trim?: boolean) => this.lineText }
+            : null,
+      },
+    };
+    // The Local Files link provider registered on open; captured so the tests can drive provideLinks
+    // and activate the returned links directly (no real hover).
+    linkProvider: unknown = null;
     linkProviderDisposed = false;
     // The render service, torn down on dispose. `dimensions` reads through it, mirroring xterm's
     // `get dimensions(){return this._renderer.value.dimensions}` - so it throws once disposed.
@@ -77,7 +92,8 @@ const hoisted = vi.hoisted(() => {
     }
     // The Local Files link provider (Phase 2) is registered on open; return a disposable so dispose()
     // can tear it down, matching xterm's registerLinkProvider contract.
-    registerLinkProvider(_provider: unknown): { dispose: () => void } {
+    registerLinkProvider(provider: unknown): { dispose: () => void } {
+      this.linkProvider = provider;
       return { dispose: () => { this.linkProviderDisposed = true; } };
     }
     write(data: unknown): void {
@@ -107,6 +123,8 @@ const hoisted = vi.hoisted(() => {
 
 const sendPrompt = hoisted.sendPrompt;
 const ensureGatewayCookie = hoisted.ensureGatewayCookie;
+// window.open is used by the link provider to open URLs in a new tab (never routed to the app).
+const windowOpen = vi.fn();
 
 vi.mock("@xterm/xterm", () => ({ Terminal: hoisted.FakeTerminal }));
 vi.mock("../api/client", () => ({
@@ -176,12 +194,14 @@ beforeEach(() => {
   sendPrompt.mockReset();
   sendPrompt.mockImplementation((_sid: string, _text: string, _appendEnter: boolean) => Promise.resolve());
   ensureGatewayCookie.mockClear();
+  windowOpen.mockReset();
   vi.useFakeTimers();
   // Minimal window/global surface the engine touches. setTimeout/clearTimeout delegate to globalThis
   // at CALL time so vitest's fake timers drive them; requestAnimationFrame/cancelAnimationFrame use the
   // drivable queue above so tests step frames explicitly (issue #1029).
   (globalThis as unknown as { window: unknown }).window = {
     location: { protocol: "http:", host: "gateway.local:8080" },
+    open: (...args: unknown[]) => windowOpen(...args),
     setTimeout: (fn: () => void, ms: number) => globalThis.setTimeout(fn, ms),
     clearTimeout: (id: unknown) => globalThis.clearTimeout(id as ReturnType<typeof setTimeout>),
     requestAnimationFrame: (fn: () => void) => {
@@ -463,5 +483,70 @@ describe("InteractiveTerminal xterm lifecycle safety (issue #1029)", () => {
     t.dispose(); // cancels the pending bring-up before it ever opens
     runFrames();
     expect(hoisted.terminals.length).toBe(0);
+  });
+});
+
+describe("InteractiveTerminal link provider (Local Files, Phase 2/4)", () => {
+  // The xterm link shape the provider hands back (a subset of xterm's ILink).
+  type XLink = {
+    text: string;
+    range: { start: { x: number; y: number }; end: { x: number; y: number } };
+    activate: (event: MouseEvent) => void;
+  };
+
+  // Build a terminal with an onFileLink callback, set buffer row 1 to `lineText`, drive the registered
+  // link provider over that row, and return the xterm links it produced plus the callback spy. This is
+  // the exact path xterm walks on hover, without a browser.
+  function linksFor(lineText: string): { onFileLink: ReturnType<typeof vi.fn>; links: XLink[] } {
+    const onFileLink = vi.fn();
+    const t = new InteractiveTerminal(host(), SID, onFileLink);
+    t.start();
+    runFrames();
+    const term = hoisted.terminals[0];
+    term.lineText = lineText;
+    const provider = term.linkProvider as {
+      provideLinks: (bufferLineNumber: number, cb: (links: XLink[] | undefined) => void) => void;
+    };
+    let links: XLink[] | undefined;
+    provider.provideLinks(1, (l) => { links = l; }); // row 1 -> getLine(0) -> lineText
+    return { onFileLink, links: links ?? [] };
+  }
+
+  it("routes a clicked FILE path to onFileLink and does NOT open a browser tab", () => {
+    const line = "wrote C:\\reports\\out.html now";
+    const { onFileLink, links } = linksFor(line);
+    const fileLink = links.find((l) => l.text === "C:\\reports\\out.html");
+    expect(fileLink).toBeDefined();
+    fileLink!.activate({} as MouseEvent);
+    expect(onFileLink).toHaveBeenCalledWith("C:\\reports\\out.html");
+    expect(windowOpen).not.toHaveBeenCalled();
+  });
+
+  it("opens a clicked http/https URL in a new tab and does NOT route it to onFileLink", () => {
+    const line = "see https://example.com/page for details";
+    const { onFileLink, links } = linksFor(line);
+    const urlLink = links.find((l) => l.text === "https://example.com/page");
+    expect(urlLink).toBeDefined();
+    urlLink!.activate({} as MouseEvent);
+    expect(windowOpen).toHaveBeenCalledWith("https://example.com/page", "_blank", "noopener,noreferrer");
+    expect(onFileLink).not.toHaveBeenCalled();
+  });
+
+  it("gives each link an xterm buffer range that lines up with the on-screen columns", () => {
+    // xterm ranges are 1-based inclusive; findLineLinks columns are 0-based half-open [start, end). The
+    // provider maps them to start.x = start+1, end.x = end, so (start.x - 1, end.x) re-slices the text.
+    const line = "C:\\a\\b.png and http://host/x";
+    const { links } = linksFor(line);
+    expect(links).toHaveLength(2);
+    for (const link of links) {
+      expect(link.range.start.y).toBe(1);
+      expect(link.range.end.y).toBe(1);
+      expect(line.slice(link.range.start.x - 1, link.range.end.x)).toBe(link.text);
+    }
+  });
+
+  it("returns no links for a line with none, so xterm leaves the line undecorated", () => {
+    const { links } = linksFor("just some ordinary output text");
+    expect(links).toEqual([]);
   });
 });

--- a/packages/client-core/src/terminal/stream.test.ts
+++ b/packages/client-core/src/terminal/stream.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Unit proof for the mobile /m terminal mirror's Local Files link provider (Phase 3, hardened in
+// Phase 4). The mirror (stream.ts) is the read-only sibling of the interactive Cockpit terminal
+// (interactive.ts) and shares the SAME link contract: a clicked FILE path routes out to the app's
+// onFileLink callback (its viewer), while an http/https URL opens in a new tab and is NEVER routed to
+// the app. These tests drive the registered xterm link provider directly - xterm, the Gateway client,
+// and WebSocket are faked - so the routing and the column ranges are asserted without a browser.
+
+// ----- fakes for xterm + the Gateway client (hoisted so vi.mock factories may reference them) -----
+const hoisted = vi.hoisted(() => {
+  const ensureGatewayCookie = vi.fn();
+  // The minimum of the xterm.js surface the mirror touches during start() + the link provider path.
+  class FakeTerminal {
+    // getLine backs the link provider's per-line lookup; lineText is buffer row 1's rendered text.
+    lineText = "";
+    buffer = {
+      active: {
+        viewportY: 0,
+        baseY: 0,
+        getLine: (y: number) =>
+          y === 0 && this.lineText
+            ? { translateToString: (_trim?: boolean) => this.lineText }
+            : null,
+      },
+    };
+    linkProvider: unknown = null;
+    linkProviderDisposed = false;
+    writes: string[] = [];
+    resetCount = 0;
+    disposed = false;
+    constructor(public options: unknown) {
+      terminals.push(this);
+    }
+    open(): void {}
+    registerLinkProvider(provider: unknown): { dispose: () => void } {
+      this.linkProvider = provider;
+      return { dispose: () => { this.linkProviderDisposed = true; } };
+    }
+    write(data: unknown): void {
+      if (typeof data === "string") this.writes.push(data);
+    }
+    reset(): void {
+      this.resetCount += 1;
+    }
+    resize(): void {}
+    dispose(): void {
+      this.disposed = true;
+    }
+  }
+  const terminals: FakeTerminal[] = [];
+  return { FakeTerminal, terminals, ensureGatewayCookie };
+});
+
+const ensureGatewayCookie = hoisted.ensureGatewayCookie;
+// window.open is used by the link provider to open URLs in a new tab (never routed to the app).
+const windowOpen = vi.fn();
+
+vi.mock("@xterm/xterm", () => ({ Terminal: hoisted.FakeTerminal }));
+vi.mock("../api/client", () => ({
+  ensureGatewayCookie: () => hoisted.ensureGatewayCookie(),
+}));
+
+// ----- fake WebSocket (the mirror opens one on connect; the tests never drive it) ---------------
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  binaryType = "";
+  readyState = 0;
+  onmessage: ((ev: { data: unknown }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  closed = false;
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+  close(): void {
+    this.closed = true;
+  }
+}
+
+// A minimal element that records event listeners (the mirror attaches touch handlers in start()).
+function fakeEl(): HTMLElement {
+  return {
+    clientWidth: 390,
+    clientHeight: 700,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  } as unknown as HTMLElement;
+}
+
+// Import AFTER the mocks are registered.
+import { TerminalMirror } from "./stream";
+
+const SID = "sess-777";
+
+beforeEach(() => {
+  hoisted.terminals.length = 0;
+  FakeWebSocket.instances.length = 0;
+  ensureGatewayCookie.mockClear();
+  windowOpen.mockReset();
+  // The mirror touches only these members of window during start()/connect(). ResizeObserver is left
+  // undefined so the observer branch is skipped (nothing to measure in these routing tests).
+  (globalThis as unknown as { window: unknown }).window = {
+    location: { protocol: "https:", host: "gateway.local" },
+    open: (...args: unknown[]) => windowOpen(...args),
+    setTimeout: (fn: () => void, ms: number) => globalThis.setTimeout(fn, ms),
+    clearTimeout: (id: unknown) => globalThis.clearTimeout(id as ReturnType<typeof setTimeout>),
+    requestAnimationFrame: (fn: () => void) => globalThis.setTimeout(fn, 0),
+    ResizeObserver: undefined,
+  };
+  (globalThis as unknown as { WebSocket: unknown }).WebSocket = FakeWebSocket;
+});
+
+afterEach(() => {
+  delete (globalThis as unknown as { window?: unknown }).window;
+  delete (globalThis as unknown as { WebSocket?: unknown }).WebSocket;
+});
+
+describe("TerminalMirror link provider (Local Files, Phase 3/4)", () => {
+  type XLink = {
+    text: string;
+    range: { start: { x: number; y: number }; end: { x: number; y: number } };
+    activate: (event: MouseEvent) => void;
+  };
+
+  // Build a mirror with an onFileLink callback, set buffer row 1 to `lineText`, drive the registered
+  // link provider over that row, and return the xterm links plus the callback spy.
+  function linksFor(lineText: string): { onFileLink: ReturnType<typeof vi.fn>; links: XLink[] } {
+    const onFileLink = vi.fn();
+    const mirror = new TerminalMirror(fakeEl(), fakeEl(), SID, () => {}, onFileLink);
+    mirror.start();
+    const term = hoisted.terminals[0];
+    term.lineText = lineText;
+    const provider = term.linkProvider as {
+      provideLinks: (bufferLineNumber: number, cb: (links: XLink[] | undefined) => void) => void;
+    };
+    let links: XLink[] | undefined;
+    provider.provideLinks(1, (l) => { links = l; }); // row 1 -> getLine(0) -> lineText
+    return { onFileLink, links: links ?? [] };
+  }
+
+  it("routes a clicked FILE path to onFileLink and does NOT open a browser tab", () => {
+    const line = "saved D:\\out\\report.pdf ok";
+    const { onFileLink, links } = linksFor(line);
+    const fileLink = links.find((l) => l.text === "D:\\out\\report.pdf");
+    expect(fileLink).toBeDefined();
+    fileLink!.activate({} as MouseEvent);
+    expect(onFileLink).toHaveBeenCalledWith("D:\\out\\report.pdf");
+    expect(windowOpen).not.toHaveBeenCalled();
+  });
+
+  it("opens a clicked http/https URL in a new tab and does NOT route it to onFileLink", () => {
+    const line = "open https://example.com/report for details";
+    const { onFileLink, links } = linksFor(line);
+    const urlLink = links.find((l) => l.text === "https://example.com/report");
+    expect(urlLink).toBeDefined();
+    urlLink!.activate({} as MouseEvent);
+    expect(windowOpen).toHaveBeenCalledWith("https://example.com/report", "_blank", "noopener,noreferrer");
+    expect(onFileLink).not.toHaveBeenCalled();
+  });
+
+  it("gives each link an xterm buffer range that lines up with the on-screen columns", () => {
+    const line = "C:\\a\\b.png and http://host/x";
+    const { links } = linksFor(line);
+    expect(links).toHaveLength(2);
+    for (const link of links) {
+      expect(link.range.start.y).toBe(1);
+      expect(link.range.end.y).toBe(1);
+      expect(line.slice(link.range.start.x - 1, link.range.end.x)).toBe(link.text);
+    }
+  });
+
+  it("returns no links for a line with none, so xterm leaves the line undecorated", () => {
+    const { links } = linksFor("plain output, nothing clickable");
+    expect(links).toEqual([]);
+  });
+});

--- a/src/CcDirector.Gateway.Tests/SessionFileProxyRoundTripTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionFileProxyRoundTripTests.cs
@@ -41,6 +41,11 @@ public sealed class SessionFileProxyRoundTripTests : IAsyncLifetime
     };
     private const string TextContent = "line one\nline two\nthe quick brown fox\n";
 
+    // A "large-ish" binary blob so the range test proves the seek-and-resume guarantee for big
+    // PDFs/images (Phase 4): each byte i holds (i * 31 + 7) mod 256, so any slice is independently
+    // verifiable against the same formula without holding a second copy.
+    private const int LargeSize = 300_000;
+
     private readonly string _instancesDir =
         Path.Combine(Path.GetTempPath(), "cc-instances-" + Guid.NewGuid().ToString("N"));
     private readonly string _filesDir =
@@ -48,6 +53,9 @@ public sealed class SessionFileProxyRoundTripTests : IAsyncLifetime
 
     private string _pngPath = "";
     private string _textPath = "";
+    private string _largePath = "";
+
+    private static byte LargeByteAt(int i) => (byte)((i * 31 + 7) % 256);
 
     public async Task InitializeAsync()
     {
@@ -55,8 +63,13 @@ public sealed class SessionFileProxyRoundTripTests : IAsyncLifetime
         Directory.CreateDirectory(_filesDir);
         _pngPath = Path.Combine(_filesDir, "a report.png");
         _textPath = Path.Combine(_filesDir, "notes 1.txt");
+        _largePath = Path.Combine(_filesDir, "big scan.pdf");
         await File.WriteAllBytesAsync(_pngPath, PngBytes);
         await File.WriteAllTextAsync(_textPath, TextContent);
+
+        var large = new byte[LargeSize];
+        for (var i = 0; i < LargeSize; i++) large[i] = LargeByteAt(i);
+        await File.WriteAllBytesAsync(_largePath, large);
 
         _gateway = new GatewayHost(port: FreePort(), token: "test-token", authEnabled: true,
             instancesDirectory: _instancesDir,
@@ -138,6 +151,58 @@ public sealed class SessionFileProxyRoundTripTests : IAsyncLifetime
         var resp = await _http.GetAsync(
             $"sessions/file-session-1/file?path={Uri.EscapeDataString(missing)}");
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    // The large-file guarantee (Phase 4): a Range request must come back 206 Partial Content with only
+    // the requested slice - byte-identical to that slice of the original - and a Content-Range whose
+    // total is the full file size. This is what lets a big PDF/image seek and resume in the browser's
+    // native viewer, and it is also the mechanism the download panel's fetchSessionFileSize relies on
+    // (Range: bytes=0-0 -> the total is read from Content-Range). Proven through the Gateway proxy, so
+    // the range header and the 206 both survive the round trip.
+    [Fact]
+    public async Task Range_request_returns_206_with_the_exact_slice_through_the_gateway()
+    {
+        const int from = 100_000;
+        const int to = 100_255; // 256 bytes, inclusive on both ends (HTTP byte ranges)
+        var req = new HttpRequestMessage(HttpMethod.Get,
+            $"sessions/file-session-1/file?path={Uri.EscapeDataString(_largePath)}");
+        req.Headers.Range = new RangeHeaderValue(from, to);
+
+        var resp = await _http.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.PartialContent, resp.StatusCode);
+
+        // The slice is exactly the requested bytes, in the right place, byte-for-byte.
+        var slice = await resp.Content.ReadAsByteArrayAsync();
+        Assert.Equal(to - from + 1, slice.Length);
+        for (var i = 0; i < slice.Length; i++)
+            Assert.Equal(LargeByteAt(from + i), slice[i]);
+
+        // Content-Range reports this slice out of the full size, so a client can compute total length.
+        Assert.NotNull(resp.Content.Headers.ContentRange);
+        Assert.Equal(from, resp.Content.Headers.ContentRange!.From);
+        Assert.Equal(to, resp.Content.Headers.ContentRange.To);
+        Assert.Equal(LargeSize, resp.Content.Headers.ContentRange.Length);
+    }
+
+    // The download panel's size probe (fetchSessionFileSize) in miniature: a one-byte Range: bytes=0-0
+    // yields 206 and the FULL size in Content-Range's total, so the panel can show a real size without
+    // downloading the file. This locks that exact contract at the proxy level.
+    [Fact]
+    public async Task Single_byte_range_reports_the_full_size_in_content_range()
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get,
+            $"sessions/file-session-1/file?path={Uri.EscapeDataString(_largePath)}");
+        req.Headers.Range = new RangeHeaderValue(0, 0);
+
+        var resp = await _http.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.PartialContent, resp.StatusCode);
+        var slice = await resp.Content.ReadAsByteArrayAsync();
+        Assert.Single(slice);
+        Assert.Equal(LargeByteAt(0), slice[0]);
+        Assert.NotNull(resp.Content.Headers.ContentRange);
+        Assert.Equal(LargeSize, resp.Content.Headers.ContentRange!.Length);
     }
 
     private static int FreePort()

--- a/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
@@ -499,6 +499,19 @@ internal static class SessionWsProxyEndpoints
             if (!string.IsNullOrEmpty(_fleetToken))
                 req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _fleetToken);
 
+            // Local Files (Phase 4): forward the client's Range / If-Range so a large PDF or image can
+            // seek and resume THROUGH the proxy. The Director serves /sessions/{sid}/file with
+            // enableRangeProcessing on, but without carrying the Range header across it never sees the
+            // request and always streams the whole file back as 200. The download panel's one-byte size
+            // probe (fetchSessionFileSize: Range bytes=0-0 -> read the total from Content-Range) depends
+            // on this too. Only these two conditional headers are forwarded - the rest of the request
+            // header set (Host, Connection, Content-Length, ...) is intentionally re-derived by the
+            // outbound HttpClient, exactly as before.
+            if (ctx.Request.Headers.TryGetValue("Range", out var rangeHeader))
+                req.Headers.TryAddWithoutValidation("Range", rangeHeader.ToArray());
+            if (ctx.Request.Headers.TryGetValue("If-Range", out var ifRangeHeader))
+                req.Headers.TryAddWithoutValidation("If-Range", ifRangeHeader.ToArray());
+
             HttpResponseMessage resp;
             try
             {


### PR DESCRIPTION
Phase 4 of the Local Files mission (remote file viewer): the code-only hardening slice. Builds on Phase 1 (#1329), Phase 2 (#1362), Phase 3 (#1368), all on main. Deploy, the macOS pass, and real-phone/real-machine sign-off are Manager-owned closeout steps, not part of this PR.

## What changed

- **Download / unknown-binary polish.** The `download` render mode now shows the file NAME, its human-readable SIZE, and a Download button, in both viewers (`FileViewerModal.tsx`, `FileView.tsx`). The size is read WITHOUT downloading the file: a one-byte ranged GET (`Range: bytes=0-0`) makes the Director answer `206` with `Content-Range: bytes 0-0/<total>`, and the total is the full size. New client-core helpers `fetchSessionFileSize` + `formatFileSize`. If the size cannot be read, the panel shows the name and Download with NO guessed size.
- **Loud, specific error states.** The size probe joins the existing fail-loud contract: a missing file shows "not found (404)", an offline owning machine shows "the session's machine is offline (503)", never a blank or a hung spinner.
- **Range fix (real gap found and closed).** The Gateway HTTP forwarder did not carry the client's `Range` / `If-Range` header to the Director, so a ranged request always came back as a full `200` - the "big PDF/image seeks and resumes" guarantee was unmet through the proxy. The forwarder now forwards those two conditional headers.
- **Round-trip tests.** `SessionFileProxyRoundTripTests` now proves a Range request returns `206` with the exact slice and the correct total in `Content-Range`, and that a one-byte range reports the full size - both through the Gateway proxy.
- **Unit tests.** Broadened `classifyFile` coverage (every viewer type, case-insensitive extensions and basenames, extensionless textual basenames, unknown -> download); `formatFileSize` and `fetchSessionFileSize` tests; terminal link-provider routing tests for BOTH engines (`interactive.test.ts` cockpit, new `stream.test.ts` mobile): a FILE path click calls `onFileLink`, an http/https URL does not (opens as a URL), xterm column ranges line up.
- **Draft verification report** at `docs/reviews/local-files-verification.md`: mission summary, the Phase 2/3 slot-build screenshots for all five types x (chat + terminal) x (cockpit + mobile), the HTML relative-asset limitation stated plainly, a PENDING real-machine + real-phone sign-off section for the Manager, and a link to issue thefrederiksen/devthrottle_internal#557 for the macOS pass.

## Proof

- `packages/client-core` vitest: **349 pass** (32 files) - incl. classifyFile, formatFileSize, fetchSessionFileSize, and both link-provider suites.
- `apps/cockpit` vitest: **81 pass**. Both apps typecheck clean (`tsc --noEmit`) and build clean (`vite build`).
- `src/CcDirector.Gateway.Tests`: **1802 pass**, incl. the new 206 range + size-probe round-trip tests.

No real-device screenshots were fabricated; the report's tables are the labelled Phase 2/3 slot-build proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)