### PR TITLE
feat(installer): clearer role-aware Tailscale wording on the prerequisites step

### DIFF
--- a/tools/cc-director-setup/MainWindow.xaml.cs
+++ b/tools/cc-director-setup/MainWindow.xaml.cs
@@ -119,6 +119,10 @@ public partial class MainWindow : Window
             // together: switching to "I already have a gateway" (Workstation) drops Sign-in and adds the
             // mandatory Connect step; switching back to the Gateway "first machine" role does the inverse.
             _role = _welcomeStep?.SelectedRole ?? _role;
+            // The Prerequisites step is cached (??=) and its Tailscale wording is role-aware, so
+            // drop the cached instance when the role flips - it rebuilds with the correct copy the
+            // next time the user reaches it.
+            _prerequisitesStep = null;
             UpdateSidebar();
         };
         return step;
@@ -238,7 +242,7 @@ public partial class MainWindow : Window
         StepContent.Content = step switch
         {
             1 => _welcomeStep ??= BuildWelcomeStep(),
-            2 => _prerequisitesStep ??= new PrerequisitesStep(OnPrerequisitesChecked, _isUpdate),
+            2 => _prerequisitesStep ??= new PrerequisitesStep(OnPrerequisitesChecked, _isUpdate, _role),
             StepSignIn => _signInStep ??= BuildSignInStep(),
             StepPrivacy => _privacyStep ??= BuildPrivacyStep(),
             StepConnect => _gatewayConnectStep ??= BuildGatewayConnectStep(),

--- a/tools/cc-director-setup/Services/PrerequisiteChecker.cs
+++ b/tools/cc-director-setup/Services/PrerequisiteChecker.cs
@@ -5,8 +5,22 @@ namespace CcDirectorSetup.Services;
 
 public static class PrerequisiteChecker
 {
-    public static List<PrerequisiteInfo> CreateChecklist()
+    public static List<PrerequisiteInfo> CreateChecklist(CcDirector.Setup.Engine.InstallRole role)
     {
+        // Tailscale stays optional and never blocks the install. Only the WHY differs by role:
+        // on the gateway it is what lets a phone or another computer reach this machine securely
+        // (browsers require HTTPS off localhost, and Tailscale supplies that certificate for free);
+        // on a workstation it only matters when the machine leaves the gateway's local network.
+        // Everything runs on this machine at localhost over plain HTTP with no Tailscale, because
+        // browsers treat localhost as already secure.
+        var tailscaleDescription = role == CcDirector.Setup.Engine.InstallRole.Gateway
+            ? "Optional but needed for your phone and other computers to reach this gateway. The "
+              + "mobile app and the Cockpit run in a browser, which requires a secure (HTTPS) "
+              + "connection off this machine - Tailscale provides that automatically and for free. "
+              + "Everything still works on this machine at localhost without it."
+            : "Optional: only needed if you use this machine away from your gateway's local "
+              + "network. On the same network it reaches the gateway directly, with no Tailscale.";
+
         return
         [
             new PrerequisiteInfo
@@ -42,7 +56,7 @@ public static class PrerequisiteChecker
             new PrerequisiteInfo
             {
                 Name = "Tailscale",
-                Description = "Optional: remote access (a Gateway/Cockpit on another machine reaches this Director over the tailnet); local-only use works without it",
+                Description = tailscaleDescription,
                 IsRequired = false,
                 CanAutoInstall = true,
                 WingetId = "tailscale.Tailscale",

--- a/tools/cc-director-setup/Steps/PrerequisitesStep.xaml.cs
+++ b/tools/cc-director-setup/Steps/PrerequisitesStep.xaml.cs
@@ -10,19 +10,21 @@ namespace CcDirectorSetup.Steps;
 public partial class PrerequisitesStep : UserControl
 {
     private readonly Action<List<PrerequisiteInfo>> _onChecksComplete;
+    private readonly CcDirector.Setup.Engine.InstallRole _role;
     private List<PrerequisiteInfo> _items;
 
-    public PrerequisitesStep(Action<List<PrerequisiteInfo>> onChecksComplete, bool isUpdate)
+    public PrerequisitesStep(Action<List<PrerequisiteInfo>> onChecksComplete, bool isUpdate, CcDirector.Setup.Engine.InstallRole role)
     {
         InitializeComponent();
         _onChecksComplete = onChecksComplete;
-        _items = PrerequisiteChecker.CreateChecklist();
+        _role = role;
+        _items = PrerequisiteChecker.CreateChecklist(_role);
         PrereqList.ItemsSource = _items;
 
         if (isUpdate)
             SubtitleText.Text = "Verifying your environment...";
 
-        SetupLog.Write($"[PrerequisitesStep] Created: isUpdate={isUpdate}");
+        SetupLog.Write($"[PrerequisitesStep] Created: isUpdate={isUpdate}, role={_role}");
     }
 
     public async void RunChecks()
@@ -30,7 +32,7 @@ public partial class PrerequisitesStep : UserControl
         SetupLog.Write("[PrerequisitesStep] RunChecks: starting");
         RefreshButton.IsEnabled = false;
 
-        _items = PrerequisiteChecker.CreateChecklist();
+        _items = PrerequisiteChecker.CreateChecklist(_role);
         PrereqList.ItemsSource = _items;
 
         await PrerequisiteChecker.CheckAllAsync(_items);


### PR DESCRIPTION
## What

Makes the Tailscale prerequisite row's wording depend on the install role, so the explanation is clear about when Tailscale is actually needed. Tailscale stays optional and never blocks the install - only the copy changed.

**On the gateway machine:**
> Optional but needed for your phone and other computers to reach this gateway. The mobile app and the Cockpit run in a browser, which requires a secure (HTTPS) connection off this machine - Tailscale provides that automatically and for free. Everything still works on this machine at localhost without it.

**On a workstation:**
> Optional: only needed if you use this machine away from your gateway's local network. On the same network it reaches the gateway directly, with no Tailscale.

## Why

The old single line did not explain why Tailscale matters (browsers require a secure connection off localhost for the phone app and the Cockpit, and Tailscale supplies that certificate for free), and it implied every machine needs it. The phone/Cockpit reason is a gateway concern; a workstation only needs Tailscale when it leaves the local network. Everything on the machine itself works at localhost with no Tailscale and no certificate.

## Notes

- Windows installer only (tools/cc-director-setup, WPF). The macOS Avalonia installer does not list Tailscale, so no parity change.
- The cached prerequisites step is dropped when the role flips at the Welcome screen so the wording never goes stale.
- Builds clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)