### PR TITLE
fix(dictation): never clip the end of speech in Car Mode; warn the user when audio was dropped

### DIFF
--- a/packages/client-core/src/carmode/useCarMode.ts
+++ b/packages/client-core/src/carmode/useCarMode.ts
@@ -953,8 +953,10 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     const pauseDetectedAt = prefetched ? prefetched.pauseDetectedAt : performance.now();
 
     // Acquire the raw command audio for BOTH paths (the voice end-phrase path passes the very clip it
-    // transcribed). This is what gets persisted so speech is never lost.
-    const clip = prefetched ? prefetched.clip : rec.snapshot();
+    // transcribed). This is what gets persisted so speech is never lost. The snapshot is FLUSHED:
+    // MediaRecorder's still-buffered tail is forced out first, so the last words before the tap are in
+    // the clip - a bare snapshot() clips up to 100ms off the end, exactly where the final word lands.
+    const clip = prefetched ? prefetched.clip : await rec.snapshotFlushed();
     if (!prefetched && clip.size < MIN_CLIP_BYTES) {
       void takeTurn("", null); // nothing captured: a canned nudge, no server turn, no durable record
       return;
@@ -1083,7 +1085,11 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     endPollBusyRef.current = true;
     const startedAt = performance.now();
     try {
-      const clip = rec.snapshot();
+      // Flushed snapshot: without forcing MediaRecorder's buffered tail out first, the just-spoken
+      // sign-off ("over and out") can be missing from the clip and the phrase is never detected -
+      // and when it IS detected, this very clip becomes the persisted command audio, so the tail
+      // must be complete here too.
+      const clip = await rec.snapshotFlushed();
       if (clip.size < MIN_CLIP_BYTES) return;
       const transcodeStart = performance.now();
       const { wav } = await blobToWav16kMono(clip);

--- a/packages/client-core/src/dictation/DictationDialog.tsx
+++ b/packages/client-core/src/dictation/DictationDialog.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { transcribeUtterance } from "../api/client";
 import type { CapturedUtterance } from "./backgroundSend";
-import { logCaptureHealth } from "./captureHealth";
+import { captureLossWarning, logCaptureHealth } from "./captureHealth";
 import { playReadyCue } from "./readyCue";
 import { MicRecorder } from "./recorder";
 import { joinText } from "./transcript";
@@ -90,6 +90,11 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
 
   const [transcript, setTranscript] = useState<string>("");
   const [hint, setHint] = useState<string>("");
+  // Sticky dropped-audio warning (issue #863 made the loss measurable; this makes it VISIBLE).
+  // Once a segment shows a material capture deficit the warning stays for the rest of the dialog -
+  // the loss happened and the text may be missing words, so it must not be cleared by a later
+  // healthy segment.
+  const [captureWarning, setCaptureWarning] = useState<string>("");
   const [errorText, setErrorText] = useState<string>("");
   const [elapsed, setElapsed] = useState<number>(0);
   const [levels, setLevels] = useState<number[]>(() => new Array(BAR_COUNT).fill(0));
@@ -178,12 +183,14 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
     };
   }, [onCaptureLive, armReadyBackstop, clearReadyBackstop]);
 
-  // Stop the current segment, transcode to WAV, and transcribe it. Returns the segment text, or
-  // null when there was no audio / transcription failed (the reason is shown). The recorder is
-  // consumed here, so a segment is never transcribed twice.
-  const transcribeCurrentSegment = useCallback(async (): Promise<string | null> => {
+  // Stop the current segment, transcode to WAV, and transcribe it. Returns the segment text plus a
+  // dropped-audio warning when the capture-health check found a material deficit, or null when there
+  // was no audio / transcription failed (the reason is shown). The recorder is consumed here, so a
+  // segment is never transcribed twice.
+  const transcribeCurrentSegment = useCallback(async (): Promise<{ text: string; lossWarning: string | null } | null> => {
     let wav: Blob;
     let health;
+    let lossWarning: string | null = null;
     try {
       const captured = await recorderRef.current.stop();
       const transcoded = await blobToWav16kMono(captured);
@@ -197,6 +204,11 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
         sourceBytes: transcoded.sourceBytes,
       };
       logCaptureHealth("mobile", health);
+      // Material loss is surfaced to the USER, not just the console: the transcript may be missing
+      // words, and a silent commit of truncated speech is exactly the failure mode this dialog
+      // exists to prevent. The caller shows the warning and parks instead of auto-committing.
+      lossWarning = captureLossWarning(health);
+      if (lossWarning !== null) setCaptureWarning(lossWarning);
     } catch (err) {
       setHint(err instanceof Error ? err.message : "Could not capture the recording.");
       return null;
@@ -207,7 +219,7 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
         // several, so show which piece is going up before the "Transcribing..." wait.
         if (total > 1) setHint(`Uploading recording... ${uploaded} of ${total}`);
       });
-      return text;
+      return { text, lossWarning };
     } catch (err) {
       setHint(err instanceof Error ? err.message : "The transcription service had a problem and couldn't process your recording.");
       return null;
@@ -224,7 +236,7 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
       setHint("Transcribing what you have said so far...");
       const segment = await transcribeCurrentSegment();
       if (segment !== null) {
-        accumulatedRef.current = joinText(accumulatedRef.current, segment);
+        accumulatedRef.current = joinText(accumulatedRef.current, segment.text);
         setTranscript(accumulatedRef.current);
         setHint("");
       }
@@ -263,7 +275,17 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
           busyRef.current = false;
           return;
         }
-        accumulatedRef.current = joinText(accumulatedRef.current, segment);
+        accumulatedRef.current = joinText(accumulatedRef.current, segment.text);
+        if (segment.lossWarning !== null) {
+          // The capture dropped audio, so this text may be missing words. Committing it silently
+          // (worst of all straight into a session via Send) would hide the loss - park in PAUSED
+          // with the warning showing so the user reviews or re-dictates, then commits by hand.
+          setTranscript(accumulatedRef.current);
+          setHint("");
+          setStage("paused");
+          busyRef.current = false;
+          return;
+        }
         busyRef.current = false;
         action(accumulatedRef.current.trim());
         onClose();
@@ -373,6 +395,10 @@ export function DictationDialog({ onInsert, onSend, onSendAudio, onClose, showIn
         )}
 
         <div className="dictate-hint" role="status">{hint}</div>
+
+        {captureWarning !== "" && !isError && (
+          <div className="dictate-warning" role="alert">{captureWarning}</div>
+        )}
 
         {isError ? (
           <div className="dictate-error" role="alert">{errorText}</div>

--- a/packages/client-core/src/dictation/captureHealth.test.ts
+++ b/packages/client-core/src/dictation/captureHealth.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { captureLossWarning, deficitFraction } from "./captureHealth";
+
+// captureLossWarning is what turns the silent capture-health measurement (issue #863) into a
+// user-visible warning in the dictation dialog: a material deficit means words may be missing from
+// the transcript, and the dialog parks instead of auto-committing. The threshold must match the
+// console log's, and small codec slack must never nag the user.
+
+describe("deficitFraction", () => {
+  it("is 0 for a healthy capture and clamps codec padding at 0", () => {
+    expect(deficitFraction({ recordedMs: 10000, decodedSeconds: 10, sourceBytes: 1 })).toBe(0);
+    // Decoded slightly LONGER than the wall-clock (codec priming/padding) must not go negative.
+    expect(deficitFraction({ recordedMs: 10000, decodedSeconds: 10.4, sourceBytes: 1 })).toBe(0);
+  });
+
+  it("measures the missing fraction of the recording wall-clock", () => {
+    // Recorded 52s, decoded 39s: a quarter of the audio never made it.
+    expect(deficitFraction({ recordedMs: 52000, decodedSeconds: 39, sourceBytes: 1 })).toBeCloseTo(0.25);
+  });
+});
+
+describe("captureLossWarning", () => {
+  it("returns null for a healthy capture and for normal codec slack (under the threshold)", () => {
+    expect(captureLossWarning({ recordedMs: 10000, decodedSeconds: 10, sourceBytes: 1 })).toBeNull();
+    // 5% short is codec slack, not loss.
+    expect(captureLossWarning({ recordedMs: 10000, decodedSeconds: 9.5, sourceBytes: 1 })).toBeNull();
+  });
+
+  it("names roughly how many seconds went missing on a material loss", () => {
+    // Recorded 52s, decoded 38s: ~14 seconds missing.
+    const warning = captureLossWarning({ recordedMs: 52000, decodedSeconds: 38, sourceBytes: 1 });
+    expect(warning).not.toBeNull();
+    expect(warning).toContain("About 14 seconds");
+    expect(warning).toContain("was not captured");
+  });
+
+  it("uses the singular for a one-second loss and reports at least one second", () => {
+    // 20% of a 4s recording is 0.8s - rounds up to the minimum of 1 second, singular.
+    const warning = captureLossWarning({ recordedMs: 4000, decodedSeconds: 3.2, sourceBytes: 1 });
+    expect(warning).not.toBeNull();
+    expect(warning).toContain("About 1 second ");
+  });
+});

--- a/packages/client-core/src/dictation/captureHealth.ts
+++ b/packages/client-core/src/dictation/captureHealth.ts
@@ -24,6 +24,28 @@ export function deficitFraction(h: BrowserCaptureHealth): number {
   return Math.max(0, 1 - decodedMs / h.recordedMs);
 }
 
+// A deficit over ~10% of the recording wall-clock is real dropped audio; below that it is normal
+// codec priming/padding slack. Shared by the console log and the user-facing warning so the two can
+// never disagree about what counts as loss.
+const MATERIAL_DEFICIT = 0.1;
+
+/**
+ * Human-readable dropped-audio warning for a finished segment, or null when the capture looks
+ * healthy. A material deficit means some of what the user said never reached transcription, so the
+ * text on screen may be missing words - the user must be TOLD, not just a console line (never fail
+ * silently on mobile). The dictation dialog shows this and parks instead of auto-committing.
+ */
+export function captureLossWarning(h: BrowserCaptureHealth): string | null {
+  const deficit = deficitFraction(h);
+  if (deficit <= MATERIAL_DEFICIT) return null;
+  const missingSeconds = Math.max(1, Math.round((h.recordedMs / 1000) * deficit));
+  const unit = missingSeconds === 1 ? "second" : "seconds";
+  return (
+    `About ${missingSeconds} ${unit} of your audio was not captured (the microphone dropped audio ` +
+    "while recording), so words may be missing. Check the text below before you use it."
+  );
+}
+
 /** Log one capture-health line for a finished segment, tagged by surface so the mobile and Blazor
  *  paths read the same way as the desktop log. A material deficit is a warning, not an error - it is
  *  a measurement, and the audio still ships. */
@@ -33,7 +55,6 @@ export function logCaptureHealth(surface: string, h: BrowserCaptureHealth): void
     `[capture-health] surface=${surface} recordedMs=${h.recordedMs.toFixed(0)} ` +
     `decodedSec=${h.decodedSeconds.toFixed(2)} deficit=${(deficit * 100).toFixed(1)}% ` +
     `sourceBytes=${h.sourceBytes}`;
-  // A deficit over ~10% is worth surfacing prominently; below that it is normal codec slack.
-  if (deficit > 0.1) console.warn(line + " (audio appears to have been dropped before transcription)");
+  if (deficit > MATERIAL_DEFICIT) console.warn(line + " (audio appears to have been dropped before transcription)");
   else console.log(line);
 }

--- a/packages/client-core/src/dictation/dictation.css
+++ b/packages/client-core/src/dictation/dictation.css
@@ -125,6 +125,18 @@
   color: var(--text-dim);
 }
 
+/* Sticky dropped-audio warning: amber, not red - the dictation continues, but the user must review
+   the (possibly truncated) text before committing it. */
+.dictate-warning {
+  margin-top: 8px;
+  padding: 10px 12px;
+  background: rgba(220, 170, 60, 0.12);
+  border: 1px solid rgba(220, 170, 60, 0.45);
+  border-radius: 8px;
+  color: #e8c878;
+  font-size: 13px;
+}
+
 .dictate-error {
   margin-top: 8px;
   padding: 10px 12px;

--- a/packages/client-core/src/dictation/recorder.test.ts
+++ b/packages/client-core/src/dictation/recorder.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MicRecorder } from "./recorder";
+
+// snapshotFlushed() is the tail-loss fix for the turn-taking paths (Car Mode "Over and out" and the
+// end-phrase watch): a bare snapshot() only sees chunks MediaRecorder has already delivered, so the
+// last words - up to one timeslice of audio still buffered inside the recorder - were missing from
+// the clip that got transcribed. These tests drive the flush contract with a fake MediaRecorder
+// (the tests run in Node, where no real recorder exists): requestData() must be asked for the tail,
+// the tail must be in the returned blob, and a recorder that never delivers (or has already gone
+// inactive) must resolve with what has arrived instead of hanging the turn.
+
+type DataListener = (e: { data: Blob }) => void;
+
+class FakeMediaRecorder {
+  state: "recording" | "inactive" | "paused" = "recording";
+  requestDataCalls = 0;
+  /** What requestData does; the test sets this to emulate the browser delivering the tail. */
+  onRequestData: (() => void) | null = null;
+  private onceListeners: DataListener[] = [];
+
+  addEventListener(type: string, listener: DataListener, options?: { once?: boolean }): void {
+    if (type !== "dataavailable") throw new Error(`unexpected listener type: ${type}`);
+    if (!options?.once) throw new Error("snapshotFlushed must register a once-listener");
+    this.onceListeners.push(listener);
+  }
+
+  requestData(): void {
+    this.requestDataCalls += 1;
+    this.onRequestData?.();
+  }
+
+  /** Emulate the browser firing dataavailable to the registered once-listeners. */
+  deliver(data: Blob): void {
+    const listeners = this.onceListeners;
+    this.onceListeners = [];
+    for (const l of listeners) l({ data });
+  }
+}
+
+// Reach into the private capture state the way start() would have set it up. TypeScript private is
+// compile-time only; the fields are the recorder's real ones, so the method under test runs unchanged.
+function wire(fake: FakeMediaRecorder, chunks: Blob[]): MicRecorder {
+  const mic = new MicRecorder();
+  const anyMic = mic as unknown as { recorder: FakeMediaRecorder; mimeType: string; chunks: Blob[] };
+  anyMic.recorder = fake;
+  anyMic.mimeType = "audio/webm";
+  anyMic.chunks = chunks;
+  return mic;
+}
+
+function bytes(n: number): Blob {
+  return new Blob([new Uint8Array(n)]);
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("MicRecorder.snapshotFlushed", () => {
+  it("includes the tail chunk MediaRecorder had not delivered yet", async () => {
+    const fake = new FakeMediaRecorder();
+    const chunks: Blob[] = [bytes(3)]; // header chunk already delivered
+    const mic = wire(fake, chunks);
+
+    // The plain snapshot documents the gap: only the delivered 3 bytes.
+    expect(mic.snapshot().size).toBe(3);
+
+    // requestData makes the browser flush the buffered tail: the production ondataavailable handler
+    // (registered first) pushes it, then the once-listener resolves - emulate exactly that order.
+    fake.onRequestData = () => {
+      chunks.push(bytes(5));
+      fake.deliver(bytes(5));
+    };
+
+    const flushed = await mic.snapshotFlushed();
+    expect(fake.requestDataCalls).toBe(1);
+    expect(flushed.size).toBe(8); // 3 delivered + 5 flushed tail
+  });
+
+  it("returns the plain snapshot when the recorder is not actively recording", async () => {
+    const fake = new FakeMediaRecorder();
+    fake.state = "inactive";
+    const mic = wire(fake, [bytes(4)]);
+
+    const flushed = await mic.snapshotFlushed();
+    expect(fake.requestDataCalls).toBe(0); // nothing is buffered in an inactive recorder
+    expect(flushed.size).toBe(4);
+  });
+
+  it("resolves via the backstop when the flush is never delivered, with what has arrived", async () => {
+    vi.useFakeTimers();
+    const fake = new FakeMediaRecorder();
+    const mic = wire(fake, [bytes(7)]);
+    // requestData is called but the recorder never fires dataavailable (a wedged recorder).
+
+    const pending = mic.snapshotFlushed();
+    await vi.advanceTimersByTimeAsync(500);
+    const flushed = await pending;
+    expect(fake.requestDataCalls).toBe(1);
+    expect(flushed.size).toBe(7);
+  });
+
+  it("resolves with what has arrived when requestData throws (a concurrent stop)", async () => {
+    const fake = new FakeMediaRecorder();
+    fake.onRequestData = () => {
+      throw new Error("The MediaRecorder is in an invalid state.");
+    };
+    const mic = wire(fake, [bytes(2)]);
+
+    const flushed = await mic.snapshotFlushed();
+    expect(flushed.size).toBe(2);
+  });
+
+  it("does not resolve twice when the delivery and the backstop both fire", async () => {
+    vi.useFakeTimers();
+    const fake = new FakeMediaRecorder();
+    const chunks: Blob[] = [bytes(1)];
+    const mic = wire(fake, chunks);
+    fake.onRequestData = () => {
+      chunks.push(bytes(1));
+      fake.deliver(bytes(1));
+    };
+
+    const flushed = await mic.snapshotFlushed();
+    expect(flushed.size).toBe(2);
+    // The backstop timer was cleared on delivery; advancing time must not blow up on a settled promise.
+    await vi.advanceTimersByTimeAsync(1000);
+  });
+});

--- a/packages/client-core/src/dictation/recorder.ts
+++ b/packages/client-core/src/dictation/recorder.ts
@@ -24,6 +24,12 @@ function pickMimeType(): string {
 // change the captured clip: the chunks are concatenated in order on stop exactly as before.
 const CHUNK_MS = 100;
 
+// Backstop for snapshotFlushed(): how long to wait for MediaRecorder to deliver the flushed tail
+// before snapshotting whatever has arrived. The browser twin of the desktop recorder's 750ms
+// RecordingStopped drain backstop - a wedged recorder must not hang the turn, and the timeout is
+// logged so a real occurrence is visible.
+const FLUSH_BACKSTOP_MS = 500;
+
 export class MicRecorder {
   private stream: MediaStream | null = null;
   private recorder: MediaRecorder | null = null;
@@ -110,6 +116,50 @@ export class MicRecorder {
   snapshot(): Blob {
     const mime = this.mimeType || "audio/webm";
     return new Blob(this.chunks, { type: mime });
+  }
+
+  /**
+   * Snapshot ALL audio captured up to now - INCLUDING the tail still buffered inside MediaRecorder -
+   * without stopping the recorder; the microphone keeps capturing and chunks keep accumulating.
+   *
+   * A plain snapshot() only sees chunks the recorder has already delivered, so up to CHUNK_MS of the
+   * most recent speech (exactly where the final word or the sign-off phrase lands) is missing from it.
+   * This variant calls requestData(), which makes MediaRecorder emit its buffered audio as an immediate
+   * dataavailable, and waits for that delivery before assembling the blob - so the last words are in.
+   * Any turn-taking path (Car Mode "Over and out", the end-phrase watch) must use this, never a bare
+   * snapshot(). When the recorder is not actively recording there is nothing buffered to flush and the
+   * plain snapshot is returned as-is.
+   */
+  async snapshotFlushed(): Promise<Blob> {
+    const rec = this.recorder;
+    if (rec === null || rec.state !== "recording") return this.snapshot();
+    await new Promise<void>((resolve) => {
+      let backstop: ReturnType<typeof setTimeout> | undefined;
+      let done = false;
+      const finish = () => {
+        if (done) return;
+        done = true;
+        if (backstop !== undefined) clearTimeout(backstop);
+        resolve();
+      };
+      // The ondataavailable handler assigned in start() was registered first, so it has already
+      // pushed the flushed chunk into this.chunks by the time this once-listener runs (event
+      // listeners fire in registration order).
+      rec.addEventListener("dataavailable", finish, { once: true });
+      backstop = setTimeout(() => {
+        console.warn(`[MicRecorder] snapshotFlushed: no flush within ${FLUSH_BACKSTOP_MS}ms; snapshotting what has arrived`);
+        finish();
+      }, FLUSH_BACKSTOP_MS);
+      try {
+        rec.requestData();
+      } catch (err) {
+        // The recorder went inactive between the state check and here (a concurrent stop). Nothing
+        // is buffered any more; the chunks list already holds everything that was delivered.
+        console.warn(`[MicRecorder] snapshotFlushed: requestData failed: ${err instanceof Error ? err.message : String(err)}`);
+        finish();
+      }
+    });
+    return this.snapshot();
   }
 
   /** Current input level in 0..1, sampled live. Returns 0 when not recording. */


### PR DESCRIPTION
Part of the dictation audit follow-up (make dictation always capture every finished buffer; no silent loss).

## What this fixes

1. **Car Mode clipped the end of speech.** The turn was taken from `MicRecorder.snapshot()`, which only sees chunks MediaRecorder has already delivered - the tail still buffered inside the recorder (up to 100 milliseconds, exactly where the final word or the "over and out" sign-off lands) was discarded when the recorder was later stopped. New `MicRecorder.snapshotFlushed()` forces the buffered tail out via `requestData()` and waits for its delivery before assembling the clip, with a bounded 500 millisecond backstop (the browser twin of the desktop recorder's 750 millisecond drain) so a wedged recorder cannot hang the turn. Both the "Over and out" button path and the end-phrase watch now use it.

2. **Dropped audio was detected but never shown to the user.** The dictation dialog's capture-health check compared recording wall-clock to decoded audio duration but only wrote a console line, then committed the possibly-truncated transcript silently. A material deficit (over ten percent of the recording) now shows a sticky amber warning in the dialog naming roughly how many seconds went missing, and Insert/Send from the recording state parks in PAUSED with the warning showing instead of auto-committing - the user reviews the words before they go anywhere.

## Tests

- `recorder.test.ts` (new): flushed tail included in the blob; inactive recorder returns the plain snapshot; backstop resolves when the flush never arrives; `requestData()` throwing resolves with delivered chunks; no double-resolve.
- `captureHealth.test.ts` (new): deficit math including the codec-padding clamp; warning threshold; seconds wording.
- Full client-core suite: 414 passed. Workspace typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)