### PR TITLE
feat(mission-screen): Phase 1b - durable, shared mission WHY store, editable inline (#1405)

### DIFF
--- a/apps/cockpit/src/missions/MissionsView.tsx
+++ b/apps/cockpit/src/missions/MissionsView.tsx
@@ -1,28 +1,33 @@
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { type SessionDto } from "@devthrottle/client-core/api/client";
 import { dotColor, effectiveColor, stateLabel } from "@devthrottle/client-core/sessions/ordering";
 import { useSharedRoster } from "@devthrottle/client-core/fleet/rosterStore";
+import { getMissionNotes, setMissionNote } from "@devthrottle/client-core/missions/missionNotes";
 import { repoBasename, relativeTime } from "../fleet/format";
 import { groupByMission, type MissionGroup } from "./missionGrouping";
 
-// The Missions page (issue #1405, Phase 1a): the same live fleet the Fleet Map draws, seen the way the
-// owner actually thinks about the work - grouped into MISSIONS rather than machines or repos. A mission
-// is derived purely from the session name ("<Mission> - <Role>") by the pure module missionGrouping.ts;
+// The Missions page (issue #1405): the same live fleet the Fleet Map draws, seen the way the owner
+// actually thinks about the work - grouped into MISSIONS rather than machines or repos. A mission is
+// derived purely from the session name ("<Mission> - <Role>") by the pure module missionGrouping.ts;
 // this page only lays the result out. Sessions that are not a mission member fall into a Standalone
 // group shown last.
 //
 // It reads the ONE shared fleet roster store (issue #1239) - the same GET /sessions envelope the Fleet
 // Map, Sessions, and Directors pages read from a single poll loop - never a Director address, and reuses
 // the ONE shared effective-color + state-label rule so a status dot here matches every other Cockpit
-// surface. Clicking a session row opens that session (/session/:id) - the "linking" this phase delivers.
+// surface. Clicking a session row opens that session (/session/:id) - the "linking".
 //
-// Phase 1a shows a WHY slot on every card with a loud "No why set" flag; Phase 1b wires a durable,
-// shared store behind it. Nothing here writes; nothing here parses (that is missionGrouping.ts).
+// The WHY (Phase 1b): every card carries its mission's WHY, front and center, from the durable + shared
+// Gateway mission-notes store (getMissionNotes / setMissionNote in client-core) - keyed by the SAME
+// normalized mission key groupByMission produces, so every client and the future chat/API read the same
+// WHY. A mission with no WHY shows a loud flag (the mission's founding rule), never a silent blank; the
+// flag is the button that adds one, and the WHY is editable inline. Roster parsing stays in
+// missionGrouping.ts; the only writes here go through the WHY store.
 
-// The Phase 1a placeholder for a mission's WHY, shown until Phase 1b wires the durable store. It is a
-// deliberately loud flag - a mission with no stated WHY is a red flag the screen makes obvious (the
-// mission's founding rule), never a silent blank.
+// The loud flag shown when a mission has no WHY set - a mission with no stated WHY is a red flag the
+// screen makes obvious (the mission's founding rule), never a silent blank. It is also the button that
+// opens the inline editor to add one.
 const NO_WHY_TEXT = "No why set - add one";
 
 export function MissionsView() {
@@ -30,6 +35,36 @@ export function MissionsView() {
   // Sessions, the unreachable-machine list, and the keep-last error banner all come from the ONE shared
   // roster store; no poll of its own.
   const { sessions, machineErrors, error: lastError } = useSharedRoster();
+
+  // The mission WHYs, keyed by the normalized mission key (the same key groupByMission produces). Read
+  // once on mount from the durable, shared Gateway store; refreshed in place after an inline edit. A
+  // failed read is non-fatal - the page still renders the fleet, every card just shows its flag.
+  const [whyByKey, setWhyByKey] = useState<Map<string, string>>(new Map());
+
+  const refreshNotes = useCallback(() => {
+    getMissionNotes()
+      .then((notes) => setWhyByKey(new Map(notes.map((n) => [n.key, n.why]))))
+      .catch(() => {
+        /* non-fatal: the WHYs are unavailable this load; the cards fall back to the flag */
+      });
+  }, []);
+
+  useEffect(() => {
+    refreshNotes();
+  }, [refreshNotes]);
+
+  // Save (or clear) one mission's WHY through the shared store, then reflect it locally. The store
+  // treats an empty why as "unset", so clearing returns the card to its flag.
+  const saveWhy = useCallback(async (missionName: string, why: string) => {
+    const note = await setMissionNote(missionName, why);
+    setWhyByKey((prev) => {
+      const next = new Map(prev);
+      const key = missionName.trim().toLowerCase();
+      if (note === null) next.delete(key);
+      else next.set(note.key, note.why);
+      return next;
+    });
+  }, []);
 
   const list = useMemo(() => sessions ?? [], [sessions]);
   const grouped = useMemo(() => groupByMission(list), [list]);
@@ -101,7 +136,13 @@ export function MissionsView() {
       {list.length > 0 && (
         <div className="msn-list">
           {grouped.missions.map((m) => (
-            <MissionCard key={m.key} mission={m} onOpen={openSession} />
+            <MissionCard
+              key={m.key}
+              mission={m}
+              why={whyByKey.get(m.key) ?? ""}
+              onSaveWhy={saveWhy}
+              onOpen={openSession}
+            />
           ))}
 
           {grouped.standalone.length > 0 && (
@@ -129,10 +170,12 @@ export function MissionsView() {
 
 interface MissionCardProps {
   mission: MissionGroup;
+  why: string;
+  onSaveWhy: (missionName: string, why: string) => Promise<void>;
   onOpen: (sessionId: string | null | undefined) => void;
 }
 
-function MissionCard({ mission, onOpen }: MissionCardProps) {
+function MissionCard({ mission, why, onSaveWhy, onOpen }: MissionCardProps) {
   const sessions = mission.members.map((m) => m.session);
 
   // The card's accent (left border) and status pill follow the same color rule as everything else: red
@@ -166,12 +209,9 @@ function MissionCard({ mission, onOpen }: MissionCardProps) {
         <MissionPill needs={needs} working={working} />
       </div>
 
-      {/* The WHY slot (issue #1405): first-class on every card from Phase 1a, shown as a loud flag until
-          Phase 1b wires the durable store. */}
-      <div className="msn-why msn-why-empty">
-        <span className="msn-why-k">Why</span>
-        <span className="msn-why-flag">{NO_WHY_TEXT}</span>
-      </div>
+      {/* The WHY slot (issue #1405): first-class on every card, front and center. The WHY comes from the
+          durable, shared Gateway store and is editable inline; a missing WHY shows the loud flag. */}
+      <WhySlot missionName={mission.name} why={why} onSave={onSaveWhy} />
 
       <div className="msn-sessions">
         {mission.members.map((m) => (
@@ -184,6 +224,94 @@ function MissionCard({ mission, onOpen }: MissionCardProps) {
         ))}
       </div>
     </section>
+  );
+}
+
+interface WhySlotProps {
+  missionName: string;
+  why: string;
+  onSave: (missionName: string, why: string) => Promise<void>;
+}
+
+// The WHY slot on a mission card: shows the mission's WHY front and center, or a loud flag when none is
+// set. Either the flag or an "Edit" affordance opens an inline editor; saving writes through the shared
+// store (an empty value clears the WHY back to the flag). Save errors are shown loudly and keep the
+// editor open rather than silently dropping the edit.
+function WhySlot({ missionName, why, onSave }: WhySlotProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(why);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const beginEdit = () => {
+    setDraft(why);
+    setError(null);
+    setEditing(true);
+  };
+
+  const cancel = () => {
+    setEditing(false);
+    setError(null);
+  };
+
+  const save = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave(missionName, draft);
+      setEditing(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not save the why");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (editing) {
+    return (
+      <div className="msn-why msn-why-editing">
+        <span className="msn-why-k">Why</span>
+        <div className="msn-why-edit">
+          <textarea
+            className="msn-why-input"
+            value={draft}
+            autoFocus
+            rows={2}
+            placeholder="Why are we on this mission?"
+            disabled={saving}
+            onChange={(e) => setDraft(e.target.value)}
+          />
+          <div className="msn-why-actions">
+            <button type="button" className="msn-why-save" disabled={saving} onClick={save}>
+              {saving ? "Saving..." : "Save"}
+            </button>
+            <button type="button" className="msn-why-cancel" disabled={saving} onClick={cancel}>
+              Cancel
+            </button>
+          </div>
+          {error !== null && <div className="msn-why-error">{error}</div>}
+        </div>
+      </div>
+    );
+  }
+
+  const hasWhy = why.trim().length > 0;
+  return (
+    <div className={hasWhy ? "msn-why" : "msn-why msn-why-empty"}>
+      <span className="msn-why-k">Why</span>
+      {hasWhy ? (
+        <>
+          <span className="msn-why-text">{why}</span>
+          <button type="button" className="msn-why-editbtn" onClick={beginEdit}>
+            Edit
+          </button>
+        </>
+      ) : (
+        <button type="button" className="msn-why-flag" onClick={beginEdit}>
+          {NO_WHY_TEXT}
+        </button>
+      )}
+    </div>
   );
 }
 

--- a/apps/cockpit/src/missions/missions.css
+++ b/apps/cockpit/src/missions/missions.css
@@ -200,15 +200,132 @@
   flex: 0 0 auto;
 }
 
-/* A missing WHY is a loud flag, never a silent blank (the mission's founding rule). */
+/* The set WHY, shown front and center on the card. */
+.msn-why-text {
+  flex: 1;
+  min-width: 0;
+  color: var(--text);
+  font-size: 12.5px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+/* A missing WHY is a loud flag, never a silent blank (the mission's founding rule). It is also the
+   button that opens the inline editor to add one. */
 .msn-why-flag {
   color: var(--warn);
   background: rgba(245, 158, 11, 0.1);
   border: 1px solid rgba(245, 158, 11, 0.35);
   border-radius: 5px;
-  padding: 2px 8px;
+  padding: 3px 8px;
   font-size: 11px;
   font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.msn-why-flag:hover {
+  background: rgba(245, 158, 11, 0.18);
+}
+
+/* The small "Edit" affordance next to a set WHY. */
+.msn-why-editbtn {
+  flex: 0 0 auto;
+  background: var(--btn, var(--surface-2));
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 2px 9px;
+  font-size: 11px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.msn-why-editbtn:hover {
+  color: var(--text);
+  background: var(--surface-2);
+}
+
+/* Inline editor: the slot lays its label at the top while the editor column grows. */
+.msn-why-editing {
+  align-items: flex-start;
+}
+
+.msn-why-k {
+  padding-top: 3px;
+}
+
+.msn-why-edit {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.msn-why-input {
+  width: 100%;
+  resize: vertical;
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 7px 9px;
+  font-size: 12.5px;
+  font-family: inherit;
+  line-height: 1.4;
+}
+
+.msn-why-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.msn-why-input::placeholder {
+  color: var(--text-dim);
+}
+
+.msn-why-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.msn-why-save {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 5px 13px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.msn-why-save:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.msn-why-cancel {
+  background: transparent;
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 5px 13px;
+  font-size: 12px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.msn-why-cancel:hover:not(:disabled) {
+  color: var(--text);
+}
+
+/* A save failure is shown loudly and keeps the editor open (no silent drop). */
+.msn-why-error {
+  color: var(--attention);
+  font-size: 11.5px;
 }
 
 /* ---- session rows ---- */

--- a/packages/client-core/src/missions/missionNotes.ts
+++ b/packages/client-core/src/missions/missionNotes.ts
@@ -1,0 +1,48 @@
+// Mission-WHY client for the Mission Screen (Phase 1b, issue #1405). Same-origin against the Gateway
+// front door with the injected Bearer (authHeaders), exactly like the AI settings client. The WHY store
+// is durable and shared on the Gateway, so every client (this Cockpit, the phone, the future
+// Mission-Control chat) reads and writes the SAME WHY through these two calls - never per-browser
+// storage. The mission is identified by the SAME normalized key the Cockpit's groupByMission derives;
+// the server lower-cases the display name, so the client sends the mission's display name as written.
+import { authHeaders, GatewayError } from "../api/client";
+
+/** One mission's WHY as the Gateway stores it (GET /gateway/missions/notes). */
+export interface MissionNote {
+  /** The normalized (trimmed, lower-cased) mission key - matches groupByMission's key. */
+  key: string;
+  /** The mission display name as last written. */
+  mission: string;
+  /** The WHY text (never empty - an empty why is stored as "unset", i.e. no note). */
+  why: string;
+  /** When the WHY was last set (ISO-8601 UTC). */
+  updatedAt: string;
+}
+
+/** All set WHYs. A mission with no note simply has no entry (the card shows its "no why set" flag). */
+export async function getMissionNotes(): Promise<MissionNote[]> {
+  const res = await fetch("/gateway/missions/notes", {
+    method: "GET",
+    headers: { Accept: "application/json", ...authHeaders() },
+  });
+  if (!res.ok) throw new GatewayError(res.status, `GET /gateway/missions/notes failed: ${res.status}`);
+  const body = (await res.json()) as { notes?: MissionNote[] };
+  return Array.isArray(body.notes) ? body.notes : [];
+}
+
+/**
+ * Set (or clear) a mission's WHY. An empty or whitespace-only `why` UNSETS it (the card returns to its
+ * flag). Returns the stored note, or null when it was cleared.
+ */
+export async function setMissionNote(mission: string, why: string): Promise<MissionNote | null> {
+  const res = await fetch("/gateway/missions/notes", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
+    body: JSON.stringify({ mission, why }),
+  });
+  if (!res.ok) {
+    const err = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new GatewayError(res.status, err.error ?? `PUT /gateway/missions/notes failed: ${res.status}`);
+  }
+  const body = (await res.json()) as { note?: MissionNote | null };
+  return body.note ?? null;
+}

--- a/src/CcDirector.Gateway.Tests/MissionNoteStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/MissionNoteStoreTests.cs
@@ -1,0 +1,143 @@
+using CcDirector.Gateway.MissionNotes;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for the Gateway-owned mission-WHY store (Mission Screen mission, Phase 1b, issue #1405):
+/// the durable, shared <c>missionKey -&gt; why</c> map behind the Mission Screen. Covers set/get/all,
+/// the empty-why-unsets rule, key normalization (the same lower-cased grouping key the Cockpit derives),
+/// and the persistence contract (write-through + reload on a fresh store + corrupt quarantine). Every
+/// test uses an isolated temp path so it never touches the real mission-notes.json.
+/// </summary>
+public sealed class MissionNoteStoreTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "cc-missionnotes-" + Guid.NewGuid().ToString("N"));
+
+    private string Path_ => System.IO.Path.Combine(_dir, "mission-notes.json");
+
+    private static readonly DateTime Now = new(2026, 7, 12, 12, 0, 0, DateTimeKind.Utc);
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, true); } catch { }
+    }
+
+    [Fact]
+    public void Set_then_Get_returns_the_why_with_the_display_name_and_updated_time()
+    {
+        var store = new MissionNoteStore(Path_);
+        var note = store.Set("Gateway Cleanup", "Kill Director remote REST; all traffic onto the tunnel.", Now);
+
+        Assert.NotNull(note);
+        Assert.Equal("gateway cleanup", note!.Key);
+        Assert.Equal("Gateway Cleanup", note.Mission);
+        Assert.Equal("Kill Director remote REST; all traffic onto the tunnel.", note.Why);
+        Assert.Equal(Now, note.UpdatedAtUtc);
+
+        var got = store.Get("Gateway Cleanup");
+        Assert.NotNull(got);
+        Assert.Equal("Kill Director remote REST; all traffic onto the tunnel.", got!.Why);
+    }
+
+    [Fact]
+    public void Get_matches_case_insensitively_on_the_normalized_key()
+    {
+        var store = new MissionNoteStore(Path_);
+        store.Set("Car Mode", "Hands-free fleet voice from the phone.", Now);
+
+        // A different display casing resolves to the same note (the groupByMission key is lower-cased).
+        Assert.NotNull(store.Get("car mode"));
+        Assert.NotNull(store.Get("CAR MODE"));
+        Assert.Equal("Car Mode", store.Get("car MODE")!.Mission);
+    }
+
+    [Fact]
+    public void Set_again_overwrites_the_same_key_and_refreshes_the_display_name_and_time()
+    {
+        var store = new MissionNoteStore(Path_);
+        store.Set("mobile resilience", "first why", Now);
+        var later = Now.AddMinutes(30);
+        var note = store.Set("Mobile Resilience", "second why", later);
+
+        Assert.NotNull(note);
+        Assert.Equal("second why", note!.Why);
+        Assert.Equal("Mobile Resilience", note.Mission);   // display refreshed to the latest write
+        Assert.Equal(later, note.UpdatedAtUtc);
+        Assert.Single(store.All());                        // still one note under the one key, not two
+    }
+
+    [Fact]
+    public void An_empty_or_whitespace_why_unsets_the_note()
+    {
+        var store = new MissionNoteStore(Path_);
+        store.Set("Snooze Length", "a real why", Now);
+        Assert.NotNull(store.Get("Snooze Length"));
+
+        // Empty why clears it (the card shows its "no why set" flag again).
+        var cleared = store.Set("Snooze Length", "   ", Now);
+        Assert.Null(cleared);
+        Assert.Null(store.Get("Snooze Length"));
+        Assert.Empty(store.All());
+
+        // Clearing an already-absent note is a no-op that returns null.
+        Assert.Null(store.Set("Snooze Length", "", Now));
+    }
+
+    [Fact]
+    public void Set_trims_outer_whitespace_from_the_stored_why()
+    {
+        var store = new MissionNoteStore(Path_);
+        var note = store.Set("Local Files", "   clickable remote viewer   ", Now);
+        Assert.Equal("clickable remote viewer", note!.Why);
+    }
+
+    [Fact]
+    public void Set_with_a_blank_mission_is_rejected()
+    {
+        var store = new MissionNoteStore(Path_);
+        Assert.Throws<ArgumentException>(() => store.Set("   ", "why", Now));
+    }
+
+    [Fact]
+    public void All_returns_a_stable_snapshot_detached_from_the_live_store()
+    {
+        var store = new MissionNoteStore(Path_);
+        store.Set("Alpha", "a", Now);
+        store.Set("Beta", "b", Now);
+
+        var snapshot = store.All();
+        store.Set("Alpha", "", Now);   // clear after snapshotting
+
+        Assert.Equal(2, snapshot.Count);          // the snapshot did not change under us
+        Assert.Single(store.All());               // the live store did
+        Assert.Equal(new[] { "alpha", "beta" }, snapshot.Select(n => n.Key).ToArray()); // ordered by key
+    }
+
+    [Fact]
+    public void A_set_why_survives_a_restart_reloaded_from_disk()
+    {
+        var store1 = new MissionNoteStore(Path_);
+        store1.Set("Gateway Cleanup", "all traffic onto the tunnel", Now);
+
+        // A fresh store over the same file = a Gateway restart. The WHY must reload.
+        var store2 = new MissionNoteStore(Path_);
+        var got = store2.Get("gateway cleanup");
+        Assert.NotNull(got);
+        Assert.Equal("all traffic onto the tunnel", got!.Why);
+        Assert.Equal("Gateway Cleanup", got.Mission);
+    }
+
+    [Fact]
+    public void A_corrupt_file_is_quarantined_and_the_store_starts_empty()
+    {
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(Path_, "{ this is not valid json ");
+
+        var store = new MissionNoteStore(Path_);   // must not throw - the Gateway still boots
+        Assert.Empty(store.All());
+
+        var quarantined = Directory.GetFiles(_dir, "mission-notes.json.corrupt-*");
+        Assert.Single(quarantined);                // the bad bytes were preserved, not overwritten
+    }
+}

--- a/src/CcDirector.Gateway.Tests/MissionNotesEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/MissionNotesEndpointTests.cs
@@ -1,0 +1,205 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json;
+using CcDirector.Gateway;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// HTTP tests for the mission-WHY surface (Mission Screen mission, Phase 1b, issue #1405) over a real
+/// Gateway with auth ON. Two things are PROVEN here, not assumed:
+///  1. AUTH: an unauthenticated GET and PUT of /gateway/missions/notes both return the JSON 401 - the
+///     host-wide device-key middleware really does gate this new client route (the Architect's hard
+///     requirement). A wrong assumption here would leave every mission's WHY world-readable/writable.
+///  2. DURABLE + SHARED: a WHY set through one authenticated client is read back by a FRESH client, and
+///     survives a Gateway restart (a second host over the same store file) - the mission's core promise
+///     that the WHY is not per-browser.
+/// Every test uses an isolated temp store path so it never touches the real mission-notes.json.
+/// </summary>
+public sealed class MissionNotesEndpointTests : IAsyncLifetime
+{
+    private const string Token = "test-token-1405";
+    private const string Route = "/gateway/missions/notes";
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "cc-missionnotes-ep-" + Guid.NewGuid().ToString("N"));
+    private string MissionNotesPath => Path.Combine(_dir, "mission-notes.json");
+    private string InstancesDir => Path.Combine(_dir, "instances");
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: InstancesDir,
+            workListsPath: Path.Combine(_dir, "worklists.json"),
+            missionNotesPath: MissionNotesPath);
+        await _gateway.StartAsync();
+
+        _http = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false })
+        {
+            BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/"),
+        };
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, true); }
+        catch { /* best-effort temp cleanup */ }
+    }
+
+    // ---- 1. AUTH PROOF (the Architect's hard requirement) ------------------------------------
+
+    [Fact]
+    public async Task Unauthenticated_GET_is_401()
+    {
+        using var res = await _http.GetAsync(Route);
+        Assert.Equal(HttpStatusCode.Unauthorized, res.StatusCode);
+    }
+
+    [Fact]
+    public async Task Unauthenticated_PUT_is_401()
+    {
+        using var res = await _http.PutAsJsonAsync(Route, new { mission = "Car Mode", why = "sneaky" });
+        Assert.Equal(HttpStatusCode.Unauthorized, res.StatusCode);
+        // And the write was refused, not silently applied: an authenticated read shows nothing.
+        Assert.Null(await GetWhy("Car Mode"));
+    }
+
+    // ---- 2. AUTHENTICATED READ/SET ------------------------------------------------------------
+
+    [Fact]
+    public async Task Authenticated_GET_is_initially_empty()
+    {
+        using var res = await Authed(HttpMethod.Get, Route);
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+        using var doc = JsonDocument.Parse(await res.Content.ReadAsStringAsync());
+        Assert.Empty(doc.RootElement.GetProperty("notes").EnumerateArray());
+    }
+
+    [Fact]
+    public async Task PUT_sets_a_why_and_GET_reads_it_back()
+    {
+        using var put = await AuthedJson(HttpMethod.Put, Route, new { mission = "Gateway Cleanup", why = "all traffic onto the tunnel" });
+        Assert.Equal(HttpStatusCode.OK, put.StatusCode);
+
+        using var putDoc = JsonDocument.Parse(await put.Content.ReadAsStringAsync());
+        var note = putDoc.RootElement.GetProperty("note");
+        Assert.Equal("gateway cleanup", note.GetProperty("key").GetString());
+        Assert.Equal("Gateway Cleanup", note.GetProperty("mission").GetString());
+        Assert.Equal("all traffic onto the tunnel", note.GetProperty("why").GetString());
+
+        Assert.Equal("all traffic onto the tunnel", await GetWhy("Gateway Cleanup"));
+    }
+
+    [Fact]
+    public async Task A_blank_mission_is_400()
+    {
+        using var res = await AuthedJson(HttpMethod.Put, Route, new { mission = "   ", why = "x" });
+        Assert.Equal(HttpStatusCode.BadRequest, res.StatusCode);
+    }
+
+    [Fact]
+    public async Task PUT_with_an_empty_why_clears_the_note()
+    {
+        using (var set = await AuthedJson(HttpMethod.Put, Route, new { mission = "Snooze Length", why = "timed snooze that always comes back" }))
+            Assert.Equal(HttpStatusCode.OK, set.StatusCode);
+        Assert.Equal("timed snooze that always comes back", await GetWhy("Snooze Length"));
+
+        using var clear = await AuthedJson(HttpMethod.Put, Route, new { mission = "Snooze Length", why = "" });
+        Assert.Equal(HttpStatusCode.OK, clear.StatusCode);
+        using var doc = JsonDocument.Parse(await clear.Content.ReadAsStringAsync());
+        Assert.True(doc.RootElement.GetProperty("cleared").GetBoolean());
+
+        Assert.Null(await GetWhy("Snooze Length"));
+    }
+
+    // ---- 2b. DURABLE + SHARED -----------------------------------------------------------------
+
+    [Fact]
+    public async Task A_why_is_read_by_a_fresh_client_and_survives_a_restart()
+    {
+        using (var set = await AuthedJson(HttpMethod.Put, Route, new { mission = "Mission Screen", why = "keep the owner oriented across the fleet" }))
+            Assert.Equal(HttpStatusCode.OK, set.StatusCode);
+
+        // A FRESH client (a different browser) against the SAME running Gateway sees the same WHY - it is
+        // shared, not per-browser.
+        using (var fresh = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") })
+        {
+            fresh.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            Assert.Equal("keep the owner oriented across the fleet", await GetWhy("Mission Screen", fresh));
+        }
+
+        // A Gateway restart: a second host over the SAME store file re-serves the WHY - it is durable.
+        await _gateway.StopAsync();
+        var restarted = new GatewayHost(port: FreePort(), token: Token, authEnabled: true,
+            instancesDirectory: InstancesDir,
+            workListsPath: Path.Combine(_dir, "worklists.json"),
+            missionNotesPath: MissionNotesPath);
+        await restarted.StartAsync();
+        try
+        {
+            using var afterRestart = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{restarted.Port}/") };
+            afterRestart.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            Assert.Equal("keep the owner oriented across the fleet", await GetWhy("Mission Screen", afterRestart));
+        }
+        finally
+        {
+            await restarted.StopAsync();
+            // Re-arm the field host so DisposeAsync's StopAsync is a no-op-safe double stop on a stopped host.
+            _gateway = restarted;
+        }
+    }
+
+    // ---- helpers ------------------------------------------------------------------------------
+
+    private Task<HttpResponseMessage> Authed(HttpMethod method, string path)
+    {
+        var req = new HttpRequestMessage(method, path);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+        return _http.SendAsync(req);
+    }
+
+    private Task<HttpResponseMessage> AuthedJson(HttpMethod method, string path, object body)
+    {
+        var req = new HttpRequestMessage(method, path)
+        {
+            Content = JsonContent.Create(body),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+        return _http.SendAsync(req);
+    }
+
+    // The WHY currently stored for a mission (via the authenticated GET-all), or null when none is set.
+    private async Task<string?> GetWhy(string mission, HttpClient? client = null)
+    {
+        var http = client ?? _http;
+        using var req = new HttpRequestMessage(HttpMethod.Get, Route);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+        using var res = await http.SendAsync(req);
+        res.EnsureSuccessStatusCode();
+        using var doc = JsonDocument.Parse(await res.Content.ReadAsStringAsync());
+        var key = mission.Trim().ToLowerInvariant();
+        foreach (var n in doc.RootElement.GetProperty("notes").EnumerateArray())
+        {
+            if (n.GetProperty("key").GetString() == key)
+                return n.GetProperty("why").GetString();
+        }
+        return null;
+    }
+
+    private static int FreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/src/CcDirector.Gateway/Api/MissionNotesEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/MissionNotesEndpoint.cs
@@ -1,0 +1,65 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.MissionNotes;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The mission-WHY surface for the Mission Screen (Phase 1b, issue #1405): read all WHYs and set one.
+/// Backed by <see cref="MissionNoteStore"/> (durable + shared, keyed by the mission's normalized name).
+///
+/// AUTH: these are device-authed CLIENT routes. They carry no per-route auth of their own - they sit
+/// under the non-public "/gateway/..." prefix, so the host-wide device-key middleware
+/// (<see cref="Util.AuthMiddleware"/>) gates them exactly like every other client data endpoint (an
+/// unauthenticated caller gets the JSON 401). This is PROVEN, not assumed, by
+/// MissionNotesEndpointTests (an unauthenticated GET and PUT both 401 over real HTTP).
+///
+/// This is a client-to-Gateway HTTP surface only; it does NOT touch Director-to-Gateway tunnel traffic
+/// (the Gateway Cleanup mission), and it deliberately stays out of GatewayEndpoints.cs and off the bare
+/// "/missions" prefix, which the Gateway-native mission store already owns.
+/// </summary>
+internal static class MissionNotesEndpoint
+{
+    public static void Map(IEndpointRouteBuilder app, MissionNoteStore store)
+    {
+        // Every set WHY, for the Mission Screen to show on each card. The Cockpit matches a note to a
+        // mission by the normalized key its own groupByMission produces.
+        app.MapGet("/gateway/missions/notes", () =>
+            Results.Json(new { notes = store.All().Select(Project).ToList() }));
+
+        // Set (or clear) one mission's WHY. An empty/whitespace why UNSETS it (the card shows its flag);
+        // any other value stores the trimmed WHY.
+        app.MapPut("/gateway/missions/notes", (MissionNoteBody? req) =>
+        {
+            if (req is null || string.IsNullOrWhiteSpace(req.Mission))
+                return Results.Json(new { error = "mission is required" }, statusCode: StatusCodes.Status400BadRequest);
+            try
+            {
+                var note = store.Set(req.Mission, req.Why, DateTime.UtcNow);
+                FileLog.Write($"[MissionNotesEndpoint] PUT mission='{req.Mission}', cleared={note is null}");
+                return Results.Json(new { note = note is null ? null : Project(note), cleared = note is null });
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status400BadRequest);
+            }
+        });
+    }
+
+    private static object Project(MissionNoteStore.MissionNote n) => new
+    {
+        key = n.Key,
+        mission = n.Mission,
+        why = n.Why,
+        updatedAt = n.UpdatedAtUtc,
+    };
+}
+
+/// <summary>Body of the set route: the mission display name and its WHY (empty/whitespace clears it).</summary>
+public sealed class MissionNoteBody
+{
+    public string Mission { get; set; } = "";
+    public string? Why { get; set; }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -301,6 +301,11 @@ public sealed class GatewayHost : IAsyncDisposable
     // built and started in StartAsync (it needs the live Director client) and disposed in StopAsync.
     private readonly Snooze.SnoozeRegistry _snoozeRegistry;
     private Snooze.SnoozeExpirySweep? _snoozeSweep;
+    // Mission Screen mission (Phase 1b, issue #1405): the Gateway-owned, restart-surviving store of each
+    // mission's WHY, keyed by the mission's normalized name. Durable + shared so every Cockpit, the phone,
+    // and the future Mission-Control chat/API read the same WHY. Constructed here (load-on-construct
+    // re-serves every WHY after a restart); exposed to the client over MissionNotesEndpoint.
+    private readonly MissionNotes.MissionNoteStore _missionNotes;
     private readonly CronJobStore _cronJobs;
     private readonly CronRunHistoryStore _cronRuns;
     private readonly Running.CronEngine _cronEngine;
@@ -413,7 +418,12 @@ public sealed class GatewayHost : IAsyncDisposable
     /// isolated temp path; production omits it for the shared default at
     /// <c>CcStorage.Root()\missions.json</c>.
     /// </param>
-    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? snoozePath = null, string? missionsPath = null)
+    /// <param name="missionNotesPath">
+    /// Override the mission-WHY store file (Mission Screen mission, Phase 1b, issue #1405). Tests pass an
+    /// isolated temp path; production omits it for the shared default at
+    /// <c>CcStorage.Root()\mission-notes.json</c>.
+    /// </param>
+    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? snoozePath = null, string? missionsPath = null, string? missionNotesPath = null)
     {
         Port = port;
         Token = token ?? GatewayAuth.LoadOrCreate();
@@ -484,6 +494,10 @@ public sealed class GatewayHost : IAsyncDisposable
         // registry is bounded by dropping a removed Director's entries so they do not accumulate on disk.
         _snoozeRegistry = new Snooze.SnoozeRegistry(snoozePath ?? Path.Combine(CcStorage.Root(), "snooze.json"));
         Registry.OnDirectorRemoved += id => _snoozeRegistry.ClearForDirector(id);
+        // Mission Screen mission (Phase 1b, issue #1405): the mission-WHY store, at a Gateway-side file
+        // (CcStorage.Root(), the same location the snooze and cron stores use). Loaded here so a Gateway
+        // restart re-serves every WHY. Tests MUST pass an isolated path so they never touch the real store.
+        _missionNotes = new MissionNotes.MissionNoteStore(missionNotesPath ?? Path.Combine(CcStorage.Root(), "mission-notes.json"));
         // Cron-job definitions persist across a Gateway restart (epic #479, #482): one JSON file in
         // the Gateway data dir, loaded here (next-run times recomputed) and written through on every
         // mutation - the WorkListStore precedent. Tests MUST pass an isolated path so they never
@@ -1478,6 +1492,12 @@ public sealed class GatewayHost : IAsyncDisposable
         TurnBriefGatewayEndpoints.Map(_app, _turnBriefStore,
             sid => _turnBriefStore.Latest(sid) is not null ? "Briefed" : "None",
             requestExplainAsync: null);
+
+        // Mission Screen mission (Phase 1b, issue #1405): the mission-WHY read/set surface. A device-authed
+        // client route under /gateway/missions/notes - the host-wide token middleware gates it (proven by
+        // MissionNotesEndpointTests). Deliberately NOT in GatewayEndpoints.cs and NOT on the bare /missions
+        // prefix (the Gateway-native mission store owns that), so it stays clear of the Gateway Cleanup work.
+        MissionNotesEndpoint.Map(_app, _missionNotes);
 
         // Issue #806 (mobile foundation): the OpenAPI document the mobile codegen consumes, and the
         // mobile app static serving at /m (built shell + token-injected index.html). Mapped before

--- a/src/CcDirector.Gateway/MissionNotes/MissionNoteStore.cs
+++ b/src/CcDirector.Gateway/MissionNotes/MissionNoteStore.cs
@@ -1,0 +1,216 @@
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.MissionNotes;
+
+/// <summary>
+/// The Gateway-owned, restart-surviving store of each mission's WHY (Mission Screen mission, Phase 1b,
+/// issue #1405). The Mission Screen's founding rule is that every mission states a WHY shown front and
+/// center; a missing WHY is a loud flag. That WHY must be DURABLE and SHARED - every Cockpit, the phone,
+/// and the future Mission-Control chat/API must read the same WHY - so it lives here on the Gateway, not
+/// in any one browser's local storage.
+///
+/// KEYING (Phase 1b is a known stepping stone): a note is keyed by the mission's NORMALIZED name - the
+/// SAME lowercased key the Cockpit's groupByMission derives from the "&lt;Mission&gt; - &lt;Role&gt;"
+/// session-name convention - so the note attaches to the derived mission regardless of display casing.
+/// The display name is stored alongside for reference. This name-keying ORPHANS a note if a mission's
+/// sessions are renamed; when missions become first-class objects (Phase 3) with a stable id - the
+/// Gateway-native <see cref="CcDirector.Core.Sessions.MissionStore"/> (missions.json) is that target -
+/// the WHY re-keys onto the stable mission id and this name-key becomes a migration source.
+///
+/// UNSET (issue #1405): a WHY that is empty or all-whitespace is treated as UNSET - the note is removed,
+/// so the Mission Screen shows its "no why set" flag rather than a blank. A PUT with an empty why is the
+/// clear path.
+///
+/// PERSISTENCE (SnoozeRegistry precedent): the whole store is ONE plain JSON file at the path the
+/// constructor receives (production: mission-notes.json in the Gateway data dir). Every mutation writes
+/// through immediately with an atomic temp-file + rename, so a crash mid-write can never half-truncate
+/// the store. On construction the file is loaded back so a Gateway restart re-serves every WHY. A corrupt
+/// file is quarantined (never silently overwritten) and the store starts empty so the Gateway still boots.
+///
+/// NO FALLBACK (CLAUDE.md): a failed persist is a LOGGED error that PROPAGATES - a WHY that cannot be
+/// written to disk would silently vanish on the next restart, so the caller's request fails loudly.
+/// </summary>
+public sealed class MissionNoteStore
+{
+    private readonly object _gate = new();
+    private readonly string _path;
+
+    // normalized mission key -> note. Ordinal keys: the key is already lower-cased by NormalizeKey.
+    private readonly Dictionary<string, MissionNote> _notes = new(StringComparer.Ordinal);
+
+    private static readonly JsonSerializerOptions FileJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
+    };
+
+    /// <param name="path">
+    /// The JSON file the store persists to. REQUIRED so no caller can silently land on the real user's
+    /// file: production (<see cref="GatewayHost"/>) passes mission-notes.json in the Gateway data dir;
+    /// tests pass an isolated temp path.
+    /// </param>
+    /// <exception cref="ArgumentException">The path is null/empty/whitespace.</exception>
+    public MissionNoteStore(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("store path is required", nameof(path));
+        _path = path;
+        Load();
+    }
+
+    /// <summary>One mission's WHY: the normalized grouping key, the display name as last written, the
+    /// WHY text, and when it was last set.</summary>
+    public sealed record MissionNote(string Key, string Mission, string Why, DateTime UpdatedAtUtc);
+
+    /// <summary>
+    /// The grouping key for a mission display name: trimmed and lower-cased, matching the Cockpit's
+    /// groupByMission key so a note attaches to the mission regardless of display casing.
+    /// </summary>
+    public static string NormalizeKey(string mission) => (mission ?? "").Trim().ToLowerInvariant();
+
+    /// <summary>
+    /// Set (or clear) a mission's WHY. An empty or all-whitespace <paramref name="why"/> UNSETS the note
+    /// (removes it) so the screen shows its flag; any other value stores the trimmed WHY. Returns the
+    /// resulting note, or null when the note was cleared/left unset. Written through to disk before
+    /// returning. <paramref name="nowUtc"/> is injected so tests are deterministic.
+    /// </summary>
+    /// <exception cref="ArgumentException">The mission name is null/empty/whitespace.</exception>
+    public MissionNote? Set(string mission, string? why, DateTime nowUtc)
+    {
+        var display = (mission ?? "").Trim();
+        if (display.Length == 0)
+            throw new ArgumentException("mission is required", nameof(mission));
+
+        var key = NormalizeKey(display);
+        lock (_gate)
+        {
+            var trimmed = (why ?? "").Trim();
+            if (trimmed.Length == 0)
+            {
+                if (_notes.Remove(key))
+                {
+                    Save();
+                    FileLog.Write($"[MissionNoteStore] Set: cleared why for mission='{display}' (key={key})");
+                }
+                return null;
+            }
+
+            var note = new MissionNote(key, display, trimmed, nowUtc.ToUniversalTime());
+            _notes[key] = note;
+            Save();
+            FileLog.Write($"[MissionNoteStore] Set: mission='{display}' (key={key}), why length={trimmed.Length}");
+            return note;
+        }
+    }
+
+    /// <summary>The note for a mission display name, or null when none is set.</summary>
+    public MissionNote? Get(string mission)
+    {
+        var key = NormalizeKey(mission);
+        if (key.Length == 0) return null;
+        lock (_gate)
+            return _notes.TryGetValue(key, out var n) ? n : null;
+    }
+
+    /// <summary>A snapshot of every set WHY, ordered by key so the read is stable. A copy, detached from
+    /// the live collection.</summary>
+    public IReadOnlyList<MissionNote> All()
+    {
+        lock (_gate)
+            return _notes.Values.OrderBy(n => n.Key, StringComparer.Ordinal).ToList();
+    }
+
+    // ---- persistence (SnoozeRegistry precedent) ----------------------------------------------
+
+    /// <summary>The on-disk shape: one document holding every mission WHY.</summary>
+    private sealed class StoreFile
+    {
+        public List<MissionNote> Notes { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Load the store file written by a previous Gateway run so a restart re-serves every WHY. A missing
+    /// file is the normal first boot (empty store, logged). A corrupt file is quarantined (renamed with a
+    /// timestamp suffix) so its bytes are preserved for the operator and never silently overwritten; the
+    /// store then starts empty so the Gateway still boots.
+    /// </summary>
+    private void Load()
+    {
+        if (!File.Exists(_path))
+        {
+            FileLog.Write($"[MissionNoteStore] Load: no store file at {_path}; starting empty");
+            return;
+        }
+
+        StoreFile? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize<StoreFile>(File.ReadAllText(_path), FileJsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            Quarantine(ex.Message);
+            return;
+        }
+
+        if (parsed is null)
+        {
+            Quarantine("file deserialized to null (no store document)");
+            return;
+        }
+
+        var loaded = 0;
+        foreach (var n in parsed.Notes)
+        {
+            var key = NormalizeKey(n.Mission);
+            if (key.Length == 0 || string.IsNullOrWhiteSpace(n.Why))
+                continue; // skip a malformed/empty row rather than fail the whole boot
+            _notes[key] = n with { Key = key, UpdatedAtUtc = n.UpdatedAtUtc.ToUniversalTime() };
+            loaded++;
+        }
+
+        FileLog.Write($"[MissionNoteStore] Load: loaded {loaded} mission why(s) from {_path}");
+    }
+
+    /// <summary>
+    /// Preserve an unreadable store file as "&lt;path&gt;.corrupt-&lt;stamp&gt;" and log loudly. The
+    /// original path is then free for the next write-through. If even the quarantine fails, the exception
+    /// propagates and the Gateway does not start half-blind.
+    /// </summary>
+    private void Quarantine(string reason)
+    {
+        var quarantinePath = $"{_path}.corrupt-{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}";
+        File.Move(_path, quarantinePath);
+        FileLog.Write($"[MissionNoteStore] Load FAILED: store file at {_path} is corrupt ({reason}); quarantined to {quarantinePath}; starting empty. Operator action: inspect the quarantined file to recover mission whys.");
+    }
+
+    /// <summary>
+    /// Write-through: serialize the whole store and atomically replace the file (temp + rename), so a
+    /// concurrent reader or a crash mid-write never sees a half-written store. Called inside the lock by
+    /// every mutation. A failed save is a LOGGED error that PROPAGATES (the caller's request fails
+    /// loudly) - never a silent skip, because a WHY that did not persist would vanish on the next restart.
+    /// </summary>
+    private void Save()
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(_path);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            var file = new StoreFile { Notes = _notes.Values.ToList() };
+            var json = JsonSerializer.Serialize(file, FileJsonOptions);
+
+            var tmp = _path + ".tmp";
+            File.WriteAllText(tmp, json);
+            File.Move(tmp, _path, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[MissionNoteStore] Save FAILED: path={_path}: {ex.Message}");
+            throw;
+        }
+    }
+}


### PR DESCRIPTION
Part of thefrederiksen/devthrottle_internal#765 (the Mission Screen mission, Phase 1b). Builds on the Phase 1a grouped Missions page (#1440).

Every mission on the Mission Screen now carries its **WHY**, front and center, from a **durable and shared** Gateway store. A mission with no stated WHY shows a loud flag (the mission's founding rule); a set WHY is read the same by every client and the future Mission-Control chat, never per-browser.

## Gateway (a client-to-Gateway HTTP surface only - no Director-tunnel traffic)

- **`MissionNoteStore`** - the Gateway-owned, restart-surviving store of each mission's WHY. One JSON file (`mission-notes.json`) with an atomic temp-file + rename write and corrupt-file quarantine, mirroring `SnoozeRegistry`. Keyed by the mission's **normalized name** - the SAME lowercased key the Cockpit's `groupByMission` derives - with the display name stored alongside. An empty/whitespace WHY is **UNSET** (the note is removed) so the card returns to its flag. A failed persist is a logged error that propagates (no fallback). Name-keying is a known **Phase-3 stepping stone**: a code comment points the re-key at the native `MissionStore`.
- **`MissionNotesEndpoint`** - `GET /gateway/missions/notes` (all) and `PUT` (one). A blank mission is 400; save errors are surfaced.
- **`GatewayHost` wiring only** - field, constructor path parameter + doc, construction, one `.Map` call. Additive, staying out of `GatewayEndpoints.cs` and the tunnel files (confirmed no collision with the Gateway Cleanup mission).

## Client

- **`client-core/missions/missionNotes.ts`** - `getMissionNotes` / `setMissionNote` over the two routes with the injected Bearer, reusable by any surface (Cockpit, phone, future chat).
- **Cockpit Missions page** - reads the WHYs once on mount and shows each mission's WHY on its card. A new inline **`WhySlot`** editor turns the flag (or an Edit affordance) into a textarea with Save/Cancel, writes through the shared store, clears back to the flag on an empty value, and shows a save failure loudly instead of dropping the edit.

## Files (8)

- NEW `src/CcDirector.Gateway/MissionNotes/MissionNoteStore.cs`
- NEW `src/CcDirector.Gateway/Api/MissionNotesEndpoint.cs`
- `src/CcDirector.Gateway/GatewayHost.cs` (additive wiring)
- NEW `src/CcDirector.Gateway.Tests/MissionNoteStoreTests.cs`
- NEW `src/CcDirector.Gateway.Tests/MissionNotesEndpointTests.cs`
- NEW `packages/client-core/src/missions/missionNotes.ts`
- `apps/cockpit/src/missions/MissionsView.tsx`
- `apps/cockpit/src/missions/missions.css`

## Proofs

**Auth (device-key gating proven, not assumed):** a Gateway test boots a real host with auth ON and fires an unauthenticated `GET` and `PUT` at `/gateway/missions/notes` - **both return 401**, and the unauthenticated `PUT` does not write (an authenticated read after shows nothing). The route is not in `AuthMiddleware.PublicPaths`, so the host-wide middleware gates it - no per-route check needed.

**Durable + shared:** a Gateway test sets a WHY through one authenticated client, then (a) a **fresh** `HttpClient` against the same running host reads the same WHY back (shared, not per-browser), and (b) after a **Gateway restart** - a second host over the same `mission-notes.json` - a new client still reads it (durable). An empty `PUT` clears it (`cleared: true`).

**UI (Playwright over the Vite dev server):** the loud "No why set - add one" flag opens the inline editor; typing a WHY and Save shows it front and center with an Edit affordance; a **full page reload persists** the WHY and the flag clears (flags 4 -> 3). Screenshot of a card with a real WHY set (Car Mode) alongside the still-flagged missions: `scratchpad/1b-saved.png` on SOREN_NORTH.

**Tests:** 16 Gateway (9 store unit + 7 real-HTTP) + 14 mission-grouping, all green. `tsc --noEmit` clean for the Cockpit and client-core.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
