### PR TITLE
feat(snooze): Phase 2 - Snooze ended marker, roster badge, and distinct phone push

### DIFF
--- a/apps/cockpit/public/sw.js
+++ b/apps/cockpit/public/sw.js
@@ -24,18 +24,21 @@ var NOTIFICATION_ICON = '/m/icon-192.png';
 
 self.addEventListener('push', function (event) {
   var count = 0;
+  var snoozeEnded = false;
   if (event.data) {
     try {
       var payload = event.data.json();
       count = Number(payload && payload.count) || 0;
+      snoozeEnded = !!(payload && payload.snoozeEnded);
     } catch (e) {
       count = 0;
+      snoozeEnded = false;
     }
   }
-  event.waitUntil(applyNeedsYou(count));
+  event.waitUntil(applyNeedsYou(count, snoozeEnded));
 });
 
-function applyNeedsYou(count) {
+function applyNeedsYou(count, snoozeEnded) {
   var tasks = [];
 
   // App badge where the browser supports it (installed desktop PWA / some Chromium builds). Harmless
@@ -59,7 +62,12 @@ function applyNeedsYou(count) {
   // (see WebPushNeedsYouNotifier.Decide), so renotify:true is correct here - each push is real news and
   // should re-alert - while the shared tag REPLACES the previous notification rather than stacking a new
   // one. Clicking it focuses the Cockpit and lands on the waiting session (see notificationclick).
-  var body = count === 1 ? '1 session needs you' : count + ' sessions need you';
+  // Snooze Length mission: a returned-from-snooze announcement (sent once when a snooze first expires)
+  // carries the distinct "Snooze ended" copy so the owner knows it is a "go investigate why it went
+  // quiet" item rather than a fresh turn-end.
+  var body = snoozeEnded
+    ? 'Snooze ended - still waiting on you'
+    : (count === 1 ? '1 session needs you' : count + ' sessions need you');
   tasks.push(
     self.registration.showNotification('DevThrottle', {
       tag: NEEDS_YOU_TAG,

--- a/apps/cockpit/src/sessions/SessionRoster.tsx
+++ b/apps/cockpit/src/sessions/SessionRoster.tsx
@@ -7,6 +7,7 @@ import {
   effectiveColor,
   inBucket,
   inDesktopOrder,
+  snoozeExpired,
 } from "@devthrottle/client-core/sessions/ordering";
 import { useNow, waitingLabel } from "@devthrottle/client-core/sessions/waiting";
 import {
@@ -207,6 +208,7 @@ function RosterRow({
           <span className="roster-meta">
             <span className="roster-state">{contextLine(session)}</span>
             {session.onHold && <span className="roster-tag">snoozed</span>}
+            {snoozeExpired(session) && <span className="roster-tag snooze-ended">Snooze ended</span>}
             {session.voiceMode && <span className="roster-tag voice">voice</span>}
             {machine && <span className="roster-machine" title={session.directorId ?? undefined}>{machine}</span>}
             {lastSeen && <span className="roster-lastseen">{lastSeen}</span>}

--- a/apps/cockpit/src/styles.css
+++ b/apps/cockpit/src/styles.css
@@ -732,6 +732,14 @@ body {
   color: var(--text-dim);
 }
 
+/* Snooze Length mission: a returned-from-snooze session wears a distinct amber "Snooze ended" tag so
+   it reads as a "go investigate why it went quiet" item, not a plain needs-you. */
+.roster-tag.snooze-ended {
+  background: rgba(217, 145, 32, 0.16);
+  border-color: rgba(217, 145, 32, 0.55);
+  color: #d99120;
+}
+
 /* The machine name yields FIRST when the meta line is tight (it truncates before the state does). */
 .roster-machine {
   flex: 0 1 auto;

--- a/apps/mobile/public/push-sw.js
+++ b/apps/mobile/public/push-sw.js
@@ -20,18 +20,21 @@ var NEEDS_YOU_TAG = 'devthrottle-needs-you';
 
 self.addEventListener('push', function (event) {
   var count = 0;
+  var snoozeEnded = false;
   if (event.data) {
     try {
       var payload = event.data.json();
       count = Number(payload && payload.count) || 0;
+      snoozeEnded = !!(payload && payload.snoozeEnded);
     } catch (e) {
       count = 0;
+      snoozeEnded = false;
     }
   }
-  event.waitUntil(applyNeedsYou(count));
+  event.waitUntil(applyNeedsYou(count, snoozeEnded));
 });
 
-function applyNeedsYou(count) {
+function applyNeedsYou(count, snoozeEnded) {
   var tasks = [];
 
   // App badge: iOS installed PWA + desktop. Not present on Android (harmless - the notification
@@ -46,6 +49,26 @@ function applyNeedsYou(count) {
 
   if (count <= 0) {
     tasks.push(closeNeedsYou());
+    return Promise.all(tasks);
+  }
+
+  // Snooze Length mission: a returned-from-snooze ANNOUNCEMENT. The Gateway sends this exactly once when
+  // a session's snooze first expires (see WebPushNeedsYouNotifier), so it is allowed to BUZZ with its own
+  // copy even though a dot may already be up - it is genuinely new "go investigate why it went quiet"
+  // news. Uses the same tag so it replaces the quiet dot; the next silent heartbeat folds it back into
+  // the plain dot, and it never buzzes again while the snooze lingers.
+  if (snoozeEnded) {
+    tasks.push(
+      self.registration.showNotification('DevThrottle', {
+        tag: NEEDS_YOU_TAG,
+        body: 'Snooze ended - still waiting on you',
+        renotify: true,
+        silent: false,
+        icon: '/m/icon-192.png',
+        badge: '/m/icon-192.png',
+        data: { url: '/m/' }
+      })
+    );
     return Promise.all(tasks);
   }
 

--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { type SessionDto } from "@devthrottle/client-core/api/client";
 import { getSessionsEnvelope } from "@devthrottle/client-core/fleet/fleetClient";
 import { emptyRetentionCache, mergeRosterRetention, type RosterSessionMark } from "@devthrottle/client-core/fleet/rosterRetention";
-import { classify, contextLine, dotColor, effectiveColor, inBucket, inDesktopOrder, inWaitingOrder, isWorking, repoLeaf } from "@devthrottle/client-core/sessions/ordering";
+import { classify, contextLine, dotColor, effectiveColor, inBucket, inDesktopOrder, inWaitingOrder, isWorking, repoLeaf, snoozeExpired } from "@devthrottle/client-core/sessions/ordering";
 import { applyFilter, filterIsActive, filterSummary, machineName, pruneFilter } from "@devthrottle/client-core/sessions/filter";
 import { useDictationStatusFor } from "@devthrottle/client-core/dictation/status";
 import { useNow, waitingLabel } from "@devthrottle/client-core/sessions/waiting";
@@ -292,6 +292,10 @@ function SessionRow({ session, mark }: { session: SessionDto; mark?: RosterSessi
             <span className="row-context">{contextLine(session)}</span>
             {attention && session.needsYouSince && <WaitingTime since={String(session.needsYouSince)} />}
           </span>
+          {/* Snooze Length mission: a distinct "Snooze ended" badge when this session just returned from
+              an expired snooze on its own (the dead-man's switch fired) - so the reader knows this is a
+              "go see why it went quiet" item, not a fresh turn-end. */}
+          {snoozeExpired(session) && <span className="row-snooze-ended">Snooze ended</span>}
           {/* The facts you navigate and filter by - the machine the session runs on and its repo - are
               a bottom row of small chips, so a fleet spread across several machines is legible at a
               glance without crowding the status line. The machine chip is accent-tinted; the repo chip

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -258,6 +258,23 @@ a.banner-btn {
   color: #cbb892;
 }
 
+/* Snooze Length mission: a distinct amber "Snooze ended" badge on a card that just returned from an
+   expired snooze on its own - reads as "go see why it went quiet", not a plain needs-you. */
+.row-snooze-ended {
+  display: inline-block;
+  align-self: flex-start;
+  margin-top: 4px;
+  padding: 1px 7px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  background: rgba(217, 145, 32, 0.16);
+  border: 1px solid rgba(217, 145, 32, 0.55);
+  color: #d99120;
+}
+
 /* Issue #838: the dot is top-aligned at the start of the FIRST name line (align-items:
    flex-start) so a name that wraps to several lines keeps the dot beside its first line. */
 .row-link {

--- a/packages/client-core/src/sessions/ordering.ts
+++ b/packages/client-core/src/sessions/ordering.ts
@@ -8,6 +8,10 @@ type GatewayStampedSession = SessionDto & {
   effectiveColor?: string | null;
   stateLabel?: string | null;
   triageBucket?: TriageBucket | string | null;
+  // Snooze Length mission: display-only marker that this session just returned from an EXPIRED snooze
+  // (its Gateway-owned timer elapsed and the fold put it back into "needs you" on its own). The Gateway
+  // stamps it; clients render a distinct "Snooze ended" badge. Optional (absent/false for most sessions).
+  snoozeExpired?: boolean | null;
 };
 
 // The stable "desktop order": honor the owning Director's SortOrder (the user-controlled,
@@ -41,6 +45,14 @@ export function effectiveColor(s: SessionDto): string {
 // re-deriving a label from the raw color or activity state.
 export function stateLabel(s: SessionDto): string {
   return requireGatewayField((s as GatewayStampedSession).stateLabel, "stateLabel", s.sessionId);
+}
+
+// Snooze Length mission: true when this session just RETURNED from an expired snooze (its Gateway-owned
+// timer fired and put it back into "needs you" on its own). Clients render a distinct "Snooze ended"
+// badge so the owner knows it is a "go investigate why it went quiet" item, not a fresh turn-end.
+// Non-throwing (optional field): a session without the marker is simply not returned-from-snooze.
+export function snoozeExpired(s: SessionDto): boolean {
+  return Boolean((s as GatewayStampedSession).snoozeExpired);
 }
 
 // True while the agent is actively running a turn - the "working" state. Blue is the authoritative

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -255,6 +255,17 @@ public sealed class SessionDto
     public bool OnHold { get; set; }
 
     /// <summary>
+    /// Snooze Length mission: display-only marker that this session has just RETURNED from an expired
+    /// snooze - its Gateway-owned snooze timer elapsed and the fold put it back into "needs you" on its
+    /// own (the dead-man's switch fired). Stamped by the Gateway aggregation overlay while the snooze
+    /// registry still holds an expired entry for the session; it is NOT a Director fact and nothing is
+    /// injected into the session's conversation. Clients render it as a distinct "Snooze ended" badge so
+    /// the owner knows this is a "go investigate why it went quiet" item rather than a fresh turn-end, and
+    /// the phone push reads "Snooze ended - still waiting on you" the one time it first appears.
+    /// </summary>
+    public bool SnoozeExpired { get; set; }
+
+    /// <summary>
     /// True when this session has asked (or been asked) to be deleted and is awaiting the owning
     /// Director's deletion reaper. Set through POST /sessions/{id}/request-deletion; cleared by
     /// DELETE /sessions/{id}/request-deletion during the grace window. Mirrors

--- a/src/CcDirector.Gateway.Tests/SessionsAggregationTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionsAggregationTests.cs
@@ -160,6 +160,9 @@ public sealed class SessionsAggregationTests : IAsyncLifetime
         Assert.False(s.OnHold);                    // overlay flipped it
         Assert.Equal("red", s.EffectiveColor);     // back to needs-you red
         Assert.Equal("needsYou", s.TriageBucket);
+        // Phase 2: the returned-from-snooze marker is stamped so clients show a distinct "Snooze ended"
+        // badge and the phone push announces it once.
+        Assert.True(s.SnoozeExpired);
     }
 
     // ---------- automatic session roles (chunk 1) ----------

--- a/src/CcDirector.Gateway.Tests/WebPushNeedsYouNotifierTests.cs
+++ b/src/CcDirector.Gateway.Tests/WebPushNeedsYouNotifierTests.cs
@@ -111,6 +111,91 @@ public sealed class WebPushNeedsYouNotifierTests : IDisposable
         Assert.Equal(0, rose.next.ZeroStreak);                      // streak reset - no pending clear
     }
 
+    // ---- snooze-expiry announcements (Snooze Length mission) -----------------------------------
+
+    [Fact]
+    public void Decide_NewlyExpiredWhileDotUp_AnnouncesOnceWithSnoozeEnded()
+    {
+        // The dot is already up for other needs-you work; a session then RETURNS from an expired snooze.
+        // That is genuinely new, actionable news, so it must push once with the snooze-ended marker even
+        // though the count already had a dot.
+        var up = WebPushNeedsYouNotifier.Decide(2, WebPushNeedsYouNotifier.DotState.Initial).next;
+
+        var r = WebPushNeedsYouNotifier.Decide(3, new[] { "s1" }, up);
+
+        Assert.True(r.push);
+        Assert.True(r.snoozeEnded);
+        Assert.Equal(3, r.count);
+        Assert.Contains("s1", r.next.Announced);
+    }
+
+    [Fact]
+    public void Decide_LingeringExpired_NeverBuzzesAgain()
+    {
+        // A dead-Director expired snooze lingers in "needs you" forever. It must be announced exactly once;
+        // every later poll (including the heartbeat re-assert) must NOT be a snooze-ended announcement.
+        var r = WebPushNeedsYouNotifier.Decide(1, new[] { "s1" }, WebPushNeedsYouNotifier.DotState.Initial);
+        Assert.True(r.push);
+        Assert.True(r.snoozeEnded); // announced once
+
+        for (var i = 0; i < WebPushNeedsYouNotifier.HeartbeatPolls + 2; i++)
+        {
+            var next = WebPushNeedsYouNotifier.Decide(1, new[] { "s1" }, r.next);
+            Assert.False(next.snoozeEnded); // a heartbeat may push, but NEVER as a snooze-ended buzz
+            r = next;
+        }
+    }
+
+    [Fact]
+    public void Decide_NewlyExpiredFromScratch_AnnouncesAndShowsTheDot()
+    {
+        var r = WebPushNeedsYouNotifier.Decide(1, new[] { "s1" }, WebPushNeedsYouNotifier.DotState.Initial);
+
+        Assert.True(r.push);
+        Assert.True(r.snoozeEnded);
+        Assert.True(r.next.DotShowing);
+    }
+
+    [Fact]
+    public void Decide_ReSnoozeThenReExpire_AnnouncesAgain()
+    {
+        // Announce s1, then the user re-snoozes it (it leaves the expired set - pruned from Announced),
+        // then it expires again -> it must announce afresh (a new dead-man's-switch event).
+        var r1 = WebPushNeedsYouNotifier.Decide(1, new[] { "s1" }, WebPushNeedsYouNotifier.DotState.Initial);
+        Assert.True(r1.snoozeEnded);
+
+        var reSnoozed = WebPushNeedsYouNotifier.Decide(1, Array.Empty<string>(), r1.next); // s1 no longer expired
+        Assert.DoesNotContain("s1", reSnoozed.next.Announced);
+
+        var reExpired = WebPushNeedsYouNotifier.Decide(1, new[] { "s1" }, reSnoozed.next);
+        Assert.True(reExpired.push);
+        Assert.True(reExpired.snoozeEnded);
+    }
+
+    [Fact]
+    public async Task RunOnce_NewlyExpiredSnooze_AnnouncesOnceThenGoesQuiet()
+    {
+        var store = new PushSubscriptionStore(_storePath);
+        store.Add("https://push.example/aaa", "p", "a");
+        var sender = new FakeSender();
+        var count = 1;
+        var expired = new List<string> { "s1" };
+        var notifier = new WebPushNeedsYouNotifier(
+            store,
+            _ => Task.FromResult(new WebPushNeedsYouNotifier.NeedsYouSnapshot(count, expired.ToArray())),
+            sender);
+
+        await notifier.RunOnceAsync(CancellationToken.None); // s1 newly expired -> announce
+        await notifier.RunOnceAsync(CancellationToken.None); // still lingering -> quiet (no heartbeat yet)
+
+        Assert.Single(sender.Sent);
+        Assert.Contains("\"snoozeEnded\":true", sender.Sent[0].payload);
+        Assert.Contains("\"count\":1", sender.Sent[0].payload);
+    }
+
+    private static WebPushNeedsYouNotifier.NeedsYouSnapshot Snap(int count, params string[] expired) =>
+        new(count, expired);
+
     [Fact]
     public void CountNeedsYou_CountsEffectiveRedNotParked()
     {
@@ -135,7 +220,7 @@ public sealed class WebPushNeedsYouNotifierTests : IDisposable
     {
         var store = new PushSubscriptionStore(_storePath);
         var reads = 0;
-        var notifier = new WebPushNeedsYouNotifier(store, _ => { reads++; return Task.FromResult(5); }, new FakeSender());
+        var notifier = new WebPushNeedsYouNotifier(store, _ => { reads++; return Task.FromResult(Snap(5)); }, new FakeSender());
 
         await notifier.RunOnceAsync(CancellationToken.None);
 
@@ -149,7 +234,7 @@ public sealed class WebPushNeedsYouNotifierTests : IDisposable
         store.Add("https://push.example/aaa", "p", "a");
         store.Add("https://push.example/bbb", "p", "a");
         var sender = new FakeSender();
-        var notifier = new WebPushNeedsYouNotifier(store, _ => Task.FromResult(2), sender);
+        var notifier = new WebPushNeedsYouNotifier(store, _ => Task.FromResult(Snap(2)), sender);
 
         await notifier.RunOnceAsync(CancellationToken.None);
 
@@ -163,7 +248,7 @@ public sealed class WebPushNeedsYouNotifierTests : IDisposable
         var store = new PushSubscriptionStore(_storePath);
         store.Add("https://push.example/aaa", "p", "a");
         var sender = new FakeSender();
-        var notifier = new WebPushNeedsYouNotifier(store, _ => Task.FromResult(2), sender);
+        var notifier = new WebPushNeedsYouNotifier(store, _ => Task.FromResult(Snap(2)), sender);
 
         await notifier.RunOnceAsync(CancellationToken.None);
         await notifier.RunOnceAsync(CancellationToken.None);
@@ -178,7 +263,7 @@ public sealed class WebPushNeedsYouNotifierTests : IDisposable
         store.Add("https://push.example/aaa", "p", "a");
         var sender = new FakeSender();
         var count = 2;
-        var notifier = new WebPushNeedsYouNotifier(store, _ => Task.FromResult(count), sender);
+        var notifier = new WebPushNeedsYouNotifier(store, _ => Task.FromResult(Snap(count)), sender);
 
         await notifier.RunOnceAsync(CancellationToken.None); // 2 -> push count:2 (rising edge)
         count = 0;
@@ -200,7 +285,7 @@ public sealed class WebPushNeedsYouNotifierTests : IDisposable
         store.Add("https://push.example/aaa", "p", "a");
         var sender = new FakeSender();
         var count = 1;
-        var notifier = new WebPushNeedsYouNotifier(store, _ => Task.FromResult(count), sender);
+        var notifier = new WebPushNeedsYouNotifier(store, _ => Task.FromResult(Snap(count)), sender);
 
         await notifier.RunOnceAsync(CancellationToken.None); // 1 -> push count:1 (rising edge)
         count = 0;
@@ -221,7 +306,7 @@ public sealed class WebPushNeedsYouNotifierTests : IDisposable
         store.Add("https://push.example/dead", "p", "a");
         var sender = new FakeSender();
         sender.GoneEndpoints.Add("https://push.example/dead");
-        var notifier = new WebPushNeedsYouNotifier(store, _ => Task.FromResult(1), sender);
+        var notifier = new WebPushNeedsYouNotifier(store, _ => Task.FromResult(Snap(1)), sender);
 
         await notifier.RunOnceAsync(CancellationToken.None);
 
@@ -236,7 +321,7 @@ public sealed class WebPushNeedsYouNotifierTests : IDisposable
         var store = new PushSubscriptionStore(_storePath);
         store.Add("https://push.example/aaa", "p", "a");
         var sender = new FakeSender();
-        var notifier = new WebPushNeedsYouNotifier(store, _ => Task.FromResult(2), sender);
+        var notifier = new WebPushNeedsYouNotifier(store, _ => Task.FromResult(Snap(2)), sender);
 
         await notifier.RunOnceAsync(CancellationToken.None); // push
         notifier.ResetDedupe();                              // a new device subscribed

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -1981,7 +1981,12 @@ internal static class GatewayEndpoints
         if (snoozeRegistry is not null)
             foreach (var s in all)
                 if (!string.IsNullOrEmpty(s.SessionId) && s.OnHold && snoozeRegistry.IsExpired(s.SessionId, nowUtc))
+                {
                     s.OnHold = false;
+                    // Phase 2: mark it as a RETURNED-from-snooze item so clients render a distinct
+                    // "Snooze ended" badge and the phone push announces it once. Display-only metadata.
+                    s.SnoozeExpired = true;
+                }
 
         var liveIds = new HashSet<string>(StringComparer.Ordinal);
         var controllersWithLiveChild = new HashSet<string>(StringComparer.Ordinal);

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1534,12 +1534,14 @@ public sealed class GatewayHost : IAsyncDisposable
     }
 
     /// <summary>
-    /// Read THIS Gateway's own aggregated roster over loopback and count the sessions that "need you".
+    /// Read THIS Gateway's own aggregated roster over loopback and compute the notifier's snapshot: the
+    /// count of sessions that "need you" plus the ids of those that just returned from an expired snooze.
     /// Going through the real <c>/sessions</c> endpoint (rather than re-implementing the fan-out) keeps
     /// the notifier's verdict identical to what every client sees - same aggregation, same effective-red
-    /// fold. The per-machine Bearer is attached so it works whether or not global Gateway auth is on.
+    /// fold, same <see cref="Contracts.SessionDto.SnoozeExpired"/> overlay. The per-machine Bearer is
+    /// attached so it works whether or not global Gateway auth is on.
     /// </summary>
-    private async Task<int> GetNeedsYouCountAsync(CancellationToken cancellationToken)
+    private async Task<Push.WebPushNeedsYouNotifier.NeedsYouSnapshot> GetNeedsYouCountAsync(CancellationToken cancellationToken)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, $"http://127.0.0.1:{Port}/sessions");
         request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {Token}");
@@ -1548,7 +1550,9 @@ public sealed class GatewayHost : IAsyncDisposable
         var json = await response.Content.ReadAsStringAsync(cancellationToken);
         var sessions = JsonSerializer.Deserialize<List<Contracts.SessionDto>>(
             json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ?? new();
-        return Push.WebPushNeedsYouNotifier.CountNeedsYou(sessions);
+        return new Push.WebPushNeedsYouNotifier.NeedsYouSnapshot(
+            Push.WebPushNeedsYouNotifier.CountNeedsYou(sessions),
+            Push.WebPushNeedsYouNotifier.ExpiredNeedsYouIds(sessions));
     }
 
     /// <summary>

--- a/src/CcDirector.Gateway/Push/WebPushNeedsYouNotifier.cs
+++ b/src/CcDirector.Gateway/Push/WebPushNeedsYouNotifier.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Net;
 using System.Text.Json;
 using CcDirector.Core.Utilities;
@@ -30,6 +31,14 @@ namespace CcDirector.Gateway.Push;
 ///   - The FALLING edge (the count has read zero for <see cref="ClearConfirmations"/> polls in a row)
 ///     pushes a single zero so the dot CLEARS even while the phone app is closed - the service worker
 ///     closes its notification on a zero payload.
+///   - A newly-EXPIRED snooze (Snooze Length mission): when a session RETURNS from an expired snooze
+///     (<see cref="SessionDto.SnoozeExpired"/>) it is genuinely new, actionable news, so it is ANNOUNCED
+///     ONCE with distinct copy that is ALLOWED to buzz even if the dot is already up. Crucially, the
+///     announcement is keyed to a session ENTERING the expired set that we have not yet announced, NOT to
+///     "any expired snooze is present" - a dead-Director expired snooze lingers in "needs you" forever, so
+///     buzzing on its mere presence would re-buzz every poll. Once announced it is remembered
+///     (<see cref="DotState.Announced"/>) and folds into the silent dot/heartbeat, never buzzing again
+///     while it lingers.
 /// A change from one non-zero count to another (2 -> 3 -> 4) is NOT pushed between heartbeats: the dot
 /// is already there. Keeping the volume this low is what stops the constant pinging, and in particular
 /// keeps the silent zero-clear push (a push that shows no notification, which browsers budget under the
@@ -65,7 +74,7 @@ public sealed class WebPushNeedsYouNotifier : IDisposable
     public const int HeartbeatPolls = 8;
 
     private readonly PushSubscriptionStore _store;
-    private readonly Func<CancellationToken, Task<int>> _getNeedsYouCount;
+    private readonly Func<CancellationToken, Task<NeedsYouSnapshot>> _getSnapshot;
     private readonly IWebPushSender _sender;
 
     private System.Threading.Timer? _timer;
@@ -75,11 +84,11 @@ public sealed class WebPushNeedsYouNotifier : IDisposable
 
     public WebPushNeedsYouNotifier(
         PushSubscriptionStore store,
-        Func<CancellationToken, Task<int>> getNeedsYouCount,
+        Func<CancellationToken, Task<NeedsYouSnapshot>> getSnapshot,
         IWebPushSender sender)
     {
         _store = store ?? throw new ArgumentNullException(nameof(store));
-        _getNeedsYouCount = getNeedsYouCount ?? throw new ArgumentNullException(nameof(getNeedsYouCount));
+        _getSnapshot = getSnapshot ?? throw new ArgumentNullException(nameof(getSnapshot));
         _sender = sender ?? throw new ArgumentNullException(nameof(sender));
     }
 
@@ -102,55 +111,90 @@ public sealed class WebPushNeedsYouNotifier : IDisposable
     }
 
     /// <summary>
+    /// The count of sessions that "need you" plus the ids of those that just returned from an expired
+    /// snooze (a subset of the needs-you set). The notifier reads this once per poll from the same
+    /// aggregated roster every client sees.
+    /// </summary>
+    public readonly record struct NeedsYouSnapshot(int Count, IReadOnlyCollection<string> ExpiredNeedsYouIds);
+
+    /// <summary>
     /// Immutable decision state for the app-icon dot: whether we have told the phone a dot is present,
     /// how many consecutive zero-count polls we have seen while it is present (the falling-edge debounce
-    /// counter), and how many polls have passed since we last pushed while it is present (the heartbeat
-    /// counter that brings a phone-cleared dot back).
+    /// counter), how many polls have passed since we last pushed while it is present (the heartbeat
+    /// counter that brings a phone-cleared dot back), and the set of returned-from-snooze session ids we
+    /// have ALREADY announced (so each is buzzed exactly once and a lingering expired snooze never
+    /// re-buzzes).
     /// </summary>
-    public readonly record struct DotState(bool DotShowing, int ZeroStreak, int PollsSincePush)
+    public readonly record struct DotState(bool DotShowing, int ZeroStreak, int PollsSincePush, ImmutableHashSet<string> Announced)
     {
-        /// <summary>The starting state: no dot on the phone, no pending clear.</summary>
-        public static readonly DotState Initial = new(false, 0, 0);
+        /// <summary>The starting state: no dot on the phone, no pending clear, nothing announced.</summary>
+        public static readonly DotState Initial = new(false, 0, 0, ImmutableHashSet<string>.Empty);
+    }
+
+    private static readonly IReadOnlyCollection<string> NoExpired = Array.Empty<string>();
+
+    /// <summary>
+    /// The pure decision, count-only overload (no snooze-expiry signal). Kept so the dot's rising /
+    /// heartbeat / falling behavior can be reasoned about and tested in isolation.
+    /// </summary>
+    public static (bool push, int count, DotState next) Decide(int current, DotState state)
+    {
+        var (push, count, _, next) = Decide(current, NoExpired, state);
+        return (push, count, next);
     }
 
     /// <summary>
     /// The pure decision. The app-icon dot is boolean on Android (a dot is present or not - the exact
     /// count does not change it), so we push on the moments that matter and stay quiet otherwise:
+    ///   - Newly-expired snooze (highest priority): one or more sessions in <paramref name="expiredNow"/>
+    ///     were not in <see cref="DotState.Announced"/> - announce ONCE (push, snoozeEnded=true, buzz
+    ///     permitted) even if the dot is already up, then remember them so they never re-buzz.
     ///   - Rising edge (no dot yet, work now needs you): push the current count so the dot appears.
     ///   - Heartbeat (dot showing, <see cref="HeartbeatPolls"/> polls since the last push): re-push the
-    ///     current count so a dot the phone cleared on its own (a swipe-away, or the app clearing it on
-    ///     foreground) comes back while sessions still wait. The re-assert is silent, so it does not buzz.
-    ///   - Falling edge (dot showing, count has read zero for <see cref="ClearConfirmations"/> polls in
-    ///     a row): push a single zero so the dot clears, even while the app is closed.
-    /// A change from one non-zero count to another (2 -> 3 -> 4) does NOT push between heartbeats: the
-    /// dot is already there. Returns whether to push, the count to send, and the next state to carry
-    /// forward.
+    ///     current count so a dot the phone cleared on its own comes back. Silent, so it does not buzz.
+    ///   - Falling edge (dot showing, count has read zero for <see cref="ClearConfirmations"/> polls in a
+    ///     row): push a single zero so the dot clears, even while the app is closed.
+    /// The <see cref="DotState.Announced"/> set is pruned to only sessions still expired each poll, so a
+    /// session whose snooze was cleared and later re-expires is announced afresh. Returns whether to push,
+    /// the count to send, whether this push is a snooze-expiry announcement, and the next state.
     /// </summary>
-    public static (bool push, int count, DotState next) Decide(int current, DotState state)
+    public static (bool push, int count, bool snoozeEnded, DotState next) Decide(
+        int current, IReadOnlyCollection<string> expiredNow, DotState state)
     {
+        // Prune the announced set to sessions still expired (a cleared/re-snoozed session drops out and
+        // may be announced again if it re-expires), then find the ones newly entering the expired set.
+        var expiredSet = expiredNow as ImmutableHashSet<string> ?? ImmutableHashSet.CreateRange(expiredNow);
+        var announcedStill = state.Announced.Intersect(expiredSet);
+        var hasNewlyExpired = expiredSet.Except(announcedStill).Count > 0;
+
         if (current > 0)
         {
+            // A newly-expired snooze is genuinely new, actionable news: announce it ONCE, and let it buzz
+            // even if the dot is already up. After this it is remembered and folds into the silent dot.
+            if (hasNewlyExpired)
+                return (true, current, true, new DotState(true, 0, 0, expiredSet));
+
             // Rising edge: work now needs you and no dot is up yet -> show it immediately.
             if (!state.DotShowing)
-                return (true, current, new DotState(DotShowing: true, ZeroStreak: 0, PollsSincePush: 0));
+                return (true, current, false, new DotState(true, 0, 0, announcedStill));
 
             // Dot already up. Re-assert on the heartbeat (recovers a phone-side clear); otherwise stay
             // quiet, only advancing the heartbeat counter.
             var polls = state.PollsSincePush + 1;
             if (polls >= HeartbeatPolls)
-                return (true, current, new DotState(DotShowing: true, ZeroStreak: 0, PollsSincePush: 0));
-            return (false, 0, new DotState(DotShowing: true, ZeroStreak: 0, PollsSincePush: polls));
+                return (true, current, false, new DotState(true, 0, 0, announcedStill));
+            return (false, 0, false, new DotState(true, 0, polls, announcedStill));
         }
 
-        // current == 0: nothing needs you right now.
+        // current == 0: nothing needs you right now (so nothing is expired either).
         if (!state.DotShowing)
-            return (false, 0, DotState.Initial); // no dot to clear (startup, or already cleared)
+            return (false, 0, false, DotState.Initial); // no dot to clear (startup, or already cleared)
 
         var streak = state.ZeroStreak + 1;
         if (streak >= ClearConfirmations)
-            return (true, 0, DotState.Initial); // settled at zero -> clear the dot once
+            return (true, 0, false, DotState.Initial); // settled at zero -> clear the dot once, forget announcements
         // Debouncing the clear: hold the dot, keep the heartbeat counter so a re-rise resumes cleanly.
-        return (false, 0, new DotState(DotShowing: true, ZeroStreak: streak, PollsSincePush: state.PollsSincePush));
+        return (false, 0, false, new DotState(true, streak, state.PollsSincePush, announcedStill));
     }
 
     /// <summary>The count of sessions that currently "need you" (effective-red, not parked).</summary>
@@ -158,7 +202,20 @@ public sealed class WebPushNeedsYouNotifier : IDisposable
         sessions.Count(s => SessionOrdering.Classify(s) == SessionOrdering.TriageBucket.NeedsYou);
 
     /// <summary>
-    /// One poll: skip entirely when no one is subscribed; otherwise read the current count, decide,
+    /// The ids of sessions that "need you" AND just returned from an expired snooze
+    /// (<see cref="SessionDto.SnoozeExpired"/>). A subset of the needs-you set - the ones the notifier
+    /// announces once with distinct copy.
+    /// </summary>
+    public static IReadOnlyCollection<string> ExpiredNeedsYouIds(IEnumerable<SessionDto> sessions) =>
+        sessions
+            .Where(s => s.SnoozeExpired
+                        && !string.IsNullOrEmpty(s.SessionId)
+                        && SessionOrdering.Classify(s) == SessionOrdering.TriageBucket.NeedsYou)
+            .Select(s => s.SessionId)
+            .ToList();
+
+    /// <summary>
+    /// One poll: skip entirely when no one is subscribed; otherwise read the current snapshot, decide,
     /// and push to every subscription when the decision says so. Public so a test can drive it directly.
     /// </summary>
     public async Task RunOnceAsync(CancellationToken cancellationToken)
@@ -170,10 +227,10 @@ public sealed class WebPushNeedsYouNotifier : IDisposable
             return;
         }
 
-        int current;
+        NeedsYouSnapshot snapshot;
         try
         {
-            current = await _getNeedsYouCount(cancellationToken);
+            snapshot = await _getSnapshot(cancellationToken);
         }
         catch (Exception ex)
         {
@@ -183,20 +240,21 @@ public sealed class WebPushNeedsYouNotifier : IDisposable
 
         bool push;
         int count;
+        bool snoozeEnded;
         lock (_dotLock)
         {
-            (push, count, _dot) = Decide(current, _dot);
+            (push, count, snoozeEnded, _dot) = Decide(snapshot.Count, snapshot.ExpiredNeedsYouIds, _dot);
         }
         if (!push) return;
 
-        await SendToAllAsync(count, cancellationToken);
+        await SendToAllAsync(count, snoozeEnded, cancellationToken);
     }
 
-    private async Task SendToAllAsync(int count, CancellationToken cancellationToken)
+    private async Task SendToAllAsync(int count, bool snoozeEnded, CancellationToken cancellationToken)
     {
-        var payload = JsonSerializer.Serialize(new NeedsYouPayload { Count = count });
+        var payload = JsonSerializer.Serialize(new NeedsYouPayload { Count = count, SnoozeEnded = snoozeEnded });
         var subscriptions = _store.All();
-        FileLog.Write($"[WebPushNeedsYouNotifier] pushing count={count} to {subscriptions.Count} subscription(s)");
+        FileLog.Write($"[WebPushNeedsYouNotifier] pushing count={count} snoozeEnded={snoozeEnded} to {subscriptions.Count} subscription(s)");
 
         foreach (var subscription in subscriptions)
         {
@@ -259,5 +317,11 @@ public sealed class WebPushNeedsYouNotifier : IDisposable
         // Lowercase on the wire so the service worker reads event.data.json().count.
         [System.Text.Json.Serialization.JsonPropertyName("count")]
         public int Count { get; set; }
+
+        // Snooze Length mission: true only on the one push that ANNOUNCES a newly-returned-from-snooze
+        // session. The service worker renders the distinct "Snooze ended" copy and lets that push buzz;
+        // every other push stays the quiet dot. Always present so the worker can read it.
+        [System.Text.Json.Serialization.JsonPropertyName("snoozeEnded")]
+        public bool SnoozeEnded { get; set; }
     }
 }


### PR DESCRIPTION
Phase 2 of the Snooze Length mission (follow-up to #1375, #1381). Makes a returned-from-snooze session **visibly distinct** from an ordinary needs-you, and announces it once on the phone.

## What
- **`SessionDto.SnoozeExpired`** - a display-only marker the Gateway aggregation overlay stamps true when it flips an expired snooze back into "needs you" (alongside `OnHold=false`). Nothing is injected into the session conversation.
- **Roster badge** - an amber **"Snooze ended"** tag on the cockpit roster and the mobile roster, read from a new `snoozeExpired()` client-core accessor (same Gateway-stamped-field pattern as `effectiveColor`/`stateLabel`, so no OpenAPI regen needed).
- **Distinct phone push, announced ONCE** - `WebPushNeedsYouNotifier` now reads the set of returned-from-snooze session ids and announces each **newly-expired** one exactly once (payload `snoozeEnded:true`), allowed to buzz even when the dot is already up. It remembers announcements (`DotState.Announced`, pruned to still-expired each poll) so a **lingering dead-Director expired snooze never re-buzzes** - the anti-buzz invariant the Architect called out. Every existing guarantee (falling-edge debounce, silent heartbeat re-asserts) is kept. Both service workers render **"Snooze ended - still waiting on you"**: the mobile worker lets that one push buzz (`silent:false`) while the plain dot stays silent; the desktop worker swaps in the distinct body.

## Verification (agent-driven, per the owner's call - no live phone hand-off)
- Notifier `Decide`/`RunOnceAsync` tests: newly-expired-while-dot-up buzzes once; a lingering expired snooze never re-buzzes; re-snooze-then-re-expire re-announces.
- Aggregation test asserts `GET /sessions` carries `SnoozeExpired=true` for an expired snooze.
- .NET snooze/notifier/aggregation suite green (79); client-core 377 green; cockpit + mobile typecheck and build clean.
- Follow-up: a Playwright PWA screenshot of the "Snooze ended" badge (mobile-pwa-proof harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)