### PR TITLE
feat(carmode): simple v1 version label + mobile-failure telemetry

### DIFF
--- a/apps/mobile/src/pages/CarMode.tsx
+++ b/apps/mobile/src/pages/CarMode.tsx
@@ -4,12 +4,12 @@ import { useCarMode, type CarModeReply } from "@devthrottle/client-core/carmode/
 import { carModeTurn } from "@devthrottle/client-core/carmode/carModeApi";
 import { useScreenWakeLock } from "../hooks/useScreenWakeLock";
 
-// The client build id, inlined by Vite's `define` at build time (git short sha + build timestamp; see
-// vite.config.ts). Shown on the screen so the owner can confirm at a glance he is on the latest page,
-// not an old cached bundle. Vite substitutes this constant in both dev and production builds, so it is
-// always a real string in the app; the typeof guard only prevents a ReferenceError if this module is
-// ever imported outside a Vite build (for example a unit test), and is not a build-time fallback.
-const CLIENT_BUILD_ID = typeof __CLIENT_BUILD_ID__ === "string" ? __CLIENT_BUILD_ID__ : "no-build-id";
+// The Car Mode page version, shown small in the header corner so the owner can confirm at a glance he is
+// on the latest page, not an old cached bundle. This is a SIMPLE hand-bumped label (Soren's explicit ask):
+// the old git short-sha + timestamp badge was replaced by a plain human version. BUMP THIS INTEGER BY HAND
+// ON EVERY DEPLOY of the mobile app (v1 -> v2 -> v3 ...), so a glance at the corner tells the owner and the
+// Architect exactly which page is live and what to look for after a deploy.
+const CAR_MODE_VERSION = "v1";
 
 // Car Mode (Car Mode mission): the standalone, chrome-less, full-screen page the owner opens to run
 // the whole fleet by voice, hands-free, phone in his pocket. It is a THIN view over the shared
@@ -75,11 +75,9 @@ export function CarMode() {
           Exit
         </Link>
         <span className="car-title">Car Mode</span>
-        {/* The client build id in the corner: the owner glances here to confirm he is on the latest page,
-            not an old cached bundle. The full build id is in the title tooltip. */}
-        <span className="car-build" title={`Client build ${CLIENT_BUILD_ID}`}>
-          {shortBuild(CLIENT_BUILD_ID)}
-        </span>
+        {/* The simple, hand-bumped version in the corner: the owner glances here to confirm he is on the
+            latest page, not an old cached bundle. Bumped by hand on every deploy (see CAR_MODE_VERSION). */}
+        <span className="car-build">{CAR_MODE_VERSION}</span>
       </header>
 
       {/* The scrollable middle: everything between the fixed header and the fixed control footer. It flexes
@@ -228,13 +226,6 @@ function MicMeter({ getLevel, active }: { getLevel: () => number; active: boolea
       ))}
     </div>
   );
-}
-
-// The short form of the build id for the header corner: just the git short sha (the first token), so
-// the badge stays tiny. The full "sha timestamp" is in the title tooltip and the debug readout.
-function shortBuild(buildId: string): string {
-  const firstSpace = buildId.indexOf(" ");
-  return firstSpace < 0 ? buildId : buildId.substring(0, firstSpace);
 }
 
 // The plain-English status line for each phase, the words that pair with the color orb and the cues.

--- a/apps/mobile/src/vite-env.d.ts
+++ b/apps/mobile/src/vite-env.d.ts
@@ -1,7 +1,2 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/client" />
-
-// The client build id, inlined by Vite's `define` at build time (see vite.config.ts). It is the git
-// short commit sha plus the build timestamp, shown on the Car Mode screen so the owner can confirm at a
-// glance he is on the latest page, not an old cached bundle.
-declare const __CLIENT_BUILD_ID__: string;

--- a/apps/mobile/vite.config.ts
+++ b/apps/mobile/vite.config.ts
@@ -1,22 +1,6 @@
-import { execSync } from "node:child_process";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
-
-// The client build id, injected at build time so a page can show at a glance which bundle it is
-// running (Car Mode diagnostic: the owner must be able to tell a fresh page from an old cached one).
-// The build timestamp alone proves a fresh build (it changes every time); the git short commit sha
-// pins the bundle to an exact commit so it can be matched against the Gateway version from /healthz.
-//
-// No fallback (CLAUDE.md): the mobile app is only ever built from a git checkout - the redeploy
-// script builds from an isolated git worktree, and the release builds from a git clone - so reading
-// the commit sha MUST succeed. A missing git is a broken build environment, surfaced loudly here
-// rather than shipping an "unknown" marker that would defeat the whole point of the indicator.
-function resolveClientBuildId(): string {
-  const sha = execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim();
-  const builtAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
-  return `${sha} ${builtAt}`;
-}
 
 // The app is served by the Gateway under /m, so every asset URL must be /m-rooted.
 // The PWA service worker caches the app shell (Issue 1, AC7) so the roster opens offline
@@ -24,11 +8,6 @@ function resolveClientBuildId(): string {
 // MSBuild target copies into wwwroot/m/.
 export default defineConfig({
   base: "/m/",
-  // Compile-time constant read by the app (see apps/mobile/src/vite-env.d.ts for its type). Stringified
-  // so it is inlined as a literal, exactly like Vite's own import.meta.env values.
-  define: {
-    __CLIENT_BUILD_ID__: JSON.stringify(resolveClientBuildId()),
-  },
   plugins: [
     react(),
     VitePWA({

--- a/packages/client-core/src/carmode/carModeApi.test.ts
+++ b/packages/client-core/src/carmode/carModeApi.test.ts
@@ -108,7 +108,8 @@ describe("carModeTurn", () => {
 describe("postCarModeTelemetry", () => {
   const record = {
     turnId: "t1", pauseToTranscribeMs: 900, transcodeMs: 120, brainMs: 1200, ttsMs: 300, firstAudioMs: 350,
-    totalTurnMs: 2450, chunks: 1, playMs: 4200, completed: true, serverTotalMs: 1100, modelCallCount: 1,
+    totalTurnMs: 2450, transcribeAttempts: 1, chunks: 1, playMs: 4200, clipDurationMs: 4300, playedToMs: 4200,
+    completed: true, micReacquiredDuringPlayback: true, speakingPollCount: 3, serverTotalMs: 1100, modelCallCount: 1,
     modelMsTotal: 1050, modelMs: [1050], fleetReadCount: 0, fleetReadMsTotal: 0, rounds: 1, commandChars: 20,
     replyChars: 40, actionsCount: 0, pendingConfirmation: false,
   };

--- a/packages/client-core/src/carmode/carModeApi.ts
+++ b/packages/client-core/src/carmode/carModeApi.ts
@@ -130,14 +130,29 @@ export interface CarModeTelemetryPost {
   ttsMs: number;
   firstAudioMs: number;
   totalTurnMs: number;
+  /** How many pause/forced transcribe probes ran this turn before the turn was taken - the "over and out"
+   *  finickiness measure. 1 means it landed on the first try; a higher count means the phrase kept being
+   *  missed and the owner had to keep trying. */
+  transcribeAttempts: number;
   /** How many audio clips the reply played (1 after the first-sentence split was reverted). A future
    *  streaming regression that clobbers the reply would show as a value other than 1 here. */
   chunks: number;
   /** How long the reply clip was actually audible (play-started to play-ended / cut off), milliseconds. */
   playMs: number;
+  /** The synthesized reply clip's media length (audio.duration), milliseconds: the whole reply the phone
+   *  received. A value far short of what replyChars implies flags a TRUNCATED SYNTHESIS. */
+  clipDurationMs: number;
+  /** How far INTO the clip playback reached at end/cutoff (audio.currentTime), milliseconds. A value far
+   *  below clipDurationMs flags a PLAYBACK cut-off (as opposed to a short synthesis). */
+  playedToMs: number;
   /** True when the reply clip played fully to its natural end; false when it was cut off (interrupt / End
    *  Car Mode). A cut-off reply - the bug this telemetry makes visible - reads as false. */
   completed: boolean;
+  /** True when the rolling-"stop" watch re-opened the microphone WHILE the reply was playing (the current
+   *  behavior). The mic-contention hypothesis: on mobile this ducks/interrupts the reply. */
+  micReacquiredDuringPlayback: boolean;
+  /** How many rolling-"stop" transcriptions ran during this reply (each re-reads the open mic). */
+  speakingPollCount: number;
   serverTotalMs: number;
   modelCallCount: number;
   modelMsTotal: number;

--- a/packages/client-core/src/carmode/useCarMode.ts
+++ b/packages/client-core/src/carmode/useCarMode.ts
@@ -70,11 +70,18 @@ interface TurnMetrics {
   ttsMs: number; // text-to-speech round trip for the whole reply (one clip since the split was reverted)
   firstAudioMs: number; // reply-in-hand to first audio playing
   totalTurnMs: number; // pause detected to first audio playing (what the owner feels)
+  // ----- Finickiness of "over and out" (the finicky-end-phrase diagnostic) -----
+  transcribeAttempts: number; // how many pause/forced transcribe probes ran this turn before the turn was taken
   // ----- Reply-audio lifecycle (the cut-off-reply diagnostic): how the spoken reply's one clip played -----
   chunks: number; // how many audio clips the reply played (1 after the split revert; a guard for a future regression)
   playStartedAt: number; // performance.now() when the reply clip's play() was requested, or 0
   playMs: number; // how long the reply clip was actually audible: play-started to play-ended / cut off
+  clipDurationMs: number; // the SYNTHESIZED reply clip's media length (audio.duration): the whole reply the phone got
+  playedToMs: number; // how far INTO the clip playback reached at end/cutoff (audio.currentTime): media-time, not wall-clock
   completed: boolean; // true when the reply clip played fully to its natural end; false when cut off (interrupt / End)
+  // ----- The mic-contention hypothesis (does grabbing the mic mid-playback cut the reply off on mobile?) -----
+  micReacquiredDuringPlayback: boolean; // did the rolling-"stop" watch re-open the microphone WHILE the reply was playing
+  speakingPollCount: number; // how many rolling-"stop" transcriptions ran during this reply (each re-reads the open mic)
   posted: boolean;
 }
 
@@ -190,6 +197,15 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
   // Performance-round telemetry: the metrics for the turn in flight, filled across transcribe -> brain ->
   // speak and posted once first audio plays. Null between turns.
   const turnMetricsRef = useRef<TurnMetrics | null>(null);
+  // Finickiness diagnostic: how many pause/forced transcribe probes have run in the current turn before it
+  // was taken. Reset when the microphone returns to the owner (enterListening) and snapshotted into the
+  // turn metrics the instant the turn is confirmed, so one real turn shows how hard "over and out" was to
+  // land (a high count means the phrase kept being missed).
+  const transcribeAttemptsRef = useRef(0);
+  // Mic-contention diagnostic: how many rolling-"stop" transcriptions ran while the current reply played.
+  // Each one re-reads the (still open) capture stream; the hypothesis is that grabbing the mic during
+  // playback ducks or interrupts the reply on mobile. Reset when a reply starts playing.
+  const speakingPollCountRef = useRef(0);
   // The chunked-playback "stop now" resolver: set while a clip is playing so an interrupt (voice "stop" or
   // the Stop button) or End Car Mode can end the current clip's play promise and unblock the play loop.
   const playbackStopRef = useRef<(() => void) | null>(null);
@@ -235,9 +251,14 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
       ttsMs: m.ttsMs,
       firstAudioMs: m.firstAudioMs,
       totalTurnMs: m.totalTurnMs,
+      transcribeAttempts: m.transcribeAttempts,
       chunks: m.chunks,
       playMs: m.playMs,
+      clipDurationMs: m.clipDurationMs,
+      playedToMs: m.playedToMs,
       completed: m.completed,
+      micReacquiredDuringPlayback: m.micReacquiredDuringPlayback,
+      speakingPollCount: m.speakingPollCount,
       serverTotalMs: m.server.totalMs,
       modelCallCount: m.server.modelCallCount,
       modelMsTotal: m.server.modelMsTotal,
@@ -332,6 +353,8 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     heardSpeechRef.current = false;
     belowSinceRef.current = 0;
     busyRef.current = false;
+    // Fresh turn: reset the finickiness probe counter so it counts only THIS turn's attempts.
+    transcribeAttemptsRef.current = 0;
     setLastHeard("");
     setCaptureError(null);
     setCaptureState("listening");
@@ -370,6 +393,8 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
 
         // Play the reply. The lifecycle hooks record the cut-off-reply diagnostic: when playback actually
         // starts, how long it stayed audible, and whether it played to its natural end or was cut off.
+        // Fresh count of rolling-"stop" polls for THIS reply; the mic-contention diagnostic reads it back.
+        speakingPollCountRef.current = 0;
         const played = playBlob(url, {
           onPlayStarted: () => {
             if (metrics === null) return;
@@ -385,14 +410,27 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
             if (metrics === null) return;
             metrics.completed = outcome === "ended";
             metrics.playMs = metrics.playStartedAt > 0 ? performance.now() - metrics.playStartedAt : 0;
+            // The cut-off-reply distinction the mission asks for: the SYNTHESIZED clip length (audio.duration,
+            // the whole reply the phone received) versus how far playback actually reached (audio.currentTime).
+            // A short clipDuration means a truncated SYNTHESIS; a playedTo far below clipDuration means the
+            // PLAYBACK was cut. Both are media-time (seconds -> ms), independent of the wall-clock playMs.
+            const audioEl = audioRef.current;
+            if (audioEl !== null) {
+              metrics.clipDurationMs = Number.isFinite(audioEl.duration) ? audioEl.duration * 1000 : 0;
+              metrics.playedToMs = Number.isFinite(audioEl.currentTime) ? audioEl.currentTime * 1000 : 0;
+            }
+            metrics.speakingPollCount = speakingPollCountRef.current;
             // Post the merged timing record now that the clip's whole lifecycle is known - including a
             // cut-off - so a truncated reply is VISIBLE at /carmode/telemetry (fire-and-forget).
             postTurnTelemetry(metrics);
           },
         });
 
-        // Barge-in: a fresh capture segment plus the rolling-window transcription watch for "stop".
+        // Barge-in: a fresh capture segment plus the rolling-window transcription watch for "stop". This is
+        // the mic-contention suspect - the microphone is re-opened WHILE the reply plays. Record that it
+        // happened so one real phone turn can prove or kill the hypothesis that this ducks/cuts the reply.
         await restartCapture();
+        if (metrics !== null) metrics.micReacquiredDuringPlayback = true;
         stopSpeakingPoll();
         speakingPollRef.current = window.setInterval(() => onSpeakingTickRef.current(), SPEAKING_POLL_MS);
 
@@ -494,6 +532,10 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
           return;
         }
         if (!force) setCaptureState("pause - transcribing");
+        // Count this transcribe probe (pause-triggered or the forced "over and out" tap): the finickiness
+        // diagnostic is how many of these ran before the turn was finally taken. A high count on a real turn
+        // means the phone kept missing "over and out". Reset when the microphone returns (enterListening).
+        transcribeAttemptsRef.current += 1;
         // Measure the client-side transcode (phone CPU) separately from the transcribe round trip (network
         // + server), so a real phone turn shows where the pause-to-transcript time actually goes.
         const transcodeStart = performance.now();
@@ -526,10 +568,16 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
             ttsMs: 0,
             firstAudioMs: 0,
             totalTurnMs: 0,
+            // How many transcribe probes it took to land "over and out" this turn (this probe included).
+            transcribeAttempts: transcribeAttemptsRef.current,
             chunks: 0,
             playStartedAt: 0,
             playMs: 0,
+            clipDurationMs: 0,
+            playedToMs: 0,
             completed: false,
+            micReacquiredDuringPlayback: false,
+            speakingPollCount: 0,
             posted: false,
           };
           void takeTurn(command);
@@ -574,6 +622,9 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     try {
       const clip = rec.snapshot();
       if (clip.size < MIN_CLIP_BYTES) return;
+      // Count this rolling-"stop" transcription: it re-reads the open capture stream WHILE the reply plays,
+      // which the turn metrics record as the mic-contention diagnostic (speakingPollCount).
+      speakingPollCountRef.current += 1;
       const { wav } = await blobToWav16kMono(clip);
       const transcript = (await transcribeCarModeAudio(wav)).trim();
       setLastHeard(transcript);

--- a/src/CcDirector.Gateway.Tests/CarModeTelemetryStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeTelemetryStoreTests.cs
@@ -106,6 +106,34 @@ public sealed class CarModeTelemetryStoreTests : IDisposable
     }
 
     [Fact]
+    public void Add_ThenRecent_RoundTripsTheMobileDiagnosticFields()
+    {
+        // The mobile-failure diagnostics (this round): the "over and out" finickiness (how many transcribe
+        // tries before the turn was taken) and the mic-contention hypothesis fields (the whole synthesized
+        // clip length, how far playback reached, whether the mic was re-opened mid-playback, and how many
+        // rolling "stop" polls ran) must all persist so ONE real phone turn is enough to read the truth.
+        var store = new CarModeTelemetryStore(_path, _ => { });
+        var turn = Record("mobile", DateTime.UtcNow.ToString("o")) with
+        {
+            TranscribeAttempts = 4,             // "over and out" took four tries to land - finicky
+            ClipDurationMs = 5200,              // the whole reply the phone received
+            PlayedToMs = 2100,                  // but playback only reached 2.1s in
+            Completed = false,
+            MicReacquiredDuringPlayback = true, // the mic was re-opened while the reply played
+            SpeakingPollCount = 2,
+        };
+        store.Add(turn);
+
+        var reloaded = new CarModeTelemetryStore(_path, _ => { }).Recent(1)[0];
+
+        Assert.Equal(4, reloaded.TranscribeAttempts);
+        Assert.Equal(5200, reloaded.ClipDurationMs);
+        Assert.Equal(2100, reloaded.PlayedToMs);
+        Assert.True(reloaded.MicReacquiredDuringPlayback);
+        Assert.Equal(2, reloaded.SpeakingPollCount);
+    }
+
+    [Fact]
     public void Load_QuarantinesCorruptFile_AndStartsEmpty()
     {
         File.WriteAllText(_path, "{ this is not valid json ][");

--- a/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
@@ -121,9 +121,14 @@ internal static class CarModeEndpoint
                 TtsMs = req.TtsMs,
                 FirstAudioMs = req.FirstAudioMs,
                 TotalTurnMs = req.TotalTurnMs,
+                TranscribeAttempts = req.TranscribeAttempts,
                 Chunks = req.Chunks,
                 PlayMs = req.PlayMs,
+                ClipDurationMs = req.ClipDurationMs,
+                PlayedToMs = req.PlayedToMs,
                 Completed = req.Completed,
+                MicReacquiredDuringPlayback = req.MicReacquiredDuringPlayback,
+                SpeakingPollCount = req.SpeakingPollCount,
                 ServerTotalMs = req.ServerTotalMs,
                 ModelCallCount = req.ModelCallCount,
                 ModelMsTotal = req.ModelMsTotal,
@@ -190,9 +195,14 @@ public sealed class CarModeTelemetryPost
     public double TtsMs { get; set; }
     public double FirstAudioMs { get; set; }
     public double TotalTurnMs { get; set; }
+    public int TranscribeAttempts { get; set; }
     public int Chunks { get; set; }
     public double PlayMs { get; set; }
+    public double ClipDurationMs { get; set; }
+    public double PlayedToMs { get; set; }
     public bool Completed { get; set; }
+    public bool MicReacquiredDuringPlayback { get; set; }
+    public int SpeakingPollCount { get; set; }
     public double ServerTotalMs { get; set; }
     public int ModelCallCount { get; set; }
     public double ModelMsTotal { get; set; }

--- a/src/CcDirector.Gateway/CarMode/CarModeTelemetry.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeTelemetry.cs
@@ -87,6 +87,13 @@ public sealed record CarModeTelemetryRecord
     /// <summary>The whole turn as the owner feels it: pause detected to first audio playing.</summary>
     public double TotalTurnMs { get; init; }
 
+    // ----- "Over and out" finickiness (the finicky-end-phrase diagnostic), measured in the browser -----
+
+    /// <summary>How many pause/forced transcribe probes ran this turn before the turn was taken. 1 means the
+    ///  end phrase landed on the first try; a higher count means "over and out" kept being missed and the
+    ///  owner had to keep trying - the direct measure of how finicky the end phrase was on this turn.</summary>
+    public int TranscribeAttempts { get; init; }
+
     // ----- Reply-audio lifecycle (the cut-off-reply diagnostic), measured in the browser -----
 
     /// <summary>How many audio clips the reply played. It is 1 after the first-sentence split was reverted
@@ -95,13 +102,34 @@ public sealed record CarModeTelemetryRecord
     public int Chunks { get; init; }
 
     /// <summary>How long the reply clip was actually audible: play-started to play-ended (or to a cut-off),
-    ///  milliseconds. A value far short of what the reply length implies flags a truncated reply.</summary>
+    ///  milliseconds (wall-clock). A value far short of what the reply length implies flags a truncated reply.</summary>
     public double PlayMs { get; init; }
+
+    /// <summary>The synthesized reply clip's media length (audio.duration), milliseconds: the whole reply the
+    ///  phone actually received. A value far short of what <see cref="ReplyChars"/> implies flags a TRUNCATED
+    ///  SYNTHESIS (the reply came back short), as opposed to a playback cut-off.</summary>
+    public double ClipDurationMs { get; init; }
+
+    /// <summary>How far INTO the clip playback reached at end/cutoff (audio.currentTime), milliseconds
+    ///  (media-time). A value far below <see cref="ClipDurationMs"/> flags a PLAYBACK cut-off: the whole reply
+    ///  was synthesized but playback stopped part way through - the exact distinction the diagnostic needs.</summary>
+    public double PlayedToMs { get; init; }
 
     /// <summary>True when the reply clip played fully to its natural end; false when it was cut off (a voice
     ///  or touch interrupt, or End Car Mode). The cut-off-reply bug this telemetry makes visible reads as
     ///  false: the reply was synthesized but the owner did not hear all of it.</summary>
     public bool Completed { get; init; }
+
+    // ----- The mic-contention hypothesis (does re-opening the mic mid-playback cut the reply on mobile?) -----
+
+    /// <summary>True when the rolling-"stop" watch re-opened the microphone WHILE the reply was playing (the
+    ///  current behavior). The strong hypothesis is that on mobile this re-acquisition ducks or interrupts the
+    ///  reply. Read together with <see cref="Completed"/>/<see cref="PlayedToMs"/> it proves or kills that.</summary>
+    public bool MicReacquiredDuringPlayback { get; init; }
+
+    /// <summary>How many rolling-"stop" transcriptions ran during this reply. Each re-reads the open capture
+    ///  stream; more polls mean more mic contention while the reply was supposed to be playing.</summary>
+    public int SpeakingPollCount { get; init; }
 
     // ----- Server stamps (from CarModeTurnTiming, echoed back by the client) -----
 

--- a/src/CcDirector.Gateway/CarMode/CarModeTelemetryPage.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeTelemetryPage.cs
@@ -63,7 +63,7 @@ internal static class CarModeTelemetryPage
 <body>
 <div class="wrap">
   <h1>Car Mode Timing</h1>
-  <p class="sub">Per-turn, per-stage latency for hands-free Car Mode - the full pipeline a real phone turn walks: pause, transcode (phone), transcribe, brain round trip, the network gap (brain minus server), each model call, the fleet read, text-to-speech, and first audio. All numbers are milliseconds. Counts and timings only; no command or reply text is ever recorded.</p>
+  <p class="sub">Per-turn, per-stage latency AND the two mobile failure diagnostics for hands-free Car Mode. The pipeline a real phone turn walks: pause, transcode (phone), transcribe, brain round trip, the network gap (brain minus server), each model call, the fleet read, text-to-speech, and first audio. The "over and out" finickiness shows as End-phrase tries (how many transcribe attempts before the turn was taken). The cut-off reply is split three ways: Clip length (the whole reply synthesized), Played to (how far playback reached), and Mic in playback (whether the rolling "stop" watch re-opened the microphone while the reply was playing - the mic-contention suspect). All times are milliseconds. Counts and timings only; no command or reply text is ever recorded.</p>
 
   <div class="cards" id="cards"></div>
 
@@ -74,6 +74,7 @@ internal static class CarModeTelemetryPage
         <tr>
           <th>When</th>
           <th>Total<br>(felt)</th>
+          <th>End-phrase<br>tries</th>
           <th>Pause-&gt;<br>transcribe</th>
           <th>Transcode<br>(phone)</th>
           <th>Brain<br>(round trip)</th>
@@ -86,7 +87,11 @@ internal static class CarModeTelemetryPage
           <th>TTS<br>(reply)</th>
           <th>First<br>audio</th>
           <th>Reply<br>played</th>
+          <th>Clip<br>length</th>
+          <th>Played<br>to</th>
           <th>Whole<br>reply?</th>
+          <th>Mic in<br>playback</th>
+          <th>Stop<br>polls</th>
           <th>Clips</th>
           <th>Rounds</th>
           <th>Cmd<br>chars</th>
@@ -131,7 +136,7 @@ internal static class CarModeTelemetryPage
 
     if (!recs.length) {
       cards.appendChild(card("-", "No turns recorded yet", "Take a turn in Car Mode on the phone"));
-      document.getElementById("rows").innerHTML = '<tr><td colspan="19" class="empty">No turns recorded yet. Open Car Mode on the phone, say something and "over and out", and it will appear here.</td></tr>';
+      document.getElementById("rows").innerHTML = '<tr><td colspan="24" class="empty">No turns recorded yet. Open Car Mode on the phone, say something and "over and out", and it will appear here.</td></tr>';
       document.getElementById("foot").textContent = "";
       return;
     }
@@ -151,6 +156,18 @@ internal static class CarModeTelemetryPage
     cards.appendChild(card(cutOff + " / " + recs.length, "Replies NOT fully heard",
       cutOff > 0 ? "these were cut off before the end" : "every reply played to its end"));
 
+    // Finickiness of "over and out": the median number of transcribe tries before a turn was taken. 1 means
+    // the phrase landed on the first try; a higher median means the phone kept missing it.
+    var tries = recs.map(function (r) { return r.transcribeAttempts; }).filter(function (n) { return n > 0; });
+    cards.appendChild(card(tries.length ? String(median(tries)) : "-", "Median 'over and out' tries",
+      "1 = landed first try; higher = finicky"));
+
+    // The mic-contention suspect: how many recent replies had the microphone re-opened WHILE they played.
+    // On mobile this is the prime suspect for the cut-off / half-heard reply.
+    var micIn = recs.filter(function (r) { return r.micReacquiredDuringPlayback === true; }).length;
+    cards.appendChild(card(micIn + " / " + recs.length, "Mic re-opened during the reply",
+      "the mobile cut-off suspect: mic grabbed mid-playback"));
+
     var body = document.getElementById("rows"); body.innerHTML = "";
     recs.forEach(function (r) {
       var tr = document.createElement("tr");
@@ -164,8 +181,15 @@ internal static class CarModeTelemetryPage
       // Network the browser saw (its brain round trip minus what the server spent inside), so a bad phone
       // network shows up as a large gap that the loopback numbers can never reveal.
       var net = (r.brainMs != null && r.serverTotalMs != null) ? Math.max(0, r.brainMs - r.serverTotalMs) : null;
+      // A reply whose playback stopped well before the synthesized clip ended: the media-time cut-off. Flags
+      // the case the "Whole reply?" flag alone can miss (played-to far below the clip length).
+      var playedShort = (r.clipDurationMs != null && r.playedToMs != null && r.clipDurationMs > 1000
+        && r.playedToMs < r.clipDurationMs - 750);
       tr.appendChild(td(when));
       tr.appendChild(td(ms(r.totalTurnMs), r.totalTurnMs > 6000 ? "slow" : ""));
+      // End-phrase tries: how many transcribe attempts before the turn was taken. More than 1 is finicky.
+      tr.appendChild(td(r.transcribeAttempts == null ? "-" : r.transcribeAttempts,
+        (r.transcribeAttempts != null && r.transcribeAttempts > 1) ? "slow" : ""));
       tr.appendChild(td(ms(r.pauseToTranscribeMs), r.pauseToTranscribeMs > 4000 ? "slow" : ""));
       tr.appendChild(td(ms(r.transcodeMs)));
       tr.appendChild(td(ms(r.brainMs), r.brainMs > 5000 ? "slow" : ""));
@@ -178,10 +202,17 @@ internal static class CarModeTelemetryPage
       tr.appendChild(td(ms(r.ttsMs), r.ttsMs > 3000 ? "slow" : ""));
       tr.appendChild(td(ms(r.firstAudioMs)));
       // The reply-audio lifecycle (the cut-off-reply diagnostic): how long the reply was actually audible,
-      // whether it played to its end, and how many clips it took (1 since the split was reverted). A reply
-      // that was NOT fully heard is called out in red so a truncated reply is impossible to miss.
+      // the whole SYNTHESIZED clip length vs how far playback reached (the media-time cut-off), whether it
+      // played to its end, whether the mic was re-opened mid-playback (the suspect), how many "stop" polls
+      // ran, and how many clips it took (1 since the split was reverted). A reply that was NOT fully heard -
+      // by the completed flag OR by playing short of the clip - is called out in red.
       tr.appendChild(td(ms(r.playMs)));
+      tr.appendChild(td(ms(r.clipDurationMs)));
+      tr.appendChild(td(ms(r.playedToMs), playedShort ? "slow" : ""));
       tr.appendChild(td(r.completed == null ? "-" : (r.completed ? "yes" : "CUT OFF"), r.completed === false ? "slow" : ""));
+      tr.appendChild(td(r.micReacquiredDuringPlayback == null ? "-" : (r.micReacquiredDuringPlayback ? "YES" : "no"),
+        r.micReacquiredDuringPlayback === true ? "slow" : ""));
+      tr.appendChild(td(r.speakingPollCount == null ? "-" : r.speakingPollCount));
       tr.appendChild(td(r.chunks == null ? "-" : r.chunks, (r.chunks != null && r.chunks !== 1) ? "slow" : ""));
       tr.appendChild(td(r.rounds == null ? "-" : r.rounds));
       tr.appendChild(td(r.commandChars == null ? "-" : r.commandChars));


### PR DESCRIPTION
## What

Two changes for the Car Mode mission, aimed at the two failures that reproduce on Soren's real Android phone but NOT on desktop Chrome: the reply cuts off (he hears about half the words) and "over and out" is finicky.

### 1. Simple version label (Soren's explicit ask)
- Replaces the long git short-sha + timestamp badge on `/m/car` with a plain, hand-bumped version. Starts at **v1**. Bump the integer by hand on every deploy (single constant `CAR_MODE_VERSION` in `CarMode.tsx`).
- Removes the git `execSync` and `__CLIENT_BUILD_ID__` define from the mobile build, so the badge is no longer clutter and the build no longer shells out to git.

### 2. Enriched per-turn telemetry so ONE real phone turn reveals the truth
New fields, recorded per turn and shown at `GET /carmode/telemetry`:
- **End-phrase tries** (`transcribeAttempts`) - how many pause/forced transcribe probes ran before the turn was taken. The direct measure of "over and out" finickiness (1 = landed first try).
- **Clip length** vs **Played to** (`clipDurationMs`, `playedToMs`) - the whole reply the phone received versus how far playback actually reached. Distinguishes a truncated SYNTHESIS from a PLAYBACK cut-off.
- **Mic in playback** (`micReacquiredDuringPlayback`) and **Stop polls** (`speakingPollCount`) - whether the rolling "stop" watch re-opened the microphone WHILE the reply played. This is the strong hypothesis for the mobile cut-off: grabbing the mic mid-playback ducks/interrupts the reply.

Two new dashboard summary cards (median "over and out" tries; mic re-opened during the reply) and five new table columns. Counts and timings only; no command or reply text is ever recorded.

## Diagnosis-first
This PR does NOT change the mic/playback behavior - it instruments it, so the ONE turn Soren takes (or a real-mobile reproduction) proves or kills the mic-contention hypothesis before any fix. A fix (do not grab the mic during playback) is a follow-up gated on that evidence.

## Tests
- client-core: 387 vitest tests pass (telemetry post record extended).
- Gateway: 68 CarMode tests pass, including a new round-trip test for the five new fields.
- Typecheck clean across all workspaces; mobile bundle builds clean.

Mission note: not claiming any fix proven on desktop. Deliverable is the version label + telemetry; real-mobile verification / Soren's one instrumented turn is the next step.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>