### PR TITLE
feat(carmode): hands-free Voice-screen actions in the fleet brain

### DIFF
--- a/src/CcDirector.Gateway.Tests/CarModeBrainTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeBrainTests.cs
@@ -40,6 +40,12 @@ public sealed class CarModeBrainTests
         public List<string> Approved { get; } = new();
         public List<string> Deleted { get; } = new();
 
+        // Voice-screen-actions phase tools.
+        public CarModeExplain ExplainResult { get; set; } = new("", false);
+        public List<string> Explained { get; } = new();
+        public List<(string SessionId, bool Enabled)> VoiceModeSet { get; } = new();
+        public List<string> Snoozed { get; } = new();
+
         public Task<IReadOnlyList<CarModeSessionInfo>> ListSessionsAsync(CancellationToken ct)
         {
             ListCalls++;
@@ -72,9 +78,30 @@ public sealed class CarModeBrainTests
             Deleted.Add(sessionId);
             return Task.CompletedTask;
         }
+        public Task<CarModeExplain> ExplainSessionAsync(string sessionId, CancellationToken ct)
+        {
+            Explained.Add(sessionId);
+            return Task.FromResult(ExplainResult);
+        }
+        public Task SwitchVoiceModeAsync(string sessionId, bool enabled, CancellationToken ct)
+        {
+            VoiceModeSet.Add((sessionId, enabled));
+            return Task.CompletedTask;
+        }
+        public Task SnoozeSessionAsync(string sessionId, CancellationToken ct)
+        {
+            Snoozed.Add(sessionId);
+            return Task.CompletedTask;
+        }
     }
 
     private static CarModeToolCall Call(string name, string args = "{}") => new("call_1", name, args);
+
+    /// <summary>A final spoken answer the way the real model must produce it under tool_choice=required: by
+    ///  calling speak_answer. Bare-content final answers are rejected by the brain's hallucination guard, so
+    ///  tests model the final say through speak_answer, matching production.</summary>
+    private static CarModeAssistantTurn Speak(string text) =>
+        new(null, new[] { new CarModeToolCall("call_speak", "speak_answer", "{\"text\":" + System.Text.Json.JsonSerializer.Serialize(text) + "}") });
 
     private static CarModeSessionInfo Info(string name, string id) => new()
     {
@@ -103,8 +130,8 @@ public sealed class CarModeBrainTests
         var fleet = new FakeFleet { Sessions = new[] { Session("Local Files Manager", true), Session("Car Mode Worker", false) } };
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("list_sessions") }),
-            new CarModeAssistantTurn("One session needs you: Local Files Manager, in the devthrottle repo.", Array.Empty<CarModeToolCall>()));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+            Speak("One session needs you: Local Files Manager, in the devthrottle repo."));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync("device-a", "how many need me over", CancellationToken.None);
 
@@ -125,7 +152,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("list_sessions") }),
             new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"One session needs you.\"}") }));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync("device-a", "who needs me over", CancellationToken.None);
 
@@ -145,7 +172,7 @@ public sealed class CarModeBrainTests
         var fleet = new FakeFleet { Sessions = new[] { Session("Local Files Manager", true) } };
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"I can run your fleet by voice.\"}") }));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync("device-a", "what can you help me with over", CancellationToken.None);
 
@@ -169,8 +196,8 @@ public sealed class CarModeBrainTests
         };
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("get_session_activity", "{\"session\":\"car mode\"}") }),
-            new CarModeAssistantTurn("Car Mode Manager, in the devthrottle repo, is building the fleet brain.", Array.Empty<CarModeToolCall>()));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+            Speak("Car Mode Manager, in the devthrottle repo, is building the fleet brain."));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync("device-a", "what is the car mode session doing", CancellationToken.None);
 
@@ -184,13 +211,13 @@ public sealed class CarModeBrainTests
     {
         var fleet = new FakeFleet();
         var store = new CarModeConversationStore();
-        var chat1 = new ScriptedChat(new CarModeAssistantTurn("Nothing needs you right now.", Array.Empty<CarModeToolCall>()));
-        var brain1 = new CarModeBrain(chat1, fleet, store, new CarModePendingStore(_ => { }), _ => { });
+        var chat1 = new ScriptedChat(Speak("Nothing needs you right now."));
+        var brain1 = new CarModeBrain(chat1, fleet, store, new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
         await brain1.RunTurnAsync("device-a", "who needs me", CancellationToken.None);
 
         // The next turn on the SAME device must carry the prior exchange into the model's messages.
-        var chat2 = new ScriptedChat(new CarModeAssistantTurn("Still nothing.", Array.Empty<CarModeToolCall>()));
-        var brain2 = new CarModeBrain(chat2, fleet, store, new CarModePendingStore(_ => { }), _ => { });
+        var chat2 = new ScriptedChat(Speak("Still nothing."));
+        var brain2 = new CarModeBrain(chat2, fleet, store, new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
         await brain2.RunTurnAsync("device-a", "and now", CancellationToken.None);
 
         Assert.Contains("who needs me", chat2.SeenMessages[0]);
@@ -202,11 +229,11 @@ public sealed class CarModeBrainTests
     {
         var fleet = new FakeFleet();
         var store = new CarModeConversationStore();
-        var brainA = new CarModeBrain(new ScriptedChat(new CarModeAssistantTurn("A reply", Array.Empty<CarModeToolCall>())), fleet, store, new CarModePendingStore(_ => { }), _ => { });
+        var brainA = new CarModeBrain(new ScriptedChat(Speak("A reply")), fleet, store, new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
         await brainA.RunTurnAsync("device-a", "secret A question", CancellationToken.None);
 
-        var chatB = new ScriptedChat(new CarModeAssistantTurn("B reply", Array.Empty<CarModeToolCall>()));
-        var brainB = new CarModeBrain(chatB, fleet, store, new CarModePendingStore(_ => { }), _ => { });
+        var chatB = new ScriptedChat(Speak("B reply"));
+        var brainB = new CarModeBrain(chatB, fleet, store, new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
         await brainB.RunTurnAsync("device-b", "question B", CancellationToken.None);
 
         Assert.DoesNotContain("secret A question", chatB.SeenMessages[0]);
@@ -215,7 +242,7 @@ public sealed class CarModeBrainTests
     [Fact]
     public async Task RunTurn_EmptyText_Throws()
     {
-        var brain = new CarModeBrain(new ScriptedChat(), new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(new ScriptedChat(), new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
         await Assert.ThrowsAsync<ArgumentException>(() => brain.RunTurnAsync("device-a", "   ", CancellationToken.None));
     }
 
@@ -225,7 +252,7 @@ public sealed class CarModeBrainTests
         var fleet = new FakeFleet { Sessions = Array.Empty<CarModeSessionInfo>() };
         // Every round asks for a tool and never answers - the loop must stop and speak a failure.
         var turns = Enumerable.Range(0, 10).Select(_ => new CarModeAssistantTurn(null, new[] { Call("list_sessions") })).ToArray();
-        var brain = new CarModeBrain(new ScriptedChat(turns), fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(new ScriptedChat(turns), fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync("device-a", "who needs me", CancellationToken.None);
 
@@ -236,8 +263,8 @@ public sealed class CarModeBrainTests
     public async Task RunTurn_EmptyFinalReply_Throws()
     {
         var brain = new CarModeBrain(
-            new ScriptedChat(new CarModeAssistantTurn("   ", Array.Empty<CarModeToolCall>())),
-            new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+            new ScriptedChat(Speak("   ")),
+            new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
         await Assert.ThrowsAsync<InvalidOperationException>(() => brain.RunTurnAsync("device-a", "hi", CancellationToken.None));
     }
 
@@ -262,7 +289,7 @@ public sealed class CarModeBrainTests
         // A pure conversational turn under tool_choice=required: the model calls only speak_answer.
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"Nothing needs you right now.\"}") }));
-        var brain = new CarModeBrain(chat, new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync("device-a", "anything for me", CancellationToken.None);
 
@@ -278,7 +305,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("list_sessions") }),
             new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"One session needs you: Local Files Manager.\"}") }));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync("device-a", "who needs me", CancellationToken.None);
 
@@ -294,7 +321,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("delete_session", "{\"session\":\"old worker\"}") }),
             new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"Deleting Old Worker is permanent. Say confirm to proceed.\"}") }));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), pending, _ => { });
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), pending, new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync("device-a", "delete old worker", CancellationToken.None);
 
@@ -312,7 +339,7 @@ public sealed class CarModeBrainTests
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"  \"}") }),
             new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"All set.\"}") }));
-        var brain = new CarModeBrain(chat, new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+        var brain = new CarModeBrain(chat, new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync("device-a", "hi", CancellationToken.None);
 
@@ -327,8 +354,8 @@ public sealed class CarModeBrainTests
         var fleet = new FakeFleet();
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("start_session", "{\"repo\":\"devthrottle\"}") }),
-            new CarModeAssistantTurn("Started a session in the devthrottle repo.", Array.Empty<CarModeToolCall>()));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+            Speak("Started a session in the devthrottle repo."));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync("device-a", "start a session in devthrottle", CancellationToken.None);
 
@@ -344,8 +371,8 @@ public sealed class CarModeBrainTests
         var fleet = new FakeFleet { ResolveResult = Info("Car Mode Worker", "s-42") };
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("message_session", "{\"session\":\"car mode worker\",\"message\":\"run the tests\"}") }),
-            new CarModeAssistantTurn("Told Car Mode Worker to run the tests.", Array.Empty<CarModeToolCall>()));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+            Speak("Told Car Mode Worker to run the tests."));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync("device-a", "message the worker", CancellationToken.None);
 
@@ -361,8 +388,8 @@ public sealed class CarModeBrainTests
         var fleet = new FakeFleet { ResolveResult = null };
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("message_session", "{\"session\":\"ghost\",\"message\":\"hi\"}") }),
-            new CarModeAssistantTurn("I couldn't find a session called ghost.", Array.Empty<CarModeToolCall>()));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), _ => { });
+            Speak("I couldn't find a session called ghost."));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
 
         await brain.RunTurnAsync("device-a", "message ghost", CancellationToken.None);
 
@@ -378,8 +405,8 @@ public sealed class CarModeBrainTests
         var pending = new CarModePendingStore(_ => { });
         var chat = new ScriptedChat(
             new CarModeAssistantTurn(null, new[] { Call("delete_session", "{\"session\":\"old worker\"}") }),
-            new CarModeAssistantTurn("Deleting Old Worker is permanent. Say confirm to proceed, or cancel.", Array.Empty<CarModeToolCall>()));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), pending, _ => { });
+            Speak("Deleting Old Worker is permanent. Say confirm to proceed, or cancel."));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), pending, new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync("device-a", "delete the old worker", CancellationToken.None);
 
@@ -400,14 +427,14 @@ public sealed class CarModeBrainTests
         var brain1 = new CarModeBrain(
             new ScriptedChat(
                 new CarModeAssistantTurn(null, new[] { Call("delete_session", "{\"session\":\"old worker\"}") }),
-                new CarModeAssistantTurn("Say confirm to delete Old Worker.", Array.Empty<CarModeToolCall>())),
-            fleet, store, pending, _ => { });
+                Speak("Say confirm to delete Old Worker.")),
+            fleet, store, pending, new CarModeSubjectStore(_ => { }), _ => { });
         await brain1.RunTurnAsync("device-a", "delete old worker", CancellationToken.None);
         Assert.Empty(fleet.Deleted);
 
         // Turn 2: the owner confirms. The model is NOT consulted - the gate executes deterministically.
         var chat2 = new ScriptedChat(); // must not be called
-        var brain2 = new CarModeBrain(chat2, fleet, store, pending, _ => { });
+        var brain2 = new CarModeBrain(chat2, fleet, store, pending, new CarModeSubjectStore(_ => { }), _ => { });
         var result = await brain2.RunTurnAsync("device-a", "confirm", CancellationToken.None);
 
         Assert.Single(fleet.Deleted);
@@ -426,7 +453,7 @@ public sealed class CarModeBrainTests
         pending.Arm("device-a", new CarModePendingAction("delete", "s-9", "Old Worker"));
 
         var chat = new ScriptedChat(); // must not be called
-        var brain = new CarModeBrain(chat, new FakeFleet(), new CarModeConversationStore(), pending, _ => { });
+        var brain = new CarModeBrain(chat, new FakeFleet(), new CarModeConversationStore(), pending, new CarModeSubjectStore(_ => { }), _ => { });
         var result = await brain.RunTurnAsync("device-a", "no cancel that", CancellationToken.None);
 
         Assert.Empty(fleet.Deleted);
@@ -440,14 +467,212 @@ public sealed class CarModeBrainTests
         var pending = new CarModePendingStore(_ => { });
         pending.Arm("device-a", new CarModePendingAction("delete", "s-9", "Old Worker"));
         var fleet = new FakeFleet { Sessions = Array.Empty<CarModeSessionInfo>() };
-        var chat = new ScriptedChat(new CarModeAssistantTurn("Nothing needs you.", Array.Empty<CarModeToolCall>()));
-        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), pending, _ => { });
+        var chat = new ScriptedChat(Speak("Nothing needs you."));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), pending, new CarModeSubjectStore(_ => { }), _ => { });
 
         var result = await brain.RunTurnAsync("device-a", "who needs me", CancellationToken.None);
 
         // The armed delete is dropped (safe) and the new command is processed normally.
         Assert.Null(pending.Get("device-a"));
         Assert.Equal("Nothing needs you.", result.Spoken);
+    }
+
+    // ---- Voice-screen-actions phase: read wingman, switch voice, snooze, focus next, current subject ----
+
+    private static CarModeSessionInfo Waiting(string name, string id, int waitingMinutes) => new()
+    {
+        SessionId = id,
+        Name = name,
+        Repo = "devthrottle",
+        MachineName = "SOREN_NORTH",
+        State = "Needs you",
+        NeedsYou = true,
+        WaitingMinutes = waitingMinutes,
+        Summary = "waiting for your answer",
+    };
+
+    [Fact]
+    public async Task RunTurn_ReadWingman_ReadsRealNarrationForResolvedSession()
+    {
+        var fleet = new FakeFleet
+        {
+            ResolveResult = Info("Car Mode Demo", "s-demo"),
+            ExplainResult = new CarModeExplain("I need you to pick option two before I continue.", false),
+        };
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("read_wingman", "{\"session\":\"car mode demo\"}") }),
+            new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"Car Mode Demo needs you to pick option two.\"}") }));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+
+        var result = await brain.RunTurnAsync("device-a", "what does the car mode demo need over", CancellationToken.None);
+
+        Assert.Single(fleet.Explained);
+        Assert.Equal("s-demo", fleet.Explained[0]);
+        // The REAL narration was handed to the model (round 2 sees it), not a canned line.
+        Assert.Contains("pick option two", chat.SeenMessages[1]);
+        Assert.Contains("Car Mode Demo", result.Spoken);
+    }
+
+    [Fact]
+    public async Task RunTurn_SwitchToVoiceMode_CallsFleetAndRecordsAction()
+    {
+        var fleet = new FakeFleet { ResolveResult = Info("Car Mode Demo", "s-demo") };
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("switch_to_voice_mode", "{\"session\":\"car mode demo\"}") }),
+            Speak("Switched Car Mode Demo to voice mode."));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+
+        var result = await brain.RunTurnAsync("device-a", "put the car mode demo in voice mode over", CancellationToken.None);
+
+        Assert.Single(fleet.VoiceModeSet);
+        Assert.Equal(("s-demo", true), fleet.VoiceModeSet[0]);
+        Assert.Contains(result.Actions, a => a.Tool == "switch_to_voice_mode");
+    }
+
+    [Fact]
+    public async Task RunTurn_Snooze_CallsFleetAndRecordsAction()
+    {
+        var fleet = new FakeFleet { ResolveResult = Info("Car Mode Demo", "s-demo") };
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("snooze_session", "{\"session\":\"car mode demo\"}") }),
+            Speak("Snoozed Car Mode Demo."));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+
+        var result = await brain.RunTurnAsync("device-a", "snooze the car mode demo over", CancellationToken.None);
+
+        Assert.Single(fleet.Snoozed);
+        Assert.Equal("s-demo", fleet.Snoozed[0]);
+        Assert.Contains(result.Actions, a => a.Tool == "snooze_session");
+    }
+
+    [Fact]
+    public async Task RunTurn_FocusNext_PicksLongestWaiting_AndSetsSubject()
+    {
+        // Two need the owner; the one waiting longest is focused and becomes the current subject.
+        var fleet = new FakeFleet
+        {
+            Sessions = new[] { Waiting("Recently Waiting", "s-new", 3), Waiting("Longest Waiting", "s-old", 40) },
+        };
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("focus_next_needs_me") }),
+            new CarModeAssistantTurn(null, new[] { Call("speak_answer", "{\"text\":\"Longest Waiting has been waiting forty minutes.\"}") }));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+
+        var result = await brain.RunTurnAsync("device-a", "who needs me next over", CancellationToken.None);
+
+        // The model saw the longest-waiting session as the focus result.
+        Assert.Contains("Longest Waiting", chat.SeenMessages[1]);
+        Assert.DoesNotContain("s-new", chat.SeenMessages[1]);
+        Assert.Contains("Longest Waiting", result.Spoken);
+    }
+
+    [Fact]
+    public async Task RunTurn_FocusThenAnswerIt_ResolvesTheCurrentSubject()
+    {
+        // The whole loop: focus the next needs-you session (turn 1), then "answer it" (turn 2) with the
+        // session OMITTED must message the focused session - proving the server-side current subject.
+        var subjects = new CarModeSubjectStore(_ => { });
+        var store = new CarModeConversationStore();
+        var fleet = new FakeFleet { Sessions = new[] { Waiting("Car Mode Demo", "s-demo", 12) } };
+
+        var brain1 = new CarModeBrain(
+            new ScriptedChat(
+                new CarModeAssistantTurn(null, new[] { Call("focus_next_needs_me") }),
+                Speak("Car Mode Demo has been waiting twelve minutes.")),
+            fleet, store, new CarModePendingStore(_ => { }), subjects, _ => { });
+        await brain1.RunTurnAsync("device-a", "read me the next one over", CancellationToken.None);
+
+        // Turn 2: "answer it and say yes" - message_session with NO session argument -> the current subject.
+        var brain2 = new CarModeBrain(
+            new ScriptedChat(
+                new CarModeAssistantTurn(null, new[] { Call("message_session", "{\"message\":\"yes\"}") }),
+                Speak("Answered Car Mode Demo.")),
+            fleet, store, new CarModePendingStore(_ => { }), subjects, _ => { });
+        await brain2.RunTurnAsync("device-a", "answer it and say yes over", CancellationToken.None);
+
+        Assert.Single(fleet.Messaged);
+        Assert.Equal("s-demo", fleet.Messaged[0].SessionId);
+        Assert.Equal("yes", fleet.Messaged[0].Message);
+    }
+
+    [Fact]
+    public async Task RunTurn_OmittedSessionWithNoSubject_ReturnsWhichOne_DoesNotAct()
+    {
+        // "snooze it" with nothing focused yet: the tool must not guess - it returns a "which one" the model
+        // relays, and no fleet act happens.
+        var fleet = new FakeFleet();
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("snooze_session", "{}") }),
+            Speak("Which session should I snooze?"));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+
+        await brain.RunTurnAsync("device-a", "snooze it over", CancellationToken.None);
+
+        Assert.Empty(fleet.Snoozed);
+        // The model was handed the "which one" prompt to relay.
+        Assert.Contains("Which session", chat.SeenMessages[1]);
+    }
+
+    [Fact]
+    public async Task RunTurn_DeleteOmittedSession_UsesSubject_AndNamesItInConfirmation()
+    {
+        // Even via the current-subject shortcut, delete must name the session and repo for the spoken
+        // confirmation (Architect safety flag) and must NOT delete on this turn.
+        var subjects = new CarModeSubjectStore(_ => { });
+        subjects.Set("device-a", new CarModeSubject("s-demo", "Car Mode Demo", "devthrottle"));
+        var pending = new CarModePendingStore(_ => { });
+        var fleet = new FakeFleet();
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("delete_session", "{}") }),
+            Speak("Deleting Car Mode Demo in the devthrottle repo. Say confirm."));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), pending, subjects, _ => { });
+
+        var result = await brain.RunTurnAsync("device-a", "remove it over", CancellationToken.None);
+
+        Assert.Empty(fleet.Deleted);
+        Assert.True(result.PendingConfirmation);
+        Assert.Equal("s-demo", pending.Get("device-a")!.SessionId);
+        // The tool result the model saw named the session and repo.
+        Assert.Contains("Car Mode Demo", chat.SeenMessages[1]);
+        Assert.Contains("devthrottle", chat.SeenMessages[1]);
+    }
+
+    [Fact]
+    public async Task RunTurn_BareContentClaimingAction_IsRejected_ForcesRealToolCall()
+    {
+        // The Car Mode hallucination gotcha: the model answers in plain text claiming it snoozed, WITHOUT
+        // calling snooze_session. The guard must NOT return that false success - it re-prompts, and only the
+        // real tool call (and its speak_answer) is the answer.
+        var subjects = new CarModeSubjectStore(_ => { });
+        subjects.Set("device-a", new CarModeSubject("s-demo", "Car Mode Demo", "devthrottle"));
+        var fleet = new FakeFleet();
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn("Okay, I've snoozed it for you.", Array.Empty<CarModeToolCall>()), // hallucinated claim, no tool
+            new CarModeAssistantTurn(null, new[] { Call("snooze_session", "{}") }),                      // re-prompted -> real call
+            Speak("Snoozed the Car Mode Demo."));
+        var brain = new CarModeBrain(chat, fleet, new CarModeConversationStore(), new CarModePendingStore(_ => { }), subjects, _ => { });
+
+        var result = await brain.RunTurnAsync("device-a", "snooze it", CancellationToken.None);
+
+        Assert.Single(fleet.Snoozed);                       // the action really happened
+        Assert.Equal("s-demo", fleet.Snoozed[0]);
+        Assert.Equal("Snoozed the Car Mode Demo.", result.Spoken);   // NOT the hallucinated "I've snoozed it"
+        Assert.Contains(result.Actions, a => a.Tool == "snooze_session");
+    }
+
+    [Fact]
+    public async Task RunTurn_PersistentBareContent_EndsInLoudFailure_NeverTheContent()
+    {
+        // A model that keeps answering in plain text and never calls a tool must end in the loud failure,
+        // never have its unbacked plain-text claim spoken as the answer.
+        var turns = Enumerable.Range(0, 10)
+            .Select(_ => new CarModeAssistantTurn("I did it.", Array.Empty<CarModeToolCall>())).ToArray();
+        var brain = new CarModeBrain(new ScriptedChat(turns), new FakeFleet(), new CarModeConversationStore(), new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+
+        var result = await brain.RunTurnAsync("device-a", "snooze it", CancellationToken.None);
+
+        Assert.DoesNotContain("I did it.", result.Spoken);
+        Assert.Contains("trouble", result.Spoken, StringComparison.OrdinalIgnoreCase);
     }
 
     // ---- The spoken-confirmation words ----
@@ -552,6 +777,47 @@ public sealed class CarModeBrainTests
     {
         var sessions = new[] { Dto("Alpha", 101, "C:/repos/one", 10) };
         Assert.Null(LoopbackCarModeFleet.ResolveSession(sessions, "nonexistent zebra"));
+    }
+
+    [Fact]
+    public void ResolveSession_NameAndRepoPhrase_ResolvesByName_NotAnotherSameRepoSession()
+    {
+        // The wrong-session bug (Car Mode QA): the model echoes its own narration - "Car Mode Demo, in the
+        // devthrottle repo" - as the tool argument. The comma must not break the name match, and a NAME match
+        // must beat every other session that merely shares the devthrottle repo (here a NEWER one).
+        var sessions = new[]
+        {
+            Dto("Car Mode Demo", 104, "C:/repos/devthrottle", createdMinutesAgo: 60),        // older, the real target
+            Dto("Gateway Cleanup - Manager", 110, "C:/repos/devthrottle", createdMinutesAgo: 5), // newer, same repo
+        };
+        var match = LoopbackCarModeFleet.ResolveSession(sessions, "Car Mode Demo, in the devthrottle repo");
+        Assert.NotNull(match);
+        Assert.Equal("Car Mode Demo", match!.Name);
+    }
+
+    [Fact]
+    public void ResolveSession_RepoOnlyPhrase_FallsBackToNewestInThatRepo()
+    {
+        // With NO name in the reference, the repo fallback still resolves "the devthrottle session" to the
+        // newest one - name-priority does not disable the repo fallback, it only outranks it.
+        var sessions = new[]
+        {
+            Dto("Alpha", 101, "C:/repos/website", 60),
+            Dto("Beta", 102, "C:/repos/devthrottle", 30),
+            Dto("Gamma", 103, "C:/repos/devthrottle", 5),
+        };
+        var match = LoopbackCarModeFleet.ResolveSession(sessions, "the devthrottle session");
+        Assert.NotNull(match);
+        Assert.Equal("Gamma", match!.Name);
+    }
+
+    [Fact]
+    public void ResolveSession_PunctuationAndDashInName_StillMatches()
+    {
+        var sessions = new[] { Dto("Car Mode - Manager", 109, "C:/repos/devthrottle", 5) };
+        var match = LoopbackCarModeFleet.ResolveSession(sessions, "car mode manager");
+        Assert.NotNull(match);
+        Assert.Equal("Car Mode - Manager", match!.Name);
     }
 
     [Theory]

--- a/src/CcDirector.Gateway/CarMode/CarModeBrain.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeBrain.cs
@@ -27,14 +27,16 @@ public sealed class CarModeBrain
     private readonly ICarModeFleet _fleet;
     private readonly CarModeConversationStore _conversations;
     private readonly CarModePendingStore _pending;
+    private readonly CarModeSubjectStore _subjects;
     private readonly Action<string> _log;
 
-    public CarModeBrain(ICarModeChat chat, ICarModeFleet fleet, CarModeConversationStore conversations, CarModePendingStore pending, Action<string>? log = null)
+    public CarModeBrain(ICarModeChat chat, ICarModeFleet fleet, CarModeConversationStore conversations, CarModePendingStore pending, CarModeSubjectStore subjects, Action<string>? log = null)
     {
         _chat = chat ?? throw new ArgumentNullException(nameof(chat));
         _fleet = fleet ?? throw new ArgumentNullException(nameof(fleet));
         _conversations = conversations ?? throw new ArgumentNullException(nameof(conversations));
         _pending = pending ?? throw new ArgumentNullException(nameof(pending));
+        _subjects = subjects ?? throw new ArgumentNullException(nameof(subjects));
         _log = log ?? FileLog.Write;
     }
 
@@ -155,17 +157,28 @@ public sealed class CarModeBrain
             var messagesJson = JsonSerializer.Serialize(messages);
             var turn = await timer.TimeModelAsync(() => _chat.CompleteAsync(messagesJson, ToolCatalogJson, ct));
 
-            // Under tool_choice=required the model normally calls a tool every turn, and says its final
-            // words by calling speak_answer. Defensive path: if a model still answers in plain content with
-            // no tool call, take that content as the final spoken reply so the loop degrades gracefully.
+            // Structural guard against the Car Mode hallucination gotcha (a known, recurring failure of the
+            // fast model): under tool_choice=required the model MUST speak by calling speak_answer and act by
+            // calling an action tool. A bare-content reply is a protocol violation - and, critically, it is how
+            // the model tries to CLAIM an action ("I've snoozed it") WITHOUT calling the tool, which would make
+            // Car Mode narrate something it never did (the banned fire-and-forget defect). So bare content is
+            // NEVER returned as the answer: push it back and require a real tool call. The prompt hard rule is
+            // the belt; this is the suspenders. The round cap still bounds it, so a model that refuses to comply
+            // ends in a loud failure below - never a false success.
             if (turn.ToolCalls.Count == 0)
             {
-                var spoken = (turn.Content ?? "").Trim();
-                if (spoken.Length == 0)
-                    throw new InvalidOperationException("The model returned an empty spoken reply.");
-                _conversations.Append(deviceKey, userText, spoken);
-                _log($"[CarModeBrain] turn done in {round + 1} round(s) via content: actions={actions.Count}, pending={armedThisTurn}");
-                return new CarModeTurnResponse { Spoken = spoken, Actions = actions, PendingConfirmation = armedThisTurn };
+                _log($"[CarModeBrain] bare content with no tool call (round {round + 1}); re-prompting for a real tool call");
+                messages.Add(new { role = "assistant", content = turn.Content ?? "" });
+                messages.Add(new
+                {
+                    role = "user",
+                    content = "You answered in plain text without calling a tool. That does not count and I did not "
+                        + "hear it. If you performed or intend an action (snooze, switch to voice mode, message, "
+                        + "approve, start, delete), you MUST call that action's tool now - saying it is not doing it. "
+                        + "If you are only speaking to me, call speak_answer with the exact words. Do not reply in "
+                        + "plain text again.",
+                });
+                continue;
             }
 
             // The model wants tools this round: echo its assistant message (with the tool_calls) back,
@@ -239,7 +252,9 @@ public sealed class CarModeBrain
     ///  (delete) is NOT run - it arms a confirmation the owner must speak next turn (decision 3).</summary>
     private async Task<ToolOutcome> ExecuteToolAsync(string deviceKey, CarModeToolCall call, TurnTimer timer, CancellationToken ct)
     {
-        _log($"[CarModeBrain] tool: {call.Name}");
+        // Log the raw arguments too: model tool arguments are the boundary where a mis-resolve (the wrong
+        // session) originates, so the exact reference the model produced must be visible when diagnosing.
+        _log($"[CarModeBrain] tool: {call.Name} args={call.ArgumentsJson}");
         switch (call.Name)
         {
             case "list_sessions":
@@ -264,7 +279,30 @@ public sealed class CarModeBrain
                 var activity = await timer.TimeFleetAsync(() => _fleet.GetSessionActivityAsync(reference, ct));
                 if (activity is null)
                     return Result(new { error = $"No session matched \"{reference}\"." });
+                // Reading a session makes it the current subject, so a follow-up "read the wingman" / "answer
+                // it" / "snooze it" resolves without the owner naming it again.
+                _subjects.Set(deviceKey, new CarModeSubject(activity.SessionId, activity.Name, activity.Repo));
                 return Result(new { activity.Name, activity.Repo, activity.State, activity.NeedsYou, activity.Summary });
+            }
+            case "focus_next_needs_me":
+            {
+                // "The next one that needs me": focus the OLDEST-waiting needs-you session (longest wait first)
+                // as the current subject, so follow-ups ("read the wingman", "answer it", "snooze it") resolve.
+                var sessions = await timer.TimeFleetAsync(() => _fleet.ListSessionsAsync(ct));
+                var next = sessions.Where(s => s.NeedsYou).OrderByDescending(s => s.WaitingMinutes).FirstOrDefault();
+                if (next is null)
+                    return Result(new { status = "none", message = "No session is waiting on the owner right now." });
+                _subjects.Set(deviceKey, new CarModeSubject(next.SessionId, next.Name, next.Repo));
+                return Result(new { session = next.Name, repo = next.Repo, next.WaitingMinutes, next.Summary });
+            }
+            case "read_wingman":
+            {
+                var reference = ReadStringArg(call.ArgumentsJson, "session");
+                var (target, error) = await ResolveActTargetAsync(deviceKey, reference, "read the wingman for", timer, ct);
+                if (target is null) return Result(new { error });
+                var explain = await timer.TimeFleetAsync(() => _fleet.ExplainSessionAsync(target.SessionId, ct));
+                // The REAL, current narration - the brain reads this aloud, never a canned "it is waiting".
+                return Result(new { session = target.Name, repo = target.Repo, narration = explain.Spoken, explain.NothingYet });
             }
             case "start_session":
             {
@@ -278,11 +316,10 @@ public sealed class CarModeBrain
             {
                 var reference = ReadStringArg(call.ArgumentsJson, "session");
                 var message = ReadStringArg(call.ArgumentsJson, "message");
-                if (string.IsNullOrWhiteSpace(reference) || string.IsNullOrWhiteSpace(message))
-                    return Result(new { error = "Provide both the session and the message to send." });
-                var target = await timer.TimeFleetAsync(() => _fleet.ResolveSessionAsync(reference, ct));
-                if (target is null)
-                    return Result(new { error = $"No session matched \"{reference}\"." });
+                if (string.IsNullOrWhiteSpace(message))
+                    return Result(new { error = "Provide the message to send into the session." });
+                var (target, error) = await ResolveActTargetAsync(deviceKey, reference, "send that to", timer, ct);
+                if (target is null) return Result(new { error });
                 await timer.TimeFleetAsync(() => _fleet.MessageSessionAsync(target.SessionId, message, ct));
                 var summary = $"Messaged {target.Name}.";
                 return Acted(new { status = "sent", session = target.Name }, new CarModeActionRecord("message_session", summary));
@@ -290,24 +327,38 @@ public sealed class CarModeBrain
             case "approve_session":
             {
                 var reference = ReadStringArg(call.ArgumentsJson, "session");
-                if (string.IsNullOrWhiteSpace(reference))
-                    return Result(new { error = "Provide the session to approve." });
-                var target = await timer.TimeFleetAsync(() => _fleet.ResolveSessionAsync(reference, ct));
-                if (target is null)
-                    return Result(new { error = $"No session matched \"{reference}\"." });
+                var (target, error) = await ResolveActTargetAsync(deviceKey, reference, "approve", timer, ct);
+                if (target is null) return Result(new { error });
                 await timer.TimeFleetAsync(() => _fleet.ApproveSessionAsync(target.SessionId, ct));
                 var summary = $"Approved {target.Name}.";
                 return Acted(new { status = "approved", session = target.Name }, new CarModeActionRecord("approve_session", summary));
             }
+            case "switch_to_voice_mode":
+            {
+                var reference = ReadStringArg(call.ArgumentsJson, "session");
+                var (target, error) = await ResolveActTargetAsync(deviceKey, reference, "switch to voice mode", timer, ct);
+                if (target is null) return Result(new { error });
+                await timer.TimeFleetAsync(() => _fleet.SwitchVoiceModeAsync(target.SessionId, true, ct));
+                var summary = $"Switched {target.Name} to voice mode.";
+                return Acted(new { status = "voice_on", session = target.Name }, new CarModeActionRecord("switch_to_voice_mode", summary));
+            }
+            case "snooze_session":
+            {
+                var reference = ReadStringArg(call.ArgumentsJson, "session");
+                var (target, error) = await ResolveActTargetAsync(deviceKey, reference, "snooze", timer, ct);
+                if (target is null) return Result(new { error });
+                await timer.TimeFleetAsync(() => _fleet.SnoozeSessionAsync(target.SessionId, ct));
+                var summary = $"Snoozed {target.Name}.";
+                return Acted(new { status = "snoozed", session = target.Name }, new CarModeActionRecord("snooze_session", summary));
+            }
             case "delete_session":
             {
                 var reference = ReadStringArg(call.ArgumentsJson, "session");
-                if (string.IsNullOrWhiteSpace(reference))
-                    return Result(new { error = "Provide the session to delete." });
-                var target = await timer.TimeFleetAsync(() => _fleet.ResolveSessionAsync(reference, ct));
-                if (target is null)
-                    return Result(new { error = $"No session matched \"{reference}\"." });
-                // Destructive: do NOT delete. Arm a confirmation the owner must speak next turn.
+                var (target, error) = await ResolveActTargetAsync(deviceKey, reference, "delete", timer, ct);
+                if (target is null) return Result(new { error });
+                // Destructive: do NOT delete. Arm a confirmation the owner must speak next turn. The
+                // confirmation ALWAYS names the resolved session and repo out loud, so even a stale current
+                // subject is heard before it acts - the omit-session convenience never makes delete less safe.
                 _pending.Arm(deviceKey, new CarModePendingAction("delete", target.SessionId, target.Name));
                 return new ToolOutcome(
                     JsonSerializer.Serialize(new
@@ -315,7 +366,7 @@ public sealed class CarModeBrain
                         status = "confirmation_required",
                         session = target.Name,
                         repo = target.Repo,
-                        message = $"Deleting {target.Name} in the {target.Repo} repo is permanent. Ask the owner to say \"confirm\" to proceed, or \"cancel\" to stop. Do not call any more tools.",
+                        message = $"Deleting {target.Name} in the {target.Repo} repo is permanent. Tell the owner exactly which session and repo you are about to delete, and ask him to say \"confirm\" to proceed, or \"cancel\" to stop. Do not call any more tools.",
                     }, ToolResultJson),
                     Action: null,
                     ArmedConfirmation: true);
@@ -323,6 +374,34 @@ public sealed class CarModeBrain
             default:
                 return Result(new { error = $"Unknown tool \"{call.Name}\"." });
         }
+    }
+
+    /// <summary>
+    /// Resolve the session an act tool will operate on, honoring the current-subject convenience (design B).
+    /// When the model supplies a <paramref name="reference"/>, resolve it live and, on success, make it the
+    /// current subject so later "it" references work. When the model OMITS the reference (the owner said
+    /// "answer it" / "snooze it" / "read the wingman"), fall back to the device's current subject. Returns the
+    /// target and a null error on success, or a null target and a specific, speakable error the model can
+    /// relay - a different message for "which one do you mean" (nothing named, no subject) versus "no session
+    /// matched X" (named something that does not exist). The subject NEVER makes delete less safe: delete's
+    /// confirmation still names the resolved session and repo out loud.
+    /// </summary>
+    private async Task<(CarModeSubject? Target, string? Error)> ResolveActTargetAsync(
+        string deviceKey, string? reference, string actionPhrase, TurnTimer timer, CancellationToken ct)
+    {
+        if (!string.IsNullOrWhiteSpace(reference))
+        {
+            var resolved = await timer.TimeFleetAsync(() => _fleet.ResolveSessionAsync(reference, ct));
+            if (resolved is null)
+                return (null, $"No session matched \"{reference}\".");
+            var subject = new CarModeSubject(resolved.SessionId, resolved.Name, resolved.Repo);
+            _subjects.Set(deviceKey, subject);
+            return (subject, null);
+        }
+        var current = _subjects.Get(deviceKey);
+        if (current is null)
+            return (null, $"Which session should I {actionPhrase}? Name it, or first say which one you mean.");
+        return (current, null);
     }
 
     /// <summary>Execute a destructive action the owner has just confirmed out loud, returning the spoken
@@ -404,15 +483,43 @@ public sealed class CarModeBrain
         + "true. \"The latest one\" is the first session in the list (it is ordered newest first).\n"
         + "- If a request is ambiguous or you cannot tell which session is meant, ask one short clarifying "
         + "question instead of guessing.\n\n"
+        + "The session you are talking about (\"it\"):\n"
+        + "- The system remembers the session you last acted on or read as the CURRENT one. When the owner "
+        + "says \"it\", \"that one\", \"this session\", \"answer it\", \"snooze it\", he means that current "
+        + "session. For those follow-ups you may OMIT the session argument and the tool acts on the current "
+        + "one. Only name a session explicitly when he named one or you are changing which session you mean.\n"
+        + "- \"the next one that needs me\", \"who's next\", \"read me the next one\": call focus_next_needs_me. "
+        + "It focuses the session that has been waiting the longest and makes it the current one; then read it "
+        + "to him. After that, \"answer it\" / \"snooze it\" act on that session.\n"
+        + "- When you DO put a session in a tool's session argument, use only its short NAME (for example "
+        + "\"Car Mode Demo\") - never the \"in the such-and-such repo\" phrase. The name alone identifies it; "
+        + "adding the repository can point the action at the wrong session in that repository.\n\n"
         + "Taking action (you have full control):\n"
-        + "- Ordinary actions just happen - do not ask permission for them. To start a session, call "
-        + "start_session with the repository name. To message a session, call message_session. To approve "
-        + "a session that is waiting, call approve_session. After an act, say briefly what you did.\n"
-        + "- Deleting or killing a session is DESTRUCTIVE and always needs the owner's spoken confirmation. "
-        + "When he asks to delete or kill a session, call delete_session; you will get a "
-        + "confirmation_required result. Then tell him exactly what will be deleted and ask him to say "
-        + "\"confirm\" to proceed or \"cancel\" to stop, and call no more tools. The system handles the "
-        + "actual deletion once he confirms out loud - you never delete without that confirmation.\n"
+        + "- CRITICAL: doing something means CALLING ITS TOOL. To snooze, you MUST call snooze_session. To "
+        + "switch to voice mode, you MUST call switch_to_voice_mode. To answer or message, message_session. To "
+        + "approve, approve_session. To start, start_session. Saying it out loud is NOT doing it. NEVER tell the "
+        + "owner you snoozed, switched, messaged, approved, started, or deleted a session unless you actually "
+        + "called that tool THIS turn. If you have not called the tool yet, you have not done it - call the tool "
+        + "first, then say what you did. Claiming an action you did not perform is a serious error.\n"
+        + "- Ordinary actions just happen - do not ask permission for them. After an act, say briefly what you "
+        + "did.\n"
+        + "- To START a session, call start_session with the repository name.\n"
+        + "- To ANSWER a session or send it an instruction - \"answer it and say yes\", \"tell it to run the "
+        + "tests\", \"reply that ...\" - call message_session with the exact words to send. If he is answering "
+        + "the current session, omit the session argument.\n"
+        + "- To READ what a session needs - \"what does it need\", \"read me that one\", \"what is it waiting "
+        + "on\" - call read_wingman. It returns the session's REAL current narration; read that narration back "
+        + "to him. Never invent a status like \"it is waiting for you\" - say what the narration actually says.\n"
+        + "- To APPROVE a waiting session (accept its highlighted default), call approve_session.\n"
+        + "- To SWITCH a session into voice mode - \"put it in voice mode\", \"switch it to voice\" - call "
+        + "switch_to_voice_mode.\n"
+        + "- To SNOOZE a session - \"snooze it\", \"hold it\", \"silence it for a bit\", \"let it wait\" - call "
+        + "snooze_session. It comes back on its own after the snooze time.\n"
+        + "- Deleting, killing, or removing a session is DESTRUCTIVE and always needs the owner's spoken "
+        + "confirmation. When he asks to delete, kill, or remove a session, call delete_session; you will get a "
+        + "confirmation_required result. Then tell him exactly which session and repo will be deleted and ask "
+        + "him to say \"confirm\" to proceed or \"cancel\" to stop, and call no more tools. The system handles "
+        + "the actual deletion once he confirms out loud - you never delete without that confirmation.\n"
         + "\n\nHow you speak:\n"
         + "- To SAY anything to the owner - an answer, a clarifying question, or an acknowledgement of what you "
         + "did - you MUST call the speak_answer tool with the exact words to say out loud. Do not put your reply "
@@ -436,13 +543,35 @@ public sealed class CarModeBrain
             "type": "function",
             "function": {
               "name": "get_session_activity",
-              "description": "Get what one specific session is doing right now. Resolve a fuzzy reference (a name, a repository, or a number) to one session.",
+              "description": "Get what one specific session is doing right now (its short one-line status). Resolve a fuzzy reference (a name, a repository, or a number) to one session. This makes that session the current one.",
               "parameters": {
                 "type": "object",
                 "properties": {
                   "session": { "type": "string", "description": "The session to read: a human name, a repository name, or a number." }
                 },
                 "required": ["session"]
+              }
+            }
+          },
+          {
+            "type": "function",
+            "function": {
+              "name": "focus_next_needs_me",
+              "description": "Focus the session that has been waiting on the owner the LONGEST (the next one that needs him) and make it the current one. Use for \"the next one that needs me\", \"who's next\", \"read me the next one\". Returns its name, repository, how long it has waited, and a short summary; if nothing is waiting it returns none.",
+              "parameters": { "type": "object", "properties": {}, "required": [] }
+            }
+          },
+          {
+            "type": "function",
+            "function": {
+              "name": "read_wingman",
+              "description": "Read a session's REAL current narration - what it actually needs or last said - so you can say it back out loud. Use for \"what does it need\", \"read me that one\", \"what is it waiting on\". Omit session to read the current session.",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "session": { "type": "string", "description": "The session to read: a name, a repository, or a number. Omit to read the current session." }
+                },
+                "required": []
               }
             }
           },
@@ -464,14 +593,14 @@ public sealed class CarModeBrain
             "type": "function",
             "function": {
               "name": "message_session",
-              "description": "Send a message (a prompt) into a running session, the same as typing to it. Use this to tell a session to do something, for example run the tests.",
+              "description": "Send a message (a prompt) into a running session, the same as typing to it. Use this to answer a session, or to tell it to do something (for example run the tests). Omit session to send it to the current session (\"answer it\", \"reply ...\").",
               "parameters": {
                 "type": "object",
                 "properties": {
-                  "session": { "type": "string", "description": "The session to message: a human name, a repository, or a number." },
-                  "message": { "type": "string", "description": "The message to send into the session." }
+                  "session": { "type": "string", "description": "The session to send to: a name, a repository, or a number. Omit to send to the current session." },
+                  "message": { "type": "string", "description": "The exact words to send into the session." }
                 },
-                "required": ["session", "message"]
+                "required": ["message"]
               }
             }
           },
@@ -479,13 +608,41 @@ public sealed class CarModeBrain
             "type": "function",
             "function": {
               "name": "approve_session",
-              "description": "Approve a session that is waiting for the owner by accepting its highlighted default (presses Enter). Use this when the owner says to approve, allow, or continue a waiting session.",
+              "description": "Approve a session that is waiting for the owner by accepting its highlighted default (presses Enter). Use when the owner says to approve, allow, or continue a waiting session. Omit session to approve the current session.",
               "parameters": {
                 "type": "object",
                 "properties": {
-                  "session": { "type": "string", "description": "The session to approve: a human name, a repository, or a number." }
+                  "session": { "type": "string", "description": "The session to approve: a name, a repository, or a number. Omit to approve the current session." }
                 },
-                "required": ["session"]
+                "required": []
+              }
+            }
+          },
+          {
+            "type": "function",
+            "function": {
+              "name": "switch_to_voice_mode",
+              "description": "Switch a session INTO voice mode (so the assistant reads its turns aloud). Use for \"put it in voice mode\", \"switch it to voice\". Omit session to switch the current session.",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "session": { "type": "string", "description": "The session to switch: a name, a repository, or a number. Omit for the current session." }
+                },
+                "required": []
+              }
+            }
+          },
+          {
+            "type": "function",
+            "function": {
+              "name": "snooze_session",
+              "description": "Snooze a session so it stops asking for now and comes back on its own after the snooze time. Use for \"snooze it\", \"hold it\", \"silence it for a bit\", \"let it wait\". Omit session to snooze the current session.",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "session": { "type": "string", "description": "The session to snooze: a name, a repository, or a number. Omit for the current session." }
+                },
+                "required": []
               }
             }
           },
@@ -493,13 +650,13 @@ public sealed class CarModeBrain
             "type": "function",
             "function": {
               "name": "delete_session",
-              "description": "Request to delete (kill and remove) a session. This is DESTRUCTIVE: it does not delete immediately - it returns confirmation_required, and the owner must confirm out loud before it happens.",
+              "description": "Request to delete (kill and remove) a session. This is DESTRUCTIVE: it does not delete immediately - it returns confirmation_required, and the owner must confirm out loud before it happens. Omit session to target the current session.",
               "parameters": {
                 "type": "object",
                 "properties": {
-                  "session": { "type": "string", "description": "The session to delete: a human name, a repository, or a number." }
+                  "session": { "type": "string", "description": "The session to delete: a name, a repository, or a number. Omit to target the current session." }
                 },
-                "required": ["session"]
+                "required": []
               }
             }
           },

--- a/src/CcDirector.Gateway/CarMode/CarModeModels.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeModels.cs
@@ -40,6 +40,13 @@ public sealed record CarModeActivity
     public bool NeedsYou { get; init; }
 }
 
+/// <summary>The spoken narration for one session, for the "what does it need" / "read me the wingman" read
+/// tool (Voice-screen-actions phase). Backed by the SAME POST /wingman/explain the Voice screen's onSwitchOn
+/// path calls: <see cref="Spoken"/> is the real, current narration the assistant reads aloud (never a canned
+/// "it is waiting for you"), and <see cref="NothingYet"/> is true for a fresh/text-only session with nothing
+/// to summarize yet (in which case Spoken carries the truthful "nothing to read yet" line).</summary>
+public sealed record CarModeExplain(string Spoken, bool NothingYet);
+
 /// <summary>One action the brain took during a turn (Phase 3+), surfaced to the page for on-screen
 /// confirmation alongside the spoken reply. The act already happened server-side.</summary>
 public sealed record CarModeActionRecord(string Tool, string Summary);

--- a/src/CcDirector.Gateway/CarMode/CarModeSubjectStore.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeSubjectStore.cs
@@ -1,0 +1,63 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.CarMode;
+
+/// <summary>The session the owner is currently talking ABOUT - the resolved id plus the human name and
+/// repository to say back. Enough for an act tool to act (by id) and to name what it did or is confirming,
+/// with no re-resolve.</summary>
+public sealed record CarModeSubject(string SessionId, string Name, string Repo);
+
+/// <summary>
+/// Per-device "current subject" for Car Mode (Car Mode mission, Voice-screen-actions phase, design B
+/// approved by the Architect 2026-07-12). Any brain tool that resolves a session sets the subject here;
+/// an act tool the owner phrases without naming a session ("read me the next one" then "answer it",
+/// "snooze it") falls back to it. This is deterministic conversational state, not a guess left to the fast
+/// model - the known Car Mode gotcha is context degrading across a multi-session triage loop, so the
+/// server tracks who "it" is rather than trusting the model to carry the reference.
+///
+/// In-memory, keyed by the device credential (never crosses the wire), with the same idle time-to-live as
+/// the conversation context so a device that stops talking does not keep a stale subject forever. The
+/// subject is intentionally NOT used to make the destructive delete less safe: delete always speaks the
+/// resolved name and repository back for a spoken confirmation, so a stale subject is heard before it acts.
+/// Thread-safe: turns can arrive concurrently from the same device.
+/// </summary>
+public sealed class CarModeSubjectStore
+{
+    private sealed record Entry(CarModeSubject Subject, DateTime SetUtc);
+
+    /// <summary>Drop a device's subject after this much idle time (matches the conversation context TTL).</summary>
+    private static readonly TimeSpan IdleTtl = TimeSpan.FromMinutes(30);
+
+    private readonly ConcurrentDictionary<string, Entry> _byDevice = new(StringComparer.Ordinal);
+    private readonly Action<string> _log;
+
+    public CarModeSubjectStore(Action<string>? log = null) => _log = log ?? FileLog.Write;
+
+    /// <summary>Set the current subject for a device (called whenever a tool resolves a session), replacing
+    ///  any prior one.</summary>
+    public void Set(string deviceKey, CarModeSubject subject)
+    {
+        _byDevice[Normalize(deviceKey)] = new Entry(subject, DateTime.UtcNow);
+        _log($"[CarModeSubject] subject set to {subject.Name}");
+    }
+
+    /// <summary>The current subject for a device, or null when none is set or it has gone idle past the TTL
+    ///  (a fresh, bounded check on read - no timer).</summary>
+    public CarModeSubject? Get(string deviceKey)
+    {
+        var key = Normalize(deviceKey);
+        if (!_byDevice.TryGetValue(key, out var entry)) return null;
+        if (DateTime.UtcNow - entry.SetUtc > IdleTtl)
+        {
+            _byDevice.TryRemove(key, out _);
+            return null;
+        }
+        return entry.Subject;
+    }
+
+    /// <summary>Forget a device's subject (available for tests and a "start over").</summary>
+    public void Clear(string deviceKey) => _byDevice.TryRemove(Normalize(deviceKey), out _);
+
+    private static string Normalize(string? deviceKey) => string.IsNullOrWhiteSpace(deviceKey) ? "anonymous" : deviceKey;
+}

--- a/src/CcDirector.Gateway/CarMode/ICarModeFleet.cs
+++ b/src/CcDirector.Gateway/CarMode/ICarModeFleet.cs
@@ -41,4 +41,20 @@ public interface ICarModeFleet
     /// <summary>Delete (kill) a session, exactly the way the remove button does (DELETE /sessions/{id}).
     ///  Destructive: the brain only calls this AFTER a spoken confirmation. Addressed by session id.</summary>
     Task DeleteSessionAsync(string sessionId, CancellationToken ct);
+
+    /// <summary>Read a session's current spoken narration, exactly the way the Voice screen's onSwitchOn does
+    ///  (POST /sessions/{id}/wingman/explain): the Gateway reads the session's latest completed turn and
+    ///  returns the speakable summary. The brain reads this REAL narration aloud - never a canned line.
+    ///  Addressed by session id (already resolved).</summary>
+    Task<CarModeExplain> ExplainSessionAsync(string sessionId, CancellationToken ct);
+
+    /// <summary>Switch a session into (or out of) voice mode, exactly the way the Voice screen's Switch button
+    ///  does (POST /sessions/{id}/voice-mode { enabled }). Addressed by session id (already resolved).</summary>
+    Task SwitchVoiceModeAsync(string sessionId, bool enabled, CancellationToken ct);
+
+    /// <summary>Snooze a session, exactly the way the per-session Snooze button does
+    ///  (POST /sessions/{id}/hold { onHold: true }). Snooze IS the hold plus a Gateway-owned timer: the
+    ///  Gateway records a snooze-until from the per-user default length, so the session RETURNS to "needs
+    ///  you" on its own when the timer fires (Snooze Length mission). Addressed by session id.</summary>
+    Task SnoozeSessionAsync(string sessionId, CancellationToken ct);
 }

--- a/src/CcDirector.Gateway/CarMode/LoopbackCarModeFleet.cs
+++ b/src/CcDirector.Gateway/CarMode/LoopbackCarModeFleet.cs
@@ -157,6 +157,42 @@ public sealed class LoopbackCarModeFleet : ICarModeFleet
         _log($"[CarModeFleet] deleted session {sessionId}");
     }
 
+    public async Task<CarModeExplain> ExplainSessionAsync(string sessionId, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId)) throw new ArgumentException("A session id is required.", nameof(sessionId));
+        // POST /sessions/{id}/wingman/explain with no body, exactly as the Voice screen's onSwitchOn does.
+        // The Gateway reads the session's latest completed turn and returns { reply, spoken, nothingYet }.
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{_baseUrl}/sessions/{Uri.EscapeDataString(sessionId)}/wingman/explain");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+        using var response = await _http.SendAsync(request, HttpCompletionOption.ResponseContentRead, ct);
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException($"The wingman explain call failed: {(int)response.StatusCode} {response.StatusCode}.");
+        var json = await response.Content.ReadAsStringAsync(ct);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        var spoken = GetString(root, "spoken");
+        var nothingYet = root.ValueKind == JsonValueKind.Object
+            && root.TryGetProperty("nothingYet", out var n) && n.ValueKind == JsonValueKind.True;
+        _log($"[CarModeFleet] explained session {sessionId} (nothingYet={nothingYet})");
+        return new CarModeExplain(spoken, nothingYet);
+    }
+
+    public async Task SwitchVoiceModeAsync(string sessionId, bool enabled, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId)) throw new ArgumentException("A session id is required.", nameof(sessionId));
+        await PostJsonAsync($"/sessions/{Uri.EscapeDataString(sessionId)}/voice-mode", new { enabled }, ct);
+        _log($"[CarModeFleet] set voice-mode {enabled} on session {sessionId}");
+    }
+
+    public async Task SnoozeSessionAsync(string sessionId, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId)) throw new ArgumentException("A session id is required.", nameof(sessionId));
+        // Snooze IS the hold: the Gateway's /hold handler records the Gateway-owned snooze-until timer (from
+        // the per-user default length) when onHold is true, so the session returns to "needs you" on its own.
+        await PostJsonAsync($"/sessions/{Uri.EscapeDataString(sessionId)}/hold", new { onHold = true }, ct);
+        _log($"[CarModeFleet] snoozed session {sessionId}");
+    }
+
     /// <summary>Read THIS Gateway's aggregated roster, reusing a read taken within the last
     ///  <see cref="RosterCacheTtl"/> so one turn's several roster reads (and back-to-back turns) collapse to
     ///  a single loopback aggregation. A cache miss does one real GET and refills the cache.</summary>
@@ -243,11 +279,22 @@ public sealed class LoopbackCarModeFleet : ICarModeFleet
             ? p.GetString() ?? ""
             : "";
 
-    /// <summary>Resolve a fuzzy reference to one session: exact number, then exact name, then a name/repo
-    ///  substring, then the newest match. Static and pure so it is unit-tested directly.</summary>
+    /// <summary>Resolve a fuzzy reference to one session: exact number, then exact name, then a NAME match,
+    ///  then (only when nothing matched by name) a REPO match, newest first. Static and pure so it is
+    ///  unit-tested directly.
+    ///
+    ///  Two safety properties matter here, both learned the hard way (a wrong-session act during Car Mode QA):
+    ///  1. The reference is punctuation-normalized first. The model echoes its own spoken narration back as the
+    ///     tool argument - for example "Car Mode Demo, in the devthrottle repo" - and the comma must not stop
+    ///     "demo," from matching the name word "demo".
+    ///  2. A NAME match ALWAYS beats a REPO match. That same "Name, in the repo repo" phrase contains the repo
+    ///     word ("devthrottle"), which every session in that repo shares; without name-priority the reference
+    ///     would spuriously match an arbitrary other same-repo session (the newest one) instead of the session
+    ///     actually named. Repo matching is only a fallback for a reference that names no session at all
+    ///     (for example "the devthrottle session").</summary>
     internal static SessionDto? ResolveSession(IReadOnlyList<SessionDto> sessions, string reference)
     {
-        var reff = reference.Trim().ToLowerInvariant();
+        var reff = NormalizeRef(reference);
         if (reff.Length == 0) return null;
 
         // A number reference ("session 104", "one hundred four" already digitized by the model).
@@ -258,27 +305,40 @@ public sealed class LoopbackCarModeFleet : ICarModeFleet
             if (byNumber is not null) return byNumber;
         }
 
-        // Exact (case-insensitive) name.
-        var exact = sessions.FirstOrDefault(s => (s.Name ?? "").Trim().ToLowerInvariant() == reff);
+        // Exact (normalized) name.
+        var exact = sessions.FirstOrDefault(s => NormalizeRef(s.Name ?? "") == reff);
         if (exact is not null) return exact;
 
-        // Match by name or repo, newest first so a tie picks the latest. A session matches when the
-        // reference is a substring of its name (the owner spoke a fragment of the name), or when its
-        // name or repo appears as WHOLE WORDS inside the reference (the owner said the name/repo within
-        // a longer phrase). Whole-word matching on the reverse direction avoids a short repo leaf like
-        // "one" spuriously matching inside an unrelated word like "nonexistent".
-        var candidates = sessions
-            .OrderByDescending(s => s.CreatedAt)
-            .Where(s =>
+        // A session matches by NAME when the reference is a substring of its name (a spoken fragment) or its
+        // name appears as whole words inside the reference (the name said within a longer phrase). A NAME
+        // match wins outright; only if no session matches by name do we fall back to the newest session whose
+        // REPO leaf appears as whole words in the reference. Newest first so a tie picks the latest.
+        SessionDto? nameMatch = null;
+        SessionDto? repoMatch = null;
+        foreach (var s in sessions.OrderByDescending(s => s.CreatedAt))
+        {
+            var name = NormalizeRef(s.Name ?? "");
+            var repo = NormalizeRef(RepoLeaf(s.RepoPath));
+            if (name.Length > 0 && (name.Contains(reff) || ContainsAsWords(reff, name)))
             {
-                var name = (s.Name ?? "").Trim().ToLowerInvariant();
-                var repo = RepoLeaf(s.RepoPath).ToLowerInvariant();
-                if (name.Length > 0 && (name.Contains(reff) || ContainsAsWords(reff, name))) return true;
-                if (repo.Length > 0 && ContainsAsWords(reff, repo)) return true;
-                return false;
-            })
-            .ToList();
-        return candidates.FirstOrDefault();
+                nameMatch = s;
+                break; // a name match always wins; the newest matching name is the answer
+            }
+            if (repoMatch is null && repo.Length > 0 && ContainsAsWords(reff, repo))
+                repoMatch = s;
+        }
+        return nameMatch ?? repoMatch;
+    }
+
+    /// <summary>Lower-case and collapse a reference (or a name/repo) to space-separated alphanumeric words,
+    ///  dropping ALL punctuation. So "Car Mode Demo, in the devthrottle repo" and "Car Mode - Manager" become
+    ///  clean word runs that <see cref="ContainsAsWords"/> can compare without a stray comma or dash breaking a
+    ///  whole-word match.</summary>
+    internal static string NormalizeRef(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return "";
+        var chars = value.ToLowerInvariant().Select(c => char.IsLetterOrDigit(c) ? c : ' ').ToArray();
+        return string.Join(' ', new string(chars).Split(' ', StringSplitOptions.RemoveEmptyEntries));
     }
 
     /// <summary>True when <paramref name="needle"/>'s words appear as a contiguous run of whole words in

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -327,6 +327,9 @@ public sealed class GatewayHost : IAsyncDisposable
     // Car Mode (decision 3): the per-device store of a destructive action armed and awaiting the owner's
     // spoken confirmation, so a delete never runs without a clear spoken "confirm".
     private readonly CarMode.CarModePendingStore _carModePending = new();
+    // Car Mode (Voice-screen-actions phase, design B): the per-device "current subject" - the session the
+    // owner is talking about - so "it" / "answer it" / "snooze it" resolve after a focus or a read.
+    private readonly CarMode.CarModeSubjectStore _carModeSubjects = new();
     // Car Mode performance round: the durable, Gateway-local store of per-turn timing records. The browser
     // posts ONE record per turn; GET /carmode/telemetry reads them back. Retained about 90 days by age.
     private readonly CarMode.CarModeTelemetryStore _carModeTelemetry = new();
@@ -1248,7 +1251,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // caller's per-device key), like every other data route.
         var carModeChat = new CarMode.HostedCarModeChat(CarMode.HostedCarModeChat.DefaultResolver(_keyVault.Get));
         var carModeFleet = new CarMode.LoopbackCarModeFleet(Port, Token);
-        var carModeBrain = new CarMode.CarModeBrain(carModeChat, carModeFleet, _carModeConversations, _carModePending);
+        var carModeBrain = new CarMode.CarModeBrain(carModeChat, carModeFleet, _carModeConversations, _carModePending, _carModeSubjects);
         // Keep-warm (Car Mode performance round): warm the SAME hosted model the brain uses and the SAME
         // text-to-speech target /wingman/tts uses, resolved fresh each warmup so a settings change applies.
         var carModeWarmup = new CarMode.CarModeWarmup(


### PR DESCRIPTION
## What

Make the Car Mode brain do, by voice and hands-free, everything the mobile Voice-mode screen does to a session - each a new brain tool calling the **same** Gateway endpoint the Voice screen already uses (no new fleet mechanics). Backend only: the phone Car Mode page already POSTs transcripts to `/carmode/turn` and speaks the reply, so nothing in `wwwroot` changes - only the Gateway binary.

| Voice-screen action | New brain tool | Endpoint reused |
|---|---|---|
| Read the wingman ("what does it need") | `read_wingman` | `POST /sessions/{id}/wingman/explain` |
| Switch a session into voice mode | `switch_to_voice_mode` | `POST /sessions/{id}/voice-mode` |
| Snooze a session (timed, returns on its own) | `snooze_session` | `POST /sessions/{id}/hold {onHold:true}` |
| Respond by voice (deliver the spoken answer in) | reuses `message_session` | `POST /sessions/{id}/prompt` |
| Remove a session (destructive, confirm-gated) | `delete_session` (already existed) | `DELETE /sessions/{id}` |
| "the next one that needs me" | `focus_next_needs_me` | `GET /sessions` (roster) |

## Current subject (design B, Architect-approved)

A per-device `CarModeSubjectStore` tracks the session the owner is talking about. Any tool that resolves a session sets it; act tools may omit the session to act on "it". This is deterministic on the fast model rather than trusting it to carry "it" across a multi-session triage loop (the documented Car Mode context-degradation gotcha). Delete is never made less safe by this - its spoken confirmation always names the resolved session and repo.

## Two safety fixes found while proving the loop on the demo

1. **Hallucination guard (structural).** Under the provider's loose `tool_choice=required`, the model sometimes narrated an action ("I've snoozed it") **without calling the tool**. Bare content is now never returned as the answer - the loop re-prompts for a real tool call, or ends in a loud failure. Plus a prompt hard-rule: never say you did something unless you called its tool this turn.
2. **Wrong-session resolve.** The model echoes its own narration ("Car Mode Demo, in the devthrottle repo") back as the tool argument; the comma broke the name word-match and a repo-word-match then grabbed the **newest session sharing that repo** (a real work session). The resolver now strips punctuation and a **NAME match always beats a REPO match** (repo is only a fallback when nothing is named). The two accidental acts caught during testing were reversed.

Model unchanged: `Qwen2.5-72B` (measured fastest reliable).

## Proven vs pending (honest)

**Proven** - driven by **text** against a minimal loopback QA host (never a full Gateway) pointed at the **real fleet**, targeting only the demo session **Car Mode Demo (number 104)**:
- Every act hit the demo's session id in the fleet log - never a real session.
- Read the demo's **real** question aloud; delivered a spoken answer into it; snoozed it (timed `/hold`); switched it to voice mode; **delete armed then CANCEL = 0 deletes** (the cancel turn took 5 ms with no model call - the deterministic gate); "next one that needs me" named the longest-waiting session by name, never a number.

**Pending** - the owner's hands-free, **by-voice** pass on the **phone** after the live redeploy (`scripts/redeploy-gateway.ps1`). This PR must be merged to main **before** that redeploy (un-merged Gateway deploys get clobbered).

## Tests

65 CarMode unit tests (new: hallucination guard, current-subject resolution, wrong-session resolver) + full **2054**-test Gateway suite green.

Car Mode mission: `docs/architecture/car-mode-mission-2026-07-11.md`.