### PR TITLE
docs(reviews): mobile bad-connection resilience mission verification report

### DIFF
--- a/docs/reviews/mobile-resilience-mission-2026-07-11.html
+++ b/docs/reviews/mobile-resilience-mission-2026-07-11.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Mobile bad-connection resilience - verification report</title>
+<style>
+  :root {
+    --bg: #0f1420; --panel: #161d2c; --panel2: #1b2334; --border: #2a3547;
+    --text: #e6ebf3; --dim: #9aa7bd; --accent: #6ea8fe; --good: #38b26b;
+    --warn: #d9a441; --bad: #e0685f; --mono: "Cascadia Mono", Consolas, monospace;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--text);
+    font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.55; }
+  .wrap { max-width: 940px; margin: 0 auto; padding: 32px 20px 80px; }
+  h1 { font-size: 28px; margin: 0 0 6px; letter-spacing: 0.2px; }
+  h2 { font-size: 20px; margin: 40px 0 12px; padding-bottom: 8px; border-bottom: 1px solid var(--border); }
+  h3 { font-size: 16px; margin: 22px 0 6px; }
+  .sub { color: var(--dim); font-size: 14px; margin: 0 0 4px; }
+  p { margin: 8px 0; }
+  code { font-family: var(--mono); background: var(--panel2); padding: 1px 6px; border-radius: 5px; font-size: 13px; }
+  .card { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 18px 20px; margin: 16px 0; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 12px; margin: 16px 0; }
+  .stat { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 14px 16px; }
+  .stat .n { font-size: 26px; font-weight: 700; }
+  .stat .l { color: var(--dim); font-size: 13px; }
+  .pill { display: inline-block; font-size: 12px; font-weight: 700; padding: 2px 9px; border-radius: 999px; vertical-align: middle; }
+  .pill.done { background: rgba(56,178,107,0.16); color: var(--good); border: 1px solid rgba(56,178,107,0.5); }
+  .pill.pending { background: rgba(217,164,65,0.16); color: var(--warn); border: 1px solid rgba(217,164,65,0.5); }
+  ul { margin: 8px 0; padding-left: 22px; }
+  li { margin: 4px 0; }
+  table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 14px; }
+  th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th { color: var(--dim); font-weight: 600; }
+  .files { font-family: var(--mono); font-size: 12.5px; color: var(--dim); }
+  .proof { border-left: 3px solid var(--accent); padding: 4px 0 4px 14px; margin: 10px 0; color: var(--text); }
+  .shot { border: 1px dashed var(--border); border-radius: 10px; padding: 22px; text-align: center; color: var(--dim); font-size: 13px; margin: 10px 0; background: var(--panel2); }
+  footer { color: var(--dim); font-size: 13px; margin-top: 48px; border-top: 1px solid var(--border); padding-top: 16px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <p class="sub">DevThrottle mission verification report</p>
+  <h1>Mobile bad-connection resilience &mdash; never clear good data</h1>
+  <p class="sub">Written 2026-07-11. Brief: <code>docs/architecture/mobile-resilience-mission-2026-07-11.md</code>. All four phases merged to origin/main and deployed to the live Gateway.</p>
+
+  <div class="grid">
+    <div class="stat"><div class="n">4 / 4</div><div class="l">phases merged &amp; deployed</div></div>
+    <div class="stat"><div class="n">386</div><div class="l">client-core tests passing</div></div>
+    <div class="stat"><div class="n">26</div><div class="l">new tests across the mission</div></div>
+    <div class="stat"><div class="n">1</div><div class="l">global bad-connection banner</div></div>
+  </div>
+
+  <div class="card">
+    <h3>The principle</h3>
+    <p>The owner travels through bad-internet areas and the phone app at <code>/m</code> is his most-used surface on the road. Before this mission a bad connection cleared things out &mdash; the session list vanished, voice disappeared. The rule applied everywhere now: <strong>never clear good data just because the connection is bad.</strong> Every surface keeps its last-known content, and one small banner at the top names the bad connection so he knows it is the network, not the fleet.</p>
+  </div>
+
+  <h2>Phase 1 &mdash; the connection-health signal and the one banner <span class="pill done">MERGED &amp; LIVE</span></h2>
+  <p class="files">PR #1374 &middot; commit 70c5b2f8</p>
+  <p>A shared client-core health store (<code>connection/health.ts</code>) that every Gateway contact reports into, fed at ONE transport choke point &mdash; a <code>gatewayFetch</code> wrapper in <code>api/client.ts</code> that all reads and writes route through &mdash; reusing the existing issue #1028 unreachable taxonomy. A <code>useConnectionHealth()</code> hook drives one global banner mounted once in <code>GatedLayout</code>: hidden while good; when bad, a slim amber strip pins to the top of every screen and says how stale things are (&ldquo;updated 40s ago&rdquo;). The roster&rsquo;s own offline strip was retired so the condition has exactly one voice.</p>
+  <div class="proof"><strong>Live proof:</strong> airplane mode on the roster, chat, voice, and terminal &mdash; content stays on all four, one banner names the bad connection, and it clears within a poll tick of the network returning.</div>
+  <div class="shot">[ owner phone screenshot: banner over the roster in airplane mode ]</div>
+
+  <h2>Phase 2 &mdash; keep-and-mark unreachable machines on the roster <span class="pill done">MERGED &amp; LIVE</span></h2>
+  <p class="files">PR #1380 &middot; commit 77c199d1</p>
+  <p>The roster moved to the <code>/sessions</code> envelope (per-Director reachability) and a new pure merge (<code>fleet/rosterRetention.ts</code>) keeps a last-known-sessions cache per owning Director. Sessions of a Wobbly/Offline machine STAY on the roster &mdash; grayed, dashed, with a plain note (&ldquo;Unreachable &mdash; MACHINE &mdash; last seen 2m ago&rdquo;) &mdash; retained even after the Gateway&rsquo;s grace window drops them. A session is removed ONLY when its owning Director answers Online without it. No shrink heuristics.</p>
+  <div class="proof"><strong>Live proof:</strong> stop a second machine&rsquo;s Director &mdash; its sessions stay, grayed and named unreachable; kill a session on a reachable Director &mdash; it leaves promptly; restart the stopped Director &mdash; its cards return to live in place.</div>
+  <div class="shot">[ owner phone screenshot: a grayed unreachable machine&rsquo;s sessions kept on the roster ]</div>
+
+  <h2>Phase 3 &mdash; terminal reconnect that never blanks <span class="pill done">MERGED &amp; LIVE</span></h2>
+  <p class="files">PR #1382 &middot; commit 2ea19f11</p>
+  <p>The live terminal mirror used to wipe the screen on every failed reconnect attempt (<code>term.reset()</code> ran at the top of <code>connect()</code>, which the ~1200ms retry loop calls repeatedly). The reset moved into the socket&rsquo;s <code>onopen</code>, right before the byte-0 history replay &mdash; so a failed attempt keeps the last-known screen and only a real replay clears it. The socket also feeds the global banner (a dead stream shows it even when polls succeed), and a &ldquo;Reconnecting to the live terminal&hellip;&rdquo; note floats over the last-known screen. Chat keeps its bubbles and a failing history poll now surfaces through the banner.</p>
+  <div class="proof"><strong>Live proof:</strong> airplane mode mid-stream &mdash; the terminal keeps its content (never blank), the banner and reconnecting note show; on reconnect it replays and is live again with no user action; chat keeps its bubbles throughout.</div>
+  <div class="shot">[ owner phone screenshot: terminal keeping its content with the reconnecting note ]</div>
+
+  <h2>Phase 4 &mdash; hardening (poll timeout, banner debounce) <span class="pill done">MERGED &amp; LIVE</span></h2>
+  <p class="files">PR #1384 &middot; commit 517ed198</p>
+  <p>The repeating poll reads (roster, chat, voice) pass a 10s timeout through <code>gatewayFetch</code>, so a request that hangs on a half-open mobile connection is aborted and reported unreachable instead of sitting in flight forever. The banner is debounced (2.5s) so a one-packet blip &mdash; a single failed poll, or the terminal stream&rsquo;s reconnect blipping while polls still succeed &mdash; never flashes it; recovery is instant. Voice playback and dictation review were exercised, not rebuilt: voice plays only a fully-buffered local clip and dictation is the durable store-and-forward path, both already drop-safe.</p>
+  <div class="proof"><strong>Live proof:</strong> a real drive or cottage visit &mdash; roster, chat, terminal, and voice all stay populated and honest, with the one banner the only sign of trouble, and it does not twitch on a passing blip.</div>
+  <div class="shot">[ owner phone screenshot / note from the live drive ]</div>
+
+  <h2>Test evidence</h2>
+  <table>
+    <tr><th>Suite</th><th>What it proves</th><th>Cases</th></tr>
+    <tr><td><code>connection/health.test.ts</code></td><td>good/bad transitions, stable-snapshot contract, true last-good time captured at the drop</td><td>6</td></tr>
+    <tr><td><code>fleet/rosterRetention.test.ts</code></td><td>online replace/prune, wobbly keep, offline keep past grace, forgotten Director, removal-requires-authority, in-place recovery, per-machine isolation, idempotency, no-mutation</td><td>11</td></tr>
+    <tr><td><code>terminal/stream.test.ts</code> (new cases)</td><td>no reset on connect (only on open), never wiped on a failed attempt, reachable+live on open, no false unreachable on a normal close, inert after dispose</td><td>5</td></tr>
+    <tr><td><code>api/gatewayFetchTimeout.test.ts</code></td><td>hung request aborts + reports unreachable, fast request reports reachable, caller abort stays silent, no-timeout unchanged</td><td>4</td></tr>
+  </table>
+  <p class="sub">Whole client-core suite: 386 passing (36 files). Typecheck clean across client-core, cockpit, mobile; mobile build clean; lint + ASCII clean on all touched files.</p>
+
+  <h2>Definition of done</h2>
+  <table>
+    <tr><th>Criterion</th><th>Status</th></tr>
+    <tr><td>All phases merged to origin/main, each deployed via <code>redeploy-gateway.ps1</code> (build-identity self-verified)</td><td><span class="pill done">DONE</span></td></tr>
+    <tr><td>No mobile surface replaces good data with empty/degraded data on a bad connection (roster, voice, chat, terminal)</td><td><span class="pill done">DONE</span></td></tr>
+    <tr><td>One small global banner names the trouble (with staleness) and clears itself on recovery, on every screen</td><td><span class="pill done">DONE</span></td></tr>
+    <tr><td>Unreachable machines&rsquo; sessions stay visible and marked until the machine answers; a genuinely removed session still leaves promptly</td><td><span class="pill done">DONE</span></td></tr>
+    <tr><td>The terminal survives connection loss without blanking, shows it is reconnecting, and recovers by itself</td><td><span class="pill done">DONE</span></td></tr>
+    <tr><td>Health store and roster merge rule have unit tests</td><td><span class="pill done">DONE</span></td></tr>
+    <tr><td>Owner live walk-through (airplane-mode, all four surfaces) on the real phone, with screenshots added above</td><td><span class="pill pending">PENDING &mdash; owner&rsquo;s live drive</span></td></tr>
+  </table>
+
+  <footer>
+    Each phase was built in an isolated git worktree off origin/main, merged, and deployed to the running Gateway with the build-identity gate confirming the exact commit. The owner deferred hands-on testing to live use; any problems found there return as defects against the relevant phase. Phone screenshots are added to this report after the live walk-through.
+  </footer>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Final verification report for the mobile bad-connection resilience mission (brief `docs/architecture/mobile-resilience-mission-2026-07-11.md`, definition of done item 6).

A self-contained HTML page in `docs/reviews/` summarizing:
- The principle (never clear good data because the connection is bad).
- All four phases, each merged and deployed live: Phase 1 banner (#1374), Phase 2 roster keep-and-mark (#1380), Phase 3 terminal never-blanks (#1382), Phase 4 hardening (#1384).
- The 26 new tests (health store, roster merge, terminal reconnect, poll timeout); 386 client-core tests passing.
- The definition-of-done checklist: all engineering criteria DONE; the owner's airplane-mode phone walk-through (with screenshots) is the one pending item, with placeholders in the report to fill after his live drive.

Docs-only change.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)