### PR TITLE
fix(ui): always draw scrollbars at full thickness, never a thin hover-only sliver (#1422)

### DIFF
--- a/src/CcDirector.Avalonia/App.axaml
+++ b/src/CcDirector.Avalonia/App.axaml
@@ -8,6 +8,14 @@
         <Style Selector="ScrollViewer">
             <Setter Property="AllowAutoHide" Value="False" />
         </Style>
+        <!-- AllowAutoHide keeps the bar from fading out, but the Fluent theme still
+             draws it as a thin sliver until the pointer is over it: the thumb carries
+             a scale transform that only the IsExpanded (hover) state removes. Strip
+             that transform unconditionally so a scrollbar that is present is drawn at
+             full thickness and is unmistakably there, not a hard-to-see hairline. -->
+        <Style Selector="ScrollBar /template/ Thumb">
+            <Setter Property="RenderTransform" Value="none" />
+        </Style>
     </Application.Styles>
 
     <Application.Resources>


### PR DESCRIPTION
Fixes #1422.

## Problem
The session rail (and every other scrollable region) showed only a faint hairline scrollbar until the pointer hovered over it, so you could not tell whether a region was scrollable. This is a long-standing, strongly-held owner preference: a scrollbar that is needed must always be clearly visible.

## Root cause
`AllowAutoHide=False` was already set app-wide (App.axaml), which stops the bar from fading away entirely. But the Fluent theme still renders the collapsed bar as a thin sliver: the scrollbar thumb carries a scale transform that is only removed by the `IsExpanded` (hover) state. So the bar was present but drawn as a hairline until hovered.

## Fix
One app-wide style that strips that scale transform from the ScrollBar thumb unconditionally, so any scrollbar that is present is drawn at full thickness:

```xml
<Style Selector="ScrollBar /template/ Thumb">
    <Setter Property="RenderTransform" Value="none" />
</Style>
```

This is exactly what Fluent already does in its `IsExpanded=true` state, applied unconditionally. Scoped to thumbs inside a ScrollBar template, so Slider and GridSplitter thumbs are unaffected. Applies everywhere (session rail, dialogs, Cockpit-desktop panels), matching the universal preference.

## Testing
Release build is clean (0 warnings, 0 errors), which validates the XAML. Runtime not exercised by request - this is a theme-only style change with no logic.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)