### PR TITLE
feat(gateway): Phase 2 - sign-in step (DevThrottle sign-in issues the device token)

### DIFF
--- a/docs/reviews/gateway-connection-qa-punch-list.md
+++ b/docs/reviews/gateway-connection-qa-punch-list.md
@@ -6,7 +6,15 @@ is lost between phases. Append new items as they are found.
 
 ## Open
 
-_(none)_
+- **Remote / headless Director sign-in enrollment** (deferred from Phase 2). Phase 2 ships the
+  co-located (same-machine, loopback) enroll-through-the-Gateway path only. A Director that is NOT on
+  the Gateway's machine (remote or headless) still needs a way to sign in and receive its own
+  per-device token - the tailnet-callback path, mirroring the phone's remote enrollment. Design and
+  build as a Phase 2 follow-up.
+- **Delete the legacy pairing dialog** (Phase 4). `ConnectToGatewayDialog` and its "Connect to
+  Gateway..." pairing-code entry are superseded by the sign-in Step 2; remove them from the user
+  interface as part of the Phase 4 settings cleanup / deletion list. (The Gateway's pairing-code
+  endpoint `/devices/register` can stay for now; this is about the desktop UI surface.)
 
 ## Resolved
 

--- a/docs/reviews/gateway-connection-qa-punch-list.md
+++ b/docs/reviews/gateway-connection-qa-punch-list.md
@@ -1,0 +1,18 @@
+# Gateway Connection - QA punch list
+
+A running list of deferred cosmetic and quality items found during the mission, to be resolved by
+the end and folded into the final verification report (definition-of-done item 5). Kept so nothing
+is lost between phases. Append new items as they are found.
+
+## Open
+
+_(none)_
+
+## Resolved
+
+- **Step 1 Advanced disclosure trailing cell** (found Phase 1, Architect review of PR #1327). The
+  collapsed "Enter the address manually" row used Avalonia's default `Expander` chrome, which left a
+  thin trailing bordered cell on the right and put the caret mid-row, so the row did not span full
+  width like the option rows above. Fix: replaced the `Expander` with a full-width `ToggleButton`
+  disclosure (caret flush right, no stray cell). Written during Phase 1; lands and is
+  screenshot-verified with the Phase 2 pull request.

--- a/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml
+++ b/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml
@@ -53,6 +53,27 @@
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="TextBlock.Foreground" Value="#9FB0D6" />
         </Style>
+        <!-- Full-width disclosure header (no default Expander chrome, so no trailing bordered cell). -->
+        <Style Selector="ToggleButton.disclosure">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="14,12" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="Cursor" Value="Hand" />
+        </Style>
+        <Style Selector="ToggleButton.disclosure /template/ ContentPresenter">
+            <Setter Property="Background" Value="Transparent" />
+        </Style>
+        <Style Selector="ToggleButton.disclosure:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="Transparent" />
+        </Style>
+        <Style Selector="ToggleButton.disclosure:checked /template/ ContentPresenter">
+            <Setter Property="Background" Value="Transparent" />
+        </Style>
+        <Style Selector="ToggleButton.disclosure:pressed /template/ ContentPresenter">
+            <Setter Property="Background" Value="Transparent" />
+        </Style>
     </UserControl.Styles>
 
     <!-- Scrolls so the panel never clips when a host (Settings tab, status-box window, onboarding) is
@@ -104,20 +125,28 @@
                     <Button x:Name="RescanButton" Classes="link" Click="Rescan_Click" Content="Scan again" />
                 </StackPanel>
 
-                <!-- Advanced: manual entry fallback, collapsed by default (decisions 5, 6) -->
+                <!-- Advanced: manual entry fallback, collapsed by default (decisions 5, 6). A custom
+                     disclosure (a full-width ToggleButton header with the caret flush right, plus a
+                     collapsible panel) so the row spans the full width like the option rows above, with
+                     no trailing bordered cell. -->
                 <Border Margin="0,14,0,0" Background="#202021" BorderBrush="#3C3C3C" BorderThickness="1"
                         CornerRadius="9">
-                    <Expander x:Name="AdvancedExpander" Background="Transparent" BorderThickness="0"
-                              Padding="4,0">
-                        <Expander.Header>
-                            <StackPanel Orientation="Horizontal" Spacing="8">
-                                <TextBlock Text="Enter the address manually" Foreground="#AAAAAA"
-                                           FontSize="13" FontWeight="SemiBold" VerticalAlignment="Center" />
-                                <TextBlock Text="- computer name plus port, or a full address"
-                                           Foreground="#666666" FontSize="11.5" VerticalAlignment="Center" />
-                            </StackPanel>
-                        </Expander.Header>
-                        <StackPanel Spacing="2" Margin="0,6,4,10">
+                    <StackPanel>
+                        <ToggleButton x:Name="AdvancedToggle" Classes="disclosure"
+                                      IsCheckedChanged="AdvancedToggle_IsCheckedChanged">
+                            <Grid ColumnDefinitions="*,Auto">
+                                <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8"
+                                            VerticalAlignment="Center">
+                                    <TextBlock Text="Enter the address manually" Foreground="#AAAAAA"
+                                               FontSize="13" FontWeight="SemiBold" VerticalAlignment="Center" />
+                                    <TextBlock Text="- computer name plus port, or a full address"
+                                               Foreground="#666666" FontSize="11.5" VerticalAlignment="Center" />
+                                </StackPanel>
+                                <TextBlock Grid.Column="1" x:Name="AdvancedCaret" Text="v" Foreground="#666666"
+                                           FontSize="12" VerticalAlignment="Center" />
+                            </Grid>
+                        </ToggleButton>
+                        <StackPanel x:Name="ManualEntryPanel" Spacing="2" Margin="14,0,14,12" IsVisible="False">
                             <TextBlock Classes="fieldLabel"
                                        Text="GATEWAY ADDRESS (computer name plus port, or a full address)" />
                             <TextBox x:Name="ManualUrlBox" Classes="input"
@@ -127,7 +156,7 @@
                             <Button x:Name="ManualConnectButton" Classes="primaryButton" Content="Connect"
                                     HorizontalAlignment="Left" Margin="0,8,0,0" Click="ManualConnect_Click" />
                         </StackPanel>
-                    </Expander>
+                    </StackPanel>
                 </Border>
 
                 <!-- Footnote: the no-hidden-test rule -->
@@ -160,19 +189,64 @@
                          Foreground="#007ACC" Background="#2A2A2A" />
         </StackPanel>
 
-        <!-- STEP 1d: connected -->
-        <StackPanel x:Name="ConnectedPanel" Spacing="10" VerticalAlignment="Top" IsVisible="False">
-            <TextBlock Classes="title" Text="Connected" />
-            <Border Background="#14241A" BorderBrush="#2E7D32" BorderThickness="1" CornerRadius="3" Padding="16">
-                <StackPanel Orientation="Horizontal" Spacing="10">
-                    <TextBlock Text="[x]" FontFamily="Consolas,Courier New" FontSize="14" Foreground="#66BB6A"
-                               VerticalAlignment="Center" />
-                    <TextBlock x:Name="ConnectedText" FontSize="14" Foreground="#CFE9CF"
-                               Text="Connected to the Gateway" VerticalAlignment="Center" TextWrapping="Wrap" />
+        <!-- STEP 2: sign in with DevThrottle (once connected). Signing in issues this device its token. -->
+        <StackPanel x:Name="SignInPanel" Spacing="10" VerticalAlignment="Top" IsVisible="False">
+            <TextBlock Classes="title" Text="Sign in" />
+            <TextBlock Classes="body"
+                       Text="Connected to the Gateway. One more step to make this device trusted: sign in with DevThrottle. Signing in is what puts this device's own token on it - there is no pairing code." />
+            <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,4,0,0">
+                <Button x:Name="SignInButton" Classes="primaryButton" Content="Sign in with DevThrottle"
+                        Click="SignIn_Click" />
+            </StackPanel>
+            <StackPanel x:Name="SignInWaitRow" Orientation="Horizontal" Spacing="10" IsVisible="False" Margin="0,4,0,0">
+                <ProgressBar IsIndeterminate="True" Width="120" Height="3" Foreground="#007ACC"
+                             Background="#2A2A2A" VerticalAlignment="Center" />
+                <TextBlock x:Name="SignInWaitText" Classes="body" Text="Waiting for you to sign in..." />
+            </StackPanel>
+            <TextBlock x:Name="SignInErrorText" FontSize="12" Foreground="#E07A7A" TextWrapping="Wrap"
+                       IsVisible="False" />
+        </StackPanel>
+
+        <!-- DONE: both checks green, with the masked device token under a collapsed Advanced (decision 7). -->
+        <StackPanel x:Name="DonePanel" Spacing="10" VerticalAlignment="Top" IsVisible="False">
+            <TextBlock Classes="title" Text="Gateway" />
+            <Border Background="#14241A" BorderBrush="#2E7D32" BorderThickness="1" CornerRadius="9" Padding="16">
+                <StackPanel Spacing="8">
+                    <StackPanel Orientation="Horizontal" Spacing="10">
+                        <TextBlock Text="[x]" FontFamily="Consolas,Courier New" FontSize="14" Foreground="#34D06E"
+                                   VerticalAlignment="Center" />
+                        <TextBlock x:Name="DoneConnectedText" FontSize="14" Foreground="#CFE9CF"
+                                   Text="Connected to the Gateway" VerticalAlignment="Center" TextWrapping="Wrap" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="10">
+                        <TextBlock Text="[x]" FontFamily="Consolas,Courier New" FontSize="14" Foreground="#34D06E"
+                                   VerticalAlignment="Center" />
+                        <TextBlock x:Name="DoneSignedInText" FontSize="14" Foreground="#CFE9CF"
+                                   Text="Signed in" VerticalAlignment="Center" TextWrapping="Wrap" />
+                    </StackPanel>
                 </StackPanel>
             </Border>
-            <TextBlock Classes="body"
-                       Text="The two-way connection is proven. Next comes signing in (added in the next step)." />
+            <Border Background="#202021" BorderBrush="#3C3C3C" BorderThickness="1" CornerRadius="9">
+                <StackPanel>
+                    <ToggleButton x:Name="DoneAdvancedToggle" Classes="disclosure"
+                                  IsCheckedChanged="DoneAdvancedToggle_IsCheckedChanged">
+                        <Grid ColumnDefinitions="*,Auto">
+                            <TextBlock Grid.Column="0" Text="Advanced" Foreground="#AAAAAA" FontSize="13"
+                                       FontWeight="SemiBold" VerticalAlignment="Center" />
+                            <TextBlock Grid.Column="1" x:Name="DoneAdvancedCaret" Text="v" Foreground="#666666"
+                                       FontSize="12" VerticalAlignment="Center" />
+                        </Grid>
+                    </ToggleButton>
+                    <StackPanel x:Name="DoneAdvancedPanel" Spacing="6" Margin="14,0,14,12" IsVisible="False">
+                        <TextBlock Classes="fieldLabel" Text="DEVICE TOKEN (this device's key, masked)" />
+                        <TextBlock x:Name="DoneMaskedToken" FontFamily="Cascadia Mono,Consolas,Courier New"
+                                   Foreground="#AAAAAA" FontSize="12.5" Text="********" />
+                        <TextBlock Classes="fieldLabel" Text="GATEWAY ADDRESS" />
+                        <TextBlock x:Name="DoneGatewayUrl" FontFamily="Cascadia Mono,Consolas,Courier New"
+                                   Foreground="#AAAAAA" FontSize="12.5" Text="" TextWrapping="Wrap" />
+                    </StackPanel>
+                </StackPanel>
+            </Border>
         </StackPanel>
 
         <!-- STEP 1e: named failure -->

--- a/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Nodes;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
@@ -11,6 +12,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Threading;
 using CcDirector.ControlApi;
+using CcDirector.Core.Account;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.GatewayConnection;
 using CcDirector.Core.Network;
@@ -68,6 +70,13 @@ public partial class GatewayConnectionPanel : UserControl
     // The last address tried, so "Try again" repeats it.
     private (string Url, string Label)? _lastAttempt;
 
+    // Cancels the Step 2 account-status polling loop when the panel is left or the flow restarts.
+    private CancellationTokenSource? _pollCts;
+
+    // Enroll is attempted at most once per sign-in flow, and NEVER from the poll loop, so status polling
+    // can never mint keys repeatedly (guardrail against the #1136 auto-mint key leak).
+    private bool _enrollAttempted;
+
     public GatewayConnectionPanel()
     {
         InitializeComponent();
@@ -84,6 +93,7 @@ public partial class GatewayConnectionPanel : UserControl
     protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnDetachedFromVisualTree(e);
+        StopPolling();
         if (_subscribed && _monitor is not null)
         {
             _monitor.Changed -= OnMonitorChanged;
@@ -96,6 +106,7 @@ public partial class GatewayConnectionPanel : UserControl
     private async void StartScan()
     {
         _connecting = false;
+        StopPolling();
         CountPillText.Text = "SCANNING...";
         ScanningProgress.IsVisible = true;
         ResultsArea.IsVisible = false;
@@ -125,7 +136,7 @@ public partial class GatewayConnectionPanel : UserControl
         var any = found.Count > 0;
         NoneFoundText.IsVisible = !any;
         // When nothing was found, open the manual-entry section so the fallback is one step away.
-        AdvancedExpander.IsExpanded = !any;
+        AdvancedToggle.IsChecked = !any;
         ResultsArea.IsVisible = true;
         ShowOnly(ConnectPanel);
         FileLog.Write($"[GatewayConnectionPanel] scan rendered: {found.Count} pick(s), recommended index {recommended}");
@@ -369,6 +380,14 @@ public partial class GatewayConnectionPanel : UserControl
             ConnectTo(pick.Url, pick.Label);
     }
 
+    private void AdvancedToggle_IsCheckedChanged(object? sender, RoutedEventArgs e)
+    {
+        var open = AdvancedToggle.IsChecked == true;
+        // Guard: this can fire during control construction, before the sibling fields are assigned.
+        if (ManualEntryPanel is not null) ManualEntryPanel.IsVisible = open;
+        if (AdvancedCaret is not null) AdvancedCaret.Text = open ? "^" : "v";
+    }
+
     private void ManualConnect_Click(object? sender, RoutedEventArgs e)
     {
         ManualErrorText.IsVisible = false;
@@ -446,7 +465,7 @@ public partial class GatewayConnectionPanel : UserControl
         switch (monitor.Status)
         {
             case GatewayConnectionStatus.Verified:
-                ShowConnected(_lastAttempt?.Label);
+                OnHandshakeVerified();
                 break;
             case GatewayConnectionStatus.Failed:
             case GatewayConnectionStatus.NoTailnetIdentity:
@@ -469,7 +488,7 @@ public partial class GatewayConnectionPanel : UserControl
         var monitor = _monitor;
         if (monitor?.Status == GatewayConnectionStatus.Verified)
         {
-            ShowConnected(_lastAttempt?.Label);
+            OnHandshakeVerified();
             return;
         }
 
@@ -480,14 +499,202 @@ public partial class GatewayConnectionPanel : UserControl
             "Check that the Gateway is running and reachable, or set the Director public URL under Advanced.");
     }
 
-    private void ShowConnected(string? label)
+    // ---- Step 2: sign in with DevThrottle -------------------------------------------------------
+
+    // The handshake proved Connected. Route to Step 2 (sign in) or the Done view based on the current
+    // signed-in state, resolved via the same resolver the status box uses (spec section 4).
+    private async void OnHandshakeVerified()
     {
         _connecting = false;
-        ConnectedText.Text = string.IsNullOrWhiteSpace(label)
+        FileLog.Write("[GatewayConnectionPanel] connected (handshake verified); resolving sign-in state");
+        await RefreshSignedInViewAsync();
+    }
+
+    // Read the account status + device-token presence, resolve, and show Step 2 or the Done view.
+    private async Task RefreshSignedInViewAsync()
+    {
+        var config = GatewayConfig.Load();
+        var account = await SafeStatusAsync(config, CancellationToken.None);
+
+        var inputs = new GatewayConnectionInputs(
+            GatewayConfigured: config.IsEnabled,
+            Connection: GatewayConnectionVerification.Connected,
+            FailedLeg: GatewayConnectionFailedLeg.None,
+            WasEverConnected: true,
+            DeviceKeyPresent: HasDeviceToken(config),
+            Account: MapAccount(account));
+
+        if (GatewayConnectionStateResolver.ResolveState(inputs) == GatewayConnectionState.AllGreen)
+            ShowDone(config, account);
+        else
+            ShowSignIn();
+    }
+
+    private void ShowSignIn()
+    {
+        StopPolling();
+        _enrollAttempted = false;
+        SignInWaitRow.IsVisible = false;
+        SignInErrorText.IsVisible = false;
+        SignInButton.IsEnabled = true;
+        ShowOnly(SignInPanel);
+        FileLog.Write("[GatewayConnectionPanel] showing Step 2 (sign in)");
+    }
+
+    private void SignIn_Click(object? sender, RoutedEventArgs e) => _ = StartSignInAsync();
+
+    private async Task StartSignInAsync()
+    {
+        SignInErrorText.IsVisible = false;
+        SignInButton.IsEnabled = false;
+        SignInWaitRow.IsVisible = true;
+        SignInWaitText.Text = "Opening the DevThrottle sign-in in your browser...";
+
+        try
+        {
+            await OpenDevThrottleSignInAsync();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayConnectionPanel] sign-in launch failed: {ex.Message}");
+            ShowSignInError("Could not open the sign-in page. " + ex.Message);
+            return;
+        }
+
+        // Watch for the Gateway reporting signed in, then settle to Done. Enroll runs at most once and
+        // NEVER from the poll loop itself (guardrail against the #1136 key leak).
+        SignInWaitText.Text = "Waiting for you to sign in...";
+        StartPolling();
+    }
+
+    // Open the DevThrottle sign-in front door in the system browser. The Gateway itself decides the
+    // loopback-versus-remote redirect (AccountSignInStartEndpoint).
+    private async Task OpenDevThrottleSignInAsync()
+    {
+        var config = GatewayConfig.Load();
+        var baseUrl = global::CcDirector.Avalonia.CockpitUrlResolver.ResolveCockpitBase(config);
+        var url = baseUrl.TrimEnd('/') + "/account/sign-in-start";
+        await Task.Run(() => System.Diagnostics.Process.Start(
+            new System.Diagnostics.ProcessStartInfo(url) { UseShellExecute = true }));
+        FileLog.Write($"[GatewayConnectionPanel] opened DevThrottle sign-in: {url}");
+    }
+
+    private void ShowSignInError(string message)
+    {
+        StopPolling();
+        SignInWaitRow.IsVisible = false;
+        SignInButton.IsEnabled = true;
+        SignInErrorText.Text = message;
+        SignInErrorText.IsVisible = true;
+    }
+
+    private void StartPolling()
+    {
+        StopPolling();
+        _pollCts = new CancellationTokenSource();
+        _ = PollAccountAsync(_pollCts.Token);
+    }
+
+    private void StopPolling()
+    {
+        _pollCts?.Cancel();
+        _pollCts?.Dispose();
+        _pollCts = null;
+    }
+
+    // Poll GET /account/status until the Gateway reports signed in; then ensure this Director holds its
+    // own device token (enrolling once through the Gateway) and settle to the Done view. The loop only
+    // READS status - it never mints a key on its own.
+    private async Task PollAccountAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            var config = GatewayConfig.Load();
+            var account = await SafeStatusAsync(config, ct);
+            if (ct.IsCancellationRequested) return;
+
+            if (account.SignedIn)
+            {
+                if (!HasDeviceToken(config) && !_enrollAttempted)
+                {
+                    _enrollAttempted = true;
+                    await EnrollThroughGatewayOnceAsync();
+                    config = GatewayConfig.Load();
+                    account = await SafeStatusAsync(config, ct);
+                }
+
+                if (HasDeviceToken(config) && account.SignedIn)
+                {
+                    var finalConfig = config;
+                    var finalAccount = account;
+                    await Dispatcher.UIThread.InvokeAsync(() => ShowDone(finalConfig, finalAccount));
+                    return;
+                }
+            }
+
+            try { await Task.Delay(TimeSpan.FromSeconds(2), ct); }
+            catch (OperationCanceledException) { return; }
+        }
+    }
+
+    // MECHANISM SEAM (Phase 2b): call POST /devices/enroll-signed-in on the co-located Gateway to mint and
+    // store this Director's own per-device token (idempotent server-side, gated on account-signed-in AND a
+    // same-machine loopback caller). No-op until that Gateway endpoint and its Director client land.
+    private static Task EnrollThroughGatewayOnceAsync()
+    {
+        FileLog.Write("[GatewayConnectionPanel] enroll-through-Gateway seam (Phase 2b) not yet wired");
+        return Task.CompletedTask;
+    }
+
+    private static async Task<GatewayAccountStatus> SafeStatusAsync(GatewayConfig config, CancellationToken ct)
+    {
+        try { return await new GatewayAccountStatusClient().GetStatusAsync(config, ct); }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayConnectionPanel] account status read failed: {ex.Message}");
+            return GatewayAccountStatus.NotConfigured();
+        }
+    }
+
+    private void ShowDone(GatewayConfig config, GatewayAccountStatus account)
+    {
+        StopPolling();
+        var host = SafeHost(config.Url);
+        DoneConnectedText.Text = string.IsNullOrWhiteSpace(host)
             ? "Connected to the Gateway"
-            : $"Connected to {label}";
-        ShowOnly(ConnectedPanel);
-        FileLog.Write("[GatewayConnectionPanel] connected (handshake verified)");
+            : $"Connected to Gateway on {host}";
+        DoneSignedInText.Text = string.IsNullOrWhiteSpace(account.Email)
+            ? "Signed in"
+            : $"Signed in as {account.Email}";
+        DoneMaskedToken.Text = MaskToken(config.Token);
+        DoneGatewayUrl.Text = config.Url;
+        ShowOnly(DonePanel);
+        FileLog.Write("[GatewayConnectionPanel] showing Done (both checks green)");
+    }
+
+    private void DoneAdvancedToggle_IsCheckedChanged(object? sender, RoutedEventArgs e)
+    {
+        var open = DoneAdvancedToggle.IsChecked == true;
+        if (DoneAdvancedPanel is not null) DoneAdvancedPanel.IsVisible = open;
+        if (DoneAdvancedCaret is not null) DoneAdvancedCaret.Text = open ? "^" : "v";
+    }
+
+    // The token is shown masked, never in the clear (decision 7) - same masking as the old pairing dialog.
+    private static string MaskToken(string? token)
+        => !string.IsNullOrEmpty(token) && token.Length > 8
+            ? token[..4] + "..." + token[^4..]
+            : "********";
+
+    // True when this device already holds its per-device token. GatewayConfig.Load resolves it from the
+    // local credential file for a same-machine Gateway, so the config token is the complete check.
+    private static bool HasDeviceToken(GatewayConfig config) => !string.IsNullOrWhiteSpace(config.Token);
+
+    private static GatewayAccountSignInState MapAccount(GatewayAccountStatus status)
+    {
+        if (!status.GatewayConfigured) return GatewayAccountSignInState.Unknown;
+        if (!status.Reachable) return GatewayAccountSignInState.Unavailable;
+        return status.SignedIn ? GatewayAccountSignInState.SignedIn : GatewayAccountSignInState.SignedOut;
     }
 
     private void ShowFailure(string summary, string? fix)
@@ -536,7 +743,8 @@ public partial class GatewayConnectionPanel : UserControl
     {
         ConnectPanel.IsVisible = ReferenceEquals(panel, ConnectPanel);
         ConnectingPanel.IsVisible = ReferenceEquals(panel, ConnectingPanel);
-        ConnectedPanel.IsVisible = ReferenceEquals(panel, ConnectedPanel);
+        SignInPanel.IsVisible = ReferenceEquals(panel, SignInPanel);
+        DonePanel.IsVisible = ReferenceEquals(panel, DonePanel);
         FailedPanel.IsVisible = ReferenceEquals(panel, FailedPanel);
     }
 }

--- a/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs
@@ -637,13 +637,39 @@ public partial class GatewayConnectionPanel : UserControl
         }
     }
 
-    // MECHANISM SEAM (Phase 2b): call POST /devices/enroll-signed-in on the co-located Gateway to mint and
-    // store this Director's own per-device token (idempotent server-side, gated on account-signed-in AND a
-    // same-machine loopback caller). No-op until that Gateway endpoint and its Director client land.
-    private static Task EnrollThroughGatewayOnceAsync()
+    // Enroll THIS co-located Director through its Gateway now that the account is signed in: the Gateway
+    // mints (or returns) this Director's own per-device token, which is stored locally. Called at most once
+    // per sign-in flow and never from the poll loop's read path (guardrail against the #1136 key leak).
+    private async Task EnrollThroughGatewayOnceAsync()
     {
-        FileLog.Write("[GatewayConnectionPanel] enroll-through-Gateway seam (Phase 2b) not yet wired");
-        return Task.CompletedTask;
+        try
+        {
+            var host = (global::Avalonia.Application.Current as App)?.ControlApiHost;
+            if (host is null)
+            {
+                FileLog.Write("[GatewayConnectionPanel] enroll-through-Gateway: Control API not running");
+                return;
+            }
+
+            var config = GatewayConfig.Load();
+            var result = await GatewayEnrollmentClient.EnrollSignedInAsync(
+                config.Url, config.Token, host.DirectorId, Environment.MachineName, "windows");
+
+            if (!result.Success || result.Value is null)
+            {
+                FileLog.Write($"[GatewayConnectionPanel] enroll-through-Gateway failed: {result.ErrorMessage}");
+                return;
+            }
+
+            // Store this device's own token, then re-apply so the running client authenticates with it.
+            await Task.Run(() => GatewayCredentialStore.SaveEnrolledKey(config.Url, result.Value.DeviceKey));
+            await host.ReapplyGatewayAsync();
+            FileLog.Write("[GatewayConnectionPanel] enroll-through-Gateway: this Director's token stored");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayConnectionPanel] enroll-through-Gateway error: {ex.Message}");
+        }
     }
 
     private static async Task<GatewayAccountStatus> SafeStatusAsync(GatewayConfig config, CancellationToken ct)

--- a/src/CcDirector.ControlApi/GatewayEnrollmentClient.cs
+++ b/src/CcDirector.ControlApi/GatewayEnrollmentClient.cs
@@ -79,4 +79,72 @@ public static class GatewayEnrollmentClient
         FileLog.Write($"[GatewayEnrollmentClient] EnrollAsync: per-device key issued for machine={body.MachineName}");
         return OperationResult<DeviceRegistrationResponse>.Ok(body);
     }
+
+    /// <summary>
+    /// Enroll THIS co-located Director with its own Gateway using the DevThrottle account sign-in instead
+    /// of a pairing code (issue #1069): POST <c>/devices/enroll-signed-in</c> with the Director's existing
+    /// Gateway token as the Bearer. The Gateway mints (or returns, if already present) this Director's own
+    /// per-device key - gated on the Gateway being signed in AND the caller being a loopback same-machine
+    /// connection. Returns the issued key, or a human-readable reason. A 409 means the Gateway is not signed
+    /// in yet (the caller should trigger the browser sign-in first); a 403 means this is not a same-machine
+    /// Director. Never throws for an expected failure.
+    /// </summary>
+    public static async Task<OperationResult<DeviceRegistrationResponse>> EnrollSignedInAsync(
+        string gatewayUrl, string? token, string deviceId, string machineName, string platform, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(gatewayUrl))
+            return OperationResult<DeviceRegistrationResponse>.Fail("No Gateway URL is configured.");
+        if (string.IsNullOrWhiteSpace(deviceId))
+            return OperationResult<DeviceRegistrationResponse>.Fail("This Director has no device id.");
+
+        FileLog.Write($"[GatewayEnrollmentClient] EnrollSignedInAsync: gateway={gatewayUrl}, deviceId={deviceId}, machine={machineName}");
+        var request = new EnrollSignedInRequest
+        {
+            DeviceId = deviceId,
+            MachineName = machineName,
+            Platform = platform,
+            DeviceType = "workstation",
+        };
+
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
+        http.BaseAddress = new Uri(gatewayUrl.TrimEnd('/') + "/");
+        if (!string.IsNullOrEmpty(token))
+            http.DefaultRequestHeaders.Authorization =
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+
+        HttpResponseMessage resp;
+        try
+        {
+            resp = await http.PostAsJsonAsync("devices/enroll-signed-in", request, ct);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayEnrollmentClient] EnrollSignedInAsync transport FAILED: {ex.Message}");
+            return OperationResult<DeviceRegistrationResponse>.Fail(
+                $"Could not reach the Gateway at {gatewayUrl}: {ex.Message}");
+        }
+
+        if (resp.StatusCode == HttpStatusCode.Conflict)
+            return OperationResult<DeviceRegistrationResponse>.Fail(
+                "Sign in to DevThrottle first, then this device gets its token.");
+        if (resp.StatusCode == HttpStatusCode.Forbidden)
+            return OperationResult<DeviceRegistrationResponse>.Fail(
+                "This Director must be on the Gateway's own machine to enroll this way.");
+        if (!resp.IsSuccessStatusCode)
+        {
+            FileLog.Write($"[GatewayEnrollmentClient] EnrollSignedInAsync failed: HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+            return OperationResult<DeviceRegistrationResponse>.Fail(
+                $"The Gateway refused enrollment: HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+        }
+
+        var body = await resp.Content.ReadFromJsonAsync<DeviceRegistrationResponse>(ct);
+        if (body is null || string.IsNullOrWhiteSpace(body.DeviceKey))
+        {
+            FileLog.Write("[GatewayEnrollmentClient] EnrollSignedInAsync: 2xx with no device key in body");
+            return OperationResult<DeviceRegistrationResponse>.Fail("The Gateway returned no device key.");
+        }
+
+        FileLog.Write($"[GatewayEnrollmentClient] EnrollSignedInAsync: per-device key issued for machine={body.MachineName}");
+        return OperationResult<DeviceRegistrationResponse>.Ok(body);
+    }
 }

--- a/src/CcDirector.Gateway.Contracts/DeviceEnrollment.cs
+++ b/src/CcDirector.Gateway.Contracts/DeviceEnrollment.cs
@@ -37,6 +37,30 @@ public sealed class DeviceRegistrationRequest
 }
 
 /// <summary>
+/// A co-located Director's request to enroll with its own Gateway using the DevThrottle account
+/// sign-in instead of a pairing code (issue #1069). The Director POSTs this to
+/// <c>/devices/enroll-signed-in</c>; the Gateway mints (or, if this device already has one, returns)
+/// the Director's own per-device key - gated on the Gateway being signed in to DevThrottle AND the
+/// caller being a loopback same-machine connection. There is no pairing code: signing in is the
+/// authorization. Carries no credential of its own; the loopback origin plus the Gateway's signed-in
+/// account are the proof.
+/// </summary>
+public sealed class EnrollSignedInRequest
+{
+    /// <summary>The Director's stable device identity (its existing device GUID).</summary>
+    public string DeviceId { get; set; } = "";
+
+    /// <summary>The Director's machine name, recorded in the registry and echoed back for confirmation.</summary>
+    public string MachineName { get; set; } = "";
+
+    /// <summary>The operating-system platform string (for example "windows"), for the cloud mirror roster.</summary>
+    public string Platform { get; set; } = "";
+
+    /// <summary>The device type - defaults to "workstation" - for the cloud mirror roster.</summary>
+    public string DeviceType { get; set; } = "";
+}
+
+/// <summary>
 /// The Gateway's response to a successful <see cref="DeviceRegistrationRequest"/> (issue #469).
 /// Carries the unique per-device key the Director writes to its local credential file. The
 /// pairing code is consumed and never returned.

--- a/src/CcDirector.Gateway.Tests/SignedInEnrollmentTests.cs
+++ b/src/CcDirector.Gateway.Tests/SignedInEnrollmentTests.cs
@@ -1,0 +1,155 @@
+using System.Net;
+using CcDirector.Core.Account;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Pairing;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Proves the two load-bearing guardrails of the sign-in enrollment path (issue #1069):
+/// the AUTH gate (POST /devices/enroll-signed-in only mints for a proven-loopback caller when the
+/// Gateway is signed in) and the IDEMPOTENT mint (a device that already holds a key gets the SAME key
+/// back, never a fresh one). The idempotency test pins the guardrail against the #1136 auto-mint key
+/// leak: enrolling the same device twice must not rotate or multiply keys.
+/// </summary>
+public sealed class SignedInEnrollmentTests
+{
+    private static readonly AccountIdentity Signed = new("person@example.com", "google");
+
+    // ---- Auth gate (SignedInEnrollmentEndpoint.Evaluate) ---------------------------------------
+
+    [Fact]
+    public void Evaluate_LoopbackAndSignedIn_Allows()
+    {
+        Assert.Equal(EnrollGateDecision.Allow,
+            SignedInEnrollmentEndpoint.Evaluate(IPAddress.Loopback, isSignedIn: true, Signed));
+        Assert.Equal(EnrollGateDecision.Allow,
+            SignedInEnrollmentEndpoint.Evaluate(IPAddress.IPv6Loopback, isSignedIn: true, Signed));
+    }
+
+    [Fact]
+    public void Evaluate_NonLoopbackCaller_IsRejectedAsNotSameMachine()
+    {
+        // A tailnet / LAN address must never reach the mint, even when the Gateway is signed in.
+        Assert.Equal(EnrollGateDecision.NotSameMachine,
+            SignedInEnrollmentEndpoint.Evaluate(IPAddress.Parse("100.86.144.11"), isSignedIn: true, Signed));
+        Assert.Equal(EnrollGateDecision.NotSameMachine,
+            SignedInEnrollmentEndpoint.Evaluate(IPAddress.Parse("192.168.1.50"), isSignedIn: true, Signed));
+    }
+
+    [Fact]
+    public void Evaluate_UnknownCaller_IsRejected_NeverAssumedSameMachine()
+    {
+        // A null remote address is NOT treated as same-machine here (this mints a credential), unlike the
+        // conservative sign-in routing default.
+        Assert.Equal(EnrollGateDecision.NotSameMachine,
+            SignedInEnrollmentEndpoint.Evaluate(null, isSignedIn: true, Signed));
+    }
+
+    [Fact]
+    public void Evaluate_LoopbackButNotSignedIn_IsRejected()
+    {
+        Assert.Equal(EnrollGateDecision.NotSignedIn,
+            SignedInEnrollmentEndpoint.Evaluate(IPAddress.Loopback, isSignedIn: false, identity: null));
+    }
+
+    [Fact]
+    public void Evaluate_LoopbackSignedInButNoIdentity_IsRejected()
+    {
+        // Signed-in flag without a resolved identity (stale credential) must not mint - there is nothing
+        // to bind the key to.
+        Assert.Equal(EnrollGateDecision.NotSignedIn,
+            SignedInEnrollmentEndpoint.Evaluate(IPAddress.Loopback, isSignedIn: true, identity: null));
+    }
+
+    [Fact]
+    public void Evaluate_SameMachineCheckOutranksSignedIn()
+    {
+        // A non-loopback caller is rejected as not-same-machine even if also not signed in - the transport
+        // proof is checked first so a remote caller never learns the sign-in state.
+        Assert.Equal(EnrollGateDecision.NotSameMachine,
+            SignedInEnrollmentEndpoint.Evaluate(IPAddress.Parse("10.0.0.5"), isSignedIn: false, identity: null));
+    }
+
+    // ---- Idempotent mint (DeviceRegistry.RegisterIfAbsent) -------------------------------------
+
+    [Fact]
+    public void RegisterIfAbsent_SameDeviceTwice_ReturnsTheSameKey_NoReMint()
+    {
+        using var temp = new TempStore();
+        var registry = new DeviceRegistry(temp.Path);
+
+        var first = registry.RegisterIfAbsent("device-1", "MACHINE_A", "windows", "workstation");
+        var second = registry.RegisterIfAbsent("device-1", "MACHINE_A", "windows", "workstation");
+
+        Assert.False(string.IsNullOrEmpty(first.DeviceKey));
+        Assert.Equal(first.DeviceKey, second.DeviceKey); // idempotent: the SAME key, not a fresh one
+        Assert.Equal(1, registry.Count); // exactly one device, no duplicates
+    }
+
+    [Fact]
+    public void RegisterIfAbsent_ManyCalls_MintOnlyOnce()
+    {
+        // The poll loop is guarded to never call enroll repeatedly, but the server is idempotent anyway:
+        // even ten calls yield one key and one device (the #1136 guardrail).
+        using var temp = new TempStore();
+        var registry = new DeviceRegistry(temp.Path);
+
+        var key = registry.RegisterIfAbsent("device-1", "MACHINE_A").DeviceKey;
+        for (var i = 0; i < 10; i++)
+            Assert.Equal(key, registry.RegisterIfAbsent("device-1", "MACHINE_A").DeviceKey);
+
+        Assert.Equal(1, registry.Count);
+    }
+
+    [Fact]
+    public void RegisterIfAbsent_DistinctDevices_GetDistinctKeys()
+    {
+        using var temp = new TempStore();
+        var registry = new DeviceRegistry(temp.Path);
+
+        var a = registry.RegisterIfAbsent("device-a", "MACHINE_A").DeviceKey;
+        var b = registry.RegisterIfAbsent("device-b", "MACHINE_B").DeviceKey;
+
+        Assert.NotEqual(a, b);
+        Assert.Equal(2, registry.Count);
+    }
+
+    [Fact]
+    public void RegisterIfAbsent_MintedKeyValidates()
+    {
+        using var temp = new TempStore();
+        var registry = new DeviceRegistry(temp.Path);
+
+        var key = registry.RegisterIfAbsent("device-1", "MACHINE_A").DeviceKey;
+
+        Assert.True(registry.IsValidDeviceKey(key));
+    }
+
+    [Fact]
+    public void RegisterIfAbsent_BlankDeviceId_Throws()
+    {
+        using var temp = new TempStore();
+        var registry = new DeviceRegistry(temp.Path);
+
+        Assert.Throws<ArgumentException>(() => registry.RegisterIfAbsent("  ", "MACHINE_A"));
+    }
+
+    // An isolated on-disk registry file per test, cleaned up afterward.
+    private sealed class TempStore : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "cc-enroll-test-" + System.IO.Path.GetRandomFileName(), "devices.json");
+
+        public void Dispose()
+        {
+            try
+            {
+                var dir = System.IO.Path.GetDirectoryName(Path);
+                if (dir is not null && Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+            }
+            catch { /* best effort */ }
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Api/SignedInEnrollmentEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/SignedInEnrollmentEndpoint.cs
@@ -1,0 +1,115 @@
+using System.Net;
+using CcDirector.Core.Account;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Account;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Pairing;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The gate decision for <c>POST /devices/enroll-signed-in</c>, extracted as a pure function so the
+/// security guardrails are unit-tested without a web host (issue #1069).
+/// </summary>
+public enum EnrollGateDecision
+{
+    /// <summary>All guardrails satisfied - mint (or reuse) the device key.</summary>
+    Allow,
+
+    /// <summary>The caller is not a proven loopback (same-machine) connection. 403.</summary>
+    NotSameMachine,
+
+    /// <summary>The Gateway is not signed in to DevThrottle, so there is no account to bind the key to. 409.</summary>
+    NotSignedIn,
+}
+
+/// <summary>
+/// Device enrollment via the DevThrottle account sign-in, for a co-located Director (issue #1069).
+/// This is the sign-in replacement for the pairing code: a device gets onto the Gateway by signing in
+/// to DevThrottle, not by reading a code off the Gateway host.
+///
+///   POST /devices/enroll-signed-in -> mint (or, if this device already has one, RETURN) this
+///       same-machine Director's own per-device key. Gated by three guardrails, each enforced here:
+///
+///   1. Same-machine PROVEN at the transport layer: the caller's remote address must be loopback.
+///      A null or non-loopback address is rejected (403). This is never a self-asserted header/flag,
+///      so the endpoint cannot be used from the tailnet or the LAN.
+///   2. Bound to the Gateway's current signed-in account identity (GatewaySignInService.GetIdentity).
+///      Not signed in -> 409 with a "sign in first" the client maps to opening the browser sign-in.
+///   3. Idempotent mint (DeviceRegistry.RegisterIfAbsent): a device that already holds an active key
+///      gets the SAME key back - never a fresh key per call. This is the guardrail against the #1136
+///      auto-mint key leak; combined with the client only calling enroll once (never from its polling
+///      loop), a key is minted at most once per device identity.
+///
+/// Every mint is logged with the account identity, device id, and timestamp (guardrail 5) so any leak
+/// is traceable. Remote/headless Directors (not on the Gateway's machine) enroll via the tailnet
+/// callback path and are a follow-up; this endpoint is deliberately same-machine only.
+/// </summary>
+internal static class SignedInEnrollmentEndpoint
+{
+    /// <summary>
+    /// The pure guardrail decision (guardrails 1 and 2). <paramref name="remoteIp"/> is the caller's
+    /// connection address; <paramref name="isSignedIn"/> and <paramref name="identity"/> come from the
+    /// Gateway's sign-in service. Returns <see cref="EnrollGateDecision.Allow"/> only when the caller is a
+    /// proven loopback connection AND the Gateway is signed in with a resolved identity.
+    /// </summary>
+    public static EnrollGateDecision Evaluate(IPAddress? remoteIp, bool isSignedIn, AccountIdentity? identity)
+    {
+        // Guardrail 1: same-machine must be PROVEN. Unknown (null) or non-loopback is rejected - we never
+        // treat an unknown caller as same-machine here (unlike sign-in routing), because this mints a key.
+        if (remoteIp is null || !IPAddress.IsLoopback(remoteIp))
+            return EnrollGateDecision.NotSameMachine;
+
+        // Guardrail 2: there must be a signed-in account to bind the key to.
+        if (!isSignedIn || identity is null)
+            return EnrollGateDecision.NotSignedIn;
+
+        return EnrollGateDecision.Allow;
+    }
+
+    public static void Map(IEndpointRouteBuilder app, DeviceRegistry devices, GatewaySignInService? signIn, ChildDeviceMirrorService? mirror = null)
+    {
+        if (devices is null) throw new ArgumentNullException(nameof(devices));
+
+        app.MapPost("/devices/enroll-signed-in", (EnrollSignedInRequest req, HttpContext ctx) =>
+        {
+            if (req is null || string.IsNullOrWhiteSpace(req.DeviceId))
+                return Results.BadRequest(new { error = "deviceId is required" });
+
+            var remoteIp = ctx.Connection.RemoteIpAddress;
+            var identity = signIn?.GetIdentity();
+            var decision = Evaluate(remoteIp, signIn?.IsSignedIn() ?? false, identity);
+
+            switch (decision)
+            {
+                case EnrollGateDecision.NotSameMachine:
+                    FileLog.Write($"[SignedInEnrollment] REJECTED not-same-machine: deviceId={req.DeviceId}, remoteIp={remoteIp?.ToString() ?? "<null>"}");
+                    return Results.Json(
+                        new { error = "This endpoint enrolls only a Director on the Gateway's own machine." },
+                        statusCode: StatusCodes.Status403Forbidden);
+
+                case EnrollGateDecision.NotSignedIn:
+                    FileLog.Write($"[SignedInEnrollment] REJECTED not-signed-in: deviceId={req.DeviceId}");
+                    return Results.Json(
+                        new { error = "Sign in to DevThrottle on the Gateway first, then enroll." },
+                        statusCode: StatusCodes.Status409Conflict);
+            }
+
+            // Guardrail 3: idempotent - reuse the existing active key if present, mint at most once.
+            var response = devices.RegisterIfAbsent(req.DeviceId, req.MachineName, req.Platform, req.DeviceType);
+
+            // Guardrail 5: log the mint with the bound account identity, device id, and (via FileLog) time.
+            FileLog.Write($"[SignedInEnrollment] enrolled deviceId={req.DeviceId}, machine={req.MachineName}, account={identity!.Email} (via {identity.Provider}), deviceCount={response.DeviceCount}");
+
+            // Mirror this device up to the account roster, best-effort and fire-and-forget - it never
+            // blocks or fails enrollment (the Director already holds its local key).
+            if (mirror is not null)
+                _ = mirror.MirrorChildUpAsync(req.DeviceId);
+
+            return Results.Json(response, statusCode: StatusCodes.Status200OK);
+        });
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1180,6 +1180,11 @@ public sealed class GatewayHost : IAsyncDisposable
         // literal routes win over the catch-all session forwarder, same as the other literal routes.
         Api.DeviceEnrollmentEndpoint.Map(_app, Pairing, Devices, _childMirror);
 
+        // POST /devices/enroll-signed-in (issue #1069): the sign-in replacement for the pairing code -
+        // a co-located Director mints its own per-device key by having the Gateway signed in to
+        // DevThrottle, gated on a loopback caller. Same-machine only; remote via tailnet is a follow-up.
+        Api.SignedInEnrollmentEndpoint.Map(_app, Devices, SignIn, _childMirror);
+
         // Wingman-voice surface for the Cockpit's Voice tab (issue #531): drive one turn of a
         // session and have the persistent wingman brain translate the reply into speakable form,
         // plus the direct-to-wingman path. Backed by the same warm Brain the brief agent uses.

--- a/src/CcDirector.Gateway/Pairing/DeviceRegistry.cs
+++ b/src/CcDirector.Gateway/Pairing/DeviceRegistry.cs
@@ -95,6 +95,36 @@ public sealed class DeviceRegistry
     }
 
     /// <summary>
+    /// Idempotent enrollment for the account-sign-in path (issue #1069): if this device id already holds an
+    /// active per-device key, return that SAME key unchanged; otherwise mint one via <see cref="Register"/>.
+    /// This is the load-bearing guardrail against minting a fresh key on every call - the auto-mint key leak
+    /// that #1136 fixed. Unlike <see cref="Register"/> (which rotates the key so a re-pairing issues a fresh
+    /// one), this never rotates: one device identity gets exactly one key until it is revoked.
+    /// </summary>
+    public DeviceRegistrationResponse RegisterIfAbsent(string deviceId, string machineName, string? platform = null, string? deviceType = null)
+    {
+        if (string.IsNullOrWhiteSpace(deviceId))
+            throw new ArgumentException("deviceId is required", nameof(deviceId));
+
+        if (_byDeviceId.TryGetValue(deviceId, out var existing)
+            && string.Equals(existing.Status, StatusActive, StringComparison.Ordinal)
+            && !string.IsNullOrEmpty(existing.DeviceKey))
+        {
+            FileLog.Write($"[DeviceRegistry] RegisterIfAbsent: device id={deviceId} already has an active key; returning it unchanged (no re-mint)");
+            return new DeviceRegistrationResponse
+            {
+                DeviceKey = existing.DeviceKey,
+                DeviceId = deviceId,
+                MachineName = existing.MachineName,
+                Status = existing.Status,
+                DeviceCount = _byDeviceId.Count,
+            };
+        }
+
+        return Register(deviceId, machineName, platform, deviceType);
+    }
+
+    /// <summary>
     /// Records the cloud roster id assigned to a mirrored child (Path B, Diagram 2b) so a later
     /// revoke-pull (Diagram 2c) can match this local child against the cloud list by id, and so a
     /// restart does not re-mirror an already-mirrored child. A no-op when the device id is unknown


### PR DESCRIPTION
Phase 2 of the Gateway Connection mission: the sign-in step, per Soren's device-auth correction (DevThrottle sign-in issues the device token; no pairing code). Design spec docs/reviews/gateway-connection-redesign-2026-07-11.md section 5 Step 2 + Done view.

## Step 2 UI (panel)
- "Sign in with DevThrottle" step, the "Waiting for you to sign in..." state, account-status polling that auto-advances, and the green Done view (two checks + the device token shown MASKED under a full-width Advanced disclosure, decision 7). Post-connect routing uses the state resolver to land on Step 2 or Done.
- Also carries the Phase-1 punch-list fix: the Advanced disclosure is now a full-width ToggleButton (caret flush right, no trailing cell).

## Enroll-through-the-Gateway (the new in-repo mechanism, no devthrottle.com change)
The Gateway is the authority that mints the local device key (DeviceRegistry). A co-located Director gets its own key by having the Gateway signed in:
- **New POST /devices/enroll-signed-in** (SignedInEnrollmentEndpoint) with the five required guardrails, each enforced:
  1. Same-machine PROVEN at the transport layer - caller must be loopback; null/non-loopback rejected 403; never a self-asserted header; not reachable from tailnet/LAN. The gate is a pure function (`Evaluate`) unit-tested without a web host.
  2. Bound to the Gateway's current signed-in account identity (`GatewaySignInService.GetIdentity`); not signed in -> 409.
  3. **Idempotent mint** (`DeviceRegistry.RegisterIfAbsent`): a device that already holds an active key gets the SAME key back - never a fresh one. This is the guardrail against the #1136 auto-mint key leak.
  4. Fail loud - named 403/409, never a silent partial credential.
  5. Every mint logged with the bound account identity, device id, and time.
- Director client `GatewayEnrollmentClient.EnrollSignedInAsync`; the panel calls it once after the Gateway reports signed in, stores via `SaveEnrolledKey`, and re-applies so the running client uses its own key. Enroll fires at most once and never from the polling loop (client-side half of the #1136 guardrail).

## Proof
- **11 unit tests pass**: the auth gate across the loopback/signed-in matrix (same-machine proof outranks sign-in state; unknown caller never assumed same-machine) and idempotency (same device twice = same key; ten calls mint once; distinct devices get distinct keys; minted key validates).
- Full CcDirector.Gateway.Tests suite green (one Kestrel port-bind flake, passes on re-run).
- **Verified in the running slot-5 build against the live signed-in Gateway**: Step 1 -> click "This computer" -> two-way handshake -> resolver routes AllGreen -> the Done view shows both green checks, "Signed in as soren@centerconsulting.com", and the masked device token (wCGo...tRio) under the full-width Advanced.

## Scope / follow-ups
Same-machine (co-located) Director first, as agreed. Remote/headless Directors (tailnet callback) are a follow-up. The legacy pairing dialog (ConnectToGatewayDialog) is deleted in Phase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)