### PR TITLE
feat(mobile): Phase 2 - keep-and-mark unreachable machines on the roster (envelope)

### DIFF
--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
-import { listSessions, type SessionDto } from "@devthrottle/client-core/api/client";
+import { type SessionDto } from "@devthrottle/client-core/api/client";
+import { getSessionsEnvelope } from "@devthrottle/client-core/fleet/fleetClient";
+import { emptyRetentionCache, mergeRosterRetention, type RosterSessionMark } from "@devthrottle/client-core/fleet/rosterRetention";
 import { classify, contextLine, dotColor, effectiveColor, inBucket, inDesktopOrder, inWaitingOrder, isWorking, repoLeaf } from "@devthrottle/client-core/sessions/ordering";
 import { applyFilter, filterIsActive, filterSummary, machineName, pruneFilter } from "@devthrottle/client-core/sessions/filter";
 import { useDictationStatusFor } from "@devthrottle/client-core/dictation/status";
@@ -15,10 +17,19 @@ import { enablePush, notificationPermission, pushSupported, reconcileBadge } fro
 // sessions" group with everything that is NOT waiting on you - so a session appears in exactly one
 // group and is never listed twice. Both use the live Gateway /sessions data and the shared triage
 // ordering. Tapping a row opens the session-detail placeholder bound to that session id.
+//
+// The roster reads the /sessions ENVELOPE (per-Director reachability), not the flat list, and runs it
+// through the keep-and-mark merge (mobile-resilience mission, Phase 2): a session whose owning machine
+// is unreachable STAYS on the roster, grayed and marked, and leaves only when its Director answers
+// without it. The retention cache is held in a ref so it survives across polls (and navigating into a
+// session and back) without churning React state.
 const POLL_INTERVAL_MS = 5000;
 
 export function Home() {
   const [sessions, setSessions] = useState<SessionDto[] | null>(null);
+  // Per-session reachability marks from the merge - only unreachable (wobbly/offline) sessions have one.
+  const [marks, setMarks] = useState<Map<string, RosterSessionMark>>(() => new Map());
+  const retentionCache = useRef(emptyRetentionCache());
   const [error, setError] = useState<string | null>(null);
   // The roster filter (by machine and/or repo) and whether its full-screen panel is open. The filter
   // is persisted across navigations and restarts by the hook; the panel is transient UI state.
@@ -31,15 +42,21 @@ export function Home() {
 
   const load = useCallback(async (signal?: AbortSignal) => {
     try {
-      const data = await listSessions(signal);
-      setSessions(data);
+      const envelope = await getSessionsEnvelope(signal);
+      // Keep-and-mark: retained sessions of unreachable machines stay on the roster, marked; a session
+      // leaves only when its owning Director answered without it (mergeRosterRetention owns the rule).
+      const merged = mergeRosterRetention(retentionCache.current, envelope);
+      retentionCache.current = merged.cache;
+      setSessions(merged.roster.sessions);
+      setMarks(merged.roster.marks);
       setError(null);
-      // Keep the app-icon "needs you" dot in sync while the app is open: set the badge to the live
-      // count, or clear the badge and the service worker's dot notification when nothing is waiting.
-      void reconcileBadge(inBucket(data, "needsYou").length);
+      // The app-icon "needs you" dot and the voice-clip sync read the LIVE sessions only (never the
+      // retained-and-marked ones): the badge must reflect what genuinely needs you right now, and only a
+      // reachable session can have a phone-ready voice clip.
+      void reconcileBadge(inBucket(envelope.sessions, "needsYou").length);
       // Pull each gateway-ready voice session's clip down to the phone so the triangle can appear
       // (phone-ready, the issue #850 rule). Fire-and-forget; it updates the clip store as bytes land.
-      void syncVoiceSessions(data);
+      void syncVoiceSessions(envelope.sessions);
     } catch (err) {
       if (signal?.aborted) return;
       // Keep the last-known roster on screen (never clear good data on a bad connection). The global
@@ -169,7 +186,7 @@ export function Home() {
           <h2 className="group-title group-title-attention">Needs you</h2>
           <ul className="roster">
             {needsYou.map((s) => (
-              <SessionRow key={`needs-${s.sessionId}`} session={s} />
+              <SessionRow key={`needs-${s.sessionId}`} session={s} mark={marks.get(s.sessionId ?? "")} />
             ))}
           </ul>
         </section>
@@ -180,7 +197,7 @@ export function Home() {
           <h2 className="group-title">Other sessions</h2>
           <ul className="roster">
             {others.map((s) => (
-              <SessionRow key={s.sessionId} session={s} />
+              <SessionRow key={s.sessionId} session={s} mark={marks.get(s.sessionId ?? "")} />
             ))}
           </ul>
         </section>
@@ -229,12 +246,24 @@ function EnableAlerts() {
   );
 }
 
-function SessionRow({ session }: { session: SessionDto }) {
+// The plain-English note under an unreachable card, naming the machine and (when known) how long ago it
+// was last seen. Wobbly reads as a soft "reconnecting"; offline as a firm "unreachable" - both honest.
+function unreachableNote(mark: RosterSessionMark): string {
+  const machine = mark.machineName.length > 0 ? mark.machineName : "its machine";
+  const base = mark.reachability === "wobbly" ? `Reconnecting to ${machine}` : `Unreachable - ${machine}`;
+  return mark.lastSeenLabel.length > 0 ? `${base} - ${mark.lastSeenLabel}` : base;
+}
+
+function SessionRow({ session, mark }: { session: SessionDto; mark?: RosterSessionMark }) {
   const color = effectiveColor(session);
   const name = session.name && session.name.trim().length > 0 ? session.name : "(unnamed session)";
   const repo = repoLeaf(session);
   const machine = machineName(session);
-  const attention = classify(session) === "needsYou";
+  // An unreachable card (its owning machine is wobbly/offline, mobile-resilience Phase 2): grayed, its
+  // stale attention state and live waiting timer suppressed, and a note naming the machine. It KEEPS its
+  // last-known content and position - unreachable is shown, never deleted.
+  const unreachable = mark !== undefined;
+  const attention = classify(session) === "needsYou" && !unreachable;
   // Issue #844: the session's short three-digit number (SessionDto.Number, #820) read from the
   // regenerated typed client. Null on sessions/Directors without a number - then no prefix shows.
   const num = session.number;
@@ -244,11 +273,11 @@ function SessionRow({ session }: { session: SessionDto }) {
   const sid = encodeURIComponent(session.sessionId ?? "");
   const to = session.voiceMode ? `/session/${sid}/voice` : `/session/${sid}`;
   return (
-    <li className={`row${attention ? " row-attention" : ""}`}>
+    <li className={`row${attention ? " row-attention" : ""}${unreachable ? " row-unreachable" : ""}`}>
       {/* Hand the known voice-mode state to the destination (issue #1015) so the Voice screen paints
           the right state on the first render instead of flashing OFF while its first poll resolves. */}
       <Link className="row-link" to={to} state={{ voiceMode: Boolean(session.voiceMode) }}>
-        <span className="dot" style={{ backgroundColor: dotColor(color) }} aria-hidden="true" />
+        <span className="dot" style={{ backgroundColor: dotColor(unreachable ? "grey" : color) }} aria-hidden="true" />
         <span className="row-body">
           {/* The name uses the full card width and WRAPS (no truncation) - issue #838. A muted
               three-digit number prefix sits before the bold name, matching the desktop SessionRail
@@ -273,6 +302,10 @@ function SessionRow({ session }: { session: SessionDto }) {
               {repo && <span className="row-chip row-chip-repo">{repo}</span>}
             </span>
           )}
+          {/* Mobile-resilience Phase 2: when the owning machine is unreachable, a short plain note says so
+              and names the machine - the card is kept and grayed, never dropped, so the reader knows this
+              is stale-but-preserved, not gone. */}
+          {mark && <span className="row-unreachable-note">{unreachableNote(mark)}</span>}
           {/* A dictation started on this session's screen keeps showing here once the user walks back
               to the roster (#1139): in-flight while it uploads/transcribes, a sticky red pill if it
               failed - so a dropped transcription is visible from the list, never silent. */}

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -239,6 +239,25 @@ a.banner-btn {
   border-color: rgba(241, 76, 76, 0.55);
 }
 
+/* Mobile-resilience Phase 2: a card whose owning machine is unreachable. It is KEPT and shown, just
+   dimmed and desaturated, so the reader sees it is stale-but-preserved (never deleted). A dashed border
+   distinguishes it from a live card at a glance without shouting. */
+.row-unreachable {
+  opacity: 0.72;
+  border-style: dashed;
+  border-color: rgba(148, 163, 184, 0.5);
+}
+
+/* The plain-English "Unreachable - MACHINE - last seen N ago" / "Reconnecting to MACHINE" note under an
+   unreachable card. Muted amber-gray: a warning, not an error - the data underneath is still good. */
+.row-unreachable-note {
+  display: block;
+  margin-top: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #cbb892;
+}
+
 /* Issue #838: the dot is top-aligned at the start of the FIRST name line (align-items:
    flex-start) so a name that wraps to several lines keeps the dot beside its first line. */
 .row-link {

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -232,8 +232,10 @@ function isGatewayUnreachable(err: unknown): boolean {
 // answered status - including 4xx/500 application errors - reports REACHABLE (the Gateway answered). A
 // bare fetch rejection (the backend is down) reports UNREACHABLE. A caller-initiated abort is not a
 // connection signal, so it is rethrown without any report. This mirrors the issue #1028 classification
-// used by isGatewayUnreachable; it does not invent a second taxonomy.
-async function gatewayFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+// used by isGatewayUnreachable; it does not invent a second taxonomy. Exported so the fleet client
+// (fleetClient.ts) routes its reads - including the roster envelope the mobile app now polls - through
+// the SAME choke point, keeping the connection-health signal fed no matter which reader is on screen.
+export async function gatewayFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
   let res: Response;
   try {
     res = await fetch(input, init);

--- a/packages/client-core/src/fleet/fleetClient.ts
+++ b/packages/client-core/src/fleet/fleetClient.ts
@@ -7,7 +7,7 @@
 // Gateway-only-ingress rule the rest of client-core obeys, and carries the same Bearer via
 // authHeaders(). A non-2xx throws GatewayError so the caller surfaces the real reason instead of a
 // silently empty list (no fallback that hides the problem).
-import { authHeaders, GatewayError, type SessionDto } from "../api/client";
+import { authHeaders, gatewayFetch, GatewayError, type SessionDto } from "../api/client";
 
 // ===== Directors registry (GET /directors) =====
 
@@ -52,7 +52,7 @@ export const ENDPOINT_STATE_UNREACHABLE_BY_NAME = "unreachable-by-name";
 // GET /directors - the machines registered with this Gateway, as the FULL DirectorDto. Throws
 // GatewayError on non-2xx so the Directors page shows the real reason instead of an empty table.
 export async function getFleetDirectors(signal?: AbortSignal): Promise<FleetDirector[]> {
-  const res = await fetch("/directors", {
+  const res = await gatewayFetch("/directors", {
     method: "GET",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -120,7 +120,7 @@ export interface SessionsEnvelope {
 // reachability. Throws GatewayError on non-2xx so the page surfaces the failure rather than showing a
 // silently empty roster.
 export async function getSessionsEnvelope(signal?: AbortSignal): Promise<SessionsEnvelope> {
-  const res = await fetch("/sessions?envelope=true", {
+  const res = await gatewayFetch("/sessions?envelope=true", {
     method: "GET",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -161,7 +161,7 @@ export function reachabilityLastSeen(ageSeconds: number | null | undefined): str
 // the Gateway trims and echoes the applied name.
 export async function renameSession(sessionId: string, name: string, signal?: AbortSignal): Promise<SessionDto> {
   const sid = encodeURIComponent(sessionId);
-  const res = await fetch(`/sessions/${sid}`, {
+  const res = await gatewayFetch(`/sessions/${sid}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
     body: JSON.stringify({ name }),
@@ -211,7 +211,7 @@ export interface RestoreInterruptedResult {
 // GET /interrupted - every interrupted session across the fleet, newest death first. Throws
 // GatewayError on non-2xx.
 export async function getInterrupted(signal?: AbortSignal): Promise<InterruptedSession[]> {
-  const res = await fetch("/interrupted", {
+  const res = await gatewayFetch("/interrupted", {
     method: "GET",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -235,7 +235,7 @@ export async function dismissInterruptedJournal(
 ): Promise<void> {
   const dir = encodeURIComponent(deadDirectorId);
   const via = encodeURIComponent(reportedByDirectorId);
-  const res = await fetch(`/interrupted/${dir}/${deadPid}?via=${via}`, {
+  const res = await gatewayFetch(`/interrupted/${dir}/${deadPid}?via=${via}`, {
     method: "DELETE",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -257,7 +257,7 @@ export async function dismissInterruptedSession(
   const dir = encodeURIComponent(deadDirectorId);
   const sid = encodeURIComponent(sessionId);
   const via = encodeURIComponent(reportedByDirectorId);
-  const res = await fetch(`/interrupted/${dir}/${deadPid}/sessions/${sid}?via=${via}`, {
+  const res = await gatewayFetch(`/interrupted/${dir}/${deadPid}/sessions/${sid}?via=${via}`, {
     method: "DELETE",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -278,7 +278,7 @@ export async function restoreInterrupted(
   signal?: AbortSignal,
 ): Promise<RestoreInterruptedResult> {
   const dir = encodeURIComponent(deadDirectorId);
-  const res = await fetch(`/interrupted/${dir}/${deadPid}/restore`, {
+  const res = await gatewayFetch(`/interrupted/${dir}/${deadPid}/restore`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
     body: JSON.stringify({ sessionId, via: reportedByDirectorId }),
@@ -305,7 +305,7 @@ export async function restoreInterrupted(
 // GET /directors/{id}/settings - the Director's current settings as the raw JSON text it emits.
 export async function getDirectorSettings(directorId: string, signal?: AbortSignal): Promise<string> {
   const id = encodeURIComponent(directorId);
-  const res = await fetch(`/directors/${id}/settings`, {
+  const res = await gatewayFetch(`/directors/${id}/settings`, {
     method: "GET",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
@@ -321,7 +321,7 @@ export async function getDirectorSettings(directorId: string, signal?: AbortSign
 // never reaches the wire.
 export async function putDirectorSettings(directorId: string, json: string, signal?: AbortSignal): Promise<void> {
   const id = encodeURIComponent(directorId);
-  const res = await fetch(`/directors/${id}/settings`, {
+  const res = await gatewayFetch(`/directors/${id}/settings`, {
     method: "PUT",
     headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
     body: json,

--- a/packages/client-core/src/fleet/rosterRetention.test.ts
+++ b/packages/client-core/src/fleet/rosterRetention.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import type { SessionDto } from "../api/client";
+import {
+  REACHABILITY_OFFLINE,
+  REACHABILITY_ONLINE,
+  REACHABILITY_WOBBLY,
+  type DirectorReachability,
+  type SessionsEnvelope,
+} from "./fleetClient";
+import { emptyRetentionCache, mergeRosterRetention, type RetentionCache } from "./rosterRetention";
+
+// Minimal SessionDto fixtures: the merge only routes sessions by id/director/machine, so the triage and
+// color fields the ordering helpers need are irrelevant here.
+function session(sessionId: string, directorId: string, machineName = "MACHINE_A"): SessionDto {
+  return { sessionId, directorId, machineName } as unknown as SessionDto;
+}
+
+function director(directorId: string, state: DirectorReachability["state"], extra: Partial<DirectorReachability> = {}): DirectorReachability {
+  return { directorId, state, machineName: "MACHINE_A", ...extra };
+}
+
+function envelope(sessions: SessionDto[], directors: DirectorReachability[] = []): SessionsEnvelope {
+  return { sessions, machineErrors: [], directors };
+}
+
+describe("roster keep-and-mark retention merge", () => {
+  it("renders live sessions of an online Director normally, with no mark", () => {
+    const cache = emptyRetentionCache();
+    const env = envelope([session("s1", "d1"), session("s2", "d1")], [director("d1", REACHABILITY_ONLINE)]);
+    const { roster } = mergeRosterRetention(cache, env);
+    expect(roster.sessions.map((s) => s.sessionId)).toEqual(["s1", "s2"]);
+    expect(roster.marks.size).toBe(0);
+  });
+
+  it("treats a Director with live sessions and NO reachability entry as online (older Gateway)", () => {
+    const { roster, cache } = mergeRosterRetention(emptyRetentionCache(), envelope([session("s1", "d1")], []));
+    expect(roster.sessions.map((s) => s.sessionId)).toEqual(["s1"]);
+    expect(roster.marks.size).toBe(0);
+    expect(cache.byDirector.get("d1")?.map((s) => s.sessionId)).toEqual(["s1"]);
+  });
+
+  it("keeps a wobbly Director's served sessions on the roster, marked wobbly", () => {
+    const env = envelope([session("s1", "d1")], [director("d1", REACHABILITY_WOBBLY, { lastSeenAgeSeconds: 12 })]);
+    const { roster } = mergeRosterRetention(emptyRetentionCache(), env);
+    expect(roster.sessions.map((s) => s.sessionId)).toEqual(["s1"]);
+    const mark = roster.marks.get("s1");
+    expect(mark?.reachability).toBe(REACHABILITY_WOBBLY);
+    expect(mark?.machineName).toBe("MACHINE_A");
+    expect(mark?.lastSeenLabel).toBe("last seen 12s ago");
+  });
+
+  it("keeps an offline Director's sessions from the cache after the Gateway drops them, marked offline", () => {
+    // First poll: d1 online with s1 - cached.
+    const first = mergeRosterRetention(emptyRetentionCache(), envelope([session("s1", "d1")], [director("d1", REACHABILITY_ONLINE)]));
+    // Second poll: d1 offline, its session dropped from the envelope's sessions[] (only a directors entry).
+    const second = mergeRosterRetention(first.cache, envelope([], [director("d1", REACHABILITY_OFFLINE, { lastSeenAgeSeconds: 130 })]));
+    expect(second.roster.sessions.map((s) => s.sessionId)).toEqual(["s1"]);
+    const mark = second.roster.marks.get("s1");
+    expect(mark?.reachability).toBe(REACHABILITY_OFFLINE);
+    expect(mark?.lastSeenLabel).toBe("last seen 2m ago");
+  });
+
+  it("keeps sessions even after the Gateway forgets the Director entirely (no entry, no live sessions)", () => {
+    const first = mergeRosterRetention(emptyRetentionCache(), envelope([session("s1", "d1")], [director("d1", REACHABILITY_ONLINE)]));
+    // The Gateway has forgotten d1 completely: not in sessions[], not in directors[].
+    const second = mergeRosterRetention(first.cache, envelope([], []));
+    expect(second.roster.sessions.map((s) => s.sessionId)).toEqual(["s1"]);
+    expect(second.roster.marks.get("s1")?.reachability).toBe(REACHABILITY_OFFLINE);
+    // The card is retained indefinitely - the cache still holds it.
+    expect(second.cache.byDirector.get("d1")?.map((s) => s.sessionId)).toEqual(["s1"]);
+  });
+
+  it("removes a session only on an authoritative online answer, never while unreachable", () => {
+    // Poll 1: d1 online with s1 and s2.
+    let cache: RetentionCache = emptyRetentionCache();
+    cache = mergeRosterRetention(cache, envelope([session("s1", "d1"), session("s2", "d1")], [director("d1", REACHABILITY_ONLINE)])).cache;
+    // Poll 2: d1 goes offline - both sessions retained (no authority to remove).
+    const offline = mergeRosterRetention(cache, envelope([], [director("d1", REACHABILITY_OFFLINE)]));
+    expect(offline.roster.sessions.map((s) => s.sessionId).sort()).toEqual(["s1", "s2"]);
+    // Poll 3: d1 answers online but now only reports s1 - s2 was genuinely killed, so it drops.
+    const back = mergeRosterRetention(offline.cache, envelope([session("s1", "d1")], [director("d1", REACHABILITY_ONLINE)]));
+    expect(back.roster.sessions.map((s) => s.sessionId)).toEqual(["s1"]);
+    expect(back.roster.marks.size).toBe(0);
+    expect(back.cache.byDirector.get("d1")?.map((s) => s.sessionId)).toEqual(["s1"]);
+  });
+
+  it("replaces retained cards in place when the machine comes back online", () => {
+    const first = mergeRosterRetention(emptyRetentionCache(), envelope([session("s1", "d1")], [director("d1", REACHABILITY_ONLINE)]));
+    const offline = mergeRosterRetention(first.cache, envelope([], [director("d1", REACHABILITY_OFFLINE)]));
+    expect(offline.roster.marks.get("s1")?.reachability).toBe(REACHABILITY_OFFLINE);
+    const online = mergeRosterRetention(offline.cache, envelope([session("s1", "d1")], [director("d1", REACHABILITY_ONLINE)]));
+    expect(online.roster.sessions.map((s) => s.sessionId)).toEqual(["s1"]);
+    expect(online.roster.marks.size).toBe(0);
+  });
+
+  it("never retains a session with no owning Director id (live-only)", () => {
+    const first = mergeRosterRetention(emptyRetentionCache(), envelope([session("s1", "")], []));
+    expect(first.roster.sessions.map((s) => s.sessionId)).toEqual(["s1"]);
+    expect(first.cache.byDirector.has("")).toBe(false);
+    // Next poll with no sessions: the no-director session is simply gone (not retained).
+    const second = mergeRosterRetention(first.cache, envelope([], []));
+    expect(second.roster.sessions).toHaveLength(0);
+  });
+
+  it("keeps a reachable Director's sessions while a DIFFERENT machine is offline", () => {
+    const first = mergeRosterRetention(
+      emptyRetentionCache(),
+      envelope(
+        [session("s1", "d1", "MACHINE_A"), session("s2", "d2", "MACHINE_B")],
+        [director("d1", REACHABILITY_ONLINE), director("d2", REACHABILITY_ONLINE)],
+      ),
+    );
+    // d2 goes offline; d1 stays online with a fresh session s3.
+    const second = mergeRosterRetention(
+      first.cache,
+      envelope(
+        [session("s1", "d1", "MACHINE_A"), session("s3", "d1", "MACHINE_A")],
+        [director("d1", REACHABILITY_ONLINE), director("d2", REACHABILITY_OFFLINE, { machineName: "MACHINE_B" })],
+      ),
+    );
+    const ids = second.roster.sessions.map((s) => s.sessionId).sort();
+    expect(ids).toEqual(["s1", "s2", "s3"]);
+    expect(second.roster.marks.get("s2")?.reachability).toBe(REACHABILITY_OFFLINE);
+    expect(second.roster.marks.get("s2")?.machineName).toBe("MACHINE_B");
+    expect(second.roster.marks.has("s1")).toBe(false);
+    expect(second.roster.marks.has("s3")).toBe(false);
+  });
+
+  it("is idempotent: applying the same envelope twice yields the same cache and roster", () => {
+    const env = envelope([session("s1", "d1")], [director("d1", REACHABILITY_WOBBLY, { lastSeenAgeSeconds: 5 })]);
+    const once = mergeRosterRetention(emptyRetentionCache(), env);
+    const twice = mergeRosterRetention(once.cache, env);
+    expect(twice.roster.sessions.map((s) => s.sessionId)).toEqual(once.roster.sessions.map((s) => s.sessionId));
+    expect([...twice.cache.byDirector.keys()]).toEqual([...once.cache.byDirector.keys()]);
+    expect(twice.cache.byDirector.get("d1")?.map((s) => s.sessionId)).toEqual(["s1"]);
+  });
+
+  it("does not mutate the previous cache (pure merge)", () => {
+    const first = mergeRosterRetention(emptyRetentionCache(), envelope([session("s1", "d1")], [director("d1", REACHABILITY_ONLINE)]));
+    const snapshot = [...(first.cache.byDirector.get("d1") ?? [])];
+    // A later online answer that drops s1 must not retroactively change the earlier cache object.
+    mergeRosterRetention(first.cache, envelope([], [director("d1", REACHABILITY_ONLINE)]));
+    expect(first.cache.byDirector.get("d1")).toEqual(snapshot);
+  });
+});

--- a/packages/client-core/src/fleet/rosterRetention.ts
+++ b/packages/client-core/src/fleet/rosterRetention.ts
@@ -1,0 +1,169 @@
+// The roster keep-and-mark merge (mobile-resilience mission, Phase 2). The rule the owner asked for:
+// never let a session vanish from the roster just because its machine became unreachable - a session
+// leaves the list ONLY when its owning Director ANSWERED (is Online) and no longer reports it. When a
+// Director reads Wobbly or Offline, its last-known sessions STAY on the roster, marked unreachable, for
+// as long as the machine stays unreachable; when the machine answers again its live sessions replace
+// them in place. This generalizes the shipped voice rule (#1334): unreachable is a state you SHOW, not
+// data you DELETE.
+//
+// Why a client-side retention cache is needed on top of the Gateway envelope: the Gateway's
+// FleetRosterCache (#1215) serves a failing Director's last-known-good sessions for only a few poll
+// cycles (state "wobbly"), then declares it "offline" and DROPS its sessions from the envelope's
+// sessions[] - keeping only a per-Director "offline" entry in directors[]. So to keep showing those
+// cards past the grace window, this module retains the last-known sessions per Director and re-injects
+// them, marked, using the envelope's per-Director state as the honest signal. It invents no shrink
+// heuristic (decision 4): removal is driven only by an Online Director's authoritative answer.
+//
+// The merge is a PURE function - it takes the previous cache and the new envelope and returns a fresh
+// cache plus the display roster, mutating nothing - so the mobile page can hold the cache in a ref and
+// the whole rule is unit-testable (a StrictMode double-invoke is safe: applying the same envelope twice
+// yields the same cache).
+import type { SessionDto } from "../api/client";
+import {
+  reachabilityLastSeen,
+  REACHABILITY_OFFLINE,
+  REACHABILITY_ONLINE,
+  REACHABILITY_WOBBLY,
+  type DirectorReachability,
+  type ReachabilityState,
+  type SessionsEnvelope,
+} from "./fleetClient";
+
+// How one session should be rendered on the roster. "online" sessions render normally (no mark); a
+// "wobbly" or "offline" session is grayed and carries a short plain note naming the machine and, when
+// known, how long ago it was last seen.
+export type SessionReachability = ReachabilityState;
+
+export interface RosterSessionMark {
+  reachability: SessionReachability;
+  /** Best-effort machine name for the note (the Director's, else the session's own stamp). */
+  machineName: string;
+  /** "last seen Ns ago" style age, or "" when unknown. */
+  lastSeenLabel: string;
+}
+
+// The retention cache carried across polls by the caller (held in a ref). The last-known session list
+// per owning Director id. Opaque to callers except through the pure functions below.
+export interface RetentionCache {
+  byDirector: Map<string, SessionDto[]>;
+}
+
+export function emptyRetentionCache(): RetentionCache {
+  return { byDirector: new Map<string, SessionDto[]>() };
+}
+
+// The display roster produced by the merge: the sessions to render (live + retained-and-marked), in a
+// stable order, plus a per-sessionId mark for the non-online ones (an online session has no entry).
+export interface RetainedRoster {
+  sessions: SessionDto[];
+  marks: Map<string, RosterSessionMark>;
+}
+
+// The owning Director id for a session, or "" when the Gateway did not stamp one (an older session, or
+// a purely local Director). "" sessions are never retained per-Director - they render live-only.
+function directorIdOf(s: SessionDto): string {
+  return (s.directorId ?? "").trim();
+}
+
+// Group the envelope's live sessions by owning Director id, preserving the Gateway's order within each
+// group so the roster does not reshuffle between polls.
+function groupByDirector(sessions: SessionDto[]): Map<string, SessionDto[]> {
+  const byDir = new Map<string, SessionDto[]>();
+  for (const s of sessions) {
+    const id = directorIdOf(s);
+    const list = byDir.get(id);
+    if (list) list.push(s);
+    else byDir.set(id, [s]);
+  }
+  return byDir;
+}
+
+function markFor(state: SessionReachability, machineName: string, reach: DirectorReachability | undefined): RosterSessionMark {
+  return {
+    reachability: state,
+    machineName,
+    lastSeenLabel: reachabilityLastSeen(reach?.lastSeenAgeSeconds),
+  };
+}
+
+// Merge a fresh roster envelope with the retained last-known cache and produce the display roster.
+//
+// The authority rule, per owning Director:
+//  - ONLINE (its state is "online", OR it has live sessions this poll and no reachability entry at all
+//    - a fully-online Director the Gateway omits from directors[]): the Director answered. Its live
+//    session set is authoritative - it REPLACES the cache for that Director, so a session genuinely
+//    killed while the machine was reachable disappears. These render normally (no mark).
+//  - WOBBLY: the Gateway is still serving this Director's last-known sessions (within its grace window).
+//    They are present in the envelope; refresh the cache with them and mark them wobbly. Never pruned -
+//    the Director did not answer, so its absence of a session is not authority to remove it.
+//  - OFFLINE / vanished: the Gateway dropped this Director's sessions from the envelope (grace exhausted)
+//    or forgot the Director entirely. Re-inject the retained cache sessions, marked offline, and keep the
+//    cache untouched - the cards stay until the machine answers again (decision 5).
+export function mergeRosterRetention(prev: RetentionCache, envelope: SessionsEnvelope): { cache: RetentionCache; roster: RetainedRoster } {
+  const liveByDir = groupByDirector(envelope.sessions);
+  const reachByDir = new Map<string, DirectorReachability>();
+  for (const d of envelope.directors) reachByDir.set(d.directorId, d);
+
+  const nextCache: RetentionCache = { byDirector: new Map(prev.byDirector) };
+  const sessions: SessionDto[] = [];
+  const marks = new Map<string, RosterSessionMark>();
+
+  // The full set of Director ids to consider: everyone with live sessions this poll, everyone the
+  // envelope reports a reachability for, and everyone we still hold retained sessions for.
+  const directorIds = new Set<string>([
+    ...liveByDir.keys(),
+    ...envelope.directors.map((d) => d.directorId),
+    ...prev.byDirector.keys(),
+  ]);
+
+  for (const id of directorIds) {
+    const reach = id ? reachByDir.get(id) : undefined;
+    const live = liveByDir.get(id);
+    // A session with no owning Director id ("") is only ever live - render it as-is, never retained.
+    if (id === "") {
+      if (live) sessions.push(...live);
+      continue;
+    }
+    const state: ReachabilityState = reach?.state ?? (live ? REACHABILITY_ONLINE : REACHABILITY_OFFLINE);
+
+    if (state === REACHABILITY_ONLINE) {
+      // Authoritative answer: the live set replaces the cache (killed sessions drop), rendered normally.
+      const list = live ?? [];
+      if (list.length > 0) nextCache.byDirector.set(id, list);
+      else nextCache.byDirector.delete(id);
+      sessions.push(...list);
+      continue;
+    }
+
+    if (state === REACHABILITY_WOBBLY && live && live.length > 0) {
+      // Still served stale within the Gateway's grace window: refresh the cache, mark wobbly, never prune.
+      nextCache.byDirector.set(id, live);
+      for (const s of live) {
+        sessions.push(s);
+        marks.set(s.sessionId ?? "", markFor(REACHABILITY_WOBBLY, machineLabel(s, reach), reach));
+      }
+      continue;
+    }
+
+    // Offline (or wobbly with nothing served this poll, or a Director the Gateway forgot): re-inject the
+    // retained cache, marked unreachable, and leave the cache untouched so the cards persist.
+    const retained = prev.byDirector.get(id);
+    if (retained && retained.length > 0) {
+      const markState: SessionReachability = state === REACHABILITY_WOBBLY ? REACHABILITY_WOBBLY : REACHABILITY_OFFLINE;
+      for (const s of retained) {
+        sessions.push(s);
+        marks.set(s.sessionId ?? "", markFor(markState, machineLabel(s, reach), reach));
+      }
+    }
+  }
+
+  return { cache: nextCache, roster: { sessions, marks } };
+}
+
+// The machine label for a mark: prefer the Director's reported machine name, fall back to the session's
+// own stamp, so the note always names a machine even when one source is blank.
+function machineLabel(s: SessionDto, reach: DirectorReachability | undefined): string {
+  const fromDirector = (reach?.machineName ?? "").trim();
+  if (fromDirector.length > 0) return fromDirector;
+  return (s.machineName ?? "").trim();
+}


### PR DESCRIPTION
## Mobile bad-connection resilience mission - Phase 2

Brief: `docs/architecture/mobile-resilience-mission-2026-07-11.md` (New build C). Follows Phase 1 (PR #1374).

**The rule:** a session must never vanish from the roster just because its machine became unreachable. A session leaves the list ONLY when its owning Director answered (is Online) and no longer reports it. While a Director reads Wobbly or Offline, its last-known sessions STAY on the roster, grayed and marked, until the machine answers again. This generalizes the shipped voice rule (#1334): unreachable is a state you SHOW, not data you DELETE.

### What changed

**Roster moves to the envelope** - `apps/mobile/src/pages/Home.tsx`
- Polls `getSessionsEnvelope` (per-Director reachability: Online / Wobbly / Offline + last-seen age) instead of the flat `listSessions`.

**New pure keep-and-mark merge** - `packages/client-core/src/fleet/rosterRetention.ts`
- Keeps a last-known-sessions cache per owning Director and re-injects the cards of unreachable machines even after the Gateway's grace window (issue #1215) drops them from the envelope. No shrink heuristic (decision 4) - removal is driven only by an Online Director's authoritative answer (decision 3). Pure function, so the page holds the cache in a ref and the rule is fully unit-tested (11 cases).

**Roster marking** - an unreachable card is grayed (gray dot, dashed dimmed card) with a plain note naming the machine: *"Reconnecting to MACHINE - last seen 12s ago"* (wobbly) or *"Unreachable - MACHINE - last seen 2m ago"* (offline). Its stale attention state and live waiting timer are suppressed. The app-icon needs-you badge and the voice-clip sync read the LIVE sessions only, so neither counts a retained-and-marked card.

**Keep the Phase 1 banner fed** - `gatewayFetch` is exported from `api/client` and `fleetClient` routes its reads through it, so a failed envelope poll still turns the global connection banner on (same single choke point). Feeding the store from the Cockpit's roster poll is inert there - it mounts no banner (decision 6).

### Verification
- `npm run typecheck` clean across all three workspaces.
- `npm run build` (mobile) succeeds.
- Client-core tests: 377 passing (35 files), including 11 new `rosterRetention` tests: online replace/prune, wobbly keep, offline keep past grace, forgotten Director, removal-requires-authority, in-place recovery, per-machine isolation, idempotency, and no-mutation-of-prior-cache.
- Lint clean on all touched files.
- Verified (and left alone) that Chat, Terminal, and Voice header labels never clear a known name on a failed poll.

### Owner proof (after deploy to the phone, against a real second machine)
Stop the test machine's Director (or pull its network): its sessions stay on the roster, grayed, named unreachable. Kill a session on a reachable Director: it leaves the roster promptly. Restart the stopped Director: its cards return to live in place.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)