### PR TITLE
fix(release): drop EnableCompressionInSingleFile from all macOS publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,12 +75,14 @@ jobs:
           dotnet-version: "10.0.x"
 
       - name: Publish for macOS arm64
+        # Do NOT add EnableCompressionInSingleFile here: on macOS arm64 under .NET 10 the
+        # compressed bundle corrupts memory in the HTTP stack (AccessViolationException,
+        # crash on the first outbound request). Proven on hardware in issue #1442.
         run: >
           dotnet publish src/CcDirector.Avalonia/CcDirector.Avalonia.csproj
           -c Release -r osx-arm64 --self-contained true
           -p:PublishSingleFile=true
           -p:IncludeNativeLibrariesForSelfExtract=true
-          -p:EnableCompressionInSingleFile=true
           -p:UpdaterEnabled=true
 
       - name: Package distributable .app bundle (zip)
@@ -145,12 +147,12 @@ jobs:
           dotnet-version: "10.0.x"
 
       - name: Publish setup wizard for macOS arm64
+        # No EnableCompressionInSingleFile on macOS - memory corruption, issue #1442.
         run: >
           dotnet publish tools/cc-director-setup-avalonia/CcDirectorSetup.csproj
           -c Release -r osx-arm64 --self-contained true
           -p:PublishSingleFile=true
           -p:IncludeNativeLibrariesForSelfExtract=true
-          -p:EnableCompressionInSingleFile=true
 
       - name: Package distributable Setup .app bundle (zip)
         run: >
@@ -426,12 +428,12 @@ jobs:
           dotnet-version: "10.0.x"
 
       - name: Publish Launcher for macOS arm64
+        # No EnableCompressionInSingleFile on macOS - memory corruption, issue #1442.
         run: >
           dotnet publish src/CcDirector.Launcher/CcDirector.Launcher.csproj
           -c Release -f net10.0 -r osx-arm64 --self-contained true
           -p:PublishSingleFile=true
           -p:IncludeNativeLibrariesForSelfExtract=true
-          -p:EnableCompressionInSingleFile=true
 
       - name: Upload launcher mac artifact
         uses: actions/upload-artifact@v6

--- a/scripts/local-build-mac.sh
+++ b/scripts/local-build-mac.sh
@@ -123,9 +123,6 @@ PUBLISH_ARGS=(
     --nologo
     -v q
 )
-if [[ "$SELF_CONTAINED" == true ]]; then
-    PUBLISH_ARGS+=(-p:EnableCompressionInSingleFile=true)
-fi
 dotnet "${PUBLISH_ARGS[@]}"
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1442.

The released cc-launcher-mac-arm64 from v1.0.8 crashes with a fatal System.AccessViolationException inside System.Net.Http on its first outbound request — five out of five runs — and crash-loops every ten seconds under launchd KeepAlive. The identical binary built without -p:EnableCompressionInSingleFile=true is stable and is currently running on Sorens-Mac-mini with a tray icon, registered with the production Gateway.

The flag was set on all three macOS release publishes (Director app, setup wizard, launcher) and in scripts/local-build-mac.sh for self-contained builds, so every released macOS binary was suspect — daily local Director builds are framework-dependent and never hit it, which is why this went unnoticed. Windows publishes keep the flag.

Guard comments added at each macOS publish site so the flag does not quietly return. A new release must be cut after this merges — the v1.0.8 Mac assets are unusable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)