### PR TITLE
fix(local-files): file viewer image/PDF/HTML authenticate via gateway cookie

### DIFF
--- a/apps/cockpit/src/components/FileViewerModal.tsx
+++ b/apps/cockpit/src/components/FileViewerModal.tsx
@@ -3,6 +3,7 @@ import { classifyFile, formatFileSize } from "@devthrottle/client-core/history/f
 import type { FileViewerType } from "@devthrottle/client-core/history/fileTypes";
 import {
   GatewayError,
+  ensureGatewayCookie,
   fetchSessionFileSize,
   fetchSessionFileText,
   sessionFileUrl,
@@ -55,6 +56,12 @@ function fileLoadMessage(err: unknown): string {
 }
 
 export function FileViewerModal({ sessionId, path, onClose }: FileViewerModalProps) {
+  // The image / PDF / HTML modes render a bare <img>/<iframe> whose src hits a gated Gateway route and
+  // so cannot carry a Bearer header; like the terminal stream (terminal/stream.ts), they authenticate
+  // through the cc-gateway-token cookie. Re-mirror it on mount so it is present the moment those
+  // elements load even if the startup cookie was evicted. Synchronous: an effect would run too late.
+  ensureGatewayCookie();
+
   const type = classifyFile(path);
   const url = sessionFileUrl(sessionId, path);
   const name = baseName(path);

--- a/apps/mobile/src/pages/FileView.tsx
+++ b/apps/mobile/src/pages/FileView.tsx
@@ -4,6 +4,7 @@ import { classifyFile, formatFileSize } from "@devthrottle/client-core/history/f
 import type { FileViewerType } from "@devthrottle/client-core/history/fileTypes";
 import {
   GatewayError,
+  ensureGatewayCookie,
   fetchSessionFileSize,
   fetchSessionFileText,
   sessionFileUrl,
@@ -48,6 +49,14 @@ function fileLoadMessage(err: unknown): string {
 }
 
 export function FileView() {
+  // The image / PDF / HTML modes below render a bare <img>/<iframe> whose src hits a gated Gateway
+  // route. Those elements cannot carry a Bearer header, so - exactly like the terminal stream before it
+  // opens its WebSocket (terminal/stream.ts) - they authenticate through the cc-gateway-token cookie.
+  // Re-mirror it here, on mount, so the cookie is present the moment those elements load even if an
+  // installed PWA evicted the app-startup cookie between launches (the "Could not load image" failure).
+  // Synchronous, not an effect: an effect runs after the first paint, too late for the initial request.
+  ensureGatewayCookie();
+
   const { sessionId } = useParams<{ sessionId: string }>();
   const [params] = useSearchParams();
   const navigate = useNavigate();

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -78,12 +78,22 @@ export function authHeaders(): HeadersInit {
 // cannot set an Authorization header, so the live terminal stream (GET /sessions/{sid}/stream)
 // authenticates via this cookie, which the same-origin handshake carries and the Gateway's
 // AuthMiddleware accepts (HasValidToken checks the cookie against the shared token OR an active
-// per-device key). The key is already in this origin's storage, so the cookie exposes nothing new; it
-// is scoped to this origin. A no-op before enrollment (no key yet - the stream is never opened then).
+// per-device key). The same constraint applies to any bare <img>/<iframe> src that hits a gated
+// Gateway route - the Local Files viewer's image/PDF/HTML modes - because those elements also cannot
+// carry a Bearer header; they authenticate through this cookie exactly as the stream does.
+// The key is already in this origin's storage, so the cookie exposes nothing new; it is scoped to this
+// origin. A no-op before enrollment (no key yet - the stream is never opened then).
+//
+// PERSISTENT (Max-Age one year), not a session cookie: an installed PWA (the phone) can evict a
+// session cookie between launches, after which a bare <img>/<iframe> src loads with no credential and
+// gets a 401 - the Local Files viewer's "Could not load image" failure. Because the credential already
+// lives on disk in localStorage, persisting it in the cookie exposes nothing further; it just keeps the
+// cookie-authenticated resource loads working after the app is closed and reopened.
 export function ensureGatewayCookie(): void {
   const token = gatewayToken();
   if (!token) return;
-  document.cookie = `cc-gateway-token=${encodeURIComponent(token)}; path=/; SameSite=Lax`;
+  const oneYearSeconds = 60 * 60 * 24 * 365;
+  document.cookie = `cc-gateway-token=${encodeURIComponent(token)}; path=/; SameSite=Lax; Max-Age=${oneYearSeconds}`;
 }
 
 // The redirect target when a credentialed call is rejected (401) mid-session is SHELL-AWARE, because


### PR DESCRIPTION
## Problem

The mobile Local Files viewer (`FileView`) and the Cockpit `FileViewerModal` render the **image, PDF and HTML** modes as a bare `<img>`/`<iframe>`. Those elements cannot send an `Authorization` header, so - like the live terminal stream before it opens its WebSocket - they can only authenticate to the gated Gateway route through the `cc-gateway-token` cookie.

Two gaps left that cookie absent when the viewer opened, so the image request hit the Gateway with no credential and got a **401**, surfacing as the viewer's **"Could not load image"** error. Markdown/text modes kept working because they use `fetch()`, which does send the Bearer header.

1. The cookie was only mirrored once at app startup; the viewer never re-ensured it.
2. The cookie was a **session cookie**, which an installed PWA can evict between launches.

This is why the phone (an installed PWA) failed while the desktop usually did not.

## Fix

1. `FileView` and `FileViewerModal` call `ensureGatewayCookie()` **on mount**, before the `<img>`/`<iframe>` loads - mirroring the terminal stream's pattern.
2. `ensureGatewayCookie()` now sets the cookie **persistent** (`Max-Age` one year) instead of a session cookie. The same key already lives in `localStorage`, so this exposes nothing new.

## Verification

Tested in a real browser against the **live Gateway** on the `ts.net` origin, in the phone's cleared-cookie state. All five file types return **200** and render; the previously-failing `<img>` loads (1280px). Screenshots captured for image / html / markdown.

Root cause proven: with the cookie cleared, `<img>` -> onerror + `fetch` -> 401; after the on-mount `ensureGatewayCookie()`, `<img>` -> loaded.