### PR TITLE
fix(wingman): re-narrate on a changed reply, not merely when a cache exists

### DIFF
--- a/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
@@ -4,6 +4,7 @@ using System.Text;
 using CcDirector.AgentBrain;
 using CcDirector.Core;
 using CcDirector.Core.Configuration;
+using CcDirector.Core.Drivers;
 using CcDirector.Core.HostedAi;
 using CcDirector.Gateway.HostedAi;
 using CcDirector.Gateway.Discovery;
@@ -185,64 +186,187 @@ public sealed class WingmanVoiceServiceTests
         finally { Cleanup(persistPath); }
     }
 
-    // ---------- Do not re-narrate an already-narrated turn (issue #1322) ----------
+    // ---------- Re-narrate only when the reply actually changed (issue #1322, identity-aware) ----------
+
+    /// <summary>A loopback "Director" whose /turns (and /history) endpoint returns a fixed JSON body and
+    /// counts how many times it was hit. Lets a test prove whether GenerateAsync fetched and what it did
+    /// with the result.</summary>
+    private sealed class LoopbackDirector : IDisposable
+    {
+        private readonly HttpListener _listener;
+        private readonly Task _serve;
+        private int _hits;
+        public int Hits => _hits;
+        public string Endpoint { get; }
+
+        public LoopbackDirector(string json)
+        {
+            // Grab a free loopback port, then release it for the HttpListener.
+            var probe = new TcpListener(IPAddress.Loopback, 0);
+            probe.Start();
+            var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+            probe.Stop();
+
+            var prefix = $"http://127.0.0.1:{port}/";
+            Endpoint = prefix.TrimEnd('/');
+            _listener = new HttpListener();
+            _listener.Prefixes.Add(prefix);
+            _listener.Start();
+            _serve = Task.Run(async () =>
+            {
+                while (_listener.IsListening)
+                {
+                    HttpListenerContext ctx;
+                    try { ctx = await _listener.GetContextAsync(); }
+                    catch { break; }   // listener stopped
+                    Interlocked.Increment(ref _hits);
+                    ctx.Response.StatusCode = 200;
+                    var body = Encoding.UTF8.GetBytes(json);
+                    await ctx.Response.OutputStream.WriteAsync(body);
+                    ctx.Response.Close();
+                }
+            });
+        }
+
+        public void Dispose()
+        {
+            _listener.Stop();
+            try { _serve.Wait(TimeSpan.FromSeconds(5)); } catch { /* stopping */ }
+        }
+    }
+
+    /// <summary>A brain that records how many times it was asked and returns a canned, marker-wrapped
+    /// spoken line - so a test can prove whether GenerateAsync actually ran the (re)narration.</summary>
+    private sealed class RecordingBrain : IAgentBrain
+    {
+        private int _askCount;
+        public int AskCount => _askCount;
+        public string? SessionId => "recording-brain";
+        public Task<AskResult> AskAsync(string prompt, CancellationToken ct = default)
+        {
+            Interlocked.Increment(ref _askCount);
+            var wrapped = $"{SessionAskRunner.AnswerBeginMarker}\nnarrated spoken text\n{SessionAskRunner.AnswerEndMarker}";
+            return Task.FromResult(new AskResult { Text = wrapped, ReplySeconds = 0.1 });
+        }
+        public Task CancelAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<ClearResult> ClearAsync(CancellationToken ct = default) => Task.FromResult(new ClearResult());
+        public Task RestartAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task KillAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<BrainHealth> GetHealthAsync(CancellationToken ct = default) => Task.FromResult(new BrainHealth { IsAlive = true });
+        public void Dispose() { }
+    }
+
+    /// <summary>A voice service wired to a recording brain and a text-to-speech stub that returns
+    /// <paramref name="audio"/>, so the full turn-end path (fetch -> translate -> synthesize -> store)
+    /// runs without a live model or provider.</summary>
+    private static WingmanVoiceService ServiceWithBrainAndTts(IAgentBrain brain, byte[] audio, string persistPath)
+    {
+        var vaultPath = Path.Combine(Path.GetTempPath(), "wmvs-" + Guid.NewGuid().ToString("N") + ".vault");
+        var vault = new KeyVault(vaultPath);
+        vault.Set("OPENAI_API_KEY", "sk-test");
+        vault.Set("DEVTHROTTLE_API_KEY", "dt_live_test");
+        var http = new HttpClient(new TtsStubHandler(HttpStatusCode.OK, "", audio));
+        return new WingmanVoiceService((_, _) => Task.FromResult(brain), vault, new DirectorEndpointClient(), persistPath, ttsHttpClient: http);
+    }
 
     [Fact]
-    public async Task GenerateAsync_WhenSessionAlreadyHasVoice_SkipsWithoutFetchingTurns()
+    public async Task GenerateAsync_WhenCurrentReplyDiffersFromCache_Regenerates()
     {
-        // Issue #1322: a re-narration must never disturb a turn that already has a fresh, playable
-        // narration - a client may be actively listening to it. The guard short-circuits BEFORE the
-        // Director turn fetch, so an already-ready session is not re-generated (which would flip it
-        // yellow again and mint a new generatedAt, restarting the listener's clip). Proven with a
-        // loopback "Director" that records whether its /turns endpoint was ever hit.
-        var hits = 0;
-        // Grab a free loopback port, then release it for the HttpListener.
-        var probe = new TcpListener(IPAddress.Loopback, 0);
-        probe.Start();
-        var port = ((IPEndPoint)probe.LocalEndpoint).Port;
-        probe.Stop();
-
-        using var listener = new HttpListener();
-        var prefix = $"http://127.0.0.1:{port}/";
-        listener.Prefixes.Add(prefix);
-        listener.Start();
-        var serve = Task.Run(async () =>
-        {
-            while (listener.IsListening)
-            {
-                HttpListenerContext ctx;
-                try { ctx = await listener.GetContextAsync(); }
-                catch { break; }   // listener stopped
-                Interlocked.Increment(ref hits);
-                ctx.Response.StatusCode = 200;
-                var body = Encoding.UTF8.GetBytes("{\"widgets\":[]}");
-                await ctx.Response.OutputStream.WriteAsync(body);
-                ctx.Response.Close();
-            }
-        });
-
-        // Own an isolated audio directory so the durable clip this test seeds never leaks into the
-        // shared temp voice-audio folder other tests load from (StoreReadyAudioForTest persists).
-        var dir = Path.Combine(Path.GetTempPath(), "wmvs-guard-" + Guid.NewGuid().ToString("N"));
+        // THE FIX (regression for the #1322 bare-HasVoice guard): when the session's CURRENT last reply
+        // differs from the one already narrated, the turn-end MUST regenerate - even though a cached clip
+        // exists. The old guard skipped here whenever the Working transition was missed, leaving the
+        // phone replaying a stale interim narration while the history had moved on to the real answer.
+        using var director = new LoopbackDirector("{\"widgets\":[{\"kind\":\"Text\",\"content\":\"the NEW final answer\"}]}");
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-regen-" + Guid.NewGuid().ToString("N"));
         var persistPath = Path.Combine(dir, "voice-sessions.json");
         try
         {
-            var svc = ServiceAt(persistPath);
-            svc.StoreReadyAudioForTest("sid-1", "spoken", "reply", new byte[] { 1, 2, 3 });
+            var brain = new RecordingBrain();
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 4, 4, 4 }, persistPath);
+            svc.StoreReadyAudioForTest("sid-1", "old spoken", "the OLD interim reply", new byte[] { 1, 2, 3 });
             Assert.True(svc.HasVoice("sid-1"));
 
-            await svc.GenerateAsync("sid-1", prefix.TrimEnd('/'), CancellationToken.None);
+            await svc.GenerateAsync("sid-1", director.Endpoint, CancellationToken.None, showReadingWindow: false);
 
-            Assert.Equal(0, hits);                    // the guard skipped before any turn fetch
-            Assert.True(svc.HasVoice("sid-1"));       // the existing clip is untouched
-            Assert.False(svc.IsGenerating("sid-1"));  // and it never flipped the session yellow
+            Assert.Equal(1, brain.AskCount);                          // it regenerated (translated the new reply)
+            var ready = svc.Get("sid-1");
+            Assert.NotNull(ready);
+            Assert.Equal("the NEW final answer", ready!.Reply);       // the cache now holds the CURRENT reply
         }
-        finally
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort cleanup */ } }
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WhenCurrentReplyMatchesCache_SkipsQuietly()
+    {
+        // Issue #1322 preserved: when the CURRENT last reply is the EXACT one already narrated, the
+        // turn-end fetches to compare but does NOT regenerate - it never calls the brain, never re-mints
+        // audio, and never flips the session yellow, so a client mid-play is not disturbed.
+        using var director = new LoopbackDirector("{\"widgets\":[{\"kind\":\"Text\",\"content\":\"the same reply\"}]}");
+        var dir = Path.Combine(Path.GetTempPath(), "wmvs-same-" + Guid.NewGuid().ToString("N"));
+        var persistPath = Path.Combine(dir, "voice-sessions.json");
+        try
         {
-            listener.Stop();
-            await serve;
-            try { Directory.Delete(dir, recursive: true); } catch { /* best-effort cleanup */ }
+            var brain = new RecordingBrain();
+            var svc = ServiceWithBrainAndTts(brain, new byte[] { 9, 9 }, persistPath);
+            svc.StoreReadyAudioForTest("sid-1", "old spoken", "the same reply", new byte[] { 1, 2, 3 });
+            Assert.True(svc.HasVoice("sid-1"));
+
+            await svc.GenerateAsync("sid-1", director.Endpoint, CancellationToken.None, showReadingWindow: true);
+
+            Assert.Equal(0, brain.AskCount);              // never regenerated
+            Assert.True(director.Hits >= 1);              // but it DID fetch to compare (identity-aware, not blind)
+            Assert.True(svc.HasVoice("sid-1"));           // the existing clip is untouched
+            Assert.False(svc.IsGenerating("sid-1"));      // and it never flipped the session yellow
+            Assert.Equal(new byte[] { 1, 2, 3 }, svc.GetAudio("sid-1"));   // same original audio, not re-minted
         }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { /* best-effort cleanup */ } }
+    }
+
+    // ---------- ShouldRegenerate decision (pure, no brain / no fetch) ----------
+
+    [Fact]
+    public void ShouldRegenerate_NoCachedNarration_IsTrue()
+    {
+        var svc = NewService();
+        Assert.True(svc.ShouldRegenerate("sid-x", "a reply to narrate"));
+    }
+
+    [Fact]
+    public void ShouldRegenerate_EmptyOrNullCurrentReply_IsFalse()
+    {
+        // Nothing to narrate yet - do not touch or regenerate.
+        var svc = NewService();
+        Assert.False(svc.ShouldRegenerate("sid-x", null));
+        Assert.False(svc.ShouldRegenerate("sid-x", "   "));
+    }
+
+    [Fact]
+    public void ShouldRegenerate_SameReplyAlreadyCached_IsFalse()
+    {
+        var svc = NewService();
+        svc.StoreReadyAudioForTest("sid-1", "spoken", "the reply text", new byte[] { 1 });
+        Assert.False(svc.ShouldRegenerate("sid-1", "the reply text"));
+    }
+
+    [Fact]
+    public void ShouldRegenerate_SameReplyIgnoringSurroundingWhitespace_IsFalse()
+    {
+        // The two sources are the same JSONL text block; incidental leading/trailing whitespace must
+        // not force a needless re-mint (which would restart a listener's clip).
+        var svc = NewService();
+        svc.StoreReadyAudioForTest("sid-1", "spoken", "the reply text", new byte[] { 1 });
+        Assert.False(svc.ShouldRegenerate("sid-1", "  the reply text\n"));
+    }
+
+    [Fact]
+    public void ShouldRegenerate_ChangedReply_IsTrue()
+    {
+        // The exact bug: an interim reply was narrated, then the real answer landed. A changed reply
+        // must regenerate even though a cached clip exists.
+        var svc = NewService();
+        svc.StoreReadyAudioForTest("sid-1", "spoken", "the interim reply", new byte[] { 1 });
+        Assert.True(svc.ShouldRegenerate("sid-1", "the FINAL answer"));
     }
 
     // ---------- Turn voice off / Unmark (issue #859) ----------

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -165,6 +165,24 @@ public sealed class WingmanVoiceService
     /// <summary>True when this session currently has a fresh, playable cached summary.</summary>
     public bool HasVoice(string sid) => _ready.ContainsKey(sid);
 
+    /// <summary>
+    /// Whether a turn-end should (re)generate the spoken narration for this session. True when there is
+    /// something to say (<paramref name="currentReply"/> non-empty) and it is NOT already the exact
+    /// reply we hold cached audio for. This replaces the old bare "does any narration exist" guard
+    /// (issue #1322): comparing the reply TEXT means a genuinely new or changed reply always regenerates
+    /// even when the Working transition that would have cleared the cache was never observed (a racy
+    /// sampled edge, missed on multi-part turns), while a redundant re-hit of the SAME turn still stays
+    /// quiet so a client already playing this turn's clip is never disturbed (no re-mint, no yellow flip).
+    /// Reply text is compared trimmed + ordinal - the two sources (cache vs the live /turns widget) are
+    /// the same JSONL text block, so an unchanged turn matches exactly.
+    /// </summary>
+    internal bool ShouldRegenerate(string sid, string? currentReply)
+    {
+        if (string.IsNullOrWhiteSpace(currentReply)) return false;   // nothing to narrate yet
+        if (!_ready.TryGetValue(sid, out var cached)) return true;    // never narrated -> make it
+        return !string.Equals(cached.Reply?.Trim(), currentReply.Trim(), StringComparison.Ordinal);
+    }
+
     /// <summary>The sessions that currently have a ready, playable spoken summary.</summary>
     public IReadOnlyCollection<string> ReadySessionIds() => _ready.Keys.ToArray();
 
@@ -316,17 +334,18 @@ public sealed class WingmanVoiceService
     {
         Mark(sid);
 
-        // Do not re-narrate a turn that already has a fresh, current narration. A genuinely new turn
-        // clears this cache first (OnSessionWorking on the Working transition), so a cache that is
-        // still present means the current turn is already narrated - regenerating it would only flip
-        // the session yellow again and mint a new generatedAt, restarting the clip a listening client
-        // is already playing (issue #1322). The idle sweep already skips cached sessions this way; the
-        // turn-end path must too. Checked before the backpressure gates - a no-op costs nothing.
-        if (HasVoice(sid))
-        {
-            FileLog.Write($"[WingmanVoiceService] GenerateAsync skip (current turn already narrated): sid={sid}");
-            return;
-        }
+        // The "already narrated" skip is now IDENTITY-AWARE and lives in GenerateOnceAsync, after the
+        // current reply has actually been read (issue #1322 done right). The old guard here was a bare
+        // "does ANY narration exist" check (HasVoice), which assumed every genuinely new turn cleared
+        // the cache first via OnSessionWorking on the Working transition. That assumption breaks: the
+        // Working transition is observed on a racy sampled edge and, on a multi-part turn (an interim
+        // reply, then a sub-agent, then the real answer), the intermediate Working can fall between two
+        // samples that both read "waiting" - so the cache is never cleared and the bare guard wrongly
+        // suppressed narration of the final answer forever (the phone replayed the stale interim clip).
+        // Comparing the reply TEXT instead removes the dependency on catching that edge: a changed reply
+        // always regenerates, the same reply still stays quiet so a client mid-play is never disturbed.
+        // The idle sweep still guards on HasVoice at its own call site, so it never reaches here for a
+        // cached session; only the turn-end path does, and it pays one cheap /turns read to compare.
 
         // Backpressure #1 (issue #1324) - respect a provider rate-limit cooldown. A 429 means "stop
         // calling", so while the cooldown is in effect we skip the model call entirely. Both callers
@@ -385,6 +404,16 @@ public sealed class WingmanVoiceService
         var widgets = turns?.Widgets ?? new List<TurnWidgetDto>();
         var lastReply = widgets.LastOrDefault(w => w.Kind == "Text")?.Content;
         if (string.IsNullOrWhiteSpace(lastReply)) return;  // nothing to say yet
+        // Identity-aware skip (issue #1322 done right): only skip when the CURRENT last reply is the
+        // exact one already narrated. Unlike the old bare HasVoice guard this does not depend on having
+        // observed the Working transition, so a genuinely new/changed reply is never suppressed by a
+        // stale cache the missed edge left behind - while the same reply stays quiet (no re-mint, no
+        // yellow flip), preserving the "never disturb a listener mid-play" guarantee.
+        if (!ShouldRegenerate(sid, lastReply))
+        {
+            FileLog.Write($"[WingmanVoiceService] GenerateOnce skip (same reply already narrated): sid={sid}");
+            return;
+        }
         // Recent conversation so the wingman can add context to a short/terse latest reply.
         var recentContext = WingmanTranslator.BuildRecentContext(widgets);
         // The wingman is now running for this session - show it yellow until the summary lands, but


### PR DESCRIPTION
## The problem

Mobile Voice mode could speak a **stale earlier reply** while the session's history had already moved on. The narration got frozen on an interim reply and never updated - which is exactly why it felt like "my sessions are not moving forward."

Proven on the live "Network Switching - Research" session: the final three-part answer landed at 05:30:22, and 12 seconds later the Gateway logged `GenerateAsync skip (current turn already narrated)` - the final answer was never narrated, so the phone kept replaying the interim clip.

## Root cause

The turn-end regeneration guard in `WingmanVoiceService.GenerateAsync` was a bare `if (HasVoice(sid)) return;` - it only asked "does *any* narration exist for this session?". It assumed every genuinely new turn cleared the cache first via `OnSessionWorking` on the Working transition.

That transition is observed on a **racy sampled edge** (`TurnEndWatcher.Observe`). On a multi-part turn - an interim reply, then a sub-agent, then the real answer - the intermediate Working state can fall between two samples that both read "waiting", so the cache is never cleared and the guard suppresses narration of the final answer forever. The code already acknowledged this on the voice-turn send path: *"do not rely on observing the Working state, which is racy for fast turns."*

## The fix

Make the skip **identity-aware**. The cache already stores the reply it narrated (`VoiceReady.Reply`), so compare the current last reply against it and skip only when they are the exact same turn - regenerate when the reply changed. This no longer depends on catching the Working edge.

Issue #1322 is preserved: the same reply still stays quiet (no re-mint of audio, no yellow "reading" flip), so a client mid-play is never disturbed. The idle sweep still guards on `HasVoice` at its own call site, so it never reaches here for a cached session; only the turn-end path does, paying one cheap `/turns` read to compare.

## Scope

Server-side (Gateway) only - no mobile app change. The existing "Generate narration now" button already force-regenerates and is unaffected.

## Tests

- Pure `ShouldRegenerate` decision: no-cache / empty / same / surrounding-whitespace / changed.
- Two loopback-Director integration tests: a **changed** reply regenerates and updates the cache; an **identical** reply fetches-to-compare but stays quiet (brain never called, audio not re-minted, session never flipped yellow).

All 45 Wingman/turn-end tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)