### PR TITLE
Gateway Cleanup Phase 0 wave 3a: shared command-context dependencies + lift facts

### DIFF
--- a/src/CcDirector.ControlApi/CatalogReadExecutor.cs
+++ b/src/CcDirector.ControlApi/CatalogReadExecutor.cs
@@ -1,8 +1,11 @@
 using CcDirector.Core.Claude;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Diagnostics;
 using CcDirector.Core.Git;
 using CcDirector.Core.History;
 using CcDirector.Core.Sessions;
 using CcDirector.Core.Storage;
+using CcDirector.Core.Tools;
 using CcDirector.Core.Utilities;
 using CcDirector.Core.Wingman;
 using CcDirector.Gateway.Contracts;
@@ -20,12 +23,11 @@ namespace CcDirector.ControlApi;
 /// deletes the routes and leaves the cores reached only over the tunnel. A preserved try/catch is kept ONLY
 /// where the source route had one (<c>fs-list</c>), so behaviour is byte-identical.
 ///
-/// Two of the group's REST reads were NOT lifted, because they depend on host state that the tunnel command
-/// surface does not carry (routing either faithfully would require a spine change, not a single-area edit):
-/// <c>GET /facts</c> embeds the host's injected version string (<c>ControlApiHost._version</c>), which is
-/// absent from <see cref="SessionCommandContext"/>; and <c>GET /repos</c> reads the live per-host
-/// <c>RepositoryRegistry</c> instance, which is a Map-time dependency not carried by the context or the
-/// stream client's <see cref="SessionCommandServices"/>. Both stay as their own REST routes for now.
+/// Gateway Cleanup Phase 0 (wave 3): the two reads R2 originally left out are now lifted, because the shared
+/// dependency they needed was threaded through <see cref="SessionCommandServices"/>: <c>facts</c> stamps the
+/// Director version (<see cref="SessionCommandServices.DirectorVersion"/>); <c>repos-list</c> reads the live
+/// <see cref="RepositoryRegistry"/> (<see cref="SessionCommandServices.Repositories"/>). This <c>facts</c>
+/// lift ships with that dependency change; <c>repos-list</c> follows in the wave-3 lift PR.
 /// </summary>
 internal sealed class CatalogReadExecutor : ISessionCommandArea
 {
@@ -43,6 +45,7 @@ internal sealed class CatalogReadExecutor : ISessionCommandArea
         "claude-sessions",
         "interrupted-list",
         "fs-list",
+        "facts",
     };
 
     public async Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken)
@@ -54,8 +57,44 @@ internal sealed class CatalogReadExecutor : ISessionCommandArea
             "claude-sessions" => ClaudeSessions(command),
             "interrupted-list" => InterruptedList(),
             "fs-list" => FsList(command),
+            "facts" => Facts(context.DirectorId, context.Services?.DirectorVersion),
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the catalog read area"),
         };
+    }
+
+    /// <summary>
+    /// The <c>facts</c> verb (director-level, no session): this machine's cc-tool inventory (names, categories,
+    /// versions, built-state) plus the launcher presence/port fact. Mirrors the Director's <c>GET /facts</c>
+    /// lambda exactly - always a 200 - and returns a serialized <see cref="DirectorFactsDto"/>. The Director
+    /// version is the one dependency the tunnel command surface did not carry before; it now rides in
+    /// <see cref="SessionCommandServices.DirectorVersion"/>, and the producing Director stamps its own version
+    /// exactly as the REST route stamped <c>ControlApiHost._version</c>, so the value is identical on both paths.
+    /// </summary>
+    internal static DirectorCommandResult Facts(string directorId, string? version)
+    {
+        FileLog.Write("[CatalogReadExecutor] facts");
+        var catalog = new ToolCatalogService();
+        var tools = ToolInventory.Build(catalog, AboutInfo.InstalledComponents());
+        var launcher = LauncherDiscovery.Read();
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new DirectorFactsDto
+        {
+            DirectorId = directorId,
+            MachineName = Environment.MachineName,
+            Version = version ?? string.Empty,
+            Tools = tools.Select(t => new ToolInventoryItemDto
+            {
+                Name = t.Name,
+                Category = t.Category,
+                Version = t.Version,
+                IsBuilt = t.IsBuilt,
+            }).ToList(),
+            Launcher = new LauncherFactDto
+            {
+                Installed = launcher.Installed,
+                Port = launcher.Port,
+                Error = launcher.Error,
+            },
+        }));
     }
 
     /// <summary>

--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -447,8 +447,9 @@ public sealed class ControlApiHost : IAsyncDisposable
         // POST /dispatch (issue #329): null accessor means "no Engine hosted here" (tests
         // that don't care, embedded hosts) - the endpoint then answers 503, never throws.
         DispatchEndpoint.Map(_app, _commDispatcherAccessor ?? (() => null));
-        // GET /facts (issue #330): the tool inventory + launcher facts the Gateway pulls.
-        FactsEndpoint.Map(_app, DirectorId, _version);
+        // GET /facts (issue #330): the tool inventory + launcher facts the Gateway pulls. Gateway Cleanup
+        // Phase 0 (wave 3): routes through the shared CatalogReadExecutor.Facts core, so it needs the SessionManager.
+        FactsEndpoint.Map(_app, _sessionManager, DirectorId, _version);
         // POST /sessions/{id}/voice-turn (issue #351): server-side walkie-talkie turn
         // (transcribe -> wait -> send -> poll -> summarize -> TTS -> SSE reply).
         VoiceTurnEndpoint.Map(_app, _sessionManager);
@@ -664,8 +665,11 @@ public sealed class ControlApiHost : IAsyncDisposable
             // The services are read per-command (inside the lambda) so they reflect the fields once
             // StartAsync has initialized them - BuildStreamClient runs before _proactiveExplain /
             // _turnSummaryCache are set. Additive: verbs that need no service ignore it (issue #1177 inc 6).
+            // Gateway Cleanup mission, Phase 0 (wave 3): also carry the Director version and the repository
+            // registry so the director-level reads that stamp/read them (facts, handover, repos-list) serve the
+            // same value over the tunnel that their REST route served.
             cmd => SessionCommandExecutor.DispatchAsync(_sessionManager, DirectorId, cmd,
-                new SessionCommandServices { ProactiveExplain = _proactiveExplain, TurnSummaryCache = _turnSummaryCache, MissionStore = _missionStore }),
+                new SessionCommandServices { ProactiveExplain = _proactiveExplain, TurnSummaryCache = _turnSummaryCache, MissionStore = _missionStore, DirectorVersion = _version, Repositories = _repositoryRegistry }),
             // Gateway Cleanup mission, Phase 0 (up-stream): pass the SessionManager so the four connection-bound
             // stream verbs work - their terminal/file producers read session and file state from it and stream
             // frames up this same connection.

--- a/src/CcDirector.ControlApi/FactsEndpoint.cs
+++ b/src/CcDirector.ControlApi/FactsEndpoint.cs
@@ -1,6 +1,4 @@
-using CcDirector.Core.Configuration;
-using CcDirector.Core.Diagnostics;
-using CcDirector.Core.Tools;
+using CcDirector.Core.Sessions;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using Microsoft.AspNetCore.Builder;
@@ -19,37 +17,30 @@ namespace CcDirector.ControlApi;
 /// (GET /directors/{id}/facts) - the "Director emits/serves everything the hub will
 /// need" half of Phase 1. Loopback-only and subject to the host's auth middleware,
 /// exactly like the other routes.
+///
+/// Gateway Cleanup mission, Phase 0 (wave 3): the inventory is built by the shared
+/// <see cref="CatalogReadExecutor.Facts"/> core, reached here through the tunnel dispatch, so this REST
+/// route and the Gateway stream down-channel are byte-identical and cannot drift. The Director version -
+/// the one dependency the tunnel command surface did not carry - is passed in through
+/// <see cref="SessionCommandServices.DirectorVersion"/>. Phase 1 deletes this route and leaves the core
+/// reached only over the tunnel.
 /// </summary>
 internal static class FactsEndpoint
 {
-    public static void Map(IEndpointRouteBuilder app, string directorId, string version)
+    public static void Map(IEndpointRouteBuilder app, SessionManager sessionManager, string directorId, string version)
     {
-        var catalog = new ToolCatalogService();
-
-        app.MapGet("/facts", () =>
+        app.MapGet("/facts", async () =>
         {
             FileLog.Write("[FactsEndpoint] GET /facts");
-            var tools = ToolInventory.Build(catalog, AboutInfo.InstalledComponents());
-            var launcher = LauncherDiscovery.Read();
-            return Results.Json(new DirectorFactsDto
+            var command = new DirectorCommand { Verb = "facts", SessionId = "" };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command,
+                new SessionCommandServices { DirectorVersion = version });
+
+            return result.Status switch
             {
-                DirectorId = directorId,
-                MachineName = Environment.MachineName,
-                Version = version,
-                Tools = tools.Select(t => new ToolInventoryItemDto
-                {
-                    Name = t.Name,
-                    Category = t.Category,
-                    Version = t.Version,
-                    IsBuilt = t.IsBuilt,
-                }).ToList(),
-                Launcher = new LauncherFactDto
-                {
-                    Installed = launcher.Installed,
-                    Port = launcher.Port,
-                    Error = launcher.Error,
-                },
-            });
+                DirectorCommandStatus.Ok => Results.Content(result.BodyJson ?? "{}", "application/json"),
+                _ => Results.Problem(result.Error ?? "facts command failed"),
+            };
         });
     }
 }

--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -29,6 +29,21 @@ internal sealed class SessionCommandServices
     /// <summary>The Mission record store (attaching a session to a Mission, and honoring a create-time
     /// MissionId, resolve the Mission's display name through it). Null skips Mission resolution.</summary>
     public MissionStore? MissionStore { get; init; }
+
+    /// <summary>
+    /// Gateway Cleanup mission, Phase 0 (wave 3): this Director's build version string, so a director-level
+    /// read that stamps it into its response (the <c>facts</c> and <c>handover</c> verbs) can serve the same
+    /// value over the tunnel that the REST route stamped from <c>ControlApiHost._version</c>. The producing
+    /// Director always stamps its own version, so the value is identical on both paths.
+    /// </summary>
+    public string? DirectorVersion { get; init; }
+
+    /// <summary>
+    /// Gateway Cleanup mission, Phase 0 (wave 3): the live per-host repository registry, so the <c>repos-list</c>
+    /// verb reads the same instance the REST route read at Map time. Null lists nothing (as the REST route
+    /// returned when no registry was wired).
+    /// </summary>
+    public RepositoryRegistry? Repositories { get; init; }
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway.Tests/CatalogReadExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/CatalogReadExecutorTests.cs
@@ -189,4 +189,47 @@ public sealed class CatalogReadExecutorTests
         }
         finally { sm.Dispose(); }
     }
+
+    // ---------- facts (Gateway Cleanup Phase 0 wave 3: needs the Director version via SessionCommandServices) ----------
+
+    [Fact]
+    public async Task DispatchAsync_Facts_ReturnsOkWithDirectorIdAndVersionFromServices()
+    {
+        // facts is director-level (no session), always a 200. The Director version rides in the services -
+        // the one dependency the tunnel command surface did not carry before wave 3 - and is stamped into the
+        // DTO exactly as the REST route stamped ControlApiHost._version.
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-facts", Cmd("facts"),
+                new SessionCommandServices { DirectorVersion = "9.9.9-test" });
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal("r2", result.CommandId);
+            var dto = JsonSerializer.Deserialize<DirectorFactsDto>(result.BodyJson ?? "", Json);
+            Assert.NotNull(dto);
+            Assert.Equal("dir-facts", dto!.DirectorId);
+            Assert.Equal("9.9.9-test", dto.Version);
+            Assert.NotNull(dto.Launcher);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_Facts_NoVersionInServices_ReturnsOkWithEmptyVersion()
+    {
+        // No services (or no version) is not an error: facts still lists tools/launcher, version just falls back
+        // to empty - the same additive-null tolerance the other services fields have.
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-facts", Cmd("facts"));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var dto = JsonSerializer.Deserialize<DirectorFactsDto>(result.BodyJson ?? "", Json);
+            Assert.NotNull(dto);
+            Assert.Equal(string.Empty, dto!.Version);
+        }
+        finally { sm.Dispose(); }
+    }
 }


### PR DESCRIPTION
## What this is

Gateway Cleanup mission, Phase 0. The shared-spine dependency step the remaining deferred tunnel verbs need, plus the first verb that consumes it. Additive; no deletions; REST responses byte-identical.

Design authority: the Architect's ratified deferred-verbs ruling (docs/architecture/gateway-cleanup-phase0-tunnel-protocol.md) - the six confirmed tunnel verbs lift inside the existing unary envelope; the only gap was that a couple of host-level dependencies weren't threaded through the command context. This adds them.

## The change

- `SessionCommandServices` gains two fields: the **Director version string** and the live **`RepositoryRegistry`**. `ControlApiHost.BuildStreamClient` now passes both, so a director-level read that stamps/reads them serves the same value over the tunnel that its REST route served (the producing Director stamps its own version, so the value is identical on both paths).
- `facts` (GET /facts) is lifted into `CatalogReadExecutor`, stamping the Director version from the new services field. `FactsEndpoint` now routes through the shared dispatch, so the REST route and the tunnel verb call the **same core** and cannot drift.

## Why facts here

R2 originally, correctly, skipped `facts` and `repos-list` because they needed a host dependency the context didn't carry. This PR adds that dependency and lifts `facts` as its proof/consumer.

## Follows on top of this (wave-3 lift PR)

`repos-list` (reads the registry), `handover` (stamps the version), `handover-generate`, `wingman-ask`, and `recap-generate` (static services, no new dependency) lift on top of this, per option (A) - plain unary verbs; the slow-LLM invocation strategy for wingman-ask/recap-generate is a Phase 2 decision, recorded.

## Tests

`facts` parity (Ok; Director id + version stamped from services; empty version when absent), plus the existing catalog, facts-endpoint, and dispatch suites stay green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>