### PR TITLE
fix(dictation): desktop Send can no longer lose the recording when transcription fails

### DIFF
--- a/src/CcDirector.Avalonia.Tests/BackgroundDictationSendTests.cs
+++ b/src/CcDirector.Avalonia.Tests/BackgroundDictationSendTests.cs
@@ -1,0 +1,149 @@
+using CcDirector.Avalonia.Voice;
+using CcDirector.Core.Backends;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Dictation;
+using CcDirector.Core.Memory;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Transcription;
+using Xunit;
+
+namespace CcDirector.Avalonia.Tests;
+
+/// <summary>
+/// The fire-and-forget Send's disk safety net (issue #1130): the recorded WAV is saved BEFORE the
+/// single transcription attempt and deleted the moment the user's words are safe in another form.
+/// The regression these tests pin down: transcription failure used to lose the spoken words entirely
+/// (the WAV lived only in memory) - now the file survives and the failure report names it. Driven
+/// through the fake-microphone and fake-transcriber seams; no real mic, no network, no user interface.
+/// </summary>
+public sealed class BackgroundDictationSendTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "cc-director-tests", Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* scratch dir; best effort */ }
+    }
+
+    private sealed class FakeMic : IAudioSource
+    {
+        public event Action<byte[]>? OnAudioChunk;
+        public string Description => "Fake Test Microphone";
+        public void Start() { }
+        public void Stop() { }
+        public void Emit(byte[] chunk) => OnAudioChunk?.Invoke(chunk);
+        public Task StopAsync(TimeSpan drainTimeout) => Task.CompletedTask;
+    }
+
+    private sealed class FakeTranscriber : IDictationTranscriber
+    {
+        public Exception? Throws { get; init; }
+        public string Text { get; init; } = "hello world";
+        public Task<DictationTranscript> TranscribeAsync(byte[] wav, CancellationToken ct = default)
+        {
+            if (Throws is not null) throw Throws;
+            return Task.FromResult(new DictationTranscript(Text, Text, 0));
+        }
+    }
+
+    private sealed class NullBackend : ISessionBackend
+    {
+        public int ProcessId => 1;
+        public string Status => "Test";
+        public bool IsRunning => true;
+        public bool HasExited => false;
+        public CircularTerminalBuffer? Buffer => null;
+#pragma warning disable CS0067
+        public event Action<string>? StatusChanged;
+        public event Action<int>? ProcessExited;
+#pragma warning restore CS0067
+        public void Start(string executable, string args, string workingDir, short cols, short rows, Dictionary<string, string>? environmentVars = null) { }
+        public void Write(byte[] data) { }
+        public Task SendTextAsync(string text) => Task.CompletedTask;
+        public Task SendEnterAsync() => Task.CompletedTask;
+        public void Resize(short cols, short rows) { }
+        public Task GracefulShutdownAsync(int timeoutMs = 5000) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+
+    private static Session NewSession() => new(
+        Guid.NewGuid(),
+        repoPath: @"C:\test\repo",
+        workingDirectory: @"C:\test\repo",
+        claudeArgs: null,
+        backend: new NullBackend(),
+        claudeSessionId: "claude-test",
+        activityState: ActivityState.Working,
+        createdAt: DateTimeOffset.UtcNow,
+        customName: null,
+        customColor: null);
+
+    private static async Task<BatchDictationRecorder> NewRecordingRecorderAsync(byte[] audio)
+    {
+        var fake = new FakeMic();
+        var recorder = new BatchDictationRecorder(new AgentOptions(), _ => fake,
+            (_, _, _) => throw new InvalidOperationException("the send path must use the injected transcriber, not the recorder's"));
+        await recorder.StartAsync();
+        fake.Emit(audio);
+        return recorder;
+    }
+
+    private string[] SavedRecordings() =>
+        Directory.Exists(_dir) ? Directory.GetFiles(_dir, "*.wav") : Array.Empty<string>();
+
+    [Fact]
+    public async Task TranscriptionFails_RecordingIsKeptOnDisk_AndTheFailureReportNamesIt()
+    {
+        var recorder = await NewRecordingRecorderAsync(new byte[] { 1, 2, 3, 4 });
+        string? failedError = null;
+        string? failedComposed = "sentinel";
+
+        await BackgroundDictationSend.RunAsync(
+            recorder, prefix: "", NewSession(),
+            new FakeTranscriber { Throws = new InvalidOperationException("provider down") },
+            submit: _ => throw new InvalidOperationException("must not submit without a transcript"),
+            onFailed: (err, composed) => { failedError = err; failedComposed = composed; },
+            recordingsDirectory: _dir);
+
+        var kept = SavedRecordings();
+        Assert.Single(kept); // the WAV survived the failed transcription - the words are recoverable
+        Assert.NotNull(failedError);
+        Assert.Contains("provider down", failedError);
+        Assert.Contains(kept[0], failedError); // the modal names the file so the user can find it
+        Assert.Null(failedComposed); // no transcript existed
+    }
+
+    [Fact]
+    public async Task Delivered_RecordingIsDeleted()
+    {
+        var recorder = await NewRecordingRecorderAsync(new byte[] { 1, 2, 3, 4 });
+        string? submitted = null;
+
+        await BackgroundDictationSend.RunAsync(
+            recorder, prefix: "", NewSession(),
+            new FakeTranscriber { Text = "the words" },
+            submit: text => { submitted = text; return Task.CompletedTask; },
+            onFailed: (_, _) => throw new InvalidOperationException("delivery must not report failure"),
+            recordingsDirectory: _dir);
+
+        Assert.Equal("the words", submitted);
+        Assert.Empty(SavedRecordings()); // words delivered - the safety-net file is gone
+    }
+
+    [Fact]
+    public async Task SubmitFails_TextIsRestored_AndRecordingIsDeleted()
+    {
+        var recorder = await NewRecordingRecorderAsync(new byte[] { 1, 2, 3, 4 });
+        string? failedComposed = null;
+
+        await BackgroundDictationSend.RunAsync(
+            recorder, prefix: "", NewSession(),
+            new FakeTranscriber { Text = "the words" },
+            submit: _ => throw new InvalidOperationException("composer refused"),
+            onFailed: (_, composed) => failedComposed = composed,
+            recordingsDirectory: _dir);
+
+        Assert.Equal("the words", failedComposed); // the words survive as restorable text...
+        Assert.Empty(SavedRecordings()); // ...so the audio copy is not needed and does not pile up
+    }
+}

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -3053,7 +3053,10 @@ public partial class MainWindow : Window
     // submit itself is the only arbiter of "the session took the text" (the old ActivityState gate
     // rejected healthy idle sessions because that state lags real silence by 10 seconds - see issue
     // #1308). On failure the words are put back in the compose box and reported with a modal, so
-    // nothing the user said is ever lost.
+    // nothing the user said is ever lost. The recorded WAV itself is saved to disk before the
+    // transcription attempt (DictationRecordingStore) and deleted once the words are safe; when
+    // transcription fails there is no text to restore, so the file is kept and the failure modal
+    // names its path - the audio is the only remaining copy of what was said.
 
     private global::CcDirector.Core.Transcription.IDictationTranscriber? _dictationTranscriber;
     private bool _dictationInfraReady;

--- a/src/CcDirector.Avalonia/Voice/BackgroundDictationSend.cs
+++ b/src/CcDirector.Avalonia/Voice/BackgroundDictationSend.cs
@@ -18,6 +18,13 @@ namespace CcDirector.Avalonia.Voice;
 /// rejected dictations into sessions that were sitting idle at their prompt, and agents accept typed
 /// input while working anyway. On ANY failure <paramref name="onFailed"/> fires with the composed text
 /// (when one exists) so the caller can put the words back in the compose box - never silent, never lost.
+///
+/// The recording itself has a DISK SAFETY NET (issue #1130): the WAV is saved to
+/// <see cref="DictationRecordingStore"/> before the single transcription attempt and deleted the moment
+/// the words are safe (delivered, or restored as text). When transcription fails there is no text to
+/// restore - the saved file is then the ONLY copy of what was said, so it is kept and the failure
+/// report names its path. This is not a queue and nothing re-drives the file; it just makes "the
+/// transcription service was down" a nuisance instead of lost speech.
 /// </summary>
 public static class BackgroundDictationSend
 {
@@ -34,6 +41,9 @@ public static class BackgroundDictationSend
     /// first argument is the error; the second is the fully-composed turn text when transcription had
     /// already succeeded (so the caller can restore the words), or null when the failure happened
     /// before a transcript existed. Never silent.</param>
+    /// <param name="recordingsDirectory">Where the disk safety net saves the WAV. Null (production)
+    /// means <see cref="DictationRecordingStore.DefaultDirectory"/>; tests point it at a scratch
+    /// directory.</param>
     public static async Task RunAsync(
         BatchDictationRecorder recorder,
         string prefix,
@@ -42,10 +52,12 @@ public static class BackgroundDictationSend
         Func<string, Task> submit,
         string before = "",
         string after = "",
-        Action<string, string?>? onFailed = null)
+        Action<string, string?>? onFailed = null,
+        string? recordingsDirectory = null)
     {
         FileLog.Write($"[BackgroundDictationSend] start: session={target.Id}, state={target.ActivityState}");
         target.IsTranscribing = true;
+        string? savedPath = null;
         try
         {
             // 1. Stop the mic and get the whole clip as a WAV. An interrupted turn with no audio throws
@@ -61,8 +73,15 @@ public static class BackgroundDictationSend
                 return;
             }
 
-            // 2. Transcribe once. On failure there is no transcript to restore - report loudly with
-            //    only the typed text recoverable, do not queue or retry.
+            // 1b. Disk safety net (issue #1130): persist the WAV BEFORE the single transcription
+            //     attempt, so a failed or slow transcription can never lose the recording. Saving is
+            //     best-effort - a full disk must not block the send - and the file is deleted below
+            //     the moment the words are safe in some other form.
+            savedPath = DictationRecordingStore.TrySave(captured.Wav, recordingsDirectory);
+
+            // 2. Transcribe once. On failure there is no transcript to restore - report loudly, do not
+            //    queue or retry. The saved WAV is now the only copy of the spoken words, so it is KEPT
+            //    and the report names it.
             string transcript;
             try
             {
@@ -70,14 +89,16 @@ public static class BackgroundDictationSend
             }
             catch (Exception ex)
             {
-                FileLog.Write($"[BackgroundDictationSend] transcription FAILED for session {target.Id} ({DiagnosticState(target)}): {ex.Message}");
-                onFailed?.Invoke(ex.Message, null);
+                FileLog.Write($"[BackgroundDictationSend] transcription FAILED for session {target.Id} ({DiagnosticState(target)}): {ex.Message}; savedRecording={savedPath ?? "none"}");
+                onFailed?.Invoke(WithSavedRecording(ex.Message, savedPath), null);
+                savedPath = null; // kept for the user; do not delete below
                 return;
             }
 
             // 3. Compose the turn (dictation dropped at the caret inside any typed text) and submit it
             //    straight through the echo-verified terminal submit. From here on the composed text is
-            //    carried into every failure report so the words can be put back in the compose box.
+            //    carried into every failure report so the words can be put back in the compose box -
+            //    the words survive as text now, so the WAV safety net is no longer needed either way.
             var dictation = DictationText.Join(prefix, transcript);
             var text = DictationText.InsertAt(before + after, before.Length, dictation).Trim();
             try
@@ -90,12 +111,15 @@ public static class BackgroundDictationSend
                 FileLog.Write($"[BackgroundDictationSend] submit FAILED for session {target.Id} ({DiagnosticState(target)}): {ex.Message}");
                 onFailed?.Invoke(ex.Message, text);
             }
+            DictationRecordingStore.TryDelete(savedPath);
+            savedPath = null;
         }
         catch (Exception ex)
         {
-            // Root of a detached task: never let it fault unobserved.
-            FileLog.Write($"[BackgroundDictationSend] unexpected error for session {target.Id} ({DiagnosticState(target)}): {ex.Message}");
-            onFailed?.Invoke(ex.Message, null);
+            // Root of a detached task: never let it fault unobserved. No transcript text reached the
+            // caller, so a saved recording (if any) is kept and named - it may be the only copy.
+            FileLog.Write($"[BackgroundDictationSend] unexpected error for session {target.Id} ({DiagnosticState(target)}): {ex.Message}; savedRecording={savedPath ?? "none"}");
+            onFailed?.Invoke(WithSavedRecording(ex.Message, savedPath), null);
         }
         finally
         {
@@ -104,6 +128,15 @@ public static class BackgroundDictationSend
             catch (Exception ex) { FileLog.Write($"[BackgroundDictationSend] recorder dispose error: {ex.Message}"); }
         }
     }
+
+    /// <summary>
+    /// Append the saved-recording pointer to a failure report, so the user learns WHERE the audio is
+    /// in the same modal that tells them the dictation failed. No file, no extra noise.
+    /// </summary>
+    private static string WithSavedRecording(string error, string? savedPath)
+        => savedPath is null
+            ? error
+            : $"{error}\n\nYour recording was saved - you can play it back or dictate again from it:\n{savedPath}";
 
     /// <summary>
     /// One-line diagnostic snapshot for failure logs: the session's activity state and how long its

--- a/src/CcDirector.Avalonia/Voice/BatchDictationRecorder.cs
+++ b/src/CcDirector.Avalonia/Voice/BatchDictationRecorder.cs
@@ -197,8 +197,9 @@ public sealed class BatchDictationRecorder : IAsyncDisposable
     /// <summary>
     /// Stop the microphone, drain NAudio's final buffered audio, and return the whole captured clip as
     /// a WAV blob WITHOUT transcribing it. This is the durable-dictation split (issue #1130): the
-    /// fire-and-forget Send saves these bytes to disk the instant Send is pressed, then transcribes the
-    /// saved copy - so a failed or slow transcription can never lose the recording. Enforces the same
+    /// fire-and-forget Send saves these bytes to disk (<see cref="CcDirector.Core.Dictation.DictationRecordingStore"/>)
+    /// before its single transcription attempt and keeps the file when transcription fails - so a
+    /// failed or slow transcription can never lose the recording. Enforces the same
     /// completeness gate as <see cref="TranscribeAsync"/> (an empty capture throws
     /// <see cref="NoAudioCapturedException"/>), so an interrupted turn with no audio is never persisted.
     /// The recorder is consumed (stopped) here; call this OR <see cref="TranscribeAsync"/>, once.

--- a/src/CcDirector.Core.Tests/DictationRecordingStoreTests.cs
+++ b/src/CcDirector.Core.Tests/DictationRecordingStoreTests.cs
@@ -1,0 +1,79 @@
+using CcDirector.Core.Dictation;
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// The disk safety net for the fire-and-forget desktop dictation Send (issue #1130): the WAV must be
+/// written before transcription and deletable once the words are safe, and neither operation may ever
+/// throw into the send path - saving is a net, not a gate.
+/// </summary>
+public sealed class DictationRecordingStoreTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "cc-director-tests", Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* scratch dir; best effort */ }
+    }
+
+    [Fact]
+    public void TrySave_WritesTheWavAndReturnsItsPath()
+    {
+        var wav = new byte[] { 1, 2, 3, 4, 5 };
+
+        var path = DictationRecordingStore.TrySave(wav, _dir);
+
+        Assert.NotNull(path);
+        Assert.StartsWith(_dir, path);
+        Assert.EndsWith(".wav", path);
+        Assert.Equal(wav, File.ReadAllBytes(path!));
+    }
+
+    [Fact]
+    public void TrySave_TwoSavesInTheSameInstant_DoNotCollide()
+    {
+        var first = DictationRecordingStore.TrySave(new byte[] { 1 }, _dir);
+        var second = DictationRecordingStore.TrySave(new byte[] { 2 }, _dir);
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void TrySave_EmptyAudio_ReturnsNullWithoutWriting()
+    {
+        var path = DictationRecordingStore.TrySave(Array.Empty<byte>(), _dir);
+
+        Assert.Null(path);
+        Assert.False(Directory.Exists(_dir));
+    }
+
+    [Fact]
+    public void TrySave_UnusableDirectory_ReturnsNullWithoutThrowing()
+    {
+        // A FILE at the directory path makes CreateDirectory throw - the net must fail soft.
+        Directory.CreateDirectory(Path.GetDirectoryName(_dir)!);
+        File.WriteAllText(_dir, "not a directory");
+
+        var path = DictationRecordingStore.TrySave(new byte[] { 1 }, _dir);
+
+        Assert.Null(path);
+        File.Delete(_dir);
+    }
+
+    [Fact]
+    public void TryDelete_RemovesTheFile_AndToleratesNullAndMissing()
+    {
+        var path = DictationRecordingStore.TrySave(new byte[] { 9 }, _dir);
+        Assert.True(File.Exists(path));
+
+        DictationRecordingStore.TryDelete(path);
+        Assert.False(File.Exists(path));
+
+        // Neither a null path nor an already-deleted file may throw into the send path.
+        DictationRecordingStore.TryDelete(null);
+        DictationRecordingStore.TryDelete(path);
+    }
+}

--- a/src/CcDirector.Core/CcDirector.Core.csproj
+++ b/src/CcDirector.Core/CcDirector.Core.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="CcDirector.Core.Tests" />
+    <InternalsVisibleTo Include="CcDirector.Avalonia.Tests" />
     <InternalsVisibleTo Include="CcDirector.Gateway.Tests" />
     <InternalsVisibleTo Include="TerminalTest" />
   </ItemGroup>

--- a/src/CcDirector.Core/Dictation/DictationRecordingStore.cs
+++ b/src/CcDirector.Core/Dictation/DictationRecordingStore.cs
@@ -1,0 +1,67 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Dictation;
+
+/// <summary>
+/// Disk safety net for the fire-and-forget desktop dictation Send (issue #1130). The recorded WAV is
+/// saved here the instant Send produces it and deleted again the moment the user's words are safe
+/// (delivered into the session, or restored as text after a submit failure) - so a failed or slow
+/// transcription can never lose the recording. This is NOT a queue: there is NO sweeper, NO retry,
+/// and nothing ever re-drives a saved file (issue #1208 removed the durable queue deliberately). A
+/// file only survives when the spoken words could not be recovered any other way, and the failure
+/// report names it so the user can play or re-dictate from the audio.
+/// </summary>
+public static class DictationRecordingStore
+{
+    /// <summary>Where recordings are kept: %LOCALAPPDATA%\cc-director\dictation\recordings.</summary>
+    public static string DefaultDirectory { get; } = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "cc-director", "dictation", "recordings");
+
+    /// <summary>
+    /// Save one recorded WAV clip and return the full path of the saved file, or null when saving
+    /// failed. Saving is a safety net, not a gate: a full disk or a locked directory must never block
+    /// the dictation itself, so a failure is logged loudly and the send continues without the net.
+    /// </summary>
+    public static string? TrySave(byte[] wav, string? directory = null)
+    {
+        if (wav is null || wav.Length == 0)
+        {
+            FileLog.Write("[DictationRecordingStore] TrySave skipped: no audio bytes");
+            return null;
+        }
+        try
+        {
+            var dir = directory ?? DefaultDirectory;
+            Directory.CreateDirectory(dir);
+            var name = $"dictation-{DateTime.Now:yyyyMMdd-HHmmss}-{Guid.NewGuid().ToString("N")[..8]}.wav";
+            var path = Path.Combine(dir, name);
+            File.WriteAllBytes(path, wav);
+            FileLog.Write($"[DictationRecordingStore] saved {wav.Length} bytes to {path}");
+            return path;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[DictationRecordingStore] TrySave FAILED: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Delete a recording whose words are now safe. Best-effort: a file that cannot be deleted is
+    /// only disk noise, never a functional problem, so the failure is logged and swallowed.
+    /// </summary>
+    public static void TryDelete(string? path)
+    {
+        if (string.IsNullOrEmpty(path)) return;
+        try
+        {
+            File.Delete(path);
+            FileLog.Write($"[DictationRecordingStore] deleted {path}");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[DictationRecordingStore] TryDelete FAILED for {path}: {ex.Message}");
+        }
+    }
+}


### PR DESCRIPTION
Part of the dictation audit follow-up (dictation must always work; no spoken words may ever be lost).

## The defect

The fire-and-forget desktop Send (`BackgroundDictationSend`) transcribed the recorded WAV straight from memory, once, with no persistence. If that one transcription call failed (Gateway down, provider error, network drop), the spoken words were gone - only previously-typed compose-box text could be restored. The recorder's own documentation claimed the bytes were saved to disk first (the issue thefrederiksen/devthrottle_internal#703 durable-dictation split), but the implementation never did it.

## The fix

- New `DictationRecordingStore` (`%LOCALAPPDATA%\cc-director\dictation\recordings`): the WAV is saved there **before** the single transcription attempt and deleted the moment the words are safe in another form - delivered into the session, or restored as editable text after a submit failure.
- When transcription fails, the saved file is the **only remaining copy** of what was said, so it is kept and the failure modal names its full path.
- This is deliberately **not** the durable queue that issue thefrederiksen/devthrottle#1208 removed: no sweeper, no retry, nothing re-drives the file. Fail-loud behavior is unchanged; the recording just stops being collateral damage.
- Saving is a safety net, not a gate: a full disk or locked directory logs loudly and the send continues without the net.
- Fixed the stale documentation in `BatchDictationRecorder.StopAndGetWavAsync` and the MainWindow delivery-contract comment to match reality.

## Tests

- `BackgroundDictationSendTests` (new, drives the real send flow through the fake-microphone / fake-transcriber / fake-session-backend seams): transcription failure keeps the file and the failure report names it; successful delivery deletes it; submit failure restores the text and deletes it.
- `DictationRecordingStoreTests` (new): save round-trip, no filename collisions, empty audio skipped, unusable directory fails soft, delete tolerates null and missing.
- Full suites green: CcDirector.Avalonia.Tests 123 passed, CcDirector.Core.Tests 3019 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)