### PR TITLE
perf(carmode): split telemetry into transcode + network stages for a real phone turn

### DIFF
--- a/packages/client-core/src/carmode/carModeApi.test.ts
+++ b/packages/client-core/src/carmode/carModeApi.test.ts
@@ -107,7 +107,7 @@ describe("carModeTurn", () => {
 
 describe("postCarModeTelemetry", () => {
   const record = {
-    turnId: "t1", pauseToTranscribeMs: 900, brainMs: 1200, ttsMs: 300, firstAudioMs: 350,
+    turnId: "t1", pauseToTranscribeMs: 900, transcodeMs: 120, brainMs: 1200, ttsMs: 300, firstAudioMs: 350,
     totalTurnMs: 2450, serverTotalMs: 1100, modelCallCount: 1, modelMsTotal: 1050,
     modelMs: [1050], fleetReadCount: 0, fleetReadMsTotal: 0, rounds: 1, commandChars: 20,
     replyChars: 40, actionsCount: 0, pendingConfirmation: false,

--- a/packages/client-core/src/carmode/carModeApi.ts
+++ b/packages/client-core/src/carmode/carModeApi.ts
@@ -125,6 +125,7 @@ export async function carModeTurn(text: string, signal?: AbortSignal): Promise<C
 export interface CarModeTelemetryPost {
   turnId: string;
   pauseToTranscribeMs: number;
+  transcodeMs: number;
   brainMs: number;
   ttsMs: number;
   firstAudioMs: number;

--- a/packages/client-core/src/carmode/useCarMode.ts
+++ b/packages/client-core/src/carmode/useCarMode.ts
@@ -56,7 +56,8 @@ export interface CarModeReply {
 interface TurnMetrics {
   turnId: string;
   pauseDetectedAt: number; // performance.now() when the ending pause was detected / "over and out" tapped
-  pauseToTranscribeMs: number; // that pause to the command transcript in hand
+  pauseToTranscribeMs: number; // that pause to the command transcript in hand (transcode + network + server)
+  transcodeMs: number; // the client-side WebM/Opus -> 16k mono WAV transcode alone (phone CPU)
   commandChars: number;
   replyChars: number;
   brainMs: number; // POST /carmode/turn round trip as the browser saw it
@@ -235,6 +236,7 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     void postCarModeTelemetry({
       turnId: m.turnId,
       pauseToTranscribeMs: m.pauseToTranscribeMs,
+      transcodeMs: m.transcodeMs,
       brainMs: m.brainMs,
       ttsMs: m.ttsMs,
       firstAudioMs: m.firstAudioMs,
@@ -498,7 +500,11 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
           return;
         }
         if (!force) setCaptureState("pause - transcribing");
+        // Measure the client-side transcode (phone CPU) separately from the transcribe round trip (network
+        // + server), so a real phone turn shows where the pause-to-transcript time actually goes.
+        const transcodeStart = performance.now();
         const { wav } = await blobToWav16kMono(clip);
+        const transcodeMs = performance.now() - transcodeStart;
         const transcript = (await transcribeCarModeAudio(wav)).trim();
         const pauseToTranscribeMs = performance.now() - pauseDetectedAt;
         setLastHeard(transcript);
@@ -515,6 +521,7 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
             turnId: "",
             pauseDetectedAt,
             pauseToTranscribeMs,
+            transcodeMs,
             commandChars: command.trim().length,
             replyChars: 0,
             brainMs: 0,

--- a/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
@@ -101,6 +101,7 @@ internal static class CarModeEndpoint
                 DeviceHash = CarModeDeviceHash.Of(ExtractCallerCredential(ctx)),
                 GatewayVersion = AppVersion.Full,
                 PauseToTranscribeMs = req.PauseToTranscribeMs,
+                TranscodeMs = req.TranscodeMs,
                 BrainMs = req.BrainMs,
                 TtsMs = req.TtsMs,
                 FirstAudioMs = req.FirstAudioMs,
@@ -166,6 +167,7 @@ public sealed class CarModeTelemetryPost
 {
     public string TurnId { get; set; } = "";
     public double PauseToTranscribeMs { get; set; }
+    public double TranscodeMs { get; set; }
     public double BrainMs { get; set; }
     public double TtsMs { get; set; }
     public double FirstAudioMs { get; set; }

--- a/src/CcDirector.Gateway/CarMode/CarModeTelemetry.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeTelemetry.cs
@@ -64,9 +64,13 @@ public sealed record CarModeTelemetryRecord
 
     // ----- Client stamps (milliseconds), measured in the browser turn-taking machine -----
 
-    /// <summary>Pause detected (or "over and out" tapped) to the command transcript in hand: the Gateway
-    ///  transcription round trip for the command.</summary>
+    /// <summary>Pause detected (or "over and out" tapped) to the command transcript in hand: the whole
+    ///  command path (client transcode + network + server transcribe).</summary>
     public double PauseToTranscribeMs { get; init; }
+
+    /// <summary>The client-side WebM/Opus to 16k mono WAV transcode alone (phone CPU), so the transcribe
+    ///  round trip (network + server) is <see cref="PauseToTranscribeMs"/> minus this.</summary>
+    public double TranscodeMs { get; init; }
 
     /// <summary>The brain round trip as the browser saw it: POST /carmode/turn request to response, network
     ///  included (so it is >= the server TotalMs by the network cost).</summary>

--- a/src/CcDirector.Gateway/CarMode/CarModeTelemetryPage.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeTelemetryPage.cs
@@ -63,7 +63,7 @@ internal static class CarModeTelemetryPage
 <body>
 <div class="wrap">
   <h1>Car Mode Timing</h1>
-  <p class="sub">Per-turn, per-stage latency for hands-free Car Mode - measured end to end, client and server. All numbers are milliseconds. Counts and timings only; no command or reply text is ever recorded.</p>
+  <p class="sub">Per-turn, per-stage latency for hands-free Car Mode - the full pipeline a real phone turn walks: pause, transcode (phone), transcribe, brain round trip, the network gap (brain minus server), each model call, the fleet read, text-to-speech, and first audio. All numbers are milliseconds. Counts and timings only; no command or reply text is ever recorded.</p>
 
   <div class="cards" id="cards"></div>
 
@@ -75,14 +75,16 @@ internal static class CarModeTelemetryPage
           <th>When</th>
           <th>Total<br>(felt)</th>
           <th>Pause-&gt;<br>transcribe</th>
+          <th>Transcode<br>(phone)</th>
           <th>Brain<br>(round trip)</th>
-          <th>First<br>audio</th>
-          <th>TTS<br>(1st)</th>
+          <th>Network<br>(brain-server)</th>
           <th>Server<br>total</th>
           <th>Model<br>calls</th>
           <th>Model<br>ms</th>
           <th>Fleet<br>reads</th>
           <th>Fleet<br>ms</th>
+          <th>TTS<br>(1st)</th>
+          <th>First<br>audio</th>
           <th>Rounds</th>
           <th>Cmd<br>chars</th>
           <th>Reply<br>chars</th>
@@ -126,7 +128,7 @@ internal static class CarModeTelemetryPage
 
     if (!recs.length) {
       cards.appendChild(card("-", "No turns recorded yet", "Take a turn in Car Mode on the phone"));
-      document.getElementById("rows").innerHTML = '<tr><td colspan="14" class="empty">No turns recorded yet. Open Car Mode on the phone, say something and "over and out", and it will appear here.</td></tr>';
+      document.getElementById("rows").innerHTML = '<tr><td colspan="16" class="empty">No turns recorded yet. Open Car Mode on the phone, say something and "over and out", and it will appear here.</td></tr>';
       document.getElementById("foot").textContent = "";
       return;
     }
@@ -151,17 +153,22 @@ internal static class CarModeTelemetryPage
         return c;
       }
       var when = r.receivedAtUtc ? new Date(r.receivedAtUtc).toLocaleTimeString() : "-";
+      // Network the browser saw (its brain round trip minus what the server spent inside), so a bad phone
+      // network shows up as a large gap that the loopback numbers can never reveal.
+      var net = (r.brainMs != null && r.serverTotalMs != null) ? Math.max(0, r.brainMs - r.serverTotalMs) : null;
       tr.appendChild(td(when));
       tr.appendChild(td(ms(r.totalTurnMs), r.totalTurnMs > 6000 ? "slow" : ""));
-      tr.appendChild(td(ms(r.pauseToTranscribeMs)));
+      tr.appendChild(td(ms(r.pauseToTranscribeMs), r.pauseToTranscribeMs > 4000 ? "slow" : ""));
+      tr.appendChild(td(ms(r.transcodeMs)));
       tr.appendChild(td(ms(r.brainMs), r.brainMs > 5000 ? "slow" : ""));
-      tr.appendChild(td(ms(r.firstAudioMs)));
-      tr.appendChild(td(ms(r.ttsMs)));
+      tr.appendChild(td(ms(net), (net != null && net > 2000) ? "slow" : ""));
       tr.appendChild(td(ms(r.serverTotalMs)));
       tr.appendChild(td(r.modelCallCount == null ? "-" : r.modelCallCount));
       tr.appendChild(td(ms(r.modelMsTotal)));
       tr.appendChild(td(r.fleetReadCount == null ? "-" : r.fleetReadCount, (r.fleetReadCount || 0) === 0 ? "zero" : ""));
       tr.appendChild(td(ms(r.fleetReadMsTotal)));
+      tr.appendChild(td(ms(r.ttsMs), r.ttsMs > 3000 ? "slow" : ""));
+      tr.appendChild(td(ms(r.firstAudioMs)));
       tr.appendChild(td(r.rounds == null ? "-" : r.rounds));
       tr.appendChild(td(r.commandChars == null ? "-" : r.commandChars));
       tr.appendChild(td(r.replyChars == null ? "-" : r.replyChars));


### PR DESCRIPTION
Follow-up to #1371 (Architect direction): a real phone turn's latency lives in stages the first round folded together - the phone's own transcode, and the network gap on a bad connection. This exposes them so ONE real phone turn reads the true end-to-end.

- Browser measures the client-side WebM/Opus -> 16k mono WAV transcode alone (`transcodeMs`), separate from the transcribe round trip.
- Dashboard adds **Transcode (phone)** and a derived **Network (brain - server)** column, in true pipeline order: pause -> transcribe -> transcode -> brain -> network -> server -> model calls -> fleet -> text-to-speech -> first audio. Slow stages flagged.

Still counts and timings only; no message text. Tests: client 320 green, Car Mode server 63 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)