### PR TITLE
fix(carmode): v2 - network-first PWA (stale bundle) + mobile autoplay unlock

### DIFF
--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -70,6 +70,23 @@ configureUnauthorizedRedirect(mobileSignInRedirect);
 // that needs a user gesture (the "Enable notifications" button on the roster). Non-fatal on failure.
 void ensurePushSubscribed();
 
+// Force the newest bundle into a long-lived Progressive Web App. The service worker is network-first for
+// the shell + bundle (vite.config.ts), so a plain reopen already fetches the latest; this handles the
+// other case - the app has been open in the background while a NEW build deployed. When the new service
+// worker takes control (skipWaiting + clientsClaim on activate), reload ONCE so the page drops the old
+// in-memory JS and runs the new build. Armed ONLY when the page is ALREADY controlled at load (a
+// returning install): a first visit that starts uncontrolled is claimed by clientsClaim, which is NOT an
+// update and must not trigger a reload. The one-shot flag prevents any reload loop.
+if ("serviceWorker" in navigator && navigator.serviceWorker.controller !== null) {
+  let reloadingForNewWorker = false;
+  navigator.serviceWorker.addEventListener("controllerchange", () => {
+    if (reloadingForNewWorker) return;
+    reloadingForNewWorker = true;
+    console.log("[mobile] a new service worker took control - reloading to run the latest build");
+    window.location.reload();
+  });
+}
+
 // The app is served under /m, so the router is rooted there. A hard navigation to a deep link
 // (e.g. /m/session/<id>) is served the injected index.html by the Gateway and the router then
 // resolves it client-side.

--- a/apps/mobile/src/pages/CarMode.tsx
+++ b/apps/mobile/src/pages/CarMode.tsx
@@ -9,7 +9,7 @@ import { useScreenWakeLock } from "../hooks/useScreenWakeLock";
 // the old git short-sha + timestamp badge was replaced by a plain human version. BUMP THIS INTEGER BY HAND
 // ON EVERY DEPLOY of the mobile app (v1 -> v2 -> v3 ...), so a glance at the corner tells the owner and the
 // Architect exactly which page is live and what to look for after a deploy.
-const CAR_MODE_VERSION = "v1";
+const CAR_MODE_VERSION = "v2";
 
 // Car Mode (Car Mode mission): the standalone, chrome-less, full-screen page the owner opens to run
 // the whole fleet by voice, hands-free, phone in his pocket. It is a THIN view over the shared

--- a/apps/mobile/vite.config.ts
+++ b/apps/mobile/vite.config.ts
@@ -58,13 +58,45 @@ export default defineConfig({
         // worker and re-import the new push handler (an unchanged sw.js is never re-fetched). The
         // Gateway serves push-sw.js ignoring the query, with no-cache.
         importScripts: ["push-sw.js?v=2"],
-        // App shell precache. index.html is served by the Gateway (token injection) and is
-        // navigation-fallback cached so a cold offline open still renders the shell.
-        navigateFallback: "/m/index.html",
-        globPatterns: ["**/*.{js,css,html,png,svg,woff2}"],
-        // Cache the last /sessions response so an offline open shows the last-known roster.
+        // NETWORK-FIRST APP SHELL (root cause fix): the app shell and the JS/CSS bundle are NO LONGER
+        // precached and served cache-first. A precached, cache-first index.html was serving the phone a
+        // STALE bundle for a whole load even though the Gateway serves a fresh index.html (no-cache) - so
+        // deploys never reached Soren's installed PWA, and skipWaiting/clientsClaim lost the race because
+        // the old worker served the stale shell before the update could win. Car Mode is under active
+        // iteration, so correctness beats offline caching here: only rarely-changing icons/fonts are
+        // precached, and the shell + bundle go through network-first runtime rules below (fresh when
+        // online, last-known copy only as an offline fallback). No navigateFallback: navigations are the
+        // network-first "m-shell" route below, not a cache-first precached page.
+        globPatterns: ["**/*.{png,svg,ico,woff2}"],
         runtimeCaching: [
           {
+            // The app shell: EVERY navigation under /m fetches the current index.html from the Gateway
+            // first (served no-cache), so the phone always loads the latest bundle with no manual cache
+            // clear. Falls back to the last-served shell ONLY when the network is unavailable (offline
+            // open), after a short timeout so a slow network does not stall the open.
+            urlPattern: ({ request, url }) => request.mode === "navigate" && url.pathname.startsWith("/m"),
+            handler: "NetworkFirst",
+            options: {
+              cacheName: "m-shell",
+              networkTimeoutSeconds: 4,
+              expiration: { maxEntries: 8, maxAgeSeconds: 60 * 60 * 24 },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+          {
+            // The hashed JS/CSS bundle: network-first so an iterating build is picked up immediately. The
+            // filenames are content-hashed, so the cached copy is always a correct offline fallback.
+            urlPattern: ({ url }) => url.pathname.startsWith("/m/assets/"),
+            handler: "NetworkFirst",
+            options: {
+              cacheName: "m-assets",
+              networkTimeoutSeconds: 4,
+              expiration: { maxEntries: 40, maxAgeSeconds: 60 * 60 * 24 * 7 },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+          {
+            // Cache the last /sessions response so an offline open shows the last-known roster.
             urlPattern: ({ url }) => url.pathname === "/sessions",
             handler: "NetworkFirst",
             options: {

--- a/packages/client-core/src/carmode/audioPlayback.ts
+++ b/packages/client-core/src/carmode/audioPlayback.ts
@@ -22,6 +22,10 @@ export interface PlayClipHooks {
   onPlayStarted?: () => void;
   /** Fired once when the clip is done, with how it ended, so the caller can record completed-vs-cutoff. */
   onPlayEnded?: (outcome: PlayOutcome) => void;
+  /** Fired when the element's play() promise REJECTS - on mobile this is the autoplay block (a play() not
+   *  tied to a live user gesture is refused with NotAllowedError). Lets the caller record that the reply
+   *  never actually sounded (the mobile cut-off bug), distinct from a normal early stop. */
+  onPlayRejected?: (error: unknown) => void;
 }
 
 /**
@@ -61,6 +65,16 @@ export function playClip(
     registerStop(() => finish("stopped"));
     audio.src = url;
     hooks?.onPlayStarted?.();
-    void audio.play().catch(() => finish("stopped"));
+    // A play() rejection is the mobile autoplay block (NotAllowedError when the play is not tied to a live
+    // user gesture): log the specific reason and mark it so the turn telemetry can show the reply never
+    // sounded, then treat it as a stop so the turn loop unwinds and the microphone returns (no silent
+    // stall). The unlock-on-Start-gesture (useCarMode) is what prevents this from happening.
+    void audio.play().catch((error: unknown) => {
+      const name = error instanceof Error ? error.name : "unknown";
+      const message = error instanceof Error ? error.message : String(error);
+      console.log(`[CarMode] reply audio play() rejected: ${name}: ${message}`);
+      hooks?.onPlayRejected?.(error);
+      finish("stopped");
+    });
   });
 }

--- a/packages/client-core/src/carmode/carModeApi.test.ts
+++ b/packages/client-core/src/carmode/carModeApi.test.ts
@@ -109,7 +109,7 @@ describe("postCarModeTelemetry", () => {
   const record = {
     turnId: "t1", pauseToTranscribeMs: 900, transcodeMs: 120, brainMs: 1200, ttsMs: 300, firstAudioMs: 350,
     totalTurnMs: 2450, transcribeAttempts: 1, chunks: 1, playMs: 4200, clipDurationMs: 4300, playedToMs: 4200,
-    completed: true, micReacquiredDuringPlayback: true, speakingPollCount: 3, serverTotalMs: 1100, modelCallCount: 1,
+    completed: true, playRejected: false, micReacquiredDuringPlayback: true, speakingPollCount: 3, serverTotalMs: 1100, modelCallCount: 1,
     modelMsTotal: 1050, modelMs: [1050], fleetReadCount: 0, fleetReadMsTotal: 0, rounds: 1, commandChars: 20,
     replyChars: 40, actionsCount: 0, pendingConfirmation: false,
   };

--- a/packages/client-core/src/carmode/carModeApi.ts
+++ b/packages/client-core/src/carmode/carModeApi.ts
@@ -148,6 +148,9 @@ export interface CarModeTelemetryPost {
   /** True when the reply clip played fully to its natural end; false when it was cut off (interrupt / End
    *  Car Mode). A cut-off reply - the bug this telemetry makes visible - reads as false. */
   completed: boolean;
+  /** True when the reply's play() was REJECTED - the mobile autoplay block (a play() not tied to a live
+   *  user gesture is refused), so the reply never sounded. The unlock-on-Start fix drives this to false. */
+  playRejected: boolean;
   /** True when the rolling-"stop" watch re-opened the microphone WHILE the reply was playing (the current
    *  behavior). The mic-contention hypothesis: on mobile this ducks/interrupts the reply. */
   micReacquiredDuringPlayback: boolean;

--- a/packages/client-core/src/carmode/useCarMode.ts
+++ b/packages/client-core/src/carmode/useCarMode.ts
@@ -3,7 +3,7 @@ import { MicRecorder } from "../dictation/recorder";
 import { blobToWav16kMono } from "../dictation/wav";
 import { playReadyCue, playYourTurnCue } from "../dictation/readyCue";
 import { detectEndPhrase, detectInterrupt } from "./controlPhrases";
-import { playClip, type PlayOutcome } from "./audioPlayback";
+import { playClip, type PlayOutcome, type PlayClipHooks } from "./audioPlayback";
 import {
   postCarModeTelemetry,
   postCarModeWarmup,
@@ -79,6 +79,7 @@ interface TurnMetrics {
   clipDurationMs: number; // the SYNTHESIZED reply clip's media length (audio.duration): the whole reply the phone got
   playedToMs: number; // how far INTO the clip playback reached at end/cutoff (audio.currentTime): media-time, not wall-clock
   completed: boolean; // true when the reply clip played fully to its natural end; false when cut off (interrupt / End)
+  playRejected: boolean; // true when the reply's play() was REJECTED (mobile autoplay block) so it never sounded
   // ----- The mic-contention hypothesis (does grabbing the mic mid-playback cut the reply off on mobile?) -----
   micReacquiredDuringPlayback: boolean; // did the rolling-"stop" watch re-open the microphone WHILE the reply was playing
   speakingPollCount: number; // how many rolling-"stop" transcriptions ran during this reply (each re-reads the open mic)
@@ -161,6 +162,36 @@ function isCaptureSupported(): boolean {
   if (typeof navigator === "undefined" || typeof window === "undefined") return false;
   const md = navigator.mediaDevices as MediaDevices | undefined;
   return Boolean(md && md.getUserMedia) && typeof MediaRecorder !== "undefined";
+}
+
+// A tiny, silent WAV clip (a valid RIFF/WAVE header with zero audio samples) used ONLY to unlock the
+// reply <audio> element inside the Start tap gesture. It is a data URI so it needs no network and no
+// bundled asset.
+const SILENT_WAV_DATA_URI =
+  "data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAgD4AAAB9AAACABAAZGF0YQAAAAA=";
+
+// Unlock an <audio> element for later programmatic playback, called INSIDE the Start tap gesture. Mobile
+// Chrome blocks a play() that is not tied to a live user gesture (NotAllowedError), and Car Mode's reply
+// plays SECONDS after the tap - after the transcribe -> brain -> speak pipeline - so by then the gesture
+// is gone and the reply is silently refused (the mobile cut-off / "heard nothing" bug). Playing a silent
+// clip now, within the tap, marks THIS element as user-activated, so every later reply on the SAME element
+// is allowed to play with no fresh gesture. Best-effort: a rejection here is logged, never thrown, because
+// the unlock is a courtesy on top of the normal play path.
+function unlockAudioElement(audio: HTMLAudioElement): void {
+  try {
+    audio.src = SILENT_WAV_DATA_URI;
+    const played = audio.play();
+    if (played && typeof played.then === "function") {
+      played
+        .then(() => console.log("[CarMode] reply audio element unlocked for autoplay"))
+        .catch((error: unknown) => {
+          const name = error instanceof Error ? error.name : "unknown";
+          console.log(`[CarMode] audio unlock play() rejected (will retry on first reply): ${name}`);
+        });
+    }
+  } catch (error) {
+    console.log(`[CarMode] audio unlock threw: ${String(error)}`);
+  }
 }
 
 export function useCarMode(options: UseCarModeOptions): CarModeView {
@@ -257,6 +288,7 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
       clipDurationMs: m.clipDurationMs,
       playedToMs: m.playedToMs,
       completed: m.completed,
+      playRejected: m.playRejected,
       micReacquiredDuringPlayback: m.micReacquiredDuringPlayback,
       speakingPollCount: m.speakingPollCount,
       serverTotalMs: m.server.totalMs,
@@ -280,10 +312,7 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
   // clip cleanly; playClip clears it (registers a no-op) once the clip is done. The optional lifecycle
   // hooks feed the cut-off-reply telemetry (play-started, play-ended, completed-vs-cutoff).
   const playBlob = useCallback(
-    (
-      url: string,
-      hooks?: { onPlayStarted?: () => void; onPlayEnded?: (outcome: PlayOutcome) => void },
-    ): Promise<PlayOutcome> => {
+    (url: string, hooks?: PlayClipHooks): Promise<PlayOutcome> => {
       const audio = audioRef.current;
       if (audio === null) return Promise.resolve<PlayOutcome>("stopped");
       return playClip(
@@ -423,6 +452,11 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
             // Post the merged timing record now that the clip's whole lifecycle is known - including a
             // cut-off - so a truncated reply is VISIBLE at /carmode/telemetry (fire-and-forget).
             postTurnTelemetry(metrics);
+          },
+          onPlayRejected: () => {
+            // The reply's play() was refused (mobile autoplay block): record it so the telemetry shows the
+            // reply never sounded. onPlayEnded still fires (as "stopped") and posts the record.
+            if (metrics !== null) metrics.playRejected = true;
           },
         });
 
@@ -576,6 +610,7 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
             clipDurationMs: 0,
             playedToMs: 0,
             completed: false,
+            playRejected: false,
             micReacquiredDuringPlayback: false,
             speakingPollCount: 0,
             posted: false,
@@ -686,7 +721,12 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     recorderRef.current = new MicRecorder();
     // The reply's sentence chunks are played by playBlob, which sets onended per clip; the speak loop hands
     // the microphone back after the LAST chunk, so no global onended handler is needed here.
-    audioRef.current = new Audio();
+    const audio = new Audio();
+    audioRef.current = audio;
+    // Unlock this element for autoplay WHILE we are still inside the Start tap's user gesture, BEFORE the
+    // first await below. The same element is reused for every reply, so once unlocked here, later replies
+    // (which play seconds after the tap, past the gesture window) are allowed to sound on mobile.
+    unlockAudioElement(audio);
 
     // The single silence-detector loop, live for the whole session; it only acts while Listening. When the
     // level drops below the threshold for PAUSE_MS AFTER speech was heard, it fires a pause probe.

--- a/src/CcDirector.Gateway.Tests/CarModeTelemetryStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeTelemetryStoreTests.cs
@@ -117,9 +117,10 @@ public sealed class CarModeTelemetryStoreTests : IDisposable
         {
             TranscribeAttempts = 4,             // "over and out" took four tries to land - finicky
             ClipDurationMs = 5200,              // the whole reply the phone received
-            PlayedToMs = 2100,                  // but playback only reached 2.1s in
+            PlayedToMs = 0,                     // but playback never advanced - it was blocked
             Completed = false,
-            MicReacquiredDuringPlayback = true, // the mic was re-opened while the reply played
+            PlayRejected = true,                // the mobile autoplay block: play() was refused
+            MicReacquiredDuringPlayback = true, // the mic was re-opened while the reply "played"
             SpeakingPollCount = 2,
         };
         store.Add(turn);
@@ -128,7 +129,8 @@ public sealed class CarModeTelemetryStoreTests : IDisposable
 
         Assert.Equal(4, reloaded.TranscribeAttempts);
         Assert.Equal(5200, reloaded.ClipDurationMs);
-        Assert.Equal(2100, reloaded.PlayedToMs);
+        Assert.Equal(0, reloaded.PlayedToMs);
+        Assert.True(reloaded.PlayRejected);
         Assert.True(reloaded.MicReacquiredDuringPlayback);
         Assert.Equal(2, reloaded.SpeakingPollCount);
     }

--- a/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
@@ -127,6 +127,7 @@ internal static class CarModeEndpoint
                 ClipDurationMs = req.ClipDurationMs,
                 PlayedToMs = req.PlayedToMs,
                 Completed = req.Completed,
+                PlayRejected = req.PlayRejected,
                 MicReacquiredDuringPlayback = req.MicReacquiredDuringPlayback,
                 SpeakingPollCount = req.SpeakingPollCount,
                 ServerTotalMs = req.ServerTotalMs,
@@ -201,6 +202,7 @@ public sealed class CarModeTelemetryPost
     public double ClipDurationMs { get; set; }
     public double PlayedToMs { get; set; }
     public bool Completed { get; set; }
+    public bool PlayRejected { get; set; }
     public bool MicReacquiredDuringPlayback { get; set; }
     public int SpeakingPollCount { get; set; }
     public double ServerTotalMs { get; set; }

--- a/src/CcDirector.Gateway/CarMode/CarModeTelemetry.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeTelemetry.cs
@@ -120,6 +120,11 @@ public sealed record CarModeTelemetryRecord
     ///  false: the reply was synthesized but the owner did not hear all of it.</summary>
     public bool Completed { get; init; }
 
+    /// <summary>True when the reply's play() was REJECTED - the mobile autoplay block (a play() not tied to
+    ///  a live user gesture is refused with NotAllowedError), so the reply never sounded at all. This is the
+    ///  data-confirmed mobile failure; the unlock-on-Start fix drives it to false.</summary>
+    public bool PlayRejected { get; init; }
+
     // ----- The mic-contention hypothesis (does re-opening the mic mid-playback cut the reply on mobile?) -----
 
     /// <summary>True when the rolling-"stop" watch re-opened the microphone WHILE the reply was playing (the

--- a/src/CcDirector.Gateway/CarMode/CarModeTelemetryPage.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeTelemetryPage.cs
@@ -63,7 +63,7 @@ internal static class CarModeTelemetryPage
 <body>
 <div class="wrap">
   <h1>Car Mode Timing</h1>
-  <p class="sub">Per-turn, per-stage latency AND the two mobile failure diagnostics for hands-free Car Mode. The pipeline a real phone turn walks: pause, transcode (phone), transcribe, brain round trip, the network gap (brain minus server), each model call, the fleet read, text-to-speech, and first audio. The "over and out" finickiness shows as End-phrase tries (how many transcribe attempts before the turn was taken). The cut-off reply is split three ways: Clip length (the whole reply synthesized), Played to (how far playback reached), and Mic in playback (whether the rolling "stop" watch re-opened the microphone while the reply was playing - the mic-contention suspect). All times are milliseconds. Counts and timings only; no command or reply text is ever recorded.</p>
+  <p class="sub">Per-turn, per-stage latency AND the two mobile failure diagnostics for hands-free Car Mode. The pipeline a real phone turn walks: pause, transcode (phone), transcribe, brain round trip, the network gap (brain minus server), each model call, the fleet read, text-to-speech, and first audio. The "over and out" finickiness shows as End-phrase tries (how many transcribe attempts before the turn was taken). The cut-off reply is split several ways: Clip length (the whole reply synthesized), Played to (how far playback reached), Play blocked (the reply's play() was refused by the mobile autoplay policy so it never sounded - the data-confirmed failure), and Mic in playback (whether the rolling "stop" watch re-opened the microphone while the reply was playing - a secondary suspect). All times are milliseconds. Counts and timings only; no command or reply text is ever recorded.</p>
 
   <div class="cards" id="cards"></div>
 
@@ -90,6 +90,7 @@ internal static class CarModeTelemetryPage
           <th>Clip<br>length</th>
           <th>Played<br>to</th>
           <th>Whole<br>reply?</th>
+          <th>Play<br>blocked</th>
           <th>Mic in<br>playback</th>
           <th>Stop<br>polls</th>
           <th>Clips</th>
@@ -136,7 +137,7 @@ internal static class CarModeTelemetryPage
 
     if (!recs.length) {
       cards.appendChild(card("-", "No turns recorded yet", "Take a turn in Car Mode on the phone"));
-      document.getElementById("rows").innerHTML = '<tr><td colspan="24" class="empty">No turns recorded yet. Open Car Mode on the phone, say something and "over and out", and it will appear here.</td></tr>';
+      document.getElementById("rows").innerHTML = '<tr><td colspan="25" class="empty">No turns recorded yet. Open Car Mode on the phone, say something and "over and out", and it will appear here.</td></tr>';
       document.getElementById("foot").textContent = "";
       return;
     }
@@ -162,11 +163,17 @@ internal static class CarModeTelemetryPage
     cards.appendChild(card(tries.length ? String(median(tries)) : "-", "Median 'over and out' tries",
       "1 = landed first try; higher = finicky"));
 
+    // The data-confirmed mobile failure: how many recent replies were BLOCKED by the autoplay policy so
+    // they never sounded. With the unlock-on-Start fix this should be 0.
+    var blocked = recs.filter(function (r) { return r.playRejected === true; }).length;
+    cards.appendChild(card(blocked + " / " + recs.length, "Replies BLOCKED (autoplay)",
+      blocked > 0 ? "play() refused - the reply never sounded" : "no autoplay block - replies could sound"));
+
     // The mic-contention suspect: how many recent replies had the microphone re-opened WHILE they played.
-    // On mobile this is the prime suspect for the cut-off / half-heard reply.
+    // On mobile this is a secondary suspect for a cut-off / half-heard reply.
     var micIn = recs.filter(function (r) { return r.micReacquiredDuringPlayback === true; }).length;
     cards.appendChild(card(micIn + " / " + recs.length, "Mic re-opened during the reply",
-      "the mobile cut-off suspect: mic grabbed mid-playback"));
+      "secondary cut-off suspect: mic grabbed mid-playback"));
 
     var body = document.getElementById("rows"); body.innerHTML = "";
     recs.forEach(function (r) {
@@ -210,6 +217,9 @@ internal static class CarModeTelemetryPage
       tr.appendChild(td(ms(r.clipDurationMs)));
       tr.appendChild(td(ms(r.playedToMs), playedShort ? "slow" : ""));
       tr.appendChild(td(r.completed == null ? "-" : (r.completed ? "yes" : "CUT OFF"), r.completed === false ? "slow" : ""));
+      // Play blocked: the reply's play() was refused by the mobile autoplay policy so it never sounded -
+      // the data-confirmed mobile failure. Called out in red; "no" (with the unlock fix) is the good state.
+      tr.appendChild(td(r.playRejected == null ? "-" : (r.playRejected ? "BLOCKED" : "no"), r.playRejected === true ? "slow" : ""));
       tr.appendChild(td(r.micReacquiredDuringPlayback == null ? "-" : (r.micReacquiredDuringPlayback ? "YES" : "no"),
         r.micReacquiredDuringPlayback === true ? "slow" : ""));
       tr.appendChild(td(r.speakingPollCount == null ? "-" : r.speakingPollCount));


### PR DESCRIPTION
## The finding that reframes everything

Soren's real-phone turn telemetry came in as **GatewayVersion bf0c3439 with the OLD schema** - his phone ran a **cached old bundle**, not v1, even though the live Gateway serves the new build and the served `/m/car` bundle shows the v1 badge. **His service worker was serving stale content. This is why fixes never reached him.**

## 1. PWA caching (top priority)

Root cause: the service worker precached `index.html` and served it **cache-first** via `navigateFallback`. A returning PWA loaded the OLD shell -> OLD JS for a whole load even though the Gateway serves a fresh `index.html` with `no-cache`. `skipWaiting`/`clientsClaim` lost the race, and the existing self-heal (#1155) only fires on a **404** (a missing route) - never on the **same route with new JS**, which is exactly Car Mode iteration.

Fix:
- Stop precaching the app shell and the JS/CSS bundle. Navigations under `/m` and `/m/assets` now go through **NetworkFirst** runtime rules: fresh from the Gateway when online, last-known copy only as an offline fallback.
- Precache now holds only small icons/fonts - **verified the precache dropped from 8 entries / 727 KiB to 3 entries / 10 KiB**, and the generated `sw.js` carries `m-shell` + `m-assets` NetworkFirst routes.
- Added a guarded **reload-once when a new service worker takes control**, so a long-open PWA also picks up a new deploy.
- Incognito (no persisted worker) always loads latest - our reliable test path.

## 2. Audio (data-confirmed autoplay block)

The telemetry pattern (first turn `Chunks=1` played, later turns `Chunks=0`/`PlayMs=0`/`Completed=false`) is **gesture-expiry**: the reply plays seconds after the Start tap, past the user-gesture window, so mobile Chrome refuses `play()` (`NotAllowedError`) and the reply never sounds.

Fix:
- **Unlock the reused `<audio>` element with a silent clip INSIDE the Start tap gesture**, so every later reply on the same element is allowed to play.
- Log `play()` rejections and record a new **`playRejected`** telemetry flag (client + Gateway record + endpoint + dashboard column + card) so the block is visible and the fix is verifiable (`playRejected` must be `false` after v2).

Bumps the version badge to **v2**.

## Verification
- Caching fix: verifiable by me in **incognito** against the live Gateway (proves latest loads with no cache); the network-first mechanism self-heals Soren's installed PWA on next open.
- Audio fix: **cannot be proven on desktop** (no autoplay block for user-activated audio) - needs Soren's next turn (or a real mobile surface). The `playRejected` flag + `Whole reply?` will confirm.
- Tests: 387 client + 68 Gateway CarMode green; typecheck clean; mobile bundle builds.

Not claiming the audio fix proven on desktop. Reporting version + caching proof; audio confirmation is Soren's next turn on v2.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>