### PR TITLE
feat(gateway-cleanup): Phase 2 PR E-C - roster pulls read the push store

### DIFF
--- a/docs/architecture/gateway-cleanup-phase2-repoint-design.md
+++ b/docs/architecture/gateway-cleanup-phase2-repoint-design.md
@@ -250,28 +250,34 @@ Classified:
   - `WingmanTrainingStore.cs` - GetBuffer.
   - `MachineSessionSpawner.cs` / `DirectorImplSessionDriver.cs` - CreateSession + GetBuffer (cron/worklist spawn
     and the seed-prompt impl driver).
-- GROUP C - roster / health PULLS for which there is NO pull verb today (the roster is a PUSH store). Needs an
-  Architect ruling (see the open question below):
-  - `ExesEndpoints.cs` - ListSessionsWithStatusAsync (per-Director session+status list).
-  - `Briefing/TurnEndWatcher.cs` - ListSessionsWithStatusAsync (turn-end detection poll).
-  - `GatewayHost.cs` - the roster fan-out (ListSessions / ListSessionsWithStatus) + GetHealthDetailedAsync.
+- GROUP C - roster / health PULLS for which there is NO pull verb (the roster is a PUSH store). RULING SETTLED
+  (Architect, 2026-07-13): the roster is served from the PUSH store, so re-point the pulls to READ
+  `PushedSessions` - NO pull verb - and DROP `GetHealthDetailedAsync` in favour of tunnel-connectedness (the
+  PushedSessionStore connection binding already answers "is this Director stream-connected") - NO health verb.
+  One check owed: verify `PushedSessions` carries EVERY field each pull consumer reads (parity) so nothing goes
+  missing.
+  - `ExesEndpoints.cs` - ListSessionsWithStatusAsync (per-Director session+status list) -> read PushedSessions.
+    DONE (PR E-C).
+  - `GatewayEndpoints.cs` /healthz session count (was ListSessionsAsync) and the DELETE /directors/{id} live
+    session gate (was ListSessionsAsync) -> read PushedSessions. DONE (PR E-C).
+  - `Briefing/TurnEndWatcher.cs` - ListSessionsWithStatusAsync (turn-end catch-up sweep) -> read PushedSessions.
+    Deferred into the voice PR (PR E-B voice cluster) because the sweep hands the owning Director's endpoint to
+    WingmanVoiceService.GenerateAsync, so the endpoint->directorId change must land together with the voice
+    service's own tunnel re-point.
+  - `GetHealthDetailedAsync` -> DROP: its ONLY caller is `AdvertisedEndpointMonitor` (GROUP D, deleted Phase 3),
+    so tunnel-connectedness becomes the health signal with NO Phase-2 re-point (the caller dies with the class).
+    The GatewayEndpoints roster fan-out (`:549` ListSessionsWithStatus) was ALREADY re-pointed in Phase 1a - it
+    reads PushedSessions first and only falls through to the HTTP pull as the coexistence path.
 - GROUP D - dialing machinery DELETED in Phase 3 (NOT re-pointed): `AdvertisedEndpointMonitor` (whole class);
   `SessionWsProxyEndpoints` SessionWsForwarder + the `/sessions/{sid}/{**rest}` catch-all + LocateOwningDirector
   (the browser stream/file/screenshot legs already tunnel-branched in PR A); the verify / verify-ws callbacks;
   ControlEndpoint advertisement reads (DeriveDirectorBaseUrl).
 
-OPEN QUESTION for the Architect (Group C): the roster is served from the PUSH store under streamMode for
-`GET /sessions`, but ExesEndpoints, TurnEndWatcher, and the GatewayHost fan-out each do their OWN
-`ListSessionsWithStatusAsync` pull. To reach zero `DirectorEndpointClient` callers, do these read the push store
-(`PushedSessions`) instead of pulling, or is a `list-sessions` pull verb wanted? And `GetHealthDetailedAsync` -
-is the tunnel connection liveness itself the health signal (so the caller is dropped as machinery), or is a
-health verb kept? Manager recommendation: push-store reads for the roster pulls (no new pull verb - the roster is
-authoritative in the push store under streamMode), and drop `GetHealthDetailedAsync` in favour of tunnel
-connectedness (Group D). Awaiting the ruling before PR E's Group-C leg.
-
-On the zero-callers timing: Groups A/B/C keep an HTTP fallback branch during streamMode coexistence, so the
-literal "zero DirectorEndpointClient callers" grep passes only when those fallback branches are removed (tunnel
-made mandatory) together with the Group-D deletions - i.e. AT the cut, not before it. Before the whole-surface
-proof, the guarantee is that every caller HAS a tunnel branch (Groups A/B/C re-pointed, Group D confirmed
-machinery); the zero-callers grep is the definition-of-done verified at the Phase 3 deletion. (Flagged to the
-Architect to confirm this reading of "re-point in Phase 2, then verify zero callers".)
+On the zero-callers timing (CONFIRMED by the Architect, 2026-07-13): Groups A/B/C keep an HTTP fallback
+else-branch during streamMode coexistence, so the literal "zero `DirectorEndpointClient` callers" grep passes
+only when those fallback branches are removed (tunnel made mandatory) together with the Group-D deletions - i.e.
+AT the cut, not before it. The PRE-PROOF gate the Architect clears the cut on is: EVERY `DirectorEndpointClient`
+caller HAS a tunnel branch, AND the whole-surface real-exe proof (streamMode ON) exercises all of them. The
+fallback else-branches still referencing `DirectorEndpointClient` are FINE pre-cut (they are the coexistence
+path). The literal zero-callers grep is the at-cut check run right before deleting `DirectorEndpointClient`
+(remove the streamMode-off fallbacks + delete Group D + grep-confirm zero callers + delete the client).

--- a/src/CcDirector.Gateway.Tests/TunnelRosterPushReadProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelRosterPushReadProofTests.cs
@@ -1,0 +1,155 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json.Nodes;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection; // AddMessagePackProtocol (client)
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 2 (PR E, Group C): the Gateway roster PULLS that used to call
+/// <c>DirectorEndpointClient.ListSessions*</c> now read the PUSH store (<c>PushedSessions</c>) under stream mode,
+/// per the Architect ruling (the roster is authoritative in the push store; no pull verb). This covers the three
+/// pure roster reads: <c>/healthz</c> session count, the <c>/exes/list</c> per-Director session list, and the
+/// <c>DELETE /directors/{id}</c> live-session safety gate.
+///
+/// TUNNEL-BY-CONSTRUCTION: the Director is registered UNREACHABLE and its sessions are delivered ONLY via a
+/// stream PushSnapshot. So a result that reflects those sessions can ONLY have come from the push store - an
+/// HTTP pull to the unreachable Director would have returned nothing.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class TunnelRosterPushReadProofTests : IAsyncLifetime
+{
+    private const string Token = "test-token-roster-push-read";
+    private const string DirectorId = "dir-roster-push";
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _instancesDir = Path.Combine(Path.GetTempPath(), "cc-rosterpush-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private HubConnection _conn = null!;
+
+    public TunnelRosterPushReadProofTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-rosterpush-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+
+        // Registered UNREACHABLE, but on THIS machine so /exes/list (local-machine only) surfaces it.
+        _gateway.Registry.Upsert(new DirectorRegistrationRequest
+        {
+            DirectorId = DirectorId,
+            TailnetEndpoint = "http://127.0.0.1:59920/", // nothing listens here
+            MachineName = Environment.MachineName,
+            Pid = 1,
+            Version = "test",
+            StartedAt = DateTime.UtcNow,
+        });
+
+        _conn = new HubConnectionBuilder()
+            .WithUrl($"http://127.0.0.1:{_gateway.Port}/director-stream", o => o.AccessTokenProvider = () => Task.FromResult<string?>(Token))
+            .AddMessagePackProtocol()
+            .Build();
+        await _conn.StartAsync();
+        await _conn.InvokeAsync("Hello", new DirectorStreamHello { DirectorId = DirectorId, Version = "test" });
+    }
+
+    public async Task DisposeAsync()
+    {
+        try { await _conn.DisposeAsync(); } catch { /* best effort */ }
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        foreach (var dir in new[] { _instancesDir, _root })
+            try { if (Directory.Exists(dir)) Directory.Delete(dir, true); } catch { /* best effort */ }
+    }
+
+    private Task PushAsync(long sequence, params SessionDto[] sessions) =>
+        _conn.InvokeAsync("PushSnapshot", sequence, sessions);
+
+    [Fact]
+    public async Task Healthz_countsSessionsFromThePushStore()
+    {
+        await PushAsync(1L,
+            new SessionDto { SessionId = Guid.NewGuid().ToString(), Status = "WaitingForInput", ActivityState = "WaitingForInput" },
+            new SessionDto { SessionId = Guid.NewGuid().ToString(), Status = "Working", ActivityState = "Working" });
+
+        var node = await _http.GetFromJsonAsync<JsonNode>("healthz");
+        // An HTTP pull to the unreachable Director would count 0; the push store carries 2.
+        Assert.Equal(2, node?["sessions"]?.GetValue<int>());
+    }
+
+    [Fact]
+    public async Task ExesList_readsTheDirectorSessionsFromThePushStore()
+    {
+        var sid = Guid.NewGuid().ToString();
+        await PushAsync(1L, new SessionDto
+        {
+            SessionId = sid,
+            Name = "a pushed session",
+            Agent = "ClaudeCode",
+            Status = "WaitingForInput",
+            ActivityState = "WaitingForInput",
+            RepoPath = @"D:\repo",
+        });
+
+        var node = await _http.GetFromJsonAsync<JsonNode>("exes/list");
+        var directors = node?["directors"]?.AsArray();
+        var mine = directors?.FirstOrDefault(d => d?["directorId"]?.GetValue<string>() == DirectorId);
+        Assert.NotNull(mine);
+        var sessions = mine!["sessions"]?.AsArray();
+        Assert.Equal(1, sessions?.Count);
+        Assert.Equal(sid, sessions?[0]?["sessionId"]?.GetValue<string>());
+        Assert.Null(mine["sessionError"]?.GetValue<string?>()); // no pull error - it never pulled
+    }
+
+    [Fact]
+    public async Task DeleteDirectorGate_readsTheLiveSessionCountFromThePushStore()
+    {
+        // One live session in the push store. An HTTP pull to the unreachable Director would return null and the
+        // gate would be SKIPPED (deletion proceeds); a 409 citing the live count proves the push-store read.
+        await PushAsync(1L, new SessionDto
+        {
+            SessionId = Guid.NewGuid().ToString(),
+            Name = "a live session",
+            Status = "WaitingForInput",
+            ActivityState = "WaitingForInput",
+            RepoPath = @"D:\repo",
+        });
+
+        var req = new HttpRequestMessage(HttpMethod.Delete, $"directors/{DirectorId}")
+        {
+            Content = JsonContent.Create(new { reason = "cleanup test", force = false }),
+        };
+        var resp = await _http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.Equal(1, node?["liveSessionCount"]?.GetValue<int>());
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/src/CcDirector.Gateway/Api/ExesEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/ExesEndpoints.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Streaming;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -31,8 +32,14 @@ internal static class ExesEndpoints
     private static readonly Regex SlotFromExe =
         new(@"cc-director(\d+)\.exe$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-    public static void Map(IEndpointRouteBuilder app, DirectorRegistry registry, DirectorEndpointClient client)
+    public static void Map(IEndpointRouteBuilder app, DirectorRegistry registry, DirectorEndpointClient client,
+        PushedSessionStore? pushedSessions = null, TimeSpan? streamStaleAfter = null)
     {
+        // Gateway Cleanup Phase 2 (PR E, Group C): under streamMode the roster lives in the push store; resolve
+        // the same freshness window the /sessions roster uses so a stream-connected Director's sessions are read
+        // from the store instead of pulled over HTTP.
+        var streamStale = streamStaleAfter ?? TimeSpan.FromSeconds(Core.Configuration.GatewayConfig.DefaultStreamStaleAfterSeconds);
+
         // ----- list local directors + slot status (JSON; /exes itself is the HTML page) -----
         app.MapGet("/exes/list", async (HttpContext ctx) =>
         {
@@ -51,7 +58,19 @@ internal static class ExesEndpoints
                 var directorTasks = local.Select(async d =>
                 {
                     var exePath = TryGetExePath(d.Pid);
-                    var (sessions, error) = await client.ListSessionsWithStatusAsync(d.ControlEndpoint, false);
+                    // Group C: prefer the push store; a stale/absent cache falls through to the HTTP pull.
+                    IReadOnlyList<SessionDto>? sessions;
+                    string? error;
+                    var cached = pushedSessions?.TryGetFresh(d.DirectorId, streamStale);
+                    if (cached is not null)
+                    {
+                        sessions = cached;
+                        error = null;
+                    }
+                    else
+                    {
+                        (sessions, error) = await client.ListSessionsWithStatusAsync(d.ControlEndpoint, false);
+                    }
                     return new
                     {
                         directorId = d.DirectorId,
@@ -66,7 +85,7 @@ internal static class ExesEndpoints
                         startedAt = d.StartedAt,
                         source = d.Source,
                         sessionError = error,
-                        sessions = (sessions ?? new()).Select(s => new
+                        sessions = (sessions ?? new List<SessionDto>()).Select(s => new
                         {
                             sessionId = s.SessionId,
                             name = s.Name,

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -215,7 +215,7 @@ internal static class GatewayEndpoints
         CommQueueEndpoints.Map(app);
 
         // Local-machine exe/slot management (the "Exes" page).
-        ExesEndpoints.Map(app, registry, client);
+        ExesEndpoints.Map(app, registry, client, pushedSessions, streamStaleResolved);
 
         // ===== HTML pages =====
         // The Gateway serves NO UI pages anymore (docs/plans/one-url-cockpit.md): "/" and every
@@ -273,6 +273,11 @@ internal static class GatewayEndpoints
             // pay one client timeout per Director sequentially.
             var counts = await Task.WhenAll(directors.Select(async d =>
             {
+                // Gateway Cleanup Phase 2 (PR E, Group C): under streamMode the roster lives in the push store,
+                // so count from there and skip the HTTP pull entirely; a stale/absent cache falls through to
+                // the byte-identical HTTP pull (the coexistence path removed when the tunnel is made mandatory).
+                var cached = pushedSessions?.TryGetFresh(d.DirectorId, streamStaleResolved);
+                if (cached is not null) return cached.Count;
                 var sessions = await client.ListSessionsAsync(d.ControlEndpoint);
                 return sessions?.Count ?? 0;
             }));
@@ -1722,7 +1727,13 @@ internal static class GatewayEndpoints
                 return Results.BadRequest(new { error = "reason is required: state why this Director is being shut down" });
             }
 
-            var sessions = await client.ListSessionsAsync(director.ControlEndpoint);
+            // Gateway Cleanup Phase 2 (PR E, Group C): under streamMode read the live session list from the push
+            // store (it carries the same SessionDto incl. Status); a stale/absent cache falls through to the
+            // byte-identical HTTP pull.
+            var cachedSessions = pushedSessions?.TryGetFresh(director.DirectorId, streamStaleResolved);
+            var sessions = cachedSessions is not null
+                ? cachedSessions.ToList()
+                : await client.ListSessionsAsync(director.ControlEndpoint);
             if (sessions is not null)
             {
                 var live = sessions


### PR DESCRIPTION
## What

Gateway Cleanup mission, Phase 2 (PR E, Group C). Per the Architect ruling, the Gateway roster PULLs that called `DirectorEndpointClient.ListSessions*` now read the PUSH store (`PushedSessions`) under stream mode. The roster is authoritative in the push store, so no pull verb is added; a stale or absent cache falls through to the byte-identical HTTP pull (the coexistence path, removed when the tunnel is made mandatory).

Re-pointed (the pure roster reads, no voice coupling):
- `GET /healthz` session count (was `ListSessionsAsync`).
- `DELETE /directors/{id}` live-session safety gate (was `ListSessionsAsync`); `PushedSessions` carries the same `SessionDto` including `Status`.
- `ExesEndpoints` `/exes/list` per-Director session list (was `ListSessionsWithStatusAsync`); `PushedSessions` threaded in.

## Scope notes

- `GetHealthDetailedAsync` needs NO Phase 2 re-point: its only caller is `AdvertisedEndpointMonitor` (deleted in Phase 3), so tunnel-connectedness becomes the health signal.
- `TurnEndWatcher`'s roster pull is deferred into the voice PR (PR E-B voice cluster): it hands the owning Director endpoint to `WingmanVoiceService.GenerateAsync`, so the endpoint to directorId change must land together with the voice service's own tunnel re-point.

## Proof

`TunnelRosterPushReadProofTests` - the Director is registered UNREACHABLE and its sessions are delivered ONLY via a stream `PushSnapshot`, so each result (healthz count, exes session list, the delete-director 409 gate) can only have come from the push store. 3/3 green. Full Gateway suite 2147/2147 green.

Merged autonomously under the mission Option A commit policy (additive work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)