### PR TITLE
feat(stats): hourly activity log + 24-hour concurrency chart

### DIFF
--- a/apps/cockpit/src/throttle/YourThrottleView.tsx
+++ b/apps/cockpit/src/throttle/YourThrottleView.tsx
@@ -8,6 +8,7 @@ import {
   SURFACE_ORDER,
   type ThrottleData,
   type ThrottleSummary,
+  type ConcurrencyHour,
 } from "@devthrottle/client-core/stats/statsClient";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 
@@ -27,6 +28,40 @@ function HeadlineCard({ label, value, sub }: { label: string; value: string; sub
       <div className="thr-card-value">{value}</div>
       <div className="thr-card-label">{label}</div>
       <div className="thr-card-sub">{sub}</div>
+    </div>
+  );
+}
+
+/** A 24-hour bar chart of the hourly peak concurrent sessions. Each bar is the max loaded/running in
+ * that hour; the darker inner portion is the max actively-working. Pure CSS bars, theme-aware. */
+function ConcurrencyChart({ hourly }: { hourly: ConcurrencyHour[] }) {
+  const recent = hourly.slice(-24);
+  const peak = Math.max(1, ...recent.map((h) => h.maxLive));
+  return (
+    <div
+      className="thr-chart"
+      role="img"
+      aria-label={`Peak concurrent sessions per hour for the last ${recent.length} hours`}
+    >
+      {recent.map((h, i) => {
+        const livePct = (h.maxLive / peak) * 100;
+        const workPct = h.maxLive > 0 ? (h.maxWorking / h.maxLive) * 100 : 0;
+        const hourNum = h.hour.slice(-2);
+        return (
+          <div
+            className="thr-bar-col"
+            key={h.hour}
+            title={`${h.hour}:00 UTC - ${h.maxLive} loaded, ${h.maxWorking} working, ${h.sessions} distinct sessions, ${h.machines} machine(s)`}
+          >
+            <div className="thr-bar-track">
+              <div className="thr-bar-live" style={{ height: `${livePct}%` }}>
+                <div className="thr-bar-work" style={{ height: `${workPct}%` }} />
+              </div>
+            </div>
+            <div className="thr-bar-label">{i % 4 === 0 ? hourNum : ""}</div>
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -118,6 +153,17 @@ export function YourThrottleView() {
               </tr>
             </tbody>
           </table>
+        </div>
+      )}
+
+      {data !== null && data.concurrency !== null && data.concurrency.hourly.length > 0 && (
+        <div className="thr-section">
+          <h2>Sessions per hour (last 24h)</h2>
+          <p className="thr-hint">
+            Peak concurrent sessions in each hour (UTC). The bar is loaded/running; the darker portion is
+            actively working. Hover a bar for that hour's distinct sessions and machines.
+          </p>
+          <ConcurrencyChart hourly={data.concurrency.hourly} />
         </div>
       )}
 

--- a/apps/cockpit/src/throttle/throttle.css
+++ b/apps/cockpit/src/throttle/throttle.css
@@ -115,6 +115,53 @@
   color: var(--text-dim);
 }
 
+/* 24-hour concurrency bar chart */
+.thr-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 3px;
+  height: 130px;
+  padding: 8px 2px 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+.thr-bar-col {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+  min-width: 0;
+}
+.thr-bar-track {
+  width: 100%;
+  max-width: 22px;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: flex-end;
+}
+.thr-bar-live {
+  width: 100%;
+  background: color-mix(in srgb, var(--accent) 32%, transparent);
+  border-radius: 3px 3px 0 0;
+  display: flex;
+  align-items: flex-end;
+  min-height: 1px;
+}
+.thr-bar-work {
+  width: 100%;
+  background: var(--accent);
+  border-radius: 3px 3px 0 0;
+}
+.thr-bar-label {
+  font-size: 9px;
+  color: var(--text-dim);
+  margin-top: 4px;
+  height: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
 /* Honesty caveats */
 .thr-caveats {
   background: var(--surface-2);

--- a/apps/mobile/src/pages/YourThrottle.tsx
+++ b/apps/mobile/src/pages/YourThrottle.tsx
@@ -9,6 +9,7 @@ import {
   SURFACE_ORDER,
   type ThrottleData,
   type ThrottleSummary,
+  type ConcurrencyHour,
 } from "@devthrottle/client-core/stats/statsClient";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 
@@ -19,6 +20,39 @@ import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 // live as the user drives by voice.
 
 const REFRESH_MS = 10_000;
+
+/** A 24-hour bar chart of the hourly peak concurrent sessions. Bar = max loaded/running that hour;
+ * darker inner portion = max actively-working. Pure CSS bars, theme-aware. */
+function ConcurrencyChart({ hourly }: { hourly: ConcurrencyHour[] }) {
+  const recent = hourly.slice(-24);
+  const peak = Math.max(1, ...recent.map((h) => h.maxLive));
+  return (
+    <div
+      className="thr-chart"
+      role="img"
+      aria-label={`Peak concurrent sessions per hour for the last ${recent.length} hours`}
+    >
+      {recent.map((h, i) => {
+        const livePct = (h.maxLive / peak) * 100;
+        const workPct = h.maxLive > 0 ? (h.maxWorking / h.maxLive) * 100 : 0;
+        return (
+          <div
+            className="thr-bar-col"
+            key={h.hour}
+            title={`${h.hour}:00 UTC - ${h.maxLive} loaded, ${h.maxWorking} working, ${h.sessions} sessions`}
+          >
+            <div className="thr-bar-track">
+              <div className="thr-bar-live" style={{ height: `${livePct}%` }}>
+                <div className="thr-bar-work" style={{ height: `${workPct}%` }} />
+              </div>
+            </div>
+            <div className="thr-bar-label">{i % 6 === 0 ? h.hour.slice(-2) : ""}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
 
 export function YourThrottle() {
   const [data, setData] = useState<ThrottleData | null>(null);
@@ -89,6 +123,13 @@ export function YourThrottle() {
               {data.concurrency.working.current} now, {data.concurrency.working.allTimeMax} peak
             </span>
           </div>
+        </section>
+      )}
+
+      {data !== null && data.concurrency !== null && data.concurrency.hourly.length > 0 && (
+        <section className="thr-list" aria-label="Sessions per hour">
+          <div className="thr-list-title">Sessions per hour (last 24h)</div>
+          <ConcurrencyChart hourly={data.concurrency.hourly} />
         </section>
       )}
 

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -2844,3 +2844,51 @@ a.banner-btn {
   color: var(--text-dim);
   margin-bottom: 6px;
 }
+
+/* 24-hour concurrency bar chart */
+.thr-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 110px;
+  padding: 8px 2px 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  margin-top: 8px;
+}
+.thr-bar-col {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+  min-width: 0;
+}
+.thr-bar-track {
+  width: 100%;
+  max-width: 16px;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: flex-end;
+}
+.thr-bar-live {
+  width: 100%;
+  background: color-mix(in srgb, var(--accent) 32%, transparent);
+  border-radius: 2px 2px 0 0;
+  display: flex;
+  align-items: flex-end;
+  min-height: 1px;
+}
+.thr-bar-work {
+  width: 100%;
+  background: var(--accent);
+  border-radius: 2px 2px 0 0;
+}
+.thr-bar-label {
+  font-size: 9px;
+  color: var(--text-dim);
+  margin-top: 3px;
+  height: 11px;
+  font-variant-numeric: tabular-nums;
+}

--- a/packages/client-core/src/stats/statsClient.ts
+++ b/packages/client-core/src/stats/statsClient.ts
@@ -34,15 +34,27 @@ export interface ConcurrencySeries {
   allTimeMaxAtUtc: string | null;
   /** Highest count in the last 7 days, derived from the hourly history. */
   weeklyMax: number;
-  /** Per-hour max history, oldest hour first (hour key "yyyy-MM-ddTHH" UTC). */
-  hourly: { hour: string; max: number }[];
+}
+
+/** One hour of the fleet activity log (hour key "yyyy-MM-ddTHH" UTC): the max concurrent live and
+ * working counts, and how many distinct sessions, machines, and repositories ran that hour. */
+export interface ConcurrencyHour {
+  hour: string;
+  maxLive: number;
+  maxWorking: number;
+  sessions: number;
+  machines: number;
+  repos: number;
 }
 
 /** Fleet concurrency: how many sessions are loaded/running at once (live) and how many are actively
- * working at once (working). Null when the Gateway has not tracked any yet. */
+ * working at once (working), plus the per-hour activity log. Null when the Gateway has not tracked any
+ * yet. */
 export interface ConcurrencyStats {
   live: ConcurrencySeries;
   working: ConcurrencySeries;
+  /** Per-hour activity log, oldest hour first. */
+  hourly: ConcurrencyHour[];
 }
 
 /** The GET /stats/data body: the fleet-wide aggregated tally plus the honesty caveats. */
@@ -134,31 +146,41 @@ export async function getThrottle(signal?: AbortSignal): Promise<ThrottleData> {
   };
 }
 
+function num(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
 function normalizeSeries(raw: unknown): ConcurrencySeries {
   const s = (raw ?? {}) as Partial<Record<keyof ConcurrencySeries, unknown>>;
-  const num = (v: unknown): number => {
-    const n = Number(v);
-    return Number.isFinite(n) ? n : 0;
-  };
-  const hourly = Array.isArray(s.hourly)
-    ? s.hourly.map((h) => {
-        const o = (h ?? {}) as { hour?: unknown; max?: unknown };
-        return { hour: String(o.hour ?? ""), max: num(o.max) };
-      })
-    : [];
   return {
     current: num(s.current),
     allTimeMax: num(s.allTimeMax),
     allTimeMaxAtUtc: typeof s.allTimeMaxAtUtc === "string" ? s.allTimeMaxAtUtc : null,
     weeklyMax: num(s.weeklyMax),
-    hourly,
+  };
+}
+
+function normalizeHour(raw: unknown): ConcurrencyHour {
+  const h = (raw ?? {}) as Partial<Record<keyof ConcurrencyHour, unknown>>;
+  return {
+    hour: String(h.hour ?? ""),
+    maxLive: num(h.maxLive),
+    maxWorking: num(h.maxWorking),
+    sessions: num(h.sessions),
+    machines: num(h.machines),
+    repos: num(h.repos),
   };
 }
 
 function normalizeConcurrency(raw: unknown): ConcurrencyStats | null {
   if (raw === null || typeof raw !== "object") return null;
-  const c = raw as { live?: unknown; working?: unknown };
-  return { live: normalizeSeries(c.live), working: normalizeSeries(c.working) };
+  const c = raw as { live?: unknown; working?: unknown; hourly?: unknown };
+  return {
+    live: normalizeSeries(c.live),
+    working: normalizeSeries(c.working),
+    hourly: Array.isArray(c.hourly) ? c.hourly.map(normalizeHour) : [],
+  };
 }
 
 /** Derive the honest headline summary from a tally snapshot. Turn shares are over counted turns only;

--- a/src/CcDirector.Gateway.Tests/GatewaySessionConcurrencyStatsTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewaySessionConcurrencyStatsTests.cs
@@ -1,3 +1,4 @@
+using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Stats;
 using Xunit;
 
@@ -5,7 +6,8 @@ namespace CcDirector.Gateway.Tests;
 
 /// <summary>
 /// Unit tests for the DevThrottle Stats fleet-concurrency tracker: both series (live + working), the
-/// all-time peak, the derived weekly max, restart durability, and hourly-history pruning.
+/// all-time peak, the derived weekly max, the hourly distinct session / machine / repository log, restart
+/// durability (including mid-hour dedup), and hourly-history pruning.
 /// </summary>
 public sealed class GatewaySessionConcurrencyStatsTests : IDisposable
 {
@@ -23,43 +25,71 @@ public sealed class GatewaySessionConcurrencyStatsTests : IDisposable
 
     private static readonly DateTime T0 = new(2026, 7, 11, 20, 0, 0, DateTimeKind.Utc);
 
+    private static SessionDto S(string id, string state, string machine = "M1", string repo = "R1") =>
+        new() { SessionId = id, ActivityState = state, MachineName = machine, RepoPath = repo };
+
+    // A roster of `live` non-exited sessions, `working` of them in the Working state, on one machine/repo.
+    private static List<SessionDto> Roster(int live, int working, string machine = "M1", string repo = "R1")
+    {
+        var list = new List<SessionDto>();
+        for (var i = 0; i < working; i++) list.Add(S($"w{i}", "Working", machine, repo));
+        for (var i = 0; i < live - working; i++) list.Add(S($"i{i}", "WaitingForInput", machine, repo));
+        return list;
+    }
+
     [Fact]
     public void Observe_TracksCurrentPeakAndHourly_ForBothSeries()
     {
         var s = new GatewaySessionConcurrencyStats(_path);
-        s.Observe(liveCount: 10, workingCount: 3, T0);
-        s.Observe(liveCount: 28, workingCount: 7, T0.AddMinutes(10));
-        s.Observe(liveCount: 20, workingCount: 5, T0.AddMinutes(20)); // lower - the peak must stand
+        s.Observe(Roster(10, 3), T0);
+        s.Observe(Roster(28, 7), T0.AddMinutes(10));
+        s.Observe(Roster(20, 5), T0.AddMinutes(20)); // lower - the peak must stand
 
         var snap = s.Snapshot(T0.AddMinutes(21));
         Assert.Equal(20, snap.Live.Current);
         Assert.Equal(28, snap.Live.AllTimeMax);
         Assert.Equal(5, snap.Working.Current);
         Assert.Equal(7, snap.Working.AllTimeMax);
-        // A single clock hour holds that hour's max for each series.
-        Assert.Single(snap.Live.Hourly);
-        Assert.Equal("2026-07-11T20", snap.Live.Hourly[0].Hour);
-        Assert.Equal(28, snap.Live.Hourly[0].Max);
-        Assert.Equal(7, snap.Working.Hourly[0].Max);
+        Assert.Single(snap.Hourly);
+        Assert.Equal("2026-07-11T20", snap.Hourly[0].Hour);
+        Assert.Equal(28, snap.Hourly[0].MaxLive);
+        Assert.Equal(7, snap.Hourly[0].MaxWorking);
     }
 
     [Fact]
-    public void Observe_CapsWorkingAtLive()
+    public void HourlyLog_CountsDistinctSessionsMachinesReposAcrossTheHour()
     {
         var s = new GatewaySessionConcurrencyStats(_path);
-        s.Observe(liveCount: 5, workingCount: 9, T0); // working can never exceed live
+        s.Observe(new List<SessionDto> { S("a", "Working", "M1", "R1"), S("b", "WaitingForInput", "M1", "R1") }, T0);
+        s.Observe(new List<SessionDto> { S("b", "Working", "M2", "R2"), S("c", "Working", "M2", "R2") }, T0.AddMinutes(5));
+
+        var snap = s.Snapshot(T0.AddMinutes(6));
+        Assert.Single(snap.Hourly);
+        Assert.Equal(3, snap.Hourly[0].Sessions); // a, b, c across the hour
+        Assert.Equal(2, snap.Hourly[0].Machines); // M1, M2
+        Assert.Equal(2, snap.Hourly[0].Repos);    // R1, R2
+        Assert.Equal(2, snap.Hourly[0].MaxLive);
+        Assert.Equal(2, snap.Hourly[0].MaxWorking);
+    }
+
+    [Fact]
+    public void ExitedSessions_AreNotCounted()
+    {
+        var s = new GatewaySessionConcurrencyStats(_path);
+        s.Observe(new List<SessionDto> { S("a", "Working"), S("b", "Exited"), S("c", "WaitingForInput") }, T0);
         var snap = s.Snapshot(T0);
-        Assert.Equal(5, snap.Working.Current);
-        Assert.Equal(5, snap.Working.AllTimeMax);
+        Assert.Equal(2, snap.Live.Current);      // a + c; b is exited
+        Assert.Equal(1, snap.Working.Current);   // a
+        Assert.Equal(2, snap.Hourly[0].Sessions);
     }
 
     [Fact]
     public void WeeklyMax_IsMaxOverLast7Days_WhileAllTimeKeepsTheOlderPeak()
     {
         var s = new GatewaySessionConcurrencyStats(_path);
-        s.Observe(liveCount: 40, workingCount: 10, T0.AddDays(-10)); // older than a week
-        s.Observe(liveCount: 25, workingCount: 6, T0.AddDays(-2));   // within the week
-        s.Observe(liveCount: 22, workingCount: 5, T0);              // within the week
+        s.Observe(Roster(40, 10), T0.AddDays(-10)); // older than a week
+        s.Observe(Roster(25, 6), T0.AddDays(-2));   // within the week
+        s.Observe(Roster(22, 5), T0);              // within the week
 
         var snap = s.Snapshot(T0);
         Assert.Equal(40, snap.Live.AllTimeMax); // all-time remembers the older peak
@@ -67,27 +97,33 @@ public sealed class GatewaySessionConcurrencyStatsTests : IDisposable
     }
 
     [Fact]
-    public void PeaksAndHistory_SurviveRestart()
+    public void PeaksAndDistinctCounts_SurviveRestart()
     {
         var a = new GatewaySessionConcurrencyStats(_path);
-        a.Observe(liveCount: 30, workingCount: 8, T0);
+        a.Observe(new List<SessionDto> { S("x", "Working"), S("y", "WaitingForInput") }, T0);
 
         var b = new GatewaySessionConcurrencyStats(_path); // reload from disk
         var snap = b.Snapshot(T0.AddMinutes(1));
-        Assert.Equal(30, snap.Live.AllTimeMax);
-        Assert.Equal(8, snap.Working.AllTimeMax);
+        Assert.Equal(2, snap.Live.AllTimeMax);
+        Assert.Equal(1, snap.Working.AllTimeMax);
+        Assert.Equal(2, snap.Hourly[0].Sessions);
+
+        // A further observation in the SAME hour dedupes against the restored current-hour set.
+        b.Observe(new List<SessionDto> { S("x", "Working"), S("z", "Working") }, T0.AddMinutes(2));
+        var snap2 = b.Snapshot(T0.AddMinutes(3));
+        Assert.Equal(3, snap2.Hourly[0].Sessions); // x, y, z - not x, y, x, z
     }
 
     [Fact]
     public void OldHourlyBuckets_ArePruned_ButAllTimePeakRemains()
     {
         var s = new GatewaySessionConcurrencyStats(_path);
-        s.Observe(liveCount: 12, workingCount: 3, T0.AddDays(-120)); // beyond the 90-day retention
-        s.Observe(liveCount: 15, workingCount: 4, T0);              // triggers a prune at now = T0
+        s.Observe(Roster(12, 3), T0.AddDays(-120)); // beyond the 90-day retention
+        s.Observe(Roster(15, 4), T0);              // triggers a prune at now = T0
 
         var snap = s.Snapshot(T0);
-        Assert.Single(snap.Live.Hourly);                 // only the recent hour survives the history
-        Assert.Equal("2026-07-11T20", snap.Live.Hourly[0].Hour);
-        Assert.Equal(15, snap.Live.AllTimeMax);          // the peak is not history-derived, so it stands
+        Assert.Single(snap.Hourly);                 // only the recent hour survives the history
+        Assert.Equal("2026-07-11T20", snap.Hourly[0].Hour);
+        Assert.Equal(15, snap.Live.AllTimeMax);     // the peak is not history-derived, so it stands
     }
 }

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -727,19 +727,12 @@ internal static class GatewayEndpoints
             // genuine increase is added, so repeated /sessions polls never double-count.
             inputStats?.ObserveSnapshot(all);
 
-            // DevThrottle Stats: record fleet concurrency from the same assembled roster - how many
-            // sessions are loaded/running (live = non-exited) and how many are actively working right now
-            // (activityState = Working). Fleet-wide with no per-Director instrumentation, since the roster
-            // already sees every session on every machine. The tracker keeps only the higher value per
-            // hour, so folding on every /sessions read captures peaks without inflating anything.
-            if (concurrency is not null)
-            {
-                var liveCount = all.Count(s =>
-                    !string.Equals(s.ActivityState, "Exited", StringComparison.OrdinalIgnoreCase));
-                var workingCount = all.Count(s =>
-                    string.Equals(s.ActivityState, "Working", StringComparison.OrdinalIgnoreCase));
-                concurrency.Observe(liveCount, workingCount, DateTime.UtcNow);
-            }
+            // DevThrottle Stats: record fleet concurrency and the hourly activity log from the same
+            // assembled roster - max concurrent loaded/running (live) and actively working, plus how many
+            // distinct sessions/machines/repositories ran each hour. Fleet-wide with no per-Director
+            // instrumentation, since the roster already sees every session on every machine. The tracker
+            // keeps only the higher value per hour, so folding on every /sessions read never inflates.
+            concurrency?.Observe(all, DateTime.UtcNow);
 
             // Issue #1292: adopt every observed number into the fleet allocator's in-use set. This is how
             // the Gateway learns numbers it did not hand out - a number a Director assigned offline, or any

--- a/src/CcDirector.Gateway/Stats/GatewaySessionConcurrencyStats.cs
+++ b/src/CcDirector.Gateway/Stats/GatewaySessionConcurrencyStats.cs
@@ -2,67 +2,63 @@ using System.Globalization;
 using System.Text.Json;
 using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
 
 namespace CcDirector.Gateway.Stats;
 
 /// <summary>
-/// The Gateway's durable record of fleet CONCURRENCY - how many sessions run at once across every machine,
-/// and how many are actively working at once. Unlike the input tally, a session COUNT needs no per-Director
-/// instrumentation: the Gateway's assembled /sessions roster already sees every session on every machine
-/// (new build or old), so this is fleet-wide from day one. Observed from that same assembled roster on
-/// every read.
+/// The Gateway's durable record of fleet CONCURRENCY and an hourly activity log. Unlike the input tally, a
+/// session count needs no per-Director instrumentation: the Gateway's assembled /sessions roster already
+/// sees every session on every machine (new build or old), so this is fleet-wide from day one. Observed
+/// from that same assembled roster on every read.
 ///
-/// Two honest series are tracked so a public number is never overstated:
-///   - LIVE: sessions loaded/running (non-exited) - the parallel capacity in flight.
-///   - WORKING: sessions whose agent is processing a turn right now (activityState = Working) - the count
-///     actually churning at an instant, which is smaller and fluctuates.
-/// Each series keeps the current value, the all-time peak (and when it happened), and a per-hour max
-/// history keyed by UTC clock hour. Weekly max (or any window) is DERIVED from the hourly history - we
-/// store hourly once and compute the rest, so there is no separate weekly store to keep consistent.
+/// Two headline series track the peak "how many at once":
+///   - LIVE: sessions loaded/running (non-exited) - parallel capacity in flight.
+///   - WORKING: sessions whose agent is processing a turn right now (activityState = Working).
+/// Each keeps the current value and the all-time peak (+when).
 ///
-/// Persisted (atomic temp-write + rename, corrupt file quarantined) so a Gateway restart keeps the peaks
-/// and the history. Hourly buckets past the retention window are pruned so the store stays bounded.
+/// An hourly log (keyed by UTC clock hour "yyyy-MM-ddTHH") records, for every hour:
+///   - the max concurrent LIVE and WORKING seen that hour (the "24-hour chart" series),
+///   - how many DISTINCT sessions, machines, and repositories were seen that hour (the "how much ran"
+///     totals). Distinct counts dedupe across the hour's observations via a current-hour id set that is
+///     persisted too, so a Gateway restart mid-hour keeps counting the same hour correctly.
+/// Weekly max (or any window) is DERIVED from the hourly log. Persisted (atomic temp-write + rename,
+/// corrupt file quarantined); hourly buckets past the retention window are pruned so the store stays
+/// bounded.
 /// </summary>
 public sealed class GatewaySessionConcurrencyStats
 {
     private static readonly JsonSerializerOptions FileJsonOptions = new() { WriteIndented = true };
-    // ~90 days of hourly buckets: enough for weekly/monthly windows and a long chartable history, bounded
-    // so the store never grows without limit.
     private const int RetentionDays = 90;
     private const string HourFormat = "yyyy-MM-ddTHH";
 
     private readonly string _path;
     private readonly object _lock = new();
-    private readonly Series _live = new();
-    private readonly Series _working = new();
 
-    // One tracked dimension: current value, all-time peak (+when), and per-hour max history.
-    private sealed class Series
+    private int _liveCurrent;
+    private int _workingCurrent;
+    private int _liveAllTimeMax;
+    private DateTime? _liveAllTimeMaxAtUtc;
+    private int _workingAllTimeMax;
+    private DateTime? _workingAllTimeMaxAtUtc;
+
+    // Per-hour log, keyed by UTC clock hour.
+    private readonly Dictionary<string, HourStat> _hours = new(StringComparer.Ordinal);
+
+    // Dedup sets for the CURRENT hour only, so distinct counts are correct across many observations. Rolled
+    // when the clock hour changes; persisted so a restart mid-hour resumes the same hour's dedup.
+    private string _currentHourKey = "";
+    private readonly HashSet<string> _curSessions = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _curMachines = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _curRepos = new(StringComparer.OrdinalIgnoreCase);
+
+    private sealed class HourStat
     {
-        public int Current;
-        public int AllTimeMax;
-        public DateTime? AllTimeMaxAtUtc;
-        public readonly Dictionary<string, int> HourlyMax = new(StringComparer.Ordinal);
-
-        // Fold one observation. Returns true when the persisted state (peak or an hour's max) changed;
-        // a bare Current refresh is not persisted on its own.
-        public bool Observe(int count, DateTime nowUtc, string hourKey)
-        {
-            Current = count;
-            var changed = false;
-            if (count > AllTimeMax)
-            {
-                AllTimeMax = count;
-                AllTimeMaxAtUtc = nowUtc;
-                changed = true;
-            }
-            if (!HourlyMax.TryGetValue(hourKey, out var m) || count > m)
-            {
-                HourlyMax[hourKey] = count;
-                changed = true;
-            }
-            return changed;
-        }
+        public int MaxLive;
+        public int MaxWorking;
+        public int DistinctSessions;
+        public int DistinctMachines;
+        public int DistinctRepos;
     }
 
     /// <param name="path">The durable store file. Defaults to gateway-concurrency-stats.json under the
@@ -79,22 +75,56 @@ public sealed class GatewaySessionConcurrencyStats
         utc.ToUniversalTime().ToString(HourFormat, CultureInfo.InvariantCulture);
 
     /// <summary>
-    /// Observe the current fleet counts at <paramref name="nowUtc"/>: <paramref name="liveCount"/> is the
-    /// non-exited session count, <paramref name="workingCount"/> the subset actively processing a turn.
-    /// Idempotent within an hour - only a value higher than this hour's max (or the all-time peak) is
-    /// persisted, so folding on every roster read never inflates anything.
+    /// Observe the current fleet <paramref name="roster"/> at <paramref name="nowUtc"/>: update the live and
+    /// working current values and all-time peaks, and fold this hour's max concurrency plus its distinct
+    /// session / machine / repository counts. Idempotent within an hour - a peak or distinct count only ever
+    /// grows - so folding on every /sessions read captures the hourly log without inflating anything.
     /// </summary>
-    public void Observe(int liveCount, int workingCount, DateTime nowUtc)
+    public void Observe(IReadOnlyCollection<SessionDto>? roster, DateTime nowUtc)
     {
-        if (liveCount < 0) liveCount = 0;
-        if (workingCount < 0) workingCount = 0;
-        if (workingCount > liveCount) workingCount = liveCount;
-
+        if (roster is null) return;
         var key = HourKey(nowUtc);
         lock (_lock)
         {
-            var changed = _live.Observe(liveCount, nowUtc, key);
-            changed |= _working.Observe(workingCount, nowUtc, key);
+            if (key != _currentHourKey)
+            {
+                _currentHourKey = key;
+                _curSessions.Clear();
+                _curMachines.Clear();
+                _curRepos.Clear();
+            }
+
+            var liveCount = 0;
+            var workingCount = 0;
+            foreach (var s in roster)
+            {
+                if (string.Equals(s.ActivityState, "Exited", StringComparison.OrdinalIgnoreCase)) continue;
+                liveCount++;
+                if (string.Equals(s.ActivityState, "Working", StringComparison.OrdinalIgnoreCase)) workingCount++;
+                if (!string.IsNullOrEmpty(s.SessionId)) _curSessions.Add(s.SessionId);
+                if (!string.IsNullOrWhiteSpace(s.MachineName)) _curMachines.Add(s.MachineName);
+                if (!string.IsNullOrWhiteSpace(s.RepoPath)) _curRepos.Add(s.RepoPath);
+            }
+
+            _liveCurrent = liveCount;
+            _workingCurrent = workingCount;
+
+            var changed = false;
+            if (liveCount > _liveAllTimeMax) { _liveAllTimeMax = liveCount; _liveAllTimeMaxAtUtc = nowUtc; changed = true; }
+            if (workingCount > _workingAllTimeMax) { _workingAllTimeMax = workingCount; _workingAllTimeMaxAtUtc = nowUtc; changed = true; }
+
+            if (!_hours.TryGetValue(key, out var h))
+            {
+                h = new HourStat();
+                _hours[key] = h;
+                changed = true;
+            }
+            if (liveCount > h.MaxLive) { h.MaxLive = liveCount; changed = true; }
+            if (workingCount > h.MaxWorking) { h.MaxWorking = workingCount; changed = true; }
+            if (_curSessions.Count > h.DistinctSessions) { h.DistinctSessions = _curSessions.Count; changed = true; }
+            if (_curMachines.Count > h.DistinctMachines) { h.DistinctMachines = _curMachines.Count; changed = true; }
+            if (_curRepos.Count > h.DistinctRepos) { h.DistinctRepos = _curRepos.Count; changed = true; }
+
             if (changed)
             {
                 PruneLocked(nowUtc);
@@ -103,66 +133,73 @@ public sealed class GatewaySessionConcurrencyStats
         }
     }
 
-    /// <summary>A read-only snapshot for the dashboard / agent API: both series with current, all-time peak
-    /// (+when), the derived weekly max (max hourly bucket in the last 7 days), and the hourly history.</summary>
+    /// <summary>A read-only snapshot for the dashboard / agent API: the live and working series (current,
+    /// all-time peak, derived weekly max) and the full hourly log.</summary>
     public ConcurrencySnapshot Snapshot(DateTime nowUtc)
     {
         lock (_lock)
         {
-            return new ConcurrencySnapshot(SeriesSnapshot(_live, nowUtc), SeriesSnapshot(_working, nowUtc));
+            var weeklyCutoff = nowUtc.AddDays(-7);
+            var liveWeekly = 0;
+            var workingWeekly = 0;
+            var hourly = new List<ConcurrencyHourDto>(_hours.Count);
+            foreach (var kvp in _hours)
+            {
+                var h = kvp.Value;
+                hourly.Add(new ConcurrencyHourDto
+                {
+                    Hour = kvp.Key,
+                    MaxLive = h.MaxLive,
+                    MaxWorking = h.MaxWorking,
+                    Sessions = h.DistinctSessions,
+                    Machines = h.DistinctMachines,
+                    Repos = h.DistinctRepos,
+                });
+                if (TryParseHour(kvp.Key, out var dt) && dt >= weeklyCutoff)
+                {
+                    if (h.MaxLive > liveWeekly) liveWeekly = h.MaxLive;
+                    if (h.MaxWorking > workingWeekly) workingWeekly = h.MaxWorking;
+                }
+            }
+            hourly.Sort((a, b) => string.CompareOrdinal(a.Hour, b.Hour));
+            return new ConcurrencySnapshot(
+                new ConcurrencySeriesDto { Current = _liveCurrent, AllTimeMax = _liveAllTimeMax, AllTimeMaxAtUtc = _liveAllTimeMaxAtUtc, WeeklyMax = liveWeekly },
+                new ConcurrencySeriesDto { Current = _workingCurrent, AllTimeMax = _workingAllTimeMax, AllTimeMaxAtUtc = _workingAllTimeMaxAtUtc, WeeklyMax = workingWeekly },
+                hourly);
         }
-    }
-
-    private static ConcurrencySeriesDto SeriesSnapshot(Series s, DateTime nowUtc)
-    {
-        var weeklyCutoff = nowUtc.AddDays(-7);
-        var weeklyMax = 0;
-        var hourly = new List<ConcurrencyHourDto>(s.HourlyMax.Count);
-        foreach (var kvp in s.HourlyMax)
-        {
-            if (TryParseHour(kvp.Key, out var dt) && dt >= weeklyCutoff && kvp.Value > weeklyMax)
-                weeklyMax = kvp.Value;
-            hourly.Add(new ConcurrencyHourDto { Hour = kvp.Key, Max = kvp.Value });
-        }
-        hourly.Sort((a, b) => string.CompareOrdinal(a.Hour, b.Hour));
-        return new ConcurrencySeriesDto
-        {
-            Current = s.Current,
-            AllTimeMax = s.AllTimeMax,
-            AllTimeMaxAtUtc = s.AllTimeMaxAtUtc,
-            WeeklyMax = weeklyMax,
-            Hourly = hourly,
-        };
     }
 
     private void PruneLocked(DateTime nowUtc)
     {
         var cutoff = nowUtc.AddDays(-RetentionDays);
-        Prune(_live, cutoff);
-        Prune(_working, cutoff);
-    }
-
-    private static void Prune(Series s, DateTime cutoff)
-    {
-        var stale = s.HourlyMax.Keys.Where(k => TryParseHour(k, out var dt) && dt < cutoff).ToList();
-        foreach (var k in stale) s.HourlyMax.Remove(k);
+        var stale = _hours.Keys.Where(k => TryParseHour(k, out var dt) && dt < cutoff).ToList();
+        foreach (var k in stale) _hours.Remove(k);
     }
 
     private static bool TryParseHour(string key, out DateTime utc) =>
         DateTime.TryParseExact(key, HourFormat, CultureInfo.InvariantCulture,
             DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out utc);
 
-    private sealed class SeriesStore
+    private sealed class HourStatStore
     {
-        public int AllTimeMax { get; set; }
-        public DateTime? AllTimeMaxAtUtc { get; set; }
-        public Dictionary<string, int> HourlyMax { get; set; } = new();
+        public int MaxLive { get; set; }
+        public int MaxWorking { get; set; }
+        public int DistinctSessions { get; set; }
+        public int DistinctMachines { get; set; }
+        public int DistinctRepos { get; set; }
     }
 
     private sealed class StoreFile
     {
-        public SeriesStore Live { get; set; } = new();
-        public SeriesStore Working { get; set; } = new();
+        public int LiveAllTimeMax { get; set; }
+        public DateTime? LiveAllTimeMaxAtUtc { get; set; }
+        public int WorkingAllTimeMax { get; set; }
+        public DateTime? WorkingAllTimeMaxAtUtc { get; set; }
+        public Dictionary<string, HourStatStore> Hours { get; set; } = new();
+        public string CurrentHourKey { get; set; } = "";
+        public List<string> CurrentSessions { get; set; } = new();
+        public List<string> CurrentMachines { get; set; } = new();
+        public List<string> CurrentRepos { get; set; } = new();
     }
 
     private void Load()
@@ -189,18 +226,24 @@ public sealed class GatewaySessionConcurrencyStats
             return;
         }
 
-        RestoreSeries(_live, parsed.Live);
-        RestoreSeries(_working, parsed.Working);
-        FileLog.Write($"[GatewaySessionConcurrencyStats] Load: live peak {_live.AllTimeMax}, working peak {_working.AllTimeMax}, {_live.HourlyMax.Count} live + {_working.HourlyMax.Count} working hourly bucket(s) from {_path}");
-    }
-
-    private static void RestoreSeries(Series s, SeriesStore? store)
-    {
-        if (store is null) return;
-        s.AllTimeMax = store.AllTimeMax;
-        s.AllTimeMaxAtUtc = store.AllTimeMaxAtUtc;
-        foreach (var (hour, max) in store.HourlyMax)
-            s.HourlyMax[hour] = max;
+        _liveAllTimeMax = parsed.LiveAllTimeMax;
+        _liveAllTimeMaxAtUtc = parsed.LiveAllTimeMaxAtUtc;
+        _workingAllTimeMax = parsed.WorkingAllTimeMax;
+        _workingAllTimeMaxAtUtc = parsed.WorkingAllTimeMaxAtUtc;
+        foreach (var (hour, hs) in parsed.Hours)
+            _hours[hour] = new HourStat
+            {
+                MaxLive = hs.MaxLive,
+                MaxWorking = hs.MaxWorking,
+                DistinctSessions = hs.DistinctSessions,
+                DistinctMachines = hs.DistinctMachines,
+                DistinctRepos = hs.DistinctRepos,
+            };
+        _currentHourKey = parsed.CurrentHourKey ?? "";
+        foreach (var s in parsed.CurrentSessions) _curSessions.Add(s);
+        foreach (var m in parsed.CurrentMachines) _curMachines.Add(m);
+        foreach (var r in parsed.CurrentRepos) _curRepos.Add(r);
+        FileLog.Write($"[GatewaySessionConcurrencyStats] Load: live peak {_liveAllTimeMax}, working peak {_workingAllTimeMax}, {_hours.Count} hourly bucket(s) from {_path}");
     }
 
     private void Quarantine(string reason)
@@ -223,9 +266,25 @@ public sealed class GatewaySessionConcurrencyStats
 
             var file = new StoreFile
             {
-                Live = ToStore(_live),
-                Working = ToStore(_working),
+                LiveAllTimeMax = _liveAllTimeMax,
+                LiveAllTimeMaxAtUtc = _liveAllTimeMaxAtUtc,
+                WorkingAllTimeMax = _workingAllTimeMax,
+                WorkingAllTimeMaxAtUtc = _workingAllTimeMaxAtUtc,
+                CurrentHourKey = _currentHourKey,
+                CurrentSessions = _curSessions.ToList(),
+                CurrentMachines = _curMachines.ToList(),
+                CurrentRepos = _curRepos.ToList(),
             };
+            foreach (var (hour, h) in _hours)
+                file.Hours[hour] = new HourStatStore
+                {
+                    MaxLive = h.MaxLive,
+                    MaxWorking = h.MaxWorking,
+                    DistinctSessions = h.DistinctSessions,
+                    DistinctMachines = h.DistinctMachines,
+                    DistinctRepos = h.DistinctRepos,
+                };
+
             var json = JsonSerializer.Serialize(file, FileJsonOptions);
             var tmp = _path + ".tmp";
             File.WriteAllText(tmp, json);
@@ -237,37 +296,32 @@ public sealed class GatewaySessionConcurrencyStats
             throw;
         }
     }
-
-    private static SeriesStore ToStore(Series s) => new()
-    {
-        AllTimeMax = s.AllTimeMax,
-        AllTimeMaxAtUtc = s.AllTimeMaxAtUtc,
-        HourlyMax = new Dictionary<string, int>(s.HourlyMax, StringComparer.Ordinal),
-    };
 }
 
-/// <summary>One hour of the concurrency history: the UTC clock-hour key ("yyyy-MM-ddTHH") and the max
-/// concurrent count seen in that hour.</summary>
+/// <summary>One tracked concurrency dimension (live or working): current, all-time peak (+when), and the
+/// derived weekly max.</summary>
+public sealed class ConcurrencySeriesDto
+{
+    public int Current { get; set; }
+    public int AllTimeMax { get; set; }
+    public DateTime? AllTimeMaxAtUtc { get; set; }
+    public int WeeklyMax { get; set; }
+}
+
+/// <summary>One hour of the fleet activity log (UTC clock hour "yyyy-MM-ddTHH"): the max concurrent live
+/// and working counts, and how many distinct sessions, machines, and repositories were seen that hour.</summary>
 public sealed class ConcurrencyHourDto
 {
     public string Hour { get; set; } = "";
-    public int Max { get; set; }
+    public int MaxLive { get; set; }
+    public int MaxWorking { get; set; }
+    public int Sessions { get; set; }
+    public int Machines { get; set; }
+    public int Repos { get; set; }
 }
 
-/// <summary>One tracked concurrency dimension (live or working) for the dashboard / agent API.</summary>
-public sealed class ConcurrencySeriesDto
-{
-    /// <summary>The most recently observed count.</summary>
-    public int Current { get; set; }
-    /// <summary>The highest count ever observed.</summary>
-    public int AllTimeMax { get; set; }
-    /// <summary>When the all-time peak was observed (UTC), or null if never.</summary>
-    public DateTime? AllTimeMaxAtUtc { get; set; }
-    /// <summary>The highest count in the last 7 days, derived from the hourly history.</summary>
-    public int WeeklyMax { get; set; }
-    /// <summary>The per-hour max history, oldest hour first.</summary>
-    public List<ConcurrencyHourDto> Hourly { get; set; } = new();
-}
-
-/// <summary>Both concurrency dimensions: sessions loaded/running (live) and sessions actively working.</summary>
-public sealed record ConcurrencySnapshot(ConcurrencySeriesDto Live, ConcurrencySeriesDto Working);
+/// <summary>The concurrency snapshot: both headline series plus the hourly activity log (oldest hour first).</summary>
+public sealed record ConcurrencySnapshot(
+    ConcurrencySeriesDto Live,
+    ConcurrencySeriesDto Working,
+    IReadOnlyList<ConcurrencyHourDto> Hourly);


### PR DESCRIPTION
## What

Extends the fleet-concurrency stat with a **richer hourly log** and a **24-hour chart** on "Your Throttle".

- `GatewaySessionConcurrencyStats` now observes the full `/sessions` roster and logs, per UTC clock hour: **max concurrent live, max concurrent working, and the distinct sessions / machines / repositories** seen that hour. Distinct counts dedupe across the hour via a current-hour id set that is persisted, so a Gateway restart mid-hour keeps the same hour's count correct. Weekly max stays derived; 90-day retention unchanged.
- `GET /stats/data` `concurrency.hourly` carries `{hour, maxLive, maxWorking, sessions, machines, repos}` per hour.
- Cockpit + mobile "Your Throttle": a **"Sessions per hour (last 24h)"** bar chart - each bar is that hour's peak loaded/running with the actively-working portion shaded darker; hover shows distinct sessions and machines.

## Verification

- Gateway compiles clean; **`GatewaySessionConcurrencyStatsTests` (6) green** - peaks, distinct session/machine/repo counts, exited-excluded, derived weekly max, restart durability incl. mid-hour dedup, hourly pruning.
- client-core / cockpit / mobile typecheck clean; client-core stats tests green.
- Will be verified **live** after redeploy (hourly log + chart data on `/stats/data`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
