### PR TITLE
feat(gateway-cleanup): Wave 4b - Gateway-native missions (store, endpoints, create MissionName plumbing, CLI re-point)

### DIFF
--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -384,16 +384,40 @@ internal static class SessionCommandExecutor
         if (req.Role is not null && !SessionRoles.IsValid(req.Role))
             return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unknown role '{req.Role}'. Valid: {string.Join(", ", SessionRoles.All)}");
 
-        // Mission attach at spawn: resolve+validate the Mission BEFORE creating the session, mirroring the
-        // explicit-role check, so attaching to an unknown Mission never silently drops. The resolved record
-        // (below) supplies the cached display name stamped onto the session after it is created.
-        Mission? mission = null;
+        // Mission attach at spawn. Missions are a FLEET-level concept and now live at the Gateway (source of
+        // truth), so the mission name that binds the session into a pod arrives ON the create request:
+        //   * GATEWAY path (MissionId AND MissionName both set): the Gateway already resolved+validated the
+        //     mission against its OWN store, so the Director stamps the attachment DIRECTLY - no local-store
+        //     lookup, no local validation. This is the end state.
+        //   * TRANSITIONAL BRIDGE (MissionId set, MissionName blank): an old caller hitting the Director's
+        //     POST /sessions directly for a Director-store mission. The Director resolves the name from its
+        //     own MissionStore exactly as before, rejecting an unknown mission. This local-lookup bridge is
+        //     TEMPORARY: it is REMOVED when the Gateway Cleanup Phase 1 drops the Director MissionStore, after
+        //     which the Director never resolves a mission name locally and only stamps what create carries.
+        //   * No MissionId: no attach.
+        // Resolved BEFORE creating the session (mirroring the explicit-role check) so an unknown mission never
+        // silently drops. attachMissionId / attachMissionName below carry the values stamped after creation.
+        Guid? attachMissionId = null;
+        string? attachMissionName = null;
         if (req.MissionId is Guid createMissionId)
         {
-            mission = services?.MissionStore?.Get(createMissionId);
-            if (mission is null)
-                return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest,
-                    $"unknown mission '{createMissionId}'. Create it first with POST /missions.");
+            if (!string.IsNullOrWhiteSpace(req.MissionName))
+            {
+                // Gateway path: trust the Gateway's already-validated mission id + name; stamp directly.
+                attachMissionId = createMissionId;
+                attachMissionName = req.MissionName;
+            }
+            else
+            {
+                // Transitional bridge: resolve the name from the local Director MissionStore. Removed with
+                // the Director MissionStore in Phase 1.
+                var mission = services?.MissionStore?.Get(createMissionId);
+                if (mission is null)
+                    return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest,
+                        $"unknown mission '{createMissionId}'. Create it first with POST /missions.");
+                attachMissionId = mission.MissionId;
+                attachMissionName = mission.MissionName;
+            }
         }
 
         // RawCli requires a Command; validate before constructing the agent.
@@ -492,10 +516,11 @@ internal static class SessionCommandExecutor
         if (explicitRole is not null)
             session.SetExplicitRole(explicitRole);
 
-        // Mission attach at spawn: stamp the session's MissionId and cache the resolved display name (the
-        // Mission was validated above). This is the attachment that binds the new session into a pod.
-        if (mission is not null)
-            session.AttachToMission(mission.MissionId, mission.MissionName);
+        // Mission attach at spawn: stamp the session's MissionId and cache the display name (resolved above,
+        // either carried by the Gateway or resolved via the transitional local-store bridge). This is the
+        // attachment that binds the new session into a pod.
+        if (attachMissionId is Guid stampMissionId)
+            session.AttachToMission(stampMissionId, attachMissionName);
 
         // Issue #212: dispatch a supplied PrePrompt once the agent is actually READY, fire-and-forget so
         // create returns immediately. Readiness = a substantial startup burst followed by a quiet poll;

--- a/src/CcDirector.Gateway.Contracts/NewSessionRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/NewSessionRequest.cs
@@ -105,6 +105,16 @@ public sealed class NewSessionRequest
     public Guid? MissionId { get; set; }
 
     /// <summary>
+    /// Optional resolved display name of the Mission named by <see cref="MissionId"/>. Set by the Gateway
+    /// when it spawns a session into a GATEWAY-NATIVE mission: the Gateway validates the mission against its
+    /// OWN store, then forwards BOTH <see cref="MissionId"/> and this name so the Director stamps the
+    /// attachment directly WITHOUT any local mission-store lookup (the Gateway is the source of truth). Left
+    /// null by a caller hitting a Director's POST /sessions directly for an old Director-store mission, in
+    /// which case the Director resolves the name locally (the transitional bridge in SessionCommandExecutor).
+    /// </summary>
+    public string? MissionName { get; set; }
+
+    /// <summary>
     /// Optional target machine for spawn routing ("start a session on another computer"). Null,
     /// empty, or the local machine name spawns on the LOCAL machine (the default, unchanged); a
     /// remote machine name routes the spawn via the Gateway to a Director on that machine (first

--- a/src/CcDirector.Gateway.Tests/GatewayHostTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayHostTests.cs
@@ -63,6 +63,9 @@ public sealed class GatewayHostTests : IAsyncLifetime
             // back to the REAL per-user path and this test's /devices/register calls leak
             // "regression-test-device" rows into the developer's live registry (found 2026-07-04).
             devicesPath: Path.Combine(_instancesDir, "devices.json"),
+            // Gateway Cleanup mission (Wave 4b): isolate the Gateway-native mission store to this test's temp
+            // dir so /missions calls never touch the developer machine's real missions.json.
+            missionsPath: Path.Combine(_instancesDir, "missions.json"),
             account: GatewayAccountFactory.Build(
                 new InMemoryTokenStore(),
                 Path.Combine(_instancesDir, "auth-events.jsonl")));
@@ -148,6 +151,46 @@ public sealed class GatewayHostTests : IAsyncLifetime
     public async Task Delete_unknown_director_returns_404()
     {
         var resp = await _http.DeleteAsync($"directors/{Guid.NewGuid()}");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    // Gateway Cleanup mission (Wave 4b): the Gateway-native mission surface. Create -> list -> get round-trip
+    // over the real loopback Gateway, plus a blank-name 400 and an unknown-id 404. Missions live at the
+    // Gateway now (the source of truth), so these routes must serve them like the Director's own /missions.
+    [Fact]
+    public async Task Missions_create_list_get_roundtrip()
+    {
+        // Create.
+        var createResp = await _http.PostAsJsonAsync("missions", new NewMissionRequest { MissionName = "Gateway Cleanup" });
+        Assert.Equal(HttpStatusCode.Created, createResp.StatusCode);
+        var created = await createResp.Content.ReadFromJsonAsync<MissionDto>();
+        Assert.NotNull(created);
+        Assert.NotEqual(Guid.Empty, created!.MissionId);
+        Assert.Equal("Gateway Cleanup", created.MissionName);
+
+        // List includes it.
+        var list = await _http.GetFromJsonAsync<List<MissionDto>>("missions");
+        Assert.NotNull(list);
+        Assert.Contains(list!, m => m.MissionId == created.MissionId && m.MissionName == "Gateway Cleanup");
+
+        // Get by id returns the same record.
+        var one = await _http.GetFromJsonAsync<MissionDto>($"missions/{created.MissionId}");
+        Assert.NotNull(one);
+        Assert.Equal(created.MissionId, one!.MissionId);
+        Assert.Equal("Gateway Cleanup", one.MissionName);
+    }
+
+    [Fact]
+    public async Task Missions_create_blank_name_returns_400()
+    {
+        var resp = await _http.PostAsJsonAsync("missions", new NewMissionRequest { MissionName = "   " });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Missions_get_unknown_returns_404()
+    {
+        var resp = await _http.GetAsync($"missions/{Guid.NewGuid()}");
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 

--- a/src/CcDirector.Gateway.Tests/MissionCommandTests.cs
+++ b/src/CcDirector.Gateway.Tests/MissionCommandTests.cs
@@ -181,6 +181,82 @@ public sealed class MissionCommandTests
         finally { sm.Dispose(); }
     }
 
+    // Gateway Cleanup mission (Wave 4b): when the create request carries BOTH a MissionId and a MissionName
+    // (the GATEWAY path - the Gateway already validated the mission against its own store), the Director
+    // stamps the attachment DIRECTLY with no local-store lookup. Proof of "no lookup": the id is NOT in the
+    // store here (in fact the store is EMPTY), yet the create succeeds and stamps the carried name - a local
+    // lookup would have rejected it as unknown.
+    [Fact]
+    public async Task Create_WithMissionNamePresent_StampsDirectly_WithoutStoreLookup()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var services = new SessionCommandServices { MissionStore = NewMissionStore() }; // empty store
+            var carriedId = Guid.NewGuid(); // never created in the store
+
+            var command = CreateCommand(new NewSessionRequest
+            {
+                RepoPath = Path.GetTempPath(),
+                Agent = "RawCli",
+                Command = TestShellPath,
+                Name = "gateway-mission-create",
+                MissionId = carriedId,
+                MissionName = "Gateway Native Mission", // resolved+validated by the Gateway already
+            });
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command, services);
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status); // NOT rejected despite the empty store
+            var dto = JsonSerializer.Deserialize<SessionDto>(result.BodyJson ?? "", Json);
+            Assert.NotNull(dto);
+            Assert.Equal(carriedId, dto.MissionId);
+            Assert.Equal("Gateway Native Mission", dto.MissionName); // stamped from the request, not the store
+
+            Assert.True(Guid.TryParse(dto.SessionId, out var sid));
+            var session = sm.GetSession(sid);
+            Assert.NotNull(session);
+            Assert.Equal(carriedId, session.MissionId);
+            Assert.Equal("Gateway Native Mission", session.MissionName);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // Gateway Cleanup mission (Wave 4b): the TRANSITIONAL BRIDGE. When the create request carries a MissionId
+    // but a BLANK MissionName (an old caller hitting the Director's POST /sessions directly for a
+    // Director-store mission), the Director resolves the name from its OWN store - so the stamped name comes
+    // from the store, not the request. Proof: the store name differs from anything on the request.
+    [Fact]
+    public async Task Create_WithMissionNameAbsent_ResolvesNameFromLocalStore()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var store = NewMissionStore();
+            var mission = store.Create("Name From Director Store");
+            var services = new SessionCommandServices { MissionStore = store };
+
+            var command = CreateCommand(new NewSessionRequest
+            {
+                RepoPath = Path.GetTempPath(),
+                Agent = "RawCli",
+                Command = TestShellPath,
+                Name = "bridge-mission-create",
+                MissionId = mission.MissionId,
+                MissionName = null, // blank -> the transitional local-store lookup resolves the name
+            });
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command, services);
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var dto = JsonSerializer.Deserialize<SessionDto>(result.BodyJson ?? "", Json);
+            Assert.NotNull(dto);
+            Assert.Equal(mission.MissionId, dto.MissionId);
+            Assert.Equal("Name From Director Store", dto.MissionName); // resolved from the store
+        }
+        finally { sm.Dispose(); }
+    }
+
     [Fact]
     public async Task Create_WithUnknownMissionId_ReturnsBadRequest_NoSessionCreated()
     {

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -90,7 +90,12 @@ internal static class GatewayEndpoints
         // overlays an EXPIRED snooze back into "needs you" (OnHold=false) so the session returns on its
         // own even if its Director has died. Null (old callers, tests) leaves hold as a plain forward
         // with no timer, byte-identical to before.
-        Snooze.SnoozeRegistry? snoozeRegistry = null)
+        Snooze.SnoozeRegistry? snoozeRegistry = null,
+        // Gateway Cleanup mission (Wave 4b): the Gateway-native mission store. When non-null, the
+        // POST/GET /missions routes are mapped and a mission-scoped spawn validates against it. Missions are
+        // a fleet-level concept, so the source of truth lives here at the Gateway. Null (old callers, tests)
+        // maps nothing, leaving missions to the Director's own /missions routes (unchanged this phase).
+        Core.Sessions.MissionStore? missions = null)
     {
         // The old issue #1188 "session lock" (423 Locked on human input while a PENDING dictation record
         // existed) was removed deliberately (issue #1308). This is a single-operator tool: a collision
@@ -136,6 +141,43 @@ internal static class GatewayEndpoints
                 sessionNumbers.Release(sessionId);
                 return Results.NoContent();
             });
+        }
+
+        // Gateway Cleanup mission (Wave 4b): the Gateway-native mission surface. Missions are a fleet-level
+        // concept (they span Directors and machines and nest), so the source of truth lives here at the
+        // Gateway - like fleet messaging and scheduling - and mission-existence VALIDATION lives here now.
+        // These routes inherit the host-wide token middleware, exactly like /cron/jobs and /session-numbers.
+        // The Director's own /missions routes stay until a later phase; this is the additive equivalent.
+        //   POST /missions        body { missionName, parentMissionId? } -> 201 MissionDto | 400
+        //   GET  /missions        -> [ MissionDto ]
+        //   GET  /missions/{mid}  -> MissionDto | 404
+        if (missions is not null)
+        {
+            app.MapPost("/missions", (NewMissionRequest req) =>
+            {
+                FileLog.Write($"[GatewayEndpoints] POST /missions: name=\"{req?.MissionName}\"");
+                if (req is null || string.IsNullOrWhiteSpace(req.MissionName))
+                    return Results.BadRequest(new { error = "missionName is required" });
+
+                var mission = missions.Create(req.MissionName, req.ParentMissionId);
+                return Results.Json(ToMissionDto(mission), statusCode: StatusCodes.Status201Created);
+            });
+
+            app.MapGet("/missions", () =>
+                Results.Json(missions.List().Select(ToMissionDto).ToList()));
+
+            app.MapGet("/missions/{mid}", (string mid) =>
+            {
+                if (!Guid.TryParse(mid, out var missionId))
+                    return Results.BadRequest(new { error = "invalid mission id format" });
+
+                var mission = missions.Get(missionId);
+                return mission is null
+                    ? Results.NotFound(new { error = "mission not found" })
+                    : Results.Json(ToMissionDto(mission));
+            });
+
+            FileLog.Write("[GatewayEndpoints] mapped Gateway-native /missions routes");
         }
 
         // Issue #469 closed the secret-embedding phone-pairing QR endpoints (/pair/qr.png and
@@ -1966,6 +2008,15 @@ internal static class GatewayEndpoints
     // (EffectiveColor/StateLabel/TriageBucket) then reads SessionRole to suppress a live Worker's red, so it
     // must run AFTER the role is known. NeedsYouSince keys off the final EffectiveColor, so it is stamped
     // here too (a suppressed Worker is not "red", so it never enters the needs-you clock).
+    // Gateway Cleanup mission (Wave 4b): map a stored Mission to the wire MissionDto - the SAME contract the
+    // Director's /missions routes return, so a client cannot tell a Gateway-native mission from a Director one.
+    private static MissionDto ToMissionDto(Core.Sessions.Mission m) => new()
+    {
+        MissionId = m.MissionId,
+        MissionName = m.MissionName,
+        ParentMissionId = m.ParentMissionId,
+    };
+
     private static void StampFleetRolesAndFold(List<SessionDto> all, Func<string, bool, DateTime?>? needsYouStampFor, Snooze.SnoozeRegistry? snoozeRegistry = null)
     {
         // Snooze Length mission: an EXPIRED snooze must read as "needs you" again. The registry is the

--- a/src/CcDirector.Gateway/Api/MachineEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/MachineEndpoints.cs
@@ -54,7 +54,13 @@ internal static class MachineEndpoints
 
     public static void Map(IEndpointRouteBuilder app, LauncherRegistry launchers,
         MachineSessionSpawner spawner,
-        LauncherCommandRouter.SendLauncherCommandAsync? sendLauncherCommand = null)
+        LauncherCommandRouter.SendLauncherCommandAsync? sendLauncherCommand = null,
+        // Gateway Cleanup mission (Wave 4b): the Gateway-native mission store. When non-null, a
+        // mission-scoped spawn (req.MissionId set) is validated against it here - the Gateway is the source
+        // of truth - and the resolved mission NAME is stamped onto the create request so the Director stamps
+        // the attachment without any local lookup. Null (old callers, tests) leaves MissionId to flow through
+        // to the Director's transitional local-store bridge unchanged.
+        Core.Sessions.MissionStore? missions = null)
     {
         if (spawner is null) throw new ArgumentNullException(nameof(spawner));
 
@@ -129,6 +135,21 @@ internal static class MachineEndpoints
             FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions: repo={req?.RepoPath}, agent={req?.Agent}");
             if (req is null || string.IsNullOrWhiteSpace(req.RepoPath))
                 return Results.BadRequest(new { error = "repoPath is required" });
+
+            // Gateway Cleanup mission (Wave 4b): a mission-scoped spawn is validated against the Gateway's OWN
+            // mission store (the source of truth) and the resolved NAME is stamped onto the create request, so
+            // the Director stamps the attachment directly with no local-store lookup. Reject an unknown mission
+            // here rather than forwarding it to a Director that no longer owns mission validation.
+            if (req.MissionId is Guid spawnMissionId && missions is not null)
+            {
+                var mission = missions.Get(spawnMissionId);
+                if (mission is null)
+                {
+                    FileLog.Write($"[MachineEndpoints] POST /machines/{machine}/sessions: unknown mission {spawnMissionId}");
+                    return Results.BadRequest(new { error = $"unknown mission '{spawnMissionId}'. Create it first with POST /missions." });
+                }
+                req.MissionName = mission.MissionName;
+            }
 
             var (ok, dto, error, _) = await spawner.SpawnOnMachineAsync(machine, req, ct);
             if (!ok || dto is null)

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -52,6 +52,17 @@ public sealed class GatewayHost : IAsyncDisposable
     public Streaming.PushedSessionStore PushedSessions { get; }
 
     /// <summary>
+    /// Gateway Cleanup mission (Wave 4b): the Gateway's OWN store of Missions. Missions are a fleet-level
+    /// concept (they span Directors and machines and nest), so the source of truth lives at the Gateway,
+    /// like fleet messaging and scheduling - not on any one Director. Reuses the same JSON-file-backed
+    /// <see cref="Core.Sessions.MissionStore"/> the Director uses, pointed at a Gateway-side file. The
+    /// mission REST endpoints (POST/GET /missions) read and write this, and a mission-scoped spawn
+    /// validates against it before forwarding the create to a Director. The Director's own /missions
+    /// routes stay until a later phase; this is the additive Gateway-native equivalent.
+    /// </summary>
+    public Core.Sessions.MissionStore Missions { get; }
+
+    /// <summary>
     /// Gateway Cleanup mission, Phase 0 (up-stream): the registry of live Director up-streams (terminal output
     /// and finite file/screenshot reads), keyed by the stream id the Gateway mints per browser request. The
     /// director-stream hub's StreamUp method pumps the Director's frames into this registry, which forwards
@@ -397,7 +408,12 @@ public sealed class GatewayHost : IAsyncDisposable
     /// <see cref="Account"/> null on a non-Windows host, where the operating-system credential store is
     /// not yet implemented).
     /// </param>
-    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? snoozePath = null)
+    /// <param name="missionsPath">
+    /// Override the Gateway-native mission store file (Gateway Cleanup mission, Wave 4b). Tests pass an
+    /// isolated temp path; production omits it for the shared default at
+    /// <c>CcStorage.Root()\missions.json</c>.
+    /// </param>
+    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? snoozePath = null, string? missionsPath = null)
     {
         Port = port;
         Token = token ?? GatewayAuth.LoadOrCreate();
@@ -407,6 +423,10 @@ public sealed class GatewayHost : IAsyncDisposable
         // own stale/unreachable sweep, so this never fires for a merely momentarily-unreachable Director.
         Registry.OnDirectorRemoved += directorId => SessionNumbers.ReleaseForDirector(directorId);
         PushedSessions = new Streaming.PushedSessionStore();
+        // Gateway Cleanup mission (Wave 4b): the Gateway-native mission store, at a Gateway-side file path
+        // (CcStorage.Root(), the same location the cron and snooze stores use), NOT the Director's tool-config
+        // missions.json. Reuses Core.Sessions.MissionStore unchanged.
+        Missions = new Core.Sessions.MissionStore(missionsPath ?? Path.Combine(CcStorage.Root(), "missions.json"));
         StreamRegistry = new Streaming.GatewayStreamRegistry();
         InputStats = new Stats.GatewayInputStatsAggregator(inputStatsPath);
         SessionConcurrency = new Stats.GatewaySessionConcurrencyStats();
@@ -964,6 +984,9 @@ public sealed class GatewayHost : IAsyncDisposable
                 o.StreamBufferCapacity = Contracts.DirectorStreamLimits.StreamBufferCapacity;
             });
         builder.Services.AddSingleton(PushedSessions);
+        // Gateway Cleanup mission (Wave 4b): the Gateway-native mission store, so the mission endpoints and
+        // spawn validation share the one instance.
+        builder.Services.AddSingleton(Missions);
         // Gateway Cleanup Phase 0: the one up-stream registry the DirectorHub (constructed per-invocation by
         // SignalR) pumps StreamUp frames into.
         builder.Services.AddSingleton(StreamRegistry);
@@ -1187,7 +1210,10 @@ public sealed class GatewayHost : IAsyncDisposable
             // Snooze Length mission: the Gateway-owned snooze registry. POST /sessions/{sid}/hold records
             // (or clears) a snooze-until here, and the /sessions fold overlays an EXPIRED snooze back into
             // "needs you" so the session returns on its own even after its Director dies.
-            snoozeRegistry: _snoozeRegistry);
+            snoozeRegistry: _snoozeRegistry,
+            // Gateway Cleanup mission (Wave 4b): the Gateway-native mission store backs POST/GET /missions and
+            // mission-scoped spawn validation. Missions are a fleet concept, so their source of truth is here.
+            missions: Missions);
 
         // Issue #268: the two raw per-session WebSocket legs (live Terminal stream + dictation)
         // proxied through the Gateway so a remote Cockpit talks same-origin to the Gateway and
@@ -1429,7 +1455,10 @@ public sealed class GatewayHost : IAsyncDisposable
         // /machines/{machine}/director/restart|start|stop to reach that machine's Director.
         // launcher-persistent-join: pass the stream-send hook only when stream mode is on. The relay tries
         // this first and falls back to the REST relay when it returns null (stream off, or launcher offline).
-        MachineEndpoints.Map(_app, Launchers, _machineSessionSpawner, _streamMode ? SendLauncherCommandAsync : null);
+        MachineEndpoints.Map(_app, Launchers, _machineSessionSpawner, _streamMode ? SendLauncherCommandAsync : null,
+            // Gateway Cleanup mission (Wave 4b): validate a mission-scoped spawn against the Gateway store and
+            // stamp the resolved mission name onto the create request forwarded to the Director.
+            missions: Missions);
 
         // The Cockpit Settings page surface (docs/architecture/gateway/SETTINGS_OWNERSHIP.md):
         // one snapshot GET plus brain-restart and autostart actions. Reads this host directly

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -448,7 +448,7 @@ def mission_create(
         None, "--parent", help="Parent Mission id to nest this Mission under (a tree of Missions)."
     ),
 ) -> None:
-    """Create a Mission record on the local Director and print its id."""
+    """Create a Mission record on the Gateway and print its id."""
     mission_ops.create_mission(name, parent)
 
 
@@ -456,7 +456,7 @@ def mission_create(
 def mission_list(
     json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON."),
 ) -> None:
-    """List every Mission record on the local Director."""
+    """List every Mission record on the Gateway."""
     mission_ops.list_missions(json_output)
 
 

--- a/tools/cc-devthrottle/src/mission_ops.py
+++ b/tools/cc-devthrottle/src/mission_ops.py
@@ -1,9 +1,11 @@
 """Mission operations for cc-devthrottle.
 
-A Mission is a first-class persisted record on the local Director that sessions attach to
-(see docs/new_architecture/mission-as-first-class-unit-of-work.md). These commands create and
-list Mission records via the Director Control API (POST /missions, GET /missions), mirroring the
-session/schedule command style.
+A Mission is a first-class persisted record that a pod of sessions is collectively chartered to
+accomplish (see docs/new_architecture/mission-as-first-class-unit-of-work.md). Missions are a
+FLEET-level concept - they span Directors and machines and nest - so their source of truth lives at
+the GATEWAY, like fleet messaging and scheduling, not on any one Director (Gateway Cleanup mission,
+Wave 4b). These commands create and list Mission records via the Gateway Control API
+(POST /missions, GET /missions), mirroring the schedule command style.
 """
 
 from __future__ import annotations
@@ -12,7 +14,9 @@ import json
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
+import requests
 import typer
 from rich import box
 from rich.console import Console
@@ -23,29 +27,139 @@ _tools_dir = str(Path(__file__).resolve().parent.parent.parent)
 if _tools_dir not in sys.path:
     sys.path.insert(0, _tools_dir)
 
-from cc_shared import director  # noqa: E402
+from cc_shared.config import CCDirectorConfig  # noqa: E402
 
 console = Console()
+err_console = Console(stderr=True)
+
+LOOPBACK_DEFAULT = "http://127.0.0.1:7878"
+TIMEOUT_SECONDS = 10
+
+
+class GatewayError(Exception):
+    """A handled, user-facing failure talking to the Gateway."""
+
+
+def resolve_base_url() -> str:
+    config = CCDirectorConfig().load()
+    url = (config.gateway.url or "").strip()
+    return url.rstrip("/") if url else LOOPBACK_DEFAULT
+
+
+def _auth_token() -> str:
+    config = CCDirectorConfig().load()
+    return (config.gateway.token or "").strip()
+
+
+def _is_loopback(url: str) -> bool:
+    """True when the URL targets this machine (a loopback Gateway needs no token)."""
+    host = (urlparse(url).hostname or "").lower()
+    return host in ("127.0.0.1", "localhost", "::1")
+
+
+class MissionClient:
+    """Talks to one Gateway's mission surface (POST/GET /missions)."""
+
+    def __init__(self, base_url: Optional[str] = None) -> None:
+        self.base_url = (base_url or resolve_base_url()).rstrip("/")
+        self._token = _auth_token()
+        # Make the auth requirement explicit instead of silently issuing an unauthenticated request to a
+        # remote Gateway: a loopback Gateway on this machine needs no token, but a remote one does.
+        if not self._token and not _is_loopback(self.base_url):
+            raise GatewayError(
+                f"Gateway URL {self.base_url} is remote but gateway.token is not set. "
+                "Set it with 'cc-devthrottle settings set gateway.token <token>' "
+                "(a loopback Gateway on this machine needs no token)."
+            )
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Accept": "application/json"}
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
+        return headers
+
+    def _request(
+        self, method: str, path: str, json_body: Optional[Dict[str, Any]] = None
+    ) -> requests.Response:
+        url = f"{self.base_url}{path}"
+        try:
+            return requests.request(
+                method,
+                url,
+                json=json_body,
+                headers=self._headers(),
+                timeout=TIMEOUT_SECONDS,
+            )
+        except requests.exceptions.ConnectionError as exc:
+            raise GatewayError(
+                f"Gateway not reachable at {self.base_url}. "
+                "Is the Gateway tray app running on this machine? "
+                "If you target a remote Gateway, set gateway.url with "
+                "'cc-devthrottle settings set gateway.url <url>'."
+            ) from exc
+        except requests.exceptions.Timeout as exc:
+            raise GatewayError(
+                f"Gateway at {self.base_url} did not respond within {TIMEOUT_SECONDS}s."
+            ) from exc
+
+    @staticmethod
+    def _gateway_message(resp: requests.Response) -> str:
+        try:
+            data = resp.json()
+            if isinstance(data, dict) and data.get("error"):
+                return str(data["error"])
+        except ValueError:
+            pass
+        text = (resp.text or "").strip()
+        return text if text else f"Gateway returned HTTP {resp.status_code}"
+
+    def _ok_or_raise(self, resp: requests.Response) -> Any:
+        if 200 <= resp.status_code < 300:
+            if not resp.content:
+                return {}
+            return resp.json()
+        raise GatewayError(self._gateway_message(resp))
+
+    def create(self, name: str, parent: Optional[str]) -> Dict[str, Any]:
+        body: Dict[str, Any] = {"missionName": name}
+        if parent:
+            body["parentMissionId"] = parent
+        return self._ok_or_raise(self._request("POST", "/missions", body))
+
+    def list_all(self) -> List[Dict[str, Any]]:
+        data = self._ok_or_raise(self._request("GET", "/missions"))
+        return list(data) if isinstance(data, list) else []
+
+
+def _field(record: Dict[str, Any], *names: str) -> Optional[str]:
+    """First present, non-empty value among the given key spellings (camel/Pascal case)."""
+    for name in names:
+        value = record.get(name)
+        if value:
+            return str(value)
+    return None
+
+
+def _short_id(value: Optional[str]) -> str:
+    if not value:
+        return "-"
+    return value.split("-")[0] if "-" in value else value
 
 
 def create_mission(name: str, parent: Optional[str]) -> None:
-    """Create a Mission record on the local Director and print its id."""
-    body: Dict[str, Any] = {"missionName": name}
-    if parent:
-        body["parentMissionId"] = parent
-
+    """Create a Mission record on the Gateway and print its id."""
     try:
-        resp = director.post_json("missions", body)
-    except director.DirectorError as err:
+        resp = MissionClient().create(name, parent)
+    except GatewayError as err:
         console.print(f"[red]Error:[/red] {err}")
         raise typer.Exit(1)
 
-    mid = director.field(resp, "missionId", "MissionId")
+    mid = _field(resp, "missionId", "MissionId")
     if not mid:
-        console.print("[red]Error:[/red] the Director did not return a mission id.")
+        console.print("[red]Error:[/red] the Gateway did not return a mission id.")
         raise typer.Exit(1)
 
-    label = director.field(resp, "missionName", "MissionName") or name
+    label = _field(resp, "missionName", "MissionName") or name
     console.print(f"[green]Created[/green] mission ({label}).")
     console.print(f"id: {mid}")
     console.print(
@@ -54,10 +168,10 @@ def create_mission(name: str, parent: Optional[str]) -> None:
 
 
 def list_missions(json_output: bool) -> None:
-    """List every Mission record on the local Director."""
+    """List every Mission record on the Gateway."""
     try:
-        missions = director.get_json("missions") or []
-    except director.DirectorError as err:
+        missions = MissionClient().list_all()
+    except GatewayError as err:
         console.print(f"[red]Error:[/red] {err}")
         raise typer.Exit(1)
 
@@ -67,7 +181,7 @@ def list_missions(json_output: bool) -> None:
 
     if not missions:
         console.print(
-            "No missions on this Director yet. Create one with 'cc-devthrottle mission create <name>'."
+            "No missions on the Gateway yet. Create one with 'cc-devthrottle mission create <name>'."
         )
         return
 
@@ -77,8 +191,8 @@ def list_missions(json_output: bool) -> None:
     table.add_column("Parent")
 
     for mission in missions:
-        mid = director.field(mission, "missionId", "MissionId")
-        name = director.field(mission, "missionName", "MissionName") or "-"
-        parent = director.field(mission, "parentMissionId", "ParentMissionId") or "-"
-        table.add_row(director.short_id(mid) if mid else "-", name, parent)
+        mid = _field(mission, "missionId", "MissionId")
+        name = _field(mission, "missionName", "MissionName") or "-"
+        parent = _field(mission, "parentMissionId", "ParentMissionId") or "-"
+        table.add_row(_short_id(mid) if mid else "-", name, parent)
     console.print(table)


### PR DESCRIPTION
## Gateway Cleanup mission - Wave 4b: make missions Gateway-native

Missions are a fleet-level concept (they span Directors and machines and nest), so per the Architect's ruling their source of truth belongs at the **Gateway** (like fleet messaging and scheduling), not on any one Director. This pull request ADDS the Gateway-native equivalent and re-points the command-line tool. It is fully additive: the Director's existing `/missions` routes and its `MissionStore` stay untouched until a later phase.

### The four parts

**1. Gateway mission store.** `GatewayHost` now owns its own `Core.Sessions.MissionStore` instance (property `Missions`) at a Gateway-side file path (`CcStorage.Root()/missions.json`, the same location the cron and snooze stores use), wired as a field and registered as a dependency-injection singleton exactly like `PushedSessions` / `InputStats` / `SessionConcurrency`. A new `missionsPath` constructor parameter lets tests isolate it.

**2. Gateway endpoints.** `GatewayEndpoints.Map` gains `POST /missions` (validate `missionName` required -> 400, create, return `MissionDto` with 201), `GET /missions` (list), and `GET /missions/{mid}` (404 if unknown). They use the SAME `MissionDto` contract the Director uses and inherit the host-wide token middleware, exactly like `/cron/jobs`. **Mission-existence validation lives here now** - the Gateway is the source of truth.

**3. Create MissionName plumbing (the key semantic).**
- `NewSessionRequest` gains an optional `MissionName`, documented as: set by the Gateway when it spawns a session into a Gateway-native mission, so the Director stamps the attachment without a local lookup.
- `SessionCommandExecutor.Create` now branches:
  - **Gateway path** (`MissionId` set AND `MissionName` non-blank): stamp `AttachToMission(id, name)` directly, with NO local-store lookup and NO local validation (the Gateway already validated).
  - **Transitional bridge** (`MissionId` set, `MissionName` blank): do the local `MissionStore` lookup exactly as today (reject unknown -> 400). This bridge is clearly commented as temporary and REMOVED when Phase 1 drops the Director `MissionStore`; the end state is the Director never resolves a mission name locally, only stamps what create carries.
  - No `MissionId`: no attach, as before.
- **Gateway spawn path.** `POST /machines/{machine}/sessions` (the reachable Gateway spawn surface, via `MachineSessionSpawner`) now validates a mission-scoped spawn against the Gateway's OWN mission store (reject unknown -> 400) and stamps BOTH `MissionId` and the resolved `MissionName` onto the create request forwarded to the Director.

**4. Command-line re-point.** `cc-devthrottle mission create` / `mission list` now hit the **Gateway** `/missions` endpoints (following the `schedule_ops` model: `resolve_base_url` from `config.gateway.url`, bearer `gateway.token`, `requests`), not the Director. Output and table layout are unchanged; the two command docstrings that said "local Director" now say "Gateway". The Director `/missions` routes are untouched.

### Spawn-path wiring status
The Gateway spawn surface that threads a `MissionId` today is `POST /machines/{machine}/sessions`; it is now fully wired (validate + stamp id and name). No spawn-path wiring is left as a follow-up.

### No-fallback note
The transitional bridge is an explicit, commented, temporary code path gated on `MissionName` being blank - not a silent fallback. When both id and name are present the store is never consulted (proven by a test that succeeds with an EMPTY store).

### Tests
- `GatewayHostTests`: Gateway `/missions` round-trip over the real loopback Gateway (create -> list -> get), blank-name 400, unknown-id 404. The test Gateway isolates its missions store to a temp path.
- `MissionCommandTests`: create-verb direct-stamp (`MissionName` present, empty store, still succeeds and stamps the carried name - proving no store lookup) and the transitional bridge (`MissionName` absent, name resolved from the local store).

Both affected projects build at **0 warnings / 0 errors**. Filtered test run: **87 passed, 0 failed**.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)