### PR TITLE
feat(gateway-cleanup): Phase 0 - route catalog read verbs through the tunnel dispatch

### DIFF
--- a/src/CcDirector.ControlApi/CatalogReadExecutor.cs
+++ b/src/CcDirector.ControlApi/CatalogReadExecutor.cs
@@ -1,3 +1,10 @@
+using CcDirector.Core.Claude;
+using CcDirector.Core.Git;
+using CcDirector.Core.History;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
+using CcDirector.Core.Wingman;
 using CcDirector.Gateway.Contracts;
 
 namespace CcDirector.ControlApi;
@@ -5,14 +12,210 @@ namespace CcDirector.ControlApi;
 /// <summary>
 /// Gateway Cleanup mission, Phase 0 (spine): the CATALOG and DIRECTOR-LEVEL READ area of the tunnel command
 /// surface. It owns the reads that are not addressed to one session (git status is per-session but grouped
-/// here with the catalogs) - repos list, facts, coaching categories, claude-sessions, interrupted list,
-/// filesystem list, directory list. Empty in the spine; Worker R2 fills it. Each verb it adds is declared in
-/// <see cref="Verbs"/> and handled in <see cref="ExecuteAsync"/>, touching only this file.
+/// here with the catalogs). Worker R2 filled it with: <c>git-status</c>, <c>coaching-categories</c>,
+/// <c>claude-sessions</c>, <c>interrupted-list</c>, and <c>fs-list</c> (the list-directory read).
+///
+/// Each core is extracted verbatim from that read's Director REST lambda. That REST route now calls this
+/// SAME core, so the tunnel verb and the route cannot drift (the core is the single source of truth); Phase 1
+/// deletes the routes and leaves the cores reached only over the tunnel. A preserved try/catch is kept ONLY
+/// where the source route had one (<c>fs-list</c>), so behaviour is byte-identical.
+///
+/// Two of the group's REST reads were NOT lifted, because they depend on host state that the tunnel command
+/// surface does not carry (routing either faithfully would require a spine change, not a single-area edit):
+/// <c>GET /facts</c> embeds the host's injected version string (<c>ControlApiHost._version</c>), which is
+/// absent from <see cref="SessionCommandContext"/>; and <c>GET /repos</c> reads the live per-host
+/// <c>RepositoryRegistry</c> instance, which is a Map-time dependency not carried by the context or the
+/// stream client's <see cref="SessionCommandServices"/>. Both stay as their own REST routes for now.
 /// </summary>
 internal sealed class CatalogReadExecutor : ISessionCommandArea
 {
-    public IReadOnlyCollection<string> Verbs { get; } = Array.Empty<string>();
+    /// <summary>
+    /// The git-status provider, ONE shared instance (its own ten-second cache), exactly as the REST route
+    /// held a single provider across requests. The REST route now reaches this same instance through the
+    /// core, so both callers share the cache.
+    /// </summary>
+    private static readonly GitStatusProvider GitProvider = new();
 
-    public Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken) =>
-        Task.FromResult(DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the catalog read area"));
+    public IReadOnlyCollection<string> Verbs { get; } = new[]
+    {
+        "git-status",
+        "coaching-categories",
+        "claude-sessions",
+        "interrupted-list",
+        "fs-list",
+    };
+
+    public async Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken)
+    {
+        return command.Verb switch
+        {
+            "git-status" => await GitStatus(context.SessionManager, command, cancellationToken),
+            "coaching-categories" => CoachingCategories(),
+            "claude-sessions" => ClaudeSessions(command),
+            "interrupted-list" => InterruptedList(),
+            "fs-list" => FsList(command),
+            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the catalog read area"),
+        };
+    }
+
+    /// <summary>
+    /// The <c>git-status</c> verb: a read-only source-control snapshot for a session's repo. Mirrors the
+    /// Director's <c>GET /sessions/{sid}/git</c> lambda - invalid id -&gt; BadRequest, missing session -&gt;
+    /// NotFound - and returns a serialized <see cref="GitSnapshot"/>. The summary fields come from
+    /// <see cref="WingmanService.GitSnapshotAsync"/>; when the repo reads "ok" the snapshot is additively
+    /// enriched with the per-file staged/unstaged lists from <see cref="GitStatusProvider"/>, exactly as the
+    /// route did. The source route had no try/catch (GitSnapshotAsync owns its own), so none is added here.
+    /// </summary>
+    internal static async Task<DirectorCommandResult> GitStatus(SessionManager sessionManager, DirectorCommand command, CancellationToken cancellationToken)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        var snap = await WingmanService.GitSnapshotAsync(session.RepoPath, cancellationToken);
+        if (snap.Status == "ok")
+        {
+            var files = await GitProvider.GetStatusAsync(session.RepoPath);
+            if (files.Success)
+                GitChangeMapper.Enrich(snap, files);
+        }
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(snap));
+    }
+
+    /// <summary>
+    /// The <c>coaching-categories</c> verb: the coaching quick-launch cards (Assistant / Coach) with their
+    /// Director-resolved on-disk paths. Mirrors the Director's <c>GET /coaching/categories</c> lambda - a
+    /// static two-entry list, always a 200 - and returns a serialized <see cref="List{CoachingCategoryDto}"/>.
+    /// No target session and no host state, so this always succeeds.
+    /// </summary>
+    internal static DirectorCommandResult CoachingCategories()
+    {
+        FileLog.Write("[CatalogReadExecutor] coaching-categories");
+        var cats = new List<CoachingCategoryDto>
+        {
+            new()
+            {
+                Key = "assistant",
+                Label = "Assistant",
+                Description = "Tasks, contacts, daily briefing",
+                Path = CcStorage.CoachingCategory("assistant"),
+            },
+            new()
+            {
+                Key = "coach",
+                Label = "Coach",
+                Description = "Life coaching across all domains",
+                Path = CcStorage.CoachingCategory("coach"),
+            },
+        };
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(cats));
+    }
+
+    /// <summary>
+    /// The <c>claude-sessions</c> verb: the resumable Claude Code sessions (the Resume Session tab). Mirrors
+    /// the Director's <c>GET /claude-sessions</c> lambda - merges the workspace history entries (which carry
+    /// custom name/color) with the Claude session-index metadata, de-duplicates by Claude session id, applies
+    /// the optional <c>repo</c> filter from the payload, orders by last-used descending, and returns a
+    /// serialized <see cref="List{ClaudeSessionDto}"/>. Always a 200 (there is no session to miss).
+    /// </summary>
+    internal static DirectorCommandResult ClaudeSessions(DirectorCommand command)
+    {
+        var request = SessionCommandExecutor.Deserialize<ClaudeSessionsRequest>(command.PayloadJson);
+        var repo = request?.Repo;
+        FileLog.Write($"[CatalogReadExecutor] claude-sessions: repo={repo}");
+
+        var claudeMeta = new Dictionary<string, ClaudeSessionMetadata>(StringComparer.Ordinal);
+        foreach (var cm in ClaudeSessionReader.ScanAllProjects())
+            claudeMeta.TryAdd(cm.SessionId, cm);
+
+        var history = new SessionHistoryStore().LoadAll();
+        var dtos = new List<ClaudeSessionDto>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        // History entries first (they carry custom name/color), enriched with Claude metadata.
+        foreach (var entry in history)
+        {
+            if (string.IsNullOrEmpty(entry.ClaudeSessionId) || !seen.Add(entry.ClaudeSessionId))
+                continue;
+            claudeMeta.TryGetValue(entry.ClaudeSessionId, out var meta);
+            dtos.Add(new ClaudeSessionDto
+            {
+                ClaudeSessionId = entry.ClaudeSessionId,
+                RepoPath = entry.RepoPath,
+                ProjectName = ControlEndpoints.ProjectNameOf(entry.RepoPath),
+                CustomName = entry.CustomName,
+                CustomColor = entry.CustomColor,
+                MessageCount = meta?.MessageCount ?? 0,
+                Summary = meta?.Summary ?? meta?.FirstPrompt ?? entry.FirstPromptSnippet,
+                LastUsedUtc = entry.LastUsedAt == default ? meta?.Modified : entry.LastUsedAt.UtcDateTime,
+            });
+        }
+
+        // Then any Claude sessions not tracked by a workspace history entry.
+        foreach (var meta in claudeMeta.Values)
+        {
+            if (string.IsNullOrEmpty(meta.SessionId) || !seen.Add(meta.SessionId))
+                continue;
+            dtos.Add(new ClaudeSessionDto
+            {
+                ClaudeSessionId = meta.SessionId,
+                RepoPath = meta.ProjectPath ?? string.Empty,
+                ProjectName = ControlEndpoints.ProjectNameOf(meta.ProjectPath ?? string.Empty),
+                MessageCount = meta.MessageCount,
+                Summary = meta.Summary ?? meta.FirstPrompt,
+                LastUsedUtc = meta.Modified == DateTime.MinValue ? null : meta.Modified,
+            });
+        }
+
+        if (!string.IsNullOrWhiteSpace(repo))
+        {
+            var wanted = ControlEndpoints.NormalizeRepoPath(repo);
+            dtos = dtos.Where(d => !string.IsNullOrEmpty(d.RepoPath)
+                                   && ControlEndpoints.NormalizeRepoPath(d.RepoPath) == wanted).ToList();
+        }
+
+        var ordered = dtos
+            .OrderByDescending(d => d.LastUsedUtc ?? DateTime.MinValue)
+            .ToList();
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(ordered));
+    }
+
+    /// <summary>
+    /// The <c>interrupted-list</c> verb: the pending crash-journal recoveries this Director found on startup
+    /// (dead Directors and their recoverable session rosters). Mirrors the Director's <c>GET /interrupted</c>
+    /// lambda - a read of <see cref="DirectorCrashJournal.ListPendingRecoveries"/>, always a 200 - and returns
+    /// a serialized <see cref="IReadOnlyList{DirectorCrashJournalData}"/>.
+    /// </summary>
+    internal static DirectorCommandResult InterruptedList()
+    {
+        FileLog.Write("[CatalogReadExecutor] interrupted-list");
+        var pending = DirectorCrashJournal.ListPendingRecoveries();
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(pending));
+    }
+
+    /// <summary>
+    /// The <c>fs-list</c> verb (the list-directory read): the remote folder browser. Mirrors the Director's
+    /// <c>GET /fs/list</c> lambda - lists the drive roots when the payload path is null/blank, otherwise the
+    /// named directory - and returns a serialized <see cref="DirectoryListingDto"/>. The source route wrapped
+    /// the listing in a try/catch that turned any fault (a missing directory, an access error) into a 400 with
+    /// the message, so that try/catch is preserved here and surfaced as a <see cref="DirectorCommandStatus.BadRequest"/>.
+    /// </summary>
+    internal static DirectorCommandResult FsList(DirectorCommand command)
+    {
+        var request = SessionCommandExecutor.Deserialize<FsListRequest>(command.PayloadJson);
+        var path = request?.Path;
+        FileLog.Write($"[CatalogReadExecutor] fs-list: path={path}");
+        try
+        {
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(ControlEndpoints.ListDirectory(path)));
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[CatalogReadExecutor] fs-list FAILED: {ex.Message}");
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, ex.Message);
+        }
+    }
 }

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1829,21 +1829,21 @@ internal static class ControlEndpoints
         // (its own ten-second cache), so the Cockpit's Source Control tab can list what is changed and insert
         // a path into the composer. The enrichment is additive-only, so the existing Wingman consumer of
         // GitSnapshotAsync is untouched.
-        var gitStatusProvider = new Core.Git.GitStatusProvider();
+        // Gateway Cleanup Phase 0 (Worker R2): the read runs through the shared CatalogReadExecutor core so
+        // this REST path and the Gateway stream down-channel are identical and cannot drift. Phase 1 deletes
+        // this route and leaves the core reached only over the tunnel.
         app.MapGet("/sessions/{sid}/git", async (string sid, HttpContext ctx) =>
         {
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
-            var session = sessionManager.GetSession(guid);
-            if (session is null) return Results.NotFound(new { error = "session not found" });
-            var snap = await WingmanService.GitSnapshotAsync(session.RepoPath, ctx.RequestAborted);
-            if (snap.Status == "ok")
+            var command = new DirectorCommand { Verb = "git-status", SessionId = sid };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command, cancellationToken: ctx.RequestAborted);
+
+            return result.Status switch
             {
-                var files = await gitStatusProvider.GetStatusAsync(session.RepoPath);
-                if (files.Success)
-                    Core.Git.GitChangeMapper.Enrich(snap, files);
-            }
-            return Results.Json(snap);
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<GitSnapshot>(result.BodyJson)),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "git-status command failed"),
+            };
         });
 
         // ===== Git WRITE actions (mirror the desktop Source Control view) =====
@@ -2814,88 +2814,39 @@ internal static class ControlEndpoints
         });
 
         // ===== REST: Coaching quick-launch categories (Assistant / Coach cards) =====
-        app.MapGet("/coaching/categories", () =>
+        // Gateway Cleanup Phase 0 (Worker R2): the read runs through the shared CatalogReadExecutor core so
+        // this REST path and the Gateway stream down-channel are identical and cannot drift. Phase 1 deletes
+        // this route.
+        app.MapGet("/coaching/categories", async () =>
         {
-            FileLog.Write("[ControlEndpoints] GET /coaching/categories");
-            var cats = new List<CoachingCategoryDto>
+            var command = new DirectorCommand { Verb = "coaching-categories" };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
+
+            return result.Status switch
             {
-                new()
-                {
-                    Key = "assistant",
-                    Label = "Assistant",
-                    Description = "Tasks, contacts, daily briefing",
-                    Path = CcStorage.CoachingCategory("assistant"),
-                },
-                new()
-                {
-                    Key = "coach",
-                    Label = "Coach",
-                    Description = "Life coaching across all domains",
-                    Path = CcStorage.CoachingCategory("coach"),
-                },
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<List<CoachingCategoryDto>>(result.BodyJson)),
+                _ => Results.Problem(result.Error ?? "coaching-categories command failed"),
             };
-            return Results.Json(cats);
         });
 
         // ===== REST: Resumable Claude Code sessions (Resume Session tab) =====
-        app.MapGet("/claude-sessions", (string? repo) =>
+        // Gateway Cleanup Phase 0 (Worker R2): the read runs through the shared CatalogReadExecutor core so
+        // this REST path and the Gateway stream down-channel are identical and cannot drift. Phase 1 deletes
+        // this route. The ?repo= filter rides in the command payload as a ClaudeSessionsRequest.
+        app.MapGet("/claude-sessions", async (string? repo) =>
         {
-            FileLog.Write($"[ControlEndpoints] GET /claude-sessions: repo={repo}");
-
-            var claudeMeta = new Dictionary<string, ClaudeSessionMetadata>(StringComparer.Ordinal);
-            foreach (var cm in ClaudeSessionReader.ScanAllProjects())
-                claudeMeta.TryAdd(cm.SessionId, cm);
-
-            var history = new SessionHistoryStore().LoadAll();
-            var dtos = new List<ClaudeSessionDto>();
-            var seen = new HashSet<string>(StringComparer.Ordinal);
-
-            // History entries first (they carry custom name/color), enriched with Claude metadata.
-            foreach (var entry in history)
+            var command = new DirectorCommand
             {
-                if (string.IsNullOrEmpty(entry.ClaudeSessionId) || !seen.Add(entry.ClaudeSessionId))
-                    continue;
-                claudeMeta.TryGetValue(entry.ClaudeSessionId, out var meta);
-                dtos.Add(new ClaudeSessionDto
-                {
-                    ClaudeSessionId = entry.ClaudeSessionId,
-                    RepoPath = entry.RepoPath,
-                    ProjectName = ProjectNameOf(entry.RepoPath),
-                    CustomName = entry.CustomName,
-                    CustomColor = entry.CustomColor,
-                    MessageCount = meta?.MessageCount ?? 0,
-                    Summary = meta?.Summary ?? meta?.FirstPrompt ?? entry.FirstPromptSnippet,
-                    LastUsedUtc = entry.LastUsedAt == default ? meta?.Modified : entry.LastUsedAt.UtcDateTime,
-                });
-            }
+                Verb = "claude-sessions",
+                PayloadJson = SessionCommandExecutor.Serialize(new ClaudeSessionsRequest { Repo = repo }),
+            };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
 
-            // Then any Claude sessions not tracked by a workspace history entry.
-            foreach (var meta in claudeMeta.Values)
+            return result.Status switch
             {
-                if (string.IsNullOrEmpty(meta.SessionId) || !seen.Add(meta.SessionId))
-                    continue;
-                dtos.Add(new ClaudeSessionDto
-                {
-                    ClaudeSessionId = meta.SessionId,
-                    RepoPath = meta.ProjectPath ?? string.Empty,
-                    ProjectName = ProjectNameOf(meta.ProjectPath ?? string.Empty),
-                    MessageCount = meta.MessageCount,
-                    Summary = meta.Summary ?? meta.FirstPrompt,
-                    LastUsedUtc = meta.Modified == DateTime.MinValue ? null : meta.Modified,
-                });
-            }
-
-            if (!string.IsNullOrWhiteSpace(repo))
-            {
-                var wanted = NormalizeRepoPath(repo);
-                dtos = dtos.Where(d => !string.IsNullOrEmpty(d.RepoPath)
-                                       && NormalizeRepoPath(d.RepoPath) == wanted).ToList();
-            }
-
-            var ordered = dtos
-                .OrderByDescending(d => d.LastUsedUtc ?? DateTime.MinValue)
-                .ToList();
-            return Results.Json(ordered);
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<List<ClaudeSessionDto>>(result.BodyJson)),
+                _ => Results.Problem(result.Error ?? "claude-sessions command failed"),
+            };
         });
 
         // ===== REST: Handover documents (Handovers tab) =====
@@ -2987,18 +2938,25 @@ internal static class ControlEndpoints
         });
 
         // ===== REST: Remote folder browser (Browse... button) =====
-        app.MapGet("/fs/list", (string? path) =>
+        // Gateway Cleanup Phase 0 (Worker R2): the list-directory read runs through the shared
+        // CatalogReadExecutor core so this REST path and the Gateway stream down-channel are identical and
+        // cannot drift. Phase 1 deletes this route. The ?path= argument rides in the command payload as an
+        // FsListRequest; the core preserves the source route's try/catch, so a bad path is still a 400.
+        app.MapGet("/fs/list", async (string? path) =>
         {
-            FileLog.Write($"[ControlEndpoints] GET /fs/list: path={path}");
-            try
+            var command = new DirectorCommand
             {
-                return Results.Json(ListDirectory(path));
-            }
-            catch (Exception ex)
+                Verb = "fs-list",
+                PayloadJson = SessionCommandExecutor.Serialize(new FsListRequest { Path = path }),
+            };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
+
+            return result.Status switch
             {
-                FileLog.Write($"[ControlEndpoints] GET /fs/list FAILED: {ex.Message}");
-                return Results.BadRequest(new { error = ex.Message });
-            }
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<DirectoryListingDto>(result.BodyJson)),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "fs-list command failed"),
+            };
         });
 
         // ===== REST: Create a session =====
@@ -3142,10 +3100,19 @@ internal static class ControlEndpoints
         // This machine's claimed dirty crash journals - Directors that died abnormally here,
         // with their recoverable session rosters. The Gateway aggregates these across the fleet
         // for the Cockpit's Interrupted sessions list.
-        app.MapGet("/interrupted", () =>
+        // Gateway Cleanup Phase 0 (Worker R2): the read runs through the shared CatalogReadExecutor core so
+        // this REST path and the Gateway stream down-channel are identical and cannot drift. Phase 1 deletes
+        // this route.
+        app.MapGet("/interrupted", async () =>
         {
-            var pending = Core.Sessions.DirectorCrashJournal.ListPendingRecoveries();
-            return Results.Json(pending);
+            var command = new DirectorCommand { Verb = "interrupted-list" };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
+
+            return result.Status switch
+            {
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<List<Core.Sessions.DirectorCrashJournalData>>(result.BodyJson)),
+                _ => Results.Problem(result.Error ?? "interrupted-list command failed"),
+            };
         });
 
         // Dismiss one claimed dirty journal once its sessions are recovered or no longer wanted.
@@ -3249,7 +3216,9 @@ internal static class ControlEndpoints
     }
 
     /// <summary>Folder name of a repo path, for display fallback. Empty path -> "Unknown Project".</summary>
-    private static string ProjectNameOf(string repoPath)
+    // Gateway Cleanup Phase 0 (Worker R2): widened to internal so CatalogReadExecutor's claude-sessions core
+    // (lifted verbatim from GET /claude-sessions) calls the SAME helper - no drift, no duplication.
+    internal static string ProjectNameOf(string repoPath)
     {
         if (string.IsNullOrEmpty(repoPath))
             return "Unknown Project";
@@ -3270,7 +3239,9 @@ internal static class ControlEndpoints
     /// case-insensitive). Callers must filter null/empty first; Path.GetFullPath throws
     /// only on empty or embedded-NUL input, which the global error envelope surfaces loudly.
     /// </summary>
-    private static string NormalizeRepoPath(string path)
+    // Gateway Cleanup Phase 0 (Worker R2): widened to internal so CatalogReadExecutor's claude-sessions core
+    // (lifted verbatim from GET /claude-sessions) calls the SAME helper - no drift, no duplication.
+    internal static string NormalizeRepoPath(string path)
     {
         return Path.GetFullPath(path).TrimEnd('\\', '/').ToLowerInvariant();
     }
@@ -3279,7 +3250,9 @@ internal static class ControlEndpoints
     /// List sub-directories of <paramref name="path"/> for the remote folder browser. A null or
     /// empty path returns the drive roots. Solo-tailnet: no path sandboxing (see remote-experience-plan.md).
     /// </summary>
-    private static DirectoryListingDto ListDirectory(string? path)
+    // Gateway Cleanup Phase 0 (Worker R2): widened to internal so CatalogReadExecutor's fs-list core (the
+    // list-directory read, lifted from GET /fs/list) calls the SAME helper - no drift, no duplication.
+    internal static DirectoryListingDto ListDirectory(string? path)
     {
         if (string.IsNullOrWhiteSpace(path))
         {

--- a/src/CcDirector.Gateway.Contracts/CatalogReadContracts.cs
+++ b/src/CcDirector.Gateway.Contracts/CatalogReadContracts.cs
@@ -1,0 +1,31 @@
+namespace CcDirector.Gateway.Contracts;
+
+// Gateway Cleanup mission, Phase 0 (Worker R2): the request shapes for the CATALOG / director-level READ
+// verbs that were moved onto the tunnel command surface. These are ADDITIVE - they name the exact
+// query-string arguments the old REST lambdas took (they have no home on DirectorCommand, so they ride in
+// the command payload), so the tunnel verb and the re-pointed REST route serialize identical JSON. The
+// response shapes are the DTOs the old routes already produced (ClaudeSessionDto, CoachingCategoryDto,
+// DirectoryListingDto, GitSnapshot, DirectorCrashJournalData) - unchanged. Kept in one new file so no shared
+// Contracts file is edited.
+
+/// <summary>
+/// GET /claude-sessions request. Carries the optional <c>repo</c> query-string argument the old REST route
+/// took to filter the resumable-session list to one repository. Null / absent means no filter (every repo),
+/// matching the route's <c>string? repo</c>.
+/// </summary>
+public sealed class ClaudeSessionsRequest
+{
+    /// <summary>When set, keep only sessions whose repo path matches this one (normalized comparison).</summary>
+    public string? Repo { get; set; }
+}
+
+/// <summary>
+/// GET /fs/list request. Carries the optional <c>path</c> query-string argument the old REST route took. Null
+/// / absent lists the drive roots; otherwise the named directory is listed, matching the route's
+/// <c>string? path</c>.
+/// </summary>
+public sealed class FsListRequest
+{
+    /// <summary>The directory to list, or null / absent to list the drive roots.</summary>
+    public string? Path { get; set; }
+}

--- a/src/CcDirector.Gateway.Tests/CatalogReadExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/CatalogReadExecutorTests.cs
@@ -1,0 +1,192 @@
+using System.Text.Json;
+using CcDirector.ControlApi;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0 (Worker R2): parity tests for the CATALOG / director-level READ verbs
+/// moved onto the tunnel command surface (<see cref="CatalogReadExecutor"/>). Each verb is exercised through
+/// the real <see cref="SessionCommandExecutor.DispatchAsync"/> path (verb map -&gt; area -&gt; core), the same
+/// way the re-pointed REST route and the Gateway stream down-channel reach it, so the core is asserted exactly
+/// once for both callers. Covers the per-session guards for <c>git-status</c> (invalid id -&gt; BadRequest,
+/// missing session -&gt; NotFound, existing session -&gt; a 200 snapshot), the always-200 director-level reads
+/// (<c>coaching-categories</c>, <c>claude-sessions</c>, <c>interrupted-list</c>, <c>fs-list</c> at the drive
+/// roots), and the one preserved try/catch (<c>fs-list</c> on a bad path -&gt; BadRequest). Reuses the
+/// buffer-only embedded-session harness from the sibling SessionCommandExecutor tests.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class CatalogReadExecutorTests
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    private static (SessionManager sm, Session session, ExecuteActionTestBackend backend) NewSession()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        var backend = new ExecuteActionTestBackend();
+        var session = sm.CreateEmbeddedSession(Path.GetTempPath(), null, backend);
+        return (sm, session, backend);
+    }
+
+    private static DirectorCommand Cmd(string verb, string sid = "", string payloadJson = "") =>
+        new() { CommandId = "r2", Verb = verb, SessionId = sid, PayloadJson = payloadJson };
+
+    // ---------- git-status ----------
+
+    [Fact]
+    public async Task DispatchAsync_GitStatus_InvalidSessionId_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("git-status", "not-a-guid"));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_GitStatus_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("git-status", Guid.NewGuid().ToString()));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_GitStatus_ExistingSession_ReturnsOkWithSnapshot()
+    {
+        // The temp path is not a git repo, so GitSnapshotAsync owns the "not a repo" domain state and returns
+        // a snapshot - still a 200 (the source route had no guard/try-catch of its own). The result is Ok with
+        // a deserializable GitSnapshot body.
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("git-status", session.Id.ToString()));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal("r2", result.CommandId);
+            var snap = JsonSerializer.Deserialize<GitSnapshot>(result.BodyJson ?? "", Json);
+            Assert.NotNull(snap);
+            Assert.False(string.IsNullOrEmpty(snap!.Status));
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- coaching-categories ----------
+
+    [Fact]
+    public async Task DispatchAsync_CoachingCategories_ReturnsOkWithAssistantAndCoach()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("coaching-categories"));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var cats = JsonSerializer.Deserialize<List<CoachingCategoryDto>>(result.BodyJson ?? "", Json);
+            Assert.NotNull(cats);
+            Assert.Equal(2, cats!.Count);
+            Assert.Contains(cats, c => c.Key == "assistant");
+            Assert.Contains(cats, c => c.Key == "coach");
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- claude-sessions ----------
+
+    [Fact]
+    public async Task DispatchAsync_ClaudeSessions_NoFilter_ReturnsOkWithList()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("claude-sessions"));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var dtos = JsonSerializer.Deserialize<List<ClaudeSessionDto>>(result.BodyJson ?? "", Json);
+            Assert.NotNull(dtos);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_ClaudeSessions_RepoFilter_ReturnsOnlyMatchingRepo()
+    {
+        // A repo path that matches nothing on this machine yields an empty (but valid) list - the ?repo=
+        // filter rides in the payload, exactly as the route's query-string argument did.
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var payload = JsonSerializer.Serialize(new ClaudeSessionsRequest { Repo = @"Z:\no\such\repo\r2-parity" }, Json);
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("claude-sessions", payloadJson: payload));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var dtos = JsonSerializer.Deserialize<List<ClaudeSessionDto>>(result.BodyJson ?? "", Json);
+            Assert.NotNull(dtos);
+            Assert.Empty(dtos!);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- interrupted-list ----------
+
+    [Fact]
+    public async Task DispatchAsync_InterruptedList_ReturnsOkWithList()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("interrupted-list"));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var pending = JsonSerializer.Deserialize<List<DirectorCrashJournalData>>(result.BodyJson ?? "", Json);
+            Assert.NotNull(pending);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- fs-list ----------
+
+    [Fact]
+    public async Task DispatchAsync_FsList_NullPath_ReturnsDriveRoots()
+    {
+        // A null/absent path lists the drive roots: CurrentPath is null and every entry is a drive.
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("fs-list"));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var listing = JsonSerializer.Deserialize<DirectoryListingDto>(result.BodyJson ?? "", Json);
+            Assert.NotNull(listing);
+            Assert.Null(listing!.CurrentPath);
+            Assert.NotEmpty(listing.Entries);
+            Assert.All(listing.Entries, e => Assert.True(e.IsDrive));
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_FsList_MissingDirectory_ReturnsBadRequest()
+    {
+        // The source route wrapped ListDirectory in a try/catch that turned a missing directory into a 400;
+        // that preserved try/catch surfaces here as a BadRequest with the message.
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var payload = JsonSerializer.Serialize(new FsListRequest { Path = @"Z:\no\such\directory\r2-parity" }, Json);
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("fs-list", payloadJson: payload));
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+            Assert.False(string.IsNullOrEmpty(result.Error));
+        }
+        finally { sm.Dispose(); }
+    }
+}


### PR DESCRIPTION
## Gateway Cleanup mission, Phase 0 (Worker R2)

One additive, mergeable pull request that moves a group of Director catalog / director-level READ verbs onto the shared tunnel command dispatch, following the `SessionReadExecutor` exemplar. NO deletions.

### What changed
Each verb's core is lifted VERBATIM from its Director REST lambda into `CatalogReadExecutor` (the previously-empty area class), and the matching REST route is re-pointed to call the SAME core via `SessionCommandExecutor.DispatchAsync`. The route and the Gateway stream down-channel now share one source of truth and cannot drift; the REST responses stay byte-identical (same guards, same status codes, same DTOs). Phase 1 later deletes the routes and leaves the cores reached only over the tunnel.

### Verbs moved (5)
- `git-status` - `GET /sessions/{sid}/git` (per-session; async, honors the request's cancellation token; enrich-when-ok preserved; no try/catch, matching the source)
- `coaching-categories` - `GET /coaching/categories`
- `claude-sessions` - `GET /claude-sessions` (the `?repo=` filter rides in the payload as a new `ClaudeSessionsRequest`)
- `interrupted-list` - `GET /interrupted`
- `fs-list` (the list-directory read) - `GET /fs/list` (the `?path=` argument rides in the payload as a new `FsListRequest`; the source route's try/catch is preserved, so a bad path is still a 400)

Note: the mission brief named `fs-list` and `directory-list` separately, but they are the SAME endpoint - `/fs/list` is backed by the `ListDirectory` helper (the only list-directory read on the Director). Moved once.

### Verbs skipped (2), with reason
- `facts` - `GET /facts`: the response embeds the host's injected version string (`ControlApiHost._version`, e.g. "1.0.0-test" in tests), which is NOT carried by `SessionCommandContext`.
- `repos-list` - `GET /repos`: reads the live per-host `RepositoryRegistry` instance, a Map-time dependency absent from the context and from the stream client's `SessionCommandServices`.

Routing either through the tunnel faithfully would require threading new state into the shared spine (`SessionCommandContext` / `SessionCommandServices` and both dispatch call sites) - a spine change, not a single-area edit, and a merge chokepoint. Rather than guess (e.g. re-reading a fresh `RepositoryRegistry` or assuming `AboutInfo.Version`), both stay as their own REST routes for now and are documented in the `CatalogReadExecutor` class comment.

### Rules followed
- No deletions; additive only. Three private helpers in `ControlEndpoints` (`ProjectNameOf`, `NormalizeRepoPath`, `ListDirectory`) were widened to `internal` so the lifted cores call the SAME helpers - no duplication, no drift (same pattern as the exemplar's `BuildTurnWidgetsFromHistory`).
- New request DTOs live in a NEW file (`CatalogReadContracts.cs`); no shared Contracts file edited. Response shapes reuse the existing DTOs the old routes already produced.
- Parity tests in a NEW file (`CatalogReadExecutorTests.cs`); no other test file edited.
- Try/catch preserved ONLY where the source route had one (`fs-list`).
- Build 0 warnings / 0 errors.

### Verification
`dotnet build src/CcDirector.ControlApi` -> 0 warnings, 0 errors.
`dotnet test ... --filter "FullyQualifiedName~CatalogReadExecutorTests|FullyQualifiedName~DirectorSurfaceEndpointTests"` -> Passed: 18, Failed: 0.

Do not merge - the Manager controls merge order.