### PR TITLE
feat(gateway-cleanup): Phase 2 PR B2 - catch-all session WRITE verbs onto the tunnel

### DIFF
--- a/src/CcDirector.Gateway.Tests/TunnelCatchAllDispatchTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelCatchAllDispatchTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json.Nodes;
 using CcDirector.Gateway.Api;
 using CcDirector.Gateway.Contracts;
 using Microsoft.AspNetCore.Http;
@@ -7,17 +8,20 @@ using Xunit;
 namespace CcDirector.Gateway.Tests;
 
 /// <summary>
-/// Gateway Cleanup mission, Phase 2 (PR B1): the catch-all read verbs dispatched over the tunnel must produce
-/// the SAME HTTP response the Director REST route (via the HTTP dial) returned - the serialized DTO with 200
-/// and application/json on success, and the matching typed error code otherwise. An unmapped path, a non-GET
-/// method (writes come later), or no active stream must return false so the caller keeps the HTTP path.
+/// Gateway Cleanup mission, Phase 2 (PR B1/B2): the catch-all session verbs dispatched over the tunnel must
+/// produce the SAME HTTP response the Director REST route (via the HTTP dial) returned - the serialized DTO
+/// with 200/application/json on success, the matching typed error code otherwise - and must marshal the
+/// request faithfully: reads and no-body writes carry no payload, body writes pass the raw body through, and
+/// the queue path-parameterised verbs fold the {itemId} path segment into the payload. An unmapped path or no
+/// active stream returns false so the caller keeps the HTTP path.
 /// </summary>
 public sealed class TunnelCatchAllDispatchTests
 {
-    private static (DefaultHttpContext ctx, MemoryStream body) NewCtx(string method)
+    private static (DefaultHttpContext ctx, MemoryStream body) NewCtx(string method, string requestBody = "")
     {
         var ctx = new DefaultHttpContext();
         ctx.Request.Method = method;
+        ctx.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(requestBody));
         var body = new MemoryStream();
         ctx.Response.Body = body;
         return (ctx, body);
@@ -25,23 +29,27 @@ public sealed class TunnelCatchAllDispatchTests
 
     private static string BodyText(MemoryStream body) => Encoding.UTF8.GetString(body.ToArray());
 
+    private static DirectorCommandRouter.SendDirectorCommandAsync Capture(out Func<DirectorCommand?> seen, DirectorCommandResult? reply)
+    {
+        DirectorCommand? captured = null;
+        seen = () => captured;
+        return (d, c, ct) => { captured = c; return Task.FromResult(reply); };
+    }
+
+    // -------------------------------------------------------------------------------- reads ----
+
     [Fact]
     public async Task Turns_read_writes_the_dto_as_200_json_matching_the_http_dial()
     {
         const string dto = "{\"sessionId\":\"s\",\"status\":\"ok\",\"widgets\":[]}";
-        var seenVerb = "";
-        DirectorCommandRouter.SendDirectorCommandAsync send = (d, c, ct) =>
-        {
-            seenVerb = c.Verb;
-            return Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Success(dto));
-        };
+        var send = Capture(out var seen, DirectorCommandResult.Success(dto));
         var dispatch = new TunnelCatchAllDispatch(send);
         var (ctx, body) = NewCtx("GET");
 
         var handled = await dispatch.TryDispatchAsync(ctx, Guid.NewGuid().ToString(), "dir1", "turns");
 
         Assert.True(handled);
-        Assert.Equal("turns", seenVerb);
+        Assert.Equal("turns", seen()!.Verb);
         Assert.Equal(StatusCodes.Status200OK, ctx.Response.StatusCode);
         Assert.Equal("application/json", ctx.Response.ContentType);
         Assert.Equal(dto, BodyText(body));
@@ -54,86 +62,134 @@ public sealed class TunnelCatchAllDispatchTests
     [InlineData("context", "context")]
     [InlineData("history", "history")]
     [InlineData("github-urls", "github-urls")]
+    [InlineData("queue", "queue-read")]
     public async Task Each_catch_all_read_path_maps_to_its_verb(string rest, string expectedVerb)
     {
-        var seenVerb = "";
-        DirectorCommandRouter.SendDirectorCommandAsync send = (d, c, ct) =>
-        {
-            seenVerb = c.Verb;
-            return Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Success("{}"));
-        };
+        var send = Capture(out var seen, DirectorCommandResult.Success("{}"));
         var dispatch = new TunnelCatchAllDispatch(send);
         var (ctx, _) = NewCtx("GET");
 
         var handled = await dispatch.TryDispatchAsync(ctx, Guid.NewGuid().ToString(), "dir1", rest);
 
         Assert.True(handled);
-        Assert.Equal(expectedVerb, seenVerb);
+        Assert.Equal(expectedVerb, seen()!.Verb);
+        Assert.Equal("", seen()!.PayloadJson); // reads carry no payload
     }
 
     [Fact]
-    public async Task NotFound_maps_to_404_matching_the_http_dial()
+    public async Task NotFound_maps_to_404_and_BadRequest_to_400()
     {
-        DirectorCommandRouter.SendDirectorCommandAsync send = (d, c, ct) =>
-            Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found"));
-        var dispatch = new TunnelCatchAllDispatch(send);
-        var (ctx, _) = NewCtx("GET");
+        var dispatch404 = new TunnelCatchAllDispatch((d, c, ct) =>
+            Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found")));
+        var (ctx404, _) = NewCtx("GET");
+        Assert.True(await dispatch404.TryDispatchAsync(ctx404, Guid.NewGuid().ToString(), "dir1", "turns"));
+        Assert.Equal(StatusCodes.Status404NotFound, ctx404.Response.StatusCode);
 
-        var handled = await dispatch.TryDispatchAsync(ctx, Guid.NewGuid().ToString(), "dir1", "turns");
-
-        Assert.True(handled);
-        Assert.Equal(StatusCodes.Status404NotFound, ctx.Response.StatusCode);
+        var dispatch400 = new TunnelCatchAllDispatch((d, c, ct) =>
+            Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format")));
+        var (ctx400, _) = NewCtx("GET");
+        Assert.True(await dispatch400.TryDispatchAsync(ctx400, "not-a-guid", "dir1", "turns"));
+        Assert.Equal(StatusCodes.Status400BadRequest, ctx400.Response.StatusCode);
     }
 
-    [Fact]
-    public async Task BadRequest_maps_to_400()
-    {
-        DirectorCommandRouter.SendDirectorCommandAsync send = (d, c, ct) =>
-            Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format"));
-        var dispatch = new TunnelCatchAllDispatch(send);
-        var (ctx, _) = NewCtx("GET");
-
-        var handled = await dispatch.TryDispatchAsync(ctx, "not-a-guid", "dir1", "turns");
-
-        Assert.True(handled);
-        Assert.Equal(StatusCodes.Status400BadRequest, ctx.Response.StatusCode);
-    }
+    // ------------------------------------------------------------------------------- writes ----
 
     [Fact]
-    public async Task An_unmapped_rest_path_falls_through_to_http()
+    public async Task Body_write_passes_the_raw_request_body_through_as_the_payload()
     {
-        var called = false;
-        DirectorCommandRouter.SendDirectorCommandAsync send = (d, c, ct) => { called = true; return Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Success("{}")); };
+        const string reqBody = "{\"cols\":100,\"rows\":40}";
+        var send = Capture(out var seen, DirectorCommandResult.Success());
         var dispatch = new TunnelCatchAllDispatch(send);
-        var (ctx, _) = NewCtx("GET");
-
-        var handled = await dispatch.TryDispatchAsync(ctx, Guid.NewGuid().ToString(), "dir1", "queue");
-
-        Assert.False(handled);   // not a mapped read verb (writes/queue are a later increment)
-        Assert.False(called);    // never dialed the Director
-    }
-
-    [Fact]
-    public async Task A_write_method_falls_through_to_http_in_this_increment()
-    {
-        DirectorCommandRouter.SendDirectorCommandAsync send = (d, c, ct) => Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Success("{}"));
-        var dispatch = new TunnelCatchAllDispatch(send);
-        var (ctx, _) = NewCtx("POST");
+        var (ctx, _) = NewCtx("POST", reqBody);
 
         var handled = await dispatch.TryDispatchAsync(ctx, Guid.NewGuid().ToString(), "dir1", "resize");
 
-        Assert.False(handled);
+        Assert.True(handled);
+        Assert.Equal("resize", seen()!.Verb);
+        Assert.Equal(reqBody, seen()!.PayloadJson);
+        Assert.Equal(StatusCodes.Status200OK, ctx.Response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("POST", "clear-context", "clear-context")]
+    [InlineData("POST", "mobile-mode", "mobile-mode")]
+    [InlineData("POST", "voice-mode", "voice-mode")]
+    [InlineData("POST", "wingman-enabled", "wingman-enabled")]
+    [InlineData("POST", "relink", "relink")]
+    [InlineData("POST", "execute-action", "execute-action")]
+    [InlineData("POST", "queue", "queue-add")]
+    [InlineData("DELETE", "queue", "queue-clear")]
+    public async Task Each_catch_all_write_path_maps_to_its_verb(string method, string rest, string expectedVerb)
+    {
+        var send = Capture(out var seen, DirectorCommandResult.Success());
+        var dispatch = new TunnelCatchAllDispatch(send);
+        var (ctx, _) = NewCtx(method, "{}");
+
+        var handled = await dispatch.TryDispatchAsync(ctx, Guid.NewGuid().ToString(), "dir1", rest);
+
+        Assert.True(handled);
+        Assert.Equal(expectedVerb, seen()!.Verb);
     }
 
     [Fact]
-    public async Task No_active_stream_falls_through_to_http()
+    public async Task Queue_update_folds_the_path_itemId_into_the_body()
     {
-        DirectorCommandRouter.SendDirectorCommandAsync send = (d, c, ct) => Task.FromResult<DirectorCommandResult?>(null);
+        var send = Capture(out var seen, DirectorCommandResult.Success("{}"));
         var dispatch = new TunnelCatchAllDispatch(send);
+        var (ctx, _) = NewCtx("PATCH", "{\"text\":\"edited prompt\"}");
+
+        var handled = await dispatch.TryDispatchAsync(ctx, Guid.NewGuid().ToString(), "dir1", "queue/item-123");
+
+        Assert.True(handled);
+        Assert.Equal("queue-update", seen()!.Verb);
+        var payload = JsonNode.Parse(seen()!.PayloadJson)!.AsObject();
+        Assert.Equal("edited prompt", (string?)payload["text"]);
+        Assert.Equal("item-123", (string?)payload["itemId"]);
+    }
+
+    [Theory]
+    [InlineData("DELETE", "queue/item-9", "queue-remove")]
+    [InlineData("POST", "queue/item-9/move-up", "queue-move-up")]
+    [InlineData("POST", "queue/item-9/move-down", "queue-move-down")]
+    [InlineData("POST", "queue/item-9/send", "queue-send")]
+    public async Task Queue_path_param_verbs_fold_the_itemId_with_no_body(string method, string rest, string expectedVerb)
+    {
+        var send = Capture(out var seen, DirectorCommandResult.Success("{}"));
+        var dispatch = new TunnelCatchAllDispatch(send);
+        var (ctx, _) = NewCtx(method);
+
+        var handled = await dispatch.TryDispatchAsync(ctx, Guid.NewGuid().ToString(), "dir1", rest);
+
+        Assert.True(handled);
+        Assert.Equal(expectedVerb, seen()!.Verb);
+        var payload = JsonNode.Parse(seen()!.PayloadJson)!.AsObject();
+        Assert.Equal("item-9", (string?)payload["itemId"]);
+    }
+
+    // ------------------------------------------------------------------------------ fallthrough ----
+
+    [Fact]
+    public async Task An_unmapped_rest_path_falls_through_to_http_without_dialing()
+    {
+        var called = false;
+        var dispatch = new TunnelCatchAllDispatch((d, c, ct) => { called = true; return Task.FromResult<DirectorCommandResult?>(DirectorCommandResult.Success("{}")); });
         var (ctx, _) = NewCtx("GET");
 
-        var handled = await dispatch.TryDispatchAsync(ctx, Guid.NewGuid().ToString(), "dir1", "turns");
+        var handled = await dispatch.TryDispatchAsync(ctx, Guid.NewGuid().ToString(), "dir1", "not-a-real-verb");
 
-        Assert.False(handled);   // caller falls back to the HTTP proxy path
+        Assert.False(handled);
+        Assert.False(called);
+    }
+
+    [Fact]
+    public async Task No_active_stream_falls_through_and_rewinds_the_body_for_the_http_forward()
+    {
+        var dispatch = new TunnelCatchAllDispatch((d, c, ct) => Task.FromResult<DirectorCommandResult?>(null));
+        var (ctx, _) = NewCtx("POST", "{\"cols\":80,\"rows\":24}");
+
+        var handled = await dispatch.TryDispatchAsync(ctx, Guid.NewGuid().ToString(), "dir1", "resize");
+
+        Assert.False(handled);                       // caller falls back to the HTTP proxy path
+        Assert.Equal(0, ctx.Request.Body.Position);  // body rewound so the HTTP forward re-reads it
     }
 }

--- a/src/CcDirector.Gateway/Api/TunnelCatchAllDispatch.cs
+++ b/src/CcDirector.Gateway/Api/TunnelCatchAllDispatch.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Nodes;
+using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using Microsoft.AspNetCore.Http;
 
@@ -11,15 +13,19 @@ namespace CcDirector.Gateway.Api;
 /// verb, or a Director with no active stream, returns false so the caller keeps the existing HTTP proxy path -
 /// byte-identical when stream mode is off.
 ///
-/// The catch-all carries the session verbs that do NOT have their own literal Gateway route (turns, buffer-html,
-/// usage, context, history, github-urls, and the session writes/queue in a later increment). The verb's request
-/// DTO and core are the SAME the Director REST route used, so the reply body is identical; the Gateway marshals
-/// the request into the verb payload and maps <see cref="DirectorCommandResult"/> back to the HTTP response the
-/// browser expects.
+/// The catch-all carries the session verbs that do NOT have their own literal Gateway route: the reads (turns,
+/// buffer-html, usage, context, history, github-urls, queue-read) and the writes (resize, clear-context,
+/// history-picker, mobile-mode, voice-mode, wingman-enabled, relink, execute-action, and the voice queue's
+/// add/update/remove/move/clear/send). The verb's request DTO and core are the SAME the Director REST route
+/// used (Phase 0), so the reply body is identical; the Gateway only marshals method + path + body into the verb
+/// payload and maps <see cref="DirectorCommandResult"/> back to the HTTP response.
 ///
-/// This increment (PR B1) handles the catch-all READS - all of them take only the session id (no payload) and
-/// return a JSON DTO, so the mapping is uniform. Writes and the queue path-parameterised verbs come next, on the
-/// same dispatch mechanism.
+/// Marshaling:
+///  - reads and the no-body writes carry no payload (the target session is the command's SessionId);
+///  - the body-shaped writes pass the raw request body straight through as PayloadJson (the REST route and the
+///    tunnel verb share one DTO+core, so the bytes are identical);
+///  - the queue path-parameterised verbs FOLD the {itemId} path segment into the payload (Architect note): the
+///    request body (a JSON object or empty) gets an "itemId" field overlaid before it is sent.
 /// </summary>
 internal sealed class TunnelCatchAllDispatch
 {
@@ -28,10 +34,12 @@ internal sealed class TunnelCatchAllDispatch
     public TunnelCatchAllDispatch(DirectorCommandRouter.SendDirectorCommandAsync sendCommand) =>
         _sendCommand = sendCommand ?? throw new ArgumentNullException(nameof(sendCommand));
 
-    // The session READ verbs that flow through the catch-all (no literal Gateway route). Each takes only the
-    // session id and returns a JSON DTO body. buffer / summary / git / handover / recap / wingman-view /
-    // snapshot have their own literal Gateway routes and are re-pointed there, NOT here.
-    private static readonly Dictionary<string, string> GetVerbByRest = new(StringComparer.OrdinalIgnoreCase)
+    private enum Payload { None, Body }
+
+    private sealed record Plan(string Verb, Payload Payload, string? ItemId = null);
+
+    // Flat GET reads (session id only, JSON DTO body).
+    private static readonly Dictionary<string, string> GetReads = new(StringComparer.OrdinalIgnoreCase)
     {
         ["turns"] = "turns",
         ["buffer/html"] = "buffer-html",
@@ -39,6 +47,22 @@ internal sealed class TunnelCatchAllDispatch
         ["context"] = "context",
         ["history"] = "history",
         ["github-urls"] = "github-urls",
+        ["queue"] = "queue-read",
+    };
+
+    // Flat writes keyed by "METHOD rest". Payload is the raw request body (empty for the no-body writes).
+    private static readonly Dictionary<string, string> BodyWrites = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["POST resize"] = "resize",
+        ["POST clear-context"] = "clear-context",
+        ["POST history-picker"] = "history-picker",
+        ["POST mobile-mode"] = "mobile-mode",
+        ["POST voice-mode"] = "voice-mode",
+        ["POST wingman-enabled"] = "wingman-enabled",
+        ["POST relink"] = "relink",
+        ["POST execute-action"] = "execute-action",
+        ["POST queue"] = "queue-add",
+        ["DELETE queue"] = "queue-clear",
     };
 
     /// <summary>
@@ -47,33 +71,106 @@ internal sealed class TunnelCatchAllDispatch
     /// </summary>
     public async Task<bool> TryDispatchAsync(HttpContext ctx, string sid, string directorId, string? rest)
     {
-        var verb = ResolveVerb(ctx.Request.Method, rest);
-        if (verb is null) return false;
+        var plan = Resolve(ctx.Request.Method, rest);
+        if (plan is null) return false;
 
-        var result = await DirectorCommandRouter.TrySendAsync(_sendCommand, directorId, verb, sid, null, ctx.RequestAborted);
+        string payloadJson = "";
+        if (plan.Payload == Payload.Body || plan.ItemId is not null)
+        {
+            // Buffer the request body so an HTTP fallback (no active stream) can still re-forward it.
+            ctx.Request.EnableBuffering();
+            var body = await ReadBodyAsync(ctx);
+            ctx.Request.Body.Position = 0;
+            payloadJson = plan.ItemId is not null ? FoldItemId(body, plan.ItemId) : body;
+        }
+
+        var command = new DirectorCommand
+        {
+            CommandId = Guid.NewGuid().ToString("N"),
+            Verb = plan.Verb,
+            SessionId = sid,
+            PayloadJson = payloadJson,
+        };
+
+        var result = await _sendCommand(directorId, command, ctx.RequestAborted);
+        FileLog.Write($"[TunnelCatchAllDispatch] {ctx.Request.Method} {rest} -> verb={plan.Verb} sid={sid}: {(result is null ? "no stream -> HTTP fallback" : result.Status.ToString())}");
         if (result is null) return false; // no active stream -> HTTP fallback
 
         await WriteResultAsync(ctx, result);
         return true;
     }
 
-    private static string? ResolveVerb(string method, string? rest)
+    private static Plan? Resolve(string method, string? rest)
     {
         if (rest is null) return null;
-        if (HttpMethods.IsGet(method) && GetVerbByRest.TryGetValue(rest, out var verb)) return verb;
+
+        if (HttpMethods.IsGet(method) && GetReads.TryGetValue(rest, out var readVerb))
+            return new Plan(readVerb, Payload.None);
+
+        if (BodyWrites.TryGetValue($"{method} {rest}", out var writeVerb))
+            return new Plan(writeVerb, Payload.Body);
+
+        // Queue path-parameterised verbs: queue/{itemId}[/move-up|/move-down|/send].
+        var segments = rest.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length >= 2 && string.Equals(segments[0], "queue", StringComparison.OrdinalIgnoreCase))
+        {
+            var itemId = segments[1];
+            if (segments.Length == 2)
+            {
+                if (HttpMethods.IsDelete(method)) return new Plan("queue-remove", Payload.Body, itemId);
+                if (HttpMethods.IsPatch(method)) return new Plan("queue-update", Payload.Body, itemId);
+            }
+            else if (segments.Length == 3 && HttpMethods.IsPost(method))
+            {
+                return segments[2].ToLowerInvariant() switch
+                {
+                    "move-up" => new Plan("queue-move-up", Payload.Body, itemId),
+                    "move-down" => new Plan("queue-move-down", Payload.Body, itemId),
+                    "send" => new Plan("queue-send", Payload.Body, itemId),
+                    _ => null,
+                };
+            }
+        }
+
         return null;
+    }
+
+    private static async Task<string> ReadBodyAsync(HttpContext ctx)
+    {
+        using var reader = new StreamReader(ctx.Request.Body, leaveOpen: true);
+        return await reader.ReadToEndAsync();
+    }
+
+    // Overlay the path {itemId} onto the request body's JSON object (empty body -> a fresh object), so the
+    // verb payload carries both the id from the path and any fields from the body (queue-update's text).
+    private static string FoldItemId(string body, string itemId)
+    {
+        JsonObject obj;
+        try
+        {
+            obj = string.IsNullOrWhiteSpace(body) ? new JsonObject() : (JsonNode.Parse(body)?.AsObject() ?? new JsonObject());
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            obj = new JsonObject();
+        }
+        obj["itemId"] = itemId;
+        return obj.ToJsonString();
     }
 
     // Map a DirectorCommandResult back to the HTTP response the browser expects - the same shape the Director
     // REST route returned (200 + application/json for Ok; the matching typed error code otherwise). BodyJson is
-    // already the serialized resource DTO, so it is written verbatim.
+    // already the serialized DTO, so it is written verbatim.
     private static async Task WriteResultAsync(HttpContext ctx, DirectorCommandResult result)
     {
         if (result.Ok)
         {
             ctx.Response.StatusCode = StatusCodes.Status200OK;
-            ctx.Response.ContentType = "application/json";
-            await ctx.Response.WriteAsync(result.BodyJson ?? "");
+            if (!string.IsNullOrEmpty(result.BodyJson))
+            {
+                ctx.Response.ContentType = "application/json";
+                await ctx.Response.WriteAsync(result.BodyJson);
+            }
             return;
         }
 


### PR DESCRIPTION
## What

Gateway Cleanup mission, **Phase 2 PR B2**: extend `TunnelCatchAllDispatch` to the session **WRITE** verbs that flow through the `/sessions/{sid}/{**rest}` catch-all - `resize`, `clear-context`, `history-picker`, `mobile-mode`, `voice-mode`, `wingman-enabled`, `relink`, `execute-action`, and the voice queue (`queue-read`/`add`/`update`/`remove`/`move-up`/`move-down`/`clear`/`send`). **Additive, behind the stream-mode flag** (off = byte-identical HTTP dial). The catch-all wiring is unchanged - it already calls `TryDispatchAsync` for every method.

## Marshaling

- reads and no-body writes carry **no payload** (target = the command `SessionId`);
- body-shaped writes pass the **raw request body straight through** as `PayloadJson` (the REST route and the tunnel verb share one DTO + core, so the bytes are identical);
- the queue **path-parameterised** verbs **fold** the `{itemId}` path segment into the payload JSON (per the Architect's note): `queue-update` overlays `itemId` onto the `{text}` body; `remove`/`move-up`/`move-down`/`send` carry just `{itemId}`.

The write body is buffered (`EnableBuffering`) and **rewound** when there is no active stream, so the HTTP fallback re-forwards the body intact. `DirectorCommandResult` maps back to the same HTTP shape the REST route returned (200/json on `Ok`, the typed error code otherwise).

## Tests

25 tests, all green: each read and write path maps to its verb; body passthrough is byte-identical; `queue-update` folds path `itemId` + body `text`; `remove`/`move`/`send` fold `itemId` with no body; `NotFound` -> 404, `BadRequest` -> 400; unmapped path / no active stream fall through (and the body is rewound for the forward).

## Next

- PR C: re-point the **literal** Gateway session routes still dialing HTTP (buffer, summary, git-status, handover, recap, wingman-view, snapshot, request-deletion, upload-image, wingman-ask) - same `TrySendAsync` pattern as the existing 9 write verbs.
- PR D: director-level reads (repos, facts, coaching-categories, claude-sessions, interrupted, fs-list) + assess the wingman-voice / voice-turn routes.
- Then the slot-5 tunnel-carries-all proof, then the gated Phase 1 deletion.

Git writes stay refused by the catch-all (the Gateway is a read-only window on source control) - unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)