### PR TITLE
feat(gateway-cleanup): Wave 4a - lift the remaining orphan verbs onto the tunnel dispatch

### DIFF
--- a/src/CcDirector.ControlApi/CatalogReadExecutor.cs
+++ b/src/CcDirector.ControlApi/CatalogReadExecutor.cs
@@ -48,6 +48,12 @@ internal sealed class CatalogReadExecutor : ISessionCommandArea
         "fs-list",
         "facts",
         "repos-list",
+        // Gateway Cleanup Phase 0 (Wave 4a): the two saved-handover-DOCUMENT reads. These read the saved
+        // handover documents on this machine (DISTINCT from the per-session "handover" info verb). Each core
+        // reproduces its old REST lambda verbatim, so the REST route and the tunnel verb share one core and
+        // cannot drift.
+        "handovers-list",
+        "handovers-content",
     };
 
     public async Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken)
@@ -61,6 +67,8 @@ internal sealed class CatalogReadExecutor : ISessionCommandArea
             "fs-list" => FsList(command),
             "facts" => Facts(context.DirectorId, context.Services?.DirectorVersion),
             "repos-list" => ReposList(context.Services?.Repositories),
+            "handovers-list" => HandoversList(command),
+            "handovers-content" => HandoversContent(command),
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the catalog read area"),
         };
     }
@@ -284,6 +292,70 @@ internal sealed class CatalogReadExecutor : ISessionCommandArea
         {
             FileLog.Write($"[CatalogReadExecutor] fs-list FAILED: {ex.Message}");
             return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// The <c>handovers-list</c> verb (director-level, no session): the saved handover DOCUMENTS on this
+    /// machine (the Handovers tab), NOT the per-session handover info. Mirrors the Director's
+    /// <c>GET /handovers</c> lambda - a scan of <see cref="HandoverScanner.ScanAll"/>, optionally filtered to
+    /// documents whose repo paths include the payload <c>repo</c> (normalized comparison), always a 200 - and
+    /// returns a serialized <see cref="List{HandoverDto}"/>. The source route had no try/catch, so none is
+    /// added here.
+    /// </summary>
+    internal static DirectorCommandResult HandoversList(DirectorCommand command)
+    {
+        var request = SessionCommandExecutor.Deserialize<HandoversListRequest>(command.PayloadJson);
+        var repo = request?.Repo;
+        FileLog.Write($"[CatalogReadExecutor] handovers-list: repo={repo}");
+
+        var infos = HandoverScanner.ScanAll();
+        if (!string.IsNullOrWhiteSpace(repo))
+        {
+            var wanted = ControlEndpoints.NormalizeRepoPath(repo);
+            infos = infos.Where(h => h.RepoPaths.Any(p => ControlEndpoints.NormalizeRepoPath(p) == wanted)).ToList();
+        }
+        var dtos = infos.Select(h => new HandoverDto
+        {
+            Path = h.Path,
+            Title = h.Title,
+            DateDisplay = h.DateDisplay,
+            DateUtc = h.DateUtc,
+            RepoPath = h.RepoPath,
+            RepoPaths = h.RepoPaths,
+            SessionName = h.SessionName,
+        }).ToList();
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(dtos));
+    }
+
+    /// <summary>
+    /// The <c>handovers-content</c> verb (director-level, no session): the raw content of one saved handover
+    /// document. Mirrors the Director's <c>GET /handovers/content</c> lambda - a null / blank path -&gt;
+    /// BadRequest - and returns a serialized <see cref="HandoverContentDto"/>. The source route wrapped the
+    /// read in a try/catch that turned an <see cref="UnauthorizedAccessException"/> into a 400 (surfaced here
+    /// as <see cref="DirectorCommandStatus.BadRequest"/>) and a <see cref="FileNotFoundException"/> into a 404
+    /// (surfaced here as <see cref="DirectorCommandStatus.NotFound"/>), so that try/catch is preserved here and
+    /// behaviour is byte-identical.
+    /// </summary>
+    internal static DirectorCommandResult HandoversContent(DirectorCommand command)
+    {
+        var request = SessionCommandExecutor.Deserialize<HandoverContentRequest>(command.PayloadJson);
+        var path = request?.Path;
+        FileLog.Write($"[CatalogReadExecutor] handovers-content: path={path}");
+        if (string.IsNullOrWhiteSpace(path))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "path is required");
+        try
+        {
+            var content = HandoverScanner.ReadContent(path);
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new HandoverContentDto { Path = path, Content = content }));
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, ex.Message);
+        }
+        catch (FileNotFoundException)
+        {
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "handover not found");
         }
     }
 }

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -2384,14 +2384,25 @@ internal static class ControlEndpoints
 
         // Delete one screenshot from disk (the per-card "Del" action). Mirrors the desktop, which
         // deletes the file off disk. Path-traversal safe via ResolveScreenshot.
-        app.MapDelete("/screenshots/file", (string name) =>
+        // Gateway Cleanup Phase 0 (Wave 4a): the delete runs through the shared SessionByteExecutor core so
+        // this REST path and the Gateway tunnel verb are identical and cannot drift. The bare name rides in
+        // the command payload; the core resolves it with the same traversal-safe ResolveScreenshot helper, so
+        // an escaping/non-image/missing name is still a 404. Phase 1 deletes this route.
+        app.MapDelete("/screenshots/file", async (string name) =>
         {
-            var full = ResolveScreenshot(name);
-            if (full is null)
-                return Results.NotFound(new { error = "screenshot not found" });
-            FileLog.Write($"[ControlEndpoints] DELETE /screenshots/file: {full}");
-            File.Delete(full);
-            return Results.Json(new { deleted = true, fileName = Path.GetFileName(full) });
+            var command = new DirectorCommand
+            {
+                Verb = "screenshot-delete",
+                PayloadJson = SessionCommandExecutor.Serialize(new ScreenshotDeleteRequest { Name = name }),
+            };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
+
+            return result.Status switch
+            {
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<ScreenshotDeleteResponse>(result.BodyJson)),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "screenshot-delete command failed"),
+            };
         });
 
         // ===== REST: Fan-out within this Director =====
@@ -2496,16 +2507,26 @@ internal static class ControlEndpoints
         });
 
         // ===== REST: Remove a repository from the recent list =====
-        app.MapDelete("/repos", (string? path) =>
+        // Gateway Cleanup Phase 0 (Wave 4a): the remove runs through the shared SessionWriteExecutor core so
+        // this REST path and the Gateway tunnel verb are identical and cannot drift. The path rides in the
+        // command payload; the live registry rides in the services (as repos-list reads it). A blank path is
+        // a 400 and a null registry is a 200 { removed = false }, exactly as before. Phase 1 deletes this route.
+        app.MapDelete("/repos", async (string? path) =>
         {
-            FileLog.Write($"[ControlEndpoints] DELETE /repos: path={path}");
-            if (string.IsNullOrWhiteSpace(path))
-                return Results.BadRequest(new { error = "path is required" });
-            if (repositoryRegistry is null)
-                return Results.Json(new { removed = false });
+            var command = new DirectorCommand
+            {
+                Verb = "repo-delete",
+                PayloadJson = SessionCommandExecutor.Serialize(new RepoDeleteRequest { Path = path }),
+            };
+            var services = new SessionCommandServices { Repositories = repositoryRegistry };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command, services);
 
-            var removed = repositoryRegistry.Remove(path);
-            return Results.Json(new { removed });
+            return result.Status switch
+            {
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<RepoDeleteResponse>(result.BodyJson)),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "repo-delete command failed"),
+            };
         });
 
         // ===== REST: Register a repository explicitly (no session needed) =====
@@ -2674,26 +2695,24 @@ internal static class ControlEndpoints
         });
 
         // ===== REST: Handover documents (Handovers tab) =====
-        app.MapGet("/handovers", (string? repo) =>
+        // Gateway Cleanup Phase 0 (Wave 4a): the saved-handover-document list runs through the shared
+        // CatalogReadExecutor core so this REST path and the Gateway tunnel verb are identical and cannot
+        // drift. This lists the saved handover DOCUMENTS on this machine (DISTINCT from the per-session
+        // "handover" info verb). The ?repo= filter rides in the command payload. Phase 1 deletes this route.
+        app.MapGet("/handovers", async (string? repo) =>
         {
-            FileLog.Write($"[ControlEndpoints] GET /handovers: repo={repo}");
-            var infos = HandoverScanner.ScanAll();
-            if (!string.IsNullOrWhiteSpace(repo))
+            var command = new DirectorCommand
             {
-                var wanted = NormalizeRepoPath(repo);
-                infos = infos.Where(h => h.RepoPaths.Any(p => NormalizeRepoPath(p) == wanted)).ToList();
-            }
-            var dtos = infos.Select(h => new HandoverDto
+                Verb = "handovers-list",
+                PayloadJson = SessionCommandExecutor.Serialize(new HandoversListRequest { Repo = repo }),
+            };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
+
+            return result.Status switch
             {
-                Path = h.Path,
-                Title = h.Title,
-                DateDisplay = h.DateDisplay,
-                DateUtc = h.DateUtc,
-                RepoPath = h.RepoPath,
-                RepoPaths = h.RepoPaths,
-                SessionName = h.SessionName,
-            }).ToList();
-            return Results.Json(dtos);
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<List<HandoverDto>>(result.BodyJson)),
+                _ => Results.Problem(result.Error ?? "handovers-list command failed"),
+            };
         });
 
         app.MapPost("/handovers", (HandoverCreateRequest req) =>
@@ -2741,24 +2760,26 @@ internal static class ControlEndpoints
             }
         });
 
-        app.MapGet("/handovers/content", (string? path) =>
+        // Gateway Cleanup Phase 0 (Wave 4a): the saved-handover-document content read runs through the shared
+        // CatalogReadExecutor core so this REST path and the Gateway tunnel verb are identical and cannot
+        // drift. The ?path= argument rides in the command payload; the core preserves the source route's
+        // try/catch, so an access error is still a 400 and a missing file a 404. Phase 1 deletes this route.
+        app.MapGet("/handovers/content", async (string? path) =>
         {
-            FileLog.Write($"[ControlEndpoints] GET /handovers/content: path={path}");
-            if (string.IsNullOrWhiteSpace(path))
-                return Results.BadRequest(new { error = "path is required" });
-            try
+            var command = new DirectorCommand
             {
-                var content = HandoverScanner.ReadContent(path);
-                return Results.Json(new HandoverContentDto { Path = path, Content = content });
-            }
-            catch (UnauthorizedAccessException ex)
+                Verb = "handovers-content",
+                PayloadJson = SessionCommandExecutor.Serialize(new HandoverContentRequest { Path = path }),
+            };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
+
+            return result.Status switch
             {
-                return Results.BadRequest(new { error = ex.Message });
-            }
-            catch (FileNotFoundException)
-            {
-                return Results.NotFound(new { error = "handover not found" });
-            }
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<HandoverContentDto>(result.BodyJson)),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "handovers-content command failed"),
+            };
         });
 
         // ===== REST: Remote folder browser (Browse... button) =====
@@ -2932,23 +2953,53 @@ internal static class ControlEndpoints
         });
 
         // Dismiss one claimed dirty journal once its sessions are recovered or no longer wanted.
-        app.MapDelete("/interrupted/{deadDirectorId}/{deadPid:int}", (HttpContext ctx, string deadDirectorId, int deadPid) =>
+        // Gateway Cleanup Phase 0 (Wave 4a): the dismiss runs through the shared SessionWriteExecutor core so
+        // this REST path and the Gateway tunnel verb are identical and cannot drift. The route segments ride
+        // in the command payload; the caller-identity boundary log (it reads the HTTP connection) stays here.
+        // A missing journal is still a 404, exactly as before. Phase 1 deletes this route.
+        app.MapDelete("/interrupted/{deadDirectorId}/{deadPid:int}", async (HttpContext ctx, string deadDirectorId, int deadPid) =>
         {
             var caller = Core.Network.LoopbackPeerResolver.Describe(ctx.Connection.RemotePort, ctx.Connection.LocalPort);
             FileLog.Write($"[ControlEndpoints] DELETE /interrupted/{deadDirectorId}/{deadPid} caller={caller}");
-            var removed = Core.Sessions.DirectorCrashJournal.Dismiss(deadDirectorId, deadPid);
-            return removed ? Results.Json(new { dismissed = true }) : Results.NotFound(new { error = "no such interrupted journal" });
+            var command = new DirectorCommand
+            {
+                Verb = "interrupted-dismiss",
+                PayloadJson = SessionCommandExecutor.Serialize(new InterruptedDismissRequest { DeadDirectorId = deadDirectorId, DeadPid = deadPid }),
+            };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
+
+            return result.Status switch
+            {
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<InterruptedDismissResponse>(result.BodyJson)),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "interrupted-dismiss command failed"),
+            };
         });
 
         // Remove ONE session from a claimed dirty journal after it has been restored
         // (issue #212 W4): the rest of the journal stays in the Interrupted sessions list.
+        // Gateway Cleanup Phase 0 (Wave 4a): the remove runs through the shared SessionWriteExecutor core so
+        // this REST path and the Gateway tunnel verb are identical and cannot drift. The route segments ride
+        // in the command payload; the caller-identity boundary log stays here. A session that is not in the
+        // journal is still a 404, exactly as before. Phase 1 deletes this route.
         app.MapDelete("/interrupted/{deadDirectorId}/{deadPid:int}/sessions/{sessionId}",
-            (HttpContext ctx, string deadDirectorId, int deadPid, string sessionId) =>
+            async (HttpContext ctx, string deadDirectorId, int deadPid, string sessionId) =>
         {
             var caller = Core.Network.LoopbackPeerResolver.Describe(ctx.Connection.RemotePort, ctx.Connection.LocalPort);
             FileLog.Write($"[ControlEndpoints] DELETE /interrupted/{deadDirectorId}/{deadPid}/sessions/{sessionId} caller={caller}");
-            var removed = Core.Sessions.DirectorCrashJournal.RemoveSession(deadDirectorId, deadPid, sessionId);
-            return removed ? Results.Json(new { removed = true }) : Results.NotFound(new { error = "no such interrupted session" });
+            var command = new DirectorCommand
+            {
+                Verb = "interrupted-remove",
+                PayloadJson = SessionCommandExecutor.Serialize(new InterruptedRemoveRequest { DeadDirectorId = deadDirectorId, DeadPid = deadPid, SessionId = sessionId }),
+            };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
+
+            return result.Status switch
+            {
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<InterruptedRemoveResponse>(result.BodyJson)),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "interrupted-remove command failed"),
+            };
         });
 
         // ===== Admin: session-number backfill (issue #846) =====
@@ -2961,13 +3012,22 @@ internal static class ControlEndpoints
         // auth is enabled. Reached through the Gateway via POST /directors/{id}/backfill-numbers,
         // which forwards here (a Director-id-keyed route, since the per-session /sessions/{sid}
         // catch-all would treat a non-session path segment as a session id).
-        app.MapPost("/admin/backfill-numbers", (HttpContext ctx) =>
+        // Gateway Cleanup Phase 0 (Wave 4a): the backfill runs through the shared SessionWriteExecutor core so
+        // this REST path and the Gateway tunnel verb are identical and cannot drift. The verb takes no input
+        // and always returns a 200 with the count newly numbered; the caller-identity boundary log stays here.
+        // Phase 1 deletes this route.
+        app.MapPost("/admin/backfill-numbers", async (HttpContext ctx) =>
         {
             var caller = Core.Network.LoopbackPeerResolver.Describe(ctx.Connection.RemotePort, ctx.Connection.LocalPort);
             FileLog.Write($"[ControlEndpoints] POST admin/backfill-numbers requested caller={caller}");
-            var assigned = sessionManager.BackfillNumbers();
-            FileLog.Write($"[ControlEndpoints] admin/backfill-numbers assigned {assigned} number(s)");
-            return Results.Json(new { assigned });
+            var command = new DirectorCommand { Verb = "backfill-numbers", SessionId = "" };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
+
+            return result.Status switch
+            {
+                DirectorCommandStatus.Ok => Results.Json(SessionCommandExecutor.Deserialize<BackfillNumbersResponse>(result.BodyJson)),
+                _ => Results.Problem(result.Error ?? "backfill-numbers command failed"),
+            };
         });
 
         // ===== Shutdown =====

--- a/src/CcDirector.ControlApi/SessionByteExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionByteExecutor.cs
@@ -17,7 +17,10 @@ namespace CcDirector.ControlApi;
 /// </summary>
 internal sealed class SessionByteExecutor : ISessionCommandArea
 {
-    public IReadOnlyCollection<string> Verbs { get; } = new[] { "screenshots-list", "upload-image" };
+    // Gateway Cleanup Phase 0 (Wave 4a): screenshot-delete is the third unary byte verb - a plain file delete
+    // keyed by a traversal-safe bare name, the tunnel twin of DELETE /screenshots/file. Its core reproduces
+    // that route verbatim, so the REST route and the tunnel verb share one core and cannot drift.
+    public IReadOnlyCollection<string> Verbs { get; } = new[] { "screenshots-list", "upload-image", "screenshot-delete" };
 
     public Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken)
     {
@@ -25,6 +28,7 @@ internal sealed class SessionByteExecutor : ISessionCommandArea
         {
             "screenshots-list" => ScreenshotsList(command),
             "upload-image" => UploadImage(context.SessionManager, command),
+            "screenshot-delete" => ScreenshotDelete(command),
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the byte area"),
         };
         return Task.FromResult(result);
@@ -138,6 +142,32 @@ internal sealed class SessionByteExecutor : ISessionCommandArea
         {
             Path = fullPath,
             FileName = name,
+        }));
+    }
+
+    /// <summary>
+    /// The <c>screenshot-delete</c> verb: delete one screenshot from disk (the per-card "Del" action). Mirrors
+    /// the Director's <c>DELETE /screenshots/file</c> lambda - the bare name is resolved traversal-safe by the
+    /// SAME <see cref="ControlEndpoints.ResolveScreenshot"/> helper the file GET/read used, so a name that
+    /// escapes the screenshots folder, is not a bare image file, or does not exist -&gt; NotFound (the route's
+    /// 404) - and returns <c>{ deleted = true, fileName }</c> on success. The name rides in the payload. This
+    /// is a plain unary write.
+    /// </summary>
+    internal static DirectorCommandResult ScreenshotDelete(DirectorCommand command)
+    {
+        var request = SessionCommandExecutor.Deserialize<ScreenshotDeleteRequest>(command.PayloadJson);
+        var name = request?.Name;
+        FileLog.Write($"[SessionByteExecutor] screenshot-delete: name={name}");
+
+        var full = ControlEndpoints.ResolveScreenshot(name);
+        if (full is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "screenshot not found");
+
+        File.Delete(full);
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new ScreenshotDeleteResponse
+        {
+            Deleted = true,
+            FileName = Path.GetFileName(full),
         }));
     }
 }

--- a/src/CcDirector.ControlApi/SessionWriteExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionWriteExecutor.cs
@@ -3,6 +3,7 @@ using CcDirector.Core.AgentPlugins;
 using CcDirector.Core.Agents;
 using CcDirector.Core.Backends;
 using CcDirector.Core.Claude;
+using CcDirector.Core.Configuration;
 using CcDirector.Core.Sessions;
 using CcDirector.Core.Utilities;
 using CcDirector.Core.Wingman;
@@ -39,6 +40,13 @@ internal sealed class SessionWriteExecutor : ISessionCommandArea
         // per-session writes that call static services (no new dependency). Each core reproduces its old
         // REST lambda verbatim, so the REST route and the tunnel verb share one core and cannot drift.
         "handover-generate", "wingman-ask", "recap-generate",
+        // Gateway Cleanup Phase 0 (Wave 4a): the remaining director-level orphan WRITE verbs. repo-delete
+        // reads the live registry from the services (as repos-list does); the two interrupted-* verbs and
+        // backfill-numbers touch static Director state. None targets a session (SessionId is ""), except that
+        // interrupted-remove names a recoverable session inside a dead Director's journal via its payload.
+        // Each core reproduces its old REST lambda verbatim, so the REST route and the tunnel verb share one
+        // core and cannot drift.
+        "repo-delete", "interrupted-dismiss", "interrupted-remove", "backfill-numbers",
     };
 
     public async Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken)
@@ -70,6 +78,10 @@ internal sealed class SessionWriteExecutor : ISessionCommandArea
             "handover-generate" => await HandoverGenerateAsync(sessionManager, context.DirectorId, command),
             "wingman-ask" => await WingmanAskAsync(context, command, cancellationToken),
             "recap-generate" => await RecapGenerateAsync(sessionManager, context.DirectorId, command, cancellationToken),
+            "repo-delete" => RepoDelete(command, context.Services?.Repositories),
+            "interrupted-dismiss" => InterruptedDismiss(command),
+            "interrupted-remove" => InterruptedRemove(command),
+            "backfill-numbers" => BackfillNumbers(sessionManager),
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the session write area"),
         };
     }
@@ -688,5 +700,85 @@ internal sealed class SessionWriteExecutor : ISessionCommandArea
                 Error = ex.Message,
             }));
         }
+    }
+
+    /// <summary>
+    /// The <c>repo-delete</c> verb (director-level, no session): remove a repository from the recent-repository
+    /// registry (the New Session picker's list). Mirrors the Director's <c>DELETE /repos</c> lambda - a null /
+    /// blank path -&gt; BadRequest, a null registry -&gt; a 200 <c>{ removed = false }</c> - and otherwise
+    /// returns the registry's own <see cref="RepositoryRegistry.Remove"/> result. The live registry rides in
+    /// the services, exactly as the <c>repos-list</c> read reads it; a null registry lists/removes nothing, as
+    /// the REST route returned when no registry was wired.
+    /// </summary>
+    internal static DirectorCommandResult RepoDelete(DirectorCommand command, RepositoryRegistry? repositories)
+    {
+        var request = SessionCommandExecutor.Deserialize<RepoDeleteRequest>(command.PayloadJson);
+        var path = request?.Path;
+        FileLog.Write($"[SessionWriteExecutor] repo-delete: path={path}");
+        if (string.IsNullOrWhiteSpace(path))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "path is required");
+        if (repositories is null)
+            return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new RepoDeleteResponse { Removed = false }));
+
+        var removed = repositories.Remove(path);
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new RepoDeleteResponse { Removed = removed }));
+    }
+
+    /// <summary>
+    /// The <c>interrupted-dismiss</c> verb (director-level, no target session): dismiss one claimed dirty
+    /// crash journal once its sessions are recovered or no longer wanted. Mirrors the Director's
+    /// <c>DELETE /interrupted/{deadDirectorId}/{deadPid}</c> lambda - <see cref="DirectorCrashJournal.Dismiss"/>
+    /// returning true -&gt; a 200 <c>{ dismissed = true }</c>, false -&gt; NotFound (the route's 404). The
+    /// dead-Director id and process id ride in the payload. The caller-identity boundary log stays on the REST
+    /// endpoint (it reads the HTTP connection).
+    /// </summary>
+    internal static DirectorCommandResult InterruptedDismiss(DirectorCommand command)
+    {
+        var request = SessionCommandExecutor.Deserialize<InterruptedDismissRequest>(command.PayloadJson);
+        if (request is null || string.IsNullOrEmpty(request.DeadDirectorId))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "deadDirectorId is required");
+
+        FileLog.Write($"[SessionWriteExecutor] interrupted-dismiss: deadDirectorId={request.DeadDirectorId} deadPid={request.DeadPid}");
+        var removed = DirectorCrashJournal.Dismiss(request.DeadDirectorId, request.DeadPid);
+        return removed
+            ? DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new InterruptedDismissResponse { Dismissed = true }))
+            : DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "no such interrupted journal");
+    }
+
+    /// <summary>
+    /// The <c>interrupted-remove</c> verb (director-level; names a recoverable session inside a dead Director's
+    /// journal, issue #212 W4): remove ONE session from a claimed dirty journal after it has been restored, so
+    /// the rest of the journal stays in the Interrupted sessions list. Mirrors the Director's
+    /// <c>DELETE /interrupted/{deadDirectorId}/{deadPid}/sessions/{sessionId}</c> lambda -
+    /// <see cref="DirectorCrashJournal.RemoveSession"/> returning true -&gt; a 200 <c>{ removed = true }</c>,
+    /// false -&gt; NotFound (the route's 404). The dead-Director id, process id, and the recoverable session id
+    /// ride in the payload. The caller-identity boundary log stays on the REST endpoint.
+    /// </summary>
+    internal static DirectorCommandResult InterruptedRemove(DirectorCommand command)
+    {
+        var request = SessionCommandExecutor.Deserialize<InterruptedRemoveRequest>(command.PayloadJson);
+        if (request is null || string.IsNullOrEmpty(request.DeadDirectorId) || string.IsNullOrEmpty(request.SessionId))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "deadDirectorId and sessionId are required");
+
+        FileLog.Write($"[SessionWriteExecutor] interrupted-remove: deadDirectorId={request.DeadDirectorId} deadPid={request.DeadPid} sessionId={request.SessionId}");
+        var removed = DirectorCrashJournal.RemoveSession(request.DeadDirectorId, request.DeadPid, request.SessionId);
+        return removed
+            ? DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new InterruptedRemoveResponse { Removed = true }))
+            : DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "no such interrupted session");
+    }
+
+    /// <summary>
+    /// The <c>backfill-numbers</c> verb (director-level, no session; issue #846): trigger
+    /// <see cref="SessionManager.BackfillNumbers"/> on a RUNNING Director - no restart - so an operator can
+    /// number sessions that predate #820 (or were restored without a number). Mirrors the Director's
+    /// <c>POST /admin/backfill-numbers</c> lambda - always a 200 - and returns the count newly numbered.
+    /// Idempotent: a second call returns 0. The caller-identity boundary log stays on the REST endpoint.
+    /// </summary>
+    internal static DirectorCommandResult BackfillNumbers(SessionManager sessionManager)
+    {
+        FileLog.Write("[SessionWriteExecutor] backfill-numbers");
+        var assigned = sessionManager.BackfillNumbers();
+        FileLog.Write($"[SessionWriteExecutor] backfill-numbers assigned {assigned} number(s)");
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new BackfillNumbersResponse { Assigned = assigned }));
     }
 }

--- a/src/CcDirector.Gateway.Contracts/CatalogReadHandoverContracts.cs
+++ b/src/CcDirector.Gateway.Contracts/CatalogReadHandoverContracts.cs
@@ -1,0 +1,31 @@
+namespace CcDirector.Gateway.Contracts;
+
+// Gateway Cleanup mission, Phase 0 (Wave 4a): the request shapes for the two saved-handover-DOCUMENT read
+// verbs moved onto the tunnel command surface (handovers-list and handovers-content). These are the reads
+// of the saved handover documents on this machine - DISTINCT from the per-session "handover" info verb.
+// They are ADDITIVE: they name the exact query-string arguments the old REST lambdas took (which have no
+// home on DirectorCommand, so they ride in the command payload), so the tunnel verb and the re-pointed REST
+// route serialize identical JSON. The response shapes (HandoverDto, HandoverContentDto) are the DTOs the old
+// routes already produced - unchanged. Kept in one new file so no shared Contracts file is edited.
+
+/// <summary>
+/// GET /handovers request. Carries the optional <c>repo</c> query-string argument the old REST route took to
+/// filter the saved-handover-document list to those touching one repository. Null / absent means no filter
+/// (every document), matching the route's <c>string? repo</c>.
+/// </summary>
+public sealed class HandoversListRequest
+{
+    /// <summary>When set, keep only documents whose repo paths include this one (normalized comparison).</summary>
+    public string? Repo { get; set; }
+}
+
+/// <summary>
+/// GET /handovers/content request. Carries the required <c>path</c> query-string argument the old REST route
+/// took: the absolute path of the saved handover document whose content is being read. A null / blank path is
+/// the route's own BadRequest, exactly as before.
+/// </summary>
+public sealed class HandoverContentRequest
+{
+    /// <summary>The absolute path of the saved handover document to read.</summary>
+    public string? Path { get; set; }
+}

--- a/src/CcDirector.Gateway.Contracts/SessionByteScreenshotDeleteContracts.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionByteScreenshotDeleteContracts.cs
@@ -1,0 +1,32 @@
+namespace CcDirector.Gateway.Contracts;
+
+// Gateway Cleanup mission, Phase 0 (Wave 4a): the request and response shapes for the screenshot-delete unary
+// byte verb (the tunnel twin of DELETE /screenshots/file). ADDITIVE: the request DTO names the bare file
+// name the old route took as a ?name= query argument (which has no home on DirectorCommand, so it rides in
+// the command payload), and the response reproduces the exact anonymous-object wire shape the old route
+// returned. Kept in one new file so no shared Contracts file is edited.
+
+/// <summary>
+/// DELETE /screenshots/file request. Carries the required <c>name</c> query-string argument the old REST
+/// route took: the bare screenshot file name to delete from THIS Director's screenshots folder. The name is
+/// resolved traversal-safe on the Director side, so an escaping or non-image name is the route's own 404.
+/// </summary>
+public sealed class ScreenshotDeleteRequest
+{
+    /// <summary>The bare screenshot file name to delete (must resolve inside the screenshots folder).</summary>
+    public string? Name { get; set; }
+}
+
+/// <summary>
+/// DELETE /screenshots/file response. Byte-identical to the <c>{ deleted = true, fileName }</c> object the
+/// REST route returned on success: the delete flag and the deleted file's bare name. A name that does not
+/// resolve to an existing screenshot is the route's 404 (carried as a NotFound command result), not a body.
+/// </summary>
+public sealed class ScreenshotDeleteResponse
+{
+    /// <summary>Always true on success (the not-found case is a NotFound, not this body).</summary>
+    public bool Deleted { get; set; }
+
+    /// <summary>The deleted file's bare name.</summary>
+    public string FileName { get; set; } = "";
+}

--- a/src/CcDirector.Gateway.Contracts/SessionWriteOrphanContracts.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionWriteOrphanContracts.cs
@@ -1,0 +1,94 @@
+namespace CcDirector.Gateway.Contracts;
+
+// Gateway Cleanup mission, Phase 0 (Wave 4a): the request and response shapes for the four director-level
+// WRITE verbs moved onto the tunnel command surface - repo-delete, interrupted-dismiss, interrupted-remove,
+// and backfill-numbers. These are ADDITIVE: the request DTOs name the exact route arguments (the DELETE
+// /repos ?path=, the /interrupted route segments) that have no home on DirectorCommand, so they ride in the
+// command payload; the response DTOs reproduce the exact anonymous-object wire shapes the old REST lambdas
+// returned, so the tunnel verb and the re-pointed REST route serialize identical JSON. Kept in one new file
+// so no shared Contracts file is edited.
+
+/// <summary>
+/// DELETE /repos request. Carries the required <c>path</c> query-string argument the old REST route took: the
+/// repository to remove from the recent-repository registry. A null / blank path is the route's own
+/// BadRequest, exactly as before.
+/// </summary>
+public sealed class RepoDeleteRequest
+{
+    /// <summary>The repository folder path to remove from the recent list.</summary>
+    public string? Path { get; set; }
+}
+
+/// <summary>
+/// DELETE /repos response. Byte-identical to the <c>{ removed }</c> object the REST route returned: true when
+/// the registry held the path and dropped it, false when it did not (or when no registry was wired). Both are
+/// a 200.
+/// </summary>
+public sealed class RepoDeleteResponse
+{
+    /// <summary>True when the path was in the registry and was removed; false otherwise.</summary>
+    public bool Removed { get; set; }
+}
+
+/// <summary>
+/// DELETE /interrupted/{deadDirectorId}/{deadPid} request. Carries the two route segments the old REST route
+/// took: the dead Director's id and process id, identifying the claimed crash-journal recovery to dismiss.
+/// </summary>
+public sealed class InterruptedDismissRequest
+{
+    /// <summary>The dead Director's id whose crash journal is being dismissed.</summary>
+    public string DeadDirectorId { get; set; } = "";
+
+    /// <summary>The dead Director's process id whose crash journal is being dismissed.</summary>
+    public int DeadPid { get; set; }
+}
+
+/// <summary>
+/// DELETE /interrupted/{deadDirectorId}/{deadPid} response. Byte-identical to the <c>{ dismissed = true }</c>
+/// object the REST route returned on success. A journal that does not exist is the route's 404 (carried as a
+/// NotFound command result), not a body.
+/// </summary>
+public sealed class InterruptedDismissResponse
+{
+    /// <summary>Always true on success (the not-found case is a NotFound, not this body).</summary>
+    public bool Dismissed { get; set; }
+}
+
+/// <summary>
+/// DELETE /interrupted/{deadDirectorId}/{deadPid}/sessions/{sessionId} request. Carries the three route
+/// segments the old REST route took: the dead Director's id and process id, plus the one recoverable session
+/// id to remove from that journal (the rest of the journal stays).
+/// </summary>
+public sealed class InterruptedRemoveRequest
+{
+    /// <summary>The dead Director's id whose crash journal is being edited.</summary>
+    public string DeadDirectorId { get; set; } = "";
+
+    /// <summary>The dead Director's process id whose crash journal is being edited.</summary>
+    public int DeadPid { get; set; }
+
+    /// <summary>The recoverable session id to remove from that journal.</summary>
+    public string SessionId { get; set; } = "";
+}
+
+/// <summary>
+/// DELETE /interrupted/{deadDirectorId}/{deadPid}/sessions/{sessionId} response. Byte-identical to the
+/// <c>{ removed = true }</c> object the REST route returned on success. A session that is not in the journal
+/// is the route's 404 (carried as a NotFound command result), not a body.
+/// </summary>
+public sealed class InterruptedRemoveResponse
+{
+    /// <summary>Always true on success (the not-found case is a NotFound, not this body).</summary>
+    public bool Removed { get; set; }
+}
+
+/// <summary>
+/// POST /admin/backfill-numbers response. Byte-identical to the <c>{ assigned }</c> object the REST route
+/// returned: the count of sessions newly given a rail number. Idempotent - a second call returns 0. Always a
+/// 200 (the verb takes no input and has no failure branch).
+/// </summary>
+public sealed class BackfillNumbersResponse
+{
+    /// <summary>The count of sessions newly numbered by this call.</summary>
+    public int Assigned { get; set; }
+}

--- a/src/CcDirector.Gateway.Tests/CatalogReadExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/CatalogReadExecutorTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using CcDirector.ControlApi;
 using CcDirector.Core.Sessions;
+using CcDirector.Core.Storage;
 using CcDirector.Gateway.Contracts;
 using Xunit;
 
@@ -285,5 +286,162 @@ public sealed class CatalogReadExecutorTests
             try { if (File.Exists(registryFile)) File.Delete(registryFile); } catch { /* best effort */ }
             try { if (Directory.Exists(repoDir)) Directory.Delete(repoDir, true); } catch { /* best effort */ }
         }
+    }
+
+    // ---------- handovers-list / handovers-content (Gateway Cleanup Phase 0 Wave 4a: the saved-handover
+    // DOCUMENT reads, DISTINCT from the per-session "handover" info verb). CC_DIRECTOR_ROOT is pinned into a
+    // temp dir so the vault handover folder these verbs scan is a controlled, empty-then-seeded folder that
+    // never touches the user's real vault. In the "DirectorRoot" collection (serializes root-touching tests).
+
+    [Fact]
+    public async Task DispatchAsync_HandoversList_EmptyFolder_ReturnsOkWithNoDocuments()
+    {
+        var (root, prev) = PinRoot();
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("handovers-list"));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal("r2", result.CommandId);
+            var dtos = JsonSerializer.Deserialize<List<HandoverDto>>(result.BodyJson ?? "", Json);
+            Assert.NotNull(dtos);
+            Assert.Empty(dtos!);
+        }
+        finally { sm.Dispose(); RestoreRoot(root, prev); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_HandoversList_SeededDocument_ReturnsItAndHonorsRepoFilter()
+    {
+        var (root, prev) = PinRoot();
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        // The frontmatter repo path only round-trips through the scanner when the directory actually exists
+        // (HandoverScanner keeps only on-disk repo paths), so the seeded repo is a real temp directory.
+        var repoDir = Path.Combine(Path.GetTempPath(), "ccd-hv-repo-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(repoDir);
+        try
+        {
+            HandoverScanner.WriteNew("Wave 4a handover", "the saved body", new[] { repoDir }, "Wave 4a - Worker");
+
+            // No filter: the seeded document is listed.
+            var all = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("handovers-list"));
+            Assert.Equal(DirectorCommandStatus.Ok, all.Status);
+            var allDtos = JsonSerializer.Deserialize<List<HandoverDto>>(all.BodyJson ?? "", Json);
+            Assert.NotNull(allDtos);
+            Assert.Contains(allDtos!, h => h.Title == "Wave 4a handover");
+
+            // Matching repo filter: still listed.
+            var matchPayload = JsonSerializer.Serialize(new HandoversListRequest { Repo = repoDir }, Json);
+            var match = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("handovers-list", payloadJson: matchPayload));
+            var matchDtos = JsonSerializer.Deserialize<List<HandoverDto>>(match.BodyJson ?? "", Json);
+            Assert.NotNull(matchDtos);
+            Assert.Contains(matchDtos!, h => h.Title == "Wave 4a handover");
+
+            // Non-matching repo filter: excluded (the ?repo= filter rides in the payload, as before).
+            var missPayload = JsonSerializer.Serialize(new HandoversListRequest { Repo = @"Z:\no\such\repo\wave4a" }, Json);
+            var miss = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("handovers-list", payloadJson: missPayload));
+            var missDtos = JsonSerializer.Deserialize<List<HandoverDto>>(miss.BodyJson ?? "", Json);
+            Assert.NotNull(missDtos);
+            Assert.DoesNotContain(missDtos!, h => h.Title == "Wave 4a handover");
+        }
+        finally
+        {
+            sm.Dispose();
+            RestoreRoot(root, prev);
+            try { if (Directory.Exists(repoDir)) Directory.Delete(repoDir, true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_HandoversContent_BlankPath_ReturnsBadRequest()
+    {
+        // The route's own guard: a null / blank path is a 400 before any file access.
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var payload = JsonSerializer.Serialize(new HandoverContentRequest { Path = "  " }, Json);
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("handovers-content", payloadJson: payload));
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+            Assert.False(string.IsNullOrEmpty(result.Error));
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_HandoversContent_MissingFileInsideFolder_ReturnsNotFound()
+    {
+        // A path INSIDE the handover folder that does not exist: the source route wrapped ReadContent in a
+        // try/catch that turned a FileNotFoundException into a 404; that preserved try/catch surfaces here as a
+        // NotFound. (A path OUTSIDE the folder is instead the UnauthorizedAccessException -> BadRequest branch.)
+        var (root, prev) = PinRoot();
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var missing = Path.Combine(CcStorage.VaultHandovers(), "no-such-handover-wave4a.md");
+            var payload = JsonSerializer.Serialize(new HandoverContentRequest { Path = missing }, Json);
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("handovers-content", payloadJson: payload));
+
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); RestoreRoot(root, prev); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_HandoversContent_PathOutsideFolder_ReturnsBadRequest()
+    {
+        // A path outside the handover folder is the route's UnauthorizedAccessException -> BadRequest branch,
+        // preserved verbatim by the lifted core.
+        var (root, prev) = PinRoot();
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var payload = JsonSerializer.Serialize(new HandoverContentRequest { Path = @"Z:\outside\handover-wave4a.md" }, Json);
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("handovers-content", payloadJson: payload));
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); RestoreRoot(root, prev); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_HandoversContent_SeededDocument_ReturnsContent()
+    {
+        var (root, prev) = PinRoot();
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var path = HandoverScanner.WriteNew("Wave 4a content", "the exact saved body", null, null);
+
+            var payload = JsonSerializer.Serialize(new HandoverContentRequest { Path = path }, Json);
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("handovers-content", payloadJson: payload));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var dto = JsonSerializer.Deserialize<HandoverContentDto>(result.BodyJson ?? "", Json);
+            Assert.NotNull(dto);
+            Assert.Equal(path, dto!.Path);
+            Assert.Contains("the exact saved body", dto.Content);
+        }
+        finally { sm.Dispose(); RestoreRoot(root, prev); }
+    }
+
+    // Pin the vault into a fresh temp dir so the vault handover folder these verbs scan is a controlled,
+    // empty-then-seeded folder that never touches the user's real vault. The vault path is resolved from
+    // CC_VAULT_PATH first (this machine has it set), so that is the variable to override - CC_DIRECTOR_ROOT
+    // alone would not redirect the vault. Returns the pinned root and the previous value so RestoreRoot can
+    // put it back and delete the temp tree.
+    private static (string root, string? prev) PinRoot()
+    {
+        var prev = Environment.GetEnvironmentVariable("CC_VAULT_PATH");
+        var root = Path.Combine(Path.GetTempPath(), "ccd-handover-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_VAULT_PATH", Path.Combine(root, "vault"));
+        return (root, prev);
+    }
+
+    private static void RestoreRoot(string root, string? prev)
+    {
+        Environment.SetEnvironmentVariable("CC_VAULT_PATH", prev);
+        try { if (Directory.Exists(root)) Directory.Delete(root, recursive: true); } catch { /* best effort */ }
     }
 }

--- a/src/CcDirector.Gateway.Tests/SessionByteExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionByteExecutorTests.cs
@@ -254,4 +254,65 @@ public sealed class SessionByteExecutorTests : IAsyncLifetime
         }
         finally { sm.Dispose(); }
     }
+
+    // ---------- screenshot-delete (Gateway Cleanup Phase 0 Wave 4a) ----------
+
+    private static DirectorCommand ScreenshotDeleteCommand(string? name) => new()
+    {
+        CommandId = "sd1",
+        Verb = "screenshot-delete",
+        PayloadJson = JsonSerializer.Serialize(new ScreenshotDeleteRequest { Name = name }, Json),
+    };
+
+    [Fact]
+    public async Task DispatchAsync_ScreenshotDelete_MissingFile_ReturnsNotFound()
+    {
+        // A name that does not resolve to an existing screenshot (traversal-safe ResolveScreenshot returns
+        // null) is the route's 404 - carried as a NotFound command result.
+        var sm = new SessionManager(new AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", ScreenshotDeleteCommand("no-such-shot.png"));
+
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_ScreenshotDelete_TraversalName_ReturnsNotFound()
+    {
+        // A name that is not a bare file (a traversal attempt) is rejected by ResolveScreenshot before any
+        // filesystem touch - a 404, exactly as the REST route returned.
+        var sm = new SessionManager(new AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", ScreenshotDeleteCommand(@"..\escape.png"));
+
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_ScreenshotDelete_ExistingFile_DeletesItAndReturnsOk()
+    {
+        SeedScreenshot("shot-to-delete.png", DateTime.UtcNow);
+        Assert.True(File.Exists(Path.Combine(_shotsDir, "shot-to-delete.png")));
+
+        var sm = new SessionManager(new AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", ScreenshotDeleteCommand("shot-to-delete.png"));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal("sd1", result.CommandId);
+            var resp = JsonSerializer.Deserialize<ScreenshotDeleteResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(resp);
+            Assert.True(resp!.Deleted);
+            Assert.Equal("shot-to-delete.png", resp.FileName);
+            Assert.False(File.Exists(Path.Combine(_shotsDir, "shot-to-delete.png")));
+        }
+        finally { sm.Dispose(); }
+    }
 }

--- a/src/CcDirector.Gateway.Tests/SessionWriteExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionWriteExecutorTests.cs
@@ -608,4 +608,220 @@ public sealed class SessionWriteExecutorTests
         }
         finally { sm.Dispose(); }
     }
+
+    // ---------- repo-delete (Gateway Cleanup Phase 0 Wave 4a: director-level, reads the live registry from
+    // the services, exactly as repos-list does) ----------
+
+    [Fact]
+    public async Task DispatchAsync_RepoDelete_BlankPath_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var command = Command("repo-delete", "", new RepoDeleteRequest { Path = "  " });
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command);
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+            Assert.False(string.IsNullOrEmpty(result.Error));
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_RepoDelete_NoRegistry_ReturnsOkRemovedFalse()
+    {
+        // With no registry wired (no services) the core removes nothing - a 200 { removed = false } - exactly
+        // as the REST route returned when no registry was set.
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var command = Command("repo-delete", "", new RepoDeleteRequest { Path = @"Z:\some\repo\wave4a" });
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command);
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var resp = JsonSerializer.Deserialize<RepoDeleteResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(resp);
+            Assert.False(resp!.Removed);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_RepoDelete_RegisteredRepo_RemovesItAndReturnsOkRemovedTrue()
+    {
+        // The live registry rides in the services (as repos-list reads it): a registered repo is removed and
+        // gone from the registry afterward.
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        var registryFile = Path.Combine(Path.GetTempPath(), "ccd-wr-repos-" + Guid.NewGuid().ToString("N") + ".json");
+        var repoDir = Path.Combine(Path.GetTempPath(), "ccd-wr-repo-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(repoDir);
+        try
+        {
+            var registry = new Core.Configuration.RepositoryRegistry(registryFile);
+            Assert.True(registry.TryAdd(repoDir));
+
+            var command = Command("repo-delete", "", new RepoDeleteRequest { Path = repoDir });
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command,
+                new SessionCommandServices { Repositories = registry });
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var resp = JsonSerializer.Deserialize<RepoDeleteResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(resp);
+            Assert.True(resp!.Removed);
+            Assert.DoesNotContain(registry.Repositories, r => string.Equals(
+                Path.GetFullPath(r.Path).TrimEnd('\\', '/'),
+                Path.GetFullPath(repoDir).TrimEnd('\\', '/'),
+                StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            sm.Dispose();
+            try { if (File.Exists(registryFile)) File.Delete(registryFile); } catch { /* best effort */ }
+            try { if (Directory.Exists(repoDir)) Directory.Delete(repoDir, true); } catch { /* best effort */ }
+        }
+    }
+
+    // ---------- interrupted-dismiss / interrupted-remove (Gateway Cleanup Phase 0 Wave 4a: director-level
+    // crash-journal edits; CC_DIRECTOR_ROOT is pinned so the journal folder is a controlled temp dir) ----------
+
+    [Fact]
+    public async Task DispatchAsync_InterruptedDismiss_NoSuchJournal_ReturnsNotFound()
+    {
+        var (root, prev) = PinRoot();
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var command = Command("interrupted-dismiss", "",
+                new InterruptedDismissRequest { DeadDirectorId = "dir-gone", DeadPid = 4242 });
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command);
+
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); RestoreRoot(root, prev); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_InterruptedDismiss_ExistingJournal_ReturnsOkDismissedTrue()
+    {
+        var (root, prev) = PinRoot();
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var deadDir = "dir-dead"; var deadPid = 9191;
+            SeedDirtyJournal(deadDir, deadPid, "11111111-1111-1111-1111-111111111111");
+
+            var command = Command("interrupted-dismiss", "",
+                new InterruptedDismissRequest { DeadDirectorId = deadDir, DeadPid = deadPid });
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command);
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var resp = JsonSerializer.Deserialize<InterruptedDismissResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(resp);
+            Assert.True(resp!.Dismissed);
+        }
+        finally { sm.Dispose(); RestoreRoot(root, prev); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_InterruptedRemove_NoSuchSession_ReturnsNotFound()
+    {
+        var (root, prev) = PinRoot();
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var command = Command("interrupted-remove", "",
+                new InterruptedRemoveRequest { DeadDirectorId = "dir-gone", DeadPid = 4242, SessionId = Guid.NewGuid().ToString() });
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command);
+
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); RestoreRoot(root, prev); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_InterruptedRemove_ExistingSession_ReturnsOkRemovedTrue()
+    {
+        var (root, prev) = PinRoot();
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var deadDir = "dir-dead2"; var deadPid = 9292;
+            var sid = "22222222-2222-2222-2222-222222222222";
+            // Seed two sessions so removing one leaves the journal (RemoveSession true, journal not deleted).
+            SeedDirtyJournal(deadDir, deadPid, sid, "33333333-3333-3333-3333-333333333333");
+
+            var command = Command("interrupted-remove", "",
+                new InterruptedRemoveRequest { DeadDirectorId = deadDir, DeadPid = deadPid, SessionId = sid });
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command);
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var resp = JsonSerializer.Deserialize<InterruptedRemoveResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(resp);
+            Assert.True(resp!.Removed);
+        }
+        finally { sm.Dispose(); RestoreRoot(root, prev); }
+    }
+
+    // ---------- backfill-numbers (Gateway Cleanup Phase 0 Wave 4a: director-level, no input, always 200) ----------
+
+    [Fact]
+    public async Task DispatchAsync_BackfillNumbers_NoSessions_ReturnsOkAssignedZero()
+    {
+        // No sessions to number, so the count is zero - still a 200, exactly as the REST route returned.
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var command = Command("backfill-numbers", "");
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command);
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal("cmd-w1", result.CommandId);
+            var resp = JsonSerializer.Deserialize<BackfillNumbersResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(resp);
+            Assert.Equal(0, resp!.Assigned);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // Pin CC_DIRECTOR_ROOT into a fresh temp dir so the crash-journal folder is controlled; returns the pinned
+    // root and the previous value so RestoreRoot can put it back and delete the temp tree.
+    private static (string root, string? prev) PinRoot()
+    {
+        var prev = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        var root = Path.Combine(Path.GetTempPath(), "ccd-wr-root-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", root);
+        return (root, prev);
+    }
+
+    private static void RestoreRoot(string root, string? prev)
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", prev);
+        try { if (Directory.Exists(root)) Directory.Delete(root, recursive: true); } catch { /* best effort */ }
+    }
+
+    // Write a claimed dirty crash journal ({directorId}.{pid}.dirty.json) into the pinned DefaultDirectory,
+    // holding the given recoverable session ids, so the dismiss/remove verbs have a real file to act on.
+    private static void SeedDirtyJournal(string directorId, int pid, params string[] sessionIds)
+    {
+        var dir = DirectorCrashJournal.DefaultDirectory;
+        Directory.CreateDirectory(dir);
+        var data = new DirectorCrashJournalData
+        {
+            DirectorId = directorId,
+            Pid = pid,
+            MachineName = Environment.MachineName,
+            User = Environment.UserName,
+            StartedAtUtc = DateTimeOffset.UtcNow.AddMinutes(-5),
+            LastUpdatedUtc = DateTimeOffset.UtcNow,
+            Sessions = sessionIds.Select(s => new DirectorCrashJournalSession
+            {
+                SessionId = s,
+                RepoPath = @"Z:\wave4a\journal-repo",
+                Agent = "ClaudeCode",
+                CreatedAtUtc = DateTimeOffset.UtcNow.AddMinutes(-5),
+            }).ToList(),
+        };
+        var path = Path.Combine(dir, $"{directorId}.{pid}.dirty.json");
+        File.WriteAllText(path, JsonSerializer.Serialize(data, Json));
+    }
 }


### PR DESCRIPTION
## Wave 4a: lift the 7 remaining orphan verbs onto the tunnel dispatch

Gateway Cleanup mission, Phase 0. This is ONE additive, mergeable pull request that lifts the last 7 orphan REST routes (routes a real Gateway/web/CLI consumer calls, but that had no tunnel verb yet) onto the shared tunnel command dispatch. Following the established exemplar pattern: the REST lambda body becomes an internal static core returning `DirectorCommandResult` (same guards + status codes); the REST route is re-pointed to build a `DirectorCommand`, call `SessionCommandExecutor.DispatchAsync`, and map the result. REST route and tunnel verb call the SAME core, so they cannot drift and REST responses stay byte-identical.

**No deletions.** Phase 1 later deletes the routes and leaves each core reached only over the tunnel.

### The 7 verbs and their executors

**CatalogReadExecutor** (director-level reads)
- `handovers-list` - `GET /handovers`. Lists the saved-handover DOCUMENTS on this machine (distinct from the per-session `handover` info verb). Returns the same `List<HandoverDto>`. Optional `?repo=` filter rides in the payload.
- `handovers-content` - `GET /handovers/content?path=...`. Reads one saved handover doc; returns the same `HandoverContentDto`. Preserves the route's try/catch: an access error outside the folder -> BadRequest, a missing file inside the folder -> NotFound.

**SessionWriteExecutor** (director-level writes)
- `repo-delete` - `DELETE /repos?path=...`. Removes a repo from the registry; reads the live registry from the services (same pattern as `repos-list`). Blank path -> BadRequest, null registry -> 200 `{ removed: false }`.
- `interrupted-dismiss` - `DELETE /interrupted/{deadDirectorId}/{deadPid}`. Dismisses a crash-journal recovery. Missing journal -> NotFound.
- `interrupted-remove` - `DELETE /interrupted/{deadDirectorId}/{deadPid}/sessions/{sessionId}`. Removes one recoverable session from a journal. Missing session -> NotFound.
- `backfill-numbers` - `POST /admin/backfill-numbers`. Triggers `SessionManager.BackfillNumbers()`; always 200 with the count.

**SessionByteExecutor** (unary byte verb)
- `screenshot-delete` - `DELETE /screenshots/file?name=...`. Deletes a screenshot, resolved via the same traversal-safe `ControlEndpoints.ResolveScreenshot` helper the file GET/read used. Escaping/non-image/missing name -> NotFound.

None skipped - all 7 lifted faithfully.

### DTOs
New request/response DTOs in NEW Contracts files only (no shared Contracts file edited):
- `CatalogReadHandoverContracts.cs` (`HandoversListRequest`, `HandoverContentRequest`)
- `SessionWriteOrphanContracts.cs` (`RepoDeleteRequest/Response`, `InterruptedDismissRequest/Response`, `InterruptedRemoveRequest/Response`, `BackfillNumbersResponse`)
- `SessionByteScreenshotDeleteContracts.cs` (`ScreenshotDeleteRequest/Response`)

The route arguments (path, name, deadDirectorId, deadPid, sessionId) that have no home on `DirectorCommand` ride in `PayloadJson`; `SessionId` is `""` for these director-level verbs. The response DTOs reproduce the exact anonymous-object wire shapes the old lambdas returned.

### Tests
Parity tests added to `CatalogReadExecutorTests`, `SessionWriteExecutorTests`, `SessionByteExecutorTests` - a guard failure (bad id / not found where applicable) and a success for each verb, exercised through the real `DispatchAsync` path.

- Build: `CcDirector.ControlApi` at 0 warnings / 0 errors.
- Tests: `Passed! - Failed: 0, Passed: 86, Skipped: 0, Total: 86`

🤖 Generated with [Claude Code](https://claude.com/claude-code)