### PR TITLE
feat(gateway-cleanup): Phase 2 PR D - director-level routes onto the tunnel

### DIFF
--- a/docs/architecture/gateway-cleanup-phase2-repoint-design.md
+++ b/docs/architecture/gateway-cleanup-phase2-repoint-design.md
@@ -203,3 +203,75 @@ fallback on a null return, byte-identical when streamMode is off). The Director 
   TunnelExplicitRouteProofTests: a 50 KB image uploaded over the tunnel in 3 chunks reassembles byte-for-byte and
   is written to disk. If the Architect prefers the literal 48 KB-binary/52 KB-limit mechanism, it is a small
   follow-up (add a byte[] payload field to DirectorCommand + set the client limit) - flagged for his call.
+
+## PR D + the DirectorEndpointClient completeness sweep - 2026-07-13 (Manager a6a3406c)
+
+Architect ruling this session (session 51f1898e): the completeness gate for the destructive cut is that EVERY
+Gateway call site that HTTP-dials the Director is re-pointed onto the tunnel in Phase 2 (additive, streamMode)
+BEFORE the cut, and that a grep confirms `DirectorEndpointClient` has ZERO callers left at the cut (only its own
+definition remains). That zero-callers state is the operational definition of "the tunnel carries everything" and
+makes the Phase 3 `DirectorEndpointClient` deletion a clean no-caller removal. Both PR-D escalations were
+approved: wingman-voice + voice-turn are Phase-2 re-points (NOT deferred to Phase 3), and the three
+director-level mutations fold into PR D.
+
+### PR D (MERGED autonomously under Option A): the `/directors/{id}/*` surface onto the tunnel
+
+Re-pointed in `GatewayEndpoints.cs`, each mirroring the create-verb pattern (`DirectorCommandRouter.TrySendAsync`
+first; a null return falls back to the byte-identical HTTP dial; a non-Ok stream result collapses to the same 502
+the HTTP null produced). All director-level, so `SessionId` is "". The Director-side verbs already existed
+(CatalogReadExecutor from Phase 0 waves 2-4a; SessionWriteExecutor for the mutations from Wave 4a), and the verb
+response DTOs match the `DirectorEndpointClient` return types exactly, so this is a pure Gateway re-point:
+
+- Reads: `repos-list`, `facts`, `coaching-categories`, `claude-sessions`, `fs-list` (path in payload),
+  `handovers-list`, `handovers-content` (path in payload), and `interrupted-list` (BOTH call sites: the
+  `GET /interrupted` fan-out across every Director, and the restore-flow journal re-read).
+- Mutations: `repo-delete` (path in payload), `interrupted-dismiss` and `interrupted-remove` (journal key /
+  session key in payload) - each on the reporting Director (`via`).
+
+Proof: `TunnelDirectorReadProofTests.cs` - a REAL streamMode `GatewayHost` + REAL DirectorHub + REAL MessagePack
+SignalR client, the Director registered UNREACHABLE so a 200 with the expected body can ONLY have ridden the
+tunnel; each test also asserts the exact verb and payload marshaling. 11/11 green; full Gateway suite green.
+
+### The full remaining DirectorEndpointClient caller sweep (the PR-E+ map)
+
+Grep of every `DirectorEndpointClient`-typed caller (the Account/Push `_client`s - RegisterAsync / HeartbeatAsync
+/ ListDevicesAsync / RequestPushMessageDeliveryAsync - are a DIFFERENT client type and are OUT of scope).
+Classified:
+
+- GROUP A - director-level `/directors/*` (DONE, PR D above). No callers remain on these routes except the HTTP
+  fallback branch (removed when the tunnel is made mandatory at the cut).
+- GROUP B - Director-backed session-verb dials still bypassing the tunnel (PR E, Phase-2 re-point). Each already
+  has a tunnel verb (turns / prompt / buffer / snapshot / create); they just call `DirectorEndpointClient`
+  directly instead of `TrySendAsync`:
+  - `GatewayWingmanVoiceEndpoint.cs` - GetTurns / PostPrompt / GetBuffer / GetSession (wingman-voice).
+  - `GatewayVoiceTurnEndpoint.cs` - GetSession (+ owner-locate) (voice-turn).
+  - `WingmanVoiceService.cs` - GetTurns.
+  - `GatewayDictationEndpoint.cs` - PostPrompt + GetSession (dictation delivers transcribed text as a prompt).
+  - `WingmanTrainingStore.cs` - GetBuffer.
+  - `MachineSessionSpawner.cs` / `DirectorImplSessionDriver.cs` - CreateSession + GetBuffer (cron/worklist spawn
+    and the seed-prompt impl driver).
+- GROUP C - roster / health PULLS for which there is NO pull verb today (the roster is a PUSH store). Needs an
+  Architect ruling (see the open question below):
+  - `ExesEndpoints.cs` - ListSessionsWithStatusAsync (per-Director session+status list).
+  - `Briefing/TurnEndWatcher.cs` - ListSessionsWithStatusAsync (turn-end detection poll).
+  - `GatewayHost.cs` - the roster fan-out (ListSessions / ListSessionsWithStatus) + GetHealthDetailedAsync.
+- GROUP D - dialing machinery DELETED in Phase 3 (NOT re-pointed): `AdvertisedEndpointMonitor` (whole class);
+  `SessionWsProxyEndpoints` SessionWsForwarder + the `/sessions/{sid}/{**rest}` catch-all + LocateOwningDirector
+  (the browser stream/file/screenshot legs already tunnel-branched in PR A); the verify / verify-ws callbacks;
+  ControlEndpoint advertisement reads (DeriveDirectorBaseUrl).
+
+OPEN QUESTION for the Architect (Group C): the roster is served from the PUSH store under streamMode for
+`GET /sessions`, but ExesEndpoints, TurnEndWatcher, and the GatewayHost fan-out each do their OWN
+`ListSessionsWithStatusAsync` pull. To reach zero `DirectorEndpointClient` callers, do these read the push store
+(`PushedSessions`) instead of pulling, or is a `list-sessions` pull verb wanted? And `GetHealthDetailedAsync` -
+is the tunnel connection liveness itself the health signal (so the caller is dropped as machinery), or is a
+health verb kept? Manager recommendation: push-store reads for the roster pulls (no new pull verb - the roster is
+authoritative in the push store under streamMode), and drop `GetHealthDetailedAsync` in favour of tunnel
+connectedness (Group D). Awaiting the ruling before PR E's Group-C leg.
+
+On the zero-callers timing: Groups A/B/C keep an HTTP fallback branch during streamMode coexistence, so the
+literal "zero DirectorEndpointClient callers" grep passes only when those fallback branches are removed (tunnel
+made mandatory) together with the Group-D deletions - i.e. AT the cut, not before it. Before the whole-surface
+proof, the guarantee is that every caller HAS a tunnel branch (Groups A/B/C re-pointed, Group D confirmed
+machinery); the zero-callers grep is the definition-of-done verified at the Phase 3 deletion. (Flagged to the
+Architect to confirm this reading of "re-point in Phase 2, then verify zero callers".)

--- a/src/CcDirector.Gateway.Tests/TunnelDirectorReadProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelDirectorReadProofTests.cs
@@ -1,0 +1,279 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using CcDirector.ControlApi;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection; // AddMessagePackProtocol (client)
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 2 (PR D): the DIRECTOR-LEVEL routes on the Gateway that used to HTTP-dial the
+/// target Director (the six reads repos-list / facts / coaching-categories / claude-sessions / interrupted-list /
+/// fs-list, plus the three director-level mutations repo-delete / interrupted-dismiss / interrupted-remove) now
+/// ride the tunnel under stream mode. This boots a REAL streamMode <see cref="GatewayHost"/>, dials the REAL
+/// DirectorHub with a REAL MessagePack SignalR client, and drives each route end to end.
+///
+/// TUNNEL-BY-CONSTRUCTION: the Director is registered with a DELIBERATELY UNREACHABLE control endpoint, so an
+/// HTTP dial cannot succeed - a 200 with the expected body can ONLY have ridden the tunnel. Each test also
+/// asserts the exact verb (and, where it matters, the payload) the Gateway sent DOWN the tunnel, so a route that
+/// silently mapped to the wrong verb or dropped its query parameters fails loudly.
+///
+/// These are DIRECTOR-LEVEL commands (SessionId is ""); the Gateway targets the Director by its id, so no live
+/// session is needed - the connected Director IS the addressable unit.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class TunnelDirectorReadProofTests : IAsyncLifetime
+{
+    private const string Token = "test-token-director-read-proof";
+    private const string DirectorId = "dir-director-read";
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _instancesDir = Path.Combine(Path.GetTempPath(), "cc-dirread-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private HubConnection _conn = null!;
+
+    // The last command the Director saw over the tunnel, so a test can assert the verb + payload the route sent.
+    private DirectorCommand? _lastCommand;
+
+    public TunnelDirectorReadProofTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-dirread-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+
+        // The Director registers UNREACHABLE, so any working route proves it rode the tunnel, never an HTTP dial.
+        _gateway.Registry.Upsert(new DirectorRegistrationRequest
+        {
+            DirectorId = DirectorId,
+            TailnetEndpoint = "http://127.0.0.1:59919/", // nothing listens here
+            MachineName = "dirread-machine",
+            Pid = 1,
+            Version = "test",
+            StartedAt = DateTime.UtcNow,
+        });
+
+        _conn = new HubConnectionBuilder()
+            .WithUrl($"http://127.0.0.1:{_gateway.Port}/director-stream", o => o.AccessTokenProvider = () => Task.FromResult<string?>(Token))
+            .AddMessagePackProtocol()
+            .Build();
+        _conn.On<DirectorCommand, DirectorCommandResult>("Command", Dispatch);
+        await _conn.StartAsync();
+        await _conn.InvokeAsync("Hello", new DirectorStreamHello { DirectorId = DirectorId, Version = "test" });
+    }
+
+    public async Task DisposeAsync()
+    {
+        try { await _conn.DisposeAsync(); } catch { /* best effort */ }
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        foreach (var dir in new[] { _instancesDir, _root })
+            try { if (Directory.Exists(dir)) Directory.Delete(dir, true); } catch { /* best effort */ }
+    }
+
+    // The Director-side Command handler: records the command, then returns a canned body per verb so the test
+    // can assert the Gateway route surfaced exactly that body as its HTTP response. Bodies are serialized from
+    // the SAME contract DTOs the real cores emit, so a shape mismatch would fail the Gateway-side deserialize.
+    private DirectorCommandResult Dispatch(DirectorCommand cmd)
+    {
+        _lastCommand = cmd;
+        return cmd.Verb switch
+        {
+            "repos-list" => Ok(new List<RepositoryDto> { new() { Name = "devthrottle", Path = @"D:\ReposFred\devthrottle" } }),
+            "facts" => Ok(new DirectorFactsDto { DirectorId = DirectorId, MachineName = "dirread-machine", Version = "9.9.9" }),
+            "coaching-categories" => Ok(new List<CoachingCategoryDto> { new() { Key = "assistant", Label = "Assistant" } }),
+            "claude-sessions" => Ok(new List<ClaudeSessionDto> { new() { ClaudeSessionId = "cs-1", RepoPath = @"D:\repo" } }),
+            "fs-list" => Ok(new DirectoryListingDto { CurrentPath = @"D:\some\dir", Entries = new() }),
+            "handovers-list" => Ok(new List<HandoverDto> { new() { Path = @"D:\h\a.md", Title = "a handover" } }),
+            "handovers-content" => Ok(new HandoverContentDto { Path = @"D:\h\a.md", Content = "the handover body" }),
+            "interrupted-list" => Ok(new List<CrashJournalDto>
+            {
+                new()
+                {
+                    DirectorId = "dead-dir",
+                    Pid = 4321,
+                    MachineName = "dirread-machine",
+                    Sessions = new List<CrashJournalSessionDto>
+                    {
+                        new() { SessionId = "sess-abc", Name = "a dead session", RepoPath = @"D:\repo" },
+                    },
+                },
+            }),
+            "repo-delete" => Ok(new RepoDeleteResponse { Removed = true }),
+            "interrupted-dismiss" => Ok(new InterruptedDismissResponse { Dismissed = true }),
+            "interrupted-remove" => Ok(new InterruptedRemoveResponse { Removed = true }),
+            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
+        };
+    }
+
+    private static DirectorCommandResult Ok(object body) => DirectorCommandResult.Success(JsonSerializer.Serialize(body, WebJson));
+    private static readonly JsonSerializerOptions WebJson = new(JsonSerializerDefaults.Web);
+
+    // ------------------------------------------------------------------------------------- reads ----
+
+    [Fact]
+    public async Task Repos_ridesTheTunnel_asReposListVerb()
+    {
+        var resp = await _http.GetAsync($"directors/{DirectorId}/repos");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode); // an HTTP dial to the unreachable Director would have failed
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal("devthrottle", node?[0]?["name"]?.GetValue<string>());
+        Assert.Equal("repos-list", _lastCommand!.Verb);
+        Assert.Equal("", _lastCommand.SessionId); // director-level: no session
+    }
+
+    [Fact]
+    public async Task Facts_ridesTheTunnel()
+    {
+        var resp = await _http.GetAsync($"directors/{DirectorId}/facts");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal("9.9.9", node?["version"]?.GetValue<string>());
+        Assert.Equal(DirectorId, node?["directorId"]?.GetValue<string>());
+        Assert.Equal("facts", _lastCommand!.Verb);
+    }
+
+    [Fact]
+    public async Task CoachingCategories_ridesTheTunnel()
+    {
+        var resp = await _http.GetAsync($"directors/{DirectorId}/coaching/categories");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal("assistant", node?[0]?["key"]?.GetValue<string>());
+        Assert.Equal("coaching-categories", _lastCommand!.Verb);
+    }
+
+    [Fact]
+    public async Task ClaudeSessions_ridesTheTunnel()
+    {
+        var resp = await _http.GetAsync($"directors/{DirectorId}/claude-sessions");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal("cs-1", node?[0]?["claudeSessionId"]?.GetValue<string>());
+        Assert.Equal("claude-sessions", _lastCommand!.Verb);
+    }
+
+    [Fact]
+    public async Task FsList_ridesTheTunnel_andCarriesThePathInThePayload()
+    {
+        var resp = await _http.GetAsync($"directors/{DirectorId}/fs/list?path={Uri.EscapeDataString(@"D:\some\dir")}");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal(@"D:\some\dir", node?["currentPath"]?.GetValue<string>());
+
+        Assert.Equal("fs-list", _lastCommand!.Verb);
+        var payload = JsonNode.Parse(_lastCommand.PayloadJson)!.AsObject();
+        Assert.Equal(@"D:\some\dir", (string?)payload["path"]); // the ?path query rode the payload
+    }
+
+    [Fact]
+    public async Task InterruptedList_fanOut_ridesTheTunnel_andFlattensToRows()
+    {
+        var resp = await _http.GetAsync("interrupted");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        // The fan-out flattened the one journal's one session into an InterruptedSessionDto row.
+        Assert.Equal("sess-abc", node?[0]?["sessionId"]?.GetValue<string>());
+        Assert.Equal("dead-dir", node?[0]?["deadDirectorId"]?.GetValue<string>());
+        Assert.Equal(DirectorId, node?[0]?["reportedByDirectorId"]?.GetValue<string>());
+        Assert.Equal("interrupted-list", _lastCommand!.Verb);
+    }
+
+    [Fact]
+    public async Task HandoversList_ridesTheTunnel()
+    {
+        var resp = await _http.GetAsync($"directors/{DirectorId}/handovers");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal("a handover", node?[0]?["title"]?.GetValue<string>());
+        Assert.Equal("handovers-list", _lastCommand!.Verb);
+    }
+
+    [Fact]
+    public async Task HandoversContent_ridesTheTunnel_andCarriesThePathInThePayload()
+    {
+        var resp = await _http.GetAsync($"directors/{DirectorId}/handovers/content?path={Uri.EscapeDataString(@"D:\h\a.md")}");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal("the handover body", node?["content"]?.GetValue<string>());
+
+        Assert.Equal("handovers-content", _lastCommand!.Verb);
+        var payload = JsonNode.Parse(_lastCommand.PayloadJson)!.AsObject();
+        Assert.Equal(@"D:\h\a.md", (string?)payload["path"]);
+    }
+
+    // ------------------------------------------------------------------------------------ writes ----
+
+    [Fact]
+    public async Task RepoDelete_ridesTheTunnel_andCarriesThePathInThePayload()
+    {
+        var resp = await _http.DeleteAsync($"directors/{DirectorId}/repos?path={Uri.EscapeDataString(@"D:\gone")}");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.True(node?["removed"]?.GetValue<bool>());
+
+        Assert.Equal("repo-delete", _lastCommand!.Verb);
+        var payload = JsonNode.Parse(_lastCommand.PayloadJson)!.AsObject();
+        Assert.Equal(@"D:\gone", (string?)payload["path"]);
+    }
+
+    [Fact]
+    public async Task InterruptedDismiss_ridesTheTunnel_andCarriesTheJournalKey()
+    {
+        var resp = await _http.DeleteAsync($"interrupted/dead-dir/4321?via={DirectorId}");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.True(node?["dismissed"]?.GetValue<bool>());
+
+        Assert.Equal("interrupted-dismiss", _lastCommand!.Verb);
+        var payload = JsonNode.Parse(_lastCommand.PayloadJson)!.AsObject();
+        Assert.Equal("dead-dir", (string?)payload["deadDirectorId"]);
+        Assert.Equal(4321, (int?)payload["deadPid"]);
+    }
+
+    [Fact]
+    public async Task InterruptedRemove_ridesTheTunnel_andCarriesTheSessionKey()
+    {
+        var resp = await _http.DeleteAsync($"interrupted/dead-dir/4321/sessions/sess-abc?via={DirectorId}");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.True(node?["removed"]?.GetValue<bool>());
+
+        Assert.Equal("interrupted-remove", _lastCommand!.Verb);
+        var payload = JsonNode.Parse(_lastCommand.PayloadJson)!.AsObject();
+        Assert.Equal("dead-dir", (string?)payload["deadDirectorId"]);
+        Assert.Equal(4321, (int?)payload["deadPid"]);
+        Assert.Equal("sess-abc", (string?)payload["sessionId"]);
+    }
+
+    // -------------------------------------------------------------------------------------- helpers ----
+
+    private static int AllocateFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -805,16 +805,24 @@ internal static class GatewayEndpoints
         // per recoverable session, and enrich each with the Gateway's last-known brief so the
         // Cockpit Interrupted sessions list is triageable. Directors on one machine share the journal dir, so the
         // same dead journal can be reported by several live Directors - dedupe by directorId+pid.
-        app.MapGet("/interrupted", async () =>
+        app.MapGet("/interrupted", async (CancellationToken ct) =>
         {
             var directors = registry.ListDirectors();
             var fanout = directors.Select(async d =>
             {
+                // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (interrupted-list verb, director-level).
+                // A non-null stream result is authoritative for this Director - Ok carries its journals, a non-Ok
+                // is treated as no journals (skipped), exactly as a failed HTTP read returned null and was
+                // skipped below. A null return (no stream) falls back to the existing reachability-gated HTTP read.
+                var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, d.DirectorId, "interrupted-list", "", null, ct);
+                if (sr is not null)
+                    return (Director: d, Journals: sr.Ok ? DirectorCommandRouter.ReadBody<List<CrashJournalDto>>(sr) : null);
+
                 if (!registry.ShouldProbe(d.DirectorId)) return (Director: d, Journals: (List<CrashJournalDto>?)null);
                 // Issue #324: a flagged no-endpoint registration has nothing to dial.
                 if (string.IsNullOrEmpty(d.ControlEndpoint)) return (Director: d, Journals: (List<CrashJournalDto>?)null);
                 var ep = d.ControlEndpoint.TrimEnd('/');
-                return (Director: d, Journals: await client.GetInterruptedAsync(ep));
+                return (Director: d, Journals: await client.GetInterruptedAsync(ep, ct));
             }).ToList();
             var results = await Task.WhenAll(fanout);
 
@@ -854,7 +862,7 @@ internal static class GatewayEndpoints
 
         // Dismiss one interrupted journal once recovered or unwanted. Routed to the live
         // Director that surfaced it (via=reportedByDirectorId), which owns its machine's dir.
-        app.MapDelete("/interrupted/{deadDirectorId}/{deadPid:int}", async (string deadDirectorId, int deadPid, string? via) =>
+        app.MapDelete("/interrupted/{deadDirectorId}/{deadPid:int}", async (string deadDirectorId, int deadPid, string? via, CancellationToken ct) =>
         {
             FileLog.Write($"[GatewayEndpoints] DELETE /interrupted/{deadDirectorId}/{deadPid} via={via}");
             if (string.IsNullOrWhiteSpace(via))
@@ -862,14 +870,23 @@ internal static class GatewayEndpoints
             var d = registry.Get(via);
             if (d is null)
                 return Results.NotFound(new { error = "reporting director not found" });
-            var ok = await client.DismissInterruptedAsync(d.ControlEndpoint, deadDirectorId, deadPid);
+
+            // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (interrupted-dismiss verb on the reporting
+            // Director). The HTTP path collapsed any non-success (incl a 404) to false -> 502, so a non-Ok
+            // stream result maps to 502 to stay byte-identical.
+            var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, via, "interrupted-dismiss", "",
+                new InterruptedDismissRequest { DeadDirectorId = deadDirectorId, DeadPid = deadPid }, ct);
+            if (sr is not null)
+                return sr.Ok ? Results.Json(new { dismissed = true }) : Results.StatusCode(StatusCodes.Status502BadGateway);
+
+            var ok = await client.DismissInterruptedAsync(d.ControlEndpoint, deadDirectorId, deadPid, ct);
             return ok ? Results.Json(new { dismissed = true }) : Results.StatusCode(StatusCodes.Status502BadGateway);
         });
 
         // Dismiss ONE session from an interrupted journal (issue #212 W4): the rest of the
         // journal stays in the Interrupted sessions list. Routed like the journal-level dismiss above.
         app.MapDelete("/interrupted/{deadDirectorId}/{deadPid:int}/sessions/{sessionId}",
-            async (string deadDirectorId, int deadPid, string sessionId, string? via) =>
+            async (string deadDirectorId, int deadPid, string sessionId, string? via, CancellationToken ct) =>
         {
             FileLog.Write($"[GatewayEndpoints] DELETE /interrupted/{deadDirectorId}/{deadPid}/sessions/{sessionId} via={via}");
             if (string.IsNullOrWhiteSpace(via))
@@ -877,7 +894,15 @@ internal static class GatewayEndpoints
             var d = registry.Get(via);
             if (d is null)
                 return Results.NotFound(new { error = "reporting director not found" });
-            var ok = await client.RemoveInterruptedSessionAsync(d.ControlEndpoint, deadDirectorId, deadPid, sessionId);
+
+            // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (interrupted-remove verb on the reporting
+            // Director). Non-Ok -> 502, matching the HTTP path's false -> 502 collapse.
+            var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, via, "interrupted-remove", "",
+                new InterruptedRemoveRequest { DeadDirectorId = deadDirectorId, DeadPid = deadPid, SessionId = sessionId }, ct);
+            if (sr is not null)
+                return sr.Ok ? Results.Json(new { removed = true }) : Results.StatusCode(StatusCodes.Status502BadGateway);
+
+            var ok = await client.RemoveInterruptedSessionAsync(d.ControlEndpoint, deadDirectorId, deadPid, sessionId, ct);
             return ok ? Results.Json(new { removed = true }) : Results.StatusCode(StatusCodes.Status502BadGateway);
         });
 
@@ -889,7 +914,7 @@ internal static class GatewayEndpoints
         // path is valid there. After a successful create the restored session is removed
         // from the dirty journal so the Interrupted sessions list reflects what is still unrecovered.
         app.MapPost("/interrupted/{deadDirectorId}/{deadPid:int}/restore",
-            async (string deadDirectorId, int deadPid, RestoreInterruptedRequest req) =>
+            async (string deadDirectorId, int deadPid, RestoreInterruptedRequest req, CancellationToken ct) =>
         {
             FileLog.Write($"[GatewayEndpoints] POST /interrupted/{deadDirectorId}/{deadPid}/restore: sid={req?.SessionId} via={req?.Via} toDir={req?.ToDirectorId}");
             if (req is null || string.IsNullOrWhiteSpace(req.SessionId))
@@ -905,8 +930,15 @@ internal static class GatewayEndpoints
                 return Results.NotFound(new { error = "target director not found" });
 
             // The journal is the source of truth for what is restorable - never trust the
-            // caller for repo/name. Re-read it from the reporting Director.
-            var journals = await client.GetInterruptedAsync((reporter.ControlEndpoint ?? "").TrimEnd('/'));
+            // caller for repo/name. Re-read it from the reporting Director. Gateway Cleanup Phase 2 (PR D):
+            // ride the tunnel first (interrupted-list verb on the reporting Director); a null return falls
+            // back to the HTTP read. A non-Ok stream result surfaces as the same 502 the HTTP null produced.
+            List<CrashJournalDto>? journals;
+            var journalsSr = await DirectorCommandRouter.TrySendAsync(sendCommand, req.Via, "interrupted-list", "", null, ct);
+            if (journalsSr is not null)
+                journals = journalsSr.Ok ? DirectorCommandRouter.ReadBody<List<CrashJournalDto>>(journalsSr) : null;
+            else
+                journals = await client.GetInterruptedAsync((reporter.ControlEndpoint ?? "").TrimEnd('/'), ct);
             if (journals is null)
                 return Results.Problem("reporting director did not serve its crash journals", statusCode: StatusCodes.Status502BadGateway);
             var journal = journals.FirstOrDefault(j =>
@@ -1438,11 +1470,22 @@ internal static class GatewayEndpoints
             return Results.Json(new { path, fileName });
         });
 
-        app.MapGet("/directors/{id}/repos", async (string id) =>
+        app.MapGet("/directors/{id}/repos", async (string id, CancellationToken ct) =>
         {
             var d = registry.Get(id);
             if (d is null) return Results.NotFound(new { error = "director not found" });
-            var repos = await client.ListReposAsync(d.ControlEndpoint);
+
+            // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (repos-list verb, director-level so SessionId
+            // is ""); a null return means no stream, so fall back to the byte-identical HTTP dial. A non-Ok stream
+            // result collapses to 502, exactly as the HTTP path surfaced a null.
+            var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, id, "repos-list", "", null, ct);
+            if (sr is not null)
+            {
+                if (!sr.Ok) return Results.StatusCode(StatusCodes.Status502BadGateway);
+                return Results.Json(DirectorCommandRouter.ReadBody<List<RepositoryDto>>(sr) ?? new List<RepositoryDto>());
+            }
+
+            var repos = await client.ListReposAsync(d.ControlEndpoint, ct);
             if (repos is null) return Results.StatusCode(StatusCodes.Status502BadGateway);
             return Results.Json(repos);
         });
@@ -1452,11 +1495,22 @@ internal static class GatewayEndpoints
         // demand rather than pushed in registration/heartbeat: the inventory is large and
         // changes rarely, so riding the 15s heartbeat would bloat the hot path for a fact
         // a consumer reads occasionally.
-        app.MapGet("/directors/{id}/facts", async (string id) =>
+        app.MapGet("/directors/{id}/facts", async (string id, CancellationToken ct) =>
         {
             var d = registry.Get(id);
             if (d is null) return Results.NotFound(new { error = "director not found" });
-            var facts = await client.GetFactsAsync(d.ControlEndpoint);
+
+            // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (facts verb, director-level).
+            var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, id, "facts", "", null, ct);
+            if (sr is not null)
+            {
+                if (!sr.Ok) return Results.StatusCode(StatusCodes.Status502BadGateway);
+                var body = DirectorCommandRouter.ReadBody<DirectorFactsDto>(sr);
+                if (body is null) return Results.StatusCode(StatusCodes.Status502BadGateway);
+                return Results.Json(body);
+            }
+
+            var facts = await client.GetFactsAsync(d.ControlEndpoint, ct);
             if (facts is null) return Results.StatusCode(StatusCodes.Status502BadGateway);
             return Results.Json(facts);
         });
@@ -1492,57 +1546,121 @@ internal static class GatewayEndpoints
             return Results.Json(body, statusCode: 201);
         });
 
-        app.MapDelete("/directors/{id}/repos", async (string id, string? path) =>
+        app.MapDelete("/directors/{id}/repos", async (string id, string? path, CancellationToken ct) =>
         {
             var d = registry.Get(id);
             if (d is null) return Results.NotFound(new { error = "director not found" });
             if (string.IsNullOrWhiteSpace(path)) return Results.BadRequest(new { error = "path is required" });
-            var removed = await client.DeleteRepoAsync(d.ControlEndpoint, path);
+
+            // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (repo-delete verb, director-level). The
+            // Director core returns { removed } in its body; a non-Ok stream result collapses to 502.
+            var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, id, "repo-delete", "", new RepoDeleteRequest { Path = path }, ct);
+            if (sr is not null)
+            {
+                if (!sr.Ok) return Results.StatusCode(StatusCodes.Status502BadGateway);
+                return Results.Content(sr.BodyJson ?? "{\"removed\":false}", "application/json");
+            }
+
+            var removed = await client.DeleteRepoAsync(d.ControlEndpoint, path, ct);
             return Results.Json(new { removed });
         });
 
-        app.MapGet("/directors/{id}/coaching/categories", async (string id) =>
+        app.MapGet("/directors/{id}/coaching/categories", async (string id, CancellationToken ct) =>
         {
             var d = registry.Get(id);
             if (d is null) return Results.NotFound(new { error = "director not found" });
-            var cats = await client.ListCoachingCategoriesAsync(d.ControlEndpoint);
+
+            // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (coaching-categories verb, director-level).
+            var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, id, "coaching-categories", "", null, ct);
+            if (sr is not null)
+            {
+                if (!sr.Ok) return Results.StatusCode(StatusCodes.Status502BadGateway);
+                return Results.Json(DirectorCommandRouter.ReadBody<List<CoachingCategoryDto>>(sr) ?? new List<CoachingCategoryDto>());
+            }
+
+            var cats = await client.ListCoachingCategoriesAsync(d.ControlEndpoint, ct);
             if (cats is null) return Results.StatusCode(StatusCodes.Status502BadGateway);
             return Results.Json(cats);
         });
 
-        app.MapGet("/directors/{id}/claude-sessions", async (string id) =>
+        app.MapGet("/directors/{id}/claude-sessions", async (string id, CancellationToken ct) =>
         {
             var d = registry.Get(id);
             if (d is null) return Results.NotFound(new { error = "director not found" });
-            var sessions = await client.ListClaudeSessionsAsync(d.ControlEndpoint);
+
+            // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (claude-sessions verb, director-level; no
+            // repo filter on this route, so the payload is empty).
+            var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, id, "claude-sessions", "", null, ct);
+            if (sr is not null)
+            {
+                if (!sr.Ok) return Results.StatusCode(StatusCodes.Status502BadGateway);
+                return Results.Json(DirectorCommandRouter.ReadBody<List<ClaudeSessionDto>>(sr) ?? new List<ClaudeSessionDto>());
+            }
+
+            var sessions = await client.ListClaudeSessionsAsync(d.ControlEndpoint, ct);
             if (sessions is null) return Results.StatusCode(StatusCodes.Status502BadGateway);
             return Results.Json(sessions);
         });
 
-        app.MapGet("/directors/{id}/handovers", async (string id) =>
+        app.MapGet("/directors/{id}/handovers", async (string id, CancellationToken ct) =>
         {
             var d = registry.Get(id);
             if (d is null) return Results.NotFound(new { error = "director not found" });
-            var handovers = await client.ListHandoversAsync(d.ControlEndpoint);
+
+            // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (handovers-list verb, director-level; this
+            // route has no repo filter, so the payload is empty).
+            var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, id, "handovers-list", "", null, ct);
+            if (sr is not null)
+            {
+                if (!sr.Ok) return Results.StatusCode(StatusCodes.Status502BadGateway);
+                return Results.Json(DirectorCommandRouter.ReadBody<List<HandoverDto>>(sr) ?? new List<HandoverDto>());
+            }
+
+            var handovers = await client.ListHandoversAsync(d.ControlEndpoint, ct);
             if (handovers is null) return Results.StatusCode(StatusCodes.Status502BadGateway);
             return Results.Json(handovers);
         });
 
-        app.MapGet("/directors/{id}/handovers/content", async (string id, string? path) =>
+        app.MapGet("/directors/{id}/handovers/content", async (string id, string? path, CancellationToken ct) =>
         {
             var d = registry.Get(id);
             if (d is null) return Results.NotFound(new { error = "director not found" });
             if (string.IsNullOrWhiteSpace(path)) return Results.BadRequest(new { error = "path is required" });
-            var content = await client.GetHandoverContentAsync(d.ControlEndpoint, path);
+
+            // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (handovers-content verb, director-level; the
+            // ?path query rides in the payload). A non-Ok stream result collapses to 502, matching the HTTP null.
+            var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, id, "handovers-content", "", new HandoverContentRequest { Path = path }, ct);
+            if (sr is not null)
+            {
+                if (!sr.Ok) return Results.StatusCode(StatusCodes.Status502BadGateway);
+                var body = DirectorCommandRouter.ReadBody<HandoverContentDto>(sr);
+                if (body is null) return Results.StatusCode(StatusCodes.Status502BadGateway);
+                return Results.Json(body);
+            }
+
+            var content = await client.GetHandoverContentAsync(d.ControlEndpoint, path, ct);
             if (content is null) return Results.StatusCode(StatusCodes.Status502BadGateway);
             return Results.Json(content);
         });
 
-        app.MapGet("/directors/{id}/fs/list", async (string id, string? path) =>
+        app.MapGet("/directors/{id}/fs/list", async (string id, string? path, CancellationToken ct) =>
         {
             var d = registry.Get(id);
             if (d is null) return Results.NotFound(new { error = "director not found" });
-            var listing = await client.ListDirectoryAsync(d.ControlEndpoint, path);
+
+            // Gateway Cleanup Phase 2 (PR D): ride the tunnel first (fs-list verb, director-level; the ?path
+            // query rides in the payload). A non-Ok stream result (e.g. the Director core's bad-path BadRequest)
+            // collapses to 502, exactly as the HTTP path surfaced a null.
+            var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, id, "fs-list", "", new FsListRequest { Path = path }, ct);
+            if (sr is not null)
+            {
+                if (!sr.Ok) return Results.StatusCode(StatusCodes.Status502BadGateway);
+                var body = DirectorCommandRouter.ReadBody<DirectoryListingDto>(sr);
+                if (body is null) return Results.StatusCode(StatusCodes.Status502BadGateway);
+                return Results.Json(body);
+            }
+
+            var listing = await client.ListDirectoryAsync(d.ControlEndpoint, path, ct);
             if (listing is null) return Results.StatusCode(StatusCodes.Status502BadGateway);
             return Results.Json(listing);
         });


### PR DESCRIPTION
## What

Gateway Cleanup mission, Phase 2 (PR D). Re-points the `/directors/{id}/*` Gateway routes that HTTP-dialed the target Director onto the tunnel under stream mode, mirroring the create-verb pattern: `DirectorCommandRouter.TrySendAsync` first; a null return falls back to the byte-identical HTTP dial; a non-Ok stream result collapses to the same 502 the HTTP null produced. All director-level, so `SessionId` is empty.

**Reads:** `repos-list`, `facts`, `coaching-categories`, `claude-sessions`, `fs-list`, `handovers-list`, `handovers-content`, and `interrupted-list` (BOTH call sites: the `GET /interrupted` fan-out across every Director, and the restore-flow journal re-read).

**Mutations:** `repo-delete`, `interrupted-dismiss`, `interrupted-remove` (each on the reporting Director via `via`).

## Why additive and safe

Every branch is `streamMode && stream-connected ? tunnel : existing HTTP dial`. Stream mode off (production today) is byte-identical to now. The Director-side verbs already existed (CatalogReadExecutor from Phase 0 waves 2 to 4a; SessionWriteExecutor for the mutations from Wave 4a); the verb response DTOs match the `DirectorEndpointClient` return types exactly, so this is a pure Gateway re-point with no Director change.

## Proof

`TunnelDirectorReadProofTests` - a real stream-mode `GatewayHost`, a real DirectorHub, a real MessagePack SignalR client, the Director registered UNREACHABLE so a 200 with the expected body can only have ridden the tunnel; each test also asserts the exact verb and payload marshaling. 11/11 green. Full Gateway suite green (2140/2140 on the rebased state).

## Context

Part of the Architect completeness gate (every Gateway-to-Director HTTP dial re-pointed onto the tunnel before the destructive cut). The phase 2 design doc now records the full `DirectorEndpointClient` caller sweep (groups A to D) mapping the remaining Phase 2 re-points (PR E) and the zero-callers gate.

Merged autonomously under the mission Option A commit policy (additive work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)