### PR TITLE
feat(carmode): hands-free "over and out" + Cockpit Car Mode settings tab

### DIFF
--- a/apps/cockpit/src/settings/SettingsView.tsx
+++ b/apps/cockpit/src/settings/SettingsView.tsx
@@ -15,6 +15,7 @@ import {
   getAiModels,
   getAiProvider,
   setCarModeModel,
+  setCarModeEndPhrase,
   setWingmanFastModel,
   setTtsModel,
   setTtsVoice,
@@ -23,6 +24,11 @@ import {
   ttsSample,
 } from "@devthrottle/client-core/api/ai";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
+import { MicRecorder } from "@devthrottle/client-core/dictation/recorder";
+import { blobToWav16kMono } from "@devthrottle/client-core/dictation/wav";
+import { transcribeCarModeAudio } from "@devthrottle/client-core/carmode/carModeApi";
+import { playReadyCue, primeCueAudio, releaseCueAudio } from "@devthrottle/client-core/dictation/readyCue";
+import { detectPhraseAtEnd } from "@devthrottle/client-core/carmode/controlPhrases";
 import {
   disablePush,
   enablePush,
@@ -44,7 +50,7 @@ import {
 
 const SAMPLE_TEXT = "Hi, I'm your DevThrottle wingman. This is how I'll sound.";
 
-type TabId = "machine" | "ai";
+type TabId = "machine" | "ai" | "carmode";
 
 export function SettingsView() {
   const [tab, setTab] = useState<TabId>("machine");
@@ -80,9 +86,18 @@ export function SettingsView() {
         >
           AI
         </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === "carmode"}
+          className={tab === "carmode" ? "settings-tab active" : "settings-tab"}
+          onClick={() => setTab("carmode")}
+        >
+          Car Mode
+        </button>
       </div>
 
-      {tab === "machine" ? <ThisMachineTab /> : <AiTab />}
+      {tab === "machine" ? <ThisMachineTab /> : tab === "ai" ? <AiTab /> : <CarModeTab />}
     </div>
   );
 }
@@ -514,20 +529,6 @@ function AiTab() {
     }
   };
 
-  const chooseCarMode = async (model: string) => {
-    setBusy(true);
-    setMsg("Saving...");
-    try {
-      await setCarModeModel(model);
-      setSnap({ ...snap, carModeModel: model });
-      setMsg("Car Mode model set.");
-    } catch (e) {
-      setMsg(errText(e));
-    } finally {
-      setBusy(false);
-    }
-  };
-
   const runFastTest = async () => {
     setBusy(true);
     setFastTestMsg("Testing " + snap.wingmanFastModel + "...");
@@ -660,28 +661,6 @@ function AiTab() {
       </div>
 
       <div className="settings-field">
-        <label htmlFor="settings-ai-carmode-model">Car Mode model</label>
-        <select
-          id="settings-ai-carmode-model"
-          className="settings-select"
-          value={snap.carModeModel}
-          disabled={busy}
-          onChange={(e) => void chooseCarMode(e.target.value)}
-        >
-          {ensureIds(snap.carModeModel, chatModels).map((id) => (
-            <option key={id} value={id}>
-              {id}
-            </option>
-          ))}
-        </select>
-        <div className="settings-actions">
-          <span className="settings-inline-msg">
-            Hands-free fleet control from the phone. A fast model is recommended; GLM-5.2 is slower but a strong tool-caller.
-          </span>
-        </div>
-      </div>
-
-      <div className="settings-field">
         <label htmlFor="settings-ai-ttsmodel">Speech model</label>
         <select
           id="settings-ai-ttsmodel"
@@ -729,6 +708,265 @@ function AiTab() {
 
       {msg !== "" && <div className="settings-msg">{msg}</div>}
     </section>
+  );
+}
+
+// ---- "Car Mode" tab: the phone's hands-free fleet control in one place (owner's ask) - its model, its
+// sign-off phrase, and a live phrase tester. The phrase is a Gateway setting (setCarModeEndPhrase) so what
+// is set here reaches the phone where Car Mode runs.
+function CarModeTab() {
+  const [snap, setSnap] = useState<AiProviderSnapshot | null>(null);
+  const [chatModels, setChatModels] = useState<AiModel[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState("");
+  const [phraseDraft, setPhraseDraft] = useState("");
+
+  const load = useCallback(async () => {
+    try {
+      setError(null);
+      const s = await getAiProvider();
+      setSnap(s);
+      setPhraseDraft(s.carModeEndPhrase);
+      setChatModels(await getAiModels("chat"));
+    } catch (e) {
+      setError(errText(e));
+    }
+  }, []);
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (error !== null) {
+    return <div className="settings-error">Could not load Car Mode settings: {error}</div>;
+  }
+  if (snap === null) {
+    return <p className="settings-loading">Loading...</p>;
+  }
+
+  const chooseModel = async (model: string) => {
+    setBusy(true);
+    setMsg("Saving...");
+    try {
+      await setCarModeModel(model);
+      setSnap({ ...snap, carModeModel: model });
+      setMsg("Car Mode model set.");
+    } catch (e) {
+      setMsg(errText(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const savePhrase = async () => {
+    setBusy(true);
+    setMsg("Saving...");
+    try {
+      const { phrase } = await setCarModeEndPhrase(phraseDraft);
+      setSnap({ ...snap, carModeEndPhrase: phrase });
+      setPhraseDraft(phrase);
+      setMsg(`End phrase set to "${phrase}". Applies to the next Car Mode turn, on every device.`);
+    } catch (e) {
+      setMsg(errText(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="settings-card">
+      <h2 className="settings-h2">Car Mode</h2>
+      <p className="settings-hint">
+        Hands-free fleet control from your phone. Set the model it thinks with, the phrase that ends your
+        turn, and test that the phrase is heard reliably - all in one place.
+      </p>
+
+      <div className="settings-field">
+        <label htmlFor="settings-carmode-model">Model</label>
+        <select
+          id="settings-carmode-model"
+          className="settings-select"
+          value={snap.carModeModel}
+          disabled={busy}
+          onChange={(e) => void chooseModel(e.target.value)}
+        >
+          {ensureIds(snap.carModeModel, chatModels).map((id) => (
+            <option key={id} value={id}>
+              {id}
+            </option>
+          ))}
+        </select>
+        <div className="settings-actions">
+          <span className="settings-inline-msg">
+            A fast model is recommended - it must also call tools reliably. GLM-5.2 is slower but a strong
+            tool-caller.
+          </span>
+        </div>
+      </div>
+
+      <div className="settings-field">
+        <label htmlFor="settings-carmode-phrase">End phrase (say this to finish your turn)</label>
+        <input
+          id="settings-carmode-phrase"
+          className="settings-input"
+          type="text"
+          value={phraseDraft}
+          disabled={busy}
+          autoCapitalize="none"
+          autoCorrect="off"
+          placeholder="over and out"
+          onChange={(e) => setPhraseDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") void savePhrase();
+          }}
+        />
+        <button type="button" className="settings-btn" disabled={busy} onClick={() => void savePhrase()}>
+          Save
+        </button>
+      </div>
+
+      <PhraseTester phrase={phraseDraft || snap.carModeEndPhrase} />
+
+      {msg !== "" && <div className="settings-msg">{msg}</div>}
+    </section>
+  );
+}
+
+// The live phrase tester: the same detection Car Mode uses (rolling transcription through the Gateway ~once
+// a second, fire when the transcript ends with the phrase), so the owner can confirm a phrase is heard
+// reliably before he relies on it on the road. Uses the shared cue audio so the "heard it" beep sounds.
+function PhraseTester({ phrase }: { phrase: string }) {
+  const [listening, setListening] = useState(false);
+  const [status, setStatus] = useState("Tap Test, speak, and finish with your phrase.");
+  const [result, setResult] = useState<{ latencyMs: number; command: string } | null>(null);
+  const [log, setLog] = useState<{ atMs: number; transcript: string; matched: boolean; transcribeMs: number }[]>([]);
+
+  const recorderRef = useRef<MicRecorder | null>(null);
+  const pollRef = useRef<number | null>(null);
+  const levelRef = useRef<number | null>(null);
+  const busyRef = useRef(false);
+  const listeningRef = useRef(false);
+  const startAtRef = useRef(0);
+  const lastLoudRef = useRef(0);
+  const phraseRef = useRef(phrase);
+  phraseRef.current = phrase;
+
+  const stopTest = useCallback(async () => {
+    listeningRef.current = false;
+    setListening(false);
+    if (pollRef.current !== null) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+    if (levelRef.current !== null) {
+      clearInterval(levelRef.current);
+      levelRef.current = null;
+    }
+    releaseCueAudio();
+    const rec = recorderRef.current;
+    recorderRef.current = null;
+    if (rec && rec.isRecording) {
+      try {
+        await rec.stop();
+      } catch {
+        /* tearing down */
+      }
+    }
+  }, []);
+
+  const poll = useCallback(async () => {
+    if (busyRef.current || !listeningRef.current) return;
+    const rec = recorderRef.current;
+    if (rec === null) return;
+    busyRef.current = true;
+    try {
+      const clip = rec.snapshot();
+      if (clip.size < 2000) return;
+      const t0 = performance.now();
+      const { wav } = await blobToWav16kMono(clip);
+      const heard = (await transcribeCarModeAudio(wav)).trim();
+      const transcribeMs = Math.round(performance.now() - t0);
+      if (!listeningRef.current) return;
+      const det = detectPhraseAtEnd(heard, phraseRef.current);
+      setLog((p) =>
+        [{ atMs: Math.round(performance.now() - startAtRef.current), transcript: heard, matched: det.ended, transcribeMs }, ...p].slice(0, 12),
+      );
+      if (det.ended) {
+        playReadyCue();
+        const latencyMs = Math.max(0, Math.round(performance.now() - lastLoudRef.current));
+        setResult({ latencyMs, command: det.command });
+        setStatus(`Heard "${phraseRef.current}" - ${latencyMs} ms after you stopped speaking.`);
+        void stopTest();
+      }
+    } catch (e) {
+      setStatus("Transcription error: " + errText(e));
+    } finally {
+      busyRef.current = false;
+    }
+  }, [stopTest]);
+
+  const startTest = useCallback(async () => {
+    if (listeningRef.current) return;
+    if (!phraseRef.current.trim()) {
+      setStatus("Set an end phrase first.");
+      return;
+    }
+    setResult(null);
+    setLog([]);
+    setStatus("Opening the microphone...");
+    const rec = new MicRecorder();
+    try {
+      await rec.start();
+    } catch (e) {
+      setStatus("Could not open the microphone: " + errText(e));
+      return;
+    }
+    recorderRef.current = rec;
+    listeningRef.current = true;
+    setListening(true);
+    primeCueAudio();
+    const now = performance.now();
+    startAtRef.current = now;
+    lastLoudRef.current = now;
+    setStatus(`Listening. Speak, then say "${phraseRef.current}".`);
+    levelRef.current = window.setInterval(() => {
+      const l = recorderRef.current?.level() ?? 0;
+      if (l > 0.06) lastLoudRef.current = performance.now();
+    }, 100);
+    pollRef.current = window.setInterval(() => void poll(), 800);
+  }, [poll]);
+
+  useEffect(() => () => void stopTest(), [stopTest]);
+
+  return (
+    <div className="settings-field" style={{ display: "block" }}>
+      <label>Test the phrase</label>
+      <p className="settings-hint">
+        Same detection Car Mode uses: it transcribes what you say about once a second and fires the instant
+        your words end with the phrase.
+      </p>
+      <div className="settings-actions">
+        <button type="button" className="settings-btn" onClick={() => (listening ? void stopTest() : void startTest())}>
+          {listening ? "Stop test" : "Test"}
+        </button>
+        <span className="settings-inline-msg">{status}</span>
+      </div>
+      {result && (
+        <div className="settings-msg">
+          DETECTED - fired {result.latencyMs} ms after you stopped speaking; command heard:{" "}
+          &quot;{result.command || "(none)"}&quot;
+        </div>
+      )}
+      {log.length > 0 && (
+        <div style={{ marginTop: 8, fontFamily: "ui-monospace, monospace", fontSize: 12 }}>
+          {log.map((e, i) => (
+            <div key={i} style={{ color: e.matched ? "#0a7d28" : "#666" }}>
+              {(e.atMs / 1000).toFixed(1)}s {e.transcribeMs}ms {e.matched ? "[MATCH]" : "[  -  ]"} &quot;{e.transcript}&quot;
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/apps/cockpit/src/settings/SettingsView.tsx
+++ b/apps/cockpit/src/settings/SettingsView.tsx
@@ -939,29 +939,32 @@ function PhraseTester({ phrase }: { phrase: string }) {
   useEffect(() => () => void stopTest(), [stopTest]);
 
   return (
-    <div className="settings-field" style={{ display: "block" }}>
-      <label>Test the phrase</label>
-      <p className="settings-hint">
-        Same detection Car Mode uses: it transcribes what you say about once a second and fires the instant
-        your words end with the phrase.
-      </p>
-      <div className="settings-actions">
-        <button type="button" className="settings-btn" onClick={() => (listening ? void stopTest() : void startTest())}>
-          {listening ? "Stop test" : "Test"}
-        </button>
-        <span className="settings-inline-msg">{status}</span>
-      </div>
+    <div className="carmode-tester">
+      <span className="carmode-tester-title">Test your phrase</span>
+      <span className="carmode-tester-sub">
+        Speak a command, then finish with your phrase. It uses the exact detection Car Mode uses and catches
+        the phrase in about a second.
+      </span>
+      <button
+        type="button"
+        className={"settings-btn primary carmode-test-btn" + (listening ? " listening" : "")}
+        onClick={() => (listening ? void stopTest() : void startTest())}
+      >
+        {listening ? "Listening - say your phrase, then Stop" : "Test the phrase"}
+      </button>
+      <div className="carmode-tester-status">{status}</div>
       {result && (
-        <div className="settings-msg">
-          DETECTED - fired {result.latencyMs} ms after you stopped speaking; command heard:{" "}
-          &quot;{result.command || "(none)"}&quot;
+        <div className="carmode-result">
+          <span className="carmode-result-badge">Heard it</span>
+          Fired {result.latencyMs} ms after you stopped speaking. Command heard: &quot;{result.command || "(none)"}&quot;
         </div>
       )}
       {log.length > 0 && (
-        <div style={{ marginTop: 8, fontFamily: "ui-monospace, monospace", fontSize: 12 }}>
+        <div className="carmode-log">
           {log.map((e, i) => (
-            <div key={i} style={{ color: e.matched ? "#0a7d28" : "#666" }}>
-              {(e.atMs / 1000).toFixed(1)}s {e.transcribeMs}ms {e.matched ? "[MATCH]" : "[  -  ]"} &quot;{e.transcript}&quot;
+            <div key={i} className={"carmode-log-row" + (e.matched ? " match" : "")}>
+              {(e.atMs / 1000).toFixed(1)}s - {e.transcribeMs}ms - {e.matched ? "MATCH" : "listening"} - &quot;
+              {e.transcript}&quot;
             </div>
           ))}
         </div>

--- a/apps/cockpit/src/settings/settings.css
+++ b/apps/cockpit/src/settings/settings.css
@@ -326,3 +326,91 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* ---- Car Mode phrase tester: a distinct, attention-drawing card with a prominent Test button ---- */
+.carmode-tester {
+  margin-top: 16px;
+  padding: 16px 18px;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 10px;
+  background: rgba(0, 122, 204, 0.06);
+}
+.carmode-tester-title {
+  display: block;
+  font-weight: 600;
+  color: var(--text);
+  font-size: 14px;
+}
+.carmode-tester-sub {
+  display: block;
+  color: var(--text-dim);
+  font-size: 12.5px;
+  margin: 3px 0 14px;
+}
+/* The Test button: deliberately the loudest control on the tab - big, accent-filled, and it pulses while
+   listening so the eye lands on it (Soren's ask to draw more attention to the Test button). */
+.carmode-test-btn {
+  font-size: 15px;
+  padding: 12px 24px;
+  border-radius: 9px;
+}
+.carmode-test-btn.listening {
+  background: #ef4444;
+  border-color: #ef4444;
+  animation: carmode-pulse 1.25s ease-in-out infinite;
+}
+.carmode-test-btn.listening:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+@keyframes carmode-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.55);
+  }
+  50% {
+    box-shadow: 0 0 0 9px rgba(239, 68, 68, 0);
+  }
+}
+.carmode-tester-status {
+  margin-top: 11px;
+  color: var(--text-dim);
+  font-size: 13px;
+  min-height: 18px;
+}
+.carmode-result {
+  margin-top: 12px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  background: #1b3a2a;
+  color: #d7f5e3;
+  font-size: 13.5px;
+  line-height: 1.5;
+}
+.carmode-result-badge {
+  display: inline-block;
+  background: #22c55e;
+  color: #06240f;
+  font-weight: 700;
+  font-size: 10.5px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 5px;
+  margin-right: 9px;
+}
+.carmode-log {
+  margin-top: 12px;
+  font-family: ui-monospace, "Cascadia Code", monospace;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.carmode-log-row {
+  padding: 2px 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.carmode-log-row.match {
+  color: #22c55e;
+}

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -8,6 +8,7 @@ import { Chat } from "./pages/Chat";
 import { FileView } from "./pages/FileView";
 import { VoiceMode } from "./pages/VoiceMode";
 import { CarMode } from "./pages/CarMode";
+import { EndWordTest } from "./pages/EndWordTest";
 import { AiSettings } from "./pages/AiSettings";
 import { About } from "./pages/About";
 import { YourThrottle } from "./pages/YourThrottle";
@@ -110,6 +111,10 @@ const router = createBrowserRouter(
             // Car Mode (Car Mode mission): its own chrome-less, full-screen route, NOT nested in any
             // tabbed session view. Hands-free voice control of the whole fleet with a screen wake-lock.
             { path: "/car", element: <CarMode /> },
+            // Car Mode End Word Test (harness for the spoken end-of-turn phrase): set a configurable
+            // phrase and test detecting it live. Standalone for now; folds into the Cockpit Car Mode
+            // settings tab once the approach is proven.
+            { path: "/endword", element: <EndWordTest /> },
             { path: "/settings", element: <AiSettings /> },
             { path: "/about", element: <About /> },
             // Your Throttle (devthrottle-stats mission): the in-app port of the standalone Gateway

--- a/apps/mobile/src/pages/CarMode.tsx
+++ b/apps/mobile/src/pages/CarMode.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { useCarMode, type CarModeReply } from "@devthrottle/client-core/carmode/useCarMode";
 import { carModeTurn } from "@devthrottle/client-core/carmode/carModeApi";
+import { getAiProvider } from "@devthrottle/client-core/api/ai";
 import { useScreenWakeLock } from "../hooks/useScreenWakeLock";
 
 // The Car Mode page version, shown small in the header corner so the owner can confirm at a glance he is
@@ -9,7 +10,7 @@ import { useScreenWakeLock } from "../hooks/useScreenWakeLock";
 // the old git short-sha + timestamp badge was replaced by a plain human version. BUMP THIS INTEGER BY HAND
 // ON EVERY DEPLOY of the mobile app (v1 -> v2 -> v3 ...), so a glance at the corner tells the owner and the
 // Architect exactly which page is live and what to look for after a deploy.
-const CAR_MODE_VERSION = "v5";
+const CAR_MODE_VERSION = "v8";
 
 // Car Mode (Car Mode mission): the standalone, chrome-less, full-screen page the owner opens to run
 // the whole fleet by voice, hands-free, phone in his pocket. It is a THIN view over the shared
@@ -78,6 +79,26 @@ export function CarMode() {
     return { spoken: `You said: ${command}. Go ahead when you're ready.` };
   }, []);
 
+  // The owner's configured hands-free sign-off phrase (set in the Cockpit "Car Mode" settings tab, a Gateway
+  // setting so it reaches this phone). Start from the cached value for an instant, offline-safe default, then
+  // sync the authoritative value from the Gateway. Default "over and out".
+  const [endPhrase, setEndPhrase] = useState(() => localStorage.getItem("carmode.endphrase") || "over and out");
+  useEffect(() => {
+    let cancelled = false;
+    void getAiProvider()
+      .then((p) => {
+        if (cancelled || !p.carModeEndPhrase) return;
+        setEndPhrase(p.carModeEndPhrase);
+        localStorage.setItem("carmode.endphrase", p.carModeEndPhrase);
+      })
+      .catch(() => {
+        // Offline or Gateway unreachable: keep the cached phrase so Car Mode still ends turns.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const {
     phase,
     started,
@@ -92,7 +113,7 @@ export function CarMode() {
     interrupt,
     start,
     stop,
-  } = useCarMode({ respond });
+  } = useCarMode({ respond, endPhrase });
 
   const statusText = phaseStatus(phase);
 
@@ -134,6 +155,17 @@ export function CarMode() {
           <p className="car-status" aria-live="polite">
             {started ? statusText : "Tap Start, then just talk."}
           </p>
+
+          {/* A small link to the End Word Test harness so the owner can reach it without remembering the
+              URL (his ask). Shown only on the idle screen; it is a tuning tool, not part of a live turn. */}
+          {!started && (
+            <Link
+              to="/endword"
+              style={{ marginTop: 16, fontSize: 14, color: "#8ab4f8", textDecoration: "underline" }}
+            >
+              Open the End Word Test
+            </Link>
+          )}
 
           {/* Live microphone level meter (Architect direction): visibly shows the owner his voice is being
               picked up. Reads the capture stream's AnalyserNode via getMicLevel on an animation frame. It
@@ -179,7 +211,7 @@ export function CarMode() {
         ) : (
           <>
             <p className="car-hint">
-              Talk, then tap <strong>Over and out</strong> to send. Tap <strong>Stop</strong> to cut me off.
+              Talk, then say (or tap) <strong>Over and out</strong> to send. Tap <strong>Stop</strong> to cut me off.
             </p>
             {/* Touch equivalents of the two spoken control phrases (Architect direction: the app must be
                 fully usable by touch, so testing is never blocked by the spoken "over and out"). Each

--- a/apps/mobile/src/pages/EndWordTest.tsx
+++ b/apps/mobile/src/pages/EndWordTest.tsx
@@ -1,0 +1,230 @@
+// Car Mode End Word Test - the interactive harness for the spoken end-of-turn phrase (the ending
+// "over and out"). This page is BOTH the test rig and the seed of the eventual Cockpit "Car Mode"
+// settings tab: the owner sets his own end phrase, taps Start, speaks, and sees whether and how fast
+// it is detected. It proves the detection approach and the felt delay on the real phone before any of
+// it is wired into Car Mode's actual turn-ending.
+//
+// The approach under test (recommended by the Architect, proven 9/9 on the real transcription path):
+// during Listening, roughly once a second, transcribe what has been captured so far through the one
+// Gateway speech-to-text front door and fire when the transcript ENDS with the owner's phrase. No
+// finicky silence/endpoint detection - it leans on the reliable transcription. There is no self-trigger
+// risk here because the assistant is silent while the owner is talking.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { MicRecorder } from "@devthrottle/client-core/dictation/recorder";
+import { blobToWav16kMono } from "@devthrottle/client-core/dictation/wav";
+import { transcribeCarModeAudio } from "@devthrottle/client-core/carmode/carModeApi";
+import { playReadyCue } from "@devthrottle/client-core/dictation/readyCue";
+import { detectPhraseAtEnd } from "@devthrottle/client-core/carmode/controlPhrases";
+
+const PHRASE_KEY = "carmode.endphrase";
+const DEFAULT_PHRASE = "over and out";
+const POLL_MS = 1000; // how often the captured audio is re-transcribed while listening
+const LEVEL_MS = 100; // how often the input level is sampled to track when the owner stops speaking
+const LEVEL_SPEAKING = 0.06; // input level above this counts as "still speaking"
+const MIN_CLIP_BYTES = 2000; // skip a transcribe until there is at least this much audio
+
+interface LogEntry {
+  atMs: number; // ms since Start
+  transcript: string;
+  matched: boolean;
+  transcribeMs: number;
+}
+
+interface DetectResult {
+  latencyMs: number; // from when the owner stopped speaking to the fire (the felt delay)
+  command: string;
+  transcript: string;
+}
+
+export function EndWordTest() {
+  const [phrase, setPhrase] = useState<string>(() => localStorage.getItem(PHRASE_KEY) || DEFAULT_PHRASE);
+  const [listening, setListening] = useState(false);
+  const [status, setStatus] = useState("Set your end phrase, then tap Start and speak.");
+  const [transcript, setTranscript] = useState("");
+  const [log, setLog] = useState<LogEntry[]>([]);
+  const [result, setResult] = useState<DetectResult | null>(null);
+  const [level, setLevel] = useState(0);
+
+  const recorderRef = useRef<MicRecorder | null>(null);
+  const pollRef = useRef<number | null>(null);
+  const levelRef = useRef<number | null>(null);
+  const busyRef = useRef(false);
+  const listeningRef = useRef(false);
+  const startAtRef = useRef(0);
+  const lastLoudAtRef = useRef(0);
+  const phraseRef = useRef(phrase);
+  phraseRef.current = phrase;
+
+  useEffect(() => {
+    localStorage.setItem(PHRASE_KEY, phrase);
+  }, [phrase]);
+
+  const clearTimers = useCallback(() => {
+    if (pollRef.current !== null) { clearInterval(pollRef.current); pollRef.current = null; }
+    if (levelRef.current !== null) { clearInterval(levelRef.current); levelRef.current = null; }
+  }, []);
+
+  const stopListening = useCallback(async () => {
+    listeningRef.current = false;
+    setListening(false);
+    clearTimers();
+    const rec = recorderRef.current;
+    recorderRef.current = null;
+    if (rec && rec.isRecording) {
+      try { await rec.stop(); } catch { /* tearing down */ }
+    }
+  }, [clearTimers]);
+
+  const onDetected = useCallback((command: string, heard: string) => {
+    playReadyCue();
+    const latencyMs = Math.max(0, Math.round(performance.now() - lastLoudAtRef.current));
+    setResult({ latencyMs, command, transcript: heard });
+    setStatus(`DETECTED "${phraseRef.current}" - fired ${latencyMs} ms after you stopped speaking.`);
+    void stopListening();
+  }, [stopListening]);
+
+  // One rolling check: transcribe what has been captured so far and test the end phrase.
+  const poll = useCallback(async () => {
+    if (busyRef.current || !listeningRef.current) return;
+    const rec = recorderRef.current;
+    if (rec === null) return;
+    busyRef.current = true;
+    try {
+      const clip = rec.snapshot();
+      if (clip.size < MIN_CLIP_BYTES) return;
+      const t0 = performance.now();
+      const { wav } = await blobToWav16kMono(clip);
+      const heard = (await transcribeCarModeAudio(wav)).trim();
+      const transcribeMs = Math.round(performance.now() - t0);
+      if (!listeningRef.current) return;
+      const det = detectPhraseAtEnd(heard, phraseRef.current);
+      setTranscript(heard);
+      setLog((prev) => [
+        { atMs: Math.round(performance.now() - startAtRef.current), transcript: heard, matched: det.ended, transcribeMs },
+        ...prev,
+      ].slice(0, 20));
+      if (det.ended) onDetected(det.command, heard);
+    } catch (err) {
+      setStatus(`Transcription error: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      busyRef.current = false;
+    }
+  }, [onDetected]);
+
+  const startListening = useCallback(async () => {
+    if (listeningRef.current) return;
+    setResult(null);
+    setLog([]);
+    setTranscript("");
+    setStatus("Opening the microphone...");
+    const rec = new MicRecorder();
+    try {
+      await rec.start();
+    } catch (err) {
+      setStatus(`Could not open the microphone: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+    recorderRef.current = rec;
+    listeningRef.current = true;
+    setListening(true);
+    const now = performance.now();
+    startAtRef.current = now;
+    lastLoudAtRef.current = now;
+    setStatus(`Listening. Speak, and finish with "${phraseRef.current}".`);
+
+    levelRef.current = window.setInterval(() => {
+      const lvl = recorderRef.current?.level() ?? 0;
+      setLevel(lvl);
+      if (lvl > LEVEL_SPEAKING) lastLoudAtRef.current = performance.now();
+    }, LEVEL_MS);
+    pollRef.current = window.setInterval(() => { void poll(); }, POLL_MS);
+  }, [poll]);
+
+  useEffect(() => () => { void stopListening(); }, [stopListening]);
+
+  return (
+    <div style={S.page}>
+      <h1 style={S.h1}>Car Mode - End Word Test</h1>
+      <p style={S.sub}>
+        Set the phrase that ends your turn, tap Start, speak a command, and finish with the phrase. It
+        checks about once a second and fires the moment your words end with the phrase.
+      </p>
+
+      <label style={S.label}>End phrase</label>
+      <input
+        style={S.input}
+        value={phrase}
+        disabled={listening}
+        onChange={(e) => setPhrase(e.target.value)}
+        placeholder="over and out"
+        autoCapitalize="none"
+        autoCorrect="off"
+      />
+
+      <button
+        style={{ ...S.button, ...(listening ? S.buttonStop : S.buttonStart) }}
+        onClick={() => (listening ? void stopListening() : void startListening())}
+      >
+        {listening ? "Stop listening" : "Start listening"}
+      </button>
+
+      {listening && (
+        <div style={S.meterWrap}>
+          <div style={{ ...S.meterFill, width: `${Math.min(100, Math.round(level * 200))}%` }} />
+        </div>
+      )}
+
+      <p style={S.status}>{status}</p>
+
+      {result && (
+        <div style={S.result}>
+          <div style={S.resultTitle}>DETECTED</div>
+          <div>Delay after you stopped speaking: <b>{result.latencyMs} ms</b></div>
+          <div>Command (phrase stripped): <b>{result.command || "(none)"}</b></div>
+          <div style={S.dim}>heard: "{result.transcript}"</div>
+        </div>
+      )}
+
+      {transcript && !result && <p style={S.live}>heard so far: "{transcript}"</p>}
+
+      {log.length > 0 && (
+        <div style={S.logWrap}>
+          <div style={S.label}>Checks (newest first)</div>
+          {log.map((e, i) => (
+            <div key={i} style={{ ...S.logRow, color: e.matched ? "#0a7d28" : "#444" }}>
+              <span style={S.logT}>{(e.atMs / 1000).toFixed(1)}s</span>
+              <span style={S.logMs}>{e.transcribeMs}ms</span>
+              <span style={S.logMatch}>{e.matched ? "[MATCH]" : "[  -  ]"}</span>
+              <span style={S.logText}>"{e.transcript}"</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const S: Record<string, React.CSSProperties> = {
+  page: { minHeight: "100dvh", boxSizing: "border-box", padding: "16px 16px calc(24px + env(safe-area-inset-bottom))", maxWidth: 640, margin: "0 auto", fontFamily: "system-ui, sans-serif" },
+  h1: { fontSize: 20, margin: "4px 0 8px" },
+  sub: { fontSize: 13, color: "#555", margin: "0 0 16px", lineHeight: 1.4 },
+  label: { display: "block", fontSize: 12, textTransform: "uppercase", letterSpacing: 0.5, color: "#666", margin: "12px 0 6px" },
+  input: { width: "100%", boxSizing: "border-box", fontSize: 18, padding: "12px 14px", borderRadius: 10, border: "1px solid #bbb" },
+  button: { width: "100%", boxSizing: "border-box", fontSize: 18, fontWeight: 600, padding: "16px", borderRadius: 12, border: "none", color: "#fff", marginTop: 16, cursor: "pointer" },
+  buttonStart: { background: "#1565c0" },
+  buttonStop: { background: "#c62828" },
+  meterWrap: { height: 8, background: "#e0e0e0", borderRadius: 4, overflow: "hidden", marginTop: 12 },
+  meterFill: { height: "100%", background: "#1565c0", transition: "width 80ms linear" },
+  status: { fontSize: 14, margin: "14px 0", minHeight: 20 },
+  result: { background: "#e8f5e9", border: "1px solid #a5d6a7", borderRadius: 12, padding: 14, fontSize: 15, lineHeight: 1.6 },
+  resultTitle: { fontSize: 18, fontWeight: 700, color: "#0a7d28", marginBottom: 6 },
+  dim: { color: "#666", fontSize: 13, marginTop: 4 },
+  live: { fontSize: 15, color: "#333", fontStyle: "italic" },
+  logWrap: { marginTop: 18 },
+  logRow: { display: "flex", gap: 8, fontSize: 12, fontFamily: "ui-monospace, monospace", padding: "3px 0", borderTop: "1px solid #eee", alignItems: "baseline" },
+  logT: { width: 42, color: "#999", flex: "0 0 auto" },
+  logMs: { width: 52, color: "#999", flex: "0 0 auto" },
+  logMatch: { width: 60, flex: "0 0 auto" },
+  logText: { flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" },
+};

--- a/packages/client-core/src/api/ai.ts
+++ b/packages/client-core/src/api/ai.ts
@@ -13,6 +13,9 @@ export interface AiProviderSnapshot {
   /** The model Car Mode's fleet brain runs on - its OWN setting, separate from the Wingman (Car Mode
    *  runs a fast tier + tool_choice=required). The user's saved choice, or the Qwen2.5-72B default. */
   carModeModel: string;
+  /** Car Mode's hands-free sign-off phrase (default "over and out"). A Gateway setting so the Cockpit can
+   *  set it and the phone, where Car Mode runs, picks it up. */
+  carModeEndPhrase: string;
   transcriptionModel: string;
   ttsModel: string;
   ttsVoice: string;
@@ -98,6 +101,13 @@ export function setWingmanFastModel(model: string): Promise<{ model: string }> {
 // override, then this saved setting, then the Qwen2.5-72B default.
 export function setCarModeModel(model: string): Promise<{ model: string }> {
   return putJson<{ model: string }>("/gateway/ai/car-mode-model", { model });
+}
+
+// PUT /gateway/ai/car-mode-end-phrase { phrase } - persist Car Mode's hands-free sign-off phrase. A blank
+// phrase resets to the "over and out" default (an empty phrase would end every turn). Returns the effective
+// phrase the Gateway stored.
+export function setCarModeEndPhrase(phrase: string): Promise<{ phrase: string }> {
+  return putJson<{ phrase: string }>("/gateway/ai/car-mode-end-phrase", { phrase });
 }
 
 export function setTtsModel(model: string): Promise<{ model: string }> {

--- a/packages/client-core/src/carmode/controlPhrases.test.ts
+++ b/packages/client-core/src/carmode/controlPhrases.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { decideControlAction, detectEndPhrase, detectInterrupt, normalizeTranscript } from "./controlPhrases";
+import { decideControlAction, detectEndPhrase, detectInterrupt, detectPhraseAtEnd, normalizeTranscript } from "./controlPhrases";
 
 // The walkie-talkie discipline is load-bearing: the assistant must never speak until "over and out",
 // and must never mistake a mid-sentence "over" or "stopover" for the end word. These tests pin the
@@ -95,5 +95,34 @@ describe("decideControlAction (the turn-taking decision)", () => {
   it("ignores control words entirely while Thinking (nothing to interrupt, turn committed)", () => {
     expect(decideControlAction("thinking", "over and out")).toBe("none");
     expect(decideControlAction("thinking", "stop")).toBe("none");
+  });
+});
+
+// detectPhraseAtEnd is the configurable end-phrase matcher behind the hands-free end-of-turn watch and the
+// Car Mode settings (the owner chooses his own sign-off phrase). Same trailing-only, whole-phrase rule as
+// detectEndPhrase, but for any phrase.
+describe("detectPhraseAtEnd (configurable end phrase)", () => {
+  it("ends and strips the phrase when the transcript ends with it", () => {
+    expect(detectPhraseAtEnd("start the tests over and out", "over and out")).toEqual({
+      ended: true,
+      command: "start the tests",
+    });
+    expect(detectPhraseAtEnd("read me that one, I'm done.", "i am done")).toEqual({ ended: false, command: "" });
+    expect(detectPhraseAtEnd("read me that one im done", "im done")).toEqual({ ended: true, command: "read me that one" });
+  });
+
+  it("matches a custom phrase the same way (case/punctuation-insensitive, trailing only)", () => {
+    expect(detectPhraseAtEnd("How many need me, GO AHEAD.", "go ahead")).toEqual({ ended: true, command: "how many need me" });
+    expect(detectPhraseAtEnd("go ahead and start it", "go ahead")).toEqual({ ended: false, command: "" }); // mid-sentence
+    expect(detectPhraseAtEnd("go ahead", "go ahead")).toEqual({ ended: true, command: "" }); // whole transcript is the phrase
+  });
+
+  it("never ends on an empty phrase (an unset setting must not end every turn)", () => {
+    expect(detectPhraseAtEnd("anything at all", "")).toEqual({ ended: false, command: "" });
+    expect(detectPhraseAtEnd("anything at all", "   ")).toEqual({ ended: false, command: "" });
+  });
+
+  it("does not fire when the transcript is empty", () => {
+    expect(detectPhraseAtEnd("", "over and out")).toEqual({ ended: false, command: "" });
   });
 });

--- a/packages/client-core/src/carmode/controlPhrases.ts
+++ b/packages/client-core/src/carmode/controlPhrases.ts
@@ -59,6 +59,27 @@ export function detectEndPhrase(rawTranscript: string): EndPhraseResult {
   return { ended: true, command };
 }
 
+/**
+ * The same end-of-turn rule as detectEndPhrase, but for a CONFIGURABLE phrase (the Car Mode end-word
+ * test page and, later, the Car Mode settings tab where the owner chooses his own sign-off phrase). The
+ * phrase must be the trailing token sequence of the normalized transcript - the whole transcript IS the
+ * phrase, or it ends with a word boundary followed by the phrase - so it never fires mid-sentence, and
+ * it is stripped to yield the command. A blank phrase never matches (so an empty setting cannot end
+ * every turn). Both the transcript and the phrase pass through the one normalizer.
+ */
+export function detectPhraseAtEnd(rawTranscript: string, phrase: string): EndPhraseResult {
+  const norm = normalizeTranscript(phrase);
+  if (norm.length === 0) return { ended: false, command: "" };
+  const text = normalizeTranscript(rawTranscript);
+  if (text.length === 0) return { ended: false, command: "" };
+
+  const endsWithPhrase = text === norm || text.endsWith(" " + norm);
+  if (!endsWithPhrase) return { ended: false, command: "" };
+
+  const command = text.slice(0, text.length - norm.length).trim();
+  return { ended: true, command };
+}
+
 /** What the turn-taking machine should do with a live control transcript, given the current phase. */
 export type ControlAction = "end" | "interrupt" | "none";
 

--- a/packages/client-core/src/carmode/useCarMode.ts
+++ b/packages/client-core/src/carmode/useCarMode.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { MicRecorder } from "../dictation/recorder";
 import { blobToWav16kMono } from "../dictation/wav";
-import { playReadyCue, playYourTurnCue, startThinkingCue } from "../dictation/readyCue";
-import { detectEndPhrase } from "./controlPhrases";
+import { playReadyCue, playYourTurnCue, startThinkingCue, primeCueAudio, releaseCueAudio } from "../dictation/readyCue";
+import { detectPhraseAtEnd } from "./controlPhrases";
 import { playClip, type PlayOutcome, type PlayClipHooks } from "./audioPlayback";
 import {
   postCarModeTelemetry,
@@ -23,13 +23,15 @@ import { gatewayErrorMessage } from "../api/client";
 // ducks/reroutes the <audio> output on mobile so it is inaudible. So the hard rule now is: WHILE SPEAKING,
 // NOTHING touches the microphone - the capture stream is fully released and only the <audio> element plays.
 //
-// The two finicky voice paths are DEFERRED in favour of buttons (Soren's directive: one thing at a time):
-//   - Ending a turn is done by the touch "Over and out" BUTTON, which transcribes whatever was captured and
-//     takes the turn. The auto pause-probe that used to listen for a spoken "over and out" is removed (it
-//     took several tries to land). If the owner happens to say "over and out", it is stripped, but it is not
-//     required.
-//   - Interrupting the reply is done by the touch "Stop" BUTTON, the SOLE interrupt. There is no voice
-//     "stop" watch, because that is exactly the mic-during-playback that made the reply inaudible.
+// The two voice control paths differ by whether the assistant is speaking:
+//   - Ending a turn is HANDS-FREE via the spoken sign-off phrase (default "over and out", owner-configurable):
+//     a rolling transcription watch runs during Listening and takes the turn the moment the transcript ends
+//     with the phrase. This replaces the old finicky silence/pause probe by leaning on the reliable
+//     transcription (measured 9/9). The touch "Over and out" BUTTON is the instant fallback. There is no
+//     self-trigger risk because the assistant is silent while the owner talks.
+//   - Interrupting the reply is done by the touch "Stop" BUTTON, the SOLE interrupt. There is deliberately no
+//     voice "stop" watch during playback, because re-opening the mic mid-playback ducks the reply on mobile,
+//     AND the generic on-device keyword model self-triggers on the assistant's own voice (issue #1411).
 //
 // The states, plus a brief Thinking state while the brain works:
 //   Listening - the owner is talking. MicRecorder (one getUserMedia stream) accumulates his audio and its
@@ -149,6 +151,11 @@ export interface CarModeView {
  *  the real POST /carmode/turn call, over the identical turn-taking machine. */
 export interface UseCarModeOptions {
   respond: (command: string, signal: AbortSignal) => Promise<CarModeReply>;
+  /** The spoken sign-off phrase that ends the owner's turn hands-free (default "over and out"). The page
+   *  passes the owner's configured phrase; when the rolling end-phrase watch hears the transcript end with
+   *  it, the turn is taken, exactly as tapping the "Over and out" button does. The button remains the
+   *  instant fallback. */
+  endPhrase?: string;
 }
 
 // How often to send a keep-warm ping WHILE Car Mode is open, so the hosted model + text-to-speech stay hot
@@ -156,6 +163,13 @@ export interface UseCarModeOptions {
 const KEEP_WARM_MS = 3 * 60 * 1000;
 // A snapshot smaller than this is just the container header with no real audio - skip transcribing it.
 const MIN_CLIP_BYTES = 2000;
+// The default hands-free sign-off phrase; the page can override it with the owner's configured phrase.
+const DEFAULT_END_PHRASE = "over and out";
+// How often, while Listening, the captured audio is re-transcribed to check whether it now ends with the
+// sign-off phrase. This replaces the removed silence/endpoint probe: it leans on the reliable transcription
+// (measured 9/9 on "over and out") instead of guessing when the owner paused. The touch button is the
+// instant path; this is the hands-free path, ~1s felt delay after the phrase (owner-accepted).
+const END_PHRASE_POLL_MS = 800;
 
 /** Whether this browser can capture audio for Car Mode. Car Mode is Chromium-first (decision 7); elsewhere
  *  the page tells the owner plainly instead of silently degrading (no fallback, decision 8). */
@@ -197,6 +211,10 @@ function unlockAudioElement(audio: HTMLAudioElement): void {
 
 export function useCarMode(options: UseCarModeOptions): CarModeView {
   const respond = options.respond;
+  // The owner's configured sign-off phrase, mirrored in a ref so the rolling watch's timer callback always
+  // reads the CURRENT phrase (a render prop would be a stale closure inside the interval).
+  const endPhraseRef = useRef(options.endPhrase ?? DEFAULT_END_PHRASE);
+  endPhraseRef.current = options.endPhrase ?? DEFAULT_END_PHRASE;
 
   const [phase, setPhase] = useState<CarModePhase>("idle");
   const [started, setStarted] = useState(false);
@@ -236,6 +254,13 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
   // work is filled with a gentle working tone. Also cleared when the mic returns to the owner or the
   // session ends, so it can never leak past its turn.
   const thinkingCueStopRef = useRef<(() => void) | null>(null);
+
+  // The hands-free end-phrase watch: a rolling transcription timer during Listening. endPollRef holds its
+  // interval id; endPollBusyRef prevents overlapping transcriptions; endTickRef points at the latest tick
+  // so the interval (started from enterListening, defined before the tick) always calls the current one.
+  const endPollRef = useRef<number | null>(null);
+  const endPollBusyRef = useRef(false);
+  const endTickRef = useRef<() => void>(() => {});
 
   // The phase, read synchronously inside the loop/timer callbacks (not a React render). A ref mirror
   // avoids a stale closure so the machine always branches on the CURRENT phase.
@@ -368,6 +393,22 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     }
   }, [announceError]);
 
+  // Stop the hands-free end-phrase watch (idempotent). Called at every exit from Listening.
+  const stopEndPhraseWatch = useCallback(() => {
+    if (endPollRef.current !== null) {
+      clearInterval(endPollRef.current);
+      endPollRef.current = null;
+    }
+    endPollBusyRef.current = false;
+  }, []);
+
+  // Start the hands-free end-phrase watch: a rolling timer that (via endTickRef, set once the tick below is
+  // defined) re-transcribes the captured audio and takes the turn when it ends with the sign-off phrase.
+  const startEndPhraseWatch = useCallback(() => {
+    stopEndPhraseWatch();
+    endPollRef.current = window.setInterval(() => endTickRef.current(), END_PHRASE_POLL_MS);
+  }, [stopEndPhraseWatch]);
+
   // Enter Listening: the microphone is the owner's again. Play the "your turn" cue, clear the on-screen
   // transcript for the fresh turn, and open a clean capture segment (a fresh getUserMedia stream).
   const enterListening = useCallback(async () => {
@@ -382,7 +423,10 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     setCaptureError(null);
     setCaptureState("listening");
     await restartCapture();
-  }, [restartCapture, setPhaseBoth, stopThinkingCue]);
+    // Hands-free: watch for the spoken sign-off phrase for the whole of this Listening turn. The touch
+    // "Over and out" button remains the instant path; this is what makes it work without a tap.
+    startEndPhraseWatch();
+  }, [restartCapture, setPhaseBoth, stopThinkingCue, startEndPhraseWatch]);
 
   // Synthesize `text` through the one good Gateway voice and play the WHOLE reply with the microphone fully
   // RELEASED (v3): nothing touches getUserMedia while the reply plays, because re-opening the mic mid-
@@ -568,30 +612,40 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
   // primary (and only) end-of-turn path in v3: the owner explicitly ended his turn, so a failure is
   // announced loudly. If he happened to say "over and out" it is stripped; otherwise the whole transcript is
   // the command (voice over-and-out is deferred - the button is the end path).
-  const transcribeAndTake = useCallback(async () => {
+  const transcribeAndTake = useCallback(async (prefetched?: { transcript: string; transcodeMs: number; pauseDetectedAt: number }) => {
     const rec = recorderRef.current;
     if (rec === null) return;
     // Time the command transcription from the tap so the telemetry shows how long the owner waits between
-    // finishing and the brain starting.
-    const pauseDetectedAt = performance.now();
+    // finishing and the brain starting. The voice end-phrase path already transcribed to DETECT the phrase,
+    // so it passes its transcript + timings and we skip a second round trip.
+    const pauseDetectedAt = prefetched ? prefetched.pauseDetectedAt : performance.now();
     try {
-      const clip = rec.snapshot();
-      if (clip.size < MIN_CLIP_BYTES) {
-        void takeTurn(""); // nothing captured: a canned nudge, no server turn
-        return;
+      let transcript: string;
+      let transcodeMs: number;
+      if (prefetched) {
+        transcript = prefetched.transcript;
+        transcodeMs = prefetched.transcodeMs;
+      } else {
+        const clip = rec.snapshot();
+        if (clip.size < MIN_CLIP_BYTES) {
+          void takeTurn(""); // nothing captured: a canned nudge, no server turn
+          return;
+        }
+        setCaptureState("transcribing");
+        transcribeAttemptsRef.current += 1;
+        // Measure the client-side transcode (phone CPU) separately from the transcribe round trip (network +
+        // server), so a real phone turn shows where the time actually goes.
+        const transcodeStart = performance.now();
+        const { wav } = await blobToWav16kMono(clip);
+        transcodeMs = performance.now() - transcodeStart;
+        transcript = (await transcribeCarModeAudio(wav)).trim();
       }
-      setCaptureState("transcribing");
-      transcribeAttemptsRef.current += 1;
-      // Measure the client-side transcode (phone CPU) separately from the transcribe round trip (network +
-      // server), so a real phone turn shows where the time actually goes.
-      const transcodeStart = performance.now();
-      const { wav } = await blobToWav16kMono(clip);
-      const transcodeMs = performance.now() - transcodeStart;
-      const transcript = (await transcribeCarModeAudio(wav)).trim();
       const pauseToTranscribeMs = performance.now() - pauseDetectedAt;
       setLastHeard(transcript);
       setCaptureError(null);
-      const parsed = detectEndPhrase(transcript);
+      // Strip the owner's configured sign-off phrase (default "over and out") if he ended with it; on the
+      // button path, if he did not say it, the whole transcript is the command.
+      const parsed = detectPhraseAtEnd(transcript, endPhraseRef.current);
       const command = parsed.ended ? parsed.command : transcript;
       setCaptureState(`heard: "${transcript}"`);
 
@@ -643,11 +697,55 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     }
   }, [announceError, enterListening, stopThinkingCue, takeTurn]);
 
-  // Touch controls (the app is fully usable by touch - this is the primary path in v3). "Over and out"
-  // ends the turn by transcribing what was captured; "Stop" cuts the reply off instantly (the sole
-  // interrupt, since no voice "stop" watch runs).
+  // The hands-free end-phrase tick: while Listening, re-transcribe the captured audio and, if it now ends
+  // with the owner's sign-off phrase, take the turn (reusing the transcript so there is no second round
+  // trip). This is the voice equivalent of tapping "Over and out"; the button remains the instant fallback.
+  // There is NO self-trigger risk here because the assistant is silent while the owner is talking.
+  const endPhraseTick = useCallback(async () => {
+    if (endPollBusyRef.current || phaseRef.current !== "listening") return;
+    const rec = recorderRef.current;
+    if (rec === null) return;
+    endPollBusyRef.current = true;
+    const startedAt = performance.now();
+    try {
+      const clip = rec.snapshot();
+      if (clip.size < MIN_CLIP_BYTES) return;
+      const transcodeStart = performance.now();
+      const { wav } = await blobToWav16kMono(clip);
+      const transcodeMs = performance.now() - transcodeStart;
+      const transcript = (await transcribeCarModeAudio(wav)).trim();
+      // The owner may have tapped the button (or the session ended) during this ~1s transcribe: only commit
+      // while STILL Listening, so the button and the watch can never both take one turn.
+      if (phaseRef.current !== "listening") return;
+      setLastHeard(transcript);
+      if (!detectPhraseAtEnd(transcript, endPhraseRef.current).ended) return; // not done yet - keep listening
+      // Heard the sign-off. Mirror the button's end-of-turn exactly: instant "my turn" cue, switch to
+      // Thinking, start the gentle working tone, stop the watch, then take the turn with the transcript we
+      // already have (transcribeAndTake reuses it and strips the phrase).
+      playReadyCue();
+      setPhaseBoth("thinking");
+      setCaptureState("thinking");
+      stopThinkingCue();
+      thinkingCueStopRef.current = startThinkingCue();
+      stopEndPhraseWatch();
+      void transcribeAndTake({ transcript, transcodeMs, pauseDetectedAt: startedAt });
+    } catch (err) {
+      // A failed rolling transcribe must not kill the turn - skip this tick and try again next second.
+      console.log(`[CarMode] end-phrase watch skipped a tick: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      endPollBusyRef.current = false;
+    }
+  }, [setPhaseBoth, stopThinkingCue, stopEndPhraseWatch, transcribeAndTake]);
+  // Keep the interval (started in enterListening, before this tick is defined) pointing at the latest tick.
+  endTickRef.current = endPhraseTick;
+
+  // Touch controls (the app is fully usable by touch). "Over and out" ends the turn by transcribing what was
+  // captured; "Stop" cuts the reply off instantly. The button is the INSTANT fallback for the hands-free
+  // end-phrase watch above.
   const endTurn = useCallback(() => {
     if (phaseRef.current !== "listening") return;
+    // The button is taking the turn: stop the hands-free watch so it cannot also fire for this same turn.
+    stopEndPhraseWatch();
     // v4: fire the "my turn" acknowledgement cue SYNCHRONOUSLY as the FIRST thing on tap, before any of
     // the async end-of-turn work (mic snapshot -> WAV transcode -> transcribe round trip). That async
     // work takes ~2 seconds, so the cue used to lag the tap badly; firing it here gives an immediate
@@ -664,7 +762,7 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     stopThinkingCue();
     thinkingCueStopRef.current = startThinkingCue();
     void transcribeAndTake();
-  }, [setPhaseBoth, stopThinkingCue, transcribeAndTake]);
+  }, [setPhaseBoth, stopThinkingCue, stopEndPhraseWatch, transcribeAndTake]);
 
   const interrupt = useCallback(() => {
     if (phaseRef.current !== "speaking") return;
@@ -705,9 +803,13 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     // first await below. The same element is reused for every reply, so once unlocked here, later replies
     // (which play seconds after the tap, past the gesture window) are allowed to sound on mobile.
     unlockAudioElement(audio);
+    // Open the ONE shared cue audio channel inside this Start tap gesture, so every cue this session - the
+    // "my turn" beep and the "thinking" tone, INCLUDING when the hands-free watch fires them from a timer -
+    // sounds cleanly and does not churn the mobile audio session (which was ducking the spoken reply in v7).
+    primeCueAudio();
 
-    // v3 has no silence detector / pause auto-probe: the turn ends when the owner taps "Over and out". The
-    // AnalyserNode still drives the on-screen level meter (getMicLevel), which reads the recorder directly.
+    // The turn ends hands-free when the rolling end-phrase watch hears the sign-off phrase, or instantly
+    // when the owner taps "Over and out". The AnalyserNode drives the on-screen level meter (getMicLevel).
     await enterListening();
   }, [started, unsupported, enterListening]);
 
@@ -719,6 +821,10 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     playbackStopRef.current?.();
     // Silence the "thinking" ambient cue if the session ends mid-turn (v5).
     stopThinkingCue();
+    // Stop the hands-free end-phrase watch so its timer does not outlive the session.
+    stopEndPhraseWatch();
+    // Release the shared cue audio channel opened at Start.
+    releaseCueAudio();
     if (keepWarmRef.current !== null) {
       clearInterval(keepWarmRef.current);
       keepWarmRef.current = null;
@@ -743,7 +849,7 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     setStarted(false);
     setCaptureState("not started");
     setPhaseBoth("idle");
-  }, [revokeClip, setPhaseBoth, stopThinkingCue]);
+  }, [revokeClip, setPhaseBoth, stopThinkingCue, stopEndPhraseWatch]);
 
   // Tear everything down if the page unmounts mid-session (navigating away from Car Mode).
   useEffect(() => {

--- a/packages/client-core/src/dictation/readyCue.ts
+++ b/packages/client-core/src/dictation/readyCue.ts
@@ -7,20 +7,64 @@
 // Best-effort by design: a cue is a courtesy, so a browser without Web Audio, or an autoplay block,
 // must never disrupt the dictation turn - it is skipped silently.
 
+// A SINGLE shared AudioContext for a whole Car Mode session. Priming this inside the Start tap gesture and
+// reusing it for every cue is what makes the HANDS-FREE cues work: a cue fired later from a background timer
+// (the end-phrase watch) can no longer create a fresh, suspended context that lags AND churns the mobile
+// audio session enough to duck the spoken reply to silence (the v7 no-voice bug). Dictation does not prime
+// it, so its cues keep the original per-call behaviour (they always fire from a gesture, so that is fine).
+let sharedCueCtx: AudioContext | null = null;
+
+function audioCtor(): typeof AudioContext | null {
+  return window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext || null;
+}
+
+/** Car Mode: open (or resume) the shared cue AudioContext. MUST be called inside the Start tap gesture so
+ *  mobile lets it run; then every cue this session uses it and stays audible even when fired from a timer. */
+export function primeCueAudio(): void {
+  try {
+    const Ctor = audioCtor();
+    if (!Ctor) return;
+    if (sharedCueCtx === null || sharedCueCtx.state === "closed") sharedCueCtx = new Ctor();
+    if (sharedCueCtx.state === "suspended") void sharedCueCtx.resume();
+  } catch {
+    // Best-effort: if audio is unavailable the cues fall back to silence.
+  }
+}
+
+/** Car Mode: release the shared cue AudioContext at session end so it does not outlive Car Mode. */
+export function releaseCueAudio(): void {
+  try {
+    if (sharedCueCtx !== null && sharedCueCtx.state !== "closed") void sharedCueCtx.close();
+  } catch {
+    // already closed
+  }
+  sharedCueCtx = null;
+}
+
+// Return the context a cue should play on, and whether the cue OWNS it (must close it after) or is borrowing
+// the shared Car Mode context (must NOT close it - that churn is exactly the mobile duck we are avoiding).
+function cueContext(): { ctx: AudioContext; owned: boolean } | null {
+  if (sharedCueCtx !== null && sharedCueCtx.state !== "closed") {
+    if (sharedCueCtx.state === "suspended") void sharedCueCtx.resume();
+    return { ctx: sharedCueCtx, owned: false };
+  }
+  const Ctor = audioCtor();
+  if (!Ctor) return null;
+  const ctx = new Ctor();
+  if (ctx.state === "suspended") void ctx.resume();
+  return { ctx, owned: true };
+}
+
 /**
  * Play the dictation "ready" water-drop bloop once. Returns immediately; the sound plays on the
- * Web Audio clock. Never throws. Should be called from within/just after a user gesture (the Speak
- * tap that opened dictation) so the browser permits playback.
+ * Web Audio clock. Never throws. Uses the shared Car Mode cue context when primed (so it sounds even from a
+ * background timer); otherwise creates a per-call context, which dictation calls from within its Speak tap.
  */
 export function playReadyCue(): void {
   try {
-    const AudioCtor =
-      window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
-    if (!AudioCtor) return;
-
-    const ctx = new AudioCtor();
-    // A context created outside a gesture can start "suspended"; resume so the cue is audible.
-    if (ctx.state === "suspended") void ctx.resume();
+    const acquired = cueContext();
+    if (acquired === null) return;
+    const { ctx, owned } = acquired;
 
     const now = ctx.currentTime;
     const duration = 0.2;
@@ -43,7 +87,8 @@ export function playReadyCue(): void {
     osc.connect(gain).connect(ctx.destination);
     osc.start(now);
     osc.stop(now + duration + 0.02);
-    osc.onended = () => void ctx.close();
+    // Close ONLY a per-call context; never close the shared Car Mode context (that churn is the mobile duck).
+    if (owned) osc.onended = () => void ctx.close();
   } catch {
     // Best-effort courtesy cue; never disrupt dictation if audio output is unavailable.
   }
@@ -64,12 +109,9 @@ export function playReadyCue(): void {
  */
 export function startThinkingCue(): () => void {
   try {
-    const AudioCtor =
-      window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
-    if (!AudioCtor) return () => {};
-
-    const ctx = new AudioCtor();
-    if (ctx.state === "suspended") void ctx.resume();
+    const acquired = cueContext();
+    if (acquired === null) return () => {};
+    const { ctx, owned } = acquired;
 
     let stopped = false;
 
@@ -105,10 +147,14 @@ export function startThinkingCue(): () => void {
       if (stopped) return;
       stopped = true;
       window.clearInterval(timer);
-      try {
-        void ctx.close();
-      } catch {
-        // context already closed; nothing to do
+      // Close ONLY a per-call context. The shared Car Mode context stays open (idle) for the reply that
+      // follows - closing it here is the churn that ducked the reply on mobile.
+      if (owned) {
+        try {
+          void ctx.close();
+        } catch {
+          // context already closed; nothing to do
+        }
       }
     };
   } catch {
@@ -129,12 +175,9 @@ export function startThinkingCue(): () => void {
  */
 export function playYourTurnCue(): void {
   try {
-    const AudioCtor =
-      window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
-    if (!AudioCtor) return;
-
-    const ctx = new AudioCtor();
-    if (ctx.state === "suspended") void ctx.resume();
+    const acquired = cueContext();
+    if (acquired === null) return;
+    const { ctx, owned } = acquired;
 
     const now = ctx.currentTime;
 
@@ -166,7 +209,7 @@ export function playYourTurnCue(): void {
     osc.connect(gain).connect(ctx.destination);
     osc.start(now);
     osc.stop(now + total + 0.02);
-    osc.onended = () => void ctx.close();
+    if (owned) osc.onended = () => void ctx.close();
   } catch {
     // Best-effort courtesy cue; never disrupt the turn if audio output is unavailable.
   }

--- a/src/CcDirector.Core/Configuration/CarModeEndPhraseConfig.cs
+++ b/src/CcDirector.Core/Configuration/CarModeEndPhraseConfig.cs
@@ -1,0 +1,45 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace CcDirector.Core.Configuration;
+
+/// <summary>
+/// The spoken sign-off phrase that ends the owner's turn hands-free in Car Mode (default "over and out").
+/// Stored on the Gateway, NOT per-device, so the owner can set it once in the Cockpit "Car Mode" settings
+/// tab and every surface (his phone especially) picks it up - a device-local value would never reach the
+/// phone where Car Mode actually runs.
+///
+/// Resolution: the user's saved setting (config.json <c>car_mode_end_phrase</c>), or <see cref="Default"/>
+/// when unset/blank. Read at turn time so a change applies to the next turn.
+/// </summary>
+public static class CarModeEndPhraseConfig
+{
+    /// <summary>The config.json key the chosen end phrase is stored under.</summary>
+    public const string ConfigKey = "car_mode_end_phrase";
+
+    /// <summary>The default sign-off phrase, the one proven reliable through the Gateway transcription.</summary>
+    public const string Default = "over and out";
+
+    /// <summary>
+    /// The user's saved Car Mode end phrase (config.json <c>car_mode_end_phrase</c>), or
+    /// <see cref="Default"/> when unset/blank.
+    /// </summary>
+    public static string Get()
+    {
+        var node = CcDirectorConfigService.ReadRaw()[ConfigKey];
+        if (node is JsonValue v && v.GetValueKind() == JsonValueKind.String)
+        {
+            var phrase = v.GetValue<string>().Trim();
+            if (phrase.Length > 0) return phrase;
+        }
+        return Default;
+    }
+
+    /// <summary>Persist the chosen end phrase to config.json (merge-patch). A blank phrase resets to default
+    /// (an empty end phrase would end every turn, so it is never stored).</summary>
+    public static void Set(string phrase)
+    {
+        var trimmed = (phrase ?? string.Empty).Trim();
+        CcDirectorConfigService.MergePatch(new JsonObject { [ConfigKey] = trimmed.Length > 0 ? trimmed : Default });
+    }
+}

--- a/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/AiModelsEndpoint.cs
@@ -129,6 +129,20 @@ internal static class AiModelsEndpoint
             catch (JsonException) { return Results.BadRequest(new { error = "invalid JSON" }); }
         });
 
+        app.MapPut("/gateway/ai/car-mode-end-phrase", async (HttpContext ctx) =>
+        {
+            try
+            {
+                var body = await JsonSerializer.DeserializeAsync<EndPhraseBody>(ctx.Request.Body, JsonOpts, ctx.RequestAborted);
+                // A blank phrase resets to the default (an empty phrase would end every turn); CarModeEndPhraseConfig.Set enforces it.
+                CarModeEndPhraseConfig.Set(body?.Phrase ?? string.Empty);
+                var phrase = CarModeEndPhraseConfig.Get();
+                FileLog.Write($"[AiModelsEndpoint] car mode end phrase set: {phrase}");
+                return Results.Json(new { phrase });
+            }
+            catch (JsonException) { return Results.BadRequest(new { error = "invalid JSON" }); }
+        });
+
         app.MapPut("/gateway/ai/tts-model", async (HttpContext ctx) =>
         {
             try
@@ -184,5 +198,6 @@ internal static class AiModelsEndpoint
     }
 
     private sealed record ModelBody(string? Model);
+    private sealed record EndPhraseBody(string? Phrase);
     private sealed record ModelDto(string Id, string Description, List<string> Voices, string? DefaultVoice);
 }

--- a/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
@@ -489,6 +489,9 @@ internal static class SettingsEndpoints
             // The snapshot shows the user's saved setting (or the Qwen2.5-72B default); the env override
             // is not reflected here because it is a per-install debug switch, not the user's choice.
             carModeModel = Core.Configuration.CarModeModelConfig.Get(),
+            // Car Mode's hands-free sign-off phrase, a Gateway setting so the Cockpit can set it and the
+            // phone (where Car Mode runs) picks it up. Default "over and out".
+            carModeEndPhrase = Core.Configuration.CarModeEndPhraseConfig.Get(),
             transcriptionModel = Core.Configuration.TranscriptionEndpointResolver.Resolve(mode).Model,
             ttsModel = Core.Configuration.TtsModelConfig.Resolve(mode),
             ttsVoice = Core.Configuration.TtsVoiceConfig.Resolve(mode),


### PR DESCRIPTION
Makes Car Mode usable hands-free and configurable from the Cockpit. Owner-verified on the phone (v8 hands-free + audio fix) and the Cockpit tab. Part of the Car Mode epic thefrederiksen/devthrottle_internal#766, issue thefrederiksen/devthrottle_internal#771.

- Hands-free end of turn: rolling transcription watch during Listening ends the turn when the owner's words end with the sign-off phrase; touch button stays as the instant fallback.
- Shared cue audio channel opened in the Start tap so the hands-free beep and the spoken reply are not muted on mobile (v7 no-voice fix).
- Configurable end phrase as a Gateway setting (CarModeEndPhraseConfig, PUT /gateway/ai/car-mode-end-phrase, carModeEndPhrase on the ai-provider snapshot) so the Cockpit sets it and the phone reads it.
- New Cockpit "Car Mode" settings tab: model + end phrase + live phrase tester.

Verified: clean merge with main, typecheck clean, 82 client tests pass, Gateway builds.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>