### PR TITLE
feat(gateway-cleanup): Phase 0 wave 3 - lift the final deferred tunnel verbs

### DIFF
--- a/src/CcDirector.ControlApi/CatalogReadExecutor.cs
+++ b/src/CcDirector.ControlApi/CatalogReadExecutor.cs
@@ -26,8 +26,9 @@ namespace CcDirector.ControlApi;
 /// Gateway Cleanup Phase 0 (wave 3): the two reads R2 originally left out are now lifted, because the shared
 /// dependency they needed was threaded through <see cref="SessionCommandServices"/>: <c>facts</c> stamps the
 /// Director version (<see cref="SessionCommandServices.DirectorVersion"/>); <c>repos-list</c> reads the live
-/// <see cref="RepositoryRegistry"/> (<see cref="SessionCommandServices.Repositories"/>). This <c>facts</c>
-/// lift ships with that dependency change; <c>repos-list</c> follows in the wave-3 lift PR.
+/// <see cref="RepositoryRegistry"/> (<see cref="SessionCommandServices.Repositories"/>). The <c>facts</c>
+/// lift shipped with that dependency change; the wave-3 lift PR now adds <c>repos-list</c>, which reads that
+/// same registry and lists nothing when it is absent (exactly as the REST route returned with no registry).
 /// </summary>
 internal sealed class CatalogReadExecutor : ISessionCommandArea
 {
@@ -46,6 +47,7 @@ internal sealed class CatalogReadExecutor : ISessionCommandArea
         "interrupted-list",
         "fs-list",
         "facts",
+        "repos-list",
     };
 
     public async Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken)
@@ -58,6 +60,7 @@ internal sealed class CatalogReadExecutor : ISessionCommandArea
             "interrupted-list" => InterruptedList(),
             "fs-list" => FsList(command),
             "facts" => Facts(context.DirectorId, context.Services?.DirectorVersion),
+            "repos-list" => ReposList(context.Services?.Repositories),
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the catalog read area"),
         };
     }
@@ -95,6 +98,32 @@ internal sealed class CatalogReadExecutor : ISessionCommandArea
                 Error = launcher.Error,
             },
         }));
+    }
+
+    /// <summary>
+    /// The <c>repos-list</c> verb (director-level, no session): the recent-repository picker list. Mirrors the
+    /// Director's <c>GET /repos</c> lambda - always a 200 - and returns a serialized
+    /// <see cref="List{RepositoryDto}"/> ordered by last-used descending. The live registry is the one
+    /// dependency the tunnel command surface did not carry before wave 3; it rides in
+    /// <see cref="SessionCommandServices.Repositories"/>. A null registry lists nothing (an empty array),
+    /// exactly as the REST route returned when no registry was wired.
+    /// </summary>
+    internal static DirectorCommandResult ReposList(RepositoryRegistry? repositories)
+    {
+        FileLog.Write("[CatalogReadExecutor] repos-list");
+        if (repositories is null)
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(Array.Empty<RepositoryDto>()));
+
+        var repos = repositories.Repositories
+            .Select(r => new RepositoryDto
+            {
+                Name = string.IsNullOrEmpty(r.Name) ? Path.GetFileName(r.Path.TrimEnd('\\', '/')) : r.Name,
+                Path = r.Path,
+                LastUsed = r.LastUsed,
+            })
+            .OrderByDescending(r => r.LastUsed ?? DateTime.MinValue)
+            .ToList();
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(repos));
     }
 
     /// <summary>

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -778,39 +778,40 @@ internal static class ControlEndpoints
         //   free-text question -> the "Ask the Wingman" channel: a read-only full-power
         //   session (Read/Grep/Glob) over the whole terminal + repo that answers
         //   faithfully and reads content VERBATIM when asked, never summarizing.
+        // Gateway Cleanup Phase 0 (wave 3): the ask runs through the shared SessionWriteExecutor core so this
+        // REST path and the Gateway stream down-channel are identical and cannot drift. The turn-summary cache
+        // (explain mode's context input) rides in the services. The wingman's own "bad_request" outcome comes
+        // back as a 200 result carrying Status="bad_request"; this route maps that Status to its original 400,
+        // exactly as the execute-action route maps its executor outcomes. Phase 1 deletes this route.
         app.MapPost("/sessions/{sid}/wingman/ask", async (string sid, WingmanAskRequest req, CancellationToken ct) =>
         {
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
-            var explain = string.Equals(req?.Mode, "explain", StringComparison.OrdinalIgnoreCase);
-            // Explain mode briefs the whole session and needs no user question; the
-            // free-text ask path still requires one.
-            if (req is null || (!explain && string.IsNullOrWhiteSpace(req.Question)))
-                return Results.BadRequest(new WingmanAskResult { Status = "bad_request", Error = "question is required" });
-
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
-
-            // Explain = the terse "what's happening" briefing (Opus over pre-built,
-            // length-capped context). Unchanged.
-            if (explain)
+            var command = new DirectorCommand
             {
-                var explainCtx = await WingmanContextBuilder.BuildAsync(session, turnSummaryCache, ct);
-                var explainResult = await Core.Wingman.WingmanService.AskAboutSessionAsync(
-                    req.Question, explainCtx, sessionManager.Options.ClaudePath, ct, explain: true);
-                return Results.Json(explainResult);
-            }
+                Verb = "wingman-ask",
+                SessionId = sid,
+                PayloadJson = req is null ? "" : SessionCommandExecutor.Serialize(req),
+            };
+            var services = new SessionCommandServices { TurnSummaryCache = turnSummaryCache };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command, services, cancellationToken: ct);
 
-            // Any free-text question = the faithful "Ask the Wingman" channel: a
-            // read-only full-power session over the WHOLE terminal + repo, on the strong
-            // model, that reads content VERBATIM instead of summarizing. This replaces the
-            // old terse one-shot ask (no more 1-3 sentence cap, no Haiku, no 4000-char tail).
-            var fullTerminal = ReadFullCleanedBuffer(session);
-            var result = await Core.Wingman.WingmanService.AnswerViaSessionAsync(
-                req.Question, fullTerminal, session.AgentKind.ToString(), session.RepoPath,
-                sessionManager.Options.ClaudePath, ct);
-            return Results.Json(result);
+            switch (result.Status)
+            {
+                case DirectorCommandStatus.Ok:
+                {
+                    var ask = SessionCommandExecutor.Deserialize<WingmanAskResult>(result.BodyJson);
+                    // The question-required guard is the wingman's bad_request outcome, returned as a 400 with
+                    // the result body - identical to the pre-lift lambda. Every other outcome is a 200.
+                    return ask?.Status == "bad_request"
+                        ? Results.BadRequest(ask)
+                        : Results.Json(ask);
+                }
+                case DirectorCommandStatus.BadRequest:
+                    return Results.BadRequest(new { error = result.Error });
+                case DirectorCommandStatus.NotFound:
+                    return Results.NotFound(new { error = result.Error });
+                default:
+                    return Results.Problem(result.Error ?? "wingman-ask command failed");
+            }
         });
 
         // Structured-intent actuation (Path A): the Wingman looks at the session's live
@@ -1357,36 +1358,23 @@ internal static class ControlEndpoints
         // this Director's Control API endpoint: the Gateway proxies this to a browser, and issue #1214
         // requires the browser to talk only to the Gateway and never learn a Director address. This is a
         // pure read of the live session record - no transcript parsing, no I/O.
-        app.MapGet("/sessions/{sid}/handover", (string sid) =>
+        // Gateway Cleanup Phase 0 (wave 3): the read runs through the shared SessionReadExecutor core so this
+        // REST path and the Gateway stream down-channel are identical and cannot drift. The Director version -
+        // the one dependency the tunnel command surface did not carry - is passed in through the services and
+        // stamped by the core. Phase 1 deletes this route and leaves the core reached only over the tunnel.
+        app.MapGet("/sessions/{sid}/handover", async (string sid) =>
         {
-            FileLog.Write($"[ControlEndpoints] /handover: sid={sid}");
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
+            var command = new DirectorCommand { Verb = "handover", SessionId = sid };
+            var services = new SessionCommandServices { DirectorVersion = version };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command, services);
 
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
+            return result.Status switch
             {
-                FileLog.Write($"[ControlEndpoints] /handover: session not found sid={sid}");
-                return Results.NotFound(new { error = "session not found" });
-            }
-
-            // Issue #800: the display name goes through the single composer so it is never the bare
-            // folder name (legacy sessions with no CustomName get folder + type + disambiguator).
-            var name = SessionName.DisplayName(session.CustomName,
-                SessionName.FolderName(session.RepoPath),
-                SessionName.Disambiguator(session.Id));
-
-            var dto = new HandoverInfoDto
-            {
-                SessionId = sid,
-                DisplayName = name,
-                RepoPath = session.RepoPath,
-                DirectorId = directorId,
-                MachineName = Environment.MachineName,
-                Version = version,
+                DirectorCommandStatus.Ok => Results.Content(result.BodyJson ?? "{}", "application/json"),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "handover command failed"),
             };
-            FileLog.Write($"[ControlEndpoints] /handover: ok sid={sid}, director={directorId}");
-            return Results.Json(dto);
         });
 
         // ===== REST: Brief - the Cockpit's full-page session view (ASK / DID / NEEDS YOU) =====
@@ -1567,116 +1555,46 @@ internal static class ControlEndpoints
             };
         });
 
+        // Gateway Cleanup Phase 0 (wave 3): the recap generation runs through the shared SessionWriteExecutor
+        // core so this REST path and the Gateway stream down-channel are identical and cannot drift. The
+        // optional ?model= query rides in the command payload. The domain-state bodies (no_session_id,
+        // no_jsonl, generation_failed) come back as Ok results the route serves as 200; a successful generation
+        // (Status="ok") is served as the route's original 201. A caller cancellation bubbles out of the core
+        // and is mapped to the route's 499 here. Phase 1 deletes this route.
         app.MapPost("/sessions/{sid}/recap", async (string sid, HttpContext ctx) =>
         {
             FileLog.Write($"[ControlEndpoints] POST /sessions/{sid}/recap");
-
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
-
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
-
             var model = ctx.Request.Query["model"].ToString();
-            if (string.IsNullOrWhiteSpace(model))
-                model = RecapGenerator.DefaultModel;
-
-            if (string.IsNullOrEmpty(session.ClaudeSessionId))
+            var command = new DirectorCommand
             {
-                return Results.Json(new RecapResponse
-                {
-                    SessionId = sid,
-                    Model = model,
-                    Status = "no_session_id",
-                    Error = "Session has not been linked to a Claude session id yet.",
-                });
-            }
-
-            var jsonl = ClaudeSessionReader.GetJsonlPath(session.ClaudeSessionId, session.RepoPath);
-            if (!File.Exists(jsonl))
-            {
-                return Results.Json(new RecapResponse
-                {
-                    SessionId = sid,
-                    Model = model,
-                    Status = "no_jsonl",
-                    Error = $"JSONL file not found at {jsonl}",
-                });
-            }
-
-            SessionSummaryDto summary;
-            string digest;
-            int currentTurns;
-            try
-            {
-                var messages = StreamMessageParser.ParseFile(jsonl);
-                summary = SummaryBuilder.Build(messages);
-                summary.SessionId = sid;
-                summary.DirectorId = directorId;
-                summary.Agent = session.AgentKind.ToString();
-                summary.RepoPath = session.RepoPath;
-                summary.ActivityState = session.ActivityState.ToString();
-                summary.CreatedAt = session.CreatedAt.UtcDateTime;
-                digest = SummaryBuilder.FormatAsHandoverPrompt(summary);
-                currentTurns = summary.TurnCount;
-            }
-            catch (Exception ex)
-            {
-                FileLog.Write($"[ControlEndpoints] /recap digest build FAILED: {ex.Message}");
-                return Results.Json(new RecapResponse
-                {
-                    SessionId = sid,
-                    Model = model,
-                    Status = "generation_failed",
-                    Error = "Failed to build session digest: " + ex.Message,
-                });
-            }
+                Verb = "recap-generate",
+                SessionId = sid,
+                PayloadJson = SessionCommandExecutor.Serialize(new RecapGenerateRequest { Model = model }),
+            };
 
             try
             {
-                var sw = Stopwatch.StartNew();
-                var recapText = await RecapGenerator.GenerateAsync(
-                    digest, sessionManager.Options.ClaudePath, model, ctx.RequestAborted);
-                sw.Stop();
+                var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command, cancellationToken: ctx.RequestAborted);
 
-                var entry = new RecapCache.Entry
+                return result.Status switch
                 {
-                    Recap = recapText,
-                    GeneratedAt = DateTime.UtcNow,
-                    AtTurnCount = currentTurns,
-                    Model = model,
-                    ElapsedMs = sw.ElapsedMilliseconds,
+                    // A successful recap carries Status="ok" and maps to the original 201; the domain-state
+                    // bodies (no_session_id / no_jsonl / generation_failed) map to 200, exactly as before.
+                    DirectorCommandStatus.Ok => RecapGenerateResult(result.BodyJson),
+                    DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                    DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                    _ => Results.Problem(result.Error ?? "recap command failed"),
                 };
-                RecapCache.Set(guid, entry);
-
-                return Results.Json(new RecapResponse
-                {
-                    SessionId = sid,
-                    Recap = entry.Recap,
-                    GeneratedAt = entry.GeneratedAt,
-                    AtTurnCount = entry.AtTurnCount,
-                    CurrentTurnCount = currentTurns,
-                    IsStale = false,
-                    Model = entry.Model,
-                    ElapsedMs = entry.ElapsedMs,
-                    Status = "ok",
-                }, statusCode: 201);
             }
             catch (OperationCanceledException)
             {
                 return Results.StatusCode(499); // Client Closed Request
             }
-            catch (Exception ex)
+
+            static IResult RecapGenerateResult(string? bodyJson)
             {
-                FileLog.Write($"[ControlEndpoints] /recap generation FAILED: {ex.Message}");
-                return Results.Json(new RecapResponse
-                {
-                    SessionId = sid,
-                    Model = model,
-                    Status = "generation_failed",
-                    Error = ex.Message,
-                });
+                var resp = SessionCommandExecutor.Deserialize<RecapResponse>(bodyJson);
+                return Results.Json(resp, statusCode: resp?.Status == "ok" ? 201 : 200);
             }
         });
 
@@ -2047,125 +1965,47 @@ internal static class ControlEndpoints
             return Results.Json(result);
         });
 
+        // Director-local handover. Source AND target must both live on this Director.
+        // Cross-Director handovers go via the Gateway proxy.
+        // Gateway Cleanup Phase 0 (wave 3): the atomic handover runs through the shared SessionWriteExecutor
+        // core so this REST path and the Gateway stream down-channel are identical and cannot drift. The core
+        // returns the target session mapped with the plain Map; this REST route re-maps it with the
+        // identity-stamped mapper for its 201, exactly as the create verb (CreateLocalSessionAsync) does.
+        // Phase 1 deletes this route and leaves the core reached only over the tunnel.
         app.MapPost("/handover", async (HandoverRequest req) =>
         {
-            // Director-local handover. Source AND target must both live on this Director.
-            // Cross-Director handovers go via the Gateway proxy.
-            FileLog.Write($"[ControlEndpoints] POST /handover: from={req?.FromSessionId} toSid={req?.ToSessionId} toRepo={req?.ToRepoPath}");
-
-            if (req is null || string.IsNullOrEmpty(req.FromSessionId))
-                return Results.BadRequest(new { error = "fromSessionId is required" });
-            if (string.IsNullOrEmpty(req.ToSessionId) && string.IsNullOrEmpty(req.ToRepoPath))
-                return Results.BadRequest(new { error = "exactly one of toSessionId or toRepoPath is required" });
-            if (!string.IsNullOrEmpty(req.ToSessionId) && !string.IsNullOrEmpty(req.ToRepoPath))
-                return Results.BadRequest(new { error = "toSessionId and toRepoPath are mutually exclusive" });
-
-            if (!Guid.TryParse(req.FromSessionId, out var fromGuid))
-                return Results.BadRequest(new { error = "invalid fromSessionId format" });
-
-            var source = sessionManager.GetSession(fromGuid);
-            if (source is null)
-                return Results.NotFound(new { error = "source session not found on this director" });
-
-            // 1) Build the context text
-            SessionSummaryDto summary;
-            if (string.IsNullOrEmpty(source.ClaudeSessionId))
+            var command = new DirectorCommand
             {
-                summary = new SessionSummaryDto
-                {
-                    SessionId = req.FromSessionId, DirectorId = directorId,
-                    Agent = source.AgentKind.ToString(),
-                    RepoPath = source.RepoPath,
-                    ActivityState = source.ActivityState.ToString(),
-                    CreatedAt = source.CreatedAt.UtcDateTime,
-                };
-            }
-            else
+                Verb = "handover-generate",
+                SessionId = "",
+                PayloadJson = req is null ? "" : SessionCommandExecutor.Serialize(req),
+            };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
+
+            switch (result.Status)
             {
-                var jsonl = ClaudeSessionReader.GetJsonlPath(source.ClaudeSessionId, source.RepoPath);
-                summary = File.Exists(jsonl)
-                    ? SummaryBuilder.Build(StreamMessageParser.ParseFile(jsonl))
-                    : new SessionSummaryDto();
-                summary.SessionId = req.FromSessionId;
-                summary.DirectorId = directorId;
-                summary.Agent = source.AgentKind.ToString();
-                summary.RepoPath = source.RepoPath;
-                summary.ActivityState = source.ActivityState.ToString();
-                summary.CreatedAt = source.CreatedAt.UtcDateTime;
-            }
-            var contextText = SummaryBuilder.FormatAsHandoverPrompt(summary, req.ExtraContext);
-
-            // 2) Find or create the target session
-            Session target;
-            if (!string.IsNullOrEmpty(req.ToSessionId))
-            {
-                if (!Guid.TryParse(req.ToSessionId, out var toGuid))
-                    return Results.BadRequest(new { error = "invalid toSessionId format" });
-                var existing = sessionManager.GetSession(toGuid);
-                if (existing is null)
-                    return Results.NotFound(new { error = "target session not found on this director" });
-                if (existing.Status is SessionStatus.Exited or SessionStatus.Failed)
-                    return Results.StatusCode(StatusCodes.Status409Conflict);
-                target = existing;
-                await target.SendTextAsync(contextText, SendSource.Internal);
-            }
-            else
-            {
-                var repo = req.ToRepoPath!;
-                if (!Directory.Exists(repo))
-                    return Results.BadRequest(new { error = $"toRepoPath does not exist: {repo}" });
-                if (!Enum.TryParse<AgentKind>(req.ToAgent, ignoreCase: true, out var kind))
-                    return Results.BadRequest(new { error = $"unknown agent: {req.ToAgent}" });
-
-                if (!AgentPluginRegistry.Contains(kind))
-                    return Results.BadRequest(new { error = $"agent {kind} is not a built-in plugin target" });
-                var agent = AgentPluginRegistry.CreateAgent(kind, sessionManager.Options);
-
-                try
+                case DirectorCommandStatus.Ok:
                 {
-                    target = sessionManager.CreateSession(repo, agent, userArgs: null, SessionBackendType.ConPty, resumeSessionId: null);
-                }
-                catch (Exception ex)
-                {
-                    return Results.Problem("failed to create target session: " + ex.Message, statusCode: 500);
-                }
-                // SessionManager.CreateSession now fires OnSessionCreated itself, so no
-                // explicit RaiseSessionCreated call is needed here.
-
-                // Dispatch the context after the new session reaches Idle. Fire-and-forget;
-                // we return the target DTO immediately so callers can navigate to it.
-                var capturedTarget = target;
-                var capturedText = contextText;
-                _ = Task.Run(async () =>
-                {
-                    var deadline = DateTime.UtcNow.AddMilliseconds(30_000);
-                    while (DateTime.UtcNow < deadline)
+                    var resp = SessionCommandExecutor.Deserialize<HandoverResponse>(result.BodyJson);
+                    // Re-map the target with this Director's identity-stamped mapper (the core returned the
+                    // plain Map; machine/user/tailnet identity is stamped here, same as CreateLocalSessionAsync).
+                    if (resp?.TargetSession is not null && Guid.TryParse(resp.TargetSession.SessionId, out var targetGuid))
                     {
-                        var st = capturedTarget.ActivityState;
-                        if (st is ActivityState.Idle or ActivityState.WaitingForInput) break;
-                        if (st is ActivityState.Exited) { FileLog.Write($"[ControlEndpoints] /handover target exited before idle, sid={capturedTarget.Id}"); return; }
-                        await Task.Delay(500);
+                        var target = sessionManager.GetSession(targetGuid);
+                        if (target is not null)
+                            resp.TargetSession = MapWithIdentity(target, turnSummaryCache);
                     }
-                    try { await capturedTarget.SendTextAsync(capturedText, SendSource.Internal); }
-                    catch (Exception ex) { FileLog.Write($"[ControlEndpoints] /handover dispatch FAILED: {ex.Message}"); }
-                });
+                    return Results.Json(resp, statusCode: 201);
+                }
+                case DirectorCommandStatus.BadRequest:
+                    return Results.BadRequest(new { error = result.Error });
+                case DirectorCommandStatus.NotFound:
+                    return Results.NotFound(new { error = result.Error });
+                case DirectorCommandStatus.Conflict:
+                    return Results.StatusCode(StatusCodes.Status409Conflict);
+                default:
+                    return Results.Problem(result.Error ?? "handover failed", statusCode: 500);
             }
-
-            // 3) Optionally archive to vault
-            string? archivedAt = null;
-            if (req.ArchiveToVault)
-            {
-                try { archivedAt = HandoverArchive.Write(summary, contextText, target.Id.ToString()); }
-                catch (Exception ex) { FileLog.Write($"[ControlEndpoints] /handover archive FAILED: {ex.Message}"); }
-            }
-
-            return Results.Json(new HandoverResponse
-            {
-                Accepted = true,
-                TargetSession = MapWithIdentity(target, turnSummaryCache),
-                ContextSent = contextText,
-                ArchivedAt = archivedAt,
-            }, statusCode: 201);
         });
 
         app.MapPost("/sessions/{sid}/prompt", async (string sid, PromptRequest req, HttpContext httpCtx) =>
@@ -2638,21 +2478,21 @@ internal static class ControlEndpoints
         });
 
         // ===== REST: Repos (for the New Session picker) =====
-        app.MapGet("/repos", () =>
+        // Gateway Cleanup Phase 0 (wave 3): the read runs through the shared CatalogReadExecutor core so this
+        // REST path and the Gateway stream down-channel are identical and cannot drift. The live registry -
+        // the one dependency the tunnel command surface did not carry - is passed in through the services.
+        // A null registry lists nothing (an empty array), exactly as before. Phase 1 deletes this route.
+        app.MapGet("/repos", async () =>
         {
-            if (repositoryRegistry is null)
-                return Results.Json(Array.Empty<RepositoryDto>());
+            var command = new DirectorCommand { Verb = "repos-list", SessionId = "" };
+            var services = new SessionCommandServices { Repositories = repositoryRegistry };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command, services);
 
-            var repos = repositoryRegistry.Repositories
-                .Select(r => new RepositoryDto
-                {
-                    Name = string.IsNullOrEmpty(r.Name) ? Path.GetFileName(r.Path.TrimEnd('\\', '/')) : r.Name,
-                    Path = r.Path,
-                    LastUsed = r.LastUsed,
-                })
-                .OrderByDescending(r => r.LastUsed ?? DateTime.MinValue)
-                .ToList();
-            return Results.Json(repos);
+            return result.Status switch
+            {
+                DirectorCommandStatus.Ok => Results.Content(result.BodyJson ?? "[]", "application/json"),
+                _ => Results.Problem(result.Error ?? "repos-list command failed"),
+            };
         });
 
         // ===== REST: Remove a repository from the recent list =====
@@ -3279,7 +3119,7 @@ internal static class ControlEndpoints
     /// snapshot file and reads only as much as it needs, so "read me the whole article"
     /// can reach content that scrolled past a tail. Read-only inspection; never mutates.
     /// </summary>
-    private static string ReadFullCleanedBuffer(Session session)
+    internal static string ReadFullCleanedBuffer(Session session)
     {
         try
         {

--- a/src/CcDirector.ControlApi/SessionReadExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionReadExecutor.cs
@@ -43,6 +43,7 @@ internal sealed class SessionReadExecutor : ISessionCommandArea
         "github-urls",
         "wingman-view",
         "wingman-explain",
+        "handover",
     };
 
     public Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken)
@@ -63,6 +64,7 @@ internal sealed class SessionReadExecutor : ISessionCommandArea
             "github-urls" => GithubUrls(sessionManager, command),
             "wingman-view" => WingmanView(context, command),
             "wingman-explain" => WingmanExplain(sessionManager, command),
+            "handover" => Handover(sessionManager, context.DirectorId, context.Services?.DirectorVersion, command),
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the session read area"),
         };
         return Task.FromResult(result);
@@ -591,6 +593,47 @@ internal sealed class SessionReadExecutor : ISessionCommandArea
             WhatClaudeWants = session.CachedExplainWhatClaudeWants,
             ClaudeVerbatim = session.CachedExplainClaudeVerbatim,
             Say = session.CachedExplainSay,
+        }));
+    }
+
+    /// <summary>
+    /// The <c>handover</c> verb (issue #1214): the small identity/locate block the desktop app's "Copy
+    /// Handover Info" menu item shows for a session (name, session id, repo, director id, machine, version).
+    /// Mirrors the Director's <c>GET /sessions/{sid}/handover</c> lambda - invalid id -&gt; BadRequest,
+    /// missing session -&gt; NotFound - and returns a serialized <see cref="HandoverInfoDto"/>. It is a pure
+    /// read of the live session record: no transcript parsing, no I/O. The Director version - the one
+    /// dependency the tunnel command surface did not carry - rides in
+    /// <see cref="SessionCommandServices.DirectorVersion"/> and is stamped exactly as the REST route stamped
+    /// <c>ControlApiHost._version</c>, so both paths serve an identical block. Deliberately does NOT include
+    /// this Director's Control API endpoint (issue #1214: the browser must never learn a Director address).
+    /// </summary>
+    internal static DirectorCommandResult Handover(SessionManager sessionManager, string directorId, string? version, DirectorCommand command)
+    {
+        FileLog.Write($"[SessionReadExecutor] handover: sid={command.SessionId}");
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+        {
+            FileLog.Write($"[SessionReadExecutor] handover: session not found sid={command.SessionId}");
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+        }
+
+        // Issue #800: the display name goes through the single composer so it is never the bare
+        // folder name (legacy sessions with no CustomName get folder + type + disambiguator).
+        var name = SessionName.DisplayName(session.CustomName,
+            SessionName.FolderName(session.RepoPath),
+            SessionName.Disambiguator(session.Id));
+
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new HandoverInfoDto
+        {
+            SessionId = command.SessionId,
+            DisplayName = name,
+            RepoPath = session.RepoPath,
+            DirectorId = directorId,
+            MachineName = Environment.MachineName,
+            Version = version ?? string.Empty,
         }));
     }
 }

--- a/src/CcDirector.ControlApi/SessionWriteExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionWriteExecutor.cs
@@ -1,3 +1,8 @@
+using System.Diagnostics;
+using CcDirector.Core.AgentPlugins;
+using CcDirector.Core.Agents;
+using CcDirector.Core.Backends;
+using CcDirector.Core.Claude;
 using CcDirector.Core.Sessions;
 using CcDirector.Core.Utilities;
 using CcDirector.Core.Wingman;
@@ -29,6 +34,11 @@ internal sealed class SessionWriteExecutor : ISessionCommandArea
         // verb share one core and cannot drift.
         "clear-context", "history-picker", "mobile-mode", "voice-mode", "wingman-enabled",
         "relink", "request-deletion", "cancel-deletion", "execute-action",
+        // Gateway Cleanup Phase 0 (wave 3): the final deferred write verbs. handover-generate is
+        // director-level (creates/targets a session from a source); wingman-ask and recap-generate are
+        // per-session writes that call static services (no new dependency). Each core reproduces its old
+        // REST lambda verbatim, so the REST route and the tunnel verb share one core and cannot drift.
+        "handover-generate", "wingman-ask", "recap-generate",
     };
 
     public async Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken)
@@ -57,6 +67,9 @@ internal sealed class SessionWriteExecutor : ISessionCommandArea
             "request-deletion" => RequestDeletion(sessionManager, command),
             "cancel-deletion" => CancelDeletion(sessionManager, command),
             "execute-action" => ExecuteAction(sessionManager, command),
+            "handover-generate" => await HandoverGenerateAsync(sessionManager, context.DirectorId, command),
+            "wingman-ask" => await WingmanAskAsync(context, command, cancellationToken),
+            "recap-generate" => await RecapGenerateAsync(sessionManager, context.DirectorId, command, cancellationToken),
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the session write area"),
         };
     }
@@ -370,5 +383,310 @@ internal sealed class SessionWriteExecutor : ISessionCommandArea
             result.Error = $"session is {session.Status}; nothing was injected";
 
         return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(result));
+    }
+
+    /// <summary>
+    /// The <c>handover-generate</c> verb (director-level, no target session on the command): the atomic
+    /// "move the work" write. Mirrors the Director's <c>POST /handover</c> lambda verbatim - it reads the
+    /// SOURCE session's context, delivers it to a TARGET (an existing session, or a brand-new one created in
+    /// a repo), and optionally archives a markdown copy to the vault. The guards return the same statuses the
+    /// route did: a bad/blank fromSessionId, the mutually-exclusive/exactly-one target rule, a bad
+    /// toSessionId/toRepoPath, or an unknown agent -&gt; BadRequest; a missing source or target -&gt; NotFound;
+    /// an Exited/Failed existing target -&gt; Conflict (the route's empty-body 409); a create fault -&gt; Error
+    /// (the route's 500). On success it returns a <see cref="HandoverResponse"/> whose <c>TargetSession</c> is
+    /// the plain <see cref="ControlEndpoints.Map"/> - the Director's own REST route re-maps it with its
+    /// identity-stamped mapper for its 201, exactly as the create verb does. The new-session dispatch (wait for
+    /// idle, then send) and the best-effort archive keep their fire-and-forget task and try/catch from the
+    /// source, so behaviour is byte-identical.
+    /// </summary>
+    internal static async Task<DirectorCommandResult> HandoverGenerateAsync(SessionManager sessionManager, string directorId, DirectorCommand command)
+    {
+        var req = SessionCommandExecutor.Deserialize<HandoverRequest>(command.PayloadJson);
+        FileLog.Write($"[SessionWriteExecutor] handover-generate: from={req?.FromSessionId} toSid={req?.ToSessionId} toRepo={req?.ToRepoPath}");
+
+        if (req is null || string.IsNullOrEmpty(req.FromSessionId))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "fromSessionId is required");
+        if (string.IsNullOrEmpty(req.ToSessionId) && string.IsNullOrEmpty(req.ToRepoPath))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "exactly one of toSessionId or toRepoPath is required");
+        if (!string.IsNullOrEmpty(req.ToSessionId) && !string.IsNullOrEmpty(req.ToRepoPath))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "toSessionId and toRepoPath are mutually exclusive");
+
+        if (!Guid.TryParse(req.FromSessionId, out var fromGuid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid fromSessionId format");
+
+        var source = sessionManager.GetSession(fromGuid);
+        if (source is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "source session not found on this director");
+
+        // 1) Build the context text
+        SessionSummaryDto summary;
+        if (string.IsNullOrEmpty(source.ClaudeSessionId))
+        {
+            summary = new SessionSummaryDto
+            {
+                SessionId = req.FromSessionId, DirectorId = directorId,
+                Agent = source.AgentKind.ToString(),
+                RepoPath = source.RepoPath,
+                ActivityState = source.ActivityState.ToString(),
+                CreatedAt = source.CreatedAt.UtcDateTime,
+            };
+        }
+        else
+        {
+            var jsonl = ClaudeSessionReader.GetJsonlPath(source.ClaudeSessionId, source.RepoPath);
+            summary = File.Exists(jsonl)
+                ? SummaryBuilder.Build(StreamMessageParser.ParseFile(jsonl))
+                : new SessionSummaryDto();
+            summary.SessionId = req.FromSessionId;
+            summary.DirectorId = directorId;
+            summary.Agent = source.AgentKind.ToString();
+            summary.RepoPath = source.RepoPath;
+            summary.ActivityState = source.ActivityState.ToString();
+            summary.CreatedAt = source.CreatedAt.UtcDateTime;
+        }
+        var contextText = SummaryBuilder.FormatAsHandoverPrompt(summary, req.ExtraContext);
+
+        // 2) Find or create the target session
+        Session target;
+        if (!string.IsNullOrEmpty(req.ToSessionId))
+        {
+            if (!Guid.TryParse(req.ToSessionId, out var toGuid))
+                return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid toSessionId format");
+            var existing = sessionManager.GetSession(toGuid);
+            if (existing is null)
+                return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "target session not found on this director");
+            if (existing.Status is SessionStatus.Exited or SessionStatus.Failed)
+                return DirectorCommandResult.Fail(DirectorCommandStatus.Conflict, "target session has exited");
+            target = existing;
+            await target.SendTextAsync(contextText, SendSource.Internal);
+        }
+        else
+        {
+            var repo = req.ToRepoPath!;
+            if (!Directory.Exists(repo))
+                return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"toRepoPath does not exist: {repo}");
+            if (!Enum.TryParse<AgentKind>(req.ToAgent, ignoreCase: true, out var kind))
+                return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unknown agent: {req.ToAgent}");
+
+            if (!AgentPluginRegistry.Contains(kind))
+                return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"agent {kind} is not a built-in plugin target");
+            var agent = AgentPluginRegistry.CreateAgent(kind, sessionManager.Options);
+
+            try
+            {
+                target = sessionManager.CreateSession(repo, agent, userArgs: null, SessionBackendType.ConPty, resumeSessionId: null);
+            }
+            catch (Exception ex)
+            {
+                return DirectorCommandResult.Fail(DirectorCommandStatus.Error, "failed to create target session: " + ex.Message);
+            }
+            // SessionManager.CreateSession now fires OnSessionCreated itself, so no
+            // explicit RaiseSessionCreated call is needed here.
+
+            // Dispatch the context after the new session reaches Idle. Fire-and-forget;
+            // we return the target DTO immediately so callers can navigate to it.
+            var capturedTarget = target;
+            var capturedText = contextText;
+            _ = Task.Run(async () =>
+            {
+                var deadline = DateTime.UtcNow.AddMilliseconds(30_000);
+                while (DateTime.UtcNow < deadline)
+                {
+                    var st = capturedTarget.ActivityState;
+                    if (st is ActivityState.Idle or ActivityState.WaitingForInput) break;
+                    if (st is ActivityState.Exited) { FileLog.Write($"[SessionWriteExecutor] handover-generate target exited before idle, sid={capturedTarget.Id}"); return; }
+                    await Task.Delay(500);
+                }
+                try { await capturedTarget.SendTextAsync(capturedText, SendSource.Internal); }
+                catch (Exception ex) { FileLog.Write($"[SessionWriteExecutor] handover-generate dispatch FAILED: {ex.Message}"); }
+            });
+        }
+
+        // 3) Optionally archive to vault
+        string? archivedAt = null;
+        if (req.ArchiveToVault)
+        {
+            try { archivedAt = HandoverArchive.Write(summary, contextText, target.Id.ToString()); }
+            catch (Exception ex) { FileLog.Write($"[SessionWriteExecutor] handover-generate archive FAILED: {ex.Message}"); }
+        }
+
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new HandoverResponse
+        {
+            Accepted = true,
+            TargetSession = ControlEndpoints.Map(target, directorId),
+            ContextSent = contextText,
+            ArchivedAt = archivedAt,
+        }));
+    }
+
+    /// <summary>
+    /// The <c>wingman-ask</c> verb: the "Ask the Wingman" channel. Mirrors the Director's
+    /// <c>POST /sessions/{sid}/wingman/ask</c> lambda - two behaviours, both on the strong model:
+    /// <c>mode=explain</c> is a terse "what's happening" briefing over pre-built context; a free-text
+    /// question opens a read-only full-power session over the whole terminal + repo that answers faithfully
+    /// and reads content VERBATIM. Invalid id -&gt; BadRequest; a missing session -&gt; NotFound. The
+    /// question-required guard is NOT an id/session error but the wingman's own <c>bad_request</c> outcome,
+    /// so it rides back as a 200 <see cref="WingmanAskResult"/> (Status "bad_request"); the REST route maps
+    /// that Status to its original 400 exactly as the execute-action verb maps its executor outcomes. The
+    /// turn-summary cache (explain mode's context input) rides in the command services; no new dependency is
+    /// introduced because the answer itself comes from the static <see cref="Core.Wingman.WingmanService"/>
+    /// methods. Lifted as a plain unary verb (Architect option A); the slow-LLM invocation strategy is a
+    /// Phase 2 decision, deliberately unchanged here.
+    /// </summary>
+    internal static async Task<DirectorCommandResult> WingmanAskAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken)
+    {
+        var sessionManager = context.SessionManager;
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var req = SessionCommandExecutor.Deserialize<WingmanAskRequest>(command.PayloadJson);
+        var explain = string.Equals(req?.Mode, "explain", StringComparison.OrdinalIgnoreCase);
+        // Explain mode briefs the whole session and needs no user question; the free-text ask path still
+        // requires one. This is the wingman's bad_request outcome, carried in the result (a 200 here, mapped
+        // to a 400 at the REST boundary), NOT an id/session guard.
+        if (req is null || (!explain && string.IsNullOrWhiteSpace(req.Question)))
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(
+                new WingmanAskResult { Status = "bad_request", Error = "question is required" }));
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        // Explain = the terse "what's happening" briefing (strong model over pre-built, length-capped
+        // context). Unchanged.
+        if (explain)
+        {
+            var explainCtx = await WingmanContextBuilder.BuildAsync(session, context.Services?.TurnSummaryCache, cancellationToken);
+            var explainResult = await Core.Wingman.WingmanService.AskAboutSessionAsync(
+                req.Question, explainCtx, sessionManager.Options.ClaudePath, cancellationToken, explain: true);
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(explainResult));
+        }
+
+        // Any free-text question = the faithful "Ask the Wingman" channel: a read-only full-power session
+        // over the WHOLE terminal + repo, on the strong model, that reads content VERBATIM instead of
+        // summarizing.
+        var fullTerminal = ControlEndpoints.ReadFullCleanedBuffer(session);
+        var result = await Core.Wingman.WingmanService.AnswerViaSessionAsync(
+            req.Question, fullTerminal, session.AgentKind.ToString(), session.RepoPath,
+            sessionManager.Options.ClaudePath, cancellationToken);
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(result));
+    }
+
+    /// <summary>
+    /// The <c>recap-generate</c> verb: build (and cache) a fresh recap for a session by running the static
+    /// <see cref="RecapGenerator.GenerateAsync"/> over a digest of the session's Claude transcript. Mirrors
+    /// the Director's <c>POST /sessions/{sid}/recap</c> lambda - invalid id -&gt; BadRequest, missing session
+    /// -&gt; NotFound. The not-yet-linked, missing-transcript, and generation-failure branches are DOMAIN
+    /// states the route returned as 200 <see cref="RecapResponse"/> bodies (status strings), so they stay
+    /// <see cref="DirectorCommandStatus.Ok"/> here; the successful generation is also an Ok body whose
+    /// <c>Status == "ok"</c>, which the REST route maps to its original 201 (a 200 for the domain-state
+    /// bodies). The <c>model</c> query argument rides in the <see cref="RecapGenerateRequest"/> payload. A
+    /// caller cancellation (the route's 499) is NOT caught here - it is a boundary concern that bubbles to
+    /// the REST/stream boundary - while every other generation fault is preserved as the route's
+    /// <c>generation_failed</c> 200, exactly as the source lambda's try/catch did.
+    /// </summary>
+    internal static async Task<DirectorCommandResult> RecapGenerateAsync(SessionManager sessionManager, string directorId, DirectorCommand command, CancellationToken cancellationToken)
+    {
+        FileLog.Write($"[SessionWriteExecutor] recap-generate: sid={command.SessionId}");
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        var request = SessionCommandExecutor.Deserialize<RecapGenerateRequest>(command.PayloadJson);
+        var model = request?.Model;
+        if (string.IsNullOrWhiteSpace(model))
+            model = RecapGenerator.DefaultModel;
+
+        if (string.IsNullOrEmpty(session.ClaudeSessionId))
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new RecapResponse
+            {
+                SessionId = command.SessionId,
+                Model = model,
+                Status = "no_session_id",
+                Error = "Session has not been linked to a Claude session id yet.",
+            }));
+
+        var jsonl = ClaudeSessionReader.GetJsonlPath(session.ClaudeSessionId, session.RepoPath);
+        if (!File.Exists(jsonl))
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new RecapResponse
+            {
+                SessionId = command.SessionId,
+                Model = model,
+                Status = "no_jsonl",
+                Error = $"JSONL file not found at {jsonl}",
+            }));
+
+        SessionSummaryDto summary;
+        string digest;
+        int currentTurns;
+        try
+        {
+            var messages = StreamMessageParser.ParseFile(jsonl);
+            summary = SummaryBuilder.Build(messages);
+            summary.SessionId = command.SessionId;
+            summary.DirectorId = directorId;
+            summary.Agent = session.AgentKind.ToString();
+            summary.RepoPath = session.RepoPath;
+            summary.ActivityState = session.ActivityState.ToString();
+            summary.CreatedAt = session.CreatedAt.UtcDateTime;
+            digest = SummaryBuilder.FormatAsHandoverPrompt(summary);
+            currentTurns = summary.TurnCount;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[SessionWriteExecutor] recap-generate digest build FAILED: {ex.Message}");
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new RecapResponse
+            {
+                SessionId = command.SessionId,
+                Model = model,
+                Status = "generation_failed",
+                Error = "Failed to build session digest: " + ex.Message,
+            }));
+        }
+
+        try
+        {
+            var sw = Stopwatch.StartNew();
+            var recapText = await RecapGenerator.GenerateAsync(
+                digest, sessionManager.Options.ClaudePath, model, cancellationToken);
+            sw.Stop();
+
+            var entry = new RecapCache.Entry
+            {
+                Recap = recapText,
+                GeneratedAt = DateTime.UtcNow,
+                AtTurnCount = currentTurns,
+                Model = model,
+                ElapsedMs = sw.ElapsedMilliseconds,
+            };
+            RecapCache.Set(guid, entry);
+
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new RecapResponse
+            {
+                SessionId = command.SessionId,
+                Recap = entry.Recap,
+                GeneratedAt = entry.GeneratedAt,
+                AtTurnCount = entry.AtTurnCount,
+                CurrentTurnCount = currentTurns,
+                IsStale = false,
+                Model = entry.Model,
+                ElapsedMs = entry.ElapsedMs,
+                Status = "ok",
+            }));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            FileLog.Write($"[SessionWriteExecutor] recap-generate generation FAILED: {ex.Message}");
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new RecapResponse
+            {
+                SessionId = command.SessionId,
+                Model = model,
+                Status = "generation_failed",
+                Error = ex.Message,
+            }));
+        }
     }
 }

--- a/src/CcDirector.Gateway.Contracts/RecapGenerateRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/RecapGenerateRequest.cs
@@ -1,0 +1,14 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 0 (wave 3): the payload for the <c>recap-generate</c> tunnel verb
+/// (POST /sessions/{sid}/recap). The only input the REST route carried was the optional <c>model</c>
+/// query-string argument; it rides here so the tunnel verb and the REST route reach the SAME core with
+/// identical inputs. A blank/absent model resolves to the recap default model inside the core, exactly
+/// as the REST lambda resolved it.
+/// </summary>
+public sealed class RecapGenerateRequest
+{
+    /// <summary>The model to generate the recap with. Blank/absent falls back to the recap default.</summary>
+    public string? Model { get; set; }
+}

--- a/src/CcDirector.Gateway.Tests/CatalogReadExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/CatalogReadExecutorTests.cs
@@ -232,4 +232,58 @@ public sealed class CatalogReadExecutorTests
         }
         finally { sm.Dispose(); }
     }
+
+    // ---------- repos-list (Gateway Cleanup Phase 0 wave 3: needs the live registry via SessionCommandServices) ----------
+
+    [Fact]
+    public async Task DispatchAsync_ReposList_NoRegistryInServices_ReturnsOkWithEmptyArray()
+    {
+        // repos-list is director-level (no session), always a 200. With no registry wired (no services) the
+        // core lists nothing - an empty array - exactly as the REST route returned when no registry was set.
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("repos-list"));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal("r2", result.CommandId);
+            var repos = JsonSerializer.Deserialize<List<RepositoryDto>>(result.BodyJson ?? "", Json);
+            Assert.NotNull(repos);
+            Assert.Empty(repos!);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_ReposList_WithRegistry_ReturnsRegisteredRepos()
+    {
+        // The live registry rides in the services - the one dependency the tunnel command surface did not carry
+        // before wave 3 - and the core reads the same instance the REST route read at Map time.
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        var registryFile = Path.Combine(Path.GetTempPath(), "ccd-repos-" + Guid.NewGuid().ToString("N") + ".json");
+        var repoDir = Path.Combine(Path.GetTempPath(), "ccd-repo-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(repoDir);
+        try
+        {
+            var registry = new Core.Configuration.RepositoryRegistry(registryFile);
+            Assert.True(registry.TryAdd(repoDir));
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("repos-list"),
+                new SessionCommandServices { Repositories = registry });
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var repos = JsonSerializer.Deserialize<List<RepositoryDto>>(result.BodyJson ?? "", Json);
+            Assert.NotNull(repos);
+            Assert.Contains(repos!, r => string.Equals(
+                Path.GetFullPath(r.Path).TrimEnd('\\', '/'),
+                Path.GetFullPath(repoDir).TrimEnd('\\', '/'),
+                StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            sm.Dispose();
+            try { if (File.Exists(registryFile)) File.Delete(registryFile); } catch { /* best effort */ }
+            try { if (Directory.Exists(repoDir)) Directory.Delete(repoDir, true); } catch { /* best effort */ }
+        }
+    }
 }

--- a/src/CcDirector.Gateway.Tests/SessionReadExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionReadExecutorTests.cs
@@ -425,4 +425,57 @@ public sealed class SessionReadExecutorTests
         }
         finally { sm.Dispose(); }
     }
+
+    // ---------- handover (Gateway Cleanup Phase 0 wave 3: needs the Director version via SessionCommandServices) ----------
+
+    [Fact]
+    public async Task DispatchAsync_Handover_InvalidSessionId_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("handover", "not-a-guid"),
+                new SessionCommandServices { DirectorVersion = "9.9.9-test" });
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_Handover_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("handover", Guid.NewGuid().ToString()),
+                new SessionCommandServices { DirectorVersion = "9.9.9-test" });
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_Handover_ExistingSession_ReturnsInfoBlockWithVersionFromServices()
+    {
+        // The identity/locate block is a pure read of the live session record. The Director version rides in
+        // the services - the one dependency the tunnel command surface did not carry - and is stamped exactly
+        // as the REST route stamped ControlApiHost._version. The block never carries a Director address.
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-handover", Cmd("handover", session.Id.ToString()),
+                new SessionCommandServices { DirectorVersion = "9.9.9-test" });
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var dto = JsonSerializer.Deserialize<HandoverInfoDto>(result.BodyJson ?? "", Json);
+            Assert.NotNull(dto);
+            Assert.Equal(session.Id.ToString(), dto!.SessionId);
+            Assert.Equal("dir-handover", dto.DirectorId);
+            Assert.Equal("9.9.9-test", dto.Version);
+            Assert.Equal(Environment.MachineName, dto.MachineName);
+            Assert.False(string.IsNullOrWhiteSpace(dto.DisplayName));
+            Assert.DoesNotContain("http://", result.BodyJson ?? "", StringComparison.OrdinalIgnoreCase);
+        }
+        finally { sm.Dispose(); }
+    }
 }

--- a/src/CcDirector.Gateway.Tests/SessionWriteExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionWriteExecutorTests.cs
@@ -415,4 +415,197 @@ public sealed class SessionWriteExecutorTests
         }
         finally { sm.Dispose(); }
     }
+
+    // ---------- handover-generate (Gateway Cleanup Phase 0 wave 3: director-level, no target session id) ----------
+
+    [Fact]
+    public async Task DispatchAsync_HandoverGenerate_MissingFromSessionId_ReturnsBadRequest()
+    {
+        // An empty payload deserializes to null -> the fromSessionId guard fires (the route's 400).
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Command("handover-generate", ""));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_HandoverGenerate_BothTargets_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var req = new HandoverRequest
+            {
+                FromSessionId = Guid.NewGuid().ToString(),
+                ToSessionId = Guid.NewGuid().ToString(),
+                ToRepoPath = Path.GetTempPath(),
+            };
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Command("handover-generate", "", req));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_HandoverGenerate_MissingSource_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var req = new HandoverRequest
+            {
+                FromSessionId = Guid.NewGuid().ToString(),
+                ToSessionId = Guid.NewGuid().ToString(),
+            };
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Command("handover-generate", "", req));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_HandoverGenerate_ExistingSourceAndTarget_ReturnsOkWithTargetSession()
+    {
+        // Source and target are both embedded sessions on this manager. Neither has a Claude session id, so the
+        // context is built from the simple branch (no file IO); the target receives it via SendTextAsync. The
+        // core returns the target mapped through the plain Map, exactly as the create verb does.
+        var (sm, source, _) = NewSession();
+        try
+        {
+            var target = sm.CreateEmbeddedSession(Path.GetTempPath(), null, new ExecuteActionTestBackend());
+            var req = new HandoverRequest
+            {
+                FromSessionId = source.Id.ToString(),
+                ToSessionId = target.Id.ToString(),
+                ArchiveToVault = false,
+            };
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Command("handover-generate", "", req));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal("cmd-w1", result.CommandId);
+            var resp = JsonSerializer.Deserialize<HandoverResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(resp);
+            Assert.True(resp!.Accepted);
+            Assert.NotNull(resp.TargetSession);
+            Assert.Equal(target.Id.ToString(), resp.TargetSession!.SessionId);
+            Assert.False(string.IsNullOrEmpty(resp.ContextSent));
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- wingman-ask (Gateway Cleanup Phase 0 wave 3: static WingmanService, no new dependency) ----------
+
+    [Fact]
+    public async Task DispatchAsync_WingmanAsk_InvalidSessionId_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("wingman-ask", "not-a-guid", new WingmanAskRequest { Question = "hi" }));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WingmanAsk_EmptyQuestion_ReturnsOkWithBadRequestOutcome()
+    {
+        // The question-required guard is the wingman's own bad_request OUTCOME (a 200 carrying the result), not
+        // an id/session error - the REST route maps that Status to its original 400.
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("wingman-ask", session.Id.ToString(), new WingmanAskRequest { Question = "" }));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var ask = JsonSerializer.Deserialize<WingmanAskResult>(result.BodyJson ?? "", Json);
+            Assert.NotNull(ask);
+            Assert.Equal("bad_request", ask!.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WingmanAsk_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("wingman-ask", Guid.NewGuid().ToString(), new WingmanAskRequest { Question = "hi" }));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WingmanAsk_NoClaudeConfigured_ReturnsOkWithNoClaudeStatus()
+    {
+        // With an empty ClaudePath, AnswerViaSessionAsync returns Status="no_claude" without spawning a
+        // process (the fail-open contract), so the free-text ask wire path is verifiable without a CLI.
+        var sm = new SessionManager(new Core.Configuration.AgentOptions { ClaudePath = "" });
+        try
+        {
+            var session = sm.CreateEmbeddedSession(Path.GetTempPath(), null, new ExecuteActionTestBackend());
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A",
+                Command("wingman-ask", session.Id.ToString(), new WingmanAskRequest { Question = "what is going on" }));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var ask = JsonSerializer.Deserialize<WingmanAskResult>(result.BodyJson ?? "", Json);
+            Assert.NotNull(ask);
+            Assert.Equal("no_claude", ask!.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- recap-generate (Gateway Cleanup Phase 0 wave 3: static RecapGenerator, no new dependency) ----------
+
+    [Fact]
+    public async Task DispatchAsync_RecapGenerate_InvalidSessionId_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Command("recap-generate", "not-a-guid"));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_RecapGenerate_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Command("recap-generate", Guid.NewGuid().ToString()));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_RecapGenerate_NoClaudeSessionId_ReturnsOkWithNoSessionIdStatus()
+    {
+        // A fresh embedded session has no linked Claude session id, so the core short-circuits to the domain
+        // state the route returned as a 200 body (Status="no_session_id") - no generation runs, no process
+        // spawns. The resolved model is stamped exactly as the route did.
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Command("recap-generate", session.Id.ToString()));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var resp = JsonSerializer.Deserialize<RecapResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(resp);
+            Assert.Equal("no_session_id", resp!.Status);
+            Assert.False(string.IsNullOrEmpty(resp.Model));
+        }
+        finally { sm.Dispose(); }
+    }
 }


### PR DESCRIPTION
## Gateway Cleanup mission, Phase 0 (wave 3b)

One additive, mergeable pull request that lifts the final 5 deferred verbs onto the shared tunnel command dispatch. NO deletions. Each core is extracted verbatim from its Director REST lambda; that REST route now calls the SAME core, so the tunnel verb and the route cannot drift (the core is the single source of truth). Phase 1 later deletes the routes and leaves the cores reached only over the tunnel.

### The 5 verbs moved (and the dependency each uses)

1. **repos-list** -> `CatalogReadExecutor`. `GET /repos`. Reads the live repository registry from `SessionCommandServices.Repositories` (the wave-3a dependency). A null registry lists nothing (an empty array), exactly as the route returned with no registry wired. Serializes the same `List<RepositoryDto>`.
2. **handover** -> `SessionReadExecutor`. `GET /sessions/{sid}/handover` (issue #1214). Builds a `HandoverInfoDto`; the `Version` field is stamped from `SessionCommandServices.DirectorVersion`, exactly like `facts`. Invalid id -> BadRequest, missing session -> NotFound. Never carries a Director address.
3. **handover-generate** -> `SessionWriteExecutor`. `POST /handover` (director-level, no session on the command). Creates/targets a session from a source (`fromSessionId` + exactly one of `toSessionId`/`toRepoPath`); guards and effect lifted verbatim (including the fire-and-forget new-session dispatch and the best-effort vault archive). Uses `SessionManager` from context. The core returns the target via the plain `ControlEndpoints.Map`; the REST route re-maps it with the identity-stamped mapper for its **201**, exactly as the create verb does. Exited target -> Conflict (the route's empty-body 409); create fault -> Error (the route's 500).
4. **wingman-ask** -> `SessionWriteExecutor`. `POST /sessions/{sid}/wingman/ask`. Calls the STATIC `WingmanService.AskAboutSessionAsync` / `AnswerViaSessionAsync` - **no new dependency** (the explain-mode context cache rides in the existing `TurnSummaryCache` service). Lifted as a plain unary verb (Architect option A); NOT redesigned as trigger-and-ack. The question-required guard is the wingman's own `bad_request` outcome, carried back in the result; the REST route maps that `Status` to its original 400, exactly as the execute-action verb maps its executor outcomes.
5. **recap-generate** -> `SessionWriteExecutor`. `POST /sessions/{sid}/recap`. Calls the STATIC `RecapGenerator.GenerateAsync` - **no new dependency**. Lifted as a plain unary verb. Domain-state bodies (`no_session_id`, `no_jsonl`, `generation_failed`) stay 200; a successful recap (`Status="ok"`) maps to the route's original **201**; a caller cancellation is NOT caught in the core (boundary concern) and bubbles to the REST boundary's **499**. The `?model=` query rides in the new `RecapGenerateRequest` payload.

None of the 5 were skipped.

### New DTO
- `src/CcDirector.Gateway.Contracts/RecapGenerateRequest.cs` (new file - carries only the optional `model` for `recap-generate`; no shared DTO file disturbed).

### Rules honored
- No fallback programming. Try/catch preserved only where the original lambda had one (recap digest/generation, handover archive/dispatch, wingman buffer read).
- `ReadFullCleanedBuffer` widened from `private` to `internal` (single-source, no copy) so `wingman-ask` reaches the same helper.
- Parity tests added to the three per-area test files: for each verb, invalid id -> BadRequest and/or missing session -> NotFound where applicable, plus a success body.

### Tests
`CatalogReadExecutorTests | SessionReadExecutorTests | SessionWriteExecutorTests | HandoverInfoEndpointTests | WingmanAskForwardingTests`: **Passed: 79, Failed: 0**. Build 0 warnings / 0 errors. Full test-project run is green except one pre-existing flaky transcription test (`DictationEndpointTests.FullPipeline_..._whole_clip_batch`) that passes in isolation and touches none of this change's code.