### PR TITLE
fix(gateway-connection): unblock a fresh token-less cc-director sign-in / enroll (epic #1069 A)

### DIFF
--- a/docs/reviews/gateway-connection-fresh-device-auth-DESIGN.md
+++ b/docs/reviews/gateway-connection-fresh-device-auth-DESIGN.md
@@ -1,0 +1,94 @@
+# DESIGN DECISION: fresh (token-less) cc-director sign-in / enrollment
+
+Architect decision on the blocker in `gateway-connection-fresh-device-auth-blocker.md`. Approves a
+minimal, correct **A** (same-machine unblock, ship today) and sets the design direction for **B**
+(any-machine, epic #1069 "issue 0b" - a follow-up mission, NOT today).
+
+## The deadlock, stated exactly
+
+`GatewayEnrollmentClient.EnrollSignedInAsync` sends the Director's EXISTING Gateway token as the
+Bearer. A brand-new Director has none, so the request arrives token-less and `AuthMiddleware` 401s it
+at the path gate BEFORE it can reach the endpoint's own guardrails. The endpoint that exists to hand
+a fresh co-located device its FIRST key is unreachable precisely by a device that has no key. That is
+the trap.
+
+## A. Same-machine unblock (approved - ship today)
+
+### A1. AuthMiddleware: make `/devices/enroll-signed-in` public - and ONLY that endpoint
+
+Add `"/devices/enroll-signed-in"` to `AuthMiddleware.PublicPaths`. This is the identical pattern the
+public set already documents for `/devices/register` (#469) and `/account/sign-in-start` (#1076):
+**the endpoint carries its own authorization**, so opening the route does not weaken the trust model.
+Its guardrails (`SignedInEnrollmentEndpoint.Evaluate`) are transport-level and self-contained:
+
+- Guardrail 1: caller's `RemoteIpAddress` must be loopback -> a tailnet/LAN attacker gets **403** from
+  the endpoint itself. Never a self-asserted header/flag.
+- Guardrail 2: the GATEWAY must be signed in -> **409** otherwise.
+- Guardrail 3: idempotent `RegisterIfAbsent` -> mints at most once per device (the #1136 leak guard).
+
+A remote attacker therefore gains nothing (403), and a local process is already inside the endpoint's
+designed trust boundary (loopback = same machine = physically trusted - the same bar `enroll-signed-in`
+was built to). The token wall in front is pure redundancy that only creates the deadlock.
+
+### A2. DO NOT open `/account/status` (correction to the brief's proposal A.1)
+
+The brief proposed opening BOTH `enroll-signed-in` and `/account/status`. Reject the second.
+`/account/status` returns account DATA (email, provider, credits); it must stay credential-gated. The
+device does not need it public: it enrolls first (public, loopback-guarded), earns its per-device key,
+then polls `/account/status` WITH that key. Opening account data to any unauthenticated caller would be
+a real weakening for zero benefit. Only the self-guarding enroll endpoint opens.
+
+### A3. Panel orchestration: token-less -> loopback enroll FIRST, browser sign-in only on 409
+
+The connect flow, when THIS Director holds no local Gateway key, must attempt loopback enrollment as
+the way to earn one - not dead-end on the register 401. Branch on the enroll result:
+
+- **200** (key minted or returned): persist the key to the local credential file (same as the pairing
+  path did), then register/heartbeat succeeds -> both checks green. On a machine whose Gateway is
+  already signed in (the common same-machine case, e.g. SOREN_NORTH today) this reaches green with
+  **zero** user clicks after "This computer" - better than "one sign-in click".
+- **409** (Gateway not signed in): route to Step 2 "Sign in with DevThrottle" (browser). That signs
+  the GATEWAY in; then retry enroll -> green. This is the only path that shows the sign-in button.
+- **403** (not loopback): this Director is NOT on the Gateway's machine -> that is case B. Until B
+  ships, show a clear "this device isn't on the Gateway's machine yet" message, NOT a raw 401.
+
+The forward-compatible panel change the Manager is already building (a 401/Unauthorized connect
+failure routes to Sign in instead of a dead-end) is correct and stays; A3 just makes the token-less
+case attempt loopback enroll before/at that 401 so the same-machine case needs no browser step at all.
+
+### A acceptance
+
+A fresh same-machine cc-director from merged main, with the Gateway signed in, reaches two green checks
+by picking "This computer" - no URL, no code, no dead-end. If the Gateway is signed out, one DevThrottle
+sign-in gets there. Prove it live on SOREN_NORTH (this closes the real 11.3 happy path). Add an
+`AuthMiddleware` unit test that `/devices/enroll-signed-in` is public, and keep the endpoint's own
+`Evaluate` tests (403/409/allow) green.
+
+## B. Any-machine flow (design direction - epic #1069 "issue 0b", a follow-up mission)
+
+A Director on machine B gets **403** from loopback enroll (correctly). It must obtain an
+account-issued key through the CLOUD sign-in, whose surfaces are ALREADY public and proven for the
+phone (`/m/enroll`) and the browser Cockpit (`/signin` + `/device-callback`, key handed back in the URL
+fragment): `/account/sign-in-start`, `/account/sign-in-callback`, `/signin`, `/device-callback`.
+
+Direction:
+
+1. The remote Director opens the DevThrottle cloud sign-in in machine B's own browser (desktop-OAuth
+   style: the Director runs a transient loopback listener and passes it as the redirect target).
+2. The user signs in once in their own browser.
+3. The cloud issues device B its OWN per-device key, bound to the account, and hands it back to the
+   Director's loopback listener (the native analog of the Cockpit `/device-callback` fragment).
+4. The Director authenticates to the Gateway with that account-issued key.
+
+**The crux (the one architectural decision):** the Gateway must TRUST a key it did not mint. The
+`ChildDeviceMirrorService` already mirrors devices UP to the account roster, so the account/cloud is
+already the shared source of truth. Recommendation, consistent with the epic #1069 north star (the
+account is the single auth source, Tailscale model): the Gateway SYNCS the account's device roster
+DOWN and accepts any active account-issued key in it (a pull that mirrors the existing push), rather
+than verifying against the cloud on every first use. That keeps one authority (the account) and one
+validation path (the local `DeviceRegistry`, now populated from the roster).
+
+**Dependency to flag:** B requires cloud-side work in devthrottle.com / Supabase (issue per-device
+keys bound to the account, expose the roster for the Gateway to sync). That is a separate codebase and
+deploy - which is why B is a follow-up mission, not today's change. Recommend: ship A now for green on
+this machine; take B as the next phase under epic #1069, sequenced with the cloud work.

--- a/docs/reviews/gateway-connection-fresh-device-auth-blocker.md
+++ b/docs/reviews/gateway-connection-fresh-device-auth-blocker.md
@@ -1,0 +1,81 @@
+# BLOCKER: a fresh (token-less) cc-director cannot sign in / connect
+
+Status: LIVE BLOCKER found during the Windows go-live (Part B). This blocks ALL go-live of the new
+cc-director build - none of it is usable until a brand-new device can reach green with only the
+DevThrottle sign-in. Soren and the Manager are working this together as the single priority.
+
+## Symptom
+
+A brand-new Director (no device token yet) opens the connection panel, the issue-1233 scan finds the
+real Gateway, the user picks "This computer", and the handshake dies with:
+
+> Could not finish connecting - Gateway refused registration: HTTP 401 Unauthorized
+
+with only "Try again" / "Back to scan". There is NO way to sign in from that screen.
+
+## Root cause - the fresh device is locked out on all three paths
+
+The Gateway runs with auth enforcement ON. A device must already hold a device token before the
+Gateway will talk to it. But a brand-new device has none, and every path that would let it obtain
+one is behind the SAME token wall (`AuthMiddleware`, path-based allow-list, no loopback exemption):
+
+- `POST /directors/register` (the connect handshake) -> 401 (this is the visible error)
+- `GET /account/status` (what the sign-in step polls) -> gated
+- `POST /devices/enroll-signed-in` (the loopback endpoint whose whole job is to hand a fresh
+  co-located Director its first token) -> gated, even though it has its OWN hard guardrails
+  (proven-loopback caller + Gateway-signed-in)
+
+Only the browser sign-in SURFACES are public (`/account/sign-in-start`, the callback, `/signin`,
+`/device-callback`) - not the Director's device-enrollment API. So the device needs a token to get
+in and must get in to obtain a token.
+
+The UI compounds it: a 401 is shown as a dead-end failure instead of "sign in to authorize this
+device".
+
+## The north star (Soren, confirmed) - epic #1069
+
+The DevThrottle account sign-in is the ONE and ONLY thing the user does, and it must work on ANY
+machine, not just the Gateway's machine. The cloud account = the single source of auth (the
+Tailscale model). Signing in once issues THIS device its own key, tied to the account; the Gateway
+trusts account-issued keys.
+
+## What exists vs. what is missing
+
+- EXISTS (Phase 2): same-machine LOOPBACK enrollment - `/devices/enroll-signed-in` mints the
+  co-located Director a key because the Gateway is signed in. It is just gated behind the auth wall.
+- MISSING (explicitly deferred): the REMOTE path. `AccountSignInStartEndpoint`'s own comment says it:
+  "the remote-vs-loopback redirect mechanics of the flow itself are a separate follow-up (epic #1069,
+  issue '0b'); here the start reuses the existing host-local loopback mechanism unchanged." So a
+  Director on another machine gets no key back today.
+
+## Proposed shape (for the Architect to design / correct)
+
+### A. Same-machine unblock (immediate - so Soren can reach green on THIS machine today)
+
+1. `AuthMiddleware`: let a PROVEN-LOOPBACK caller reach the two self-guarded endpoints
+   `/devices/enroll-signed-in` (already checks loopback + signed-in) and `/account/status`. Either add
+   a narrow loopback exemption, or make enroll-signed-in public like `/devices/register` already is
+   (it carries its own authorization). A remote attacker still gets 403 from the endpoint's own
+   loopback guard, so the trust model is not weakened.
+2. Panel: on a 401/Unauthorized connect failure, route to Step 2 "Sign in with DevThrottle" instead
+   of the dead-end. After sign-in enrolls the device and issues the token, re-apply -> register
+   succeeds -> green.
+
+### B. Any-machine flow (the real feature - epic #1069 "issue 0b")
+
+A Director on machine B opens the DevThrottle CLOUD sign-in in machine B's browser -> the user signs
+in once -> the cloud issues device B its own key, tied to the account -> the Director captures it
+(loopback hand-back on machine B) -> authenticates to the Gateway with it. Design questions for the
+Architect:
+
+- How the cloud issues per-device keys bound to the account, and how the Gateway validates
+  account-issued keys (does the `Devices` registry sync from the account / cloud, or does the Gateway
+  verify against the cloud on first use?).
+- The redirect / loopback hand-back mechanics for a device NOT co-located with the Gateway.
+- Whether the same-machine loopback enrollment stays as a fast path, or the cloud flow is used
+  uniformly.
+
+## Acceptance
+
+A brand-new cc-director on ANY machine, with only the user's DevThrottle sign-in, reaches two green
+checks (Connected + Signed in), registers in the fleet, and can create sessions - proven live.

--- a/docs/reviews/gateway-connection-verification-report.html
+++ b/docs/reviews/gateway-connection-verification-report.html
@@ -1,0 +1,198 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Gateway Connection - Final Verification Report</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: #1e1e1e; color: #d4d4d4;
+    font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    line-height: 1.55; font-size: 15px;
+  }
+  .wrap { max-width: 1000px; margin: 0 auto; padding: 40px 24px 96px; }
+  h1 { font-size: 30px; font-weight: 700; color: #ffffff; margin: 0 0 6px; letter-spacing: .3px; }
+  h2 { font-size: 21px; color: #ffffff; margin: 44px 0 8px; padding-bottom: 8px; border-bottom: 1px solid #333; }
+  h3 { font-size: 16px; color: #e6e6e6; margin: 26px 0 6px; }
+  p { margin: 8px 0; }
+  .sub { color: #8a8a8a; font-size: 13.5px; margin: 0 0 6px; }
+  .lead { color: #b8b8b8; }
+  code { background: #2a2a2a; padding: 1px 6px; border-radius: 3px; font-family: "Cascadia Mono", Consolas, monospace; font-size: 13px; color: #d7d7d7; }
+  a { color: #5aa9f0; }
+  .pill { display: inline-block; font-size: 11px; font-weight: 700; letter-spacing: .4px; padding: 2px 9px; border-radius: 11px; vertical-align: middle; }
+  .green { background: #14311f; color: #34d06e; }
+  .amber { background: #3a331b; color: #f0b848; }
+  .red { background: #3a1b1b; color: #ef6a6a; }
+  .blue { background: #16283f; color: #5aa9f0; }
+  figure { margin: 14px 0 22px; }
+  figure img { max-width: 100%; height: auto; display: block; border: 1px solid #333; border-radius: 8px; background: #111; }
+  figcaption { color: #8a8a8a; font-size: 13px; margin-top: 8px; }
+  table { border-collapse: collapse; width: 100%; margin: 12px 0 8px; font-size: 14px; }
+  th, td { border: 1px solid #333; padding: 8px 10px; text-align: left; vertical-align: top; }
+  th { background: #262626; color: #e6e6e6; font-weight: 600; }
+  .ok { color: #34d06e; font-weight: 600; }
+  .note { color: #c79a9a; }
+  .card { background: #232323; border: 1px solid #333; border-radius: 9px; padding: 14px 18px; margin: 14px 0; }
+  ul { margin: 8px 0; padding-left: 22px; }
+  li { margin: 3px 0; }
+  .scroll { overflow-x: auto; }
+  .placeholder { border: 1px dashed #555; border-radius: 8px; padding: 22px; color: #9a9a9a; text-align: center; background: #202020; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <h1>Gateway Connection &mdash; Final Verification Report</h1>
+  <p class="sub">Design spec: <code>docs/reviews/gateway-connection-redesign-2026-07-11.md</code> &nbsp;&middot;&nbsp; Mission: Gateway Connection redesign &nbsp;&middot;&nbsp; All five build phases merged to origin/main.</p>
+  <p class="lead">This report gathers the running-app evidence for every state and step of the redesign, across all five phases, plus the Mac verification pass and the end-to-end success test. Every screenshot is from the real app running on <code>SOREN_NORTH</code> (Windows) or <code>Sorens-Mac-mini</code> (macOS) against the real Gateway.</p>
+
+  <h2>1. The outcome, in one line</h2>
+  <p>The desktop Director's Gateway setup went from a page of plumbing (URL box, two Detect buttons, a Test button, a token box, a pairing-code dialog, a re-run-wizard button, a troubleshooter dialog, and two stacked status boxes) to <strong>ONE guided flow, in ONE reusable panel, reachable from ONE status box</strong>. A brand-new machine reaches "fully connected" by doing exactly three things: click the amber status box, click Connect, sign in with DevThrottle. No URL typed, no Detect, no Test, no pairing codes, no separate dialogs.</p>
+
+  <h2>2. Merged phases</h2>
+  <div class="scroll">
+  <table>
+    <tr><th>Phase</th><th>Delivered</th><th>Pull request</th><th>Status</th></tr>
+    <tr><td>1</td><td>The reusable panel + the pure state resolver; Step 1 connect (automatic issue-1233 scan, one-click picks, manual fallback under Advanced, live handshake, named failures)</td><td>merged</td><td class="ok">Done</td></tr>
+    <tr><td>2</td><td>Sign-in step (DevThrottle browser sign-in issues this device its token) + the green Done view</td><td>#1393</td><td class="ok">Done</td></tr>
+    <tr><td>3</td><td>One merged status box (<code>GatewayStatusBox</code>) with two check lines and four visual states</td><td>#1406</td><td class="ok">Done</td></tr>
+    <tr><td>4</td><td>Settings cleanup: the Gateway tab IS the panel; Account tab = summary + one button; onboarding embeds the panel; the whole deletion list executed; pairing dialog deleted</td><td>#1409</td><td class="ok">Done</td></tr>
+    <tr><td>5</td><td>Repair mode: red-state routing, inline diagnostics, automatic changed-address rediscovery, re-sign-in to Step 2; troubleshooter dialog deleted</td><td>#1417</td><td class="ok">Done</td></tr>
+  </table>
+  </div>
+
+  <h2>3. The state model &mdash; the one resolver</h2>
+  <p>Both the panel and the status box render from ONE pure resolver (<code>GatewayConnectionStateResolver</code>) that reduces the two verification sources (the two-way handshake and the Gateway's own signed-in report) into a single state. Green is earned, never assumed: Connected green only from the proven handshake, Signed-in green only from the Gateway's report.</p>
+  <div class="scroll">
+  <table>
+    <tr><th>Resolved state</th><th>Meaning</th><th>Box</th><th>Panel opens on</th></tr>
+    <tr><td>NotConfigured</td><td>No Gateway address, never connected</td><td><span class="pill amber">Amber</span></td><td>Step 1 (connect)</td></tr>
+    <tr><td>Connecting</td><td>Address set, handshake verifying</td><td><span class="pill amber">Yellow</span></td><td>Step 1 (progress)</td></tr>
+    <tr><td>ConnectFailed</td><td>Handshake failed, a named leg is down</td><td><span class="pill red">Red</span></td><td>Step 1 (repair)</td></tr>
+    <tr><td>ConnectedNotSignedIn</td><td>Handshake proven, device has no token / signed out</td><td><span class="pill amber">Amber</span></td><td>Step 2 (sign in)</td></tr>
+    <tr><td>AllGreen</td><td>Handshake proven AND Gateway reports signed in</td><td><span class="pill green">Green</span></td><td>Done view</td></tr>
+    <tr><td>WasConnectedNowUnreachable</td><td>Was green this run, now the handshake is failing</td><td><span class="pill red">Red</span></td><td>Step 1 (repair)</td></tr>
+  </table>
+  </div>
+  <p class="sub">Unit-tested in isolation (plain inputs in, resolved state out, no UI, no I/O): 30 GatewayConnection Core tests pass, including the red-state precedence (<code>WasConnectedNowUnreachable</code> outranks <code>ConnectFailed</code> only when <code>wasEverConnected</code> is true this run) and the "never a false green / never a false sign-out" rules.</p>
+
+  <h2>4. The one status box &mdash; four visual states (Phase 3)</h2>
+  <p>The two former bottom-left boxes (<code>GatewayIndicator</code> + <code>AccountIndicator</code>) merged into ONE box with two check lines. One click opens the panel on the resolver's current step.</p>
+
+  <h3>Amber &mdash; first run <span class="pill amber">NotConfigured</span></h3>
+  <figure>
+    <img src="gateway-connection-phase3-proof/gateway-statusbox-amber-firstrun.png" alt="Amber first-run status box" />
+    <figcaption>Line 1 hollow ring "Connect to Gateway", line 2 muted "Sign in". Both lines show the next action.</figcaption>
+  </figure>
+  <figure>
+    <img src="gateway-connection-phase3-proof/gateway-statusbox-amber-closeup.png" alt="Amber box close-up" />
+    <figcaption>Close-up of the amber first-run box.</figcaption>
+  </figure>
+
+  <h3>Green &mdash; all good <span class="pill green">AllGreen</span></h3>
+  <figure>
+    <img src="gateway-connection-phase3-proof/gateway-statusbox-green-allgreen.png" alt="Green all-good status box" />
+    <figcaption>Line 1 check "Connected", line 2 check "Signed in: soren@centerconsulting.com".</figcaption>
+  </figure>
+  <figure>
+    <img src="gateway-connection-phase3-proof/gateway-statusbox-green-closeup.png" alt="Green box close-up" />
+    <figcaption>Close-up of the all-green box.</figcaption>
+  </figure>
+
+  <h3>Red &mdash; was working / connect failed <span class="pill red">ConnectFailed / WasConnectedNowUnreachable</span></h3>
+  <figure>
+    <img src="gateway-connection-phase5-proof/red-status-box-names-leg.png" alt="Red status box naming the failing leg" />
+    <figcaption>The red box names the failing leg ("Cannot reach the Gateway"); the home card offers Reconnect.</figcaption>
+  </figure>
+  <p class="sub"><span class="pill amber">Yellow</span> (Connecting) is a brief transient handshake state; it is pinned by the presenter unit tests rather than a still screenshot, as is the "cannot tell yet" muted account line.</p>
+
+  <h2>5. Settings + onboarding &mdash; one panel, three hosts (Phase 4)</h2>
+  <h3>Settings Gateway tab IS the panel (Done view)</h3>
+  <figure>
+    <img src="gateway-connection-phase4-proof/settings-gateway-tab-embeds-panel.png" alt="Settings Gateway tab embedding the connection panel" />
+    <figcaption>The whole old control set is gone; the tab embeds the panel, opened on the resolver's current step (here the Done view, with Advanced collapsed).</figcaption>
+  </figure>
+  <h3>Onboarding wizard Gateway step IS the panel (Step 1 scan)</h3>
+  <figure>
+    <img src="gateway-connection-phase4-proof/onboarding-gateway-step-embeds-panel.png" alt="Onboarding wizard Gateway step embedding the connection panel" />
+    <figcaption>Step 1 of 3 embeds the panel: automatic scan, "2 FOUND", recommended "This computer", manual entry under Advanced, with the wizard's own Skip / Next.</figcaption>
+  </figure>
+
+  <h3>The deletion list &mdash; executed</h3>
+  <p>By the end of Phase 4/5 none of the following is reachable from the user interface. Verified by grep across <code>src/</code> (excluding build output): every name resolves to <strong>0 references</strong>.</p>
+  <div class="scroll">
+  <table>
+    <tr><th>Removed control / dialog</th><th>References in src</th></tr>
+    <tr><td><code>DetectGatewayButton</code>, <code>TestGatewayButton</code>, <code>DetectPublicUrlButton</code></td><td class="ok">0</td></tr>
+    <tr><td><code>GatewayTokenBox</code> (plain-text token)</td><td class="ok">0</td></tr>
+    <tr><td><code>ConnectToGatewayButton</code> + the whole <code>ConnectToGatewayDialog</code> (pairing code)</td><td class="ok">0 (files deleted)</td></tr>
+    <tr><td><code>RerunOnboardingButton</code></td><td class="ok">0</td></tr>
+    <tr><td><code>GatewayUrlBox</code>, <code>GatewayAdvertisedBox</code> (demoted to the panel's Advanced manual entry)</td><td class="ok">0</td></tr>
+    <tr><td><code>GatewayTroubleshootDialog</code> (dialog-as-destination; diagnostics now inline)</td><td class="ok">0 (files deleted)</td></tr>
+  </table>
+  </div>
+
+  <h2>6. Repair mode (Phase 5)</h2>
+  <h3>Step 1 repair with the rediscovered address as a one-click fix</h3>
+  <figure>
+    <img src="gateway-connection-phase5-proof/repair-mode-rediscovered-oneclick.png" alt="Repair mode with rediscovered one-click address" />
+    <figcaption>A simulated Gateway move (unreachable <code>http://127.0.0.1:59999</code>). The header reads "Reconnect to your Gateway", the banner names the exact failure, and the issue-1233 rediscovery scan has run automatically, offering the Gateway's current address as a one-click fix ("This computer" recommended + "Over Tailscale").</figcaption>
+  </figure>
+  <h3>Inline diagnostics &mdash; the troubleshooter ladder, reused</h3>
+  <figure>
+    <img src="gateway-connection-phase5-proof/repair-mode-inline-diagnostics.png" alt="Inline diagnostics ladder" />
+    <figcaption>"Show diagnostics" renders the same <code>GatewayConnectivitySelfTest</code> ladder inline: the two-way verdict plus every rung (Tailscale up, Serve mapping, local listener, advertised URL reaches this Director, build versions, Windows firewall). The <code>GatewayTroubleshootDialog</code> window is deleted; the logic is reused.</figcaption>
+  </figure>
+  <h3>Re-sign-in lands directly on Step 2</h3>
+  <p><code>ConnectedNotSignedIn</code> resolves to <code>GatewayPanelStep.SignIn</code> (unit test <code>Resolve_HandshakeProvenButSignedOut_IsConnectedNotSignedIn_OpensOnSignIn</code>), and the panel's routing to Step 2 is unchanged from Phase 2. A live re-capture against the production Gateway is not possible because a fresh unauthenticated device is correctly refused registration with <strong>HTTP 401</strong> (auth enforcement is on by design), so a live "connected but signed out" state is unreachable there. The Mac browser-launch pass (section 7) shows the sign-in step in action.</p>
+
+  <h2>7. Mac verification pass (spec 11.4)</h2>
+  <p class="sub">Run on <code>Sorens-Mac-mini</code> (repo <code>/Users/soren/ReposFred/devthrottle</code>), on merged <code>origin/main</code> (<code>9b821edf</code>). One Avalonia codebase, so this is a verification pass, not a port. The three platform-sensitive spots are network discovery, browser launch, and the per-device token storage path.</p>
+  <div class="card">
+    <p><strong>Deferred and tracked as GitHub issue <a href="https://github.com/thefrederiksen/devthrottle/issues/1420">#1420</a>.</strong> To move to live Windows testing without waiting on the Mac, the macOS verification pass was split out. All five build phases are merged and Windows-verified; the Mac run (network discovery, browser launch, per-device token storage path, plus the green Done view and merged status box) is scheduled on <code>Sorens-Mac-mini</code> and will be folded into this section when complete. One Avalonia codebase, so no porting is involved &mdash; this is a platform verification pass, not a code change.</p>
+  </div>
+
+  <h2>8. The end-to-end success test + Windows go-live (spec 11.3)</h2>
+  <div class="card note">
+    <strong>Honest status:</strong> the three legs of the happy path are individually shown across the phase screenshots, but the strict 11.3 claim &mdash; a <em>token-less fresh device</em> completing "Sign in with DevThrottle" and <em>earning</em> two green checks &mdash; is <strong>pending the Part B live run</strong> (below). The Windows go-live table proves a device that <em>already held</em> a token boots green; that is a different, weaker claim. Green is earned, never assumed (section 3), so 11.3 stays open until the fresh sign-in actually earns it.
+  </div>
+  <p>The happy path, from a clean profile to two green checks without typing a URL: <strong>click the amber box &rarr; click Connect &rarr; sign in with DevThrottle</strong>. Each leg's UI is shown above:</p>
+  <ul>
+    <li><strong>Click the amber box</strong> &rarr; the panel opens on Step 1 (section 4 amber box; section 5 onboarding Step 1 scan).</li>
+    <li><strong>Click Connect</strong> &rarr; the automatic scan lists the Gateway as a one-click pick; picking it runs the two-way handshake (section 5 onboarding scan).</li>
+    <li><strong>Sign in with DevThrottle</strong> &rarr; the sign-in opens the browser and issues this device its token; the panel polls status and advances to the green Done view. <em>This exact leg on a token-less device is what Part B exercises live.</em></li>
+  </ul>
+
+  <h3>Windows go-live &mdash; a real Director from merged main (a device that already held a token)</h3>
+  <p>A real new cc-director was built from merged <code>origin/main</code> (<code>9b821edf</code>) to slot 5 and launched via the <code>cc-director-launch</code> Task Scheduler task (parent = <code>svchost</code>, so grandchild agents get clean stdio). This device inherited an existing device token, so it proves boots-clean / registration / handshake / session / Cockpit &mdash; but NOT the token-less earn-green of 11.3 (that is Part B). Verified against the real Gateway on <code>SOREN_NORTH</code>:</p>
+  <div class="scroll">
+  <table>
+    <tr><th>Check</th><th>Result</th></tr>
+    <tr><td>Boots clean</td><td class="ok">No crash / functional error; tool health pass=8, fail=0. (The only Exception/ERROR/FAIL log substrings are benign status lines plus two pre-existing best-effort calls &mdash; startup telemetry 401 "ignored" and one usage-stat retry &mdash; unrelated to this mission.)</td></tr>
+    <tr><td>Gateway registration</td><td class="ok">POST /directors/register &rarr; 201; instance file written to the real discovery dir (in the fleet).</td></tr>
+    <tr><td>Two-way handshake</td><td class="ok">Handshake PASSED: two-way connection verified (Connected).</td></tr>
+    <tr><td>Signed in + device token</td><td class="ok">ApplyAccountStatus: account=SignedIn, deviceKey=True, reachable=True &rarr; merged status box GREEN, both checks.</td></tr>
+    <tr><td>Session creation (ConPty)</td><td class="ok">POST /sessions created session #104 (Gateway-issued number) which reached WaitingForInput/Idle &mdash; a real <code>claude.exe</code> child survives under the Director. Session creation works with zero ConPty errors.</td></tr>
+    <tr><td>Cockpit</td><td class="ok">Front door up at <code>https://soren-north.taildb08ed.ts.net/</code>; the Director and session #104 are visible in the fleet (the data Cockpit renders).</td></tr>
+  </table>
+  </div>
+
+  <h2>9. Definition of done (spec section 11)</h2>
+  <div class="scroll">
+  <table>
+    <tr><th>#</th><th>Criterion</th><th>Status</th></tr>
+    <tr><td>11.1</td><td>All five phases merged to origin/main, each with resolver/presenter unit tests, each human-verified on Windows against the real Gateway</td><td class="ok">Met</td></tr>
+    <tr><td>11.2</td><td>The section-8 deletion list fully executed &mdash; none of the removed buttons, boxes, or dialogs reachable from the UI</td><td class="ok">Met (grep = 0)</td></tr>
+    <tr><td>11.3</td><td>The end-to-end success test passes on a fresh profile: clean start to two green checks without typing a URL</td><td class="note">In progress &mdash; pending the fresh-profile live sign-in (Part B). A token-less device must EARN green; the go-live table only proves a token-holding device.</td></tr>
+    <tr><td>11.4</td><td>The Mac verification pass (network discovery, browser launch, per-device token storage path)</td><td class="note" id="dod-mac">Deferred &mdash; tracked as issue #1420 (section 7)</td></tr>
+    <tr><td>11.5</td><td>This final verification report with screenshots from the running app</td><td class="ok">This document</td></tr>
+  </table>
+  </div>
+
+  <p class="sub" style="margin-top:40px">Generated for the Gateway Connection mission. Screenshots are the committed proof under <code>docs/reviews/gateway-connection-phase{3,4,5}-proof/</code> and the Mac pass folder.</p>
+
+</div>
+</body>
+</html>

--- a/src/CcDirector.Avalonia.Tests/GatewayLoopbackEnrollUrlTests.cs
+++ b/src/CcDirector.Avalonia.Tests/GatewayLoopbackEnrollUrlTests.cs
@@ -1,0 +1,33 @@
+using CcDirector.Avalonia.Controls;
+using CcDirector.Core.Network;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// Pins the loopback URL construction for the fresh-device enrollment (epic #1069 A3). The same-machine
+/// enroll MUST be dialed at 127.0.0.1 - the Gateway's guardrail 1 checks the caller's remote IP with
+/// IPAddress.IsLoopback, so dialing the machine name or the tailnet address (which is what "This computer"
+/// DISPLAYS) would arrive as a LAN/tailnet IP and 403, defeating the whole unblock. This test is the guard
+/// against that regressing: whatever the pick's host, the enroll URL forces the literal 127.0.0.1 and keeps
+/// the pick's port (the local Gateway's own port).
+/// </summary>
+public sealed class GatewayLoopbackEnrollUrlTests
+{
+    [Theory]
+    [InlineData("http://127.0.0.1:7878", "http://127.0.0.1:7878")]
+    [InlineData("http://SOREN_NORTH:7878", "http://127.0.0.1:7878")]
+    [InlineData("http://soren-north:7930", "http://127.0.0.1:7930")]
+    [InlineData("https://soren-north.taildb08ed.ts.net:7878", "http://127.0.0.1:7878")]
+    public void ForcesLoopbackHost_AndKeepsThePickPort(string picked, string expected)
+    {
+        Assert.Equal(expected, GatewayConnectionPanel.BuildLoopbackEnrollUrl(picked));
+    }
+
+    [Fact]
+    public void FallsBackToDefaultGatewayPort_ForAnUnparseableUrl()
+    {
+        Assert.Equal($"http://127.0.0.1:{EndpointProbe.DefaultGatewayPort}",
+            GatewayConnectionPanel.BuildLoopbackEnrollUrl("not-a-url"));
+    }
+}

--- a/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs
@@ -73,10 +73,6 @@ public partial class GatewayConnectionPanel : UserControl
     // Cancels the Step 2 account-status polling loop when the panel is left or the flow restarts.
     private CancellationTokenSource? _pollCts;
 
-    // Enroll is attempted at most once per sign-in flow, and NEVER from the poll loop, so status polling
-    // can never mint keys repeatedly (guardrail against the #1136 auto-mint key leak).
-    private bool _enrollAttempted;
-
     // Which step the panel opens on (spec section 6: the status-box click opens the panel on the resolver's
     // current step). Connect (the default) starts the auto-scan; SignIn/Done skip the scan and read the
     // signed-in state directly, because the handshake is already proven in those states.
@@ -760,6 +756,29 @@ public partial class GatewayConnectionPanel : UserControl
                 ["gateway"] = new JsonObject { ["url"] = url },
             }));
 
+            // Epic #1069 (fresh-device unblock): a brand-new Director holds NO Gateway key, and the register
+            // handshake needs one, so it would 401. Earn the key FIRST via the co-located loopback
+            // enrollment (which is public and self-guards), then the handshake succeeds. On the common
+            // same-machine case where the Gateway is already signed in this reaches green with ZERO extra
+            // clicks. A signed-out Gateway (409) routes to the browser sign-in; a remote device (403) is
+            // case B, not yet supported.
+            if (!HasDeviceToken(GatewayConfig.Load()))
+            {
+                switch (await TryEnrollFirstAsync(url, host))
+                {
+                    case EnrollFirst.SignInNeeded:
+                        ShowSignIn();
+                        return;
+                    case EnrollFirst.RemoteNotSupported:
+                        ShowFailure(
+                            "This Director is not on the Gateway's own machine, so it cannot sign itself in yet.",
+                            "Run this Director on the Gateway's machine for now. Signing in from another machine is coming next.");
+                        return;
+                    // Enrolled (key earned) or FellThrough (no local Gateway to enroll with) both continue to
+                    // the handshake below - a real failure there surfaces through the normal verdict path.
+                }
+            }
+
             EnsureSubscribed(host.GatewayMonitor);
             await host.ReapplyGatewayAsync();
             _ = TimeoutAsync(attempt);
@@ -769,6 +788,50 @@ public partial class GatewayConnectionPanel : UserControl
             FileLog.Write($"[GatewayConnectionPanel] ConnectTo FAILED to start: {ex.Message}");
             ShowFailure($"Could not start connecting: {ex.Message}", null);
         }
+    }
+
+    private enum EnrollFirst { Enrolled, SignInNeeded, RemoteNotSupported, FellThrough }
+
+    // Try to earn this device's first Gateway key via the co-located loopback enrollment (epic #1069 A3).
+    // Dials the LOOPBACK address explicitly (127.0.0.1 + the local Gateway port from the pick) so the
+    // Gateway's guardrail-1 IsLoopback check passes even though "This computer" displays the machine name.
+    private async Task<EnrollFirst> TryEnrollFirstAsync(string pickedUrl, ControlApiHost host)
+    {
+        var loopbackUrl = BuildLoopbackEnrollUrl(pickedUrl);
+        var result = await GatewayEnrollmentClient.EnrollSignedInAsync(
+            loopbackUrl, token: null, host.DirectorId, Environment.MachineName, "windows");
+
+        switch (result.Outcome)
+        {
+            case EnrollOutcome.Enrolled:
+                // Store the key under the address the running client will actually register with (the pick),
+                // then the re-apply below registers WITH the key -> handshake -> green.
+                await Task.Run(() => GatewayCredentialStore.SaveEnrolledKey(pickedUrl, result.Value!.DeviceKey));
+                FileLog.Write("[GatewayConnectionPanel] enroll-first: device key issued (zero-click, Gateway already signed in)");
+                return EnrollFirst.Enrolled;
+            case EnrollOutcome.GatewayNotSignedIn:
+                FileLog.Write("[GatewayConnectionPanel] enroll-first: Gateway not signed in -> browser sign-in");
+                return EnrollFirst.SignInNeeded;
+            case EnrollOutcome.NotLoopback:
+                FileLog.Write("[GatewayConnectionPanel] enroll-first: not a loopback caller -> remote device (epic #1069 case B)");
+                return EnrollFirst.RemoteNotSupported;
+            default:
+                FileLog.Write($"[GatewayConnectionPanel] enroll-first: no local Gateway to enroll with ({result.Message}); continuing to the handshake");
+                return EnrollFirst.FellThrough;
+        }
+    }
+
+    // The same-machine enroll MUST be dialed at loopback (guardrail 1 checks the caller's remote IP with
+    // IPAddress.IsLoopback). Take the port from the pick - which for "This computer" is the local Gateway's
+    // own port (issue-1233) - and force the host to the literal 127.0.0.1 (deterministic over "localhost",
+    // which could resolve to the IPv6 ::1). If this is wrong the guard 403s, so keep this construction (and
+    // its test) intact.
+    internal static string BuildLoopbackEnrollUrl(string pickedUrl)
+    {
+        var port = EndpointProbe.DefaultGatewayPort;
+        if (Uri.TryCreate(pickedUrl, UriKind.Absolute, out var uri) && uri.Port > 0)
+            port = uri.Port;
+        return $"http://127.0.0.1:{port}";
     }
 
     private void EnsureSubscribed(GatewayConnectionMonitor monitor)
@@ -799,7 +862,19 @@ public partial class GatewayConnectionPanel : UserControl
                 break;
             case GatewayConnectionStatus.Failed:
             case GatewayConnectionStatus.NoTailnetIdentity:
-                ShowFailure(monitor.FailureSummary ?? "The connection could not be completed.", DeriveFix(monitor));
+                // Epic #1069 A3 fallback: a 401/Unauthorized handshake means this device is not authorized
+                // yet (e.g. a stale key). Route to Sign in - which re-enrolls and earns a fresh key - rather
+                // than a dead-end failure. (A brand-new no-key device is already handled by enroll-first in
+                // ConnectTo, so this covers the has-a-bad-key case.)
+                if (IsUnauthorizedFailure(monitor.FailureSummary))
+                {
+                    FileLog.Write("[GatewayConnectionPanel] handshake unauthorized (401) -> routing to Sign in");
+                    ShowSignIn();
+                }
+                else
+                {
+                    ShowFailure(monitor.FailureSummary ?? "The connection could not be completed.", DeriveFix(monitor));
+                }
                 break;
             case GatewayConnectionStatus.Connecting:
             case GatewayConnectionStatus.NotConfigured:
@@ -863,14 +938,23 @@ public partial class GatewayConnectionPanel : UserControl
 
     private void ShowSignIn()
     {
+        // Reaching Step 2 ends any in-flight connect attempt, so background verdict churn stops driving the
+        // view (ApplyVerdict ignores changes while not connecting).
+        _connecting = false;
         StopPolling();
-        _enrollAttempted = false;
         SignInWaitRow.IsVisible = false;
         SignInErrorText.IsVisible = false;
         SignInButton.IsEnabled = true;
         ShowOnly(SignInPanel);
         FileLog.Write("[GatewayConnectionPanel] showing Step 2 (sign in)");
     }
+
+    // Epic #1069 A3 fallback: is a handshake failure an authorization failure (401)? The monitor's failure
+    // summary carries the HTTP reason from the register call (GatewayClient.ReportRegistrationFailure).
+    private static bool IsUnauthorizedFailure(string? summary) =>
+        summary is not null
+        && (summary.Contains("401")
+            || summary.Contains("Unauthorized", StringComparison.OrdinalIgnoreCase));
 
     private void SignIn_Click(object? sender, RoutedEventArgs e) => _ = StartSignInAsync();
 
@@ -933,28 +1017,33 @@ public partial class GatewayConnectionPanel : UserControl
         _pollCts = null;
     }
 
-    // Poll GET /account/status until the Gateway reports signed in; then ensure this Director holds its
-    // own device token (enrolling once through the Gateway) and settle to the Done view. The loop only
-    // READS status - it never mints a key on its own.
+    // After the user starts the browser sign-in, watch for it to complete and settle to the Done view.
+    //
+    // A brand-new device has NO key, so it cannot read the credential-gated /account/status yet (epic #1069
+    // A2 keeps account data gated). It therefore polls by RETRYING the loopback enrollment: that returns 409
+    // while the Gateway is still signed out and 200 the instant it is signed in, and the server mint is
+    // idempotent per device (the #1136 leak guard, so retrying is safe). Once the device earns its key, the
+    // authenticated status read confirms signed-in and the view settles to Done.
     private async Task PollAccountAsync(CancellationToken ct)
     {
         while (!ct.IsCancellationRequested)
         {
             var config = GatewayConfig.Load();
-            var account = await SafeStatusAsync(config, ct);
-            if (ct.IsCancellationRequested) return;
 
-            if (account.SignedIn)
+            // Keyless: retry the enroll until the Gateway is signed in (then it hands over the key).
+            if (!HasDeviceToken(config))
             {
-                if (!HasDeviceToken(config) && !_enrollAttempted)
-                {
-                    _enrollAttempted = true;
-                    await EnrollThroughGatewayOnceAsync();
-                    config = GatewayConfig.Load();
-                    account = await SafeStatusAsync(config, ct);
-                }
+                await EnrollThroughGatewayOnceAsync();
+                if (ct.IsCancellationRequested) return;
+                config = GatewayConfig.Load();
+            }
 
-                if (HasDeviceToken(config) && account.SignedIn)
+            // With a key, read the (now authenticated) status; signed-in means both checks are green.
+            if (HasDeviceToken(config))
+            {
+                var account = await SafeStatusAsync(config, ct);
+                if (ct.IsCancellationRequested) return;
+                if (account.SignedIn)
                 {
                     var finalConfig = config;
                     var finalAccount = account;
@@ -983,16 +1072,19 @@ public partial class GatewayConnectionPanel : UserControl
             }
 
             var config = GatewayConfig.Load();
+            // Dial the enroll at LOOPBACK (guardrail 1), same as the pre-sign-in enroll-first path - the
+            // configured URL may be the machine name, which would 403.
             var result = await GatewayEnrollmentClient.EnrollSignedInAsync(
-                config.Url, config.Token, host.DirectorId, Environment.MachineName, "windows");
+                BuildLoopbackEnrollUrl(config.Url), token: null, host.DirectorId, Environment.MachineName, "windows");
 
-            if (!result.Success || result.Value is null)
+            if (result.Outcome != EnrollOutcome.Enrolled || result.Value is null)
             {
-                FileLog.Write($"[GatewayConnectionPanel] enroll-through-Gateway failed: {result.ErrorMessage}");
+                FileLog.Write($"[GatewayConnectionPanel] enroll-through-Gateway not enrolled ({result.Outcome}): {result.Message}");
                 return;
             }
 
-            // Store this device's own token, then re-apply so the running client authenticates with it.
+            // Store this device's own token under the configured URL, then re-apply so the running client
+            // authenticates with it.
             await Task.Run(() => GatewayCredentialStore.SaveEnrolledKey(config.Url, result.Value.DeviceKey));
             await host.ReapplyGatewayAsync();
             FileLog.Write("[GatewayConnectionPanel] enroll-through-Gateway: this Director's token stored");

--- a/src/CcDirector.ControlApi/GatewayEnrollmentClient.cs
+++ b/src/CcDirector.ControlApi/GatewayEnrollmentClient.cs
@@ -81,21 +81,27 @@ public static class GatewayEnrollmentClient
     }
 
     /// <summary>
-    /// Enroll THIS co-located Director with its own Gateway using the DevThrottle account sign-in instead
-    /// of a pairing code (issue #1069): POST <c>/devices/enroll-signed-in</c> with the Director's existing
-    /// Gateway token as the Bearer. The Gateway mints (or returns, if already present) this Director's own
-    /// per-device key - gated on the Gateway being signed in AND the caller being a loopback same-machine
-    /// connection. Returns the issued key, or a human-readable reason. A 409 means the Gateway is not signed
-    /// in yet (the caller should trigger the browser sign-in first); a 403 means this is not a same-machine
-    /// Director. Never throws for an expected failure.
+    /// Enroll THIS co-located Director with its own Gateway using the DevThrottle account sign-in instead of
+    /// a pairing code (issue #1069): POST <c>/devices/enroll-signed-in</c>. The Gateway mints (or returns, if
+    /// already present) this Director's own per-device key - gated on the Gateway being signed in AND the
+    /// caller being a proven loopback same-machine connection. The distinct outcomes are what let the panel
+    /// orchestrate the fresh-device flow: <see cref="EnrollOutcome.GatewayNotSignedIn"/> (409) means trigger
+    /// the browser sign-in first; <see cref="EnrollOutcome.NotLoopback"/> (403) means this is a remote
+    /// Director (epic #1069 case B). Never throws for an expected failure.
+    ///
+    /// The caller MUST pass a LOOPBACK <paramref name="gatewayUrl"/> (http://127.0.0.1:&lt;local gateway
+    /// port&gt;) for the same-machine case - the Gateway's guardrail 1 checks the caller's remote IP with
+    /// IPAddress.IsLoopback, so dialing the machine-name or tailnet address instead would 403 even on the
+    /// same machine. A brand-new device has no Gateway token, so it passes <paramref name="token"/> null and
+    /// the route is public (its own guards do the work).
     /// </summary>
-    public static async Task<OperationResult<DeviceRegistrationResponse>> EnrollSignedInAsync(
+    public static async Task<EnrollSignedInResult> EnrollSignedInAsync(
         string gatewayUrl, string? token, string deviceId, string machineName, string platform, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(gatewayUrl))
-            return OperationResult<DeviceRegistrationResponse>.Fail("No Gateway URL is configured.");
+            return new EnrollSignedInResult(EnrollOutcome.Failed, null, "No Gateway URL is configured.");
         if (string.IsNullOrWhiteSpace(deviceId))
-            return OperationResult<DeviceRegistrationResponse>.Fail("This Director has no device id.");
+            return new EnrollSignedInResult(EnrollOutcome.Failed, null, "This Director has no device id.");
 
         FileLog.Write($"[GatewayEnrollmentClient] EnrollSignedInAsync: gateway={gatewayUrl}, deviceId={deviceId}, machine={machineName}");
         var request = new EnrollSignedInRequest
@@ -120,20 +126,20 @@ public static class GatewayEnrollmentClient
         catch (Exception ex)
         {
             FileLog.Write($"[GatewayEnrollmentClient] EnrollSignedInAsync transport FAILED: {ex.Message}");
-            return OperationResult<DeviceRegistrationResponse>.Fail(
+            return new EnrollSignedInResult(EnrollOutcome.Failed, null,
                 $"Could not reach the Gateway at {gatewayUrl}: {ex.Message}");
         }
 
         if (resp.StatusCode == HttpStatusCode.Conflict)
-            return OperationResult<DeviceRegistrationResponse>.Fail(
+            return new EnrollSignedInResult(EnrollOutcome.GatewayNotSignedIn, null,
                 "Sign in to DevThrottle first, then this device gets its token.");
         if (resp.StatusCode == HttpStatusCode.Forbidden)
-            return OperationResult<DeviceRegistrationResponse>.Fail(
+            return new EnrollSignedInResult(EnrollOutcome.NotLoopback, null,
                 "This Director must be on the Gateway's own machine to enroll this way.");
         if (!resp.IsSuccessStatusCode)
         {
             FileLog.Write($"[GatewayEnrollmentClient] EnrollSignedInAsync failed: HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
-            return OperationResult<DeviceRegistrationResponse>.Fail(
+            return new EnrollSignedInResult(EnrollOutcome.Failed, null,
                 $"The Gateway refused enrollment: HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
         }
 
@@ -141,10 +147,35 @@ public static class GatewayEnrollmentClient
         if (body is null || string.IsNullOrWhiteSpace(body.DeviceKey))
         {
             FileLog.Write("[GatewayEnrollmentClient] EnrollSignedInAsync: 2xx with no device key in body");
-            return OperationResult<DeviceRegistrationResponse>.Fail("The Gateway returned no device key.");
+            return new EnrollSignedInResult(EnrollOutcome.Failed, null, "The Gateway returned no device key.");
         }
 
         FileLog.Write($"[GatewayEnrollmentClient] EnrollSignedInAsync: per-device key issued for machine={body.MachineName}");
-        return OperationResult<DeviceRegistrationResponse>.Ok(body);
+        return new EnrollSignedInResult(EnrollOutcome.Enrolled, body, "");
     }
 }
+
+/// <summary>
+/// The distinct outcomes of <see cref="GatewayEnrollmentClient.EnrollSignedInAsync"/> (epic #1069), so the
+/// connect panel can orchestrate the fresh-device flow without string-matching failure messages.
+/// </summary>
+public enum EnrollOutcome
+{
+    /// <summary>200: a per-device key was minted (or returned). <see cref="EnrollSignedInResult.Value"/> holds it.</summary>
+    Enrolled,
+
+    /// <summary>409: the Gateway is not signed in to DevThrottle yet - the panel must open the browser sign-in first.</summary>
+    GatewayNotSignedIn,
+
+    /// <summary>403: the caller is not a loopback/same-machine connection - this is a remote Director (case B).</summary>
+    NotLoopback,
+
+    /// <summary>A transport error or any other non-success - a real failure to surface.</summary>
+    Failed,
+}
+
+/// <summary>The outcome of a signed-in enrollment attempt (epic #1069).</summary>
+/// <param name="Outcome">Which of the distinct results occurred.</param>
+/// <param name="Value">The issued device key response when <see cref="Outcome"/> is <see cref="EnrollOutcome.Enrolled"/>; otherwise null.</param>
+/// <param name="Message">A human-readable reason for the non-enrolled outcomes.</param>
+public sealed record EnrollSignedInResult(EnrollOutcome Outcome, DeviceRegistrationResponse? Value, string Message);

--- a/src/CcDirector.Core.Tests/NoCrossMachineLoopbackGuardTests.cs
+++ b/src/CcDirector.Core.Tests/NoCrossMachineLoopbackGuardTests.cs
@@ -34,6 +34,7 @@ public sealed class NoCrossMachineLoopbackGuardTests
         ["src/CcDirector.ControlApi/ControlEndpoints.cs"] = "Same-machine control endpoint helpers / local references.",
         ["src/CcDirector.ControlApi/TailscaleServeSelfProvisioner.cs"] = "Maps the tailnet front door to local loopback backend.",
         ["src/CcDirector.ControlApi/GatewayConnectivitySelfTest.cs"] = "Probes the local loopback Control API as part of self-test.",
+        ["src/CcDirector.ControlApi/GatewayEnrollmentClient.cs"] = "Epic #1069 A: doc comment on EnrollSignedInAsync states the same-machine caller MUST pass a LOOPBACK gatewayUrl (http://127.0.0.1:<local gateway port>) so the Gateway's guardrail-1 IsLoopback check passes. Documents the policy; the literal address is built by the panel's BuildLoopbackEnrollUrl.",
         ["src/CcDirector.ControlApi/DictationEndpoint.cs"] = "Doc comment: 'Localhost-only by default' (describes the loopback bind).",
         ["src/CcDirector.ControlApi/TerminalStreamEndpoint.cs"] = "Doc comment: 'Localhost-only by default' (describes the loopback bind).",
         ["src/CcDirector.Gateway/GatewayHost.cs"] = "Local loopback bind / same-machine wiring.",
@@ -71,6 +72,7 @@ public sealed class NoCrossMachineLoopbackGuardTests
         // --- Desktop app: local Director/Cockpit access + local-only labels ---
         ["src/CcDirector.Avalonia/App.axaml.cs"] = "Local Control API bootstrap / loopback references.",
         ["src/CcDirector.Avalonia/CockpitUrlResolver.cs"] = "Resolves the local Cockpit URL (same machine).",
+        ["src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs"] = "Epic #1069 A: BuildLoopbackEnrollUrl dials the co-located Gateway's /devices/enroll-signed-in at the literal 127.0.0.1 BY DESIGN - the Gateway's guardrail 1 requires the enroll caller to be a proven SAME-machine loopback connection (IPAddress.IsLoopback), so a machine-name or tailnet address would 403. Same-machine only; the enrolled key then registers/heartbeats over the pick's real address.",
         ["src/CcDirector.Avalonia/MainWindow.axaml.cs"] = "Local-only labelled endpoint strings (handover/about).",
         ["src/CcDirector.Avalonia/Controls/ConnectionsView.axaml.cs"] = "Local connection references.",
         ["src/CcDirector.Avalonia/Controls/DirectorView/DirectorView.axaml.cs"] = "Embedded local Director view.",

--- a/src/CcDirector.Gateway.Tests/AuthMiddlewareTests.cs
+++ b/src/CcDirector.Gateway.Tests/AuthMiddlewareTests.cs
@@ -98,4 +98,44 @@ public sealed class AuthMiddlewareTests
         var key = devices.Register("phone-3", "PHONE").DeviceKey;
         Assert.True(AuthMiddleware.HasValidToken(WithBearer(key), SharedToken, devices));
     }
+
+    // Epic #1069 (fresh-device unblock): the sign-in enrollment endpoint must be reachable by a
+    // token-less device, or a brand-new co-located Director can never earn its first key (the deadlock).
+    // It carries its own loopback + signed-in guards, so opening the route is safe. This pins that the
+    // route is in the public set so the gate can never silently re-close it.
+    [Fact]
+    public async Task Enroll_signed_in_is_public_and_reachable_without_a_credential()
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Path = "/devices/enroll-signed-in";
+        ctx.Request.Method = "POST";
+
+        var passedThrough = false;
+        await AuthMiddleware.Run(
+            ctx,
+            new AuthMiddleware.RequireToken { Token = SharedToken, Devices = TempRegistry() },
+            () => { passedThrough = true; return Task.CompletedTask; });
+
+        Assert.True(passedThrough, "a token-less enroll-signed-in must reach the endpoint (it self-guards loopback + signed-in)");
+        Assert.NotEqual(StatusCodes.Status401Unauthorized, ctx.Response.StatusCode);
+    }
+
+    // The corrective half: a DATA endpoint (account status returns email/provider/credits) must STILL be
+    // gated - opening enroll-signed-in must not have widened the hole to account data.
+    [Fact]
+    public async Task Account_status_stays_gated_without_a_credential()
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Path = "/account/status";
+        ctx.Request.Method = "GET";
+
+        var passedThrough = false;
+        await AuthMiddleware.Run(
+            ctx,
+            new AuthMiddleware.RequireToken { Token = SharedToken, Devices = TempRegistry() },
+            () => { passedThrough = true; return Task.CompletedTask; });
+
+        Assert.False(passedThrough, "account status must not be reachable without a credential");
+        Assert.Equal(StatusCodes.Status401Unauthorized, ctx.Response.StatusCode);
+    }
 }

--- a/src/CcDirector.Gateway/Util/AuthMiddleware.cs
+++ b/src/CcDirector.Gateway/Util/AuthMiddleware.cs
@@ -8,7 +8,9 @@ namespace CcDirector.Gateway.Util;
 /// <summary>
 /// Bearer-or-cookie auth for the Gateway.
 ///
-/// Public, no auth:    /healthz, /login, /logout, /favicon.ico, /devices/register, the credential-free
+/// Public, no auth:    /healthz, /login, /logout, /favicon.ico, /devices/register,
+///                     /devices/enroll-signed-in (epic #1069: carries its own loopback + signed-in
+///                     guards, so a token-less fresh device can earn its first key), the credential-free
 ///                     cloud sign-in start front door /account/sign-in-start (issue #1076, GET + POST -
 ///                     it reads/returns no credential and no account data), the mobile app
 ///                     shell /m + everything under /m/ (which includes the enroll path
@@ -85,6 +87,15 @@ internal static class AuthMiddleware
         // device with no credential yet can reach it. The endpoint itself rejects a wrong/expired/
         // used code, so opening the route does not weaken the trust model.
         "/devices/register",
+        // Epic #1069 (fresh-device unblock): the sign-in replacement for the pairing code. A brand-new
+        // co-located Director has NO Gateway token yet, so its enroll call arrives token-less and would
+        // 401 at this gate BEFORE reaching the endpoint's own guards - the deadlock (the one endpoint that
+        // hands a fresh device its FIRST key was unreachable by a device with no key). Opening it does not
+        // weaken the trust model: SignedInEnrollmentEndpoint carries its OWN transport-level authorization,
+        // exactly like /devices/register above - a proven-loopback caller (403 for any non-loopback, so a
+        // tailnet/LAN attacker gains nothing), the Gateway signed in (409 otherwise), and an idempotent
+        // mint (the #1136 leak guard). Loopback = same machine = already inside the trust boundary.
+        "/devices/enroll-signed-in",
         // Issue #1076 (epic #1069): the credential-free cloud sign-in START front door. A signed-out
         // browser must reach this to BEGIN cloud sign-in, so it cannot sit behind the raw-token wall
         // (that is the deadlock the epic breaks). It is exact-match, so ONLY /account/sign-in-start is


### PR DESCRIPTION
## The blocker

A brand-new Director with no device token could not connect on an **auth-enforced Gateway**: `/directors/register` 401s, and **both** paths that would give it a token — `/account/status` and the loopback `/devices/enroll-signed-in` — were also behind the same token wall. The one endpoint built to hand a fresh co-located device its first key was unreachable by a device with no key. The panel then showed a dead-end 401 with no way to sign in. Found live during the Windows go-live (Part B).

## The fix (epic thefrederiksen/devthrottle_internal#675, part A — same-machine)

**Server (A1):** add **only** `/devices/enroll-signed-in` to `AuthMiddleware.PublicPaths`. It carries its own transport-level authorization — proven-loopback caller (403 otherwise), Gateway signed in (409 otherwise), idempotent mint (#1136 leak guard) — exactly the pattern `/devices/register` already uses. `/account/status` stays gated (a test pins both).

**Client (A3):** when this Director holds no local key, `ConnectTo` attempts the loopback enrollment **first**, dialed at the literal `127.0.0.1` + the pick's port (so guardrail 1 passes even though "This computer" displays the machine name):
- **200** → save key + register → **both checks green with ZERO extra clicks** when the Gateway is already signed in
- **409** → browser "Sign in with DevThrottle"
- **403** → clear "not on the Gateway's machine yet" message (case B, a follow-up)

A 401/Unauthorized handshake now routes to Sign in instead of a dead-end. The sign-in poll retries enroll (a keyless device can't read the gated `/account/status`; the idempotent server mint makes retrying safe). `EnrollSignedInAsync` returns a typed `EnrollOutcome`.

## Proof
- **+7 targeted tests** (AuthMiddleware: enroll-signed-in public / account-status stays gated; loopback URL construction). **43 Gateway + 120 Avalonia tests pass, 0 warnings.**
- Live zero-click green will be captured after the merged Gateway is deployed to the fleet (coordinated with the owner).

Case B (any-machine cloud device-key flow) is designed in `docs/reviews/gateway-connection-fresh-device-auth-DESIGN.md` as the epic thefrederiksen/devthrottle_internal#675 follow-up (needs devthrottle.com/Supabase work).

Architect-approved (reviewed the real diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)