### PR TITLE
fix(local-files): file viewer Back, Download feedback, wrapped terminal links

### DIFF
--- a/apps/mobile/src/pages/Chat.tsx
+++ b/apps/mobile/src/pages/Chat.tsx
@@ -62,9 +62,12 @@ export function Chat() {
   }, []);
 
   // Local Files (Phase 3): a detected file path opens the full-screen file viewer for that path (the
-  // copy button below is unchanged). The absolute path rides as ?path= so a reload/deep-link resolves.
+  // copy button below is unchanged). The absolute path rides as ?path= so a reload/deep-link resolves,
+  // and ?from= records THIS tab so the viewer's Back returns to Chat (not a dead history.back()).
   const openFile = useCallback((path: string) => {
-    navigate(`/session/${encodeURIComponent(sessionId ?? "")}/file?path=${encodeURIComponent(path)}`);
+    const sid = encodeURIComponent(sessionId ?? "");
+    const from = encodeURIComponent(`/session/${sessionId ?? ""}/chat`);
+    navigate(`/session/${sid}/file?path=${encodeURIComponent(path)}&from=${from}`);
   }, [navigate, sessionId]);
 
   const copyLink = useCallback(async (text: string) => {

--- a/apps/mobile/src/pages/FileView.tsx
+++ b/apps/mobile/src/pages/FileView.tsx
@@ -4,6 +4,7 @@ import { classifyFile, formatFileSize } from "@devthrottle/client-core/history/f
 import type { FileViewerType } from "@devthrottle/client-core/history/fileTypes";
 import {
   GatewayError,
+  authHeaders,
   ensureGatewayCookie,
   fetchSessionFileSize,
   fetchSessionFileText,
@@ -62,9 +63,17 @@ export function FileView() {
   const navigate = useNavigate();
   const path = params.get("path") ?? "";
 
-  // Back returns to the exact session tab (Chat or Terminal) the file was opened from - the browser's
-  // own back step, which is how the half-built "mobile view-links" feature intended Back to work.
-  const goBack = () => navigate(-1);
+  // Back returns to the tab the file was opened from. Chat/Terminal pass that tab as ?from= when they
+  // navigate here, so Back is an EXPLICIT route, not history.back(): navigate(-1) does nothing when the
+  // viewer was reached with no in-app history to pop - a hard reload, a deep link, or a link that opened
+  // a fresh context - which left the Back button dead and forced an app restart. With no ?from we still
+  // have a working destination: the session itself (its Chat), so Back is never a no-op.
+  const from = params.get("from");
+  const goBack = () => {
+    if (from) navigate(from);
+    else if (sessionId) navigate(`/session/${sessionId}`);
+    else navigate("/");
+  };
 
   if (!sessionId || !path) {
     return (
@@ -89,12 +98,56 @@ export function FileView() {
       <header className="app-bar">
         <button type="button" className="file-view-back" onClick={goBack}>Back</button>
         <h1 className="term-title" title={path}>{name}</h1>
-        <a className="file-view-download" href={url} download={name}>Download</a>
+        <DownloadButton url={url} name={name} />
       </header>
       <div className="file-view-body">
         <FileViewContent type={type} url={url} name={name} sessionId={sessionId} path={path} />
       </div>
     </div>
+  );
+}
+
+// The Download control. The old bare <a download> gave the phone NO sign a tap registered - so a file
+// that saved silently (or failed silently) looked like nothing happened, and the button got tapped over
+// and over. This fetches the bytes itself (carrying the Bearer, so it works regardless of the cookie),
+// shows "Saving..." while it runs, then a visible "Saved ... to your device" (or the specific failure),
+// and only then triggers the browser's save. One in-flight download at a time.
+function DownloadButton({ url, name }: { url: string; name: string }) {
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+
+  const onDownload = async () => {
+    if (busy) return;
+    setBusy(true);
+    setNote(`Saving ${name}...`);
+    try {
+      const res = await fetch(url, { headers: authHeaders() });
+      if (!res.ok) throw new GatewayError(res.status, `download failed: ${res.status}`);
+      const blob = await res.blob();
+      const objectUrl = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = objectUrl;
+      a.download = name;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.setTimeout(() => URL.revokeObjectURL(objectUrl), 15000);
+      setNote(`Saved ${name} to your device`);
+    } catch (err) {
+      setNote(fileLoadMessage(err));
+    } finally {
+      setBusy(false);
+      window.setTimeout(() => setNote(null), 4000);
+    }
+  };
+
+  return (
+    <>
+      <button type="button" className="file-view-download" onClick={onDownload} disabled={busy}>
+        {busy ? "Saving..." : "Download"}
+      </button>
+      {note !== null && <div className="file-view-download-toast" role="status">{note}</div>}
+    </>
   );
 }
 

--- a/apps/mobile/src/pages/Terminal.tsx
+++ b/apps/mobile/src/pages/Terminal.tsx
@@ -40,7 +40,10 @@ export function Terminal() {
   // path. A stable callback so the TerminalMirror (constructed once per session) holds it across renders
   // without being torn down. http/https URLs are opened by the mirror itself and never reach here.
   const openFile = useCallback((path: string) => {
-    navigate(`/session/${encodeURIComponent(sessionId ?? "")}/file?path=${encodeURIComponent(path)}`);
+    const sid = encodeURIComponent(sessionId ?? "");
+    // ?from= records THIS tab so the viewer's Back returns to Terminal (not a dead history.back()).
+    const from = encodeURIComponent(`/session/${sessionId ?? ""}/terminal`);
+    navigate(`/session/${sid}/file?path=${encodeURIComponent(path)}&from=${from}`);
   }, [navigate, sessionId]);
 
   const [name, setName] = useState<string | null>(null);

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -1828,6 +1828,30 @@ a.banner-btn {
   color: #ffffff;
   border-color: transparent;
 }
+.file-view-download:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+
+/* Download feedback toast: a floating status just under the app bar so a tap is never silent (it says
+   "Saving...", then "Saved ... to your device", or the specific failure). Fixed + high z-index so it
+   shows over the image/iframe body. */
+.file-view-download-toast {
+  position: fixed;
+  top: 56px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 50;
+  max-width: 90%;
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 14px;
+  font-size: 13px;
+  text-align: center;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+}
 
 /* The body is the single give-point of the screen (the blanket .terminal-screen > * rule pins every
    child at its natural size; this override lets the file body flex and scroll internally). */

--- a/packages/client-core/src/terminal/stream.test.ts
+++ b/packages/client-core/src/terminal/stream.test.ts
@@ -15,24 +15,38 @@ const hoisted = vi.hoisted(() => {
   const reportGatewayUnreachable = vi.fn();
   // The minimum of the xterm.js surface the mirror touches during start() + the link provider path.
   class FakeTerminal {
-    // getLine backs the link provider's per-line lookup; lineText is buffer row 1's rendered text.
+    // getLine backs the link provider's per-line lookup. `lineText` is the simple single-row case;
+    // `rows` (when set) models a LOGICAL line wrapped across several buffer rows, each carrying its own
+    // isWrapped flag - so the provider's wrapped-line join can be exercised.
     lineText = "";
-    buffer = {
-      active: {
-        viewportY: 0,
-        baseY: 0,
-        getLine: (y: number) =>
-          y === 0 && this.lineText
-            ? { translateToString: (_trim?: boolean) => this.lineText }
-            : null,
-      },
-    };
+    rows: { text: string; isWrapped: boolean }[] | null = null;
+    cols = 80; // wide enough that the single-row cases never wrap
+    buffer: { active: { viewportY: number; baseY: number; length: number; getLine: (y: number) => unknown } };
     linkProvider: unknown = null;
     linkProviderDisposed = false;
     writes: string[] = [];
     resetCount = 0;
     disposed = false;
     constructor(public options: unknown) {
+      const self = this;
+      this.buffer = {
+        active: {
+          viewportY: 0,
+          baseY: 0,
+          get length(): number {
+            return self.rows ? self.rows.length : self.lineText ? 1 : 0;
+          },
+          getLine(y: number): unknown {
+            if (self.rows) {
+              const r = self.rows[y];
+              return r ? { isWrapped: r.isWrapped, translateToString: (_trim?: boolean) => r.text } : null;
+            }
+            return y === 0 && self.lineText
+              ? { isWrapped: false, translateToString: (_trim?: boolean) => self.lineText }
+              : null;
+          },
+        },
+      };
       terminals.push(this);
     }
     open(): void {}
@@ -193,6 +207,33 @@ describe("TerminalMirror link provider (Local Files, Phase 3/4)", () => {
   it("returns no links for a line with none, so xterm leaves the line undecorated", () => {
     const { links } = linksFor("plain output, nothing clickable");
     expect(links).toEqual([]);
+  });
+
+  // The mobile regression: a long absolute path WRAPS across buffer rows on a narrow phone. Detecting
+  // per visual row saw only a fragment and produced no link. The provider now joins the logical line
+  // (this row + wrapped continuation rows) and returns a range that can span rows.
+  it("detects a file path that wraps across two rows and spans them in the range", () => {
+    const onFileLink = vi.fn();
+    const mirror = new TerminalMirror(fakeEl(), fakeEl(), SID, () => {}, onFileLink);
+    mirror.start();
+    const term = hoisted.terminals[0];
+    term.cols = 10;
+    // "D:\a\bcdef.png" (14 chars) split at column 10: row 0 is the first 10, row 1 (wrapped) the rest.
+    term.rows = [
+      { text: "D:\\a\\bcdef", isWrapped: false },
+      { text: ".png rest", isWrapped: true },
+    ];
+    const provider = term.linkProvider as {
+      provideLinks: (n: number, cb: (l: XLink[] | undefined) => void) => void;
+    };
+    let links: XLink[] | undefined;
+    provider.provideLinks(1, (l) => { links = l; });
+    const link = (links ?? []).find((l) => l.text === "D:\\a\\bcdef.png");
+    expect(link).toBeDefined();
+    expect(link!.range.start.y).toBe(1);
+    expect(link!.range.end.y).toBe(2); // the link body continues onto the wrapped row
+    link!.activate({} as MouseEvent);
+    expect(onFileLink).toHaveBeenCalledWith("D:\\a\\bcdef.png");
   });
 });
 

--- a/packages/client-core/src/terminal/stream.ts
+++ b/packages/client-core/src/terminal/stream.ts
@@ -166,37 +166,66 @@ export class TerminalMirror {
 
   // ----- clickable links (Local Files, Phase 3) -----------------------------------------------
 
-  // Make absolute file paths and http/https URLs in the mirror clickable. xterm asks per line via
-  // provideLinks; we run the shared detector (findLineLinks) over that line's rendered text and hand
-  // back one xterm link per detected span with its column range. A FILE path click routes to the app's
-  // onFileLink (its viewer); a URL opens in a new tab here. This is the SAME contract the interactive
-  // Cockpit terminal (interactive.ts) uses, so both terminals behave identically. The provider is
-  // disposed with the terminal so it never outlives the render service.
+  // Make absolute file paths and http/https URLs in the mirror clickable. xterm asks per VISUAL row via
+  // provideLinks. A long absolute path (e.g. D:\ReposFred\devthrottle\.temp\lf-samples\sample-image.png)
+  // WRAPS across several rows on a narrow phone, so detecting per visual row would only ever see a
+  // fragment and produce no link - which is why terminal file links did nothing on mobile while the wide
+  // Cockpit terminal (paths on one line) worked. So we reconstruct the whole LOGICAL line first (this row
+  // plus the wrapped continuation rows), run the shared detector over the joined text, then map each
+  // detected span back to a possibly multi-row xterm range. A FILE path click routes to the app's
+  // onFileLink (its viewer); a URL opens in a new tab. Provider disposed with the terminal.
   private registerLinks(term: Xterm): void {
     const provider: ILinkProvider = {
       provideLinks: (bufferLineNumber: number, callback: (links: ILink[] | undefined) => void) => {
-        const bufLine = term.buffer.active.getLine(bufferLineNumber - 1);
-        if (!bufLine) {
+        const buffer = term.buffer.active;
+        const cols = term.cols;
+        const reqLine = buffer.getLine(bufferLineNumber - 1);
+        if (!reqLine || cols <= 0) {
           callback(undefined);
           return;
         }
-        const text = bufLine.translateToString(true);
+
+        // Walk back over wrapped continuation rows to the logical line's first row.
+        let startIdx = bufferLineNumber - 1; // 0-based
+        while (startIdx > 0 && buffer.getLine(startIdx)?.isWrapped) startIdx--;
+
+        // Join this row + the wrapped rows that follow, each padded to the full width so a character
+        // OFFSET in the joined text maps cleanly to (row = offset / cols, column = offset % cols).
+        let text = "";
+        for (let j = startIdx; j < buffer.length; j++) {
+          const line = buffer.getLine(j);
+          if (!line) break;
+          if (j > startIdx && !line.isWrapped) break;
+          let row = line.translateToString(false);
+          if (row.length < cols) row = row.padEnd(cols, " ");
+          else if (row.length > cols) row = row.slice(0, cols);
+          text += row;
+        }
+
         const found = findLineLinks(text);
         if (found.length === 0) {
           callback(undefined);
           return;
         }
-        const links: ILink[] = found.map((l) => ({
-          text: l.text,
-          // xterm buffer ranges are 1-based and inclusive on both ends. l is a 0-based half-open
-          // [start, end) column range, so the first cell is start+1 and the last cell is end.
-          range: {
-            start: { x: l.start + 1, y: bufferLineNumber },
-            end: { x: l.end, y: bufferLineNumber },
-          },
-          activate: (event: MouseEvent) => this.onLinkActivate(l, event),
-        }));
-        callback(links);
+
+        const links: ILink[] = [];
+        for (const l of found) {
+          // l is a 0-based half-open [start, end) offset span in the joined text. xterm ranges are
+          // 1-based and inclusive on both ends; a span can cross wrapped rows, so start/end may differ in y.
+          const startY = startIdx + Math.floor(l.start / cols) + 1;
+          const startX = (l.start % cols) + 1;
+          const lastOffset = l.end - 1;
+          const endY = startIdx + Math.floor(lastOffset / cols) + 1;
+          const endX = (lastOffset % cols) + 1;
+          // Only hand xterm the links that actually cover the row it asked about.
+          if (bufferLineNumber < startY || bufferLineNumber > endY) continue;
+          links.push({
+            text: l.text,
+            range: { start: { x: startX, y: startY }, end: { x: endX, y: endY } },
+            activate: (event: MouseEvent) => this.onLinkActivate(l, event),
+          });
+        }
+        callback(links.length > 0 ? links : undefined);
       },
     };
     this.linkProvider = term.registerLinkProvider(provider);


### PR DESCRIPTION
Three phone-only bugs in the Local Files viewer, all surfaced from the **Terminal tab** (the Chat path worked, which is why they were missed):

## 1. Back button was dead (worst - forced an app restart)
`history.back()` does nothing when the viewer was opened with no in-app history to pop (deep link / hard reload / a link that opened a fresh context). Chat and Terminal now pass the origin tab as `?from=`, and Back navigates to it explicitly; with no `?from` it falls back to the session's Chat. Back is never a no-op now.

## 2. Download gave no feedback
The bare `<a download>` gave no sign a tap registered, so a silent save (or silent failure) looked like nothing and the button got tapped repeatedly. It now fetches the bytes (carrying the Bearer), shows **"Saving..."** then **"Saved ... to your device"** (or the specific error), and only then triggers the save.

## 3. Terminal file links did nothing on a phone
A long absolute path wraps across buffer rows on a narrow screen; the link provider detected per visual row and only ever saw a fragment. It now joins the whole logical line (row + wrapped continuation rows), runs the shared detector, and maps each span back to a possibly multi-row xterm range.

## Verification
- Back + Download: driven in a real browser on the live `ts.net` origin (Back returns to Chat; the no-`from` fallback lands on the session; the Download toast shows "Saved ... to your device").
- Wrapped terminal link: new unit test in `stream.test.ts` (a path split across two rows yields one link with a range spanning both), alongside the existing single-row tests. All 10 pass.