### PR TITLE
feat(gateway-cleanup): Phase 0 - route session read verbs through the tunnel dispatch

### DIFF
--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -425,14 +425,16 @@ public sealed class ControlApiHost : IAsyncDisposable
             _sessionManager.Options, Core.Configuration.GatewayConfig.Load);
         DictationEndpoint.Map(_app, _sessionManager.Options, dictionaryResolver);
         TerminalStreamEndpoint.Map(_app, _sessionManager);
-        SessionUsageEndpoint.Map(_app, _sessionManager);
+        // Gateway Cleanup Phase 0: these three reads now dispatch through the shared SessionReadExecutor,
+        // which needs this Director's id (for the command context/logging), so it is passed in.
+        SessionUsageEndpoint.Map(_app, _sessionManager, DirectorId);
         // GET /sessions/{sid}/context (issue #799): the always-visible "how full is the window"
         // gauge data, via the session driver's ContextUsage capability (Claude today).
-        SessionContextEndpoint.Map(_app, _sessionManager);
+        SessionContextEndpoint.Map(_app, _sessionManager, DirectorId);
         // GET /sessions/{sid}/history (epic #733): the parsed, agent-agnostic conversation
         // history (reuses Core SessionHistoryReader) plus the transcript-derived history state.
         // Forwarded to the Cockpit verbatim by the Gateway's generic /sessions/{sid}/{**rest} proxy.
-        SessionHistoryEndpoint.Map(_app, _sessionManager);
+        SessionHistoryEndpoint.Map(_app, _sessionManager, DirectorId);
         ClaudeTranscriptsEndpoint.Map(_app);
         SettingsEndpoint.Map(_app, ReapplyGatewayAsync, () => Port);
         // /settings/agents (issue #584): full Settings-dialog Agents-tab parity over REST -

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -237,16 +237,28 @@ internal static class ControlEndpoints
             return Results.Json(sessions);
         });
 
-        app.MapGet("/sessions/{sid}", (string sid) =>
+        // Gateway Cleanup Phase 0: the read runs through the shared SessionReadExecutor core so this REST
+        // path and the Gateway stream down-channel are identical and cannot drift. The Director's local
+        // response still uses its identity-stamped mapper (MachineName/User/TailnetEndpoint), so this
+        // endpoint stays byte-identical; the executor returns the plain stream DTO that the Gateway stamps
+        // during aggregation (exactly as the patch verb does). Phase 1 deletes this route.
+        app.MapGet("/sessions/{sid}", async (string sid) =>
         {
             if (!Guid.TryParse(sid, out var guid))
                 return Results.BadRequest(new { error = "invalid session id format" });
 
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
+            var command = new DirectorCommand { Verb = "snapshot", SessionId = sid };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
 
-            return Results.Json(MapWithIdentity(session, turnSummaryCache));
+            if (result.Status == DirectorCommandStatus.BadRequest)
+                return Results.BadRequest(new { error = result.Error });
+            if (result.Status != DirectorCommandStatus.Ok)
+                return Results.NotFound(new { error = result.Error });
+
+            var session = sessionManager.GetSession(guid);
+            return session is null
+                ? Results.NotFound(new { error = "session not found" })
+                : Results.Json(MapWithIdentity(session, turnSummaryCache));
         });
 
         // The launch-time "fleet awareness" preamble for a session: its own identity plus the
@@ -859,28 +871,20 @@ internal static class ControlEndpoints
         // Returns instantly (no LLM call) so a phone shows it the moment the view opens.
         // text is null when nothing has been cached yet (mobile mode off, or first turn
         // not finished). The phone falls back to the on-demand /wingman/ask in that case.
-        app.MapGet("/sessions/{sid}/wingman/explain", (string sid) =>
+        // Gateway Cleanup Phase 0: the read runs through the shared SessionReadExecutor core so this REST
+        // path and the Gateway stream down-channel are identical and cannot drift. Phase 1 deletes this route.
+        app.MapGet("/sessions/{sid}/wingman/explain", async (string sid) =>
         {
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
+            var command = new DirectorCommand { Verb = "wingman-explain", SessionId = sid };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
 
-            return Results.Json(new
+            return result.Status switch
             {
-                mobileMode = session.MobileMode,
-                text = session.CachedExplainText,
-                at = session.CachedExplainAt,
-                model = session.CachedExplainModel,
-                quickReplies = session.CachedQuickReplies,
-                headline = session.CachedExplainHeadline,
-                whatHappened = session.CachedExplainWhatHappened,
-                longDescription = session.CachedExplainLongDescription,
-                whatClaudeWants = session.CachedExplainWhatClaudeWants,
-                claudeVerbatim = session.CachedExplainClaudeVerbatim,
-                say = session.CachedExplainSay,
-            });
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<WingmanExplainResponse>(result.BodyJson)),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "wingman-explain command failed"),
+            };
         });
 
         // Toggle mobile mode for a session. When turned on, kick off an immediate background
@@ -1016,25 +1020,22 @@ internal static class ControlEndpoints
         // Cockpit's session menu (#191) calls this because the repo lives on THIS Director's
         // machine - the browser cannot read the git config itself. 409 when the repo has no
         // GitHub origin (the menu shows the message verbatim).
-        app.MapGet("/sessions/{sid}/github-urls", (string sid) =>
+        // Gateway Cleanup Phase 0: the read runs through the shared SessionReadExecutor core so this REST
+        // path and the Gateway stream down-channel are identical and cannot drift. A repo with no GitHub
+        // origin is a Conflict, mapped back to the route's 409. Phase 1 deletes this route.
+        app.MapGet("/sessions/{sid}/github-urls", async (string sid) =>
         {
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
+            var command = new DirectorCommand { Verb = "github-urls", SessionId = sid };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
 
-            FileLog.Write($"[ControlEndpoints] GET /sessions/{guid}/github-urls: repo={session.RepoPath}");
-            try
+            return result.Status switch
             {
-                var url = GitHubUrls.BuildNewIssueUrl(session.RepoPath);
-                return Results.Json(new { newIssueUrl = url });
-            }
-            catch (InvalidOperationException ex)
-            {
-                FileLog.Write($"[ControlEndpoints] github-urls FAILED: {ex.Message}");
-                return Results.Json(new { error = ex.Message }, statusCode: 409);
-            }
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<GithubUrlsResponse>(result.BodyJson)),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                DirectorCommandStatus.Conflict => Results.Json(new { error = result.Error }, statusCode: 409),
+                _ => Results.Problem(result.Error ?? "github-urls command failed"),
+            };
         });
 
         // Mobile view-links: serve a local file INLINE so a phone can tap a link and VIEW
@@ -1085,49 +1086,22 @@ internal static class ControlEndpoints
 
         // Phase 4b: observability into the wingman. Returns current color + reason,
         // a timestamped log of recent decisions, and the latest TurnSummary if any.
-        app.MapGet("/sessions/{sid}/wingman", (string sid) =>
+        // Gateway Cleanup Phase 0: the read runs through the shared SessionReadExecutor core (given the
+        // Director-local TurnSummaryCache via the command services) so this REST path and the Gateway stream
+        // down-channel are identical and cannot drift. Phase 1 deletes this route.
+        app.MapGet("/sessions/{sid}/wingman", async (string sid) =>
         {
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
+            var command = new DirectorCommand { Verb = "wingman-view", SessionId = sid };
+            var services = new SessionCommandServices { TurnSummaryCache = turnSummaryCache };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command, services);
 
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
-
-            var events = session.RecentWingmanEvents;
-            var latestSummary = turnSummaryCache?.GetForSession(session.Id).LastOrDefault();
-
-            return Results.Json(new WingmanViewDto
+            return result.Status switch
             {
-                SessionId = session.Id.ToString(),
-                Name = session.CustomName,
-                CurrentColor = session.StatusColor,
-                CurrentReason = session.LastStatusReason,
-                Since = events.Count > 0 ? events[0].At : (DateTime?)null,
-                Events = events.Select(e => new WingmanEventDto
-                {
-                    At = e.At,
-                    OldColor = e.OldColor,
-                    NewColor = e.NewColor,
-                    Reason = e.Reason,
-                    Llm = e.Llm,
-                }).ToList(),
-                Actions = session.RecentWingmanActions.Select(a => new WingmanActionDto
-                {
-                    At = a.At,
-                    Action = a.Action,
-                    Detail = a.Detail,
-                    Reason = a.Reason,
-                }).ToList(),
-                LatestTurnSummary = latestSummary,
-                Goal = session.WingmanGoal,
-                GoalSetAt = session.WingmanGoalSetAt,
-                GoalState = session.WingmanGoalState,
-                GoalReason = session.WingmanGoalReason,
-                GoalEvaluatedAt = session.WingmanGoalEvaluatedAt,
-                LastUserPrompt = session.LastUserPrompt,
-                LastUserPromptAt = session.LastUserPromptAt,
-            });
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<WingmanViewDto>(result.BodyJson)),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "wingman-view command failed"),
+            };
         });
 
         // Goal management: set (or clear) the session's stated goal. Setting a goal
@@ -1284,50 +1258,26 @@ internal static class ControlEndpoints
                 : Results.Json(MapWithIdentity(session, turnSummaryCache));
         });
 
-        app.MapGet("/sessions/{sid}/buffer", (string sid, int? lines, bool? raw, long? since) =>
+        // Gateway Cleanup Phase 0: the read runs through the shared SessionReadExecutor core so this REST
+        // path and the Gateway stream down-channel are identical and cannot drift. The route's query-string
+        // arguments (lines/raw/since) ride in the command payload as a BufferRequest. Phase 1 deletes this route.
+        app.MapGet("/sessions/{sid}/buffer", async (string sid, int? lines, bool? raw, long? since) =>
         {
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
-
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
-
-            var buffer = session.Buffer;
-            if (buffer is null)
-                return Results.Json(new BufferResponse { SessionId = sid });
-
-            byte[] bytes;
-            long newCursor;
-            if (since is long pos && pos >= 0)
+            var command = new DirectorCommand
             {
-                var (data, np) = buffer.GetWrittenSince(pos);
-                bytes = data;
-                newCursor = np;
-            }
-            else
-            {
-                bytes = buffer.DumpAll();
-                newCursor = buffer.TotalBytesWritten;
-            }
-
-            string text;
-            if (raw == true)
-                text = Encoding.UTF8.GetString(bytes);
-            else
-            {
-                text = AnsiCleaner.Clean(bytes);
-                if (lines is int n && n > 0)
-                    text = AnsiCleaner.LastLines(text, n);
-            }
-
-            return Results.Json(new BufferResponse
-            {
+                Verb = "buffer",
                 SessionId = sid,
-                TotalBytes = buffer.TotalBytesWritten,
-                NewCursor = newCursor,
-                Text = text,
-            });
+                PayloadJson = SessionCommandExecutor.Serialize(new BufferRequest { Lines = lines, Raw = raw, Since = since }),
+            };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
+
+            return result.Status switch
+            {
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<BufferResponse>(result.BodyJson)),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "buffer command failed"),
+            };
         });
 
         // ===== HTML snapshot of the terminal grid =====
@@ -1336,28 +1286,20 @@ internal static class ControlEndpoints
         // terminal" tab needs the same treatment, otherwise CR-overwrites and
         // status-bar redraws stack as junk lines. We expose the per-session
         // parser snapshot here as styled HTML; the client just swaps innerHTML.
-        app.MapGet("/sessions/{sid}/buffer/html", (string sid) =>
+        // Gateway Cleanup Phase 0: the read runs through the shared SessionReadExecutor core so this REST
+        // path and the Gateway stream down-channel are identical and cannot drift. Phase 1 deletes this route.
+        app.MapGet("/sessions/{sid}/buffer/html", async (string sid) =>
         {
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
+            var command = new DirectorCommand { Verb = "buffer-html", SessionId = sid };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
 
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
-
-            var (scrollbackHtml, gridHtml, scrollbackCount) = session.GetHtmlSnapshotSplit();
-            return Results.Json(new
+            return result.Status switch
             {
-                sessionId = sid,
-                totalBytes = session.Buffer?.TotalBytesWritten ?? 0,
-                scrollbackHtml,
-                gridHtml,
-                scrollbackCount,
-                // Backward-compat: existing callers (and integration tests) read
-                // .html as the concatenated stream. Keep this so a partial
-                // client update doesn't break.
-                html = scrollbackHtml + gridHtml,
-            });
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<BufferHtmlResponse>(result.BodyJson)),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "buffer-html command failed"),
+            };
         });
 
         // (The agent-agnostic conversation history endpoint, GET /sessions/{sid}/history, is already
@@ -1381,61 +1323,20 @@ internal static class ControlEndpoints
             };
         });
 
-        app.MapGet("/sessions/{sid}/summary", (string sid) =>
+        // Gateway Cleanup Phase 0: the read runs through the shared SessionReadExecutor core so this REST
+        // path and the Gateway stream down-channel are identical and cannot drift. Phase 1 deletes this route.
+        app.MapGet("/sessions/{sid}/summary", async (string sid) =>
         {
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
+            var command = new DirectorCommand { Verb = "summary", SessionId = sid };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
 
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
-
-            var dto = new SessionSummaryDto
+            return result.Status switch
             {
-                SessionId = sid,
-                DirectorId = directorId,
-                Agent = session.AgentKind.ToString(),
-                RepoPath = session.RepoPath,
-                ActivityState = session.ActivityState.ToString(),
-                CreatedAt = session.CreatedAt.UtcDateTime,
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<SessionSummaryDto>(result.BodyJson)),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "summary command failed"),
             };
-
-            if (string.IsNullOrEmpty(session.ClaudeSessionId))
-            {
-                dto.Status = "no_session_id";
-                dto.Error = "Session has not been linked to a Claude session id yet.";
-                return Results.Json(dto);
-            }
-
-            try
-            {
-                var jsonl = ClaudeSessionReader.GetJsonlPath(session.ClaudeSessionId, session.RepoPath);
-                if (!File.Exists(jsonl))
-                {
-                    dto.Status = "no_jsonl";
-                    dto.Error = $"JSONL file not found at {jsonl}";
-                    return Results.Json(dto);
-                }
-
-                var messages = StreamMessageParser.ParseFile(jsonl);
-                var summary = SummaryBuilder.Build(messages);
-                // Fold the structural fields we already filled into the freshly built one.
-                summary.SessionId = sid;
-                summary.DirectorId = directorId;
-                summary.Agent = dto.Agent;
-                summary.RepoPath = dto.RepoPath;
-                summary.ActivityState = dto.ActivityState;
-                summary.CreatedAt = dto.CreatedAt;
-                summary.Status = "ok";
-                return Results.Json(summary);
-            }
-            catch (Exception ex)
-            {
-                FileLog.Write($"[ControlEndpoints] /summary FAILED: {ex.Message}");
-                dto.Status = "parse_error";
-                dto.Error = ex.Message;
-                return Results.Json(dto);
-            }
         });
 
         // ===== REST: Handover info (issue #1214) =====
@@ -1638,41 +1539,20 @@ internal static class ControlEndpoints
         // Two endpoints: GET returns whatever is in the cache (or status=not_cached),
         // POST regenerates and writes to cache. We never start a generation on GET
         // because GET should always be cheap and never trigger an API spend.
-        app.MapGet("/sessions/{sid}/recap", (string sid) =>
+        // Gateway Cleanup Phase 0: the read runs through the shared SessionReadExecutor core so this REST
+        // path and the Gateway stream down-channel are identical and cannot drift. Phase 1 deletes this route.
+        app.MapGet("/sessions/{sid}/recap", async (string sid) =>
         {
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
+            var command = new DirectorCommand { Verb = "recap", SessionId = sid };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
 
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
-
-            var cached = RecapCache.TryGet(guid);
-            var currentTurns = ComputeTurnCount(session);
-
-            if (cached is null)
+            return result.Status switch
             {
-                return Results.Json(new RecapResponse
-                {
-                    SessionId = sid,
-                    CurrentTurnCount = currentTurns,
-                    Status = "not_cached",
-                    Error = "No recap has been generated yet. POST to /sessions/{sid}/recap to create one.",
-                });
-            }
-
-            return Results.Json(new RecapResponse
-            {
-                SessionId = sid,
-                Recap = cached.Recap,
-                GeneratedAt = cached.GeneratedAt,
-                AtTurnCount = cached.AtTurnCount,
-                CurrentTurnCount = currentTurns,
-                IsStale = currentTurns > cached.AtTurnCount,
-                Model = cached.Model,
-                ElapsedMs = cached.ElapsedMs,
-                Status = "ok",
-            });
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<RecapResponse>(result.BodyJson)),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "recap command failed"),
+            };
         });
 
         app.MapPost("/sessions/{sid}/recap", async (string sid, HttpContext ctx) =>
@@ -2058,16 +1938,22 @@ internal static class ControlEndpoints
         // Per-completed-turn structured summary produced by the SessionWingman.
         // Feeds the Agent View AND the voice mode's TTS (via summary.spokenText).
         // See docs/goals/GOAL_CC_DIRECTOR_SUPERVISOR.md section 4.
-        app.MapGet("/sessions/{sid}/turn-summaries", (string sid) =>
+        // Gateway Cleanup Phase 0: the read runs through the shared SessionReadExecutor core (given the
+        // Director-local TurnSummaryCache via the command services) so this REST path and the Gateway stream
+        // down-channel are identical and cannot drift. Phase 1 deletes this route.
+        app.MapGet("/sessions/{sid}/turn-summaries", async (string sid) =>
         {
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
+            var command = new DirectorCommand { Verb = "turn-summaries", SessionId = sid };
+            var services = new SessionCommandServices { TurnSummaryCache = turnSummaryCache };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command, services);
 
-            if (sessionManager.GetSession(guid) is null)
-                return Results.NotFound(new { error = "session not found" });
-
-            var list = turnSummaryCache?.GetForSession(guid).ToList() ?? new List<TurnSummary>();
-            return Results.Json(new TurnSummariesResponse { SessionId = sid, Summaries = list });
+            return result.Status switch
+            {
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<TurnSummariesResponse>(result.BodyJson)),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "turn-summaries command failed"),
+            };
         });
 
         // POST /sessions/{sid}/turn-summaries - generate a summary for the LATEST turn
@@ -3677,7 +3563,9 @@ internal static class ControlEndpoints
     /// Returns 0 if the session isn't linked or the file isn't there yet.
     /// Used by the recap endpoints to compute the IsStale flag.
     /// </summary>
-    private static int ComputeTurnCount(Session session)
+    // Gateway Cleanup Phase 0: internal so the shared SessionReadExecutor.Recap core (which the tunnel
+    // recap verb and the re-pointed GET /sessions/{sid}/recap route both call) reads the SAME turn count.
+    internal static int ComputeTurnCount(Session session)
     {
         if (string.IsNullOrEmpty(session.ClaudeSessionId)) return 0;
         try

--- a/src/CcDirector.ControlApi/SessionContextEndpoint.cs
+++ b/src/CcDirector.ControlApi/SessionContextEndpoint.cs
@@ -1,6 +1,5 @@
-using CcDirector.Core.Drivers;
 using CcDirector.Core.Sessions;
-using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -17,39 +16,24 @@ namespace CcDirector.ControlApi;
 /// </summary>
 internal static class SessionContextEndpoint
 {
-    public static void Map(IEndpointRouteBuilder app, SessionManager sessionManager)
+    public static void Map(IEndpointRouteBuilder app, SessionManager sessionManager, string directorId)
     {
-        app.MapGet("/sessions/{sid}/context", (string sid) =>
+        // Gateway Cleanup Phase 0: the read runs through the shared SessionReadExecutor core (verb
+        // "context") so this REST path and the Gateway stream down-channel are identical and cannot drift.
+        // The route's capability/no-turn 404s and its read-fault 500 are preserved by the core and mapped
+        // back here. Phase 1 deletes this route.
+        app.MapGet("/sessions/{sid}/context", async (string sid) =>
         {
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
+            var command = new DirectorCommand { Verb = "context", SessionId = sid };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
 
-            var driver = session.Driver;
-            if (!driver.Capabilities.HasFlag(DriverCapabilities.ContextUsage))
-                return Results.NotFound(new { error = $"agent {driver.Kind} does not report context usage" });
-
-            // No agent-session-id guard here: only Claude carries a preassigned ClaudeSessionId.
-            // Codex and pi have none - they locate their rollout/session by repo path - so requiring
-            // it would make the gauge permanently dark for them. Each driver decides what it needs;
-            // a driver that cannot resolve a transcript yet returns null below (handled as 404).
-            try
+            return result.Status switch
             {
-                // EffectiveLaunchArgs (the merged launch line) carries the launched --model even when
-                // it came from the configured default; ClaudeArgs alone is null in that case (#803).
-                var launchArgs = session.EffectiveLaunchArgs ?? session.ClaudeArgs;
-                var context = driver.ReadContextUsage(session.ClaudeSessionId ?? "", session.RepoPath, launchArgs);
-                if (context is null)
-                    return Results.NotFound(new { error = "no context usage yet (no completed turn)" });
-                return Results.Json(context);
-            }
-            catch (Exception ex)
-            {
-                FileLog.Write($"[SessionContextEndpoint] context FAILED: sid={sid} {ex.Message}");
-                return Results.Problem($"context usage read failed: {ex.Message}");
-            }
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<ContextUsageDto>(result.BodyJson)),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "context command failed"),
+            };
         });
     }
 }

--- a/src/CcDirector.ControlApi/SessionHistoryEndpoint.cs
+++ b/src/CcDirector.ControlApi/SessionHistoryEndpoint.cs
@@ -20,28 +20,25 @@ namespace CcDirector.ControlApi;
 /// </summary>
 internal static class SessionHistoryEndpoint
 {
-    public static void Map(IEndpointRouteBuilder app, SessionManager sessionManager)
+    public static void Map(IEndpointRouteBuilder app, SessionManager sessionManager, string directorId)
     {
-        app.MapGet("/sessions/{sid}/history", (string sid) =>
+        // Gateway Cleanup Phase 0: the read runs through the shared SessionReadExecutor core (verb
+        // "history"), which calls the SAME BuildHistory mapper below, so this REST path and the Gateway
+        // stream down-channel are identical and cannot drift. The route's read-fault 500 is preserved by the
+        // core and mapped back here. Phase 1 deletes this route.
+        app.MapGet("/sessions/{sid}/history", async (string sid) =>
         {
             FileLog.Write($"[SessionHistoryEndpoint] GET /sessions/{sid}/history");
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
+            var command = new DirectorCommand { Verb = "history", SessionId = sid };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
 
-            try
+            return result.Status switch
             {
-                var dto = BuildHistory(session, sid);
-                FileLog.Write($"[SessionHistoryEndpoint] history: sid={sid} agent={dto.Agent} status={dto.Status} messages={dto.Messages.Count} state={dto.HistoryState ?? "(none)"}");
-                return Results.Json(dto);
-            }
-            catch (Exception ex)
-            {
-                FileLog.Write($"[SessionHistoryEndpoint] history FAILED: sid={sid} {ex.Message}");
-                return Results.Problem($"history read failed: {ex.Message}");
-            }
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<SessionHistoryDto>(result.BodyJson)),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "history command failed"),
+            };
         });
     }
 

--- a/src/CcDirector.ControlApi/SessionReadExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionReadExecutor.cs
@@ -1,31 +1,68 @@
+using System.Linq;
+using System.Text;
 using CcDirector.Core.Agents;
 using CcDirector.Core.Claude;
+using CcDirector.Core.Drivers;
 using CcDirector.Core.History;
 using CcDirector.Core.Sessions;
 using CcDirector.Core.Utilities;
+using CcDirector.Core.Wingman;
 using CcDirector.Gateway.Contracts;
 
 namespace CcDirector.ControlApi;
 
 /// <summary>
 /// Gateway Cleanup mission, Phase 0 (spine): the SESSION READ area of the tunnel command surface. It owns
-/// the per-session read verbs (the reply body is the resource DTO). The spine seeds it with ONE exemplar -
-/// <c>turns</c> - to fix the pattern a worker copies; Worker R1 fills in the rest (snapshot, buffer, summary,
-/// handover, brief, recap, and so on) by adding each verb to <see cref="Verbs"/> and a core method here.
+/// the per-session read verbs (the reply body is the resource DTO). The spine seeded it with ONE exemplar -
+/// <c>turns</c> - to fix the pattern; Worker R1 filled in the rest (snapshot, buffer, buffer-html, summary,
+/// recap, turn-summaries, usage, context, history, github-urls, wingman-view, wingman-explain) by adding
+/// each verb to <see cref="Verbs"/>, a case in <see cref="ExecuteAsync"/>, and a core method here.
 ///
-/// The core is extracted verbatim from the Director's <c>GET /sessions/{sid}/turns</c> lambda. That REST
-/// route now calls this SAME core, so the tunnel verb and the route cannot drift (the core is the single
-/// source of truth); Phase 1 deletes the route and leaves the core reached only over the tunnel.
+/// Each core is extracted verbatim from that read's Director REST lambda. That REST route now calls this
+/// SAME core, so the tunnel verb and the route cannot drift (the core is the single source of truth); Phase 1
+/// deletes the routes and leaves the cores reached only over the tunnel. Every non-error branch a source
+/// route returned as a 200 with a status string (a DOMAIN state, e.g. "no_session_id", "parse_error") stays
+/// a <see cref="DirectorCommandStatus.Ok"/> here; only a bad id, a missing session, an unsupported capability,
+/// or a genuine fault are error statuses. A preserved try/catch is kept ONLY where the source route had one,
+/// so behaviour is byte-identical.
 /// </summary>
 internal sealed class SessionReadExecutor : ISessionCommandArea
 {
-    public IReadOnlyCollection<string> Verbs { get; } = new[] { "turns" };
+    public IReadOnlyCollection<string> Verbs { get; } = new[]
+    {
+        "turns",
+        "snapshot",
+        "buffer",
+        "buffer-html",
+        "summary",
+        "recap",
+        "turn-summaries",
+        "usage",
+        "context",
+        "history",
+        "github-urls",
+        "wingman-view",
+        "wingman-explain",
+    };
 
     public Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken)
     {
+        var sessionManager = context.SessionManager;
         var result = command.Verb switch
         {
-            "turns" => Turns(context.SessionManager, command),
+            "turns" => Turns(sessionManager, command),
+            "snapshot" => Snapshot(sessionManager, context.DirectorId, command),
+            "buffer" => Buffer(sessionManager, command),
+            "buffer-html" => BufferHtml(sessionManager, command),
+            "summary" => Summary(sessionManager, context.DirectorId, command),
+            "recap" => Recap(sessionManager, command),
+            "turn-summaries" => TurnSummaries(context, command),
+            "usage" => Usage(sessionManager, command),
+            "context" => Context(sessionManager, command),
+            "history" => History(sessionManager, command),
+            "github-urls" => GithubUrls(sessionManager, command),
+            "wingman-view" => WingmanView(context, command),
+            "wingman-explain" => WingmanExplain(sessionManager, command),
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the session read area"),
         };
         return Task.FromResult(result);
@@ -104,5 +141,456 @@ internal sealed class SessionReadExecutor : ISessionCommandArea
             resp.Error = ex.Message;
             return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(resp));
         }
+    }
+
+    /// <summary>
+    /// The <c>snapshot</c> verb: the full session record. Mirrors the Director's <c>GET /sessions/{sid}</c>
+    /// lambda - invalid id -&gt; BadRequest, missing session -&gt; NotFound - and returns the session mapped
+    /// through the SAME plain <see cref="ControlEndpoints.Map"/> the stream snapshot uses (the Gateway stamps
+    /// machine/user/tailnet identity onto pushed rows during aggregation). The Director's own REST endpoint
+    /// re-maps with its identity-stamped mapper for its local response, keeping that path byte-identical -
+    /// exactly as the <c>patch</c> verb already does.
+    /// </summary>
+    internal static DirectorCommandResult Snapshot(SessionManager sessionManager, string directorId, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(ControlEndpoints.Map(session, directorId)));
+    }
+
+    /// <summary>
+    /// The <c>buffer</c> verb: the session's terminal buffer as text. Mirrors the Director's
+    /// <c>GET /sessions/{sid}/buffer</c> lambda - invalid id -&gt; BadRequest, missing session -&gt; NotFound.
+    /// The route's three query-string arguments (<c>lines</c>, <c>raw</c>, <c>since</c>) ride in the command
+    /// payload as a <see cref="BufferRequest"/>. A session with no buffer returns an empty
+    /// <see cref="BufferResponse"/> (a 200), exactly as before.
+    /// </summary>
+    internal static DirectorCommandResult Buffer(SessionManager sessionManager, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        var request = SessionCommandExecutor.Deserialize<BufferRequest>(command.PayloadJson);
+        var lines = request?.Lines;
+        var raw = request?.Raw;
+        var since = request?.Since;
+
+        var buffer = session.Buffer;
+        if (buffer is null)
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new BufferResponse { SessionId = command.SessionId }));
+
+        byte[] bytes;
+        long newCursor;
+        if (since is long pos && pos >= 0)
+        {
+            var (data, np) = buffer.GetWrittenSince(pos);
+            bytes = data;
+            newCursor = np;
+        }
+        else
+        {
+            bytes = buffer.DumpAll();
+            newCursor = buffer.TotalBytesWritten;
+        }
+
+        string text;
+        if (raw == true)
+            text = Encoding.UTF8.GetString(bytes);
+        else
+        {
+            text = AnsiCleaner.Clean(bytes);
+            if (lines is int n && n > 0)
+                text = AnsiCleaner.LastLines(text, n);
+        }
+
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new BufferResponse
+        {
+            SessionId = command.SessionId,
+            TotalBytes = buffer.TotalBytesWritten,
+            NewCursor = newCursor,
+            Text = text,
+        }));
+    }
+
+    /// <summary>
+    /// The <c>buffer-html</c> verb: the styled HTML terminal snapshot (scrollback + live grid). Mirrors the
+    /// Director's <c>GET /sessions/{sid}/buffer/html</c> lambda - invalid id -&gt; BadRequest, missing session
+    /// -&gt; NotFound - and returns a <see cref="BufferHtmlResponse"/> naming the exact anonymous object the
+    /// route returned (including the concatenated <c>html</c> back-compat field).
+    /// </summary>
+    internal static DirectorCommandResult BufferHtml(SessionManager sessionManager, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        var (scrollbackHtml, gridHtml, scrollbackCount) = session.GetHtmlSnapshotSplit();
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new BufferHtmlResponse
+        {
+            SessionId = command.SessionId,
+            TotalBytes = session.Buffer?.TotalBytesWritten ?? 0,
+            ScrollbackHtml = scrollbackHtml,
+            GridHtml = gridHtml,
+            ScrollbackCount = scrollbackCount,
+            // Backward-compat: existing callers read .html as the concatenated stream.
+            Html = scrollbackHtml + gridHtml,
+        }));
+    }
+
+    /// <summary>
+    /// The <c>summary</c> verb: the session's structured Claude-transcript summary. Mirrors the Director's
+    /// <c>GET /sessions/{sid}/summary</c> lambda - invalid id -&gt; BadRequest, missing session -&gt; NotFound
+    /// - and returns a serialized <see cref="SessionSummaryDto"/>. The not-yet-linked and parse-failure
+    /// branches are 200 statuses with a status string (DOMAIN states), and the parse try/catch is preserved
+    /// from the source for the same reason as <c>turns</c>.
+    /// </summary>
+    internal static DirectorCommandResult Summary(SessionManager sessionManager, string directorId, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        var dto = new SessionSummaryDto
+        {
+            SessionId = command.SessionId,
+            DirectorId = directorId,
+            Agent = session.AgentKind.ToString(),
+            RepoPath = session.RepoPath,
+            ActivityState = session.ActivityState.ToString(),
+            CreatedAt = session.CreatedAt.UtcDateTime,
+        };
+
+        if (string.IsNullOrEmpty(session.ClaudeSessionId))
+        {
+            dto.Status = "no_session_id";
+            dto.Error = "Session has not been linked to a Claude session id yet.";
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(dto));
+        }
+
+        try
+        {
+            var jsonl = ClaudeSessionReader.GetJsonlPath(session.ClaudeSessionId, session.RepoPath);
+            if (!File.Exists(jsonl))
+            {
+                dto.Status = "no_jsonl";
+                dto.Error = $"JSONL file not found at {jsonl}";
+                return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(dto));
+            }
+
+            var messages = StreamMessageParser.ParseFile(jsonl);
+            var summary = SummaryBuilder.Build(messages);
+            // Fold the structural fields we already filled into the freshly built one.
+            summary.SessionId = command.SessionId;
+            summary.DirectorId = directorId;
+            summary.Agent = dto.Agent;
+            summary.RepoPath = dto.RepoPath;
+            summary.ActivityState = dto.ActivityState;
+            summary.CreatedAt = dto.CreatedAt;
+            summary.Status = "ok";
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(summary));
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[SessionReadExecutor] summary FAILED: {ex.Message}");
+            dto.Status = "parse_error";
+            dto.Error = ex.Message;
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(dto));
+        }
+    }
+
+    /// <summary>
+    /// The <c>recap</c> verb: whatever recap is currently cached (never a generation - GET stays cheap and
+    /// never spends). Mirrors the Director's <c>GET /sessions/{sid}/recap</c> lambda - invalid id -&gt;
+    /// BadRequest, missing session -&gt; NotFound - and always returns a 200 <see cref="RecapResponse"/>
+    /// (status "not_cached" when nothing is cached yet).
+    /// </summary>
+    internal static DirectorCommandResult Recap(SessionManager sessionManager, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        var cached = RecapCache.TryGet(guid);
+        var currentTurns = ControlEndpoints.ComputeTurnCount(session);
+
+        if (cached is null)
+        {
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new RecapResponse
+            {
+                SessionId = command.SessionId,
+                CurrentTurnCount = currentTurns,
+                Status = "not_cached",
+                Error = "No recap has been generated yet. POST to /sessions/{sid}/recap to create one.",
+            }));
+        }
+
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new RecapResponse
+        {
+            SessionId = command.SessionId,
+            Recap = cached.Recap,
+            GeneratedAt = cached.GeneratedAt,
+            AtTurnCount = cached.AtTurnCount,
+            CurrentTurnCount = currentTurns,
+            IsStale = currentTurns > cached.AtTurnCount,
+            Model = cached.Model,
+            ElapsedMs = cached.ElapsedMs,
+            Status = "ok",
+        }));
+    }
+
+    /// <summary>
+    /// The <c>turn-summaries</c> verb: the per-completed-turn structured summaries the wingman produced.
+    /// Mirrors the Director's <c>GET /sessions/{sid}/turn-summaries</c> lambda - invalid id -&gt; BadRequest,
+    /// missing session -&gt; NotFound - and returns a <see cref="TurnSummariesResponse"/>. The summaries come
+    /// from the Director-local <see cref="TurnSummaryCache"/> via the command services; an absent cache
+    /// yields an empty list, exactly as the route's null-conditional did.
+    /// </summary>
+    internal static DirectorCommandResult TurnSummaries(SessionCommandContext context, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        if (context.SessionManager.GetSession(guid) is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        var list = context.Services?.TurnSummaryCache?.GetForSession(guid).ToList() ?? new List<TurnSummary>();
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new TurnSummariesResponse
+        {
+            SessionId = command.SessionId,
+            Summaries = list,
+        }));
+    }
+
+    /// <summary>
+    /// The <c>usage</c> verb: the session's token usage, computed from its Claude JSONL transcript. Mirrors
+    /// the Director's <c>GET /sessions/{sid}/usage</c> lambda - invalid id -&gt; BadRequest; missing session,
+    /// no linked Claude session id, or no transcript file -&gt; NotFound; a compute fault -&gt; Error (the
+    /// route's 500). The transcript-path 404 folds the path into the error message (the route surfaced it as
+    /// a separate <c>path</c> field). The compute try/catch is preserved from the source.
+    /// </summary>
+    internal static DirectorCommandResult Usage(SessionManager sessionManager, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+        if (string.IsNullOrEmpty(session.ClaudeSessionId))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session has no claude session id yet");
+
+        var jsonl = ClaudeSessionReader.GetJsonlPath(session.ClaudeSessionId, session.RepoPath);
+        if (!File.Exists(jsonl))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, $"transcript not found: {jsonl}");
+
+        try
+        {
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(SessionTokenUsage.ComputeFromFile(jsonl, command.SessionId)));
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[SessionReadExecutor] usage FAILED: sid={command.SessionId} {ex.Message}");
+            return DirectorCommandResult.Fail(DirectorCommandStatus.Error, $"usage computation failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// The <c>context</c> verb: how full the session's context window is right now. Mirrors the Director's
+    /// <c>GET /sessions/{sid}/context</c> lambda - invalid id -&gt; BadRequest; missing session, an agent
+    /// without the ContextUsage capability, or no completed turn yet -&gt; NotFound; a read fault -&gt; Error
+    /// (the route's 500). The read try/catch is preserved from the source.
+    /// </summary>
+    internal static DirectorCommandResult Context(SessionManager sessionManager, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        var driver = session.Driver;
+        if (!driver.Capabilities.HasFlag(DriverCapabilities.ContextUsage))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, $"agent {driver.Kind} does not report context usage");
+
+        // No agent-session-id guard here: only Claude carries a preassigned ClaudeSessionId. Codex and pi
+        // have none - they locate their rollout/session by repo path - so requiring it would make the gauge
+        // permanently dark for them. A driver that cannot resolve a transcript yet returns null (handled as
+        // NotFound below).
+        try
+        {
+            // EffectiveLaunchArgs (the merged launch line) carries the launched --model even when it came
+            // from the configured default; ClaudeArgs alone is null in that case (#803).
+            var launchArgs = session.EffectiveLaunchArgs ?? session.ClaudeArgs;
+            var context = driver.ReadContextUsage(session.ClaudeSessionId ?? "", session.RepoPath, launchArgs);
+            if (context is null)
+                return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "no context usage yet (no completed turn)");
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(context));
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[SessionReadExecutor] context FAILED: sid={command.SessionId} {ex.Message}");
+            return DirectorCommandResult.Fail(DirectorCommandStatus.Error, $"context usage read failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// The <c>history</c> verb: the parsed, agent-agnostic conversation history for a session. Mirrors the
+    /// Director's <c>GET /sessions/{sid}/history</c> lambda - invalid id -&gt; BadRequest, missing session
+    /// -&gt; NotFound, a read fault -&gt; Error (the route's 500) - and returns a serialized
+    /// <see cref="SessionHistoryDto"/> built by the SAME <see cref="SessionHistoryEndpoint.BuildHistory"/>
+    /// pure mapper. The read try/catch is preserved from the source.
+    /// </summary>
+    internal static DirectorCommandResult History(SessionManager sessionManager, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        try
+        {
+            var dto = SessionHistoryEndpoint.BuildHistory(session, command.SessionId);
+            FileLog.Write($"[SessionReadExecutor] history: sid={command.SessionId} agent={dto.Agent} status={dto.Status} messages={dto.Messages.Count} state={dto.HistoryState ?? "(none)"}");
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(dto));
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[SessionReadExecutor] history FAILED: sid={command.SessionId} {ex.Message}");
+            return DirectorCommandResult.Fail(DirectorCommandStatus.Error, $"history read failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// The <c>github-urls</c> verb: the repo's GitHub "new issue" URL, resolved from its origin remote.
+    /// Mirrors the Director's <c>GET /sessions/{sid}/github-urls</c> lambda - invalid id -&gt; BadRequest,
+    /// missing session -&gt; NotFound - and returns a <see cref="GithubUrlsResponse"/>. A repo with no GitHub
+    /// origin raises <see cref="InvalidOperationException"/>, surfaced as a Conflict (the route's 409); this
+    /// catch is preserved from the source because it is a DOMAIN state (no origin), not a fault to bubble.
+    /// </summary>
+    internal static DirectorCommandResult GithubUrls(SessionManager sessionManager, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        FileLog.Write($"[SessionReadExecutor] github-urls: sid={guid} repo={session.RepoPath}");
+        try
+        {
+            var url = GitHubUrls.BuildNewIssueUrl(session.RepoPath);
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new GithubUrlsResponse { NewIssueUrl = url }));
+        }
+        catch (InvalidOperationException ex)
+        {
+            FileLog.Write($"[SessionReadExecutor] github-urls FAILED: {ex.Message}");
+            return DirectorCommandResult.Fail(DirectorCommandStatus.Conflict, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// The <c>wingman-view</c> verb: observability into the wingman - current color and reason, a timestamped
+    /// log of recent decisions and actions, the latest turn summary, and the goal state. Mirrors the
+    /// Director's <c>GET /sessions/{sid}/wingman</c> lambda - invalid id -&gt; BadRequest, missing session
+    /// -&gt; NotFound - and returns a <see cref="WingmanViewDto"/>. The latest turn summary comes from the
+    /// Director-local <see cref="TurnSummaryCache"/> via the command services (null-safe, as the route was).
+    /// </summary>
+    internal static DirectorCommandResult WingmanView(SessionCommandContext context, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = context.SessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        var events = session.RecentWingmanEvents;
+        var latestSummary = context.Services?.TurnSummaryCache?.GetForSession(session.Id).LastOrDefault();
+
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new WingmanViewDto
+        {
+            SessionId = session.Id.ToString(),
+            Name = session.CustomName,
+            CurrentColor = session.StatusColor,
+            CurrentReason = session.LastStatusReason,
+            Since = events.Count > 0 ? events[0].At : (DateTime?)null,
+            Events = events.Select(e => new WingmanEventDto
+            {
+                At = e.At,
+                OldColor = e.OldColor,
+                NewColor = e.NewColor,
+                Reason = e.Reason,
+                Llm = e.Llm,
+            }).ToList(),
+            Actions = session.RecentWingmanActions.Select(a => new WingmanActionDto
+            {
+                At = a.At,
+                Action = a.Action,
+                Detail = a.Detail,
+                Reason = a.Reason,
+            }).ToList(),
+            LatestTurnSummary = latestSummary,
+            Goal = session.WingmanGoal,
+            GoalSetAt = session.WingmanGoalSetAt,
+            GoalState = session.WingmanGoalState,
+            GoalReason = session.WingmanGoalReason,
+            GoalEvaluatedAt = session.WingmanGoalEvaluatedAt,
+            LastUserPrompt = session.LastUserPrompt,
+            LastUserPromptAt = session.LastUserPromptAt,
+        }));
+    }
+
+    /// <summary>
+    /// The <c>wingman-explain</c> verb: the proactively-cached mobile briefing for a session (no LLM call, so
+    /// a phone renders it instantly). Mirrors the Director's <c>GET /sessions/{sid}/wingman/explain</c> lambda
+    /// - invalid id -&gt; BadRequest, missing session -&gt; NotFound - and returns a
+    /// <see cref="WingmanExplainResponse"/> naming the exact anonymous object the route returned. Every field
+    /// is served from the session's cached explain state.
+    /// </summary>
+    internal static DirectorCommandResult WingmanExplain(SessionManager sessionManager, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new WingmanExplainResponse
+        {
+            MobileMode = session.MobileMode,
+            Text = session.CachedExplainText,
+            At = session.CachedExplainAt,
+            Model = session.CachedExplainModel,
+            QuickReplies = session.CachedQuickReplies,
+            Headline = session.CachedExplainHeadline,
+            WhatHappened = session.CachedExplainWhatHappened,
+            LongDescription = session.CachedExplainLongDescription,
+            WhatClaudeWants = session.CachedExplainWhatClaudeWants,
+            ClaudeVerbatim = session.CachedExplainClaudeVerbatim,
+            Say = session.CachedExplainSay,
+        }));
     }
 }

--- a/src/CcDirector.ControlApi/SessionUsageEndpoint.cs
+++ b/src/CcDirector.ControlApi/SessionUsageEndpoint.cs
@@ -1,6 +1,5 @@
-using CcDirector.Core.Claude;
 using CcDirector.Core.Sessions;
-using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -11,34 +10,27 @@ namespace CcDirector.ControlApi;
 /// GET /sessions/{sid}/usage - the session's token usage, computed mechanically from its
 /// Claude Code JSONL transcript (every assistant line carries a usage block). Feeds the
 /// Cockpit's session story panel: session totals, current context size, per-turn deltas.
+///
+/// Gateway Cleanup Phase 0: the computation now lives in the shared <see cref="SessionReadExecutor"/>
+/// core (verb <c>usage</c>); this route just dispatches to it, so the REST path and the Gateway stream
+/// down-channel are identical and cannot drift.
 /// </summary>
 internal static class SessionUsageEndpoint
 {
-    public static void Map(IEndpointRouteBuilder app, SessionManager sessionManager)
+    public static void Map(IEndpointRouteBuilder app, SessionManager sessionManager, string directorId)
     {
-        app.MapGet("/sessions/{sid}/usage", (string sid) =>
+        app.MapGet("/sessions/{sid}/usage", async (string sid) =>
         {
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
-            if (string.IsNullOrEmpty(session.ClaudeSessionId))
-                return Results.NotFound(new { error = "session has no claude session id yet" });
+            var command = new DirectorCommand { Verb = "usage", SessionId = sid };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
 
-            var jsonl = ClaudeSessionReader.GetJsonlPath(session.ClaudeSessionId, session.RepoPath);
-            if (!File.Exists(jsonl))
-                return Results.NotFound(new { error = "transcript not found", path = jsonl });
-
-            try
+            return result.Status switch
             {
-                return Results.Json(SessionTokenUsage.ComputeFromFile(jsonl, sid));
-            }
-            catch (Exception ex)
-            {
-                FileLog.Write($"[SessionUsageEndpoint] usage FAILED: sid={sid} {ex.Message}");
-                return Results.Problem($"usage computation failed: {ex.Message}");
-            }
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<SessionUsageDto>(result.BodyJson)),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "usage command failed"),
+            };
         });
     }
 }

--- a/src/CcDirector.Gateway.Contracts/SessionReadContracts.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionReadContracts.cs
@@ -1,0 +1,71 @@
+namespace CcDirector.Gateway.Contracts;
+
+// Gateway Cleanup mission, Phase 0 (Worker R1): the request and response shapes for the session READ verbs
+// that were moved onto the tunnel command surface. These are ADDITIVE - they name the exact wire shapes the
+// old REST lambdas already produced (as anonymous objects or from query-string arguments), so the tunnel
+// verb and the re-pointed REST route serialize identical JSON. Kept in one new file so no shared Contracts
+// file is edited.
+
+/// <summary>
+/// GET /sessions/{sid}/buffer request. Carries the three query-string arguments the old REST route took
+/// (they have no home on <see cref="DirectorCommand"/>, so they ride in the command payload). All optional,
+/// matching the route's <c>int? lines, bool? raw, long? since</c>.
+/// </summary>
+public sealed class BufferRequest
+{
+    /// <summary>When set (and positive) and not raw, keep only the last N cleaned lines.</summary>
+    public int? Lines { get; set; }
+
+    /// <summary>When true, return the raw bytes as text (no ANSI cleaning).</summary>
+    public bool? Raw { get; set; }
+
+    /// <summary>When set (and non-negative), return only the bytes written since this cursor.</summary>
+    public long? Since { get; set; }
+}
+
+/// <summary>
+/// GET /sessions/{sid}/buffer/html response - the styled HTML terminal snapshot, split into scrollback and
+/// the live grid. Names the exact anonymous object the old REST route returned (including the concatenated
+/// <see cref="Html"/> back-compat field).
+/// </summary>
+public sealed class BufferHtmlResponse
+{
+    public string SessionId { get; set; } = "";
+    public long TotalBytes { get; set; }
+    public string ScrollbackHtml { get; set; } = "";
+    public string GridHtml { get; set; } = "";
+    public int ScrollbackCount { get; set; }
+
+    /// <summary>Back-compat: the scrollback and grid concatenated, for callers reading the whole stream.</summary>
+    public string Html { get; set; } = "";
+}
+
+/// <summary>
+/// GET /sessions/{sid}/github-urls response - the repo's GitHub "new issue" URL, resolved from its origin
+/// remote. Names the anonymous <c>{ newIssueUrl }</c> the old REST route returned. A repo with no GitHub
+/// origin is a Conflict (the route's 409), carried as the command result's error rather than in this body.
+/// </summary>
+public sealed class GithubUrlsResponse
+{
+    public string NewIssueUrl { get; set; } = "";
+}
+
+/// <summary>
+/// GET /sessions/{sid}/wingman/explain response - the proactively-cached mobile briefing for a session.
+/// Names the exact anonymous object the old REST route returned; every field is served from the session's
+/// cached explain state with no LLM call, so a phone renders it instantly.
+/// </summary>
+public sealed class WingmanExplainResponse
+{
+    public bool MobileMode { get; set; }
+    public string? Text { get; set; }
+    public System.DateTime? At { get; set; }
+    public string? Model { get; set; }
+    public IReadOnlyList<string> QuickReplies { get; set; } = System.Array.Empty<string>();
+    public string? Headline { get; set; }
+    public string? WhatHappened { get; set; }
+    public string? LongDescription { get; set; }
+    public string? WhatClaudeWants { get; set; }
+    public string? ClaudeVerbatim { get; set; }
+    public string? Say { get; set; }
+}

--- a/src/CcDirector.Gateway.Tests/SessionReadExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionReadExecutorTests.cs
@@ -1,0 +1,428 @@
+using System.Text.Json;
+using CcDirector.ControlApi;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0 (Worker R1): parity tests for the session READ verbs moved onto the
+/// tunnel command surface (<see cref="SessionReadExecutor"/>). Each verb is exercised through the real
+/// <see cref="SessionCommandExecutor.DispatchAsync"/> path (verb map -&gt; area -&gt; core), the same way the
+/// re-pointed REST route and the Gateway stream down-channel reach it, so the core is asserted exactly once
+/// for both callers. Covers, for a representative spread of the verbs, the three standard outcomes an invalid
+/// id (BadRequest), a missing session (NotFound), and a real success body plus the two non-standard results
+/// the sources carried (a repo with no GitHub origin -&gt; Conflict; a not-yet-linked session -&gt; a 200 with
+/// a domain-state status string). Reuses the buffer-only embedded-session harness from the sibling
+/// SessionCommandExecutor tests.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class SessionReadExecutorTests
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    private static (SessionManager sm, Session session, ExecuteActionTestBackend backend) NewSession()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        var backend = new ExecuteActionTestBackend();
+        var session = sm.CreateEmbeddedSession(Path.GetTempPath(), null, backend);
+        return (sm, session, backend);
+    }
+
+    private static DirectorCommand Cmd(string verb, string sid) => new() { CommandId = "r1", Verb = verb, SessionId = sid };
+
+    // ---------- snapshot ----------
+
+    [Fact]
+    public async Task DispatchAsync_Snapshot_InvalidSessionId_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("snapshot", "not-a-guid"));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_Snapshot_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("snapshot", Guid.NewGuid().ToString()));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_Snapshot_ExistingSession_ReturnsMappedSessionDto()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("snapshot", session.Id.ToString()));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal("r1", result.CommandId);
+            var dto = JsonSerializer.Deserialize<SessionDto>(result.BodyJson ?? "", Json);
+            Assert.NotNull(dto);
+            Assert.Equal(session.Id.ToString(), dto.SessionId);
+            Assert.Equal("dir-A", dto.DirectorId); // plain map stamps the director id (Gateway stamps identity later)
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- buffer ----------
+
+    [Fact]
+    public async Task DispatchAsync_Buffer_InvalidSessionId_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("buffer", "not-a-guid"));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_Buffer_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("buffer", Guid.NewGuid().ToString()));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_Buffer_ExistingSession_ReturnsBufferResponse()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("buffer", session.Id.ToString()));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var resp = JsonSerializer.Deserialize<BufferResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(resp);
+            Assert.Equal(session.Id.ToString(), resp.SessionId);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- buffer-html ----------
+
+    [Fact]
+    public async Task DispatchAsync_BufferHtml_ExistingSession_ReturnsHtmlResponse()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("buffer-html", session.Id.ToString()));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var resp = JsonSerializer.Deserialize<BufferHtmlResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(resp);
+            Assert.Equal(session.Id.ToString(), resp.SessionId);
+            // Back-compat html is the scrollback and grid concatenated.
+            Assert.Equal(resp.ScrollbackHtml + resp.GridHtml, resp.Html);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_BufferHtml_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("buffer-html", Guid.NewGuid().ToString()));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- summary ----------
+
+    [Fact]
+    public async Task DispatchAsync_Summary_InvalidSessionId_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("summary", "not-a-guid"));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_Summary_NotYetLinked_ReturnsOkWithNoSessionIdStatus()
+    {
+        // A fresh ClaudeCode session has no Claude session id yet: the source route returned this as a 200
+        // with status "no_session_id" (a domain state), so the tunnel verb returns Ok with that body.
+        var (sm, session, _) = NewSession();
+        try
+        {
+            Assert.True(string.IsNullOrEmpty(session.ClaudeSessionId));
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("summary", session.Id.ToString()));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var dto = JsonSerializer.Deserialize<SessionSummaryDto>(result.BodyJson ?? "", Json);
+            Assert.NotNull(dto);
+            Assert.Equal("no_session_id", dto.Status);
+            Assert.Equal(session.Id.ToString(), dto.SessionId);
+            Assert.Equal("dir-A", dto.DirectorId);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- recap ----------
+
+    [Fact]
+    public async Task DispatchAsync_Recap_NotCached_ReturnsOkWithNotCachedStatus()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("recap", session.Id.ToString()));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var resp = JsonSerializer.Deserialize<RecapResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(resp);
+            Assert.Equal("not_cached", resp.Status);
+            Assert.Equal(session.Id.ToString(), resp.SessionId);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_Recap_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("recap", Guid.NewGuid().ToString()));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- turn-summaries ----------
+
+    [Fact]
+    public async Task DispatchAsync_TurnSummaries_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("turn-summaries", Guid.NewGuid().ToString()));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_TurnSummaries_NoCache_ReturnsOkWithEmptyList()
+    {
+        // No services supplied -> no TurnSummaryCache, so the list is empty (exactly the route's null-safe
+        // behaviour), still a 200.
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("turn-summaries", session.Id.ToString()));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var resp = JsonSerializer.Deserialize<TurnSummariesResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(resp);
+            Assert.Equal(session.Id.ToString(), resp.SessionId);
+            Assert.Empty(resp.Summaries);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- usage ----------
+
+    [Fact]
+    public async Task DispatchAsync_Usage_InvalidSessionId_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("usage", "not-a-guid"));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_Usage_NoClaudeSessionId_ReturnsNotFound()
+    {
+        // A fresh session has no linked Claude session id, so usage cannot be computed - the source route's
+        // 404 for that case is preserved.
+        var (sm, session, _) = NewSession();
+        try
+        {
+            Assert.True(string.IsNullOrEmpty(session.ClaudeSessionId));
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("usage", session.Id.ToString()));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- context ----------
+
+    [Fact]
+    public async Task DispatchAsync_Context_InvalidSessionId_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("context", "not-a-guid"));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_Context_FreshSession_ReturnsNotFound()
+    {
+        // A fresh session reports no context usage yet (either the driver lacks the capability or there is no
+        // completed turn) - both are the source route's 404.
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("context", session.Id.ToString()));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- history ----------
+
+    [Fact]
+    public async Task DispatchAsync_History_InvalidSessionId_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("history", "not-a-guid"));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_History_ExistingSession_ReturnsOkWithHistoryDto()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("history", session.Id.ToString()));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var dto = JsonSerializer.Deserialize<SessionHistoryDto>(result.BodyJson ?? "", Json);
+            Assert.NotNull(dto);
+            Assert.Equal(session.Id.ToString(), dto.SessionId);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- github-urls ----------
+
+    [Fact]
+    public async Task DispatchAsync_GithubUrls_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("github-urls", Guid.NewGuid().ToString()));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_GithubUrls_RepoWithoutGithubOrigin_ReturnsConflict()
+    {
+        // The temp path is not a git repo with a GitHub origin, so BuildNewIssueUrl throws
+        // InvalidOperationException - the source route's 409, surfaced as a Conflict result.
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("github-urls", session.Id.ToString()));
+            Assert.Equal(DirectorCommandStatus.Conflict, result.Status);
+            Assert.False(string.IsNullOrEmpty(result.Error));
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- wingman-view ----------
+
+    [Fact]
+    public async Task DispatchAsync_WingmanView_ExistingSession_ReturnsViewDto()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("wingman-view", session.Id.ToString()));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var dto = JsonSerializer.Deserialize<WingmanViewDto>(result.BodyJson ?? "", Json);
+            Assert.NotNull(dto);
+            Assert.Equal(session.Id.ToString(), dto.SessionId);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WingmanView_InvalidSessionId_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("wingman-view", "not-a-guid"));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- wingman-explain ----------
+
+    [Fact]
+    public async Task DispatchAsync_WingmanExplain_ExistingSession_ReturnsExplainResponse()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("wingman-explain", session.Id.ToString()));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var resp = JsonSerializer.Deserialize<WingmanExplainResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(resp);
+            Assert.False(resp.MobileMode); // a fresh session's view mode is Off
+            Assert.Null(resp.Text);        // nothing cached yet
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WingmanExplain_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("wingman-explain", Guid.NewGuid().ToString()));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+}


### PR DESCRIPTION
## What this does

Gateway Cleanup mission, Phase 0. Moves a group of Director session READ verbs onto the shared tunnel command surface, following the merged `turns` exemplar. For each verb the core is extracted verbatim from its Director REST lambda into an internal static method on `SessionReadExecutor` returning `DirectorCommandResult`; the verb is added to `SessionReadExecutor.Verbs` and its `ExecuteAsync` switch; and the REST route is re-pointed to `SessionCommandExecutor.DispatchAsync` and mapped back.

**Same core, no drift:** the REST route and the tunnel verb call the SAME core method, so they cannot diverge. Phase 1 later deletes the routes and leaves the cores reached only over the tunnel.

**Additive, no deletions.**

## Verbs moved (12)

`snapshot`, `buffer`, `buffer-html`, `summary`, `recap`, `turn-summaries`, `usage`, `context`, `history`, `github-urls`, `wingman-view`, `wingman-explain`.

- `snapshot` follows the `patch` precedent: the core returns the plain `ControlEndpoints.Map` DTO (the Gateway stamps identity during aggregation) and the REST route re-maps with its identity-stamped mapper for a byte-identical local response.
- `buffer` carries its three query-string arguments (lines/raw/since) in the command payload as a new `BufferRequest`.
- `github-urls` maps a repo with no GitHub origin to Conflict, mapped back to the route's 409.
- `usage`/`context`/`history` preserve their extra 404s and their read-fault 500 (surfaced as the `Error` status, mapped to `Results.Problem`). The `usage` transcript-not-found 404 folds the path into the error message (the route had it as a separate `path` field).

## Deliberately left out (too entangled to extract faithfully)

- **handover** - its response body includes the Director version string, which is only a `ControlEndpoints.Map` parameter and is not in the shared command context, so it cannot be served identically over the tunnel without editing the shared context/services.
- **handover-context** - returns `text/plain` (not a resource DTO) and takes a query argument; does not fit the JSON-DTO read area cleanly.
- **brief** - bound to the HTTP request (`RequestAborted` cancellation, a 499 result) and to endpoint-local condenser/cache state; too entangled.

## Supporting changes (all additive)

- New file `src/CcDirector.Gateway.Contracts/SessionReadContracts.cs` holds the new DTOs (`BufferRequest`, `BufferHtmlResponse`, `GithubUrlsResponse`, `WingmanExplainResponse`) so no shared Contracts file is edited.
- `ControlEndpoints.ComputeTurnCount` widened from `private` to `internal` so the shared recap core reads the same turn count.
- The three per-endpoint read files (`SessionUsageEndpoint`, `SessionContextEndpoint`, `SessionHistoryEndpoint`) take the Director id so they can dispatch; the three call sites in `ControlApiHost` pass it.

## Tests

New file `src/CcDirector.Gateway.Tests/SessionReadExecutorTests.cs` (23 tests) exercises the verbs through the real `DispatchAsync` path: invalid id -> BadRequest, missing session -> NotFound, success bodies, plus the Conflict (no GitHub origin) and the 200-with-domain-status (not-yet-linked) results.

Build: `dotnet build src/CcDirector.ControlApi` = 0 warnings, 0 errors.
Test: `SessionReadExecutorTests | DirectorSurfaceEndpointTests | CockpitParityEndpointsTests` = Passed 48, Failed 0.

Do NOT merge - the Manager controls merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)