### PR TITLE
feat(gateway-cleanup): Phase 0 - route the unary byte verbs through the tunnel dispatch

### DIFF
--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -2567,16 +2567,15 @@ internal static class ControlEndpoints
         // the saved absolute path so the client can drop it into the composer for the user
         // to send. The session and the saved file live on the same machine by construction
         // (the session runs here), so the path is always valid for that session.
+        // Gateway Cleanup Phase 0: the multipart form is read at THIS HTTP boundary (the tunnel never
+        // carries multipart), then the already-read bytes and file name are handed to the SAME
+        // upload-image byte verb the Gateway tunnel dispatches, so the SAVE logic lives in exactly one
+        // place (SessionByteExecutor.SaveUploadedImage) and the two paths file bytes identically. The
+        // id/session guards moved into that verb; only the genuinely boundary-specific multipart guards
+        // (a non-form body, a missing/empty file field) stay in this lambda.
         app.MapPost("/sessions/{sid}/upload-image", async (string sid, HttpContext httpCtx) =>
         {
             FileLog.Write($"[ControlEndpoints] POST upload-image: sid={sid}");
-
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
-
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
 
             if (!httpCtx.Request.HasFormContentType)
                 return Results.BadRequest(new { error = "expected multipart/form-data with an image file field 'file'" });
@@ -2586,23 +2585,33 @@ internal static class ControlEndpoints
             if (file is null || file.Length == 0)
                 return Results.BadRequest(new { error = "no image uploaded; use form field 'file'" });
 
-            var ext = Path.GetExtension(file.FileName).ToLowerInvariant();
-            var allowed = new[] { ".png", ".jpg", ".jpeg", ".gif", ".webp", ".heic", ".bmp" };
-            if (!allowed.Contains(ext))
-                return Results.BadRequest(new { error = $"unsupported image type '{ext}'. Allowed: {string.Join(", ", allowed)}" });
-
-            var dir = CcStorage.Screenshots();
-            var name = $"upload-{DateTime.Now:yyyyMMdd-HHmmss-fff}{ext}";
-            var fullPath = Path.Combine(dir, name);
-
-            await using (var dest = File.Create(fullPath))
+            byte[] bytes;
             await using (var src = file.OpenReadStream())
+            using (var memory = new MemoryStream())
             {
-                await src.CopyToAsync(dest, httpCtx.RequestAborted);
+                await src.CopyToAsync(memory, httpCtx.RequestAborted);
+                bytes = memory.ToArray();
             }
 
-            FileLog.Write($"[ControlEndpoints] upload-image saved: {fullPath} ({file.Length} bytes)");
-            return Results.Json(new { path = fullPath, fileName = name });
+            var command = new DirectorCommand
+            {
+                Verb = "upload-image",
+                SessionId = sid,
+                PayloadJson = SessionCommandExecutor.Serialize(new UploadImageRequest
+                {
+                    FileName = file.FileName,
+                    BytesBase64 = Convert.ToBase64String(bytes),
+                }),
+            };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
+
+            return result.Status switch
+            {
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<UploadImageResponse>(result.BodyJson)),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "upload-image command failed"),
+            };
         });
 
         // ===== REST: Screenshots gallery =====
@@ -2618,27 +2627,23 @@ internal static class ControlEndpoints
         // DefaultScreenshotCount. The folder can hold thousands of images and no client ever
         // shows more than the newest few - older files are deliberately ignored. "total"
         // always reports the full folder count so clients can say "newest N of total".
-        app.MapGet("/screenshots", (int? count) =>
+        // Gateway Cleanup Phase 0: the list runs through the shared SessionByteExecutor core so this REST
+        // path and the Gateway tunnel verb are identical and cannot drift. Phase 1 deletes this route and
+        // leaves the core reached only over the tunnel.
+        app.MapGet("/screenshots", async (int? count) =>
         {
-            var cap = count is > 0 ? count.Value : DefaultScreenshotCount;
-            FileLog.Write($"[ControlEndpoints] GET /screenshots cap={cap}");
-            var dir = CcStorage.Screenshots();
-            var all = ScreenshotFiles(dir);
-            var items = all
-                .Take(cap)
-                .Select(info => new
-                {
-                    fileName = info.Name,
-                    // Absolute on-disk path on THIS Director's machine. The Cockpit injects it
-                    // into the composer at the cursor (desktop parity: drop the path into the
-                    // prompt) - the owning Claude session reads it directly, no upload needed.
-                    path = info.FullName,
-                    timeLabel = info.LastWriteTime.ToString("MMM d, h:mm tt"),
-                    lastWriteUtc = info.LastWriteTimeUtc,
-                    sizeBytes = info.Length,
-                })
-                .ToList();
-            return Results.Json(new { directory = dir, total = all.Count, items });
+            var command = new DirectorCommand
+            {
+                Verb = "screenshots-list",
+                PayloadJson = SessionCommandExecutor.Serialize(new ScreenshotListRequest { Count = count }),
+            };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
+
+            return result.Status switch
+            {
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<ScreenshotListResponse>(result.BodyJson)),
+                _ => Results.Problem(result.Error ?? "screenshots-list command failed"),
+            };
         });
 
         // Serve one screenshot's bytes. Loaded browser-direct as an <img src> and fetched for the
@@ -3721,7 +3726,9 @@ internal static class ControlEndpoints
     /// calls. The previous string-path version stat'ed every file twice (sort + FileInfo),
     /// which took ~100ms on a 1400-file folder; this takes ~1-2ms.
     /// </summary>
-    private static List<FileInfo> ScreenshotFiles(string directory)
+    // Internal (Gateway Cleanup Phase 0) so the screenshots-list byte verb enumerates the same folder this
+    // REST route does - one enumerator, no drift.
+    internal static List<FileInfo> ScreenshotFiles(string directory)
     {
         if (!Directory.Exists(directory))
             return new List<FileInfo>();

--- a/src/CcDirector.ControlApi/SessionByteExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionByteExecutor.cs
@@ -1,3 +1,6 @@
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
 namespace CcDirector.ControlApi;
@@ -8,14 +11,133 @@ namespace CcDirector.ControlApi;
 /// screenshots list (a directory read) and upload-image (bytes DOWN in the payload, chunked if large). The
 /// three connection-bound byte STREAMS - read-file, screenshot-file, and the terminal stream - are NOT here:
 /// they are handled at the connection layer in GatewayStreamClient with the up-stream primitive, because
-/// only they need the live connection (Architect ruling A). Empty in the spine; Worker S1 fills it once the
-/// spine's up-stream producers are in place. Each verb it adds is declared in <see cref="Verbs"/> and handled
-/// in <see cref="ExecuteAsync"/>, touching only this file.
+/// only they need the live connection (Architect ruling A). Worker S1 fills it once the spine's up-stream
+/// producers are in place. Each verb is declared in <see cref="Verbs"/> and handled in
+/// <see cref="ExecuteAsync"/>, touching only this file.
 /// </summary>
 internal sealed class SessionByteExecutor : ISessionCommandArea
 {
-    public IReadOnlyCollection<string> Verbs { get; } = Array.Empty<string>();
+    public IReadOnlyCollection<string> Verbs { get; } = new[] { "screenshots-list", "upload-image" };
 
-    public Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken) =>
-        Task.FromResult(DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the byte area"));
+    public Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken)
+    {
+        var result = command.Verb switch
+        {
+            "screenshots-list" => ScreenshotsList(command),
+            "upload-image" => UploadImage(context.SessionManager, command),
+            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the byte area"),
+        };
+        return Task.FromResult(result);
+    }
+
+    /// <summary>
+    /// The <c>screenshots-list</c> verb: list the screenshots on THIS Director's machine, newest first, with
+    /// a pre-formatted local time label. Mirrors the Director's <c>GET /screenshots</c> lambda exactly - a
+    /// null or non-positive count falls back to <see cref="ControlEndpoints.DefaultScreenshotCount"/>, the
+    /// items are capped to that cap while <see cref="ScreenshotListResponse.Total"/> always reports the full
+    /// folder count, and older files past the cap are deliberately dropped. This is a plain unary read: no
+    /// target session and no error branches (an empty or missing folder simply lists nothing).
+    /// </summary>
+    internal static DirectorCommandResult ScreenshotsList(DirectorCommand command)
+    {
+        var request = SessionCommandExecutor.Deserialize<ScreenshotListRequest>(command.PayloadJson);
+        var cap = request?.Count is > 0 ? request.Count.Value : ControlEndpoints.DefaultScreenshotCount;
+        FileLog.Write($"[SessionByteExecutor] screenshots-list cap={cap}");
+
+        var dir = CcStorage.Screenshots();
+        var all = ControlEndpoints.ScreenshotFiles(dir);
+        var items = all
+            .Take(cap)
+            .Select(info => new ScreenshotItem
+            {
+                FileName = info.Name,
+                // Absolute on-disk path on THIS Director's machine. The Cockpit injects it into the composer
+                // at the cursor (desktop parity: drop the path into the prompt) - the owning Claude session
+                // reads it directly, no upload needed.
+                Path = info.FullName,
+                TimeLabel = info.LastWriteTime.ToString("MMM d, h:mm tt"),
+                LastWriteUtc = info.LastWriteTimeUtc,
+                SizeBytes = info.Length,
+            })
+            .ToList();
+
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new ScreenshotListResponse
+        {
+            Directory = dir,
+            Total = all.Count,
+            Items = items,
+        }));
+    }
+
+    /// <summary>
+    /// The image extensions <c>upload-image</c> accepts, byte-identical to the set the REST route enforced.
+    /// A phone can offer HEIC, so it is included; the on-disk file simply keeps whatever extension was sent.
+    /// </summary>
+    private static readonly string[] UploadAllowedExtensions = { ".png", ".jpg", ".jpeg", ".gif", ".webp", ".heic", ".bmp" };
+
+    /// <summary>
+    /// The <c>upload-image</c> verb: file an uploaded image into the user's screenshots folder on THIS
+    /// Director's machine, where the owning Claude session can read it by absolute path. Mirrors the
+    /// Director's <c>POST /sessions/{sid}/upload-image</c> lambda - invalid id -&gt; BadRequest, missing
+    /// session -&gt; NotFound - then hands the already-read bytes and file name to the shared save core.
+    /// The REST route reads the multipart form at the HTTP boundary and dispatches this SAME verb, so the
+    /// save logic lives in exactly one place (<see cref="SaveUploadedImage"/>).
+    /// </summary>
+    internal static DirectorCommandResult UploadImage(SessionManager sessionManager, DirectorCommand command)
+    {
+        FileLog.Write($"[SessionByteExecutor] upload-image: sid={command.SessionId}");
+
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        var request = SessionCommandExecutor.Deserialize<UploadImageRequest>(command.PayloadJson);
+        return SaveUploadedImage(request);
+    }
+
+    /// <summary>
+    /// The shared SAVE core, past the id/session guards: validate the image, decode the base64 bytes, and
+    /// write the file into the screenshots folder under a timestamped name that keeps the uploaded
+    /// extension. Called by the <c>upload-image</c> verb over the tunnel AND directly by the REST route
+    /// after it reads the multipart form, so the two paths file bytes identically. Empty bytes -&gt;
+    /// BadRequest (matching the REST route's empty-file guard), an unsupported extension -&gt; BadRequest,
+    /// and undecodable base64 -&gt; a fail-loud BadRequest naming the cause. Returns the saved absolute path.
+    /// </summary>
+    internal static DirectorCommandResult SaveUploadedImage(UploadImageRequest? request)
+    {
+        if (request is null || string.IsNullOrEmpty(request.BytesBase64))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "no image uploaded; use form field 'file'");
+
+        var ext = Path.GetExtension(request.FileName).ToLowerInvariant();
+        if (!UploadAllowedExtensions.Contains(ext))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unsupported image type '{ext}'. Allowed: {string.Join(", ", UploadAllowedExtensions)}");
+
+        byte[] bytes;
+        try
+        {
+            bytes = Convert.FromBase64String(request.BytesBase64);
+        }
+        catch (FormatException)
+        {
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "image bytes must be base64");
+        }
+
+        if (bytes.Length == 0)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "no image uploaded; use form field 'file'");
+
+        var dir = CcStorage.Screenshots();
+        var name = $"upload-{DateTime.Now:yyyyMMdd-HHmmss-fff}{ext}";
+        var fullPath = Path.Combine(dir, name);
+        File.WriteAllBytes(fullPath, bytes);
+
+        FileLog.Write($"[SessionByteExecutor] upload-image saved: {fullPath} ({bytes.Length} bytes)");
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new UploadImageResponse
+        {
+            Path = fullPath,
+            FileName = name,
+        }));
+    }
 }

--- a/src/CcDirector.Gateway.Contracts/SessionByteContracts.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionByteContracts.cs
@@ -1,0 +1,84 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0: the request for the <c>screenshots-list</c> unary byte verb (the
+/// tunnel twin of <c>GET /screenshots</c>). The list is a directory read on THIS Director's machine, so
+/// the only input is the newest-first cap. A null or non-positive <see cref="Count"/> falls back to the
+/// Director's default cap, exactly as the query parameter did on the REST route.
+/// </summary>
+public sealed class ScreenshotListRequest
+{
+    /// <summary>Newest-first cap. Null or non-positive means "use the default cap".</summary>
+    public int? Count { get; set; }
+}
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0: one screenshot row in a <see cref="ScreenshotListResponse"/>. The
+/// field set is byte-identical to the anonymous object the <c>GET /screenshots</c> route returned, so the
+/// Cockpit gallery reads the same shape whether the list came over the REST route or the tunnel verb.
+/// </summary>
+public sealed class ScreenshotItem
+{
+    /// <summary>The bare file name, e.g. "shot-2026-07-12.png".</summary>
+    public string FileName { get; set; } = "";
+
+    /// <summary>The absolute on-disk path on THIS Director's machine (injected into the composer on tap).</summary>
+    public string Path { get; set; } = "";
+
+    /// <summary>A pre-formatted local time label ("MMM d, h:mm tt") so clients need not re-derive it.</summary>
+    public string TimeLabel { get; set; } = "";
+
+    /// <summary>Last write time in universal time, used for newest-first ordering on the client.</summary>
+    public DateTime LastWriteUtc { get; set; }
+
+    /// <summary>The file size in bytes.</summary>
+    public long SizeBytes { get; set; }
+}
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0: the response of the <c>screenshots-list</c> verb. Mirrors the
+/// <c>GET /screenshots</c> body exactly: the screenshots directory, the FULL folder count (so a client can
+/// say "newest N of total"), and the capped, newest-first <see cref="Items"/>.
+/// </summary>
+public sealed class ScreenshotListResponse
+{
+    /// <summary>The screenshots folder on THIS Director's machine.</summary>
+    public string Directory { get; set; } = "";
+
+    /// <summary>The full folder count (never capped), so clients can report "newest N of total".</summary>
+    public int Total { get; set; }
+
+    /// <summary>The capped, newest-first screenshot rows.</summary>
+    public List<ScreenshotItem> Items { get; set; } = new();
+}
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0: the request for the <c>upload-image</c> unary byte verb (the tunnel
+/// twin of <c>POST /sessions/{sid}/upload-image</c>). The image bytes ride DOWN in the payload,
+/// base64-encoded so they survive the JSON envelope intact; <see cref="FileName"/> carries the original
+/// name so the saved file keeps the uploaded extension. The REST route reads the multipart form at the
+/// HTTP boundary and fills this same request before dispatching, so the SAVE logic is shared, not
+/// duplicated.
+/// </summary>
+public sealed class UploadImageRequest
+{
+    /// <summary>The original file name (only its extension is used to pick the saved file's extension).</summary>
+    public string FileName { get; set; } = "";
+
+    /// <summary>The raw image bytes, base64-encoded.</summary>
+    public string BytesBase64 { get; set; } = "";
+}
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0: the response of the <c>upload-image</c> verb. Byte-identical to the
+/// <c>{ path, fileName }</c> object the REST route returned: the absolute saved path (which the owning
+/// Claude session reads directly) and the saved file name.
+/// </summary>
+public sealed class UploadImageResponse
+{
+    /// <summary>The absolute path the image was saved to on THIS Director's machine.</summary>
+    public string Path { get; set; } = "";
+
+    /// <summary>The saved file name (an "upload-yyyyMMdd-HHmmss-fff" stamp plus the uploaded extension).</summary>
+    public string FileName { get; set; } = "";
+}

--- a/src/CcDirector.Gateway.Tests/SessionByteExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionByteExecutorTests.cs
@@ -1,0 +1,257 @@
+using System.Text.Json;
+using CcDirector.ControlApi;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Storage;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0: parity unit tests for the unary BYTE verbs the
+/// <see cref="SessionByteExecutor"/> owns - <c>screenshots-list</c> (a directory read) and
+/// <c>upload-image</c> (bytes down the payload, filed to disk). Each verb is exercised through the real
+/// <see cref="SessionCommandExecutor.DispatchAsync"/> path (the same entry the Gateway tunnel uses), so the
+/// tunnel verb and the REST route that now dispatches it cannot drift. The screenshots folder is pinned
+/// (via CC_DIRECTOR_ROOT + config.json) into a temp dir so nothing touches the user's real
+/// Pictures\Screenshots folder. In the "DirectorRoot" collection (serializes root-touching tests).
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class SessionByteExecutorTests : IAsyncLifetime
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    // A tiny valid 1x1 PNG (decodes cleanly), used as the image bytes.
+    private static readonly byte[] OnePngBytes = Convert.FromBase64String(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==");
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private string _shotsDir = null!;
+
+    public SessionByteExecutorTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-byte-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        // Pin the screenshots folder into the temp root via config.json so CcStorage.Screenshots()
+        // resolves to it instead of the real Pictures\Screenshots.
+        _shotsDir = Path.Combine(_root, "shots");
+        Directory.CreateDirectory(_shotsDir);
+        var configDir = CcStorage.Config();
+        Directory.CreateDirectory(configDir);
+        var json = JsonSerializer.Serialize(new
+        {
+            screenshots = new { source_directory = _shotsDir },
+        });
+        await File.WriteAllTextAsync(CcStorage.ConfigJson(), json);
+    }
+
+    public Task DisposeAsync()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+        return Task.CompletedTask;
+    }
+
+    private static (SessionManager sm, Session session) NewSession()
+    {
+        var sm = new SessionManager(new AgentOptions());
+        var backend = new ExecuteActionTestBackend();
+        var session = sm.CreateEmbeddedSession(Path.GetTempPath(), null, backend);
+        return (sm, session);
+    }
+
+    // ---------- screenshots-list ----------
+
+    private void SeedScreenshot(string fileName, DateTime lastWriteUtc)
+    {
+        var path = Path.Combine(_shotsDir, fileName);
+        File.WriteAllBytes(path, OnePngBytes);
+        File.SetLastWriteTimeUtc(path, lastWriteUtc);
+    }
+
+    private static DirectorCommand ScreenshotsListCommand(int? count) => new()
+    {
+        CommandId = "sl1",
+        Verb = "screenshots-list",
+        PayloadJson = JsonSerializer.Serialize(new ScreenshotListRequest { Count = count }, Json),
+    };
+
+    [Fact]
+    public async Task DispatchAsync_ScreenshotsList_ReturnsOkWithNewestFirstItems()
+    {
+        SeedScreenshot("shot-older.png", DateTime.UtcNow.AddMinutes(-10));
+        SeedScreenshot("shot-newer.png", DateTime.UtcNow);
+        // A non-image file that must be ignored by the listing.
+        await File.WriteAllTextAsync(Path.Combine(_shotsDir, "notes.txt"), "ignore me");
+
+        var sm = new SessionManager(new AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", ScreenshotsListCommand(null));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal("sl1", result.CommandId);
+
+            var resp = JsonSerializer.Deserialize<ScreenshotListResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(resp);
+            Assert.Equal(_shotsDir, resp!.Directory);
+            Assert.Equal(2, resp.Total);                              // notes.txt excluded
+            Assert.Equal(2, resp.Items.Count);
+            Assert.Equal("shot-newer.png", resp.Items[0].FileName);   // newest first
+            Assert.Equal("shot-older.png", resp.Items[1].FileName);
+            Assert.Equal(Path.Combine(_shotsDir, "shot-newer.png"), resp.Items[0].Path);
+            Assert.All(resp.Items, i => Assert.False(string.IsNullOrWhiteSpace(i.TimeLabel)));
+            Assert.All(resp.Items, i => Assert.True(i.SizeBytes > 0));
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_ScreenshotsList_CountCapsItemsButTotalReportsFolder()
+    {
+        SeedScreenshot("shot-older.png", DateTime.UtcNow.AddMinutes(-10));
+        SeedScreenshot("shot-newer.png", DateTime.UtcNow);
+
+        var sm = new SessionManager(new AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", ScreenshotsListCommand(1));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var resp = JsonSerializer.Deserialize<ScreenshotListResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(resp);
+            Assert.Single(resp!.Items);                               // capped to the newest one
+            Assert.Equal("shot-newer.png", resp.Items[0].FileName);
+            Assert.Equal(2, resp.Total);                              // folder count, not the cap
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_ScreenshotsList_EmptyFolder_ReturnsOkWithNoItems()
+    {
+        var sm = new SessionManager(new AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", ScreenshotsListCommand(null));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var resp = JsonSerializer.Deserialize<ScreenshotListResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(resp);
+            Assert.Equal(0, resp!.Total);
+            Assert.Empty(resp.Items);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- upload-image ----------
+
+    private static DirectorCommand UploadImageCommand(string sid, string fileName, string bytesBase64) => new()
+    {
+        CommandId = "ui1",
+        Verb = "upload-image",
+        SessionId = sid,
+        PayloadJson = JsonSerializer.Serialize(new UploadImageRequest { FileName = fileName, BytesBase64 = bytesBase64 }, Json),
+    };
+
+    [Fact]
+    public async Task DispatchAsync_UploadImage_InvalidSessionId_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                UploadImageCommand("not-a-guid", "photo.png", Convert.ToBase64String(OnePngBytes)));
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_UploadImage_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                UploadImageCommand(Guid.NewGuid().ToString(), "photo.png", Convert.ToBase64String(OnePngBytes)));
+
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_UploadImage_SavesBytesToScreenshotsFolderAndReturnsPath()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                UploadImageCommand(session.Id.ToString(), "photo.png", Convert.ToBase64String(OnePngBytes)));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal("ui1", result.CommandId);
+
+            var resp = JsonSerializer.Deserialize<UploadImageResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(resp);
+            // Saved under a timestamped name that keeps the uploaded .png extension, inside the pinned folder.
+            Assert.StartsWith("upload-", resp!.FileName);
+            Assert.EndsWith(".png", resp.FileName);
+            Assert.Equal(Path.Combine(_shotsDir, resp.FileName), resp.Path);
+            Assert.True(File.Exists(resp.Path));
+            Assert.Equal(OnePngBytes, await File.ReadAllBytesAsync(resp.Path));
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_UploadImage_UnsupportedExtension_ReturnsBadRequest()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                UploadImageCommand(session.Id.ToString(), "notes.txt", Convert.ToBase64String(OnePngBytes)));
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_UploadImage_EmptyBytes_ReturnsBadRequest()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                UploadImageCommand(session.Id.ToString(), "photo.png", ""));
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_UploadImage_NotBase64_ReturnsBadRequest()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                UploadImageCommand(session.Id.ToString(), "photo.png", "not valid base64 !!!"));
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+}


### PR DESCRIPTION
## What this does

Gateway Cleanup mission, Phase 0. Additive only, no deletions. Fills the empty `SessionByteExecutor` (which the merged spine left with an empty verb list) with the two UNARY byte verbs, and re-points their REST routes through the shared `SessionCommandExecutor.DispatchAsync` core - the exact extract-core + route-through-dispatch pattern the spine set with `turns` (a read) and `resize` (a write).

The connection-bound STREAM verbs (open-terminal-stream, read-file, screenshot-file, close-stream) are NOT touched - they live in the connection layer per Architect ruling A.

## Verbs moved

**screenshots-list** (unary read, the `GET /screenshots` route)
- New core `SessionByteExecutor.ScreenshotsList` enumerates the screenshots folder on this machine (newest-first, capped) and returns a typed `ScreenshotListResponse`. It reuses `ControlEndpoints.ScreenshotFiles` (changed `private` -> `internal`, one enumerator, no drift).
- The `GET /screenshots` route now builds a `screenshots-list` command and dispatches it, deserializing the response back for `Results.Json`. Return shape is byte-identical to the old anonymous `{ directory, total, items[] }`.

**upload-image** (unary write, the `POST /sessions/{sid}/upload-image` route)
- The multipart/form-data read stays at the HTTP boundary (the tunnel never carries multipart). The route reads the form, pulls the bytes out of the `IFormFile`, base64-encodes them into `UploadImageRequest { FileName, BytesBase64 }`, and dispatches the same `upload-image` verb.
- The verb handler validates the id/session, then hands the request to the shared `SaveUploadedImage` core, which does the extension check, base64 decode, and the file write, returning `UploadImageResponse { Path, FileName }`. So the SAVE logic lives in exactly one place, reached identically by the tunnel and by the REST route.

### One behavioral nuance (upload-image guard order)
Following the exemplar (turns/resize routes delegate id/session validation to the core rather than pre-checking), the id and session guards moved from the route lambda into the verb. Only the genuinely boundary-specific multipart guards (non-form body, missing/empty file field) stay in the lambda. For every normal request the observable result (status + message) is unchanged. The single extreme edge case that differs: a request with BOTH a malformed session id AND a non-multipart body now returns the "expected multipart" BadRequest instead of the "invalid session id format" BadRequest - same 400 status, different message, on a doubly-malformed request. Flagged for transparency.

## New files
- `src/CcDirector.Gateway.Contracts/SessionByteContracts.cs` - the five new DTOs (`ScreenshotListRequest`, `ScreenshotItem`, `ScreenshotListResponse`, `UploadImageRequest`, `UploadImageResponse`). No shared DTO file was edited.
- `src/CcDirector.Gateway.Tests/SessionByteExecutorTests.cs` - parity tests.

## Verification
- `dotnet build src/CcDirector.ControlApi/CcDirector.ControlApi.csproj` - 0 warnings, 0 errors.
- `dotnet test ... --filter "FullyQualifiedName~SessionByteExecutorTests|FullyQualifiedName~ScreenshotEndpointsTests"` - Passed! Failed: 0, Passed: 22, Skipped: 0. The existing `ScreenshotEndpointsTests` (end-to-end through the re-pointed route) still pass unchanged, proving the return shape is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)