### PR TITLE
fix(carmode): v4 - primary button stays on-screen + instant ack cue on tap

### DIFF
--- a/apps/mobile/src/pages/CarMode.tsx
+++ b/apps/mobile/src/pages/CarMode.tsx
@@ -9,7 +9,7 @@ import { useScreenWakeLock } from "../hooks/useScreenWakeLock";
 // the old git short-sha + timestamp badge was replaced by a plain human version. BUMP THIS INTEGER BY HAND
 // ON EVERY DEPLOY of the mobile app (v1 -> v2 -> v3 ...), so a glance at the corner tells the owner and the
 // Architect exactly which page is live and what to look for after a deploy.
-const CAR_MODE_VERSION = "v3";
+const CAR_MODE_VERSION = "v4";
 
 // Car Mode (Car Mode mission): the standalone, chrome-less, full-screen page the owner opens to run
 // the whole fleet by voice, hands-free, phone in his pocket. It is a THIN view over the shared

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -2582,7 +2582,16 @@ a.banner-btn {
    visible (docs/VisualStyle.md, the app-like session-screen rule). */
 .car-screen {
   position: fixed;
-  inset: 0;
+  /* Anchor top/left/right ONLY - deliberately NOT `inset: 0`. `inset: 0` sets both top:0 AND bottom:0,
+     which OVER-CONSTRAINS a fixed box: its height is then derived from top+bottom (the tall, toolbar-
+     hidden LAYOUT viewport) and the `height: 100dvh` below is IGNORED. The box then extends BELOW the
+     phone's bottom browser toolbar, pushing the footer's primary button off the visible area (the
+     "button cut off" bug, v4). Anchoring top-only lets `height: 100dvh` win, so the box tracks the
+     DYNAMIC visible viewport and the footer sits above the toolbar - the same reason .terminal-screen
+     uses dvh, not vh. */
+  top: 0;
+  left: 0;
+  right: 0;
   display: flex;
   flex-direction: column;
   background: var(--bg);
@@ -2664,11 +2673,15 @@ a.banner-btn {
   text-align: center;
 }
 
-/* The one big status orb: its color IS the state at a distance (paired with the two audible cues). */
+/* The one big status orb: its color IS the state at a distance (paired with the two audible cues). It is
+   SIZED RESPONSIVELY (v4): a viewport-height clamp so it shrinks on short screens (landscape, small
+   phones) instead of forcing the middle taller and shoving the footer's button off the bottom edge. It
+   also never flex-grows/shrinks unexpectedly, so it holds this size and the middle scrolls if needed. */
 .car-orb {
   position: relative;
-  width: 140px;
-  height: 140px;
+  flex: 0 0 auto;
+  width: clamp(96px, 22vh, 140px);
+  height: clamp(96px, 22vh, 140px);
   border-radius: 50%;
   display: flex;
   align-items: center;

--- a/packages/client-core/src/carmode/useCarMode.ts
+++ b/packages/client-core/src/carmode/useCarMode.ts
@@ -544,9 +544,10 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
       const command = parsed.ended ? parsed.command : transcript;
       setCaptureState(`heard: "${transcript}"`);
 
-      // Fire the "my turn" cue the INSTANT the command is in hand (before the brain responds) for an
-      // immediate audible acknowledgement, seed the turn metrics the brain + speak steps fill, then take it.
-      playReadyCue();
+      // Seed the turn metrics the brain + speak steps fill, then take the turn. (v4: the "my turn" cue is
+      // no longer fired here - it now fires SYNCHRONOUSLY in the endTurn tap handler, before this async
+      // transcode+transcribe work, so the owner hears the acknowledgement the instant he taps, not ~2s
+      // later. See endTurn below.)
       turnMetricsRef.current = {
         turnId: "",
         pauseDetectedAt,
@@ -587,6 +588,11 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
   // interrupt, since no voice "stop" watch runs).
   const endTurn = useCallback(() => {
     if (phaseRef.current !== "listening") return;
+    // v4: fire the "my turn" acknowledgement cue SYNCHRONOUSLY as the FIRST thing on tap, before any of
+    // the async end-of-turn work (mic snapshot -> WAV transcode -> transcribe round trip). That async
+    // work took ~2 seconds, so the cue used to lag the tap badly; firing it here gives an immediate
+    // (<150ms) audible "got it". Firing inside the tap gesture also guarantees mobile permits it to sound.
+    playReadyCue();
     void transcribeAndTake();
   }, [transcribeAndTake]);
 


### PR DESCRIPTION
Two focused fixes on top of v3 (Soren's directive: one thing at a time, button-first).

## (1) Layout - the primary blue button was cut off at the bottom of /m/car

Affected the idle **Start Car Mode** button and the active **Over and out / Stop / End Car Mode** controls, in both states.

**Root cause:** `.car-screen` was `position: fixed; inset: 0` **and** `height: 100dvh`. `inset: 0` sets `top:0` **and** `bottom:0`, which over-constrains a fixed box - its height is then derived from top+bottom (the tall, toolbar-hidden **layout** viewport) and the `height: 100dvh` is **ignored**. The box extended **below** the phone's bottom browser toolbar, pushing the footer off the visible area.

**Fix:** anchor `top/left/right` only (drop `bottom`) so `height: 100dvh` wins and the box tracks the **dynamic visible viewport** - the same reason `.terminal-screen` uses `dvh` not `vh`. Also made the status orb shrink on short viewports (`clamp(96px, 22vh, 140px)`, `flex: 0 0 auto`) so a landscape/small screen never forces the middle taller and shoves the footer off the bottom. The footer already carries `padding-bottom: calc(20px + env(safe-area-inset-bottom))`, so the button also clears the home indicator.

## (2) Instant ack cue - tapping "Over and out" lagged the "my turn" cue by ~2s

The cue was fired inside `transcribeAndTake` **after** the async `snapshot -> WAV transcode -> transcribe` round trip. Moved `playReadyCue()` to be the **first synchronous statement** in the `endTurn` tap handler, before any async work, so the owner hears an immediate (<150ms) "got it". Firing it inside the tap gesture also guarantees mobile permits it to sound.

## Also
- Bumps the on-screen version badge to **v4**.
- Keeps the network-first PWA caching (v2) and the v3 mic-released-during-playback behavior untouched.

## Verification
- Client-only (no Gateway change). Tests: **388 client green**, typecheck clean across all workspaces, mobile bundle builds (PWA intact).
- **Not declaring done on desktop.** This layout bug only bites on a real phone where the browser toolbar makes `dvh` < the layout viewport - a desktop render (where `dvh == vh`) cannot reproduce it. Success = Soren, after **close+reopen `/m/car`** (corner reads **v4**), sees the primary button fully visible/tappable in both states AND hears the ack cue the instant he taps "Over and out".

🤖 Generated with [Claude Code](https://claude.com/claude-code)