### PR TITLE
Gateway Cleanup Phase 0 spine (part 1 of 2): the Director command dispatch skeleton

### DIFF
--- a/src/CcDirector.ControlApi/CatalogReadExecutor.cs
+++ b/src/CcDirector.ControlApi/CatalogReadExecutor.cs
@@ -1,0 +1,18 @@
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0 (spine): the CATALOG and DIRECTOR-LEVEL READ area of the tunnel command
+/// surface. It owns the reads that are not addressed to one session (git status is per-session but grouped
+/// here with the catalogs) - repos list, facts, coaching categories, claude-sessions, interrupted list,
+/// filesystem list, directory list. Empty in the spine; Worker R2 fills it. Each verb it adds is declared in
+/// <see cref="Verbs"/> and handled in <see cref="ExecuteAsync"/>, touching only this file.
+/// </summary>
+internal sealed class CatalogReadExecutor : ISessionCommandArea
+{
+    public IReadOnlyCollection<string> Verbs { get; } = Array.Empty<string>();
+
+    public Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken) =>
+        Task.FromResult(DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the catalog read area"));
+}

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1364,70 +1364,21 @@ internal static class ControlEndpoints
         // provided by SessionHistoryEndpoint via SessionHistoryReader - it covers Claude, Codex, and
         // Pi. cc-history reads that existing endpoint; no duplicate is registered here.)
 
-        app.MapGet("/sessions/{sid}/turns", (string sid) =>
+        // Issue #1177 / Gateway Cleanup Phase 0: the read runs through the shared SessionReadExecutor core so
+        // this REST path and the Gateway stream down-channel are identical and cannot drift. Phase 1 deletes
+        // this route and leaves the core reached only over the tunnel.
+        app.MapGet("/sessions/{sid}/turns", async (string sid) =>
         {
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
+            var command = new DirectorCommand { Verb = "turns", SessionId = sid };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
 
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
-
-            var resp = new TurnsResponse
+            return result.Status switch
             {
-                SessionId = sid,
-                ClaudeSessionId = session.ClaudeSessionId,
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<TurnsResponse>(result.BodyJson)),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "turns command failed"),
             };
-
-            if (session.AgentKind != AgentKind.ClaudeCode)
-            {
-                if (!SessionHistoryReader.IsSupported(session))
-                {
-                    resp.Status = "unsupported";
-                    resp.Error = $"Agent {session.AgentKind} does not expose conversation history.";
-                    return Results.Json(resp);
-                }
-
-                var history = SessionHistoryReader.Read(session);
-                resp.JsonlPath = SessionHistoryReader.ResolveTranscriptPath(session);
-                resp.LineCount = history.Messages.Count;
-                resp.Widgets = BuildTurnWidgetsFromHistory(history);
-                resp.Status = "ok";
-                return Results.Json(resp);
-            }
-
-            if (string.IsNullOrEmpty(session.ClaudeSessionId))
-            {
-                resp.Status = "no_session_id";
-                resp.Error = "Session has not been linked to a Claude session id yet.";
-                return Results.Json(resp);
-            }
-
-            try
-            {
-                var jsonl = ClaudeSessionReader.GetJsonlPath(session.ClaudeSessionId, session.RepoPath);
-                resp.JsonlPath = jsonl;
-
-                if (!File.Exists(jsonl))
-                {
-                    resp.Status = "no_jsonl";
-                    resp.Error = $"JSONL file not found at {jsonl}";
-                    return Results.Json(resp);
-                }
-
-                var messages = StreamMessageParser.ParseFile(jsonl);
-                resp.LineCount = messages.Count;
-                resp.Widgets = WidgetBuilder.BuildFromMessages(messages);
-                resp.Status = "ok";
-                return Results.Json(resp);
-            }
-            catch (Exception ex)
-            {
-                FileLog.Write($"[ControlEndpoints] /turns FAILED: {ex.Message}");
-                resp.Status = "parse_error";
-                resp.Error = ex.Message;
-                return Results.Json(resp);
-            }
         });
 
         app.MapGet("/sessions/{sid}/summary", (string sid) =>
@@ -2588,19 +2539,26 @@ internal static class ControlEndpoints
         // Resize the session's PTY grid so a remote terminal (the Cockpit) can use the full
         // window width. Session.Resize no-ops on an unchanged size, so a chatty client can't
         // hammer the PTY (the Wingman repaint-loop invariant).
-        app.MapPost("/sessions/{sid}/resize", (string sid, ResizeRequest req) =>
+        // Issue #1177 / Gateway Cleanup Phase 0: the resize runs through the shared SessionWriteExecutor core
+        // so this REST path and the Gateway stream down-channel are identical and cannot drift. Phase 1
+        // deletes this route and leaves the core reached only over the tunnel.
+        app.MapPost("/sessions/{sid}/resize", async (string sid, ResizeRequest req) =>
         {
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
-            if (req is null || req.Cols <= 0 || req.Rows <= 0)
-                return Results.BadRequest(new { error = "cols and rows must be > 0" });
+            var command = new DirectorCommand
+            {
+                Verb = "resize",
+                SessionId = sid,
+                PayloadJson = req is null ? "" : SessionCommandExecutor.Serialize(req),
+            };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
 
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
-
-            session.Resize((short)Math.Min(req.Cols, short.MaxValue), (short)Math.Min(req.Rows, short.MaxValue));
-            return Results.Json(new { accepted = true, cols = (int)session.CurrentCols, rows = (int)session.CurrentRows });
+            return result.Status switch
+            {
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<ResizeResponse>(result.BodyJson)),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "resize command failed"),
+            };
         });
 
         // Upload an image (from the phone) and file it into the user's screenshots folder
@@ -3654,7 +3612,10 @@ internal static class ControlEndpoints
     /// the Gateway Wingman voice path. Assistant text must stay Kind="Text": that is the contract
     /// WingmanTranslator uses to find the latest reply to summarize and speak.
     /// </summary>
-    private static List<TurnWidgetDto> BuildTurnWidgetsFromHistory(ConversationHistory history)
+    // Internal (not private) so the extracted SessionReadExecutor.Turns core can call the SAME widget
+    // builder the REST route used, keeping the tunnel verb and the route byte-identical (Gateway Cleanup
+    // mission, Phase 0).
+    internal static List<TurnWidgetDto> BuildTurnWidgetsFromHistory(ConversationHistory history)
     {
         var widgets = new List<TurnWidgetDto>();
         foreach (var message in history.Messages)

--- a/src/CcDirector.ControlApi/QueueGitExecutor.cs
+++ b/src/CcDirector.ControlApi/QueueGitExecutor.cs
@@ -1,0 +1,18 @@
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0 (spine): the QUEUE and GIT WRITE area of the tunnel command surface. It
+/// owns the voice-queue mutation group (add, patch, remove, move-up, move-down, clear, send) and the git
+/// working-tree writes (stage, unstage, discard, commit), plus create-from-github. Empty in the spine;
+/// Worker W2 fills it. Each verb it adds is declared in <see cref="Verbs"/> and handled in
+/// <see cref="ExecuteAsync"/>, touching only this file.
+/// </summary>
+internal sealed class QueueGitExecutor : ISessionCommandArea
+{
+    public IReadOnlyCollection<string> Verbs { get; } = Array.Empty<string>();
+
+    public Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken) =>
+        Task.FromResult(DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the queue/git area"));
+}

--- a/src/CcDirector.ControlApi/SessionByteExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionByteExecutor.cs
@@ -1,0 +1,21 @@
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0 (spine): the UNARY BYTE area of the tunnel command surface. It owns the
+/// byte verbs that are plain unary commands (the small-payload ones), NOT the up-stream byte streams: the
+/// screenshots list (a directory read) and upload-image (bytes DOWN in the payload, chunked if large). The
+/// three connection-bound byte STREAMS - read-file, screenshot-file, and the terminal stream - are NOT here:
+/// they are handled at the connection layer in GatewayStreamClient with the up-stream primitive, because
+/// only they need the live connection (Architect ruling A). Empty in the spine; Worker S1 fills it once the
+/// spine's up-stream producers are in place. Each verb it adds is declared in <see cref="Verbs"/> and handled
+/// in <see cref="ExecuteAsync"/>, touching only this file.
+/// </summary>
+internal sealed class SessionByteExecutor : ISessionCommandArea
+{
+    public IReadOnlyCollection<string> Verbs { get; } = Array.Empty<string>();
+
+    public Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken) =>
+        Task.FromResult(DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the byte area"));
+}

--- a/src/CcDirector.ControlApi/SessionCommandArea.cs
+++ b/src/CcDirector.ControlApi/SessionCommandArea.cs
@@ -1,0 +1,42 @@
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0 (spine): the context every command area needs to execute a verb -
+/// the target <see cref="SessionManager"/>, this Director's id, the optional side-effect services, and the
+/// send source. It is passed to <see cref="ISessionCommandArea.ExecuteAsync"/> so the area classes stay
+/// stateless singletons (no per-call fields), which is what lets the verb-to-area dictionary be composed
+/// exactly once at startup.
+/// </summary>
+internal readonly record struct SessionCommandContext(
+    SessionManager SessionManager,
+    string DirectorId,
+    SessionCommandServices? Services,
+    SendSource Source);
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0 (spine): one AREA of the Director's tunnel command surface (session
+/// reads, catalog reads, session writes, queue/git writes, unary byte verbs). Each area declares the verbs
+/// it owns and executes them. <see cref="SessionCommandExecutor.DispatchAsync"/> builds a single
+/// verb-to-area dictionary from every area's <see cref="Verbs"/> ONCE at startup (throwing loudly if two
+/// areas declare the same verb) and routes each command to the owning area.
+///
+/// This is the structure that removes the merge chokepoint: a worker adds a verb by editing ONLY its own
+/// area file - the verb list plus the handling - never a shared central switch. The four connection-bound
+/// stream verbs (open-terminal-stream, read-file, screenshot-file, close-stream) are deliberately NOT areas
+/// here: they branch earlier, in <c>GatewayStreamClient</c>, because only they need the live connection and
+/// the per-stream cancellation registry (Architect ruling A, 2026-07-12).
+/// </summary>
+internal interface ISessionCommandArea
+{
+    /// <summary>The verbs this area owns. Each verb must be owned by exactly one area (enforced at composition).</summary>
+    IReadOnlyCollection<string> Verbs { get; }
+
+    /// <summary>
+    /// Execute one command whose verb this area owns. The dispatcher has already looked the verb up, so an
+    /// area only ever receives a verb from its own <see cref="Verbs"/>; a mismatch is a fail-loud BadRequest.
+    /// </summary>
+    Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken);
+}

--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -48,30 +48,69 @@ internal static class SessionCommandExecutor
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     /// <summary>
-    /// Execute a command by verb. Resolves the payload and target session with the shared guards, then
-    /// dispatches to the matching verb handler. An unknown verb is a <see cref="DirectorCommandStatus.BadRequest"/>.
+    /// Gateway Cleanup mission, Phase 0 (spine): every command AREA, pre-created ONCE. The verb-to-area map
+    /// below is built from these. A worker fills its own area class; this list changes only when a whole new
+    /// area is introduced (never for adding a verb), so it is not a merge chokepoint.
     /// </summary>
-    public static async Task<DirectorCommandResult> DispatchAsync(SessionManager sessionManager, string directorId, DirectorCommand command, SessionCommandServices? services = null, SendSource source = SendSource.UserInput)
+    private static readonly ISessionCommandArea[] Areas =
+    {
+        new SessionReadExecutor(),
+        new CatalogReadExecutor(),
+        new SessionWriteExecutor(),
+        new QueueGitExecutor(),
+        new SessionByteExecutor(),
+    };
+
+    /// <summary>
+    /// Gateway Cleanup mission, Phase 0 (spine): the single verb-to-area dictionary, the one source of truth
+    /// for which area owns which verb. Built ONCE at type initialization from the areas' declared verb lists;
+    /// a duplicate verb across two areas throws immediately (fail loud, no silent shadow).
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, ISessionCommandArea> VerbMap = BuildVerbMap(Areas);
+
+    internal static IReadOnlyDictionary<string, ISessionCommandArea> BuildVerbMap(IReadOnlyList<ISessionCommandArea> areas)
+    {
+        var map = new Dictionary<string, ISessionCommandArea>(StringComparer.Ordinal);
+        foreach (var area in areas)
+        {
+            foreach (var verb in area.Verbs)
+            {
+                if (map.TryGetValue(verb, out var existing))
+                    throw new InvalidOperationException(
+                        $"Duplicate command verb '{verb}' declared by both {existing.GetType().Name} and {area.GetType().Name}. Each verb must be owned by exactly one command area.");
+                map[verb] = area;
+            }
+        }
+        return map;
+    }
+
+    /// <summary>
+    /// Execute a command by verb. Looks the verb up in the single verb-to-area map and routes it to the
+    /// owning area, which resolves the payload and target session with the shared guards and executes it.
+    /// An unknown verb is a fail-loud <see cref="DirectorCommandStatus.BadRequest"/> naming the verb. The
+    /// four connection-bound stream verbs are NOT dispatched here - they branch earlier, in the connection
+    /// layer (Architect ruling A) - so this map is exactly the unary read and write surface.
+    /// </summary>
+    public static async Task<DirectorCommandResult> DispatchAsync(SessionManager sessionManager, string directorId, DirectorCommand command, SessionCommandServices? services = null, SendSource source = SendSource.UserInput, CancellationToken cancellationToken = default)
     {
         if (sessionManager is null) throw new ArgumentNullException(nameof(sessionManager));
         if (command is null) throw new ArgumentNullException(nameof(command));
 
         FileLog.Write($"[SessionCommandExecutor] DispatchAsync: verb={command.Verb}, sid={command.SessionId}, cmdId={command.CommandId}, source={source}, director={directorId}");
 
-        var result = command.Verb switch
+        if (!VerbMap.TryGetValue(command.Verb, out var area))
         {
-            "prompt" => await PromptAsync(sessionManager, command, source),
-            "interrupt" => await InterruptAsync(sessionManager, command),
-            "escape" => await EscapeAsync(sessionManager, command),
-            "hold" => Hold(sessionManager, command),
-            "kill" => await KillAsync(sessionManager, command),
-            "patch" => Patch(sessionManager, directorId, command),
-            "create" => Create(sessionManager, directorId, command, services),
-            "wingman-goal" => WingmanGoal(sessionManager, command, services),
-            "set-role" => SetRole(sessionManager, directorId, command),
-            "attach-mission" => AttachMission(sessionManager, directorId, command, services),
-            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unknown verb '{command.Verb}'"),
-        };
+            FileLog.Write($"[SessionCommandExecutor] DispatchAsync: unknown verb '{command.Verb}'");
+            return new DirectorCommandResult
+            {
+                CommandId = command.CommandId,
+                Status = DirectorCommandStatus.BadRequest,
+                Error = $"unknown verb '{command.Verb}'",
+            };
+        }
+
+        var context = new SessionCommandContext(sessionManager, directorId, services, source);
+        var result = await area.ExecuteAsync(context, command, cancellationToken);
 
         result.CommandId = command.CommandId;
         FileLog.Write($"[SessionCommandExecutor] DispatchAsync result: verb={command.Verb}, sid={command.SessionId}, status={result.Status}");

--- a/src/CcDirector.ControlApi/SessionReadExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionReadExecutor.cs
@@ -1,0 +1,108 @@
+using CcDirector.Core.Agents;
+using CcDirector.Core.Claude;
+using CcDirector.Core.History;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0 (spine): the SESSION READ area of the tunnel command surface. It owns
+/// the per-session read verbs (the reply body is the resource DTO). The spine seeds it with ONE exemplar -
+/// <c>turns</c> - to fix the pattern a worker copies; Worker R1 fills in the rest (snapshot, buffer, summary,
+/// handover, brief, recap, and so on) by adding each verb to <see cref="Verbs"/> and a core method here.
+///
+/// The core is extracted verbatim from the Director's <c>GET /sessions/{sid}/turns</c> lambda. That REST
+/// route now calls this SAME core, so the tunnel verb and the route cannot drift (the core is the single
+/// source of truth); Phase 1 deletes the route and leaves the core reached only over the tunnel.
+/// </summary>
+internal sealed class SessionReadExecutor : ISessionCommandArea
+{
+    public IReadOnlyCollection<string> Verbs { get; } = new[] { "turns" };
+
+    public Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken)
+    {
+        var result = command.Verb switch
+        {
+            "turns" => Turns(context.SessionManager, command),
+            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the session read area"),
+        };
+        return Task.FromResult(result);
+    }
+
+    /// <summary>
+    /// The <c>turns</c> verb: the agent-agnostic conversation history widgets for a session. Mirrors the
+    /// Director's <c>GET /sessions/{sid}/turns</c> lambda exactly - invalid id -&gt; BadRequest, missing
+    /// session -&gt; NotFound - and returns a serialized <see cref="TurnsResponse"/> on success. Every
+    /// non-error branch (unsupported agent, not-yet-linked, missing JSONL, a parse failure) is a 200 status
+    /// with a <see cref="TurnsResponse.Status"/> string, exactly as the REST route returned; only a bad id
+    /// or a missing session are true error statuses. The parse try/catch is preserved from the source
+    /// because a parse failure is a DOMAIN state ("parse_error") the caller reads, not a fault to bubble.
+    /// </summary>
+    internal static DirectorCommandResult Turns(SessionManager sessionManager, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        var resp = new TurnsResponse
+        {
+            SessionId = command.SessionId,
+            ClaudeSessionId = session.ClaudeSessionId,
+        };
+
+        if (session.AgentKind != AgentKind.ClaudeCode)
+        {
+            if (!SessionHistoryReader.IsSupported(session))
+            {
+                resp.Status = "unsupported";
+                resp.Error = $"Agent {session.AgentKind} does not expose conversation history.";
+                return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(resp));
+            }
+
+            var history = SessionHistoryReader.Read(session);
+            resp.JsonlPath = SessionHistoryReader.ResolveTranscriptPath(session);
+            resp.LineCount = history.Messages.Count;
+            resp.Widgets = ControlEndpoints.BuildTurnWidgetsFromHistory(history);
+            resp.Status = "ok";
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(resp));
+        }
+
+        if (string.IsNullOrEmpty(session.ClaudeSessionId))
+        {
+            resp.Status = "no_session_id";
+            resp.Error = "Session has not been linked to a Claude session id yet.";
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(resp));
+        }
+
+        try
+        {
+            var jsonl = ClaudeSessionReader.GetJsonlPath(session.ClaudeSessionId, session.RepoPath);
+            resp.JsonlPath = jsonl;
+
+            if (!File.Exists(jsonl))
+            {
+                resp.Status = "no_jsonl";
+                resp.Error = $"JSONL file not found at {jsonl}";
+                return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(resp));
+            }
+
+            var messages = StreamMessageParser.ParseFile(jsonl);
+            resp.LineCount = messages.Count;
+            resp.Widgets = WidgetBuilder.BuildFromMessages(messages);
+            resp.Status = "ok";
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(resp));
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[SessionReadExecutor] turns FAILED: {ex.Message}");
+            resp.Status = "parse_error";
+            resp.Error = ex.Message;
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(resp));
+        }
+    }
+}

--- a/src/CcDirector.ControlApi/SessionWriteExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionWriteExecutor.cs
@@ -1,0 +1,109 @@
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0 (spine): the SESSION WRITE area of the tunnel command surface. It owns
+/// the per-session and director-level write verbs. The ten verbs that already rode the tunnel before this
+/// mission (prompt, interrupt, escape, hold, kill, patch, create, wingman-goal, set-role, attach-mission)
+/// keep their extracted cores in <see cref="SessionCommandExecutor"/> - unchanged and already tested - and
+/// this area simply routes to them, so there is ONE dispatch path with no legacy switch left behind. The
+/// spine adds two new exemplar cores here to fix the pattern a worker copies: <c>resize</c> (a clean
+/// representative write) and <c>terminal-input</c> (the unary keystroke write - NOT a stream verb, per
+/// Architect ruling A: it needs neither the connection nor the stream registry). Worker W1 fills in the
+/// remaining state writes; which of the ten legacy verbs later move their cores into this file is a refinement.
+/// </summary>
+internal sealed class SessionWriteExecutor : ISessionCommandArea
+{
+    public IReadOnlyCollection<string> Verbs { get; } = new[]
+    {
+        // The ten verbs that already rode the tunnel (cores in SessionCommandExecutor, routed here).
+        "prompt", "interrupt", "escape", "hold", "kill", "patch", "create", "wingman-goal", "set-role", "attach-mission",
+        // New spine exemplars owned here.
+        "resize", "terminal-input",
+    };
+
+    public async Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken)
+    {
+        var sessionManager = context.SessionManager;
+        return command.Verb switch
+        {
+            "prompt" => await SessionCommandExecutor.PromptAsync(sessionManager, command, context.Source),
+            "interrupt" => await SessionCommandExecutor.InterruptAsync(sessionManager, command),
+            "escape" => await SessionCommandExecutor.EscapeAsync(sessionManager, command),
+            "hold" => SessionCommandExecutor.Hold(sessionManager, command),
+            "kill" => await SessionCommandExecutor.KillAsync(sessionManager, command),
+            "patch" => SessionCommandExecutor.Patch(sessionManager, context.DirectorId, command),
+            "create" => SessionCommandExecutor.Create(sessionManager, context.DirectorId, command, context.Services),
+            "wingman-goal" => SessionCommandExecutor.WingmanGoal(sessionManager, command, context.Services),
+            "set-role" => SessionCommandExecutor.SetRole(sessionManager, context.DirectorId, command),
+            "attach-mission" => SessionCommandExecutor.AttachMission(sessionManager, context.DirectorId, command, context.Services),
+            "resize" => Resize(sessionManager, command),
+            "terminal-input" => TerminalInput(sessionManager, command),
+            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the session write area"),
+        };
+    }
+
+    /// <summary>
+    /// The <c>resize</c> verb: set a session's PTY grid so a remote terminal can use the full window width.
+    /// Mirrors the Director's <c>POST /sessions/{sid}/resize</c> lambda exactly - invalid id -&gt; BadRequest,
+    /// non-positive cols/rows -&gt; BadRequest, missing session -&gt; NotFound - and returns the resulting grid.
+    /// </summary>
+    internal static DirectorCommandResult Resize(SessionManager sessionManager, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var request = SessionCommandExecutor.Deserialize<ResizeRequest>(command.PayloadJson);
+        if (request is null || request.Cols <= 0 || request.Rows <= 0)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "cols and rows must be > 0");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        session.Resize((short)Math.Min(request.Cols, short.MaxValue), (short)Math.Min(request.Rows, short.MaxValue));
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new ResizeResponse
+        {
+            Accepted = true,
+            Cols = session.CurrentCols,
+            Rows = session.CurrentRows,
+        }));
+    }
+
+    /// <summary>
+    /// The <c>terminal-input</c> verb: forward a browser keystroke frame to the session's PTY, the same call
+    /// the live terminal stream's input pump made (<see cref="Session.SendInput(byte[])"/>). The payload is a
+    /// base64 byte blob so control bytes (arrows, Ctrl+C, Esc) survive the JSON envelope. Invalid id -&gt;
+    /// BadRequest, missing/undecodable bytes -&gt; BadRequest, missing session -&gt; NotFound. This is a plain
+    /// unary write; it is NOT a stream verb (Architect ruling A). The Gateway wires the browser's keystrokes
+    /// to this verb in Phase 2; the spine adds the core and makes it dispatchable and testable now.
+    /// </summary>
+    internal static DirectorCommandResult TerminalInput(SessionManager sessionManager, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var request = SessionCommandExecutor.Deserialize<TerminalInputRequest>(command.PayloadJson);
+        if (request is null || string.IsNullOrEmpty(request.Bytes))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "bytes are required");
+
+        byte[] bytes;
+        try
+        {
+            bytes = Convert.FromBase64String(request.Bytes);
+        }
+        catch (FormatException)
+        {
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "bytes must be base64");
+        }
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        session.SendInput(bytes);
+        return DirectorCommandResult.Success();
+    }
+}

--- a/src/CcDirector.Gateway.Contracts/PromptRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/PromptRequest.cs
@@ -72,6 +72,35 @@ public sealed class ResizeRequest
     public int Rows { get; set; }
 }
 
+/// <summary>
+/// Response of the resize verb / POST /sessions/{sid}/resize: the grid the session settled on after the
+/// resize (clamped to the PTY's limits). Gateway Cleanup mission, Phase 0: the resize verb returns this so
+/// the REST route and the tunnel verb share one typed body.
+/// </summary>
+public sealed class ResizeResponse
+{
+    /// <summary>Always true on success (the resize was applied).</summary>
+    public bool Accepted { get; set; }
+
+    /// <summary>The session's resulting column count.</summary>
+    public int Cols { get; set; }
+
+    /// <summary>The session's resulting row count.</summary>
+    public int Rows { get; set; }
+}
+
+/// <summary>
+/// Payload of the terminal-input verb (Gateway Cleanup mission, Phase 0): a browser keystroke frame to
+/// forward verbatim to the session's PTY. The bytes are base64-encoded so control bytes (arrows, Ctrl+C,
+/// Esc) survive the JSON envelope intact. The target session is the command's SessionId. This is a plain
+/// unary write, not a stream verb.
+/// </summary>
+public sealed class TerminalInputRequest
+{
+    /// <summary>The raw keystroke bytes, base64-encoded.</summary>
+    public string Bytes { get; set; } = "";
+}
+
 /// <summary>Body of the git stage/unstage/discard endpoints. Empty paths means "all" (stage/unstage only).</summary>
 public sealed class GitPathsRequest
 {

--- a/src/CcDirector.Gateway.Tests/SessionCommandExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionCommandExecutorTests.cs
@@ -939,4 +939,220 @@ public sealed class SessionCommandExecutorTests
             sm.Dispose();
         }
     }
+
+    [Fact]
+    public async Task DispatchAsync_UnknownVerb_NamesTheVerb()
+    {
+        // Fail loud: the unknown-verb result names the offending verb (Gateway Cleanup Phase 0, Ruling B).
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var command = new DirectorCommand { Verb = "totally-made-up-verb", SessionId = Guid.NewGuid().ToString() };
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command);
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+            Assert.Contains("totally-made-up-verb", result.Error);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- turns (Gateway Cleanup Phase 0: representative READ exemplar) ----------
+
+    private static DirectorCommand TurnsCommand(string sid) => new() { CommandId = "t1", Verb = "turns", SessionId = sid };
+
+    [Fact]
+    public async Task DispatchAsync_Turns_InvalidSessionId_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", TurnsCommand("not-a-guid"));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_Turns_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", TurnsCommand(Guid.NewGuid().ToString()));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_Turns_ClaudeSessionNotYetLinked_ReturnsOkWithNoSessionIdStatus()
+    {
+        // A fresh ClaudeCode session has no Claude session id yet: the REST route returned this as a 200 with
+        // status "no_session_id" (a domain state, not an error), so the tunnel verb returns DirectorCommandStatus.Ok
+        // with that body. This exercises the read returning a serialized DTO on the success path.
+        var (sm, session, _) = NewSession();
+        try
+        {
+            Assert.True(string.IsNullOrEmpty(session.ClaudeSessionId));
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", TurnsCommand(session.Id.ToString()));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal("t1", result.CommandId);
+            var resp = JsonSerializer.Deserialize<TurnsResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(resp);
+            Assert.Equal("no_session_id", resp.Status);
+            Assert.Equal(session.Id.ToString(), resp.SessionId);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- resize (Gateway Cleanup Phase 0: representative WRITE exemplar) ----------
+
+    private static DirectorCommand ResizeCommand(string sid, int cols, int rows) => new()
+    {
+        CommandId = "rz1",
+        Verb = "resize",
+        SessionId = sid,
+        PayloadJson = JsonSerializer.Serialize(new ResizeRequest { Cols = cols, Rows = rows }, Json),
+    };
+
+    [Fact]
+    public async Task DispatchAsync_Resize_ValidGrid_ReturnsAcceptedAndSettledGrid()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", ResizeCommand(session.Id.ToString(), 100, 40));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal("rz1", result.CommandId);
+            var resp = JsonSerializer.Deserialize<ResizeResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(resp);
+            Assert.True(resp.Accepted);
+            // The verb reports the grid the session actually settled on (clamped to the PTY's limits).
+            Assert.Equal((int)session.CurrentCols, resp.Cols);
+            Assert.Equal((int)session.CurrentRows, resp.Rows);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_Resize_NonPositiveGrid_ReturnsBadRequest()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", ResizeCommand(session.Id.ToString(), 0, 40));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_Resize_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", ResizeCommand(Guid.NewGuid().ToString(), 100, 40));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_Resize_InvalidSessionId_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", ResizeCommand("not-a-guid", 100, 40));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- terminal-input (Gateway Cleanup Phase 0: the unary keystroke write, NOT a stream verb) ----------
+
+    private static DirectorCommand TerminalInputCommand(string sid, string base64Bytes) => new()
+    {
+        CommandId = "ti1",
+        Verb = "terminal-input",
+        SessionId = sid,
+        PayloadJson = JsonSerializer.Serialize(new TerminalInputRequest { Bytes = base64Bytes }, Json),
+    };
+
+    [Fact]
+    public async Task DispatchAsync_TerminalInput_DeliversBytesToSession()
+    {
+        var (sm, session, backend) = NewSession();
+        try
+        {
+            var bytes = Encoding.UTF8.GetBytes("hi");
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", TerminalInputCommand(session.Id.ToString(), Convert.ToBase64String(bytes)));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal("ti1", result.CommandId);
+            Assert.NotNull(backend.Buffer);
+            var written = Encoding.UTF8.GetString(backend.Buffer.DumpAll());
+            Assert.Contains("hi", written);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_TerminalInput_NotBase64_ReturnsBadRequest()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", TerminalInputCommand(session.Id.ToString(), "not valid base64 !!!"));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_TerminalInput_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", TerminalInputCommand(Guid.NewGuid().ToString(), Convert.ToBase64String(new byte[] { 1, 2, 3 })));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- composition: fail loud on a duplicate verb (Gateway Cleanup Phase 0, Ruling B) ----------
+
+    private sealed class StubArea : ISessionCommandArea
+    {
+        public StubArea(params string[] verbs) => Verbs = verbs;
+        public IReadOnlyCollection<string> Verbs { get; }
+        public Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken) =>
+            Task.FromResult(DirectorCommandResult.Success());
+    }
+
+    [Fact]
+    public void BuildVerbMap_DuplicateVerbAcrossAreas_ThrowsNamingTheVerb()
+    {
+        var areas = new ISessionCommandArea[] { new StubArea("alpha", "beta"), new StubArea("beta", "gamma") };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => SessionCommandExecutor.BuildVerbMap(areas));
+        Assert.Contains("beta", ex.Message);
+    }
+
+    [Fact]
+    public void BuildVerbMap_DistinctVerbs_BuildsMap()
+    {
+        var areas = new ISessionCommandArea[] { new StubArea("one", "two"), new StubArea("three") };
+
+        var map = SessionCommandExecutor.BuildVerbMap(areas);
+
+        Assert.Equal(3, map.Count);
+        Assert.True(map.ContainsKey("one"));
+        Assert.True(map.ContainsKey("three"));
+    }
 }


### PR DESCRIPTION
## What this is

Gateway Cleanup mission, Phase 0 (the tunnel protocol) - the first of two additive spine units. It introduces the command-area dispatch structure that every later read and write verb plugs into. It changes no behavior and deletes nothing; it is purely additive groundwork so Phase 1 can later delete the Director's remote REST surface with the tunnel path already in place.

Design authority: docs/architecture/gateway-cleanup-phase0-tunnel-protocol.md (Architect ruling B, settled 2026-07-12).

## The change

- A small command-area contract (`ISessionCommandArea`: its verbs plus one execute method) with five area classes - session reads, catalog reads, session writes, queue and git writes, and the unary byte area.
- One verb-to-area dictionary composed once at startup from each area's declared verb list. A verb declared by two areas throws at composition, naming both areas and the verb (fail loud, never a silent shadow); an unknown verb fails loud naming the verb. This removes the merge chokepoint: a worker adds a verb by editing only its own area file, never a shared central switch.
- The ten verbs that already rode the tunnel now route through the session write area, delegating to their unchanged existing cores, so there is one dispatch path with no legacy switch left behind.
- Two exemplar cores fix the pattern the remaining verbs copy: `turns` (a representative read) and `resize` (a representative write), plus `terminal-input` (the unary keystroke write - not a stream verb, per the Architect ruling). Their REST routes now call the same cores as the tunnel, so the two paths cannot drift.

## Tests

Parity tests for `turns`, `resize`, and `terminal-input` (invalid id, missing session, and the success body), plus composition tests for the fail-loud duplicate-verb guard. The existing dispatch, stream, host, and Director-surface suites stay green.

## Not in this PR

The up-stream primitive (the `StreamUp` receiver and registry, the Director-side producers, and the connection-bound stream verbs) is spine part 2 and lands as its own separate pull request on top of this one.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>