### PR TITLE
fix(mac-pty): strip parent-agent environment variables from spawned children

### DIFF
--- a/src/CcDirector.Core.Tests/UnixPtyBackendTests.cs
+++ b/src/CcDirector.Core.Tests/UnixPtyBackendTests.cs
@@ -99,4 +99,65 @@ public class UnixPtyBackendTests
         var actual = UnixProcessHost.TokenizeArgs(input);
         Assert.Equal(expected, actual);
     }
+
+    /// <summary>
+    /// Regression for the macOS session-history loss: a Director launched from inside a
+    /// Claude Code session inherits CLAUDE_CODE_CHILD_SESSION=1, and if that leaks into a
+    /// spawned agent, interactive Claude Code treats itself as a subagent and silently
+    /// never writes its session transcript. The child environment must strip the same
+    /// parent-agent variables the Windows ProcessHost strips.
+    /// </summary>
+    [Fact]
+    public void BuildEnvironment_StripsParentAgentVariables()
+    {
+        var poisoned = new Dictionary<string, string?>
+        {
+            ["CLAUDECODE"] = "1",
+            ["CLAUDE_CODE_CHILD_SESSION"] = "1",
+            ["CLAUDE_CODE_SESSION_ID"] = "11111111-2222-3333-4444-555555555555",
+            ["CLAUDE_CODE_ENTRYPOINT"] = "cli",
+            ["CODEX_THREAD_ID"] = "abc",
+            ["GIT_EDITOR"] = "true",
+        };
+        var originals = new Dictionary<string, string?>();
+        foreach (var kv in poisoned)
+        {
+            originals[kv.Key] = Environment.GetEnvironmentVariable(kv.Key);
+            Environment.SetEnvironmentVariable(kv.Key, kv.Value);
+        }
+        Environment.SetEnvironmentVariable("CODEX_HOME", "/tmp/codex-home-test");
+        try
+        {
+            var env = UnixProcessHost.BuildEnvironment(null)
+                .Where(e => e is not null)
+                .Select(e => e!)
+                .ToList();
+
+            Assert.DoesNotContain(env, e => e.StartsWith("CLAUDECODE=", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(env, e => e.StartsWith("CLAUDE_CODE_", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(env, e => e.StartsWith("CODEX_THREAD_ID=", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(env, e => e.StartsWith("GIT_EDITOR=", StringComparison.OrdinalIgnoreCase));
+            // CODEX_HOME is the deliberate exception, and TERM is forced.
+            Assert.Contains(env, e => e.StartsWith("CODEX_HOME=", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains("TERM=xterm-256color", env);
+        }
+        finally
+        {
+            foreach (var kv in originals)
+                Environment.SetEnvironmentVariable(kv.Key, kv.Value);
+            Environment.SetEnvironmentVariable("CODEX_HOME", null);
+        }
+    }
+
+    [Fact]
+    public void BuildEnvironment_AppliesCallerOverrides()
+    {
+        var env = UnixProcessHost.BuildEnvironment(new Dictionary<string, string>
+        {
+            ["CC_SESSION_ID"] = "test-session-id",
+        }).Where(e => e is not null).Select(e => e!).ToList();
+
+        Assert.Contains("CC_SESSION_ID=test-session-id", env);
+        Assert.Null(UnixProcessHost.BuildEnvironment(null)[^1]); // null-terminated
+    }
 }

--- a/src/CcDirector.Core/UnixPty/UnixProcessHost.cs
+++ b/src/CcDirector.Core/UnixPty/UnixProcessHost.cs
@@ -340,17 +340,32 @@ public sealed class UnixProcessHost : IDisposable
 
     /// <summary>
     /// Build the child environment: inherit the parent's, force TERM, apply any
-    /// caller overrides, and strip CLAUDECODE so Claude does not treat the session
-    /// as a nested Claude Code invocation. Returns a null-terminated KEY=VALUE array.
+    /// caller overrides, and strip parent-agent variables (same list as the
+    /// Windows ProcessHost) so a Director that was itself launched from inside a
+    /// terminal agent does not poison its children. In particular an inherited
+    /// CLAUDE_CODE_CHILD_SESSION=1 makes interactive Claude Code treat itself as
+    /// a subagent and silently skip writing its session transcript, which broke
+    /// session history on macOS. Returns a null-terminated KEY=VALUE array.
     /// </summary>
-    private static string?[] BuildEnvironment(Dictionary<string, string>? overrides)
+    internal static string?[] BuildEnvironment(Dictionary<string, string>? overrides)
     {
         var env = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (System.Collections.DictionaryEntry kv in Environment.GetEnvironmentVariables())
-            env[(string)kv.Key] = kv.Value?.ToString() ?? string.Empty;
+        {
+            var key = (string)kv.Key;
+            if (key.Equals("CLAUDECODE", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (key.StartsWith("CLAUDE_CODE_", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (key.StartsWith("CODEX_", StringComparison.OrdinalIgnoreCase)
+                && !key.Equals("CODEX_HOME", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (key.Equals("GIT_EDITOR", StringComparison.OrdinalIgnoreCase))
+                continue;
+            env[key] = kv.Value?.ToString() ?? string.Empty;
+        }
 
         env["TERM"] = "xterm-256color";
-        env.Remove("CLAUDECODE");
 
         if (overrides != null)
             foreach (var kv in overrides)


### PR DESCRIPTION
A Director launched from inside a Claude Code session inherits variables such as CLAUDE_CODE_CHILD_SESSION=1, and when those leak into a spawned agent, interactive Claude Code treats itself as a subagent and silently never writes its session transcript, which broke session history on macOS.

The Unix process host now strips the same parent-agent variable list as the Windows process host (CLAUDECODE, CLAUDE_CODE_*, CODEX_* except CODEX_HOME, GIT_EDITOR). Includes regression tests; all 10 UnixPtyBackendTests pass on the Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)