### PR TITLE
feat(gateway-cleanup): Phase 0 - route queue and git write verbs through the tunnel dispatch

### DIFF
--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1848,28 +1848,39 @@ internal static class ControlEndpoints
 
         // ===== Git WRITE actions (mirror the desktop Source Control view) =====
         // Reads stay on GET /git above; these mutate the working tree of the session's repo.
-        var gitWrite = new Core.Git.GitWriteService();
-
-        async Task<IResult> RunGitWrite(string sid, Func<string, Task<Core.Git.GitWriteResult>> op)
+        // Gateway Cleanup Phase 0 (Worker W2): each git write now runs through the shared QueueGitExecutor
+        // core so the REST route and the Gateway tunnel down-channel cannot drift. The command body (the
+        // git result) rides back verbatim; a non-zero git exit surfaces as accepted=false, which this route
+        // maps to HTTP 409 exactly as the old RunGitWrite helper did.
+        async Task<IResult> DispatchGitWrite(string verb, string sid, object? payload)
         {
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
-            var session = sessionManager.GetSession(guid);
-            if (session is null) return Results.NotFound(new { error = "session not found" });
-            var r = await op(session.RepoPath);
-            return r.Success
-                ? Results.Json(new { accepted = true, output = r.Output })
-                : Results.Json(new { accepted = false, error = r.Error, exitCode = r.ExitCode }, statusCode: StatusCodes.Status409Conflict);
+            var command = new DirectorCommand
+            {
+                Verb = verb,
+                SessionId = sid,
+                PayloadJson = payload is null ? "" : SessionCommandExecutor.Serialize(payload),
+            };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
+            return result.Status switch
+            {
+                DirectorCommandStatus.Ok =>
+                    SessionCommandExecutor.Deserialize<GitWriteEnvelope>(result.BodyJson)!.Accepted
+                        ? Results.Content(result.BodyJson ?? "", "application/json")
+                        : Results.Content(result.BodyJson ?? "", "application/json", null, StatusCodes.Status409Conflict),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "git command failed"),
+            };
         }
 
         app.MapPost("/sessions/{sid}/git/stage", (string sid, GitPathsRequest? req) =>
-            RunGitWrite(sid, repo => gitWrite.StageAsync(repo, req?.Paths ?? new())));
+            DispatchGitWrite("git-stage", sid, req));
         app.MapPost("/sessions/{sid}/git/unstage", (string sid, GitPathsRequest? req) =>
-            RunGitWrite(sid, repo => gitWrite.UnstageAsync(repo, req?.Paths ?? new())));
+            DispatchGitWrite("git-unstage", sid, req));
         app.MapPost("/sessions/{sid}/git/discard", (string sid, GitPathsRequest? req) =>
-            RunGitWrite(sid, repo => gitWrite.DiscardAsync(repo, req?.Paths ?? new())));
+            DispatchGitWrite("git-discard", sid, req));
         app.MapPost("/sessions/{sid}/git/commit", (string sid, GitCommitRequest? req) =>
-            RunGitWrite(sid, repo => gitWrite.CommitAsync(repo, req?.Message ?? "")));
+            DispatchGitWrite("git-commit", sid, req));
 
         // Re-point a Director session at a different Claude session id (mirrors the desktop
         // Relink button - recover continuity when the underlying Claude session id changed).
@@ -2195,118 +2206,91 @@ internal static class ControlEndpoints
         // Messages the user composed while the agent was busy. Stored on the session's
         // PromptQueue; the Cockpit's Queue button adds here, the queue panel lists/removes,
         // and "send" delivers an item to the PTY now. Mirrors the existing desktop queue.
-        app.MapGet("/sessions/{sid}/queue", (string sid) =>
+        // Gateway Cleanup Phase 0 (Worker W2): every queue verb now runs through the shared QueueGitExecutor
+        // core so the REST route and the Gateway tunnel down-channel cannot drift. Each route packages its
+        // arguments into a DirectorCommand, dispatches, and maps the typed result back to the same HTTP shape
+        // the old lambda returned (the success body is the queue projection, shipped verbatim).
+        IResult MapQueueResult(DirectorCommandResult result) => result.Status switch
         {
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
-            return Results.Json(new { items = ProjectQueue(session) });
-        });
+            DirectorCommandStatus.Ok => Results.Content(result.BodyJson ?? "", "application/json"),
+            DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+            DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+            _ => Results.Problem(result.Error ?? "queue command failed"),
+        };
+
+        async Task<IResult> DispatchQueue(string verb, string sid, object? payload)
+        {
+            var command = new DirectorCommand
+            {
+                Verb = verb,
+                SessionId = sid,
+                PayloadJson = payload is null ? "" : SessionCommandExecutor.Serialize(payload),
+            };
+            return MapQueueResult(await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command));
+        }
+
+        app.MapGet("/sessions/{sid}/queue", (string sid) =>
+            DispatchQueue("queue-read", sid, null));
 
         app.MapPost("/sessions/{sid}/queue", (string sid, PromptRequest req) =>
         {
             FileLog.Write($"[ControlEndpoints] POST queue enqueue: sid={sid}, len={req?.Text?.Length ?? 0}");
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
-            if (req is null || string.IsNullOrWhiteSpace(req.Text))
-                return Results.BadRequest(new { error = "text is required" });
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
-
-            session.PromptQueue.Enqueue(req.Text);
-            return Results.Json(new { items = ProjectQueue(session) });
+            return DispatchQueue("queue-add", sid, new QueueItemCommand(Text: req?.Text));
         });
 
         app.MapDelete("/sessions/{sid}/queue/{itemId}", (string sid, string itemId) =>
         {
             FileLog.Write($"[ControlEndpoints] DELETE queue item: sid={sid}, item={itemId}");
-            if (!Guid.TryParse(sid, out var guid) || !Guid.TryParse(itemId, out var itemGuid))
-                return Results.BadRequest(new { error = "invalid id format" });
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
-
-            session.PromptQueue.Remove(itemGuid);
-            return Results.Json(new { items = ProjectQueue(session) });
+            return DispatchQueue("queue-remove", sid, new QueueItemCommand(ItemId: itemId));
         });
 
         // Edit the text of a queued item in place.
         app.MapPatch("/sessions/{sid}/queue/{itemId}", (string sid, string itemId, PromptRequest req) =>
         {
             FileLog.Write($"[ControlEndpoints] PATCH queue edit: sid={sid}, item={itemId}");
-            if (!Guid.TryParse(sid, out var guid) || !Guid.TryParse(itemId, out var itemGuid))
-                return Results.BadRequest(new { error = "invalid id format" });
-            if (req is null || string.IsNullOrWhiteSpace(req.Text))
-                return Results.BadRequest(new { error = "text is required" });
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
-            session.PromptQueue.UpdateText(itemGuid, req.Text);
-            return Results.Json(new { items = ProjectQueue(session) });
+            return DispatchQueue("queue-update", sid, new QueueItemCommand(ItemId: itemId, Text: req?.Text));
         });
 
         app.MapPost("/sessions/{sid}/queue/{itemId}/move-up", (string sid, string itemId) =>
         {
             FileLog.Write($"[ControlEndpoints] POST queue move-up: sid={sid}, item={itemId}");
-            if (!Guid.TryParse(sid, out var guid) || !Guid.TryParse(itemId, out var itemGuid))
-                return Results.BadRequest(new { error = "invalid id format" });
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
-            session.PromptQueue.MoveUp(itemGuid);
-            return Results.Json(new { items = ProjectQueue(session) });
+            return DispatchQueue("queue-move-up", sid, new QueueItemCommand(ItemId: itemId));
         });
 
         app.MapPost("/sessions/{sid}/queue/{itemId}/move-down", (string sid, string itemId) =>
         {
             FileLog.Write($"[ControlEndpoints] POST queue move-down: sid={sid}, item={itemId}");
-            if (!Guid.TryParse(sid, out var guid) || !Guid.TryParse(itemId, out var itemGuid))
-                return Results.BadRequest(new { error = "invalid id format" });
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
-            session.PromptQueue.MoveDown(itemGuid);
-            return Results.Json(new { items = ProjectQueue(session) });
+            return DispatchQueue("queue-move-down", sid, new QueueItemCommand(ItemId: itemId));
         });
 
         app.MapDelete("/sessions/{sid}/queue", (string sid) =>
         {
             FileLog.Write($"[ControlEndpoints] DELETE queue clear: sid={sid}");
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
-            session.PromptQueue.Clear();
-            return Results.Json(new { items = ProjectQueue(session) });
+            return DispatchQueue("queue-clear", sid, null);
         });
 
         // Deliver one queued item to the PTY now (and drop it from the queue). Used by the
-        // queue panel's per-item "send" and by a "send next" action.
+        // queue panel's per-item "send" and by a "send next" action. Unlike the other queue verbs
+        // this one can return 409 (an Exited/Failed session), returned here as an empty 409 exactly
+        // as the old lambda did.
         app.MapPost("/sessions/{sid}/queue/{itemId}/send", async (string sid, string itemId) =>
         {
             FileLog.Write($"[ControlEndpoints] POST queue send: sid={sid}, item={itemId}");
-            if (!Guid.TryParse(sid, out var guid) || !Guid.TryParse(itemId, out var itemGuid))
-                return Results.BadRequest(new { error = "invalid id format" });
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
-            if (session.Status is SessionStatus.Exited or SessionStatus.Failed)
-                return Results.StatusCode(StatusCodes.Status409Conflict);
-
-            var item = session.PromptQueue.FindById(itemGuid);
-            if (item is null)
-                return Results.NotFound(new { error = "queue item not found" });
-
-            var text = item.Text;
-            session.PromptQueue.Remove(itemGuid);
-            // Queue drain is an explicit, ordered mechanism (issue #1181, Task 3b lists it exempt): the
-            // user asked to release this queued item, so it is not blocked by the dictation lock.
-            await session.SendTextAsync(text, SendSource.Internal);
-            return Results.Json(new { items = ProjectQueue(session) });
+            var command = new DirectorCommand
+            {
+                Verb = "queue-send",
+                SessionId = sid,
+                PayloadJson = SessionCommandExecutor.Serialize(new QueueItemCommand(ItemId: itemId)),
+            };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
+            return result.Status switch
+            {
+                DirectorCommandStatus.Ok => Results.Content(result.BodyJson ?? "", "application/json"),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                DirectorCommandStatus.Conflict => Results.StatusCode(StatusCodes.Status409Conflict),
+                _ => Results.Problem(result.Error ?? "queue send command failed"),
+            };
         });
 
         // Hard interrupt via the session's agent driver (Ctrl+C for Claude). Drivers
@@ -3017,43 +3001,35 @@ internal static class ControlEndpoints
         });
 
         // ===== REST: Create a GitHub Actions remote session =====
-        app.MapPost("/sessions/github", (GitHubSessionRequest req) =>
+        // Gateway Cleanup Phase 0 (Worker W2): the whole create-from-github - the validation guards and the
+        // CreateGitHubActionsSession call - runs through the shared QueueGitExecutor so this REST path and the
+        // Gateway tunnel down-channel create identically. The Director's own 201 response is still built with
+        // the identity-stamped MapWithIdentity (unchanged), so this endpoint stays byte-identical; the executor
+        // returns the plain stream DTO. Mirrors CreateLocalSessionAsync for the local `create` verb.
+        app.MapPost("/sessions/github", async (GitHubSessionRequest req) =>
         {
             FileLog.Write($"[ControlEndpoints] POST /sessions/github: {req?.Owner}/{req?.Repo} mode={req?.TriggerMode}");
 
-            if (req is null || string.IsNullOrWhiteSpace(req.Owner) || string.IsNullOrWhiteSpace(req.Repo))
-                return Results.BadRequest(new { error = "owner and repo are required" });
-            if (string.IsNullOrWhiteSpace(req.InitialPrompt))
-                return Results.BadRequest(new { error = "initialPrompt is required" });
-            if (!Enum.TryParse<RemoteTriggerMode>(req.TriggerMode, ignoreCase: true, out var mode))
-                return Results.BadRequest(new { error = $"unknown triggerMode: {req.TriggerMode}. Valid: NewIssue, ExistingThread, WorkflowDispatch" });
-            if (mode == RemoteTriggerMode.ExistingThread && (req.ThreadNumber is null || req.ThreadNumber <= 0))
-                return Results.BadRequest(new { error = "threadNumber is required (and must be positive) for ExistingThread mode" });
-            if (mode == RemoteTriggerMode.WorkflowDispatch && string.IsNullOrWhiteSpace(req.WorkflowFile))
-                return Results.BadRequest(new { error = "workflowFile is required for WorkflowDispatch mode" });
-
-            var config = new RemoteSessionConfig
+            var command = new DirectorCommand
             {
-                Owner = req.Owner.Trim(),
-                Repo = req.Repo.Trim(),
-                BaseBranch = string.IsNullOrWhiteSpace(req.BaseBranch) ? "main" : req.BaseBranch.Trim(),
-                TriggerMode = mode,
-                InitialPrompt = req.InitialPrompt.Trim(),
-                ThreadNumber = req.ThreadNumber,
-                IssueTitle = req.IssueTitle,
-                WorkflowFile = req.WorkflowFile,
+                Verb = "create-from-github",
+                SessionId = "",
+                PayloadJson = req is null ? "" : SessionCommandExecutor.Serialize(req),
             };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
 
-            try
-            {
-                var session = sessionManager.CreateGitHubActionsSession(config);
-                return Results.Json(MapWithIdentity(session, turnSummaryCache), statusCode: 201);
-            }
-            catch (Exception ex)
-            {
-                FileLog.Write($"[ControlEndpoints] POST /sessions/github FAILED: {ex.Message}");
-                return Results.Problem(ex.Message, statusCode: 500);
-            }
+            if (result.Status == DirectorCommandStatus.BadRequest)
+                return Results.BadRequest(new { error = result.Error });
+            if (result.Status != DirectorCommandStatus.Ok)
+                return Results.Problem(result.Error ?? "create-from-github failed", statusCode: 500);
+
+            var created = SessionCommandExecutor.Deserialize<SessionDto>(result.BodyJson);
+            if (created is null || !Guid.TryParse(created.SessionId, out var newGuid))
+                return Results.Problem("created session id missing", statusCode: 500);
+            var session = sessionManager.GetSession(newGuid);
+            return session is null
+                ? Results.Problem("created session not found", statusCode: 500)
+                : Results.Json(MapWithIdentity(session, turnSummaryCache), statusCode: 201);
         });
 
         // ===== REST: Kill a session =====
@@ -3344,12 +3320,6 @@ internal static class ControlEndpoints
             return "";
         }
     }
-
-    /// <summary>Project a session's prompt queue to the wire shape the Cockpit renders.</summary>
-    private static IReadOnlyList<object> ProjectQueue(Session s) =>
-        s.PromptQueue.Items
-            .Select(i => (object)new { id = i.Id.ToString(), text = i.Text, createdAt = i.CreatedAt })
-            .ToList();
 
     /// <summary>The session driver's capability flags as names, for UIs to render
     /// action buttons from (no per-agent special cases client-side).</summary>

--- a/src/CcDirector.ControlApi/QueueGitCommandRequests.cs
+++ b/src/CcDirector.ControlApi/QueueGitCommandRequests.cs
@@ -1,0 +1,26 @@
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0 (Worker W2): the payload for the voice-queue mutation verbs moved onto
+/// the tunnel dispatch. The REST routes address a queue item through the URL (<c>{itemId}</c>) and carry the
+/// text in a <see cref="CcDirector.Gateway.Contracts.PromptRequest"/> body; the tunnel has only the single
+/// <c>PayloadJson</c> envelope, so this record carries both pieces. <see cref="ItemId"/> is the target queue
+/// item (null for the whole-queue verbs queue-add / queue-clear / queue-read); <see cref="Text"/> is the
+/// prompt text (set for queue-add and queue-update, null otherwise). This keeps the REST route and the tunnel
+/// verb calling the exact same core so they cannot drift.
+/// </summary>
+internal sealed record QueueItemCommand(string? ItemId = null, string? Text = null);
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0 (Worker W2): the minimal shape the git-write REST routes deserialize from
+/// a git verb's success/failure body just to read the <see cref="Accepted"/> flag, so they can pick the same
+/// HTTP status the original lambdas did (200 on success, 409 Conflict on a non-zero git exit). The full body
+/// the client renders (<c>{ accepted, output }</c> or <c>{ accepted, error, exitCode }</c>) is shipped back
+/// verbatim from the command result, so the REST response stays byte-identical; this envelope only inspects
+/// the flag. Mirrors the "outcome rides inside the body" pattern the execute-action verb established.
+/// </summary>
+internal sealed class GitWriteEnvelope
+{
+    /// <summary>True when the git command exited zero; false on a non-zero exit (which the REST layer maps to 409).</summary>
+    public bool Accepted { get; set; }
+}

--- a/src/CcDirector.ControlApi/QueueGitExecutor.cs
+++ b/src/CcDirector.ControlApi/QueueGitExecutor.cs
@@ -1,18 +1,351 @@
+using CcDirector.Core.Backends;
+using CcDirector.Core.Git;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
 namespace CcDirector.ControlApi;
 
 /// <summary>
-/// Gateway Cleanup mission, Phase 0 (spine): the QUEUE and GIT WRITE area of the tunnel command surface. It
-/// owns the voice-queue mutation group (add, patch, remove, move-up, move-down, clear, send) and the git
-/// working-tree writes (stage, unstage, discard, commit), plus create-from-github. Empty in the spine;
-/// Worker W2 fills it. Each verb it adds is declared in <see cref="Verbs"/> and handled in
-/// <see cref="ExecuteAsync"/>, touching only this file.
+/// Gateway Cleanup mission, Phase 0 (Worker W2): the QUEUE and GIT WRITE area of the tunnel command surface. It
+/// owns the voice-queue group (read, add, update, remove, move-up, move-down, clear, send), the git working-tree
+/// writes (stage, unstage, discard, commit), and create-from-github. Each core below reproduces its old REST
+/// lambda's guards and effect verbatim, so the REST route and the tunnel verb share ONE core and cannot drift;
+/// the REST route re-points to <see cref="SessionCommandExecutor.DispatchAsync"/> and maps the typed result back
+/// to the same HTTP status codes the lambda returned. Adding a verb touches only this file.
 /// </summary>
 internal sealed class QueueGitExecutor : ISessionCommandArea
 {
-    public IReadOnlyCollection<string> Verbs { get; } = Array.Empty<string>();
+    /// <summary>
+    /// The git write actions are stateless (each shells <c>git</c> in the given repo), so one shared instance
+    /// is safe - exactly as the REST layer kept a single <c>gitWrite</c> instance for its four routes.
+    /// </summary>
+    private static readonly GitWriteService GitWrite = new();
 
-    public Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken) =>
-        Task.FromResult(DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the queue/git area"));
+    public IReadOnlyCollection<string> Verbs { get; } = new[]
+    {
+        // Voice queue: the read plus the seven mutations.
+        "queue-read", "queue-add", "queue-update", "queue-remove",
+        "queue-move-up", "queue-move-down", "queue-clear", "queue-send",
+        // Git working-tree writes (mirror the desktop Source Control view).
+        "git-stage", "git-unstage", "git-discard", "git-commit",
+        // Director-level create (no target session): a GitHub Actions remote session.
+        "create-from-github",
+    };
+
+    public async Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken)
+    {
+        var sessionManager = context.SessionManager;
+        return command.Verb switch
+        {
+            "queue-read" => QueueRead(sessionManager, command),
+            "queue-add" => QueueAdd(sessionManager, command),
+            "queue-update" => QueueUpdate(sessionManager, command),
+            "queue-remove" => QueueRemove(sessionManager, command),
+            "queue-move-up" => QueueMoveUp(sessionManager, command),
+            "queue-move-down" => QueueMoveDown(sessionManager, command),
+            "queue-clear" => QueueClear(sessionManager, command),
+            "queue-send" => await QueueSendAsync(sessionManager, command),
+            "git-stage" => await GitStageAsync(sessionManager, command),
+            "git-unstage" => await GitUnstageAsync(sessionManager, command),
+            "git-discard" => await GitDiscardAsync(sessionManager, command),
+            "git-commit" => await GitCommitAsync(sessionManager, command),
+            "create-from-github" => CreateFromGitHub(sessionManager, context.DirectorId, command),
+            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the queue/git area"),
+        };
+    }
+
+    // ===================== Voice queue =====================
+
+    /// <summary>Project a session's prompt queue to the wire shape the Cockpit renders (<c>{ items = [...] }</c>),
+    /// identical to the old <c>ControlEndpoints.ProjectQueue</c> so the response body is byte-for-byte the same.</summary>
+    private static string SerializeQueue(Session session) =>
+        SessionCommandExecutor.Serialize(new
+        {
+            items = session.PromptQueue.Items
+                .Select(i => (object)new { id = i.Id.ToString(), text = i.Text, createdAt = i.CreatedAt })
+                .ToList(),
+        });
+
+    /// <summary>
+    /// The <c>queue-read</c> verb: return the session's prompt queue. Mirrors the Director's
+    /// <c>GET /sessions/{sid}/queue</c> lambda - invalid id -&gt; BadRequest, missing session -&gt; NotFound.
+    /// </summary>
+    internal static DirectorCommandResult QueueRead(SessionManager sessionManager, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        return DirectorCommandResult.Success(SerializeQueue(session));
+    }
+
+    /// <summary>
+    /// The <c>queue-add</c> verb: enqueue prompt text. Mirrors the Director's <c>POST /sessions/{sid}/queue</c>
+    /// lambda - invalid id -&gt; BadRequest, blank text -&gt; BadRequest, missing session -&gt; NotFound - in
+    /// the same order, and returns the resulting queue.
+    /// </summary>
+    internal static DirectorCommandResult QueueAdd(SessionManager sessionManager, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var request = SessionCommandExecutor.Deserialize<QueueItemCommand>(command.PayloadJson);
+        if (request is null || string.IsNullOrWhiteSpace(request.Text))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "text is required");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        session.PromptQueue.Enqueue(request.Text);
+        FileLog.Write($"[QueueGitExecutor] queue-add: session={guid} len={request.Text.Length}");
+        return DirectorCommandResult.Success(SerializeQueue(session));
+    }
+
+    /// <summary>
+    /// The <c>queue-update</c> verb: edit the text of a queued item in place. Mirrors the Director's
+    /// <c>PATCH /sessions/{sid}/queue/{itemId}</c> lambda - invalid session/item id -&gt; BadRequest, blank text
+    /// -&gt; BadRequest, missing session -&gt; NotFound - and returns the resulting queue.
+    /// </summary>
+    internal static DirectorCommandResult QueueUpdate(SessionManager sessionManager, DirectorCommand command)
+    {
+        var request = SessionCommandExecutor.Deserialize<QueueItemCommand>(command.PayloadJson);
+        if (!Guid.TryParse(command.SessionId, out var guid) || !Guid.TryParse(request?.ItemId, out var itemGuid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid id format");
+
+        if (string.IsNullOrWhiteSpace(request!.Text))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "text is required");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        session.PromptQueue.UpdateText(itemGuid, request.Text);
+        FileLog.Write($"[QueueGitExecutor] queue-update: session={guid} item={itemGuid}");
+        return DirectorCommandResult.Success(SerializeQueue(session));
+    }
+
+    /// <summary>
+    /// The <c>queue-remove</c> verb: drop a queued item. Mirrors the Director's
+    /// <c>DELETE /sessions/{sid}/queue/{itemId}</c> lambda - invalid session/item id -&gt; BadRequest, missing
+    /// session -&gt; NotFound - and returns the resulting queue.
+    /// </summary>
+    internal static DirectorCommandResult QueueRemove(SessionManager sessionManager, DirectorCommand command)
+    {
+        var request = SessionCommandExecutor.Deserialize<QueueItemCommand>(command.PayloadJson);
+        if (!Guid.TryParse(command.SessionId, out var guid) || !Guid.TryParse(request?.ItemId, out var itemGuid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        session.PromptQueue.Remove(itemGuid);
+        FileLog.Write($"[QueueGitExecutor] queue-remove: session={guid} item={itemGuid}");
+        return DirectorCommandResult.Success(SerializeQueue(session));
+    }
+
+    /// <summary>
+    /// The <c>queue-move-up</c> verb: move a queued item one place earlier. Mirrors the Director's
+    /// <c>POST /sessions/{sid}/queue/{itemId}/move-up</c> lambda - invalid session/item id -&gt; BadRequest,
+    /// missing session -&gt; NotFound - and returns the resulting queue.
+    /// </summary>
+    internal static DirectorCommandResult QueueMoveUp(SessionManager sessionManager, DirectorCommand command)
+    {
+        var request = SessionCommandExecutor.Deserialize<QueueItemCommand>(command.PayloadJson);
+        if (!Guid.TryParse(command.SessionId, out var guid) || !Guid.TryParse(request?.ItemId, out var itemGuid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        session.PromptQueue.MoveUp(itemGuid);
+        FileLog.Write($"[QueueGitExecutor] queue-move-up: session={guid} item={itemGuid}");
+        return DirectorCommandResult.Success(SerializeQueue(session));
+    }
+
+    /// <summary>
+    /// The <c>queue-move-down</c> verb: move a queued item one place later. Mirrors the Director's
+    /// <c>POST /sessions/{sid}/queue/{itemId}/move-down</c> lambda - invalid session/item id -&gt; BadRequest,
+    /// missing session -&gt; NotFound - and returns the resulting queue.
+    /// </summary>
+    internal static DirectorCommandResult QueueMoveDown(SessionManager sessionManager, DirectorCommand command)
+    {
+        var request = SessionCommandExecutor.Deserialize<QueueItemCommand>(command.PayloadJson);
+        if (!Guid.TryParse(command.SessionId, out var guid) || !Guid.TryParse(request?.ItemId, out var itemGuid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        session.PromptQueue.MoveDown(itemGuid);
+        FileLog.Write($"[QueueGitExecutor] queue-move-down: session={guid} item={itemGuid}");
+        return DirectorCommandResult.Success(SerializeQueue(session));
+    }
+
+    /// <summary>
+    /// The <c>queue-clear</c> verb: empty the whole queue. Mirrors the Director's
+    /// <c>DELETE /sessions/{sid}/queue</c> lambda - invalid id -&gt; BadRequest, missing session -&gt; NotFound -
+    /// and returns the (now empty) queue.
+    /// </summary>
+    internal static DirectorCommandResult QueueClear(SessionManager sessionManager, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        session.PromptQueue.Clear();
+        FileLog.Write($"[QueueGitExecutor] queue-clear: session={guid}");
+        return DirectorCommandResult.Success(SerializeQueue(session));
+    }
+
+    /// <summary>
+    /// The <c>queue-send</c> verb: deliver one queued item to the PTY now and drop it from the queue. Mirrors
+    /// the Director's <c>POST /sessions/{sid}/queue/{itemId}/send</c> lambda - invalid session/item id -&gt;
+    /// BadRequest, missing session -&gt; NotFound, an Exited/Failed session -&gt; Conflict (the REST layer returns
+    /// an empty 409, so no body is carried here), a missing queue item -&gt; NotFound - and returns the resulting
+    /// queue. The drain is an explicit ordered mechanism (issue #1181, Task 3b lists it exempt from the dictation
+    /// lock), so it sends as <see cref="SendSource.Internal"/> exactly as the REST lambda did.
+    /// </summary>
+    internal static async Task<DirectorCommandResult> QueueSendAsync(SessionManager sessionManager, DirectorCommand command)
+    {
+        var request = SessionCommandExecutor.Deserialize<QueueItemCommand>(command.PayloadJson);
+        if (!Guid.TryParse(command.SessionId, out var guid) || !Guid.TryParse(request?.ItemId, out var itemGuid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        if (session.Status is SessionStatus.Exited or SessionStatus.Failed)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.Conflict, "session has exited");
+
+        var item = session.PromptQueue.FindById(itemGuid);
+        if (item is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "queue item not found");
+
+        var text = item.Text;
+        session.PromptQueue.Remove(itemGuid);
+        FileLog.Write($"[QueueGitExecutor] queue-send: session={guid} item={itemGuid}");
+        await session.SendTextAsync(text, SendSource.Internal);
+        return DirectorCommandResult.Success(SerializeQueue(session));
+    }
+
+    // ===================== Git working-tree writes =====================
+
+    /// <summary>
+    /// Shared git-write core (past the id/session guards): resolve the session's repo, run the git operation,
+    /// and return the SAME two body shapes the old <c>RunGitWrite</c> local function produced -
+    /// <c>{ accepted = true, output }</c> on a zero exit, <c>{ accepted = false, error, exitCode }</c> on a
+    /// non-zero exit. Both ride back as a successful command (the verb DID run); the REST layer inspects the
+    /// <c>accepted</c> flag and maps a non-zero exit to HTTP 409, exactly as the lambda did. This is the same
+    /// "the command ran; its outcome is in the body" shape the execute-action exemplar uses. Invalid id -&gt;
+    /// BadRequest, missing session -&gt; NotFound.
+    /// </summary>
+    private static async Task<DirectorCommandResult> RunGitWrite(SessionManager sessionManager, string sessionId, Func<string, Task<GitWriteResult>> op)
+    {
+        if (!Guid.TryParse(sessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        var r = await op(session.RepoPath);
+        return r.Success
+            ? DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new { accepted = true, output = r.Output }))
+            : DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new { accepted = false, error = r.Error, exitCode = r.ExitCode }));
+    }
+
+    /// <summary>The <c>git-stage</c> verb: <c>git add</c> the given paths (or everything when none given). Mirrors
+    /// the Director's <c>POST /sessions/{sid}/git/stage</c> lambda.</summary>
+    internal static Task<DirectorCommandResult> GitStageAsync(SessionManager sessionManager, DirectorCommand command)
+    {
+        var req = SessionCommandExecutor.Deserialize<GitPathsRequest>(command.PayloadJson);
+        return RunGitWrite(sessionManager, command.SessionId, repo => GitWrite.StageAsync(repo, req?.Paths ?? new()));
+    }
+
+    /// <summary>The <c>git-unstage</c> verb: <c>git reset HEAD</c> the given paths (or everything). Mirrors the
+    /// Director's <c>POST /sessions/{sid}/git/unstage</c> lambda.</summary>
+    internal static Task<DirectorCommandResult> GitUnstageAsync(SessionManager sessionManager, DirectorCommand command)
+    {
+        var req = SessionCommandExecutor.Deserialize<GitPathsRequest>(command.PayloadJson);
+        return RunGitWrite(sessionManager, command.SessionId, repo => GitWrite.UnstageAsync(repo, req?.Paths ?? new()));
+    }
+
+    /// <summary>The <c>git-discard</c> verb: <c>git checkout --</c> the given paths (a non-zero exit, e.g. no
+    /// paths, rides back as accepted=false / 409). Mirrors the Director's <c>POST /sessions/{sid}/git/discard</c>
+    /// lambda.</summary>
+    internal static Task<DirectorCommandResult> GitDiscardAsync(SessionManager sessionManager, DirectorCommand command)
+    {
+        var req = SessionCommandExecutor.Deserialize<GitPathsRequest>(command.PayloadJson);
+        return RunGitWrite(sessionManager, command.SessionId, repo => GitWrite.DiscardAsync(repo, req?.Paths ?? new()));
+    }
+
+    /// <summary>The <c>git-commit</c> verb: <c>git commit -m</c> the given message (a blank message rides back as
+    /// accepted=false / 409). Mirrors the Director's <c>POST /sessions/{sid}/git/commit</c> lambda.</summary>
+    internal static Task<DirectorCommandResult> GitCommitAsync(SessionManager sessionManager, DirectorCommand command)
+    {
+        var req = SessionCommandExecutor.Deserialize<GitCommitRequest>(command.PayloadJson);
+        return RunGitWrite(sessionManager, command.SessionId, repo => GitWrite.CommitAsync(repo, req?.Message ?? ""));
+    }
+
+    // ===================== Director-level create =====================
+
+    /// <summary>
+    /// The <c>create-from-github</c> verb (director-level: no target session id): create a GitHub Actions remote
+    /// session. Mirrors the Director's <c>POST /sessions/github</c> lambda exactly - owner/repo required,
+    /// initialPrompt required, an unknown triggerMode, a missing/non-positive threadNumber for ExistingThread,
+    /// and a missing workflowFile for WorkflowDispatch all -&gt; BadRequest; a creation fault -&gt; Error (which
+    /// the REST layer maps to 500). On success it returns the new session mapped through the plain
+    /// <see cref="ControlEndpoints.Map"/> (the REST endpoint re-maps it with its identity-stamped mapper for the
+    /// local 201 response, so that response stays byte-identical), exactly as the <c>create</c> verb does.
+    /// </summary>
+    internal static DirectorCommandResult CreateFromGitHub(SessionManager sessionManager, string directorId, DirectorCommand command)
+    {
+        var req = SessionCommandExecutor.Deserialize<GitHubSessionRequest>(command.PayloadJson);
+
+        if (req is null || string.IsNullOrWhiteSpace(req.Owner) || string.IsNullOrWhiteSpace(req.Repo))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "owner and repo are required");
+        if (string.IsNullOrWhiteSpace(req.InitialPrompt))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "initialPrompt is required");
+        if (!Enum.TryParse<RemoteTriggerMode>(req.TriggerMode, ignoreCase: true, out var mode))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unknown triggerMode: {req.TriggerMode}. Valid: NewIssue, ExistingThread, WorkflowDispatch");
+        if (mode == RemoteTriggerMode.ExistingThread && (req.ThreadNumber is null || req.ThreadNumber <= 0))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "threadNumber is required (and must be positive) for ExistingThread mode");
+        if (mode == RemoteTriggerMode.WorkflowDispatch && string.IsNullOrWhiteSpace(req.WorkflowFile))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "workflowFile is required for WorkflowDispatch mode");
+
+        var config = new RemoteSessionConfig
+        {
+            Owner = req.Owner.Trim(),
+            Repo = req.Repo.Trim(),
+            BaseBranch = string.IsNullOrWhiteSpace(req.BaseBranch) ? "main" : req.BaseBranch.Trim(),
+            TriggerMode = mode,
+            InitialPrompt = req.InitialPrompt.Trim(),
+            ThreadNumber = req.ThreadNumber,
+            IssueTitle = req.IssueTitle,
+            WorkflowFile = req.WorkflowFile,
+        };
+
+        try
+        {
+            var session = sessionManager.CreateGitHubActionsSession(config);
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(ControlEndpoints.Map(session, directorId)));
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[QueueGitExecutor] create-from-github FAILED: {ex.Message}");
+            return DirectorCommandResult.Fail(DirectorCommandStatus.Error, ex.Message);
+        }
+    }
 }

--- a/src/CcDirector.Gateway.Tests/QueueGitExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/QueueGitExecutorTests.cs
@@ -1,0 +1,496 @@
+using System.Diagnostics;
+using System.Text.Json;
+using CcDirector.ControlApi;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0 (Worker W2): parity tests for the voice-queue, git-write, and
+/// create-from-github verbs moved onto the shared tunnel dispatch (<see cref="SessionCommandExecutor.DispatchAsync"/>
+/// routing into <see cref="QueueGitExecutor"/>). These verbs used to live only as REST lambdas; now the REST path
+/// and the Gateway stream down-channel call the SAME core, so this asserts the core's guards and effect directly
+/// against a real <see cref="SessionManager"/> holding an embedded buffer-only session (the same harness the W1
+/// exemplar uses). Representative coverage per the mission brief: an invalid id -&gt; BadRequest, a missing session
+/// -&gt; NotFound, and a real success effect (plus the git non-zero-exit and queue-send Conflict special cases).
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class QueueGitExecutorTests
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    private static (SessionManager sm, Session session, ExecuteActionTestBackend backend) NewSession(string? repoPath = null)
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        var backend = new ExecuteActionTestBackend();
+        var session = sm.CreateEmbeddedSession(repoPath ?? Path.GetTempPath(), null, backend);
+        return (sm, session, backend);
+    }
+
+    private static DirectorCommand Command(string verb, string sessionId, object? payload = null) => new()
+    {
+        CommandId = "cmd-w2",
+        Verb = verb,
+        SessionId = sessionId,
+        PayloadJson = payload is null ? "" : JsonSerializer.Serialize(payload, Json),
+    };
+
+    // ---------- queue-add / queue-read ----------
+
+    [Fact]
+    public async Task DispatchAsync_QueueAdd_EnqueuesText_AndReturnsItems()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("queue-add", session.Id.ToString(), new QueueItemCommand(Text: "first task")));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal("cmd-w2", result.CommandId);
+            Assert.Single(session.PromptQueue.Items);
+            Assert.Equal("first task", session.PromptQueue.Items[0].Text);
+            Assert.Contains("first task", result.BodyJson ?? "");
+            Assert.Contains("items", result.BodyJson ?? "");
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_QueueAdd_BlankText_ReturnsBadRequest()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("queue-add", session.Id.ToString(), new QueueItemCommand(Text: "   ")));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+            Assert.Empty(session.PromptQueue.Items);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_QueueAdd_InvalidSessionId_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("queue-add", "not-a-guid", new QueueItemCommand(Text: "x")));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_QueueRead_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("queue-read", Guid.NewGuid().ToString()));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_QueueRead_ReturnsQueuedItems()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            session.PromptQueue.Enqueue("alpha");
+            session.PromptQueue.Enqueue("beta");
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("queue-read", session.Id.ToString()));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Contains("alpha", result.BodyJson ?? "");
+            Assert.Contains("beta", result.BodyJson ?? "");
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- queue-update ----------
+
+    [Fact]
+    public async Task DispatchAsync_QueueUpdate_EditsItemText()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            session.PromptQueue.Enqueue("before");
+            var itemId = session.PromptQueue.Items[0].Id;
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("queue-update", session.Id.ToString(), new QueueItemCommand(ItemId: itemId.ToString(), Text: "after")));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal("after", session.PromptQueue.Items[0].Text);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_QueueUpdate_InvalidItemId_ReturnsBadRequest()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("queue-update", session.Id.ToString(), new QueueItemCommand(ItemId: "not-a-guid", Text: "x")));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_QueueUpdate_BlankText_ReturnsBadRequest()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            session.PromptQueue.Enqueue("before");
+            var itemId = session.PromptQueue.Items[0].Id;
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("queue-update", session.Id.ToString(), new QueueItemCommand(ItemId: itemId.ToString(), Text: "   ")));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+            Assert.Equal("before", session.PromptQueue.Items[0].Text); // unchanged
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- queue-remove / queue-clear ----------
+
+    [Fact]
+    public async Task DispatchAsync_QueueRemove_DropsItem()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            session.PromptQueue.Enqueue("keep");
+            session.PromptQueue.Enqueue("drop");
+            var dropId = session.PromptQueue.Items[1].Id;
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("queue-remove", session.Id.ToString(), new QueueItemCommand(ItemId: dropId.ToString())));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Single(session.PromptQueue.Items);
+            Assert.Equal("keep", session.PromptQueue.Items[0].Text);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_QueueClear_EmptiesQueue()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            session.PromptQueue.Enqueue("a");
+            session.PromptQueue.Enqueue("b");
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("queue-clear", session.Id.ToString()));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Empty(session.PromptQueue.Items);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- queue-move-up / queue-move-down ----------
+
+    [Fact]
+    public async Task DispatchAsync_QueueMoveUp_ReordersItem()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            session.PromptQueue.Enqueue("one");
+            session.PromptQueue.Enqueue("two");
+            var secondId = session.PromptQueue.Items[1].Id;
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("queue-move-up", session.Id.ToString(), new QueueItemCommand(ItemId: secondId.ToString())));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal("two", session.PromptQueue.Items[0].Text); // moved to the front
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_QueueMoveDown_ReordersItem()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            session.PromptQueue.Enqueue("one");
+            session.PromptQueue.Enqueue("two");
+            var firstId = session.PromptQueue.Items[0].Id;
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("queue-move-down", session.Id.ToString(), new QueueItemCommand(ItemId: firstId.ToString())));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal("two", session.PromptQueue.Items[0].Text); // "one" moved down
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- queue-send ----------
+
+    [Fact]
+    public async Task DispatchAsync_QueueSend_DeliversItemAndDropsIt()
+    {
+        // The delivery itself is a SendTextAsync through the driver's typing path (asynchronous, exactly as
+        // the old lambda did); the deterministic, observable parity effect is that the item is dropped from
+        // the queue and the command succeeds. (The prompt exemplar likewise only asserts synchronous bytes
+        // for the raw AppendEnter=false path, not the async typing path.)
+        var (sm, session, _) = NewSession();
+        try
+        {
+            session.PromptQueue.Enqueue("run me");
+            var itemId = session.PromptQueue.Items[0].Id;
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("queue-send", session.Id.ToString(), new QueueItemCommand(ItemId: itemId.ToString())));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Empty(session.PromptQueue.Items); // dropped after send
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_QueueSend_MissingItem_ReturnsNotFound()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("queue-send", session.Id.ToString(), new QueueItemCommand(ItemId: Guid.NewGuid().ToString())));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_QueueSend_ExitedSession_ReturnsConflict()
+    {
+        var (sm, session, backend) = NewSession();
+        try
+        {
+            session.PromptQueue.Enqueue("too late");
+            var itemId = session.PromptQueue.Items[0].Id;
+            backend.RaiseProcessExited(1); // drive Session.Status -> Exited via the real backend event
+            Assert.True(session.Status is SessionStatus.Exited or SessionStatus.Failed);
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("queue-send", session.Id.ToString(), new QueueItemCommand(ItemId: itemId.ToString())));
+
+            Assert.Equal(DirectorCommandStatus.Conflict, result.Status);
+            Assert.Single(session.PromptQueue.Items); // not dropped - the send was refused
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- git writes ----------
+
+    private static string NewGitRepo()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "qgit-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        RunGit(dir, "init");
+        File.WriteAllText(Path.Combine(dir, "a.txt"), "hello");
+        return dir;
+    }
+
+    private static void RunGit(string dir, string args)
+    {
+        using var proc = Process.Start(new ProcessStartInfo("git", args)
+        {
+            WorkingDirectory = dir,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        })!;
+        proc.WaitForExit();
+    }
+
+    [Fact]
+    public async Task DispatchAsync_GitStage_RealRepo_ReturnsAccepted()
+    {
+        var repo = NewGitRepo();
+        var (sm, session, _) = NewSession(repo);
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("git-stage", session.Id.ToString(), new GitPathsRequest { Paths = new() }));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var env = JsonSerializer.Deserialize<GitStageProbe>(result.BodyJson ?? "", Json);
+            Assert.NotNull(env);
+            Assert.True(env.Accepted); // git add -A exits zero
+        }
+        finally
+        {
+            sm.Dispose();
+            TryDelete(repo);
+        }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_GitDiscard_NoPaths_RidesBackAsNotAccepted()
+    {
+        // DiscardAsync rejects an empty path list before shelling git; the verb still executes (Ok at the
+        // tunnel), with the failure shape { accepted=false, error, exitCode } the REST layer maps to 409.
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("git-discard", session.Id.ToString(), new GitPathsRequest { Paths = new() }));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var env = JsonSerializer.Deserialize<GitStageProbe>(result.BodyJson ?? "", Json);
+            Assert.NotNull(env);
+            Assert.False(env.Accepted);
+            Assert.Contains("discard requires at least one path", result.BodyJson ?? "");
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_GitCommit_BlankMessage_RidesBackAsNotAccepted()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("git-commit", session.Id.ToString(), new GitCommitRequest { Message = "   " }));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var env = JsonSerializer.Deserialize<GitStageProbe>(result.BodyJson ?? "", Json);
+            Assert.NotNull(env);
+            Assert.False(env.Accepted);
+            Assert.Contains("commit message is required", result.BodyJson ?? "");
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_GitStage_InvalidSessionId_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("git-stage", "not-a-guid", new GitPathsRequest { Paths = new() }));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_GitStage_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("git-stage", Guid.NewGuid().ToString(), new GitPathsRequest { Paths = new() }));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    /// <summary>Minimal probe for a git-write body's <c>accepted</c> flag (mirrors the GitWriteEnvelope the REST layer reads).</summary>
+    private sealed class GitStageProbe
+    {
+        public bool Accepted { get; set; }
+    }
+
+    private static void TryDelete(string dir)
+    {
+        try { Directory.Delete(dir, recursive: true); }
+        catch (IOException) { /* a git lock may hold the dir briefly; a leftover temp dir is harmless */ }
+        catch (UnauthorizedAccessException) { /* same */ }
+    }
+
+    // ---------- create-from-github (guards; the success path needs a live GitHub token/network) ----------
+
+    [Fact]
+    public async Task DispatchAsync_CreateFromGitHub_MissingOwnerRepo_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("create-from-github", "", new GitHubSessionRequest { Owner = "", Repo = "", InitialPrompt = "do it" }));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_CreateFromGitHub_BlankInitialPrompt_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("create-from-github", "", new GitHubSessionRequest { Owner = "o", Repo = "r", InitialPrompt = "  " }));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_CreateFromGitHub_UnknownTriggerMode_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("create-from-github", "", new GitHubSessionRequest { Owner = "o", Repo = "r", InitialPrompt = "go", TriggerMode = "Nonsense" }));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_CreateFromGitHub_ExistingThreadWithoutNumber_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("create-from-github", "", new GitHubSessionRequest { Owner = "o", Repo = "r", InitialPrompt = "go", TriggerMode = "ExistingThread" }));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_CreateFromGitHub_WorkflowDispatchWithoutFile_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("create-from-github", "", new GitHubSessionRequest { Owner = "o", Repo = "r", InitialPrompt = "go", TriggerMode = "WorkflowDispatch" }));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+}


### PR DESCRIPTION
## Gateway Cleanup mission, Phase 0 (Worker W2)

Additive, no deletions of behavior. Fills in the `QueueGitExecutor` area class that the Phase 0 spine left empty, following the W1 `SessionWriteExecutor` exemplar exactly: each verb gets an internal static core lifted verbatim from its old REST lambda (same guards, same status codes), the verb is added to `Verbs` and to the `ExecuteAsync` switch, and the REST route is re-pointed to `SessionCommandExecutor.DispatchAsync` and maps the typed result back. The REST route and the tunnel verb call the SAME core, so they cannot drift, and REST response bodies stay byte-identical.

### Verbs moved onto the tunnel dispatch
- Voice queue on `/sessions/{sid}/queue`: `queue-read` (GET), `queue-add` (POST), `queue-update` (PATCH `/{itemId}`), `queue-remove` (DELETE `/{itemId}`), `queue-move-up`, `queue-move-down`, `queue-clear` (DELETE `/queue`), `queue-send` (`/{itemId}/send`).
- Git working-tree writes on `/sessions/{sid}/git`: `git-stage`, `git-unstage`, `git-discard`, `git-commit`.
- Director-level create: `create-from-github` (POST `/sessions/github`, SessionId = "").

### None skipped
`create-from-github` returns HTTP 201 Created, which `DirectorCommandStatus` does not model - but this is the exact shape the existing `create` verb already handles: the core returns `Ok` with the plain session DTO, and the REST endpoint re-maps it through the identity-stamped mapper and returns 201 (mirroring `CreateLocalSessionAsync`). So it is lifted faithfully rather than skipped.

Two outcome-in-body cases were preserved without inventing new statuses:
- Git non-zero exit: the verb runs (tunnel `Ok`) and the failure shape `{ accepted:false, error, exitCode }` rides in the body; the REST layer reads the `accepted` flag and returns 409, exactly as the old lambda did. This is the same "outcome rides inside the body" pattern the `execute-action` exemplar established.
- `queue-send` on an Exited/Failed session returns `Conflict`, which the REST route maps to an empty 409, byte-identical to the old `Results.StatusCode(409)`.

### Notes
- New DTOs (`QueueItemCommand`, `GitWriteEnvelope`) live in a new file `QueueGitCommandRequests.cs`; no shared DTO files edited.
- Removed the now-dead `RunGitWrite`/`gitWrite` helper and the `ProjectQueue` helper from `ControlEndpoints.cs` (their logic moved verbatim into the executor); required to keep the build at 0 warnings under `TreatWarningsAsErrors`.
- Parity tests in a new file `QueueGitExecutorTests.cs`.

### Verification
- `dotnet build src/CcDirector.ControlApi` - Build succeeded, 0 Warning(s), 0 Error(s).
- `dotnet test ... --filter "QueueGitExecutorTests|StreamCommandTests"` - Passed! Failed: 0, Passed: 55, Skipped: 0.

Do NOT merge - the Manager controls merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)