### PR TITLE
perf(carmode): keep model + text-to-speech warm while Car Mode is open

### DIFF
--- a/packages/client-core/src/carmode/carModeApi.test.ts
+++ b/packages/client-core/src/carmode/carModeApi.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { carModeTurn, postCarModeTelemetry, speakCarModeText, transcribeCarModeAudio } from "./carModeApi";
+import { carModeTurn, postCarModeTelemetry, postCarModeWarmup, speakCarModeText, transcribeCarModeAudio } from "./carModeApi";
 import { CreditsError, GatewayError } from "../api/client";
 
 // The Car Mode Gateway calls must fail LOUD and SPECIFIC (mission decision 8): a money refusal (402) is
@@ -123,6 +123,20 @@ describe("postCarModeTelemetry", () => {
   it("never throws when the post fails (best-effort observability)", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("network down"); }));
     await expect(postCarModeTelemetry(record)).resolves.toBeUndefined();
+  });
+});
+
+describe("postCarModeWarmup", () => {
+  it("posts to /carmode/warmup", async () => {
+    const fetchMock = mockFetch(200, { warmed: true });
+    vi.stubGlobal("fetch", fetchMock);
+    await postCarModeWarmup();
+    expect(fetchMock).toHaveBeenCalledWith("/carmode/warmup", expect.objectContaining({ method: "POST" }));
+  });
+
+  it("never throws when the warmup ping fails (best-effort)", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("down"); }));
+    await expect(postCarModeWarmup()).resolves.toBeUndefined();
   });
 
   it("maps 402 to the shared CreditsError", async () => {

--- a/packages/client-core/src/carmode/carModeApi.ts
+++ b/packages/client-core/src/carmode/carModeApi.ts
@@ -161,3 +161,18 @@ export async function postCarModeTelemetry(record: CarModeTelemetryPost): Promis
     console.log(`[CarMode] telemetry post failed (ignored): ${String(err)}`);
   }
 }
+
+/**
+ * Warm the Car Mode hosted model + text-to-speech provider (POST /carmode/warmup). The page calls this the
+ * instant the owner taps Start (so the providers are hot before the first utterance is transcribed) and
+ * every few minutes while Car Mode is open, so cold-start - the measured dominant latency - is paid before
+ * the drive, not during it. The Gateway gates it on the keep-warm config (default on for Car Mode) and runs
+ * the actual warmup in the background. Best-effort: it never throws and never blocks the turn loop.
+ */
+export async function postCarModeWarmup(): Promise<void> {
+  try {
+    await fetch("/carmode/warmup", { method: "POST", headers: { ...authHeaders() }, keepalive: true });
+  } catch (err) {
+    console.log(`[CarMode] warmup ping failed (ignored): ${String(err)}`);
+  }
+}

--- a/packages/client-core/src/carmode/useCarMode.ts
+++ b/packages/client-core/src/carmode/useCarMode.ts
@@ -5,6 +5,7 @@ import { playReadyCue, playYourTurnCue } from "../dictation/readyCue";
 import { detectEndPhrase, detectInterrupt } from "./controlPhrases";
 import {
   postCarModeTelemetry,
+  postCarModeWarmup,
   speakCarModeText,
   transcribeCarModeAudio,
   type CarModeAction,
@@ -135,6 +136,9 @@ const SILENCE_THRESHOLD = 0.06;
 const PAUSE_MS = 700;
 // How often the rolling window is transcribed while the assistant is speaking, to catch an interrupt word.
 const SPEAKING_POLL_MS = 1500;
+// How often to send a keep-warm ping WHILE Car Mode is open, so the hosted model + text-to-speech stay hot
+// for the drive. Comfortably inside a typical provider keep-alive window; only fires while Car Mode is open.
+const KEEP_WARM_MS = 3 * 60 * 1000;
 // A snapshot smaller than this is just the container header with no real audio - skip transcribing it.
 const MIN_CLIP_BYTES = 2000;
 
@@ -192,6 +196,7 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
   const belowSinceRef = useRef(0); // performance.now() the level first dropped below the threshold, or 0
   const busyRef = useRef(false); // a background transcription is in flight (do not start another)
   const speakingPollRef = useRef<number | null>(null); // setInterval id for the speaking rolling window
+  const keepWarmRef = useRef<number | null>(null); // setInterval id for the keep-warm ping while Car Mode is open
 
   // Performance-round telemetry: the metrics for the turn in flight, filled across transcribe -> brain ->
   // speak and posted once first audio plays. Null between turns.
@@ -625,6 +630,15 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     console.log("[CarMode] start");
     setStarted(true);
     setError(null);
+
+    // Warm-on-entry (Car Mode performance round): fire a warmup the INSTANT the owner taps Start, so the
+    // hosted model + text-to-speech are hot by the time the first utterance is transcribed - cold-start is
+    // the measured dominant latency. Then keep them warm every few minutes WHILE Car Mode is open, so
+    // credits are spent only during active use. Best-effort - it never blocks Start.
+    void postCarModeWarmup();
+    if (keepWarmRef.current !== null) clearInterval(keepWarmRef.current);
+    keepWarmRef.current = window.setInterval(() => void postCarModeWarmup(), KEEP_WARM_MS);
+
     recorderRef.current = new MicRecorder();
     // The reply's sentence chunks are played by playBlob, which sets onended per clip; the speak loop hands
     // the microphone back after the LAST chunk, so no global onended handler is needed here.
@@ -666,6 +680,10 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
       rafRef.current = 0;
     }
     stopSpeakingPoll();
+    if (keepWarmRef.current !== null) {
+      clearInterval(keepWarmRef.current);
+      keepWarmRef.current = null;
+    }
     try {
       recorderRef.current?.dispose();
     } catch {
@@ -695,6 +713,7 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
       playbackStopRef.current?.();
       if (rafRef.current !== 0) window.cancelAnimationFrame(rafRef.current);
       if (speakingPollRef.current !== null) clearInterval(speakingPollRef.current);
+      if (keepWarmRef.current !== null) clearInterval(keepWarmRef.current);
       try {
         recorderRef.current?.dispose();
       } catch {

--- a/src/CcDirector.Core/Configuration/CarModeKeepWarmConfig.cs
+++ b/src/CcDirector.Core/Configuration/CarModeKeepWarmConfig.cs
@@ -1,0 +1,68 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace CcDirector.Core.Configuration;
+
+/// <summary>
+/// Whether Car Mode keeps its hosted model and text-to-speech provider WARM while the owner is using it
+/// (Car Mode performance round). The measured evidence is conclusive that cold-start is the dominant felt
+/// latency (the model ran ~9s cold vs ~1.5s warm, text-to-speech ~4.7s cold vs ~1.3s warm - roughly eleven
+/// seconds of cold-start swing). So Car Mode fires a tiny warmup the instant the owner taps Start and a
+/// small keep-warm ping every few minutes WHILE Car Mode is open, so the providers are hot before the
+/// first utterance and stay hot for the drive. Credits are spent ONLY during active use, never 24/7.
+///
+/// DEFAULT ON for Car Mode: the owner prioritizes speed and credits are not a constraint here. The flag is
+/// the belt - a per-install env override or a saved setting can turn it off.
+///
+/// Resolution precedence (mirrors <see cref="CarModeModelConfig"/>):
+///   1. the <c>CC_CARMODE_KEEPWARM</c> environment variable ("0"/"false"/"off" disables) - wins;
+///   2. the user's saved setting (config.json <c>car_mode_keep_warm</c>);
+///   3. the default, ON.
+/// </summary>
+public static class CarModeKeepWarmConfig
+{
+    /// <summary>The config.json key the keep-warm choice is stored under.</summary>
+    public const string ConfigKey = "car_mode_keep_warm";
+
+    /// <summary>The environment variable that overrides everything (per-install / debugging).</summary>
+    public const string EnvVar = "CC_CARMODE_KEEPWARM";
+
+    /// <summary>Keep-warm is ON by default for Car Mode.</summary>
+    public const bool Default = true;
+
+    /// <summary>
+    /// The EFFECTIVE keep-warm setting, applying the full precedence: the <see cref="EnvVar"/> override
+    /// wins, then the saved setting, then <see cref="Default"/> (ON). Read at call time so a change is
+    /// honoured on the next warmup without a restart.
+    /// </summary>
+    public static bool Enabled()
+    {
+        var env = Environment.GetEnvironmentVariable(EnvVar);
+        if (!string.IsNullOrWhiteSpace(env))
+        {
+            var e = env.Trim().ToLowerInvariant();
+            if (e is "0" or "false" or "off" or "no") return false;
+            if (e is "1" or "true" or "on" or "yes") return true;
+        }
+        return Get();
+    }
+
+    /// <summary>The user's saved keep-warm setting (config.json <c>car_mode_keep_warm</c>), or
+    ///  <see cref="Default"/> when unset. Does NOT consult the environment override.</summary>
+    public static bool Get()
+    {
+        var node = CcDirectorConfigService.ReadRaw()[ConfigKey];
+        if (node is JsonValue v)
+        {
+            var kind = v.GetValueKind();
+            if (kind is JsonValueKind.True or JsonValueKind.False) return v.GetValue<bool>();
+        }
+        return Default;
+    }
+
+    /// <summary>Persist the chosen keep-warm setting to config.json (merge-patch).</summary>
+    public static void Set(bool enabled)
+    {
+        CcDirectorConfigService.MergePatch(new JsonObject { [ConfigKey] = enabled });
+    }
+}

--- a/src/CcDirector.Gateway.Tests/CarModeWarmupTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeWarmupTests.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using CcDirector.Gateway.CarMode;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Car Mode keep-warm (performance round) fires one tiny request to the hosted model and one to the
+/// text-to-speech provider so a cold-start is paid before the drive, not during it. These tests drive it
+/// with a stub HTTP handler (no network) to prove it warms BOTH providers, skips a leg with no key without
+/// erroring, and NEVER throws on an upstream failure (a warmup is best-effort - it must not disrupt a turn).
+/// </summary>
+public sealed class CarModeWarmupTests
+{
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public List<string> Paths { get; } = new();
+        public Func<HttpRequestMessage, HttpResponseMessage>? Responder;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            lock (Paths) Paths.Add(request.RequestUri!.AbsolutePath);
+            var resp = Responder?.Invoke(request) ?? new HttpResponseMessage(HttpStatusCode.OK);
+            return Task.FromResult(resp);
+        }
+    }
+
+    [Fact]
+    public async Task WarmAsync_WarmsBothModelAndTextToSpeech()
+    {
+        var handler = new RecordingHandler();
+        var warmup = new CarModeWarmup(
+            () => ("https://api.test/v1", "test-model", "dt_live_key"),
+            () => ("https://api.test/v1", "af_bella", "tts-model", "dt_live_key"),
+            new HttpClient(handler), _ => { });
+
+        await warmup.WarmAsync(CancellationToken.None);
+
+        Assert.Contains("/v1/chat/completions", handler.Paths);
+        Assert.Contains("/v1/audio/speech", handler.Paths);
+    }
+
+    [Fact]
+    public async Task WarmAsync_NoModelKey_SkipsModelLeg_ButStillWarmsTextToSpeech()
+    {
+        var handler = new RecordingHandler();
+        var warmup = new CarModeWarmup(
+            () => ("https://api.test/v1", "test-model", ""),          // no model key
+            () => ("https://api.test/v1", "af_bella", "tts-model", "dt_live_key"),
+            new HttpClient(handler), _ => { });
+
+        await warmup.WarmAsync(CancellationToken.None);
+
+        Assert.DoesNotContain("/v1/chat/completions", handler.Paths);
+        Assert.Contains("/v1/audio/speech", handler.Paths);
+    }
+
+    [Fact]
+    public async Task WarmAsync_NeverThrows_WhenUpstreamFails()
+    {
+        var handler = new RecordingHandler { Responder = _ => throw new HttpRequestException("upstream down") };
+        var warmup = new CarModeWarmup(
+            () => ("https://api.test/v1", "m", "k"),
+            () => ("https://api.test/v1", "v", "tm", "k"),
+            new HttpClient(handler), _ => { });
+
+        // Best-effort: a warmup failure must be swallowed, never thrown into the caller.
+        await warmup.WarmAsync(CancellationToken.None);
+    }
+}

--- a/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Configuration;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.CarMode;
 using CcDirector.Gateway.HostedAi;
@@ -30,8 +31,22 @@ namespace CcDirector.Gateway.Api;
 /// </summary>
 internal static class CarModeEndpoint
 {
-    public static void Map(IEndpointRouteBuilder app, CarModeBrain brain, CarModeTelemetryStore telemetry)
+    public static void Map(IEndpointRouteBuilder app, CarModeBrain brain, CarModeTelemetryStore telemetry, CarModeWarmup warmup)
     {
+        // Keep-warm (Car Mode performance round): the browser calls this the instant the owner taps Start,
+        // and every few minutes WHILE Car Mode is open, so the hosted model + text-to-speech are hot before
+        // the first utterance and stay hot for the drive. Gated on the keep-warm config (default ON for Car
+        // Mode); when off it is a cheap no-op. The warmup runs in the BACKGROUND on CancellationToken.None
+        // so the Start tap is never blocked and navigating away does not cancel the warm. Best-effort - a
+        // warmup failure never surfaces to the owner.
+        app.MapPost("/carmode/warmup", () =>
+        {
+            if (!CarModeKeepWarmConfig.Enabled())
+                return Results.Json(new { warmed = false, reason = "keep-warm disabled" });
+            _ = Task.Run(() => warmup.WarmAsync(CancellationToken.None));
+            return Results.Json(new { warmed = true });
+        });
+
         app.MapPost("/carmode/turn", async (HttpContext ctx, CarModeTurnRequest? req, CancellationToken ct) =>
         {
             FileLog.Write($"[CarModeEndpoint] turn: len={req?.Text?.Length ?? 0}");

--- a/src/CcDirector.Gateway/CarMode/CarModeWarmup.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeWarmup.cs
@@ -1,0 +1,115 @@
+using System.Diagnostics;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.CarMode;
+
+/// <summary>
+/// Keeps the Car Mode hosted model and text-to-speech provider WARM (Car Mode performance round). The
+/// measured cold-start swing was the dominant felt latency (~9s cold vs ~1.5s warm model; ~4.7s vs ~1.3s
+/// text-to-speech), so the browser fires a warmup the instant the owner taps Start and a small keep-warm
+/// ping every few minutes WHILE Car Mode is open; both land here. One tiny request to each provider spins
+/// its worker up so the REAL first turn a moment later reuses the hot worker.
+///
+/// Best-effort by design: a warmup is a courtesy, so any failure is logged and swallowed - it must NEVER
+/// disrupt a turn or throw into the endpoint. Overlapping warmups (Start plus a keep-warm tick) are
+/// collapsed with an in-flight guard so we never stampede the upstream. Credits are spent only while Car
+/// Mode is actively open (the endpoint gates on the keep-warm config), never 24/7.
+/// </summary>
+public sealed class CarModeWarmup
+{
+    private static readonly HttpClient SharedHttp = new() { Timeout = TimeSpan.FromSeconds(20) };
+
+    private readonly Func<(string BaseUrl, string Model, string Key)> _model;
+    private readonly Func<(string BaseUrl, string Voice, string Model, string Key)> _tts;
+    private readonly HttpClient _http;
+    private readonly Action<string> _log;
+
+    // 0 = idle, 1 = a warmup is in flight. Collapses an overlapping Start + keep-warm tick.
+    private int _inFlight;
+
+    public CarModeWarmup(
+        Func<(string BaseUrl, string Model, string Key)> modelResolver,
+        Func<(string BaseUrl, string Voice, string Model, string Key)> ttsResolver,
+        HttpClient? http = null,
+        Action<string>? log = null)
+    {
+        _model = modelResolver ?? throw new ArgumentNullException(nameof(modelResolver));
+        _tts = ttsResolver ?? throw new ArgumentNullException(nameof(ttsResolver));
+        _http = http ?? SharedHttp;
+        _log = log ?? FileLog.Write;
+    }
+
+    /// <summary>Warm the model and text-to-speech provider in parallel, once. A warmup already in flight is
+    ///  skipped (not queued). Never throws - both legs swallow and log their own failures.</summary>
+    public async Task WarmAsync(CancellationToken ct)
+    {
+        if (Interlocked.CompareExchange(ref _inFlight, 1, 0) != 0)
+        {
+            _log("[CarModeWarmup] skip: a warmup is already in flight");
+            return;
+        }
+        try
+        {
+            var sw = Stopwatch.StartNew();
+            await Task.WhenAll(WarmModelAsync(ct), WarmTtsAsync(ct));
+            _log($"[CarModeWarmup] warmed model + text-to-speech in {sw.ElapsedMilliseconds}ms");
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _inFlight, 0);
+        }
+    }
+
+    // A one-token chat completion so the hosted model worker spins up. Best-effort: logged and swallowed.
+    private async Task WarmModelAsync(CancellationToken ct)
+    {
+        try
+        {
+            var (baseUrl, model, key) = _model();
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                _log("[CarModeWarmup] model warm skipped: no key configured");
+                return;
+            }
+            var body = $"{{\"model\":{JsonSerializer.Serialize(model)},\"messages\":[{{\"role\":\"user\",\"content\":\"ping\"}}],\"max_tokens\":1,\"stream\":false}}";
+            var url = baseUrl.TrimEnd('/') + "/chat/completions";
+            using var req = new HttpRequestMessage(HttpMethod.Post, url);
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", key);
+            req.Content = new StringContent(body, Encoding.UTF8, "application/json");
+            using var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct);
+            _log($"[CarModeWarmup] model {model} -> {(int)resp.StatusCode}");
+        }
+        catch (Exception ex)
+        {
+            _log($"[CarModeWarmup] model warm failed (ignored): {ex.Message}");
+        }
+    }
+
+    // A tiny synthesis so the text-to-speech worker spins up. Best-effort: logged and swallowed.
+    private async Task WarmTtsAsync(CancellationToken ct)
+    {
+        try
+        {
+            var (baseUrl, voice, model, key) = _tts();
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                _log("[CarModeWarmup] text-to-speech warm skipped: no key configured");
+                return;
+            }
+            var payload = new { model, voice, input = "ok", response_format = "mp3" };
+            var url = baseUrl.TrimEnd('/') + "/audio/speech";
+            using var req = new HttpRequestMessage(HttpMethod.Post, url);
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", key);
+            req.Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+            using var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct);
+            _log($"[CarModeWarmup] text-to-speech {model}/{voice} -> {(int)resp.StatusCode}");
+        }
+        catch (Exception ex)
+        {
+            _log($"[CarModeWarmup] text-to-speech warm failed (ignored): {ex.Message}");
+        }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1187,7 +1187,18 @@ public sealed class GatewayHost : IAsyncDisposable
         var carModeChat = new CarMode.HostedCarModeChat(CarMode.HostedCarModeChat.DefaultResolver(_keyVault.Get));
         var carModeFleet = new CarMode.LoopbackCarModeFleet(Port, Token);
         var carModeBrain = new CarMode.CarModeBrain(carModeChat, carModeFleet, _carModeConversations, _carModePending);
-        Api.CarModeEndpoint.Map(_app, carModeBrain, _carModeTelemetry);
+        // Keep-warm (Car Mode performance round): warm the SAME hosted model the brain uses and the SAME
+        // text-to-speech target /wingman/tts uses, resolved fresh each warmup so a settings change applies.
+        var carModeWarmup = new CarMode.CarModeWarmup(
+            CarMode.HostedCarModeChat.DefaultResolver(_keyVault.Get),
+            () =>
+            {
+                var mode = Core.Configuration.TranscriptionModeConfig.Get();
+                var tts = Core.Configuration.TranscriptionEndpointResolver.ResolveTts(mode);
+                var key = _keyVault.Get(tts.KeyName) ?? "";
+                return (tts.BaseUrl, Core.Configuration.TtsVoiceConfig.Resolve(mode), Core.Configuration.TtsModelConfig.Resolve(mode), key);
+            });
+        Api.CarModeEndpoint.Map(_app, carModeBrain, _carModeTelemetry, carModeWarmup);
         // Editable/versioned wingman instructions settings surface (issue #537), incl. A/B test
         // over saved training sessions (reads the shared training store; uses the hosted wingman brain).
         WingmanInstructionsEndpoint.Map(_app, _instructionsStore, _trainingStore, WingmanBrainAsync);


### PR DESCRIPTION
Follow-up to #1371/#1373 (Architect direction). The telemetry proved **cold-start is the dominant felt latency**: the hosted model ran ~9s cold vs ~1.5s warm and text-to-speech ~4.7s cold vs ~1.3s warm - roughly eleven seconds of cold-start swing, which is the slowness the owner felt. So pay it before the drive, not during it.

- **Warm-on-entry**: the browser fires `POST /carmode/warmup` the instant the owner taps Start, so the model + text-to-speech are hot by the time the first utterance is transcribed.
- **Keep-warm-while-open**: a small ping every 3 minutes, only WHILE Car Mode is open (cleared on End Car Mode and unmount) - credits spent only during active use, never 24/7.
- `CarModeWarmup` fires one tiny request to the SAME hosted model the brain uses and the SAME text-to-speech target `/wingman/tts` uses, in parallel, with an in-flight guard so an overlapping Start + tick never stampedes the upstream. Best-effort: a warmup failure is logged and swallowed.
- `CarModeKeepWarmConfig` gates it, **default ON** for Car Mode (owner prioritizes speed; credits not a constraint, spent only while open). `CC_CARMODE_KEEPWARM` env / `car_mode_keep_warm` setting is the belt.

Note: keep-warm fixes cold-start; it does not fix the phone-network gap (visible separately on the dashboard's Network column).

Tests: warmup warms both providers, skips a leg with no key, never throws on upstream failure; client warmup ping best-effort. 66 Car Mode server tests + 366 client tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)