### PR TITLE
feat(gateway-cleanup): Phase 2 PR B1 - catch-all session READ verbs onto the tunnel

### DIFF
--- a/src/CcDirector.Gateway.Tests/TunnelCatchAllDispatchTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelCatchAllDispatchTests.cs
@@ -1,0 +1,139 @@
+using System.Text;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 2 (PR B1): the catch-all read verbs dispatched over the tunnel must produce
+/// the SAME HTTP response the Director REST route (via the HTTP dial) returned - the serialized DTO with 200
+/// and application/json on success, and the matching typed error code otherwise. An unmapped path, a non-GET
+/// method (writes come later), or no active stream must return false so the caller keeps the HTTP path.
+/// </summary>
+public sealed class TunnelCatchAllDispatchTests
+{
+    private static (DefaultHttpContext ctx, MemoryStream body) NewCtx(string method)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Method = method;
+        var body = new MemoryStream();
+        ctx.Response.Body = body;
+        return (ctx, body);
+    }
+
+    private static string BodyText(MemoryStream body) => Encoding.UTF8.GetString(body.ToArray());
+
+    [Fact]
+    public async Task Turns_read_writes_the_dto_as_200_json_matching_the_http_dial()
+    {
+        const string dto = "{\"sessionId\":\"s\",\"status\":\"ok\",\"widgets\":[]}";
+        var seenVerb = "";
+        DirectorCommandRouter.SendDirectorCommandAsync send = (d, c, ct) =>
+        {
+            seenVerb = c.Verb;
+            return Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Success(dto));
+        };
+        var dispatch = new TunnelCatchAllDispatch(send);
+        var (ctx, body) = NewCtx("GET");
+
+        var handled = await dispatch.TryDispatchAsync(ctx, Guid.NewGuid().ToString(), "dir1", "turns");
+
+        Assert.True(handled);
+        Assert.Equal("turns", seenVerb);
+        Assert.Equal(StatusCodes.Status200OK, ctx.Response.StatusCode);
+        Assert.Equal("application/json", ctx.Response.ContentType);
+        Assert.Equal(dto, BodyText(body));
+    }
+
+    [Theory]
+    [InlineData("turns", "turns")]
+    [InlineData("buffer/html", "buffer-html")]
+    [InlineData("usage", "usage")]
+    [InlineData("context", "context")]
+    [InlineData("history", "history")]
+    [InlineData("github-urls", "github-urls")]
+    public async Task Each_catch_all_read_path_maps_to_its_verb(string rest, string expectedVerb)
+    {
+        var seenVerb = "";
+        DirectorCommandRouter.SendDirectorCommandAsync send = (d, c, ct) =>
+        {
+            seenVerb = c.Verb;
+            return Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Success("{}"));
+        };
+        var dispatch = new TunnelCatchAllDispatch(send);
+        var (ctx, _) = NewCtx("GET");
+
+        var handled = await dispatch.TryDispatchAsync(ctx, Guid.NewGuid().ToString(), "dir1", rest);
+
+        Assert.True(handled);
+        Assert.Equal(expectedVerb, seenVerb);
+    }
+
+    [Fact]
+    public async Task NotFound_maps_to_404_matching_the_http_dial()
+    {
+        DirectorCommandRouter.SendDirectorCommandAsync send = (d, c, ct) =>
+            Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found"));
+        var dispatch = new TunnelCatchAllDispatch(send);
+        var (ctx, _) = NewCtx("GET");
+
+        var handled = await dispatch.TryDispatchAsync(ctx, Guid.NewGuid().ToString(), "dir1", "turns");
+
+        Assert.True(handled);
+        Assert.Equal(StatusCodes.Status404NotFound, ctx.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task BadRequest_maps_to_400()
+    {
+        DirectorCommandRouter.SendDirectorCommandAsync send = (d, c, ct) =>
+            Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format"));
+        var dispatch = new TunnelCatchAllDispatch(send);
+        var (ctx, _) = NewCtx("GET");
+
+        var handled = await dispatch.TryDispatchAsync(ctx, "not-a-guid", "dir1", "turns");
+
+        Assert.True(handled);
+        Assert.Equal(StatusCodes.Status400BadRequest, ctx.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task An_unmapped_rest_path_falls_through_to_http()
+    {
+        var called = false;
+        DirectorCommandRouter.SendDirectorCommandAsync send = (d, c, ct) => { called = true; return Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Success("{}")); };
+        var dispatch = new TunnelCatchAllDispatch(send);
+        var (ctx, _) = NewCtx("GET");
+
+        var handled = await dispatch.TryDispatchAsync(ctx, Guid.NewGuid().ToString(), "dir1", "queue");
+
+        Assert.False(handled);   // not a mapped read verb (writes/queue are a later increment)
+        Assert.False(called);    // never dialed the Director
+    }
+
+    [Fact]
+    public async Task A_write_method_falls_through_to_http_in_this_increment()
+    {
+        DirectorCommandRouter.SendDirectorCommandAsync send = (d, c, ct) => Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Success("{}"));
+        var dispatch = new TunnelCatchAllDispatch(send);
+        var (ctx, _) = NewCtx("POST");
+
+        var handled = await dispatch.TryDispatchAsync(ctx, Guid.NewGuid().ToString(), "dir1", "resize");
+
+        Assert.False(handled);
+    }
+
+    [Fact]
+    public async Task No_active_stream_falls_through_to_http()
+    {
+        DirectorCommandRouter.SendDirectorCommandAsync send = (d, c, ct) => Task.FromResult<DirectorCommandResult?>(null);
+        var dispatch = new TunnelCatchAllDispatch(send);
+        var (ctx, _) = NewCtx("GET");
+
+        var handled = await dispatch.TryDispatchAsync(ctx, Guid.NewGuid().ToString(), "dir1", "turns");
+
+        Assert.False(handled);   // caller falls back to the HTTP proxy path
+    }
+}

--- a/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs
@@ -61,6 +61,9 @@ internal static class SessionWsProxyEndpoints
         var tunnel = (pushedSessions is not null && streamRegistry is not null && sendCommand is not null)
             ? new TunnelStreamLegs(streamRegistry, sendCommand)
             : null;
+        // The catch-all's session-verb dispatch (turns, buffer-html, usage, ... and, in later increments, the
+        // session writes). Enabled under the same stream-mode guard; null => the catch-all keeps its HTTP dial.
+        var catchAll = sendCommand is not null ? new TunnelCatchAllDispatch(sendCommand) : null;
         var stale = streamStaleAfter ?? TimeSpan.FromSeconds(10);
 
         // Live terminal stream: over the tunnel (open-terminal-stream up-stream) when the owner is
@@ -160,6 +163,12 @@ internal static class SessionWsProxyEndpoints
                 await ctx.Response.WriteAsJsonAsync(new { error = "git write actions are not available through the Gateway" });
                 return;
             }
+
+            // Gateway Cleanup Phase 2: serve a mapped session verb over the tunnel when the owner is
+            // stream-connected; an unmapped verb (or no active stream) falls through to the HTTP forward below.
+            if (catchAll is not null && pushedSessions!.TryLocate(sid, stale) is { } loc
+                && await catchAll.TryDispatchAsync(ctx, sid, loc.DirectorId, rest))
+                return;
 
             var directorPath = string.IsNullOrEmpty(rest) ? $"/sessions/{sid}" : $"/sessions/{sid}/{rest}";
             // fastPath: this leg carries high-frequency calls (per-keystroke input POSTs), so try the

--- a/src/CcDirector.Gateway/Api/TunnelCatchAllDispatch.cs
+++ b/src/CcDirector.Gateway/Api/TunnelCatchAllDispatch.cs
@@ -1,0 +1,90 @@
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.Http;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 2: dispatch the SESSION-scoped verbs that flow through the
+/// <c>/sessions/{sid}/{**rest}</c> catch-all onto the tunnel, instead of dialing the owning Director over HTTP.
+/// Used only when stream mode is on and the owner is stream-connected (the caller resolves that via
+/// <see cref="Streaming.PushedSessionStore.TryLocate"/>); a request whose (method, rest-path) is not a mapped
+/// verb, or a Director with no active stream, returns false so the caller keeps the existing HTTP proxy path -
+/// byte-identical when stream mode is off.
+///
+/// The catch-all carries the session verbs that do NOT have their own literal Gateway route (turns, buffer-html,
+/// usage, context, history, github-urls, and the session writes/queue in a later increment). The verb's request
+/// DTO and core are the SAME the Director REST route used, so the reply body is identical; the Gateway marshals
+/// the request into the verb payload and maps <see cref="DirectorCommandResult"/> back to the HTTP response the
+/// browser expects.
+///
+/// This increment (PR B1) handles the catch-all READS - all of them take only the session id (no payload) and
+/// return a JSON DTO, so the mapping is uniform. Writes and the queue path-parameterised verbs come next, on the
+/// same dispatch mechanism.
+/// </summary>
+internal sealed class TunnelCatchAllDispatch
+{
+    private readonly DirectorCommandRouter.SendDirectorCommandAsync _sendCommand;
+
+    public TunnelCatchAllDispatch(DirectorCommandRouter.SendDirectorCommandAsync sendCommand) =>
+        _sendCommand = sendCommand ?? throw new ArgumentNullException(nameof(sendCommand));
+
+    // The session READ verbs that flow through the catch-all (no literal Gateway route). Each takes only the
+    // session id and returns a JSON DTO body. buffer / summary / git / handover / recap / wingman-view /
+    // snapshot have their own literal Gateway routes and are re-pointed there, NOT here.
+    private static readonly Dictionary<string, string> GetVerbByRest = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["turns"] = "turns",
+        ["buffer/html"] = "buffer-html",
+        ["usage"] = "usage",
+        ["context"] = "context",
+        ["history"] = "history",
+        ["github-urls"] = "github-urls",
+    };
+
+    /// <summary>
+    /// Try to serve this catch-all request over the tunnel. Returns true when handled (the response is written),
+    /// false to fall through to the caller's HTTP proxy path (an unmapped verb, or no active stream).
+    /// </summary>
+    public async Task<bool> TryDispatchAsync(HttpContext ctx, string sid, string directorId, string? rest)
+    {
+        var verb = ResolveVerb(ctx.Request.Method, rest);
+        if (verb is null) return false;
+
+        var result = await DirectorCommandRouter.TrySendAsync(_sendCommand, directorId, verb, sid, null, ctx.RequestAborted);
+        if (result is null) return false; // no active stream -> HTTP fallback
+
+        await WriteResultAsync(ctx, result);
+        return true;
+    }
+
+    private static string? ResolveVerb(string method, string? rest)
+    {
+        if (rest is null) return null;
+        if (HttpMethods.IsGet(method) && GetVerbByRest.TryGetValue(rest, out var verb)) return verb;
+        return null;
+    }
+
+    // Map a DirectorCommandResult back to the HTTP response the browser expects - the same shape the Director
+    // REST route returned (200 + application/json for Ok; the matching typed error code otherwise). BodyJson is
+    // already the serialized resource DTO, so it is written verbatim.
+    private static async Task WriteResultAsync(HttpContext ctx, DirectorCommandResult result)
+    {
+        if (result.Ok)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status200OK;
+            ctx.Response.ContentType = "application/json";
+            await ctx.Response.WriteAsync(result.BodyJson ?? "");
+            return;
+        }
+
+        ctx.Response.StatusCode = result.Status switch
+        {
+            DirectorCommandStatus.BadRequest => StatusCodes.Status400BadRequest,
+            DirectorCommandStatus.NotFound => StatusCodes.Status404NotFound,
+            DirectorCommandStatus.Conflict => StatusCodes.Status409Conflict,
+            DirectorCommandStatus.Locked => StatusCodes.Status423Locked,
+            _ => StatusCodes.Status500InternalServerError,
+        };
+        await ctx.Response.WriteAsJsonAsync(new { error = result.Error ?? $"director returned {result.Status}" });
+    }
+}


### PR DESCRIPTION
## What

Gateway Cleanup mission, **Phase 2 PR B1**: dispatch the session **READ** verbs that flow through the `/sessions/{sid}/{**rest}` catch-all - `turns`, `buffer-html`, `usage`, `context`, `history`, `github-urls` - over the tunnel instead of dialing the owning Director over HTTP, when the owner is stream-connected. **Additive, behind the stream-mode flag** (off = byte-identical HTTP dial). An unmapped path, a write method, or no active stream falls through to the existing HTTP proxy path.

Unblocks `turns` for the slot-5 tunnel-carries-all proof and establishes the `TunnelCatchAllDispatch` mechanism the session writes + queue path-parameterised verbs will extend next.

## How

- **`TunnelCatchAllDispatch`** - resolves `(method, rest-path)` to a verb, sends it down the tunnel via `DirectorCommandRouter`, and maps `DirectorCommandResult` back to the HTTP response: `Ok` -> 200 + `application/json` + `BodyJson` verbatim; typed failures -> their HTTP code (`NotFound` -> 404, `BadRequest` -> 400, `Conflict` -> 409, `Locked` -> 423). These reads take only the session id (no payload) and return a JSON DTO, so the mapping is uniform.
- Wired into the catch-all **after** the git-write refusal; the git read-only rule and the HTTP fallback are unchanged.
- Verbs with their own literal Gateway route (`buffer`, `summary`, `git`, `handover`, `recap`, `wingman-view`, `snapshot`, `request-deletion`, `upload-image`) are re-pointed there in a later increment, not here - no double-handling.

The verb DTO and core are the **same** the Director REST route used (Phase 0), so the response body is identical to the HTTP dial.

## Tests

12 new tests, all green: each read path maps to its verb; `Ok` -> 200 json matching the dial; `NotFound` -> 404; `BadRequest` -> 400; an unmapped path / a write method / no active stream all fall through to HTTP without dialing.

## Next

- PR B2: the catch-all **writes** (resize, clear-context, mobile-mode, ..., and the queue path-parameterised verbs with path+query+body folding) on this same mechanism.
- PR C: re-point the literal Gateway session routes still dialing HTTP (buffer, summary, git-status, handover, recap, wingman-view, snapshot, request-deletion, upload-image, wingman-ask).
- Then the slot-5 tunnel-carries-all proof, then the gated Phase 1 deletion.

Design + proof plan: `docs/architecture/gateway-cleanup-phase2-repoint-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)