### PR TITLE
fix(test): repoint prompt-chokepoint audit at queue-send's new home (restore green main)

### DIFF
--- a/src/CcDirector.Core.Tests/TerminalPromptInjectionChokepointTests.cs
+++ b/src/CcDirector.Core.Tests/TerminalPromptInjectionChokepointTests.cs
@@ -39,13 +39,17 @@ public sealed class TerminalPromptInjectionChokepointTests
         var executor = File.ReadAllText(Path.Combine(root, "src", "CcDirector.ControlApi", "SessionCommandExecutor.cs"));
         var voice = File.ReadAllText(Path.Combine(root, "src", "CcDirector.ControlApi", "VoiceTurnEndpoint.cs"));
         var chat = File.ReadAllText(Path.Combine(root, "src", "CcDirector.ControlApi", "Chat", "ChatService.cs"));
+        // Gateway Cleanup mission, Phase 0: the queue-send path's chokepoint call moved with the verb, from
+        // ControlEndpoints.cs into the QueueGitExecutor.cs core (the REST route and the tunnel verb now share
+        // that one core). The audit stays STRICT - it pins the call to its new known home, not "any file".
+        var queueGit = File.ReadAllText(Path.Combine(root, "src", "CcDirector.ControlApi", "QueueGitExecutor.cs"));
 
         Assert.Contains("Verb = \"prompt\"", control);
         Assert.Contains("SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command, source: source);", control);
         Assert.Contains("await session.SendTextAsync(request.Text, source, origin);", executor);
         Assert.Contains("await local.SendTextAsync(framed, SendSource.Internal);", control);
         Assert.Contains("await s.SendTextAsync(framed, SendSource.Internal);", control);
-        Assert.Contains("await session.SendTextAsync(text, SendSource.Internal);", control);
+        Assert.Contains("await session.SendTextAsync(text, SendSource.Internal);", queueGit);
         Assert.Contains("await session.SendTextAsync(inputText, SendSource.Internal);", voice);
         Assert.Contains("await session.SendTextAsync(req.Text, SendSource.Internal);", chat);
 


### PR DESCRIPTION
## Urgent: restores green main

The source-audit test `TerminalPromptInjectionChokepointTests.Control_api_prompt_routes_send_submitted_text_through_session_send_text` asserted that the queue-send submission call `await session.SendTextAsync(text, SendSource.Internal);` lives in `ControlEndpoints.cs`. The Gateway Cleanup Phase 0 queue-send lift (#1421) moved that call into the shared `QueueGitExecutor.cs` core, where the REST route and the tunnel verb now both reach it.

**Behavior is unchanged** — queue-send still funnels submitted text through the single `SendTextAsync` chokepoint (no raw `SendInput`, no Enter-retry); only the call's file location moved. This is purely the audit's file-location assertion going stale after the merge.

The fix repoints that one assertion at `QueueGitExecutor.cs` specifically, keeping the audit **strict** (pinned to a known home, not loosened to "any file").

It slipped because #1421's CI ran against a base where the assertion was still satisfied in `ControlEndpoints.cs`; the merged main is not. Follow-up process fix: require each PR up-to-date with main (or re-run the full suite on the merged state) before merge.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>