### PR TITLE
feat(snooze): Phase 3 - route desktop snooze through the Gateway + settings control + dead-Director proof

### DIFF
--- a/apps/cockpit/src/settings/SettingsView.tsx
+++ b/apps/cockpit/src/settings/SettingsView.tsx
@@ -4,6 +4,7 @@ import {
   getGatewaySettings,
   setAddressingMode,
   setAutostart,
+  setSnoozeDefaultMinutes,
   setTrainingCapture,
   type AddressingMode,
   type GatewaySettings,
@@ -114,6 +115,8 @@ function ThisMachineTab() {
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState("");
+  // Snooze Length mission: a draft of the default-snooze-length input, synced from the loaded settings.
+  const [snoozeDraft, setSnoozeDraft] = useState("");
 
   const load = useCallback(async (signal?: AbortSignal) => {
     try {
@@ -130,6 +133,11 @@ function ThisMachineTab() {
     void load(controller.signal);
     return () => controller.abort();
   }, [load]);
+
+  // Keep the snooze input in sync with the loaded/saved value.
+  useEffect(() => {
+    if (settings !== null) setSnoozeDraft(String(settings.snoozeDefaultMinutes));
+  }, [settings?.snoozeDefaultMinutes]);
 
   const chooseAddressing = async (mode: AddressingMode) => {
     if (settings === null || busy || mode === settings.addressingMode) return;
@@ -173,6 +181,26 @@ function ThisMachineTab() {
       const applied = await setTrainingCapture(enabled);
       setSettings({ ...settings, wingmanTrainingCapture: applied });
       setMsg(applied ? "Capturing wingman training data." : "Training capture turned off.");
+    } catch (e) {
+      setMsg(errText(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const saveSnooze = async () => {
+    if (settings === null || busy) return;
+    const minutes = Number(snoozeDraft);
+    if (!Number.isInteger(minutes) || minutes < 1 || minutes > 7 * 24 * 60) {
+      setMsg("Snooze length must be a whole number of minutes from 1 to 10080.");
+      return;
+    }
+    setBusy(true);
+    setMsg("Saving...");
+    try {
+      const applied = await setSnoozeDefaultMinutes(minutes);
+      setSettings({ ...settings, snoozeDefaultMinutes: applied });
+      setMsg(`Snooze length set to ${applied} minute${applied === 1 ? "" : "s"}. Applies to the next snooze, on every device.`);
     } catch (e) {
       setMsg(errText(e));
     } finally {
@@ -242,6 +270,35 @@ function ThisMachineTab() {
         {!settings.autostart.supported && (
           <p className="settings-hint settings-hint-inline">Not supported on this host (no tray).</p>
         )}
+      </section>
+
+      <section className="settings-card">
+        <h2 className="settings-h2">Snooze</h2>
+        <p className="settings-hint">
+          How long a snoozed session stays parked before it returns to &quot;needs you&quot; on its own -
+          a dead-man&apos;s switch, so a session you snooze can never be lost. One length for every snooze,
+          the same on every device. Read at snooze time, so a change applies to the next snooze.
+        </p>
+        <div className="settings-field">
+          <label htmlFor="settings-snooze">Default snooze length (minutes)</label>
+          <input
+            id="settings-snooze"
+            className="settings-input"
+            type="number"
+            min={1}
+            max={10080}
+            step={1}
+            value={snoozeDraft}
+            disabled={busy}
+            onChange={(e) => setSnoozeDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void saveSnooze();
+            }}
+          />
+          <button type="button" className="settings-btn" disabled={busy} onClick={() => void saveSnooze()}>
+            Save
+          </button>
+        </div>
       </section>
 
       <NotificationsCard />

--- a/packages/client-core/src/settings/settingsClient.ts
+++ b/packages/client-core/src/settings/settingsClient.ts
@@ -39,6 +39,9 @@ export interface GatewaySettings {
   autostart: AutostartState;
   wingmanTrainingCapture: boolean;
   telemetryConsent: boolean;
+  // Snooze Length mission: the per-user default snooze length in minutes (one value across every device,
+  // because they all talk to this one Gateway). Default 60.
+  snoozeDefaultMinutes: number;
 }
 
 async function gatewayErrorFrom(res: Response, label: string): Promise<GatewayError> {
@@ -107,7 +110,16 @@ export async function getGatewaySettings(signal?: AbortSignal): Promise<GatewayS
     },
     wingmanTrainingCapture: Boolean(body.wingmanTrainingCapture),
     telemetryConsent: Boolean(body.telemetryConsent),
+    snoozeDefaultMinutes: Number(body.snoozeDefaultMinutes ?? 60),
   };
+}
+
+// PUT /gateway/snooze-default { minutes } - set the per-user default snooze length (Snooze Length
+// mission). Read at snooze time, so a change applies to the next snooze with no restart, and it is the
+// same value on every device (all talk to this one Gateway). Returns the applied minutes.
+export async function setSnoozeDefaultMinutes(minutes: number, signal?: AbortSignal): Promise<number> {
+  const body = await putJson<{ minutes?: number }>("/gateway/snooze-default", "PUT /gateway/snooze-default", { minutes }, signal);
+  return Number(body.minutes ?? minutes);
 }
 
 // PUT /gateway/addressing-mode { mode } - set the fleet network addressing mode. Applies to this host's

--- a/src/CcDirector.Avalonia/FifoWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/FifoWindow.axaml.cs
@@ -11,6 +11,7 @@ using Avalonia.Media;
 using Avalonia.Threading;
 using CcDirector.Avalonia.HostedAi;
 using CcDirector.Avalonia.Voice;
+using CcDirector.ControlApi;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Dictation;
 using CcDirector.Core.HostedAi;
@@ -218,13 +219,46 @@ public partial class FifoWindow : Window
         Advance();
     }
 
-    private void OnHoldClick(object? sender, RoutedEventArgs e)
+    private async void OnHoldClick(object? sender, RoutedEventArgs e)
     {
         if (_busy || _recording || _current is null) return;
-        SetStatus("Holding this session...", Yellow);
-        _current.OnHold = true; // parks it out of the rotation until taken off hold
-        FileLog.Write($"[FifoWindow] hold session={_current.Id}");
-        Advance();
+
+        // Snooze Length mission (Phase 3): snooze is Gateway-owned. Route the hold THROUGH the Gateway so
+        // it gets the Gateway-owned timer, instead of setting Session.OnHold in-process. The Gateway
+        // records the snooze-until AND forwards the hold back down to this Director (which sets OnHold),
+        // so OnHold is already set when we Advance - no optimistic local set.
+        var host = (global::Avalonia.Application.Current as App)?.ControlApiHost;
+        if (host?.GatewayMonitor.Status != GatewayConnectionStatus.Verified || host.GatewayHold is null)
+        {
+            // No Gateway -> no snooze (owner rule, no-fallback). Do NOT advance, set NO local hold.
+            SetStatus("Connect to a Gateway to snooze.", Red);
+            return;
+        }
+
+        var sid = _current.Id;
+        _busy = true;                              // immediate feedback + block concurrent steering
+        SetStatus("Snoozing this session...", Yellow);
+        var ok = false;
+        try
+        {
+            // Async off the UI thread: the Gateway may be cross-machine over Tailscale, so this can be slow.
+            await host.GatewayHold.RecordHoldAsync(sid.ToString(), true);
+            FileLog.Write($"[FifoWindow] snoozed session={sid} via Gateway");
+            ok = true;
+        }
+        catch (Exception ex)
+        {
+            // Fail loud: name the error, do NOT advance, and set NO local OnHold (no divergence).
+            FileLog.Write($"[FifoWindow] snooze FAILED session={sid}: {ex.Message}");
+            SetStatus($"Snooze failed - {ex.Message}", Red);
+        }
+        finally
+        {
+            _busy = false;
+        }
+
+        // Only advance once the Gateway confirmed the hold (OnHold is now set on the session).
+        if (ok) Advance();
     }
 
     private void OnExitClick(object? sender, RoutedEventArgs e) => Close();

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -2337,14 +2337,38 @@ public partial class MainWindow : Window
         }
     }
 
-    private void ToggleSessionHold(SessionViewModel vm)
+    private async void ToggleSessionHold(SessionViewModel vm)
     {
-        var newState = !vm.Session.OnHold;
-        FileLog.Write($"[MainWindow] ToggleSessionHold: session={vm.Session.Id}, onHold={newState}");
-        vm.Session.OnHold = newState;
-        ShowNotification(newState
-            ? $"{vm.DisplayName} put on hold"
-            : $"{vm.DisplayName} taken off hold");
+        // Snooze Length mission (Phase 3): snooze is Gateway-owned. Instead of setting Session.OnHold
+        // in-process (which gave no timer), drive the Gateway hold seam so this snooze gets the same
+        // Gateway-owned timer the phone and cockpit get. The Gateway records the snooze-until AND forwards
+        // the hold back DOWN to this Director, which sets OnHold - so we never set it locally here.
+        var target = !vm.Session.OnHold;
+        var host = (global::Avalonia.Application.Current as App)?.ControlApiHost;
+
+        // No Gateway -> no snooze (owner rule, no-fallback): require a VERIFIED connection, which proves
+        // BOTH legs the round-trip needs (Director->Gateway to record, Gateway->Director to forward back).
+        if (host?.GatewayMonitor.Status != GatewayConnectionStatus.Verified || host.GatewayHold is null)
+        {
+            ShowNotification("You need to be connected to a Gateway to use snooze.");
+            return;
+        }
+
+        // Immediate feedback (<100ms); the Gateway round-trip runs async off the UI thread - it is NOT
+        // always loopback (the Gateway may be on another machine over Tailscale), so it may be slow.
+        ShowNotification(target ? $"Snoozing {vm.DisplayName}..." : $"Waking {vm.DisplayName}...");
+        try
+        {
+            await host.GatewayHold.RecordHoldAsync(vm.Session.Id.ToString(), target);
+            FileLog.Write($"[MainWindow] ToggleSessionHold via Gateway: session={vm.Session.Id}, onHold={target}");
+            ShowNotification(target ? $"{vm.DisplayName} snoozed" : $"{vm.DisplayName} taken off snooze");
+        }
+        catch (Exception ex)
+        {
+            // Fail loud: no local OnHold set, so nothing diverges from the Gateway's truth.
+            FileLog.Write($"[MainWindow] ToggleSessionHold FAILED: session={vm.Session.Id}: {ex.Message}");
+            ShowNotification($"Could not snooze {vm.DisplayName} - {ex.Message}");
+        }
     }
 
     /// <summary>

--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -132,6 +132,16 @@ public sealed class ControlApiHost : IAsyncDisposable
     /// </summary>
     public GatewayConnectionMonitor GatewayMonitor { get; } = new();
 
+    /// <summary>
+    /// Snooze Length mission (Phase 3): the seam the desktop drives to record/clear a Gateway-owned
+    /// snooze THROUGH the Gateway (so a desktop snooze gets the same timer the phone/cockpit get),
+    /// instead of setting <c>Session.OnHold</c> in-process. Backed by the live <see cref="GatewayClient"/>
+    /// (which already holds the resolved Gateway address + fleet token), so it reuses the Director's
+    /// existing Gateway connection. Null while the Gateway is not configured (no client) - the desktop
+    /// gates the Snooze button on <see cref="GatewayMonitor"/> being Verified anyway.
+    /// </summary>
+    public IGatewayHold? GatewayHold => _gatewayClient;
+
     /// <summary>This Director's own serve provisioner (issue #197). Exposed for the
     /// troubleshooting dialog: rung 2's "Fix it now" runs EnsureMappingAsync, and the
     /// provisioner's LastError explains WHY a mapping is missing. Null on ephemeral-port

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -27,7 +27,7 @@ namespace CcDirector.ControlApi;
 /// When the config is disabled (no gateway.url) the client is inert - every method
 /// is a no-op so the Director boots normally in local-only mode.
 /// </summary>
-public sealed class GatewayClient : IDisposable
+public sealed class GatewayClient : IGatewayHold, IDisposable
 {
     /// <summary>How often the heartbeat fires.</summary>
     public static TimeSpan HeartbeatInterval { get; } = TimeSpan.FromSeconds(15);
@@ -363,6 +363,32 @@ public sealed class GatewayClient : IDisposable
             throw new InvalidOperationException("Gateway start-on-machine returned an unparsable body.");
         FileLog.Write($"[GatewayClient] SpawnOnMachineAsync: started sid={parsed.SessionId} on machine={machine}");
         return parsed;
+    }
+
+    /// <summary>
+    /// Snooze Length mission (Phase 3): record or clear a Gateway-owned snooze/hold for a session by
+    /// driving the Gateway's <c>POST /sessions/{sid}/hold</c> with the SAME authenticated client (already
+    /// pointed at the resolved Gateway address and carrying the fleet token) the other Director-to-Gateway
+    /// relays use - so the desktop reuses the Director's existing Gateway connection, never binding its own
+    /// URL or token. The Gateway records the snooze-until AND forwards the hold back DOWN to the owning
+    /// Director before answering, so on success <c>Session.OnHold</c> is already set.
+    ///
+    /// This is the <see cref="IGatewayHold"/> seam - the ONE method the Gateway Cleanup migration re-points
+    /// from HTTP to the tunnel. Fail-loud (no fallback): THROWS when the Gateway is disabled or the call
+    /// does not confirm, so the desktop shows a clear error and sets no local hold.
+    /// </summary>
+    public async Task RecordHoldAsync(string sessionId, bool onHold, CancellationToken ct = default)
+    {
+        if (!_config.IsEnabled)
+            throw new InvalidOperationException("The Gateway is not configured; snooze needs a Gateway connection.");
+        if (string.IsNullOrWhiteSpace(sessionId))
+            throw new ArgumentException("Session id is required", nameof(sessionId));
+
+        FileLog.Write($"[GatewayClient] RecordHoldAsync: POST /sessions/{sessionId}/hold onHold={onHold}");
+        var body = new HoldRequest { OnHold = onHold };
+        using var resp = await _http.PostAsJsonAsync($"sessions/{sessionId}/hold", body, ct);
+        if (!resp.IsSuccessStatusCode)
+            throw new InvalidOperationException($"Gateway hold for {sessionId} returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
     }
 
     // ===== Fleet session numbers (issue #1292) =====

--- a/src/CcDirector.ControlApi/IGatewayHold.cs
+++ b/src/CcDirector.ControlApi/IGatewayHold.cs
@@ -1,0 +1,29 @@
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// The ONE seam through which a Director records or clears a Gateway-owned snooze/hold for a session
+/// (Snooze Length mission, Phase 3). Snooze is Gateway-owned: the timer lives on the Gateway so it
+/// survives a dead Director, so a desktop Snooze button must go THROUGH the Gateway rather than set
+/// <c>Session.OnHold</c> in-process (the in-process set gave no timer - the Phase 3 bug we remove).
+///
+/// Today this is implemented as a direct Director-to-Gateway HTTP POST to
+/// <c>/sessions/{sessionId}/hold</c> (<see cref="GatewayClient"/>). The Gateway Cleanup mission is
+/// moving ALL Director-to-Gateway traffic onto the tunnel; its Architect (d640f023) ruled that the
+/// HTTP path ships now and that snooze-hold is the first named customer for the Director-initiated
+/// unary upstream verb the tunnel will add. Keeping the "how it reaches the Gateway" behind this ONE
+/// interface makes that later HTTP-to-tunnel swap a one-line change of the implementation, not a hunt.
+///
+/// The call is fail-loud (no fallback): it THROWS when the Gateway is not configured/reachable or the
+/// hold is not confirmed, so the caller can show a clear error and set NO local hold. On SUCCESS the
+/// Gateway has already recorded the snooze-until AND forwarded the hold back DOWN to the owning
+/// Director (which set <c>Session.OnHold</c>), so the local state is already correct when this returns.
+/// </summary>
+public interface IGatewayHold
+{
+    /// <summary>
+    /// Record (<paramref name="onHold"/> = true) or clear (false) the Gateway-owned snooze for the
+    /// session and forward the hold to its owning Director. Returns only after the Gateway confirms;
+    /// throws on any failure (no fallback).
+    /// </summary>
+    Task RecordHoldAsync(string sessionId, bool onHold, CancellationToken ct = default);
+}

--- a/src/CcDirector.Gateway.Tests/SnoozeEndToEndTests.cs
+++ b/src/CcDirector.Gateway.Tests/SnoozeEndToEndTests.cs
@@ -185,6 +185,34 @@ public sealed class SnoozeEndToEndTests : IAsyncLifetime
         Assert.Equal("needsYou", returned.TriageBucket);
     }
 
+    [Fact]
+    public async Task A_dead_director_snooze_still_returns_to_needs_you_from_the_cached_roster()
+    {
+        // THE mission scenario: a session is snoozed, then its whole Director dies, and the snooze must
+        // still bring it back - the dead-man's switch. The timer lives on the Gateway, and the last-known
+        // roster (FleetRosterCache) keeps the session visible, so the fold's expiry overlay returns it to
+        // "needs you" on its own even though the Director is gone.
+        await SetDefaultMinutes(1);
+        var fake = await StartFakeAsync("s5", onHold: true); // held on the Director
+        await Register(fake);
+
+        // Prime the last-known-good roster while the Director is still alive.
+        var alive = await GetSession("s5");
+        Assert.True(alive.OnHold); // shown as snoozed while held (no expiry entry yet)
+
+        // Arm an already-expired snooze, then the Director DIES (its host stops).
+        _gw.SnoozeRegistry.Snooze("s5", DateTime.UtcNow.AddSeconds(-1), fake.DirectorId);
+        await fake.DisposeAsync();
+        _fakes.Remove(fake);
+
+        // The Gateway can no longer reach the Director, but the cached roster still carries s5 and the
+        // expiry overlay returns it to "needs you" - the session was NOT lost by snoozing.
+        var returned = await GetSession("s5");
+        Assert.False(returned.OnHold);
+        Assert.Equal("needsYou", returned.TriageBucket);
+        Assert.True(returned.SnoozeExpired);
+    }
+
     // ---- helpers ----
 
     private async Task SetDefaultMinutes(int minutes)


### PR DESCRIPTION
Closes the Snooze Length mission (after #1375, #1381, #1383). A desktop snooze now gets the same Gateway-owned timer the phone and cockpit already had, snooze length is editable in Settings, and the dead-Director dead-man's switch is proven end to end.

## Desktop routing (the last surface)
Snooze is Gateway-owned, so the desktop must go **through** the Gateway instead of setting `Session.OnHold` in-process (that gave no timer - the bug decision #7 called out). New **`IGatewayHold.RecordHoldAsync`** seam, implemented on the Director's existing `GatewayClient` as `POST /sessions/{sid}/hold` using the Gateway address + fleet token it **already holds** (no new binding). The Gateway records the snooze-until **and forwards the hold back down** to this Director, so every local reader (FIFO voice rotation, view-model color, queue-drain, the #470 auto-clear) keeps working unchanged. Both write-sites converted (`MainWindow.ToggleSessionHold`, `FifoWindow.OnHoldClick`):
- gated on `GatewayConnectionMonitor.Status == Verified` (proves **both** legs the round-trip needs); no verified Gateway -> "you need to be connected to a Gateway to use snooze", **no hold set** (no local timer, no fallback);
- immediate `<100ms` feedback with the round-trip **async off the UI thread** (Gateway may be cross-machine over Tailscale);
- **fail-loud**: on error, show it, do **not** advance the FIFO belt, set no local `OnHold`. The FIFO window awaits the confirmed hold before advancing (race-free - `OnHold` is already set by then).

Channel is behind the one seam so the **Gateway Cleanup** migration re-points HTTP->tunnel in a single line (their Architect ruled Option A now; snooze-hold is logged as the first customer for the tunnel's Director-initiated unary upstream verb).

## Settings
Default snooze length is editable on the Cockpit Settings page (minutes input, 1..10080) via the `GET/PUT /gateway/snooze-default` the Phase 1 server already exposed. One value across every device.

## Dead-Director proof
New in-process e2e test: snooze a session, kill its whole Director, and the fold's expiry overlay still returns it to "needs you" from the cached roster - **the session cannot be lost by snoozing**.

## Verification
Avalonia + client-core + cockpit build clean; **80** gateway snooze/aggregation/notifier tests green (incl. dead-Director); **387** client-core tests green.

Follow-up (mission-closing): the HTML verification report in `docs/reviews/` with the Playwright "Snooze ended" badge + settings-control screenshots, and an all-four-surfaces consistency pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)