### PR TITLE
feat(gateway-cleanup): Phase 2 PR C - explicit session routes onto the tunnel

### DIFF
--- a/docs/architecture/gateway-cleanup-phase2-repoint-design.md
+++ b/docs/architecture/gateway-cleanup-phase2-repoint-design.md
@@ -161,3 +161,30 @@ phone link", not just a demo):
 These four turn the proof from "it works" into "it works under the exact conditions that broke the old path".
 Fold them into the slot-5 run, and where cheap into PR A's integration tests. Everything else in the plan stands
 - proceed.
+
+## PR C - the explicit GatewayEndpoints session routes - SETTLED 2026-07-13 (session 51f1898e)
+
+PRs A/B1/B2 moved the browser stream legs + the catch-all read/write dispatch onto the tunnel. But the
+EXPLICITLY-registered session routes in GatewayEndpoints.cs shadow the catch-all, so they were still dialing the
+Director over HTTP. PR C gives each the same stream-first branch (DirectorCommandRouter.TrySendAsync, HTTP
+fallback on a null return, byte-identical when streamMode is off). The Director side already handles every verb
+(the read/write executors), so PR C is Gateway-side only.
+
+- Landed in PR C (plain unary): buffer, summary, git-status, handover, recap (READ), wingman-view,
+  request-deletion, cancel-deletion - plus the two slow-LLM verbs below. Covered by TunnelExplicitRouteProofTests
+  (the unreachable-Director trick proves each rode the tunnel with the correct verb + payload).
+
+- Slow LLM (wingman-ask, recap-generate) - RULING: plain SYNCHRONOUS unary threading the request
+  CancellationToken, NO trigger-and-ack. SignalR client-results have no per-invocation timeout, keep-alive pings
+  sustain a multi-minute await, and the ct mirrors RequestAborted exactly like today's HTTP forwarder, so the
+  synchronous browser contract is byte-identical (the browser contract must NOT change). VERIFY in the
+  whole-surface real-exe proof: a genuinely-slow call (>30s, past ClientTimeoutInterval) over the tunnel
+  COMPLETES with no connection drop - closes the only residual risk.
+
+- upload-image - RULING: OPTION 1 (CHUNK), as its own small additive PR. It is ruling 2 (no single message
+  monopolizes the shared tunnel) plus the Phase 0 protocol's "uploads chunk across unary commands". The Director
+  client (GatewayStreamClient) sets NO MaximumReceiveMessageSize (SignalR default 32 KB) - SET IT to the SAME
+  bounded value as the hub (MaxBinaryFrameBytes + FrameEnvelopeAllowanceBytes ~= 52 KB), symmetric up/down. Chunk
+  the image at MaxBinaryFrameBytes, reassembled on the Director by an uploadId (begin / chunk / complete), then
+  run the existing SaveUploadedImage handler. Bounded both directions, no monopoly. Option 2 (raise the down-limit
+  to a few MB) is REJECTED - it monopolizes the connection and raises the receive ceiling for ALL down-traffic.

--- a/src/CcDirector.Gateway.Tests/TunnelExplicitRouteProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelExplicitRouteProofTests.cs
@@ -1,0 +1,249 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection; // AddMessagePackProtocol (client)
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 2 (PR C): the EXPLICITLY-registered session routes in
+/// <c>GatewayEndpoints</c> that used to dial the owning Director over HTTP now ride the tunnel under stream
+/// mode. This boots a REAL streamMode <see cref="GatewayHost"/>, dials the REAL DirectorHub with a REAL
+/// MessagePack SignalR client, and drives each route end to end.
+///
+/// TUNNEL-BY-CONSTRUCTION: the Director is registered with a DELIBERATELY UNREACHABLE control endpoint, so an
+/// HTTP dial cannot succeed - a 200 with the expected body can ONLY have ridden the tunnel. Each test also
+/// asserts the exact verb (and, where it matters, the payload) the Gateway sent DOWN the tunnel, so a route
+/// that silently mapped to the wrong verb or dropped its query parameters fails loudly.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class TunnelExplicitRouteProofTests : IAsyncLifetime
+{
+    private const string Token = "test-token-explicit-route-proof";
+    private const string DirectorId = "dir-explicit";
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _instancesDir = Path.Combine(Path.GetTempPath(), "cc-explicit-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private HubConnection _conn = null!;
+    private string _sid = "";
+
+    // The last command the Director saw over the tunnel, so a test can assert the verb + payload the route sent.
+    private DirectorCommand? _lastCommand;
+
+    public TunnelExplicitRouteProofTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-explicit-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+        _sid = Guid.NewGuid().ToString();
+
+        // The Director registers UNREACHABLE, so any working route proves it rode the tunnel, never an HTTP dial.
+        _gateway.Registry.Upsert(new DirectorRegistrationRequest
+        {
+            DirectorId = DirectorId,
+            TailnetEndpoint = "http://127.0.0.1:59918/", // nothing listens here
+            MachineName = "explicit-machine",
+            Pid = 1,
+            Version = "test",
+            StartedAt = DateTime.UtcNow,
+        });
+
+        _conn = new HubConnectionBuilder()
+            .WithUrl($"http://127.0.0.1:{_gateway.Port}/director-stream", o => o.AccessTokenProvider = () => Task.FromResult<string?>(Token))
+            .AddMessagePackProtocol()
+            .Build();
+        _conn.On<DirectorCommand, DirectorCommandResult>("Command", Dispatch);
+        await _conn.StartAsync();
+        await _conn.InvokeAsync("Hello", new DirectorStreamHello { DirectorId = DirectorId, Version = "test" });
+        // Push the session so the Gateway resolves this Director as its owner (TryLocate) and targets the tunnel.
+        await _conn.InvokeAsync("PushSnapshot", 1L, new[]
+        {
+            new SessionDto { SessionId = _sid, ActivityState = "WaitingForInput" },
+        });
+    }
+
+    public async Task DisposeAsync()
+    {
+        try { await _conn.DisposeAsync(); } catch { /* best effort */ }
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        foreach (var dir in new[] { _instancesDir, _root })
+            try { if (Directory.Exists(dir)) Directory.Delete(dir, true); } catch { /* best effort */ }
+    }
+
+    // The Director-side Command handler: records the command, then returns a canned body per verb so the test
+    // can assert the Gateway route surfaced exactly that body as its HTTP response.
+    private DirectorCommandResult Dispatch(DirectorCommand cmd)
+    {
+        _lastCommand = cmd;
+        return cmd.Verb switch
+        {
+            "buffer" => DirectorCommandResult.Success(JsonSerializer.Serialize(new { sessionId = cmd.SessionId, buffer = "hello", newCursor = 5 })),
+            "summary" => DirectorCommandResult.Success(JsonSerializer.Serialize(new { sessionId = cmd.SessionId, directorId = DirectorId, title = "a summary" })),
+            "git-status" => DirectorCommandResult.Success(JsonSerializer.Serialize(new { branch = "main", ahead = 0, behind = 0 })),
+            "handover" => DirectorCommandResult.Success(JsonSerializer.Serialize(new { sessionId = cmd.SessionId, directorId = DirectorId, displayName = "a session" })),
+            "recap" => DirectorCommandResult.Success(JsonSerializer.Serialize(new { sessionId = cmd.SessionId, recap = "a recap", cached = true })),
+            "wingman-view" => DirectorCommandResult.Success(JsonSerializer.Serialize(new { sessionId = cmd.SessionId, color = "green" })),
+            "request-deletion" => DirectorCommandResult.Success(),
+            "cancel-deletion" => DirectorCommandResult.Success(),
+            "wingman-ask" => DirectorCommandResult.Success(JsonSerializer.Serialize(new { status = "ok", answer = "an answer" })),
+            "recap-generate" => DirectorCommandResult.Success(JsonSerializer.Serialize(new { sessionId = cmd.SessionId, recap = "a generated recap", model = "opus" })),
+            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
+        };
+    }
+
+    // ------------------------------------------------------------------------------------- reads ----
+
+    [Fact]
+    public async Task Buffer_ridesTheTunnel_andCarriesItsQueryParamsInThePayload()
+    {
+        var resp = await _http.GetAsync($"sessions/{_sid}/buffer?lines=25&raw=true&since=7");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode); // an HTTP dial to the unreachable Director would have failed
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal("hello", node?["buffer"]?.GetValue<string>());
+
+        Assert.Equal("buffer", _lastCommand!.Verb);
+        var payload = JsonNode.Parse(_lastCommand.PayloadJson)!.AsObject();
+        Assert.Equal(25, (int?)payload["lines"]);
+        Assert.Equal(true, (bool?)payload["raw"]);
+        Assert.Equal(7, (long?)payload["since"]);
+    }
+
+    [Fact]
+    public async Task Summary_ridesTheTunnel()
+    {
+        var resp = await _http.GetAsync($"sessions/{_sid}/summary");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal("a summary", node?["title"]?.GetValue<string>());
+        Assert.Equal(DirectorId, node?["directorId"]?.GetValue<string>()); // the Director core sets DirectorId in its body
+        Assert.Equal("summary", _lastCommand!.Verb);
+    }
+
+    [Fact]
+    public async Task Git_ridesTheTunnel_asTheGitStatusVerb()
+    {
+        var resp = await _http.GetAsync($"sessions/{_sid}/git");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal("main", node?["branch"]?.GetValue<string>());
+        Assert.Equal("git-status", _lastCommand!.Verb); // the /git route maps to the git-status tunnel verb
+    }
+
+    [Fact]
+    public async Task Handover_ridesTheTunnel()
+    {
+        var resp = await _http.GetAsync($"sessions/{_sid}/handover");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal("a session", node?["displayName"]?.GetValue<string>());
+        Assert.Equal(DirectorId, node?["directorId"]?.GetValue<string>());
+        Assert.Equal("handover", _lastCommand!.Verb);
+    }
+
+    [Fact]
+    public async Task RecapRead_ridesTheTunnel()
+    {
+        var resp = await _http.GetAsync($"sessions/{_sid}/recap");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal("a recap", node?["recap"]?.GetValue<string>());
+        Assert.Equal("recap", _lastCommand!.Verb);
+    }
+
+    [Fact]
+    public async Task WingmanView_ridesTheTunnel()
+    {
+        var resp = await _http.GetAsync($"sessions/{_sid}/wingman");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal("green", node?["color"]?.GetValue<string>());
+        Assert.Equal("wingman-view", _lastCommand!.Verb);
+    }
+
+    // ------------------------------------------------------------------------------------ writes ----
+
+    [Fact]
+    public async Task RequestDeletion_ridesTheTunnel_andSynthesizesPendingDeletionTrue()
+    {
+        var resp = await _http.PostAsJsonAsync($"sessions/{_sid}/request-deletion", new { reason = "done" });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.True(node?["pendingDeletion"]?.GetValue<bool>());
+
+        Assert.Equal("request-deletion", _lastCommand!.Verb);
+        var payload = JsonNode.Parse(_lastCommand.PayloadJson)!.AsObject();
+        Assert.Equal("done", (string?)payload["reason"]); // the deletion reason rode the payload
+    }
+
+    [Fact]
+    public async Task CancelDeletion_ridesTheTunnel_andSynthesizesPendingDeletionFalse()
+    {
+        var resp = await _http.DeleteAsync($"sessions/{_sid}/request-deletion");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.False(node?["pendingDeletion"]?.GetValue<bool>());
+        Assert.Equal("cancel-deletion", _lastCommand!.Verb);
+    }
+
+    // ---------------------------------------------------------------------------- slow LLM (unary) ----
+
+    [Fact]
+    public async Task WingmanAsk_ridesTheTunnel_asASynchronousUnaryVerb()
+    {
+        var resp = await _http.PostAsJsonAsync($"sessions/{_sid}/wingman/ask", new { question = "what is happening" });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal("an answer", node?["answer"]?.GetValue<string>());
+
+        Assert.Equal("wingman-ask", _lastCommand!.Verb);
+        var payload = JsonNode.Parse(_lastCommand.PayloadJson)!.AsObject();
+        Assert.Equal("what is happening", (string?)payload["question"]); // the question rode the payload
+    }
+
+    [Fact]
+    public async Task RecapGenerate_ridesTheTunnel_andPreservesThe201AndModel()
+    {
+        var resp = await _http.PostAsync($"sessions/{_sid}/recap?model=opus", content: null);
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode); // the HTTP path returned 201; the tunnel path preserves it
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal("a generated recap", node?["recap"]?.GetValue<string>());
+
+        Assert.Equal("recap-generate", _lastCommand!.Verb);
+        var payload = JsonNode.Parse(_lastCommand.PayloadJson)!.AsObject();
+        Assert.Equal("opus", (string?)payload["model"]); // the model query param rode the payload
+    }
+
+    // -------------------------------------------------------------------------------------- helpers ----
+
+    private static int AllocateFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -1014,26 +1014,40 @@ internal static class GatewayEndpoints
         // Forward "flag this session for deletion" to the owning Director, so a session on ONE
         // machine (or a remote client) can request the async teardown of a session on another. The
         // owning Director's reaper does the actual removal. Body is optional ({ "reason": "..." }).
-        app.MapPost("/sessions/{sid}/request-deletion", async (string sid, SessionDeletionRequest? body) =>
+        app.MapPost("/sessions/{sid}/request-deletion", async (string sid, SessionDeletionRequest? body, CancellationToken ct) =>
         {
             var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
+            // Gateway Cleanup (Phase 2, PR C): try the owning Director's tunnel first; a null return (stream
+            // mode off / Director not stream-connected) falls back to the HTTP dial below, byte-identical. The
+            // stream Ok result is success, so it synthesizes the same { pendingDeletion } body the HTTP path returns.
+            var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "request-deletion", sid, body, ct);
+            if (streamResult is not null)
+                return streamResult.Ok
+                    ? Results.Json(new { pendingDeletion = true })
+                    : Results.StatusCode(StatusCodes.Status502BadGateway);
             var ep = (director.ControlEndpoint ?? "").TrimEnd('/');
-            var ok = await client.RequestSessionDeletionAsync(ep, sid, body?.Reason);
+            var ok = await client.RequestSessionDeletionAsync(ep, sid, body?.Reason, ct);
             if (!ok)
                 return Results.StatusCode(StatusCodes.Status502BadGateway);
             return Results.Json(new { pendingDeletion = true });
         });
 
         // Forward "cancel the pending deletion" to the owning Director (grace-window undo).
-        app.MapDelete("/sessions/{sid}/request-deletion", async (string sid) =>
+        app.MapDelete("/sessions/{sid}/request-deletion", async (string sid, CancellationToken ct) =>
         {
             var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
+            // Gateway Cleanup (Phase 2, PR C): tunnel-first, HTTP fallback on a null return (byte-identical).
+            var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "cancel-deletion", sid, null, ct);
+            if (streamResult is not null)
+                return streamResult.Ok
+                    ? Results.Json(new { pendingDeletion = false })
+                    : Results.StatusCode(StatusCodes.Status502BadGateway);
             var ep = (director.ControlEndpoint ?? "").TrimEnd('/');
-            var ok = await client.CancelSessionDeletionAsync(ep, sid);
+            var ok = await client.CancelSessionDeletionAsync(ep, sid, ct);
             if (!ok)
                 return Results.StatusCode(StatusCodes.Status502BadGateway);
             return Results.Json(new { pendingDeletion = false });
@@ -1041,13 +1055,20 @@ internal static class GatewayEndpoints
 
         // Phase 4b: forward wingman observability through the Gateway so the merged
         // Session View on the gateway side can render WHY a dot is the color it is.
-        app.MapGet("/sessions/{sid}/wingman", async (string sid) =>
+        app.MapGet("/sessions/{sid}/wingman", async (string sid, CancellationToken ct) =>
         {
             var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
+            // Gateway Cleanup (Phase 2, PR C): tunnel-first; a null return falls back to the HTTP dial below,
+            // byte-identical. The Ok body IS the WingmanViewDto JSON, passed through exactly as the HTTP body.
+            var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "wingman-view", sid, null, ct);
+            if (streamResult is not null)
+                return streamResult.Ok && !string.IsNullOrEmpty(streamResult.BodyJson)
+                    ? Results.Content(streamResult.BodyJson, "application/json")
+                    : Results.StatusCode(StatusCodes.Status502BadGateway);
             var ep = (director.ControlEndpoint ?? "").TrimEnd('/');
-            var view = await client.GetWingmanAsync(ep, sid);
+            var view = await client.GetWingmanAsync(ep, sid, ct);
             if (view is null)
                 return Results.StatusCode(StatusCodes.Status502BadGateway);
             return Results.Json(view);
@@ -1063,6 +1084,15 @@ internal static class GatewayEndpoints
             var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
+            // Gateway Cleanup (Phase 2, PR C): tunnel-first. This is a SLOW LLM call - the request ct threads
+            // straight into the SignalR invocation (which has no per-invocation timeout; keep-alive pings sustain
+            // the long await), so the synchronous browser contract is byte-identical to the HTTP forward. A null
+            // return falls back to the HTTP dial below. The Ok body IS the WingmanAskResult JSON.
+            var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "wingman-ask", sid, req, ct);
+            if (streamResult is not null)
+                return streamResult.Ok && !string.IsNullOrEmpty(streamResult.BodyJson)
+                    ? Results.Content(streamResult.BodyJson, "application/json")
+                    : Results.StatusCode(StatusCodes.Status502BadGateway);
             var ep = (director.ControlEndpoint ?? "").TrimEnd('/');
             var result = await client.AskWingmanAsync(ep, sid, req, ct);
             if (result is null)
@@ -1206,13 +1236,25 @@ internal static class GatewayEndpoints
             return Results.Json(body);
         });
 
-        app.MapGet("/sessions/{sid}/buffer", async (string sid, int? lines, bool? raw, long? since) =>
+        app.MapGet("/sessions/{sid}/buffer", async (string sid, int? lines, bool? raw, long? since, CancellationToken ct) =>
         {
             var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null)
                 return Results.NotFound(new { error = "session not found across any director" });
 
-            var buffer = await client.GetBufferAsync(director!.ControlEndpoint, sid, lines, raw == true, since);
+            // Gateway Cleanup (Phase 2, PR C): tunnel-first; a null return falls back to the HTTP dial below,
+            // byte-identical. The query params ride in a BufferRequest payload the Director's buffer verb reads.
+            if (director is not null)
+            {
+                var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "buffer", sid,
+                    new BufferRequest { Lines = lines, Raw = raw == true, Since = since }, ct);
+                if (streamResult is not null)
+                    return streamResult.Ok && !string.IsNullOrEmpty(streamResult.BodyJson)
+                        ? Results.Content(streamResult.BodyJson, "application/json")
+                        : Results.StatusCode(StatusCodes.Status502BadGateway);
+            }
+
+            var buffer = await client.GetBufferAsync(director!.ControlEndpoint, sid, lines, raw == true, since, ct);
             if (buffer is null)
                 return Results.StatusCode(StatusCodes.Status502BadGateway);
 
@@ -1580,12 +1622,22 @@ internal static class GatewayEndpoints
             return Results.StatusCode(StatusCodes.Status502BadGateway);
         });
 
-        app.MapGet("/sessions/{sid}/summary", async (string sid) =>
+        app.MapGet("/sessions/{sid}/summary", async (string sid, CancellationToken ct) =>
         {
             var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null)
                 return Results.NotFound(new { error = "session not found across any director" });
-            var summary = await client.GetSummaryAsync(director!.ControlEndpoint, sid);
+            // Gateway Cleanup (Phase 2, PR C): tunnel-first; a null return falls back to the HTTP dial below,
+            // byte-identical. The Director's summary core sets DirectorId in its body, so the pass-through matches.
+            if (director is not null)
+            {
+                var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "summary", sid, null, ct);
+                if (streamResult is not null)
+                    return streamResult.Ok && !string.IsNullOrEmpty(streamResult.BodyJson)
+                        ? Results.Content(streamResult.BodyJson, "application/json")
+                        : Results.StatusCode(StatusCodes.Status502BadGateway);
+            }
+            var summary = await client.GetSummaryAsync(director!.ControlEndpoint, sid, ct);
             if (summary is null)
                 return Results.StatusCode(StatusCodes.Status502BadGateway);
             summary.DirectorId = director.DirectorId;
@@ -1609,6 +1661,13 @@ internal static class GatewayEndpoints
             var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
+            // Gateway Cleanup (Phase 2, PR C): tunnel-first (verb "git-status"); a null return falls back to the
+            // HTTP dial below, byte-identical. The Ok body IS the GitSnapshot JSON, passed through unchanged.
+            var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "git-status", sid, null, ctx.RequestAborted);
+            if (streamResult is not null)
+                return streamResult.Ok && !string.IsNullOrEmpty(streamResult.BodyJson)
+                    ? Results.Content(streamResult.BodyJson, "application/json")
+                    : Results.StatusCode(StatusCodes.Status502BadGateway);
             var snap = await client.GetGitAsync(director.ControlEndpoint, sid, ctx.RequestAborted);
             if (snap is null)
                 return Results.StatusCode(StatusCodes.Status502BadGateway);
@@ -1622,13 +1681,20 @@ internal static class GatewayEndpoints
         // address is never leaked: this returns HandoverInfoDto, which carries no Control API endpoint,
         // and the resolved ControlEndpoint stays server-side. 404 when the session is unknown to every
         // Director; 502 when the owning Director is unreachable (never a silent empty body).
-        app.MapGet("/sessions/{sid}/handover", async (string sid) =>
+        app.MapGet("/sessions/{sid}/handover", async (string sid, CancellationToken ct) =>
         {
             // Issue #1240: resolve the owner through the same cache fast path as every other per-session route.
             var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
-            var handover = await client.GetHandoverAsync(director.ControlEndpoint, sid);
+            // Gateway Cleanup (Phase 2, PR C): tunnel-first; a null return falls back to the HTTP dial below,
+            // byte-identical. The Director's handover core sets DirectorId in its body, so the pass-through matches.
+            var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "handover", sid, null, ct);
+            if (streamResult is not null)
+                return streamResult.Ok && !string.IsNullOrEmpty(streamResult.BodyJson)
+                    ? Results.Content(streamResult.BodyJson, "application/json")
+                    : Results.StatusCode(StatusCodes.Status502BadGateway);
+            var handover = await client.GetHandoverAsync(director.ControlEndpoint, sid, ct);
             if (handover is null)
                 return Results.StatusCode(StatusCodes.Status502BadGateway);
             handover.DirectorId = director.DirectorId;
@@ -1638,12 +1704,19 @@ internal static class GatewayEndpoints
         // Recap proxy. Both endpoints transparently forward to whichever Director owns the
         // session. The Director side does the heavy lifting (claude --print + cache); this
         // is just routing.
-        app.MapGet("/sessions/{sid}/recap", async (string sid) =>
+        app.MapGet("/sessions/{sid}/recap", async (string sid, CancellationToken ct) =>
         {
             var (director, session) = await LocateSessionAsync(registry, client, sid, pushedSessions, streamStaleResolved, owners);
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
-            var recap = await client.GetRecapAsync(director.ControlEndpoint, sid);
+            // Gateway Cleanup (Phase 2, PR C): tunnel-first (read the cached recap); a null return falls back to
+            // the HTTP dial below, byte-identical. This is the READ; the slow generate (POST) is handled separately.
+            var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "recap", sid, null, ct);
+            if (streamResult is not null)
+                return streamResult.Ok && !string.IsNullOrEmpty(streamResult.BodyJson)
+                    ? Results.Content(streamResult.BodyJson, "application/json")
+                    : Results.StatusCode(StatusCodes.Status502BadGateway);
+            var recap = await client.GetRecapAsync(director.ControlEndpoint, sid, ct);
             if (recap is null)
                 return Results.StatusCode(StatusCodes.Status502BadGateway);
             return Results.Json(recap);
@@ -1656,6 +1729,16 @@ internal static class GatewayEndpoints
                 return Results.NotFound(new { error = "session not found across any director" });
             var model = ctx.Request.Query["model"].ToString();
             FileLog.Write($"[GatewayEndpoints] POST /recap: sid={sid}, director={director.DirectorId}, model={model ?? "(default)"}");
+            // Gateway Cleanup (Phase 2, PR C): tunnel-first. Like wingman-ask this is a SLOW LLM call, so the
+            // request ct (ctx.RequestAborted) threads into the SignalR invocation (no per-invocation timeout;
+            // keep-alive pings sustain the long await) - synchronous browser contract byte-identical. A null
+            // return falls back to the HTTP dial below. The Ok body IS the RecapResponse JSON, returned 201 as before.
+            var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "recap-generate", sid,
+                new RecapGenerateRequest { Model = model }, ctx.RequestAborted);
+            if (streamResult is not null)
+                return streamResult.Ok && !string.IsNullOrEmpty(streamResult.BodyJson)
+                    ? Results.Content(streamResult.BodyJson, "application/json", null, StatusCodes.Status201Created)
+                    : Results.Problem("recap failed", statusCode: StatusCodes.Status502BadGateway);
             var (ok, body, err) = await client.PostRecapAsync(director.ControlEndpoint, sid, model, ctx.RequestAborted);
             if (!ok || body is null)
                 return Results.Problem(err ?? "recap failed", statusCode: StatusCodes.Status502BadGateway);


### PR DESCRIPTION
## What

The explicitly-registered `/sessions/{sid}/...` routes in `GatewayEndpoints` shadowed the catch-all and still dialed the owning Director over HTTP. Each now tries the **tunnel first** (`DirectorCommandRouter.TrySendAsync`) with the existing HTTP dial as the null-fallback, byte-identical when stream mode is off. The Director side already handled every verb, so this is a **Gateway-side** change.

### Routes moved (all additive, streamMode-gated)
- **Reads:** buffer (query params ride a `BufferRequest` payload), summary, git (the `git-status` verb), handover, recap (READ), wingman (`wingman-view`).
- **Writes:** request-deletion, cancel-deletion (the stream Ok result synthesizes the same `{ pendingDeletion }` body the HTTP path returned).
- **Slow LLM (wingman-ask, recap-generate):** plain **synchronous unary** threading the request `CancellationToken`. SignalR client-results have no per-invocation timeout and keep-alive pings sustain a multi-minute await, so the synchronous browser contract is byte-identical to today's HTTP forwarder (Architect ruling, recorded in the phase2 design doc). `recap-generate` preserves its 201.

## Proof

`TunnelExplicitRouteProofTests` boots a real streamMode Gateway, dials the real `DirectorHub` with a real MessagePack client, and registers the Director with a deliberately **UNREACHABLE** control endpoint - so a 200/201 with the expected body can ONLY have ridden the tunnel, never an HTTP dial. Each route asserts the correct verb + payload marshaling (buffer query params, deletion reason, wingman question, recap model) and the surfaced body.

- `TunnelExplicitRouteProofTests`: **10/10 pass**.
- Full `CcDirector.Gateway.Tests` suite: **2128 passed, 0 failed**.
- Rebased onto `origin/main` (up-to-date).

## Not in this PR

`upload-image` chunking (Architect ruling: option 1 - chunk across unary commands with a symmetric bounded Director-client receive limit) lands as its own additive PR next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)