### PR TITLE
release: bump product version to 1.0.8

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.0.7</Version>
+    <Version>1.0.8</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Bumps Directory.Build.props to 1.0.8 ahead of tagging v1.0.8 — the first release that ships the Mac launcher asset (cc-launcher-mac-arm64), the Mac installer launcher step, and a Gateway build containing the launcher command stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)