### PR TITLE
fix(carmode): v5 - pin screen to visible viewport (button on-screen) + responsive-first

### DIFF
--- a/apps/mobile/src/pages/CarMode.tsx
+++ b/apps/mobile/src/pages/CarMode.tsx
@@ -9,7 +9,7 @@ import { useScreenWakeLock } from "../hooks/useScreenWakeLock";
 // the old git short-sha + timestamp badge was replaced by a plain human version. BUMP THIS INTEGER BY HAND
 // ON EVERY DEPLOY of the mobile app (v1 -> v2 -> v3 ...), so a glance at the corner tells the owner and the
 // Architect exactly which page is live and what to look for after a deploy.
-const CAR_MODE_VERSION = "v4";
+const CAR_MODE_VERSION = "v5";
 
 // Car Mode (Car Mode mission): the standalone, chrome-less, full-screen page the owner opens to run
 // the whole fleet by voice, hands-free, phone in his pocket. It is a THIN view over the shared
@@ -31,6 +31,34 @@ export function CarMode() {
   // Car Mode is eyes-free with the phone in a pocket: keep the screen awake the whole time (mission
   // Phase 1: a standalone page under /m with a screen wake-lock).
   useScreenWakeLock();
+
+  // v5 - PIN THE SCREEN HEIGHT TO THE ACTUALLY-VISIBLE VIEWPORT. On the owner's Android PWA, CSS `dvh`
+  // proved unreliable: the fixed .car-screen stayed taller than the visible area, so the footer's primary
+  // button rendered BELOW the phone's bottom browser toolbar (cut off), in both idle and active states.
+  // window.visualViewport.height is the true visible height (it excludes the toolbars and the keyboard), so
+  // we publish it into the `--car-vh` CSS variable and the stylesheet sizes .car-screen to it (with a `dvh`
+  // fallback for the first paint / browsers without visualViewport). We refresh on every visualViewport
+  // resize/scroll and on orientation change, so it re-fits as the toolbars show and hide.
+  useEffect(() => {
+    const vv = window.visualViewport;
+    const root = document.documentElement;
+    const apply = () => {
+      const height = vv !== null ? vv.height : window.innerHeight;
+      root.style.setProperty("--car-vh", `${Math.round(height)}px`);
+    };
+    apply();
+    vv?.addEventListener("resize", apply);
+    vv?.addEventListener("scroll", apply);
+    window.addEventListener("resize", apply);
+    window.addEventListener("orientationchange", apply);
+    return () => {
+      vv?.removeEventListener("resize", apply);
+      vv?.removeEventListener("scroll", apply);
+      window.removeEventListener("resize", apply);
+      window.removeEventListener("orientationchange", apply);
+      root.style.removeProperty("--car-vh");
+    };
+  }, []);
 
   // The injected brain responder. Phase 2+: the real fleet brain. The stand-in (below) just echoes the
   // heard command so Phase 1's barge-in proof needs no server and no credits.

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -2584,11 +2584,7 @@ a.banner-btn {
   position: fixed;
   /* Anchor top/left/right ONLY - deliberately NOT `inset: 0`. `inset: 0` sets both top:0 AND bottom:0,
      which OVER-CONSTRAINS a fixed box: its height is then derived from top+bottom (the tall, toolbar-
-     hidden LAYOUT viewport) and the `height: 100dvh` below is IGNORED. The box then extends BELOW the
-     phone's bottom browser toolbar, pushing the footer's primary button off the visible area (the
-     "button cut off" bug, v4). Anchoring top-only lets `height: 100dvh` win, so the box tracks the
-     DYNAMIC visible viewport and the footer sits above the toolbar - the same reason .terminal-screen
-     uses dvh, not vh. */
+     hidden LAYOUT viewport) and the height below is IGNORED. Anchoring top-only lets the height win. */
   top: 0;
   left: 0;
   right: 0;
@@ -2596,10 +2592,29 @@ a.banner-btn {
   flex-direction: column;
   background: var(--bg);
   color: var(--text);
+  /* v5 - HEIGHT IS PINNED TO THE ACTUALLY-VISIBLE VIEWPORT via --car-vh (set from
+     window.visualViewport.height in CarMode.tsx). On the owner's Android PWA, `dvh` did NOT track the
+     visible height reliably, so the box stayed taller than the screen and the footer's primary button
+     rendered below the bottom browser toolbar (cut off), idle AND active. --car-vh is the real visible
+     height (excludes the toolbars/keyboard); the fallbacks (100dvh, then 100vh) cover the first paint
+     before the effect runs and browsers without visualViewport. */
   height: 100vh;
   height: 100dvh;
+  height: var(--car-vh, 100dvh);
   max-height: 100dvh;
+  max-height: var(--car-vh, 100dvh);
   overflow: hidden;
+}
+/* The pin only works if the column lays out as: header (natural) -> middle (absorbs + scrolls) -> footer
+   (natural, at the bottom, NEVER pushed off). The middle is the single give-point, so no matter how tall
+   the body content gets, the footer's buttons stay laid out at the bottom of the visible viewport. */
+.car-screen > .car-middle {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.car-screen > .car-bar,
+.car-screen > .car-foot {
+  flex: 0 0 auto;
 }
 .car-bar {
   flex: 0 0 auto;

--- a/packages/client-core/src/carmode/carModeApi.test.ts
+++ b/packages/client-core/src/carmode/carModeApi.test.ts
@@ -109,7 +109,9 @@ describe("postCarModeTelemetry", () => {
   const record = {
     turnId: "t1", pauseToTranscribeMs: 900, transcodeMs: 120, brainMs: 1200, ttsMs: 300, firstAudioMs: 350,
     totalTurnMs: 2450, transcribeAttempts: 1, chunks: 1, playMs: 4200, clipDurationMs: 4300, playedToMs: 4200,
-    completed: true, playRejected: false, micReacquiredDuringPlayback: true, speakingPollCount: 3, serverTotalMs: 1100, modelCallCount: 1,
+    completed: true, playRejected: false, micReacquiredDuringPlayback: true, speakingPollCount: 3,
+    viewportInnerHeight: 915, visualViewportHeight: 740, documentClientHeight: 915, footerBottom: 700, footerVisible: true,
+    serverTotalMs: 1100, modelCallCount: 1,
     modelMsTotal: 1050, modelMs: [1050], fleetReadCount: 0, fleetReadMsTotal: 0, rounds: 1, commandChars: 20,
     replyChars: 40, actionsCount: 0, pendingConfirmation: false,
   };

--- a/packages/client-core/src/carmode/carModeApi.ts
+++ b/packages/client-core/src/carmode/carModeApi.ts
@@ -156,6 +156,20 @@ export interface CarModeTelemetryPost {
   micReacquiredDuringPlayback: boolean;
   /** How many rolling-"stop" transcriptions ran during this reply (each re-reads the open mic). */
   speakingPollCount: number;
+  /** window.innerHeight on the phone at telemetry time - the layout viewport height (the tall,
+   *  toolbar-hidden height on mobile). */
+  viewportInnerHeight: number;
+  /** window.visualViewport.height - the ACTUALLY visible height (minus the browser toolbars / keyboard), or
+   *  0 if the API is unavailable. This is the height the fixed Car Mode screen must match, and dvh proved
+   *  unreliable at tracking it in the owner's Android PWA (why v5 pins the container to this number). */
+  visualViewportHeight: number;
+  /** document.documentElement.clientHeight - a third, independent viewport read to cross-check the other two. */
+  documentClientHeight: number;
+  /** The .car-foot element's getBoundingClientRect().bottom in pixels: where the primary buttons actually end. */
+  footerBottom: number;
+  /** footerBottom <= the visible viewport height: TRUE only when the buttons are ON-SCREEN. The direct,
+   *  from-the-phone proof of whether the button-cut-off bug is fixed - false means still cut off. */
+  footerVisible: boolean;
   serverTotalMs: number;
   modelCallCount: number;
   modelMsTotal: number;

--- a/packages/client-core/src/carmode/useCarMode.ts
+++ b/packages/client-core/src/carmode/useCarMode.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { MicRecorder } from "../dictation/recorder";
 import { blobToWav16kMono } from "../dictation/wav";
-import { playReadyCue, playYourTurnCue } from "../dictation/readyCue";
+import { playReadyCue, playYourTurnCue, startThinkingCue } from "../dictation/readyCue";
 import { detectEndPhrase } from "./controlPhrases";
 import { playClip, type PlayOutcome, type PlayClipHooks } from "./audioPlayback";
 import {
@@ -84,6 +84,12 @@ interface TurnMetrics {
   // ----- Mic-during-playback proof (v3: the mic is released while the reply plays, so these read healthy) -----
   micReacquiredDuringPlayback: boolean; // v3: always false (the mic is never re-opened during playback); kept to PROVE it
   speakingPollCount: number; // v3: always 0 (no rolling-"stop" transcription runs during the reply)
+  // ----- Real viewport measurements (v5: the button-cut-off diagnostic, read from HIS phone, not desktop) -----
+  viewportInnerHeight: number; // window.innerHeight at telemetry time (the layout viewport height)
+  visualViewportHeight: number; // window.visualViewport.height (the ACTUALLY visible height, minus toolbars) or 0
+  documentClientHeight: number; // document.documentElement.clientHeight (a third viewport read to cross-check)
+  footerBottom: number; // the .car-foot element's getBoundingClientRect().bottom (where the buttons end, in px)
+  footerVisible: boolean; // footerBottom <= the visible viewport height: TRUE only when the buttons are on-screen
   posted: boolean;
 }
 
@@ -225,6 +231,11 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
   // The playback "stop now" resolver: set while the reply clip is playing so the touch Stop button or End
   // Car Mode can end the play promise and unblock the speak loop.
   const playbackStopRef = useRef<(() => void) | null>(null);
+  // The "thinking" ambient cue's stopper (v5): set the instant the owner taps "Over and out" (in the tap
+  // gesture, so mobile lets it sound) and called the instant the reply audio starts, so the ~2s of silent
+  // work is filled with a gentle working tone. Also cleared when the mic returns to the owner or the
+  // session ends, so it can never leak past its turn.
+  const thinkingCueStopRef = useRef<(() => void) | null>(null);
 
   // The phase, read synchronously inside the loop/timer callbacks (not a React render). A ref mirror
   // avoids a stale closure so the machine always branches on the CURRENT phase.
@@ -239,6 +250,13 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
       URL.revokeObjectURL(clipUrlRef.current);
       clipUrlRef.current = null;
     }
+  }, []);
+
+  // Stop the "thinking" ambient cue if it is playing (v5). Idempotent: safe to call whether or not a cue
+  // is running. Called when the reply audio starts, when the mic returns to the owner, and on teardown.
+  const stopThinkingCue = useCallback(() => {
+    thinkingCueStopRef.current?.();
+    thinkingCueStopRef.current = null;
   }, []);
 
   // Post one turn's merged timing record ONCE (guards double-post). Only a real brain turn (with a server
@@ -264,6 +282,11 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
       playRejected: m.playRejected,
       micReacquiredDuringPlayback: m.micReacquiredDuringPlayback,
       speakingPollCount: m.speakingPollCount,
+      viewportInnerHeight: m.viewportInnerHeight,
+      visualViewportHeight: m.visualViewportHeight,
+      documentClientHeight: m.documentClientHeight,
+      footerBottom: m.footerBottom,
+      footerVisible: m.footerVisible,
       serverTotalMs: m.server.totalMs,
       modelCallCount: m.server.modelCallCount,
       modelMsTotal: m.server.modelMsTotal,
@@ -348,6 +371,8 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
   // Enter Listening: the microphone is the owner's again. Play the "your turn" cue, clear the on-screen
   // transcript for the fresh turn, and open a clean capture segment (a fresh getUserMedia stream).
   const enterListening = useCallback(async () => {
+    // The mic is the owner's again: make sure the "thinking" ambient cue is not still running (v5).
+    stopThinkingCue();
     setPhaseBoth("listening");
     setError(null);
     playYourTurnCue();
@@ -357,7 +382,7 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     setCaptureError(null);
     setCaptureState("listening");
     await restartCapture();
-  }, [restartCapture, setPhaseBoth]);
+  }, [restartCapture, setPhaseBoth, stopThinkingCue]);
 
   // Synthesize `text` through the one good Gateway voice and play the WHOLE reply with the microphone fully
   // RELEASED (v3): nothing touches getUserMedia while the reply plays, because re-opening the mic mid-
@@ -397,6 +422,9 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
         // re-opens it here, which is the whole point of v3.
         const played = playBlob(url, {
           onPlayStarted: () => {
+            // The reply is now sounding: stop the gentle "thinking" ambient cue so it does not play under
+            // the reply (v5 - the ambient fills only the silent working gap, never overlaps the answer).
+            stopThinkingCue();
             if (metrics === null) return;
             const nowMs = performance.now();
             metrics.chunks = 1;
@@ -424,6 +452,27 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
             // the /carmode/telemetry dashboard can PROVE the mic stayed released this turn.
             metrics.micReacquiredDuringPlayback = false;
             metrics.speakingPollCount = 0;
+            // v5: capture the REAL viewport numbers from THIS phone so the button-cut-off bug is proven from
+            // his device, not guessed from desktop. innerHeight (layout viewport), visualViewport.height (the
+            // ACTUALLY visible height minus browser toolbars), and documentElement.clientHeight are three
+            // independent reads; footerBottom is where the buttons actually end, and footerVisible is the
+            // bottom line: is that below or at the visible viewport bottom (buttons on-screen) or past it
+            // (cut off). Measured now, while the active footer with its buttons is on screen.
+            const vv = typeof window !== "undefined" ? window.visualViewport : null;
+            const innerH = typeof window !== "undefined" ? window.innerHeight : 0;
+            const clientH =
+              typeof document !== "undefined" ? document.documentElement.clientHeight : 0;
+            const visualH = vv !== null ? vv.height : 0;
+            const footEl =
+              typeof document !== "undefined" ? document.querySelector(".car-foot") : null;
+            const footBottom = footEl !== null ? footEl.getBoundingClientRect().bottom : 0;
+            const viewportH = visualH > 0 ? visualH : innerH;
+            metrics.viewportInnerHeight = innerH;
+            metrics.visualViewportHeight = visualH;
+            metrics.documentClientHeight = clientH;
+            metrics.footerBottom = footBottom;
+            // +1px tolerance for sub-pixel rounding. Only true when the footer's bottom edge is within view.
+            metrics.footerVisible = footBottom > 0 && viewportH > 0 ? footBottom <= viewportH + 1 : false;
             // Post the merged timing record now that the clip's whole lifecycle is known - including a
             // cut-off - so a truncated reply is VISIBLE at /carmode/telemetry (fire-and-forget).
             postTurnTelemetry(metrics);
@@ -448,15 +497,17 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
         await enterListening();
       }
     },
-    [announceError, enterListening, playBlob, postTurnTelemetry, revokeClip, setPhaseBoth],
+    [announceError, enterListening, playBlob, postTurnTelemetry, revokeClip, setPhaseBoth, stopThinkingCue],
   );
 
   // Take the turn: the command (already stripped of "over and out") is answered by the brain and the reply
   // is spoken. Guards against double-entry so a touch tap and a pause probe cannot both fire one turn.
   const takeTurn = useCallback(
     async (command: string) => {
-      if (phaseRef.current !== "listening") return;
-      setPhaseBoth("thinking");
+      // v5: the screen is switched to Thinking SYNCHRONOUSLY in the endTurn tap handler (responsive-first),
+      // so by the time this runs the phase is already "thinking" - guard on that (not "listening") so the
+      // turn proceeds, while a second rapid tap is still a no-op (endTurn's own listening-guard blocks it).
+      if (phaseRef.current !== "thinking") return;
       // Stop AND release the microphone before Thinking + Speaking: no getUserMedia stays open while the
       // brain works and the reply plays (v3 - the mic must not touch the audio session during playback).
       const rec = recorderRef.current;
@@ -573,15 +624,24 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
         playRejected: false,
         micReacquiredDuringPlayback: false,
         speakingPollCount: 0,
+        viewportInnerHeight: 0,
+        visualViewportHeight: 0,
+        documentClientHeight: 0,
+        footerBottom: 0,
+        footerVisible: false,
         posted: false,
       };
       void takeTurn(command);
     } catch (err) {
+      // The transcribe failed while we are already in Thinking (v5): silence the ambient cue and hand the
+      // microphone back to the owner so the screen does not stall on Thinking after a failure.
+      stopThinkingCue();
       const msg = gatewayErrorMessage(err);
       setCaptureError(msg);
       announceError(msg);
+      await enterListening();
     }
-  }, [announceError, takeTurn]);
+  }, [announceError, enterListening, stopThinkingCue, takeTurn]);
 
   // Touch controls (the app is fully usable by touch - this is the primary path in v3). "Over and out"
   // ends the turn by transcribing what was captured; "Stop" cuts the reply off instantly (the sole
@@ -590,11 +650,21 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     if (phaseRef.current !== "listening") return;
     // v4: fire the "my turn" acknowledgement cue SYNCHRONOUSLY as the FIRST thing on tap, before any of
     // the async end-of-turn work (mic snapshot -> WAV transcode -> transcribe round trip). That async
-    // work took ~2 seconds, so the cue used to lag the tap badly; firing it here gives an immediate
+    // work takes ~2 seconds, so the cue used to lag the tap badly; firing it here gives an immediate
     // (<150ms) audible "got it". Firing inside the tap gesture also guarantees mobile permits it to sound.
     playReadyCue();
+    // v5 (responsive-first): switch the SCREEN to Thinking SYNCHRONOUSLY too, so the orb/status change the
+    // instant he taps instead of sitting on Listening for the whole ~2s transcribe+brain+tts. This also
+    // makes the takeTurn guard (which now checks for "thinking") pass, and blocks a double-tap (a second
+    // endTurn sees phase != "listening" and no-ops).
+    setPhaseBoth("thinking");
+    setCaptureState("thinking");
+    // And fill the silent working gap with the gentle ambient droplet, started HERE inside the tap gesture
+    // so mobile lets its audio run; speakAndPlay stops it the instant the reply starts.
+    stopThinkingCue();
+    thinkingCueStopRef.current = startThinkingCue();
     void transcribeAndTake();
-  }, [transcribeAndTake]);
+  }, [setPhaseBoth, stopThinkingCue, transcribeAndTake]);
 
   const interrupt = useCallback(() => {
     if (phaseRef.current !== "speaking") return;
@@ -647,6 +717,8 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     // Unblock any in-flight playback so the speak loop unwinds instead of awaiting an ended event that will
     // never fire.
     playbackStopRef.current?.();
+    // Silence the "thinking" ambient cue if the session ends mid-turn (v5).
+    stopThinkingCue();
     if (keepWarmRef.current !== null) {
       clearInterval(keepWarmRef.current);
       keepWarmRef.current = null;
@@ -671,13 +743,14 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     setStarted(false);
     setCaptureState("not started");
     setPhaseBoth("idle");
-  }, [revokeClip, setPhaseBoth]);
+  }, [revokeClip, setPhaseBoth, stopThinkingCue]);
 
   // Tear everything down if the page unmounts mid-session (navigating away from Car Mode).
   useEffect(() => {
     return () => {
       abortRef.current?.abort();
       playbackStopRef.current?.();
+      thinkingCueStopRef.current?.();
       if (keepWarmRef.current !== null) clearInterval(keepWarmRef.current);
       try {
         recorderRef.current?.dispose();

--- a/packages/client-core/src/dictation/readyCue.ts
+++ b/packages/client-core/src/dictation/readyCue.ts
@@ -50,6 +50,74 @@ export function playReadyCue(): void {
 }
 
 /**
+ * Start the Car Mode "thinking" ambient cue and return a function that stops it. Played WHILE the brain
+ * works (after the owner taps "Over and out"), so the ~2s of transcribe -> brain -> text-to-speech is not
+ * dead silence - the owner hears, gently, that his turn was taken and is being worked. It reuses the
+ * dictation water-droplet character (playReadyCue) but SOFT and LOW-VOLUME (Grok-style gentle, peak ~0.07
+ * vs the ack cue's 0.5), repeating slowly, so it is an unobtrusive "working" texture, NOT the sharp ack
+ * "plink". The caller stops it the instant the reply audio starts (see useCarMode speakAndPlay). Same
+ * best-effort contract as the other cues - it is synthesized with the Web Audio API (no bundled asset) and
+ * never throws; if audio output is unavailable the returned stop function is a harmless no-op.
+ *
+ * It MUST be started from within a user gesture (the "Over and out" tap) so mobile lets its AudioContext
+ * run; a context created past the gesture would stay suspended and silent.
+ */
+export function startThinkingCue(): () => void {
+  try {
+    const AudioCtor =
+      window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AudioCtor) return () => {};
+
+    const ctx = new AudioCtor();
+    if (ctx.state === "suspended") void ctx.resume();
+
+    let stopped = false;
+
+    // One soft droplet: the same rising-glide plink as the ack cue but at a fraction of the volume, so it
+    // reads as a calm, distant "working" tone rather than a foreground beep.
+    const drop = () => {
+      if (stopped || ctx.state === "closed") return;
+      const now = ctx.currentTime;
+      const duration = 0.18;
+
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = "sine";
+      osc.frequency.setValueAtTime(300, now);
+      osc.frequency.exponentialRampToValueAtTime(640, now + duration * 0.9);
+
+      gain.gain.setValueAtTime(0.0001, now);
+      // Peak ~0.07 - deliberately gentle (the ack cue peaks at 0.5). Low enough to sit under the room, so
+      // it never competes with the reply that follows.
+      gain.gain.exponentialRampToValueAtTime(0.07, now + 0.02);
+      gain.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+
+      osc.connect(gain).connect(ctx.destination);
+      osc.start(now);
+      osc.stop(now + duration + 0.02);
+    };
+
+    drop();
+    // A slow, unhurried repeat (~1.4s) so it is an ambient pulse, not a rapid alarm.
+    const timer = window.setInterval(drop, 1400);
+
+    return () => {
+      if (stopped) return;
+      stopped = true;
+      window.clearInterval(timer);
+      try {
+        void ctx.close();
+      } catch {
+        // context already closed; nothing to do
+      }
+    };
+  } catch {
+    // Best-effort courtesy cue; if audio output is unavailable, hand back a no-op stopper.
+    return () => {};
+  }
+}
+
+/**
  * Play the Car Mode "your turn" cue once - the second, deliberately DIFFERENT turn-boundary tone
  * (Car Mode mission, "The audible handshake"). It fires when the assistant finishes speaking (or is
  * interrupted) and the microphone is live again for the owner, so - eyes-free, phone in pocket - he

--- a/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
@@ -130,6 +130,11 @@ internal static class CarModeEndpoint
                 PlayRejected = req.PlayRejected,
                 MicReacquiredDuringPlayback = req.MicReacquiredDuringPlayback,
                 SpeakingPollCount = req.SpeakingPollCount,
+                ViewportInnerHeight = req.ViewportInnerHeight,
+                VisualViewportHeight = req.VisualViewportHeight,
+                DocumentClientHeight = req.DocumentClientHeight,
+                FooterBottom = req.FooterBottom,
+                FooterVisible = req.FooterVisible,
                 ServerTotalMs = req.ServerTotalMs,
                 ModelCallCount = req.ModelCallCount,
                 ModelMsTotal = req.ModelMsTotal,
@@ -205,6 +210,11 @@ public sealed class CarModeTelemetryPost
     public bool PlayRejected { get; set; }
     public bool MicReacquiredDuringPlayback { get; set; }
     public int SpeakingPollCount { get; set; }
+    public double ViewportInnerHeight { get; set; }
+    public double VisualViewportHeight { get; set; }
+    public double DocumentClientHeight { get; set; }
+    public double FooterBottom { get; set; }
+    public bool FooterVisible { get; set; }
     public double ServerTotalMs { get; set; }
     public int ModelCallCount { get; set; }
     public double ModelMsTotal { get; set; }

--- a/src/CcDirector.Gateway/CarMode/CarModeTelemetry.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeTelemetry.cs
@@ -136,6 +136,31 @@ public sealed record CarModeTelemetryRecord
     ///  stream; more polls mean more mic contention while the reply was supposed to be playing.</summary>
     public int SpeakingPollCount { get; init; }
 
+    // ----- Real viewport measurements (v5: the button-cut-off diagnostic, read from the phone) -----
+
+    /// <summary>window.innerHeight on the phone at telemetry time - the layout viewport height (the tall,
+    ///  toolbar-hidden height on mobile).</summary>
+    public double ViewportInnerHeight { get; init; }
+
+    /// <summary>window.visualViewport.height - the ACTUALLY visible height (minus the browser toolbars and
+    ///  the on-screen keyboard), or 0 if the API is unavailable. This is the height the fixed Car Mode screen
+    ///  must match; `dvh` proved unreliable at tracking it in the owner's Android PWA, which is why v5 pins
+    ///  the container to this number.</summary>
+    public double VisualViewportHeight { get; init; }
+
+    /// <summary>document.documentElement.clientHeight - a third, independent viewport read to cross-check the
+    ///  other two.</summary>
+    public double DocumentClientHeight { get; init; }
+
+    /// <summary>The .car-foot element's getBoundingClientRect().bottom in pixels: where the primary buttons
+    ///  actually end on screen.</summary>
+    public double FooterBottom { get; init; }
+
+    /// <summary>FooterBottom &lt;= the visible viewport height: true only when the primary buttons are
+    ///  ON-SCREEN. The direct, from-the-phone proof of whether the button-cut-off bug is fixed - false means
+    ///  the buttons were still cut off on the owner's device.</summary>
+    public bool FooterVisible { get; init; }
+
     // ----- Server stamps (from CarModeTurnTiming, echoed back by the client) -----
 
     public double ServerTotalMs { get; init; }

--- a/src/CcDirector.Gateway/CarMode/CarModeTelemetryPage.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeTelemetryPage.cs
@@ -63,7 +63,7 @@ internal static class CarModeTelemetryPage
 <body>
 <div class="wrap">
   <h1>Car Mode Timing</h1>
-  <p class="sub">Per-turn, per-stage latency AND the two mobile failure diagnostics for hands-free Car Mode. The pipeline a real phone turn walks: pause, transcode (phone), transcribe, brain round trip, the network gap (brain minus server), each model call, the fleet read, text-to-speech, and first audio. The "over and out" finickiness shows as End-phrase tries (how many transcribe attempts before the turn was taken). The cut-off reply is split several ways: Clip length (the whole reply synthesized), Played to (how far playback reached), Play blocked (the reply's play() was refused by the mobile autoplay policy so it never sounded - the data-confirmed failure), and Mic in playback (whether the rolling "stop" watch re-opened the microphone while the reply was playing - a secondary suspect). All times are milliseconds. Counts and timings only; no command or reply text is ever recorded.</p>
+  <p class="sub">Per-turn, per-stage latency AND the two mobile failure diagnostics for hands-free Car Mode. The pipeline a real phone turn walks: pause, transcode (phone), transcribe, brain round trip, the network gap (brain minus server), each model call, the fleet read, text-to-speech, and first audio. The "over and out" finickiness shows as End-phrase tries (how many transcribe attempts before the turn was taken). The cut-off reply is split several ways: Clip length (the whole reply synthesized), Played to (how far playback reached), Play blocked (the reply's play() was refused by the mobile autoplay policy so it never sounded - the data-confirmed failure), and Mic in playback (whether the rolling "stop" watch re-opened the microphone while the reply was playing - a secondary suspect). The button-cut-off bug is proven from the phone: Buttons on-screen (were the primary buttons within the visible viewport this turn), Footer bottom (where the buttons end, in pixels), and the three raw viewport reads (Visual vp = window.visualViewport.height, Inner vp = window.innerHeight, Client vp = documentElement.clientHeight). All times are milliseconds. Counts and timings only; no command or reply text is ever recorded.</p>
 
   <div class="cards" id="cards"></div>
 
@@ -97,6 +97,11 @@ internal static class CarModeTelemetryPage
           <th>Rounds</th>
           <th>Cmd<br>chars</th>
           <th>Reply<br>chars</th>
+          <th>Buttons<br>on-screen</th>
+          <th>Footer<br>bottom</th>
+          <th>Visual<br>vp</th>
+          <th>Inner<br>vp</th>
+          <th>Client<br>vp</th>
         </tr>
       </thead>
       <tbody id="rows"></tbody>
@@ -137,7 +142,7 @@ internal static class CarModeTelemetryPage
 
     if (!recs.length) {
       cards.appendChild(card("-", "No turns recorded yet", "Take a turn in Car Mode on the phone"));
-      document.getElementById("rows").innerHTML = '<tr><td colspan="25" class="empty">No turns recorded yet. Open Car Mode on the phone, say something and "over and out", and it will appear here.</td></tr>';
+      document.getElementById("rows").innerHTML = '<tr><td colspan="30" class="empty">No turns recorded yet. Open Car Mode on the phone, say something and "over and out", and it will appear here.</td></tr>';
       document.getElementById("foot").textContent = "";
       return;
     }
@@ -174,6 +179,13 @@ internal static class CarModeTelemetryPage
     var micIn = recs.filter(function (r) { return r.micReacquiredDuringPlayback === true; }).length;
     cards.appendChild(card(micIn + " / " + recs.length, "Mic re-opened during the reply",
       "secondary cut-off suspect: mic grabbed mid-playback"));
+
+    // v5 button-cut-off proof, read from the phone: how many recent turns had the footer's primary buttons
+    // fall PAST the visible viewport (footerBottom > the visible height). 0 means the buttons were on-screen
+    // every turn - the direct, from-the-device confirmation that the cut-off is fixed.
+    var btnCut = recs.filter(function (r) { return r.footerVisible === false; }).length;
+    cards.appendChild(card(btnCut + " / " + recs.length, "Turns with buttons CUT OFF",
+      btnCut > 0 ? "footer fell past the visible viewport" : "buttons on-screen every turn"));
 
     var body = document.getElementById("rows"); body.innerHTML = "";
     recs.forEach(function (r) {
@@ -227,6 +239,13 @@ internal static class CarModeTelemetryPage
       tr.appendChild(td(r.rounds == null ? "-" : r.rounds));
       tr.appendChild(td(r.commandChars == null ? "-" : r.commandChars));
       tr.appendChild(td(r.replyChars == null ? "-" : r.replyChars));
+      // v5 button-visibility (from the phone): were the primary buttons on-screen, where did the footer end,
+      // and the three raw viewport reads. "CUT OFF" in red is the bug this whole round is chasing.
+      tr.appendChild(td(r.footerVisible == null ? "-" : (r.footerVisible ? "yes" : "CUT OFF"), r.footerVisible === false ? "slow" : ""));
+      tr.appendChild(td(ms(r.footerBottom)));
+      tr.appendChild(td(ms(r.visualViewportHeight)));
+      tr.appendChild(td(ms(r.viewportInnerHeight)));
+      tr.appendChild(td(ms(r.documentClientHeight)));
       body.appendChild(tr);
     });
 


### PR DESCRIPTION
v4 still failed on Soren's real Android phone: the primary blue button was cut off in **both** idle (Start) and active (Over-and-out / Stop) states. Three changes.

## (1) Pin the screen height to the actually-visible viewport
The v4 flex column is correct - header, middle (absorbs + scrolls), footer (natural, at the bottom) - but `.car-screen` **itself** stayed taller than the visible area, so the footer sat at the bottom of an oversized box, below the phone's bottom browser toolbar. Root cause: CSS `dvh` does **not** track the visible height reliably in his Android PWA.

**Fix:** publish `window.visualViewport.height` (the true visible height - excludes toolbars + keyboard) into a `--car-vh` CSS variable from `CarMode.tsx`, refreshed on every `visualViewport` resize/scroll and orientation change, and size `.car-screen` to `var(--car-vh)` with `dvh`/`vh` fallbacks for the first paint. Reinforced the flex-column pin (middle `flex:1 1 auto; min-height:0`; header + footer `flex:0 0 auto`) so the buttons are laid out at the bottom and **cannot** be pushed off, idle and active.

## (2) Prove it from the phone - real viewport telemetry
`/carmode/telemetry` now records `window.innerHeight`, `window.visualViewport.height`, `documentElement.clientHeight`, the `.car-foot` bottom (`getBoundingClientRect().bottom`), and `footerVisible` (footerBottom ≤ visible viewport = buttons on-screen). New dashboard card **"Turns with buttons CUT OFF"** + 5 columns - so button visibility is proven from **his** device, not a desktop where `dvh == vh` hides the bug.

## (3) Responsive-first on the Over-and-out tap
The beep stays the first synchronous line (fast). Then switch the **screen** to Thinking **synchronously** (orb/status change instantly instead of sitting on Listening for the ~2s transcribe→brain→tts), and fill that silent gap with a **soft, low-volume ambient water-droplet** (`startThinkingCue`, ~0.07 peak vs the ack cue's 0.5, gentle slow repeat) started inside the tap gesture so mobile lets it sound; it stops the instant the reply audio starts. `takeTurn` now guards on `thinking` (set by the tap) instead of `listening`; a double-tap is still a no-op.

## Also
- Badge → **v5**. Keeps the network-first PWA caching (v2) and the v3 mic-released-during-playback behavior.

## Verification
- Tests: **388 client green**, typecheck clean across all workspaces, mobile builds, Gateway builds clean, **68 CarMode Gateway tests pass**.
- **Not declaring done on desktop** - real-phone-only bug. Success = Soren (after close+reopen `/m/car`, corner reads **v5**) sees the primary buttons fully visible/tappable in both states, hears the beep instantly + the gentle working tone during Thinking, AND his telemetry shows `footerVisible=true` / "Turns with buttons CUT OFF" = 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)