### PR TITLE
feat(gateway): Snooze Length Phase 1 - a Gateway-owned snooze that always comes back

### DIFF
--- a/src/CcDirector.Core/Configuration/SnoozeDefaultConfig.cs
+++ b/src/CcDirector.Core/Configuration/SnoozeDefaultConfig.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Configuration;
+
+/// <summary>
+/// The GATEWAY-OWNED, per-user default snooze length, in whole minutes (Snooze Length mission,
+/// docs/architecture/snooze-length-mission-2026-07-11.md). Snoozing a session always holds it for
+/// this one length - there is no per-snooze duration. Because every one of the user's devices talks
+/// to their one Gateway, this single Gateway setting IS "the same snooze length across all devices".
+///
+/// Persisted in <c>config.json</c> as the top-level integer key <c>snooze_default_minutes</c>, the
+/// same store the other Gateway settings use (<see cref="TelemetryConsentConfig"/>,
+/// <see cref="AddressingModeConfig"/>). Default 60 (one hour): a Gateway with no persisted value
+/// snoozes for one hour. Read at the moment a snooze is set, so a change takes effect on the next
+/// snooze - no Gateway restart.
+/// </summary>
+public static class SnoozeDefaultConfig
+{
+    /// <summary>The config.json top-level key holding the per-user default snooze length in minutes.</summary>
+    public const string Key = "snooze_default_minutes";
+
+    /// <summary>The default when no value has ever been persisted: 60 minutes (one hour).</summary>
+    public const int Default = 60;
+
+    /// <summary>The smallest snooze length a caller may persist. One minute is the shortest useful
+    /// hold and is exactly the value the Phase 1 live round-trip cranks the default down to.</summary>
+    public const int MinMinutes = 1;
+
+    /// <summary>The largest snooze length a caller may persist: 7 days, a generous ceiling that still
+    /// keeps an accidental huge value (which would defeat the always-comes-back guarantee) out.</summary>
+    public const int MaxMinutes = 7 * 24 * 60;
+
+    /// <summary>
+    /// Returns the per-user default snooze length in minutes. Defaults to <see cref="Default"/> (60)
+    /// when no value has ever been persisted, and reads the persisted integer otherwise.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The <c>snooze_default_minutes</c> key is present but is not a positive JSON integer.
+    /// </exception>
+    public static int Get()
+    {
+        var node = CcDirectorConfigService.ReadRaw()[Key];
+        if (node is null)
+        {
+            FileLog.Write("[SnoozeDefaultConfig] Get: no persisted value -> default 60 minutes");
+            return Default;
+        }
+
+        if (node is JsonValue v && v.TryGetValue<int>(out var minutes) && minutes >= MinMinutes)
+        {
+            FileLog.Write($"[SnoozeDefaultConfig] Get: persisted value minutes={minutes}");
+            return minutes;
+        }
+
+        throw new InvalidOperationException(
+            "config.json key 'snooze_default_minutes' must be a positive whole number of minutes. " +
+            "Fix the value or remove the key to use the default (60 = one hour).");
+    }
+
+    /// <summary>
+    /// True when <paramref name="minutes"/> is a length this setting will accept: at least
+    /// <see cref="MinMinutes"/> and at most <see cref="MaxMinutes"/>. Pure, so the endpoint can
+    /// validate the request body before writing anything.
+    /// </summary>
+    public static bool IsValid(int minutes) => minutes >= MinMinutes && minutes <= MaxMinutes;
+
+    /// <summary>
+    /// Persists the per-user default snooze length to <c>config.json</c> under
+    /// <c>snooze_default_minutes</c>, merging into the existing file so no other section is dropped.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="minutes"/> is outside <see cref="MinMinutes"/>..<see cref="MaxMinutes"/>.
+    /// </exception>
+    public static void Set(int minutes)
+    {
+        if (!IsValid(minutes))
+            throw new ArgumentOutOfRangeException(nameof(minutes), minutes,
+                $"snooze default must be between {MinMinutes} and {MaxMinutes} minutes");
+
+        FileLog.Write($"[SnoozeDefaultConfig] Set: minutes={minutes}");
+        CcDirectorConfigService.MergePatch(new JsonObject { [Key] = minutes });
+        FileLog.Write("[SnoozeDefaultConfig] Set: persisted");
+    }
+}

--- a/src/CcDirector.Gateway.Tests/SessionsAggregationTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionsAggregationTests.cs
@@ -40,7 +40,8 @@ public sealed class SessionsAggregationTests : IAsyncLifetime
     {
         _gateway = new GatewayHost(port: FreePort(), token: "test-token", authEnabled: true,
             instancesDirectory: _instancesDir,
-            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            snoozePath: Path.Combine(_instancesDir, "snooze", "snooze.json"));
         await _gateway.StartAsync();
         _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
         _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "test-token");
@@ -123,6 +124,42 @@ public sealed class SessionsAggregationTests : IAsyncLifetime
         var parkedOut = Assert.Single(sessions, s => s.SessionId == "hold1");
         Assert.Equal("grey", parkedOut.EffectiveColor);
         Assert.Equal("onHold", parkedOut.TriageBucket);
+    }
+
+    // ---------- snooze expiry overlay (Snooze Length mission) ----------
+
+    [Fact]
+    public async Task Snooze_that_has_not_expired_still_reads_as_snoozed()
+    {
+        // A held session with a snooze that is still in the future stays parked (grey / onHold).
+        var held = Sample("snz1", "ClaudeCode", "repo", "WaitingForInput", "red");
+        held.OnHold = true;
+        var fake = await StartFake("M", "u", new[] { held });
+        await Register(fake);
+        _gateway.SnoozeRegistry.Snooze("snz1", DateTime.UtcNow.AddMinutes(30), fake.DirectorId);
+
+        var s = Assert.Single(await GetSessions());
+        Assert.True(s.OnHold);
+        Assert.Equal("grey", s.EffectiveColor);
+        Assert.Equal("onHold", s.TriageBucket);
+    }
+
+    [Fact]
+    public async Task Expired_snooze_overlays_the_session_back_into_needs_you()
+    {
+        // The Director still reports the session held, but its snooze has elapsed. The /sessions fold
+        // must override OnHold=false so the session reads as "needs you" again on its own - the whole
+        // point of the mission. This holds even though the Director itself has not yet cleared the hold.
+        var held = Sample("snz2", "ClaudeCode", "repo", "WaitingForInput", "red");
+        held.OnHold = true;
+        var fake = await StartFake("M", "u", new[] { held });
+        await Register(fake);
+        _gateway.SnoozeRegistry.Snooze("snz2", DateTime.UtcNow.AddMinutes(-1), fake.DirectorId); // already due
+
+        var s = Assert.Single(await GetSessions());
+        Assert.False(s.OnHold);                    // overlay flipped it
+        Assert.Equal("red", s.EffectiveColor);     // back to needs-you red
+        Assert.Equal("needsYou", s.TriageBucket);
     }
 
     // ---------- automatic session roles (chunk 1) ----------

--- a/src/CcDirector.Gateway.Tests/SnoozeDefaultConfigTests.cs
+++ b/src/CcDirector.Gateway.Tests/SnoozeDefaultConfigTests.cs
@@ -1,0 +1,30 @@
+using CcDirector.Core.Configuration;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for the per-user default snooze length setting (Snooze Length mission). Only the pure
+/// surface is exercised (the default constant and the range validation), so the tests never read or
+/// write the real config.json.
+/// </summary>
+public sealed class SnoozeDefaultConfigTests
+{
+    [Fact]
+    public void Default_is_one_hour()
+    {
+        Assert.Equal(60, SnoozeDefaultConfig.Default);
+    }
+
+    [Theory]
+    [InlineData(1, true)]                 // the shortest useful hold (and the live round-trip value)
+    [InlineData(60, true)]                // the default
+    [InlineData(7 * 24 * 60, true)]       // the ceiling (7 days)
+    [InlineData(0, false)]                // zero would defeat "always comes back"
+    [InlineData(-5, false)]               // negative is nonsense
+    [InlineData(7 * 24 * 60 + 1, false)]  // past the ceiling
+    public void IsValid_accepts_only_a_sane_minute_range(int minutes, bool expected)
+    {
+        Assert.Equal(expected, SnoozeDefaultConfig.IsValid(minutes));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/SnoozeExpirySweepTests.cs
+++ b/src/CcDirector.Gateway.Tests/SnoozeExpirySweepTests.cs
@@ -1,0 +1,120 @@
+using CcDirector.Gateway.Snooze;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for the snooze watchdog (Snooze Length mission). The sweep reads each pending snooze's
+/// owning Director RAW state and decides: leave a not-yet-expired hold; nudge an expired hold on a
+/// LIVE Director off hold (keeping the entry until the Director confirms); clear when the Director
+/// reports the session already came back (issue #470 early return, or a prior nudge that took); and
+/// NEVER touch an entry whose Director is unreachable (the dead-man's-switch). All Director I/O is
+/// injected, so no real Director is needed and the expiry boundary is deterministic.
+/// </summary>
+public sealed class SnoozeExpirySweepTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "cc-snoozesweep-" + Guid.NewGuid().ToString("N"));
+    private readonly DateTime _now = new(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
+
+    private string Path_ => System.IO.Path.Combine(_dir, "snooze.json");
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, true); } catch { }
+    }
+
+    // Build a sweep whose Director reads are driven by a dictionary: sid -> raw OnHold (true held, false
+    // not held, null absent), and whose Directors are all reachable unless listed in unreachable. Returns
+    // the registry (to arrange entries and assert on), the sweep, and the list of sids nudged off hold.
+    private (SnoozeRegistry reg, SnoozeExpirySweep sweep, List<string> nudged) Make(
+        DateTime now, Dictionary<string, bool?> onHoldBySid, ISet<string>? unreachableDirectors = null)
+    {
+        var reg = new SnoozeRegistry(Path_);
+        var nudged = new List<string>();
+        var sweep = new SnoozeExpirySweep(
+            reg,
+            resolveEndpoint: dir => (unreachableDirectors?.Contains(dir) ?? false) ? null : $"http://{dir}",
+            readOnHold: (ep, sid, ct) => Task.FromResult(onHoldBySid.TryGetValue(sid, out var v) ? v : (bool?)null),
+            forwardUnhold: (ep, sid, ct) => { nudged.Add(sid); return Task.CompletedTask; },
+            utcNow: () => now);
+        return (reg, sweep, nudged);
+    }
+
+    [Fact]
+    public async Task Future_snooze_still_held_is_left_alone()
+    {
+        var (reg, sweep, nudged) = Make(_now, new() { ["s1"] = true });
+        reg.Snooze("s1", _now.AddMinutes(60), "dir-1"); // an hour to go
+
+        await sweep.RunOnceAsync(CancellationToken.None);
+
+        Assert.Empty(nudged);              // not expired -> no nudge
+        Assert.True(reg.Contains("s1"));   // entry stays
+    }
+
+    [Fact]
+    public async Task Expired_snooze_on_a_live_director_is_nudged_off_hold_and_the_entry_is_kept()
+    {
+        var (reg, sweep, nudged) = Make(_now, new() { ["s1"] = true }); // director still reports held
+        reg.Snooze("s1", _now.AddMinutes(-1), "dir-1");                 // already expired
+
+        await sweep.RunOnceAsync(CancellationToken.None);
+
+        Assert.Equal(new[] { "s1" }, nudged);   // nudged the live Director off hold
+        Assert.True(reg.Contains("s1"));        // KEPT - cleared only once the Director confirms not-held
+    }
+
+    [Fact]
+    public async Task Once_the_director_reports_not_held_the_entry_is_cleared()
+    {
+        var (reg, sweep, nudged) = Make(_now, new() { ["s1"] = false }); // came back on its own (#470) or nudge took
+        reg.Snooze("s1", _now.AddMinutes(-1), "dir-1");
+
+        await sweep.RunOnceAsync(CancellationToken.None);
+
+        Assert.False(reg.Contains("s1"));  // cleared on the confirmed transition
+        Assert.Empty(nudged);              // no nudge needed - it is already off hold
+    }
+
+    [Fact]
+    public async Task Early_return_before_expiry_clears_the_entry()
+    {
+        // Not yet expired, but the Director already reports the user drove the session again (#470).
+        var (reg, sweep, nudged) = Make(_now, new() { ["s1"] = false });
+        reg.Snooze("s1", _now.AddMinutes(30), "dir-1");
+
+        await sweep.RunOnceAsync(CancellationToken.None);
+
+        Assert.False(reg.Contains("s1"));  // the snooze cleared the moment the session came back
+        Assert.Empty(nudged);
+    }
+
+    [Fact]
+    public async Task Expired_snooze_on_an_unreachable_director_is_left_pinned()
+    {
+        // The dead-man's-switch: the owning Director is unreachable, so the sweep does nothing and keeps
+        // the entry. The aggregation overlay surfaces the session as "needs you" from the cached roster.
+        var (reg, sweep, nudged) = Make(_now, new() { ["s1"] = true },
+            unreachableDirectors: new HashSet<string> { "dir-dead" });
+        reg.Snooze("s1", _now.AddMinutes(-1), "dir-dead");
+
+        await sweep.RunOnceAsync(CancellationToken.None);
+
+        Assert.Empty(nudged);              // no forward to a dead Director
+        Assert.True(reg.Contains("s1"));   // pinned - never lost
+    }
+
+    [Fact]
+    public async Task An_absent_or_missed_read_does_not_lose_the_pending_snooze()
+    {
+        // A reachable Director but the read returned null (session momentarily absent / transient miss).
+        // The sweep must NOT clear on that - only an explicit not-held clears.
+        var (reg, sweep, nudged) = Make(_now, new() { ["s1"] = null });
+        reg.Snooze("s1", _now.AddMinutes(-1), "dir-1");
+
+        await sweep.RunOnceAsync(CancellationToken.None);
+
+        Assert.True(reg.Contains("s1"));   // kept - a transient miss never drops a snooze
+        Assert.Empty(nudged);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/SnoozeRegistryTests.cs
+++ b/src/CcDirector.Gateway.Tests/SnoozeRegistryTests.cs
@@ -1,0 +1,154 @@
+using CcDirector.Gateway.Snooze;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for the Gateway-owned snooze registry (Snooze Length mission): the persisted
+/// <c>sessionId -&gt; SnoozeUntilUtc</c> map that is the one piece of new Gateway state. Covers the
+/// expiry predicate, the clear paths, the two bound-guards (per-Director removal and per-Director
+/// live-set prune), and the persistence contract (write-through + re-arm on load + corrupt quarantine).
+/// Every test uses an isolated temp path so it never touches the real snooze.json.
+/// </summary>
+public sealed class SnoozeRegistryTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "cc-snooze-" + Guid.NewGuid().ToString("N"));
+
+    private string Path_ => System.IO.Path.Combine(_dir, "snooze.json");
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, true); } catch { }
+    }
+
+    [Fact]
+    public void IsExpired_is_false_for_a_future_snooze_and_true_once_the_time_passes()
+    {
+        var reg = new SnoozeRegistry(Path_);
+        var now = new DateTime(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
+        reg.Snooze("s1", now.AddMinutes(60), "dir-1");
+
+        Assert.True(reg.Contains("s1"));
+        Assert.False(reg.IsExpired("s1", now));                 // one hour to go
+        Assert.False(reg.IsExpired("s1", now.AddMinutes(59)));  // still holding
+        Assert.True(reg.IsExpired("s1", now.AddMinutes(60)));   // exactly due -> expired
+        Assert.True(reg.IsExpired("s1", now.AddMinutes(61)));   // past due
+    }
+
+    [Fact]
+    public void IsExpired_is_false_for_a_session_with_no_entry()
+    {
+        var reg = new SnoozeRegistry(Path_);
+        Assert.False(reg.IsExpired("nobody", DateTime.UtcNow));
+        Assert.False(reg.Contains("nobody"));
+    }
+
+    [Fact]
+    public void Snooze_again_overwrites_the_prior_time_no_escalation()
+    {
+        var reg = new SnoozeRegistry(Path_);
+        var now = new DateTime(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
+        reg.Snooze("s1", now.AddMinutes(1), "dir-1");
+        Assert.True(reg.IsExpired("s1", now.AddMinutes(2)));   // first snooze would be expired
+
+        reg.Snooze("s1", now.AddMinutes(60), "dir-1");         // re-snooze: fresh hour
+        Assert.False(reg.IsExpired("s1", now.AddMinutes(2)));  // the fresh time governs
+        Assert.Single(reg.Entries());                          // still one entry, not two
+    }
+
+    [Fact]
+    public void Clear_removes_the_entry_and_reports_whether_there_was_one()
+    {
+        var reg = new SnoozeRegistry(Path_);
+        reg.Snooze("s1", DateTime.UtcNow.AddMinutes(60), "dir-1");
+
+        Assert.True(reg.Clear("s1"));
+        Assert.False(reg.Contains("s1"));
+        Assert.False(reg.Clear("s1"));   // already gone
+    }
+
+    [Fact]
+    public void ClearForDirector_drops_only_that_directors_entries()
+    {
+        var reg = new SnoozeRegistry(Path_);
+        var until = DateTime.UtcNow.AddMinutes(60);
+        reg.Snooze("a1", until, "dir-1");
+        reg.Snooze("a2", until, "dir-1");
+        reg.Snooze("b1", until, "dir-2");
+
+        Assert.Equal(2, reg.ClearForDirector("dir-1"));
+        Assert.False(reg.Contains("a1"));
+        Assert.False(reg.Contains("a2"));
+        Assert.True(reg.Contains("b1"));   // the other Director's entry survives
+    }
+
+    [Fact]
+    public void PruneNotLive_drops_only_that_directors_gone_sessions()
+    {
+        var reg = new SnoozeRegistry(Path_);
+        var until = DateTime.UtcNow.AddMinutes(60);
+        reg.Snooze("live", until, "dir-1");
+        reg.Snooze("exited", until, "dir-1");
+        reg.Snooze("other", until, "dir-2");
+
+        // dir-1 answered with only "live" still present; "exited" is gone. "other" belongs to dir-2 and
+        // must be untouched even though it is not in dir-1's live set.
+        var removed = reg.PruneNotLive("dir-1", new HashSet<string> { "live" });
+
+        Assert.Equal(1, removed);
+        Assert.True(reg.Contains("live"));
+        Assert.False(reg.Contains("exited"));
+        Assert.True(reg.Contains("other"));
+    }
+
+    [Fact]
+    public void Entries_returned_snapshot_is_detached_from_the_live_store()
+    {
+        var reg = new SnoozeRegistry(Path_);
+        reg.Snooze("s1", DateTime.UtcNow.AddMinutes(60), "dir-1");
+
+        var snapshot = reg.Entries();
+        reg.Clear("s1");   // mutate after snapshotting
+
+        Assert.Single(snapshot);              // the snapshot did not change under us
+        Assert.False(reg.Contains("s1"));     // the live store did
+    }
+
+    [Fact]
+    public void Pending_snooze_survives_a_restart_re_armed_from_disk()
+    {
+        var now = new DateTime(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
+        var reg1 = new SnoozeRegistry(Path_);
+        reg1.Snooze("s1", now.AddMinutes(60), "dir-1");
+
+        // A fresh registry over the same file = a Gateway restart. The pending snooze must re-arm.
+        var reg2 = new SnoozeRegistry(Path_);
+        Assert.True(reg2.Contains("s1"));
+        Assert.False(reg2.IsExpired("s1", now.AddMinutes(30)));
+        Assert.True(reg2.IsExpired("s1", now.AddMinutes(90)));
+    }
+
+    [Fact]
+    public void An_already_past_snooze_reloads_as_expired_so_it_fires_immediately()
+    {
+        var now = new DateTime(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
+        var reg1 = new SnoozeRegistry(Path_);
+        reg1.Snooze("s1", now.AddMinutes(-5), "dir-1"); // already past when written
+
+        var reg2 = new SnoozeRegistry(Path_);          // restart
+        Assert.True(reg2.IsExpired("s1", now));        // reads as expired -> the first sweep fires it
+    }
+
+    [Fact]
+    public void A_corrupt_file_is_quarantined_and_the_registry_starts_empty()
+    {
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(Path_, "{ this is not valid json ");
+
+        var reg = new SnoozeRegistry(Path_);   // must not throw - the Gateway still boots
+        Assert.Empty(reg.Entries());
+
+        var quarantined = Directory.GetFiles(_dir, "snooze.json.corrupt-*");
+        Assert.Single(quarantined);            // the bad bytes were preserved, not overwritten
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -84,7 +84,13 @@ internal static class GatewayEndpoints
         // DevThrottle Stats: the durable fleet concurrency record. Observed from the same assembled roster
         // (live count + actively-working count), so the peak is captured fleet-wide whether stream mode is
         // on or off. Null (old callers, tests) records nothing.
-        Stats.GatewaySessionConcurrencyStats? concurrency = null)
+        Stats.GatewaySessionConcurrencyStats? concurrency = null,
+        // Snooze Length mission: the Gateway-owned snooze registry. When non-null, POST
+        // /sessions/{sid}/hold records/clears a snooze-until for the session, and the /sessions fold
+        // overlays an EXPIRED snooze back into "needs you" (OnHold=false) so the session returns on its
+        // own even if its Director has died. Null (old callers, tests) leaves hold as a plain forward
+        // with no timer, byte-identical to before.
+        Snooze.SnoozeRegistry? snoozeRegistry = null)
     {
         // The old issue #1188 "session lock" (423 Locked on human input while a PENDING dictation record
         // existed) was removed deliberately (issue #1308). This is a single-operator tool: a collision
@@ -608,6 +614,12 @@ internal static class GatewayEndpoints
                             .Select(x => x.SessionId),
                         StringComparer.Ordinal);
                     owners?.RetainForDirector(d.DirectorId, liveIds);
+                    // Snooze Length mission: a reachable Director's returned list is authoritative, so a
+                    // snoozed session that has permanently exited is no longer live here - drop its
+                    // snooze entry so the registry does not accumulate stale entries on disk. Runs only
+                    // for a Director that actually answered (!stale), so a transient miss never loses a
+                    // pending snooze.
+                    snoozeRegistry?.PruneNotLive(d.DirectorId, liveIds);
                 }
 
                 var baseUrl = DeriveDirectorBaseUrl(ctx, d);
@@ -705,7 +717,7 @@ internal static class GatewayEndpoints
             // The whole fleet is now assembled: compute each session's automatic role from the roster and
             // stamp the presentation fold (which reads the role to suppress a live Worker's red toward the
             // human). Done here, once, because the role needs the full fleet view.
-            StampFleetRolesAndFold(all, needsYouStampFor);
+            StampFleetRolesAndFold(all, needsYouStampFor, snoozeRegistry);
 
             // DevThrottle Stats: fold the assembled roster's per-session input tallies into the always-
             // available aggregate that backs "Your Throttle". This is the ONE path that carries
@@ -1061,7 +1073,13 @@ internal static class GatewayEndpoints
             return Results.Content(body, "application/json");
         });
 
-        // Forward the FIFO "park / un-park this session" (hold) call to the owning Director.
+        // Forward the FIFO "park / un-park this session" (hold) call to the owning Director, AND
+        // record/clear the Gateway-owned snooze timer for it (Snooze Length mission,
+        // docs/architecture/snooze-length-mission-2026-07-11.md). Snooze IS the hold, plus a
+        // Gateway-owned expiry timestamp: holding a session records a snooze-until so the session is
+        // GUARANTEED to return to "needs you" on its own even if its Director later dies; un-holding
+        // clears it. The registry mutation happens only AFTER the forward succeeds, so a hold that did
+        // not take never arms (or leaves) a timer.
         app.MapPost("/sessions/{sid}/hold", async (string sid, HoldRequest req, CancellationToken ct) =>
         {
             var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
@@ -1078,6 +1096,22 @@ internal static class GatewayEndpoints
                 : await client.SetHoldAsync(ep, sid, holdReq, ct);
             if (body is null)
                 return Results.StatusCode(StatusCodes.Status502BadGateway);
+
+            if (snoozeRegistry is not null)
+            {
+                if (holdReq.OnHold)
+                {
+                    // One snooze length for everyone (the per-user Gateway default) - read now so a
+                    // Settings change applies to the next snooze. No per-snooze duration by design.
+                    var minutes = Core.Configuration.SnoozeDefaultConfig.Get();
+                    snoozeRegistry.Snooze(sid, DateTime.UtcNow.AddMinutes(minutes), director.DirectorId);
+                }
+                else
+                {
+                    // Manual unsnooze: drop the timer (an alarm turned off).
+                    snoozeRegistry.Clear(sid);
+                }
+            }
             return Results.Content(body, "application/json");
         });
 
@@ -1939,8 +1973,23 @@ internal static class GatewayEndpoints
     // (EffectiveColor/StateLabel/TriageBucket) then reads SessionRole to suppress a live Worker's red, so it
     // must run AFTER the role is known. NeedsYouSince keys off the final EffectiveColor, so it is stamped
     // here too (a suppressed Worker is not "red", so it never enters the needs-you clock).
-    private static void StampFleetRolesAndFold(List<SessionDto> all, Func<string, bool, DateTime?>? needsYouStampFor)
+    private static void StampFleetRolesAndFold(List<SessionDto> all, Func<string, bool, DateTime?>? needsYouStampFor, Snooze.SnoozeRegistry? snoozeRegistry = null)
     {
+        // Snooze Length mission: an EXPIRED snooze must read as "needs you" again. The registry is the
+        // source of truth for the timer; the cleanest fold (issue #1177 keeps the Gateway the single
+        // fold, decision #6) is to override OnHold=false on this aggregated DTO copy BEFORE the color /
+        // label / triage are computed, so SessionOrdering.Classify puts the session straight back into
+        // NeedsYou with no new classification logic. This is a pure, continuous overlay: while a snooze
+        // is expired every read reports the session as un-held, so it never flickers back to "Snoozed"
+        // between the moment it expires and the moment its Director confirms the clear. A DEAD Director's
+        // session still carries its last-known OnHold=true in the cached roster; this overlay is exactly
+        // what surfaces it anyway - the dead-man's-switch.
+        var nowUtc = DateTime.UtcNow;
+        if (snoozeRegistry is not null)
+            foreach (var s in all)
+                if (!string.IsNullOrEmpty(s.SessionId) && s.OnHold && snoozeRegistry.IsExpired(s.SessionId, nowUtc))
+                    s.OnHold = false;
+
         var liveIds = new HashSet<string>(StringComparer.Ordinal);
         var controllersWithLiveChild = new HashSet<string>(StringComparer.Ordinal);
         foreach (var s in all)

--- a/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
@@ -76,6 +76,9 @@ internal static class SettingsEndpoints
                 // Gates ONLY the richer usage telemetry; the always-on login/startup events are
                 // never gated by it.
                 telemetryConsent = Core.Configuration.TelemetryConsentConfig.Get(),
+                // Snooze Length mission: the per-user default snooze length in minutes (default 60),
+                // so the one Settings page can render and edit it in Phase 3.
+                snoozeDefaultMinutes = Core.Configuration.SnoozeDefaultConfig.Get(),
             });
         });
 
@@ -224,6 +227,37 @@ internal static class SettingsEndpoints
             catch (JsonException ex)
             {
                 FileLog.Write($"[SettingsEndpoints] PUT /gateway/addressing-mode bad JSON: {ex.Message}");
+                return Results.BadRequest(new { error = "invalid JSON" });
+            }
+        });
+
+        // The per-user default snooze length in minutes (Snooze Length mission,
+        // docs/architecture/snooze-length-mission-2026-07-11.md). One value for the whole account:
+        // because every device talks to this one Gateway, this Gateway-owned setting IS "the same
+        // snooze length across all my devices". Read at snooze time, so a change applies to the next
+        // snooze with no Gateway restart. There is no per-snooze duration by design - this is the one
+        // length every Snooze button uses.
+        app.MapGet("/gateway/snooze-default", () =>
+            Results.Json(new { minutes = Core.Configuration.SnoozeDefaultConfig.Get() }));
+
+        app.MapPut("/gateway/snooze-default", async (HttpContext ctx) =>
+        {
+            try
+            {
+                var body = await JsonSerializer.DeserializeAsync<SnoozeDefaultBody>(
+                    ctx.Request.Body, JsonOpts, ctx.RequestAborted);
+                if (body?.Minutes is not int minutes)
+                    return Results.BadRequest(new { error = "body { \"minutes\": <whole minutes> } is required" });
+                if (!Core.Configuration.SnoozeDefaultConfig.IsValid(minutes))
+                    return Results.BadRequest(new { error = $"minutes must be between {Core.Configuration.SnoozeDefaultConfig.MinMinutes} and {Core.Configuration.SnoozeDefaultConfig.MaxMinutes}" });
+
+                Core.Configuration.SnoozeDefaultConfig.Set(minutes);
+                FileLog.Write($"[SettingsEndpoints] snooze_default_minutes set to {minutes}");
+                return Results.Json(new { minutes });
+            }
+            catch (JsonException ex)
+            {
+                FileLog.Write($"[SettingsEndpoints] PUT /gateway/snooze-default bad JSON: {ex.Message}");
                 return Results.BadRequest(new { error = "invalid JSON" });
             }
         });
@@ -467,6 +501,7 @@ internal static class SettingsEndpoints
     private sealed record AddressingModeBody(string? Mode);
     private sealed record TranscriptionModeBody(string? Mode);
     private sealed record AutostartBody(bool Enabled);
+    private sealed record SnoozeDefaultBody(int? Minutes);
     private sealed record WingmanBody(bool Enabled);
     private sealed record BrainConfigBody(string? AgentId, string? Tool, string? Model);
 }

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -140,6 +140,12 @@ public sealed class GatewayHost : IAsyncDisposable
     public Pairing.PairingCodeService Pairing { get; } = new();
 
     /// <summary>
+    /// Snooze Length mission: the Gateway-owned snooze registry. Exposed so a test can inject a pending
+    /// (or already-expired) snooze and assert the /sessions overlay flips it back into "needs you".
+    /// </summary>
+    internal Snooze.SnoozeRegistry SnoozeRegistry => _snoozeRegistry;
+
+    /// <summary>
     /// Issue #469: the registry of enrolled devices and their unique per-device keys - the single
     /// issuer and record of credentials in the per-device-key trust model. Persisted under the
     /// config root so issued keys survive a Gateway restart.
@@ -261,6 +267,12 @@ public sealed class GatewayHost : IAsyncDisposable
     // host with no credential service (nothing to sign in to).
     private readonly Account.TranscriptionKeyAutoProvisioner? _transcriptionKeyProvisioner;
     private readonly WorkListStore _workLists;
+    // Snooze Length mission: the Gateway-owned, restart-surviving snooze registry (the one piece of
+    // new state) and the watchdog sweep that makes an expired snooze come back on its own. The
+    // registry is constructed here (load-on-construct re-arms every pending snooze); the sweep is
+    // built and started in StartAsync (it needs the live Director client) and disposed in StopAsync.
+    private readonly Snooze.SnoozeRegistry _snoozeRegistry;
+    private Snooze.SnoozeExpirySweep? _snoozeSweep;
     private readonly CronJobStore _cronJobs;
     private readonly CronRunHistoryStore _cronRuns;
     private readonly Running.CronEngine _cronEngine;
@@ -368,7 +380,7 @@ public sealed class GatewayHost : IAsyncDisposable
     /// <see cref="Account"/> null on a non-Windows host, where the operating-system credential store is
     /// not yet implemented).
     /// </param>
-    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null)
+    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? snoozePath = null)
     {
         Port = port;
         Token = token ?? GatewayAuth.LoadOrCreate();
@@ -428,6 +440,12 @@ public sealed class GatewayHost : IAsyncDisposable
         // Gateway data dir, loaded here (stale claims released) and written through on every
         // mutation. Tests MUST pass an isolated path so they never touch the real store.
         _workLists = new WorkListStore(workListsPath ?? Path.Combine(CcStorage.Root(), "worklists.json"));
+        // Snooze Length mission: the persisted snooze registry (sessionId -> SnoozeUntilUtc). Loaded here
+        // so a Gateway restart re-arms every pending snooze; an entry already past its time simply fires
+        // on the first sweep. Tests MUST pass an isolated path so they never touch the real store. The
+        // registry is bounded by dropping a removed Director's entries so they do not accumulate on disk.
+        _snoozeRegistry = new Snooze.SnoozeRegistry(snoozePath ?? Path.Combine(CcStorage.Root(), "snooze.json"));
+        Registry.OnDirectorRemoved += id => _snoozeRegistry.ClearForDirector(id);
         // Cron-job definitions persist across a Gateway restart (epic #479, #482): one JSON file in
         // the Gateway data dir, loaded here (next-run times recomputed) and written through on every
         // mutation - the WorkListStore precedent. Tests MUST pass an isolated path so they never
@@ -1134,7 +1152,11 @@ public sealed class GatewayHost : IAsyncDisposable
             inputStats: InputStats,
             // DevThrottle Stats: record fleet concurrency (live + actively-working session counts) from the
             // same assembled roster, so the peak is captured fleet-wide regardless of stream mode.
-            concurrency: SessionConcurrency);
+            concurrency: SessionConcurrency,
+            // Snooze Length mission: the Gateway-owned snooze registry. POST /sessions/{sid}/hold records
+            // (or clears) a snooze-until here, and the /sessions fold overlays an EXPIRED snooze back into
+            // "needs you" so the session returns on its own even after its Director dies.
+            snoozeRegistry: _snoozeRegistry);
 
         // Issue #268: the two raw per-session WebSocket legs (live Terminal stream + dictation)
         // proxied through the Gateway so a remote Cockpit talks same-origin to the Gateway and
@@ -1458,6 +1480,30 @@ public sealed class GatewayHost : IAsyncDisposable
         // only logs and retries next tick. Null on a host with no credential service.
         _deviceHeartbeat?.Start();
 
+        // Snooze Length mission: start the snooze watchdog. On its cadence it walks the registry and, for
+        // each pending snooze, reads the owning Director's RAW hold state directly (never the overlaid
+        // /sessions roster, so the fold's expiry overlay can never mask the Director's own clear). An
+        // expired-and-still-held session on a LIVE Director is nudged off hold (its own state and voice
+        // rotation then agree); the entry is cleared once the Director reports OnHold=false. A dead
+        // Director's entry is left alone - the /sessions fold surfaces it as "needs you" from the cached
+        // roster (the dead-man's-switch), and it is dropped only when that Director leaves the fleet.
+        _snoozeSweep = new Snooze.SnoozeExpirySweep(
+            _snoozeRegistry,
+            // Owning Director id -> the base URL the Gateway dials, or null when it has no reachable
+            // endpoint (offline/dead) - the case the sweep leaves untouched.
+            resolveEndpoint: directorId =>
+            {
+                var d = Registry.Get(directorId);
+                return d is null ? null : Api.SessionWsProxyEndpoints.ForwardDestination(d);
+            },
+            // RAW hold state read straight from the owning Director: true = held, false = not held,
+            // null = the session is absent there or the read did not land.
+            readOnHold: async (endpoint, sid, ct) => (await _client.GetSessionAsync(endpoint, sid, ct))?.OnHold,
+            // The expiry nudge: forward a hold=false to the owning Director.
+            forwardUnhold: (endpoint, sid, ct) => _client.SetHoldAsync(endpoint, sid, new Contracts.HoldRequest { OnHold = false }, ct),
+            utcNow: () => DateTime.UtcNow);
+        _snoozeSweep.Start();
+
         // Web Push (mobile app-icon "needs you" dot): start the background notifier now that this
         // Gateway's own /sessions endpoint is live on loopback. The notifier reads that endpoint (so its
         // "needs you" verdict is byte-identical to the roster's) and pushes the count to subscribed
@@ -1611,6 +1657,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // loopback HTTP client it read /sessions with. Subscriptions are already on disk (written through
         // on every change), so stopping loses nothing.
         try { _pushNotifier?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] push notifier dispose error: {ex.Message}"); }
+        try { _snoozeSweep?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] snooze sweep dispose error: {ex.Message}"); }
         _pushNotifier = null;
         try { _pushLoopbackHttp.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] push loopback client dispose error: {ex.Message}"); }
 

--- a/src/CcDirector.Gateway/Snooze/SnoozeExpirySweep.cs
+++ b/src/CcDirector.Gateway/Snooze/SnoozeExpirySweep.cs
@@ -1,0 +1,171 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Snooze;
+
+/// <summary>
+/// The Gateway-owned watchdog that makes a snooze always come back (Snooze Length mission,
+/// docs/architecture/snooze-length-mission-2026-07-11.md). On a fixed cadence it walks the
+/// <see cref="SnoozeRegistry"/> and, for each pending snooze, decides one of three things from the
+/// OWNING DIRECTOR'S RAW state (read straight from the Director, NOT from the overlaid /sessions
+/// roster, so the aggregation overlay can never mask the Director's own signal):
+///
+///   * The Director reports the session is NO LONGER held (OnHold=false) - the session came back on
+///     its own (a new turn or a keystroke cleared the hold, issue #470) OR a prior expiry nudge has
+///     now taken. The snooze has served its purpose, so the entry is CLEARED.
+///   * The snooze has EXPIRED (now &gt;= SnoozeUntilUtc) and the Director is still holding it - the
+///     session went quiet and never came back on its own, the exact stuck/dead population the
+///     watchdog exists to surface. The sweep NUDGES the live Director off hold (so its own state and
+///     voice rotation agree) and KEEPS the entry; the next sweep sees the Director report OnHold=false
+///     and clears it. The entry is kept across the nudge on purpose: the aggregation overlay pins the
+///     session to "needs you" CONTINUOUSLY from the instant of expiry, so there is never a beat where
+///     the roster flashes back to "Snoozed".
+///   * The owning Director is UNREACHABLE (dead/offline). The sweep does NOTHING and KEEPS the entry -
+///     this is the dead-man's-switch: the aggregation overlay surfaces the session from the cached
+///     roster as "needs you" without the Director's help. The entry is dropped only when that Director
+///     is removed from the fleet (SnoozeRegistry.ClearForDirector via Registry.OnDirectorRemoved).
+///
+/// The sweep NEVER clears an entry merely because a read came back empty (a transient miss or a
+/// momentarily-unreachable Director must not lose a pending snooze); "the session permanently left
+/// the roster" is handled authoritatively by the aggregation (a reachable Director's live set prunes
+/// exited sessions) and by Director removal - not by this sweep guessing from one failed read.
+///
+/// Already-past entries at startup need no special handling: the registry re-arms them on load, and
+/// the first sweep tick reads them as expired and fires them immediately.
+/// </summary>
+public sealed class SnoozeExpirySweep : IDisposable
+{
+    /// <summary>How often the watchdog re-evaluates the registry.</summary>
+    public static readonly TimeSpan SweepInterval = TimeSpan.FromSeconds(15);
+
+    /// <summary>A short settling delay before the first sweep, so startup finishes first (and any
+    /// already-past entry fires promptly, one interval after boot at the latest).</summary>
+    public static readonly TimeSpan StartupDelay = TimeSpan.FromSeconds(12);
+
+    private readonly SnoozeRegistry _registry;
+    private readonly Func<string, string?> _resolveEndpoint;
+    private readonly Func<string, string, CancellationToken, Task<bool?>> _readOnHold;
+    private readonly Func<string, string, CancellationToken, Task> _forwardUnhold;
+    private readonly Func<DateTime> _utcNow;
+
+    private System.Threading.Timer? _timer;
+    private int _busy; // 0 = idle, 1 = a tick is running (reentrancy guard)
+
+    /// <param name="registry">The pending-snooze registry to sweep.</param>
+    /// <param name="resolveEndpoint">
+    /// Maps an owning Director id to the base URL the Gateway dials to reach it, or null when that
+    /// Director has no reachable endpoint (offline/dead) - the dead-man's-switch case, which the sweep
+    /// leaves untouched.
+    /// </param>
+    /// <param name="readOnHold">
+    /// Reads the owning Director's RAW hold state for a session: true = still held, false = no longer
+    /// held, null = the session is absent from that Director or the read did not land. Reads the
+    /// Director directly, never the overlaid roster.
+    /// </param>
+    /// <param name="forwardUnhold">Forwards a hold=false to the owning Director (the expiry nudge).</param>
+    /// <param name="utcNow">The clock; injected so the expiry boundary is deterministic in tests.</param>
+    public SnoozeExpirySweep(
+        SnoozeRegistry registry,
+        Func<string, string?> resolveEndpoint,
+        Func<string, string, CancellationToken, Task<bool?>> readOnHold,
+        Func<string, string, CancellationToken, Task> forwardUnhold,
+        Func<DateTime> utcNow)
+    {
+        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        _resolveEndpoint = resolveEndpoint ?? throw new ArgumentNullException(nameof(resolveEndpoint));
+        _readOnHold = readOnHold ?? throw new ArgumentNullException(nameof(readOnHold));
+        _forwardUnhold = forwardUnhold ?? throw new ArgumentNullException(nameof(forwardUnhold));
+        _utcNow = utcNow ?? throw new ArgumentNullException(nameof(utcNow));
+    }
+
+    /// <summary>Start the background sweep. Returns immediately; the first tick runs after a short delay.</summary>
+    public void Start()
+    {
+        _timer = new System.Threading.Timer(_ => Tick(), null, StartupDelay, SweepInterval);
+        FileLog.Write($"[SnoozeExpirySweep] started: every {SweepInterval.TotalSeconds:0}s");
+    }
+
+    /// <summary>
+    /// One sweep pass over the whole registry. Public so a test can drive it directly. Each entry is
+    /// handled independently; a failure on one entry is logged and never stops the others.
+    /// </summary>
+    public async Task RunOnceAsync(CancellationToken cancellationToken)
+    {
+        var now = _utcNow().ToUniversalTime();
+        foreach (var entry in _registry.Entries())
+        {
+            if (cancellationToken.IsCancellationRequested) return;
+            try
+            {
+                await HandleEntryAsync(entry, now, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[SnoozeExpirySweep] entry sid={entry.SessionId} FAILED: {ex.Message}");
+            }
+        }
+    }
+
+    private async Task HandleEntryAsync(SnoozeRegistry.SnoozeEntry entry, DateTime now, CancellationToken ct)
+    {
+        var endpoint = _resolveEndpoint(entry.DirectorId);
+        if (endpoint is null)
+        {
+            // Owning Director unreachable/dead: leave the entry alone. The aggregation overlay
+            // surfaces the session as "needs you" from the cached roster (the dead-man's-switch);
+            // the entry is dropped only when the Director is removed from the fleet.
+            return;
+        }
+
+        var onHold = await _readOnHold(endpoint, entry.SessionId, ct);
+        if (onHold == false)
+        {
+            // The Director itself reports the session is no longer held - it came back on its own
+            // (issue #470) or a prior nudge took. The snooze is done; clear it.
+            _registry.Clear(entry.SessionId);
+            FileLog.Write($"[SnoozeExpirySweep] sid={entry.SessionId}: director reports not-held -> cleared");
+            return;
+        }
+
+        if (onHold == true && now >= entry.SnoozeUntilUtc)
+        {
+            // Expired and still held on a live Director: nudge it off hold so its own state and voice
+            // rotation resume. Keep the entry; the overlay already reads the session as "needs you",
+            // and the next sweep clears the entry once the Director reports OnHold=false.
+            FileLog.Write($"[SnoozeExpirySweep] sid={entry.SessionId}: expired (untilUtc={entry.SnoozeUntilUtc:O}) -> nudging director off hold");
+            await _forwardUnhold(endpoint, entry.SessionId, ct);
+        }
+
+        // onHold == null (session absent from a reachable Director, or the read did not land): keep the
+        // entry. A permanently-exited session is pruned authoritatively by the aggregation, not guessed
+        // at here.
+    }
+
+    private void Tick()
+    {
+        if (Interlocked.CompareExchange(ref _busy, 1, 0) != 0)
+            return; // a previous tick is still running - skip this one
+        _ = TickAsync();
+    }
+
+    private async Task TickAsync()
+    {
+        try
+        {
+            await RunOnceAsync(CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[SnoozeExpirySweep] tick FAILED: {ex.Message}");
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _busy, 0);
+        }
+    }
+
+    public void Dispose()
+    {
+        _timer?.Dispose();
+        _timer = null;
+    }
+}

--- a/src/CcDirector.Gateway/Snooze/SnoozeRegistry.cs
+++ b/src/CcDirector.Gateway/Snooze/SnoozeRegistry.cs
@@ -1,0 +1,280 @@
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Snooze;
+
+/// <summary>
+/// The Gateway-owned, restart-surviving snooze registry (Snooze Length mission,
+/// docs/architecture/snooze-length-mission-2026-07-11.md). A snooze is a time-bounded hold with a
+/// GUARANTEED return: the map <c>sessionId -&gt; SnoozeUntilUtc</c> is the one piece of new
+/// Gateway-owned state, and it is the thing that keeps a snoozed session from vanishing when its
+/// owning Director dies. The timer MUST live here (not on the Director) precisely so it survives a
+/// dead Director - the whole point of the mission.
+///
+/// Each entry also carries the owning <see cref="SnoozeEntry.DirectorId"/> so the registry can be
+/// bounded: when a Director is removed from the fleet (<c>Registry.OnDirectorRemoved</c>), every
+/// entry it owned is dropped, so entries for sessions that permanently left the roster do not
+/// accumulate on disk.
+///
+/// PERSISTENCE (WorkListStore precedent): the whole registry lives in ONE plain JSON file at the
+/// path the constructor receives (production: snooze.json in the Gateway data dir). Every mutation
+/// writes through immediately with an atomic temp-file + rename, so a crash mid-write can never
+/// half-truncate the store. On construction the file is loaded back so every pending snooze is
+/// re-armed - an entry already past its time at startup simply reads as expired on the first sweep
+/// and fires immediately (the mission's "fire any already-past entry immediately" rule), rather than
+/// being lost. A corrupt file is quarantined (never silently overwritten) and the registry starts
+/// empty so the Gateway still boots.
+///
+/// NO FALLBACK (CLAUDE.md): a failed persist is a LOGGED error that PROPAGATES - a snooze that
+/// cannot be written to disk would not survive a restart, so the caller fails loudly rather than
+/// silently running a snooze that will not come back.
+/// </summary>
+public sealed class SnoozeRegistry
+{
+    private readonly object _gate = new();
+    private readonly string _path;
+
+    // sessionId -> entry. Ordinal keys: a session id is an exact GUID string.
+    private readonly Dictionary<string, SnoozeEntry> _entries = new(StringComparer.Ordinal);
+
+    private static readonly JsonSerializerOptions FileJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
+    };
+
+    /// <param name="path">
+    /// The JSON file the registry persists to. REQUIRED so no caller can silently land on the real
+    /// user's file: production (<see cref="GatewayHost"/>) passes snooze.json in the Gateway data
+    /// dir; tests pass an isolated temp path.
+    /// </param>
+    /// <exception cref="ArgumentException">The path is null/empty/whitespace.</exception>
+    public SnoozeRegistry(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("registry path is required", nameof(path));
+        _path = path;
+        Load();
+    }
+
+    /// <summary>One pending snooze: the session, the absolute UTC time it returns, and the Director
+    /// that owned it when the snooze was set (used to bound the registry on Director removal).</summary>
+    public sealed record SnoozeEntry(string SessionId, DateTime SnoozeUntilUtc, string DirectorId);
+
+    /// <summary>
+    /// Record (or refresh) a snooze for <paramref name="sessionId"/> that returns at
+    /// <paramref name="untilUtc"/>. Re-snoozing is just calling this again - it overwrites the prior
+    /// entry with the fresh time (an alarm-clock, no escalation, no cap). Written through to disk
+    /// before returning.
+    /// </summary>
+    /// <exception cref="ArgumentException">The session id is null/empty/whitespace.</exception>
+    public void Snooze(string sessionId, DateTime untilUtc, string directorId)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId))
+            throw new ArgumentException("session id is required", nameof(sessionId));
+
+        lock (_gate)
+        {
+            _entries[sessionId] = new SnoozeEntry(sessionId, untilUtc.ToUniversalTime(), directorId ?? "");
+            Save();
+            FileLog.Write($"[SnoozeRegistry] Snooze: sid={sessionId}, untilUtc={untilUtc.ToUniversalTime():O}, director={directorId}");
+        }
+    }
+
+    /// <summary>
+    /// Remove the snooze entry for <paramref name="sessionId"/>. Returns true when an entry was
+    /// removed (and persisted), false when there was none. This is the ONE clear path - a manual
+    /// unsnooze, the #470 early return, and the post-expiry confirm all funnel through it.
+    /// </summary>
+    public bool Clear(string sessionId)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId)) return false;
+        lock (_gate)
+        {
+            if (!_entries.Remove(sessionId)) return false;
+            Save();
+            FileLog.Write($"[SnoozeRegistry] Clear: sid={sessionId}");
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Drop every entry owned by <paramref name="directorId"/>. Called from
+    /// <c>Registry.OnDirectorRemoved</c> so entries for sessions whose Director permanently left the
+    /// fleet do not accumulate on disk. Returns the number of entries removed; persists once if any.
+    /// </summary>
+    public int ClearForDirector(string directorId)
+    {
+        if (string.IsNullOrWhiteSpace(directorId)) return 0;
+        lock (_gate)
+        {
+            var gone = _entries.Values
+                .Where(e => string.Equals(e.DirectorId, directorId, StringComparison.Ordinal))
+                .Select(e => e.SessionId)
+                .ToList();
+            foreach (var sid in gone)
+                _entries.Remove(sid);
+            if (gone.Count > 0)
+            {
+                Save();
+                FileLog.Write($"[SnoozeRegistry] ClearForDirector: director={directorId}, removed={gone.Count}");
+            }
+            return gone.Count;
+        }
+    }
+
+    /// <summary>
+    /// Drop every entry owned by <paramref name="directorId"/> whose session is NOT in
+    /// <paramref name="liveSessionIds"/>. Called from the aggregation for a Director that actually
+    /// answered (its returned list is authoritative), so a session that has permanently exited is
+    /// pruned - without ever guessing from a transient miss, since it runs only for a reachable
+    /// Director. Returns the number removed; persists once if any.
+    /// </summary>
+    public int PruneNotLive(string directorId, ISet<string> liveSessionIds)
+    {
+        if (string.IsNullOrWhiteSpace(directorId)) return 0;
+        liveSessionIds ??= new HashSet<string>(StringComparer.Ordinal);
+        lock (_gate)
+        {
+            var gone = _entries.Values
+                .Where(e => string.Equals(e.DirectorId, directorId, StringComparison.Ordinal)
+                            && !liveSessionIds.Contains(e.SessionId))
+                .Select(e => e.SessionId)
+                .ToList();
+            foreach (var sid in gone)
+                _entries.Remove(sid);
+            if (gone.Count > 0)
+            {
+                Save();
+                FileLog.Write($"[SnoozeRegistry] PruneNotLive: director={directorId}, removed={gone.Count}");
+            }
+            return gone.Count;
+        }
+    }
+
+    /// <summary>
+    /// True when <paramref name="sessionId"/> has an entry whose return time is at or before
+    /// <paramref name="nowUtc"/> - i.e. the snooze has elapsed. This is the ONE expiry predicate the
+    /// aggregation overlay uses to flip the session back into "needs you", and the sweep uses to
+    /// decide whether to nudge the owning Director off hold. Pure (no mutation), so it is safe to
+    /// call on the hot read path.
+    /// </summary>
+    public bool IsExpired(string sessionId, DateTime nowUtc)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId)) return false;
+        lock (_gate)
+            return _entries.TryGetValue(sessionId, out var e) && nowUtc.ToUniversalTime() >= e.SnoozeUntilUtc;
+    }
+
+    /// <summary>True when <paramref name="sessionId"/> has a pending entry (expired or not).</summary>
+    public bool Contains(string sessionId)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId)) return false;
+        lock (_gate)
+            return _entries.ContainsKey(sessionId);
+    }
+
+    /// <summary>A snapshot of every pending entry, for the expiry sweep. A copy, so the sweep can
+    /// iterate and mutate the registry (Clear) without touching the live collection.</summary>
+    public IReadOnlyList<SnoozeEntry> Entries()
+    {
+        lock (_gate)
+            return _entries.Values.ToList();
+    }
+
+    // ---- persistence (WorkListStore precedent) -----------------------------------------------
+
+    /// <summary>The on-disk shape: one document holding every pending snooze.</summary>
+    private sealed class StoreFile
+    {
+        public List<SnoozeEntry> Entries { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Load the registry file written by a previous Gateway run - this is the re-arm on startup.
+    /// Missing file = the normal first boot (empty registry, logged). A corrupt file is quarantined
+    /// (renamed next to the original with a timestamp suffix) so its bytes are preserved for the
+    /// operator and never silently overwritten; the registry then starts empty so the Gateway still
+    /// boots. An entry already past its time is kept as-is: the first sweep reads it as expired and
+    /// fires it immediately (mission rule), so nothing is dropped and nothing all-fires-at-once.
+    /// </summary>
+    private void Load()
+    {
+        if (!File.Exists(_path))
+        {
+            FileLog.Write($"[SnoozeRegistry] Load: no registry file at {_path}; starting empty");
+            return;
+        }
+
+        StoreFile? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize<StoreFile>(File.ReadAllText(_path), FileJsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            Quarantine(ex.Message);
+            return;
+        }
+
+        if (parsed is null)
+        {
+            Quarantine("file deserialized to null (no registry document)");
+            return;
+        }
+
+        var rearmed = 0;
+        foreach (var e in parsed.Entries)
+        {
+            if (string.IsNullOrWhiteSpace(e.SessionId))
+                continue; // skip a malformed row rather than fail the whole boot
+            _entries[e.SessionId] = e with { SnoozeUntilUtc = e.SnoozeUntilUtc.ToUniversalTime() };
+            rearmed++;
+        }
+
+        FileLog.Write($"[SnoozeRegistry] Load: re-armed {rearmed} pending snooze(s) from {_path}");
+    }
+
+    /// <summary>
+    /// Preserve an unreadable registry file as "&lt;path&gt;.corrupt-&lt;stamp&gt;" and log loudly.
+    /// The original path is then free for the next write-through. The move is not allowed to fail
+    /// silently: if even the quarantine fails, the exception propagates and the Gateway does not
+    /// start half-blind.
+    /// </summary>
+    private void Quarantine(string reason)
+    {
+        var quarantinePath = $"{_path}.corrupt-{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}";
+        File.Move(_path, quarantinePath);
+        FileLog.Write($"[SnoozeRegistry] Load FAILED: registry file at {_path} is corrupt ({reason}); quarantined to {quarantinePath}; starting empty. Operator action: inspect the quarantined file to recover pending snoozes.");
+    }
+
+    /// <summary>
+    /// Write-through: serialize the whole registry and atomically replace the file (temp + rename),
+    /// so a concurrent reader or a crash mid-write never sees a half-written registry. Called inside
+    /// the lock by every mutation. A failed save is a LOGGED error that PROPAGATES (the caller's
+    /// request fails loudly) - never a silent skip, because a snooze that did not persist would not
+    /// survive a restart.
+    /// </summary>
+    private void Save()
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(_path);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            var file = new StoreFile { Entries = _entries.Values.ToList() };
+            var json = JsonSerializer.Serialize(file, FileJsonOptions);
+
+            var tmp = _path + ".tmp";
+            File.WriteAllText(tmp, json);
+            File.Move(tmp, _path, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[SnoozeRegistry] Save FAILED: path={_path}: {ex.Message}");
+            throw;
+        }
+    }
+}


### PR DESCRIPTION
## Mission
Snooze Length (docs/architecture/snooze-length-mission-2026-07-11.md). Turns open-ended snooze into a time-bounded hold with a **guaranteed return** - a dead-man's switch, so a dead or stuck session (the enrichment session that vanished) can never be lost by snoozing.

## Phase 1 - the Gateway-owned machinery (phone + cockpit paths)

- **SnoozeRegistry** (`src/CcDirector.Gateway/Snooze/SnoozeRegistry.cs`) - persisted `sessionId -> (SnoozeUntilUtc, directorId)`, atomic write-through, **re-armed from disk on startup** (a Gateway restart never loses a pending snooze; an already-past entry fires on the first sweep), corrupt-file quarantine, bound by `ClearForDirector` (on `Registry.OnDirectorRemoved`) + `PruneNotLive` (a reachable Director's exited sessions).
- **Record on hold**: `POST /sessions/{sid}/hold` records a snooze-until (`now + per-user default`) on hold / clears on unhold, only after the forward succeeds, then forwards to the Director as before.
- **Expiry overlay** in the `/sessions` fold - a pure, continuous override of `OnHold=false` for an expired snooze, so `SessionOrdering.Classify` returns it to `needsYou` with no new classification logic and **no grey flicker** between expiry and the Director confirming the clear. Surfaces a dead Director's cached session the same way.
- **SnoozeExpirySweep** - a 15s watchdog reading each owning Director's **raw** `OnHold` directly (never the overlaid roster, so the fold can never mask the Director's own clear). Expired-and-held on a **live** Director -> nudge off hold, keep the entry until the Director confirms `OnHold=false`; #470 early-return -> clear; **dead** Director -> leave pinned (dead-man's switch); transient/absent read -> never drop a snooze.
- **Setting**: `SnoozeDefaultConfig` (`snooze_default_minutes`, default 60) + `GET/PUT /gateway/snooze-default` - one value across all of a user's devices.

The existing `WebPushNeedsYouNotifier` reaches the phone for free (expiry raises the NeedsYou count it already watches). **Nothing is injected into the session conversation.**

## Tests
`SnoozeRegistryTests` (persistence, re-arm, quarantine, bounds), `SnoozeExpirySweepTests` (future / expired / early-return / dead-Director / transient), `SnoozeDefaultConfigTests` (range validation), and a `SessionsAggregationTests` case proving an expired snooze overlays back to `needsYou`. Full Gateway suite: 1843/1844 (the one failure is the pre-existing flaky `LauncherRegistryEndpointTests`, which passes in isolation).

## Follow-ups
- Live round-trip on the real Gateway (default cranked to ~1 min; return-on-its-own + survives a Gateway restart mid-snooze) - doing next, before Phase 2.
- **Phase 3 scope correction**: the desktop Avalonia snooze buttons set `OnHold` in-process and bypass the Gateway today, so a desktop-initiated snooze currently gets no timer. Architect agreed to route them through the Gateway hold path in Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)