### PR TITLE
feat(mobile): Phase 3 - terminal reconnect that never blanks + banner covers a dead stream

### DIFF
--- a/apps/mobile/src/pages/Terminal.tsx
+++ b/apps/mobile/src/pages/Terminal.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import "@xterm/xterm/css/xterm.css";
 import { listSessions } from "@devthrottle/client-core/api/client";
-import { TerminalMirror } from "@devthrottle/client-core/terminal/stream";
+import { TerminalMirror, type TerminalStreamStatus } from "@devthrottle/client-core/terminal/stream";
 import { DictationStatusStrip } from "../components/DictationStatusStrip";
 import { SessionControls } from "../components/SessionControls";
 import { SessionManageBar } from "../components/SessionManageBar";
@@ -48,6 +48,10 @@ export function Terminal() {
   const [status, setStatus] = useState<string>(STATUS_BASE);
   const [showKeys, setShowKeys] = useState(false); // controls hidden by default (Android parity)
   const [fitLabel, setFitLabel] = useState<"Fit" | "1:1">("1:1");
+  // The live-stream connection state (mobile-resilience Phase 3). While it is not "live" a small note
+  // shows over the terminal that it is (re)connecting - the last-known screen stays visible underneath,
+  // never blanked, and the note is the only sign of trouble.
+  const [streamStatus, setStreamStatus] = useState<TerminalStreamStatus>("connecting");
 
   // One-shot fetch of the session's display name for the header (the mirror itself never needs it).
   useEffect(() => {
@@ -64,7 +68,7 @@ export function Terminal() {
   // The live mirror: a real xterm.js terminal fed by the WebSocket session stream.
   useEffect(() => {
     if (!sessionId || wrapRef.current === null || hostRef.current === null) return;
-    const mirror = new TerminalMirror(wrapRef.current, hostRef.current, sessionId, setFitLabel, openFile);
+    const mirror = new TerminalMirror(wrapRef.current, hostRef.current, sessionId, setFitLabel, openFile, setStreamStatus);
     mirrorRef.current = mirror;
     mirror.start();
     return () => { mirror.dispose(); mirrorRef.current = null; };
@@ -107,6 +111,14 @@ export function Terminal() {
       {/* The terminal fills all remaining space. .term-wrap is the only scroll container (vertical
           scrollback + horizontal pan); the Fit and A-/A+ controls float over its corners. */}
       <div className="term-stage">
+        {/* Mobile-resilience Phase 3: while the live stream is down, a small note floats over the top of
+            the terminal. The last-known screen stays visible underneath (never blanked); this note is the
+            only sign the mirror is (re)connecting, and it clears itself the instant the socket reopens. */}
+        {streamStatus !== "live" && (
+          <div className="term-reconnecting" role="status">
+            {streamStatus === "connecting" ? "Connecting to the live terminal..." : "Reconnecting to the live terminal..."}
+          </div>
+        )}
         <div className="term-wrap" ref={wrapRef}><div className="term-xterm" ref={hostRef} /></div>
         <div className="term-zoom">
           <button type="button" className="term-zoom-btn" aria-label="Zoom out"

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -849,6 +849,30 @@ a.banner-btn {
   touch-action: pan-x pan-y;
 }
 
+/* Mobile-resilience Phase 3: the "reconnecting" note floats at the top-center of the terminal stage
+   while the live stream is down. It OVERLAYS the terminal (which keeps its last-known content beneath,
+   never blanked) and clears itself the instant the socket reopens. Amber - a warning, not an error. */
+.term-reconnecting {
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 6;
+  max-width: calc(100% - 24px);
+  padding: 5px 12px;
+  border-radius: 999px;
+  background: rgba(122, 82, 0, 0.94);
+  border: 1px solid #b8860b;
+  color: #ffe6a3;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+  pointer-events: none;
+}
+
 /* The grid renders at the PTY's exact geometry; bottom padding reserves a strip so the live input
    row scrolls clear of the floating Fit / zoom controls instead of hiding under them. */
 .term-xterm {

--- a/packages/client-core/src/terminal/stream.test.ts
+++ b/packages/client-core/src/terminal/stream.test.ts
@@ -10,6 +10,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 // ----- fakes for xterm + the Gateway client (hoisted so vi.mock factories may reference them) -----
 const hoisted = vi.hoisted(() => {
   const ensureGatewayCookie = vi.fn();
+  // Spies for the shared connection-health signal the mirror feeds on socket open/close (Phase 3).
+  const reportGatewayReachable = vi.fn();
+  const reportGatewayUnreachable = vi.fn();
   // The minimum of the xterm.js surface the mirror touches during start() + the link provider path.
   class FakeTerminal {
     // getLine backs the link provider's per-line lookup; lineText is buffer row 1's rendered text.
@@ -49,7 +52,7 @@ const hoisted = vi.hoisted(() => {
     }
   }
   const terminals: FakeTerminal[] = [];
-  return { FakeTerminal, terminals, ensureGatewayCookie };
+  return { FakeTerminal, terminals, ensureGatewayCookie, reportGatewayReachable, reportGatewayUnreachable };
 });
 
 const ensureGatewayCookie = hoisted.ensureGatewayCookie;
@@ -60,6 +63,10 @@ vi.mock("@xterm/xterm", () => ({ Terminal: hoisted.FakeTerminal }));
 vi.mock("../api/client", () => ({
   ensureGatewayCookie: () => hoisted.ensureGatewayCookie(),
 }));
+vi.mock("../connection/health", () => ({
+  reportGatewayReachable: () => hoisted.reportGatewayReachable(),
+  reportGatewayUnreachable: () => hoisted.reportGatewayUnreachable(),
+}));
 
 // ----- fake WebSocket (the mirror opens one on connect; the tests never drive it) ---------------
 class FakeWebSocket {
@@ -68,11 +75,21 @@ class FakeWebSocket {
   static readonly OPEN = 1;
   binaryType = "";
   readyState = 0;
+  onopen: (() => void) | null = null;
   onmessage: ((ev: { data: unknown }) => void) | null = null;
   onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
   closed = false;
   constructor(public url: string) {
     FakeWebSocket.instances.push(this);
+  }
+  // Test drivers for the socket lifecycle the mirror wires up.
+  open(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+  fireClose(): void {
+    this.onclose?.();
   }
   close(): void {
     this.closed = true;
@@ -98,6 +115,8 @@ beforeEach(() => {
   hoisted.terminals.length = 0;
   FakeWebSocket.instances.length = 0;
   ensureGatewayCookie.mockClear();
+  hoisted.reportGatewayReachable.mockClear();
+  hoisted.reportGatewayUnreachable.mockClear();
   windowOpen.mockReset();
   // The mirror touches only these members of window during start()/connect(). ResizeObserver is left
   // undefined so the observer branch is skipped (nothing to measure in these routing tests).
@@ -174,5 +193,66 @@ describe("TerminalMirror link provider (Local Files, Phase 3/4)", () => {
   it("returns no links for a line with none, so xterm leaves the line undecorated", () => {
     const { links } = linksFor("plain output, nothing clickable");
     expect(links).toEqual([]);
+  });
+});
+
+// Reconnect-without-blanking (mobile-resilience mission, Phase 3): the mirror must NOT reset the screen
+// on a failed connect attempt (that would blank the terminal for the whole outage); it resets only on a
+// SUCCESSFUL open, right before the byte-0 history replay. It also feeds the shared connection-health
+// signal (reachable on open, unreachable on a failed attempt) and publishes a status the shell shows as
+// a "reconnecting" note.
+describe("TerminalMirror reconnect without blanking (Phase 3)", () => {
+  function startMirror(): { ws: FakeWebSocket; term: (typeof hoisted.terminals)[number]; statuses: string[] } {
+    const statuses: string[] = [];
+    const mirror = new TerminalMirror(fakeEl(), fakeEl(), SID, () => {}, undefined, (s) => statuses.push(s));
+    mirror.start();
+    return { ws: FakeWebSocket.instances[0], term: hoisted.terminals[0], statuses };
+  }
+
+  it("does NOT reset the terminal on connect - only on a successful socket open", () => {
+    const { ws, term } = startMirror();
+    expect(term.resetCount).toBe(0); // the failed-connection blanking bug: no reset before the socket opens
+    ws.open();
+    expect(term.resetCount).toBe(1); // reset happens once, right before the byte-0 replay
+  });
+
+  it("keeps the last-known screen (no reset) and reports the Gateway unreachable when a connect attempt fails", () => {
+    const { ws, term, statuses } = startMirror();
+    ws.fireClose(); // a socket that never opened = a failed attempt (the stream leg is down)
+    expect(term.resetCount).toBe(0); // the screen is NEVER wiped on a failed attempt
+    expect(hoisted.reportGatewayUnreachable).toHaveBeenCalledTimes(1);
+    expect(hoisted.reportGatewayReachable).not.toHaveBeenCalled();
+    expect(statuses).toEqual(["connecting", "reconnecting"]);
+  });
+
+  it("reports the Gateway reachable and goes live on a successful open", () => {
+    const { ws, statuses } = startMirror();
+    ws.open();
+    expect(hoisted.reportGatewayReachable).toHaveBeenCalledTimes(1);
+    expect(statuses).toEqual(["connecting", "live"]);
+  });
+
+  it("does NOT report unreachable when a stream that had opened later closes (a normal end, not a drop)", () => {
+    const { ws, statuses } = startMirror();
+    ws.open();
+    hoisted.reportGatewayUnreachable.mockClear();
+    ws.fireClose(); // opened=true, so this close is a normal end/brief drop the retry loop handles
+    expect(hoisted.reportGatewayUnreachable).not.toHaveBeenCalled();
+    expect(statuses).toEqual(["connecting", "live", "reconnecting"]);
+  });
+
+  it("does nothing on a close after dispose (no health report, no status)", () => {
+    const statuses: string[] = [];
+    const mirror = new TerminalMirror(fakeEl(), fakeEl(), SID, () => {}, undefined, (s) => statuses.push(s));
+    mirror.start();
+    const ws = FakeWebSocket.instances[0];
+    ws.open();
+    hoisted.reportGatewayReachable.mockClear();
+    hoisted.reportGatewayUnreachable.mockClear();
+    const before = [...statuses];
+    mirror.dispose(); // dispose nulls the socket's onclose, so a later close is inert
+    ws.fireClose();
+    expect(hoisted.reportGatewayUnreachable).not.toHaveBeenCalled();
+    expect(statuses).toEqual(before);
   });
 });

--- a/packages/client-core/src/terminal/stream.ts
+++ b/packages/client-core/src/terminal/stream.ts
@@ -24,6 +24,7 @@
 import { Terminal as Xterm } from "@xterm/xterm";
 import type { IDisposable, ILink, ILinkProvider } from "@xterm/xterm";
 import { ensureGatewayCookie } from "../api/client";
+import { reportGatewayReachable, reportGatewayUnreachable } from "../connection/health";
 import { findLineLinks, type LineLink } from "./lineLinks";
 
 const BASE_FONT = 13; // 1:1 (actual-size) font, in px - matches RawTerminalPage.cs
@@ -41,6 +42,14 @@ const STICKY_SLACK_PX = 48; // auto-scroll only when within this many px of the 
 /** Called when the fit/zoom state changes so the React shell can relabel the Fit button. */
 export type FitLabelListener = (label: "Fit" | "1:1") => void;
 
+// The live-stream connection state, surfaced to the React shell so it can show a small "reconnecting"
+// note while the socket is down (mobile-resilience mission, Phase 3). "connecting" is the first attempt
+// before any open; "live" once a socket is open and replaying; "reconnecting" whenever the socket has
+// dropped and the ~1200ms retry loop is trying again. The terminal content stays on screen the whole
+// time - the note is the only sign of trouble, never a blank screen.
+export type TerminalStreamStatus = "connecting" | "live" | "reconnecting";
+export type StreamStatusListener = (status: TerminalStreamStatus) => void;
+
 function streamUrl(sessionId: string): string {
   const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
   return `${proto}//${window.location.host}/sessions/${encodeURIComponent(sessionId)}/stream`;
@@ -51,6 +60,10 @@ export class TerminalMirror {
   private readonly hostEl: HTMLElement;
   private readonly sessionId: string;
   private readonly onFitLabel: FitLabelListener;
+  // Optional: the React shell's setter for the live-stream status note (Phase 3). Absent for callers
+  // that do not render a note (the link-provider unit tests). Only ever called with a CHANGED status.
+  private readonly onStatus?: StreamStatusListener;
+  private status: TerminalStreamStatus = "connecting";
   // Local Files (Phase 3): the app supplies this to open its own file viewer when a FILE path in the
   // mirror is clicked. client-core stays app-agnostic (it must not import app UI - brief decision 6),
   // so the click routes back out through this callback. http/https URLs are opened here directly (a new
@@ -80,12 +93,23 @@ export class TerminalMirror {
     sessionId: string,
     onFitLabel: FitLabelListener,
     onFileLink?: (path: string) => void,
+    onStatus?: StreamStatusListener,
   ) {
     this.wrapEl = wrapEl;
     this.hostEl = hostEl;
     this.sessionId = sessionId;
     this.onFitLabel = onFitLabel;
     this.onFileLink = onFileLink;
+    this.onStatus = onStatus;
+  }
+
+  // Publish a live-stream status transition to the shell (Phase 3), de-duped so the same status does
+  // not re-notify. The initial "connecting" is published on start() so the note shows from the first
+  // frame until the socket opens.
+  private setStatus(next: TerminalStreamStatus): void {
+    if (next === this.status) return;
+    this.status = next;
+    this.onStatus?.(next);
   }
 
   start(): void {
@@ -119,6 +143,8 @@ export class TerminalMirror {
     this.wrapEl.addEventListener("touchmove", this.onTouchMove, { passive: false });
     this.wrapEl.addEventListener("touchend", this.onTouchEnd, { passive: true });
 
+    // Publish the initial "connecting" so the note shows from the first frame until the socket opens.
+    this.onStatus?.(this.status);
     this.connect();
   }
 
@@ -326,10 +352,25 @@ export class TerminalMirror {
     // authenticates (browsers cannot set an Authorization header on a WebSocket).
     ensureGatewayCookie();
 
-    term.reset(); // each connection replays full history from byte 0
+    // NOTE: the terminal is NOT reset here. On a bad connection connect() is retried every ~1200ms, and
+    // resetting before a socket that never opens would wipe the screen and leave it blank the whole time
+    // the network is down (mobile-resilience mission: never clear good data). The reset moves to a
+    // SUCCESSFUL open (sock.onopen), immediately before the byte-0 history replay that a new connection
+    // always sends - so a failed attempt keeps the last-known screen and only a real replay clears it.
     const sock = new WebSocket(streamUrl(this.sessionId));
     sock.binaryType = "arraybuffer";
     this.ws = sock;
+    // Whether THIS socket ever opened. A close with opened=false is a failed attempt (the stream leg is
+    // down) and lights the shared connection banner; a close after a successful open is a normal end or a
+    // mid-stream drop the retry loop handles, and must not be mistaken for an unreachable Gateway.
+    let opened = false;
+
+    sock.onopen = () => {
+      opened = true;
+      term.reset(); // a new connection replays the full history from byte 0 - clear right before it
+      reportGatewayReachable(); // the stream reached a healthy backend (feeds the global banner)
+      this.setStatus("live");
+    };
 
     sock.onmessage = (ev: MessageEvent) => {
       if (typeof ev.data === "string") {
@@ -349,7 +390,14 @@ export class TerminalMirror {
 
     sock.onclose = () => {
       if (this.ws === sock) this.ws = null;
-      if (this.want && this.reconnectTimer === null) {
+      // Disposing (want=false): no reconnect, no status, no health report - a deliberate teardown.
+      if (!this.want) return;
+      // A socket that never opened is a failed connect attempt: the stream leg is down, so light the
+      // shared connection banner. A close AFTER a successful open is a normal stream end or a brief drop
+      // the retry loop handles; the next failed attempt (if the network is really down) reports it then.
+      if (!opened) reportGatewayUnreachable();
+      this.setStatus("reconnecting");
+      if (this.reconnectTimer === null) {
         this.reconnectTimer = window.setTimeout(() => {
           this.reconnectTimer = null;
           if (this.want) this.connect();


### PR DESCRIPTION
## Mobile bad-connection resilience mission - Phase 3

Brief: `docs/architecture/mobile-resilience-mission-2026-07-11.md` (New build D). Follows Phase 1 (#1374) and Phase 2 (#1380).

**The bug:** the live terminal mirror wiped the screen on EVERY failed reconnect attempt - `term.reset()` ran at the top of `connect()`, which the ~1200ms retry loop calls repeatedly, so on a bad connection the terminal sat blank the whole time the network was down.

### What changed

**Terminal never blanks** - `packages/client-core/src/terminal/stream.ts`
- `term.reset()` moves out of `connect()` into the socket's `onopen`, right before the byte-0 history replay a new connection always sends. A failed attempt (a socket that never opens) keeps the last-known screen; only a real replay clears it. The terminal stays populated through an outage and rebuilds in place the instant the socket reopens - no user action, never a blank.

**Banner covers a dead stream** - the socket feeds the Phase 1 connection-health signal: a successful open reports reachable, a connect attempt that never opened reports unreachable, so the one global banner covers a dead stream even when plain polls still succeed. A close AFTER a successful open (a normal end or a brief drop the retry loop handles) does not falsely report the Gateway unreachable.

**Reconnecting note** - a new stream status (`connecting` / `live` / `reconnecting`) is surfaced to the Terminal page (`apps/mobile/src/pages/Terminal.tsx`), which floats a small "Reconnecting to the live terminal..." note over the top of the terminal while the stream is down. The last-known screen stays visible beneath it; the note clears itself the moment the socket reopens.

**Chat confirmed (no change)** - a failing history poll keeps the rendered bubbles (they are only replaced on a successful load) and now surfaces through the global banner, because `getSessionHistory` routes through the Phase 1 `gatewayFetch` choke point. This poll was silent before the mission.

### Verification
- `npm run typecheck` clean across all three workspaces.
- `npm run build` (mobile) succeeds.
- Client-core tests: 382 passing (35 files), including 5 new mirror tests: no reset on connect (only on open), the screen is never wiped on a failed attempt while the Gateway is reported unreachable, open reports reachable and goes live, a close after a successful open does not report unreachable, and a close after dispose is inert.
- Lint + ASCII clean on all touched files.

### Owner proof (after deploy to the phone)
Airplane mode mid-stream: the terminal keeps showing the last content (never blank), the banner shows and a small "Reconnecting..." note floats over the terminal; on reconnect the terminal replays and is live again with no user action. Chat keeps its bubbles throughout.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)