### PR TITLE
feat(mobile): Phase 4 - hardening (poll timeout, banner debounce)

### DIFF
--- a/apps/mobile/src/components/ConnectionBanner.tsx
+++ b/apps/mobile/src/components/ConnectionBanner.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useConnectionHealth } from "@devthrottle/client-core/connection/health";
 import { useNow } from "@devthrottle/client-core/sessions/waiting";
 
@@ -17,6 +17,13 @@ import { useNow } from "@devthrottle/client-core/sessions/waiting";
 // Below this the age is too small to be worth naming; the banner just says the connection is bad.
 const STALE_THRESHOLD_MS = 3000;
 
+// The connection must stay bad this long before the banner appears (mobile-resilience mission, Phase 4).
+// One lost packet - a single failed poll that the next tick recovers, or a terminal stream reconnect
+// blipping while plain polls still succeed - flips the health signal bad then good in well under this
+// window, so the banner never flashes for it. A genuine outage stays bad past the window and shows.
+// Recovery is NOT debounced: the banner hides the instant the connection is good again.
+const BAD_DEBOUNCE_MS = 2500;
+
 // A compact "how long ago" label with seconds granularity (the mission's "updated 40s ago"), climbing
 // to minutes and hours for a longer outage: "40s" -> "3m" -> "1h 4m".
 function agoLabel(gapMs: number): string {
@@ -31,13 +38,25 @@ function agoLabel(gapMs: number): string {
 
 export function ConnectionBanner(): React.ReactElement | null {
   const health = useConnectionHealth();
-  // Tick once a second while the connection is bad, so the staleness age climbs live. While it is good
-  // the banner renders nothing, so there is nothing to tick - drop to a slow 60s heartbeat rather than
-  // running a 1s timer app-wide forever (a small mobile-battery courtesy). useNow restarts its interval
-  // when the value changes, so the fast tick begins the moment the connection goes bad.
-  const now = useNow(health.state === "bad" ? 1000 : 60000);
+  // Debounced visibility: the banner shows only after the connection has been bad for BAD_DEBOUNCE_MS,
+  // so a one-packet blip never flashes it; it hides immediately on recovery. The health store emits only
+  // on an actual good<->bad flip, so this effect runs once per real transition, not per poll.
+  const [shown, setShown] = useState(false);
+  useEffect(() => {
+    if (health.state === "good") {
+      setShown(false);
+      return;
+    }
+    const timer = window.setTimeout(() => setShown(true), BAD_DEBOUNCE_MS);
+    return () => window.clearTimeout(timer);
+  }, [health.state]);
 
-  if (health.state === "good") return null;
+  // Tick once a second only while the banner is shown, so the staleness age climbs live. While it is
+  // hidden there is nothing to tick - drop to a slow 60s heartbeat rather than running a 1s timer
+  // app-wide forever (a small mobile-battery courtesy).
+  const now = useNow(shown ? 1000 : 60000);
+
+  if (!shown) return null;
 
   const gap = health.lastGoodContactAt > 0 ? now - health.lastGoodContactAt : 0;
   const showAge = health.lastGoodContactAt > 0 && gap >= STALE_THRESHOLD_MS;

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -235,16 +235,55 @@ function isGatewayUnreachable(err: unknown): boolean {
 // used by isGatewayUnreachable; it does not invent a second taxonomy. Exported so the fleet client
 // (fleetClient.ts) routes its reads - including the roster envelope the mobile app now polls - through
 // the SAME choke point, keeping the connection-health signal fed no matter which reader is on screen.
-export async function gatewayFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+//
+// timeoutMs (mobile-resilience mission, Phase 4): a hardening cap for the repeating POLL reads (the
+// roster, chat history, voice). Without it a request that HANGS (a half-open connection on a flaky
+// mobile network - the TCP never resets, so fetch neither resolves nor rejects) would sit in flight
+// forever, so the health signal never flips to bad and the banner never shows. With it, a poll that
+// exceeds the cap is aborted and reported UNREACHABLE (a timed-out request could not reach a healthy
+// backend), distinct from a caller-initiated abort. One-shot writes pass no timeout and are unchanged.
+export async function gatewayFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  opts?: { timeoutMs?: number },
+): Promise<Response> {
+  const timeoutMs = opts?.timeoutMs;
+  const callerSignal = init?.signal ?? undefined;
+  let controller: AbortController | undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+  let onCallerAbort: (() => void) | undefined;
+  let signal = callerSignal;
+  if (timeoutMs !== undefined) {
+    // Race the fetch against the timeout via our own controller, and forward a caller abort to it so
+    // both an unmount and a timeout cancel the in-flight request.
+    controller = new AbortController();
+    signal = controller.signal;
+    if (callerSignal) {
+      if (callerSignal.aborted) controller.abort();
+      else { onCallerAbort = () => controller!.abort(); callerSignal.addEventListener("abort", onCallerAbort, { once: true }); }
+    }
+    timer = setTimeout(() => { timedOut = true; controller!.abort(); }, timeoutMs);
+  }
+
   let res: Response;
   try {
-    res = await fetch(input, init);
+    res = await fetch(input, signal ? { ...init, signal } : init);
   } catch (err) {
+    // A timeout is a connection failure (the request could not reach a healthy backend in time), so it
+    // is reported and surfaced as an error rather than swallowed like a caller cancel.
+    if (timedOut) {
+      reportGatewayUnreachable();
+      throw new GatewayError(504, "Gateway request timed out");
+    }
     // A caller-initiated abort (the browser throws a DOMException named "AbortError", which extends
     // Error) is a cancel, not a connection signal - rethrow it without recording anything.
     if (err instanceof Error && err.name === "AbortError") throw err;
     reportGatewayUnreachable();
     throw err;
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+    if (onCallerAbort && callerSignal) callerSignal.removeEventListener("abort", onCallerAbort);
   }
   if (res.status === 0 || res.status === 502 || res.status === 503 || res.status === 504) {
     reportGatewayUnreachable();
@@ -253,6 +292,11 @@ export async function gatewayFetch(input: RequestInfo | URL, init?: RequestInit)
   }
   return res;
 }
+
+// The cap for the repeating poll reads (roster, chat history, voice). Long enough not to trip on a slow
+// but alive mobile connection, short enough that a hung request surfaces as a bad connection within one
+// or two poll cycles instead of never (mobile-resilience mission, Phase 4).
+export const POLL_TIMEOUT_MS = 10000;
 
 // Map any error thrown by a Gateway read/write into ONE user-facing line, never leaking the internal
 // "METHOD /path failed: NNN" diagnostic the client throws on a non-2xx, nor the browser's bare
@@ -312,7 +356,7 @@ export async function listSessions(signal?: AbortSignal): Promise<SessionDto[]> 
     method: "GET",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
-  });
+  }, { timeoutMs: POLL_TIMEOUT_MS });
   if (res.status === 401) {
     // The device key was revoked (or is otherwise invalid): forget it and re-gate to Sign in. The
     // roster is the first credentialed call the app makes, so this is where a revoke surfaces.
@@ -341,7 +385,7 @@ export async function getSessionHistory(
     method: "GET",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
-  });
+  }, { timeoutMs: POLL_TIMEOUT_MS });
   if (!res.ok) {
     throw new GatewayError(res.status, `GET history failed: ${res.status}`);
   }

--- a/packages/client-core/src/api/gatewayFetchTimeout.test.ts
+++ b/packages/client-core/src/api/gatewayFetchTimeout.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The poll-timeout hardening on the shared transport choke point (mobile-resilience mission, Phase 4):
+// a repeating poll read passes a timeoutMs so a HUNG request (a half-open connection that never resolves
+// or rejects) is aborted and reported as a bad connection, instead of sitting in flight forever and
+// leaving the health signal stuck "good". A timeout is distinct from a caller-initiated abort (an
+// unmount), which stays silent. The connection-health module is mocked so the reports are asserted
+// directly; fake timers make the timeout deterministic.
+const health = vi.hoisted(() => ({ reachable: vi.fn(), unreachable: vi.fn() }));
+vi.mock("../connection/health", () => ({
+  reportGatewayReachable: () => health.reachable(),
+  reportGatewayUnreachable: () => health.unreachable(),
+}));
+
+import { gatewayFetch } from "./client";
+
+// A fetch that never settles on its own but rejects with an AbortError the moment its signal aborts -
+// exactly how the browser fetch behaves for a hung request that is then aborted.
+function hangingFetch(): typeof fetch {
+  return ((_input: unknown, init?: RequestInit) =>
+    new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => {
+        const e = new Error("aborted");
+        e.name = "AbortError";
+        reject(e);
+      });
+    })) as unknown as typeof fetch;
+}
+
+describe("gatewayFetch poll timeout (Phase 4)", () => {
+  const realFetch = globalThis.fetch;
+  beforeEach(() => {
+    vi.useFakeTimers();
+    health.reachable.mockClear();
+    health.unreachable.mockClear();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    globalThis.fetch = realFetch;
+  });
+
+  it("aborts a hung request after the timeout and reports the Gateway unreachable", async () => {
+    globalThis.fetch = hangingFetch();
+    const call = gatewayFetch("/sessions", {}, { timeoutMs: 5000 });
+    const assertion = expect(call).rejects.toMatchObject({ status: 504 });
+    await vi.advanceTimersByTimeAsync(5000); // trip the timeout
+    await assertion;
+    expect(health.unreachable).toHaveBeenCalledTimes(1);
+    expect(health.reachable).not.toHaveBeenCalled();
+  });
+
+  it("returns normally and reports reachable when the request beats the timeout", async () => {
+    globalThis.fetch = (async () => ({ status: 200, ok: true }) as Response) as unknown as typeof fetch;
+    const res = await gatewayFetch("/sessions", {}, { timeoutMs: 5000 });
+    expect(res.status).toBe(200);
+    expect(health.reachable).toHaveBeenCalledTimes(1);
+    expect(health.unreachable).not.toHaveBeenCalled();
+  });
+
+  it("stays silent for a caller-initiated abort (an unmount), not a timeout", async () => {
+    const controller = new AbortController();
+    globalThis.fetch = hangingFetch();
+    const call = gatewayFetch("/sessions", { signal: controller.signal }, { timeoutMs: 5000 });
+    const assertion = expect(call).rejects.toMatchObject({ name: "AbortError" });
+    controller.abort(); // the caller cancels before the timeout could fire
+    await assertion;
+    expect(health.unreachable).not.toHaveBeenCalled();
+    expect(health.reachable).not.toHaveBeenCalled();
+  });
+
+  it("does not time out a request with no timeoutMs (one-shot writes are unchanged)", async () => {
+    globalThis.fetch = (async () => ({ status: 200, ok: true }) as Response) as unknown as typeof fetch;
+    const res = await gatewayFetch("/sessions/s/prompt", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(health.reachable).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/client-core/src/fleet/fleetClient.ts
+++ b/packages/client-core/src/fleet/fleetClient.ts
@@ -7,7 +7,7 @@
 // Gateway-only-ingress rule the rest of client-core obeys, and carries the same Bearer via
 // authHeaders(). A non-2xx throws GatewayError so the caller surfaces the real reason instead of a
 // silently empty list (no fallback that hides the problem).
-import { authHeaders, gatewayFetch, GatewayError, type SessionDto } from "../api/client";
+import { authHeaders, gatewayFetch, GatewayError, POLL_TIMEOUT_MS, type SessionDto } from "../api/client";
 
 // ===== Directors registry (GET /directors) =====
 
@@ -120,11 +120,13 @@ export interface SessionsEnvelope {
 // reachability. Throws GatewayError on non-2xx so the page surfaces the failure rather than showing a
 // silently empty roster.
 export async function getSessionsEnvelope(signal?: AbortSignal): Promise<SessionsEnvelope> {
+  // The mobile roster polls this every couple of seconds; cap it so a hung request cannot leave the
+  // health signal stuck "good" during an outage (mobile-resilience mission, Phase 4).
   const res = await gatewayFetch("/sessions?envelope=true", {
     method: "GET",
     headers: { Accept: "application/json", ...authHeaders() },
     signal,
-  });
+  }, { timeoutMs: POLL_TIMEOUT_MS });
   if (!res.ok) {
     throw new GatewayError(res.status, `GET /sessions?envelope=true failed: ${res.status}`);
   }


### PR DESCRIPTION
## Mobile bad-connection resilience mission - Phase 4 (final)

Brief: `docs/architecture/mobile-resilience-mission-2026-07-11.md`. Follows Phases 1-3 (#1374, thefrederiksen/devthrottle#1380, thefrederiksen/devthrottle#1382). The general "a lot more resilient" pass for genuinely flaky conditions.

### What changed

**Poll timeout** - `packages/client-core/src/api/client.ts`, `fleetClient.ts`
- The repeating poll reads (roster, chat history, voice) pass a 10s timeout through the shared `gatewayFetch` choke point. Without it a request that HANGS on a half-open mobile connection (the TCP never resets, so fetch neither resolves nor rejects) would sit in flight forever, leaving the health signal stuck "good" and the banner never showing. With it, a poll that exceeds the cap is aborted and reported unreachable - distinct from a caller-initiated abort (an unmount), which stays silent. One-shot writes pass no timeout and are unchanged.

**Banner debounce** - `apps/mobile/src/components/ConnectionBanner.tsx`
- The one global banner shows only after the connection has been bad for 2.5s, so a one-packet blip never flashes it: a single failed poll the next tick recovers, or the terminal stream's ~1200ms reconnect blipping while plain polls still succeed, both flip bad->good well inside the window. Recovery is not debounced - the banner hides the instant the connection is good again.

**Voice + dictation exercised, not rebuilt** (as the brief directs) - voice records locally and plays only a fully-buffered clip; dictation is the durable store-and-forward path (#1006/#1182). Both already survive a dropped connection by design and are left unchanged.

### Verification
- `npm run typecheck` clean across all three workspaces; `npm run build` (mobile) succeeds.
- Client-core tests: 386 passing (36 files), including 4 new `gatewayFetch` timeout cases (a hung request aborts and reports unreachable; a fast request returns and reports reachable; a caller abort stays silent; no timeoutMs is unchanged). The health store (Phase 1) and the roster keep-and-mark merge (Phase 2) already carry their unit tests.
- Lint + ASCII clean on all touched files.

### Owner proof (live)
A real drive or cottage visit: the roster, chat, terminal, and voice all stay populated and honest, with the one banner the only sign of trouble - and it does not twitch on a passing blip.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)