### PR TITLE
feat(car-mode): Phase 4a - bad-connection resilience (never lose speech, durable buffer, audible offline state)

### DIFF
--- a/apps/mobile/src/pages/CarMode.tsx
+++ b/apps/mobile/src/pages/CarMode.tsx
@@ -10,7 +10,7 @@ import { useScreenWakeLock } from "../hooks/useScreenWakeLock";
 // the old git short-sha + timestamp badge was replaced by a plain human version. BUMP THIS INTEGER BY HAND
 // ON EVERY DEPLOY of the mobile app (v1 -> v2 -> v3 ...), so a glance at the corner tells the owner and the
 // Architect exactly which page is live and what to look for after a deploy.
-const CAR_MODE_VERSION = "v8";
+const CAR_MODE_VERSION = "v9";
 
 // Car Mode (Car Mode mission): the standalone, chrome-less, full-screen page the owner opens to run
 // the whole fleet by voice, hands-free, phone in his pocket. It is a THIN view over the shared
@@ -108,6 +108,13 @@ export function CarMode() {
     pendingConfirmation,
     error,
     unsupported,
+    holding,
+    heldCount,
+    holdMessage,
+    askOwnerTurn,
+    connectionDown,
+    sendHeldTurn,
+    discardHeldTurn,
     getMicLevel,
     endTurn,
     interrupt,
@@ -143,6 +150,58 @@ export function CarMode() {
           <div className="car-error" role="alert">
             Car Mode needs Chrome or another Chromium browser for hands-free voice. Open this page in
             Chrome.
+          </div>
+        )}
+
+        {/* Offline resilience (Phase 4a, #1427). The connection-down notice: the hands-free watch cannot
+            reach the fleet, but the owner's audio keeps recording locally, so nothing is lost. */}
+        {connectionDown && (
+          <div className="car-conn-down" role="status">
+            Connection down - I'll keep trying. Your recording is still being saved.
+          </div>
+        )}
+
+        {/* The calm "saved, will send" holding banner: never a red error, because the speech is SAVED and
+            auto-sends when the connection returns. Shows how many requests are waiting. */}
+        {holding && (
+          <div className="car-holding" role="status">
+            <span className="car-holding-text">
+              {holdMessage ?? "Saved - I'll send your request the moment we're back online."}
+            </span>
+            {heldCount > 1 && <span className="car-holding-count">{heldCount} requests saved</span>}
+          </div>
+        )}
+
+        {/* A held turn that needs the owner's explicit choice. A "stale" turn (never sent to the brain,
+            just old) can be sent safely; an "ambiguous" turn (already sent, result unknown) can only be
+            discarded in Phase 4a, since a blind resend could act twice. */}
+        {askOwnerTurn && (
+          <div className="car-askowner" role="status">
+            <span className="car-askowner-text">
+              {askOwnerTurn.reason === "ambiguous"
+                ? "I sent an earlier request but couldn't confirm it. I've left it alone to avoid doing it twice."
+                : "You have an earlier saved request from a while ago."}
+              {askOwnerTurn.transcript.length > 0 && <> "{askOwnerTurn.transcript}"</>}
+            </span>
+            <div className="car-askowner-buttons">
+              {askOwnerTurn.reason === "stale" && (
+                <button
+                  type="button"
+                  className="car-askowner-send"
+                  onClick={() => sendHeldTurn(askOwnerTurn.id)}
+                  disabled={phase !== "listening"}
+                >
+                  Send it now
+                </button>
+              )}
+              <button
+                type="button"
+                className="car-askowner-discard"
+                onClick={() => discardHeldTurn(askOwnerTurn.id)}
+              >
+                Discard
+              </button>
+            </div>
           </div>
         )}
 

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -2677,6 +2677,79 @@ a.banner-btn {
   font-size: 15px;
 }
 
+/* Offline resilience (Phase 4a, #1427). These are NOT red errors: holding is a calm "saved, will send"
+   state, so it reads amber/blue, never as a failure. The audio is safe; nothing is lost. */
+.car-conn-down {
+  margin: 12px 16px 0;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: #3a2f1c;
+  border: 1px solid #c79a3a;
+  color: #ffe6b0;
+  font-size: 15px;
+}
+
+.car-holding {
+  margin: 12px 16px 0;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: #1c2a3a;
+  border: 1px solid #3a6ea5;
+  color: #cfe4ff;
+  font-size: 15px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.car-holding-count {
+  font-size: 13px;
+  opacity: 0.8;
+}
+
+.car-askowner {
+  margin: 12px 16px 0;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: #26233a;
+  border: 1px solid #6a5acd;
+  color: #ddd6ff;
+  font-size: 15px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.car-askowner-buttons {
+  display: flex;
+  gap: 10px;
+}
+
+.car-askowner-send,
+.car-askowner-discard {
+  flex: 1 1 0;
+  padding: 10px 12px;
+  border-radius: 10px;
+  font-size: 15px;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+
+.car-askowner-send {
+  background: #2f7d4f;
+  color: #fff;
+}
+
+.car-askowner-send:disabled {
+  opacity: 0.5;
+}
+
+.car-askowner-discard {
+  background: transparent;
+  border-color: #6a5acd;
+  color: #ddd6ff;
+}
+
 .car-body {
   flex: 1 1 auto;
   display: flex;

--- a/docs/architecture/carmode-offline-resilience-research-2026-07-13.md
+++ b/docs/architecture/carmode-offline-resilience-research-2026-07-13.md
@@ -1,0 +1,221 @@
+# Car Mode - Bad-connection / offline resilience: research findings + plan
+
+Status: research handoff from the Car Mode - Manager (session 965d43f8, machine SOREN_NORTH) to the
+Car Mode - Architect (session f44f39c0). Written 2026-07-13. Issue #1427, expanded by the owner.
+NOTHING built yet - this is the "research first, send the Architect findings + plan + design
+questions before any code" step the phase mandates.
+
+## The goal (owner, restated)
+
+Driving in and out of bad signal, Car Mode must:
+- (a) NEVER lose the owner's speech - capture every utterance locally, always.
+- (b) durably BUFFER a turn finished in a dead zone and AUTO-RETRY it when the connection returns
+  (in-and-out must never drop a request).
+- (c) degrade GRACEFULLY with a clear AUDIBLE offline / holding state - never a silent stall.
+
+Reality to design around: transcription, the brain, and text-to-speech ALL run on the Gateway, so
+fully offline Car Mode cannot answer or act. The deliverable is "never lose speech + graceful
+degradation + retry on reconnect", NOT running the model offline.
+
+## How one Car Mode turn talks to the network today
+
+Three network stages, plus two best-effort side calls. Every one is a RAW `fetch` in
+`packages/client-core/src/carmode/carModeApi.ts` - NOT the shared `gatewayFetch`:
+
+1. Transcription - `POST /wingman/transcribe` (multipart WAV -> `{ transcript }`).
+   ALSO runs every 800 ms during Listening as the rolling "over and out" end-phrase watch.
+2. Brain - `POST /carmode/turn` (`{ text }` -> spoken reply + actions + pendingConfirmation).
+3. Text-to-speech - `POST /wingman/tts` (`{ text }` -> raw audio bytes).
+4. Warmup - `POST /carmode/warmup` (best-effort, already swallows errors).
+5. Telemetry - `POST /carmode/telemetry` (best-effort, already swallows errors).
+
+Because these use raw `fetch`, they DO NOT feed the connection-health store
+(`connection/health.ts` `reportGatewayReachable/Unreachable`), which is fed only through
+`gatewayFetch`. So the app's single "bad connection" signal is BLIND to all Car Mode traffic today.
+
+## Failure-mode map - what happens TODAY when the connection drops at each stage
+
+### (A) Rolling end-phrase watch during Listening (`endPhraseTick`, every 800 ms)
+- Each tick: `MicRecorder.snapshot()` -> transcode WAV -> `transcribeCarModeAudio` (raw fetch).
+- On failure the `catch` just logs "end-phrase watch skipped a tick" and tries again next second.
+- Consequence: in a dead zone the hands-free "over and out" NEVER fires - the transcript is never
+  obtained, so the phrase can never be detected. The mic audio KEEPS accumulating (good, not lost),
+  but the owner gets NO "my turn" cue and NO feedback. This is a SILENT STALL of the hands-free path
+  (violates (c)). He can still tap the "Over and out" button - which lands in (B).
+
+### (B) The "Over and out" button / end-of-turn transcription (`transcribeAndTake`)
+- `snapshot()` -> transcode -> `transcribeCarModeAudio` (raw fetch).
+- On failure: `catch` -> `announceError` (LOUD, spoken via the browser's LOCAL speechSynthesis) ->
+  `enterListening()`.
+- BUT `enterListening()` -> `restartCapture()` -> `stop()`+`start()` which THROWS AWAY the recorder
+  buffer. The owner's just-spoken utterance is LOST. He is told "the Gateway is unreachable" but his
+  words are gone. This directly VIOLATES requirement (a) - never lose speech.
+
+### (C) The brain call (`takeTurn` -> `respond` -> `carModeTurn`, `POST /carmode/turn`)
+- Transcription already succeeded (we hold the command text). If the brain call fails (drop between
+  transcribe and brain): `catch` -> `announceError` loud -> `enterListening()`.
+- The COMMAND TEXT is dropped (it lived only in local `transcript` state). No retry, no buffer.
+  VIOLATES (b) - a turn finished in a dead zone is dropped, not held-and-retried.
+
+### (D) The text-to-speech call (`speakAndPlay` -> `speakCarModeText`, `POST /wingman/tts`)
+- The brain ALREADY answered, which means for an action turn the fleet action ALREADY HAPPENED
+  server-side. If TTS fails: `catch` -> `announceError` loud -> `enterListening()`.
+- The action is not lost (server did it) and the reply text is on screen, but the spoken reply is
+  never heard through the good voice. Partial (c) gap: he hears the error, not the answer.
+
+Summary: today Car Mode has NO durable buffer, NO retry, NO offline/holding state, and it actively
+DESTROYS the captured utterance on a failed end-of-turn. All three requirements are unmet.
+
+## The existing resilience infrastructure we should reuse (do not reinvent)
+
+The mobile dictation store-and-forward is the proven pattern and solves almost exactly this problem
+(issues #1006 / #1181 / #1182 / #1184):
+
+- `dictation/pendingStore.ts` - a durable IndexedDB store of recorded audio Blobs. Audio is the
+  single source of truth; a record is deleted ONLY when the server confirms it owns the turn, or on
+  explicit abandon; undelivered audio is NEVER aged out.
+- `dictation/backgroundSend.ts` - the retry driver: persist audio BEFORE any network work, then
+  drive delivery; retry HARD for the first hour (exponential 2s->15s), then THROTTLE to every 5 min,
+  FOREVER; resume the instant the `online` event fires or the app is foregrounded, and on every app
+  load; every attempt idempotent by a client-generated upload id that is ALSO the server
+  Idempotency-Key, so a retry can never double-inject.
+- `dictation/status.ts` - a module store + `useSyncExternalStore` hook publishing per-item held /
+  retrying / done / parked status (honest "saved, still trying" copy, never "lost").
+- `connection/health.ts` - the single app-wide good/bad connection signal (fed at the transport
+  choke point in `gatewayFetch`).
+
+`MicRecorder` (`dictation/recorder.ts`) already accumulates the full utterance locally and can
+`snapshot()` it without stopping - the local capture is already there; nothing is lost AT capture.
+The loss happens later, when a failed transcribe restarts the recorder and discards the buffer.
+
+## The one hard blocker for reusing store-and-forward: `/carmode/turn` is NOT idempotent
+
+This is the crux and the main thing I need the Architect to rule on.
+
+Dictation's store-and-forward is safe to retry blindly because the Gateway dedupes by the upload id
+(Idempotency-Key) and single-flights. `POST /carmode/turn` has NO such key and is NOT idempotent:
+
+- It APPENDS to the server-side per-device conversation history (`CarModeConversationStore.Append`).
+- It EXECUTES fleet actions immediately and non-idempotently inside the tool loop
+  (`start_session`, `message_session`, `approve_session` in `CarModeBrain.ExecuteToolAsync`).
+- It arms / executes destructive confirmations (`delete_session`).
+
+So blindly auto-retrying a turn we are unsure landed could DOUBLE-start a session, DOUBLE-send a
+message, or DOUBLE-approve. The two sub-cases differ sharply:
+- Turn NEVER reached the server (fetch threw / connection refused / 502/503/504): nothing happened
+  server-side - safe to retry.
+- Turn REACHED the server, it acted, and the RESPONSE was lost coming back: retrying would
+  double-act.
+
+The dictation feature solves this exact ambiguity with an Idempotency-Key + server single-flight /
+cached-result dedupe. To reuse the store-and-forward safely for Car Mode, the Gateway
+`/carmode/turn` needs to accept a client-generated turn id and dedupe on it: a repeated turn id
+returns the cached result of the first (having acted at most once). That is the "maybe some Gateway
+robustness" the phase anticipates.
+
+## The durable unit is AUDIO, not text
+
+Because transcription is server-side, an offline client cannot turn speech into text. So the thing we
+buffer for a dead-zone turn is the RAW COMMAND AUDIO (exactly like dictation), not a transcript. On
+reconnect the buffered turn is driven through transcribe -> brain -> speak. This keeps requirement
+(a) and (b) unified: the local audio Blob is the source of truth for the whole turn.
+
+## Proposed design (for the Architect to shape / approve before any code)
+
+Reuse the dictation store-and-forward shape, adapted to Car Mode's 3-stage pipeline:
+
+1. NEVER lose speech (req a):
+   - On a failed end-of-turn transcribe, STOP discarding the buffer. Persist the captured command
+     audio Blob to a durable IndexedDB store (a Car Mode analog of `pendingStore`) the instant the
+     turn is taken, BEFORE the transcribe call - so even a mid-transcribe drop keeps the audio.
+   - Only delete it once the server owns the turn (see idempotency below).
+
+2. Durable buffer + auto-retry (req b):
+   - A Car Mode background driver mirroring `backgroundSend.ts`: on failure, hold the audio and
+     retry through transcribe -> `/carmode/turn` -> `/wingman/tts`, resuming on `online` /
+     foreground / next load, with the same hard-then-throttled-forever cadence.
+   - Gate the retry on a NEW Gateway turn-id Idempotency-Key so a re-driven turn acts at most once.
+   - On a successful re-driven turn, SPEAK the reply (and announce what was done) so the owner hears
+     the outcome of the request he made in the dead zone.
+
+3. Graceful, audible offline / holding state (req c):
+   - Route Car Mode's fetches through `gatewayFetch` (or otherwise feed `connection/health.ts`) so
+     the app's bad-connection signal finally sees Car Mode traffic.
+   - When a turn is held, AUDIBLY say it ("I can't reach the fleet right now - I've saved your
+     request and I'll send it the moment we're back online"), show a held state on the orb, and on
+     recovery audibly confirm ("Back online - here's that answer: ...").
+   - Fix the rolling end-phrase watch's silent stall: after N consecutive failed ticks, audibly tell
+     the owner the connection is down instead of silently missing his "over and out" forever.
+
+## Design questions for the Architect (need your call before I build)
+
+1. IDEMPOTENCY (the big one): do you want `/carmode/turn` to take a client turn-id Idempotency-Key
+   with server-side single-flight + cached-result dedupe (mirroring dictation), so a buffered turn
+   can auto-retry safely? This is Gateway work. Without it, safe auto-retry is impossible for action
+   turns - we could only safely retry turns we KNOW never reached the server.
+
+2. RETRY SCOPE: should we auto-retry ALL held turns (reads AND actions) hard-then-throttled-forever
+   like dictation, or treat them differently? A read answer arriving 3 min later is odd-but-harmless;
+   an ACTION ("start a session", "message X to run tests") almost certainly SHOULD still fire - that
+   is the "in-and-out must never drop a request" point. Do you want any staleness cap on reads?
+
+3. STALE-ANSWER POLICY: when a held turn finally lands minutes later, do we always speak the reply
+   aloud, or only announce that the action completed (quieter) for action turns and skip speaking a
+   now-stale read answer? Owner is driving and context has moved on.
+
+4. CONVERSATION CONTEXT: a buffered turn that lands late may be out of order relative to newer turns
+   the owner spoke after reconnect, corrupting the per-device server conversation history. Do we
+   serialize per-device (one in-flight turn at a time, queue the rest), or is best-effort fine?
+
+5. SCOPE / PHASING: is this one phase, or split (e.g. 4a "never lose speech + audible offline state"
+   client-only, then 4b "durable buffer + idempotent retry" needing the Gateway key)? 4a delivers
+   the highest-value safety (no lost speech, no silent stall) with zero Gateway change and could ship
+   first.
+
+## Test plan (mobile-only, never declared done on desktop)
+
+- Simulate intermittent + dead connection by blocking the Gateway / offlining the network mid-turn
+  (chrome://inspect devtools network offline against the phone, and/or a fetch block).
+- Prove: (a) NO speech is lost across a mid-transcribe drop; (b) a turn finished offline is held and
+  auto-retries + completes on reconnect with no double-action; (c) the offline/holding state is
+  announced audibly, not a silent stall.
+- Verify on the real phone (Z Flip, Tailscale 100.86.144.11, wireless ADB) and/or via the
+  `/carmode/telemetry` store - never claim a mobile fix from a desktop test.
+
+## Phase 4a - BUILT (2026-07-13), pending owner/Architect sign-off to merge + on-device proof
+
+The Architect approved 4a on 2026-07-13 (all 5 questions answered; the key unlock: a fully-offline turn
+fails at transcribe and never reaches the brain, so re-driving it is a first brain call = safe, no
+idempotency needed). Built, client-only, zero Gateway change:
+
+New files:
+- `packages/client-core/src/carmode/pendingTurnStore.ts` - durable IndexedDB store of command AUDIO
+  (mirrors dictation/pendingStore.ts). Record carries `brainSent` (the safety boundary) and a cached
+  `transcript`.
+- `packages/client-core/src/carmode/turnRetry.ts` - the pure retry policy: `classifyHeldTurn`
+  (auto vs ask-owner, on the brainSent boundary + a 30-minute staleness cap), the hard-then-throttled
+  cadence, and the audible held / recovery / connection-down lines. Unit-tested (`turnRetry.test.ts`, 9
+  tests).
+
+Changed:
+- `carModeApi.ts` - the transcribe / brain / speak calls now route through `gatewayFetch`, so
+  `connection/health.ts` finally sees Car Mode traffic.
+- `useCarMode.ts` - persist the command audio BEFORE transcribe (never lose speech); on a transcribe
+  failure enter the calm HOLDING state instead of discarding the recorder buffer; mark `brainSent=true`
+  right before the brain call; delete the durable record ONLY after the brain returns a definitive
+  success; a brain failure holds (money refusal stays auto-retriable with the shared credits notice; any
+  other failure is held for the owner, discard-only); a hook-owned background driver re-drives the oldest
+  AUTO held turn on the `online` event / foreground / Start / cadence, serialized (one in flight, never
+  preempts a live or in-progress utterance), speaking recovered replies with the "Back online" prefix;
+  the end-phrase watch announces the connection is down after four failed ticks (the silent-stall fix).
+- `apps/mobile/src/pages/CarMode.tsx` (+ `styles.css`) - surfaces the connection-down, holding, and
+  ask-owner (send/discard) states; version bumped v8 -> v9.
+
+Verification so far (pre-merge, off-device): client-core typecheck clean; mobile typecheck clean; mobile
+production build clean; full client-core suite 401 tests pass (including the 9 new policy tests). The
+required end-to-end proof - offline the network mid-turn on the REAL phone and show (a) no speech lost,
+(b) the held turn auto-completes on reconnect, (c) the state is announced audibly - is on-device and
+therefore needs merge -> deploy first (un-merged wwwroot deploys get clobbered). Awaiting sign-off to
+commit + merge + deploy, then that on-device proof.
+</content>
+</invoke>

--- a/packages/client-core/src/carmode/carModeApi.ts
+++ b/packages/client-core/src/carmode/carModeApi.ts
@@ -7,7 +7,12 @@
 // speech-to-text front door), the voice is POST /wingman/tts (the one good voice, raw audio bytes).
 // The brain is the new POST /carmode/turn (built in Phase 2). Every call fails LOUD and specific -
 // no silent stall, no guess (decision 8).
-import { authHeaders, creditsErrorFrom, GatewayError } from "../api/client";
+import { authHeaders, creditsErrorFrom, gatewayFetch, GatewayError } from "../api/client";
+
+// Car Mode's transcribe / brain / speak calls route through gatewayFetch (NOT a raw fetch) so every
+// contact feeds the ONE app-wide connection-health signal (connection/health.ts): a thrown fetch or a
+// front-proxy 502/503/504 flips the shared "bad connection" state, and any answered request clears it.
+// Before Phase 4a these used raw fetch and the health store was blind to all Car Mode traffic (#1427).
 
 /**
  * Transcribe a captured utterance through the single Gateway speech-to-text front door
@@ -19,7 +24,7 @@ import { authHeaders, creditsErrorFrom, GatewayError } from "../api/client";
 export async function transcribeCarModeAudio(wav: Blob, signal?: AbortSignal): Promise<string> {
   const form = new FormData();
   form.append("audio", wav, "carmode.wav");
-  const res = await fetch("/wingman/transcribe", {
+  const res = await gatewayFetch("/wingman/transcribe", {
     method: "POST",
     headers: { ...authHeaders() },
     body: form,
@@ -41,7 +46,7 @@ export async function transcribeCarModeAudio(wav: Blob, signal?: AbortSignal): P
  * A 402 is the shared credits error; any other non-2xx throws a specific GatewayError.
  */
 export async function speakCarModeText(text: string, signal?: AbortSignal): Promise<Blob> {
-  const res = await fetch("/wingman/tts", {
+  const res = await gatewayFetch("/wingman/tts", {
     method: "POST",
     headers: { "Content-Type": "application/json", ...authHeaders() },
     body: JSON.stringify({ text }),
@@ -97,7 +102,7 @@ export interface CarModeTurnResult {
  * credits error; any other non-2xx throws a specific GatewayError so the failure is spoken, never silent.
  */
 export async function carModeTurn(text: string, signal?: AbortSignal): Promise<CarModeTurnResult> {
-  const res = await fetch("/carmode/turn", {
+  const res = await gatewayFetch("/carmode/turn", {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
     body: JSON.stringify({ text }),

--- a/packages/client-core/src/carmode/pendingTurnStore.ts
+++ b/packages/client-core/src/carmode/pendingTurnStore.ts
@@ -1,0 +1,118 @@
+// Durable local store for Car Mode command audio (Car Mode mission, offline-resilience Phase 4a,
+// issue #1427). It mirrors the mobile dictation durable store (dictation/pendingStore.ts): the raw
+// recorded COMMAND audio for a turn is written here (IndexedDB, which holds Blobs on disk) BEFORE any
+// network work, so a dead zone, a page refresh, a tab crash, or a phone reboot can no longer lose the
+// owner's spoken request. The background driver (turnRetry.ts + the useCarMode hook) re-drives the held
+// audio through transcribe -> brain -> speak when connectivity returns.
+//
+// Why AUDIO and not text: transcription runs on the Gateway, so an offline client cannot turn speech
+// into text. The durable unit for a whole turn is therefore the raw command audio; the transcript (once
+// obtained) is cached on the record so a later re-drive need not transcribe twice.
+//
+// The on-device copy is the single source of truth. A record is deleted ONLY when the brain call returns
+// a definitive success (the turn is owned server-side), or when the owner explicitly discards it.
+// Undelivered audio is NEVER aged out automatically - a request the owner could not send yet is kept
+// until it is delivered or discarded.
+//
+// The `brainSent` flag is the safety boundary (Architect decision, 2026-07-13). A fully-offline turn
+// fails at transcribe and NEVER reaches the brain, so re-driving it is a FIRST brain call = no
+// double-action = safe to auto-retry. The ONLY unsafe case is a turn whose brain call was already SENT
+// and whose result is unknown (transcribe briefly succeeded, then the connection dropped): that could
+// have acted, so it is HELD for the owner rather than auto-fired (Phase 4b makes even that safe with a
+// server idempotency key). `brainSent` records exactly which side of that line a held turn is on.
+
+export interface PendingCarModeTurn {
+  /** Client-generated GUID. Doubles as the future Phase 4b server Idempotency-Key for the brain call. */
+  id: string;
+  /** The raw recorded command audio exactly as the microphone produced it (WebM/Opus etc.). */
+  audio: Blob;
+  /** The owner's sign-off phrase to strip from the transcript, captured at record time so a later
+   *  re-drive strips the phrase the owner actually used, not whatever is configured at re-drive time. */
+  endPhrase: string;
+  /** Epoch milliseconds the command was captured. Drives the retry cadence (hard for the first hour,
+   *  then throttled) and the staleness cap (a turn older than ~30 minutes is not auto-fired). NOT a
+   *  prune deadline: undelivered audio is never aged out. */
+  createdAt: number;
+  /** False until the brain call for this turn has been DISPATCHED. While false the turn provably never
+   *  reached the brain, so it is safe to auto-retry. Set true immediately BEFORE the /carmode/turn fetch;
+   *  a true value means the turn may have acted and its result is unknown, so it is held for the owner. */
+  brainSent: boolean;
+  /** The command transcript (sign-off phrase already stripped), cached once transcription succeeded so a
+   *  re-drive does not transcribe the same audio twice. Absent until the first successful transcription. */
+  transcript?: string;
+}
+
+const DB_NAME = "dt-carmode";
+const STORE = "pending-turns";
+const DB_VERSION = 1;
+
+function hasIndexedDb(): boolean {
+  try {
+    return typeof indexedDB !== "undefined";
+  } catch {
+    return false;
+  }
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE, { keyPath: "id" });
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error ?? new Error("indexedDB open failed"));
+  });
+}
+
+function tx<T>(mode: IDBTransactionMode, run: (store: IDBObjectStore) => IDBRequest<T>): Promise<T> {
+  return openDb().then(
+    (db) =>
+      new Promise<T>((resolve, reject) => {
+        const t = db.transaction(STORE, mode);
+        const req = run(t.objectStore(STORE));
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error ?? new Error("indexedDB request failed"));
+        t.oncomplete = () => db.close();
+      }),
+  );
+}
+
+/** True where durable storage is available (a microphone-capable PWA normally is). Car Mode is
+ *  Chromium-first, where IndexedDB is always present; this guards the rare private-mode tab. */
+export function pendingTurnStoreAvailable(): boolean {
+  return hasIndexedDb();
+}
+
+/** Persist (or update) a Car Mode command-audio record. Rejects only if IndexedDB is unusable, which
+ *  the caller surfaces loudly rather than silently dropping the audio. */
+export async function savePendingTurn(rec: PendingCarModeTurn): Promise<void> {
+  if (!hasIndexedDb()) throw new Error("durable Car Mode turn store unavailable");
+  await tx("readwrite", (s) => s.put(rec));
+}
+
+/** Every held command-audio record still on disk, oldest first (FIFO). Empty when the store is
+ *  unavailable. */
+export async function listPendingTurns(): Promise<PendingCarModeTurn[]> {
+  if (!hasIndexedDb()) return [];
+  const all = await tx<PendingCarModeTurn[]>("readonly", (s) => s.getAll() as IDBRequest<PendingCarModeTurn[]>);
+  return all.sort((a, b) => a.createdAt - b.createdAt);
+}
+
+/** One held record by id, or null when it is gone (already delivered, discarded, or no durable store). */
+export async function getPendingTurn(id: string): Promise<PendingCarModeTurn | null> {
+  if (!hasIndexedDb()) return null;
+  const rec = await tx<PendingCarModeTurn | undefined>(
+    "readonly",
+    (s) => s.get(id) as IDBRequest<PendingCarModeTurn | undefined>,
+  );
+  return rec ?? null;
+}
+
+/** Remove a record once the brain has owned the turn (definitive success), or the owner discards it.
+ *  There is deliberately no time-based prune: undelivered audio is kept until delivered or discarded. */
+export async function deletePendingTurn(id: string): Promise<void> {
+  if (!hasIndexedDb()) return;
+  await tx("readwrite", (s) => s.delete(id));
+}

--- a/packages/client-core/src/carmode/turnRetry.test.ts
+++ b/packages/client-core/src/carmode/turnRetry.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyHeldTurn,
+  HARD_WINDOW_MS,
+  nextTurnRetryDelayMs,
+  STALE_TURN_MS,
+} from "./turnRetry";
+
+// The pure retry policy for held Car Mode turns (offline-resilience Phase 4a, #1427). These lock in the
+// two safety decisions the Architect made (2026-07-13): the brainSent boundary and the staleness cap
+// decide whether a held turn is auto-retried or held for the owner, and the cadence is hard-then-throttled.
+
+const NOW = 1_000_000_000_000;
+
+describe("classifyHeldTurn", () => {
+  it("auto-retries a fresh turn that never reached the brain (the dominant dead-zone case)", () => {
+    // brainSent=false means transcribe never succeeded, so re-driving is a FIRST brain call = safe.
+    expect(classifyHeldTurn({ brainSent: false, createdAt: NOW - 1000 }, NOW)).toBe("auto");
+  });
+
+  it("holds for the owner a turn already sent to the brain (result unknown, could double-act)", () => {
+    // Even a brand-new brainSent turn is ambiguous - it may have acted - so it is never auto-fired in 4a.
+    expect(classifyHeldTurn({ brainSent: true, createdAt: NOW - 1000 }, NOW)).toBe("ask-owner");
+  });
+
+  it("holds for the owner a never-sent turn that is older than the staleness cap", () => {
+    // brainSent=false but stale: firing a half-hour-old action blind is wrong, so surface it for a yes.
+    expect(classifyHeldTurn({ brainSent: false, createdAt: NOW - STALE_TURN_MS - 1 }, NOW)).toBe("ask-owner");
+  });
+
+  it("still auto-retries a never-sent turn right up to the staleness cap", () => {
+    expect(classifyHeldTurn({ brainSent: false, createdAt: NOW - (STALE_TURN_MS - 1) }, NOW)).toBe("auto");
+  });
+
+  it("treats exactly the staleness cap as too old to auto-fire", () => {
+    expect(classifyHeldTurn({ brainSent: false, createdAt: NOW - STALE_TURN_MS }, NOW)).toBe("ask-owner");
+  });
+});
+
+describe("nextTurnRetryDelayMs", () => {
+  it("backs off exponentially from two seconds during the first hard hour", () => {
+    const created = NOW;
+    expect(nextTurnRetryDelayMs(created, 0, NOW)).toBe(2_000);
+    expect(nextTurnRetryDelayMs(created, 1, NOW)).toBe(4_000);
+    expect(nextTurnRetryDelayMs(created, 2, NOW)).toBe(8_000);
+  });
+
+  it("caps the hard backoff at fifteen seconds", () => {
+    expect(nextTurnRetryDelayMs(NOW, 10, NOW)).toBe(15_000);
+  });
+
+  it("throttles to five minutes once past the first hour since capture", () => {
+    const created = NOW - HARD_WINDOW_MS; // exactly one hour old
+    expect(nextTurnRetryDelayMs(created, 0, NOW)).toBe(5 * 60 * 1000);
+    // and it stays throttled no matter the attempt count
+    expect(nextTurnRetryDelayMs(created, 20, NOW)).toBe(5 * 60 * 1000);
+  });
+
+  it("never stops - it always returns a finite, positive delay", () => {
+    const created = NOW - 10 * HARD_WINDOW_MS; // very old
+    const delay = nextTurnRetryDelayMs(created, 100, NOW);
+    expect(delay).toBeGreaterThan(0);
+    expect(Number.isFinite(delay)).toBe(true);
+  });
+});

--- a/packages/client-core/src/carmode/turnRetry.ts
+++ b/packages/client-core/src/carmode/turnRetry.ts
@@ -1,0 +1,69 @@
+// The pure retry policy for held Car Mode turns (Car Mode mission, offline-resilience Phase 4a, issue
+// #1427). No React, no network, no storage - just the decisions the useCarMode driver applies, extracted
+// so they can be unit-tested exactly. The cadence mirrors the proven dictation background driver
+// (dictation/backgroundSend.ts): try hard for the first hour, then throttle to a slow background attempt
+// forever - never stop, never discard the audio.
+
+import type { PendingCarModeTurn } from "./pendingTurnStore";
+
+// ---- retry cadence ---------------------------------------------------------------------------------
+// Try hard for the first hour after the command was captured, then throttle to a slow attempt so a long
+// outage does not hammer a dead connection - but never stop and never discard the audio.
+export const HARD_WINDOW_MS = 60 * 60 * 1000; // "hard" retries for the first hour since capture
+const HARD_MIN_DELAY_MS = 2_000; // first hard retry after two seconds
+const HARD_MAX_DELAY_MS = 15_000; // hard exponential backoff caps at fifteen seconds
+const THROTTLED_DELAY_MS = 5 * 60 * 1000; // after the hard hour: one slow attempt every five minutes
+
+// A held turn older than this is NOT auto-fired even if it never reached the brain (Architect decision,
+// Q2): the world has moved on, so firing a stale action blind is wrong. It is surfaced to the owner for a
+// spoken/tapped yes instead. Reads are equally gated - a half-hour-old answer is not worth speaking blind.
+export const STALE_TURN_MS = 30 * 60 * 1000;
+
+/** How a held turn should be handled when connectivity returns.
+ *  - "auto": the brain call never started AND the turn is fresh, so re-driving it is a safe first brain
+ *    call - auto-retry it.
+ *  - "ask-owner": either the brain call was already sent (its result is unknown, so a blind retry could
+ *    double-act - held until Phase 4b's idempotency key makes it safe) OR the turn is too old to fire
+ *    blind. Surface it to the owner for an explicit send/discard. */
+export type HeldDisposition = "auto" | "ask-owner";
+
+/** Decide how a held turn is handled on reconnect (Architect decisions Q1/Q2). The `brainSent` flag is
+ *  the safety boundary; the staleness cap is the second gate. */
+export function classifyHeldTurn(rec: Pick<PendingCarModeTurn, "brainSent" | "createdAt">, now: number): HeldDisposition {
+  if (rec.brainSent) return "ask-owner"; // already sent to the brain; result unknown; do not auto-fire
+  if (now - rec.createdAt >= STALE_TURN_MS) return "ask-owner"; // too old to fire blind
+  return "auto";
+}
+
+/** The delay before the next automatic retry attempt: hard exponential (from two seconds, capped at
+ *  fifteen) for the first hour since capture, then throttled to five minutes - forever. `attempt` is the
+ *  zero-based count of hard attempts already made this run. */
+export function nextTurnRetryDelayMs(createdAt: number, attempt: number, now: number): number {
+  const age = now - createdAt;
+  if (age >= HARD_WINDOW_MS) return THROTTLED_DELAY_MS;
+  return Math.min(HARD_MIN_DELAY_MS * 2 ** attempt, HARD_MAX_DELAY_MS);
+}
+
+// ---- the audible, honest, plain-English lines (mission decision 8: never a silent stall) -------------
+
+/** Spoken + shown the moment a turn is held because the fleet is unreachable. It says the request is
+ *  SAVED, never lost, and will send automatically - the walkie-talkie equivalent of the dictation
+ *  "waiting for a connection" line. */
+export const HOLDING_MESSAGE =
+  "I can't reach the fleet right now. I've saved your request and I'll send it the moment we're back online.";
+
+/** Spoken prefix on the reply of a held turn that finally lands after reconnect, so the owner knows this
+ *  answer is the delayed one he asked for earlier, not a reply to something he just said (Architect Q3:
+ *  always audibly acknowledge a landed held turn, briefly). */
+export const RECOVERY_PREFIX = "Back online. ";
+
+/** Spoken + shown when a turn was already sent to the brain but its result is unknown, so it is held for
+ *  the owner rather than auto-fired. Honest about the uncertainty. */
+export const AMBIGUOUS_HELD_MESSAGE =
+  "I sent your last request but couldn't confirm it went through, so I've left it alone to avoid doing it twice. Say or tap discard to clear it.";
+
+/** Spoken once when the hands-free end-phrase watch has failed to reach the Gateway several times in a
+ *  row, so the owner is not left silently wondering why his "over and out" never lands (the silent-stall
+ *  fix). It stays trying in the background. */
+export const CONNECTION_DOWN_MESSAGE =
+  "I'm not able to reach the fleet - the connection looks down. I'll keep trying, and your recording is saved.";

--- a/packages/client-core/src/carmode/useCarMode.ts
+++ b/packages/client-core/src/carmode/useCarMode.ts
@@ -12,7 +12,22 @@ import {
   type CarModeAction,
   type CarModeServerTiming,
 } from "./carModeApi";
-import { gatewayErrorMessage } from "../api/client";
+import {
+  deletePendingTurn,
+  getPendingTurn,
+  listPendingTurns,
+  savePendingTurn,
+  type PendingCarModeTurn,
+} from "./pendingTurnStore";
+import {
+  AMBIGUOUS_HELD_MESSAGE,
+  CONNECTION_DOWN_MESSAGE,
+  classifyHeldTurn,
+  HOLDING_MESSAGE,
+  nextTurnRetryDelayMs,
+  RECOVERY_PREFIX,
+} from "./turnRetry";
+import { CreditsError, gatewayErrorMessage } from "../api/client";
 
 // The Car Mode turn-taking machine (v3: button-first, mic never touched during playback). This shared hook
 // owns the whole walkie-talkie loop so the page is a thin view (decision 6).
@@ -128,8 +143,30 @@ export interface CarModeView {
    *  owner SEE what the phone heard). Empty until the first transcription of the current turn. */
   lastHeard: string;
   /** A short capture/transcription state for the debug readout ("listening", "transcribing",
-   *  'heard: "..."', "thinking", "speaking", "interrupt"). */
+   *  'heard: "..."', "thinking", "speaking", "interrupt", "held"). */
   captureState: string;
+  // ----- Offline resilience (mission Phase 4a, issue #1427) -------------------------------------------
+  /** True while one or more of the owner's spoken requests are SAVED on the device and waiting to send
+   *  (a dead zone). Never a loss: the audio is durable and auto-retries when the connection returns. */
+  holding: boolean;
+  /** How many spoken requests are currently saved-and-waiting on the device. */
+  heldCount: number;
+  /** The honest, saved-not-lost line to show/say for the current held state, or null when nothing is held.
+   *  Distinct from `error` (a loud red failure): holding is a calm "saved, will send" state. */
+  holdMessage: string | null;
+  /** The oldest held turn that cannot be auto-fired and needs the owner's explicit choice, or null.
+   *  `reason` is "stale" (never sent to the brain but older than the auto-fire cap - safe to send on the
+   *  owner's yes) or "ambiguous" (already sent to the brain, result unknown - can only be discarded in
+   *  Phase 4a, since a blind resend could act twice; Phase 4b's idempotency key makes resend safe). */
+  askOwnerTurn: { id: string; transcript: string; reason: "stale" | "ambiguous" } | null;
+  /** True once the hands-free end-phrase watch has failed to reach the Gateway several times in a row, so
+   *  the page can show the connection is down (paired with the spoken CONNECTION_DOWN cue). */
+  connectionDown: boolean;
+  /** Owner explicitly sends a "stale" held turn now (safe: it never reached the brain). A no-op for an
+   *  ambiguous held turn (resend is unsafe until Phase 4b) or an unknown id. */
+  sendHeldTurn: (id: string) => void;
+  /** Owner explicitly discards a held turn, dropping its saved audio for good. */
+  discardHeldTurn: (id: string) => void;
   /** The last transcription error line, or null when none. Distinct from `error` (the loud user-facing
    *  failure); this is the raw diagnostic detail from a background probe. */
   captureError: string | null;
@@ -170,6 +207,11 @@ const DEFAULT_END_PHRASE = "over and out";
 // (measured 9/9 on "over and out") instead of guessing when the owner paused. The touch button is the
 // instant path; this is the hands-free path, ~1s felt delay after the phrase (owner-accepted).
 const END_PHRASE_POLL_MS = 800;
+// How many consecutive failed end-phrase transcribe ticks (each ~800 ms) before Car Mode audibly tells
+// the owner the connection is down, so a dead zone never silently swallows his "over and out" forever
+// (the silent-stall fix). Four ticks is ~3 seconds - long enough to ride out a single blip, short enough
+// that a real dead zone is announced quickly.
+const END_PHRASE_FAIL_THRESHOLD = 4;
 
 /** Whether this browser can capture audio for Car Mode. Car Mode is Chromium-first (decision 7); elsewhere
  *  the page tells the owner plainly instead of silently degrading (no fallback, decision 8). */
@@ -177,6 +219,12 @@ function isCaptureSupported(): boolean {
   if (typeof navigator === "undefined" || typeof window === "undefined") return false;
   const md = navigator.mediaDevices as MediaDevices | undefined;
   return Boolean(md && md.getUserMedia) && typeof MediaRecorder !== "undefined";
+}
+
+/** True when the browser reports it is offline. A cheap pre-check so the retry driver does not burn a
+ *  transcribe round trip into a known-dead network; the real classification still comes from gatewayFetch. */
+function isOffline(): boolean {
+  return typeof navigator !== "undefined" && navigator.onLine === false;
 }
 
 // A tiny, silent WAV clip (a valid RIFF/WAVE header with zero audio samples) used ONLY to unlock the
@@ -230,6 +278,12 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
   const [captureError, setCaptureError] = useState<string | null>(null);
   const unsupported = !isCaptureSupported();
 
+  // Offline resilience (Phase 4a): the held-turn state the page shows, plus the connection-down flag the
+  // end-phrase watch raises. `heldTurns` mirrors the durable store, refreshed after every store mutation.
+  const [heldTurns, setHeldTurns] = useState<PendingCarModeTurn[]>([]);
+  const [holdMessage, setHoldMessage] = useState<string | null>(null);
+  const [connectionDown, setConnectionDown] = useState(false);
+
   // Long-lived collaborators, held in refs so the effect wiring never re-creates them mid-session.
   const recorderRef = useRef<MicRecorder | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
@@ -261,6 +315,24 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
   const endPollRef = useRef<number | null>(null);
   const endPollBusyRef = useRef(false);
   const endTickRef = useRef<() => void>(() => {});
+
+  // Offline resilience (Phase 4a) refs. currentRecordIdRef is the durable id of the turn in flight, so a
+  // brain success can delete exactly that record. The drive* refs run the background re-drive of held
+  // audio: drivingRef single-flights it, driveTimerRef holds the cadence timer, driveAttemptRef is the
+  // backoff step, and driveTickRef breaks the scheduleDrive <-> driveHeldTurns callback cycle (the same
+  // ref-indirection the end-phrase watch uses). endFailCountRef + connDownAnnouncedRef drive the silent-
+  // stall fix: after several failed end-phrase ticks the connection-down cue is spoken once.
+  const currentRecordIdRef = useRef<string | null>(null);
+  const drivingRef = useRef(false);
+  const driveTimerRef = useRef<number | null>(null);
+  const driveAttemptRef = useRef(0);
+  const driveTickRef = useRef<() => void>(() => {});
+  const endFailCountRef = useRef(0);
+  const connDownAnnouncedRef = useRef(false);
+  // The connectivity listeners installed while Car Mode is open, held so stop()/unmount can remove exactly
+  // them: a re-drive of held turns is kicked the instant the network returns or the app is foregrounded.
+  const onlineHandlerRef = useRef<(() => void) | null>(null);
+  const visibilityHandlerRef = useRef<(() => void) | null>(null);
 
   // The phase, read synchronously inside the loop/timer callbacks (not a React render). A ref mirror
   // avoids a stale closure so the machine always branches on the CURRENT phase.
@@ -361,13 +433,11 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     playbackStopRef.current?.();
   }, []);
 
-  // Announce a failure LOUDLY (decision 8). The failure is put on screen AND spoken through the browser's
-  // local speech synthesis - deliberately NOT the Gateway voice, because the most common failure (an
-  // offline / out-of-credit Gateway) is exactly when POST /wingman/tts is also down, and a spoken failure
-  // must still be heard eyes-free. Used ONLY to announce failures, never the assistant's normal replies.
-  const announceError = useCallback((message: string) => {
-    setError(message);
-    console.log(`[CarMode] FAILURE: ${message}`);
+  // Speak a short line through the browser's LOCAL speech synthesis - deliberately NOT the Gateway voice,
+  // because the states this is used for (a failure, or an offline/holding state) are exactly when
+  // POST /wingman/tts is also unreachable, and the line must still be heard eyes-free. Best-effort: a
+  // synthesis hiccup never throws into the turn loop.
+  const speakLocal = useCallback((message: string) => {
     try {
       const synth = (window as unknown as { speechSynthesis?: SpeechSynthesis }).speechSynthesis;
       if (synth) {
@@ -375,7 +445,26 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
         synth.speak(new SpeechSynthesisUtterance(message));
       }
     } catch {
-      // Local synthesis is a courtesy on top of the on-screen error; never let it throw into the loop.
+      // Local synthesis is a courtesy on top of the on-screen state; never let it throw into the loop.
+    }
+  }, []);
+
+  // Announce a failure LOUDLY (decision 8): on screen AND spoken locally. Used ONLY for true failures,
+  // never the assistant's normal replies and never the calm "saved, will send" holding state (which uses
+  // holdMessage + speakLocal directly, not the red error surface).
+  const announceError = useCallback((message: string) => {
+    setError(message);
+    console.log(`[CarMode] FAILURE: ${message}`);
+    speakLocal(message);
+  }, [speakLocal]);
+
+  // Reload the held-turn list from the durable store into React state, so the page reflects exactly what
+  // is saved and waiting after every store mutation. Best-effort: an unreadable store shows nothing held.
+  const refreshHeldTurns = useCallback(async () => {
+    try {
+      setHeldTurns(await listPendingTurns());
+    } catch {
+      setHeldTurns([]);
     }
   }, []);
 
@@ -544,10 +633,233 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     [announceError, enterListening, playBlob, postTurnTelemetry, revokeClip, setPhaseBoth, stopThinkingCue],
   );
 
+  // ----- Offline resilience: holding, the audible states, and the background re-drive driver (Phase 4a) -
+
+  // Enter the HOLDING state after a transcribe failure (the brain call never started, so the durable
+  // record is brainSent=false and safe to auto-retry). This is NOT a red failure: the owner's speech is
+  // SAVED and will send when the connection returns. Say + show the calm held line, refresh the held list,
+  // hand the microphone back (the durable audio is safe, so restarting the live capture is fine now), and
+  // kick the retry driver so the cadence / online wait begins.
+  const enterHolding = useCallback(async () => {
+    stopThinkingCue();
+    setCaptureState("held");
+    setHoldMessage(HOLDING_MESSAGE);
+    speakLocal(HOLDING_MESSAGE);
+    await refreshHeldTurns();
+    await enterListening();
+    driveTickRef.current();
+  }, [stopThinkingCue, speakLocal, refreshHeldTurns, enterListening]);
+
+  // Clear the brain-sent mark on a held record back to auto-retriable. Used when a brain call failed for a
+  // reason that PROVES no action was taken (a money refusal: no credits means no model call and no tools),
+  // so the saved turn is safe to auto-retry when the cause clears - it is NOT the ambiguous "may have
+  // acted" case. Best-effort: a store hiccup just leaves the record marked ambiguous (still safe: it holds
+  // for the owner rather than firing blind).
+  const markAutoRetriable = useCallback(async (id: string) => {
+    try {
+      const r = await getPendingTurn(id);
+      if (r !== null) await savePendingTurn({ ...r, brainSent: false });
+    } catch {
+      // leave it as-is; the worst case is a held-for-owner turn instead of an auto one - never a double act
+    }
+    await refreshHeldTurns();
+  }, [refreshHeldTurns]);
+
+  // Enter the HELD-FOR-OWNER state after a brain-call failure whose result is unknown (the durable record
+  // is brainSent=true). It may have acted, so it is NOT auto-retried (a blind resend could act twice); it
+  // waits for the owner to discard it (Phase 4a) - Phase 4b's idempotency key will make an automatic
+  // resend safe. Say + show the honest ambiguous line and hand the microphone back.
+  const holdForOwner = useCallback(async () => {
+    stopThinkingCue();
+    setCaptureState("held");
+    setHoldMessage(AMBIGUOUS_HELD_MESSAGE);
+    speakLocal(AMBIGUOUS_HELD_MESSAGE);
+    await refreshHeldTurns();
+    await enterListening();
+  }, [stopThinkingCue, speakLocal, refreshHeldTurns, enterListening]);
+
+  // Re-drive ONE held command-audio record through the whole pipeline (transcribe -> brain -> speak),
+  // exactly like a live turn but announced with the "Back online" prefix so the owner knows this is the
+  // delayed answer to a request he made earlier (Architect Q3). The durable record is deleted ONLY after
+  // the brain call returns a definitive success (the turn is owned server-side); a failure keeps the audio
+  // and holds. brainSent is flipped true on the record right before the brain call, so a failure AFTER
+  // that point becomes held-for-owner (ambiguous), while a failure at transcribe stays auto-retriable.
+  const driveHeldTurn = useCallback(
+    async (rec: PendingCarModeTurn) => {
+      const recorder = recorderRef.current;
+      if (recorder === null) return;
+      // The mic must be the owner's and idle to take a recovered turn. Re-check here (not just in the
+      // caller) because a live "over and out" can fire during the driver's async gap - the phase would
+      // already be "thinking", and two turns must never run on one recorder/audio element.
+      if (phaseRef.current !== "listening") return;
+      // Reflect the recovered turn taking the turn, synchronously (responsive-first), same as a live end.
+      playReadyCue();
+      setPhaseBoth("thinking");
+      setCaptureState("thinking");
+      setHoldMessage(null);
+      stopThinkingCue();
+      thinkingCueStopRef.current = startThinkingCue();
+      const controller = new AbortController();
+      abortRef.current = controller;
+      let sentBrain = false;
+      try {
+        // Stop + release the live microphone before Thinking/Speaking (v3 rule), so the recovered reply
+        // plays with getUserMedia released, just like a live reply.
+        try {
+          if (recorder.isRecording) await recorder.stop();
+        } catch {
+          // the segment is being torn down; nothing more to do
+        }
+
+        // Transcribe unless a prior attempt already cached the command text on the record.
+        let command = rec.transcript ?? null;
+        if (command === null) {
+          const { wav } = await blobToWav16kMono(rec.audio);
+          const transcript = (await transcribeCarModeAudio(wav, controller.signal)).trim();
+          const parsed = detectPhraseAtEnd(transcript, rec.endPhrase);
+          command = (parsed.ended ? parsed.command : transcript).trim();
+          try {
+            await savePendingTurn({ ...rec, transcript: command });
+          } catch {
+            // durable update failed; continue from the in-memory command this run
+          }
+        }
+        if (controller.signal.aborted) return;
+
+        if (command.length === 0) {
+          // The saved audio transcribed to nothing (noise): drop it rather than nagging the owner later.
+          await deletePendingTurn(rec.id);
+          await refreshHeldTurns();
+          await enterListening();
+          return;
+        }
+
+        setTranscript(command);
+        setLastHeard(command);
+        // Cross the brain boundary: a failure from here is ambiguous (may have acted).
+        try {
+          await savePendingTurn({ ...rec, transcript: command, brainSent: true });
+        } catch {
+          // durable update failed; the in-memory sentBrain flag below still routes the failure correctly
+        }
+        sentBrain = true;
+        turnMetricsRef.current = null; // re-drives are recovery, not part of the live performance telemetry
+
+        const answer = await respond(command, controller.signal);
+        if (controller.signal.aborted) return;
+        // The brain owns the turn: delete the durable record so it can never be re-driven / double-acted.
+        await deletePendingTurn(rec.id);
+        if (currentRecordIdRef.current === rec.id) currentRecordIdRef.current = null;
+        driveAttemptRef.current = 0; // a success resets the backoff so the next held turn retries hard
+        await refreshHeldTurns();
+
+        const spoken = answer.spoken.trim();
+        setReply(spoken);
+        setActions(answer.actions ?? []);
+        setPendingConfirmation(Boolean(answer.pendingConfirmation));
+        setHistory((prev) => [...prev, { command: command as string, spoken, actions: answer.actions ?? [] }]);
+        if (spoken.length === 0) {
+          await enterListening();
+          return;
+        }
+        // Speak the recovered answer with the "Back online" prefix so it is clearly the delayed reply.
+        await speakAndPlay(RECOVERY_PREFIX + spoken, controller.signal);
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        stopThinkingCue();
+        console.log(`[CarMode] re-drive of a held turn failed: ${err instanceof Error ? err.message : String(err)}`);
+        // Keep the audio. A money refusal (402) proves nothing acted, so keep it auto-retriable and let the
+        // NEXT foreground / online / open re-drive it (no aggressive loop that a fast retry cannot fix). If
+        // the brain had already been sent for a non-credits reason, it is now ambiguous (held for the
+        // owner); otherwise the transcribe never reached the brain and it stays auto-retriable.
+        if (err instanceof CreditsError) {
+          await markAutoRetriable(rec.id);
+          setHoldMessage(HOLDING_MESSAGE);
+          await refreshHeldTurns();
+          await enterListening();
+        } else if (sentBrain) {
+          await holdForOwner();
+        } else {
+          setHoldMessage(HOLDING_MESSAGE);
+          await refreshHeldTurns();
+          await enterListening();
+          driveTickRef.current();
+        }
+      }
+    },
+    [refreshHeldTurns, enterListening, respond, speakAndPlay, setPhaseBoth, stopThinkingCue, holdForOwner, markAutoRetriable],
+  );
+
+  // Schedule the next automatic drive attempt on the retry cadence (hard for the first hour since the
+  // oldest auto-eligible turn was captured, then throttled - never stops). No-op when nothing is
+  // auto-eligible. Idempotent: a pending timer is not doubled.
+  const scheduleDrive = useCallback(() => {
+    if (driveTimerRef.current !== null) return;
+    void (async () => {
+      let all: PendingCarModeTurn[];
+      try {
+        all = await listPendingTurns();
+      } catch {
+        return;
+      }
+      const now = Date.now();
+      const auto = all
+        .filter((r) => classifyHeldTurn(r, now) === "auto")
+        .sort((a, b) => a.createdAt - b.createdAt)[0];
+      if (auto === undefined) return; // only ask-owner turns remain; they wait for the owner, not a timer
+      const delay = nextTurnRetryDelayMs(auto.createdAt, driveAttemptRef.current, now);
+      driveTimerRef.current = window.setTimeout(() => {
+        driveTimerRef.current = null;
+        driveAttemptRef.current += 1;
+        driveTickRef.current();
+      }, delay);
+    })();
+  }, []);
+
+  // Drive held turns when connectivity may have returned (the online event, app foreground, Start, and the
+  // cadence timer). Serialized: never while a live turn or another drive is in flight, never while the
+  // owner is mid-utterance (so a recovered answer cannot cut him off). Fires the oldest AUTO turn; any
+  // ask-owner turns are left surfaced in the UI for the owner's explicit choice.
+  const driveHeldTurns = useCallback(async () => {
+    if (drivingRef.current) return;
+    if (phaseRef.current !== "listening") return; // only when the microphone is the owner's and idle
+    const recorder = recorderRef.current;
+    // If the owner has already started talking this segment, defer so the drive cannot preempt him.
+    if (recorder !== null && recorder.snapshot().size >= MIN_CLIP_BYTES) {
+      scheduleDrive();
+      return;
+    }
+    let all: PendingCarModeTurn[];
+    try {
+      all = await listPendingTurns();
+    } catch {
+      return;
+    }
+    await refreshHeldTurns(); // keep the UI (ask-owner surface, held count) in sync every kick
+    const now = Date.now();
+    const auto = all
+      .filter((r) => classifyHeldTurn(r, now) === "auto")
+      .sort((a, b) => a.createdAt - b.createdAt)[0];
+    if (auto === undefined) return; // nothing safe to auto-fire
+    if (isOffline()) {
+      scheduleDrive(); // no point transcribing into a dead network; wait for online / the cadence
+      return;
+    }
+    drivingRef.current = true;
+    try {
+      await driveHeldTurn(auto);
+    } finally {
+      drivingRef.current = false;
+    }
+    scheduleDrive(); // continue draining any remaining auto turns on the cadence
+  }, [scheduleDrive, refreshHeldTurns, driveHeldTurn]);
+  // Point the scheduler's indirection ref at the latest driveHeldTurns (breaks the scheduleDrive cycle).
+  driveTickRef.current = () => void driveHeldTurns();
+
   // Take the turn: the command (already stripped of "over and out") is answered by the brain and the reply
   // is spoken. Guards against double-entry so a touch tap and a pause probe cannot both fire one turn.
   const takeTurn = useCallback(
-    async (command: string) => {
+    async (command: string, recordId: string | null) => {
       // v5: the screen is switched to Thinking SYNCHRONOUSLY in the endTurn tap handler (responsive-first),
       // so by the time this runs the phase is already "thinking" - guard on that (not "listening") so the
       // turn proceeds, while a second rapid tap is still a no-op (endTurn's own listening-guard blocks it).
@@ -571,13 +883,34 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
 
       try {
         if (trimmed.length === 0) {
-          // A forced turn with nothing heard: a canned nudge, no server turn, so no telemetry record.
+          // A forced turn with nothing heard: a canned nudge, no server turn, so no telemetry record. Drop
+          // any durable record too - saved noise is not worth holding or retrying.
           turnMetricsRef.current = null;
+          if (recordId !== null) {
+            try {
+              await deletePendingTurn(recordId);
+            } catch {
+              /* store hiccup; a later resume simply re-drops it */
+            }
+            if (currentRecordIdRef.current === recordId) currentRecordIdRef.current = null;
+            await refreshHeldTurns();
+          }
           await speakAndPlay("I didn't catch a request. Go ahead when you're ready.", controller.signal);
           return;
         }
         const brainStart = performance.now();
         const answer = await respond(trimmed, controller.signal);
+        // The brain owns the turn: delete the durable record so it can never be re-driven / double-acted.
+        if (recordId !== null) {
+          try {
+            await deletePendingTurn(recordId);
+          } catch {
+            /* store hiccup; the turn still succeeded, so a later resume re-drops it harmlessly */
+          }
+          if (currentRecordIdRef.current === recordId) currentRecordIdRef.current = null;
+          setHoldMessage(null);
+          await refreshHeldTurns();
+        }
         const spoken = answer.spoken.trim();
         // Fill the turn metrics the transcribe step started (same object via the ref), for telemetry.
         const metrics = turnMetricsRef.current;
@@ -601,24 +934,70 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
         await speakAndPlay(spoken, controller.signal);
       } catch (err) {
         if (controller.signal.aborted) return; // stop()/interrupt aborted this turn on purpose
-        announceError(gatewayErrorMessage(err));
-        await enterListening();
+        // The brain call failed. A money refusal (402) proves nothing acted (no credits = no model call =
+        // no tools), so it is NOT ambiguous: announce the shared credits notice, keep the saved turn
+        // auto-retriable (it completes when credits return, on the next foreground / online), and hand the
+        // microphone back. Any OTHER failure with a durable record was marked brainSent=true, so its result
+        // is unknown - HOLD it for the owner (a blind resend could act twice). Without a durable record,
+        // fall back to the loud failure.
+        if (recordId !== null && err instanceof CreditsError) {
+          await markAutoRetriable(recordId);
+          announceError(err.message);
+          setHoldMessage(HOLDING_MESSAGE);
+          await enterListening();
+        } else if (recordId !== null) {
+          await holdForOwner();
+        } else {
+          announceError(gatewayErrorMessage(err));
+          await enterListening();
+        }
       }
     },
-    [respond, announceError, enterListening, speakAndPlay, setPhaseBoth],
+    [respond, announceError, enterListening, speakAndPlay, setPhaseBoth, holdForOwner, refreshHeldTurns, markAutoRetriable],
   );
 
   // Transcribe the audio captured so far and take the turn. This is the touch "Over and out" path, the
   // primary (and only) end-of-turn path in v3: the owner explicitly ended his turn, so a failure is
   // announced loudly. If he happened to say "over and out" it is stripped; otherwise the whole transcript is
   // the command (voice over-and-out is deferred - the button is the end path).
-  const transcribeAndTake = useCallback(async (prefetched?: { transcript: string; transcodeMs: number; pauseDetectedAt: number }) => {
+  const transcribeAndTake = useCallback(async (prefetched?: { transcript: string; transcodeMs: number; pauseDetectedAt: number; clip: Blob }) => {
     const rec = recorderRef.current;
     if (rec === null) return;
     // Time the command transcription from the tap so the telemetry shows how long the owner waits between
     // finishing and the brain starting. The voice end-phrase path already transcribed to DETECT the phrase,
     // so it passes its transcript + timings and we skip a second round trip.
     const pauseDetectedAt = prefetched ? prefetched.pauseDetectedAt : performance.now();
+
+    // Acquire the raw command audio for BOTH paths (the voice end-phrase path passes the very clip it
+    // transcribed). This is what gets persisted so speech is never lost.
+    const clip = prefetched ? prefetched.clip : rec.snapshot();
+    if (!prefetched && clip.size < MIN_CLIP_BYTES) {
+      void takeTurn("", null); // nothing captured: a canned nudge, no server turn, no durable record
+      return;
+    }
+
+    // Persist the command audio to the durable store BEFORE any transcribe, so a connection drop mid-turn
+    // can no longer lose the owner's speech (req a, #1427). brainSent=false marks it safe to auto-retry -
+    // the brain provably has not started yet.
+    const record: PendingCarModeTurn = {
+      id: crypto.randomUUID(),
+      audio: clip,
+      endPhrase: endPhraseRef.current,
+      createdAt: Date.now(),
+      brainSent: false,
+    };
+    let persisted = false;
+    try {
+      await savePendingTurn(record);
+      persisted = true;
+      currentRecordIdRef.current = record.id;
+      void refreshHeldTurns();
+    } catch {
+      // Durable storage genuinely unavailable (rare private-mode tab): continue best-effort on the live
+      // path; a transcribe failure then falls back to the loud error, since we cannot hold what we could
+      // not save (no fallback that silently drops the speech - it is announced).
+    }
+
     try {
       let transcript: string;
       let transcodeMs: number;
@@ -626,11 +1005,6 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
         transcript = prefetched.transcript;
         transcodeMs = prefetched.transcodeMs;
       } else {
-        const clip = rec.snapshot();
-        if (clip.size < MIN_CLIP_BYTES) {
-          void takeTurn(""); // nothing captured: a canned nudge, no server turn
-          return;
-        }
         setCaptureState("transcribing");
         transcribeAttemptsRef.current += 1;
         // Measure the client-side transcode (phone CPU) separately from the transcribe round trip (network +
@@ -648,6 +1022,18 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
       const parsed = detectPhraseAtEnd(transcript, endPhraseRef.current);
       const command = parsed.ended ? parsed.command : transcript;
       setCaptureState(`heard: "${transcript}"`);
+
+      // Transcription succeeded. Cache the command on the durable record and cross the brain boundary
+      // (brainSent=true) BEFORE the brain call: a failure from here on is ambiguous (held for the owner),
+      // while everything up to here stayed auto-retriable.
+      if (persisted) {
+        try {
+          await savePendingTurn({ ...record, transcript: command.trim(), brainSent: true });
+        } catch {
+          // durable update failed; the record stays brainSent=false. Worst case a later resume re-drives
+          // it as a fresh first brain call - still safe, and speech is never lost.
+        }
+      }
 
       // Seed the turn metrics the brain + speak steps fill, then take the turn. (v4: the "my turn" cue is
       // no longer fired here - it now fires SYNCHRONOUSLY in the endTurn tap handler, before this async
@@ -685,17 +1071,22 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
         footerVisible: false,
         posted: false,
       };
-      void takeTurn(command);
+      void takeTurn(command, persisted ? record.id : null);
     } catch (err) {
-      // The transcribe failed while we are already in Thinking (v5): silence the ambient cue and hand the
-      // microphone back to the owner so the screen does not stall on Thinking after a failure.
+      // The transcribe (or transcode) failed while we are already in Thinking (v5): silence the ambient
+      // cue. The brain never started, so the durable record is brainSent=false and safe to auto-retry:
+      // enter the calm HOLDING state (speech SAVED, not lost) instead of discarding the utterance. Without
+      // a durable record (no store) fall back to the loud failure, since there is nothing to hold.
       stopThinkingCue();
-      const msg = gatewayErrorMessage(err);
-      setCaptureError(msg);
-      announceError(msg);
-      await enterListening();
+      setCaptureError(gatewayErrorMessage(err));
+      if (persisted) {
+        await enterHolding();
+      } else {
+        announceError(gatewayErrorMessage(err));
+        await enterListening();
+      }
     }
-  }, [announceError, enterListening, stopThinkingCue, takeTurn]);
+  }, [announceError, enterListening, stopThinkingCue, takeTurn, refreshHeldTurns, enterHolding]);
 
   // The hands-free end-phrase tick: while Listening, re-transcribe the captured audio and, if it now ends
   // with the owner's sign-off phrase, take the turn (reusing the transcript so there is no second round
@@ -714,28 +1105,45 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
       const { wav } = await blobToWav16kMono(clip);
       const transcodeMs = performance.now() - transcodeStart;
       const transcript = (await transcribeCarModeAudio(wav)).trim();
+      // This tick reached the Gateway: the connection is alive. Reset the silent-stall counter and clear
+      // the connection-down state / announce-once latch, so a recovered connection stops warning.
+      endFailCountRef.current = 0;
+      if (connDownAnnouncedRef.current) {
+        connDownAnnouncedRef.current = false;
+        setConnectionDown(false);
+      }
       // The owner may have tapped the button (or the session ended) during this ~1s transcribe: only commit
       // while STILL Listening, so the button and the watch can never both take one turn.
       if (phaseRef.current !== "listening") return;
       setLastHeard(transcript);
       if (!detectPhraseAtEnd(transcript, endPhraseRef.current).ended) return; // not done yet - keep listening
       // Heard the sign-off. Mirror the button's end-of-turn exactly: instant "my turn" cue, switch to
-      // Thinking, start the gentle working tone, stop the watch, then take the turn with the transcript we
-      // already have (transcribeAndTake reuses it and strips the phrase).
+      // Thinking, start the gentle working tone, stop the watch, then take the turn with the transcript AND
+      // the very clip we already transcribed (transcribeAndTake reuses both, persists the audio, strips the
+      // phrase).
       playReadyCue();
       setPhaseBoth("thinking");
       setCaptureState("thinking");
       stopThinkingCue();
       thinkingCueStopRef.current = startThinkingCue();
       stopEndPhraseWatch();
-      void transcribeAndTake({ transcript, transcodeMs, pauseDetectedAt: startedAt });
+      void transcribeAndTake({ transcript, transcodeMs, pauseDetectedAt: startedAt, clip });
     } catch (err) {
-      // A failed rolling transcribe must not kill the turn - skip this tick and try again next second.
+      // A failed rolling transcribe must not kill the turn - skip this tick and try again next second. But
+      // a dead zone must not silently swallow "over and out" forever: after several consecutive failures,
+      // say ONCE that the connection is down (the silent-stall fix). The owner's audio keeps accumulating
+      // locally the whole time, so nothing is lost - when the connection returns, his "over and out" lands.
+      endFailCountRef.current += 1;
+      if (endFailCountRef.current >= END_PHRASE_FAIL_THRESHOLD && !connDownAnnouncedRef.current) {
+        connDownAnnouncedRef.current = true;
+        setConnectionDown(true);
+        speakLocal(CONNECTION_DOWN_MESSAGE);
+      }
       console.log(`[CarMode] end-phrase watch skipped a tick: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       endPollBusyRef.current = false;
     }
-  }, [setPhaseBoth, stopThinkingCue, stopEndPhraseWatch, transcribeAndTake]);
+  }, [setPhaseBoth, stopThinkingCue, stopEndPhraseWatch, transcribeAndTake, speakLocal]);
   // Keep the interval (started in enterListening, before this tick is defined) pointing at the latest tick.
   endTickRef.current = endPhraseTick;
 
@@ -776,6 +1184,54 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
   // capture stream's AnalyserNode (display only) and returns 0 when the microphone is not capturing.
   const getMicLevel = useCallback(() => recorderRef.current?.level() ?? 0, []);
 
+  // Owner explicitly sends a "stale" held turn now (Architect Q2: a turn older than the auto-fire cap is
+  // surfaced for a yes). Safe ONLY because a stale held turn has brainSent=false - it never reached the
+  // brain, so this is a first brain call, no double-action. An ambiguous held turn (brainSent=true) is a
+  // no-op here: resend is unsafe until Phase 4b, so the UI only offers discard for it. Only drives while
+  // the microphone is the owner's and no other drive is running.
+  const sendHeldTurn = useCallback(
+    async (id: string) => {
+      if (drivingRef.current || phaseRef.current !== "listening") return;
+      let rec: PendingCarModeTurn | null;
+      try {
+        rec = await getPendingTurn(id);
+      } catch {
+        return;
+      }
+      if (rec === null || rec.brainSent) return; // gone, or ambiguous (resend unsafe in Phase 4a)
+      drivingRef.current = true;
+      try {
+        await driveHeldTurn(rec);
+      } finally {
+        drivingRef.current = false;
+      }
+    },
+    [driveHeldTurn],
+  );
+
+  // Owner explicitly discards a held turn, dropping its saved audio for good. Clears the held banner and
+  // the connection-down state when nothing is left waiting.
+  const discardHeldTurn = useCallback(
+    async (id: string) => {
+      try {
+        await deletePendingTurn(id);
+      } catch {
+        // store hiccup; a later resume simply re-drops it
+      }
+      if (currentRecordIdRef.current === id) currentRecordIdRef.current = null;
+      const remaining = await (async () => {
+        try {
+          return await listPendingTurns();
+        } catch {
+          return [];
+        }
+      })();
+      setHeldTurns(remaining);
+      if (remaining.length === 0) setHoldMessage(null);
+    },
+    [],
+  );
+
   const start = useCallback(async () => {
     if (started) return;
     if (unsupported) {
@@ -808,10 +1264,33 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     // sounds cleanly and does not churn the mobile audio session (which was ducking the spoken reply in v7).
     primeCueAudio();
 
+    // Offline resilience (Phase 4a): install the connectivity kickers so a held turn re-drives the instant
+    // the network returns or the app comes back to the foreground - not only on the cadence timer. On a
+    // kick the backoff resets to hard so recovery is immediate. Held both in refs so stop()/unmount removes
+    // exactly these listeners.
+    const onOnline = () => {
+      driveAttemptRef.current = 0;
+      driveTickRef.current();
+    };
+    const onVisible = () => {
+      if (typeof document !== "undefined" && !document.hidden) {
+        driveAttemptRef.current = 0;
+        driveTickRef.current();
+      }
+    };
+    onlineHandlerRef.current = onOnline;
+    visibilityHandlerRef.current = onVisible;
+    if (typeof window !== "undefined") window.addEventListener("online", onOnline);
+    if (typeof document !== "undefined") document.addEventListener("visibilitychange", onVisible);
+    // Resume: surface (and, when the mic settles into Listening, auto-drive) any turns saved on a previous
+    // visit that never got delivered. refreshHeldTurns shows them now; driveTickRef drains the safe ones.
+    void refreshHeldTurns();
+    driveTickRef.current();
+
     // The turn ends hands-free when the rolling end-phrase watch hears the sign-off phrase, or instantly
     // when the owner taps "Over and out". The AnalyserNode drives the on-screen level meter (getMicLevel).
     await enterListening();
-  }, [started, unsupported, enterListening]);
+  }, [started, unsupported, enterListening, refreshHeldTurns]);
 
   const stop = useCallback(() => {
     console.log("[CarMode] stop");
@@ -825,6 +1304,26 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     stopEndPhraseWatch();
     // Release the shared cue audio channel opened at Start.
     releaseCueAudio();
+    // Offline resilience (Phase 4a): remove the connectivity kickers and cancel the retry cadence timer so
+    // nothing drives held turns after the owner leaves Car Mode. The saved AUDIO is deliberately kept in
+    // the durable store - it is never lost by ending the session - and re-surfaces next time Car Mode opens.
+    if (onlineHandlerRef.current !== null && typeof window !== "undefined") {
+      window.removeEventListener("online", onlineHandlerRef.current);
+      onlineHandlerRef.current = null;
+    }
+    if (visibilityHandlerRef.current !== null && typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", visibilityHandlerRef.current);
+      visibilityHandlerRef.current = null;
+    }
+    if (driveTimerRef.current !== null) {
+      clearTimeout(driveTimerRef.current);
+      driveTimerRef.current = null;
+    }
+    driveAttemptRef.current = 0;
+    connDownAnnouncedRef.current = false;
+    endFailCountRef.current = 0;
+    setConnectionDown(false);
+    setHoldMessage(null);
     if (keepWarmRef.current !== null) {
       clearInterval(keepWarmRef.current);
       keepWarmRef.current = null;
@@ -858,6 +1357,13 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
       playbackStopRef.current?.();
       thinkingCueStopRef.current?.();
       if (keepWarmRef.current !== null) clearInterval(keepWarmRef.current);
+      // Offline resilience (Phase 4a): remove the connectivity kickers and cancel the retry cadence timer
+      // on unmount too (navigating away from Car Mode). The saved audio stays durable.
+      if (onlineHandlerRef.current !== null && typeof window !== "undefined")
+        window.removeEventListener("online", onlineHandlerRef.current);
+      if (visibilityHandlerRef.current !== null && typeof document !== "undefined")
+        document.removeEventListener("visibilitychange", visibilityHandlerRef.current);
+      if (driveTimerRef.current !== null) clearTimeout(driveTimerRef.current);
       try {
         recorderRef.current?.dispose();
       } catch {
@@ -876,6 +1382,21 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     };
   }, []);
 
+  // Derive the owner-facing held state from the store mirror. The oldest turn needing an explicit choice
+  // is surfaced as askOwnerTurn, tagged "stale" (never sent, safe to send on a yes) or "ambiguous" (sent
+  // to the brain, result unknown, discard-only in Phase 4a).
+  const now = Date.now();
+  const askOwnerRec = heldTurns
+    .filter((r) => classifyHeldTurn(r, now) === "ask-owner")
+    .sort((a, b) => a.createdAt - b.createdAt)[0];
+  const askOwnerTurn = askOwnerRec
+    ? {
+        id: askOwnerRec.id,
+        transcript: askOwnerRec.transcript ?? "",
+        reason: askOwnerRec.brainSent ? ("ambiguous" as const) : ("stale" as const),
+      }
+    : null;
+
   return {
     phase,
     started,
@@ -889,6 +1410,13 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     lastHeard,
     captureState,
     captureError,
+    holding: heldTurns.length > 0,
+    heldCount: heldTurns.length,
+    holdMessage,
+    askOwnerTurn,
+    connectionDown,
+    sendHeldTurn: (id: string) => void sendHeldTurn(id),
+    discardHeldTurn: (id: string) => void discardHeldTurn(id),
     getMicLevel,
     endTurn,
     interrupt,


### PR DESCRIPTION
Car Mode offline-resilience mission, **Phase 4a** (issue thefrederiksen/devthrottle_internal#772). Client-only, no Gateway binary change.

## What this delivers
Driving in and out of bad signal, Car Mode now:
- **(a) never loses the owner's speech** - the command audio is written to a durable IndexedDB store BEFORE any transcribe, and a failed end-of-turn no longer discards the recorder buffer.
- **(b) durably buffers a turn finished in a dead zone and auto-retries it on reconnect** - a hook-owned background driver re-drives held audio through transcribe -> brain -> speak on the `online` event, foreground, Start, and a hard-then-throttled-forever cadence.
- **(c) degrades gracefully with an audible offline/holding state** - a calm "saved, I'll send it when we're back" line, a "Back online" recovery prefix on the delayed reply, and a connection-down announcement after the end-phrase watch fails four ticks (the silent-stall fix). No silent stall anywhere.

## The safety design (Architect decision, 2026-07-13)
The durable record's **`brainSent`** flag is the boundary. A fully-offline turn fails at transcription and never reaches the brain, so re-driving it is a **first** brain call = no double-action = **safe to auto-retry** (`brainSent` false). A turn whose brain call was already sent has an **unknown result**, so it is **held for the owner** (discard-only) rather than auto-fired (`brainSent` true) - Phase 4b's server idempotency key will make even that safe. A money refusal (402) is a **definitive non-action** (no credits = no model call = no tools), so it stays auto-retriable with the shared credits notice. A thirty-minute staleness cap also holds old never-sent turns for the owner rather than firing them blind.

## Files
- **New** `packages/client-core/src/carmode/pendingTurnStore.ts` - durable IndexedDB command-audio store (mirrors the proven dictation store).
- **New** `packages/client-core/src/carmode/turnRetry.ts` (+ `turnRetry.test.ts`) - the pure retry policy: classify, cadence, and the audible lines.
- **Changed** `carModeApi.ts` - transcribe/brain/speak now route through `gatewayFetch`, so `connection/health.ts` sees Car Mode traffic.
- **Changed** `useCarMode.ts` - persist-before-transcribe, hold-instead-of-discard, the `brainSent` boundary, delete-only-after-brain-success, the serialized background driver, and the end-phrase stall fix.
- **Changed** `apps/mobile/src/pages/CarMode.tsx` + `styles.css` - the connection-down / holding / ask-owner (send/discard) UI; page version v8 -> v9.

## Verification
**Proven (off-device):** client-core and mobile typecheck clean; mobile production build clean; full client-core suite **401 tests pass**, including the **9 new** `turnRetry` policy tests.

**PENDING (on-phone, can only run after deploy):** the real offline-mid-turn proof - kill the network mid-utterance on the phone and confirm no speech is lost, the held turn auto-completes on reconnect, and the state is announced audibly. Offline behaviour cannot be proven off-device, so this runs after this merges and the mobile app is deployed to the Gateway `wwwroot/m`.

Merge is being held for the owner's OK (Architect is getting it). Phase 4b (Gateway idempotency key) will not start until the on-phone proof passes and the Architect signs off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)