### PR TITLE
feat(mac-build): stable local code signing, testing slot 5, and CC Launcher mission documents

### DIFF
--- a/docs/architecture/cc-launcher-mission-2026-07-11.md
+++ b/docs/architecture/cc-launcher-mission-2026-07-11.md
@@ -1,0 +1,189 @@
+# Mission Brief: CC Launcher on the Mac (remote launch and mutual updates)
+
+> **STATUS CORRECTION 2026-07-11 (late evening): the mission is ACTIVE again.** The earlier
+> mission-wide park was a relay scope error - the owner's instruction ("we're not implementing
+> this right now") referred only to the auto-update work stream, not the whole mission. The Mac
+> port (pull request 1365) and installer (pull request 1364) streams are resumed. Only the
+> mutual-update stream (pull request 1367) is parked, confirmed by the owner verbatim: "I didn't
+> park all launcher missions! I parked the auto-update, that's all I parked! We need the launcher
+> working, but no auto-update while sessions are running." (His condition - never update while
+> sessions are running - is exactly what decision 8 and the DirectorUpdateGuardian on the parked
+> branch already enforce.)
+>
+> The resume-gate list below remains the accurate map of what is left to prove:
+> **Resume gates** - what remained unproven at stand-down, in merge order:
+> 1. Pull request 1365 (Mac port): the Director-restart-over-the-stream proof leg needs the
+>    screen unlocked or the never-lock posture applied; everything else was proven live.
+> 2. Pull request 1364 (installer): merges after 1365 (shared launch agent label constant),
+>    and the end-to-end clean-install proof needs a release that ships cc-launcher-mac-arm64.
+> 3. Pull request 1367 (mutual updates): the live deliberate-bad-build rollback proof never
+>    ran; that is the gate before it could be undrafted.
+> 4. Fleet-wide: the production Gateway must be updated to a build containing the launcher
+>    stream before remote commands work outside a local test Gateway.
+
+Status: active mission (auto-update stream on hold - see the status correction above). Written 2026-07-11 by the Architect session
+("CC Launcher Mission - Architect", session 7b78e474, machine Sorens-Mac-mini). The Architect
+settles the design and coordinates; the worker sessions listed under "The work" own execution.
+
+## The mission
+
+The fleet must keep itself alive and current on unattended Macs. The Windows tray launcher
+(cc-launcher) is the model: an always-on tray application that connects out to the Gateway, can
+launch applications on the machine with clean process parentage - most importantly cc-director
+itself - and pairs with the Director so each can update the other. The owner wants the same
+experience on the Mac: install once, and out of the box the machine has a Director, a launcher, a
+tunnel connection, and a two-way update scheme where the launcher updates cc-director and
+cc-director updates the launcher, so a fleet of unattended machines stays current even when an
+update goes wrong - each binary is the other's rescuer.
+
+## Decisions already made - do not re-litigate
+
+1. **One application, both platforms.** We do not build a separate Mac launcher. The existing
+   `src/CcDirector.Launcher` (Avalonia tray application) is multi-targeted to run on macOS; the
+   Windows tray behavior is the thing being emulated. Avalonia puts the tray icon in the Mac menu
+   bar. Roughly 80 percent of the launcher (Gateway registration, command stream, token
+   authentication, web interface, self-update logic) is already platform-neutral.
+2. **The Python daemon in `tools/cc-launcher` is retired** once the .NET launcher runs on the Mac.
+   The Windows tray launcher is the only launcher we care about.
+3. **Never overwrite a running binary in place** - on macOS that is an instant code-signature
+   kill. Every swap is rename-based: place the new file beside the target, rename the current
+   target aside as `.old`, rename the new one in. Delete the `.old` backup only after the new
+   build proves healthy.
+4. **A machine never updates both binaries in the same pass.** Update one, confirm it healthy,
+   then the other on a later cycle. At least one healthy supervisor exists at every moment.
+   Underneath both sits launchd (`RunAtLoad` + `KeepAlive`) as the bottom safety layer.
+5. **The persistent stream is the command path on the Mac.** The launcher's web interface stays
+   loopback-only; remote commands arrive over the outbound SignalR stream to the Gateway, which
+   works with the screen locked. (The Gateway's HTTP relay cannot reach a loopback-bound launcher
+   on another machine - that is accepted, not a bug to fix.)
+6. **Unattended posture** (owner-accepted, see memory "mac-unattended-posture"): fleet Macs run
+   never-lock plus display-off plus automatic login. The launcher runs as a user launch agent in
+   the logged-in graphical session, which is what lets it launch graphical applications remotely.
+7. Plain English everywhere. No fallback programming. Enterprise logging on every public method.
+8. **Restart policy for applying Director updates** (owner ruling, 2026-07-11): the launcher must
+   NEVER restart a Director that has any actively working session. If ALL of a Director's
+   sessions are idle or waiting, a restart to apply an update is allowed, but only inside a
+   nightly maintenance window. Both are configurable settings - window start and end hours, and
+   an enable/disable switch for automatic restarts entirely - because the owner expects to tune
+   them. When an update is staged but blocked by activity, never force anything: surface a
+   "new version waiting" notification to the owner instead. Implement the restart step as a
+   policy seam, not hard-coded, because a version 2 is deferred but expected: the owner is torn
+   between (a) saving every session as a handover document (the Director already has /handover
+   endpoints), updating, then restarting sessions from the handovers, and (b) staying
+   notify-only. That decision waits until version 1 shows how often updates actually get
+   blocked. Do not build version 2 now.
+
+## Core findings (verified 2026-07-11 against the working tree)
+
+Full discovery and design detail: `docs/plans/cc-launcher-mac-tunnel-and-mutual-updates.md`.
+The short version:
+
+- The Gateway side is DONE and tested: launcher registration (`POST /launchers/register`,
+  heartbeat, 90-second timeout), relay endpoints (`/machines/{machine}/director/restart` and
+  friends), the `LauncherHub` persistent stream with verbs `director/start`, `director/stop`,
+  `director/restart`, `launch`, and the protected-slot guard.
+- The launcher's Gateway clients (`GatewayRegistrationClient.cs`, `LauncherStreamClient.cs`) are
+  written and platform-neutral. The blockers are packaging, not architecture: the project targets
+  `net10.0-windows` / `WinExe`, autostart is a registry Run key, `LaunchService` routes through
+  `cmd.exe`, `DirectorSupervisor` matches processes via `MainModule`, and the release ships only
+  `cc-launcher-win-x64.exe`.
+- The Director already self-updates on macOS arm64 (GitHub release poll, sha-256 verification
+  against `release-manifest.json`, staged bundle, swap at next startup via `SwapMac`). But
+  `SwapMac` keeps no backup, rollback and half-swap recovery return early on non-Windows, and
+  nothing applies a staged update on an unattended machine (it waits for "next time you open the
+  app", which is never).
+- The launcher's managed self-update (stop, swap, relaunch, health check, roll back to `.old`)
+  exists and is the right shape - gated `OperatingSystem.IsWindows()`.
+- The tunnel is the Tailscale mesh and already works from this Mac: outbound-only connections to
+  the Gateway's tailnet address, verified live with the screen-locked constraint in mind.
+
+## The work - three sessions, one mission
+
+### Session 1 - "CC Launcher - Mac Port" (build the launcher for the Mac)
+
+Port `src/CcDirector.Launcher` per the plan document, part 3.1:
+- Multi-target `net10.0-windows;net10.0`; publish `osx-arm64` self-contained single-file.
+- launchd autostart (`~/Library/LaunchAgents/com.devthrottle.cc-launcher.plist`, `RunAtLoad`,
+  `KeepAlive`, `--managed`), the macOS twin of the registry Run key.
+- `LaunchService` macOS branch: `/usr/bin/open` for application bundles, fresh process group for
+  plain executables, no `cmd.exe`.
+- `DirectorSupervisor` macOS branch: resolve the installed `CC Director.app`, start via
+  `/usr/bin/open`, graceful stop through the Director Control API (already portable), process
+  matching without `MainModule`.
+- Prove it end to end on Sorens-Mac-mini: launcher registers with the Gateway, appears in
+  `GET /launchers`, and a `director/restart` sent over the stream restarts a test-slot Director
+  (slot 5 or higher only - never the owner's running Directors).
+
+### Session 2 - "CC Launcher - Mac Installer" (install everything, out of the box)
+
+The owner installs once on a fresh Mac and it just works: cc-director installed, cc-launcher
+installed and autostarted, Gateway connection configured, launch agent loaded. Work:
+- Discover the current Mac installer (`devthrottle-setup-mac-arm64.zip`, the setup engine,
+  `MacAppPlacer`) and what it covers today.
+- Add the launcher as an installed component on macOS: a macOS asset name in the setup-engine
+  `Component` record, `InstallLayout` path, placement, launch-agent registration, first start.
+- Release pipeline: build and publish `cc-launcher-mac-arm64` in `.github/workflows/release.yml`
+  and add it to `release-manifest.json` (the completeness guard must know about it).
+- Prove it: a clean install on this Mac ends with both binaries installed, the launcher
+  registered with the Gateway, and the Director connected.
+
+### Session 3 - "CC Launcher - Mutual Update" (research, then build, the two-way update)
+
+Research first, then implement the scheme in the plan document, parts 3.2 to 3.4:
+- Launcher updates the Director: version comparison from the release manifest, restart to apply
+  the already-staged update when the machine is quiet, post-restart health check, rollback via a
+  kept `.old` bundle (change `SwapMac` to rename aside instead of delete), bad-version pinning,
+  rescue install via `MacAppPlacer` when no Director is runnable.
+- Director updates the launcher: un-gate the tool-update loop and `LauncherSelfUpdate` from
+  Windows, rename-based swap, start via `launchctl kickstart`, restore `.old` when the launcher's
+  health endpoint stays dead.
+- Startup recovery on macOS (the port of `RecoverHalfAppliedSwap`): target missing plus `.old`
+  present means restore.
+- Research items to settle with evidence before building: exactly how macOS treats a renamed
+  running bundle across all our cases (running from `.old` after rename, Gatekeeper on the swapped
+  bundle, quarantine on downloads), and whether the Director should also apply staged updates on a
+  timer when it has zero sessions rather than only at startup.
+- Prove it both directions on this Mac with test builds: a deliberate bad Director build rolls
+  back; a deliberate bad launcher build rolls back; a mid-swap kill recovers at next start.
+
+Sequencing: Session 1 leads. Session 3 researches in parallel and implements once the launcher
+runs on the Mac. Session 2 discovers in parallel and wires the installer once the
+`cc-launcher-mac-arm64` asset exists. The Architect session coordinates and holds owner
+questions.
+
+## Environment gaps found during execution (owner actions)
+
+- **The production Gateway is too old for the launcher stream.** Verified 2026-07-11 by Session 1:
+  the Gateway on SOREN_NORTH runs release 1.0.7 (commit af963b38), which predates the LauncherHub -
+  `/launcher-stream` returns 404 there (and this Mac Director's `/director-stream` connection is
+  rejected the same way). Launcher registration and heartbeat work against it; stream commands do
+  not. Owner action: update the production Gateway to a build containing the launcher stream
+  before the fleet-wide remote-launch proof.
+- **The locked screen blocks the last proof leg.** The launcher itself survives a locked screen in
+  headless degraded mode, but a restarted Director is a graphical application and dies on a locked
+  screen. The Director-restart-over-the-stream proof needs the screen unlocked or the never-lock
+  posture applied to this Mac mini.
+
+## Open questions (withdrawal reversed with the resume; question 2 re-asked, 3 and 4 pending)
+
+1. ANSWERED 2026-07-11 - restart policy. See decision 8 above.
+2. VOID by owner ruling 2026-07-11 - the protected-builds question only exists for automatic
+   restarts, and the auto-update stream is parked, so nothing restarts any Director
+   automatically and there is nothing to protect. Do not re-ask. If the auto-update work ever
+   resumes, this returns as a design question inside that work, not as an owner question.
+3. Any Intel Macs in the fleet, now or planned? (Release pipeline is Apple-silicon only.)
+4. Apple Developer signing identity, or stay ad-hoc signed with quarantine stripping?
+
+## Definition of done for the mission
+
+1. On a fresh Mac: one install produces a working Director, a working launcher in the menu bar,
+   both connected to the Gateway, launcher visible in `GET /launchers`.
+2. From another machine, with the Mac's screen locked and nobody at it: the Gateway stream can
+   start, stop, and restart the Mac's Director, and launch an application, with clean parentage.
+3. Two-way updates proven on a real Mac: the launcher applies a Director update and rolls back a
+   deliberately broken one; the Director replaces a dead or outdated launcher and rolls back a
+   deliberately broken one; a mid-swap interruption recovers on the next start. Never both in one
+   pass; no running binary ever overwritten in place.
+4. The Python daemon in `tools/cc-launcher` is deleted.
+5. All work merged to origin/main with tests, enterprise logging, and a verification report with
+   evidence from this Mac.

--- a/docs/plans/cc-launcher-mac-tunnel-and-mutual-updates.md
+++ b/docs/plans/cc-launcher-mac-tunnel-and-mutual-updates.md
@@ -1,0 +1,222 @@
+# CC Launcher on macOS: tunnel connectivity, remote launch, and mutual updates
+
+> **PARKED - DESIGN ONLY, NOT SCHEDULED** (owner decision, 2026-07-11). See the mission brief
+> docs/architecture/cc-launcher-mission-2026-07-11.md for recorded decisions and where the
+> pre-stand-down work is preserved.
+
+> Discovery, gap analysis, and design draft. Nothing here is implemented yet. Written by session
+> "CC Launcher - Tunnel + Updates" (7b78e474) on Sorens-Mac-mini, 2026-07-11. Open questions at the
+> end are held for the owner, relayed one at a time by the coordinating session (04a37e53).
+
+## Part 1 - What exists today (discovery findings)
+
+There are two unrelated things called "cc-launcher" in this repository:
+
+1. **The product launcher, `src/CcDirector.Launcher`** (.NET 10, Avalonia tray application,
+   issue #250). This is the real one, and it already does most of what this mission needs -
+   on Windows only:
+   - A loopback-only web interface on port 7900, gated by a random bearer token
+     (`LauncherHost.cs`, `LauncherAuth.cs`): health, status, launch an arbitrary application,
+     start / stop / restart the Director, shut down the launcher.
+   - Clean process parentage launching (`LaunchService.cs`) - the whole reason the launcher
+     exists (the "rule 0b" nested pseudo-console problem).
+   - Director supervision (`DirectorSupervisor.cs`): resolves the installed Director, stops it
+     gracefully through its Control API, restarts it.
+   - **Outbound Gateway connectivity, already written and mostly platform-neutral:**
+     - `GatewayRegistrationClient.cs` registers at `POST {gateway.url}/launchers/register`,
+       heartbeats every 30 seconds, re-registers on 410, unregisters on shutdown.
+     - `LauncherStreamClient.cs` holds a persistent SignalR connection to
+       `{gateway.url}/launcher-stream`, authenticated with `gateway.token`, auto-reconnecting,
+       and executes the commands `director/start`, `director/stop`, `director/restart`, and
+       `launch` through the same supervisor and launch service the local web interface uses.
+   - Managed self-update on Windows (`--managed` flag): a polling loop downloads a new launcher,
+     then a detached helper (`Program.cs --apply-update`) stops the old one, swaps the file,
+     relaunches, health-checks, and rolls back to the `.old` copy on failure.
+
+2. **The Python daemon in `tools/cc-launcher`** - an older macOS-only development helper
+   (launchd, port 8765, no authentication, no Gateway connection, window and screenshot
+   control through the Accessibility interface). It is not installed on this Mac mini, its
+   `main.py` entry point is broken, and it shares no code with the product launcher.
+
+**Gateway side is fully built and tested.** The Gateway already has the complete counterpart:
+launcher registration and discovery endpoints, heartbeat with a 90-second timeout, relay
+endpoints (`POST /machines/{machine}/director/restart`, `/start`, `/stop`, `/launch`, and
+remote session spawning), the `LauncherHub` persistent stream, a per-connection registry, and a
+protected-slot guard (the main build and slots 1-4 refuse restart or stop without an explicit
+`confirmProtected` flag). Integration tests exercise the stream end to end. What is missing is
+only a user interface that drives these endpoints - and a launcher that runs on a Mac.
+
+**The tunnel is the Tailscale mesh, and it already works from this Mac.** Verified live on
+Sorens-Mac-mini: Tailscale runs as an application plus a root system network extension, the
+Gateway at `http://soren-north.taildb08ed.ts.net:7878` answers, and this machine's Director is
+connected with `streamMode: true` in its configuration file. Both the Director stream and the
+launcher stream are outbound connections - nothing ever dials into the Mac - so they keep
+working when the screen is locked. The Tailscale Serve provisioners (Gateway machine plus each
+Director's own front door) exist for inbound web access to Director ports and are not needed
+for the launcher's outbound stream.
+
+**The Director's own update path already works on macOS arm64, with gaps.**
+`UpdateService` polls the latest GitHub release, picks `cc-director-mac-arm64.zip`, verifies
+the download against the sha-256 in `release-manifest.json`, extracts the application bundle,
+strips the quarantine attribute, and stages it. At the next startup the staged build re-invokes
+itself as a helper (`--apply-update`), waits for the old process to exit, and swaps the bundle
+(`SwapMac`). The gaps on macOS:
+- `SwapMac` deletes the old bundle outright (`rm -rf` then `mv`) - **no backup is kept**, so
+  there is nothing to roll back to.
+- `RecoverHalfAppliedSwap` and `TryRollBackFailedUpdate` both return early on non-Windows -
+  the issue-242 self-healing does not run on a Mac.
+- Startup notices are Windows-only message boxes; on a Mac a failed update is silent.
+- Only Apple-silicon (arm64) assets exist; there is no Intel build.
+- The bundles are ad-hoc signed and not notarized; the updater relies on stripping quarantine.
+
+## Part 2 - Gap analysis (honest and short)
+
+| Capability | State | Gap |
+|---|---|---|
+| Tunnel connectivity for the launcher | Registration and stream clients fully written, platform-neutral, tested against a real Gateway | The launcher does not build on macOS at all (`net10.0-windows`, `WinExe`), so none of it runs here |
+| Remote launch | Gateway protocol, relay, stream, and slot guard complete and tested | macOS process code: no `cmd.exe`, application bundles need `/usr/bin/open`, process matching uses `MainModule` which is unreliable on macOS; registry autostart must become a launchd agent; no macOS release asset or packaging |
+| Launcher updates the Director | Director self-stages updates on macOS already; the launcher only needs to trigger a restart and the staged build applies itself | No rollback on macOS (no backup bundle, recovery code Windows-only); nobody health-checks the Director after an update; if the Director is dead or absent, nothing can install it |
+| Director updates the launcher | `LauncherSelfUpdate`, `InstallSwapper`, and the tool-update loop exist | All gated `OperatingSystem.IsWindows()`; no macOS launcher asset in the release; no way to start the launcher on a Mac after placing it (needs `launchctl kickstart`) |
+| Survives an update gone wrong | Windows: `.old` backup, health check, bad-version pinning, bounded attempts | On macOS, none of that safety net exists today, for either binary |
+
+The loopback web interface deserves one honest note: the Gateway's fallback relay dials the
+launcher at `{networkAddress}:7900`, but the launcher binds loopback only, so the relay can
+never reach a launcher on a different machine. On a remote Mac the persistent stream is the
+only command path. That is acceptable - connecting a Director now turns stream mode on - but
+it means the stream is load-bearing, not an optimization.
+
+## Part 3 - Design: the Mac launcher and the mutual-update scheme
+
+### Principle
+
+Each binary is the other's rescuer, and **no running binary is ever overwritten in place**
+(on macOS that is an instant code-signature kill). Every swap is: write the new file beside
+the target, rename the current target aside as a backup, rename the new file in. A running
+process keeps its old file node across a rename, so renames are always safe; only writing
+into the live file is fatal.
+
+Underneath both binaries sits launchd: the launcher runs as a user launch agent with
+`RunAtLoad` and `KeepAlive`, so the operating system itself resurrects it after crashes and
+at login. That is the bottom safety layer that needs no code.
+
+### 3.1 Getting the launcher onto macOS (port, not rewrite)
+
+Reuse `src/CcDirector.Launcher` - the Gateway clients, the token authentication, the web
+interface, and the tray flyout are already platform-neutral. The work is:
+
+1. Retarget the project (and its test project) from `net10.0-windows` to multi-target
+   `net10.0-windows;net10.0`, publish `osx-arm64` self-contained single-file as
+   `cc-launcher-mac-arm64` in the release workflow, add it to `release-manifest.json`, and
+   give the setup-engine `Component` record a macOS asset name beside `WindowsAsset`.
+2. Autostart: a new `LauncherLaunchdAutostart` that writes
+   `~/Library/LaunchAgents/com.devthrottle.cc-launcher.plist` (`RunAtLoad`, `KeepAlive`,
+   the `--managed` flag) and loads it with `launchctl bootstrap` - the macOS twin of the
+   registry Run key, modeled on the plist in `tools/cc-launcher`.
+3. `LaunchService` macOS branch: no `cmd.exe` routing; launch `.app` bundles with
+   `/usr/bin/open`; plain executables with `UseShellExecute = false` and
+   `start_new_session` semantics (a fresh process group), which is what the Python daemon
+   already proved gives clean parentage on macOS.
+4. `DirectorSupervisor` macOS branch: resolve the installed `CC Director.app` through
+   `InstallLayout`, start it with `/usr/bin/open`, keep the graceful stop through the
+   Director's Control API exactly as on Windows (that part is portable), and match processes
+   by name plus the instance registration files instead of `MainModule`.
+5. Retire `tools/cc-launcher` (the Python daemon) once the .NET launcher runs here, so there
+   is exactly one launcher. Its window-control tricks are not part of this scope.
+
+Because the launch agent lives in the logged-in user's graphical session, it can launch
+graphical applications even while the screen is locked - which is exactly the capability we
+confirmed is impossible from a remote shell. The requirement it inherits: the user must be
+logged in, which for an unattended fleet machine means automatic login at boot (see open
+question 5).
+
+### 3.2 Launcher updates the Director
+
+The Director keeps its existing self-update (poll, verify, stage). The launcher adds the
+missing safety around it:
+
+- **Trigger**: the Director stages silently today and applies only "next time you open the
+  app" - on an unattended machine, never. The launcher closes that loop: its poll notices
+  the Director is running an older version than the latest release manifest (both version
+  numbers are already exposed: the manifest by `ReleaseSource`, the Director's version by
+  its health endpoint), waits until the machine is quiet enough (open question 3), then
+  performs `director/restart`. The staged build applies itself during that restart - the
+  launcher never fights `UpdateInstaller`.
+- **Backup**: change `SwapMac` to rename the old bundle to `CC Director.app.old` instead of
+  deleting it, and delete the backup only when the new build marks itself healthy (the
+  `MarkCurrentBuildHealthy` call that already exists). This is one small change in
+  `UpdateInstaller` and gives macOS the same `.old` safety Windows has.
+- **Health check and rollback**: after any restart the launcher initiated, it polls the
+  Director's Control API health endpoint (port discovered from the instance registration
+  files). If the Director is not healthy within a deadline, the launcher renames the `.old`
+  bundle back, records the bad version in the updater state so it is not retried (the
+  pinning mechanism already exists in `UpdaterState`), relaunches, and reports the failure
+  through its Gateway stream.
+- **Rescue install**: if no Director is installed or the bundle is damaged, the launcher can
+  download the verified release itself and place it - the placing code already exists as
+  `MacAppPlacer` in the setup engine; the launcher just needs to call it.
+
+### 3.3 Director updates the launcher
+
+The launcher's managed self-update already implements the right shape on Windows
+(poll, stage, detached helper: stop, swap, relaunch, health check, roll back to `.old`).
+The macOS work is to un-gate it and make the swap rename-based:
+
+- Remove the `OperatingSystem.IsWindows()` gate on the update loop and on
+  `LauncherSelfUpdate`, and make the helper's swap on macOS a rename-aside plus rename-in
+  (never a copy over the live file).
+- The Director's existing periodic tool-update loop becomes the rescuer: if the launcher's
+  health endpoint has been dead longer than a threshold, or its binary is missing, the
+  Director places a fresh launcher binary (rename-based, through `InstallSwapper`) and
+  starts it with `launchctl kickstart -k gui/<uid>/com.devthrottle.cc-launcher`. If the
+  new launcher binary itself is broken, launchd keeps failing to start it - and the
+  Director's loop restores the `.old` copy.
+
+### 3.4 Ordering rule and the failure matrix
+
+**A machine never updates both binaries in the same pass.** Update one, wait for it to be
+confirmed healthy, and only then (next cycle) update the other. This guarantees at least one
+healthy supervisor exists at every moment.
+
+| Failure | What happens |
+|---|---|
+| Download corrupt or truncated | Sha-256 mismatch, file deleted, retried next poll. The live binary was never touched. |
+| New Director will not start | Launcher's health check fails, launcher restores `CC Director.app.old`, pins the bad version, relaunches, reports over the stream. |
+| New launcher will not start | The helper's own health check rolls back to `.old`. If the helper died too, launchd keeps retrying while the Director's loop notices the dead health endpoint and restores `.old`. |
+| Machine reboots mid-swap | The rename-based swap has a tiny window where the target name is absent. A startup recovery check (the macOS port of `RecoverHalfAppliedSwap`): if the target is missing and a `.old` exists, restore it. |
+| Both binaries broken at once | Prevented by the ordering rule - the second update never starts before the first is confirmed healthy. |
+| Launcher crashes for any other reason | launchd `KeepAlive` restarts it; at worst it re-registers with the Gateway thirty seconds later. |
+
+### Out of scope for this design
+
+Fleet-wide update orchestration in the Gateway user interface (a "update all machines"
+button), Intel Macs, notarization, and Linux. All can layer on later without changing this
+scheme.
+
+## Part 4 - Open questions for the owner (held for relay)
+
+1. **One launcher or two?** The plan is to port the .NET launcher to macOS and retire the
+   Python daemon in `tools/cc-launcher` entirely. Confirm the Python daemon has nothing you
+   still rely on (its window minimize/focus and screenshot endpoints would go away).
+2. **Menu-bar icon on the Mac, or headless?** The Windows launcher shows a tray icon. On
+   macOS a menu-bar icon means packaging the launcher as an application bundle; a headless
+   launch agent (log files and the web interface only) is a plainer first version. Which do
+   you want first?
+3. **When may the launcher restart a Director to apply an update?** An unattended machine can
+   restart any time it is idle, but a restart kills the running sessions. Proposal: only
+   restart when the Director reports zero active sessions, plus a nightly window as a
+   fallback. Acceptable?
+4. **Protected builds on the Mac.** On Windows the main build and slots 1 through 4 are
+   protected from remote restart. What is the equivalent on your Macs - protect the installed
+   `CC Director.app` plus mac slots 1 through 4, reserving slot 5 and up for agents, same as
+   Windows?
+5. **Automatic login on fleet Macs.** A launch agent only runs while the user is logged in.
+   For unattended recovery after a reboot or power loss, the fleet Macs need automatic login
+   at boot - and FileVault disk encryption blocks automatic login, so this is a real
+   trade-off. Are the fleet Macs (this Mac mini included) set to log in automatically, and is
+   turning FileVault off (or leaving it off) acceptable on them?
+6. **Apple-silicon only?** The release pipeline builds arm64 only. Are there any Intel Macs
+   in the fleet, now or planned?
+7. **Signing.** Everything on macOS today is ad-hoc signed and not notarized; the updater
+   strips the quarantine flag itself, which works but is fragile against future macOS
+   tightening. Is acquiring an Apple Developer identity for real signing worth doing now, or
+   defer?

--- a/docs/plans/cc-launcher-mutual-update-research-2026-07-11.md
+++ b/docs/plans/cc-launcher-mutual-update-research-2026-07-11.md
@@ -1,0 +1,277 @@
+# Mutual update on macOS: research findings with evidence from this Mac
+
+> Research report for the CC Launcher mission, part of the two-way update work (mission brief:
+> `docs/architecture/cc-launcher-mission-2026-07-11.md`, design draft:
+> `docs/plans/cc-launcher-mac-tunnel-and-mutual-updates.md`). Written by session
+> "CC Launcher - Mutual Update" (79f0d94f) on Sorens-Mac-mini, 2026-07-11. Every claim in part 1
+> was verified by a live experiment on this machine (macOS 26.5, Apple silicon), using throwaway
+> test bundles in the session scratchpad and a throwaway launchd agent - never the owner's
+> running Directors. Part 2 is a map of the code as it exists in the working tree today.
+
+## Part 1 - Operating system behavior, verified by experiment
+
+The test fixture was a small self-contained single-file .NET application (the same shape as
+cc-director and cc-launcher), placed inside an ad-hoc-signed `.app` bundle, serving a health
+endpoint over a plain socket and able to spawn a child process on request.
+
+### 1.1 Renaming a running application bundle is safe
+
+With the test application running from `live/SwapLab.app`:
+
+1. `mv live/SwapLab.app live/SwapLab.app.old` - the process **kept running, kept serving
+   requests, and kept spawning child processes**. A running process holds its executable by
+   file node, not by path, and a rename keeps the file node.
+2. `mv staging/SwapLab-B.app live/SwapLab.app` (the new build renamed in) - the old process
+   was still unaffected.
+3. The new build was launched from the swapped-in path while the old one still ran from
+   `.old` - **both versions ran side by side**, each healthy.
+4. After stopping the old process and deleting the `.old` backup, the new build kept running,
+   its code signature verified (`codesign --verify`: "valid on disk, satisfies its Designated
+   Requirement"), and it launched fine both by direct execution and by `/usr/bin/open` - from
+   its real path, with **no App Translocation**.
+
+**One hazard found.** The running process's idea of its own directory is a stale string:
+
+- During the window between rename-aside and rename-in, any file the old process tries to read
+  beside its own executable **fails** (directory not found).
+- After the new bundle is renamed in, the old process reading "its own" files by path actually
+  reads the **new** bundle's files - a silent cross-version mix.
+
+Consequences for the design: keep the swap window to two back-to-back renames (never a copy in
+between), and stop or restart the old process promptly after the swap rather than letting it
+run indefinitely against the new bundle's files.
+
+### 1.2 Gatekeeper: execution is gated by quarantine, not by the ad-hoc signature
+
+- `spctl --assess` **rejects** our ad-hoc-signed bundles. That verdict does not matter for us:
+  with **no quarantine attribute present**, the bundle executes fine both by direct execution
+  and via `/usr/bin/open`, from its real path, no translocation, no prompt.
+- With a quarantine attribute present, the bundle is unusable: `open` ran it under **App
+  Translocation** (a randomized read-only mount - every path assumption broken) where it
+  stalled, and direct execution **hung indefinitely** (blocked on the Gatekeeper assessment,
+  which may also put a dialog on the machine's screen).
+
+### 1.3 New and critical: quarantine can only be stripped BEFORE the first launch attempt
+
+Verified twice, cleanly isolated:
+
+- Quarantine set, **never launched**, then `xattr -dr com.apple.quarantine` → strip works,
+  application runs instantly. (This is the updater's current order, and it must stay that way.)
+- Quarantine set, **launched once** (and therefore assessed by Gatekeeper), then strip →
+  **"Operation not permitted" on every file, permanently.** macOS stamps a
+  `com.apple.provenance` attribute at first launch, and from then on the ordinary user cannot
+  remove the quarantine attribute at all. The bundle can still be deleted - the only recovery
+  is delete and re-download.
+
+Rule for all our code paths, including every rescue path: **strip quarantine immediately after
+extraction and never attempt to launch first.** If a quarantined bundle was ever launched, do
+not try to repair it; delete it and download again.
+
+### 1.4 Our real download-and-extract flow produces no quarantine at all
+
+Tested against the genuine `cc-director-mac-arm64.zip` from release v1.0.7:
+
+- Downloading with .NET `HttpClient` (exactly what `UpdateService.DownloadFileAsync` does)
+  attaches **no quarantine attribute** - quarantine is added by applications that opt into it
+  (browsers), not by plain socket writes.
+- Extracting with `ZipFile.ExtractToDirectory` (exactly what `UpdateService.ExtractMacApp`
+  does) preserved the executable bits on both `cc-director` and the `launch` script, attached
+  no quarantine, and the extracted bundle **passed `codesign --verify`**.
+
+So the existing `StripQuarantine` call is belt-and-braces rather than load-bearing today. Keep
+it (it is cheap and protects against a future download path that does set quarantine), and keep
+it positioned before anything could launch the bundle, per finding 1.3.
+
+### 1.5 launchd behavior (user agent with RunAtLoad and KeepAlive)
+
+Verified with a throwaway agent `com.devthrottle.swaplab-test` (bare single-file binary, the
+launcher's shape), then torn down:
+
+- **KeepAlive resurrects a killed process** within a few seconds, no action needed.
+- **`launchctl kickstart -k gui/501/<label>` kills and restarts the agent**; the replacement
+  process picks up whatever binary now sits at the plist's path. So the update flow "rename the
+  new binary in, then kickstart" atomically moves the agent to the new build.
+- **Renaming the binary under a live agent is safe** - the running process is unaffected until
+  the kickstart.
+- **Missing binary** (the simulated mid-swap crash): launchd logs exit code 78 (configuration
+  error), keeps rescheduling the spawn, and the moment the `.old` backup was renamed back to
+  the target name, **launchd recovered the service by itself** - no `launchctl` command needed.
+  The bottom safety layer works exactly as the design hoped.
+
+**Design consequence discovered.** On macOS there are no file locks, so the Windows-style
+sequence (stop the running launcher, wait for its executable to unlock, swap, start) is both
+unnecessary and racy: with plain `KeepAlive true`, launchd restarts the launcher immediately
+after a graceful shutdown - potentially before the swap has happened, restarting the old build.
+The natural macOS sequence is the reverse of Windows:
+
+1. Rename-swap **while the old launcher is still running** (safe, per 1.1).
+2. `launchctl kickstart -k` to atomically replace the process with the new build.
+3. Health-check; on failure rename the `.old` back and kickstart again.
+
+No stop, no unlock wait, no window where no supervisor is configured.
+
+### 1.6 Overwriting a running binary in place: nondeterministic, still forbidden
+
+Overwriting a small, fully-resident test binary in place did not always kill it (the kernel
+kills on the next page-in of an invalidated executable page; a small hot binary may never
+fault). One trial stopped serving, another survived untouched. The owner's own observation
+(recorded in project memory) is that the real 64-megabyte Director dies instantly when copied
+over. The behavior ranges from "instant kill" to "silent time bomb", which is worse than a
+deterministic failure. The rule stands absolutely: **every swap is rename-based; never write
+into a live file.**
+
+### 1.7 A quirk worth recording (cost an hour; not a product issue)
+
+A .NET `HttpListener` **hangs in its constructor** when the process is launched through
+LaunchServices (`open`) on this macOS version, while the same code works when launched from a
+shell. A plain socket listener (`TcpListener`) binds instantly either way. The Director and the
+launcher both use Kestrel (socket-based), so this does not affect the product - but no test
+harness for this mission should use `HttpListener`.
+
+## Part 2 - The code as it stands (map for the implementation)
+
+### Director self-update (`src/CcDirector.Core/Update/`)
+
+- **`UpdateInstaller.SwapMac` (UpdateInstaller.cs:443)** builds the replacement beside the
+  target (`ditto` to `<target>.new`, strip quarantine, `chmod +x`), then `rm -rf <target>` and
+  `mv <target>.new <target>`. **The `rm -rf` is the whole macOS rollback gap** - change it to
+  `mv <target> <target>.old` and the backup exists. One line of behavior.
+- **`RecoverHalfAppliedSwap` (UpdateInstaller.cs:265)** returns early on non-Windows (its
+  comment predates keeping a macOS backup). The macOS port is: target bundle missing while a
+  non-empty `.old` bundle exists → rename `.old` back. Directory operations instead of file
+  operations; the decision helper `NeedsHalfSwapRecovery` is already pure and reusable.
+- **`TryRollBackFailedUpdate` (UpdateInstaller.cs:314)** returns early on non-Windows. The
+  Windows body is file-copy based; the macOS port is two renames. The health-marker and
+  bad-version-pinning state (`UpdaterState.PendingHealthCheckVersion`,
+  `UpdaterState.PinnedBadVersion`, `updater-state.json`) is platform-neutral and needs no
+  change.
+- **Found a flaw that also affects Windows:** `CleanupAfterUpdate` (called at
+  CcDirector.Avalonia/Program.cs:93) deletes the `.old` backup on the **first** boot of a
+  freshly swapped build, while `PendingHealthCheckVersion` is still armed -
+  `MarkCurrentBuildHealthy` only runs later, when the main window is shown
+  (App.axaml.cs:101). A new build that crashes after early startup but before the window
+  leaves **no backup to roll back to**. The fix for macOS (and recommended for Windows too):
+  only delete the `.old` backup when no post-update health check is pending - in effect, the
+  backup dies when the build proves healthy, exactly as the mission brief states.
+- **Nothing applies a staged update without a process start.** `TryApplyStagedUpdateAtStartup`
+  runs only at startup; there is no timer. On an unattended machine the launcher's
+  `director/restart` is what closes this loop (by design). See recommendation 3 below on
+  whether the Director should also restart itself.
+- The relauncher flow (`--apply-update <target> <parentPid>`, Program.cs:37) and `Relaunch` via
+  `/usr/bin/open` both already work on macOS and match the verified-safe behavior from part 1.
+
+### Launcher self-update (`src/CcDirector.Launcher/`, `tools/cc-director-setup-engine/`)
+
+- **`LauncherSelfUpdate` and `InstallSwapper` are already rename-based and platform-neutral.**
+  `InstallSwapper.Place` copies the staged file to `<target>.new` (a fresh file node) and
+  renames; `Rollback` renames `.old` back. No changes needed for safety; verified against the
+  experiments.
+- **The gates to remove or rework:**
+  - `LauncherTrayController.cs:426`: the update loop runs only `if (cfg.Enabled &&
+    OperatingSystem.IsWindows())`.
+  - `LauncherUpdater.LaunchDetachedUpdater` and `CheckStageAndLaunchAsync` carry
+    `[SupportedOSPlatform("windows")]`.
+  - `LauncherUpdater` reads `ComponentRegistry.Launcher.WindowsAsset`
+    ("cc-launcher-win-x64.exe") and stages to a hard-coded `staged/cc-launcher.exe`. The
+    `Component` record (Component.cs:15) has no macOS asset name field yet - **Session 2 owns
+    adding it** along with the `cc-launcher-mac-arm64` release asset; the field and asset name
+    must be agreed between us.
+- **`LauncherSelfUpdate.WaitUntilWritable` is meaningless on macOS** (no file locks - it
+  returns immediately even while the old launcher runs). Per finding 1.5 the macOS helper
+  should not stop-and-wait at all: swap first, then `launchctl kickstart -k`, then
+  health-check, renaming back plus kickstart on failure. The existing delegate-injected shape
+  of `ApplyAsync` makes this a macOS branch in the injected `stopLauncher`/`startLauncher`
+  delegates plus a skip of the writability wait, not a rewrite.
+- The launcher's health endpoint (`GET /healthz`, no authentication, LauncherHost.cs:119) and
+  version pinning (`PinStore`) already exist and are platform-neutral.
+
+### Director as the launcher's rescuer
+
+- **The Director does not reference the launcher anywhere today** - no rescue exists on any
+  platform. The natural home is the Director's periodic auto-update loop
+  (App.axaml.cs:324-351), which already runs `UpdateService.CheckAndStageAsync` plus
+  `ToolUpdater.RefreshAsync` on a configured cadence. The new step: probe the launcher's
+  `/healthz`; if dead longer than a threshold or the binary is missing, place a fresh binary
+  through `InstallSwapper` and start it with `launchctl kickstart -k
+  gui/<uid>/com.devthrottle.cc-launcher`; if the fresh binary also fails, restore the `.old`.
+- `InstallLayout.PathFor` already maps the launcher on macOS to `<LauncherDir>/cc-launcher`
+  (InstallLayout.cs:121), and Session 1 has `LauncherLaunchdAutostart` in flight in the working
+  tree, so the plist label and paths will come from there.
+
+### Launcher as the Director's updater (what the launcher needs, all verified available)
+
+- The Director's Control API `GET /healthz` returns `Version` **and** `Sessions` (a live
+  session count) - ControlEndpoints.cs:86 - which is exactly what the launcher needs both for
+  the version comparison and for the "only restart when quiet" gate.
+- `DirectorSupervisor` already discovers running Directors (process id and port) from the
+  instance registration files `config/director/instances/{id}.json`.
+- The release manifest side (`ReleaseSource`, sha-256 verification) is shared setup-engine code
+  the launcher already links.
+- **`MacAppPlacer` (MacAppPlacer.cs:22)** is the rescue installer: download, verify, `ditto`
+  extract, place into `~/Applications`, strip quarantine, record the installed version. It is
+  correctly macOS-gated and its quarantine order matches finding 1.3. Note it deletes any
+  existing bundle without a backup - correct for "no runnable Director exists", and it must
+  only ever be used in that state.
+
+## Part 3 - Recommendations for the Architect (decisions to settle before implementation)
+
+1. **macOS helper order differs from Windows on purpose.** Windows: stop, wait for unlock,
+   swap, start. macOS: swap while running, then restart (`launchctl kickstart -k` for the
+   launcher; Control API shutdown plus `open` for the Director). Recommend encoding this as two
+   named strategies rather than sprinkling platform checks.
+2. **KeepAlive semantics need one decision.** With plain `KeepAlive true`, any graceful
+   shutdown of the launcher is undone by launchd within seconds, which breaks stop-based flows
+   and any human "quit the launcher" affordance. Options: keep `KeepAlive true` and make every
+   programmatic restart go through `kickstart -k` (never stop-start), or use the
+   `SuccessfulExit false` form so a clean exit stays down. Recommend the first (an unattended
+   machine should never have the launcher down), coordinated with Session 1 who owns the plist.
+3. **The `.old` backup must survive until the build proves healthy** - move the deletion out of
+   unconditional startup cleanup and gate it on the pending-health-check marker being clear.
+   Recommend fixing this on Windows in the same change, since the flaw is live there today.
+4. **Quarantine handling in every path, including rescues:** strip after extraction, before any
+   possible launch; treat a bundle that was ever launched while quarantined as unrecoverable
+   (delete and re-download). This is now a verified hard rule, not a style preference.
+5. **Should the Director also apply staged updates on a timer at zero sessions?** Recommend
+   no - one restart mechanism (the launcher's, health-checked and rollback-capable) is easier
+   to reason about than two racing ones, and the launcher is itself rescued by the Director
+   and launchd. If the fleet later runs Directors on machines with no launcher, revisit.
+
+## Part 3a - Owner ruling on the restart policy (received 2026-07-11, decision 8 in the mission brief)
+
+Version 1, the one to build now:
+
+- The launcher must **never** restart a Director that has any actively working session.
+- An automatic restart is allowed only when **all** of the Director's sessions are idle or
+  waiting **and** the current time is inside a nightly maintenance window.
+- Both are configurable: the window's start and end hours, and a switch that disables
+  automatic restarts entirely.
+- When an update is staged but the policy blocks the restart, force nothing - surface a
+  "new version waiting" notification to the owner instead.
+
+Build the restart step as a **policy seam** (an injected decision, not logic hard-coded into
+the update loop), because version 2 is explicitly deferred and undecided: it may save the
+running sessions as handover documents through the existing /handover endpoints, apply the
+update, and restore them - or stay notify-only. That choice will be made later, with
+version 1 evidence in hand. Do not build any part of version 2 now.
+
+Implementation note for the policy check: the Director's health endpoint reports only a
+session **count**; "all sessions idle or waiting" needs the per-session activity state from
+the Director's session-list endpoint, which sits behind the Control API's authentication.
+The launcher's supervisor already talks to the Control API for graceful stop, so the policy
+check rides the same authenticated channel.
+
+## Part 4 - Coordination notes and blockers
+
+- **Implementation is sequenced behind Session 1** ("CC Launcher - Mac Port", 5ad3c44f), per
+  the mission brief. Session 1 currently has uncommitted changes to the same launcher files
+  the un-gating touches (`LauncherTrayController.cs`, `Program.cs`,
+  `LauncherLaunchdAutostart.cs`), and all three worker sessions share one working tree - the
+  Director-side changes (`UpdateInstaller`, `UpdaterState` callers) do not overlap Session 1's
+  files, but commit coordination needs a plan from the Architect.
+- **Session 2 dependency:** the `Component` record needs a macOS asset name field and the
+  release needs a `cc-launcher-mac-arm64` asset before `LauncherUpdater` can stage launcher
+  updates on the Mac. Proposed asset name: `cc-launcher-mac-arm64` (matching the existing
+  `cc-director-mac-arm64.zip` convention, no extension since it is a bare binary).
+- All experiments were cleaned up: test bundles and processes removed, the throwaway launchd
+  agent booted out and its plist deleted. Nothing was installed and no running Director was
+  touched.

--- a/scripts/local-build-mac.sh
+++ b/scripts/local-build-mac.sh
@@ -149,13 +149,27 @@ DEST_PATH="$DEST_DIR/$EXE_NAME"
 cp -f "$EXE_PATH" "$DEST_PATH"
 chmod +x "$DEST_PATH"
 
-# Re-apply an ad-hoc signature to the copy. A single-file macOS binary is signed by the SDK at
-# publish time, but the app bundle is appended into the host AFTER signing and `cp` does not carry
-# the signature across intact - so the copied slot binary is seen as having an invalid/adhoc-rejected
-# signature and macOS SIGKILLs it at exec ("Killed: 9"; `spctl` reports "rejected"), with no output.
-# Forcing a fresh ad-hoc signature on the destination makes the slot binary launchable.
+# Re-sign the copy. A single-file macOS binary is signed by the SDK at publish time, but the app
+# bundle is appended into the host AFTER signing and `cp` does not carry the signature across
+# intact - so the copied slot binary is seen as having an invalid/adhoc-rejected signature and
+# macOS SIGKILLs it at exec ("Killed: 9"; `spctl` reports "rejected"), with no output.
+#
+# Prefer the stable local identity "CC Director Local Signing" (created once by
+# scripts/local-build/mac/make-signing-certificate.sh). macOS privacy grants (Desktop/Documents
+# folder access, Full Disk Access) are keyed to the code signature; with the stable identity plus
+# a stable per-slot identifier they survive rebuilds, so the permission popups are answered once
+# and never come back. Fall back to an ad-hoc signature when the identity is absent - the binary
+# still runs, but every rebuild then re-triggers the privacy popups.
 xattr -cr "$DEST_PATH" 2>/dev/null || true
-codesign --force --sign - "$DEST_PATH"
+SIGN_IDENTITY="CC Director Local Signing"
+if security find-identity -v -p codesigning 2>/dev/null | grep -q "$SIGN_IDENTITY"; then
+    codesign --force --sign "$SIGN_IDENTITY" --identifier "com.devthrottle.$EXE_NAME" "$DEST_PATH"
+    echo "  Signed with '$SIGN_IDENTITY' (macOS privacy grants survive rebuilds)"
+else
+    codesign --force --sign - "$DEST_PATH"
+    echo "  WARNING: ad-hoc signed - macOS privacy popups will return after every rebuild."
+    echo "           Fix once with: scripts/local-build/mac/make-signing-certificate.sh"
+fi
 
 EXE_SIZE_MB="$(echo "scale=1; $(stat -f%z "$DEST_PATH") / 1048576" | bc)"
 echo ""

--- a/scripts/local-build/mac/make-app-bundle.sh
+++ b/scripts/local-build/mac/make-app-bundle.sh
@@ -12,7 +12,8 @@
 #
 # Targets:
 #   main         -> "CC Director.app"   <- cc-director-mac-main   (your stable copy)
-#   1|2|3|4      -> "CC Director N.app" <- cc-director-macN       (dev test slots)
+#   1|2|3|4      -> "CC Director N.app" <- cc-director-macN       (normal-work slots)
+#   5            -> "CC Director 5.app" <- cc-director-mac5       (testing slot)
 #
 # Each target gets a distinct CFBundleIdentifier so macOS treats them as separate
 # apps (own Dock tile, own Spotlight entry, can run side by side). The bundle's
@@ -75,13 +76,13 @@ case "$TARGET" in
         BIN="cc-director-mac-main"
         BID="com.devthrottle.ccdirector"
         REBUILD="scripts/mac-rebuild.sh main" ;;
-    1|2|3|4)
+    1|2|3|4|5)
         APP_NAME="CC Director $TARGET"
         BIN="cc-director-mac$TARGET"
         BID="com.devthrottle.ccdirector.slot$TARGET"
         REBUILD="scripts/mac-rebuild.sh $TARGET" ;;
     *)
-        echo "ERROR: invalid --target '$TARGET' (use: main|1|2|3|4)" >&2; exit 1 ;;
+        echo "ERROR: invalid --target '$TARGET' (use: main|1|2|3|4|5)" >&2; exit 1 ;;
 esac
 
 BIN_PATH="$BIN_DIR/$BIN"

--- a/scripts/local-build/mac/make-signing-certificate.sh
+++ b/scripts/local-build/mac/make-signing-certificate.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# make-signing-certificate.sh — One-time setup: create a stable local
+# code-signing certificate for CC Director builds on this Mac.
+#
+# Why this exists: macOS privacy permissions (the popups like
+# "cc-director-mac3 would like to access files in your Desktop folder", and
+# Full Disk Access grants) are keyed to the code signature of the binary.
+# Our builds were ad-hoc signed, and an ad-hoc signature is just a hash of
+# the binary — it changes on EVERY rebuild. So macOS forgot every "Allow"
+# click at the next build and asked again, which stalls unattended Directors.
+#
+# This script creates a self-signed certificate named "CC Director Local
+# Signing" in your login keychain and trusts it for code signing. Once it
+# exists, scripts/local-build-mac.sh signs every slot binary with it (with a
+# stable identifier per slot), so privacy grants survive rebuilds.
+#
+# Run it once per Mac. Re-running is safe (idempotent). The trust step needs
+# an administrator password.
+#
+# After this script succeeds, rebuild the slots (only the ones whose Director
+# is not running), then either:
+#   • click "Allow" once per slot the next time a popup appears — it now
+#     sticks across rebuilds, or
+#   • grant the slot binaries Full Disk Access once in System Settings →
+#     Privacy & Security → Full Disk Access (press the plus button, then
+#     Command+Shift+G, go to <repo>/local_builds/mac, add each cc-director-mac
+#     binary). Full Disk Access covers Desktop, Documents and Downloads with
+#     no popups at all.
+#
+set -euo pipefail
+
+IDENTITY_NAME="CC Director Local Signing"
+KEYCHAIN="$HOME/Library/Keychains/login.keychain-db"
+
+# Already present and valid for code signing? Nothing to do.
+if security find-identity -v -p codesigning 2>/dev/null | grep -q "$IDENTITY_NAME"; then
+    echo "Signing identity '$IDENTITY_NAME' already exists and is valid. Nothing to do."
+    exit 0
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+CERT_PEM="$TMP/certificate.pem"
+
+if security find-certificate -c "$IDENTITY_NAME" >/dev/null 2>&1; then
+    # Created on an earlier run but the trust step did not complete — export
+    # the existing certificate so we can (re)trust it below.
+    echo "Certificate already in the keychain, but not yet trusted for code signing."
+    security find-certificate -c "$IDENTITY_NAME" -p > "$CERT_PEM"
+else
+    echo "Creating certificate '$IDENTITY_NAME' (valid 10 years)..."
+    # Use the system LibreSSL explicitly: a Homebrew OpenSSL 3 on the PATH
+    # exports PKCS12 files in a newer format that `security import` rejects
+    # ("MAC verification failed"). A configuration file (instead of
+    # command-line extension flags) keeps the request portable too.
+    OPENSSL="/usr/bin/openssl"
+    cat > "$TMP/openssl.cnf" <<CNF
+[req]
+distinguished_name = dn
+x509_extensions = ext
+prompt = no
+[dn]
+CN = $IDENTITY_NAME
+[ext]
+keyUsage = critical, digitalSignature
+extendedKeyUsage = critical, codeSigning
+basicConstraints = critical, CA:false
+CNF
+    "$OPENSSL" req -x509 -newkey rsa:2048 -sha256 -days 3650 -nodes \
+        -config "$TMP/openssl.cnf" \
+        -keyout "$TMP/key.pem" -out "$CERT_PEM" 2>/dev/null
+
+    "$OPENSSL" pkcs12 -export -inkey "$TMP/key.pem" -in "$CERT_PEM" \
+        -name "$IDENTITY_NAME" -out "$TMP/identity.p12" -passout pass:ccdirector
+
+    # -A lets any application use this key without a per-use keychain prompt.
+    # That is acceptable here: this is a machine-local development signing key
+    # with no value outside this Mac, not a real Apple identity.
+    security import "$TMP/identity.p12" -k "$KEYCHAIN" -P ccdirector -A
+    echo "Imported into the login keychain."
+fi
+
+# Trust the certificate for code signing. This writes to the system trust
+# store, so it needs administrator rights.
+if sudo -n true 2>/dev/null || [[ -t 0 ]]; then
+    echo "Trusting the certificate for code signing (your administrator password may be requested)..."
+    sudo security add-trusted-cert -d -r trustRoot -p codeSign \
+        -k /Library/Keychains/System.keychain "$CERT_PEM"
+else
+    # No terminal to ask for the password (for example when run by an agent).
+    # Leave the certificate behind and tell the human exactly what to run.
+    CERT_COPY="$HOME/.cc-director-signing-certificate.pem"
+    cp "$CERT_PEM" "$CERT_COPY"
+    echo ""
+    echo "The certificate is created, but trusting it needs an administrator"
+    echo "password, which cannot be asked for here. Run this yourself:"
+    echo ""
+    echo "  sudo security add-trusted-cert -d -r trustRoot -p codeSign -k /Library/Keychains/System.keychain \"$CERT_COPY\""
+    echo ""
+    echo "then re-run this script to confirm, and delete $CERT_COPY."
+    exit 2
+fi
+
+if security find-identity -v -p codesigning 2>/dev/null | grep -q "$IDENTITY_NAME"; then
+    echo ""
+    echo "Done. '$IDENTITY_NAME' is ready."
+    echo "Rebuild each slot (only while its Director is NOT running) with"
+    echo "scripts/mac-rebuild.sh — from then on macOS privacy grants stick."
+else
+    echo "ERROR: the identity is still not valid for code signing after the trust step." >&2
+    exit 1
+fi

--- a/scripts/mac-rebuild.sh
+++ b/scripts/mac-rebuild.sh
@@ -8,9 +8,10 @@
 #
 # Targets:
 #   main        Build the stable copy -> "CC Director.app", pinned to the Dock.
-#   1|2|3|4     Build a dev test slot -> "CC Director N.app" (run several at once).
-#   all         Build main + all four slots.
-#   apps        (Re)create all five .app bundles WITHOUT building — fast, used by
+#   1|2|3|4     Build a normal-work slot -> "CC Director N.app" (run several at once).
+#   5           Build the testing slot -> "CC Director 5.app" (started and stopped freely).
+#   all         Build main + slots 1 through 5.
+#   apps        (Re)create all six .app bundles WITHOUT building — fast, used by
 #               mac-setup.sh to lay down the icons before anything is built.
 #
 # Usage:
@@ -25,7 +26,7 @@ set -euo pipefail
 
 TARGET="${1:-}"
 if [[ -z "$TARGET" ]]; then
-    echo "Usage: scripts/mac-rebuild.sh <main|1|2|3|4|all|apps>" >&2
+    echo "Usage: scripts/mac-rebuild.sh <main|1|2|3|4|5|all|apps>" >&2
     exit 1
 fi
 
@@ -79,16 +80,16 @@ case "$TARGET" in
     main)
         build_one main
         pin_dock ;;
-    1|2|3|4)
+    1|2|3|4|5)
         build_one "$TARGET"
         echo "Open it from Launchpad/Spotlight, or: open \"$APPS_DIR/CC Director $TARGET.app\"" ;;
     all)
         build_one main
-        for n in 1 2 3 4; do build_one "$n"; done
+        for n in 1 2 3 4 5; do build_one "$n"; done
         pin_dock ;;
     apps)
-        for t in main 1 2 3 4; do "$MAC_HELPERS/make-app-bundle.sh" --target "$t"; done ;;
+        for t in main 1 2 3 4 5; do "$MAC_HELPERS/make-app-bundle.sh" --target "$t"; done ;;
     *)
-        echo "ERROR: invalid target '$TARGET' (use: main|1|2|3|4|all|apps)" >&2
+        echo "ERROR: invalid target '$TARGET' (use: main|1|2|3|4|5|all|apps)" >&2
         exit 1 ;;
 esac

--- a/scripts/mac-setup.sh
+++ b/scripts/mac-setup.sh
@@ -4,8 +4,9 @@
 #
 # After this runs you'll have:
 #   • "CC Director" — your stable copy, in /Applications AND pinned to the Dock.
-#   • "CC Director 1".."CC Director 4" — dev test slots, in /Applications
-#     (find them in Launchpad or Spotlight). Build a slot when you want to test.
+#   • "CC Director 1".."CC Director 4" — normal-work slots, in /Applications
+#     (find them in Launchpad or Spotlight).
+#   • "CC Director 5" — the testing slot, started and stopped freely.
 #
 # Re-running is safe (idempotent). Requires the .NET 10 SDK (see scripts/local-build/mac/README.md).
 #
@@ -18,9 +19,16 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # bundle id and would confuse LaunchServices/Dock about which app to open.
 rm -rf "$REPO_ROOT/local_builds/mac/CC Director.app"
 
-echo "Setting up CC Director apps (1 main + 4 test slots)..."
+echo "Setting up CC Director apps (1 main + 5 slots)..."
 
-# 1) Lay down all five app icons first (instant; slots have no binary yet).
+# 0) Create and trust the stable local code-signing certificate (idempotent;
+#    may ask for your administrator password). Without it every rebuild
+#    re-triggers the macOS privacy popups ("... would like to access files in
+#    your Desktop folder"), which stall unattended Directors.
+"$SCRIPT_DIR/local-build/mac/make-signing-certificate.sh" || \
+    echo "WARNING: signing certificate not set up - privacy popups will return after every rebuild."
+
+# 1) Lay down all six app icons first (instant; slots have no binary yet).
 "$SCRIPT_DIR/mac-rebuild.sh" apps
 
 # 2) Build the main copy and pin it to the Dock.
@@ -33,9 +41,10 @@ cat <<'EOF'
   • "CC Director" is now in your Dock (bottom toolbar) and in /Applications.
     Click the Dock icon any time — this is your everyday copy.
 
-  • Test slots "CC Director 1" … "CC Director 4" are in /Applications.
-    Find them with Spotlight (press Cmd+Space, type "CC Director 2") or in
-    Launchpad. They aren't built yet — clicking one tells you how to build it.
+  • Slots "CC Director 1" … "CC Director 4" (normal work) and "CC Director 5"
+    (testing) are in /Applications. Find them with Spotlight (press Cmd+Space,
+    type "CC Director 2") or in Launchpad. A slot that isn't built yet tells
+    you how to build it when you click it.
 
 Everyday commands (run from the repo root):
 
@@ -44,4 +53,10 @@ Everyday commands (run from the repo root):
     scripts/mac-rebuild.sh all      # rebuild everything
 
 Each app launches under launchd, so the Terminal/Wingman tabs work correctly.
+
+To stop the macOS privacy popups from ever interrupting unattended work, grant
+the slot binaries Full Disk Access once: System Settings → Privacy & Security →
+Full Disk Access → press the plus button → press Command+Shift+G → go to
+<repo>/local_builds/mac → add each cc-director-mac binary. Thanks to the
+signing certificate created above, that grant survives rebuilds.
 EOF


### PR DESCRIPTION
Create a stable self-signed certificate ("CC Director Local Signing") and sign slot binaries with it so macOS privacy grants survive rebuilds instead of re-prompting after every build. Add slot 5 as the agents' testing slot to the Mac build and bundle scripts. Record the CC Launcher mission brief, the Mac tunnel and mutual-update design, and the mutual-update research findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)