### PR TITLE
feat(stats): turns per hour (working day) log + chart

### DIFF
--- a/apps/cockpit/src/throttle/YourThrottleView.tsx
+++ b/apps/cockpit/src/throttle/YourThrottleView.tsx
@@ -9,6 +9,7 @@ import {
   type ThrottleData,
   type ThrottleSummary,
   type ConcurrencyHour,
+  type InputHour,
 } from "@devthrottle/client-core/stats/statsClient";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 
@@ -63,6 +64,47 @@ function ConcurrencyChart({ hourly }: { hourly: ConcurrencyHour[] }) {
         );
       })}
     </div>
+  );
+}
+
+/** A 24-hour bar chart of turns submitted per hour - the "working day" shape. Each bar is the total turns
+ * that hour, stacked voice (accent) over typed (muted). Pure CSS bars, theme-aware. */
+function TurnsPerHourChart({ hourly }: { hourly: InputHour[] }) {
+  const recent = hourly.slice(-24);
+  const peak = Math.max(1, ...recent.map((h) => h.turns));
+  return (
+    <>
+      <div
+        className="thr-chart"
+        role="img"
+        aria-label={`Turns submitted per hour for the last ${recent.length} hours`}
+      >
+        {recent.map((h, i) => {
+          const totalPct = (h.turns / peak) * 100;
+          const voicePortion = h.turns > 0 ? (h.voiceTurns / h.turns) * 100 : 0;
+          const typedPortion = h.turns > 0 ? (h.typedTurns / h.turns) * 100 : 0;
+          return (
+            <div
+              className="thr-bar-col"
+              key={h.hour}
+              title={`${h.hour}:00 UTC - ${h.turns} turns (${h.voiceTurns} voice, ${h.typedTurns} typed), ${h.characters.toLocaleString()} chars`}
+            >
+              <div className="thr-bar-track">
+                <div className="thr-turns-bar" style={{ height: `${totalPct}%` }}>
+                  <div className="thr-turns-typed" style={{ height: `${typedPortion}%` }} />
+                  <div className="thr-turns-voice" style={{ height: `${voicePortion}%` }} />
+                </div>
+              </div>
+              <div className="thr-bar-label">{i % 4 === 0 ? h.hour.slice(-2) : ""}</div>
+            </div>
+          );
+        })}
+      </div>
+      <div className="thr-legend">
+        <span className="thr-legend-item"><span className="thr-swatch thr-swatch-voice" /> Voice</span>
+        <span className="thr-legend-item"><span className="thr-swatch thr-swatch-typed" /> Typed</span>
+      </div>
+    </>
   );
 }
 
@@ -164,6 +206,17 @@ export function YourThrottleView() {
             actively working. Hover a bar for that hour's distinct sessions and machines.
           </p>
           <ConcurrencyChart hourly={data.concurrency.hourly} />
+        </div>
+      )}
+
+      {data !== null && data.hourlyTurns.length > 0 && (
+        <div className="thr-section">
+          <h2>Turns per hour (last 24h)</h2>
+          <p className="thr-hint">
+            Your working day: how many turns you submitted each hour (UTC), voice over typed. Empty hours
+            are when you were away.
+          </p>
+          <TurnsPerHourChart hourly={data.hourlyTurns} />
         </div>
       )}
 

--- a/apps/cockpit/src/throttle/throttle.css
+++ b/apps/cockpit/src/throttle/throttle.css
@@ -162,6 +162,49 @@
   font-variant-numeric: tabular-nums;
 }
 
+/* Turns-per-hour stacked bar (voice over typed) */
+.thr-turns-bar {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  border-radius: 3px 3px 0 0;
+  overflow: hidden;
+  min-height: 1px;
+}
+.thr-turns-voice {
+  width: 100%;
+  background: var(--accent);
+}
+.thr-turns-typed {
+  width: 100%;
+  background: color-mix(in srgb, var(--text-dim) 55%, transparent);
+}
+.thr-legend {
+  display: flex;
+  gap: 16px;
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--text-dim);
+}
+.thr-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.thr-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  display: inline-block;
+}
+.thr-swatch-voice {
+  background: var(--accent);
+}
+.thr-swatch-typed {
+  background: color-mix(in srgb, var(--text-dim) 55%, transparent);
+}
+
 /* Honesty caveats */
 .thr-caveats {
   background: var(--surface-2);

--- a/apps/mobile/src/pages/YourThrottle.tsx
+++ b/apps/mobile/src/pages/YourThrottle.tsx
@@ -10,6 +10,7 @@ import {
   type ThrottleData,
   type ThrottleSummary,
   type ConcurrencyHour,
+  type InputHour,
 } from "@devthrottle/client-core/stats/statsClient";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 
@@ -51,6 +52,47 @@ function ConcurrencyChart({ hourly }: { hourly: ConcurrencyHour[] }) {
         );
       })}
     </div>
+  );
+}
+
+/** A 24-hour bar chart of turns submitted per hour - the "working day" shape. Bar = total turns that
+ * hour, stacked voice (accent) over typed (muted). Pure CSS bars, theme-aware. */
+function TurnsPerHourChart({ hourly }: { hourly: InputHour[] }) {
+  const recent = hourly.slice(-24);
+  const peak = Math.max(1, ...recent.map((h) => h.turns));
+  return (
+    <>
+      <div
+        className="thr-chart"
+        role="img"
+        aria-label={`Turns submitted per hour for the last ${recent.length} hours`}
+      >
+        {recent.map((h, i) => {
+          const totalPct = (h.turns / peak) * 100;
+          const voicePortion = h.turns > 0 ? (h.voiceTurns / h.turns) * 100 : 0;
+          const typedPortion = h.turns > 0 ? (h.typedTurns / h.turns) * 100 : 0;
+          return (
+            <div
+              className="thr-bar-col"
+              key={h.hour}
+              title={`${h.hour}:00 UTC - ${h.turns} turns (${h.voiceTurns} voice, ${h.typedTurns} typed)`}
+            >
+              <div className="thr-bar-track">
+                <div className="thr-turns-bar" style={{ height: `${totalPct}%` }}>
+                  <div className="thr-turns-typed" style={{ height: `${typedPortion}%` }} />
+                  <div className="thr-turns-voice" style={{ height: `${voicePortion}%` }} />
+                </div>
+              </div>
+              <div className="thr-bar-label">{i % 6 === 0 ? h.hour.slice(-2) : ""}</div>
+            </div>
+          );
+        })}
+      </div>
+      <div className="thr-legend">
+        <span className="thr-legend-item"><span className="thr-swatch thr-swatch-voice" /> Voice</span>
+        <span className="thr-legend-item"><span className="thr-swatch thr-swatch-typed" /> Typed</span>
+      </div>
+    </>
   );
 }
 
@@ -130,6 +172,13 @@ export function YourThrottle() {
         <section className="thr-list" aria-label="Sessions per hour">
           <div className="thr-list-title">Sessions per hour (last 24h)</div>
           <ConcurrencyChart hourly={data.concurrency.hourly} />
+        </section>
+      )}
+
+      {data !== null && data.hourlyTurns.length > 0 && (
+        <section className="thr-list" aria-label="Turns per hour">
+          <div className="thr-list-title">Turns per hour (last 24h)</div>
+          <TurnsPerHourChart hourly={data.hourlyTurns} />
         </section>
       )}
 

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -2892,3 +2892,44 @@ a.banner-btn {
   height: 11px;
   font-variant-numeric: tabular-nums;
 }
+.thr-turns-bar {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  border-radius: 2px 2px 0 0;
+  overflow: hidden;
+  min-height: 1px;
+}
+.thr-turns-voice {
+  width: 100%;
+  background: var(--accent);
+}
+.thr-turns-typed {
+  width: 100%;
+  background: color-mix(in srgb, var(--text-dim) 55%, transparent);
+}
+.thr-legend {
+  display: flex;
+  gap: 16px;
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--text-dim);
+}
+.thr-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.thr-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  display: inline-block;
+}
+.thr-swatch-voice {
+  background: var(--accent);
+}
+.thr-swatch-typed {
+  background: color-mix(in srgb, var(--text-dim) 55%, transparent);
+}

--- a/packages/client-core/src/stats/statsClient.test.ts
+++ b/packages/client-core/src/stats/statsClient.test.ts
@@ -5,7 +5,7 @@ import { summarizeThrottle, formatShare, type ThrottleData } from "./statsClient
 // exercised through the app; here we lock the honest share arithmetic that both shells render.
 
 function data(buckets: ThrottleData["buckets"]): ThrottleData {
-  return { generatedAtUtc: "2026-07-11T00:00:00Z", buckets, concurrency: null, notCaptured: [] };
+  return { generatedAtUtc: "2026-07-11T00:00:00Z", buckets, hourlyTurns: [], concurrency: null, notCaptured: [] };
 }
 
 describe("summarizeThrottle", () => {

--- a/packages/client-core/src/stats/statsClient.ts
+++ b/packages/client-core/src/stats/statsClient.ts
@@ -57,11 +57,23 @@ export interface ConcurrencyStats {
   hourly: ConcurrencyHour[];
 }
 
+/** One hour of the "working day" log: turns (total + by modality) and characters submitted that UTC hour
+ * (hour key "yyyy-MM-ddTHH"). */
+export interface InputHour {
+  hour: string;
+  turns: number;
+  voiceTurns: number;
+  typedTurns: number;
+  characters: number;
+}
+
 /** The GET /stats/data body: the fleet-wide aggregated tally plus the honesty caveats. */
 export interface ThrottleData {
   /** When the Gateway generated this snapshot (ISO 8601 UTC), or "" when absent. */
   generatedAtUtc: string;
   buckets: ThrottleBucket[];
+  /** Turns per UTC hour (the "working day" series), oldest hour first. */
+  hourlyTurns: InputHour[];
   /** Fleet concurrency (both series), or null when nothing tracked yet. */
   concurrency: ConcurrencyStats | null;
   /** Plain-English caveats about what the numbers do and do not include. */
@@ -131,18 +143,32 @@ export async function getThrottle(signal?: AbortSignal): Promise<ThrottleData> {
   const body = (await res.json()) as {
     generatedAtUtc?: unknown;
     buckets?: unknown;
+    hourlyTurns?: unknown;
     concurrency?: unknown;
     notCaptured?: unknown;
   } | null;
   const buckets = Array.isArray(body?.buckets) ? body!.buckets.map(normalizeBucket) : [];
+  const hourlyTurns = Array.isArray(body?.hourlyTurns) ? body!.hourlyTurns.map(normalizeInputHour) : [];
   const notCaptured = Array.isArray(body?.notCaptured)
     ? body!.notCaptured.filter((x): x is string => typeof x === "string")
     : [];
   return {
     generatedAtUtc: typeof body?.generatedAtUtc === "string" ? body.generatedAtUtc : "",
     buckets,
+    hourlyTurns,
     concurrency: normalizeConcurrency(body?.concurrency),
     notCaptured,
+  };
+}
+
+function normalizeInputHour(raw: unknown): InputHour {
+  const h = (raw ?? {}) as Partial<Record<keyof InputHour, unknown>>;
+  return {
+    hour: String(h.hour ?? ""),
+    turns: num(h.turns),
+    voiceTurns: num(h.voiceTurns),
+    typedTurns: num(h.typedTurns),
+    characters: num(h.characters),
   };
 }
 

--- a/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
@@ -125,4 +125,48 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
         Assert.Equal(4, Turns(agg2.CurrentTotals(), "voice", "phone"));
         Assert.Equal(160, Chars(agg2.CurrentTotals(), "voice", "phone"));
     }
+
+    private static readonly DateTime H17 = new(2026, 7, 11, 17, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime H18 = new(2026, 7, 11, 18, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void HourlyTurns_LogsTurnDeltasByHourAndModality()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        // Hour 17: 3 voice/phone turns and 1 typed/desktop turn arrive.
+        agg.Observe(Session("s1", ("voice", "phone", 3, 300)), H17);
+        agg.Observe(Session("s2", ("typed", "desktop", 1, 50)), H17);
+        // Hour 18: s1 grows by 2 more voice turns (5 total) - only the +2 delta lands in hour 18.
+        agg.Observe(Session("s1", ("voice", "phone", 5, 500)), H18);
+
+        var hours = agg.HourlyTurns();
+        Assert.Equal(2, hours.Count);
+
+        var h17 = hours.First(h => h.Hour == "2026-07-11T17");
+        Assert.Equal(4, h17.Turns);       // 3 voice + 1 typed
+        Assert.Equal(3, h17.VoiceTurns);
+        Assert.Equal(1, h17.TypedTurns);
+        Assert.Equal(350, h17.Characters);
+
+        var h18 = hours.First(h => h.Hour == "2026-07-11T18");
+        Assert.Equal(2, h18.Turns);       // only the +2 voice delta
+        Assert.Equal(2, h18.VoiceTurns);
+        Assert.Equal(0, h18.TypedTurns);
+        Assert.Equal(200, h18.Characters);
+    }
+
+    [Fact]
+    public void HourlyTurns_SurviveRestart()
+    {
+        var a = new GatewayInputStatsAggregator(_path);
+        a.Observe(Session("s1", ("voice", "phone", 3, 300)), H17);
+
+        var b = new GatewayInputStatsAggregator(_path); // reload from disk
+        var hours = b.HourlyTurns();
+        Assert.Single(hours);
+        Assert.Equal("2026-07-11T17", hours[0].Hour);
+        Assert.Equal(3, hours[0].VoiceTurns);
+        Assert.Equal(300, hours[0].Characters);
+    }
 }

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -725,7 +725,7 @@ internal static class GatewayEndpoints
             // fold only runs when stream mode is on, which it is not in production). The aggregator's
             // per-session high-water logic makes folding the full roster on every read idempotent - only a
             // genuine increase is added, so repeated /sessions polls never double-count.
-            inputStats?.ObserveSnapshot(all);
+            inputStats?.ObserveSnapshot(all, DateTime.UtcNow);
 
             // DevThrottle Stats: record fleet concurrency and the hourly activity log from the same
             // assembled roster - max concurrent loaded/running (live) and actively working, plus how many

--- a/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
+++ b/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
@@ -34,6 +34,20 @@ public sealed class GatewayInputStatsAggregator
     // Per-live-session last-seen counts, so only the INCREASE is folded into the totals.
     private readonly Dictionary<string, Dictionary<(string Modality, string Surface), Counters>> _highWater = new();
 
+    // Per UTC clock hour: the turns (by modality) and characters SUBMITTED in that hour - the "working day"
+    // series. Accumulated from the same high-water deltas as the totals, attributed to the hour the delta
+    // was observed. Pruned past the retention window so the store stays bounded.
+    private const string HourFormat = "yyyy-MM-ddTHH";
+    private const int RetentionDays = 90;
+    private readonly Dictionary<string, HourTurns> _hourly = new(StringComparer.Ordinal);
+
+    private sealed class HourTurns
+    {
+        public long VoiceTurns;
+        public long TypedTurns;
+        public long Characters;
+    }
+
     private sealed class Counters
     {
         public long Turns { get; set; }
@@ -50,26 +64,30 @@ public sealed class GatewayInputStatsAggregator
         Load();
     }
 
-    /// <summary>Fold every session in a full snapshot into the totals.</summary>
-    public void ObserveSnapshot(IEnumerable<SessionDto>? sessions)
+    /// <summary>Fold every session in a full snapshot into the totals and the per-hour turn log.</summary>
+    public void ObserveSnapshot(IEnumerable<SessionDto>? sessions, DateTime? nowUtc = null)
     {
         if (sessions is null) return;
+        var now = nowUtc ?? DateTime.UtcNow;
+        var hourKey = HourKey(now);
         lock (_lock)
         {
             var changed = false;
             foreach (var s in sessions)
-                changed |= FoldLocked(s);
-            if (changed) Save();
+                changed |= FoldLocked(s, hourKey);
+            if (changed) { PruneLocked(now); Save(); }
         }
     }
 
-    /// <summary>Fold one session (a delta) into the totals.</summary>
-    public void Observe(SessionDto? session)
+    /// <summary>Fold one session (a delta) into the totals and the per-hour turn log.</summary>
+    public void Observe(SessionDto? session, DateTime? nowUtc = null)
     {
         if (session is null) return;
+        var now = nowUtc ?? DateTime.UtcNow;
+        var hourKey = HourKey(now);
         lock (_lock)
         {
-            if (FoldLocked(session)) Save();
+            if (FoldLocked(session, hourKey)) { PruneLocked(now); Save(); }
         }
     }
 
@@ -95,9 +113,45 @@ public sealed class GatewayInputStatsAggregator
         }
     }
 
-    // Fold one session's tally into the totals via the high-water increment. Returns true when the totals
-    // changed. Caller holds the lock.
-    private bool FoldLocked(SessionDto s)
+    /// <summary>The per-hour turn log (the "working day" series: turns by modality and character volume per
+    /// UTC clock hour), oldest hour first.</summary>
+    public IReadOnlyList<InputHourDto> HourlyTurns()
+    {
+        lock (_lock)
+        {
+            var list = new List<InputHourDto>(_hourly.Count);
+            foreach (var kvp in _hourly)
+                list.Add(new InputHourDto
+                {
+                    Hour = kvp.Key,
+                    VoiceTurns = kvp.Value.VoiceTurns,
+                    TypedTurns = kvp.Value.TypedTurns,
+                    Turns = kvp.Value.VoiceTurns + kvp.Value.TypedTurns,
+                    Characters = kvp.Value.Characters,
+                });
+            list.Sort((a, b) => string.CompareOrdinal(a.Hour, b.Hour));
+            return list;
+        }
+    }
+
+    private static string HourKey(DateTime utc) =>
+        utc.ToUniversalTime().ToString(HourFormat, System.Globalization.CultureInfo.InvariantCulture);
+
+    private static bool TryParseHour(string key, out DateTime utc) =>
+        DateTime.TryParseExact(key, HourFormat, System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal, out utc);
+
+    private void PruneLocked(DateTime nowUtc)
+    {
+        var cutoff = nowUtc.AddDays(-RetentionDays);
+        var stale = _hourly.Keys.Where(k => TryParseHour(k, out var dt) && dt < cutoff).ToList();
+        foreach (var k in stale) _hourly.Remove(k);
+    }
+
+    // Fold one session's tally into the totals via the high-water increment, attributing each increase to
+    // <paramref name="hourKey"/> in the per-hour turn log. Returns true when the totals changed. Caller
+    // holds the lock.
+    private bool FoldLocked(SessionDto s, string hourKey)
     {
         if (string.IsNullOrEmpty(s.SessionId) || s.InputStats?.Buckets is null || s.InputStats.Buckets.Count == 0)
             return false;
@@ -131,6 +185,21 @@ public sealed class GatewayInputStatsAggregator
                 }
                 total.Turns += deltaTurns;
                 total.Characters += deltaChars;
+
+                // Attribute this increase to the hour it was observed (the "working day" series). Turns are
+                // split by modality; characters are summed. Surface is not split here - the hourly log is
+                // about WHEN work happened, not from where.
+                if (!_hourly.TryGetValue(hourKey, out var hour))
+                {
+                    hour = new HourTurns();
+                    _hourly[hourKey] = hour;
+                }
+                if (string.Equals(key.Item1, "voice", StringComparison.OrdinalIgnoreCase))
+                    hour.VoiceTurns += deltaTurns;
+                else
+                    hour.TypedTurns += deltaTurns;
+                hour.Characters += deltaChars;
+
                 changed = true;
             }
 
@@ -159,6 +228,14 @@ public sealed class GatewayInputStatsAggregator
     {
         public List<InputStatBucketDto> Totals { get; set; } = new();
         public Dictionary<string, List<InputStatBucketDto>> HighWater { get; set; } = new();
+        public Dictionary<string, HourTurnsStore> Hourly { get; set; } = new();
+    }
+
+    private sealed class HourTurnsStore
+    {
+        public long VoiceTurns { get; set; }
+        public long TypedTurns { get; set; }
+        public long Characters { get; set; }
     }
 
     private void Load()
@@ -194,7 +271,9 @@ public sealed class GatewayInputStatsAggregator
                 hw[(b.Modality ?? "", b.Surface ?? "")] = new Counters { Turns = b.Turns, Characters = b.Characters };
             _highWater[sid] = hw;
         }
-        FileLog.Write($"[GatewayInputStatsAggregator] Load: restored {_totals.Count} total bucket(s), {_highWater.Count} live session(s) from {_path}");
+        foreach (var (hour, ht) in parsed.Hourly)
+            _hourly[hour] = new HourTurns { VoiceTurns = ht.VoiceTurns, TypedTurns = ht.TypedTurns, Characters = ht.Characters };
+        FileLog.Write($"[GatewayInputStatsAggregator] Load: restored {_totals.Count} total bucket(s), {_highWater.Count} live session(s), {_hourly.Count} hourly bucket(s) from {_path}");
     }
 
     private void Quarantine(string reason)
@@ -218,6 +297,8 @@ public sealed class GatewayInputStatsAggregator
             var file = new StoreFile { Totals = ToDtoLocked(_totals).Buckets };
             foreach (var (sid, hw) in _highWater)
                 file.HighWater[sid] = ToDtoLocked(hw).Buckets;
+            foreach (var (hour, ht) in _hourly)
+                file.Hourly[hour] = new HourTurnsStore { VoiceTurns = ht.VoiceTurns, TypedTurns = ht.TypedTurns, Characters = ht.Characters };
 
             var json = JsonSerializer.Serialize(file, FileJsonOptions);
             var tmp = _path + ".tmp";
@@ -230,4 +311,15 @@ public sealed class GatewayInputStatsAggregator
             throw;
         }
     }
+}
+
+/// <summary>One hour of the input "working day" log: the turns (total and by modality) and character
+/// volume submitted in that UTC clock hour ("yyyy-MM-ddTHH").</summary>
+public sealed class InputHourDto
+{
+    public string Hour { get; set; } = "";
+    public long Turns { get; set; }
+    public long VoiceTurns { get; set; }
+    public long TypedTurns { get; set; }
+    public long Characters { get; set; }
 }

--- a/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
+++ b/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
@@ -44,6 +44,8 @@ public static class StatsPageEndpoint
             {
                 generatedAtUtc = DateTime.UtcNow,
                 buckets = totals.Buckets,
+                // DevThrottle Stats: the "working day" series - turns (by modality) + characters per UTC hour.
+                hourlyTurns = aggregator.HourlyTurns(),
                 // DevThrottle Stats: fleet concurrency (both series: live loaded/running, and actively
                 // working). Null until the aggregator is wired (old callers / tests).
                 concurrency = concurrency?.Snapshot(DateTime.UtcNow),


### PR DESCRIPTION
## What

Adds a **turns-per-hour** log and a **"Turns per hour" chart** to "Your Throttle" - the shape of the working day (bars light up when you're working, empty overnight), split voice vs typed.

- `GatewayInputStatsAggregator` now attributes each high-water turn/character delta to the **UTC clock hour** it was observed, keeping a per-hour log of turns by modality (voice/typed) + characters. Same high-water fold as the all-time totals (no double-count), persisted alongside them, pruned at 90 days. `ObserveSnapshot`/`Observe` take an optional `nowUtc` (the roster fold passes it; defaults to now for other callers).
- `GET /stats/data` gains `hourlyTurns: [{hour, turns, voiceTurns, typedTurns, characters}]`.
- Cockpit + mobile "Your Throttle": a **"Turns per hour (last 24h)"** stacked bar chart (voice over typed) with a legend; hover a bar for that hour's split.

## Verification

- Gateway compiles clean; **`GatewayInputStatsAggregatorTests` (8) green** - incl. two new: per-hour delta attribution by modality, and hourly log survives a restart.
- client-core / cockpit / mobile typecheck clean; client-core stats tests green.
- Will be verified **live** after redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
