### PR TITLE
feat(mission-screen): Phase 1a - read-only Missions page grouping the fleet by mission (#1405)

### DIFF
--- a/apps/cockpit/src/AppShell.tsx
+++ b/apps/cockpit/src/AppShell.tsx
@@ -34,6 +34,7 @@ const NAV_SECTIONS: ReadonlyArray<{ title: string; items: ReadonlyArray<NavItem>
     title: "Fleet",
     items: [
       { to: "/fleet-map", label: "Fleet Map" },
+      { to: "/missions", label: "Missions" },
       { to: "/sessions", label: "Sessions", subtree: "/session" },
       { to: "/directors", label: "Directors" },
       { to: "/schedule", label: "Schedule" },

--- a/apps/cockpit/src/main.tsx
+++ b/apps/cockpit/src/main.tsx
@@ -14,6 +14,7 @@ import { SessionsEmpty, SessionsView } from "./sessions/SessionsView";
 import { SessionDetail } from "./sessions/SessionDetail";
 import { SessionRedirect } from "./sessions/SessionRedirect";
 import { FleetMapView } from "./fleet/FleetMapView";
+import { MissionsView } from "./missions/MissionsView";
 import { DirectorsView } from "./fleet/DirectorsView";
 import { DirectorDetailView } from "./fleet/DirectorDetailView";
 import { ScheduleView } from "./schedule/ScheduleView";
@@ -33,6 +34,7 @@ import "./styles.css";
 import "./components/components.css";
 import "./fleet/fleet.css";
 import "./fleet/fleetmap.css";
+import "./missions/missions.css";
 import "./schedule/schedule.css";
 import "./wingman/wingman.css";
 import "./dictionary/dictionary.css";
@@ -139,6 +141,10 @@ const router = createBrowserRouter(
             // page lists, pivotable by machine / repository / agent. Reads the same GET /sessions
             // envelope through client-core.
             { path: "/fleet-map", element: <FleetMapView /> },
+            // The Missions page (issue #1405, Phase 1a): the same GET /sessions roster the Fleet Map
+            // reads, grouped by mission (derived from the session name) with each session row linking
+            // into /session/:id. Full width - the Phase 2 chat pane is not shipped yet.
+            { path: "/missions", element: <MissionsView /> },
             { path: "/directors", element: <DirectorsView /> },
             { path: "/directors/:directorId", element: <DirectorDetailView /> },
             // The Schedule + Wingman-pipeline pages (issue #976): one-to-one ports of the Blazor

--- a/apps/cockpit/src/missions/MissionsView.tsx
+++ b/apps/cockpit/src/missions/MissionsView.tsx
@@ -1,0 +1,261 @@
+import { useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { type SessionDto } from "@devthrottle/client-core/api/client";
+import { dotColor, effectiveColor, stateLabel } from "@devthrottle/client-core/sessions/ordering";
+import { useSharedRoster } from "@devthrottle/client-core/fleet/rosterStore";
+import { repoBasename, relativeTime } from "../fleet/format";
+import { groupByMission, type MissionGroup } from "./missionGrouping";
+
+// The Missions page (issue #1405, Phase 1a): the same live fleet the Fleet Map draws, seen the way the
+// owner actually thinks about the work - grouped into MISSIONS rather than machines or repos. A mission
+// is derived purely from the session name ("<Mission> - <Role>") by the pure module missionGrouping.ts;
+// this page only lays the result out. Sessions that are not a mission member fall into a Standalone
+// group shown last.
+//
+// It reads the ONE shared fleet roster store (issue #1239) - the same GET /sessions envelope the Fleet
+// Map, Sessions, and Directors pages read from a single poll loop - never a Director address, and reuses
+// the ONE shared effective-color + state-label rule so a status dot here matches every other Cockpit
+// surface. Clicking a session row opens that session (/session/:id) - the "linking" this phase delivers.
+//
+// Phase 1a shows a WHY slot on every card with a loud "No why set" flag; Phase 1b wires a durable,
+// shared store behind it. Nothing here writes; nothing here parses (that is missionGrouping.ts).
+
+// The Phase 1a placeholder for a mission's WHY, shown until Phase 1b wires the durable store. It is a
+// deliberately loud flag - a mission with no stated WHY is a red flag the screen makes obvious (the
+// mission's founding rule), never a silent blank.
+const NO_WHY_TEXT = "No why set - add one";
+
+export function MissionsView() {
+  const navigate = useNavigate();
+  // Sessions, the unreachable-machine list, and the keep-last error banner all come from the ONE shared
+  // roster store; no poll of its own.
+  const { sessions, machineErrors, error: lastError } = useSharedRoster();
+
+  const list = useMemo(() => sessions ?? [], [sessions]);
+  const grouped = useMemo(() => groupByMission(list), [list]);
+
+  // Fleet-wide summary counts, read from the same shared color rule the cards use.
+  const missionCount = grouped.missions.length;
+  const standaloneCount = grouped.standalone.length;
+  const redCount = list.filter((s) => effectiveColor(s) === "red").length;
+  const workingCount = list.filter((s) => effectiveColor(s) === "blue").length;
+
+  const openSession = (sid: string | null | undefined) => {
+    const id = (sid ?? "").trim();
+    if (id.length > 0) navigate(`/session/${encodeURIComponent(id)}`);
+  };
+
+  return (
+    <div className="msn">
+      <header className="msn-head">
+        <h1 className="msn-title">Missions</h1>
+        <span className="msn-stats">
+          <span>
+            {missionCount} mission{missionCount === 1 ? "" : "s"}
+          </span>
+          {workingCount > 0 && (
+            <>
+              <span className="msn-sep" aria-hidden="true" />
+              <span className="msn-stat-blue">{workingCount} working</span>
+            </>
+          )}
+          {redCount > 0 && (
+            <>
+              <span className="msn-sep" aria-hidden="true" />
+              <span className="msn-stat-red">{redCount} needs you</span>
+            </>
+          )}
+          {standaloneCount > 0 && (
+            <>
+              <span className="msn-sep" aria-hidden="true" />
+              <span>
+                {standaloneCount} standalone
+              </span>
+            </>
+          )}
+        </span>
+      </header>
+
+      {lastError !== null && <div className="msn-error">{lastError}</div>}
+
+      {machineErrors.length > 0 && (
+        <div className="msn-warn">
+          {machineErrors.length} machine{machineErrors.length === 1 ? "" : "s"} unreachable on the last
+          sweep:{" "}
+          {machineErrors
+            .map((m) => (m.machineName ?? "").trim())
+            .filter((n) => n.length > 0)
+            .join(", ") || "(unknown)"}
+        </div>
+      )}
+
+      {sessions === null && lastError === null && <div className="msn-empty">Loading the fleet...</div>}
+
+      {sessions !== null && list.length === 0 && machineErrors.length === 0 && (
+        <div className="msn-empty">
+          <p>No sessions are running anywhere on the fleet.</p>
+          <p className="msn-empty-sub">A mission appears here the moment its sessions start.</p>
+        </div>
+      )}
+
+      {list.length > 0 && (
+        <div className="msn-list">
+          {grouped.missions.map((m) => (
+            <MissionCard key={m.key} mission={m} onOpen={openSession} />
+          ))}
+
+          {grouped.standalone.length > 0 && (
+            <>
+              <div className="msn-group-label">Standalone</div>
+              <div className="msn-card msn-card-standalone">
+                <div className="msn-sessions">
+                  {grouped.standalone.map((s) => (
+                    <SessionRow
+                      key={s.sessionId ?? s.number}
+                      session={s}
+                      label={(s.name ?? "").trim().length === 0 ? "(unnamed)" : (s.name as string)}
+                      onOpenSession={openSession}
+                    />
+                  ))}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface MissionCardProps {
+  mission: MissionGroup;
+  onOpen: (sessionId: string | null | undefined) => void;
+}
+
+function MissionCard({ mission, onOpen }: MissionCardProps) {
+  const sessions = mission.members.map((m) => m.session);
+
+  // The card's accent (left border) and status pill follow the same color rule as everything else: red
+  // if any session needs you, else blue if any is working, else a neutral idle.
+  const needs = sessions.filter((s) => effectiveColor(s) === "red").length;
+  const working = sessions.filter((s) => effectiveColor(s) === "blue").length;
+  const accent = needs > 0 ? "red" : working > 0 ? "blue" : "grey";
+
+  // The repositories this mission spans - one label when they agree, a count when they do not.
+  const repos = useMemo(() => {
+    const set = new Set<string>();
+    for (const s of sessions) set.add(repoBasename(s.repoPath));
+    return [...set];
+  }, [sessions]);
+  const repoLabel = repos.length === 1 ? repos[0] : `${repos.length} repos`;
+
+  const count = mission.members.length;
+
+  return (
+    <section className="msn-card">
+      <div className="msn-card-head" style={{ borderLeftColor: dotColor(accent) }}>
+        <div className="msn-card-title">
+          <div className="msn-name">{mission.name}</div>
+          <div className="msn-meta">
+            <span className="msn-repo">{repoLabel}</span>
+            <span>
+              {count} session{count === 1 ? "" : "s"}
+            </span>
+          </div>
+        </div>
+        <MissionPill needs={needs} working={working} />
+      </div>
+
+      {/* The WHY slot (issue #1405): first-class on every card from Phase 1a, shown as a loud flag until
+          Phase 1b wires the durable store. */}
+      <div className="msn-why msn-why-empty">
+        <span className="msn-why-k">Why</span>
+        <span className="msn-why-flag">{NO_WHY_TEXT}</span>
+      </div>
+
+      <div className="msn-sessions">
+        {mission.members.map((m) => (
+          <SessionRow
+            key={m.session.sessionId ?? m.session.number}
+            session={m.session}
+            label={m.role}
+            onOpenSession={onOpen}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function MissionPill({ needs, working }: { needs: number; working: number }) {
+  if (needs > 0) {
+    return (
+      <span className="msn-pill msn-pill-needs">
+        <span className="msn-pdot" style={{ backgroundColor: dotColor("red") }} />
+        {needs} needs you
+      </span>
+    );
+  }
+  if (working > 0) {
+    return (
+      <span className="msn-pill msn-pill-work">
+        <span className="msn-pdot" style={{ backgroundColor: dotColor("blue") }} />
+        working
+      </span>
+    );
+  }
+  return (
+    <span className="msn-pill msn-pill-idle">
+      <span className="msn-pdot" style={{ backgroundColor: dotColor("grey") }} />
+      idle
+    </span>
+  );
+}
+
+interface SessionRowProps {
+  session: SessionDto;
+  // The primary label for the row: the parsed role inside a mission, or the session name in Standalone.
+  label: string;
+  onOpenSession: (sessionId: string | null | undefined) => void;
+}
+
+// One clickable session row: number badge, primary label, a short context line, machine chip, and the
+// live state label - all colored by the ONE shared effective-color rule so the row agrees with the rail
+// and the Fleet Map. Clicking (or Enter/Space) opens the session.
+function SessionRow({ session: s, label, onOpenSession }: SessionRowProps) {
+  const color = effectiveColor(s);
+  const hex = dotColor(color);
+  const sid = s.sessionId ?? "";
+  const num = s.number;
+  const hasNum = num !== null && num !== undefined && String(num).trim().length > 0;
+  const machine = (s.machineName ?? "").trim();
+  const context = (s.lastStatusReason ?? "").trim();
+
+  return (
+    <div
+      className="msn-srow"
+      tabIndex={0}
+      role="button"
+      title={sid.length > 0 ? "Open session" : undefined}
+      onClick={() => onOpenSession(sid)}
+      onKeyDown={(e) => {
+        if (sid.length > 0 && (e.key === "Enter" || e.key === " ")) {
+          e.preventDefault();
+          onOpenSession(sid);
+        }
+      }}
+    >
+      <span className="msn-lbar" style={{ backgroundColor: hex }} />
+      {hasNum && <span className="num-badge">{num}</span>}
+      <div className="msn-srow-grow">
+        <div className="msn-role">{label}</div>
+        {context.length > 0 && <div className="msn-rmeta">{context}</div>}
+      </div>
+      {machine.length > 0 && <span className="msn-machine">{machine}</span>}
+      <span className="msn-state" style={{ color: hex }}>
+        {stateLabel(s)}
+        <span className="msn-idle">{relativeTime(s.lastActivityAt)}</span>
+      </span>
+    </div>
+  );
+}

--- a/apps/cockpit/src/missions/missionGrouping.test.ts
+++ b/apps/cockpit/src/missions/missionGrouping.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import type { SessionDto } from "@devthrottle/client-core/api/client";
+import { groupByMission, parseMissionName, stripBracketTag } from "./missionGrouping";
+
+// Phase 1a of the Mission Screen (issue #1405) derives missions purely from the session name. These
+// lock the two rules the Architect pinned before it was built: strip a leading bracket tag, and match
+// on the LAST " - Role" - plus the non-role dash (#108 "mindzieWeb - remove Ask Mindzie") staying
+// Standalone rather than becoming a bogus "mindzieWeb" mission.
+
+describe("stripBracketTag", () => {
+  it("removes one leading bracket tag and its trailing space", () => {
+    expect(stripBracketTag("[Moving Started] Gateway Cleanup - Manager")).toBe(
+      "Gateway Cleanup - Manager",
+    );
+    expect(stripBracketTag("[moving] Gateway Connection - Architect")).toBe(
+      "Gateway Connection - Architect",
+    );
+  });
+
+  it("leaves a name without a leading tag untouched", () => {
+    expect(stripBracketTag("Car Mode - Architect")).toBe("Car Mode - Architect");
+  });
+
+  it("only strips a LEADING bracket - brackets elsewhere are kept", () => {
+    expect(stripBracketTag("Car Mode [beta] - Manager")).toBe("Car Mode [beta] - Manager");
+  });
+});
+
+describe("parseMissionName", () => {
+  it("parses <Mission> - <Role> for each known role, case-insensitively", () => {
+    expect(parseMissionName("Gateway Cleanup - Manager")).toEqual({
+      mission: "Gateway Cleanup",
+      role: "Manager",
+    });
+    expect(parseMissionName("Car Mode - architect")).toEqual({
+      mission: "Car Mode",
+      role: "Architect",
+    });
+    expect(parseMissionName("Docs - WORKER")).toEqual({ mission: "Docs", role: "Worker" });
+  });
+
+  it("strips a leading bracket tag before parsing (the move markers)", () => {
+    expect(parseMissionName("[Moving Started] Gateway Cleanup - Manager")).toEqual({
+      mission: "Gateway Cleanup",
+      role: "Manager",
+    });
+    expect(parseMissionName("[moving] Gateway Connection - Architect")).toEqual({
+      mission: "Gateway Connection",
+      role: "Architect",
+    });
+  });
+
+  it("matches the LAST ' - Role', so the mission keeps its own inner dash", () => {
+    expect(parseMissionName("Foo - Bar - Manager")).toEqual({
+      mission: "Foo - Bar",
+      role: "Manager",
+    });
+  });
+
+  it("returns null for a trailing token that is not a known role (stays Standalone)", () => {
+    // The live #108 case: a dash, but the trailing text is not a role.
+    expect(parseMissionName("mindzieWeb - remove Ask Mindzie")).toBeNull();
+  });
+
+  it("returns null when there is no ' - ' separator at all", () => {
+    expect(parseMissionName("Mac Cleanup")).toBeNull();
+    expect(parseMissionName("Working Mac")).toBeNull();
+  });
+
+  it("returns null for empty, whitespace, or missing names", () => {
+    expect(parseMissionName("")).toBeNull();
+    expect(parseMissionName("   ")).toBeNull();
+    expect(parseMissionName(null)).toBeNull();
+    expect(parseMissionName(undefined)).toBeNull();
+  });
+
+  it("returns null when the mission part is empty (only a role after the dash)", () => {
+    expect(parseMissionName(" - Manager")).toBeNull();
+  });
+});
+
+// A minimal SessionDto factory for the grouping tests - only the fields the parser and sort read.
+function session(name: string, number: number, sessionId: string): SessionDto {
+  return { name, number, sessionId } as unknown as SessionDto;
+}
+
+describe("groupByMission", () => {
+  it("groups members under their mission and puts non-members in Standalone", () => {
+    const { missions, standalone } = groupByMission([
+      session("Gateway Cleanup - Manager", 102, "a"),
+      session("Gateway Cleanup - Architect", 107, "b"),
+      session("mindzieWeb - remove Ask Mindzie", 108, "c"),
+      session("Working Mac", 101, "d"),
+    ]);
+
+    expect(missions).toHaveLength(1);
+    expect(missions[0].name).toBe("Gateway Cleanup");
+    expect(missions[0].members.map((m) => m.role)).toEqual(["Architect", "Manager"]);
+    expect(standalone.map((s) => s.number)).toEqual([101, 108]);
+  });
+
+  it("sorts missions alphabetically (case-insensitive) and groups case-insensitively", () => {
+    const { missions } = groupByMission([
+      session("Zebra - Manager", 3, "a"),
+      session("apple - Manager", 1, "b"),
+      session("APPLE - Architect", 2, "c"),
+    ]);
+
+    expect(missions.map((m) => m.name)).toEqual(["apple", "Zebra"]);
+    // "apple" and "APPLE" collapse into one mission (display = first seen).
+    expect(missions[0].members).toHaveLength(2);
+  });
+
+  it("orders members Architect, Manager, Worker then by number", () => {
+    const { missions } = groupByMission([
+      session("Big - Worker", 50, "a"),
+      session("Big - Manager", 20, "b"),
+      session("Big - Architect", 30, "c"),
+      session("Big - Worker", 10, "d"),
+    ]);
+
+    expect(missions[0].members.map((m) => `${m.role}:${m.session.number}`)).toEqual([
+      "Architect:30",
+      "Manager:20",
+      "Worker:10",
+      "Worker:50",
+    ]);
+  });
+
+  it("groups mid-move sessions with their mission (bracket tag stripped)", () => {
+    const { missions, standalone } = groupByMission([
+      session("[Moving Started] Gateway Cleanup - Manager", 115, "a"),
+      session("Gateway Cleanup - Architect", 107, "b"),
+    ]);
+
+    expect(standalone).toHaveLength(0);
+    expect(missions).toHaveLength(1);
+    expect(missions[0].name).toBe("Gateway Cleanup");
+    expect(missions[0].members).toHaveLength(2);
+  });
+});

--- a/apps/cockpit/src/missions/missionGrouping.ts
+++ b/apps/cockpit/src/missions/missionGrouping.ts
@@ -1,0 +1,139 @@
+// Phase 1a of the Mission Screen (issue #1405): derive "missions" from the live fleet purely from the
+// session NAME, with no backend change. The Cockpit's SessionDto (from the Gateway roster) does not
+// carry a mission or role field, so for now a mission is read from the naming convention
+// "<Mission> - <Role>" (dash, role second). Everything here is a pure function so the parser and the
+// grouping are unit-tested on their own (see missionGrouping.test.ts); the view does no parsing.
+//
+// Two rules the Architect pinned before this was built (session 3457ddcf):
+//   1. Strip ONE leading bracket tag first. Live names carry a move marker, e.g.
+//      "[Moving Started] Gateway Cleanup - Manager" - without stripping the "[...]" the name would fall
+//      to Standalone and we would lose the very mission we want grouped.
+//   2. Match on the LAST " - <Role>". The mission is the text BEFORE that final " - <Role>", so a name
+//      that itself contains " - " (e.g. "Foo - Bar - Manager") groups under "Foo - Bar".
+// A trailing token that is NOT one of the known roles keeps the session Standalone (a bogus mission is
+// worse than Standalone) - e.g. "mindzieWeb - remove Ask Mindzie" is Standalone, not a "mindzieWeb"
+// mission.
+import type { SessionDto } from "@devthrottle/client-core/api/client";
+
+// The known roles a mission is staffed with. Only a session whose name ends in one of these (after the
+// final " - ") is treated as part of a mission; anything else is Standalone. Case-insensitive match,
+// canonical display casing.
+const ROLE_DISPLAY: Record<string, string> = {
+  architect: "Architect",
+  manager: "Manager",
+  worker: "Worker",
+};
+
+// The " - " that separates a mission name from its role in the naming convention.
+const ROLE_SEPARATOR = " - ";
+
+export interface ParsedMissionName {
+  // The mission name exactly as written (bracket tag stripped, the text before the final " - Role").
+  mission: string;
+  // The role in canonical casing ("Architect" | "Manager" | "Worker").
+  role: string;
+}
+
+// Strip one leading bracket tag from a session name: "[Moving Started] Gateway Cleanup - Manager" ->
+// "Gateway Cleanup - Manager". Only a single leading "[...]" group (and the whitespace after it) is
+// removed; brackets elsewhere in the name are left alone.
+export function stripBracketTag(name: string): string {
+  return name.replace(/^\s*\[[^\]]*\]\s*/, "").trim();
+}
+
+// Parse a raw session name into its mission + role, or null when the name is not a mission member. The
+// name is first trimmed of a leading bracket tag, then split on its LAST " - "; the trailing token must
+// be a known role for it to count as a mission.
+export function parseMissionName(rawName: string | null | undefined): ParsedMissionName | null {
+  const stripped = stripBracketTag((rawName ?? "").trim());
+  if (stripped.length === 0) return null;
+
+  const lastSep = stripped.lastIndexOf(ROLE_SEPARATOR);
+  if (lastSep < 0) return null;
+
+  const rolePart = stripped.slice(lastSep + ROLE_SEPARATOR.length).trim();
+  const roleDisplay = ROLE_DISPLAY[rolePart.toLowerCase()];
+  if (roleDisplay === undefined) return null;
+
+  const mission = stripped.slice(0, lastSep).trim();
+  if (mission.length === 0) return null;
+
+  return { mission, role: roleDisplay };
+}
+
+// One session inside a mission card, carrying the role parsed from its name.
+export interface MissionMember {
+  session: SessionDto;
+  role: string;
+}
+
+// One mission: a display name (as first seen) and its member sessions, ordered role-first.
+export interface MissionGroup {
+  // Lowercased mission name - the grouping identity, case-insensitive.
+  key: string;
+  // The mission name as first seen in the fleet (display casing).
+  name: string;
+  members: MissionMember[];
+}
+
+// The whole fleet split into missions (alphabetical) plus the Standalone sessions (rendered last as
+// their own group).
+export interface GroupedFleet {
+  missions: MissionGroup[];
+  standalone: SessionDto[];
+}
+
+// Order roles Architect -> Manager -> Worker within a mission card, so the lead reads first; an
+// unknown role (should not happen past the parser) sorts last.
+const ROLE_RANK: Record<string, number> = { Architect: 0, Manager: 1, Worker: 2 };
+
+function roleRank(role: string): number {
+  const r = ROLE_RANK[role];
+  return r === undefined ? 99 : r;
+}
+
+// Stable order by session number ascending (the identity the owner reads), numbers before the
+// unnumbered, then session id - so a row never jumps when its color changes. Mirrors the Fleet Map's
+// flat sort so the two surfaces agree.
+function byNumber(a: SessionDto, b: SessionDto): number {
+  const na = Number(a.number);
+  const nb = Number(b.number);
+  const aHas = Number.isFinite(na);
+  const bHas = Number.isFinite(nb);
+  if (aHas && bHas && na !== nb) return na - nb;
+  if (aHas !== bHas) return aHas ? -1 : 1;
+  return String(a.sessionId ?? "").localeCompare(String(b.sessionId ?? ""));
+}
+
+// Group the live fleet by mission. Missions come out alphabetical (case-insensitive) by display name;
+// each mission's members are ordered role-first then by session number; Standalone sessions (no
+// parseable mission role) come out in session-number order for the caller to render last.
+export function groupByMission(sessions: SessionDto[]): GroupedFleet {
+  const byKey = new Map<string, MissionGroup>();
+  const standalone: SessionDto[] = [];
+
+  for (const s of sessions) {
+    const parsed = parseMissionName(s.name);
+    if (parsed === null) {
+      standalone.push(s);
+      continue;
+    }
+    const key = parsed.mission.toLowerCase();
+    let group = byKey.get(key);
+    if (group === undefined) {
+      group = { key, name: parsed.mission, members: [] };
+      byKey.set(key, group);
+    }
+    group.members.push({ session: s, role: parsed.role });
+  }
+
+  const missions = [...byKey.values()].sort((a, b) =>
+    a.name.toLowerCase().localeCompare(b.name.toLowerCase()),
+  );
+  for (const m of missions) {
+    m.members.sort((a, b) => roleRank(a.role) - roleRank(b.role) || byNumber(a.session, b.session));
+  }
+  standalone.sort(byNumber);
+
+  return { missions, standalone };
+}

--- a/apps/cockpit/src/missions/missions.css
+++ b/apps/cockpit/src/missions/missions.css
@@ -1,0 +1,297 @@
+/* Missions page (issue #1405, Phase 1a): the fleet grouped into missions. Like fleetmap.css, every
+   color is a token from the app theme (src/styles.css :root) or a status hex from the shared ordering
+   palette applied inline in the component - nothing hard-codes a color here. Renders as normal
+   scrolling content in the padded main pane. */
+
+.msn {
+  max-width: 1100px;
+}
+
+/* ---- header ---- */
+.msn-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.msn-title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+}
+
+.msn-stats {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-dim);
+  font-size: 13px;
+}
+
+.msn-sep {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--text-dim);
+  opacity: 0.6;
+}
+
+.msn-stat-blue {
+  color: var(--accent);
+}
+
+.msn-stat-red {
+  color: var(--attention);
+}
+
+/* ---- states (mirrors the Fleet Map's error / warn / empty blocks) ---- */
+.msn-error {
+  margin: 0 0 14px;
+  padding: 10px 12px;
+  background: rgba(241, 76, 76, 0.1);
+  border: 1px solid rgba(241, 76, 76, 0.4);
+  border-radius: 8px;
+  color: var(--attention);
+  font-size: 13px;
+}
+
+.msn-warn {
+  margin: 0 0 14px;
+  padding: 10px 12px;
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.4);
+  border-radius: 8px;
+  color: var(--warn);
+  font-size: 13px;
+}
+
+.msn-empty {
+  margin-top: 24px;
+  padding: 28px;
+  text-align: center;
+  color: var(--text-dim);
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+}
+
+.msn-empty-sub {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+/* ---- list ---- */
+.msn-list {
+  padding-bottom: 28px;
+}
+
+.msn-group-label {
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  font-weight: 600;
+  margin: 22px 0 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.msn-group-label::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+/* ---- mission card ---- */
+.msn-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  margin-bottom: 12px;
+  overflow: hidden;
+}
+
+.msn-card-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  /* The accent color is applied inline from the shared palette (dotColor). */
+  border-left: 3px solid var(--border);
+}
+
+.msn-card-title {
+  min-width: 0;
+  flex: 1;
+}
+
+.msn-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.msn-meta {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 3px;
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.msn-repo {
+  font-family: "Cascadia Mono", Consolas, Menlo, monospace;
+  color: var(--text);
+}
+
+/* status pill */
+.msn-pill {
+  flex: 0 0 auto;
+  font-size: 10px;
+  font-weight: 600;
+  padding: 3px 9px;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.msn-pdot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.msn-pill-needs {
+  background: rgba(241, 76, 76, 0.14);
+  color: #f4787c;
+}
+
+.msn-pill-work {
+  background: rgba(59, 130, 246, 0.14);
+  color: #6ea8f7;
+}
+
+.msn-pill-idle {
+  background: var(--surface-2);
+  color: var(--text-dim);
+}
+
+/* ---- the WHY slot ---- */
+.msn-why {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 14px;
+  border-top: 1px solid var(--border);
+  font-size: 12px;
+}
+
+.msn-why-k {
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  font-weight: 600;
+  flex: 0 0 auto;
+}
+
+/* A missing WHY is a loud flag, never a silent blank (the mission's founding rule). */
+.msn-why-flag {
+  color: var(--warn);
+  background: rgba(245, 158, 11, 0.1);
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  border-radius: 5px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+/* ---- session rows ---- */
+.msn-sessions {
+  border-top: 1px solid var(--border);
+}
+
+.msn-srow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 14px;
+  border-top: 1px solid var(--border);
+  cursor: pointer;
+}
+
+.msn-srow:first-child {
+  border-top: none;
+}
+
+.msn-srow:hover {
+  background: var(--surface-2);
+}
+
+.msn-srow:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+/* the left status bar - color applied inline from the shared palette */
+.msn-lbar {
+  width: 3px;
+  align-self: stretch;
+  border-radius: 2px;
+  margin: -9px 0;
+  flex: 0 0 auto;
+  background: var(--border);
+}
+
+.msn-srow-grow {
+  flex: 1;
+  min-width: 0;
+}
+
+.msn-role {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.msn-rmeta {
+  font-size: 10.5px;
+  color: var(--text-dim);
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 46ch;
+}
+
+.msn-machine {
+  font-size: 10px;
+  color: var(--text-dim);
+  font-family: "Cascadia Mono", Consolas, Menlo, monospace;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 2px 7px;
+  flex: 0 0 auto;
+}
+
+.msn-state {
+  font-size: 10.5px;
+  flex: 0 0 auto;
+  min-width: 82px;
+  text-align: right;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 1px;
+}
+
+.msn-idle {
+  color: var(--text-dim);
+  font-size: 10px;
+}


### PR DESCRIPTION
Closes part of thefrederiksen/devthrottle_internal#765 (the Mission Screen mission, Phase 1a).

A new **Missions** page in the Cockpit - a Fleet-section nav destination at route `/missions` - that shows the live fleet grouped the way the owner thinks about the work: by **mission**, not by machine or session. Same shared roster data as the Fleet Map, seen a different way. This is the read-only grouped list; the Phase 2 chat pane is intentionally not here (the list ships full width).

## What it does

- **Derives missions purely from the session name** ("<Mission> - <Role>") in a pure, unit-tested module. A leading bracket tag is stripped first (so `[Moving Started] Gateway Cleanup - Manager` groups under Gateway Cleanup), the match is on the **last** ` - Role`, and only the known roles Architect, Manager, and Worker count - anything else (e.g. `mindzieWeb - remove Ask Mindzie`) stays **Standalone** rather than becoming a bogus mission.
- Missions render **alphabetically**; a **Standalone** group comes last. Each mission is a card with its name, repositories, session count, a status pill, and a **WHY slot** showing a loud "No why set - add one" flag until Phase 1b wires the durable store.
- Each session is a **clickable row** (number badge, role, machine, live state) that opens that session at `/session/:id` - the linking this phase delivers.
- Reads the **one shared roster store** (`useSharedRoster`) - no new poll, no Director address - and reuses the one shared effective-color and state-label rule so a status dot here matches every other Cockpit surface. Loading, empty, and error states mirror the Fleet Map. New stylesheet in the Cockpit dark palette.

## Files (6)

- `apps/cockpit/src/missions/missionGrouping.ts` - the pure parser + grouping
- `apps/cockpit/src/missions/missionGrouping.test.ts` - 14 unit tests
- `apps/cockpit/src/missions/MissionsView.tsx` - the page
- `apps/cockpit/src/missions/missions.css` - new stylesheet
- `apps/cockpit/src/AppShell.tsx` - nav item under Fleet (+1 line)
- `apps/cockpit/src/main.tsx` - route + imports (+6 lines)

## Verified in the running Cockpit

Proven with the Vite dev server and an in-page fetch shim seeded from the **real current fleet** (no production Gateway - the documented self-verify pattern). All seven acceptance criteria hold:

1. Nav "Missions" under Fleet renders and activates; `/missions` renders the page.
2. Reads the shared roster store - no new poll, no Director address.
3. Five mission cards appear **alphabetically** (Car Mode, Enrichment Co-Pilot, Gateway Cleanup, Gateway Connection, Mission Screen); **Standalone last** (Working Mac, Car Mode Demo, mindzieWeb - remove Ask Mindzie, mindzie Upwork, Stream Mismatch Watcher).
4. Each card shows name, repo, session count, status pill, and the loud "No why set - add one" WHY flag.
5. Rows show number badge, role, machine, live color + label; clicking a row navigates to `/session/:id` (asserted `sid-113`).
6. Loading / empty / error states handled like the Fleet Map.
7. New CSS file in the Cockpit dark palette.

The role whitelist and bracket-tag stripping are proven live (Car Mode Demo and the #108 non-role dash land in Standalone) and locked by unit tests. **14 unit tests pass; `tsc --noEmit` is clean.**

Cockpit screenshot (shown to the owner in chat): `scratchpad/missions.png` on SOREN_NORTH.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
