### PR TITLE
feat(mobile-voice): persistent "Regenerate response" button in Voice mode

### DIFF
--- a/apps/mobile/src/pages/VoiceMode.tsx
+++ b/apps/mobile/src/pages/VoiceMode.tsx
@@ -216,6 +216,22 @@ export function VoiceMode() {
           </>
         )}
 
+        {/* Regenerate response: force a fresh narration of the session's CURRENT last reply, without
+            toggling voice off/on. Present in the on-states that already have (or are making) a clip -
+            NOT in the unavailable state, which shows its own "Generate narration now". This is the
+            manual override for the rare case the auto-narration is stale or you just want it re-read;
+            it hits the same force path (/wingman/explain) that overwrites the cached clip. */}
+        {voiceOn && !audioUnavailable && (
+          <button
+            type="button"
+            className="voice-regen-btn"
+            onClick={() => void onGenerateNow()}
+            disabled={regenerating}
+          >
+            {regenerating ? "Regenerating..." : "Regenerate response"}
+          </button>
+        )}
+
         {/* Turn voice off: a low-emphasis control present in every on-state (working, speaking). It
             tells the owning Director to leave voice mode (ViewMode -> Text), the same call the native
             app makes, and the screen returns to the off state. */}

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -1158,6 +1158,28 @@ a.banner-btn {
   cursor: pointer;
 }
 
+/* Regenerate response: a secondary action sitting just above Turn voice off. More emphasis than the
+   muted off-toggle (full text color, accent-tinted border) so it reads as an action, but still a
+   ghost button so it never competes with the primary in-state controls (Respond, the player). */
+.voice-regen-btn {
+  display: block;
+  width: 100%;
+  margin-top: 18px;
+  border: 1px solid #5b2bd6;
+  border-radius: 10px;
+  padding: 11px 0;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text);
+  background: transparent;
+  cursor: pointer;
+}
+
+.voice-regen-btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
 /* Status bar: a state pill on the left, an optional reference note on the right. */
 .voice-statusbar {
   display: flex;
@@ -1276,7 +1298,8 @@ a.banner-btn {
 }
 
 /* "Turn voice off" stays a fixed strip at the very bottom, below the scrolling narrative. */
-.voice-body-speaking .voice-off-toggle {
+.voice-body-speaking .voice-off-toggle,
+.voice-body-speaking .voice-regen-btn {
   flex: 0 0 auto;
 }
 


### PR DESCRIPTION
## Why

Voice mode only offered **"Generate narration now"** in the no-voice / error state. Once a voice response already existed, the only way to force a fresh narration was to **turn voice off and back on**. Requested directly by the owner.

## What

Adds a persistent **"Regenerate response"** button directly above **"Turn voice off"**, shown in the on-states that already have (or are making) a clip - *not* the unavailable state, which keeps its own Generate button (no duplicate).

It reuses the existing force path: `onGenerateNow` -> `markVoiceAndExplain` -> `POST /wingman/explain`, which reads the session's **current** last reply and **overwrites** the cached clip, so the poll picks up the fresh narration. Disabled + "Regenerating..." while in flight. Styled as an accent-bordered ghost button so it reads as an action without competing with Respond or the player.

## Scope

Mobile app (`apps/mobile`) only - two files (`VoiceMode.tsx`, `styles.css`). No backend change. The shared hook already exposed `onGenerateNow` / `regenerating`.

## Verification

Mobile typecheck (`tsc --noEmit`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)