### PR TITLE
feat(gateway-cleanup): Phase 2 - chunked upload-image onto the tunnel

### DIFF
--- a/docs/architecture/gateway-cleanup-phase2-repoint-design.md
+++ b/docs/architecture/gateway-cleanup-phase2-repoint-design.md
@@ -188,3 +188,18 @@ fallback on a null return, byte-identical when streamMode is off). The Director 
   the image at MaxBinaryFrameBytes, reassembled on the Director by an uploadId (begin / chunk / complete), then
   run the existing SaveUploadedImage handler. Bounded both directions, no monopoly. Option 2 (raise the down-limit
   to a few MB) is REJECTED - it monopolizes the connection and raises the receive ceiling for ALL down-traffic.
+
+  IMPLEMENTATION NOTE (Manager, 2026-07-13): shipped the CHUNKED path (option 1) with begin / chunk / complete
+  reassembled on the Director by uploadId, with a 25 MB fail-loud ceiling, a 2-minute abandoned-upload sweep,
+  and out-of-order / size-mismatch / bad-base64 all failing loud. It reuses the SAME save core as the single-shot
+  path (SaveUploadedImage now delegates to a shared SaveImageBytes). One deviation from the exact mechanism above:
+  the chunks ride as BASE64 in the command payload (the existing DirectorCommand.PayloadJson) sized at
+  DirectorStreamLimits.UploadChunkRawBytes = 20 KB raw (~27 KB on the wire), NOT 48 KB binary with a raised
+  ~52 KB Director-client receive limit. Reason: the SignalR client (the Director's HubConnection) does not expose
+  a clean public MaximumReceiveMessageSize setter, so rather than depend on a fragile/internal API, the chunk is
+  kept comfortably under the SignalR default (~32 KB) - which sidesteps the client-limit question entirely and
+  still satisfies the load-bearing invariant (ruling 2: bounded, no single message monopolizes the tunnel). The
+  cost is the base64 tax on an infrequent, small payload (images), which is negligible. Proven end to end by
+  TunnelExplicitRouteProofTests: a 50 KB image uploaded over the tunnel in 3 chunks reassembles byte-for-byte and
+  is written to disk. If the Architect prefers the literal 48 KB-binary/52 KB-limit mechanism, it is a small
+  follow-up (add a byte[] payload field to DirectorCommand + set the client limit) - flagged for his call.

--- a/src/CcDirector.ControlApi/SessionByteExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionByteExecutor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using CcDirector.Core.Sessions;
 using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
@@ -20,7 +21,13 @@ internal sealed class SessionByteExecutor : ISessionCommandArea
     // Gateway Cleanup Phase 0 (Wave 4a): screenshot-delete is the third unary byte verb - a plain file delete
     // keyed by a traversal-safe bare name, the tunnel twin of DELETE /screenshots/file. Its core reproduces
     // that route verbatim, so the REST route and the tunnel verb share one core and cannot drift.
-    public IReadOnlyCollection<string> Verbs { get; } = new[] { "screenshots-list", "upload-image", "screenshot-delete" };
+    public IReadOnlyCollection<string> Verbs { get; } = new[]
+    {
+        "screenshots-list", "upload-image", "screenshot-delete",
+        // Gateway Cleanup Phase 2: the chunked upload-image path (begin / chunk / complete). An image rides
+        // DOWN the tunnel in bounded pieces so no single unary message monopolizes the shared connection.
+        "upload-image-begin", "upload-image-chunk", "upload-image-complete",
+    };
 
     public Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken)
     {
@@ -29,9 +36,148 @@ internal sealed class SessionByteExecutor : ISessionCommandArea
             "screenshots-list" => ScreenshotsList(command),
             "upload-image" => UploadImage(context.SessionManager, command),
             "screenshot-delete" => ScreenshotDelete(command),
+            "upload-image-begin" => UploadImageBegin(context.SessionManager, command),
+            "upload-image-chunk" => UploadImageChunk(command),
+            "upload-image-complete" => UploadImageComplete(command),
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the byte area"),
         };
         return Task.FromResult(result);
+    }
+
+    // ---------------------------------------------------------------- chunked upload-image (Phase 2) ----
+
+    /// <summary>An in-flight chunked upload's reassembly state, keyed by its upload id in <see cref="_uploads"/>.</summary>
+    private sealed class UploadReassembly
+    {
+        public required string FileName { get; init; }
+        public required long TotalBytes { get; init; }
+        public MemoryStream Buffer { get; } = new();
+        public int NextSeq { get; set; }
+        public DateTime CreatedUtc { get; } = DateTime.UtcNow;
+    }
+
+    /// <summary>Live chunked uploads awaiting their remaining chunks + complete, keyed by upload id.</summary>
+    private static readonly ConcurrentDictionary<string, UploadReassembly> _uploads = new();
+
+    /// <summary>The largest image a chunked upload may reassemble - a fail-loud ceiling on buffered memory.</summary>
+    private const long MaxUploadBytes = 25L * 1024 * 1024;
+
+    /// <summary>How long an abandoned upload (begun but never completed) lingers before it is swept.</summary>
+    private static readonly TimeSpan UploadTtl = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// The <c>upload-image-begin</c> verb: open a reassembly buffer for a fresh upload id. Validates the
+    /// session, the extension (fail fast before any bytes transfer), and the declared total size, and sweeps
+    /// any abandoned uploads. No image bytes ride on this command.
+    /// </summary>
+    internal static DirectorCommandResult UploadImageBegin(SessionManager sessionManager, DirectorCommand command)
+    {
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+        if (sessionManager.GetSession(guid) is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        var request = SessionCommandExecutor.Deserialize<UploadImageBeginRequest>(command.PayloadJson);
+        if (request is null || string.IsNullOrEmpty(request.UploadId))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "upload id is required");
+
+        var ext = Path.GetExtension(request.FileName).ToLowerInvariant();
+        if (!UploadAllowedExtensions.Contains(ext))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unsupported image type '{ext}'. Allowed: {string.Join(", ", UploadAllowedExtensions)}");
+        if (request.TotalBytes <= 0 || request.TotalBytes > MaxUploadBytes)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"image size {request.TotalBytes} is out of range (max {MaxUploadBytes})");
+
+        SweepStaleUploads();
+
+        var entry = new UploadReassembly { FileName = request.FileName, TotalBytes = request.TotalBytes };
+        if (!_uploads.TryAdd(request.UploadId, entry))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.Conflict, "upload id already in use");
+
+        FileLog.Write($"[SessionByteExecutor] upload-image-begin: id={request.UploadId}, file={request.FileName}, total={request.TotalBytes}");
+        return DirectorCommandResult.Success();
+    }
+
+    /// <summary>
+    /// The <c>upload-image-chunk</c> verb: append one in-order base64 chunk to its upload's buffer. Rejects an
+    /// unknown id, an out-of-order sequence, undecodable base64, or an overflow past the declared/allowed size.
+    /// </summary>
+    internal static DirectorCommandResult UploadImageChunk(DirectorCommand command)
+    {
+        var request = SessionCommandExecutor.Deserialize<UploadImageChunkRequest>(command.PayloadJson);
+        if (request is null || string.IsNullOrEmpty(request.UploadId))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "upload id is required");
+
+        if (!_uploads.TryGetValue(request.UploadId, out var entry))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "unknown or expired upload id");
+
+        if (request.Seq != entry.NextSeq)
+        {
+            _uploads.TryRemove(request.UploadId, out _);
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"out-of-order chunk (expected {entry.NextSeq}, got {request.Seq})");
+        }
+
+        byte[] chunk;
+        try
+        {
+            chunk = Convert.FromBase64String(request.BytesBase64);
+        }
+        catch (FormatException)
+        {
+            _uploads.TryRemove(request.UploadId, out _);
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "chunk bytes must be base64");
+        }
+
+        if (entry.Buffer.Length + chunk.Length > entry.TotalBytes || entry.Buffer.Length + chunk.Length > MaxUploadBytes)
+        {
+            _uploads.TryRemove(request.UploadId, out _);
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "upload exceeded its declared size");
+        }
+
+        entry.Buffer.Write(chunk, 0, chunk.Length);
+        entry.NextSeq++;
+        return DirectorCommandResult.Success();
+    }
+
+    /// <summary>
+    /// The <c>upload-image-complete</c> verb: finalize an upload - the assembled bytes must equal the declared
+    /// total, then the SAME save core the single-shot path uses writes the file and returns its saved path.
+    /// The reassembly buffer is always released.
+    /// </summary>
+    internal static DirectorCommandResult UploadImageComplete(DirectorCommand command)
+    {
+        var request = SessionCommandExecutor.Deserialize<UploadImageCompleteRequest>(command.PayloadJson);
+        if (request is null || string.IsNullOrEmpty(request.UploadId))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "upload id is required");
+
+        if (!_uploads.TryRemove(request.UploadId, out var entry))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "unknown or expired upload id");
+
+        try
+        {
+            if (entry.Buffer.Length != entry.TotalBytes)
+                return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"incomplete upload ({entry.Buffer.Length} of {entry.TotalBytes} bytes)");
+
+            FileLog.Write($"[SessionByteExecutor] upload-image-complete: id={request.UploadId}, bytes={entry.Buffer.Length}");
+            return SaveImageBytes(entry.FileName, entry.Buffer.ToArray());
+        }
+        finally
+        {
+            entry.Buffer.Dispose();
+        }
+    }
+
+    /// <summary>Drop uploads that were begun but never completed within <see cref="UploadTtl"/> (a dead Gateway mid-upload).</summary>
+    private static void SweepStaleUploads()
+    {
+        var cutoff = DateTime.UtcNow - UploadTtl;
+        foreach (var kv in _uploads)
+        {
+            if (kv.Value.CreatedUtc < cutoff && _uploads.TryRemove(kv.Key, out var stale))
+            {
+                stale.Buffer.Dispose();
+                FileLog.Write($"[SessionByteExecutor] swept abandoned upload id={kv.Key}");
+            }
+        }
     }
 
     /// <summary>
@@ -128,6 +274,21 @@ internal sealed class SessionByteExecutor : ISessionCommandArea
         {
             return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "image bytes must be base64");
         }
+
+        return SaveImageBytes(request.FileName, bytes);
+    }
+
+    /// <summary>
+    /// Write already-decoded image bytes into the screenshots folder under a timestamped name that keeps the
+    /// uploaded extension, and return the saved absolute path. Shared by the single-shot save core
+    /// (<see cref="SaveUploadedImage"/>) and the chunked complete (<see cref="UploadImageComplete"/>) so both
+    /// file bytes identically. Empty bytes or an unsupported extension -&gt; a fail-loud BadRequest.
+    /// </summary>
+    private static DirectorCommandResult SaveImageBytes(string fileName, byte[] bytes)
+    {
+        var ext = Path.GetExtension(fileName).ToLowerInvariant();
+        if (!UploadAllowedExtensions.Contains(ext))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unsupported image type '{ext}'. Allowed: {string.Join(", ", UploadAllowedExtensions)}");
 
         if (bytes.Length == 0)
             return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "no image uploaded; use form field 'file'");

--- a/src/CcDirector.Gateway.Contracts/DirectorUpStreamMessages.cs
+++ b/src/CcDirector.Gateway.Contracts/DirectorUpStreamMessages.cs
@@ -90,6 +90,17 @@ public static class DirectorStreamLimits
     /// MaximumReceiveMessageSize = MaxBinaryFrameBytes + this.
     /// </summary>
     public const int FrameEnvelopeAllowanceBytes = 4 * 1024;
+
+    /// <summary>
+    /// Gateway Cleanup mission, Phase 2 (upload-image): the RAW byte size of one DOWN-stream image chunk. An
+    /// image uploaded to the Gateway is split into pieces this large and sent to the Director across unary
+    /// commands (begin / chunk / complete), so a whole photo never rides as one large unary message that would
+    /// monopolize the shared tunnel (Architect ruling 2). Deliberately small: each chunk is base64-encoded in
+    /// the command payload (+33%), so 20 KB raw is ~27 KB on the wire - comfortably under the SignalR default
+    /// receive limit even with the command envelope, whatever a client's limit is. Images are small and
+    /// infrequent, so the extra chunks are free; the invariant that matters is bounded, no-monopoly framing.
+    /// </summary>
+    public const int UploadChunkRawBytes = 20 * 1024;
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway.Contracts/SessionByteContracts.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionByteContracts.cs
@@ -82,3 +82,55 @@ public sealed class UploadImageResponse
     /// <summary>The saved file name (an "upload-yyyyMMdd-HHmmss-fff" stamp plus the uploaded extension).</summary>
     public string FileName { get; set; } = "";
 }
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 2 (PR upload-image): an image is uploaded DOWN the tunnel in bounded
+/// chunks across three unary commands - begin / chunk (repeated) / complete - reassembled on the Director by
+/// <see cref="UploadId"/>. This honours the Architect's ruling 2 (no single message monopolizes the shared
+/// tunnel): a whole photo would be a multi-hundred-KB unary message, so it is split into pieces each smaller
+/// than the SignalR receive limit. This is the BEGIN command: it opens a reassembly buffer for a fresh
+/// <see cref="UploadId"/> and carries the file name (for the saved extension). No bytes yet.
+/// </summary>
+public sealed class UploadImageBeginRequest
+{
+    /// <summary>A fresh Guid the Gateway mints for this upload; every chunk and the complete carry it.</summary>
+    public string UploadId { get; set; } = "";
+
+    /// <summary>The original file name (only its extension is used to pick the saved file's extension).</summary>
+    public string FileName { get; set; } = "";
+
+    /// <summary>The total raw byte length of the image, so the Director can reject a mismatch on complete.</summary>
+    public long TotalBytes { get; set; }
+}
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 2 (PR upload-image): one CHUNK of an in-flight upload. The raw bytes are
+/// base64-encoded (so they survive the JSON payload envelope) and kept small - see
+/// <see cref="DirectorStreamLimits.UploadChunkRawBytes"/> - so the framed command stays well under the
+/// SignalR receive limit and never monopolizes the tunnel. Chunks are sent in order; <see cref="Seq"/> is
+/// zero-based and the Director rejects an out-of-order chunk (the Gateway awaits each chunk's reply before
+/// sending the next, so in-order delivery is guaranteed on the happy path).
+/// </summary>
+public sealed class UploadImageChunkRequest
+{
+    /// <summary>The upload this chunk belongs to (matches the begin's UploadId).</summary>
+    public string UploadId { get; set; } = "";
+
+    /// <summary>The zero-based chunk index; must equal the number of chunks already appended.</summary>
+    public int Seq { get; set; }
+
+    /// <summary>This chunk's raw image bytes, base64-encoded.</summary>
+    public string BytesBase64 { get; set; } = "";
+}
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 2 (PR upload-image): the COMPLETE command - all chunks are in, so the
+/// Director assembles them, validates the extension and total length, writes the file into the screenshots
+/// folder (the SAME save as the single-shot path), and returns the saved <see cref="UploadImageResponse"/>.
+/// It also releases the reassembly buffer. Completing an unknown/expired upload is a fail-loud BadRequest.
+/// </summary>
+public sealed class UploadImageCompleteRequest
+{
+    /// <summary>The upload to finalize (matches the begin's UploadId).</summary>
+    public string UploadId { get; set; } = "";
+}

--- a/src/CcDirector.Gateway.Tests/TunnelExplicitRouteProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelExplicitRouteProofTests.cs
@@ -4,6 +4,9 @@ using System.Net.Http.Json;
 using System.Net.Sockets;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using CcDirector.ControlApi;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
 using CcDirector.Gateway.Contracts;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.DependencyInjection; // AddMessagePackProtocol (client)
@@ -35,6 +38,8 @@ public sealed class TunnelExplicitRouteProofTests : IAsyncLifetime
     private GatewayHost _gateway = null!;
     private HttpClient _http = null!;
     private HubConnection _conn = null!;
+    private SessionManager _sm = null!;
+    private Session _session = null!;
     private string _sid = "";
 
     // The last command the Director saw over the tunnel, so a test can assert the verb + payload the route sent.
@@ -56,7 +61,11 @@ public sealed class TunnelExplicitRouteProofTests : IAsyncLifetime
         await _gateway.StartAsync();
         _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
         _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
-        _sid = Guid.NewGuid().ToString();
+
+        // A REAL session so the Director-side handlers (which validate the session exists) run the real code.
+        _sm = new SessionManager(new AgentOptions());
+        _session = _sm.CreateEmbeddedSession(Path.GetTempPath(), null, new ExecuteActionTestBackend());
+        _sid = _session.Id.ToString();
 
         // The Director registers UNREACHABLE, so any working route proves it rode the tunnel, never an HTTP dial.
         _gateway.Registry.Upsert(new DirectorRegistrationRequest
@@ -86,6 +95,7 @@ public sealed class TunnelExplicitRouteProofTests : IAsyncLifetime
     public async Task DisposeAsync()
     {
         try { await _conn.DisposeAsync(); } catch { /* best effort */ }
+        _sm.Dispose();
         _http.Dispose();
         await _gateway.StopAsync();
         Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
@@ -110,6 +120,11 @@ public sealed class TunnelExplicitRouteProofTests : IAsyncLifetime
             "cancel-deletion" => DirectorCommandResult.Success(),
             "wingman-ask" => DirectorCommandResult.Success(JsonSerializer.Serialize(new { status = "ok", answer = "an answer" })),
             "recap-generate" => DirectorCommandResult.Success(JsonSerializer.Serialize(new { sessionId = cmd.SessionId, recap = "a generated recap", model = "opus" })),
+            // The chunked upload verbs run the REAL Director reassembly + save so the proof exercises the real
+            // begin/chunk/complete path end to end (a real file is written under the test's screenshots folder).
+            "upload-image-begin" => SessionByteExecutor.UploadImageBegin(_sm, cmd),
+            "upload-image-chunk" => SessionByteExecutor.UploadImageChunk(cmd),
+            "upload-image-complete" => SessionByteExecutor.UploadImageComplete(cmd),
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
         };
     }
@@ -234,6 +249,36 @@ public sealed class TunnelExplicitRouteProofTests : IAsyncLifetime
         Assert.Equal("recap-generate", _lastCommand!.Verb);
         var payload = JsonNode.Parse(_lastCommand.PayloadJson)!.AsObject();
         Assert.Equal("opus", (string?)payload["model"]); // the model query param rode the payload
+    }
+
+    // ------------------------------------------------------------------------- chunked upload-image ----
+
+    [Fact]
+    public async Task UploadImage_ridesTheTunnel_chunked_andReassemblesByteForByte()
+    {
+        // A 50 KB image spans multiple chunks (UploadChunkRawBytes = 20 KB -> 3 chunks: 20 + 20 + 10).
+        var image = new byte[(DirectorStreamLimits.UploadChunkRawBytes * 2) + 10 * 1024];
+        for (var i = 0; i < image.Length; i++) image[i] = (byte)((i * 31 + 7) % 251);
+
+        using var form = new MultipartFormDataContent();
+        var filePart = new ByteArrayContent(image);
+        filePart.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/png");
+        form.Add(filePart, "file", "photo.png");
+
+        var resp = await _http.PostAsync($"sessions/{_sid}/upload-image", form);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode); // an HTTP dial to the unreachable Director would have failed
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        var savedPath = node?["path"]?.GetValue<string>();
+        Assert.False(string.IsNullOrEmpty(savedPath));
+
+        // The chunked upload rode the tunnel: begin, three chunks, then complete were the commands seen.
+        Assert.Equal("upload-image-complete", _lastCommand!.Verb);
+
+        // The Director reassembled the chunks byte-for-byte and saved the real file (same machine, in-process).
+        Assert.True(File.Exists(savedPath), $"expected the reassembled image at {savedPath}");
+        var saved = await File.ReadAllBytesAsync(savedPath!);
+        Assert.Equal(image, saved);
+        Assert.EndsWith(".png", savedPath);
     }
 
     // -------------------------------------------------------------------------------------- helpers ----

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -1393,8 +1393,45 @@ internal static class GatewayEndpoints
 
             FileLog.Write($"[GatewayEndpoints] POST upload-image: sid={sid}, director={director.DirectorId}, bytes={ms.Length}");
 
+            var bytes = ms.ToArray();
+
+            // Gateway Cleanup (Phase 2): upload the image DOWN the tunnel in bounded chunks - begin, then a
+            // chunk per UploadChunkRawBytes, then complete - so a whole photo never rides as one large unary
+            // message that would monopolize the shared tunnel (Architect ruling 2). A null begin means no
+            // stream (mode off / Director not stream-connected), so fall through to the HTTP dial below. A
+            // non-null-but-failed step is authoritative and collapses to 502 (a retryable upload failure).
+            var uploadId = Guid.NewGuid().ToString("N");
+            var begin = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "upload-image-begin", sid,
+                new UploadImageBeginRequest { UploadId = uploadId, FileName = file.FileName, TotalBytes = bytes.Length }, ctx.RequestAborted);
+            if (begin is not null)
+            {
+                if (!begin.Ok)
+                    return Results.Json(new { error = DirectorCommandRouter.DescribeFailure(begin) }, statusCode: StatusCodes.Status502BadGateway);
+
+                for (var off = 0; off < bytes.Length; off += DirectorStreamLimits.UploadChunkRawBytes)
+                {
+                    var len = Math.Min(DirectorStreamLimits.UploadChunkRawBytes, bytes.Length - off);
+                    var chunk = new UploadImageChunkRequest
+                    {
+                        UploadId = uploadId,
+                        Seq = off / DirectorStreamLimits.UploadChunkRawBytes,
+                        BytesBase64 = Convert.ToBase64String(bytes, off, len),
+                    };
+                    var cr = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "upload-image-chunk", sid, chunk, ctx.RequestAborted);
+                    if (cr is null || !cr.Ok)
+                        return Results.Json(new { error = cr is null ? "tunnel dropped mid-upload" : DirectorCommandRouter.DescribeFailure(cr) }, statusCode: StatusCodes.Status502BadGateway);
+                }
+
+                var done = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "upload-image-complete", sid,
+                    new UploadImageCompleteRequest { UploadId = uploadId }, ctx.RequestAborted);
+                if (done is null || !done.Ok || string.IsNullOrEmpty(done.BodyJson))
+                    return Results.Json(new { error = done is null ? "tunnel dropped mid-upload" : DirectorCommandRouter.DescribeFailure(done) }, statusCode: StatusCodes.Status502BadGateway);
+
+                return Results.Content(done.BodyJson, "application/json"); // { path, fileName } - byte-identical to the HTTP body
+            }
+
             var (ok, path, fileName, err) = await client.UploadImageAsync(
-                director.ControlEndpoint, sid, ms.ToArray(), file.FileName, file.ContentType, ctx.RequestAborted);
+                director.ControlEndpoint, sid, bytes, file.FileName, file.ContentType, ctx.RequestAborted);
             if (!ok)
                 return Results.Json(new { error = err }, statusCode: StatusCodes.Status502BadGateway);
 


### PR DESCRIPTION
## What

The last explicit session route still dialing the Director over HTTP. An uploaded image now rides DOWN the tunnel in **bounded chunks** (begin / chunk / complete), reassembled on the Director by a fresh `uploadId`, so a whole photo never rides as one large unary message that would monopolize the shared tunnel (Architect ruling 2). streamMode-gated with the existing HTTP dial as the null-fallback, byte-identical when off.

## Director side (`SessionByteExecutor`)

Three new verbs:
- **begin** - opens a reassembly buffer (validates session + extension + declared size; sweeps abandoned uploads).
- **chunk** - appends one in-order base64 piece (rejects unknown id / out-of-order / bad-base64 / overflow, fail loud).
- **complete** - asserts the assembled length equals the declared total, then writes the file via the **same save core** the single-shot path uses (`SaveUploadedImage` now delegates to a shared `SaveImageBytes`).

A 25 MB fail-loud ceiling and a 2-minute abandoned-upload sweep bound memory.

## Chunk sizing (deviation flagged to the Architect)

Chunks ride as base64 in the existing `DirectorCommand.PayloadJson` at `DirectorStreamLimits.UploadChunkRawBytes = 20 KB` raw (~27 KB on the wire), kept under the SignalR ~32 KB default. This realizes the Architect's option 1 (chunk across unary commands, bounded, no monopoly) **without** depending on a client-side `MaximumReceiveMessageSize` setter the SignalR client does not cleanly expose. The deviation from the exact 48 KB-binary/52 KB-limit mechanism is recorded in the phase2 design doc; the literal version is a small follow-up if the Architect prefers it.

## Proof

`TunnelExplicitRouteProofTests` uploads a **50 KB image over the tunnel in 3 chunks**, the Director's REAL reassembly handlers run, and the saved file is asserted **byte-for-byte identical** to the original.
- `TunnelExplicitRouteProofTests`: **11/11 pass**.
- Full Gateway suite: green.

> Merge is held pending the Architect's yes/no on the base64/20KB vs binary/48KB chunk mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)