### PR TITLE
feat(gateway-cleanup): Phase 2 PR A - browser terminal/file/screenshot legs onto the tunnel up-stream

### DIFF
--- a/docs/architecture/gateway-cleanup-phase2-repoint-design.md
+++ b/docs/architecture/gateway-cleanup-phase2-repoint-design.md
@@ -1,0 +1,163 @@
+# Gateway Cleanup - Phase 2: the Gateway browser-leg re-point onto the tunnel (design + slot-5 proof plan)
+
+Author: Manager session d1286c9f, 2026-07-12, machine SOREN_NORTH. Additive, Option-A-autonomous (build + merge
+without a gate). This is the "new road carries traffic before the old road is removed" work that must land
+BEFORE the Phase 1 Director-floor deletion, so a floor-only Director can be proven through the Gateway.
+
+Invariant: EVERYTHING is additive and gated on the existing streamMode flag. streamMode OFF (production today)
+= byte-identical to now (the Gateway keeps dialing the Director over HTTP). streamMode ON = the Gateway serves
+the browser-facing legs through the tunnel. Both paths coexist until Phase 6 makes the tunnel mandatory. Nothing
+on main changes behavior for production until the rollout gate.
+
+## What is already true (Phase 0, on main)
+
+- The tunnel carries 9 write verbs on the Gateway (kill, prompt, interrupt, escape, hold, patch, set-role,
+  wingman-goal, create) via DirectorCommandRouter.TrySendAsync(sendCommand, ...); sendCommand is non-null only
+  under streamMode. Roster is served from the Director push store under streamMode (PushedSessions).
+- The up-stream primitive is complete on both ends but wired to NO browser leg:
+  - Director: DirectorUpStreamHandler handles open-terminal-stream / read-file / screenshot-file / close-stream;
+    OpenStreamRequest { StreamId, Path, ScreenshotId }; open-terminal-stream returns Ok (no body); read-file /
+    screenshot-file return Ok with OpenReadResponse { long? TotalBytes, string? ContentType } or NotFound;
+    close-stream is idempotent. terminal-input is a unary write (SessionWriteExecutor) that calls SendInput.
+  - Gateway: DirectorHub.StreamUp(streamId, frames) -> GatewayStreamRegistry.ConsumeAsync pumps frames into a
+    registered IStreamSink with pull-then-forward backpressure; Register(streamId, sink) mints the open-timeout
+    and returns a teardown token; Close(streamId) is the browser-disconnect teardown. IStreamSink is
+    WriteFrameAsync(frame) + CompleteAsync(reason). Phase 0 shipped only a test sink.
+
+So Phase 2 = provide the two real sinks and branch the browser legs onto the tunnel under streamMode.
+
+## Piece 1 - the up-stream browser legs (terminal, file, screenshot)
+
+Two IStreamSink implementations (new, in src/CcDirector.Gateway/Streaming/):
+
+- WebSocketStreamSink: wraps an accepted browser WebSocket. WriteFrameAsync translates one DirectorStreamFrame
+  back into the EXACT browser terminal wire protocol (TerminalStreamEndpoint's protocol, unchanged for the
+  browser): Size -> text {"type":"size","cols":C,"rows":R}; Binary -> a binary WS message of frame.Data; Closed
+  -> text {"type":"closed","reason":R} then close the socket. CompleteAsync closes the socket if still open.
+  Because the registry is pull-then-forward, the sink just awaits the one WS send and returns (no buffering).
+- HttpResponseStreamSink: wraps the browser HttpResponse for a file / screenshot GET. On the open command's Ok
+  it sets Content-Type and (when OpenReadResponse.TotalBytes is known) Content-Length, from the Ok BodyJson,
+  BEFORE the first Binary frame. WriteFrameAsync writes Binary frame.Data to the response body and flushes;
+  Size frames do not occur for a file read; Closed/eof completes the response. CompleteAsync finishes the body.
+
+Browser-leg wiring (SessionWsProxyEndpoints.cs), each leg gains a streamMode branch that precedes the existing
+ProxyAsync HTTP dial (the HTTP dial stays as the streamMode-off fallback, byte-identical):
+
+- GET /sessions/{sid}/stream (terminal): if streamMode and the session's owning Director is known (owners
+  cache), accept the WebSocket, mint streamId = fresh Guid, register a WebSocketStreamSink, send
+  open-terminal-stream { StreamId } with SessionId=sid to the owning Director via sendCommand. On NotFound ->
+  close with "session not found"; on Ok -> run a keystroke receive loop that forwards each browser message DOWN
+  as a terminal-input unary verb { sessionId, bytes(base64) }, and await the registry teardown token. On browser
+  disconnect -> registry.Close(streamId) + send close-stream { StreamId }. Else (streamMode off / owner unknown)
+  -> the existing ProxyAsync HTTP dial.
+- GET /sessions/{sid}/file (file view): if streamMode + owner known, mint streamId, register an
+  HttpResponseStreamSink over ctx.Response, send read-file { StreamId, Path=<the ?path query> }; map NotFound ->
+  404, BadRequest -> 400; on Ok set headers from OpenReadResponse and let frames stream into the response; await
+  teardown. Else the HTTP dial. (NOTE: /sessions/{sid}/file is the Local Files viewer leg; confirm its current
+  Gateway route - it may be inside the catch-all today - and give it the same up-stream branch.)
+- /sessions/{sid}/screenshots/file and .../screenshots (bytes): same HttpResponseStreamSink pattern via
+  screenshot-file { StreamId, ScreenshotId=<the ?name query> }. The LIST (/screenshots) is a unary read verb
+  (screenshots-list), handled in Piece 2, not the up-stream.
+
+sendCommand + the GatewayStreamRegistry + the owners cache are threaded into SessionWsProxyEndpoints.Map as new
+optional parameters (null when streamMode off => the branch is never taken => byte-identical).
+
+## Piece 2 - unary read/write dispatch replacing the catch-all Director-dial
+
+The catch-all app.Map("/sessions/{sid}/{**rest}") today forwards ANY method+path to the Director over HTTP.
+Under streamMode, dispatch it as a tunnel verb instead, with the SAME fall-back-to-HTTP-when-off rule.
+
+- A Gateway-side path+method -> verb table, built directly from the checkpoint Appendix A1 route->verb mapping
+  (it already enumerates every route and its verb). Examples: GET .../turns -> turns; GET .../buffer -> buffer;
+  GET .../buffer/html -> buffer-html; GET .../summary -> summary; GET .../usage -> usage; GET .../context ->
+  context; GET .../history -> history; GET .../git -> git-status (read-only, already shadowed); GET .../queue ->
+  queue-read; GET .../github-urls -> github-urls; GET .../wingman -> wingman-view; GET .../handover -> handover;
+  POST .../resize -> resize; POST .../clear-context -> clear-context; POST .../mobile-mode -> mobile-mode; POST
+  .../queue -> queue-add; DELETE .../queue/{itemId} -> queue-remove; POST .../request-deletion ->
+  request-deletion; DELETE .../request-deletion -> cancel-deletion; POST .../execute-action -> execute-action;
+  ... (the full set is Appendix A1's DELETE-> lists). Director-level verbs (repos-list, facts,
+  coaching-categories, claude-sessions, interrupted-list, create-from-github) keep SessionId="".
+- Marshal: the HTTP request body (for writes) and/or query string become the verb's PayloadJson via the same
+  request DTO the REST route used; the DirectorCommand carries SessionId=sid (or "" for director-level).
+  DirectorCommandResult -> HTTP via the DirectorCommandRouter mapping already in use (status -> code, BodyJson ->
+  the response, content type per verb; text/plain verbs carry BodyJson as a string with their content type).
+- An unknown rest-path under streamMode is NOT silently dialed: it fails loud (the table is the source of truth;
+  a missing entry is a build/dispatch error naming the path), so nothing slips back onto the HTTP leg silently.
+  (The git-WRITE refusal at the top of the catch-all stays exactly as is - the Gateway is a read-only window on
+  source control.)
+
+This piece is mechanical but broad (~30+ verbs). It may split into its own PR after Piece 1, or a small sub-chain
+by area (session reads, session writes, queue/git, director-level, byte lists), each with parity tests.
+
+## Both-paths-coexist and the kill switch
+
+- Every branch is `if (streamMode && ownerKnown) { tunnel } else { existing HTTP dial }`. streamMode off keeps
+  today's behavior to the byte. This is the same kill-switch discipline the 9 write verbs already follow.
+- No browser/phone contract changes: the browser still speaks the same terminal WS protocol, the same file GET,
+  the same session REST verbs; only the Gateway's Director-facing leg moves from an HTTP dial to a tunnel verb /
+  up-stream.
+
+## PR chain (all additive, merged autonomously under Option A)
+
+- PR A: the two IStreamSink implementations + the terminal/file/screenshot streamMode branches (Piece 1) + unit
+  tests (sink frame translation golden bytes; a fake registry/owner e2e) + an integration test proving a
+  streamMode Gateway serves a terminal + a file from a fake tunnel Director.
+- PR B (may sub-split): the catch-all read/write verb dispatch table + marshal + reply mapping (Piece 2) +
+  per-verb parity tests (tunnel result == what the HTTP dial returned for a representative read and write).
+- Each PR: up-to-date-with-main AND audit-read-aware before merge (the TerminalPromptInjectionChokepointTests
+  lesson - an intervening commit editing a file a source-audit test READS can red main).
+
+## Slot-5 proof plan (tunnel-carries-all) - run after PR A + PR B merge, before Phase 1
+
+Prove on a FULL-surface Director (pre-deletion) on slot 5 + a streamMode Gateway that the tunnel carries the
+whole browser-facing surface, so Phase 1's floor-only re-proof is then just "the same, with the HTTP routes
+gone":
+
+1. Build a full-surface Director to slot 5: scripts/local-build-avalonia.ps1 -Slot 5. Launch ONLY via the
+   cc-director-launch scheduled task (CLAUDE.md rule 0b; svchost parent, clean stdio for any spawned agent).
+2. Run a Gateway with streamMode ON (config StreamMode=true) pointed so the slot-5 Director dials its tunnel.
+   Confirm the slot-5 Director's tunnel connection is bound (DirectorHub Hello in the Gateway log) and the
+   roster serves from the push store.
+3. Through the Gateway (streamMode on), with a live agent session on the slot-5 Director, prove each rides the
+   tunnel (confirm via the [DirectorCommandRouter] / [GatewayStreamRegistry] / [DirectorHub] log lines, not just
+   a 200):
+   - roster: GET /sessions shows the slot-5 session from the push store (no HTTP pull).
+   - terminal: open /sessions/{sid}/stream; frames arrive via open-terminal-stream + StreamUp; a keystroke rides
+     terminal-input.
+   - prompt: POST a prompt; rides the prompt verb.
+   - turns: GET /sessions/{sid}/turns; rides the turns verb (NOT an HTTP dial).
+   - file: open /sessions/{sid}/file for a real file; rides read-file up-stream with correct Content-Length.
+4. Negative control: flip streamMode OFF on the same Gateway and confirm the identical operations still work
+   over the HTTP dial (proves the coexistence / kill switch).
+5. Teardown: POST /shutdown to the slot-5 Director (graceful). Never force-kill.
+
+Only after this passes do I cut the Phase 1 Director-floor deletion branch and RE-prove floor-only (every
+deleted route 404s; the 6 floor routes + POST /reconnect answer; roster + terminal + prompt + turns + file still
+work because they now ride the tunnel, not the deleted HTTP routes). That floor-only proof is the one I bring to
+the Architect before the destructive merge (Soren's gate).
+
+## Architect note on the slot-5 proof plan - 2026-07-12 (session 51f1898e)
+
+The proof plan is strong - especially verifying each operation by the [DirectorCommandRouter] /
+[GatewayStreamRegistry] / [DirectorHub] LOG LINES (not just a 200, which could be the HTTP dial) and the
+streamMode-off negative control. APPROVED, with FOUR ADDITIONS so the proof exercises the up-stream INVARIANTS
+and the original under-load failure this mission exists to fix ("works when a build spews output over a slow
+phone link", not just a demo):
+
+1. UNDER LOAD, not trivial: prove a LARGE file read (many frames, chunked at MaxBinaryFrameBytes, correct
+   Content-Length) and a HIGH-VOLUME terminal burst (a command that spews output). A tiny read proves wiring,
+   not the backpressure invariant (ruling 1); confirm bounded in-flight frames (the producer blocks on a stalled
+   sink) - the whole reason native streaming was chosen.
+2. CONCURRENCY / no-monopoly (ruling 2): run a terminal stream AND a large file read SIMULTANEOUSLY over the one
+   shared tunnel connection and confirm BOTH make progress (neither starves) - proves a big frame does not stall
+   the shared connection.
+3. TEARDOWN (ruling 3): disconnect the browser mid-terminal-stream and confirm close-stream fires AND the
+   Director producer STOPS (log evidence of the cancellation) - no leaked producer streaming into a dead sink;
+   also exercise the file eof / natural-close path.
+4. ERROR PARITY: the tunnel must reproduce the HTTP error mapping, not just happy paths - prove GET turns on a
+   missing session -> NotFound / 404 over the tunnel, and read-file of a missing path -> 404, matching what the
+   HTTP dial returned.
+
+These four turn the proof from "it works" into "it works under the exact conditions that broke the old path".
+Fold them into the slot-5 run, and where cheap into PR A's integration tests. Everything else in the plan stands
+- proceed.

--- a/src/CcDirector.Gateway.Tests/HttpResponseStreamSinkTests.cs
+++ b/src/CcDirector.Gateway.Tests/HttpResponseStreamSinkTests.cs
@@ -1,0 +1,68 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Streaming;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 2: the finite-read sink writes a file/screenshot's up-frames into the
+/// browser HTTP response, setting Content-Type and Content-Length from the open reply BEFORE the first body
+/// byte (Architect ruling 4). The header gate is the interesting part: the first Binary up-frame can race the
+/// open reply, so WriteFrameAsync must wait for ApplyMetadata before it writes anything.
+/// </summary>
+public sealed class HttpResponseStreamSinkTests
+{
+    private static (DefaultHttpContext ctx, MemoryStream body) NewCtx()
+    {
+        var ctx = new DefaultHttpContext();
+        var body = new MemoryStream();
+        ctx.Response.Body = body;
+        return (ctx, body);
+    }
+
+    [Fact]
+    public async Task ApplyMetadata_sets_content_type_and_length_then_the_body_is_written()
+    {
+        var (ctx, body) = NewCtx();
+        var sink = new HttpResponseStreamSink(ctx.Response);
+
+        sink.ApplyMetadata(new OpenReadResponse { TotalBytes = 5, ContentType = "text/plain" });
+        await sink.WriteFrameAsync(new DirectorStreamFrame { Kind = DirectorStreamFrameType.Binary, Data = new byte[] { 1, 2, 3, 4, 5 } }, default);
+
+        Assert.Equal("text/plain", ctx.Response.ContentType);
+        Assert.Equal(5, ctx.Response.ContentLength);
+        Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, body.ToArray());
+    }
+
+    [Fact]
+    public async Task WriteFrameAsync_waits_for_ApplyMetadata_before_writing_the_first_byte()
+    {
+        var (ctx, body) = NewCtx();
+        var sink = new HttpResponseStreamSink(ctx.Response);
+
+        var write = sink.WriteFrameAsync(new DirectorStreamFrame { Kind = DirectorStreamFrameType.Binary, Data = new byte[] { 9 } }, default);
+        await Task.Delay(80);
+
+        Assert.False(write.IsCompleted);        // gated on the headers
+        Assert.Empty(body.ToArray());
+
+        sink.ApplyMetadata(new OpenReadResponse { TotalBytes = 1, ContentType = "application/octet-stream" });
+        await write;
+
+        Assert.Equal(new byte[] { 9 }, body.ToArray());
+    }
+
+    [Fact]
+    public async Task Fail_releases_the_gate_and_WriteFrameAsync_throws_without_writing()
+    {
+        var (ctx, body) = NewCtx();
+        var sink = new HttpResponseStreamSink(ctx.Response);
+
+        sink.Fail();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sink.WriteFrameAsync(new DirectorStreamFrame { Kind = DirectorStreamFrameType.Binary, Data = new byte[] { 1 } }, default));
+        Assert.Empty(body.ToArray());
+    }
+}

--- a/src/CcDirector.Gateway.Tests/TunnelStreamLegsTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelStreamLegsTests.cs
@@ -1,0 +1,257 @@
+using System.Net.WebSockets;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Streaming;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 2: in-process integration of the browser-facing up-stream legs over the
+/// tunnel. A fake sendCommand plays the owning Director: on an open command it returns the typed result AND
+/// (for a success) drives the Gateway <see cref="GatewayStreamRegistry"/> with produced frames exactly as the
+/// real Director's StreamUp would. This exercises the file/screenshot and terminal legs end to end through the
+/// real sinks and registry, including the Architect's error-parity and teardown proof additions.
+/// </summary>
+public sealed class TunnelStreamLegsTests
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    // -------------------------------------------------------------------------------- file leg ----
+
+    [Fact]
+    public async Task File_leg_streams_the_bytes_with_content_length_then_fires_close_stream()
+    {
+        var registry = new GatewayStreamRegistry();
+        var fileBytes = Encoding.UTF8.GetBytes("the file contents, delivered as up-frames over the tunnel");
+        var closeStreamSent = new List<string>();
+
+        DirectorCommandRouter.SendDirectorCommandAsync send = (directorId, command, ct) =>
+        {
+            switch (command.Verb)
+            {
+                case "read-file":
+                    var req = JsonSerializer.Deserialize<OpenStreamRequest>(command.PayloadJson, Json)!;
+                    _ = registry.ConsumeAsync(req.StreamId, FileFrames(req.StreamId, fileBytes), CancellationToken.None);
+                    return Ok(new OpenReadResponse { TotalBytes = fileBytes.Length, ContentType = "text/plain" });
+                case "close-stream":
+                    closeStreamSent.Add(JsonSerializer.Deserialize<CloseStreamRequest>(command.PayloadJson, Json)!.StreamId);
+                    return Ok();
+                default:
+                    return Fail(DirectorCommandStatus.BadRequest, "unexpected verb");
+            }
+        };
+
+        var legs = new TunnelStreamLegs(registry, send);
+        var (ctx, body) = NewHttpContext();
+
+        var handled = await legs.TryServeFileAsync(ctx, Guid.NewGuid().ToString(), "dir1", "/some/abs/path.txt");
+
+        Assert.True(handled);
+        Assert.Equal("text/plain", ctx.Response.ContentType);
+        Assert.Equal(fileBytes.Length, ctx.Response.ContentLength);
+        Assert.Equal(fileBytes, body.ToArray());
+        Assert.Single(closeStreamSent);
+        Assert.Equal(0, registry.LiveStreamCount);
+    }
+
+    [Fact]
+    public async Task File_leg_maps_a_missing_path_to_404_matching_the_http_dial()
+    {
+        var registry = new GatewayStreamRegistry();
+        DirectorCommandRouter.SendDirectorCommandAsync send = (d, c, ct) =>
+            c.Verb == "read-file" ? Fail(DirectorCommandStatus.NotFound, "file not found") : Ok();
+        var legs = new TunnelStreamLegs(registry, send);
+        var (ctx, _) = NewHttpContext();
+
+        var handled = await legs.TryServeFileAsync(ctx, Guid.NewGuid().ToString(), "dir1", "/missing");
+
+        Assert.True(handled);
+        Assert.Equal(StatusCodes.Status404NotFound, ctx.Response.StatusCode);
+        Assert.Equal(0, registry.LiveStreamCount);
+    }
+
+    [Fact]
+    public async Task File_leg_returns_false_for_http_fallback_when_the_stream_was_lost()
+    {
+        var registry = new GatewayStreamRegistry();
+        DirectorCommandRouter.SendDirectorCommandAsync send = (d, c, ct) => Task.FromResult<DirectorCommandResult?>(null);
+        var legs = new TunnelStreamLegs(registry, send);
+        var (ctx, body) = NewHttpContext();
+
+        var handled = await legs.TryServeFileAsync(ctx, Guid.NewGuid().ToString(), "dir1", "/x");
+
+        Assert.False(handled); // caller falls back to the HTTP proxy path
+        Assert.Empty(body.ToArray());
+        Assert.Equal(0, registry.LiveStreamCount);
+    }
+
+    // ---------------------------------------------------------------------------- terminal leg ----
+
+    [Fact]
+    public async Task Terminal_leg_open_notfound_tells_the_browser_and_closes()
+    {
+        var registry = new GatewayStreamRegistry();
+        DirectorCommandRouter.SendDirectorCommandAsync send = (d, c, ct) =>
+            c.Verb == "open-terminal-stream" ? Fail(DirectorCommandStatus.NotFound, "session not found") : Ok();
+        var legs = new TunnelStreamLegs(registry, send);
+        var stub = new StubServerWebSocket();
+        var ctx = NewWebSocketContext(stub);
+
+        await legs.ServeTerminalAsync(ctx, Guid.NewGuid().ToString(), "dir1");
+
+        Assert.Contains(stub.SentText, t => t.Contains("\"type\":\"closed\"") && t.Contains("session not found"));
+        Assert.Equal(0, registry.LiveStreamCount);
+    }
+
+    [Fact]
+    public async Task Terminal_leg_streams_frames_then_fires_close_stream_and_stops_the_producer_on_disconnect()
+    {
+        var registry = new GatewayStreamRegistry();
+        var closeStreamSent = new List<string>();
+        var producerEnded = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        DirectorCommandRouter.SendDirectorCommandAsync send = (directorId, command, ct) =>
+        {
+            switch (command.Verb)
+            {
+                case "open-terminal-stream":
+                    var req = JsonSerializer.Deserialize<OpenStreamRequest>(command.PayloadJson, Json)!;
+                    _ = Task.Run(async () =>
+                    {
+                        try { await registry.ConsumeAsync(req.StreamId, TerminalForever(req.StreamId), CancellationToken.None); }
+                        finally { producerEnded.TrySetResult(); }
+                    });
+                    return Ok();
+                case "close-stream":
+                    closeStreamSent.Add(JsonSerializer.Deserialize<CloseStreamRequest>(command.PayloadJson, Json)!.StreamId);
+                    return Ok();
+                default:
+                    return Ok();
+            }
+        };
+
+        var legs = new TunnelStreamLegs(registry, send);
+        var stub = new StubServerWebSocket();
+        var ctx = NewWebSocketContext(stub);
+
+        var serve = legs.ServeTerminalAsync(ctx, Guid.NewGuid().ToString(), "dir1");
+
+        await WaitUntil(() => stub.SentBinaryCount > 0, TimeSpan.FromSeconds(3));
+        Assert.Equal(1, registry.LiveStreamCount);
+
+        stub.SignalClose();     // the browser disconnects
+        await serve;
+
+        Assert.Single(closeStreamSent);                 // close-stream fired (ruling 3 teardown)
+        await producerEnded.Task.WaitAsync(TimeSpan.FromSeconds(3)); // the Director producer stopped (no leak)
+        Assert.Equal(0, registry.LiveStreamCount);
+    }
+
+    // ---------------------------------------------------------------------------------- helpers ----
+
+    private static Task<DirectorCommandResult?> Ok(object? body = null) =>
+        Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Success(body is null ? null : JsonSerializer.Serialize(body, Json)));
+
+    private static Task<DirectorCommandResult?> Fail(DirectorCommandStatus status, string error) =>
+        Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Fail(status, error));
+
+    private static async IAsyncEnumerable<DirectorStreamFrame> FileFrames(string streamId, byte[] bytes, [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var mid = bytes.Length / 2;
+        yield return new DirectorStreamFrame { StreamId = streamId, Kind = DirectorStreamFrameType.Binary, Data = bytes[..mid] };
+        await Task.Yield();
+        yield return new DirectorStreamFrame { StreamId = streamId, Kind = DirectorStreamFrameType.Binary, Data = bytes[mid..] };
+        yield return new DirectorStreamFrame { StreamId = streamId, Kind = DirectorStreamFrameType.Closed, Reason = "eof" };
+    }
+
+    private static async IAsyncEnumerable<DirectorStreamFrame> TerminalForever(string streamId, [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        yield return new DirectorStreamFrame { StreamId = streamId, Kind = DirectorStreamFrameType.Size, Cols = 80, Rows = 24 };
+        var i = 0;
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return new DirectorStreamFrame { StreamId = streamId, Kind = DirectorStreamFrameType.Binary, Data = new[] { (byte)(i++ & 0xFF) } };
+            await Task.Delay(20, ct);
+        }
+    }
+
+    private static async Task WaitUntil(Func<bool> cond, TimeSpan timeout)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (!cond())
+        {
+            if (sw.Elapsed > timeout) throw new TimeoutException("condition not met in time");
+            await Task.Delay(15);
+        }
+    }
+
+    private static (DefaultHttpContext ctx, MemoryStream body) NewHttpContext()
+    {
+        var ctx = new DefaultHttpContext();
+        var body = new MemoryStream();
+        ctx.Response.Body = body;
+        return (ctx, body);
+    }
+
+    private static DefaultHttpContext NewWebSocketContext(StubServerWebSocket stub)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Features.Set<IHttpWebSocketFeature>(new FakeWebSocketFeature(stub));
+        return ctx;
+    }
+
+    private sealed class FakeWebSocketFeature : IHttpWebSocketFeature
+    {
+        private readonly WebSocket _ws;
+        public FakeWebSocketFeature(WebSocket ws) => _ws = ws;
+        public bool IsWebSocketRequest => true;
+        public Task<WebSocket> AcceptAsync(WebSocketAcceptContext context) => Task.FromResult(_ws);
+    }
+
+    // A server-side stub WebSocket: records sends, and its ReceiveAsync blocks until SignalClose() (or a
+    // cancellation) delivers a Close result - modelling the browser disconnecting.
+    private sealed class StubServerWebSocket : WebSocket
+    {
+        private readonly TaskCompletionSource _close = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public List<string> SentText { get; } = new();
+        private int _binary;
+        public int SentBinaryCount => Volatile.Read(ref _binary);
+        private WebSocketState _state = WebSocketState.Open;
+
+        public void SignalClose() => _close.TrySetResult();
+
+        public override WebSocketState State => _state;
+
+        public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken ct)
+        {
+            if (messageType == WebSocketMessageType.Text)
+                lock (SentText) SentText.Add(Encoding.UTF8.GetString(buffer.Array!, buffer.Offset, buffer.Count));
+            else
+                Interlocked.Increment(ref _binary);
+            return Task.CompletedTask;
+        }
+
+        public override async Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken ct)
+        {
+            using var reg = ct.Register(() => _close.TrySetResult());
+            await _close.Task;
+            _state = WebSocketState.CloseReceived;
+            return new WebSocketReceiveResult(0, WebSocketMessageType.Close, true);
+        }
+
+        public override Task CloseOutputAsync(WebSocketCloseStatus s, string? d, CancellationToken ct) { _state = WebSocketState.CloseSent; return Task.CompletedTask; }
+        public override WebSocketCloseStatus? CloseStatus => null;
+        public override string? CloseStatusDescription => null;
+        public override string? SubProtocol => null;
+        public override void Abort() => _state = WebSocketState.Aborted;
+        public override Task CloseAsync(WebSocketCloseStatus s, string? d, CancellationToken ct) => Task.CompletedTask;
+        public override void Dispose() { }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/WebSocketStreamSinkTests.cs
+++ b/src/CcDirector.Gateway.Tests/WebSocketStreamSinkTests.cs
@@ -1,0 +1,117 @@
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Streaming;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 2: the browser-terminal sink must translate each Director up-frame back into
+/// the EXACT terminal wire protocol the browser has always spoken, so the browser contract is unchanged when
+/// the frames start coming from the tunnel instead of a dialed Director WebSocket.
+/// </summary>
+public sealed class WebSocketStreamSinkTests
+{
+    // A stub WebSocket that records what was sent and whether the output was closed. Only the members the sink
+    // uses are implemented.
+    private sealed class StubWebSocket : WebSocket
+    {
+        public List<(WebSocketMessageType Type, byte[] Data)> Sent { get; } = new();
+        public bool ClosedOutput { get; private set; }
+        private WebSocketState _state = WebSocketState.Open;
+
+        public void ForceState(WebSocketState s) => _state = s;
+
+        public override WebSocketState State => _state;
+
+        public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken ct)
+        {
+            Sent.Add((messageType, buffer.ToArray()));
+            return Task.CompletedTask;
+        }
+
+        public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken ct)
+        {
+            ClosedOutput = true;
+            _state = WebSocketState.CloseSent;
+            return Task.CompletedTask;
+        }
+
+        public override WebSocketCloseStatus? CloseStatus => null;
+        public override string? CloseStatusDescription => null;
+        public override string? SubProtocol => null;
+        public override void Abort() { }
+        public override Task CloseAsync(WebSocketCloseStatus s, string? d, CancellationToken ct) => Task.CompletedTask;
+        public override void Dispose() { }
+        public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken ct) => throw new NotSupportedException();
+    }
+
+    [Fact]
+    public async Task Size_frame_becomes_a_size_json_text_message()
+    {
+        var ws = new StubWebSocket();
+        var sink = new WebSocketStreamSink(ws);
+
+        await sink.WriteFrameAsync(new DirectorStreamFrame { Kind = DirectorStreamFrameType.Size, Cols = 120, Rows = 40 }, default);
+
+        var (type, data) = Assert.Single(ws.Sent);
+        Assert.Equal(WebSocketMessageType.Text, type);
+        var json = JsonDocument.Parse(data).RootElement;
+        Assert.Equal("size", json.GetProperty("type").GetString());
+        Assert.Equal(120, json.GetProperty("cols").GetInt32());
+        Assert.Equal(40, json.GetProperty("rows").GetInt32());
+    }
+
+    [Fact]
+    public async Task Binary_frame_becomes_a_binary_message_of_the_raw_bytes()
+    {
+        var ws = new StubWebSocket();
+        var sink = new WebSocketStreamSink(ws);
+        var payload = Encoding.UTF8.GetBytes("raw pty bytes");
+
+        await sink.WriteFrameAsync(new DirectorStreamFrame { Kind = DirectorStreamFrameType.Binary, Data = payload }, default);
+
+        var (type, data) = Assert.Single(ws.Sent);
+        Assert.Equal(WebSocketMessageType.Binary, type);
+        Assert.Equal(payload, data);
+    }
+
+    [Fact]
+    public async Task Closed_frame_becomes_a_closed_json_text_message()
+    {
+        var ws = new StubWebSocket();
+        var sink = new WebSocketStreamSink(ws);
+
+        await sink.WriteFrameAsync(new DirectorStreamFrame { Kind = DirectorStreamFrameType.Closed, Reason = "session exited" }, default);
+
+        var (type, data) = Assert.Single(ws.Sent);
+        Assert.Equal(WebSocketMessageType.Text, type);
+        var json = JsonDocument.Parse(data).RootElement;
+        Assert.Equal("closed", json.GetProperty("type").GetString());
+        Assert.Equal("session exited", json.GetProperty("reason").GetString());
+    }
+
+    [Fact]
+    public async Task CompleteAsync_closes_the_output_send_only()
+    {
+        var ws = new StubWebSocket();
+        var sink = new WebSocketStreamSink(ws);
+
+        await sink.CompleteAsync("eof");
+
+        Assert.True(ws.ClosedOutput);
+    }
+
+    [Fact]
+    public async Task WriteFrameAsync_throws_when_the_socket_is_not_open_so_the_registry_tears_down()
+    {
+        var ws = new StubWebSocket();
+        ws.ForceState(WebSocketState.Closed);
+        var sink = new WebSocketStreamSink(ws);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sink.WriteFrameAsync(new DirectorStreamFrame { Kind = DirectorStreamFrameType.Binary, Data = new byte[] { 1 } }, default));
+    }
+}

--- a/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
@@ -47,14 +47,49 @@ internal static class SessionWsProxyEndpoints
     /// owning Director from <paramref name="registry"/> via <paramref name="client"/>; 404 when
     /// the session is unknown across the fleet, 503 when the owning Director cannot be reached.
     /// </summary>
-    public static void Map(IEndpointRouteBuilder app, DirectorRegistry registry, DirectorEndpointClient client, SessionOwnerCache owners, string? fleetToken = null)
+    public static void Map(IEndpointRouteBuilder app, DirectorRegistry registry, DirectorEndpointClient client, SessionOwnerCache owners, string? fleetToken = null,
+        Streaming.PushedSessionStore? pushedSessions = null, Streaming.GatewayStreamRegistry? streamRegistry = null,
+        DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = null, TimeSpan? streamStaleAfter = null)
     {
         var proxy = new SessionWsForwarder(fleetToken);
 
-        // Live terminal stream: forward to the owning Director's /sessions/{sid}/stream .
+        // Gateway Cleanup Phase 2: when stream mode is on (all three non-null), the browser-facing UP-STREAM
+        // legs (terminal, file, screenshot) ride the tunnel instead of dialing the owning Director over HTTP.
+        // Null => stream mode off => every leg keeps its existing HTTP proxy path, byte-identical. The owner is
+        // resolved from the pushed session store, which only returns a stream-connected, fresh Director, so a
+        // located owner is reachable over the tunnel.
+        var tunnel = (pushedSessions is not null && streamRegistry is not null && sendCommand is not null)
+            ? new TunnelStreamLegs(streamRegistry, sendCommand)
+            : null;
+        var stale = streamStaleAfter ?? TimeSpan.FromSeconds(10);
+
+        // Live terminal stream: over the tunnel (open-terminal-stream up-stream) when the owner is
+        // stream-connected, else forward to the owning Director's /sessions/{sid}/stream over HTTP.
         app.MapGet("/sessions/{sid}/stream", async (string sid, HttpContext ctx) =>
         {
+            if (tunnel is not null && pushedSessions!.TryLocate(sid, stale) is { } loc)
+            {
+                await tunnel.ServeTerminalAsync(ctx, sid, loc.DirectorId);
+                return;
+            }
             await ProxyAsync(ctx, sid, "stream", $"/sessions/{sid}/stream", registry, client, proxy, owners);
+        });
+
+        // Local Files viewer (session file read): over the tunnel (read-file up-stream) when the owner is
+        // stream-connected and this is a whole-file GET, else the owning Director's /sessions/{sid}/file over
+        // HTTP. This LITERAL route shadows the generic catch-all below for the file path. A Range request
+        // (large-PDF/media seek) keeps the HTTP path - the up-stream read is whole-file today, so partial
+        // content is a tracked Phase 2 follow-up, never a silent truncation.
+        app.MapGet("/sessions/{sid}/file", async (string sid, HttpContext ctx) =>
+        {
+            if (tunnel is not null && !ctx.Request.Headers.ContainsKey("Range")
+                && pushedSessions!.TryLocate(sid, stale) is { } loc)
+            {
+                ctx.Response.Headers["X-Content-Type-Options"] = "nosniff";
+                if (await tunnel.TryServeFileAsync(ctx, sid, loc.DirectorId, ctx.Request.Query["path"].ToString()))
+                    return;
+            }
+            await ProxyAsync(ctx, sid, "file", $"/sessions/{sid}/file", registry, client, proxy, owners, fastPath: true);
         });
 
         // Dictation: the Gateway exposes a sid-scoped path; the Director's own endpoint is /dictate .
@@ -76,6 +111,16 @@ internal static class SessionWsProxyEndpoints
         // the screenshot forward itself.
         app.Map("/sessions/{sid}/screenshots/file", async (string sid, HttpContext ctx) =>
         {
+            // GET screenshot bytes over the tunnel (screenshot-file up-stream) when the owner is
+            // stream-connected and this is a non-Range GET; DELETE and Range GETs keep the HTTP path.
+            if (tunnel is not null && HttpMethods.IsGet(ctx.Request.Method) && !ctx.Request.Headers.ContainsKey("Range")
+                && pushedSessions!.TryLocate(sid, stale) is { } loc)
+            {
+                ctx.Response.Headers["Access-Control-Allow-Origin"] = "*";
+                ctx.Response.Headers["Cache-Control"] = "public, max-age=3600";
+                if (await tunnel.TryServeScreenshotAsync(ctx, sid, loc.DirectorId, ctx.Request.Query["name"].ToString()))
+                    return;
+            }
             await ProxyAsync(ctx, sid, "shot", "/screenshots/file", registry, client, proxy, owners, fastPath: true);
         });
 

--- a/src/CcDirector.Gateway/Api/TunnelStreamLegs.cs
+++ b/src/CcDirector.Gateway/Api/TunnelStreamLegs.cs
@@ -1,0 +1,257 @@
+using System.Net.WebSockets;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Streaming;
+using Microsoft.AspNetCore.Http;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 2: serve the browser-facing UP-STREAM legs (live terminal, session file
+/// read, screenshot bytes) over the tunnel instead of dialing the owning Director over HTTP. Used ONLY when
+/// stream mode is on AND the session's owning Director has an active tunnel connection (the caller resolves
+/// that via <see cref="PushedSessionStore.TryLocate"/>); otherwise the caller keeps the existing HTTP proxy
+/// path, byte-identical. So this is purely additive behind the stream-mode kill switch.
+///
+/// Each leg mints a fresh stream id, registers a browser-facing <see cref="IStreamSink"/> in the
+/// <see cref="GatewayStreamRegistry"/>, sends the matching open command (open-terminal-stream / read-file /
+/// screenshot-file) DOWN the tunnel, and lets the Director's up-frames flow into the sink with the registry's
+/// pull-then-forward backpressure. A browser disconnect (or a natural end) sends close-stream - the
+/// load-bearing stop signal (Architect ruling 3) - and tears the sink down. The browser wire contract is
+/// unchanged; only the Gateway's Director-facing leg moves from an HTTP dial to the tunnel.
+/// </summary>
+internal sealed class TunnelStreamLegs
+{
+    private readonly GatewayStreamRegistry _registry;
+    private readonly DirectorCommandRouter.SendDirectorCommandAsync _sendCommand;
+
+    public TunnelStreamLegs(GatewayStreamRegistry registry, DirectorCommandRouter.SendDirectorCommandAsync sendCommand)
+    {
+        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        _sendCommand = sendCommand ?? throw new ArgumentNullException(nameof(sendCommand));
+    }
+
+    // ---------------------------------------------------------------- Terminal (open-ended) ----
+
+    /// <summary>
+    /// Serve <c>GET /sessions/{sid}/stream</c> over the tunnel: accept the browser WebSocket, open a terminal
+    /// up-stream on the owning Director, translate the up-frames back into the browser terminal protocol, and
+    /// forward the browser's keystrokes DOWN as terminal-input unary verbs. There is no HTTP fallback after the
+    /// upgrade is accepted (the caller already committed to the tunnel because the owner is stream-connected);
+    /// an open failure closes the socket with a reason and the browser reconnects.
+    /// </summary>
+    public async Task ServeTerminalAsync(HttpContext ctx, string sid, string directorId)
+    {
+        if (!ctx.WebSockets.IsWebSocketRequest)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+            await ctx.Response.WriteAsync("expected websocket upgrade");
+            return;
+        }
+
+        // permessage-deflate matches the old dialed terminal leg (ANSI compresses 5-10x on the tailnet).
+        using var ws = await ctx.WebSockets.AcceptWebSocketAsync(
+            new WebSocketAcceptContext { DangerousEnableCompression = true });
+
+        var streamId = Guid.NewGuid().ToString("N");
+        var sink = new WebSocketStreamSink(ws);
+        var teardown = _registry.Register(streamId, sink);
+
+        // The browser is "gone" when the request aborts OR the keystroke receive loop ends (a close frame or a
+        // socket fault). Either tears the stream down and sends close-stream.
+        using var browserGone = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted);
+        var keystrokes = PumpKeystrokesAsync(ws, sid, directorId, browserGone);
+
+        FileLog.Write($"[TunnelStreamLegs] terminal open sid={sid} director={directorId} stream={streamId}");
+        DirectorCommandResult? open;
+        try
+        {
+            open = await DirectorCommandRouter.TrySendAsync(
+                _sendCommand, directorId, "open-terminal-stream", sid,
+                new OpenStreamRequest { StreamId = streamId }, browserGone.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            _registry.Close(streamId);
+            await Swallow(keystrokes);
+            return;
+        }
+
+        if (open is null || !open.Ok)
+        {
+            var reason = open is null ? "owning director stream unavailable"
+                       : open.Status == DirectorCommandStatus.NotFound ? "session not found"
+                       : $"director returned {open.Status}";
+            FileLog.Write($"[TunnelStreamLegs] terminal open FAILED sid={sid} stream={streamId}: {reason}");
+            await SafeSendClosedAsync(ws, reason, browserGone.Token);
+            _registry.Close(streamId);
+            browserGone.Cancel();
+            await Swallow(keystrokes);
+            return;
+        }
+
+        // Ok: the up-frames now flow StreamUp -> registry -> sink -> browser WS. Wait until the stream is torn
+        // down: a Closed frame completed it, the browser left, or the open-timeout fired.
+        await WaitForCancelAsync(teardown, browserGone.Token);
+
+        _registry.Close(streamId);                                  // idempotent; completes the sink
+        await SendCloseStreamAsync(directorId, streamId);           // stop the Director producer (ruling 3)
+        browserGone.Cancel();
+        await Swallow(keystrokes);
+        FileLog.Write($"[TunnelStreamLegs] terminal closed sid={sid} stream={streamId}");
+    }
+
+    private async Task PumpKeystrokesAsync(WebSocket ws, string sid, string directorId, CancellationTokenSource browserGone)
+    {
+        var buffer = new byte[4096];
+        using var message = new MemoryStream();
+        try
+        {
+            while (!browserGone.IsCancellationRequested && ws.State == WebSocketState.Open)
+            {
+                var result = await ws.ReceiveAsync(buffer, browserGone.Token);
+                if (result.MessageType == WebSocketMessageType.Close) break;
+                if (result.Count > 0) message.Write(buffer, 0, result.Count);
+                if (!result.EndOfMessage) continue;
+                if (message.Length == 0) continue;
+
+                var bytes = message.ToArray();
+                message.SetLength(0);
+                var payload = new TerminalInputRequest { Bytes = Convert.ToBase64String(bytes) };
+                try
+                {
+                    await DirectorCommandRouter.TrySendAsync(_sendCommand, directorId, "terminal-input", sid, payload, browserGone.Token);
+                }
+                catch (OperationCanceledException) { break; }
+                catch (Exception ex) { FileLog.Write($"[TunnelStreamLegs] terminal-input send failed sid={sid}: {ex.Message}"); }
+            }
+        }
+        catch
+        {
+            // A receive fault (browser dropped, socket aborted) is the expected end-of-life for this pump.
+        }
+        finally
+        {
+            browserGone.Cancel();
+        }
+    }
+
+    // ------------------------------------------------------------- File / screenshot (finite) ----
+
+    /// <summary>
+    /// Serve <c>GET /sessions/{sid}/file?path=...</c> over the tunnel (read-file). Returns true when handled
+    /// (streamed, or answered 404/400); false ONLY when nothing was written and the caller should fall back to
+    /// the HTTP proxy path (the owning Director's stream was lost between resolution and open).
+    /// </summary>
+    public Task<bool> TryServeFileAsync(HttpContext ctx, string sid, string directorId, string? path) =>
+        TryServeReadAsync(ctx, sid, directorId, "read-file", new OpenStreamRequest { StreamId = "", Path = path }, "file");
+
+    /// <summary>
+    /// Serve <c>GET /sessions/{sid}/screenshots/file?name=...</c> over the tunnel (screenshot-file). Same
+    /// contract as <see cref="TryServeFileAsync"/>.
+    /// </summary>
+    public Task<bool> TryServeScreenshotAsync(HttpContext ctx, string sid, string directorId, string? name) =>
+        TryServeReadAsync(ctx, sid, directorId, "screenshot-file", new OpenStreamRequest { StreamId = "", ScreenshotId = name }, "screenshot");
+
+    private async Task<bool> TryServeReadAsync(HttpContext ctx, string sid, string directorId, string verb, OpenStreamRequest req, string label)
+    {
+        var streamId = Guid.NewGuid().ToString("N");
+        req.StreamId = streamId;
+        var sink = new HttpResponseStreamSink(ctx.Response);
+        var teardown = _registry.Register(streamId, sink);
+
+        FileLog.Write($"[TunnelStreamLegs] {label} open sid={sid} director={directorId} stream={streamId}");
+        DirectorCommandResult? open;
+        try
+        {
+            open = await DirectorCommandRouter.TrySendAsync(_sendCommand, directorId, verb, sid, req, ctx.RequestAborted);
+        }
+        catch (OperationCanceledException)
+        {
+            sink.Fail();
+            _registry.Close(streamId);
+            return true; // the browser left mid-open; there is nothing to fall back to
+        }
+
+        if (open is null)
+        {
+            // The owning Director's stream was lost between resolution and open; nothing has been written, so
+            // let the caller fall back to the coexisting HTTP path (this is explicit routing, not a silent
+            // degrade - the HTTP dial is the same-behaviour path that is live when stream mode is off).
+            sink.Fail();
+            _registry.Close(streamId);
+            FileLog.Write($"[TunnelStreamLegs] {label} sid={sid} stream={streamId}: no stream at open -> HTTP fallback");
+            return false;
+        }
+
+        if (!open.Ok)
+        {
+            sink.Fail();
+            _registry.Close(streamId);
+            var code = open.Status switch
+            {
+                DirectorCommandStatus.NotFound => StatusCodes.Status404NotFound,
+                DirectorCommandStatus.BadRequest => StatusCodes.Status400BadRequest,
+                _ => StatusCodes.Status502BadGateway,
+            };
+            FileLog.Write($"[TunnelStreamLegs] {label} open FAILED sid={sid} stream={streamId}: {open.Status} {open.Error}");
+            if (!ctx.Response.HasStarted)
+            {
+                ctx.Response.StatusCode = code;
+                await ctx.Response.WriteAsJsonAsync(new { error = open.Error ?? $"director returned {open.Status}" });
+            }
+            return true;
+        }
+
+        // Ok: set Content-Type/Content-Length from the open reply (this OPENS the sink's write gate), then let
+        // the up-frames stream into the response body. Wait until eof/teardown, then stop the producer.
+        sink.ApplyMetadata(DirectorCommandRouter.ReadBody<OpenReadResponse>(open));
+        await WaitForCancelAsync(teardown, ctx.RequestAborted);
+        _registry.Close(streamId);
+        await SendCloseStreamAsync(directorId, streamId);
+        FileLog.Write($"[TunnelStreamLegs] {label} closed sid={sid} stream={streamId}");
+        return true;
+    }
+
+    // ------------------------------------------------------------------------------- helpers ----
+
+    private async Task SendCloseStreamAsync(string directorId, string streamId)
+    {
+        try
+        {
+            await DirectorCommandRouter.TrySendAsync(_sendCommand, directorId, "close-stream", "", new CloseStreamRequest { StreamId = streamId }, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[TunnelStreamLegs] close-stream send failed stream={streamId}: {ex.Message}");
+        }
+    }
+
+    private static async Task SafeSendClosedAsync(WebSocket ws, string reason, CancellationToken ct)
+    {
+        if (ws.State != WebSocketState.Open) return;
+        try
+        {
+            var bytes = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(new { type = "closed", reason });
+            await ws.SendAsync(bytes, WebSocketMessageType.Text, endOfMessage: true, ct);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[TunnelStreamLegs] send closed-frame failed: {ex.Message}");
+        }
+    }
+
+    // Complete when EITHER token fires (the stream torn down, or the browser gone). No polling.
+    private static async Task WaitForCancelAsync(CancellationToken a, CancellationToken b)
+    {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(a, b);
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var reg = linked.Token.Register(static s => ((TaskCompletionSource)s!).TrySetResult(), tcs);
+        await tcs.Task;
+    }
+
+    private static async Task Swallow(Task task)
+    {
+        try { await task; } catch { /* the pump's own end-of-life; already logged where it matters */ }
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1221,7 +1221,14 @@ public sealed class GatewayHost : IAsyncDisposable
         // fallback Cockpit proxy below.
         // Pass the fleet token (issue #457): the proxy injects it as the Bearer on every forward
         // so an auth-enabled Director (LAN mode) accepts the call. Harmless for auth-off Directors.
-        SessionWsProxyEndpoints.Map(_app, Registry, _client, SessionOwners, Token);
+        // Gateway Cleanup Phase 2: pass the tunnel hooks so the browser-facing up-stream legs (terminal, file,
+        // screenshot) ride the tunnel when stream mode is on. Null when off => the legs keep their HTTP proxy
+        // path, byte-identical. StreamRegistry is the SAME singleton the DirectorHub pumps StreamUp frames into.
+        SessionWsProxyEndpoints.Map(_app, Registry, _client, SessionOwners, Token,
+            pushedSessions: _streamMode ? PushedSessions : null,
+            streamRegistry: _streamMode ? StreamRegistry : null,
+            sendCommand: _streamMode ? SendCommandAsync : null,
+            streamStaleAfter: _streamStaleAfter);
 
         // Issue #469: device enrollment via local pairing code (the ONLY way a new device gets in).
         // POST /devices/register verifies+consumes the 4-digit code and issues a unique per-device

--- a/src/CcDirector.Gateway/Streaming/HttpResponseStreamSink.cs
+++ b/src/CcDirector.Gateway/Streaming/HttpResponseStreamSink.cs
@@ -1,0 +1,78 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.Http;
+
+namespace CcDirector.Gateway.Streaming;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 2: the browser-facing sink for a FINITE byte read (a session file or a
+/// screenshot) served over the tunnel up-stream. Wraps the browser <see cref="HttpResponse"/>: each Binary
+/// up-frame is written to the response body and flushed; the finishing Closed/eof frame just ends the stream.
+///
+/// Header ordering (Architect ruling 4): the open command's Ok reply carries the total size and content type
+/// (<see cref="OpenReadResponse"/>) so the Gateway can set Content-Type and Content-Length BEFORE the first
+/// body byte. But the Director's first Binary up-frame can race the open reply on the shared connection, so
+/// this sink GATES the first write on <see cref="ApplyMetadata"/>: <see cref="WriteFrameAsync"/> awaits the
+/// metadata signal before it writes, and the endpoint calls <see cref="ApplyMetadata"/> exactly once when the
+/// open returns Ok (or <see cref="Fail"/> when the open failed with nothing written yet). No frame can reach
+/// the response before its headers, and the backpressure invariant holds the producer at the gate meanwhile.
+/// </summary>
+public sealed class HttpResponseStreamSink : IStreamSink
+{
+    private readonly HttpResponse _response;
+    private readonly TaskCompletionSource _metadataReady = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private volatile bool _failed;
+
+    public HttpResponseStreamSink(HttpResponse response) => _response = response ?? throw new ArgumentNullException(nameof(response));
+
+    /// <summary>
+    /// Apply the finite read's headers from the open command's Ok body and OPEN the write gate. Called exactly
+    /// once, before any body byte can be written (WriteFrameAsync awaits this). Safe to call with a null body
+    /// (headers stay unset; the response is then chunked).
+    /// </summary>
+    public void ApplyMetadata(OpenReadResponse? meta)
+    {
+        if (meta?.ContentType is { Length: > 0 } ctype)
+            _response.ContentType = ctype;
+        if (meta?.TotalBytes is { } total && total >= 0)
+            _response.ContentLength = total;
+        _metadataReady.TrySetResult();
+    }
+
+    /// <summary>The open failed (or there was no stream); release the gate so a racing WriteFrameAsync unwinds
+    /// WITHOUT writing to the body (the endpoint writes the error status/body instead).</summary>
+    public void Fail()
+    {
+        _failed = true;
+        _metadataReady.TrySetResult();
+    }
+
+    public async Task WriteFrameAsync(DirectorStreamFrame frame, CancellationToken cancellationToken)
+    {
+        // Gate the FIRST byte on the headers (ruling 4). Once the gate is open this returns immediately, so
+        // later frames pass straight through. A slow gate holds the producer (backpressure), never buffers.
+        await _metadataReady.Task.WaitAsync(cancellationToken);
+        if (_failed)
+            throw new InvalidOperationException("finite read open failed; no body to write");
+
+        if (frame.Kind == DirectorStreamFrameType.Binary)
+        {
+            var data = frame.Data ?? Array.Empty<byte>();
+            if (data.Length > 0)
+            {
+                await _response.Body.WriteAsync(data, cancellationToken);
+                await _response.Body.FlushAsync(cancellationToken);
+            }
+        }
+        // A finite read never emits Size frames; a Closed/eof frame just ends the stream (CompleteAsync).
+    }
+
+    public Task CompleteAsync(string? reason)
+    {
+        // The response body is completed by the request pipeline when the endpoint handler returns; there is
+        // nothing to close here. Log an abnormal end so a truncated download is visible, never silent.
+        if (!string.IsNullOrEmpty(reason) && reason != "eof" && reason != "closed")
+            FileLog.Write($"[HttpResponseStreamSink] finite read ended early: {reason}");
+        return Task.CompletedTask;
+    }
+}

--- a/src/CcDirector.Gateway/Streaming/WebSocketStreamSink.cs
+++ b/src/CcDirector.Gateway/Streaming/WebSocketStreamSink.cs
@@ -1,0 +1,79 @@
+using System.Net.WebSockets;
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Streaming;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 2: the browser-facing sink for a LIVE terminal up-stream. Wraps the
+/// accepted browser WebSocket and translates each Director up-frame back into the EXACT terminal wire
+/// protocol the browser has always spoken (the protocol <c>TerminalStreamEndpoint</c> defines), so the
+/// browser contract is unchanged - only the Gateway's source of the frames moved from a dialed Director
+/// WebSocket to the tunnel up-stream:
+///   Size   -> a text frame {"type":"size","cols":C,"rows":R}
+///   Binary -> a binary WebSocket message of the raw bytes
+///   Closed -> a text frame {"type":"closed","reason":R}; the socket is then closed by <see cref="CompleteAsync"/>.
+///
+/// The backpressure invariant (Architect ruling 1) lives in <see cref="GatewayStreamRegistry"/>, which awaits
+/// each <see cref="WriteFrameAsync"/> before pulling the next up-frame; this sink therefore just sends the one
+/// frame and returns when that send has drained - it never buffers. It only ever WRITES to the socket; the
+/// browser's keystrokes are read by a separate receive pump (WebSockets are full-duplex, so one sender and one
+/// receiver do not conflict), and <see cref="CompleteAsync"/> uses <c>CloseOutputAsync</c> (send-only) so it
+/// never contends with that pending receive.
+/// </summary>
+public sealed class WebSocketStreamSink : IStreamSink
+{
+    private readonly WebSocket _socket;
+
+    public WebSocketStreamSink(WebSocket socket) => _socket = socket ?? throw new ArgumentNullException(nameof(socket));
+
+    public async Task WriteFrameAsync(DirectorStreamFrame frame, CancellationToken cancellationToken)
+    {
+        if (_socket.State != WebSocketState.Open)
+            throw new InvalidOperationException("terminal WebSocket is no longer open");
+
+        switch (frame.Kind)
+        {
+            case DirectorStreamFrameType.Size:
+                await SendTextAsync(new { type = "size", cols = frame.Cols, rows = frame.Rows }, cancellationToken);
+                break;
+            case DirectorStreamFrameType.Binary:
+                var data = frame.Data ?? Array.Empty<byte>();
+                if (data.Length > 0)
+                    await _socket.SendAsync(data, WebSocketMessageType.Binary, endOfMessage: true, cancellationToken);
+                break;
+            case DirectorStreamFrameType.Closed:
+                await SendTextAsync(new { type = "closed", reason = frame.Reason ?? "" }, cancellationToken);
+                break;
+        }
+    }
+
+    public async Task CompleteAsync(string? reason)
+    {
+        try
+        {
+            // CloseOutputAsync (send-only) so this never contends with the keystroke receive pump that may be
+            // mid ReceiveAsync; a plain CloseAsync would also try to RECEIVE the peer's close ack and conflict.
+            if (_socket.State == WebSocketState.Open || _socket.State == WebSocketState.CloseReceived)
+                await _socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, CloseReason(reason), CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[WebSocketStreamSink] close failed: {ex.Message}");
+        }
+    }
+
+    private async Task SendTextAsync(object payload, CancellationToken ct)
+    {
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(payload);
+        await _socket.SendAsync(bytes, WebSocketMessageType.Text, endOfMessage: true, ct);
+    }
+
+    // A WebSocket close reason is capped at 123 UTF-8 bytes by the protocol; keep it short and never null.
+    private static string CloseReason(string? reason)
+    {
+        if (string.IsNullOrEmpty(reason)) return "done";
+        return reason.Length <= 120 ? reason : reason[..120];
+    }
+}


### PR DESCRIPTION
## What

Gateway Cleanup mission, **Phase 2 (Option A), PR A**: re-point the Gateway's browser-facing UP-STREAM legs (live terminal, session file read, screenshot bytes) onto the tunnel, instead of dialing the owning Director over HTTP. **Additive, behind the existing `streamMode` flag** - off (production today) is byte-identical to now; on serves those legs through the tunnel. Both paths coexist until Phase 6.

This is the "new road carries traffic before the old road is removed" work that must land **before** the Phase 1 Director-floor deletion, so a floor-only Director can be proven through the Gateway. (Sequencing ruling: the Architect approved doing the Gateway re-point first - the up-stream primitive shipped in Phase 0 but was wired to no browser leg.)

## How

- **`WebSocketStreamSink`** - translates each Director up-frame back into the exact terminal wire protocol the browser already speaks (`Size` -> `{"type":"size"}`, `Binary` -> a binary message, `Closed` -> `{"type":"closed"}` then close). Send-only `CloseOutputAsync` so it never contends with the keystroke receive pump.
- **`HttpResponseStreamSink`** - writes a finite file/screenshot read into the browser response, gating the first body byte on the open reply's `Content-Type`/`Content-Length` (ruling 4) so a racing first frame can never precede the headers.
- **`TunnelStreamLegs`** - mints a fresh stream id, registers the sink in `GatewayStreamRegistry`, sends `open-terminal-stream`/`read-file`/`screenshot-file` down the tunnel, forwards browser keystrokes as `terminal-input` unary verbs, and sends `close-stream` on teardown (the load-bearing stop signal, ruling 3).
- **`SessionWsProxyEndpoints`** - the terminal leg, a new literal `/sessions/{sid}/file` route, and the screenshot-bytes leg take the tunnel when stream mode is on and the owner is stream-connected (resolved via `PushedSessionStore.TryLocate`); otherwise the existing HTTP proxy path, unchanged. `Range` requests keep the HTTP path (the up-stream read is whole-file; partial content is a tracked follow-up).

Backpressure and the lifecycle races stay in the Phase 0 `GatewayStreamRegistry`; these sinks are non-buffering by contract.

## Tests

13 new tests, all green:
- Sink wire-fidelity (Size/Binary/Closed -> browser bytes) and header-gating (first byte waits for the open reply).
- In-process integration of the file and terminal legs through the real sinks + registry, including the Architect's **error-parity** (missing path/session -> 404/NotFound over the tunnel) and **teardown** (browser disconnect fires `close-stream` and stops the Director producer) proof additions.

Full Gateway suite green. The two `VoiceTurnEndpointTests` summarizer-timeout failures seen in a full-suite run are pre-existing full-suite-contention flakes - they pass in isolation on this branch **and** on clean `origin/main` (verified).

## Not in this PR

- **PR B**: the catch-all read/write verb dispatch (`turns`, `buffer`, `git-status`, writes, ...) replacing the `/sessions/{sid}/{**rest}` HTTP dial under stream mode.
- The **slot-5 tunnel-carries-all proof** (full-surface Director + streamMode Gateway, incl. under-load/concurrency) - run after PR A + PR B, before the gated Phase 1 deletion.

Design + proof plan: `docs/architecture/gateway-cleanup-phase2-repoint-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)