### PR TITLE
fix(test): prompt-chokepoint guard follows client.ts fetch -> gatewayFetch rename

### DIFF
--- a/src/CcDirector.Core.Tests/TerminalPromptInjectionChokepointTests.cs
+++ b/src/CcDirector.Core.Tests/TerminalPromptInjectionChokepointTests.cs
@@ -70,7 +70,7 @@ public sealed class TerminalPromptInjectionChokepointTests
         var directorClient = File.ReadAllText(Path.Combine(root, "src", "CcDirector.Gateway", "Discovery", "DirectorEndpointClient.cs"));
         var stream = File.ReadAllText(Path.Combine(root, "src", "CcDirector.ControlApi", "TerminalStreamEndpoint.cs"));
 
-        Assert.Contains("fetch(`/sessions/${sid}/prompt`", client);
+        Assert.Contains("gatewayFetch(`/sessions/${sid}/prompt`", client);
         Assert.Contains("await sendPrompt(sessionId, text, true);", cockpit);
         Assert.Contains("await sendPrompt(sessionId, text, true);", mobileControls);
         Assert.Contains("await sendPrompt(sessionId, combined, true);", mobileControls);


### PR DESCRIPTION
origin/main is red: TerminalPromptInjectionChokepointTests.Web_and_gateway_prompt_routes_keep_submit_separate_from_raw_terminal_input asserts client.ts contains `fetch(\`, but a recent commit renamed that call to the auth-aware wrapper `gatewayFetch(\` (injected Bearer). The guard was left on the old name. One-line assertion update to match the current wrapper; the chokepoint still protects that prompts funnel through the /prompt route. All 4 tests in the class pass. Unblocks main (and the Gateway Connection Phase 2 PR #1393).

🤖 Generated with [Claude Code](https://claude.com/claude-code)