### PR TITLE
feat(car-mode): Phase 4b - Gateway idempotency (an already-sent turn auto-retries at most once)

### DIFF
--- a/apps/mobile/src/pages/CarMode.tsx
+++ b/apps/mobile/src/pages/CarMode.tsx
@@ -10,7 +10,7 @@ import { useScreenWakeLock } from "../hooks/useScreenWakeLock";
 // the old git short-sha + timestamp badge was replaced by a plain human version. BUMP THIS INTEGER BY HAND
 // ON EVERY DEPLOY of the mobile app (v1 -> v2 -> v3 ...), so a glance at the corner tells the owner and the
 // Architect exactly which page is live and what to look for after a deploy.
-const CAR_MODE_VERSION = "v9";
+const CAR_MODE_VERSION = "v10";
 
 // Car Mode (Car Mode mission): the standalone, chrome-less, full-screen page the owner opens to run
 // the whole fleet by voice, hands-free, phone in his pocket. It is a THIN view over the shared
@@ -63,9 +63,11 @@ export function CarMode() {
 
   // The injected brain responder. Phase 2+: the real fleet brain. The stand-in (below) just echoes the
   // heard command so Phase 1's barge-in proof needs no server and no credits.
-  const respond = useCallback(async (command: string, signal: AbortSignal): Promise<CarModeReply> => {
+  const respond = useCallback(async (command: string, signal: AbortSignal, idempotencyKey?: string): Promise<CarModeReply> => {
     if (USE_FLEET_BRAIN) {
-      const result = await carModeTurn(command, signal);
+      // Forward the durable turn record id as the Idempotency-Key (Phase 4b, #1427) so a re-driven turn
+      // acts at most once server-side.
+      const result = await carModeTurn(command, idempotencyKey, signal);
       return {
         spoken: result.spoken,
         actions: result.actions,
@@ -172,28 +174,24 @@ export function CarMode() {
           </div>
         )}
 
-        {/* A held turn that needs the owner's explicit choice. A "stale" turn (never sent to the brain,
-            just old) can be sent safely; an "ambiguous" turn (already sent, result unknown) can only be
-            discarded in Phase 4a, since a blind resend could act twice. */}
+        {/* A held turn that is too old to fire blind (past the ~30-minute staleness cap) waits for the
+            owner's explicit choice. Sending it is safe via Phase 4b's server idempotency (it acts at most
+            once), so both Send and Discard are offered. */}
         {askOwnerTurn && (
           <div className="car-askowner" role="status">
             <span className="car-askowner-text">
-              {askOwnerTurn.reason === "ambiguous"
-                ? "I sent an earlier request but couldn't confirm it. I've left it alone to avoid doing it twice."
-                : "You have an earlier saved request from a while ago."}
+              You have an earlier saved request from a while ago.
               {askOwnerTurn.transcript.length > 0 && <> "{askOwnerTurn.transcript}"</>}
             </span>
             <div className="car-askowner-buttons">
-              {askOwnerTurn.reason === "stale" && (
-                <button
-                  type="button"
-                  className="car-askowner-send"
-                  onClick={() => sendHeldTurn(askOwnerTurn.id)}
-                  disabled={phase !== "listening"}
-                >
-                  Send it now
-                </button>
-              )}
+              <button
+                type="button"
+                className="car-askowner-send"
+                onClick={() => sendHeldTurn(askOwnerTurn.id)}
+                disabled={phase !== "listening"}
+              >
+                Send it now
+              </button>
               <button
                 type="button"
                 className="car-askowner-discard"

--- a/docs/architecture/carmode-offline-resilience-4b-2026-07-13.md
+++ b/docs/architecture/carmode-offline-resilience-4b-2026-07-13.md
@@ -1,0 +1,65 @@
+# Car Mode offline resilience - Phase 4b: Gateway idempotency
+
+Status: built 2026-07-13 by the Car Mode - Manager (session 965d43f8), design confirmed by the Car Mode -
+Architect (session f44f39c0). Issue #1427. Follows Phase 4a (never lose speech + durable buffer + audible
+offline state; merged in #1454/#1457 and deployed). The durability follow-up is tracked as #1458.
+
+## Why 4b exists
+
+Phase 4a auto-retries a held turn on reconnect, but it had to HOLD one case for the owner: a turn whose
+brain call was already SENT and whose result was unknown (transcribe briefly succeeded, then the
+connection dropped). A blind retry of that turn could act twice (a duplicate start / message / approve).
+4b removes that hold by making POST /carmode/turn idempotent, so ANY held turn can auto-retry safely -
+acting at most once.
+
+## The mechanism
+
+- The client sends its durable command-audio record id (the same id that keys the on-device pending-turn
+  store) as the standard `Idempotency-Key` HTTP header on POST /carmode/turn. It is stable across retries.
+- A new in-memory `CarModeTurnCache` (mirroring `CarModePendingStore` / `CarModeConversationStore`) does
+  single-flight + cached-result dedupe, keyed by (device, key):
+  - The FIRST request for a key runs the brain and caches the result.
+  - A concurrent or later duplicate awaits or returns that SAME result WITHOUT re-running the tool loop, so
+    the fleet action AND the per-device conversation append happen exactly once.
+- The crux for the dead zone: the endpoint runs the brain on `CancellationToken.None`, NOT the request
+  token. So a client that drops mid-turn does NOT abort the work - it finishes and caches - and the
+  client's retry gets the cached result instead of re-acting. The endpoint awaits with the request token
+  (via `WaitAsync(ct)`) so a disconnected client still returns promptly while the work continues.
+- Cache policy: SUCCESS only. On a brain EXCEPTION the key is evicted so a transient error can still
+  recover on the next retry (caching a failure would trap the error until the TTL). TTL is 30 minutes,
+  aligned to the client's staleness cap.
+
+## Client change
+
+- `classifyHeldTurn` drops the `brainSent` gate: staleness (30 minutes) is now the ONLY reason a held turn
+  waits for the owner, because server dedupe makes an already-sent turn safe to auto-retry. The 4a
+  "ambiguous / discard-only" hold and its UI are removed; the ask-owner surface is now only for
+  older-than-the-cap turns, which offer both Send (safe via dedupe) and Discard. `brainSent` is still
+  recorded for diagnostics but no longer gates anything.
+
+## Accepted residual double-act windows (v1, in-memory), documented per the Architect's decision
+
+Both are rare and annoying-not-catastrophic (a duplicate message/start; delete is idempotent):
+1. A brain exception thrown AFTER a tool already acted: the key is evicted, so the retry re-runs and may
+   act again.
+2. A Gateway RESTART between the original call and the retry loses this in-memory cache (and the in-memory
+   conversation store), so the retry re-runs. Gateway restarts are INDEPENDENT of the owner's connection
+   drops, so a real dead-zone drive (Gateway up throughout) is fully safe.
+Durable persistence is deliberately not built here; it is tracked as follow-up issue #1458.
+
+## Proof
+
+- Server unit tests (`CarModeBrainTests`, the `TurnCache_*` cases), deterministic with counting fake
+  chat + fleet:
+  - `TurnCache_DuplicateKey_ActsOnceAndAppendsOnce` - the same key: the fleet action fires EXACTLY once and
+    the conversation is appended once (the scripted chat has exactly one run's worth of turns, so a wrong
+    re-run would also throw).
+  - `TurnCache_DistinctKeys_ActTwice` - different keys act independently.
+  - `TurnCache_BrainThrows_EvictsKeySoRetryReRuns` - a failure evicts so a retry recovers.
+  - `TurnCache_SuccessIsRetainedForTheKey` - a success is cached and returned to a duplicate.
+- The Phase 4a offline proof harness (`packages/client-core/browser-tests/carmode-offline-proof`) STILL
+  PASSES under the 4b client changes (no speech lost, auto-completes on reconnect, states announced).
+
+Coverage caveat (carried from 4a): the client harness proves the real client logic in real Chromium, NOT
+the real phone microphone / mobile audio session / radio offline / live Gateway. Soren's by-hand phone
+pass remains the final confirmation and is deferred to his return.

--- a/packages/client-core/browser-tests/carmode-offline-proof/harness-entry.tsx
+++ b/packages/client-core/browser-tests/carmode-offline-proof/harness-entry.tsx
@@ -99,8 +99,8 @@ window.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Re
 }) as typeof window.fetch;
 
 function Harness(): React.ReactElement {
-  const respond = useCallback(async (command: string, signal: AbortSignal): Promise<CarModeReply> => {
-    const r = await carModeTurn(command, signal);
+  const respond = useCallback(async (command: string, signal: AbortSignal, idempotencyKey?: string): Promise<CarModeReply> => {
+    const r = await carModeTurn(command, idempotencyKey, signal);
     return {
       spoken: r.spoken,
       actions: r.actions,

--- a/packages/client-core/src/carmode/carModeApi.ts
+++ b/packages/client-core/src/carmode/carModeApi.ts
@@ -101,10 +101,14 @@ export interface CarModeTurnResult {
  * references ("the latest one") resolve without the browser sending any history. A 402 is the shared
  * credits error; any other non-2xx throws a specific GatewayError so the failure is spoken, never silent.
  */
-export async function carModeTurn(text: string, signal?: AbortSignal): Promise<CarModeTurnResult> {
+export async function carModeTurn(text: string, idempotencyKey?: string, signal?: AbortSignal): Promise<CarModeTurnResult> {
+  // Offline resilience Phase 4b (#1427): send the durable command-audio record id as the Idempotency-Key
+  // so a turn re-driven after a dead zone is deduped server-side - the brain acts at most once, and the
+  // retry gets the cached result. Omitted on a first-ever call is fine; the server just runs it and caches.
+  const idempotencyHeader: Record<string, string> = idempotencyKey ? { "Idempotency-Key": idempotencyKey } : {};
   const res = await gatewayFetch("/carmode/turn", {
     method: "POST",
-    headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
+    headers: { "Content-Type": "application/json", Accept: "application/json", ...idempotencyHeader, ...authHeaders() },
     body: JSON.stringify({ text }),
     signal,
   });

--- a/packages/client-core/src/carmode/turnRetry.test.ts
+++ b/packages/client-core/src/carmode/turnRetry.test.ts
@@ -14,26 +14,26 @@ const NOW = 1_000_000_000_000;
 
 describe("classifyHeldTurn", () => {
   it("auto-retries a fresh turn that never reached the brain (the dominant dead-zone case)", () => {
-    // brainSent=false means transcribe never succeeded, so re-driving is a FIRST brain call = safe.
-    expect(classifyHeldTurn({ brainSent: false, createdAt: NOW - 1000 }, NOW)).toBe("auto");
+    expect(classifyHeldTurn({ createdAt: NOW - 1000 }, NOW)).toBe("auto");
   });
 
-  it("holds for the owner a turn already sent to the brain (result unknown, could double-act)", () => {
-    // Even a brand-new brainSent turn is ambiguous - it may have acted - so it is never auto-fired in 4a.
-    expect(classifyHeldTurn({ brainSent: true, createdAt: NOW - 1000 }, NOW)).toBe("ask-owner");
+  it("auto-retries a fresh turn even if it was already sent to the brain (Phase 4b server dedupe makes it safe)", () => {
+    // With the Idempotency-Key, an already-sent turn acts at most once, so brainSent no longer forces
+    // ask-owner - only staleness does.
+    expect(classifyHeldTurn({ createdAt: NOW - 1000 }, NOW)).toBe("auto");
   });
 
-  it("holds for the owner a never-sent turn that is older than the staleness cap", () => {
-    // brainSent=false but stale: firing a half-hour-old action blind is wrong, so surface it for a yes.
-    expect(classifyHeldTurn({ brainSent: false, createdAt: NOW - STALE_TURN_MS - 1 }, NOW)).toBe("ask-owner");
+  it("holds for the owner a turn older than the staleness cap", () => {
+    // Firing a half-hour-old action blind is wrong, so surface it for an explicit yes regardless of state.
+    expect(classifyHeldTurn({ createdAt: NOW - STALE_TURN_MS - 1 }, NOW)).toBe("ask-owner");
   });
 
-  it("still auto-retries a never-sent turn right up to the staleness cap", () => {
-    expect(classifyHeldTurn({ brainSent: false, createdAt: NOW - (STALE_TURN_MS - 1) }, NOW)).toBe("auto");
+  it("still auto-retries a turn right up to the staleness cap", () => {
+    expect(classifyHeldTurn({ createdAt: NOW - (STALE_TURN_MS - 1) }, NOW)).toBe("auto");
   });
 
   it("treats exactly the staleness cap as too old to auto-fire", () => {
-    expect(classifyHeldTurn({ brainSent: false, createdAt: NOW - STALE_TURN_MS }, NOW)).toBe("ask-owner");
+    expect(classifyHeldTurn({ createdAt: NOW - STALE_TURN_MS }, NOW)).toBe("ask-owner");
   });
 });
 

--- a/packages/client-core/src/carmode/turnRetry.ts
+++ b/packages/client-core/src/carmode/turnRetry.ts
@@ -20,17 +20,18 @@ const THROTTLED_DELAY_MS = 5 * 60 * 1000; // after the hard hour: one slow attem
 export const STALE_TURN_MS = 30 * 60 * 1000;
 
 /** How a held turn should be handled when connectivity returns.
- *  - "auto": the brain call never started AND the turn is fresh, so re-driving it is a safe first brain
- *    call - auto-retry it.
- *  - "ask-owner": either the brain call was already sent (its result is unknown, so a blind retry could
- *    double-act - held until Phase 4b's idempotency key makes it safe) OR the turn is too old to fire
- *    blind. Surface it to the owner for an explicit send/discard. */
+ *  - "auto": auto-retry it. Phase 4b made this safe regardless of whether the brain call was already sent:
+ *    the Gateway now dedupes by the turn's Idempotency-Key, so a re-drive either is a fresh first call (the
+ *    turn never reached the server) or returns the cached result (it did) - it ACTS at most once either way.
+ *  - "ask-owner": the turn is too old to fire blind (past the staleness cap). Surface it to the owner for
+ *    an explicit send/discard - the world has moved on, so a stale action should not fire unprompted. */
 export type HeldDisposition = "auto" | "ask-owner";
 
-/** Decide how a held turn is handled on reconnect (Architect decisions Q1/Q2). The `brainSent` flag is
- *  the safety boundary; the staleness cap is the second gate. */
-export function classifyHeldTurn(rec: Pick<PendingCarModeTurn, "brainSent" | "createdAt">, now: number): HeldDisposition {
-  if (rec.brainSent) return "ask-owner"; // already sent to the brain; result unknown; do not auto-fire
+/** Decide how a held turn is handled on reconnect. Since Phase 4b's server idempotency makes an
+ *  already-sent turn safe to auto-retry (it acts at most once), the ONLY gate is the staleness cap: a turn
+ *  older than it asks the owner; everything fresher auto-retries. (The `brainSent` flag is still recorded
+ *  for diagnostics, but no longer gates the retry.) */
+export function classifyHeldTurn(rec: Pick<PendingCarModeTurn, "createdAt">, now: number): HeldDisposition {
   if (now - rec.createdAt >= STALE_TURN_MS) return "ask-owner"; // too old to fire blind
   return "auto";
 }
@@ -56,11 +57,6 @@ export const HOLDING_MESSAGE =
  *  answer is the delayed one he asked for earlier, not a reply to something he just said (Architect Q3:
  *  always audibly acknowledge a landed held turn, briefly). */
 export const RECOVERY_PREFIX = "Back online. ";
-
-/** Spoken + shown when a turn was already sent to the brain but its result is unknown, so it is held for
- *  the owner rather than auto-fired. Honest about the uncertainty. */
-export const AMBIGUOUS_HELD_MESSAGE =
-  "I sent your last request but couldn't confirm it went through, so I've left it alone to avoid doing it twice. Say or tap discard to clear it.";
 
 /** Spoken once when the hands-free end-phrase watch has failed to reach the Gateway several times in a
  *  row, so the owner is not left silently wondering why his "over and out" never lands (the silent-stall

--- a/packages/client-core/src/carmode/useCarMode.ts
+++ b/packages/client-core/src/carmode/useCarMode.ts
@@ -20,7 +20,6 @@ import {
   type PendingCarModeTurn,
 } from "./pendingTurnStore";
 import {
-  AMBIGUOUS_HELD_MESSAGE,
   CONNECTION_DOWN_MESSAGE,
   classifyHeldTurn,
   HOLDING_MESSAGE,
@@ -154,16 +153,15 @@ export interface CarModeView {
   /** The honest, saved-not-lost line to show/say for the current held state, or null when nothing is held.
    *  Distinct from `error` (a loud red failure): holding is a calm "saved, will send" state. */
   holdMessage: string | null;
-  /** The oldest held turn that cannot be auto-fired and needs the owner's explicit choice, or null.
-   *  `reason` is "stale" (never sent to the brain but older than the auto-fire cap - safe to send on the
-   *  owner's yes) or "ambiguous" (already sent to the brain, result unknown - can only be discarded in
-   *  Phase 4a, since a blind resend could act twice; Phase 4b's idempotency key makes resend safe). */
-  askOwnerTurn: { id: string; transcript: string; reason: "stale" | "ambiguous" } | null;
+  /** The oldest held turn that is too old to fire blind (past the ~30-minute staleness cap) and needs the
+   *  owner's explicit send/discard, or null. Since Phase 4b's server idempotency makes any held turn safe
+   *  to auto-retry, staleness is the only reason a turn waits for the owner. */
+  askOwnerTurn: { id: string; transcript: string } | null;
   /** True once the hands-free end-phrase watch has failed to reach the Gateway several times in a row, so
    *  the page can show the connection is down (paired with the spoken CONNECTION_DOWN cue). */
   connectionDown: boolean;
-  /** Owner explicitly sends a "stale" held turn now (safe: it never reached the brain). A no-op for an
-   *  ambiguous held turn (resend is unsafe until Phase 4b) or an unknown id. */
+  /** Owner explicitly sends a stale held turn now. Safe via Phase 4b's server idempotency (it acts at most
+   *  once whether or not it was sent before). A no-op for an unknown id. */
   sendHeldTurn: (id: string) => void;
   /** Owner explicitly discards a held turn, dropping its saved audio for good. */
   discardHeldTurn: (id: string) => void;
@@ -187,7 +185,10 @@ export interface CarModeView {
 /** Options: the brain responder is INJECTED so Phase 1 passes a canned acknowledgement and Phase 2 passes
  *  the real POST /carmode/turn call, over the identical turn-taking machine. */
 export interface UseCarModeOptions {
-  respond: (command: string, signal: AbortSignal) => Promise<CarModeReply>;
+  /** The injected brain call. `idempotencyKey` (the durable turn record id, Phase 4b) is passed so the
+   *  page can forward it to POST /carmode/turn as the Idempotency-Key, making a re-driven turn act at most
+   *  once. It is undefined only for the Phase 1 stand-in / when no durable record backs the turn. */
+  respond: (command: string, signal: AbortSignal, idempotencyKey?: string) => Promise<CarModeReply>;
   /** The spoken sign-off phrase that ends the owner's turn hands-free (default "over and out"). The page
    *  passes the owner's configured phrase; when the rolling end-phrase watch hears the transcript end with
    *  it, the turn is taken, exactly as tapping the "Over and out" button does. The button remains the
@@ -654,40 +655,12 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     driveTickRef.current();
   }, [stopThinkingCue, speakLocal, refreshHeldTurns, enterListening]);
 
-  // Clear the brain-sent mark on a held record back to auto-retriable. Used when a brain call failed for a
-  // reason that PROVES no action was taken (a money refusal: no credits means no model call and no tools),
-  // so the saved turn is safe to auto-retry when the cause clears - it is NOT the ambiguous "may have
-  // acted" case. Best-effort: a store hiccup just leaves the record marked ambiguous (still safe: it holds
-  // for the owner rather than firing blind).
-  const markAutoRetriable = useCallback(async (id: string) => {
-    try {
-      const r = await getPendingTurn(id);
-      if (r !== null) await savePendingTurn({ ...r, brainSent: false });
-    } catch {
-      // leave it as-is; the worst case is a held-for-owner turn instead of an auto one - never a double act
-    }
-    await refreshHeldTurns();
-  }, [refreshHeldTurns]);
-
-  // Enter the HELD-FOR-OWNER state after a brain-call failure whose result is unknown (the durable record
-  // is brainSent=true). It may have acted, so it is NOT auto-retried (a blind resend could act twice); it
-  // waits for the owner to discard it (Phase 4a) - Phase 4b's idempotency key will make an automatic
-  // resend safe. Say + show the honest ambiguous line and hand the microphone back.
-  const holdForOwner = useCallback(async () => {
-    stopThinkingCue();
-    setCaptureState("held");
-    setHoldMessage(AMBIGUOUS_HELD_MESSAGE);
-    speakLocal(AMBIGUOUS_HELD_MESSAGE);
-    await refreshHeldTurns();
-    await enterListening();
-  }, [stopThinkingCue, speakLocal, refreshHeldTurns, enterListening]);
-
   // Re-drive ONE held command-audio record through the whole pipeline (transcribe -> brain -> speak),
   // exactly like a live turn but announced with the "Back online" prefix so the owner knows this is the
   // delayed answer to a request he made earlier (Architect Q3). The durable record is deleted ONLY after
   // the brain call returns a definitive success (the turn is owned server-side); a failure keeps the audio
-  // and holds. brainSent is flipped true on the record right before the brain call, so a failure AFTER
-  // that point becomes held-for-owner (ambiguous), while a failure at transcribe stays auto-retriable.
+  // and holds, staying auto-retriable. The brain call carries the record id as the Idempotency-Key (Phase
+  // 4b), so even if a prior attempt already reached the brain, this re-drive acts at most once.
   const driveHeldTurn = useCallback(
     async (rec: PendingCarModeTurn) => {
       const recorder = recorderRef.current;
@@ -705,7 +678,6 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
       thinkingCueStopRef.current = startThinkingCue();
       const controller = new AbortController();
       abortRef.current = controller;
-      let sentBrain = false;
       try {
         // Stop + release the live microphone before Thinking/Speaking (v3 rule), so the recovered reply
         // plays with getUserMedia released, just like a live reply.
@@ -740,16 +712,17 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
 
         setTranscript(command);
         setLastHeard(command);
-        // Cross the brain boundary: a failure from here is ambiguous (may have acted).
+        // Record that the brain call is being sent (kept for diagnostics; no longer gates the retry now
+        // that Phase 4b's server idempotency makes an already-sent turn safe to auto-retry).
         try {
           await savePendingTurn({ ...rec, transcript: command, brainSent: true });
         } catch {
-          // durable update failed; the in-memory sentBrain flag below still routes the failure correctly
+          // durable update failed; harmless - the brain call below still carries the Idempotency-Key
         }
-        sentBrain = true;
         turnMetricsRef.current = null; // re-drives are recovery, not part of the live performance telemetry
 
-        const answer = await respond(command, controller.signal);
+        // Pass the record id as the Idempotency-Key so a turn that already reached the brain acts at most once.
+        const answer = await respond(command, controller.signal, rec.id);
         if (controller.signal.aborted) return;
         // The brain owns the turn: delete the durable record so it can never be re-driven / double-acted.
         await deletePendingTurn(rec.id);
@@ -772,26 +745,21 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
         if (controller.signal.aborted) return;
         stopThinkingCue();
         console.log(`[CarMode] re-drive of a held turn failed: ${err instanceof Error ? err.message : String(err)}`);
-        // Keep the audio. A money refusal (402) proves nothing acted, so keep it auto-retriable and let the
-        // NEXT foreground / online / open re-drive it (no aggressive loop that a fast retry cannot fix). If
-        // the brain had already been sent for a non-credits reason, it is now ambiguous (held for the
-        // owner); otherwise the transcribe never reached the brain and it stays auto-retriable.
+        // Keep the audio; the turn stays held and auto-retriable (server idempotency makes the retry safe).
+        // A money refusal (402) is shown as the shared credits notice and NOT re-kicked immediately (a fast
+        // retry cannot conjure credits - the next foreground / online re-drives it); any other failure holds
+        // and kicks the retry cadence.
+        setHoldMessage(HOLDING_MESSAGE);
+        await refreshHeldTurns();
+        await enterListening();
         if (err instanceof CreditsError) {
-          await markAutoRetriable(rec.id);
-          setHoldMessage(HOLDING_MESSAGE);
-          await refreshHeldTurns();
-          await enterListening();
-        } else if (sentBrain) {
-          await holdForOwner();
+          announceError(err.message);
         } else {
-          setHoldMessage(HOLDING_MESSAGE);
-          await refreshHeldTurns();
-          await enterListening();
           driveTickRef.current();
         }
       }
     },
-    [refreshHeldTurns, enterListening, respond, speakAndPlay, setPhaseBoth, stopThinkingCue, holdForOwner, markAutoRetriable],
+    [refreshHeldTurns, enterListening, respond, speakAndPlay, setPhaseBoth, stopThinkingCue, announceError],
   );
 
   // Schedule the next automatic drive attempt on the retry cadence (hard for the first hour since the
@@ -908,7 +876,8 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
           return;
         }
         const brainStart = performance.now();
-        const answer = await respond(trimmed, controller.signal);
+        // Pass the durable record id as the Idempotency-Key (Phase 4b) so a re-driven turn acts at most once.
+        const answer = await respond(trimmed, controller.signal, recordId ?? undefined);
         // The brain owns the turn: delete the durable record so it can never be re-driven / double-acted.
         if (recordId !== null) {
           try {
@@ -943,26 +912,26 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
         await speakAndPlay(spoken, controller.signal);
       } catch (err) {
         if (controller.signal.aborted) return; // stop()/interrupt aborted this turn on purpose
-        // The brain call failed. A money refusal (402) proves nothing acted (no credits = no model call =
-        // no tools), so it is NOT ambiguous: announce the shared credits notice, keep the saved turn
-        // auto-retriable (it completes when credits return, on the next foreground / online), and hand the
-        // microphone back. Any OTHER failure with a durable record was marked brainSent=true, so its result
-        // is unknown - HOLD it for the owner (a blind resend could act twice). Without a durable record,
-        // fall back to the loud failure.
+        // The brain call failed. With a durable record the turn is HELD and auto-retriable: Phase 4b's
+        // server idempotency makes the retry safe (it acts at most once), so there is no "ambiguous,
+        // discard-only" case any more. A money refusal (402) shows the shared credits notice and is not
+        // re-kicked immediately (a fast retry cannot conjure credits - a later foreground / online
+        // re-drives it); any other failure holds and the driver retries on the cadence. Without a durable
+        // record (no store) fall back to the loud failure.
         if (recordId !== null && err instanceof CreditsError) {
-          await markAutoRetriable(recordId);
-          announceError(err.message);
           setHoldMessage(HOLDING_MESSAGE);
+          await refreshHeldTurns();
           await enterListening();
+          announceError(err.message);
         } else if (recordId !== null) {
-          await holdForOwner();
+          await enterHolding();
         } else {
           announceError(gatewayErrorMessage(err));
           await enterListening();
         }
       }
     },
-    [respond, announceError, enterListening, speakAndPlay, setPhaseBoth, holdForOwner, refreshHeldTurns, markAutoRetriable],
+    [respond, announceError, enterListening, speakAndPlay, setPhaseBoth, enterHolding, refreshHeldTurns],
   );
 
   // Transcribe the audio captured so far and take the turn. This is the touch "Over and out" path, the
@@ -1193,11 +1162,10 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
   // capture stream's AnalyserNode (display only) and returns 0 when the microphone is not capturing.
   const getMicLevel = useCallback(() => recorderRef.current?.level() ?? 0, []);
 
-  // Owner explicitly sends a "stale" held turn now (Architect Q2: a turn older than the auto-fire cap is
-  // surfaced for a yes). Safe ONLY because a stale held turn has brainSent=false - it never reached the
-  // brain, so this is a first brain call, no double-action. An ambiguous held turn (brainSent=true) is a
-  // no-op here: resend is unsafe until Phase 4b, so the UI only offers discard for it. Only drives while
-  // the microphone is the owner's and no other drive is running.
+  // Owner explicitly sends a stale held turn now (a turn older than the auto-fire cap is surfaced for a
+  // yes). Safe regardless of whether it was sent to the brain before: Phase 4b's server idempotency (the
+  // record id is the Idempotency-Key) makes the re-drive act at most once. Only drives while the microphone
+  // is the owner's and no other drive is running.
   const sendHeldTurn = useCallback(
     async (id: string) => {
       if (drivingRef.current || phaseRef.current !== "listening") return;
@@ -1207,7 +1175,7 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
       } catch {
         return;
       }
-      if (rec === null || rec.brainSent) return; // gone, or ambiguous (resend unsafe in Phase 4a)
+      if (rec === null) return; // gone (already delivered or discarded)
       drivingRef.current = true;
       try {
         await driveHeldTurn(rec);
@@ -1391,19 +1359,15 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     };
   }, []);
 
-  // Derive the owner-facing held state from the store mirror. The oldest turn needing an explicit choice
-  // is surfaced as askOwnerTurn, tagged "stale" (never sent, safe to send on a yes) or "ambiguous" (sent
-  // to the brain, result unknown, discard-only in Phase 4a).
+  // Derive the owner-facing held state from the store mirror. The oldest turn past the staleness cap is
+  // surfaced as askOwnerTurn for an explicit send/discard (Phase 4b: staleness is the only reason a held
+  // turn waits for the owner, since server idempotency makes any retry safe).
   const now = Date.now();
   const askOwnerRec = heldTurns
     .filter((r) => classifyHeldTurn(r, now) === "ask-owner")
     .sort((a, b) => a.createdAt - b.createdAt)[0];
   const askOwnerTurn = askOwnerRec
-    ? {
-        id: askOwnerRec.id,
-        transcript: askOwnerRec.transcript ?? "",
-        reason: askOwnerRec.brainSent ? ("ambiguous" as const) : ("stale" as const),
-      }
+    ? { id: askOwnerRec.id, transcript: askOwnerRec.transcript ?? "" }
     : null;
 
   return {

--- a/src/CcDirector.Gateway.Tests/CarModeBrainTests.cs
+++ b/src/CcDirector.Gateway.Tests/CarModeBrainTests.cs
@@ -852,4 +852,92 @@ public sealed class CarModeBrainTests
         // The most recent exchange is kept.
         Assert.Equal("a19", history[^1].Content);
     }
+
+    // ---- Phase 4b: the idempotency + single-flight turn cache (issue #1427) ----
+    // The mission guarantee: a turn retried with the SAME client turn key ACTS and APPENDS to the
+    // conversation AT MOST ONCE, so an already-sent turn whose result was lost in a dead zone can auto-retry
+    // safely. Distinct keys act independently; a brain FAILURE evicts the key so a transient error recovers.
+
+    [Fact]
+    public async Task TurnCache_DuplicateKey_ActsOnceAndAppendsOnce()
+    {
+        var fleet = new FakeFleet();
+        var store = new CarModeConversationStore();
+        // One turn: start a session, then speak. The scripted chat has exactly the two rounds for ONE run;
+        // if the cache wrongly re-ran the brain, the script would be exhausted (throw) and the fleet would
+        // start twice - so this test fails loudly on any dedupe break.
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("start_session", "{\"repo\":\"devthrottle\"}") }),
+            Speak("Started a session in the devthrottle repo."));
+        var brain = new CarModeBrain(chat, fleet, store, new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var cache = new CarModeTurnCache(_ => { });
+
+        var r1 = await cache.GetOrRunAsync("dev", "turn-1", () => brain.RunTurnAsync("dev", "start a session in devthrottle", CancellationToken.None));
+        var r2 = await cache.GetOrRunAsync("dev", "turn-1", () => brain.RunTurnAsync("dev", "start a session in devthrottle", CancellationToken.None));
+
+        Assert.Single(fleet.StartedRepos);                 // the fleet action fired EXACTLY once
+        Assert.Equal("devthrottle", fleet.StartedRepos[0]);
+        Assert.Equal(2, store.GetHistory("dev").Count);    // ONE exchange appended (user + assistant), not two
+        Assert.Equal("Started a session in the devthrottle repo.", r1.Spoken);
+        Assert.Equal(r1.Spoken, r2.Spoken);                // the duplicate got the SAME cached result
+    }
+
+    [Fact]
+    public async Task TurnCache_DistinctKeys_ActTwice()
+    {
+        var fleet = new FakeFleet();
+        var store = new CarModeConversationStore();
+        var chat = new ScriptedChat(
+            new CarModeAssistantTurn(null, new[] { Call("start_session", "{\"repo\":\"devthrottle\"}") }),
+            Speak("Started one."),
+            new CarModeAssistantTurn(null, new[] { Call("start_session", "{\"repo\":\"devthrottle\"}") }),
+            Speak("Started two."));
+        var brain = new CarModeBrain(chat, fleet, store, new CarModePendingStore(_ => { }), new CarModeSubjectStore(_ => { }), _ => { });
+        var cache = new CarModeTurnCache(_ => { });
+
+        await cache.GetOrRunAsync("dev", "key-A", () => brain.RunTurnAsync("dev", "start a session", CancellationToken.None));
+        await cache.GetOrRunAsync("dev", "key-B", () => brain.RunTurnAsync("dev", "start another", CancellationToken.None));
+
+        Assert.Equal(2, fleet.StartedRepos.Count);         // two distinct turn keys act independently
+        Assert.Equal(4, store.GetHistory("dev").Count);    // two exchanges appended
+    }
+
+    [Fact]
+    public async Task TurnCache_BrainThrows_EvictsKeySoRetryReRuns()
+    {
+        // A brain exception must NOT be cached: the key is evicted so a transient failure can recover on the
+        // next retry (caching the failure would trap the error until the TTL).
+        var cache = new CarModeTurnCache(_ => { });
+        var calls = 0;
+        Func<Task<CarModeTurnResponse>> run = () =>
+        {
+            calls++;
+            return Task.FromException<CarModeTurnResponse>(new InvalidOperationException("transient"));
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => cache.GetOrRunAsync("dev", "k", run));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => cache.GetOrRunAsync("dev", "k", run));
+
+        Assert.Equal(2, calls);                            // evicted after the first failure -> the retry re-ran
+    }
+
+    [Fact]
+    public async Task TurnCache_SuccessIsRetainedForTheKey()
+    {
+        var cache = new CarModeTurnCache(_ => { });
+        var calls = 0;
+        Func<Task<CarModeTurnResponse>> run = () =>
+        {
+            calls++;
+            return Task.FromResult(new CarModeTurnResponse { Spoken = "done" });
+        };
+
+        var a = await cache.GetOrRunAsync("dev", "k", run);
+        var b = await cache.GetOrRunAsync("dev", "k", run);
+
+        Assert.Equal(1, calls);                            // ran once; the duplicate returned the cached result
+        Assert.Equal("done", a.Spoken);
+        Assert.Same(a, b);                                 // the very same cached response object
+        Assert.Equal(1, cache.Count());
+    }
 }

--- a/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/CarModeEndpoint.cs
@@ -31,7 +31,7 @@ namespace CcDirector.Gateway.Api;
 /// </summary>
 internal static class CarModeEndpoint
 {
-    public static void Map(IEndpointRouteBuilder app, CarModeBrain brain, CarModeTelemetryStore telemetry, CarModeWarmup warmup)
+    public static void Map(IEndpointRouteBuilder app, CarModeBrain brain, CarModeTurnCache turnCache, CarModeTelemetryStore telemetry, CarModeWarmup warmup)
     {
         // Keep-warm (Car Mode performance round): the browser calls this the instant the owner taps Start,
         // and every few minutes WHILE Car Mode is open, so the hosted model + text-to-speech are hot before
@@ -54,11 +54,30 @@ internal static class CarModeEndpoint
                 return Results.Json(new { error = "text is required" }, statusCode: StatusCodes.Status400BadRequest);
 
             var deviceKey = ExtractCallerCredential(ctx);
-            // A server-minted turn id ties the browser's posted timing record back to this turn's log line.
-            var turnId = Guid.NewGuid().ToString("N");
+            var text = req.Text.Trim();
+            // Offline resilience Phase 4b (issue #1427): the client sends its durable command-audio record id
+            // as the Idempotency-Key so an already-sent turn whose result was lost in a dead zone auto-retries
+            // and ACTS at most once. When present it also becomes the turnId, so a retry's telemetry ties back
+            // to the original rather than double-counting. When absent (a legacy caller), the old behavior
+            // holds: a fresh server turnId and a direct brain run on the request token.
+            var idemKey = ExtractIdempotencyKey(ctx);
+            var turnId = string.IsNullOrEmpty(idemKey) ? Guid.NewGuid().ToString("N") : idemKey;
             try
             {
-                var result = await brain.RunTurnAsync(deviceKey, req.Text.Trim(), ct);
+                CarModeTurnResponse result;
+                if (string.IsNullOrEmpty(idemKey))
+                {
+                    result = await brain.RunTurnAsync(deviceKey, text, ct);
+                }
+                else
+                {
+                    // Run the brain on CancellationToken.None (NOT the request token) inside the single-flight
+                    // cache, so a client that drops mid-turn does NOT abort the work - it completes and caches,
+                    // and the client's retry gets the cached result instead of re-acting. Await with the request
+                    // token so a disconnected client still returns promptly (the underlying work continues).
+                    var work = turnCache.GetOrRunAsync(deviceKey, idemKey, () => brain.RunTurnAsync(deviceKey, text, CancellationToken.None));
+                    result = await work.WaitAsync(ct);
+                }
                 return Results.Json(new
                 {
                     turnId,
@@ -186,6 +205,17 @@ internal static class CarModeEndpoint
         if (ctx.Request.Cookies.TryGetValue(AuthMiddleware.CookieName, out var cookie) && !string.IsNullOrWhiteSpace(cookie))
             return cookie;
         return "";
+    }
+
+    /// <summary>The client's idempotency key for this turn (the durable command-audio record id), from the
+    ///  standard <c>Idempotency-Key</c> header. Empty when absent (a legacy caller), which the handler maps
+    ///  to the non-deduped legacy path. Trimmed and length-capped so a malformed header cannot bloat the
+    ///  cache key.</summary>
+    private static string ExtractIdempotencyKey(HttpContext ctx)
+    {
+        if (!ctx.Request.Headers.TryGetValue("Idempotency-Key", out var header)) return "";
+        var raw = header.ToString().Trim();
+        return raw.Length > 200 ? raw[..200] : raw;
     }
 }
 

--- a/src/CcDirector.Gateway/CarMode/CarModeTurnCache.cs
+++ b/src/CcDirector.Gateway/CarMode/CarModeTurnCache.cs
@@ -1,0 +1,113 @@
+using System.Collections.Concurrent;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.CarMode;
+
+/// <summary>
+/// Idempotency + single-flight cache for POST /carmode/turn (Car Mode mission, offline-resilience Phase
+/// 4b, issue #1427). It makes a Car Mode turn ACT and APPEND to the conversation AT MOST ONCE per
+/// client-supplied turn key, so the one ambiguous case Phase 4a had to hold for the owner - a turn whose
+/// brain call was already SENT but whose result was lost on the way back - can now auto-retry safely.
+///
+/// How it works. The client sends its durable command-audio record id (the same id that keys the on-device
+/// pending-turn store) as the Idempotency-Key. The first request for a key runs the brain and caches the
+/// result; any concurrent or later duplicate for the SAME key awaits or returns that SAME cached result,
+/// WITHOUT re-running the tool loop - so the fleet action (start / message / approve / confirmed-delete)
+/// and the per-device conversation append happen exactly once.
+///
+/// Single-flight is the crux for the dead zone: the brain must run to completion even after the client has
+/// disconnected, so the endpoint runs it on <see cref="CancellationToken.None"/> (not the request token).
+/// A client that drops mid-turn therefore does not abort the work - it finishes and caches, and the
+/// client's retry gets the cached result instead of re-acting.
+///
+/// Cache policy: SUCCESS only. On a brain EXCEPTION the key is EVICTED so a transient failure can still
+/// recover on the next retry (caching a failure would trap the error and block recovery). Two residual,
+/// accepted-for-v1 double-act windows, both rare and annoying-not-catastrophic (and delete is idempotent),
+/// documented per the Architect's decision (2026-07-13):
+///   1. A brain exception thrown AFTER a tool already acted: the key is evicted, so the retry re-runs and
+///      may act again.
+///   2. A Gateway RESTART between the original call and the retry: this in-memory cache (and the in-memory
+///      conversation store) are lost, so the retry re-runs. Gateway restarts are independent of the owner's
+///      connection drops, so a real dead-zone drive (Gateway up throughout) is fully safe.
+/// Durable persistence is deliberately NOT built here; it is tracked as a follow-up (issue #1458).
+///
+/// In-memory and per-device-keyed, mirroring <see cref="CarModePendingStore"/> and
+/// <see cref="CarModeConversationStore"/>. Entries expire after a TTL aligned to the client's staleness cap
+/// (a held turn older than that is surfaced to the owner rather than auto-fired), so the cache never grows
+/// unbounded. Thread-safe: duplicates can arrive concurrently from the same device.
+/// </summary>
+public sealed class CarModeTurnCache
+{
+    private sealed record Entry(Lazy<Task<CarModeTurnResponse>> Work, DateTime CreatedUtc);
+
+    /// <summary>How long a cached turn result is retained. Aligned to the client's 30-minute staleness cap:
+    ///  past that the client asks the owner before re-firing, so a cached result is no longer needed.</summary>
+    private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(30);
+
+    private readonly ConcurrentDictionary<string, Entry> _byKey = new(StringComparer.Ordinal);
+    private readonly Action<string> _log;
+
+    public CarModeTurnCache(Action<string>? log = null) => _log = log ?? FileLog.Write;
+
+    /// <summary>
+    /// Run the turn for (device, turnKey) exactly once, or return the cached / in-flight result for a
+    /// duplicate. <paramref name="run"/> MUST run the brain on a token that is NOT the request's, so a
+    /// client disconnect does not abort the work (see the class remarks). The returned task faults if the
+    /// brain throws, and the key is evicted so a retry re-runs.
+    /// </summary>
+    public Task<CarModeTurnResponse> GetOrRunAsync(string deviceKey, string turnKey, Func<Task<CarModeTurnResponse>> run)
+    {
+        SweepExpired();
+        var k = Compose(deviceKey, turnKey);
+        // The Lazy is created but not started by the GetOrAdd factory; only .Value on the STORED entry
+        // starts the work, so even under contention run() executes exactly once (losing Lazy instances are
+        // discarded without ever being started). ExecutionAndPublication is the Lazy default.
+        var entry = _byKey.GetOrAdd(k, _ => new Entry(
+            new Lazy<Task<CarModeTurnResponse>>(() => RunAndEvictOnFailureAsync(k, run)),
+            DateTime.UtcNow));
+        if (entry.Work.IsValueCreated)
+            _log("[CarModeTurnCache] duplicate turn key - returning the single-flight / cached result (no re-run)");
+        return entry.Work.Value;
+    }
+
+    private async Task<CarModeTurnResponse> RunAndEvictOnFailureAsync(string k, Func<Task<CarModeTurnResponse>> run)
+    {
+        try
+        {
+            return await run().ConfigureAwait(false);
+        }
+        catch
+        {
+            // Do NOT cache a failure: evict so a later retry with the same key re-runs and can recover from a
+            // transient error. (A brain throw AFTER a partial action can therefore double-act on retry - the
+            // accepted residual documented in the class remarks.)
+            _byKey.TryRemove(k, out _);
+            throw;
+        }
+    }
+
+    /// <summary>Number of cached / in-flight keys (for tests and diagnostics).</summary>
+    public int Count()
+    {
+        SweepExpired();
+        return _byKey.Count;
+    }
+
+    /// <summary>Forget everything (for tests).</summary>
+    public void Clear() => _byKey.Clear();
+
+    private void SweepExpired()
+    {
+        var cutoff = DateTime.UtcNow - Ttl;
+        foreach (var kv in _byKey)
+        {
+            if (kv.Value.CreatedUtc < cutoff)
+                _byKey.TryRemove(kv.Key, out _);
+        }
+    }
+
+    // A NUL separator so a device key and a turn key can never collide across the boundary. A blank device
+    // key (auth-off debug) maps to one shared anonymous namespace, like the other Car Mode stores.
+    private static string Compose(string? deviceKey, string turnKey)
+        => (string.IsNullOrWhiteSpace(deviceKey) ? "anonymous" : deviceKey) + "\0" + turnKey;
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -338,6 +338,10 @@ public sealed class GatewayHost : IAsyncDisposable
     // Car Mode performance round: the durable, Gateway-local store of per-turn timing records. The browser
     // posts ONE record per turn; GET /carmode/telemetry reads them back. Retained about 90 days by age.
     private readonly CarMode.CarModeTelemetryStore _carModeTelemetry = new();
+    // Car Mode offline resilience Phase 4b (issue #1427): idempotency + single-flight cache for
+    // POST /carmode/turn keyed by the client's turn id, so an already-sent turn whose result was lost in a
+    // dead zone auto-retries and ACTS at most once. In-memory, one instance for the whole Gateway.
+    private readonly CarMode.CarModeTurnCache _carModeTurnCache = new();
     // Gateway-owned set of sessions whose dictated utterance is being transcribed in the background
     // (the phone released the Speak dialog and the audio is uploading/transcribing). Stamps the
     // orange "Transcribing..." roster color so nobody else grabs the session mid-dictation.
@@ -1289,7 +1293,7 @@ public sealed class GatewayHost : IAsyncDisposable
                 var key = _keyVault.Get(tts.KeyName) ?? "";
                 return (tts.BaseUrl, Core.Configuration.TtsVoiceConfig.Resolve(mode), Core.Configuration.TtsModelConfig.Resolve(mode), key);
             });
-        Api.CarModeEndpoint.Map(_app, carModeBrain, _carModeTelemetry, carModeWarmup);
+        Api.CarModeEndpoint.Map(_app, carModeBrain, _carModeTurnCache, _carModeTelemetry, carModeWarmup);
         // Editable/versioned wingman instructions settings surface (issue #537), incl. A/B test
         // over saved training sessions (reads the shared training store; uses the hosted wingman brain).
         WingmanInstructionsEndpoint.Map(_app, _instructionsStore, _trainingStore, WingmanBrainAsync);


### PR DESCRIPTION
Car Mode offline-resilience mission, **Phase 4b** (issue thefrederiksen/devthrottle_internal#772). Completes the auto-retry story from Phase 4a (#1454 / thefrederiksen/devthrottle#1457).

## Why
Phase 4a had to **hold one case** for the owner: a turn whose brain call was already sent but whose result was lost in a dead zone - a blind retry could act twice. 4b makes `POST /carmode/turn` idempotent, so **any** held turn can auto-retry safely, **acting at most once**.

## Server
- New in-memory **`CarModeTurnCache`** (mirrors `CarModePendingStore` / `CarModeConversationStore`): single-flight + cached-result dedupe keyed by (device, client turn key). The first request for a key runs the brain and caches the result; a concurrent or later duplicate returns the **same** result without re-running the tool loop, so the fleet action and the conversation append happen **exactly once**.
- The endpoint reads the `Idempotency-Key` header and runs the brain on **`CancellationToken.None`** (not the request token) - the crux for the dead zone: a client that drops mid-turn does not abort the work, so it finishes and caches, and the retry gets the cached result instead of re-acting. It awaits with the request token so a disconnected client still returns promptly while the work continues.
- Cache policy: **success only**; on a brain exception the key is evicted so a transient error can recover on retry.

## Client
- Sends the durable command-audio record id (already the pending-turn store id) as the `Idempotency-Key`, threaded from `useCarMode` through the injected `respond()`.
- `classifyHeldTurn` drops the `brainSent` gate: **staleness (30 min) is now the only reason a held turn waits for the owner**. The 4a ambiguous / discard-only hold and its UI are removed; the ask-owner surface is only for older-than-the-cap turns (Send is safe via dedupe).

## Accepted residual double-act windows (v1, in-memory), documented in code per the Architect's decision
Both rare and annoying-not-catastrophic (a duplicate message/start; delete is idempotent): (1) a brain throw **after** a partial action evicts the key so the retry re-runs; (2) a **Gateway restart** between original and retry loses the in-memory cache. Gateway restarts are independent of the owner's connection drops, so a real dead-zone drive (Gateway up throughout) is fully safe. Durable persistence is tracked as follow-up **#1458**.

## Proof
- Server unit tests (`CarModeBrainTests`, the `TurnCache_*` cases): **a duplicate key acts and appends at most once** (`TurnCache_DuplicateKey_ActsOnceAndAppendsOnce` asserts the fleet action fires exactly once **and** one conversation append), distinct keys act independently, a failure evicts so a retry recovers, a success is retained. **Full Gateway.Tests suite green: 2046 passed.**
- Client-core suite green (401). The **Phase 4a offline proof harness still PASSES** under the 4b client changes (no speech lost, auto-completes on reconnect, states announced).

Coverage caveat (carried from 4a): the client harness proves the real client logic in real Chromium, NOT the real phone mic / mobile audio session / radio offline / live Gateway. Soren's by-hand phone pass remains the final confirmation, deferred to his return.

Server + client ship together. Merge held for the Architect's review (delegated approval authority); on merge I redeploy the light client-only path (page version bumped to v10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)