### PR TITLE
feat(gateway-cleanup): Phase 2 PR E-B3 - snooze expiry sweep rides the tunnel

### DIFF
--- a/docs/architecture/gateway-cleanup-phase2-repoint-design.md
+++ b/docs/architecture/gateway-cleanup-phase2-repoint-design.md
@@ -313,10 +313,43 @@ DONE and merged in PR E-B:
   mapping) and `TunnelWingmanVoiceProofTests` (unreachable-Director + PushSnapshot: the wingman menu reads the
   session buffer over the tunnel by construction, proving the Map wiring threads sendCommand + the push store).
 
-DEFERRED to a follow-up PR (PR E-B2), still Group B: `MachineSessionSpawner.cs` / `DirectorImplSessionDriver.cs`
-(cron / worklist spawn + seed-prompt). These need the create + buffer verbs on the tunnel and touch the
-cron/worklist launcher plumbing (ICronWorkListDrainLauncher + its runner + the driver factory + tests); split out
-to keep the voice PR a coherent, tested unit. They MUST land before the completeness gate / the cut.
+DONE and merged in PR E-B2 (#1465, Manager a2de9030): `MachineSessionSpawner.cs` / `DirectorImplSessionDriver.cs`
+(cron / worklist spawn + seed-prompt). `SessionVerbClient` gained a director-level `CreateSessionAsync` (the
+`create` verb, empty session id, `NewSessionRequest` payload -> `SessionDto`) plus a `ForDirector` factory for
+callers that hold only a director id + control endpoint; the spawner + driver route create tunnel-first through
+the resolved director id (HTTP fallback on the control endpoint) and the driver reads the session buffer through
+the same `SessionVerbClient`. Director id + the stream hook threaded through `ICronWorkListDrainLauncher.LaunchAsync`,
+the driver factory, `DirectorCronWorkListRunner`, `WorkListRunnerEndpoints.Map`, and the `GatewayHost` wiring.
+Proof: `SessionVerbClientTests` (director-level create) + `TunnelSpawnerDriverProofTests` (unreachable control
+endpoint => success can only be the tunnel).
+
+## PR E-B3 (Group B, completeness-gate find) - 2026-07-13 (Manager a2de9030)
+
+The Phase-2 completeness-gate sweep (run after E-B2) found ONE `DirectorEndpointClient` caller not in the A-D
+classification and with NO tunnel branch and NO stream-mode guard: the **snooze expiry watchdog**
+(`SnoozeExpirySweep`, Snooze Length mission), wired in `GatewayHost` with `readOnHold` = `client.GetSessionAsync`
+and `forwardUnhold` = `client.SetHoldAsync` dialed unconditionally on the Director's control endpoint. `hold` and
+the session snapshot are NOT in the 6-item Director floor, so post-cut those dials 404 and snooze expiry silently
+stops (a snoozed session stuck on hold forever). Architect RULING (2026-07-13): re-point NOW as PR E-B3, additive
+- per the completeness invariant every `DirectorEndpointClient` caller must have a tunnel branch before the cut.
+
+DONE and merged in PR E-B3 (#1468): new choke point `SnoozeSweepDirectorClient`
+(`src/CcDirector.Gateway/Api/SnoozeSweepDirectorClient.cs`), tunnel-first under stream mode with the existing
+HTTP dial as the byte-identical fallback:
+- the RAW `OnHold` READ rides the `snapshot` read verb (chosen over reading `PushedSessions`: the sweep's
+  nudge->next-sweep-clears cycle needs the Director's post-nudge raw state promptly and byte-identically to the
+  old `GetSession`; the round-trip is negligible for the few snoozed entries - Architect gave the call);
+- the expiry NUDGE rides the `hold` write verb (`OnHold=false`).
+- `SnoozeExpirySweep` is now director-id addressed: its resolve-to-an-endpoint gate became `isDirectorReachable`
+  (reachable over the tunnel - stream-connected - OR over HTTP - advertised endpoint), so it survives the cut (a
+  stream-only Director with no HTTP endpoint is still reachable); the read/nudge seams take the director id. The
+  three-way decision logic is unchanged.
+- Proof: `TunnelSnoozeSweepProofTests` (snapshot/hold verbs + payload + reachability gate, by construction);
+  `SnoozeExpirySweepTests` updated to the id-addressed seams.
+
+With E-B2 + E-B3 merged, every remaining `DirectorEndpointClient` caller is either a tunnel-first HTTP-fallback
+branch (Groups A/B/C - fine pre-cut) or Group-D machinery deleted at the cut. The literal zero-callers grep lands
+AT the cut (remove the fallbacks + delete Group D + delete the client), as ruled above.
 
 ## Architect ruling (retire the client-dead async voice-turn path) - SETTLED 2026-07-13 (session 51f1898e)
 

--- a/src/CcDirector.Gateway.Tests/SnoozeExpirySweepTests.cs
+++ b/src/CcDirector.Gateway.Tests/SnoozeExpirySweepTests.cs
@@ -33,9 +33,9 @@ public sealed class SnoozeExpirySweepTests : IDisposable
         var nudged = new List<string>();
         var sweep = new SnoozeExpirySweep(
             reg,
-            resolveEndpoint: dir => (unreachableDirectors?.Contains(dir) ?? false) ? null : $"http://{dir}",
-            readOnHold: (ep, sid, ct) => Task.FromResult(onHoldBySid.TryGetValue(sid, out var v) ? v : (bool?)null),
-            forwardUnhold: (ep, sid, ct) => { nudged.Add(sid); return Task.CompletedTask; },
+            isDirectorReachable: dir => !(unreachableDirectors?.Contains(dir) ?? false),
+            readOnHold: (dir, sid, ct) => Task.FromResult(onHoldBySid.TryGetValue(sid, out var v) ? v : (bool?)null),
+            forwardUnhold: (dir, sid, ct) => { nudged.Add(sid); return Task.CompletedTask; },
             utcNow: () => now);
         return (reg, sweep, nudged);
     }
@@ -115,13 +115,13 @@ public sealed class SnoozeExpirySweepTests : IDisposable
         var nudged = new List<string>();
         var sweep = new SnoozeExpirySweep(
             reg,
-            resolveEndpoint: _ => "http://dir-1",
-            readOnHold: (ep, sid, ct) =>
+            isDirectorReachable: _ => true,
+            readOnHold: (dir, sid, ct) =>
             {
                 reg.Snooze(sid, _now.AddMinutes(59), "dir-1"); // re-snooze lands mid-pass -> future
                 return Task.FromResult<bool?>(true);           // Director still reports held
             },
-            forwardUnhold: (ep, sid, ct) => { nudged.Add(sid); return Task.CompletedTask; },
+            forwardUnhold: (dir, sid, ct) => { nudged.Add(sid); return Task.CompletedTask; },
             utcNow: () => _now);
 
         await sweep.RunOnceAsync(CancellationToken.None);

--- a/src/CcDirector.Gateway.Tests/TunnelSnoozeSweepProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelSnoozeSweepProofTests.cs
@@ -1,0 +1,117 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Streaming;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 2 (PR E-B3): the snooze watchdog's Director I/O now rides the tunnel
+/// through <see cref="SnoozeSweepDirectorClient"/>. These tests prove the tunnel-vs-HTTP decision and the
+/// per-verb marshaling directly, without a live Director:
+///  - the RAW OnHold read rides the "snapshot" read verb and maps SessionDto.OnHold;
+///  - the expiry nudge rides the "hold" write verb with OnHold=false;
+///  - a failed tunnel read maps to null (keep the entry), exactly as the HTTP dial returned null on a non-200;
+///  - reachability is true over a live stream even with no HTTP endpoint (the post-cut case) and false for a
+///    Director the Gateway does not know at all (the dead-man's-switch).
+/// The HTTP fallback path (null sendCommand) is the pre-existing behavior, covered by SnoozeExpirySweepTests /
+/// SnoozeEndToEndTests; here we assert the tunnel branch, so no real endpoint is dialed.
+/// </summary>
+public sealed class TunnelSnoozeSweepProofTests : IDisposable
+{
+    private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "cc-snoozetunnel-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, true); } catch { }
+    }
+
+    private sealed class RecordingHub
+    {
+        public DirectorCommand? Last;
+        public string? LastDirectorId;
+        public DirectorCommandResult? Next;
+
+        public DirectorCommandRouter.SendDirectorCommandAsync Send => (directorId, command, ct) =>
+        {
+            LastDirectorId = directorId;
+            Last = command;
+            return Task.FromResult<DirectorCommandResult?>(Next);
+        };
+    }
+
+    // A tunnel-enabled client whose Director is otherwise unknown to the registry, so any SUCCESS proves the
+    // tunnel branch ran (the HTTP fallback resolves no endpoint and returns null).
+    private SnoozeSweepDirectorClient TunnelClient(RecordingHub hub, PushedSessionStore? push = null) =>
+        new(new DirectorRegistry(_dir), push, new DirectorEndpointClient(), hub.Send);
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ReadOnHold_ridesTheSnapshotVerb_andMapsOnHold(bool held)
+    {
+        var hub = new RecordingHub
+        {
+            Next = DirectorCommandResult.Success(JsonSerializer.Serialize(new SessionDto { OnHold = held }, Web)),
+        };
+
+        var onHold = await TunnelClient(hub).ReadOnHoldAsync("dir-1", "sid-1", CancellationToken.None);
+
+        Assert.Equal(held, onHold);
+        Assert.Equal("snapshot", hub.Last!.Verb);
+        Assert.Equal("sid-1", hub.Last.SessionId);
+        Assert.Equal("dir-1", hub.LastDirectorId);
+    }
+
+    [Fact]
+    public async Task ReadOnHold_failedTunnelResult_returnsNull_soTheEntryIsKept()
+    {
+        var hub = new RecordingHub { Next = DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "no such session") };
+
+        var onHold = await TunnelClient(hub).ReadOnHoldAsync("dir-1", "sid-1", CancellationToken.None);
+
+        Assert.Null(onHold);
+    }
+
+    [Fact]
+    public async Task NudgeUnhold_ridesTheHoldVerb_withOnHoldFalse()
+    {
+        var hub = new RecordingHub { Next = DirectorCommandResult.Success() };
+
+        await TunnelClient(hub).NudgeUnholdAsync("dir-1", "sid-1", CancellationToken.None);
+
+        Assert.Equal("hold", hub.Last!.Verb);
+        Assert.Equal("sid-1", hub.Last.SessionId);
+        Assert.Equal("dir-1", hub.LastDirectorId);
+        Assert.False((bool?)JsonNode.Parse(hub.Last.PayloadJson)!.AsObject()["onHold"]);
+    }
+
+    [Fact]
+    public void IsReachable_trueOverAStreamWithNoHttpEndpoint_falseForAnUnknownDirector()
+    {
+        var registry = new DirectorRegistry(_dir);
+        var push = new PushedSessionStore();
+        var client = new SnoozeSweepDirectorClient(registry, push, new DirectorEndpointClient(), (_, _, _) => Task.FromResult<DirectorCommandResult?>(null));
+
+        // Unknown to the Gateway entirely -> dead-man's-switch (leave the entry alone).
+        Assert.False(client.IsReachable("dir-unknown"));
+
+        // Registered but with NO reachable HTTP endpoint, yet stream-connected -> reachable over the tunnel
+        // (the post-cut, stream-only case).
+        registry.Upsert(new DirectorRegistrationRequest
+        {
+            DirectorId = "dir-stream",
+            MachineName = Environment.MachineName,
+            Pid = 1,
+            Version = "test",
+            StartedAt = DateTime.UtcNow,
+        });
+        Assert.False(client.IsReachable("dir-stream")); // registered, no endpoint, no stream -> not reachable yet
+        push.RegisterConnection("dir-stream", "conn-1");
+        Assert.True(client.IsReachable("dir-stream"));  // now stream-connected -> reachable via the tunnel
+    }
+}

--- a/src/CcDirector.Gateway/Api/SnoozeSweepDirectorClient.cs
+++ b/src/CcDirector.Gateway/Api/SnoozeSweepDirectorClient.cs
@@ -1,0 +1,91 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Streaming;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 2 (PR E-B3): the ONE choke point the snooze watchdog
+/// (<see cref="Snooze.SnoozeExpirySweep"/>) reaches the owning Director through. It replaces the raw
+/// <see cref="DirectorEndpointClient"/> HTTP dials the sweep used (GetSession for the raw OnHold read,
+/// SetHold for the expiry nudge) with a tunnel-first path: under stream mode the owning Director is reached
+/// DOWN its stream (the "snapshot" read verb and the "hold" write verb), and only over HTTP as the
+/// byte-identical fallback (stream mode off, or the Director has no active stream). This keeps the sweep
+/// itself Director-id addressed and free of any endpoint plumbing, and lands it on the same coexistence
+/// pattern as every other Gateway-&gt;Director caller so the Phase 3 deletion of the HTTP surface is a
+/// clean removal of the fallback branch.
+///
+/// The <paramref name="sendCommand"/> hook and <paramref name="pushedSessions"/> are non-null only under
+/// stream mode, exactly like every other tunnel caller; with them null the client behaves byte-identically
+/// to the old direct HTTP sweep.
+/// </summary>
+internal sealed class SnoozeSweepDirectorClient
+{
+    private readonly DirectorRegistry _registry;
+    private readonly PushedSessionStore? _pushedSessions;
+    private readonly DirectorEndpointClient _client;
+    private readonly DirectorCommandRouter.SendDirectorCommandAsync? _sendCommand;
+
+    public SnoozeSweepDirectorClient(DirectorRegistry registry, PushedSessionStore? pushedSessions,
+        DirectorEndpointClient client, DirectorCommandRouter.SendDirectorCommandAsync? sendCommand)
+    {
+        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        _pushedSessions = pushedSessions;
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _sendCommand = sendCommand;
+    }
+
+    /// <summary>The HTTP fallback base URL for a Director id (the SAME forward destination the WS proxy
+    /// uses - never a raw loopback ControlEndpoint for a remote Director), or null when it advertises none.</summary>
+    private string? FallbackEndpoint(string directorId)
+    {
+        var d = _registry.Get(directorId);
+        return d is null ? null : SessionWsProxyEndpoints.ForwardDestination(d);
+    }
+
+    /// <summary>
+    /// Whether the owning Director is reachable at all - over the tunnel (a live stream) OR over HTTP (an
+    /// advertised forward endpoint). False = offline/dead, the dead-man's-switch case the sweep leaves
+    /// untouched. Post-cut a stream-only Director has no HTTP endpoint but is still reachable via its stream.
+    /// </summary>
+    public bool IsReachable(string directorId)
+    {
+        if (_registry.Get(directorId) is null)
+            return false;
+        if (_pushedSessions is not null && _pushedSessions.IsStreamConnected(directorId))
+            return true;
+        return FallbackEndpoint(directorId) is not null;
+    }
+
+    /// <summary>
+    /// Read the owning Director's RAW hold state for a session: true = still held, false = no longer held,
+    /// null = the session is absent there or the read did not land. Tunnel-first via the "snapshot" read verb
+    /// (a round-trip to the Director's own <see cref="SessionDto"/>, byte-identical to the old GetSession),
+    /// HTTP fallback on the advertised endpoint. A failed tunnel result maps to null exactly as the HTTP dial
+    /// returned null on a non-200.
+    /// </summary>
+    public async Task<bool?> ReadOnHoldAsync(string directorId, string sessionId, CancellationToken ct)
+    {
+        var result = await DirectorCommandRouter.TrySendAsync(_sendCommand, directorId, "snapshot", sessionId, null, ct);
+        if (result is not null)
+            return result.Ok ? DirectorCommandRouter.ReadBody<SessionDto>(result)?.OnHold : null;
+        var ep = FallbackEndpoint(directorId);
+        return ep is null ? null : (await _client.GetSessionAsync(ep, sessionId, ct))?.OnHold;
+    }
+
+    /// <summary>
+    /// The expiry nudge: forward a hold=false to the owning Director. Tunnel-first via the "hold" write verb,
+    /// HTTP fallback on the advertised endpoint. A non-null tunnel result (success OR a typed failure) is
+    /// authoritative, so the fallback runs only when there is no stream.
+    /// </summary>
+    public async Task NudgeUnholdAsync(string directorId, string sessionId, CancellationToken ct)
+    {
+        var holdReq = new HoldRequest { OnHold = false };
+        var result = await DirectorCommandRouter.TrySendAsync(_sendCommand, directorId, "hold", sessionId, holdReq, ct);
+        if (result is not null)
+            return;
+        var ep = FallbackEndpoint(directorId);
+        if (ep is not null)
+            await _client.SetHoldAsync(ep, sessionId, holdReq, ct);
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1628,20 +1628,19 @@ public sealed class GatewayHost : IAsyncDisposable
         // rotation then agree); the entry is cleared once the Director reports OnHold=false. A dead
         // Director's entry is left alone - the /sessions fold surfaces it as "needs you" from the cached
         // roster (the dead-man's-switch), and it is dropped only when that Director leaves the fleet.
+        // Gateway Cleanup mission, Phase 2 (PR E-B3): the snooze watchdog reaches the owning Director
+        // tunnel-first (by director id) under stream mode, HTTP fallback otherwise - the same coexistence
+        // pattern as every other Gateway->Director caller, folded into one choke point. The RAW hold READ
+        // rides the "snapshot" read verb (a round-trip to the Director's own SessionDto, byte-identical to
+        // the old GetSessionAsync and so faithful to the nudge->next-sweep-clears cycle); the expiry NUDGE
+        // rides the "hold" write verb.
+        var snoozeClient = new Api.SnoozeSweepDirectorClient(
+            Registry, _streamMode ? PushedSessions : null, _client, _streamMode ? SendCommandAsync : null);
         _snoozeSweep = new Snooze.SnoozeExpirySweep(
             _snoozeRegistry,
-            // Owning Director id -> the base URL the Gateway dials, or null when it has no reachable
-            // endpoint (offline/dead) - the case the sweep leaves untouched.
-            resolveEndpoint: directorId =>
-            {
-                var d = Registry.Get(directorId);
-                return d is null ? null : Api.SessionWsProxyEndpoints.ForwardDestination(d);
-            },
-            // RAW hold state read straight from the owning Director: true = held, false = not held,
-            // null = the session is absent there or the read did not land.
-            readOnHold: async (endpoint, sid, ct) => (await _client.GetSessionAsync(endpoint, sid, ct))?.OnHold,
-            // The expiry nudge: forward a hold=false to the owning Director.
-            forwardUnhold: (endpoint, sid, ct) => _client.SetHoldAsync(endpoint, sid, new Contracts.HoldRequest { OnHold = false }, ct),
+            isDirectorReachable: snoozeClient.IsReachable,
+            readOnHold: snoozeClient.ReadOnHoldAsync,
+            forwardUnhold: snoozeClient.NudgeUnholdAsync,
             utcNow: () => DateTime.UtcNow);
         _snoozeSweep.Start();
 

--- a/src/CcDirector.Gateway/Snooze/SnoozeExpirySweep.cs
+++ b/src/CcDirector.Gateway/Snooze/SnoozeExpirySweep.cs
@@ -42,7 +42,7 @@ public sealed class SnoozeExpirySweep : IDisposable
     public static readonly TimeSpan StartupDelay = TimeSpan.FromSeconds(12);
 
     private readonly SnoozeRegistry _registry;
-    private readonly Func<string, string?> _resolveEndpoint;
+    private readonly Func<string, bool> _isDirectorReachable;
     private readonly Func<string, string, CancellationToken, Task<bool?>> _readOnHold;
     private readonly Func<string, string, CancellationToken, Task> _forwardUnhold;
     private readonly Func<DateTime> _utcNow;
@@ -51,27 +51,29 @@ public sealed class SnoozeExpirySweep : IDisposable
     private int _busy; // 0 = idle, 1 = a tick is running (reentrancy guard)
 
     /// <param name="registry">The pending-snooze registry to sweep.</param>
-    /// <param name="resolveEndpoint">
-    /// Maps an owning Director id to the base URL the Gateway dials to reach it, or null when that
-    /// Director has no reachable endpoint (offline/dead) - the dead-man's-switch case, which the sweep
-    /// leaves untouched.
+    /// <param name="isDirectorReachable">
+    /// Whether the owning Director (by id) is reachable at all - over the tunnel (stream-connected) OR over
+    /// HTTP (an advertised endpoint). False when it is offline/dead: the dead-man's-switch case, which the
+    /// sweep leaves untouched. (Gateway Cleanup mission, Phase 2 PR E-B3: this replaced the earlier
+    /// resolve-to-an-endpoint gate so the sweep no longer depends on a dialable HTTP URL - the read/forward
+    /// seams reach the Director by id, tunnel-first.)
     /// </param>
     /// <param name="readOnHold">
-    /// Reads the owning Director's RAW hold state for a session: true = still held, false = no longer
-    /// held, null = the session is absent from that Director or the read did not land. Reads the
-    /// Director directly, never the overlaid roster.
+    /// Reads the owning Director's RAW hold state for a session, addressed by DIRECTOR ID: true = still held,
+    /// false = no longer held, null = the session is absent from that Director or the read did not land.
+    /// Reads the Director directly (its own pushed/snapshotted state), never the overlaid roster.
     /// </param>
-    /// <param name="forwardUnhold">Forwards a hold=false to the owning Director (the expiry nudge).</param>
+    /// <param name="forwardUnhold">Forwards a hold=false to the owning Director (by id) - the expiry nudge.</param>
     /// <param name="utcNow">The clock; injected so the expiry boundary is deterministic in tests.</param>
     public SnoozeExpirySweep(
         SnoozeRegistry registry,
-        Func<string, string?> resolveEndpoint,
+        Func<string, bool> isDirectorReachable,
         Func<string, string, CancellationToken, Task<bool?>> readOnHold,
         Func<string, string, CancellationToken, Task> forwardUnhold,
         Func<DateTime> utcNow)
     {
         _registry = registry ?? throw new ArgumentNullException(nameof(registry));
-        _resolveEndpoint = resolveEndpoint ?? throw new ArgumentNullException(nameof(resolveEndpoint));
+        _isDirectorReachable = isDirectorReachable ?? throw new ArgumentNullException(nameof(isDirectorReachable));
         _readOnHold = readOnHold ?? throw new ArgumentNullException(nameof(readOnHold));
         _forwardUnhold = forwardUnhold ?? throw new ArgumentNullException(nameof(forwardUnhold));
         _utcNow = utcNow ?? throw new ArgumentNullException(nameof(utcNow));
@@ -107,8 +109,7 @@ public sealed class SnoozeExpirySweep : IDisposable
 
     private async Task HandleEntryAsync(SnoozeRegistry.SnoozeEntry entry, DateTime now, CancellationToken ct)
     {
-        var endpoint = _resolveEndpoint(entry.DirectorId);
-        if (endpoint is null)
+        if (!_isDirectorReachable(entry.DirectorId))
         {
             // Owning Director unreachable/dead: leave the entry alone. The aggregation overlay
             // surfaces the session as "needs you" from the cached roster (the dead-man's-switch);
@@ -116,7 +117,7 @@ public sealed class SnoozeExpirySweep : IDisposable
             return;
         }
 
-        var onHold = await _readOnHold(endpoint, entry.SessionId, ct);
+        var onHold = await _readOnHold(entry.DirectorId, entry.SessionId, ct);
         if (onHold == false)
         {
             // The Director itself reports the session is no longer held - it came back on its own
@@ -137,7 +138,7 @@ public sealed class SnoozeExpirySweep : IDisposable
             // rotation resume. Keep the entry; the overlay already reads the session as "needs you",
             // and the next sweep clears the entry once the Director reports OnHold=false.
             FileLog.Write($"[SnoozeExpirySweep] sid={entry.SessionId}: expired (untilUtc={entry.SnoozeUntilUtc:O}) -> nudging director off hold");
-            await _forwardUnhold(endpoint, entry.SessionId, ct);
+            await _forwardUnhold(entry.DirectorId, entry.SessionId, ct);
         }
 
         // onHold == null (session absent from a reachable Director, or the read did not land): keep the


### PR DESCRIPTION
## What

The snooze watchdog was the **last** Gateway->Director caller that HTTP-dialed the Director directly (`GetSession` for the raw `OnHold` read, `SetHold` for the expiry nudge) with **no tunnel branch and no stream-mode guard** - surfaced by the Phase 2 completeness-gate sweep. Left un-re-pointed it would (a) block the Phase 3 deletion of `DirectorEndpointClient` (still referenced it) and (b) post-cut dial routes that no longer exist (`hold`/snapshot are not in the 6-item floor), silently stranding every snoozed session on hold forever - a real regression against the Snooze Length mission's "a snooze always comes back".

## How
- **New `SnoozeSweepDirectorClient`** - the one choke point the sweep reaches the owning Director through. Tunnel-first under stream mode: the RAW `OnHold` read rides the **`snapshot`** read verb (a round-trip to the Director's own `SessionDto`, byte-identical to the old `GetSession` and faithful to the nudge->next-sweep-clears cycle); the expiry nudge rides the **`hold`** write verb. Existing HTTP dial is the byte-identical fallback (stream mode off, or no active stream).
- `SnoozeExpirySweep` is now **Director-id addressed**: its resolve-to-an-endpoint gate became `isDirectorReachable(directorId)` (reachable over the tunnel OR over HTTP), and the read/nudge seams take the director id. Its three-way decision logic is unchanged.
- Reachability is true over a live stream even with no HTTP endpoint (the post-cut, stream-only Director) and false for a Director the Gateway does not know (dead-man's-switch), so snooze expiry keeps working after the REST surface is cut.

## Read-source decision
Used the **`snapshot` round-trip** over reading `PushedSessions`: the sweep's nudge->next-sweep-clears cycle needs the Director's *post-nudge* raw state promptly and byte-identically to today; the round-trip is negligible for the few snoozed entries. (Architect gave the call; noted the rationale.)

## Proof
- New `TunnelSnoozeSweepProofTests`: `snapshot`/`hold` verbs + payload + reachability gate proven **by construction** (unknown Director => not dialed; success => tunnel).
- `SnoozeExpirySweepTests` updated to the id-addressed seams.
- Full Gateway suite green (2131/2131).

Additive only; no deletions. Merged autonomously under the mission's Option A (Architect-approved PR E-B3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)