### PR TITLE
feat(mobile): Phase 1 - one global bad-connection banner fed by a shared health signal

### DIFF
--- a/apps/mobile/src/components/ConnectionBanner.tsx
+++ b/apps/mobile/src/components/ConnectionBanner.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { useConnectionHealth } from "@devthrottle/client-core/connection/health";
+import { useNow } from "@devthrottle/client-core/sessions/waiting";
+
+// The ONE global bad-connection indicator for the whole mobile app (mission: never clear good data
+// just because the connection is bad). Mounted once in GatedLayout, so it sits above every gated
+// screen - the roster, Chat, Voice, the terminal - and is the single voice for "the network is bad,
+// what you see is the last known information." No page carries its own offline strip; they keep their
+// content and this banner is the one explanation.
+//
+// It reads the shared connection-health signal (fed at the api/client.ts transport choke points) and
+// renders nothing while the connection is good. When it goes bad it pins a slim strip at the very top
+// of the screen and, once the last good contact is more than a few seconds old, says HOW stale things
+// are ("updated 40s ago") - the honesty mechanism, so nothing on screen pretends to be live when it is
+// not. It clears itself the moment the next contact succeeds.
+
+// Below this the age is too small to be worth naming; the banner just says the connection is bad.
+const STALE_THRESHOLD_MS = 3000;
+
+// A compact "how long ago" label with seconds granularity (the mission's "updated 40s ago"), climbing
+// to minutes and hours for a longer outage: "40s" -> "3m" -> "1h 4m".
+function agoLabel(gapMs: number): string {
+  const seconds = Math.floor(gapMs / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remMinutes = minutes % 60;
+  return remMinutes > 0 ? `${hours}h ${remMinutes}m` : `${hours}h`;
+}
+
+export function ConnectionBanner(): React.ReactElement | null {
+  const health = useConnectionHealth();
+  // Tick once a second while the connection is bad, so the staleness age climbs live. While it is good
+  // the banner renders nothing, so there is nothing to tick - drop to a slow 60s heartbeat rather than
+  // running a 1s timer app-wide forever (a small mobile-battery courtesy). useNow restarts its interval
+  // when the value changes, so the fast tick begins the moment the connection goes bad.
+  const now = useNow(health.state === "bad" ? 1000 : 60000);
+
+  if (health.state === "good") return null;
+
+  const gap = health.lastGoodContactAt > 0 ? now - health.lastGoodContactAt : 0;
+  const showAge = health.lastGoodContactAt > 0 && gap >= STALE_THRESHOLD_MS;
+
+  return (
+    <div className="conn-banner" role="status" aria-live="polite">
+      <span className="conn-banner-text">Bad connection - showing last known information</span>
+      {showAge && <span className="conn-banner-age">updated {agoLabel(gap)} ago</span>}
+    </div>
+  );
+}

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -17,6 +17,7 @@ import { hasDeviceKey } from "@devthrottle/client-core/auth/deviceKey";
 import { ensureGatewayCookie, configureUnauthorizedRedirect, mobileSignInRedirect } from "@devthrottle/client-core/api/client";
 import { ensurePushSubscribed } from "@devthrottle/client-core/push/register";
 import { CreditsNotice } from "./components/CreditsNotice";
+import { ConnectionBanner } from "./components/ConnectionBanner";
 import { useScreenWakeLock } from "./hooks/useScreenWakeLock";
 import { resumePendingDictations } from "@devthrottle/client-core/dictation/backgroundSend";
 import { RouteRecoveryBoundary, RootLayout } from "./components/StaleShellRecovery";
@@ -41,7 +42,15 @@ function GatedLayout() {
   React.useEffect(() => {
     void resumePendingDictations();
   }, []);
-  return <Outlet />;
+  // The one global bad-connection banner (mobile-resilience mission): mounted once here so it pins to
+  // the top of every gated screen and is the single voice for a bad connection. Hidden while the
+  // connection is good; the pages keep their last-known content underneath either way.
+  return (
+    <>
+      <ConnectionBanner />
+      <Outlet />
+    </>
+  );
 }
 
 // Mirror the enrolled per-device key into the cc-gateway-token cookie at startup so the live

--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { listSessions, type SessionDto } from "@devthrottle/client-core/api/client";
 import { classify, contextLine, dotColor, effectiveColor, inBucket, inDesktopOrder, inWaitingOrder, isWorking, repoLeaf } from "@devthrottle/client-core/sessions/ordering";
@@ -20,7 +20,6 @@ const POLL_INTERVAL_MS = 5000;
 export function Home() {
   const [sessions, setSessions] = useState<SessionDto[] | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const loadedOnce = useRef(false);
   // The roster filter (by machine and/or repo) and whether its full-screen panel is open. The filter
   // is persisted across navigations and restarts by the hook; the panel is transient UI state.
   const [filter, setFilter] = useSessionFilter();
@@ -35,7 +34,6 @@ export function Home() {
       const data = await listSessions(signal);
       setSessions(data);
       setError(null);
-      loadedOnce.current = true;
       // Keep the app-icon "needs you" dot in sync while the app is open: set the badge to the live
       // count, or clear the badge and the service worker's dot notification when nothing is waiting.
       void reconcileBadge(inBucket(data, "needsYou").length);
@@ -44,7 +42,11 @@ export function Home() {
       void syncVoiceSessions(data);
     } catch (err) {
       if (signal?.aborted) return;
-      // Keep the last-known roster on screen (offline shell); only show the error banner.
+      // Keep the last-known roster on screen (never clear good data on a bad connection). The global
+      // ConnectionBanner - fed by the same failed contact through the shared health signal - is now the
+      // single voice for "bad connection, showing last known", so this page no longer shows its own
+      // offline strip. The error is kept only to stop the "Loading sessions..." line from lying after a
+      // first-load failure.
       setError(err instanceof Error ? err.message : "Failed to load sessions");
     }
   }, []);
@@ -114,12 +116,6 @@ export function Home() {
           <button type="button" className="filter-strip-clear" onClick={() => setFilter({ machines: [], repos: [] })}>
             Clear
           </button>
-        </div>
-      )}
-
-      {error !== null && (
-        <div className="banner banner-error" role="alert">
-          {loadedOnce.current ? "Offline - showing last-known roster" : error}
         </div>
       )}
 

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -164,6 +164,39 @@ a.banner-btn {
   border-color: rgba(255, 255, 255, 0.25);
 }
 
+/* Mobile-resilience mission: the ONE global bad-connection banner. A slim strip pinned to the very top
+   of every gated screen, shown only when the shared connection-health signal reads bad. It OVERLAYS the
+   top edge (fixed, not in flow) so it never reflows the fixed-height session screens or pushes the
+   terminal, and it names the bad connection plus how stale the data is - the single voice for "showing
+   last known information". Amber (a warning, not an error): the data underneath is fine, the network is
+   not. Sits above the sticky app bar and per-session headers (z-index 5) but below full-screen modals. */
+.conn-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1500;
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 3px 8px;
+  padding: calc(6px + env(safe-area-inset-top)) 12px 6px;
+  background: #7a5200;
+  border-bottom: 1px solid #b8860b;
+  color: #ffe6a3;
+  font-size: 12.5px;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+}
+
+.conn-banner-age {
+  color: #ffcf7a;
+  font-weight: 500;
+  opacity: 0.9;
+}
+
 .status-line {
   color: var(--text-dim);
   font-size: 14px;

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -11,6 +11,7 @@ import type { SessionHistoryDto } from "../history/types";
 import { planUploadChunks } from "./chunking";
 import { getDeviceKey, clearDeviceKey } from "../auth/deviceKey";
 import { publishDictationStatus } from "../dictation/status";
+import { reportGatewayReachable, reportGatewayUnreachable } from "../connection/health";
 
 export type SessionDto = components["schemas"]["SessionDto"];
 
@@ -223,6 +224,34 @@ function isGatewayUnreachable(err: unknown): boolean {
   return err instanceof Error;
 }
 
+// The ONE transport choke point every Gateway contact in this client routes through, so the shared
+// connection-health signal (connection/health.ts) is fed in exactly one place instead of hand-wired
+// into each page's poll. It is a transparent wrapper around the browser fetch: it returns the same
+// Response and rethrows the same error, adding only a health report. An answered request whose status
+// means the backend was unreachable (502/503/504, or a synthetic 0) reports UNREACHABLE; every other
+// answered status - including 4xx/500 application errors - reports REACHABLE (the Gateway answered). A
+// bare fetch rejection (the backend is down) reports UNREACHABLE. A caller-initiated abort is not a
+// connection signal, so it is rethrown without any report. This mirrors the issue #1028 classification
+// used by isGatewayUnreachable; it does not invent a second taxonomy.
+async function gatewayFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  let res: Response;
+  try {
+    res = await fetch(input, init);
+  } catch (err) {
+    // A caller-initiated abort (the browser throws a DOMException named "AbortError", which extends
+    // Error) is a cancel, not a connection signal - rethrow it without recording anything.
+    if (err instanceof Error && err.name === "AbortError") throw err;
+    reportGatewayUnreachable();
+    throw err;
+  }
+  if (res.status === 0 || res.status === 502 || res.status === 503 || res.status === 504) {
+    reportGatewayUnreachable();
+  } else {
+    reportGatewayReachable();
+  }
+  return res;
+}
+
 // Map any error thrown by a Gateway read/write into ONE user-facing line, never leaking the internal
 // "METHOD /path failed: NNN" diagnostic the client throws on a non-2xx, nor the browser's bare
 // "Failed to fetch" when the backend is down (issue #1028). An unreachable Gateway collapses to the
@@ -277,7 +306,7 @@ async function readGatewayErrorBody(res: Response): Promise<string | undefined> 
 // Mobile page consumes. Throws GatewayError on a non-2xx so the caller surfaces it (no silent
 // fallback). The request is same-origin against the Gateway front door.
 export async function listSessions(signal?: AbortSignal): Promise<SessionDto[]> {
-  const res = await fetch("/sessions", {
+  const res = await gatewayFetch("/sessions", {
     method: "GET",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -306,7 +335,7 @@ export async function getSessionHistory(
   signal?: AbortSignal,
 ): Promise<SessionHistoryDto> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}/history`, {
+  const res = await gatewayFetch(`/sessions/${sid}/history`, {
     method: "GET",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -328,7 +357,7 @@ export async function sendPrompt(
 ): Promise<void> {
   const sid = encodeURIComponent(sessionId);
   const body: PromptRequest = { text, appendEnter };
-  const res = await fetch(`/sessions/${sid}/prompt`, {
+  const res = await gatewayFetch(`/sessions/${sid}/prompt`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
     body: JSON.stringify(body),
@@ -342,7 +371,7 @@ export async function sendPrompt(
 // Soft-stop the current turn (the agent driver's Escape). POST /sessions/{sid}/escape.
 export async function sendEscape(sessionId: string, signal?: AbortSignal): Promise<void> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}/escape`, {
+  const res = await gatewayFetch(`/sessions/${sid}/escape`, {
     method: "POST",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -355,7 +384,7 @@ export async function sendEscape(sessionId: string, signal?: AbortSignal): Promi
 // Interrupt a running agent turn (Ctrl+C). POST /sessions/{sid}/interrupt.
 export async function sendInterrupt(sessionId: string, signal?: AbortSignal): Promise<void> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}/interrupt`, {
+  const res = await gatewayFetch(`/sessions/${sid}/interrupt`, {
     method: "POST",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -370,7 +399,7 @@ export async function sendInterrupt(sessionId: string, signal?: AbortSignal): Pr
 // ClearContext capability; the caller gates the button on SessionDto.driverCapabilities.
 export async function sendClearContext(sessionId: string, signal?: AbortSignal): Promise<void> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}/clear-context`, {
+  const res = await gatewayFetch(`/sessions/${sid}/clear-context`, {
     method: "POST",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -384,7 +413,7 @@ export async function sendClearContext(sessionId: string, signal?: AbortSignal):
 // /sessions/{sid}/history-picker. Gated on the History capability - a visible-terminal feature.
 export async function sendHistoryPicker(sessionId: string, signal?: AbortSignal): Promise<void> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}/history-picker`, {
+  const res = await gatewayFetch(`/sessions/${sid}/history-picker`, {
     method: "POST",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -421,7 +450,7 @@ async function readQueue(res: Response, label: string): Promise<QueueItem[]> {
 // GET /sessions/{sid}/queue - the session's current queued prompts, in order.
 export async function getQueue(sessionId: string, signal?: AbortSignal): Promise<QueueItem[]> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}/queue`, {
+  const res = await gatewayFetch(`/sessions/${sid}/queue`, {
     method: "GET",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -462,7 +491,7 @@ export interface GitSnapshot {
 // result the caller renders ("not a git repository" / "git failed"), not an error.
 export async function getGitStatus(sessionId: string, signal?: AbortSignal): Promise<GitSnapshot> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}/git`, {
+  const res = await gatewayFetch(`/sessions/${sid}/git`, {
     method: "GET",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -481,7 +510,7 @@ export async function getGitStatus(sessionId: string, signal?: AbortSignal): Pro
 // POST /sessions/{sid}/queue { text } - append a prompt to the queue; returns the new queue.
 export async function enqueuePrompt(sessionId: string, text: string, signal?: AbortSignal): Promise<QueueItem[]> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}/queue`, {
+  const res = await gatewayFetch(`/sessions/${sid}/queue`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
     body: JSON.stringify({ text }),
@@ -494,7 +523,7 @@ export async function enqueuePrompt(sessionId: string, text: string, signal?: Ab
 export async function deleteQueueItem(sessionId: string, itemId: string, signal?: AbortSignal): Promise<QueueItem[]> {
   const sid = encodeURIComponent(sessionId);
   const id = encodeURIComponent(itemId);
-  const res = await fetch(`/sessions/${sid}/queue/${id}`, {
+  const res = await gatewayFetch(`/sessions/${sid}/queue/${id}`, {
     method: "DELETE",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -506,7 +535,7 @@ export async function deleteQueueItem(sessionId: string, itemId: string, signal?
 export async function sendQueueItem(sessionId: string, itemId: string, signal?: AbortSignal): Promise<QueueItem[]> {
   const sid = encodeURIComponent(sessionId);
   const id = encodeURIComponent(itemId);
-  const res = await fetch(`/sessions/${sid}/queue/${id}/send`, {
+  const res = await gatewayFetch(`/sessions/${sid}/queue/${id}/send`, {
     method: "POST",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -518,7 +547,7 @@ export async function sendQueueItem(sessionId: string, itemId: string, signal?: 
 export async function editQueueItem(sessionId: string, itemId: string, text: string, signal?: AbortSignal): Promise<QueueItem[]> {
   const sid = encodeURIComponent(sessionId);
   const id = encodeURIComponent(itemId);
-  const res = await fetch(`/sessions/${sid}/queue/${id}`, {
+  const res = await gatewayFetch(`/sessions/${sid}/queue/${id}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
     body: JSON.stringify({ text }),
@@ -531,7 +560,7 @@ export async function editQueueItem(sessionId: string, itemId: string, text: str
 export async function moveQueueItemUp(sessionId: string, itemId: string, signal?: AbortSignal): Promise<QueueItem[]> {
   const sid = encodeURIComponent(sessionId);
   const id = encodeURIComponent(itemId);
-  const res = await fetch(`/sessions/${sid}/queue/${id}/move-up`, {
+  const res = await gatewayFetch(`/sessions/${sid}/queue/${id}/move-up`, {
     method: "POST",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -543,7 +572,7 @@ export async function moveQueueItemUp(sessionId: string, itemId: string, signal?
 export async function moveQueueItemDown(sessionId: string, itemId: string, signal?: AbortSignal): Promise<QueueItem[]> {
   const sid = encodeURIComponent(sessionId);
   const id = encodeURIComponent(itemId);
-  const res = await fetch(`/sessions/${sid}/queue/${id}/move-down`, {
+  const res = await gatewayFetch(`/sessions/${sid}/queue/${id}/move-down`, {
     method: "POST",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -554,7 +583,7 @@ export async function moveQueueItemDown(sessionId: string, itemId: string, signa
 // DELETE /sessions/{sid}/queue - clear the whole queue; returns the (empty) queue.
 export async function clearQueue(sessionId: string, signal?: AbortSignal): Promise<QueueItem[]> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}/queue`, {
+  const res = await gatewayFetch(`/sessions/${sid}/queue`, {
     method: "DELETE",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -618,7 +647,7 @@ export function sessionFileUrl(sessionId: string, path: string): string {
 // so the viewer can show the real reason - 404 for a missing file, 503 for an offline Director -
 // never a silent blank.
 export async function fetchSessionFileText(sessionId: string, path: string, signal?: AbortSignal): Promise<string> {
-  const res = await fetch(sessionFileUrl(sessionId, path), {
+  const res = await gatewayFetch(sessionFileUrl(sessionId, path), {
     method: "GET",
     headers: { ...authHeaders() },
     signal,
@@ -636,7 +665,7 @@ export async function fetchSessionFileText(sessionId: string, path: string, sign
 export async function getScreenshots(sessionId: string, count = 0, signal?: AbortSignal): Promise<ScreenshotsResult> {
   const sid = encodeURIComponent(sessionId);
   const path = count > 0 ? `/sessions/${sid}/screenshots?count=${count}` : `/sessions/${sid}/screenshots`;
-  const res = await fetch(path, {
+  const res = await gatewayFetch(path, {
     method: "GET",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -655,7 +684,7 @@ export async function getScreenshots(sessionId: string, count = 0, signal?: Abor
 // DELETE /sessions/{sid}/screenshots/file?name=... - delete one screenshot file from the Director's disk.
 export async function deleteScreenshot(sessionId: string, fileName: string, signal?: AbortSignal): Promise<void> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}/screenshots/file?name=${encodeURIComponent(fileName)}`, {
+  const res = await gatewayFetch(`/sessions/${sid}/screenshots/file?name=${encodeURIComponent(fileName)}`, {
     method: "DELETE",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -673,7 +702,7 @@ export async function uploadImage(sessionId: string, file: File, signal?: AbortS
   const sid = encodeURIComponent(sessionId);
   const form = new FormData();
   form.append("file", file, file.name);
-  const res = await fetch(`/sessions/${sid}/upload-image`, {
+  const res = await gatewayFetch(`/sessions/${sid}/upload-image`, {
     method: "POST",
     headers: { ...authHeaders() },
     body: form,
@@ -706,7 +735,7 @@ export interface SessionHandover {
 // panel): 404 when the session is unknown to every Director, 502 when the owning Director is offline.
 export async function getHandover(sessionId: string, signal?: AbortSignal): Promise<SessionHandover> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}/handover`, {
+  const res = await gatewayFetch(`/sessions/${sid}/handover`, {
     method: "GET",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -733,7 +762,7 @@ export async function getHandover(sessionId: string, signal?: AbortSignal): Prom
 // GET /healthz - the running Gateway's own status and version. No auth needed. Backs the mobile
 // About screen so the user can confirm which build they are on.
 export async function getGatewayHealth(signal?: AbortSignal): Promise<GatewayHealth> {
-  const res = await fetch("/healthz", {
+  const res = await gatewayFetch("/healthz", {
     method: "GET",
     headers: { Accept: "application/json" },
     signal,
@@ -749,7 +778,7 @@ export async function getGatewayHealth(signal?: AbortSignal): Promise<GatewayHea
 // Entries with no directorId are dropped (they cannot be addressed). Throws GatewayError on non-2xx
 // so the picker shows the real reason instead of a silently empty list.
 export async function getDirectors(signal?: AbortSignal): Promise<DirectorInfo[]> {
-  const res = await fetch("/directors", {
+  const res = await gatewayFetch("/directors", {
     method: "GET",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -781,7 +810,7 @@ export async function getDirectors(signal?: AbortSignal): Promise<DirectorInfo[]
 // FleetParser.ParseRepos). Entries with no path are dropped. Throws GatewayError on non-2xx.
 export async function getRepos(directorId: string, signal?: AbortSignal): Promise<RepoInfo[]> {
   const id = encodeURIComponent(directorId);
-  const res = await fetch(`/directors/${id}/repos`, {
+  const res = await gatewayFetch(`/directors/${id}/repos`, {
     method: "GET",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -821,7 +850,7 @@ export async function createSession(
   const body: NewSessionRequest = { repoPath: repoPath.trim(), agent: "ClaudeCode", wingmanEnabled: false };
   const trimmedArgs = (launchArgs ?? "").trim();
   if (trimmedArgs.length > 0) body.args = trimmedArgs;
-  const res = await fetch(`/directors/${id}/sessions`, {
+  const res = await gatewayFetch(`/directors/${id}/sessions`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
     body: JSON.stringify(body),
@@ -849,7 +878,7 @@ export async function holdSession(
   signal?: AbortSignal,
 ): Promise<boolean> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}/hold`, {
+  const res = await gatewayFetch(`/sessions/${sid}/hold`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
     body: JSON.stringify({ onHold }),
@@ -875,7 +904,7 @@ export async function setTranscribing(
   signal?: AbortSignal,
 ): Promise<void> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}/transcribing`, {
+  const res = await gatewayFetch(`/sessions/${sid}/transcribing`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
     body: JSON.stringify({ transcribing }),
@@ -891,7 +920,7 @@ export async function setTranscribing(
 // the Director through the Gateway catch-all session proxy with the injected Bearer.
 export async function killSession(sessionId: string, signal?: AbortSignal): Promise<void> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}`, {
+  const res = await gatewayFetch(`/sessions/${sid}`, {
     method: "DELETE",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -934,7 +963,7 @@ export async function transcribeUtterance(
   onProgress?: (uploadedChunks: number, totalChunks: number) => void,
 ): Promise<string> {
   // 1. Register the upload (mints an id the chunk + complete calls address).
-  const reg = await fetch(`/wingman/utterance/upload`, {
+  const reg = await gatewayFetch(`/wingman/utterance/upload`, {
     method: "POST",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -959,7 +988,7 @@ export async function transcribeUtterance(
   for (const range of ranges) {
     const part = bytes.subarray(range.start, range.end);
     const sha = await sha256Hex(part);
-    const put = await fetch(`/wingman/utterance/${id}/chunk/${range.index}`, {
+    const put = await gatewayFetch(`/wingman/utterance/${id}/chunk/${range.index}`, {
       method: "PUT",
       headers: { "Content-Type": "application/octet-stream", "X-Chunk-Sha256": sha, ...authHeaders() },
       body: part,
@@ -975,7 +1004,7 @@ export async function transcribeUtterance(
   // 3. Complete with the real chunk count -> the server reassembles all chunks, transcribes the clip
   //    (the pipeline itself splits the reassembled audio into bounded transcription requests), applies
   //    the dictionary correction, and returns the cleaned transcript.
-  const comp = await fetch(`/wingman/utterance/${id}/complete`, {
+  const comp = await gatewayFetch(`/wingman/utterance/${id}/complete`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
     body: JSON.stringify({
@@ -1103,7 +1132,7 @@ export async function uploadDictationToSession(
   publishDictationStatus({ sessionId: sid, uploadId, phase: "uploading", uploaded: 0, total: 1 });
   let reg: Response;
   try {
-    reg = await fetch(`/dictation/upload`, {
+    reg = await gatewayFetch(`/dictation/upload`, {
       method: "POST",
       headers: { "Content-Type": "application/json", Accept: "application/json", "Idempotency-Key": args.uploadId, ...authHeaders() },
       body: JSON.stringify({ sessionId: args.sessionId, baselineBufferBytes: args.baselineBufferBytes }),
@@ -1154,7 +1183,7 @@ export async function uploadDictationToSession(
     resumed: args.resumed,
   };
   const complete = (): Promise<Response> =>
-    fetch(`/dictation/${id}/complete`, {
+    gatewayFetch(`/dictation/${id}/complete`, {
       method: "POST",
       headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
       body: JSON.stringify(completeBody),
@@ -1193,7 +1222,7 @@ export async function uploadDictationToSession(
         const sha = await sha256Hex(part);
         let put: Response;
         try {
-          put = await fetch(`/dictation/${id}/chunk/${r.index}`, {
+          put = await gatewayFetch(`/dictation/${id}/chunk/${r.index}`, {
             method: "PUT",
             headers: { "Content-Type": "application/octet-stream", "X-Chunk-Sha256": sha, ...authHeaders() },
             body: part,
@@ -1282,7 +1311,7 @@ function permanentReasonFrom(permanent: boolean | undefined, reason: string | un
 // a failed ack must never turn a delivered turn into an error.
 async function ackDictation(encodedUploadId: string): Promise<void> {
   try {
-    await fetch(`/dictation/${encodedUploadId}/ack`, {
+    await gatewayFetch(`/dictation/${encodedUploadId}/ack`, {
       method: "POST",
       headers: { Accept: "application/json", ...authHeaders() },
     });
@@ -1298,7 +1327,7 @@ async function ackDictation(encodedUploadId: string): Promise<void> {
 // call could not reach a healthy Gateway, so the caller keeps the abandoning record and retries.
 export async function abandonDictation(uploadId: string): Promise<boolean> {
   try {
-    const res = await fetch(`/dictation/${encodeURIComponent(uploadId)}/abandon`, {
+    const res = await gatewayFetch(`/dictation/${encodeURIComponent(uploadId)}/abandon`, {
       method: "POST",
       headers: { Accept: "application/json", ...authHeaders() },
     });
@@ -1442,7 +1471,7 @@ export interface WingmanMenu {
 // voice mode fires; the Gateway caches the spoken text + audio so the phone can then download it.
 export async function markVoiceAndExplain(sessionId: string, signal?: AbortSignal): Promise<WingmanExplain> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}/wingman/explain`, {
+  const res = await gatewayFetch(`/sessions/${sid}/wingman/explain`, {
     method: "POST",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -1465,7 +1494,7 @@ export async function markVoiceAndExplain(sessionId: string, signal?: AbortSigna
 // current (latest) narration. ready=false means the Gateway has nothing cached yet.
 export async function getWingmanVoice(sessionId: string, signal?: AbortSignal): Promise<WingmanVoice> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}/wingman/voice`, {
+  const res = await gatewayFetch(`/sessions/${sid}/wingman/voice`, {
     method: "GET",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -1487,7 +1516,7 @@ export async function getWingmanVoice(sessionId: string, signal?: AbortSignal): 
 // and expose a "phone-ready" state distinct from "gateway-ready". Binary, never base64 over the wire.
 export async function fetchWingmanVoiceAudio(sessionId: string, signal?: AbortSignal): Promise<ArrayBuffer> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}/wingman/voice/audio`, {
+  const res = await gatewayFetch(`/sessions/${sid}/wingman/voice/audio`, {
     method: "GET",
     headers: { Accept: "audio/mpeg", ...authHeaders() },
     signal,
@@ -1505,7 +1534,7 @@ export async function fetchWingmanVoiceAudio(sessionId: string, signal?: AbortSi
 // isMenu=false cheaply (no model call) when the terminal does not look like a menu.
 export async function getWingmanMenu(sessionId: string, signal?: AbortSignal): Promise<WingmanMenu> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}/wingman/menu`, {
+  const res = await gatewayFetch(`/sessions/${sid}/wingman/menu`, {
     method: "GET",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -1542,7 +1571,7 @@ export async function pressWingmanMenu(
 ): Promise<void> {
   const sid = encodeURIComponent(sessionId);
   const body: { send: string; submit?: string } = submit ? { send, submit } : { send };
-  const res = await fetch(`/sessions/${sid}/wingman/menu-press`, {
+  const res = await gatewayFetch(`/sessions/${sid}/wingman/menu-press`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
     body: JSON.stringify(body),
@@ -1562,7 +1591,7 @@ export async function pressWingmanMenu(
 // markVoiceAndExplain (which marks the Gateway's turn-end re-narration set and reads the first turn).
 export async function setVoiceMode(sessionId: string, enabled: boolean, signal?: AbortSignal): Promise<void> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}/voice-mode`, {
+  const res = await gatewayFetch(`/sessions/${sid}/voice-mode`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
     body: JSON.stringify({ enabled }),
@@ -1582,7 +1611,7 @@ export async function setVoiceMode(sessionId: string, enabled: boolean, signal?:
 // it sends nothing into the session.
 export async function stopWingmanVoice(sessionId: string, signal?: AbortSignal): Promise<void> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}/wingman/voice/stop`, {
+  const res = await gatewayFetch(`/sessions/${sid}/wingman/voice/stop`, {
     method: "POST",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,

--- a/packages/client-core/src/connection/health.test.ts
+++ b/packages/client-core/src/connection/health.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { connectionHealth, reportGatewayReachable, reportGatewayUnreachable } from "./health";
+
+// The store is a module-level singleton, so each test first drives it to a known-good baseline via the
+// public report functions (there is no test-only reset backdoor). Fake timers make Date.now
+// deterministic so the "last good time captured at the moment it goes bad" behaviour is testable.
+describe("connection health store", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    // Force a known baseline via a real flip (bad -> good) so the published snapshot folds in the
+    // known last-good time. A plain reachable call from an already-good state would not re-publish
+    // (that is the store's contract: it only emits a new snapshot when the state actually flips).
+    reportGatewayUnreachable();
+    reportGatewayReachable();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reads good with a last-good time after a reachable contact", () => {
+    const h = connectionHealth();
+    expect(h.state).toBe("good");
+    expect(h.lastGoodContactAt).toBe(1_000_000);
+  });
+
+  it("flips to bad on an unreachable contact", () => {
+    reportGatewayUnreachable();
+    expect(connectionHealth().state).toBe("bad");
+  });
+
+  it("keeps a stable snapshot reference while the state does not flip (useSyncExternalStore contract)", () => {
+    const first = connectionHealth();
+    reportGatewayReachable(); // good -> good: no flip, so no new snapshot
+    expect(connectionHealth()).toBe(first);
+    reportGatewayUnreachable(); // good -> bad: a flip, so a new snapshot
+    expect(connectionHealth()).not.toBe(first);
+  });
+
+  it("captures the TRUE last-good time (moments before the drop), not the flip-to-good time", () => {
+    // Go bad, then good at t=2_000_000 (this is the flip-to-good time)...
+    reportGatewayUnreachable();
+    vi.setSystemTime(2_000_000);
+    reportGatewayReachable();
+    // ...keep succeeding up to t=2_050_000 without any flip (state stays good, no new snapshot)...
+    vi.setSystemTime(2_050_000);
+    reportGatewayReachable();
+    // ...then the connection drops. The banner must show the LAST success (2_050_000), not 2_000_000.
+    reportGatewayUnreachable();
+    expect(connectionHealth().lastGoodContactAt).toBe(2_050_000);
+  });
+
+  it("recovers to good and advances the last-good time on the next reachable contact", () => {
+    reportGatewayUnreachable();
+    vi.setSystemTime(3_000_000);
+    reportGatewayReachable();
+    const h = connectionHealth();
+    expect(h.state).toBe("good");
+    expect(h.lastGoodContactAt).toBe(3_000_000);
+  });
+
+  it("does not emit a new snapshot on repeated unreachable contacts", () => {
+    reportGatewayUnreachable();
+    const bad = connectionHealth();
+    reportGatewayUnreachable();
+    expect(connectionHealth()).toBe(bad);
+  });
+});

--- a/packages/client-core/src/connection/health.ts
+++ b/packages/client-core/src/connection/health.ts
@@ -1,0 +1,87 @@
+import { useSyncExternalStore } from "react";
+
+// The single connection-health signal for the whole app (mission: never clear good data just
+// because the connection is bad). Every contact with the Gateway reports into this ONE store -
+// success or failure - and the mobile shell reads the derived state to show (or hide) a single
+// "bad connection" banner. It is fed ONLY at the transport choke points, never hand-wired per page:
+// the fetch calls in api/client.ts all route through gatewayFetch, which calls reportGatewayReachable
+// on any answered request and reportGatewayUnreachable when the request never reached a healthy
+// backend. A later phase adds the terminal WebSocket's open/close events as a second feeder.
+//
+// The classification is the issue #1028 taxonomy already used for the friendly error copy: a fetch
+// that throws (the browser could not reach the backend at all) or a front-proxy status that means the
+// backend was unreachable (502/503/504, or a synthetic 0) is UNREACHABLE; every other answered status
+// - including 4xx/500 application errors - proves the Gateway is reachable. A caller-initiated abort
+// is not a connection signal and is not reported.
+//
+// The pattern mirrors the dictation status store (dictation/status.ts): a module-level store with a
+// useSyncExternalStore subscriber hook, already proven in this codebase.
+
+export type ConnectionState = "good" | "bad";
+
+export interface ConnectionHealth {
+  /** "good" while the last answered contact reached a healthy backend; "bad" once a contact could not
+   *  reach one. Starts "good" so a freshly-loaded app shows no banner until something actually fails. */
+  state: ConnectionState;
+  /** Epoch milliseconds of the last time any Gateway contact reached a healthy backend, or 0 if this
+   *  app has never had one. The banner reads this (only while "bad") to say how stale things are - so
+   *  the value captured at the moment the connection went bad is the TRUE last-good time, moments ago,
+   *  not the time the connection first became good. */
+  lastGoodContactAt: number;
+}
+
+type Listener = () => void;
+
+const _listeners = new Set<Listener>();
+
+// The real last-good time, advanced on EVERY successful contact even while the state is already good.
+// Kept separate from the published snapshot so a healthy run of polls does not churn React renders;
+// it is folded into the snapshot only when the state actually flips.
+let _lastGoodAt = 0;
+let _state: ConnectionState = "good";
+
+// A frozen snapshot recomputed only when the derived state flips, so useSyncExternalStore's getSnapshot
+// returns a stable reference between renders (a fresh object every call would loop forever). The banner
+// is hidden while "good", so not re-rendering on every successful poll is both cheaper and correct.
+let _snapshot: ConnectionHealth = Object.freeze({ state: _state, lastGoodContactAt: _lastGoodAt });
+
+function emit(): void {
+  _snapshot = Object.freeze({ state: _state, lastGoodContactAt: _lastGoodAt });
+  for (const l of _listeners) l();
+}
+
+function subscribe(listener: Listener): () => void {
+  _listeners.add(listener);
+  return () => {
+    _listeners.delete(listener);
+  };
+}
+
+/** Record that a Gateway contact reached a healthy backend. Advances the last-good time always, and
+ *  flips the state back to "good" (notifying subscribers) if it was "bad". */
+export function reportGatewayReachable(): void {
+  _lastGoodAt = Date.now();
+  if (_state !== "good") {
+    _state = "good";
+    emit();
+  }
+}
+
+/** Record that a Gateway contact could not reach a healthy backend. Flips the state to "bad"
+ *  (notifying subscribers) if it was "good"; the snapshot then carries the true last-good time. */
+export function reportGatewayUnreachable(): void {
+  if (_state !== "bad") {
+    _state = "bad";
+    emit();
+  }
+}
+
+/** The current connection health (for non-React callers and tests). */
+export function connectionHealth(): ConnectionHealth {
+  return _snapshot;
+}
+
+/** React hook: the current connection health, re-rendering the caller whenever the derived state flips. */
+export function useConnectionHealth(): ConnectionHealth {
+  return useSyncExternalStore(subscribe, () => _snapshot, () => _snapshot);
+}


### PR DESCRIPTION
## Mobile bad-connection resilience mission - Phase 1

Brief: `docs/architecture/mobile-resilience-mission-2026-07-11.md`

The owner travels through bad-internet areas and the mobile app at /m clears things out when the connection drops. The mission principle: **never clear good data just because the connection is bad**, and give the whole app one small indicator that names the bad connection so the user knows it is the network, not the fleet. This phase delivers the shared connection-health signal and the one global banner (the biggest visible win).

### What changed

**New shared connection-health signal** - `packages/client-core/src/connection/health.ts`
- One module-level store that every Gateway contact reports into, holding a derived `good`/`bad` state and the time of the last successful contact.
- Fed at the ONE transport choke point: a new `gatewayFetch` wrapper in `api/client.ts` that every read and write already routes through (42 call sites), never hand-wired per page.
- Classification reuses the existing issue #1028 unreachable taxonomy: a bare fetch rejection or a 502/503/504 reports unreachable; any other answered status (including application 4xx/500) reports reachable; a caller-initiated abort reports nothing.
- `useConnectionHealth()` hook exposes it to React, mirroring the proven dictation status store pattern.

**New global banner** - `apps/mobile/src/components/ConnectionBanner.tsx`, mounted once in `GatedLayout`
- Hidden while good; when bad it pins one slim amber strip to the top of every gated screen ("Bad connection - showing last known information") and, once the last good contact is more than a few seconds old, says how stale things are ("updated 40s ago"). Clears itself on the next successful contact.

**Retired the roster's own offline strip** - `apps/mobile/src/pages/Home.tsx`
- The old "Offline - showing last-known roster" strip folds into the one global banner, so the condition has exactly one voice in the whole app. The roster still keeps its last-known sessions on screen through an outage.

### Verification
- `npm run typecheck` clean across all three workspaces (client-core, cockpit, mobile).
- `npm run build` (mobile) succeeds.
- Client-core tests: 317 passing (32 files), including 6 new tests for the health store (good/bad transitions, the stable-snapshot contract, and capturing the true last-good time at the moment of the drop).
- Lint clean on all touched files (one pre-existing unrelated error in `apps/cockpit/src/push/sw.test.ts`, untouched by this change).
- No fallback programming: `gatewayFetch` is transparent - it returns the same Response and rethrows the same error, adding only a health report.

### Owner proof (after deploy to the phone)
Airplane mode while on the roster, in chat, in voice, and in the terminal: the content stays put on all four screens, one small banner at the top names the bad connection, and it clears by itself within a poll tick of the network coming back.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)