### PR TITLE
Gateway Cleanup Phase 0 spine (part 2 of 2): the tunnel up-stream primitive

### DIFF
--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -663,7 +663,11 @@ public sealed class ControlApiHost : IAsyncDisposable
             // StartAsync has initialized them - BuildStreamClient runs before _proactiveExplain /
             // _turnSummaryCache are set. Additive: verbs that need no service ignore it (issue #1177 inc 6).
             cmd => SessionCommandExecutor.DispatchAsync(_sessionManager, DirectorId, cmd,
-                new SessionCommandServices { ProactiveExplain = _proactiveExplain, TurnSummaryCache = _turnSummaryCache, MissionStore = _missionStore }));
+                new SessionCommandServices { ProactiveExplain = _proactiveExplain, TurnSummaryCache = _turnSummaryCache, MissionStore = _missionStore }),
+            // Gateway Cleanup mission, Phase 0 (up-stream): pass the SessionManager so the four connection-bound
+            // stream verbs work - their terminal/file producers read session and file state from it and stream
+            // frames up this same connection.
+            sessionManager: _sessionManager);
     }
 
     /// <summary>

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -3737,7 +3737,9 @@ internal static class ControlEndpoints
     /// folder, or null if it escapes the folder, is not a bare file name, has a non-image
     /// extension, or does not exist. Defends GET/DELETE /screenshots/file against traversal.
     /// </summary>
-    private static string? ResolveScreenshot(string? name)
+    // Internal (Gateway Cleanup Phase 0) so the screenshot-file stream verb resolves the same traversal-safe
+    // path this REST route does - one resolver, no drift.
+    internal static string? ResolveScreenshot(string? name)
     {
         if (string.IsNullOrWhiteSpace(name))
             return null;
@@ -3756,7 +3758,7 @@ internal static class ControlEndpoints
         return File.Exists(full) ? full : null;
     }
 
-    private static string ScreenshotContentType(string path) => Path.GetExtension(path).ToLowerInvariant() switch
+    internal static string ScreenshotContentType(string path) => Path.GetExtension(path).ToLowerInvariant() switch
     {
         ".png" => "image/png",
         ".jpg" or ".jpeg" => "image/jpeg",
@@ -3772,7 +3774,7 @@ internal static class ControlEndpoints
     /// new type is added in exactly one place. The octet-stream fallback means an unknown extension is
     /// served as an opaque download, never guessed as text or an image.
     /// </summary>
-    private static string FileContentType(string path) => Path.GetExtension(path).ToLowerInvariant() switch
+    internal static string FileContentType(string path) => Path.GetExtension(path).ToLowerInvariant() switch
     {
         ".html" or ".htm" => "text/html; charset=utf-8",
         ".pdf"            => "application/pdf",

--- a/src/CcDirector.ControlApi/DirectorStreamProducers.cs
+++ b/src/CcDirector.ControlApi/DirectorStreamProducers.cs
@@ -1,0 +1,176 @@
+using System.Runtime.CompilerServices;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0 (up-stream): the Director-side producers that yield the frames an
+/// up-stream carries. Both are connection-agnostic (Architect ruling A): they take only a
+/// <see cref="SessionManager"/> (or a path) plus a stream id and a CancellationToken, and <c>yield return</c>
+/// <see cref="DirectorStreamFrame"/>s, so the connection concern never leaks into them and they are unit
+/// testable in isolation. The 4 KB-to-64 KB frame cap (Architect ruling 2) is enforced here by chunking at
+/// <see cref="DirectorStreamLimits.MaxBinaryFrameBytes"/>, so no single frame can monopolize the one shared
+/// tunnel connection.
+/// </summary>
+internal static class DirectorStreamProducers
+{
+    private const int Max = DirectorStreamLimits.MaxBinaryFrameBytes;
+
+    /// <summary>
+    /// The live terminal producer: the exact cursor loop <c>TerminalStreamEndpoint.StreamSessionAsync</c>
+    /// runs today, lifted to <c>yield return</c> frames instead of writing a WebSocket. Sends a Size frame and
+    /// the self-contained screen SNAPSHOT first (so a fresh client terminal reconstructs correctly), then the
+    /// live tail from one monotonic cursor via the session buffer's <c>GetWrittenSince</c>, a Size frame on a
+    /// live PTY resize, and a Closed frame when the session exits. The one difference from the WebSocket
+    /// version is the frame cap: a burst larger than <see cref="Max"/> is split into several bounded Binary
+    /// frames (the WebSocket allowed one large frame; the shared tunnel does not).
+    /// </summary>
+    public static async IAsyncEnumerable<DirectorStreamFrame> ProduceTerminalAsync(
+        SessionManager sessionManager, Guid sessionId, string streamId, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var session0 = sessionManager.GetSession(sessionId);
+        if (session0 is null)
+        {
+            yield return Closed(streamId, "session not found");
+            yield break;
+        }
+
+        var (snapshot, reflected, snapCols, snapRows) = session0.GetTerminalSnapshot();
+        yield return Size(streamId, snapCols, snapRows);
+        foreach (var chunk in Chunk(snapshot))
+            yield return Binary(streamId, chunk);
+
+        long cursor = reflected;
+        short lastCols = (short)snapCols;
+        short lastRows = (short)snapRows;
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var session = sessionManager.GetSession(sessionId);
+            if (session is null)
+            {
+                yield return Closed(streamId, "session not found");
+                yield break;
+            }
+
+            if (session.CurrentCols != lastCols || session.CurrentRows != lastRows)
+            {
+                lastCols = session.CurrentCols;
+                lastRows = session.CurrentRows;
+                yield return Size(streamId, lastCols, lastRows);
+            }
+
+            var buffer = session.Buffer;
+            if (buffer is not null)
+            {
+                var (data, newCursor) = buffer.GetWrittenSince(cursor);
+                if (data.Length > 0)
+                {
+                    foreach (var chunk in Chunk(data))
+                        yield return Binary(streamId, chunk);
+                    cursor = newCursor;
+                    continue; // drain at full speed while bytes are flowing before sleeping
+                }
+            }
+
+            if (session.Status is SessionStatus.Exited or SessionStatus.Failed)
+            {
+                yield return Closed(streamId, "session exited");
+                yield break;
+            }
+
+            if (!await DelayNoThrowAsync(40, cancellationToken))
+                yield break; // cancelled (close-stream) - stop cleanly, no fault
+        }
+    }
+
+    /// <summary>
+    /// The finite file producer: read a file in <see cref="Max"/>-sized chunks, yielding one Binary frame per
+    /// chunk, then a single Closed frame with reason "eof" at the natural end. Serves both a session file read
+    /// (the Local Files viewer) and a screenshot read; the caller stats the size up front for Content-Length
+    /// (Architect ruling 4). A cancel mid-read (browser disconnect via close-stream) stops cleanly with no eof
+    /// frame and no fault.
+    /// </summary>
+    public static async IAsyncEnumerable<DirectorStreamFrame> ProduceFileAsync(
+        string path, string streamId, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, bufferSize: Max, useAsync: true);
+        var buffer = new byte[Max];
+        while (true)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                yield break;
+
+            var read = await ReadChunkAsync(stream, buffer, cancellationToken);
+            if (read < 0)
+                yield break; // cancelled mid-read - stop cleanly
+            if (read == 0)
+            {
+                yield return Closed(streamId, "eof");
+                yield break;
+            }
+
+            var chunk = new byte[read];
+            Array.Copy(buffer, chunk, read);
+            yield return Binary(streamId, chunk);
+        }
+    }
+
+    // Split a payload into bounded frames so no single Binary frame exceeds the cap. An empty payload yields
+    // nothing (no empty frame), matching the old "if length > 0 send" behaviour.
+    private static IEnumerable<byte[]> Chunk(byte[] data)
+    {
+        if (data.Length == 0)
+            yield break;
+        if (data.Length <= Max)
+        {
+            yield return data;
+            yield break;
+        }
+        for (var offset = 0; offset < data.Length; offset += Max)
+        {
+            var length = Math.Min(Max, data.Length - offset);
+            var chunk = new byte[length];
+            Array.Copy(data, offset, chunk, 0, length);
+            yield return chunk;
+        }
+    }
+
+    // A cancellation-safe delay: returns true after the delay, false if cancelled (so the caller stops without
+    // an exception escaping the async iterator).
+    private static async Task<bool> DelayNoThrowAsync(int milliseconds, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Delay(milliseconds, cancellationToken);
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+    }
+
+    // A cancellation-safe read: returns the byte count (0 on end of file), or -1 if cancelled mid-read.
+    private static async Task<int> ReadChunkAsync(Stream stream, byte[] buffer, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await stream.ReadAsync(buffer, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return -1;
+        }
+    }
+
+    private static DirectorStreamFrame Size(string streamId, int cols, int rows) =>
+        new() { StreamId = streamId, Kind = DirectorStreamFrameType.Size, Cols = cols, Rows = rows };
+
+    private static DirectorStreamFrame Binary(string streamId, byte[] data) =>
+        new() { StreamId = streamId, Kind = DirectorStreamFrameType.Binary, Data = data };
+
+    private static DirectorStreamFrame Closed(string streamId, string reason) =>
+        new() { StreamId = streamId, Kind = DirectorStreamFrameType.Closed, Reason = reason };
+}

--- a/src/CcDirector.ControlApi/DirectorUpStreamHandler.cs
+++ b/src/CcDirector.ControlApi/DirectorUpStreamHandler.cs
@@ -1,0 +1,188 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0 (up-stream): the handler for the four CONNECTION-BOUND stream verbs
+/// (Architect ruling A). These four are NOT in the unary verb-to-area dictionary - they branch earlier, in
+/// <see cref="GatewayStreamClient"/>'s Command handler, because only they need the live SignalR connection
+/// (to start an up-stream) and a per-stream <see cref="CancellationTokenSource"/> registry.
+///
+///  - <c>open-terminal-stream</c>: start the terminal producer streaming up under the Gateway's stream id.
+///  - <c>read-file</c> / <c>screenshot-file</c>: start the finite file producer; returns the total size and
+///    content type up front so the Gateway can set Content-Length (ruling 4).
+///  - <c>close-stream</c>: cancel the producer for a stream id (idempotent - an unknown or already-finished id
+///    is a safe no-op Ok, ruling 3).
+///
+/// On accepting an open the handler starts the producer in the background and returns Ok IMMEDIATELY (it does
+/// not await the whole stream inside the unary call). If the tunnel connection drops, <see cref="CancelAll"/>
+/// tears down EVERY live stream (ruling A): a dropped connection can no longer carry frames, so nothing is
+/// left producing into a dead socket.
+/// </summary>
+internal sealed class DirectorUpStreamHandler
+{
+    private readonly SessionManager _sessionManager;
+    private readonly Func<string, IAsyncEnumerable<DirectorStreamFrame>, Task> _sendUp;
+    private readonly ConcurrentDictionary<string, CancellationTokenSource> _streams = new();
+
+    /// <param name="sendUp">
+    /// Sends the producer's frames UP the tunnel under a stream id - in production this wraps
+    /// <c>connection.SendAsync("StreamUp", streamId, frames)</c>. Injected (not the connection itself) so the
+    /// handler and its producers stay unit-testable without a live SignalR connection.
+    /// </param>
+    public DirectorUpStreamHandler(SessionManager sessionManager, Func<string, IAsyncEnumerable<DirectorStreamFrame>, Task> sendUp)
+    {
+        _sessionManager = sessionManager ?? throw new ArgumentNullException(nameof(sessionManager));
+        _sendUp = sendUp ?? throw new ArgumentNullException(nameof(sendUp));
+    }
+
+    /// <summary>The number of streams this handler currently has producing. For diagnostics and tests.</summary>
+    public int ActiveStreamCount => _streams.Count;
+
+    /// <summary>True for exactly the four connection-bound stream verbs; everything else is a unary verb.</summary>
+    public static bool IsStreamVerb(string verb) =>
+        verb is "open-terminal-stream" or "read-file" or "screenshot-file" or "close-stream";
+
+    /// <summary>Handle one of the four stream verbs. Never throws for a normal failure; returns a typed result.</summary>
+    public DirectorCommandResult Handle(DirectorCommand command)
+    {
+        return command.Verb switch
+        {
+            "open-terminal-stream" => OpenTerminal(command),
+            "read-file" => OpenFile(command),
+            "screenshot-file" => OpenScreenshot(command),
+            "close-stream" => Close(command),
+            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not a stream verb"),
+        };
+    }
+
+    /// <summary>Cancel and drop EVERY live stream. Called when the tunnel connection drops (Architect ruling A).</summary>
+    public void CancelAll()
+    {
+        foreach (var streamId in _streams.Keys)
+            CancelStream(streamId);
+        FileLog.Write("[DirectorUpStreamHandler] CancelAll: all live streams torn down (tunnel dropped)");
+    }
+
+    private DirectorCommandResult OpenTerminal(DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var request = SessionCommandExecutor.Deserialize<OpenStreamRequest>(command.PayloadJson);
+        if (request is null || string.IsNullOrEmpty(request.StreamId))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "streamId is required");
+
+        if (_sessionManager.GetSession(guid) is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        var streamId = request.StreamId;
+        StartProducer(streamId, ct => DirectorStreamProducers.ProduceTerminalAsync(_sessionManager, guid, streamId, ct));
+        return DirectorCommandResult.Success(); // open-ended terminal: no body
+    }
+
+    private DirectorCommandResult OpenFile(DirectorCommand command)
+    {
+        var request = SessionCommandExecutor.Deserialize<OpenStreamRequest>(command.PayloadJson);
+        if (request is null || string.IsNullOrEmpty(request.StreamId))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "streamId is required");
+        if (string.IsNullOrEmpty(request.Path))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "path is required");
+        if (!File.Exists(request.Path))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "file not found");
+
+        var streamId = request.StreamId;
+        var path = request.Path;
+        StartProducer(streamId, ct => DirectorStreamProducers.ProduceFileAsync(path, streamId, ct));
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(BuildReadResponse(path, ControlEndpoints.FileContentType(path))));
+    }
+
+    private DirectorCommandResult OpenScreenshot(DirectorCommand command)
+    {
+        var request = SessionCommandExecutor.Deserialize<OpenStreamRequest>(command.PayloadJson);
+        if (request is null || string.IsNullOrEmpty(request.StreamId))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "streamId is required");
+
+        // Resolve + traversal-check through the SAME helper the REST /screenshots/file route uses, so the two
+        // paths cannot drift. A missing / bad / non-image name resolves to null -> NotFound.
+        var path = ControlEndpoints.ResolveScreenshot(request.ScreenshotId);
+        if (path is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "screenshot not found");
+
+        var streamId = request.StreamId;
+        StartProducer(streamId, ct => DirectorStreamProducers.ProduceFileAsync(path, streamId, ct));
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(BuildReadResponse(path, ControlEndpoints.ScreenshotContentType(path))));
+    }
+
+    private DirectorCommandResult Close(DirectorCommand command)
+    {
+        var request = SessionCommandExecutor.Deserialize<CloseStreamRequest>(command.PayloadJson);
+        if (request is null || string.IsNullOrEmpty(request.StreamId))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "streamId is required");
+
+        // Idempotent (ruling 3): closing a stream that already finished or never started is a safe no-op Ok.
+        CancelStream(request.StreamId);
+        return DirectorCommandResult.Success();
+    }
+
+    private static OpenReadResponse BuildReadResponse(string path, string? contentType)
+    {
+        long? total = null;
+        try { total = new FileInfo(path).Length; }
+        catch (Exception ex) { FileLog.Write($"[DirectorUpStreamHandler] could not stat {path} for total size: {ex.Message}"); }
+        return new OpenReadResponse { TotalBytes = total, ContentType = contentType };
+    }
+
+    private void StartProducer(string streamId, Func<CancellationToken, IAsyncEnumerable<DirectorStreamFrame>> makeProducer)
+    {
+        var cts = new CancellationTokenSource();
+        if (!_streams.TryAdd(streamId, cts))
+        {
+            cts.Dispose();
+            throw new InvalidOperationException($"stream id already active (ids must be fresh): {streamId}");
+        }
+        FileLog.Write($"[DirectorUpStreamHandler] starting producer for stream {streamId} (active={_streams.Count})");
+        _ = PumpAsync(streamId, makeProducer(cts.Token), cts);
+    }
+
+    // Fire-and-forget: stream the producer's frames up the tunnel until it completes (Closed/eof) or is
+    // cancelled (close-stream / tunnel drop). Best-effort; a send fault ends the stream and is logged, never
+    // thrown into the caller (the open command already returned Ok). PumpAsync is the SOLE disposer of the
+    // stream's CancellationTokenSource, and it disposes only here in the finally - after the producer has
+    // fully unwound - so a concurrent close-stream/CancelAll only ever CANCELS the source, never disposes it
+    // while a Task.Delay/ReadAsync still holds its token (which would throw ObjectDisposedException).
+    private async Task PumpAsync(string streamId, IAsyncEnumerable<DirectorStreamFrame> frames, CancellationTokenSource cts)
+    {
+        try
+        {
+            await _sendUp(streamId, frames);
+        }
+        catch (OperationCanceledException)
+        {
+            // close-stream / tunnel drop cancelled us. Normal.
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[DirectorUpStreamHandler] stream {streamId} pump failed: {ex.Message}");
+        }
+        finally
+        {
+            _streams.TryRemove(streamId, out _); // no-op if close-stream/CancelAll already removed it
+            cts.Dispose();
+        }
+    }
+
+    // Cancel (never dispose) a live stream's token so its producer stops; PumpAsync's finally disposes the
+    // source once the producer has unwound. Idempotent: an already-removed stream is a no-op.
+    private void CancelStream(string streamId)
+    {
+        if (_streams.TryRemove(streamId, out var cts))
+        {
+            try { cts.Cancel(); }
+            catch (ObjectDisposedException) { /* pump already disposed it - nothing to do */ }
+        }
+    }
+}

--- a/src/CcDirector.ControlApi/GatewayStreamClient.cs
+++ b/src/CcDirector.ControlApi/GatewayStreamClient.cs
@@ -1,4 +1,5 @@
 using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using Microsoft.AspNetCore.SignalR.Client;
@@ -30,6 +31,13 @@ public sealed class GatewayStreamClient : IAsyncDisposable
     private readonly Func<DirectorCommand, Task<DirectorCommandResult>>? _commandDispatcher;
     private readonly TimeSpan _rePushInterval;
 
+    /// <summary>
+    /// Gateway Cleanup mission, Phase 0 (up-stream): the handler for the four connection-bound stream verbs.
+    /// Null when no <see cref="SessionManager"/> was supplied (older callers and tests that never drive a
+    /// stream verb); in that case a stream verb returns a typed Error, exactly as an absent dispatcher does.
+    /// </summary>
+    private readonly DirectorUpStreamHandler? _upStreamHandler;
+
     private HubConnection? _connection;
     private long _sequence;
     private int _started;
@@ -50,9 +58,16 @@ public sealed class GatewayStreamClient : IAsyncDisposable
     /// QUIET session's pushed cache never ages past the Gateway's stale window. Null uses half the default
     /// stale window (comfortably under it). A test seam; production passes null.
     /// </param>
+    /// <param name="sessionManager">
+    /// Issue: Gateway Cleanup mission, Phase 0 (up-stream). When supplied, enables the four connection-bound
+    /// stream verbs (open-terminal-stream / read-file / screenshot-file / close-stream) by building the
+    /// up-stream handler, whose producer sends frames up this same connection. Null (older callers, tests)
+    /// leaves stream verbs declined with a typed Error, so behaviour is unchanged for them.
+    /// </param>
     public GatewayStreamClient(GatewayConfig config, string directorId, string version, Func<List<SessionDto>> snapshot,
         Func<DirectorCommand, Task<DirectorCommandResult>>? commandDispatcher = null,
-        TimeSpan? rePushInterval = null)
+        TimeSpan? rePushInterval = null,
+        SessionManager? sessionManager = null)
     {
         _config = config ?? throw new ArgumentNullException(nameof(config));
         _directorId = string.IsNullOrWhiteSpace(directorId) ? throw new ArgumentException("directorId is required", nameof(directorId)) : directorId;
@@ -60,6 +75,9 @@ public sealed class GatewayStreamClient : IAsyncDisposable
         _snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
         _commandDispatcher = commandDispatcher;
         _rePushInterval = rePushInterval ?? TimeSpan.FromSeconds(GatewayConfig.DefaultStreamStaleAfterSeconds / 2.0);
+        _upStreamHandler = sessionManager is null
+            ? null
+            : new DirectorUpStreamHandler(sessionManager, (streamId, frames) => _connection!.SendAsync("StreamUp", streamId, frames));
     }
 
     /// <summary>True when stream mode is enabled for a configured Gateway. When false, <see cref="Start"/> is a no-op.</summary>
@@ -124,8 +142,17 @@ public sealed class GatewayStreamClient : IAsyncDisposable
             })
             .Build();
 
-        _connection.Reconnecting += ex => { FileLog.Write($"[GatewayStreamClient] reconnecting: {ex?.Message}"); return Task.CompletedTask; };
+        _connection.Reconnecting += ex =>
+        {
+            FileLog.Write($"[GatewayStreamClient] reconnecting: {ex?.Message}");
+            // Gateway Cleanup Phase 0 (Architect ruling A): the tunnel dropped, so no frame can reach the
+            // Gateway - tear down every live up-stream instead of leaving a producer sending into a dead socket.
+            _upStreamHandler?.CancelAll();
+            return Task.CompletedTask;
+        };
         _connection.Reconnected += async _ => await ReseedAsync();
+        // Also tear streams down on a full close (auto-reconnect gave up); the supervise loop then re-dials.
+        _connection.Closed += _ => { _upStreamHandler?.CancelAll(); return Task.CompletedTask; };
 
         // Issue #1176 (Phase 1b): the down-channel proof. The Gateway can call this and await the reply
         // over the same connection (SignalR client results), demonstrating request-both-ways on one
@@ -140,13 +167,30 @@ public sealed class GatewayStreamClient : IAsyncDisposable
         {
             try
             {
-                if (_commandDispatcher is null)
-                {
-                    FileLog.Write($"[GatewayStreamClient] Command declined (no dispatcher): verb={cmd?.Verb}, cmdId={cmd?.CommandId}");
-                    return DirectorCommandResult.Fail(DirectorCommandStatus.Error, "director has no command dispatcher");
-                }
                 if (cmd is null)
                     return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "command is required");
+
+                // Gateway Cleanup Phase 0 (Architect ruling A): the four connection-bound stream verbs branch
+                // here - they need this live connection and the per-stream cancellation registry, so they are
+                // NOT in the unary verb-to-area dictionary. Everything else forwards to the unary dispatcher.
+                if (DirectorUpStreamHandler.IsStreamVerb(cmd.Verb))
+                {
+                    if (_upStreamHandler is null)
+                    {
+                        FileLog.Write($"[GatewayStreamClient] stream verb declined (no up-stream handler): verb={cmd.Verb}, cmdId={cmd.CommandId}");
+                        return DirectorCommandResult.Fail(DirectorCommandStatus.Error, "director has no up-stream handler");
+                    }
+                    FileLog.Write($"[GatewayStreamClient] stream verb received: verb={cmd.Verb}, sid={cmd.SessionId}, cmdId={cmd.CommandId}");
+                    var streamResult = _upStreamHandler.Handle(cmd);
+                    streamResult.CommandId = cmd.CommandId;
+                    return streamResult;
+                }
+
+                if (_commandDispatcher is null)
+                {
+                    FileLog.Write($"[GatewayStreamClient] Command declined (no dispatcher): verb={cmd.Verb}, cmdId={cmd.CommandId}");
+                    return DirectorCommandResult.Fail(DirectorCommandStatus.Error, "director has no command dispatcher");
+                }
 
                 FileLog.Write($"[GatewayStreamClient] Command received: verb={cmd.Verb}, sid={cmd.SessionId}, cmdId={cmd.CommandId}");
                 return await _commandDispatcher(cmd);

--- a/src/CcDirector.Gateway.Contracts/DirectorUpStreamMessages.cs
+++ b/src/CcDirector.Gateway.Contracts/DirectorUpStreamMessages.cs
@@ -1,0 +1,133 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0: the up-stream primitive. This is the ONE frame type that carries every
+/// Director-to-Gateway byte stream over the tunnel - both the open-ended live terminal output AND a finite
+/// file/screenshot byte read - keyed by <see cref="StreamId"/>.
+///
+/// The tunnel is the existing two-way SignalR channel (the Director dials the Gateway's DirectorHub and binds
+/// its id with <see cref="DirectorStreamHello"/>). The Director is the SignalR CLIENT, so an up-stream is
+/// native client-to-server streaming: the Gateway sends a unary "open" command carrying a fresh
+/// <see cref="StreamId"/>, the Director starts a producer and streams these frames UP under that id via the
+/// hub's StreamUp method until the Gateway sends a "close-stream" command (the load-bearing stop signal - see
+/// the Architect ruling in docs/architecture/gateway-cleanup-phase0-tunnel-protocol.md) or the producer
+/// reaches its end.
+///
+/// The browser-facing contract is UNCHANGED: the browser still opens the same WebSocket at
+/// <c>/sessions/{sid}/stream</c> and the same GET for a file; the Gateway translates each frame back into the
+/// browser wire form it always sent (a Size frame -> the {"type":"size"} json, a Binary frame -> a binary
+/// WebSocket message or an HTTP body chunk, a Closed frame -> {"type":"closed"} then close).
+/// </summary>
+public sealed class DirectorStreamFrame
+{
+    /// <summary>Correlates this frame to the browser request the Gateway is serving. A fresh Guid per open, never reused.</summary>
+    public string StreamId { get; set; } = "";
+
+    /// <summary>What this frame carries. See <see cref="DirectorStreamFrameType"/>.</summary>
+    public DirectorStreamFrameType Kind { get; set; }
+
+    /// <summary>
+    /// The binary payload for a <see cref="DirectorStreamFrameType.Binary"/> frame: raw PTY bytes for the
+    /// terminal, or a file chunk for a finite read. Null for Size/Closed frames. BOUNDED: a producer never
+    /// emits more than <see cref="DirectorStreamLimits.MaxBinaryFrameBytes"/> in one frame, so no single frame
+    /// can monopolize the one shared tunnel connection (Architect ruling 2).
+    /// </summary>
+    public byte[]? Data { get; set; }
+
+    /// <summary>Terminal grid columns; meaningful only on a <see cref="DirectorStreamFrameType.Size"/> frame.</summary>
+    public int Cols { get; set; }
+
+    /// <summary>Terminal grid rows; meaningful only on a <see cref="DirectorStreamFrameType.Size"/> frame.</summary>
+    public int Rows { get; set; }
+
+    /// <summary>
+    /// Why the stream ended; meaningful only on a <see cref="DirectorStreamFrameType.Closed"/> frame
+    /// (for example "session exited", "session not found", or "eof" for the natural end of a finite read).
+    /// </summary>
+    public string? Reason { get; set; }
+}
+
+/// <summary>The three frame kinds that serve both the terminal stream and a finite byte read.</summary>
+public enum DirectorStreamFrameType
+{
+    /// <summary>A terminal grid size (Cols x Rows). Sent first on a terminal stream and again on every PTY resize.</summary>
+    Size = 0,
+
+    /// <summary>A chunk of bytes (<see cref="DirectorStreamFrame.Data"/>): live PTY output, or a file chunk.</summary>
+    Binary = 1,
+
+    /// <summary>The stream has ended (<see cref="DirectorStreamFrame.Reason"/> says why). The last frame of any stream.</summary>
+    Closed = 2,
+}
+
+/// <summary>
+/// Shared numeric bounds for the up-stream (Architect ruling 2). The frame cap and the hub's
+/// MaximumReceiveMessageSize are set from the SAME constant so they can never drift apart: a producer that
+/// chunks at the cap can never emit a frame the hub would reject, and a bounded frame keeps the one shared
+/// tunnel connection interleaving terminal output, file chunks, and unary commands instead of stalling on a
+/// single large message.
+/// </summary>
+public static class DirectorStreamLimits
+{
+    /// <summary>
+    /// The maximum bytes in a single <see cref="DirectorStreamFrame.Data"/> payload (48 KB - inside the
+    /// 32-to-64 KB band the Architect fixed). The file producer chunks at this bound; the terminal producer's
+    /// tail frames are already smaller. The hub's MaximumReceiveMessageSize is set to this plus a small
+    /// envelope allowance so the framed message (with its StreamId and metadata) still fits.
+    /// </summary>
+    public const int MaxBinaryFrameBytes = 48 * 1024;
+
+    /// <summary>
+    /// SignalR StreamBufferCapacity for the up-stream (Architect ruling 1): small, single-digit, so a slow
+    /// browser sink fills this channel quickly and pushes back onto the Director producer's <c>yield return</c>,
+    /// giving end-to-end backpressure with bounded memory. NOT an optimization - the backpressure invariant.
+    /// </summary>
+    public const int StreamBufferCapacity = 4;
+
+    /// <summary>
+    /// The extra envelope room (over <see cref="MaxBinaryFrameBytes"/>) allowed for a framed message's own
+    /// fields (StreamId, kind, size ints, reason) plus the SignalR/MessagePack framing, used to set the hub's
+    /// MaximumReceiveMessageSize = MaxBinaryFrameBytes + this.
+    /// </summary>
+    public const int FrameEnvelopeAllowanceBytes = 4 * 1024;
+}
+
+/// <summary>
+/// The payload of the unary "open" command that starts an up-stream (verbs open-terminal-stream / read-file /
+/// screenshot-file). Rides in <see cref="DirectorCommand.PayloadJson"/>; the target session is
+/// <see cref="DirectorCommand.SessionId"/> on the command itself.
+/// </summary>
+public sealed class OpenStreamRequest
+{
+    /// <summary>The fresh Guid the Gateway minted for this stream. The Director tags every up-frame with it.</summary>
+    public string StreamId { get; set; } = "";
+
+    /// <summary>For a file read (read-file): the file path to serve. Null/absent for a terminal stream.</summary>
+    public string? Path { get; set; }
+
+    /// <summary>For a screenshot read (screenshot-file): the screenshot id/name to serve. Null/absent otherwise.</summary>
+    public string? ScreenshotId { get; set; }
+}
+
+/// <summary>
+/// The success body of a finite read's "open" command (Architect ruling 4). When the Director can cheaply
+/// stat the resource up front, it returns the total byte length and content type in the open command's
+/// <see cref="DirectorCommandResult.BodyJson"/>, so the Gateway can set <c>Content-Length</c> on the browser
+/// response instead of falling back to chunked transfer. A terminal open returns no body (open-ended).
+/// </summary>
+public sealed class OpenReadResponse
+{
+    /// <summary>Total bytes the finite read will deliver, when known up front; null when not cheaply knowable.</summary>
+    public long? TotalBytes { get; set; }
+
+    /// <summary>The resource's content type (for the browser response), when known.</summary>
+    public string? ContentType { get; set; }
+}
+
+/// <summary>The payload of the unary "close-stream" command (Architect ruling 3): the id of the stream to stop.
+/// Idempotent on the Director - closing a stream that already ended or never started is a safe no-op.</summary>
+public sealed class CloseStreamRequest
+{
+    /// <summary>The stream to stop. Cancels the Director producer's CancellationToken for this id.</summary>
+    public string StreamId { get; set; } = "";
+}

--- a/src/CcDirector.Gateway.Tests/DirectorHubTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorHubTests.cs
@@ -42,7 +42,7 @@ public sealed class DirectorHubTests : IDisposable
     private (DirectorHub hub, FakeHubCallerContext ctx) NewHub(string connectionId)
     {
         var ctx = new FakeHubCallerContext(connectionId);
-        var hub = new DirectorHub(_store, _registry, _inputStats) { Context = ctx };
+        var hub = new DirectorHub(_store, _registry, _inputStats, new GatewayStreamRegistry()) { Context = ctx };
         return (hub, ctx);
     }
 

--- a/src/CcDirector.Gateway.Tests/DirectorStreamProducersTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorStreamProducersTests.cs
@@ -1,0 +1,276 @@
+using System.Text;
+using CcDirector.ControlApi;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0 (up-stream): tests for the Director-side producers and the four-verb
+/// <see cref="DirectorUpStreamHandler"/>. The terminal producer is asserted against the SAME snapshot-then-tail
+/// golden bytes the old TerminalStreamEndpoint would have sent; the file producer is asserted to chunk at the
+/// frame cap and end with an eof frame; the handler is asserted to return Ok immediately on open (streaming in
+/// the background), to be idempotent on close, and to fail loud on a missing session.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class DirectorStreamProducersTests
+{
+    private static (SessionManager sm, Session session, ExecuteActionTestBackend backend) NewSession()
+    {
+        var sm = new SessionManager(new AgentOptions());
+        var backend = new ExecuteActionTestBackend();
+        var session = sm.CreateEmbeddedSession(Path.GetTempPath(), null, backend);
+        return (sm, session, backend);
+    }
+
+    private static byte[] Concat(IEnumerable<byte[]> parts)
+    {
+        using var ms = new MemoryStream();
+        foreach (var p in parts) ms.Write(p, 0, p.Length);
+        return ms.ToArray();
+    }
+
+    private static async Task<List<DirectorStreamFrame>> CollectAsync(IAsyncEnumerable<DirectorStreamFrame> frames, CancellationToken ct)
+    {
+        var list = new List<DirectorStreamFrame>();
+        await foreach (var f in frames.WithCancellation(ct))
+            list.Add(f);
+        return list;
+    }
+
+    // Poll a condition to a deadline. The handler's stream teardown (its PumpAsync finally) runs just after the
+    // producer completes, which can lag the drained() signal by a scheduler tick, so ActiveStreamCount is
+    // polled rather than read once.
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var attempts = (int)(timeout.TotalMilliseconds / 10) + 1;
+        for (var i = 0; i < attempts && !condition(); i++)
+            await Task.Delay(10);
+    }
+
+    [Fact]
+    public async Task ProduceTerminal_YieldsSnapshotThenTailGoldenBytes_ThenClosedOnExit()
+    {
+        var (sm, session, backend) = NewSession();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        try
+        {
+            backend.Write(Encoding.UTF8.GetBytes("hello golden terminal world\r\n"));
+
+            // The golden reference: exactly what the old StreamSessionAsync sent - the self-contained screen
+            // snapshot first, then the live tail from the snapshot's cursor. Computed from the same buffer
+            // primitives the producer uses, off the static (about-to-exit) buffer.
+            var (snapshot, reflected, snapCols, snapRows) = session.GetTerminalSnapshot();
+            var (tail, _) = session.Buffer!.GetWrittenSince(reflected);
+            var expected = Concat(new[] { snapshot, tail });
+
+            backend.RaiseProcessExited(0); // make the stream finite: the loop emits Closed once drained
+
+            var frames = await CollectAsync(
+                DirectorStreamProducers.ProduceTerminalAsync(sm, session.Id, "term-1", timeout.Token), timeout.Token);
+
+            Assert.True(frames.Count >= 2);
+            Assert.Equal(DirectorStreamFrameType.Size, frames[0].Kind);
+            Assert.Equal(snapCols, frames[0].Cols);
+            Assert.Equal(snapRows, frames[0].Rows);
+
+            var last = frames[^1];
+            Assert.Equal(DirectorStreamFrameType.Closed, last.Kind);
+            Assert.Equal("session exited", last.Reason);
+
+            var binaries = frames.Where(f => f.Kind == DirectorStreamFrameType.Binary).Select(f => f.Data!).ToList();
+            Assert.All(binaries, b => Assert.True(b.Length <= DirectorStreamLimits.MaxBinaryFrameBytes));
+            Assert.Equal(expected, Concat(binaries));
+            Assert.All(frames, f => Assert.Equal("term-1", f.StreamId));
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task ProduceTerminal_MissingSession_YieldsOnlyAClosedFrame()
+    {
+        var sm = new SessionManager(new AgentOptions());
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        try
+        {
+            var frames = await CollectAsync(
+                DirectorStreamProducers.ProduceTerminalAsync(sm, Guid.NewGuid(), "term-missing", timeout.Token), timeout.Token);
+
+            var only = Assert.Single(frames);
+            Assert.Equal(DirectorStreamFrameType.Closed, only.Kind);
+            Assert.Equal("session not found", only.Reason);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task ProduceFile_ChunksAtTheFrameCap_ThenEofFrame_AndReconstructsTheFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "ccd-upstream-file-" + Guid.NewGuid().ToString("N") + ".bin");
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        try
+        {
+            // Two full-cap chunks plus a partial third, so chunking is actually exercised.
+            var content = new byte[(DirectorStreamLimits.MaxBinaryFrameBytes * 2) + 123];
+            for (var i = 0; i < content.Length; i++) content[i] = (byte)(i % 251);
+            await File.WriteAllBytesAsync(path, content, timeout.Token);
+
+            var frames = await CollectAsync(DirectorStreamProducers.ProduceFileAsync(path, "file-1", timeout.Token), timeout.Token);
+
+            var binaries = frames.Where(f => f.Kind == DirectorStreamFrameType.Binary).Select(f => f.Data!).ToList();
+            Assert.Equal(3, binaries.Count);
+            Assert.All(binaries, b => Assert.True(b.Length <= DirectorStreamLimits.MaxBinaryFrameBytes));
+            Assert.Equal(content, Concat(binaries));
+
+            var last = frames[^1];
+            Assert.Equal(DirectorStreamFrameType.Closed, last.Kind);
+            Assert.Equal("eof", last.Reason);
+        }
+        finally
+        {
+            try { File.Delete(path); } catch { /* best effort */ }
+        }
+    }
+
+    // ---------- DirectorUpStreamHandler ----------
+
+    // A sendUp that drains the producer into a list, so a test can assert what the handler streamed.
+    private static (DirectorUpStreamHandler handler, List<DirectorStreamFrame> captured, Func<Task> drained) NewHandler(SessionManager sm)
+    {
+        var captured = new List<DirectorStreamFrame>();
+        var done = new TaskCompletionSource();
+        var handler = new DirectorUpStreamHandler(sm, async (streamId, frames) =>
+        {
+            try
+            {
+                await foreach (var f in frames)
+                    lock (captured) captured.Add(f);
+            }
+            finally { done.TrySetResult(); }
+        });
+        return (handler, captured, () => done.Task);
+    }
+
+    private static DirectorCommand OpenTerminalCommand(Guid sid, string streamId) => new()
+    {
+        CommandId = "o1",
+        Verb = "open-terminal-stream",
+        SessionId = sid.ToString(),
+        PayloadJson = SessionCommandExecutor.Serialize(new OpenStreamRequest { StreamId = streamId }),
+    };
+
+    [Fact]
+    public async Task Handler_OpenTerminal_ReturnsOkImmediately_ThenStreamsUp()
+    {
+        var (sm, session, backend) = NewSession();
+        var (handler, captured, drained) = NewHandler(sm);
+        try
+        {
+            backend.Write(Encoding.UTF8.GetBytes("streaming up\r\n"));
+
+            var result = handler.Handle(OpenTerminalCommand(session.Id, "up-1"));
+
+            // Returned Ok WITHOUT waiting for the whole stream (the producer runs in the background). The
+            // CommandId is stamped by the caller (GatewayStreamClient), not by Handle itself, so it is not
+            // asserted on the raw handler result here.
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal(1, handler.ActiveStreamCount);
+
+            backend.RaiseProcessExited(0); // let the background producer finish
+            await drained().WaitAsync(TimeSpan.FromSeconds(5));
+
+            List<DirectorStreamFrame> snapshot;
+            lock (captured) snapshot = captured.ToList();
+            Assert.Equal(DirectorStreamFrameType.Size, snapshot[0].Kind);
+            Assert.Equal(DirectorStreamFrameType.Closed, snapshot[^1].Kind);
+            await WaitUntilAsync(() => handler.ActiveStreamCount == 0, TimeSpan.FromSeconds(2));
+            Assert.Equal(0, handler.ActiveStreamCount); // torn down once the producer completed
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public void Handler_OpenTerminal_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new AgentOptions());
+        var (handler, _, _) = NewHandler(sm);
+        try
+        {
+            var result = handler.Handle(OpenTerminalCommand(Guid.NewGuid(), "x"));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public void Handler_CloseStream_UnknownId_IsIdempotentOk()
+    {
+        var sm = new SessionManager(new AgentOptions());
+        var (handler, _, _) = NewHandler(sm);
+        try
+        {
+            var result = handler.Handle(new DirectorCommand
+            {
+                Verb = "close-stream",
+                PayloadJson = SessionCommandExecutor.Serialize(new CloseStreamRequest { StreamId = "never-started" }),
+            });
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task Handler_ReadFile_ReturnsOkWithTotalSize_AndStreamsTheFile()
+    {
+        var sm = new SessionManager(new AgentOptions());
+        var (handler, captured, drained) = NewHandler(sm);
+        var path = Path.Combine(Path.GetTempPath(), "ccd-upstream-read-" + Guid.NewGuid().ToString("N") + ".txt");
+        try
+        {
+            var content = Encoding.UTF8.GetBytes("the quick brown fox");
+            await File.WriteAllBytesAsync(path, content);
+
+            var result = handler.Handle(new DirectorCommand
+            {
+                Verb = "read-file",
+                PayloadJson = SessionCommandExecutor.Serialize(new OpenStreamRequest { StreamId = "rf-1", Path = path }),
+            });
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var body = SessionCommandExecutor.Deserialize<OpenReadResponse>(result.BodyJson);
+            Assert.NotNull(body);
+            Assert.Equal(content.Length, body!.TotalBytes);
+
+            await drained().WaitAsync(TimeSpan.FromSeconds(5));
+            List<DirectorStreamFrame> frames;
+            lock (captured) frames = captured.ToList();
+            var binaries = frames.Where(f => f.Kind == DirectorStreamFrameType.Binary).Select(f => f.Data!).ToList();
+            Assert.Equal(content, Concat(binaries));
+            Assert.Equal("eof", frames[^1].Reason);
+        }
+        finally
+        {
+            sm.Dispose();
+            try { File.Delete(path); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void Handler_ReadFile_MissingFile_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new AgentOptions());
+        var (handler, _, _) = NewHandler(sm);
+        try
+        {
+            var result = handler.Handle(new DirectorCommand
+            {
+                Verb = "read-file",
+                PayloadJson = SessionCommandExecutor.Serialize(new OpenStreamRequest { StreamId = "rf-x", Path = Path.Combine(Path.GetTempPath(), "does-not-exist-" + Guid.NewGuid().ToString("N")) }),
+            });
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/GatewayStreamRegistryTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayStreamRegistryTests.cs
@@ -1,0 +1,175 @@
+using System.Runtime.CompilerServices;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Streaming;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0 (up-stream): acceptance tests for <see cref="GatewayStreamRegistry"/> -
+/// the Gateway's receive side of the tunnel up-stream. Covers the three Architect refinements that live in the
+/// registry: pull-then-forward backpressure (ruling 1), and the two close-stream lifecycle races plus the
+/// StreamUp-never-arrives timeout (ruling 3). Framing order and completion are covered too.
+/// </summary>
+public sealed class GatewayStreamRegistryTests
+{
+    // A sink that records the frames it is handed, optionally blocking each write on a supplied gate so a test
+    // can hold the pull and observe backpressure.
+    private sealed class RecordingSink : IStreamSink
+    {
+        private readonly Func<Task>? _gate;
+        public RecordingSink(Func<Task>? gate = null) => _gate = gate;
+        public List<DirectorStreamFrame> Frames { get; } = new();
+        public bool Completed { get; private set; }
+        public string? CompletedReason { get; private set; }
+
+        public async Task WriteFrameAsync(DirectorStreamFrame frame, CancellationToken cancellationToken)
+        {
+            if (_gate is not null) await _gate();
+            Frames.Add(frame);
+        }
+
+        public Task CompleteAsync(string? reason)
+        {
+            Completed = true;
+            CompletedReason = reason;
+            return Task.CompletedTask;
+        }
+    }
+
+    private static DirectorStreamFrame Size(string s) => new() { StreamId = s, Kind = DirectorStreamFrameType.Size, Cols = 80, Rows = 24 };
+    private static DirectorStreamFrame Bin(string s, byte b) => new() { StreamId = s, Kind = DirectorStreamFrameType.Binary, Data = new[] { b } };
+    private static DirectorStreamFrame Closed(string s, string reason) => new() { StreamId = s, Kind = DirectorStreamFrameType.Closed, Reason = reason };
+
+    private static async IAsyncEnumerable<DirectorStreamFrame> SizeBinaryClosed(string s, [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        yield return Size(s);
+        yield return Bin(s, 1);
+        await Task.Yield();
+        yield return Closed(s, "eof");
+    }
+
+    [Fact]
+    public async Task ConsumeAsync_RoutesFramesToSinkInOrder_ThenTearsDown()
+    {
+        var registry = new GatewayStreamRegistry();
+        var sink = new RecordingSink();
+        registry.Register("s1", sink);
+
+        await registry.ConsumeAsync("s1", SizeBinaryClosed("s1"), CancellationToken.None);
+
+        Assert.Equal(3, sink.Frames.Count);
+        Assert.Equal(DirectorStreamFrameType.Size, sink.Frames[0].Kind);
+        Assert.Equal(DirectorStreamFrameType.Binary, sink.Frames[1].Kind);
+        Assert.Equal(DirectorStreamFrameType.Closed, sink.Frames[2].Kind);
+        Assert.True(sink.Completed);
+        Assert.Equal("eof", sink.CompletedReason);
+        Assert.Equal(0, registry.LiveStreamCount); // torn down after completion
+    }
+
+    [Fact]
+    public async Task ConsumeAsync_IsPullThenForward_BackpressuresTheProducer()
+    {
+        // The backpressure invariant (ruling 1): the registry must await the sink write of one frame BEFORE it
+        // pulls the next frame. A sink whose write is held therefore stops the producer from running ahead.
+        var registry = new GatewayStreamRegistry();
+        var gate = new TaskCompletionSource();
+        var sink = new RecordingSink(gate: () => gate.Task);
+        registry.Register("bp", sink);
+
+        var yielded = 0;
+        async IAsyncEnumerable<DirectorStreamFrame> Produce([EnumeratorCancellation] CancellationToken ct = default)
+        {
+            for (var i = 0; i < 5; i++)
+            {
+                Interlocked.Increment(ref yielded);
+                yield return Bin("bp", (byte)i);
+                await Task.Yield();
+            }
+            yield return Closed("bp", "eof");
+        }
+
+        var consume = registry.ConsumeAsync("bp", Produce(), CancellationToken.None);
+        await Task.Delay(150); // let the consumer pull the first frame and block on the held sink write
+
+        Assert.Equal(1, Volatile.Read(ref yielded)); // only the first frame was pulled; the next pull is blocked
+        Assert.False(consume.IsCompleted);
+
+        gate.SetResult(); // release the sink writes
+        await consume;
+
+        Assert.Equal(5, Volatile.Read(ref yielded)); // all five binaries were pulled (the counter counts binaries)
+        Assert.Equal(6, sink.Frames.Count); // and the sink received all five binaries plus the closed frame
+    }
+
+    [Fact]
+    public async Task ConsumeAsync_CloseCancelsTheStream_EndsTheEnumerableAndTearsDown()
+    {
+        var registry = new GatewayStreamRegistry();
+        var sink = new RecordingSink();
+        registry.Register("inf", sink);
+
+        var started = new TaskCompletionSource();
+        async IAsyncEnumerable<DirectorStreamFrame> Forever([EnumeratorCancellation] CancellationToken ct = default)
+        {
+            started.TrySetResult();
+            var i = 0;
+            while (true)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return Bin("inf", (byte)(i++ & 0xFF));
+                await Task.Delay(20, ct);
+            }
+        }
+
+        var consume = registry.ConsumeAsync("inf", Forever(), CancellationToken.None);
+        await started.Task;
+        await Task.Delay(60); // let a few frames flow
+
+        registry.Close("inf"); // browser disconnected
+        await consume; // completes cleanly (cancellation swallowed), does not throw
+
+        Assert.True(sink.Completed);
+        Assert.Equal(0, registry.LiveStreamCount);
+    }
+
+    [Fact]
+    public async Task ConsumeAsync_ForAStreamWhoseSinkIsGone_DropsImmediately()
+    {
+        // StreamUp-after-sink-gone (ruling 3): the browser disconnected before the frames arrived; there is no
+        // registered sink, so consume returns at once without touching any sink.
+        var registry = new GatewayStreamRegistry();
+        var sink = new RecordingSink();
+        registry.Register("gone", sink);
+        registry.Close("gone"); // sink torn down before StreamUp arrives
+
+        await registry.ConsumeAsync("gone", SizeBinaryClosed("gone"), CancellationToken.None);
+
+        Assert.Empty(sink.Frames); // nothing was pumped into the gone sink
+        Assert.Equal(0, registry.LiveStreamCount);
+    }
+
+    [Fact]
+    public async Task Register_WhenStreamUpNeverArrives_TearsTheSinkDownAfterTheTimeout()
+    {
+        // StreamUp-never-arrives (ruling 3): the Director died mid-open, so no StreamUp ever comes; the sink
+        // must not wait forever - the open timeout tears it down and fires the caller's token.
+        var registry = new GatewayStreamRegistry(openTimeout: TimeSpan.FromMilliseconds(100));
+        var sink = new RecordingSink();
+        var token = registry.Register("late", sink);
+
+        await Task.Delay(400);
+
+        Assert.True(sink.Completed);
+        Assert.True(token.IsCancellationRequested);
+        Assert.Equal(0, registry.LiveStreamCount);
+    }
+
+    [Fact]
+    public void Register_DuplicateStreamId_ThrowsFailLoud()
+    {
+        var registry = new GatewayStreamRegistry();
+        registry.Register("dup", new RecordingSink());
+        Assert.Throws<InvalidOperationException>(() => registry.Register("dup", new RecordingSink()));
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -52,6 +52,15 @@ public sealed class GatewayHost : IAsyncDisposable
     public Streaming.PushedSessionStore PushedSessions { get; }
 
     /// <summary>
+    /// Gateway Cleanup mission, Phase 0 (up-stream): the registry of live Director up-streams (terminal output
+    /// and finite file/screenshot reads), keyed by the stream id the Gateway mints per browser request. The
+    /// director-stream hub's StreamUp method pumps the Director's frames into this registry, which forwards
+    /// them to the browser-facing sink with pull-then-forward backpressure. Phase 2 wires the browser-facing
+    /// legs to it; Phase 0 delivers and unit-tests the machinery.
+    /// </summary>
+    public Streaming.GatewayStreamRegistry StreamRegistry { get; }
+
+    /// <summary>
     /// DevThrottle Stats: the always-available aggregate of every session's input tally (turns + character
     /// volume by modality and surface). Fed by the director-stream hub from the pushed
     /// <see cref="Contracts.SessionDto.InputStats"/> and read by the private Gateway dashboard at
@@ -398,6 +407,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // own stale/unreachable sweep, so this never fires for a merely momentarily-unreachable Director.
         Registry.OnDirectorRemoved += directorId => SessionNumbers.ReleaseForDirector(directorId);
         PushedSessions = new Streaming.PushedSessionStore();
+        StreamRegistry = new Streaming.GatewayStreamRegistry();
         InputStats = new Stats.GatewayInputStatsAggregator(inputStatsPath);
         SessionConcurrency = new Stats.GatewaySessionConcurrencyStats();
         RosterCache = new Discovery.FleetRosterCache();
@@ -942,8 +952,21 @@ public sealed class GatewayHost : IAsyncDisposable
         // Issue #1176 (Phase 1a): the Director-push stream. The hub and its two collaborators are
         // registered as singletons so the hub (constructed per-invocation by SignalR's container) and the
         // /sessions aggregation (wired explicitly below) share the one PushedSessionStore instance.
-        builder.Services.AddSignalR();
+        // Gateway Cleanup mission, Phase 0 (up-stream): set the DirectorHub's message-size and stream-buffer
+        // bounds from the shared DirectorStreamLimits so the hub and the Director's producer can never drift
+        // (Architect ruling 2 + 1). MaximumReceiveMessageSize must admit a full-size framed binary frame
+        // (the cap plus a small envelope allowance); StreamBufferCapacity is small so a slow browser sink
+        // pushes back onto the producer's yield - the backpressure invariant, not an optimization.
+        builder.Services.AddSignalR()
+            .AddHubOptions<Streaming.DirectorHub>(o =>
+            {
+                o.MaximumReceiveMessageSize = Contracts.DirectorStreamLimits.MaxBinaryFrameBytes + Contracts.DirectorStreamLimits.FrameEnvelopeAllowanceBytes;
+                o.StreamBufferCapacity = Contracts.DirectorStreamLimits.StreamBufferCapacity;
+            });
         builder.Services.AddSingleton(PushedSessions);
+        // Gateway Cleanup Phase 0: the one up-stream registry the DirectorHub (constructed per-invocation by
+        // SignalR) pumps StreamUp frames into.
+        builder.Services.AddSingleton(StreamRegistry);
         // DevThrottle Stats: the hub (constructed per-invocation by SignalR) folds each pushed session's
         // tally into this one aggregator instance, which the /stats dashboard reads.
         builder.Services.AddSingleton(InputStats);

--- a/src/CcDirector.Gateway/Streaming/DirectorHub.cs
+++ b/src/CcDirector.Gateway/Streaming/DirectorHub.cs
@@ -30,12 +30,29 @@ public sealed class DirectorHub : Hub
     private readonly PushedSessionStore _store;
     private readonly DirectorRegistry _registry;
     private readonly GatewayInputStatsAggregator _inputStats;
+    private readonly GatewayStreamRegistry _streamRegistry;
 
-    public DirectorHub(PushedSessionStore store, DirectorRegistry registry, GatewayInputStatsAggregator inputStats)
+    public DirectorHub(PushedSessionStore store, DirectorRegistry registry, GatewayInputStatsAggregator inputStats, GatewayStreamRegistry streamRegistry)
     {
         _store = store;
         _registry = registry;
         _inputStats = inputStats;
+        _streamRegistry = streamRegistry;
+    }
+
+    /// <summary>
+    /// Gateway Cleanup mission, Phase 0 (up-stream): the Director streams a byte/frame stream UP under the
+    /// stream id the Gateway minted when it opened the stream over the tunnel. This is native client-to-server
+    /// streaming (the Director is the SignalR client). The registry pumps the frames into the browser-facing
+    /// sink with pull-then-forward backpressure, so a slow browser blocks the pull, which - with a small
+    /// StreamBufferCapacity - blocks the Director's producer. One primitive serves both the live terminal and a
+    /// finite file/screenshot read (keyed by the stream id). Requires the connection be bound first (Hello).
+    /// </summary>
+    public Task StreamUp(string streamId, IAsyncEnumerable<DirectorStreamFrame> frames)
+    {
+        var directorId = RequireBoundDirector();
+        FileLog.Write($"[DirectorHub] StreamUp: director={directorId}, stream={streamId}, conn={Short(Context.ConnectionId)}");
+        return _streamRegistry.ConsumeAsync(streamId, frames, Context.ConnectionAborted);
     }
 
     /// <summary>Bind this connection to a Director. Must be the first message; aborts the connection on a bad id.</summary>

--- a/src/CcDirector.Gateway/Streaming/GatewayStreamRegistry.cs
+++ b/src/CcDirector.Gateway/Streaming/GatewayStreamRegistry.cs
@@ -1,0 +1,148 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Streaming;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0 (up-stream): the Gateway's registry of live up-streams, keyed by the
+/// fresh stream id the Gateway minted when it opened the stream over the tunnel. It maps a stream id to the
+/// browser-facing <see cref="IStreamSink"/>, and its <see cref="ConsumeAsync"/> is what the hub's StreamUp
+/// method calls to pump the Director's frames into that sink.
+///
+/// Three of the Architect's four binding refinements live here (the fourth, bounded frames, lives in the
+/// producer and the contract):
+///  1. Backpressure (ruling 1): <see cref="ConsumeAsync"/> is pull-then-forward - it awaits the sink write of
+///     one frame BEFORE pulling the next frame from the Director's up-stream. A slow sink therefore stalls the
+///     pull, which (with a small SignalR StreamBufferCapacity) blocks the Director's producer. Bounded memory
+///     end to end; this is the whole reason for native streaming, not an optimization.
+///  3. close-stream / lifecycle races (ruling 3): a StreamUp that arrives after its sink is already gone is a
+///     safe no-op (nothing to pump into); a StreamUp that never arrives after an open is torn down by a
+///     timeout so a sink is never left waiting forever. Stream ids are fresh Guids and never reused, so no
+///     late frame can alias a later stream.
+/// </summary>
+public sealed class GatewayStreamRegistry
+{
+    private sealed class Entry
+    {
+        public required IStreamSink Sink { get; init; }
+        public required CancellationTokenSource Cts { get; init; }
+        public Timer? OpenTimeout { get; set; }
+        public int Claimed;
+    }
+
+    private readonly ConcurrentDictionary<string, Entry> _streams = new();
+
+    /// <summary>How long a registered sink waits for its StreamUp before it is torn down (ruling 3).</summary>
+    private readonly TimeSpan _openTimeout;
+
+    /// <param name="openTimeout">
+    /// The StreamUp-never-arrives teardown window. Null uses ten seconds. A test seam; production passes null.
+    /// </param>
+    public GatewayStreamRegistry(TimeSpan? openTimeout = null)
+    {
+        _openTimeout = openTimeout ?? TimeSpan.FromSeconds(10);
+    }
+
+    /// <summary>The number of live (registered, not yet torn down) streams. For diagnostics and tests.</summary>
+    public int LiveStreamCount => _streams.Count;
+
+    /// <summary>
+    /// Register the sink for a stream the Gateway just opened over the tunnel (Phase 2 callers). Arms the
+    /// StreamUp-never-arrives timeout. Returns a token that fires when the stream is torn down (a browser
+    /// disconnect via <see cref="Close"/>, the timeout, or natural completion) so the caller can stop waiting.
+    /// A duplicate stream id is a fail-loud error (ids are fresh Guids and must be unique).
+    /// </summary>
+    public CancellationToken Register(string streamId, IStreamSink sink)
+    {
+        if (string.IsNullOrEmpty(streamId)) throw new ArgumentException("streamId is required", nameof(streamId));
+        if (sink is null) throw new ArgumentNullException(nameof(sink));
+
+        var entry = new Entry { Sink = sink, Cts = new CancellationTokenSource() };
+        if (!_streams.TryAdd(streamId, entry))
+            throw new InvalidOperationException($"stream id already registered (ids must be fresh and unique): {streamId}");
+
+        entry.OpenTimeout = new Timer(_ => TimeoutUnclaimed(streamId), null, _openTimeout, Timeout.InfiniteTimeSpan);
+        FileLog.Write($"[GatewayStreamRegistry] registered stream {streamId} (live={_streams.Count})");
+        return entry.Cts.Token;
+    }
+
+    // StreamUp-never-arrives (ruling 3): if nothing claimed this stream within the window, tear the sink down
+    // so it is not left waiting forever (the Director died mid-open, or the open never produced).
+    private void TimeoutUnclaimed(string streamId)
+    {
+        if (!_streams.TryGetValue(streamId, out var entry)) return;
+        if (Interlocked.CompareExchange(ref entry.Claimed, 0, 0) == 1) return; // already claimed - fine
+        FileLog.Write($"[GatewayStreamRegistry] stream {streamId} never received its StreamUp within the open window; tearing down");
+        Teardown(streamId, "stream did not start");
+    }
+
+    /// <summary>
+    /// Consume a Director up-stream into its registered sink (called by the hub's StreamUp method). Pull-then-
+    /// forward: awaits the sink write of each frame before pulling the next (the backpressure invariant). Ends
+    /// on the Closed frame, natural completion, cancellation (a browser disconnect via <see cref="Close"/>), or
+    /// the hub connection aborting. If no sink is registered for this id the frames are dropped and the method
+    /// returns at once (StreamUp-after-sink-gone: the browser is already gone).
+    /// </summary>
+    public async Task ConsumeAsync(string streamId, IAsyncEnumerable<DirectorStreamFrame> frames, CancellationToken hubCancellation)
+    {
+        if (frames is null) throw new ArgumentNullException(nameof(frames));
+
+        if (!_streams.TryGetValue(streamId, out var entry))
+        {
+            // StreamUp-after-sink-gone (ruling 3): the browser disconnected before the frames arrived. There
+            // is nothing to pump into; return immediately so the Director's producer is not consumed further.
+            FileLog.Write($"[GatewayStreamRegistry] StreamUp for unknown/closed stream {streamId}; dropping (sink already gone)");
+            return;
+        }
+
+        Interlocked.Exchange(ref entry.Claimed, 1);
+        entry.OpenTimeout?.Dispose();
+        entry.OpenTimeout = null;
+
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(entry.Cts.Token, hubCancellation);
+        string? reason = null;
+        try
+        {
+            await foreach (var frame in frames.WithCancellation(linked.Token))
+            {
+                // Pull-then-forward (ruling 1): await this frame's delivery BEFORE the loop pulls the next one.
+                await entry.Sink.WriteFrameAsync(frame, linked.Token);
+                if (frame.Kind == DirectorStreamFrameType.Closed)
+                {
+                    reason = frame.Reason;
+                    break;
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected teardown: the browser disconnected (Close) or the hub connection aborted. Not a fault -
+            // the finally tears the stream down normally.
+            reason ??= "cancelled";
+        }
+        finally
+        {
+            Teardown(streamId, reason);
+        }
+    }
+
+    /// <summary>Tear a stream down from the browser-facing side (the browser disconnected). Idempotent.</summary>
+    public void Close(string streamId) => Teardown(streamId, "closed");
+
+    private void Teardown(string streamId, string? reason)
+    {
+        if (!_streams.TryRemove(streamId, out var entry)) return;
+        entry.OpenTimeout?.Dispose();
+        try { entry.Cts.Cancel(); } catch { /* already disposed */ }
+        _ = SafeCompleteAsync(entry.Sink, reason);
+        entry.Cts.Dispose();
+        FileLog.Write($"[GatewayStreamRegistry] torn down stream {streamId} (reason={reason ?? "none"}, live={_streams.Count})");
+    }
+
+    private static async Task SafeCompleteAsync(IStreamSink sink, string? reason)
+    {
+        try { await sink.CompleteAsync(reason); }
+        catch (Exception ex) { FileLog.Write($"[GatewayStreamRegistry] sink CompleteAsync failed: {ex.Message}"); }
+    }
+}

--- a/src/CcDirector.Gateway/Streaming/IStreamSink.cs
+++ b/src/CcDirector.Gateway/Streaming/IStreamSink.cs
@@ -1,0 +1,33 @@
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Streaming;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0 (up-stream): the browser-facing consumer of one up-stream's frames.
+/// The Gateway opens a stream over the tunnel, registers a sink for it in <see cref="GatewayStreamRegistry"/>,
+/// and the Director's frames flow up and out through this sink to the browser. Phase 2 provides the real
+/// sinks - a WebSocket writer for the live terminal, a buffered HTTP response writer for a file or screenshot
+/// read; Phase 0 exercises the registry with a test sink.
+///
+/// The backpressure invariant (Architect ruling 1) lives in the registry, not here: the registry awaits
+/// <see cref="WriteFrameAsync"/> for one frame BEFORE it pulls the next frame from the Director's up-stream,
+/// so a slow sink stalls the pull, which fills the small SignalR channel, which blocks the Director's
+/// producer - end-to-end backpressure with bounded memory. A sink implementation therefore does NOT need to
+/// buffer; it just writes the one frame it is handed and returns when that write has drained.
+/// </summary>
+public interface IStreamSink
+{
+    /// <summary>
+    /// Write one frame to the browser-facing transport and return only when it has drained (so the registry
+    /// does not pull the next frame until this one is delivered). Throwing signals the sink is broken; the
+    /// registry tears the stream down.
+    /// </summary>
+    Task WriteFrameAsync(DirectorStreamFrame frame, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Called exactly once when the stream ends - a natural end / end-of-file, a browser disconnect, or a
+    /// teardown - so the sink can close its transport. <paramref name="reason"/> is the Closed frame's reason
+    /// when the stream ended naturally, or a teardown reason otherwise; null when not known.
+    /// </summary>
+    Task CompleteAsync(string? reason);
+}


### PR DESCRIPTION
## What this is

Gateway Cleanup mission, Phase 0 (the tunnel protocol) - the second of two additive spine units, on top of part 1 (#1407). It adds the one Director-to-Gateway byte/frame up-stream that later phases wire the browser-facing terminal and file reads onto. It changes no behavior and deletes nothing.

Design authority: docs/architecture/gateway-cleanup-phase0-tunnel-protocol.md, including the four binding Architect refinements (backpressure, bounded frames, load-bearing close, size-up-front).

## Gateway receive side

- `StreamUp` hub method + `GatewayStreamRegistry`: pumps a Director up-stream into the browser-facing sink with **pull-then-forward backpressure** - it awaits one frame's delivery before pulling the next, so a slow browser blocks the pull, which (with a small stream buffer) blocks the Director's producer. Bounded memory end to end.
- Both lifecycle races handled: a `StreamUp` whose sink is already gone is dropped immediately; a stream opened but whose `StreamUp` never arrives is torn down by a timeout.
- Hub `MaximumReceiveMessageSize` and `StreamBufferCapacity` set from the shared `DirectorStreamLimits`, so the hub and producer can never disagree on the frame cap.

## Director produce side

- `DirectorUpStreamHandler` owns the four connection-bound stream verbs (`open-terminal-stream`, `read-file`, `screenshot-file`, `close-stream`) plus a per-stream cancellation registry. Open returns Ok immediately and streams in the background; close is idempotent; a tunnel drop tears down **every** live stream.
- Terminal producer: the exact cursor loop the terminal endpoint runs, lifted to `yield` frames, each burst split into bounded frames. File producer: bounded chunks then an eof frame; the open returns the total size up front for Content-Length.
- The keystroke write stays a plain unary verb (`terminal-input`), not a stream verb.

One primitive (`DirectorStreamFrame`: Size / Binary / Closed) serves both the open-ended terminal and a finite file/screenshot read, keyed by a fresh stream id. The browser-facing contracts are unchanged; only the Gateway-to-Director leg gains this up-stream.

## Tests

The backpressure acceptance test, frame order + completion, both lifecycle races, the duplicate stream-id guard, the terminal producer's snapshot-then-tail **golden bytes**, file chunking, and the handler's open / idempotent close / read behavior. The streaming regression suites (DirectorHub, GatewayStreamClient, StreamCommand, GatewayHost) stay green.

## After this merges

The full Phase 0 spine is on main. Next is the five-worker fan-out for the read/write handler extraction - all additive. Deletions are Phase 1, which is a separate Architect checkpoint.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>