### PR TITLE
feat(gateway-cleanup): Phase 2 - MessagePack tunnel protocol (root-cause fix for large up-stream frames)

### DIFF
--- a/src/CcDirector.ControlApi/CcDirector.ControlApi.csproj
+++ b/src/CcDirector.ControlApi/CcDirector.ControlApi.csproj
@@ -11,7 +11,12 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <!-- Issue #1176 (Phase 1a): the SignalR CLIENT (separate from the server in the shared framework)
          so the Director can dial the Gateway's DirectorHub and push its session state. -->
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
+    <!-- Gateway Cleanup mission: MessagePack for the Director's tunnel connection - binary framing so a
+         full-cap 48KB up-stream byte[] frame stays ~48KB on the wire (JSON base64 inflates it past the hub
+         receive limit and disconnects). 10.0.9 = the patched servicing release (10.0.0 carried a high-severity
+         advisory that the repo's NuGet audit blocks). -->
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CcDirector.ControlApi/GatewayStreamClient.cs
+++ b/src/CcDirector.ControlApi/GatewayStreamClient.cs
@@ -3,6 +3,7 @@ using CcDirector.Core.Sessions;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection; // AddMessagePackProtocol (client)
 
 namespace CcDirector.ControlApi;
 
@@ -140,6 +141,11 @@ public sealed class GatewayStreamClient : IAsyncDisposable
             {
                 TimeSpan.Zero, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10),
             })
+            // Gateway Cleanup mission: MessagePack (binary) so a full-cap 48KB up-stream byte[] frame stays
+            // ~48KB on the wire. Under JSON it base64-inflates to ~64KB and exceeds the hub's receive limit,
+            // dropping the tunnel on any file read >48KB or a terminal burst. The hub also speaks JSON, so this
+            // is safe to roll out per-Director.
+            .AddMessagePackProtocol()
             .Build();
 
         _connection.Reconnecting += ex =>

--- a/src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj
+++ b/src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj
@@ -15,7 +15,10 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
     <!-- Issue #1176 (Phase 1a): the SignalR CLIENT (a separate package from the server, which ships in
          the AspNetCore shared framework) so the integration harness can dial the DirectorHub end to end. -->
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
+    <!-- Gateway Cleanup mission: MessagePack so the mechanism-proof test client speaks the same binary
+         tunnel protocol the real Director does. 10.0.9 = the patched servicing release. -->
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CcDirector.Gateway.Tests/TunnelMechanismProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelMechanismProofTests.cs
@@ -1,0 +1,416 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using CcDirector.ControlApi;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Streaming;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection; // AddMessagePackProtocol (client)
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 2: the up-stream MECHANISM proof. Boots a REAL <see cref="GatewayHost"/> with
+/// stream mode ON, dials the REAL DirectorHub with a REAL SignalR client, and drives the browser-facing legs
+/// (roster, turns, prompt, terminal, file) end to end over the tunnel. The Director side runs the REAL
+/// <see cref="DirectorUpStreamHandler"/> and the REAL producers, and the Gateway side runs the REAL
+/// <see cref="GatewayStreamRegistry"/> + the REAL sinks - nothing about the up-stream is stubbed.
+///
+/// TUNNEL-BY-CONSTRUCTION: the Director is registered with a DELIBERATELY UNREACHABLE control endpoint, so an
+/// HTTP dial cannot succeed - anything that works can ONLY have ridden the tunnel. This is a stronger proof than
+/// reading log lines.
+///
+/// It exercises the Architect's four invariants: backpressure (ruling 1 - the producer blocks on a stalled sink
+/// over the real SignalR StreamBufferCapacity), no-monopoly concurrency (ruling 2 - a terminal stream and a
+/// large file read progress together), teardown (ruling 3 - a browser disconnect fires close-stream and stops
+/// the Director producer), and error parity (a missing file / session returns 404 over the tunnel, as the HTTP
+/// dial did).
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class TunnelMechanismProofTests : IAsyncLifetime
+{
+    private const string Token = "test-token-mechanism-proof";
+    private const string DirectorId = "dir-mech";
+    private const string MissingSid = "00000000-0000-0000-0000-0000000000ff";
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _instancesDir = Path.Combine(Path.GetTempPath(), "cc-mech-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private SessionManager _sm = null!;
+    private DirectorUpStreamHandler _handler = null!;
+    private HubConnection _conn = null!;
+    private Session _session = null!;
+    private string _sid = "";
+    private int _closeStreamCount;
+
+    public TunnelMechanismProofTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-mech-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+
+        // A REAL session with real terminal bytes, driven by a test backend (no real process).
+        _sm = new SessionManager(new AgentOptions());
+        var backend = new ExecuteActionTestBackend();
+        _session = _sm.CreateEmbeddedSession(Path.GetTempPath(), null, backend);
+        backend.Write(Encoding.UTF8.GetBytes("hello from the real terminal producer\r\n"));
+        _sid = _session.Id.ToString();
+
+        // The Director registers UNREACHABLE, so a working op proves it rode the tunnel, never an HTTP dial.
+        _gateway.Registry.Upsert(new DirectorRegistrationRequest
+        {
+            DirectorId = DirectorId,
+            TailnetEndpoint = "http://127.0.0.1:59919/", // nothing listens here
+            MachineName = "mech-machine",
+            Pid = 1,
+            Version = "test",
+            StartedAt = DateTime.UtcNow,
+        });
+
+        // The REAL up-stream handler streams frames UP over the REAL SignalR connection.
+        _conn = new HubConnectionBuilder()
+            .WithUrl($"http://127.0.0.1:{_gateway.Port}/director-stream", o => o.AccessTokenProvider = () => Task.FromResult<string?>(Token))
+            .AddMessagePackProtocol() // speak the same binary tunnel protocol the real Director does
+            .Build();
+        _handler = new DirectorUpStreamHandler(_sm, (streamId, frames) => _conn.SendAsync("StreamUp", streamId, frames));
+        _conn.On<DirectorCommand, DirectorCommandResult>("Command", Dispatch);
+        await _conn.StartAsync();
+        await _conn.InvokeAsync("Hello", new DirectorStreamHello { DirectorId = DirectorId, Version = "test" });
+        // Push the session so the Gateway resolves this Director as its owner (TryLocate) and targets the tunnel.
+        await _conn.InvokeAsync("PushSnapshot", 1L, new[]
+        {
+            new SessionDto { SessionId = _sid, ActivityState = "WaitingForInput" },
+            new SessionDto { SessionId = MissingSid, ActivityState = "WaitingForInput" }, // known to the roster, absent on the Director
+        });
+    }
+
+    public async Task DisposeAsync()
+    {
+        try { await _conn.DisposeAsync(); } catch { /* best effort */ }
+        _sm.Dispose();
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        foreach (var dir in new[] { _instancesDir, _root })
+            try { if (Directory.Exists(dir)) Directory.Delete(dir, true); } catch { /* best effort */ }
+    }
+
+    // The Director-side Command handler: stream verbs run the REAL handler; the rest return typed results.
+    private DirectorCommandResult Dispatch(DirectorCommand cmd)
+    {
+        if (cmd.Verb == "close-stream")
+            Interlocked.Increment(ref _closeStreamCount);
+        if (DirectorUpStreamHandler.IsStreamVerb(cmd.Verb))
+            return _handler.Handle(cmd);
+
+        return cmd.Verb switch
+        {
+            "turns" => cmd.SessionId == MissingSid
+                ? DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found")
+                : DirectorCommandResult.Success(JsonSerializer.Serialize(new { sessionId = cmd.SessionId, status = "ok", widgets = Array.Empty<object>() })),
+            "prompt" => DirectorCommandResult.Success(JsonSerializer.Serialize(new { accepted = true })),
+            _ => DirectorCommandResult.Success(),
+        };
+    }
+
+    // ---------------------------------------------------------------- representative (tunnel-only) ----
+
+    [Fact]
+    public async Task Roster_isServedFromTheTunnelPushCache_notAnHttpPull()
+    {
+        var (ids, errorDirectors) = await GetSessionsAsync();
+        Assert.Contains(_sid, ids);
+        Assert.DoesNotContain(DirectorId, errorDirectors); // never pulled the unreachable endpoint
+    }
+
+    [Fact]
+    public async Task Turns_read_ridesTheTunnel()
+    {
+        var resp = await _http.GetAsync($"sessions/{_sid}/turns");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode); // an HTTP dial to the unreachable Director would have failed
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal("ok", node?["status"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task Prompt_write_ridesTheTunnel()
+    {
+        var resp = await _http.PostAsJsonAsync($"sessions/{_sid}/prompt", new { text = "hello" });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    // ------------------------------------------------------------------------------- error parity ----
+
+    [Fact]
+    public async Task Turns_missingSession_is404_overTheTunnel()
+    {
+        var resp = await _http.GetAsync($"sessions/{MissingSid}/turns");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task ReadFile_missingPath_is404_overTheTunnel()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), "no-such-file-" + Guid.NewGuid().ToString("N"));
+        var resp = await _http.GetAsync($"sessions/{_sid}/file?path={Uri.EscapeDataString(missing)}");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    // ---------------------------------------------------------- real up-stream producers over the wire ----
+
+    [Fact]
+    public async Task Terminal_streamsRealProducerFramesOverTheTunnel()
+    {
+        using var ws = await OpenTerminalAsync(_sid);
+        // First a size text frame, then the snapshot/tail binary carrying the buffer bytes.
+        var size = await ReceiveTextAsync(ws);
+        Assert.Equal("size", JsonNode.Parse(size)?["type"]?.GetValue<string>());
+        var bin = await ReceiveBinaryAsync(ws);
+        Assert.Contains("hello from the real terminal producer", Encoding.UTF8.GetString(bin));
+        await ws.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "done", CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task File_streamsWithCorrectContentLength_overTheTunnel()
+    {
+        var (path, content) = await WriteTempFileAsync((DirectorStreamLimits.MaxBinaryFrameBytes * 3) + 777); // many full-cap chunks
+        try
+        {
+            var resp = await _http.GetAsync($"sessions/{_sid}/file?path={Uri.EscapeDataString(path)}");
+            var diag = resp.IsSuccessStatusCode ? "" : await resp.Content.ReadAsStringAsync();
+            Assert.True(resp.StatusCode == HttpStatusCode.OK, $"file GET -> {resp.StatusCode}: {diag}");
+            Assert.Equal(content.Length, resp.Content.Headers.ContentLength); // TotalBytes from the open reply (ruling 4)
+            var body = await resp.Content.ReadAsByteArrayAsync();
+            Assert.Equal(content, body); // reassembled byte-for-byte from the chunked up-stream
+        }
+        finally { try { File.Delete(path); } catch { /* best effort */ } }
+    }
+
+    // ------------------------------------------------------------------- ruling 2: no-monopoly concurrency ----
+
+    [Fact]
+    public async Task TerminalAndLargeFile_concurrently_bothProgress()
+    {
+        var (path, content) = await WriteTempFileAsync(DirectorStreamLimits.MaxBinaryFrameBytes * 8);
+        try
+        {
+            using var ws = await OpenTerminalAsync(_sid);
+            var fileTask = _http.GetByteArrayAsync($"sessions/{_sid}/file?path={Uri.EscapeDataString(path)}");
+
+            // The terminal makes progress (a size frame arrives) WHILE the large file is streaming on the same
+            // shared tunnel connection - neither starves the other.
+            var size = await ReceiveTextAsync(ws);
+            Assert.Equal("size", JsonNode.Parse(size)?["type"]?.GetValue<string>());
+
+            var fileBytes = await fileTask;
+            Assert.Equal(content, fileBytes);
+            await ws.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "done", CancellationToken.None);
+        }
+        finally { try { File.Delete(path); } catch { /* best effort */ } }
+    }
+
+    // ------------------------------------------------------------------------- ruling 3: teardown ----
+
+    [Fact]
+    public async Task BrowserDisconnect_firesCloseStream_andStopsTheDirectorProducer()
+    {
+        var ws = await OpenTerminalAsync(_sid);
+        await ReceiveTextAsync(ws); // size - the producer is streaming
+
+        // Browser goes away: the Gateway must send close-stream (ruling 3) and the Director producer must stop.
+        await ws.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "bye", CancellationToken.None);
+        ws.Dispose();
+
+        await WaitUntilAsync(() => Volatile.Read(ref _closeStreamCount) >= 1 && _handler.ActiveStreamCount == 0, TimeSpan.FromSeconds(5));
+        Assert.True(Volatile.Read(ref _closeStreamCount) >= 1, "close-stream was not sent on browser disconnect");
+        Assert.Equal(0, _handler.ActiveStreamCount); // producer stopped, nothing left streaming into a dead sink
+    }
+
+    // ------------------------------------------------------------- ruling 1: producer-side backpressure ----
+
+    [Fact]
+    public async Task Producer_blocksOnAStalledSink_overTheRealSignalRStreamBuffer()
+    {
+        // Register a REAL sink in the REAL registry that stalls every write, then stream an instrumented
+        // producer UP over the REAL SignalR connection. Pull-then-forward + a bounded StreamBufferCapacity must
+        // PIN the producer: with the sink held, the producer runs ahead only until the server channel, the
+        // transport pipe, and the socket buffers fill, then it blocks on its yield - it must NOT run to
+        // completion. Frames are at the cap so transport buffers cannot silently absorb the whole stream.
+        //
+        // The proof is that the producer's progress STOPS and STAYS stopped below the total while the sink is
+        // held (bounded memory - the Architect's ruling 1), and then drains fully the instant the sink releases.
+        // (The exact pinning depth is buffer-dependent - on loopback it settles in the low tens because the OS
+        // socket and pipe buffers dwarf the 4-deep server channel; over a real slow link it pins far tighter.)
+        //
+        // NOTE (Gateway Cleanup, MessagePack fix): SendAsync for a client-to-server stream completes as soon as
+        // the invocation is DISPATCHED - the item pump then runs on a background task - so send.IsCompleted is
+        // NOT the backpressure signal. The producer's own yield counter is. An overall CancellationToken makes
+        // this FAIL FAST with a diagnostic instead of hanging if backpressure ever regresses, and the sink is
+        // ALWAYS released in a finally so a failed assertion can never wedge teardown on the held sink.
+        const int total = 100;
+        using var testTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var streamId = Guid.NewGuid().ToString("N");
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sink = new StallingSink(gate);
+        var yielded = 0;
+
+        _gateway.StreamRegistry.Register(streamId, sink);
+
+        async IAsyncEnumerable<DirectorStreamFrame> Produce([EnumeratorCancellation] CancellationToken ct = default)
+        {
+            var payload = new byte[DirectorStreamLimits.MaxBinaryFrameBytes];
+            for (var i = 0; i < total; i++)
+            {
+                Interlocked.Increment(ref yielded);
+                yield return new DirectorStreamFrame { StreamId = streamId, Kind = DirectorStreamFrameType.Binary, Data = payload };
+            }
+            yield return new DirectorStreamFrame { StreamId = streamId, Kind = DirectorStreamFrameType.Closed, Reason = "eof" };
+        }
+
+        var send = _conn.SendAsync("StreamUp", streamId, Produce(), testTimeout.Token);
+        try
+        {
+            // Let it run ahead as far as buffering allows, then confirm it has STOPPED (pinned), not merely slow.
+            await Task.Delay(600, testTimeout.Token);
+            var pinnedA = Volatile.Read(ref yielded);
+            await Task.Delay(1500, testTimeout.Token);
+            var pinnedB = Volatile.Read(ref yielded);
+
+            Assert.True(pinnedA < total, $"producer ran to {pinnedA}/{total} with the sink stalled - backpressure is broken");
+            Assert.Equal(pinnedA, pinnedB); // stable: the producer is BLOCKED on its yield, not slowly draining ahead
+            Assert.Equal(0, sink.CompletedWrites); // the first write is in-flight (held by the gate); none have completed
+        }
+        finally
+        {
+            gate.SetResult(); // ALWAYS release so a failed assertion cannot wedge teardown on the held sink
+        }
+
+        await send; // already completed at dispatch; harmless to await
+
+        // With the sink released the whole stream drains: every frame is produced and every frame lands on the
+        // sink (the 100 binary frames plus the trailing Closed frame = total + 1 writes).
+        const int expectedWrites = total + 1;
+        await WaitUntilAsync(() => Volatile.Read(ref yielded) == total && sink.CompletedWrites == expectedWrites, TimeSpan.FromSeconds(10));
+        Assert.Equal(total, Volatile.Read(ref yielded));
+        Assert.Equal(expectedWrites, sink.CompletedWrites); // 100 binary + 1 closed, delivered to the sink in order
+    }
+
+    // A sink whose writes block on a gate, so a test can hold the Gateway's pull and observe backpressure. It
+    // honors the cancellation token (as a real sink must on teardown) so a torn-down held stream cannot wedge,
+    // and counts completed writes so a test can prove nothing drained while held and everything drained after.
+    private sealed class StallingSink : IStreamSink
+    {
+        private readonly TaskCompletionSource _gate;
+        private int _completedWrites;
+        public StallingSink(TaskCompletionSource gate) => _gate = gate;
+        public int CompletedWrites => Volatile.Read(ref _completedWrites);
+
+        public async Task WriteFrameAsync(DirectorStreamFrame frame, CancellationToken cancellationToken)
+        {
+            await _gate.Task.WaitAsync(cancellationToken);
+            Interlocked.Increment(ref _completedWrites);
+        }
+
+        public Task CompleteAsync(string? reason) => Task.CompletedTask;
+    }
+
+    // -------------------------------------------------------------------------------------- helpers ----
+
+    private async Task<ClientWebSocket> OpenTerminalAsync(string sid)
+    {
+        var ws = new ClientWebSocket();
+        ws.Options.SetRequestHeader("Authorization", $"Bearer {Token}");
+        await ws.ConnectAsync(new Uri($"ws://127.0.0.1:{_gateway.Port}/sessions/{sid}/stream"), CancellationToken.None);
+        return ws;
+    }
+
+    private static async Task<string> ReceiveTextAsync(ClientWebSocket ws)
+    {
+        var (bytes, type) = await ReceiveAsync(ws);
+        Assert.Equal(WebSocketMessageType.Text, type);
+        return Encoding.UTF8.GetString(bytes);
+    }
+
+    private static async Task<byte[]> ReceiveBinaryAsync(ClientWebSocket ws)
+    {
+        var (bytes, type) = await ReceiveAsync(ws);
+        Assert.Equal(WebSocketMessageType.Binary, type);
+        return bytes;
+    }
+
+    private static async Task<(byte[] bytes, WebSocketMessageType type)> ReceiveAsync(ClientWebSocket ws)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var buffer = new byte[64 * 1024];
+        using var ms = new MemoryStream();
+        WebSocketReceiveResult result;
+        do
+        {
+            result = await ws.ReceiveAsync(buffer, timeout.Token);
+            ms.Write(buffer, 0, result.Count);
+        } while (!result.EndOfMessage);
+        return (ms.ToArray(), result.MessageType);
+    }
+
+    private static async Task<(string path, byte[] content)> WriteTempFileAsync(int size)
+    {
+        var path = Path.Combine(Path.GetTempPath(), "ccd-mech-file-" + Guid.NewGuid().ToString("N") + ".bin");
+        var content = new byte[size];
+        for (var i = 0; i < size; i++) content[i] = (byte)(i % 251);
+        await File.WriteAllBytesAsync(path, content);
+        return (path, content);
+    }
+
+    private async Task<(List<string> ids, List<string> errorDirectors)> GetSessionsAsync()
+    {
+        var resp = await _http.GetAsync("sessions?envelope=true");
+        resp.EnsureSuccessStatusCode();
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        var sessions = node?["sessions"]?.AsArray() ?? node?.AsArray() ?? new JsonArray();
+        var ids = new List<string>();
+        foreach (var s in sessions)
+            if (s?["sessionId"]?.GetValue<string>() is { Length: > 0 } id) ids.Add(id);
+        var errors = new List<string>();
+        foreach (var e in node?["machineErrors"]?.AsArray() ?? new JsonArray())
+            if (e?["directorId"]?.GetValue<string>() is { Length: > 0 } id) errors.Add(id);
+        return (ids, errors);
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var attempts = (int)(timeout.TotalMilliseconds / 15) + 1;
+        for (var i = 0; i < attempts && !condition(); i++) await Task.Delay(15);
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/src/CcDirector.Gateway/CcDirector.Gateway.csproj
+++ b/src/CcDirector.Gateway/CcDirector.Gateway.csproj
@@ -17,6 +17,11 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <!-- Gateway Cleanup mission: the SignalR MessagePack protocol for the DirectorHub (the tunnel). NOT in
+         the shared framework, so it is referenced explicitly. Binary framing keeps a 48KB byte[] up-stream
+         frame ~48KB on the wire (not ~64KB base64 under JSON), so the MaxBinaryFrameBytes+envelope receive
+         limit is correct and there is no 33% base64 tax on every tunnel byte. -->
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.9" />
     <!-- Direct HTTP forwarding (IHttpForwarder) for the one-URL front door: every request no
          explicit Gateway endpoint claims falls through to the loopback Cockpit. -->
     <PackageReference Include="Yarp.ReverseProxy" Version="2.2.0" />

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -994,7 +994,12 @@ public sealed class GatewayHost : IAsyncDisposable
         // (Architect ruling 2 + 1). MaximumReceiveMessageSize must admit a full-size framed binary frame
         // (the cap plus a small envelope allowance); StreamBufferCapacity is small so a slow browser sink
         // pushes back onto the producer's yield - the backpressure invariant, not an optimization.
+        // AddMessagePackProtocol is ADDITIVE: the hub now negotiates MessagePack OR JSON, so a MessagePack
+        // Director gets binary framing (a 48KB byte[] up-stream frame stays ~48KB, not ~64KB base64 that would
+        // blow past MaximumReceiveMessageSize and drop the connection) while a JSON-only client still connects
+        // (backward-compat for the fleet rollout). It removes the 33% base64 tax on every tunnel byte.
         builder.Services.AddSignalR()
+            .AddMessagePackProtocol()
             .AddHubOptions<Streaming.DirectorHub>(o =>
             {
                 o.MaximumReceiveMessageSize = Contracts.DirectorStreamLimits.MaxBinaryFrameBytes + Contracts.DirectorStreamLimits.FrameEnvelopeAllowanceBytes;


### PR DESCRIPTION
## What

Switches the Gateway-to-Director tunnel (the two-way SignalR stream) to the **MessagePack** protocol on both ends (the Gateway `DirectorHub`, the Director's `HubConnectionBuilder`) plus the mechanism-proof test client, and adds the in-process mechanism proof (`TunnelMechanismProofTests`).

## Why (Architect ruling)

Under the default JSON protocol a `byte[]` frame is base64-encoded (+33%). A full-cap 48KB up-stream binary frame inflated to ~64KB and exceeded the hub `MaximumReceiveMessageSize` (~52KB), aborting the tunnel on any file read over 48KB or a terminal burst. Binary framing keeps a 48KB frame ~48KB on the wire, so the existing `MaxBinaryFrameBytes` + envelope limit is correct as-is and the 33% base64 bandwidth/CPU tax is removed from every tunnel byte - directly serving the slow-link case this mission exists for. Settled in `docs/architecture/gateway-cleanup-phase2-repoint-design.md` (Option A - root-cause fix).

`AddMessagePackProtocol()` is **additive**: the hub still negotiates JSON, so an un-updated Director still connects during rollout.

## The reported "hang" was the TEST, not the mechanism

The backpressure proof asserted `Assert.False(send.IsCompleted)`, but `SendAsync` for a client-to-server stream completes at **dispatch** (the item pump runs on a background task). That assertion threw, so the deliberately-stalled sink was never released, deadlocking teardown (>30s hang). Under JSON the connection died at frame 0, so this path never ran before MessagePack let frames flow.

The corrected test proves the real ruling-1 invariant: a stalled sink **pins the producer at a bounded, stable depth** below the total (bounded memory), always releases the sink in a `finally`, makes the sink honor its cancellation token, and asserts the whole stream drains once released. **Product code is unchanged.**

## Package pinning

MessagePack protocol pinned to `10.0.9` (patched servicing release) to clear the NuGet security audit; `SignalR.Client` bumped to match.

## Verification

- All 10 `TunnelMechanismProofTests` pass in ~5s (no hang), including large-file (3 full-cap chunks), no-monopoly concurrency (8 chunks + terminal), teardown, error-parity, and the corrected backpressure proof.
- Full `CcDirector.Gateway.Tests` suite: **2090 passed, 0 failed** - no regression from the protocol switch.
- Verified up-to-date with `origin/main` (rebased); mechanism proof re-run green post-rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)