### PR TITLE
docs(snooze): final Snooze Length mission verification report

### DIFF
--- a/docs/reviews/snooze-length-verification-2026-07-12.html
+++ b/docs/reviews/snooze-length-verification-2026-07-12.html
@@ -1,0 +1,248 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Snooze Length - Mission Verification Report</title>
+<style>
+  :root {
+    --bg: #0f1216; --card: #171b21; --border: #2a313b; --text: #dfe4ea; --dim: #9aa5b1;
+    --accent: #6ea8fe; --ok: #4caf7d; --amber: #d99120; --red: #f26d6d;
+    --surface: #1d232b;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--text);
+         font: 15px/1.6 -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
+  .wrap { max-width: 900px; margin: 0 auto; padding: 32px 20px 80px; }
+  h1 { font-size: 26px; margin: 0 0 4px; }
+  h2 { font-size: 19px; margin: 34px 0 10px; padding-bottom: 6px; border-bottom: 1px solid var(--border); }
+  h3 { font-size: 15px; margin: 22px 0 8px; color: var(--accent); }
+  .sub { color: var(--dim); margin: 0 0 24px; }
+  .card { background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: 16px 18px; margin: 14px 0; }
+  code { background: #10141a; border: 1px solid var(--border); border-radius: 4px; padding: 1px 5px; font-size: 13px;
+         font-family: Consolas, Menlo, monospace; }
+  ul { margin: 8px 0; padding-left: 22px; } li { margin: 5px 0; }
+  table { border-collapse: collapse; width: 100%; margin: 10px 0; font-size: 14px; }
+  th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th { color: var(--dim); font-weight: 600; }
+  .pass { color: var(--ok); font-weight: 700; }
+  .pill { display: inline-block; font-size: 11px; text-transform: uppercase; letter-spacing: .5px;
+          padding: 2px 8px; border-radius: 20px; border: 1px solid var(--border); color: var(--dim); }
+  .pill.ok { color: var(--ok); border-color: rgba(76,175,125,.5); background: rgba(76,175,125,.12); }
+  .lede { font-size: 16px; }
+  .note { color: var(--dim); font-size: 13px; font-style: italic; }
+  .mock { background: #0c0f13; border: 1px dashed var(--border); border-radius: 8px; padding: 18px; margin: 8px 0; }
+  .mock-label { color: var(--dim); font-size: 12px; text-transform: uppercase; letter-spacing: .5px; margin-bottom: 10px; }
+
+  /* Faithful reproduction of the SHIPPED mobile roster row + "Snooze ended" badge (apps/mobile/src/styles.css). */
+  .m-row { display: flex; align-items: flex-start; gap: 12px; background: var(--surface); border: 1px solid var(--border);
+           border-radius: 10px; padding: 12px 14px; max-width: 420px; }
+  .m-dot { width: 12px; height: 12px; border-radius: 50%; background: #f26d6d; margin-top: 4px; flex: 0 0 auto; }
+  .m-body { display: flex; flex-direction: column; min-width: 0; }
+  .m-name { font-weight: 700; }
+  .m-num { color: var(--dim); font-weight: 400; margin-right: 6px; }
+  .m-context { color: var(--dim); font-size: 13px; }
+  .row-snooze-ended { display: inline-block; align-self: flex-start; margin-top: 4px; padding: 1px 7px; border-radius: 6px;
+    font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.4px;
+    background: rgba(217,145,32,0.16); border: 1px solid rgba(217,145,32,0.55); color: #d99120; }
+
+  /* Faithful reproduction of the SHIPPED cockpit roster tag (apps/cockpit/src/styles.css). */
+  .c-meta { display: flex; align-items: center; gap: 8px; }
+  .roster-tag { flex: 0 0 auto; font-size: 10px; text-transform: uppercase; letter-spacing: 0.4px; padding: 1px 5px;
+    border-radius: 5px; background: var(--surface); border: 1px solid var(--border); color: var(--dim); }
+  .roster-tag.snooze-ended { background: rgba(217,145,32,0.16); border-color: rgba(217,145,32,0.55); color: #d99120; }
+  .c-state { color: var(--red); font-size: 13px; }
+
+  /* Faithful reproduction of the SHIPPED settings control (apps/cockpit/src/settings). */
+  .settings-card { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 14px 16px; max-width: 480px; }
+  .settings-h2 { font-size: 15px; margin: 0 0 6px; }
+  .settings-hint { color: var(--dim); font-size: 13px; margin: 0 0 12px; }
+  .settings-field { display: flex; align-items: center; gap: 10px; }
+  .settings-field > label { color: var(--dim); font-size: 13px; }
+  .settings-input { width: 90px; background: #10141a; border: 1px solid var(--border); border-radius: 6px;
+    color: var(--text); padding: 6px 8px; }
+  .settings-btn { background: var(--accent); color: #06101f; border: none; border-radius: 6px; padding: 6px 14px;
+    font-weight: 600; cursor: pointer; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <h1>Snooze Length - Mission Verification Report</h1>
+  <p class="sub">DevThrottle &middot; verified 2026-07-12 &middot; all three phases merged to origin/main</p>
+
+  <div class="card">
+    <p class="lede" style="margin-top:0">
+      Snooze used to be open-ended: you tapped Snooze, the session went grey, and it stayed that way until
+      <em>something new happened</em> to it. When a session died or went quiet, nothing new ever happened, so
+      the snooze never lifted and the session fell off the radar forever. This mission turned snooze into a
+      <strong>time-bounded hold with a guaranteed return</strong> - a dead-man's switch. The worst case is now:
+      every snoozed session comes back. <strong>You can no longer lose a session by snoozing it.</strong>
+    </p>
+  </div>
+
+  <h2>Outcome</h2>
+  <table>
+    <tr><th>Phase</th><th>What shipped</th><th>Pull request</th><th>State</th></tr>
+    <tr><td>Phase 1</td><td>Gateway-owned snooze registry, timer, expiry sweep, and the default-length setting</td>
+        <td>#1375, #1381</td><td><span class="pill ok">merged</span></td></tr>
+    <tr><td>Phase 2</td><td>The "Snooze ended" marker, roster badges, and the distinct announce-once phone push</td>
+        <td>#1383</td><td><span class="pill ok">merged</span></td></tr>
+    <tr><td>Phase 3</td><td>Desktop snooze routed through the Gateway, the settings control, and the dead-Director proof</td>
+        <td>#1388</td><td><span class="pill ok">merged</span></td></tr>
+  </table>
+
+  <h2>How it works</h2>
+  <div class="card">
+    <ul>
+      <li><strong>The timer lives on the Gateway, not the Director.</strong> That is the whole point: the timer must
+        fire even when the owning Director is offline or the session is dead. A persisted registry
+        (<code>sessionId -&gt; SnoozeUntilUtc</code>) is re-armed from disk on every Gateway restart, so a restart
+        mid-snooze never loses the hold.</li>
+      <li><strong>Expiry re-uses the one shared fold.</strong> When a snooze elapses, the Gateway's <code>/sessions</code>
+        aggregation overrides <code>OnHold</code> to false on the aggregated session, so
+        <code>SessionOrdering.Classify</code> puts it straight back into "needs you" with no new classification
+        logic. The overlay is pure and continuous, so the roster never flickers back to "Snoozed" between expiry
+        and the Director confirming the clear.</li>
+      <li><strong>The phone push reaches you for free.</strong> The existing needs-you notifier already watches that
+        bucket; an expired snooze raises the count and buzzes the phone - announced exactly once with distinct
+        copy, then it folds into the silent dot and never re-buzzes (even a lingering dead-Director snooze).</li>
+      <li><strong>Nothing is written into the session's conversation.</strong> The "Snooze ended" marker lives only in
+        roster and notification metadata.</li>
+      <li><strong>All surfaces go through the one Gateway hold command,</strong> including the desktop - which in Phase 3
+        was converted from an in-process <code>Session.OnHold</code> set (which gave no timer) to a
+        Gateway round-trip behind the <code>IGatewayHold.RecordHoldAsync</code> seam.</li>
+    </ul>
+  </div>
+
+  <h2>Definition of done</h2>
+  <table>
+    <tr><th>Requirement</th><th>Evidence</th></tr>
+    <tr><td>All three phases merged, each verified before the next</td>
+        <td class="pass">PASS &mdash; #1375/#1381, #1383, #1388</td></tr>
+    <tr><td>Snoozing holds a session for the user default (default one hour) then returns it on its own - for a live
+        session gone quiet AND for a session whose Director has died</td>
+        <td class="pass">PASS &mdash; <code>SnoozeEndToEndTests</code>: return-on-its-own; and
+        <code>A_dead_director_snooze_still_returns_to_needs_you_from_the_cached_roster</code></td></tr>
+    <tr><td>A session that comes back on its own before the timer clears its snooze immediately (early return);
+        re-snoozing works any number of times</td>
+        <td class="pass">PASS &mdash; sweep early-return + <code>ClearIfUnchanged</code> re-snooze-race hardening tests</td></tr>
+    <tr><td>The returned item is visibly distinct ("Snooze ended") on the roster and in the push; nothing written to
+        the conversation</td>
+        <td class="pass">PASS &mdash; <code>SessionDto.SnoozeExpired</code> overlay + roster badges + announce-once notifier</td></tr>
+    <tr><td>The default length is a single per-user Gateway setting, editable in Settings, same across every device;
+        the registry survives a Gateway restart</td>
+        <td class="pass">PASS &mdash; <code>GET/PUT /gateway/snooze-default</code> + Cockpit control + restart-survival test</td></tr>
+    <tr><td>A final verification report</td><td class="pass">PASS &mdash; this document</td></tr>
+  </table>
+
+  <h2>Automated verification (agent-driven, no live phone hand-off)</h2>
+  <p>The owner deliberately kept out of the loop for the logic phases; every claim below is proven by a test that
+     runs in continuous integration, not a manual click.</p>
+  <table>
+    <tr><th>Suite</th><th>Covers</th><th>Result</th></tr>
+    <tr><td>Gateway snooze / aggregation / notifier</td>
+        <td>Registry persistence, re-arm, corrupt-quarantine, bounds; the sweep state machine (future / expired /
+            early-return / dead-Director / transient / concurrent-re-snooze); the pure expiry overlay; the
+            announce-once push (newly-expired buzzes once, lingering never re-buzzes, re-snooze re-announces); the
+            in-process end-to-end round-trip; the dead-Director dead-man's switch</td>
+        <td class="pass">80 passed</td></tr>
+    <tr><td>Client-core</td><td>The <code>snoozeExpired</code> accessor and roster ordering/classification</td>
+        <td class="pass">387 passed</td></tr>
+    <tr><td>Builds</td><td>Avalonia desktop, ControlApi, Gateway, cockpit, mobile</td>
+        <td class="pass">clean (0 warnings)</td></tr>
+  </table>
+  <p class="note">The one unrelated flaky test in the full Gateway suite (<code>LauncherRegistryEndpointTests</code>,
+     a port/timing race) passes in isolation and is untouched by this mission.</p>
+
+  <h2>The centerpiece: a snoozed session cannot be lost</h2>
+  <div class="card">
+    <p style="margin-top:0">The mission exists because an enrichment session once went wrong, nothing surfaced it, and
+       the owner had no way to know it needed him. The dead-Director end-to-end test reproduces exactly that and
+       proves the fix:</p>
+    <ul>
+      <li>a session is snoozed and held;</li>
+      <li>its <strong>whole Director is then killed</strong>;</li>
+      <li>the Gateway can no longer reach it - yet the last-known cached roster still carries the session, and the
+          expiry overlay returns it to "needs you" on its own, marked "Snooze ended".</li>
+    </ul>
+    <p style="margin-bottom:0">Test: <code>SnoozeEndToEndTests.A_dead_director_snooze_still_returns_to_needs_you_from_the_cached_roster</code>
+       - boots a real Gateway on an ephemeral loopback port (no Tailscale front door), drives the real
+       <code>POST /sessions/{sid}/hold</code>, kills the fake Director, and asserts the session comes back as
+       <code>needsYou</code> with <code>SnoozeExpired = true</code>.</p>
+  </div>
+
+  <h2>What the owner sees</h2>
+  <p class="note">Rendered below from the exact markup and CSS shipped in this mission (not a live screenshot).</p>
+
+  <h3>Mobile roster - the "Snooze ended" badge</h3>
+  <div class="mock">
+    <div class="mock-label">apps/mobile/src/pages/Home.tsx + styles.css</div>
+    <div class="m-row">
+      <span class="m-dot"></span>
+      <span class="m-body">
+        <span class="m-name"><span class="m-num">137</span>enrichment-run</span>
+        <span class="m-context">Needs you</span>
+        <span class="row-snooze-ended">Snooze ended</span>
+      </span>
+    </div>
+  </div>
+
+  <h3>Cockpit roster - the "Snooze ended" tag</h3>
+  <div class="mock">
+    <div class="mock-label">apps/cockpit/src/sessions/SessionRoster.tsx + styles.css</div>
+    <div class="c-meta">
+      <span class="c-state">Needs you</span>
+      <span class="roster-tag snooze-ended">Snooze ended</span>
+    </div>
+  </div>
+
+  <h3>Cockpit Settings - the default snooze length control</h3>
+  <div class="mock">
+    <div class="mock-label">apps/cockpit/src/settings/SettingsView.tsx</div>
+    <div class="settings-card">
+      <h2 class="settings-h2">Snooze</h2>
+      <p class="settings-hint">How long a snoozed session stays parked before it returns to "needs you" on its own -
+        a dead-man's switch, so a session you snooze can never be lost. One length for every snooze, the same on
+        every device. Read at snooze time, so a change applies to the next snooze.</p>
+      <div class="settings-field">
+        <label for="demo-snooze">Default snooze length (minutes)</label>
+        <input id="demo-snooze" class="settings-input" type="number" value="60" min="1" max="10080">
+        <button class="settings-btn" type="button">Save</button>
+      </div>
+    </div>
+  </div>
+
+  <h3>The phone push copy</h3>
+  <div class="mock">
+    <div class="mock-label">apps/mobile/public/push-sw.js + apps/cockpit/public/sw.js</div>
+    <p style="margin:0">A newly-expired snooze buzzes once with the distinct body:
+       <strong>"Snooze ended - still waiting on you"</strong> - vs the ordinary silent "N sessions need you" dot.</p>
+  </div>
+
+  <h2>Cross-mission note</h2>
+  <div class="card">
+    <p style="margin:0">The desktop-to-Gateway hold rides a plain HTTP call today, deliberately behind the single
+       <code>IGatewayHold.RecordHoldAsync</code> seam. The Gateway Cleanup mission is migrating all
+       Director-to-Gateway traffic onto the tunnel; its Architect ruled Option A now and logged snooze-hold as the
+       first named customer for the tunnel's future Director-initiated unary upstream verb. When that lands, the
+       swap from HTTP to tunnel is a one-line change of the seam's implementation, nothing else.</p>
+  </div>
+
+  <h2>All four snooze surfaces</h2>
+  <p>Because the marker, colour, label and triage bucket are all computed by the ONE Gateway fold and rendered
+     verbatim by every client, the four Snooze surfaces are consistent by construction, not by four separate
+     implementations:</p>
+  <table>
+    <tr><th>Surface</th><th>Path</th><th>Snooze goes through the Gateway</th></tr>
+    <tr><td>Cockpit session menu / roster</td><td>Browser -&gt; Gateway <code>POST /sessions/{sid}/hold</code></td><td class="pass">yes</td></tr>
+    <tr><td>Mobile manage bar</td><td>Phone -&gt; Gateway <code>POST /sessions/{sid}/hold</code></td><td class="pass">yes</td></tr>
+    <tr><td>Desktop rail (ToggleSessionHold)</td><td>Director -&gt; Gateway via <code>IGatewayHold</code> (Phase 3)</td><td class="pass">yes</td></tr>
+    <tr><td>Desktop FIFO voice window (Hold)</td><td>Director -&gt; Gateway via <code>IGatewayHold</code> (Phase 3)</td><td class="pass">yes</td></tr>
+  </table>
+  <p class="note">A Director with no verified Gateway connection cannot snooze: the button reports "you need to be
+     connected to a Gateway to use snooze" and sets no hold - a stated limitation, never a silent local timer.</p>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
The mission-closing verification report for Snooze Length (after #1375, #1381, #1383, #1388): `docs/reviews/snooze-length-verification-2026-07-12.html`.

Contents:
- the three merged phases and the definition-of-done checklist, each item mapped to its evidence;
- the automated-test coverage (80 gateway snooze/aggregation/notifier + 387 client-core, all builds clean);
- the **dead-Director dead-man's-switch** proof as the centerpiece - a snoozed session cannot be lost even when its whole Director dies;
- faithful renderings of the shipped "Snooze ended" badge (mobile + cockpit), the settings control, and the push copy, **rendered from the exact shipped markup and CSS and labeled as such** (not a fabricated screenshot);
- the all-four-surfaces consistency table and the Gateway Cleanup seam handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)