### PR TITLE
release: bump product version to 1.0.9

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.0.8</Version>
+    <Version>1.0.9</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Version bump for v1.0.9 - the first release with uncompressed (working) macOS binaries after issue #1442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)