### PR TITLE
feat(throttle): Your Throttle redesign - tabbed dashboard, timezone, wingman usage, mobile

### DIFF
--- a/apps/cockpit/src/settings/SettingsView.tsx
+++ b/apps/cockpit/src/settings/SettingsView.tsx
@@ -10,6 +10,7 @@ import {
   setAddressingMode,
   setAutostart,
   setSnoozeDefaultMinutes,
+  setTimeZone,
   setTrainingCapture,
   type AddressingMode,
   type GatewaySettings,
@@ -339,6 +340,21 @@ function ThisMachineTab() {
     }
   };
 
+  const chooseTimeZone = async (tz: string) => {
+    if (settings === null || busy || tz === settings.timeZone) return;
+    setBusy(true);
+    setMsg("Saving...");
+    try {
+      const applied = await setTimeZone(tz);
+      setSettings({ ...settings, timeZone: applied });
+      setMsg(`Time zone set to ${applied}. Your Throttle charts now read this zone.`);
+    } catch (e) {
+      setMsg(errText(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
   if (error !== null) {
     return <div className="settings-error">Could not load settings from the Gateway: {error}</div>;
   }
@@ -429,6 +445,42 @@ function ThisMachineTab() {
           <button type="button" className="settings-btn" disabled={busy} onClick={() => void saveSnooze()}>
             Save
           </button>
+        </div>
+      </section>
+
+      <section className="settings-card">
+        <h2 className="settings-h2">Time zone</h2>
+        <p className="settings-hint">
+          The zone your private dashboards read local clock hours in - the Your Throttle hourly charts. It
+          starts on this Gateway machine&apos;s own zone ({settings.timeZoneMachineDefault}); change it if
+          you want the charts shown in a different zone. Read at render time, so it applies on the next
+          refresh.
+        </p>
+        <div className="settings-field">
+          <label htmlFor="settings-timezone">Zone</label>
+          <select
+            id="settings-timezone"
+            className="settings-select"
+            value={settings.timeZone}
+            disabled={busy}
+            onChange={(e) => void chooseTimeZone(e.target.value)}
+          >
+            {timeZoneOptions(settings.timeZone).map((tz) => (
+              <option key={tz} value={tz}>
+                {tz}
+              </option>
+            ))}
+          </select>
+          {settings.timeZone !== settings.timeZoneMachineDefault && (
+            <button
+              type="button"
+              className="settings-btn"
+              disabled={busy}
+              onClick={() => void chooseTimeZone(settings.timeZoneMachineDefault)}
+            >
+              Use gateway zone
+            </button>
+          )}
         </div>
       </section>
 
@@ -1105,4 +1157,18 @@ function ensureStrings(current: string, values: string[]): string[] {
 
 function errText(e: unknown): string {
   return gatewayErrorMessage(e);
+}
+
+// The IANA time-zone options for the picker: the browser's full supported list (Intl.supportedValuesOf),
+// with the current value guaranteed present even if the browser cannot enumerate zones.
+function timeZoneOptions(current: string): string[] {
+  let list: string[] = [];
+  try {
+    const supported = (Intl as unknown as { supportedValuesOf?: (key: string) => string[] }).supportedValuesOf;
+    if (typeof supported === "function") list = supported("timeZone");
+  } catch {
+    /* Intl.supportedValuesOf unavailable - fall through to just the current value */
+  }
+  if (current && list.indexOf(current) < 0) list = [current, ...list];
+  return list.length > 0 ? list : [current || "UTC"];
 }

--- a/apps/cockpit/src/throttle/YourThrottleView.tsx
+++ b/apps/cockpit/src/throttle/YourThrottleView.tsx
@@ -3,6 +3,12 @@ import {
   getThrottle,
   summarizeThrottle,
   formatShare,
+  last24HourKeys,
+  windowSeries,
+  emptyInputHour,
+  emptyConcurrencyHour,
+  localHourLabel,
+  safeTimeZone,
   MODALITY_LABEL,
   SURFACE_LABEL,
   SURFACE_ORDER,
@@ -335,6 +341,16 @@ function ActivityTab({ data }: { data: ThrottleData }) {
     return <div className="thr-empty">No hourly activity recorded in the last day yet.</div>;
   }
 
+  // Both charts render the SAME canonical 24-hour window (the last 24 clock hours ending now), so they
+  // line up exactly regardless of which hours each series happens to have data for. Labels are formatted
+  // in the configured display time zone, so the axis reads in local time, not UTC.
+  const now = data.generatedAtUtc ? new Date(data.generatedAtUtc) : new Date();
+  const keys = last24HourKeys(Number.isNaN(now.getTime()) ? new Date() : now);
+  const timeZone = safeTimeZone(data.timeZone);
+  const turnsWindow = windowSeries(data.hourlyTurns, keys, emptyInputHour);
+  const concurrencyWindow = windowSeries(data.concurrency?.hourly ?? [], keys, emptyConcurrencyHour);
+  const zoneLabel = friendlyZone(timeZone);
+
   return (
     <>
       {hasTurns && (
@@ -342,11 +358,11 @@ function ActivityTab({ data }: { data: ThrottleData }) {
           <div className="thr-panel-head">
             <h2>Turns per hour (last 24h)</h2>
             <span className="thr-panel-sub">
-              Your working day: how many turns you submitted each hour (UTC), voice over typed. Empty
-              hours are when you were away.
+              Your working day: how many turns you submitted each hour ({zoneLabel}), voice over typed.
+              Empty hours are when you were away.
             </span>
           </div>
-          <TurnsPerHourChart hourly={data.hourlyTurns} />
+          <TurnsPerHourChart hourly={turnsWindow} timeZone={timeZone} />
         </div>
       )}
 
@@ -355,15 +371,22 @@ function ActivityTab({ data }: { data: ThrottleData }) {
           <div className="thr-panel-head">
             <h2>Sessions per hour (last 24h)</h2>
             <span className="thr-panel-sub">
-              Peak concurrent sessions in each hour (UTC). The bar is loaded/running; the darker portion
-              is actively working. Hover a bar for that hour&apos;s distinct sessions and machines.
+              Peak concurrent sessions in each hour ({zoneLabel}). The bar is loaded/running; the darker
+              portion is actively working. Hover a bar for that hour&apos;s distinct sessions and machines.
             </span>
           </div>
-          <ConcurrencyChart hourly={data.concurrency!.hourly} />
+          <ConcurrencyChart hourly={concurrencyWindow} timeZone={timeZone} />
         </div>
       )}
     </>
   );
+}
+
+// A short, human label for the display zone shown in the chart captions: the IANA id's last segment with
+// underscores turned to spaces (e.g. "America/New_York" -> "New York"), so the caption reads plainly.
+function friendlyZone(timeZone: string): string {
+  const seg = timeZone.split("/").pop() ?? timeZone;
+  return seg.replace(/_/g, " ");
 }
 
 // One column of a bar chart: the bar node itself (its height is a percent of the plot), plus its x-axis
@@ -444,18 +467,19 @@ function BarChart({
 }
 
 // A 24-hour chart of turns submitted per hour - the "working day" shape. Each bar is the total turns that
-// hour, split voice (accent) over typed (muted), scaled against a readable y-axis.
-function TurnsPerHourChart({ hourly }: { hourly: InputHour[] }) {
-  const recent = hourly.slice(-24);
-  const { niceMax, ticks } = niceScale(Math.max(...recent.map((h) => h.turns), 0));
-  const columns: BarColumn[] = recent.map((h, i) => {
+// hour, split voice (accent) over typed (muted), scaled against a readable y-axis. The hourly array is the
+// already-windowed 24 hours; labels are the local hour in `timeZone`.
+function TurnsPerHourChart({ hourly, timeZone }: { hourly: InputHour[]; timeZone: string }) {
+  const { niceMax, ticks } = niceScale(Math.max(...hourly.map((h) => h.turns), 0));
+  const columns: BarColumn[] = hourly.map((h, i) => {
     const heightPct = (h.turns / niceMax) * 100;
     const voicePortion = h.turns > 0 ? (h.voiceTurns / h.turns) * 100 : 0;
     const typedPortion = h.turns > 0 ? (h.typedTurns / h.turns) * 100 : 0;
+    const label = localHourLabel(h.hour, timeZone);
     return {
       key: h.hour,
-      xlabel: i % 3 === 0 ? h.hour.slice(-2) : "",
-      title: `${h.hour}:00 UTC - ${h.turns} turns (${h.voiceTurns} voice, ${h.typedTurns} typed), ${h.characters.toLocaleString()} chars`,
+      xlabel: i % 3 === 0 ? label : "",
+      title: `${label}:00 ${timeZone} - ${h.turns} turns (${h.voiceTurns} voice, ${h.typedTurns} typed), ${h.characters.toLocaleString()} chars`,
       bar: (
         <div className="thr-bar" style={{ height: `${heightPct}%` }}>
           <div className="thr-seg thr-seg-typed" style={{ height: `${typedPortion}%` }} />
@@ -466,7 +490,7 @@ function TurnsPerHourChart({ hourly }: { hourly: InputHour[] }) {
   });
   return (
     <BarChart
-      ariaLabel={`Turns submitted per hour for the last ${recent.length} hours`}
+      ariaLabel={`Turns submitted per hour for the last ${hourly.length} hours`}
       ticks={ticks}
       niceMax={niceMax}
       columns={columns}
@@ -485,17 +509,18 @@ function TurnsPerHourChart({ hourly }: { hourly: InputHour[] }) {
 }
 
 // A 24-hour chart of the hourly peak concurrent sessions. Each bar is the max loaded/running that hour;
-// the darker inner portion is the max actively-working, scaled against a readable y-axis.
-function ConcurrencyChart({ hourly }: { hourly: ConcurrencyHour[] }) {
-  const recent = hourly.slice(-24);
-  const { niceMax, ticks } = niceScale(Math.max(...recent.map((h) => h.maxLive), 0));
-  const columns: BarColumn[] = recent.map((h, i) => {
+// the darker inner portion is the max actively-working, scaled against a readable y-axis. The hourly array
+// is the already-windowed 24 hours; labels are the local hour in `timeZone`.
+function ConcurrencyChart({ hourly, timeZone }: { hourly: ConcurrencyHour[]; timeZone: string }) {
+  const { niceMax, ticks } = niceScale(Math.max(...hourly.map((h) => h.maxLive), 0));
+  const columns: BarColumn[] = hourly.map((h, i) => {
     const heightPct = (h.maxLive / niceMax) * 100;
     const workPct = h.maxLive > 0 ? (h.maxWorking / h.maxLive) * 100 : 0;
+    const label = localHourLabel(h.hour, timeZone);
     return {
       key: h.hour,
-      xlabel: i % 3 === 0 ? h.hour.slice(-2) : "",
-      title: `${h.hour}:00 UTC - ${h.maxLive} loaded, ${h.maxWorking} working, ${h.sessions} distinct sessions, ${h.machines} machine(s)`,
+      xlabel: i % 3 === 0 ? label : "",
+      title: `${label}:00 ${timeZone} - ${h.maxLive} loaded, ${h.maxWorking} working, ${h.sessions} distinct sessions, ${h.machines} machine(s)`,
       bar: (
         <div className="thr-bar thr-bar-live" style={{ height: `${heightPct}%` }}>
           <div className="thr-seg thr-seg-work" style={{ height: `${workPct}%` }} />
@@ -505,7 +530,7 @@ function ConcurrencyChart({ hourly }: { hourly: ConcurrencyHour[] }) {
   });
   return (
     <BarChart
-      ariaLabel={`Peak concurrent sessions per hour for the last ${recent.length} hours`}
+      ariaLabel={`Peak concurrent sessions per hour for the last ${hourly.length} hours`}
       ticks={ticks}
       niceMax={niceMax}
       columns={columns}

--- a/apps/cockpit/src/throttle/YourThrottleView.tsx
+++ b/apps/cockpit/src/throttle/YourThrottleView.tsx
@@ -156,11 +156,17 @@ function OverviewTab({ summary, data }: { summary: ThrottleSummary; data: Thrott
 
   const peakLive = data.concurrency?.live.allTimeMax ?? 0;
 
+  // Wingman usage (a session "uses the wingman" when voice mode is on): the share of turns submitted while
+  // in voice mode, over the same total the other rings use, and the count of distinct sessions that used it.
+  const wingmanTurns = data.wingman.turns;
+  const wingmanShare = summary.totalTurns > 0 ? wingmanTurns / summary.totalTurns : null;
+  const wingmanSessions = data.wingman.sessions;
+
   return (
     <>
-      {/* The two hero rings: the questions the owner actually asks - how much do I speak, and how much do
-          I drive from my phone. Each ring is its own metric (not two series in one chart), so each fills
-          with its own accent against a muted remainder; the center number is the headline. */}
+      {/* The three hero rings: the questions the owner actually asks - how much do I speak, how much do I
+          drive from my phone, and how much do I lean on the wingman (voice mode). Each ring is its own
+          metric, so each fills with its own accent against a muted remainder; the center is the headline. */}
       <div className="thr-heroes">
         <HeroRing
           title="Voice vs typing"
@@ -180,6 +186,15 @@ function OverviewTab({ summary, data }: { summary: ThrottleSummary; data: Thrott
             label: "Desktop + Cockpit",
             count: summary.totalTurns - summary.turnsBySurface.phone,
           }}
+        />
+        <HeroRing
+          title="Wingman (voice mode)"
+          share={wingmanShare}
+          accentVar="--thr-wingman"
+          centerCaption="in voice mode"
+          primary={{ label: "Voice mode", count: wingmanTurns }}
+          secondary={{ label: "Hands-on", count: Math.max(0, summary.totalTurns - wingmanTurns) }}
+          note={`${wingmanSessions.toLocaleString()} session${wingmanSessions === 1 ? "" : "s"} used the wingman`}
         />
       </div>
 
@@ -212,6 +227,7 @@ function HeroRing({
   centerCaption,
   primary,
   secondary,
+  note,
 }: {
   title: string;
   share: number | null;
@@ -219,6 +235,7 @@ function HeroRing({
   centerCaption: string;
   primary: { label: string; count: number };
   secondary: { label: string; count: number };
+  note?: string;
 }) {
   const R = 42;
   const C = 2 * Math.PI * R;
@@ -264,6 +281,7 @@ function HeroRing({
           <b>{secondary.count.toLocaleString()}</b>
         </span>
       </div>
+      {note !== undefined && <div className="thr-hero-note">{note}</div>}
     </section>
   );
 }

--- a/apps/cockpit/src/throttle/YourThrottleView.tsx
+++ b/apps/cockpit/src/throttle/YourThrottleView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import { useEffect, useMemo, useState, type CSSProperties, type ReactNode } from "react";
 import {
   getThrottle,
   summarizeThrottle,
@@ -366,92 +366,160 @@ function ActivityTab({ data }: { data: ThrottleData }) {
   );
 }
 
-// A 24-hour bar chart of turns submitted per hour - the "working day" shape. Each bar is the total turns
-// that hour, stacked voice (accent) over typed (muted). Pure CSS bars.
-function TurnsPerHourChart({ hourly }: { hourly: InputHour[] }) {
-  const recent = hourly.slice(-24);
-  const peak = Math.max(1, ...recent.map((h) => h.turns));
+// One column of a bar chart: the bar node itself (its height is a percent of the plot), plus its x-axis
+// label and hover title.
+interface BarColumn {
+  key: string;
+  xlabel: string;
+  title: string;
+  bar: ReactNode;
+}
+
+// A "nice" linear scale from 0 to a rounded ceiling >= max, with evenly spaced integer ticks (~4-5), so
+// the y-axis reads in round numbers and the top bar never touches the frame. Counts only, so the step is
+// clamped to a whole number.
+function niceScale(max: number): { niceMax: number; ticks: number[] } {
+  if (max <= 0) return { niceMax: 1, ticks: [0, 1] };
+  const rawStep = max / 5;
+  const pow = Math.pow(10, Math.floor(Math.log10(rawStep)));
+  const n = rawStep / pow;
+  const stepMul = n <= 1 ? 1 : n <= 2 ? 2 : n <= 5 ? 5 : 10;
+  const step = Math.max(1, Math.round(stepMul * pow));
+  const niceMax = Math.ceil(max / step) * step;
+  const ticks: number[] = [];
+  for (let t = 0; t <= niceMax; t += step) ticks.push(t);
+  return { niceMax, ticks };
+}
+
+// The shared chart frame: a left y-axis of tick labels, recessive horizontal gridlines at those ticks,
+// the bars scaled to the SAME nice ceiling as the gridlines (so a bar top lands on a gridline you can
+// read), and an aligned x-axis row beneath. role="img" with a caption; the legend below carries series
+// identity so it is never color-alone.
+function BarChart({
+  ariaLabel,
+  ticks,
+  niceMax,
+  columns,
+  legend,
+}: {
+  ariaLabel: string;
+  ticks: number[];
+  niceMax: number;
+  columns: BarColumn[];
+  legend: ReactNode;
+}) {
   return (
     <>
-      <div
-        className="thr-chart thr-chart-tall"
-        role="img"
-        aria-label={`Turns submitted per hour for the last ${recent.length} hours`}
-      >
-        {recent.map((h, i) => {
-          const totalPct = (h.turns / peak) * 100;
-          const voicePortion = h.turns > 0 ? (h.voiceTurns / h.turns) * 100 : 0;
-          const typedPortion = h.turns > 0 ? (h.typedTurns / h.turns) * 100 : 0;
-          return (
-            <div
-              className="thr-bar-col"
-              key={h.hour}
-              title={`${h.hour}:00 UTC - ${h.turns} turns (${h.voiceTurns} voice, ${h.typedTurns} typed), ${h.characters.toLocaleString()} chars`}
-            >
-              <div className="thr-bar-track">
-                <div className="thr-turns-bar" style={{ height: `${totalPct}%` }}>
-                  <div className="thr-turns-typed" style={{ height: `${typedPortion}%` }} />
-                  <div className="thr-turns-voice" style={{ height: `${voicePortion}%` }} />
-                </div>
+      <div className="thr-chartframe tall" role="img" aria-label={ariaLabel}>
+        <div className="thr-plotrow">
+          <div className="thr-yaxis">
+            {ticks.map((t) => (
+              <div key={t} className="thr-ytick" style={{ bottom: `${(t / niceMax) * 100}%` }}>
+                {t.toLocaleString()}
               </div>
-              <div className="thr-bar-label">{i % 3 === 0 ? h.hour.slice(-2) : ""}</div>
+            ))}
+          </div>
+          <div className="thr-plot">
+            {ticks.map((t) => (
+              <div key={t} className="thr-gridline" style={{ bottom: `${(t / niceMax) * 100}%` }} />
+            ))}
+            {columns.map((c) => (
+              <div key={c.key} className="thr-col" title={c.title}>
+                {c.bar}
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="thr-xrow">
+          {columns.map((c) => (
+            <div key={c.key} className="thr-xlabel">
+              {c.xlabel}
             </div>
-          );
-        })}
+          ))}
+        </div>
       </div>
-      <div className="thr-legend">
-        <span className="thr-legend-item">
-          <span className="thr-swatch thr-swatch-voice" /> Voice
-        </span>
-        <span className="thr-legend-item">
-          <span className="thr-swatch thr-swatch-typed" /> Typed
-        </span>
-      </div>
+      <div className="thr-legend">{legend}</div>
     </>
   );
 }
 
-// A 24-hour bar chart of the hourly peak concurrent sessions. Each bar is the max loaded/running in that
-// hour; the darker inner portion is the max actively-working. Pure CSS bars.
+// A 24-hour chart of turns submitted per hour - the "working day" shape. Each bar is the total turns that
+// hour, split voice (accent) over typed (muted), scaled against a readable y-axis.
+function TurnsPerHourChart({ hourly }: { hourly: InputHour[] }) {
+  const recent = hourly.slice(-24);
+  const { niceMax, ticks } = niceScale(Math.max(...recent.map((h) => h.turns), 0));
+  const columns: BarColumn[] = recent.map((h, i) => {
+    const heightPct = (h.turns / niceMax) * 100;
+    const voicePortion = h.turns > 0 ? (h.voiceTurns / h.turns) * 100 : 0;
+    const typedPortion = h.turns > 0 ? (h.typedTurns / h.turns) * 100 : 0;
+    return {
+      key: h.hour,
+      xlabel: i % 3 === 0 ? h.hour.slice(-2) : "",
+      title: `${h.hour}:00 UTC - ${h.turns} turns (${h.voiceTurns} voice, ${h.typedTurns} typed), ${h.characters.toLocaleString()} chars`,
+      bar: (
+        <div className="thr-bar" style={{ height: `${heightPct}%` }}>
+          <div className="thr-seg thr-seg-typed" style={{ height: `${typedPortion}%` }} />
+          <div className="thr-seg thr-seg-voice" style={{ height: `${voicePortion}%` }} />
+        </div>
+      ),
+    };
+  });
+  return (
+    <BarChart
+      ariaLabel={`Turns submitted per hour for the last ${recent.length} hours`}
+      ticks={ticks}
+      niceMax={niceMax}
+      columns={columns}
+      legend={
+        <>
+          <span className="thr-legend-item">
+            <span className="thr-swatch thr-swatch-voice" /> Voice
+          </span>
+          <span className="thr-legend-item">
+            <span className="thr-swatch thr-swatch-typed" /> Typed
+          </span>
+        </>
+      }
+    />
+  );
+}
+
+// A 24-hour chart of the hourly peak concurrent sessions. Each bar is the max loaded/running that hour;
+// the darker inner portion is the max actively-working, scaled against a readable y-axis.
 function ConcurrencyChart({ hourly }: { hourly: ConcurrencyHour[] }) {
   const recent = hourly.slice(-24);
-  const peak = Math.max(1, ...recent.map((h) => h.maxLive));
+  const { niceMax, ticks } = niceScale(Math.max(...recent.map((h) => h.maxLive), 0));
+  const columns: BarColumn[] = recent.map((h, i) => {
+    const heightPct = (h.maxLive / niceMax) * 100;
+    const workPct = h.maxLive > 0 ? (h.maxWorking / h.maxLive) * 100 : 0;
+    return {
+      key: h.hour,
+      xlabel: i % 3 === 0 ? h.hour.slice(-2) : "",
+      title: `${h.hour}:00 UTC - ${h.maxLive} loaded, ${h.maxWorking} working, ${h.sessions} distinct sessions, ${h.machines} machine(s)`,
+      bar: (
+        <div className="thr-bar thr-bar-live" style={{ height: `${heightPct}%` }}>
+          <div className="thr-seg thr-seg-work" style={{ height: `${workPct}%` }} />
+        </div>
+      ),
+    };
+  });
   return (
-    <>
-      <div
-        className="thr-chart thr-chart-tall"
-        role="img"
-        aria-label={`Peak concurrent sessions per hour for the last ${recent.length} hours`}
-      >
-        {recent.map((h, i) => {
-          const livePct = (h.maxLive / peak) * 100;
-          const workPct = h.maxLive > 0 ? (h.maxWorking / h.maxLive) * 100 : 0;
-          const hourNum = h.hour.slice(-2);
-          return (
-            <div
-              className="thr-bar-col"
-              key={h.hour}
-              title={`${h.hour}:00 UTC - ${h.maxLive} loaded, ${h.maxWorking} working, ${h.sessions} distinct sessions, ${h.machines} machine(s)`}
-            >
-              <div className="thr-bar-track">
-                <div className="thr-bar-live" style={{ height: `${livePct}%` }}>
-                  <div className="thr-bar-work" style={{ height: `${workPct}%` }} />
-                </div>
-              </div>
-              <div className="thr-bar-label">{i % 3 === 0 ? hourNum : ""}</div>
-            </div>
-          );
-        })}
-      </div>
-      <div className="thr-legend">
-        <span className="thr-legend-item">
-          <span className="thr-swatch thr-swatch-live" /> Loaded / running
-        </span>
-        <span className="thr-legend-item">
-          <span className="thr-swatch thr-swatch-voice" /> Actively working
-        </span>
-      </div>
-    </>
+    <BarChart
+      ariaLabel={`Peak concurrent sessions per hour for the last ${recent.length} hours`}
+      ticks={ticks}
+      niceMax={niceMax}
+      columns={columns}
+      legend={
+        <>
+          <span className="thr-legend-item">
+            <span className="thr-swatch thr-swatch-live" /> Loaded / running
+          </span>
+          <span className="thr-legend-item">
+            <span className="thr-swatch thr-swatch-voice" /> Actively working
+          </span>
+        </>
+      }
+    />
   );
 }
 

--- a/apps/cockpit/src/throttle/YourThrottleView.tsx
+++ b/apps/cockpit/src/throttle/YourThrottleView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
 import {
   getThrottle,
   summarizeThrottle,
@@ -10,107 +10,57 @@ import {
   type ThrottleSummary,
   type ConcurrencyHour,
   type InputHour,
+  type Surface,
 } from "@devthrottle/client-core/stats/statsClient";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 
-// The "Your Throttle" page (devthrottle-stats mission): the in-Cockpit port of the standalone Gateway
-// /stats HTML page, so the user reads their own throttle in the app they already have open rather than
-// navigating to a bare URL. Read-only, reads the same GET /stats/data feed the standalone page uses.
-// Responsive (CodingStyle.md): renders immediately with a loading state, loads asynchronously, and on a
-// load failure shows an explicit error banner (no-fallback rule). Auto-refreshes so the split visibly
-// moves as the user keeps driving.
+// The "Your Throttle" page (devthrottle-stats mission): the in-Cockpit view of how the owner drives the
+// fleet - spoken vs typed, and from phone vs desktop vs cockpit. Read-only over the same GET /stats/data
+// feed the standalone Gateway page uses. Responsive (CodingStyle.md): renders immediately with a loading
+// state, loads asynchronously, and on a load failure shows an explicit error banner (no-fallback rule).
+// Auto-refreshes so the split visibly moves as the owner keeps driving.
+//
+// The page is TABBED so the two questions the owner actually cares about are not buried under supporting
+// tables (owner ask, 2026-07-13): Overview leads with the two headline percentages as big rings - how
+// much do I speak vs type, and how much do I drive from my phone; Activity holds the (now larger) time
+// charts; Breakdown holds the supporting tables and honesty caveats.
 
 const REFRESH_MS = 10_000;
 
-/** A big headline metric card (voice share, phone share, total turns). */
-function HeadlineCard({ label, value, sub }: { label: string; value: string; sub: string }) {
-  return (
-    <div className="thr-card">
-      <div className="thr-card-value">{value}</div>
-      <div className="thr-card-label">{label}</div>
-      <div className="thr-card-sub">{sub}</div>
-    </div>
-  );
-}
+type ThrottleTab = "overview" | "activity" | "breakdown";
 
-/** A 24-hour bar chart of the hourly peak concurrent sessions. Each bar is the max loaded/running in
- * that hour; the darker inner portion is the max actively-working. Pure CSS bars, theme-aware. */
-function ConcurrencyChart({ hourly }: { hourly: ConcurrencyHour[] }) {
-  const recent = hourly.slice(-24);
-  const peak = Math.max(1, ...recent.map((h) => h.maxLive));
-  return (
-    <div
-      className="thr-chart"
-      role="img"
-      aria-label={`Peak concurrent sessions per hour for the last ${recent.length} hours`}
-    >
-      {recent.map((h, i) => {
-        const livePct = (h.maxLive / peak) * 100;
-        const workPct = h.maxLive > 0 ? (h.maxWorking / h.maxLive) * 100 : 0;
-        const hourNum = h.hour.slice(-2);
-        return (
-          <div
-            className="thr-bar-col"
-            key={h.hour}
-            title={`${h.hour}:00 UTC - ${h.maxLive} loaded, ${h.maxWorking} working, ${h.sessions} distinct sessions, ${h.machines} machine(s)`}
-          >
-            <div className="thr-bar-track">
-              <div className="thr-bar-live" style={{ height: `${livePct}%` }}>
-                <div className="thr-bar-work" style={{ height: `${workPct}%` }} />
-              </div>
-            </div>
-            <div className="thr-bar-label">{i % 4 === 0 ? hourNum : ""}</div>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
+const TABS: ReadonlyArray<{ key: ThrottleTab; label: string }> = [
+  { key: "overview", label: "Overview" },
+  { key: "activity", label: "Activity" },
+  { key: "breakdown", label: "Breakdown" },
+];
 
-/** A 24-hour bar chart of turns submitted per hour - the "working day" shape. Each bar is the total turns
- * that hour, stacked voice (accent) over typed (muted). Pure CSS bars, theme-aware. */
-function TurnsPerHourChart({ hourly }: { hourly: InputHour[] }) {
-  const recent = hourly.slice(-24);
-  const peak = Math.max(1, ...recent.map((h) => h.turns));
-  return (
-    <>
-      <div
-        className="thr-chart"
-        role="img"
-        aria-label={`Turns submitted per hour for the last ${recent.length} hours`}
-      >
-        {recent.map((h, i) => {
-          const totalPct = (h.turns / peak) * 100;
-          const voicePortion = h.turns > 0 ? (h.voiceTurns / h.turns) * 100 : 0;
-          const typedPortion = h.turns > 0 ? (h.typedTurns / h.turns) * 100 : 0;
-          return (
-            <div
-              className="thr-bar-col"
-              key={h.hour}
-              title={`${h.hour}:00 UTC - ${h.turns} turns (${h.voiceTurns} voice, ${h.typedTurns} typed), ${h.characters.toLocaleString()} chars`}
-            >
-              <div className="thr-bar-track">
-                <div className="thr-turns-bar" style={{ height: `${totalPct}%` }}>
-                  <div className="thr-turns-typed" style={{ height: `${typedPortion}%` }} />
-                  <div className="thr-turns-voice" style={{ height: `${voicePortion}%` }} />
-                </div>
-              </div>
-              <div className="thr-bar-label">{i % 4 === 0 ? h.hour.slice(-2) : ""}</div>
-            </div>
-          );
-        })}
-      </div>
-      <div className="thr-legend">
-        <span className="thr-legend-item"><span className="thr-swatch thr-swatch-voice" /> Voice</span>
-        <span className="thr-legend-item"><span className="thr-swatch thr-swatch-typed" /> Typed</span>
-      </div>
-    </>
-  );
+// The tab is sticky per browser so returning to the page lands on whatever the owner last read.
+const TAB_STORAGE_KEY = "cockpit.throttleTab";
+
+function initialTab(): ThrottleTab {
+  try {
+    const saved = window.localStorage.getItem(TAB_STORAGE_KEY);
+    if (saved === "overview" || saved === "activity" || saved === "breakdown") return saved;
+  } catch {
+    /* storage unavailable (private mode) - fall through to the default */
+  }
+  return "overview";
 }
 
 export function YourThrottleView() {
   const [data, setData] = useState<ThrottleData | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [tab, setTabState] = useState<ThrottleTab>(initialTab);
+
+  const setTab = (next: ThrottleTab) => {
+    setTabState(next);
+    try {
+      window.localStorage.setItem(TAB_STORAGE_KEY, next);
+    } catch {
+      /* storage unavailable - the selection still applies this session */
+    }
+  };
 
   useEffect(() => {
     const controller = new AbortController();
@@ -137,7 +87,10 @@ export function YourThrottleView() {
     };
   }, []);
 
-  const summary: ThrottleSummary | null = data === null ? null : summarizeThrottle(data);
+  const summary: ThrottleSummary | null = useMemo(
+    () => (data === null ? null : summarizeThrottle(data)),
+    [data],
+  );
 
   return (
     <div className="page thr">
@@ -155,22 +108,367 @@ export function YourThrottleView() {
         </div>
       )}
 
-      {summary === null && error === null && <div className="thr-loading">Loading...</div>}
+      {summary === null && error === null && <div className="thr-loading">Loading your throttle...</div>}
 
-      {summary !== null && !summary.hasData && (
-        <div className="thr-empty">
-          No input counted yet. Send a turn from the composer, dictation, phone, or cockpit and it will
-          appear here.
+      {data !== null && summary !== null && (
+        <>
+          <div className="thr-tabs" role="tablist" aria-label="Your Throttle sections">
+            {TABS.map((t) => (
+              <button
+                key={t.key}
+                type="button"
+                role="tab"
+                aria-selected={tab === t.key}
+                className={tab === t.key ? "thr-tab active" : "thr-tab"}
+                onClick={() => setTab(t.key)}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+
+          {tab === "overview" && <OverviewTab summary={summary} data={data} />}
+          {tab === "activity" && <ActivityTab data={data} />}
+          {tab === "breakdown" && <BreakdownTab summary={summary} data={data} />}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ---- Overview: the landing dashboard - the two headline percentages first, big and clear ------------
+
+function OverviewTab({ summary, data }: { summary: ThrottleSummary; data: ThrottleData }) {
+  if (!summary.hasData) {
+    return (
+      <div className="thr-empty">
+        No input counted yet. Send a turn from the composer, dictation, phone, or cockpit and your
+        throttle will appear here.
+      </div>
+    );
+  }
+
+  const peakLive = data.concurrency?.live.allTimeMax ?? 0;
+
+  return (
+    <>
+      {/* The two hero rings: the questions the owner actually asks - how much do I speak, and how much do
+          I drive from my phone. Each ring is its own metric (not two series in one chart), so each fills
+          with its own accent against a muted remainder; the center number is the headline. */}
+      <div className="thr-heroes">
+        <HeroRing
+          title="Voice vs typing"
+          share={summary.voiceShare}
+          accentVar="--thr-voice"
+          centerCaption="spoken"
+          primary={{ label: "Voice", count: summary.voiceTurns }}
+          secondary={{ label: "Typed", count: summary.typedTurns }}
+        />
+        <HeroRing
+          title="Mobile vs desktop"
+          share={summary.phoneShare}
+          accentVar="--thr-mobile"
+          centerCaption="from phone"
+          primary={{ label: "Phone", count: summary.turnsBySurface.phone }}
+          secondary={{
+            label: "Desktop + Cockpit",
+            count: summary.totalTurns - summary.turnsBySurface.phone,
+          }}
+        />
+      </div>
+
+      {/* Where the turns come from, in one glance - the supporting detail behind the mobile ring. */}
+      <div className="thr-panel">
+        <div className="thr-panel-head">
+          <h2>Where you drive from</h2>
+          <span className="thr-panel-sub">{summary.totalTurns} turns across every surface</span>
+        </div>
+        <SurfaceSplitBar summary={summary} />
+      </div>
+
+      {/* Supporting headline numbers. */}
+      <div className="thr-stats">
+        <StatTile value={summary.totalTurns.toLocaleString()} label="Total turns" />
+        <StatTile value={summary.totalCharacters.toLocaleString()} label="Characters driven" />
+        <StatTile value={String(peakLive)} label="Peak sessions at once" sub="all-time" />
+      </div>
+    </>
+  );
+}
+
+// A big donut ring: the share as an arc, the headline percent in the center, the two sides named with
+// their counts below. role="img" + aria-label so the number is announced; the legend carries identity so
+// it is never color-alone.
+function HeroRing({
+  title,
+  share,
+  accentVar,
+  centerCaption,
+  primary,
+  secondary,
+}: {
+  title: string;
+  share: number | null;
+  accentVar: string;
+  centerCaption: string;
+  primary: { label: string; count: number };
+  secondary: { label: string; count: number };
+}) {
+  const R = 42;
+  const C = 2 * Math.PI * R;
+  const filled = share === null ? 0 : share * C;
+  const pctText = formatShare(share);
+
+  return (
+    <section className="thr-hero">
+      <div className="thr-hero-title">{title}</div>
+      <div
+        className="thr-ring"
+        role="img"
+        aria-label={`${title}: ${primary.label} ${pctText} (${primary.count} of ${primary.count + secondary.count} turns)`}
+      >
+        <svg
+          viewBox="0 0 100 100"
+          className="thr-ring-svg"
+          style={{ "--thr-arc": `var(${accentVar})` } as CSSProperties}
+        >
+          <circle className="thr-ring-track" cx="50" cy="50" r={R} />
+          <circle
+            className="thr-ring-arc"
+            cx="50"
+            cy="50"
+            r={R}
+            style={{ strokeDasharray: `${filled} ${C}` }}
+          />
+        </svg>
+        <div className="thr-ring-center">
+          <div className="thr-ring-pct">{pctText}</div>
+          <div className="thr-ring-cap">{centerCaption}</div>
+        </div>
+      </div>
+      <div className="thr-hero-legend">
+        <span className="thr-hero-leg">
+          <span className="thr-dot" style={{ background: `var(${accentVar})` }} />
+          {primary.label}
+          <b>{primary.count.toLocaleString()}</b>
+        </span>
+        <span className="thr-hero-leg">
+          <span className="thr-dot thr-dot-muted" />
+          {secondary.label}
+          <b>{secondary.count.toLocaleString()}</b>
+        </span>
+      </div>
+    </section>
+  );
+}
+
+// A single horizontal stacked bar of turns by surface, each present segment labeled with its share, plus
+// a legend beneath. One accent hue at descending opacity per surface (a magnitude ramp, not arbitrary
+// categorical colors) so the bar reads as "one measure split by where".
+function SurfaceSplitBar({ summary }: { summary: ThrottleSummary }) {
+  const total = summary.totalTurns;
+  // Largest surface first, so the brightest accent step lands on the surface you drive from most (the
+  // magnitude ramp reads big -> small in both width and color).
+  const segments = SURFACE_ORDER.map((s) => ({
+    surface: s,
+    turns: summary.turnsBySurface[s],
+  }))
+    .filter((seg) => seg.turns > 0)
+    .sort((a, b) => b.turns - a.turns);
+
+  return (
+    <div className="thr-split">
+      <div className="thr-split-bar" role="img" aria-label="Turns by surface">
+        {segments.map((seg, i) => {
+          const pct = total > 0 ? (seg.turns / total) * 100 : 0;
+          return (
+            <div
+              key={seg.surface}
+              className="thr-split-seg"
+              style={{ width: `${pct}%`, background: surfaceFill(i) }}
+              title={`${SURFACE_LABEL[seg.surface]}: ${seg.turns} turns (${Math.round(pct)}%)`}
+            >
+              {pct >= 8 && <span className="thr-split-lbl">{Math.round(pct)}%</span>}
+            </div>
+          );
+        })}
+      </div>
+      <div className="thr-split-legend">
+        {segments.map((seg, i) => (
+          <span key={seg.surface} className="thr-split-leg">
+            <span className="thr-dot" style={{ background: surfaceFill(i) }} />
+            {SURFACE_LABEL[seg.surface]}
+            <b>{seg.turns.toLocaleString()}</b>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// The accent, stepped down in opacity for each successive surface segment - a one-hue magnitude ramp.
+function surfaceFill(index: number): string {
+  const opacities = [100, 66, 42, 26];
+  const o = opacities[Math.min(index, opacities.length - 1)];
+  return `color-mix(in srgb, var(--accent) ${o}%, transparent)`;
+}
+
+function StatTile({ value, label, sub }: { value: string; label: string; sub?: string }) {
+  return (
+    <div className="thr-stat">
+      <div className="thr-stat-value">{value}</div>
+      <div className="thr-stat-label">
+        {label}
+        {sub !== undefined && <span className="thr-stat-sub"> {sub}</span>}
+      </div>
+    </div>
+  );
+}
+
+// ---- Activity: the time charts, now full-width and tall enough to read ------------------------------
+
+function ActivityTab({ data }: { data: ThrottleData }) {
+  const hasTurns = data.hourlyTurns.length > 0;
+  const hasConcurrency = data.concurrency !== null && data.concurrency.hourly.length > 0;
+
+  if (!hasTurns && !hasConcurrency) {
+    return <div className="thr-empty">No hourly activity recorded in the last day yet.</div>;
+  }
+
+  return (
+    <>
+      {hasTurns && (
+        <div className="thr-panel">
+          <div className="thr-panel-head">
+            <h2>Turns per hour (last 24h)</h2>
+            <span className="thr-panel-sub">
+              Your working day: how many turns you submitted each hour (UTC), voice over typed. Empty
+              hours are when you were away.
+            </span>
+          </div>
+          <TurnsPerHourChart hourly={data.hourlyTurns} />
         </div>
       )}
 
-      {data !== null && data.concurrency !== null && (
-        <div className="thr-section">
-          <h2>Fleet concurrency</h2>
-          <p className="thr-hint">
-            How many sessions run at once across every machine. Loaded/running is the parallel capacity in
-            flight; actively working is the subset whose agent is processing a turn this instant.
-          </p>
+      {hasConcurrency && (
+        <div className="thr-panel">
+          <div className="thr-panel-head">
+            <h2>Sessions per hour (last 24h)</h2>
+            <span className="thr-panel-sub">
+              Peak concurrent sessions in each hour (UTC). The bar is loaded/running; the darker portion
+              is actively working. Hover a bar for that hour&apos;s distinct sessions and machines.
+            </span>
+          </div>
+          <ConcurrencyChart hourly={data.concurrency!.hourly} />
+        </div>
+      )}
+    </>
+  );
+}
+
+// A 24-hour bar chart of turns submitted per hour - the "working day" shape. Each bar is the total turns
+// that hour, stacked voice (accent) over typed (muted). Pure CSS bars.
+function TurnsPerHourChart({ hourly }: { hourly: InputHour[] }) {
+  const recent = hourly.slice(-24);
+  const peak = Math.max(1, ...recent.map((h) => h.turns));
+  return (
+    <>
+      <div
+        className="thr-chart thr-chart-tall"
+        role="img"
+        aria-label={`Turns submitted per hour for the last ${recent.length} hours`}
+      >
+        {recent.map((h, i) => {
+          const totalPct = (h.turns / peak) * 100;
+          const voicePortion = h.turns > 0 ? (h.voiceTurns / h.turns) * 100 : 0;
+          const typedPortion = h.turns > 0 ? (h.typedTurns / h.turns) * 100 : 0;
+          return (
+            <div
+              className="thr-bar-col"
+              key={h.hour}
+              title={`${h.hour}:00 UTC - ${h.turns} turns (${h.voiceTurns} voice, ${h.typedTurns} typed), ${h.characters.toLocaleString()} chars`}
+            >
+              <div className="thr-bar-track">
+                <div className="thr-turns-bar" style={{ height: `${totalPct}%` }}>
+                  <div className="thr-turns-typed" style={{ height: `${typedPortion}%` }} />
+                  <div className="thr-turns-voice" style={{ height: `${voicePortion}%` }} />
+                </div>
+              </div>
+              <div className="thr-bar-label">{i % 3 === 0 ? h.hour.slice(-2) : ""}</div>
+            </div>
+          );
+        })}
+      </div>
+      <div className="thr-legend">
+        <span className="thr-legend-item">
+          <span className="thr-swatch thr-swatch-voice" /> Voice
+        </span>
+        <span className="thr-legend-item">
+          <span className="thr-swatch thr-swatch-typed" /> Typed
+        </span>
+      </div>
+    </>
+  );
+}
+
+// A 24-hour bar chart of the hourly peak concurrent sessions. Each bar is the max loaded/running in that
+// hour; the darker inner portion is the max actively-working. Pure CSS bars.
+function ConcurrencyChart({ hourly }: { hourly: ConcurrencyHour[] }) {
+  const recent = hourly.slice(-24);
+  const peak = Math.max(1, ...recent.map((h) => h.maxLive));
+  return (
+    <>
+      <div
+        className="thr-chart thr-chart-tall"
+        role="img"
+        aria-label={`Peak concurrent sessions per hour for the last ${recent.length} hours`}
+      >
+        {recent.map((h, i) => {
+          const livePct = (h.maxLive / peak) * 100;
+          const workPct = h.maxLive > 0 ? (h.maxWorking / h.maxLive) * 100 : 0;
+          const hourNum = h.hour.slice(-2);
+          return (
+            <div
+              className="thr-bar-col"
+              key={h.hour}
+              title={`${h.hour}:00 UTC - ${h.maxLive} loaded, ${h.maxWorking} working, ${h.sessions} distinct sessions, ${h.machines} machine(s)`}
+            >
+              <div className="thr-bar-track">
+                <div className="thr-bar-live" style={{ height: `${livePct}%` }}>
+                  <div className="thr-bar-work" style={{ height: `${workPct}%` }} />
+                </div>
+              </div>
+              <div className="thr-bar-label">{i % 3 === 0 ? hourNum : ""}</div>
+            </div>
+          );
+        })}
+      </div>
+      <div className="thr-legend">
+        <span className="thr-legend-item">
+          <span className="thr-swatch thr-swatch-live" /> Loaded / running
+        </span>
+        <span className="thr-legend-item">
+          <span className="thr-swatch thr-swatch-voice" /> Actively working
+        </span>
+      </div>
+    </>
+  );
+}
+
+// ---- Breakdown: the supporting tables + honesty caveats ---------------------------------------------
+
+function BreakdownTab({ summary, data }: { summary: ThrottleSummary; data: ThrottleData }) {
+  return (
+    <>
+      {data.concurrency !== null && (
+        <div className="thr-panel">
+          <div className="thr-panel-head">
+            <h2>Fleet concurrency</h2>
+            <span className="thr-panel-sub">
+              How many sessions run at once across every machine. Loaded/running is the parallel capacity
+              in flight; actively working is the subset whose agent is processing a turn this instant.
+            </span>
+          </div>
           <table className="thr-table">
             <thead>
               <tr>
@@ -198,50 +496,12 @@ export function YourThrottleView() {
         </div>
       )}
 
-      {data !== null && data.concurrency !== null && data.concurrency.hourly.length > 0 && (
-        <div className="thr-section">
-          <h2>Sessions per hour (last 24h)</h2>
-          <p className="thr-hint">
-            Peak concurrent sessions in each hour (UTC). The bar is loaded/running; the darker portion is
-            actively working. Hover a bar for that hour's distinct sessions and machines.
-          </p>
-          <ConcurrencyChart hourly={data.concurrency.hourly} />
-        </div>
-      )}
-
-      {data !== null && data.hourlyTurns.length > 0 && (
-        <div className="thr-section">
-          <h2>Turns per hour (last 24h)</h2>
-          <p className="thr-hint">
-            Your working day: how many turns you submitted each hour (UTC), voice over typed. Empty hours
-            are when you were away.
-          </p>
-          <TurnsPerHourChart hourly={data.hourlyTurns} />
-        </div>
-      )}
-
-      {summary !== null && summary.hasData && (
+      {summary.hasData && (
         <>
-          <div className="thr-cards">
-            <HeadlineCard
-              label="Voice share of turns"
-              value={formatShare(summary.voiceShare)}
-              sub={`${summary.voiceTurns} of ${summary.totalTurns} turns spoken`}
-            />
-            <HeadlineCard
-              label="Phone share of turns"
-              value={formatShare(summary.phoneShare)}
-              sub={`${summary.turnsBySurface.phone} of ${summary.totalTurns} turns from phone`}
-            />
-            <HeadlineCard
-              label="Total turns"
-              value={String(summary.totalTurns)}
-              sub={`${summary.totalCharacters.toLocaleString()} characters`}
-            />
-          </div>
-
-          <div className="thr-section">
-            <h2>Turns by surface</h2>
+          <div className="thr-panel">
+            <div className="thr-panel-head">
+              <h2>Turns by surface</h2>
+            </div>
             <table className="thr-table">
               <thead>
                 <tr>
@@ -250,7 +510,7 @@ export function YourThrottleView() {
                 </tr>
               </thead>
               <tbody>
-                {SURFACE_ORDER.map((s) => (
+                {SURFACE_ORDER.map((s: Surface) => (
                   <tr key={s}>
                     <td>{SURFACE_LABEL[s]}</td>
                     <td className="thr-num">{summary.turnsBySurface[s]}</td>
@@ -260,8 +520,10 @@ export function YourThrottleView() {
             </table>
           </div>
 
-          <div className="thr-section">
-            <h2>Full breakdown</h2>
+          <div className="thr-panel">
+            <div className="thr-panel-head">
+              <h2>Full breakdown</h2>
+            </div>
             <table className="thr-table">
               <thead>
                 <tr>
@@ -272,14 +534,14 @@ export function YourThrottleView() {
                 </tr>
               </thead>
               <tbody>
-                {data!.buckets.length === 0 ? (
+                {data.buckets.length === 0 ? (
                   <tr>
                     <td colSpan={4} className="thr-muted">
                       No buckets yet.
                     </td>
                   </tr>
                 ) : (
-                  data!.buckets.map((b) => (
+                  data.buckets.map((b) => (
                     <tr key={`${b.modality}-${b.surface}`}>
                       <td>{MODALITY_LABEL[b.modality]}</td>
                       <td>{SURFACE_LABEL[b.surface]}</td>
@@ -294,7 +556,7 @@ export function YourThrottleView() {
         </>
       )}
 
-      {data !== null && data.notCaptured.length > 0 && (
+      {data.notCaptured.length > 0 && (
         <div className="thr-caveats">
           <h2>What these numbers do not include</h2>
           <ul>
@@ -304,6 +566,6 @@ export function YourThrottleView() {
           </ul>
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/apps/cockpit/src/throttle/throttle.css
+++ b/apps/cockpit/src/throttle/throttle.css
@@ -303,76 +303,111 @@
   color: var(--text-dim);
 }
 
-/* ---- Hourly bar charts (bigger than the old page so the shape is readable) ----------------------- */
-.thr-chart {
-  display: flex;
-  align-items: flex-end;
-  gap: 4px;
-  height: 130px;
-  padding: 10px 4px 0;
+/* ---- Hourly bar charts: a framed plot with a readable y-axis (ticks + recessive gridlines) -------- */
+.thr-chartframe {
+  --thr-plot-h: 160px;
+  --thr-yaxis-w: 34px;
+  --thr-col-gap: 4px;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 12px;
+  padding: 14px 16px 10px;
 }
-.thr-chart-tall {
-  height: 240px;
+.thr-chartframe.tall {
+  --thr-plot-h: 240px;
 }
-.thr-bar-col {
-  flex: 1 1 0;
+.thr-plotrow {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  height: 100%;
+  gap: 8px;
+}
+/* The y-axis: tick labels absolutely placed at their value's height, centered on their gridline. */
+.thr-yaxis {
+  position: relative;
+  width: var(--thr-yaxis-w);
+  height: var(--thr-plot-h);
+  flex: none;
+}
+.thr-ytick {
+  position: absolute;
+  right: 0;
+  width: 100%;
+  transform: translateY(50%);
+  text-align: right;
+  padding-right: 4px;
+  font-size: 10px;
+  line-height: 1;
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+/* The plot: gridlines behind, bars in front (bars are position:relative so they win the stack). */
+.thr-plot {
+  position: relative;
+  flex: 1 1 0;
+  height: var(--thr-plot-h);
+  display: flex;
+  align-items: flex-end;
+  gap: var(--thr-col-gap);
   min-width: 0;
 }
-.thr-bar-track {
-  width: 100%;
-  max-width: 22px;
-  flex: 1 1 auto;
-  display: flex;
-  align-items: flex-end;
+.thr-gridline {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--border);
+  opacity: 0.55;
 }
-.thr-chart-tall .thr-bar-track {
+.thr-col {
+  position: relative;
+  flex: 1 1 0;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  min-width: 0;
+}
+.thr-bar {
+  width: 100%;
   max-width: 40px;
-}
-.thr-bar-live {
-  width: 100%;
-  background: color-mix(in srgb, var(--accent) 32%, transparent);
-  border-radius: 4px 4px 0 0;
-  display: flex;
-  align-items: flex-end;
   min-height: 1px;
-}
-.thr-bar-work {
-  width: 100%;
-  background: var(--accent);
-  border-radius: 4px 4px 0 0;
-}
-.thr-bar-label {
-  font-size: 10px;
-  color: var(--text-dim);
-  margin-top: 6px;
-  height: 12px;
-  font-variant-numeric: tabular-nums;
-}
-
-/* Turns-per-hour stacked bar (voice over typed) */
-.thr-turns-bar {
-  width: 100%;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
   border-radius: 4px 4px 0 0;
   overflow: hidden;
-  min-height: 1px;
 }
-.thr-turns-voice {
+.thr-seg {
   width: 100%;
+}
+.thr-seg-voice {
   background: var(--accent);
 }
-.thr-turns-typed {
-  width: 100%;
+.thr-seg-typed {
   background: var(--thr-muted);
+}
+/* Concurrency bars: the outer bar is loaded/running (accent, faded); the inner bar is actively working
+   (accent, solid), anchored to the baseline. */
+.thr-bar-live {
+  background: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+.thr-seg-work {
+  background: var(--accent);
+}
+/* The x-axis row, offset by the y-axis gutter so each label sits under its bar. */
+.thr-xrow {
+  display: flex;
+  gap: var(--thr-col-gap);
+  padding-left: calc(var(--thr-yaxis-w) + 8px);
+  margin-top: 7px;
+}
+.thr-xlabel {
+  flex: 1 1 0;
+  min-width: 0;
+  text-align: center;
+  font-size: 10px;
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
 }
 
 .thr-legend {

--- a/apps/cockpit/src/throttle/throttle.css
+++ b/apps/cockpit/src/throttle/throttle.css
@@ -9,6 +9,7 @@
      the colors are reinforcement, not the sole carrier of identity. */
   --thr-voice: var(--accent);
   --thr-mobile: #8b5cf6;
+  --thr-wingman: #14b8a6;
   --thr-track: color-mix(in srgb, var(--text-dim) 20%, transparent);
   --thr-muted: color-mix(in srgb, var(--text-dim) 55%, transparent);
 }
@@ -81,7 +82,7 @@
 /* ---- Overview: hero rings ------------------------------------------------------------------------ */
 .thr-heroes {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 18px;
   margin-bottom: 22px;
 }
@@ -173,6 +174,12 @@
 }
 .thr-dot-muted {
   background: var(--thr-muted);
+}
+.thr-hero-note {
+  margin-top: 12px;
+  font-size: 12px;
+  color: var(--text-dim);
+  text-align: center;
 }
 
 /* ---- Panels (a titled section wrapping a chart, table, or bar) ----------------------------------- */

--- a/apps/cockpit/src/throttle/throttle.css
+++ b/apps/cockpit/src/throttle/throttle.css
@@ -1,9 +1,16 @@
-/* Your Throttle page (devthrottle-stats mission) - the in-Cockpit port of the standalone Gateway
-   /stats page. Rendered as normal scrolling content inside the padded main pane. Every color is a
-   token from the app theme (src/styles.css :root); nothing hard-codes a color so the page reads as one
-   product in both light and dark. */
+/* Your Throttle page (devthrottle-stats mission). A tabbed dashboard: Overview leads with the two
+   headline percentages as big rings, Activity holds the larger time charts, Breakdown holds the tables.
+   The app is dark-only; every color is a token from the theme (src/styles.css :root) plus the two local
+   accent tokens below, so the page reads as one product. */
 .thr {
-  max-width: 860px;
+  max-width: 1040px;
+  /* Local accents for the two hero metrics: voice rides the product accent; mobile gets a companion
+     violet so the two headline rings read as distinct metrics at a glance. Each ring is self-labeled, so
+     the colors are reinforcement, not the sole carrier of identity. */
+  --thr-voice: var(--accent);
+  --thr-mobile: #8b5cf6;
+  --thr-track: color-mix(in srgb, var(--text-dim) 20%, transparent);
+  --thr-muted: color-mix(in srgb, var(--text-dim) 55%, transparent);
 }
 
 .thr .page-head {
@@ -18,7 +25,7 @@
   color: var(--text-dim);
   font-size: 13px;
   margin: 0;
-  max-width: 640px;
+  max-width: 680px;
 }
 
 .thr-banner {
@@ -38,52 +45,233 @@
   padding: 24px 0;
 }
 
-/* Headline metric cards */
-.thr-cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 14px;
-  margin-bottom: 24px;
+/* ---- Tabs ---------------------------------------------------------------------------------------- */
+.thr-tabs {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 22px;
 }
-.thr-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 16px 18px;
-}
-.thr-card-value {
-  font-size: 32px;
-  font-weight: 700;
-  color: var(--accent);
-  line-height: 1.1;
-}
-.thr-card-label {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text);
-  margin-top: 6px;
-}
-.thr-card-sub {
-  font-size: 12px;
+.thr-tab {
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
   color: var(--text-dim);
-  margin-top: 2px;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 9px 16px;
+  margin-bottom: -1px;
+  cursor: pointer;
+}
+.thr-tab:hover {
+  color: var(--text);
+}
+.thr-tab.active {
+  color: var(--text);
+  border-bottom-color: var(--accent);
+  font-weight: 600;
+}
+.thr-tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  border-radius: 4px 4px 0 0;
 }
 
-/* Breakdown tables */
-.thr-section {
-  margin-bottom: 24px;
+/* ---- Overview: hero rings ------------------------------------------------------------------------ */
+.thr-heroes {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 18px;
+  margin-bottom: 22px;
 }
-.thr-section h2 {
+.thr-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: linear-gradient(180deg, var(--surface) 0%, var(--bg) 140%);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 24px 20px 22px;
+}
+.thr-hero-title {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin-bottom: 18px;
+}
+.thr-ring {
+  position: relative;
+  width: 210px;
+  height: 210px;
+}
+.thr-ring-svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+.thr-ring-track {
+  fill: none;
+  stroke: var(--thr-track);
+  stroke-width: 10;
+}
+.thr-ring-arc {
+  fill: none;
+  stroke: var(--thr-arc);
+  stroke-width: 11;
+  stroke-linecap: round;
+  filter: drop-shadow(0 0 5px color-mix(in srgb, var(--thr-arc) 55%, transparent));
+  transition: stroke-dasharray 500ms ease;
+}
+.thr-ring-center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+.thr-ring-pct {
+  font-size: 52px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+.thr-ring-cap {
+  font-size: 13px;
+  color: var(--text-dim);
+  margin-top: 6px;
+}
+.thr-hero-legend {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px 20px;
+  margin-top: 20px;
+  font-size: 13px;
+  color: var(--text-dim);
+}
+.thr-hero-leg {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+.thr-hero-leg b {
+  color: var(--text);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.thr-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+  flex: none;
+}
+.thr-dot-muted {
+  background: var(--thr-muted);
+}
+
+/* ---- Panels (a titled section wrapping a chart, table, or bar) ----------------------------------- */
+.thr-panel {
+  margin-bottom: 22px;
+}
+.thr-panel-head {
+  margin-bottom: 12px;
+}
+.thr-panel-head h2 {
   font-size: 15px;
   font-weight: 600;
-  margin: 0 0 10px;
+  margin: 0;
 }
-.thr-hint {
+.thr-panel-sub {
+  display: block;
   font-size: 12px;
   color: var(--text-dim);
-  margin: 0 0 10px;
-  max-width: 600px;
+  margin-top: 4px;
+  max-width: 680px;
 }
+
+/* ---- Surface split bar --------------------------------------------------------------------------- */
+.thr-split {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 16px 18px;
+}
+.thr-split-bar {
+  display: flex;
+  width: 100%;
+  height: 30px;
+  border-radius: 8px;
+  overflow: hidden;
+  gap: 2px;
+  background: var(--bg);
+}
+.thr-split-seg {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2px;
+  transition: width 500ms ease;
+}
+.thr-split-lbl {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+.thr-split-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+  margin-top: 14px;
+  font-size: 13px;
+  color: var(--text-dim);
+}
+.thr-split-leg {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+.thr-split-leg b {
+  color: var(--text);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---- Supporting stat tiles ----------------------------------------------------------------------- */
+.thr-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 14px;
+}
+.thr-stat {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 16px 18px;
+}
+.thr-stat-value {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+}
+.thr-stat-label {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-top: 6px;
+}
+.thr-stat-sub {
+  opacity: 0.75;
+}
+
+/* ---- Breakdown tables ---------------------------------------------------------------------------- */
 .thr-table {
   width: 100%;
   border-collapse: collapse;
@@ -115,16 +303,19 @@
   color: var(--text-dim);
 }
 
-/* 24-hour concurrency bar chart */
+/* ---- Hourly bar charts (bigger than the old page so the shape is readable) ----------------------- */
 .thr-chart {
   display: flex;
   align-items: flex-end;
-  gap: 3px;
+  gap: 4px;
   height: 130px;
-  padding: 8px 2px 0;
+  padding: 10px 4px 0;
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: 12px;
+}
+.thr-chart-tall {
+  height: 240px;
 }
 .thr-bar-col {
   flex: 1 1 0;
@@ -141,10 +332,13 @@
   display: flex;
   align-items: flex-end;
 }
+.thr-chart-tall .thr-bar-track {
+  max-width: 40px;
+}
 .thr-bar-live {
   width: 100%;
   background: color-mix(in srgb, var(--accent) 32%, transparent);
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
   display: flex;
   align-items: flex-end;
   min-height: 1px;
@@ -152,12 +346,12 @@
 .thr-bar-work {
   width: 100%;
   background: var(--accent);
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
 }
 .thr-bar-label {
-  font-size: 9px;
+  font-size: 10px;
   color: var(--text-dim);
-  margin-top: 4px;
+  margin-top: 6px;
   height: 12px;
   font-variant-numeric: tabular-nums;
 }
@@ -168,7 +362,7 @@
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px 4px 0 0;
   overflow: hidden;
   min-height: 1px;
 }
@@ -178,34 +372,38 @@
 }
 .thr-turns-typed {
   width: 100%;
-  background: color-mix(in srgb, var(--text-dim) 55%, transparent);
+  background: var(--thr-muted);
 }
+
 .thr-legend {
   display: flex;
-  gap: 16px;
-  margin-top: 8px;
-  font-size: 11px;
+  gap: 18px;
+  margin-top: 10px;
+  font-size: 12px;
   color: var(--text-dim);
 }
 .thr-legend-item {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
 }
 .thr-swatch {
-  width: 10px;
-  height: 10px;
-  border-radius: 2px;
+  width: 11px;
+  height: 11px;
+  border-radius: 3px;
   display: inline-block;
 }
 .thr-swatch-voice {
   background: var(--accent);
 }
 .thr-swatch-typed {
-  background: color-mix(in srgb, var(--text-dim) 55%, transparent);
+  background: var(--thr-muted);
+}
+.thr-swatch-live {
+  background: color-mix(in srgb, var(--accent) 32%, transparent);
 }
 
-/* Honesty caveats */
+/* ---- Honesty caveats ----------------------------------------------------------------------------- */
 .thr-caveats {
   background: var(--surface-2);
   border: 1px solid var(--border);

--- a/apps/mobile/src/pages/YourThrottle.tsx
+++ b/apps/mobile/src/pages/YourThrottle.tsx
@@ -1,100 +1,29 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import {
   getThrottle,
   summarizeThrottle,
   formatShare,
-  MODALITY_LABEL,
   SURFACE_LABEL,
   SURFACE_ORDER,
   type ThrottleData,
   type ThrottleSummary,
-  type ConcurrencyHour,
-  type InputHour,
 } from "@devthrottle/client-core/stats/statsClient";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 
-// Your Throttle (devthrottle-stats mission): the in-app port of the standalone Gateway /stats page for
-// the phone. Reads the same GET /stats/data feed the Cockpit reads, so the phone shows the same numbers
-// in the app the user already has open. Renders immediately with a loading state, loads asynchronously,
-// shows an explicit error banner on failure (no-fallback rule), and auto-refreshes so the split moves
-// live as the user drives by voice.
+// Your Throttle on the phone (devthrottle-stats mission): a compact dashboard of the MAIN stats, not the
+// whole desktop page - many people drive the fleet mostly from their phone, so this is a clean, glanceable
+// view of how they work. It reads the same GET /stats/data feed as the Cockpit, so the numbers match.
+// Leads with the three headline rings (spoken, from phone, wingman voice mode), then where the turns come
+// from, then the totals. The hourly charts, full breakdown, and caveats stay on the desktop page.
+// Renders immediately with a loading state, shows an explicit error banner on failure (no-fallback rule),
+// and auto-refreshes so the split moves live as the user drives by voice.
 
 const REFRESH_MS = 10_000;
 
-/** A 24-hour bar chart of the hourly peak concurrent sessions. Bar = max loaded/running that hour;
- * darker inner portion = max actively-working. Pure CSS bars, theme-aware. */
-function ConcurrencyChart({ hourly }: { hourly: ConcurrencyHour[] }) {
-  const recent = hourly.slice(-24);
-  const peak = Math.max(1, ...recent.map((h) => h.maxLive));
-  return (
-    <div
-      className="thr-chart"
-      role="img"
-      aria-label={`Peak concurrent sessions per hour for the last ${recent.length} hours`}
-    >
-      {recent.map((h, i) => {
-        const livePct = (h.maxLive / peak) * 100;
-        const workPct = h.maxLive > 0 ? (h.maxWorking / h.maxLive) * 100 : 0;
-        return (
-          <div
-            className="thr-bar-col"
-            key={h.hour}
-            title={`${h.hour}:00 UTC - ${h.maxLive} loaded, ${h.maxWorking} working, ${h.sessions} sessions`}
-          >
-            <div className="thr-bar-track">
-              <div className="thr-bar-live" style={{ height: `${livePct}%` }}>
-                <div className="thr-bar-work" style={{ height: `${workPct}%` }} />
-              </div>
-            </div>
-            <div className="thr-bar-label">{i % 6 === 0 ? h.hour.slice(-2) : ""}</div>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-/** A 24-hour bar chart of turns submitted per hour - the "working day" shape. Bar = total turns that
- * hour, stacked voice (accent) over typed (muted). Pure CSS bars, theme-aware. */
-function TurnsPerHourChart({ hourly }: { hourly: InputHour[] }) {
-  const recent = hourly.slice(-24);
-  const peak = Math.max(1, ...recent.map((h) => h.turns));
-  return (
-    <>
-      <div
-        className="thr-chart"
-        role="img"
-        aria-label={`Turns submitted per hour for the last ${recent.length} hours`}
-      >
-        {recent.map((h, i) => {
-          const totalPct = (h.turns / peak) * 100;
-          const voicePortion = h.turns > 0 ? (h.voiceTurns / h.turns) * 100 : 0;
-          const typedPortion = h.turns > 0 ? (h.typedTurns / h.turns) * 100 : 0;
-          return (
-            <div
-              className="thr-bar-col"
-              key={h.hour}
-              title={`${h.hour}:00 UTC - ${h.turns} turns (${h.voiceTurns} voice, ${h.typedTurns} typed)`}
-            >
-              <div className="thr-bar-track">
-                <div className="thr-turns-bar" style={{ height: `${totalPct}%` }}>
-                  <div className="thr-turns-typed" style={{ height: `${typedPortion}%` }} />
-                  <div className="thr-turns-voice" style={{ height: `${voicePortion}%` }} />
-                </div>
-              </div>
-              <div className="thr-bar-label">{i % 6 === 0 ? h.hour.slice(-2) : ""}</div>
-            </div>
-          );
-        })}
-      </div>
-      <div className="thr-legend">
-        <span className="thr-legend-item"><span className="thr-swatch thr-swatch-voice" /> Voice</span>
-        <span className="thr-legend-item"><span className="thr-swatch thr-swatch-typed" /> Typed</span>
-      </div>
-    </>
-  );
-}
+const RING_VOICE = "var(--accent)";
+const RING_MOBILE = "#8b5cf6";
+const RING_WINGMAN = "#14b8a6";
 
 export function YourThrottle() {
   const [data, setData] = useState<ThrottleData | null>(null);
@@ -142,7 +71,7 @@ export function YourThrottle() {
         </div>
       )}
 
-      {summary === null && error === null && <div className="thr-note">Loading...</div>}
+      {summary === null && error === null && <div className="thr-note">Loading your throttle...</div>}
 
       {summary !== null && !summary.hasData && (
         <div className="thr-note">
@@ -150,97 +79,145 @@ export function YourThrottle() {
         </div>
       )}
 
-      {data !== null && data.concurrency !== null && (
-        <section className="thr-list" aria-label="Fleet concurrency">
-          <div className="thr-list-title">Fleet concurrency</div>
-          <div className="thr-row">
-            <span className="thr-row-label">Loaded / running</span>
-            <span className="thr-row-value">
-              {data.concurrency.live.current} now, {data.concurrency.live.allTimeMax} peak
-            </span>
-          </div>
-          <div className="thr-row">
-            <span className="thr-row-label">Actively working</span>
-            <span className="thr-row-value">
-              {data.concurrency.working.current} now, {data.concurrency.working.allTimeMax} peak
-            </span>
-          </div>
-        </section>
-      )}
-
-      {data !== null && data.concurrency !== null && data.concurrency.hourly.length > 0 && (
-        <section className="thr-list" aria-label="Sessions per hour">
-          <div className="thr-list-title">Sessions per hour (last 24h)</div>
-          <ConcurrencyChart hourly={data.concurrency.hourly} />
-        </section>
-      )}
-
-      {data !== null && data.hourlyTurns.length > 0 && (
-        <section className="thr-list" aria-label="Turns per hour">
-          <div className="thr-list-title">Turns per hour (last 24h)</div>
-          <TurnsPerHourChart hourly={data.hourlyTurns} />
-        </section>
-      )}
-
-      {summary !== null && summary.hasData && (
-        <>
-          <section className="thr-cards" aria-label="Headline shares">
-            <div className="thr-card">
-              <div className="thr-card-value">{formatShare(summary.voiceShare)}</div>
-              <div className="thr-card-label">Voice</div>
-            </div>
-            <div className="thr-card">
-              <div className="thr-card-value">{formatShare(summary.phoneShare)}</div>
-              <div className="thr-card-label">Phone</div>
-            </div>
-            <div className="thr-card">
-              <div className="thr-card-value">{summary.totalTurns}</div>
-              <div className="thr-card-label">Turns</div>
-            </div>
-          </section>
-
-          <div className="thr-caption">
-            {summary.voiceTurns} of {summary.totalTurns} turns spoken;{" "}
-            {summary.turnsBySurface.phone} of {summary.totalTurns} from phone.{" "}
-            {summary.totalCharacters.toLocaleString()} characters total.
+      {data !== null && summary !== null && summary.hasData && (
+        <div className="mthr">
+          <div className="mthr-metrics">
+            <MetricRing
+              title="Voice vs typing"
+              share={summary.voiceShare}
+              color={RING_VOICE}
+              primary={{ label: "Voice", count: summary.voiceTurns }}
+              secondary={{ label: "Typed", count: summary.typedTurns }}
+            />
+            <MetricRing
+              title="Mobile vs desktop"
+              share={summary.phoneShare}
+              color={RING_MOBILE}
+              primary={{ label: "Phone", count: summary.turnsBySurface.phone }}
+              secondary={{ label: "Desk + Cockpit", count: summary.totalTurns - summary.turnsBySurface.phone }}
+            />
+            <MetricRing
+              title="Wingman (voice mode)"
+              share={summary.totalTurns > 0 ? data.wingman.turns / summary.totalTurns : null}
+              color={RING_WINGMAN}
+              primary={{ label: "Voice mode", count: data.wingman.turns }}
+              secondary={{ label: "Hands-on", count: Math.max(0, summary.totalTurns - data.wingman.turns) }}
+              note={`${data.wingman.sessions.toLocaleString()} session${data.wingman.sessions === 1 ? "" : "s"} used the wingman`}
+            />
           </div>
 
-          <section className="thr-list" aria-label="Turns by surface">
-            <div className="thr-list-title">Turns by surface</div>
-            {SURFACE_ORDER.map((s) => (
-              <div className="thr-row" key={s}>
-                <span className="thr-row-label">{SURFACE_LABEL[s]}</span>
-                <span className="thr-row-value">{summary.turnsBySurface[s]}</span>
-              </div>
-            ))}
-          </section>
+          <SurfaceSplitBar summary={summary} />
 
-          <section className="thr-list" aria-label="Full breakdown">
-            <div className="thr-list-title">Full breakdown</div>
-            {data!.buckets.map((b) => (
-              <div className="thr-row" key={`${b.modality}-${b.surface}`}>
-                <span className="thr-row-label">
-                  {MODALITY_LABEL[b.modality]} / {SURFACE_LABEL[b.surface]}
-                </span>
-                <span className="thr-row-value">
-                  {b.turns} turns, {b.characters.toLocaleString()} chars
-                </span>
-              </div>
-            ))}
-          </section>
-        </>
-      )}
+          <div className="mthr-stats">
+            <div className="mthr-stat">
+              <div className="mthr-stat-value">{summary.totalTurns.toLocaleString()}</div>
+              <div className="mthr-stat-label">Total turns</div>
+            </div>
+            <div className="mthr-stat">
+              <div className="mthr-stat-value">{summary.totalCharacters.toLocaleString()}</div>
+              <div className="mthr-stat-label">Characters</div>
+            </div>
+          </div>
 
-      {data !== null && data.notCaptured.length > 0 && (
-        <section className="thr-caveats" aria-label="What is not included">
-          <div className="thr-list-title">What these numbers do not include</div>
-          <ul>
-            {data.notCaptured.map((c, i) => (
-              <li key={i}>{c}</li>
-            ))}
-          </ul>
-        </section>
+          <p className="mthr-foot">
+            The full hourly charts and breakdown live on Your Throttle in the desktop Cockpit.
+          </p>
+        </div>
       )}
     </div>
+  );
+}
+
+// One metric as a compact card: a donut ring (the share) on the left, the title and the two named counts
+// on the right. role="img" + aria-label so the number is announced; the counts carry identity so it is
+// never color-alone.
+function MetricRing({
+  title,
+  share,
+  color,
+  primary,
+  secondary,
+  note,
+}: {
+  title: string;
+  share: number | null;
+  color: string;
+  primary: { label: string; count: number };
+  secondary: { label: string; count: number };
+  note?: string;
+}) {
+  const R = 42;
+  const C = 2 * Math.PI * R;
+  const filled = share === null ? 0 : share * C;
+  const pctText = formatShare(share);
+
+  return (
+    <section className="mthr-metric">
+      <div
+        className="mthr-ring"
+        role="img"
+        aria-label={`${title}: ${primary.label} ${pctText} (${primary.count} of ${primary.count + secondary.count} turns)`}
+      >
+        <svg viewBox="0 0 100 100" className="mthr-ring-svg" style={{ ["--mthr-arc" as string]: color } as CSSProperties}>
+          <circle className="mthr-ring-track" cx="50" cy="50" r={R} />
+          <circle className="mthr-ring-arc" cx="50" cy="50" r={R} style={{ strokeDasharray: `${filled} ${C}` }} />
+        </svg>
+        <div className="mthr-ring-pct">{pctText}</div>
+      </div>
+      <div className="mthr-metric-body">
+        <div className="mthr-metric-title">{title}</div>
+        <div className="mthr-metric-legend">
+          <span className="mthr-leg">
+            <span className="mthr-dot" style={{ background: color }} />
+            {primary.label} <b>{primary.count.toLocaleString()}</b>
+          </span>
+          <span className="mthr-leg">
+            <span className="mthr-dot mthr-dot-muted" />
+            {secondary.label} <b>{secondary.count.toLocaleString()}</b>
+          </span>
+        </div>
+        {note !== undefined && <div className="mthr-metric-note">{note}</div>}
+      </div>
+    </section>
+  );
+}
+
+// A single horizontal stacked bar of turns by surface (largest first, brightest first), plus a legend -
+// the compact "where you drive from" the phone version keeps.
+function SurfaceSplitBar({ summary }: { summary: ThrottleSummary }) {
+  const total = summary.totalTurns;
+  const segments = SURFACE_ORDER.map((s) => ({ surface: s, turns: summary.turnsBySurface[s] }))
+    .filter((seg) => seg.turns > 0)
+    .sort((a, b) => b.turns - a.turns);
+  const fill = (i: number) => {
+    const o = [100, 66, 42, 26][Math.min(i, 3)];
+    return `color-mix(in srgb, var(--accent) ${o}%, transparent)`;
+  };
+
+  return (
+    <section className="mthr-split" aria-label="Where you drive from">
+      <div className="mthr-split-title">Where you drive from</div>
+      <div className="mthr-split-bar">
+        {segments.map((seg, i) => {
+          const pct = total > 0 ? (seg.turns / total) * 100 : 0;
+          return (
+            <div
+              key={seg.surface}
+              className="mthr-split-seg"
+              style={{ width: `${pct}%`, background: fill(i) }}
+              title={`${SURFACE_LABEL[seg.surface]}: ${seg.turns} (${Math.round(pct)}%)`}
+            />
+          );
+        })}
+      </div>
+      <div className="mthr-split-legend">
+        {segments.map((seg, i) => (
+          <span key={seg.surface} className="mthr-leg">
+            <span className="mthr-dot" style={{ background: fill(i) }} />
+            {SURFACE_LABEL[seg.surface]} <b>{seg.turns.toLocaleString()}</b>
+          </span>
+        ))}
+      </div>
+    </section>
   );
 }

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -3242,3 +3242,165 @@ a.banner-btn {
 .thr-swatch-typed {
   background: color-mix(in srgb, var(--text-dim) 55%, transparent);
 }
+
+/* Your Throttle mobile dashboard (devthrottle-stats): the compact headline view - three metric rings,
+   a surface split, and the totals. The heavy tables/charts stay on the desktop page. */
+.mthr {
+  padding: 12px 14px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.mthr-metrics {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.mthr-metric {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 14px 16px;
+}
+.mthr-ring {
+  position: relative;
+  width: 88px;
+  height: 88px;
+  flex: none;
+}
+.mthr-ring-svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+.mthr-ring-track {
+  fill: none;
+  stroke: color-mix(in srgb, var(--text-dim) 20%, transparent);
+  stroke-width: 10;
+}
+.mthr-ring-arc {
+  fill: none;
+  stroke: var(--mthr-arc);
+  stroke-width: 11;
+  stroke-linecap: round;
+  filter: drop-shadow(0 0 4px color-mix(in srgb, var(--mthr-arc) 55%, transparent));
+  transition: stroke-dasharray 500ms ease;
+}
+.mthr-ring-pct {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+.mthr-metric-body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.mthr-metric-title {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin-bottom: 8px;
+}
+.mthr-metric-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.mthr-leg {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-dim);
+}
+.mthr-leg b {
+  color: var(--text);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.mthr-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  flex: none;
+  display: inline-block;
+}
+.mthr-dot-muted {
+  background: color-mix(in srgb, var(--text-dim) 55%, transparent);
+}
+.mthr-metric-note {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.mthr-split {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 14px 16px;
+}
+.mthr-split-title {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin-bottom: 10px;
+}
+.mthr-split-bar {
+  display: flex;
+  height: 26px;
+  border-radius: 7px;
+  overflow: hidden;
+  gap: 2px;
+  background: var(--bg);
+}
+.mthr-split-seg {
+  min-width: 2px;
+  transition: width 500ms ease;
+}
+.mthr-split-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  margin-top: 12px;
+}
+.mthr-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+.mthr-stat {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 14px 16px;
+}
+.mthr-stat-value {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+.mthr-stat-label {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-top: 4px;
+}
+.mthr-foot {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin: 4px 2px 0;
+  text-align: center;
+}

--- a/packages/client-core/src/settings/settingsClient.ts
+++ b/packages/client-core/src/settings/settingsClient.ts
@@ -42,6 +42,11 @@ export interface GatewaySettings {
   // Snooze Length mission: the per-user default snooze length in minutes (one value across every device,
   // because they all talk to this one Gateway). Default 60.
   snoozeDefaultMinutes: number;
+  // The display time zone (IANA id) the private dashboards' hourly charts read local hours in. Auto-
+  // defaults to the Gateway machine's own zone when unset; the owner can override it here.
+  timeZone: string;
+  // What "automatic" resolves to: the Gateway machine's own zone. Lets the page show it and offer a reset.
+  timeZoneMachineDefault: string;
 }
 
 async function gatewayErrorFrom(res: Response, label: string): Promise<GatewayError> {
@@ -111,7 +116,20 @@ export async function getGatewaySettings(signal?: AbortSignal): Promise<GatewayS
     wingmanTrainingCapture: Boolean(body.wingmanTrainingCapture),
     telemetryConsent: Boolean(body.telemetryConsent),
     snoozeDefaultMinutes: Number(body.snoozeDefaultMinutes ?? 60),
+    timeZone: typeof body.timeZone === "string" && body.timeZone.length > 0 ? body.timeZone : "UTC",
+    timeZoneMachineDefault:
+      typeof body.timeZoneMachineDefault === "string" && body.timeZoneMachineDefault.length > 0
+        ? body.timeZoneMachineDefault
+        : "UTC",
   };
+}
+
+// PUT /gateway/time-zone { timeZone } - set the display time zone (an IANA id) the private dashboards read
+// local hours in. Read at render time, so a change applies on the next refresh with no restart. Returns
+// the applied id.
+export async function setTimeZone(timeZone: string, signal?: AbortSignal): Promise<string> {
+  const body = await putJson<{ timeZone?: string }>("/gateway/time-zone", "PUT /gateway/time-zone", { timeZone }, signal);
+  return typeof body.timeZone === "string" && body.timeZone.length > 0 ? body.timeZone : timeZone;
 }
 
 // PUT /gateway/snooze-default { minutes } - set the per-user default snooze length (Snooze Length

--- a/packages/client-core/src/stats/statsClient.test.ts
+++ b/packages/client-core/src/stats/statsClient.test.ts
@@ -1,11 +1,28 @@
 import { describe, it, expect } from "vitest";
-import { summarizeThrottle, formatShare, type ThrottleData } from "./statsClient";
+import {
+  summarizeThrottle,
+  formatShare,
+  last24HourKeys,
+  windowSeries,
+  emptyInputHour,
+  localHourLabel,
+  safeTimeZone,
+  type ThrottleData,
+  type InputHour,
+} from "./statsClient";
 
 // The pure "Your Throttle" summary math (devthrottle-stats mission). The network read (getThrottle) is
 // exercised through the app; here we lock the honest share arithmetic that both shells render.
 
 function data(buckets: ThrottleData["buckets"]): ThrottleData {
-  return { generatedAtUtc: "2026-07-11T00:00:00Z", buckets, hourlyTurns: [], concurrency: null, notCaptured: [] };
+  return {
+    generatedAtUtc: "2026-07-11T00:00:00Z",
+    timeZone: "UTC",
+    buckets,
+    hourlyTurns: [],
+    concurrency: null,
+    notCaptured: [],
+  };
 }
 
 describe("summarizeThrottle", () => {
@@ -56,5 +73,59 @@ describe("formatShare", () => {
 
   it("renders no-data as an ASCII placeholder, never a fabricated 0%", () => {
     expect(formatShare(null)).toBe("n/a");
+  });
+});
+
+describe("last24HourKeys", () => {
+  it("returns 24 consecutive UTC hour keys ending at the current hour, oldest first", () => {
+    const keys = last24HourKeys(new Date("2026-07-13T17:42:00Z"));
+    expect(keys).toHaveLength(24);
+    expect(keys[23]).toBe("2026-07-13T17"); // the hour containing "now"
+    expect(keys[22]).toBe("2026-07-13T16");
+    expect(keys[0]).toBe("2026-07-12T18"); // 23 hours earlier, across the day boundary
+  });
+});
+
+describe("windowSeries", () => {
+  it("aligns a sparse series onto the window and zero-fills the gaps", () => {
+    const keys = last24HourKeys(new Date("2026-07-13T02:00:00Z"));
+    const sparse: InputHour[] = [
+      { hour: "2026-07-13T01", turns: 5, voiceTurns: 4, typedTurns: 1, characters: 200 },
+    ];
+    const windowed = windowSeries(sparse, keys, emptyInputHour);
+    expect(windowed).toHaveLength(24);
+    // The one populated hour lands in its slot; every other hour is a real zero entry.
+    expect(windowed[23]).toEqual({ hour: "2026-07-13T02", turns: 0, voiceTurns: 0, typedTurns: 0, characters: 0 });
+    expect(windowed[22]).toEqual(sparse[0]);
+    expect(windowed[0].turns).toBe(0);
+  });
+
+  it("gives two different series the SAME aligned window so charts line up", () => {
+    const keys = last24HourKeys(new Date("2026-07-13T10:00:00Z"));
+    const a = windowSeries([{ hour: "2026-07-13T02", turns: 3, voiceTurns: 3, typedTurns: 0, characters: 9 }], keys, emptyInputHour);
+    const b = windowSeries([{ hour: "2026-07-13T09", turns: 7, voiceTurns: 1, typedTurns: 6, characters: 40 }], keys, emptyInputHour);
+    expect(a.map((h) => h.hour)).toEqual(b.map((h) => h.hour)); // identical hour axis -> aligned
+  });
+});
+
+describe("localHourLabel", () => {
+  it("formats a UTC hour key as the local 2-digit hour in the given zone", () => {
+    // 17:00 UTC on a July date is 13:00 in New York (EDT, UTC-4) and 17:00 in UTC.
+    expect(localHourLabel("2026-07-13T17", "UTC")).toBe("17");
+    expect(localHourLabel("2026-07-13T17", "America/New_York")).toBe("13");
+  });
+});
+
+describe("safeTimeZone", () => {
+  it("passes a usable zone through", () => {
+    expect(safeTimeZone("UTC")).toBe("UTC");
+    expect(safeTimeZone("America/New_York")).toBe("America/New_York");
+  });
+
+  it("falls back to a usable zone for a bad or empty id (never throws)", () => {
+    const fallback = safeTimeZone("Not/AZone");
+    // Whatever it resolves to, it must be a zone Intl can actually format with.
+    expect(() => new Intl.DateTimeFormat("en-US", { timeZone: fallback })).not.toThrow();
+    expect(safeTimeZone("").length).toBeGreaterThan(0);
   });
 });

--- a/packages/client-core/src/stats/statsClient.test.ts
+++ b/packages/client-core/src/stats/statsClient.test.ts
@@ -21,6 +21,7 @@ function data(buckets: ThrottleData["buckets"]): ThrottleData {
     buckets,
     hourlyTurns: [],
     concurrency: null,
+    wingman: { turns: 0, sessions: 0 },
     notCaptured: [],
   };
 }

--- a/packages/client-core/src/stats/statsClient.ts
+++ b/packages/client-core/src/stats/statsClient.ts
@@ -79,8 +79,17 @@ export interface ThrottleData {
   hourlyTurns: InputHour[];
   /** Fleet concurrency (both series), or null when nothing tracked yet. */
   concurrency: ConcurrencyStats | null;
+  /** Wingman usage (a session "uses the wingman" when it has voice mode on). */
+  wingman: WingmanUsage;
   /** Plain-English caveats about what the numbers do and do not include. */
   notCaptured: string[];
+}
+
+/** All-time wingman usage: turns submitted while a session had voice mode on, and the count of distinct
+ *  sessions ever seen with voice mode on. */
+export interface WingmanUsage {
+  turns: number;
+  sessions: number;
 }
 
 /** A derived, presentation-ready summary of the tally. Shares are fractions in [0,1], or null when
@@ -149,6 +158,7 @@ export async function getThrottle(signal?: AbortSignal): Promise<ThrottleData> {
     buckets?: unknown;
     hourlyTurns?: unknown;
     concurrency?: unknown;
+    wingman?: unknown;
     notCaptured?: unknown;
   } | null;
   const buckets = Array.isArray(body?.buckets) ? body!.buckets.map(normalizeBucket) : [];
@@ -162,8 +172,14 @@ export async function getThrottle(signal?: AbortSignal): Promise<ThrottleData> {
     buckets,
     hourlyTurns,
     concurrency: normalizeConcurrency(body?.concurrency),
+    wingman: normalizeWingman(body?.wingman),
     notCaptured,
   };
+}
+
+function normalizeWingman(raw: unknown): WingmanUsage {
+  const w = (raw ?? {}) as { turns?: unknown; sessions?: unknown };
+  return { turns: num(w.turns), sessions: num(w.sessions) };
 }
 
 function normalizeInputHour(raw: unknown): InputHour {

--- a/packages/client-core/src/stats/statsClient.ts
+++ b/packages/client-core/src/stats/statsClient.ts
@@ -71,6 +71,9 @@ export interface InputHour {
 export interface ThrottleData {
   /** When the Gateway generated this snapshot (ISO 8601 UTC), or "" when absent. */
   generatedAtUtc: string;
+  /** The display time zone (IANA id) the hourly charts render local clock hours in. Defaults to the
+   *  Gateway machine's own zone; a browser zone fills in for an older Gateway that does not send one. */
+  timeZone: string;
   buckets: ThrottleBucket[];
   /** Turns per UTC hour (the "working day" series), oldest hour first. */
   hourlyTurns: InputHour[];
@@ -142,6 +145,7 @@ export async function getThrottle(signal?: AbortSignal): Promise<ThrottleData> {
   if (!res.ok) throw await gatewayErrorFrom(res, "GET /stats/data");
   const body = (await res.json()) as {
     generatedAtUtc?: unknown;
+    timeZone?: unknown;
     buckets?: unknown;
     hourlyTurns?: unknown;
     concurrency?: unknown;
@@ -154,6 +158,7 @@ export async function getThrottle(signal?: AbortSignal): Promise<ThrottleData> {
     : [];
   return {
     generatedAtUtc: typeof body?.generatedAtUtc === "string" ? body.generatedAtUtc : "",
+    timeZone: safeTimeZone(typeof body?.timeZone === "string" ? body.timeZone : null),
     buckets,
     hourlyTurns,
     concurrency: normalizeConcurrency(body?.concurrency),
@@ -257,3 +262,85 @@ export const SURFACE_LABEL: Record<Surface, string> = {
 
 /** The surfaces in a stable presentation order. */
 export const SURFACE_ORDER = SURFACES;
+
+// ---- Hourly-chart time window + time zone --------------------------------------------------------
+//
+// The two hourly series (turns, concurrency) only carry the hours that had activity, so slicing each to
+// its own "last 24" produced two DIFFERENT windows that did not line up. Instead, both charts render one
+// canonical window: the 24 consecutive UTC clock hours ending at "now", with absent hours zero-filled.
+// Labels are then formatted in the configured display time zone, so the axis reads in local time.
+
+function padHourKey(d: Date): string {
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getUTCFullYear()}-${p(d.getUTCMonth() + 1)}-${p(d.getUTCDate())}T${p(d.getUTCHours())}`;
+}
+
+/** The 24 consecutive UTC hour keys ("yyyy-MM-ddTHH") ending at the hour containing `nowUtc`, oldest
+ *  first. Both hourly charts render this SAME window so they line up exactly. */
+export function last24HourKeys(nowUtc: Date): string[] {
+  const topOfHour = Date.UTC(
+    nowUtc.getUTCFullYear(),
+    nowUtc.getUTCMonth(),
+    nowUtc.getUTCDate(),
+    nowUtc.getUTCHours(),
+  );
+  const keys: string[] = [];
+  for (let i = 23; i >= 0; i--) keys.push(padHourKey(new Date(topOfHour - i * 3_600_000)));
+  return keys;
+}
+
+/** Map an hourly series (keyed by UTC hour) onto a fixed window of hour keys, filling any absent hour with
+ *  a zero entry, so a chart renders a continuous, aligned axis. */
+export function windowSeries<T extends { hour: string }>(
+  series: readonly T[],
+  keys: readonly string[],
+  zero: (hour: string) => T,
+): T[] {
+  const byHour = new Map(series.map((s) => [s.hour, s]));
+  return keys.map((k) => byHour.get(k) ?? zero(k));
+}
+
+/** A zero-filled turn-hour for an absent hour in the window. */
+export function emptyInputHour(hour: string): InputHour {
+  return { hour, turns: 0, voiceTurns: 0, typedTurns: 0, characters: 0 };
+}
+
+/** A zero-filled concurrency-hour for an absent hour in the window. */
+export function emptyConcurrencyHour(hour: string): ConcurrencyHour {
+  return { hour, maxLive: 0, maxWorking: 0, sessions: 0, machines: 0, repos: 0 };
+}
+
+function canFormatZone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function browserTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone ?? "";
+  } catch {
+    return "";
+  }
+}
+
+/** A time zone id we can format with: the given id when usable, else the browser's zone, else "UTC" - so
+ *  one bad setting never throws inside a render. */
+export function safeTimeZone(timeZone: string | null | undefined): string {
+  const candidate = (timeZone ?? "").trim();
+  if (candidate.length > 0 && canFormatZone(candidate)) return candidate;
+  const browser = browserTimeZone();
+  if (browser.length > 0 && canFormatZone(browser)) return browser;
+  return "UTC";
+}
+
+/** Format one UTC hour key ("yyyy-MM-ddTHH") as its 2-digit local hour ("00".."23") in the given IANA
+ *  zone. Assumes `timeZone` is already a usable id (see {@link safeTimeZone}). */
+export function localHourLabel(hourKeyUtc: string, timeZone: string): string {
+  const d = new Date(`${hourKeyUtc}:00:00Z`);
+  if (Number.isNaN(d.getTime())) return hourKeyUtc.slice(-2);
+  return new Intl.DateTimeFormat("en-US", { hour: "2-digit", hourCycle: "h23", timeZone }).format(d);
+}

--- a/src/CcDirector.Core/Configuration/TimeZoneConfig.cs
+++ b/src/CcDirector.Core/Configuration/TimeZoneConfig.cs
@@ -1,0 +1,95 @@
+using System.Text.Json.Nodes;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Configuration;
+
+/// <summary>
+/// The GATEWAY-OWNED display time zone - an IANA zone id, e.g. "America/New_York" - that the owner's
+/// private dashboards (the DevThrottle Stats "Your Throttle" hourly charts) render local clock hours in.
+/// Because every one of the owner's devices talks to their one Gateway, this single Gateway setting IS
+/// "the time zone my charts read in".
+///
+/// Persisted in <c>config.json</c> as the top-level string key <c>time_zone</c>, the same store the other
+/// Gateway settings use (<see cref="SnoozeDefaultConfig"/>, <see cref="TelemetryConsentConfig"/>). When no
+/// value has ever been persisted it AUTO-DEFAULTS to the Gateway machine's own zone
+/// (<see cref="MachineDefault"/>), so the charts read local time out of the box with no setup; the owner
+/// can override it on the Settings page. Read at render time, so a change takes effect on the next refresh
+/// with no Gateway restart.
+/// </summary>
+public static class TimeZoneConfig
+{
+    /// <summary>The config.json top-level key holding the display time zone (an IANA zone id).</summary>
+    public const string Key = "time_zone";
+
+    /// <summary>
+    /// The display time zone: the persisted IANA id if one is set, else the Gateway machine's own zone
+    /// (the automatic default). Never returns an empty or invalid id.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The <c>time_zone</c> key is present but is not a valid IANA zone id.
+    /// </exception>
+    public static string Get()
+    {
+        var node = CcDirectorConfigService.ReadRaw()[Key];
+        if (node is null)
+        {
+            var auto = MachineDefault();
+            FileLog.Write($"[TimeZoneConfig] Get: no persisted value -> machine default {auto}");
+            return auto;
+        }
+
+        if (node is JsonValue v && v.TryGetValue<string>(out var saved) && IsValid(saved))
+        {
+            FileLog.Write($"[TimeZoneConfig] Get: persisted value {saved!.Trim()}");
+            return saved!.Trim();
+        }
+
+        throw new InvalidOperationException(
+            "config.json key 'time_zone' must be a valid IANA time zone id (for example \"America/New_York\"). " +
+            "Fix the value or remove the key to use the Gateway machine's own zone.");
+    }
+
+    /// <summary>
+    /// The Gateway machine's own zone as an IANA id - the automatic default when nothing is persisted.
+    /// On a host whose local zone is a Windows id (e.g. "Eastern Standard Time"), it is converted to the
+    /// matching IANA id so a browser's Intl formatter can consume it. Falls back to "Etc/UTC" only when the
+    /// machine's zone cannot be represented as IANA at all.
+    /// </summary>
+    public static string MachineDefault()
+    {
+        var local = TimeZoneInfo.Local;
+        if (local.HasIanaId)
+            return local.Id;
+        if (TimeZoneInfo.TryConvertWindowsIdToIanaId(local.Id, out var iana) && !string.IsNullOrWhiteSpace(iana))
+            return iana!;
+        FileLog.Write($"[TimeZoneConfig] MachineDefault: local zone '{local.Id}' has no IANA mapping -> Etc/UTC");
+        return "Etc/UTC";
+    }
+
+    /// <summary>
+    /// True when <paramref name="id"/> is a zone id this host recognizes (IANA, or a Windows id the
+    /// runtime accepts). Pure, so the endpoint can validate the request body before writing anything.
+    /// </summary>
+    public static bool IsValid(string? id)
+    {
+        if (string.IsNullOrWhiteSpace(id)) return false;
+        return TimeZoneInfo.TryFindSystemTimeZoneById(id.Trim(), out _);
+    }
+
+    /// <summary>
+    /// Persists the display time zone to <c>config.json</c> under <c>time_zone</c>, merging into the
+    /// existing file so no other section is dropped.
+    /// </summary>
+    /// <exception cref="ArgumentException"><paramref name="id"/> is not a valid zone id.</exception>
+    public static void Set(string id)
+    {
+        if (!IsValid(id))
+            throw new ArgumentException(
+                "time zone must be a valid IANA zone id (for example \"America/New_York\")", nameof(id));
+
+        var value = id.Trim();
+        FileLog.Write($"[TimeZoneConfig] Set: timeZone={value}");
+        CcDirectorConfigService.MergePatch(new JsonObject { [Key] = value });
+        FileLog.Write("[TimeZoneConfig] Set: persisted");
+    }
+}

--- a/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
@@ -36,6 +36,14 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
         return dto;
     }
 
+    // A session with voice mode ON - the owner's definition of "using the wingman".
+    private static SessionDto VoiceSession(string id, params (string modality, string surface, long turns, long chars)[] buckets)
+    {
+        var dto = Session(id, buckets);
+        dto.VoiceMode = true;
+        return dto;
+    }
+
     private static long Turns(InputStatsDto dto, string modality, string surface) =>
         dto.Buckets.FirstOrDefault(b => b.Modality == modality && b.Surface == surface)?.Turns ?? 0;
 
@@ -168,5 +176,57 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
         Assert.Equal("2026-07-11T17", hours[0].Hour);
         Assert.Equal(3, hours[0].VoiceTurns);
         Assert.Equal(300, hours[0].Characters);
+    }
+
+    [Fact]
+    public void WingmanUsage_CountsVoiceModeSessionsAndTheirTurns()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        agg.Observe(VoiceSession("s1", ("voice", "phone", 3, 120))); // voice mode on -> 3 wingman turns
+        agg.Observe(Session("s2", ("typed", "desktop", 5, 100)));    // no voice mode -> not the wingman
+
+        var w = agg.WingmanUsage();
+        Assert.Equal(3, w.Turns);
+        Assert.Equal(1, w.Sessions);
+    }
+
+    [Fact]
+    public void WingmanUsage_CountsAVoiceModeSessionEvenWithNoInputYet()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        // Voice mode on, no turns typed yet - the session still counts as "using the wingman".
+        agg.Observe(new SessionDto { SessionId = "s1", VoiceMode = true });
+
+        var w = agg.WingmanUsage();
+        Assert.Equal(0, w.Turns);
+        Assert.Equal(1, w.Sessions);
+    }
+
+    [Fact]
+    public void WingmanUsage_AddsOnlyTheTurnIncrease_AndDoesNotDoubleCountTheSession()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        agg.Observe(VoiceSession("s1", ("voice", "phone", 2, 40)));
+        agg.Observe(VoiceSession("s1", ("voice", "phone", 5, 100))); // grew by 3 while voice mode on
+
+        var w = agg.WingmanUsage();
+        Assert.Equal(5, w.Turns);
+        Assert.Equal(1, w.Sessions); // still one distinct wingman session
+    }
+
+    [Fact]
+    public void WingmanUsage_SurvivesRestart_AndDoesNotDoubleCountOnRepush()
+    {
+        var a = new GatewayInputStatsAggregator(_path);
+        a.Observe(VoiceSession("s1", ("voice", "phone", 3, 120)));
+
+        var b = new GatewayInputStatsAggregator(_path); // reload from disk
+        Assert.Equal(3, b.WingmanUsage().Turns);
+        Assert.Equal(1, b.WingmanUsage().Sessions);
+
+        // The same live session re-pushes its current snapshot - must not re-add its turns.
+        b.Observe(VoiceSession("s1", ("voice", "phone", 3, 120)));
+        Assert.Equal(3, b.WingmanUsage().Turns);
+        Assert.Equal(1, b.WingmanUsage().Sessions);
     }
 }

--- a/src/CcDirector.Gateway.Tests/TimeZoneConfigTests.cs
+++ b/src/CcDirector.Gateway.Tests/TimeZoneConfigTests.cs
@@ -1,0 +1,34 @@
+using CcDirector.Core.Configuration;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for the Gateway display-time-zone setting. Only the pure surface is exercised (the machine
+/// default and the id validation), so the tests never read or write the real config.json.
+/// </summary>
+public sealed class TimeZoneConfigTests
+{
+    [Fact]
+    public void MachineDefault_is_a_valid_non_empty_zone()
+    {
+        var id = TimeZoneConfig.MachineDefault();
+        Assert.False(string.IsNullOrWhiteSpace(id));
+        // Whatever the build host's zone is, the returned id must be one the runtime can resolve.
+        Assert.True(TimeZoneConfig.IsValid(id));
+    }
+
+    [Theory]
+    [InlineData("America/New_York", true)]  // a common IANA id
+    [InlineData("Europe/London", true)]
+    [InlineData("UTC", true)]               // the runtime resolves "UTC"
+    [InlineData("Etc/UTC", true)]
+    [InlineData("Not/AZone", false)]        // nonsense id
+    [InlineData("", false)]                 // empty
+    [InlineData("   ", false)]              // whitespace
+    [InlineData(null, false)]               // missing
+    public void IsValid_accepts_only_a_resolvable_zone(string? id, bool expected)
+    {
+        Assert.Equal(expected, TimeZoneConfig.IsValid(id));
+    }
+}

--- a/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/SettingsEndpoints.cs
@@ -79,6 +79,11 @@ internal static class SettingsEndpoints
                 // Snooze Length mission: the per-user default snooze length in minutes (default 60),
                 // so the one Settings page can render and edit it in Phase 3.
                 snoozeDefaultMinutes = Core.Configuration.SnoozeDefaultConfig.Get(),
+                // The display time zone (IANA id) the private dashboards' hourly charts read local hours
+                // in. Auto-defaults to this Gateway machine's own zone when unset; machineDefault lets the
+                // Settings page show what "automatic" resolves to.
+                timeZone = Core.Configuration.TimeZoneConfig.Get(),
+                timeZoneMachineDefault = Core.Configuration.TimeZoneConfig.MachineDefault(),
             });
         });
 
@@ -258,6 +263,40 @@ internal static class SettingsEndpoints
             catch (JsonException ex)
             {
                 FileLog.Write($"[SettingsEndpoints] PUT /gateway/snooze-default bad JSON: {ex.Message}");
+                return Results.BadRequest(new { error = "invalid JSON" });
+            }
+        });
+
+        // The display time zone (an IANA id) the private dashboards' hourly charts read local hours in.
+        // Auto-defaults to this Gateway machine's own zone; read at render time so a change applies to the
+        // next refresh with no restart. GET also reports the machine default so the page can show what
+        // "automatic" resolves to.
+        app.MapGet("/gateway/time-zone", () =>
+            Results.Json(new
+            {
+                timeZone = Core.Configuration.TimeZoneConfig.Get(),
+                machineDefault = Core.Configuration.TimeZoneConfig.MachineDefault(),
+            }));
+
+        app.MapPut("/gateway/time-zone", async (HttpContext ctx) =>
+        {
+            try
+            {
+                var body = await JsonSerializer.DeserializeAsync<TimeZoneBody>(
+                    ctx.Request.Body, JsonOpts, ctx.RequestAborted);
+                if (body is null || string.IsNullOrWhiteSpace(body.TimeZone))
+                    return Results.BadRequest(new { error = "body { \"timeZone\": \"America/New_York\" } is required" });
+                if (!Core.Configuration.TimeZoneConfig.IsValid(body.TimeZone))
+                    return Results.BadRequest(new { error = "timeZone must be a valid IANA time zone id" });
+
+                Core.Configuration.TimeZoneConfig.Set(body.TimeZone);
+                var value = body.TimeZone.Trim();
+                FileLog.Write($"[SettingsEndpoints] time_zone set to {value}");
+                return Results.Json(new { timeZone = value });
+            }
+            catch (JsonException ex)
+            {
+                FileLog.Write($"[SettingsEndpoints] PUT /gateway/time-zone bad JSON: {ex.Message}");
                 return Results.BadRequest(new { error = "invalid JSON" });
             }
         });
@@ -505,6 +544,7 @@ internal static class SettingsEndpoints
     private sealed record TranscriptionModeBody(string? Mode);
     private sealed record AutostartBody(bool Enabled);
     private sealed record SnoozeDefaultBody(int? Minutes);
+    private sealed record TimeZoneBody(string? TimeZone);
     private sealed record WingmanBody(bool Enabled);
     private sealed record BrainConfigBody(string? AgentId, string? Tool, string? Model);
 }

--- a/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
+++ b/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
@@ -41,6 +41,13 @@ public sealed class GatewayInputStatsAggregator
     private const int RetentionDays = 90;
     private readonly Dictionary<string, HourTurns> _hourly = new(StringComparer.Ordinal);
 
+    // Wingman usage (owner's definition: a session "uses the wingman" when it has voice mode on).
+    // _wingmanSessions is the all-time set of session ids ever seen with voice mode on (never pruned on
+    // removal, like the totals); _wingmanTurns is the count of submitted turns folded while a session had
+    // voice mode on (a subset of the all-time turn total). Both persist across restarts.
+    private long _wingmanTurns;
+    private readonly HashSet<string> _wingmanSessions = new(StringComparer.Ordinal);
+
     private sealed class HourTurns
     {
         public long VoiceTurns;
@@ -113,6 +120,16 @@ public sealed class GatewayInputStatsAggregator
         }
     }
 
+    /// <summary>All-time wingman usage: the number of submitted turns folded while a session had voice mode
+    /// on, and the count of distinct sessions ever seen with voice mode on.</summary>
+    public WingmanUsageDto WingmanUsage()
+    {
+        lock (_lock)
+        {
+            return new WingmanUsageDto { Turns = _wingmanTurns, Sessions = _wingmanSessions.Count };
+        }
+    }
+
     /// <summary>The per-hour turn log (the "working day" series: turns by modality and character volume per
     /// UTC clock hour), oldest hour first.</summary>
     public IReadOnlyList<InputHourDto> HourlyTurns()
@@ -153,8 +170,19 @@ public sealed class GatewayInputStatsAggregator
     // holds the lock.
     private bool FoldLocked(SessionDto s, string hourKey)
     {
-        if (string.IsNullOrEmpty(s.SessionId) || s.InputStats?.Buckets is null || s.InputStats.Buckets.Count == 0)
+        if (string.IsNullOrEmpty(s.SessionId))
             return false;
+
+        var changed = false;
+
+        // Wingman usage (owner's definition): a session "uses the wingman" the moment it is seen with voice
+        // mode on - recorded even if it has no input this fold, so a voice-mode session that never typed a
+        // turn still counts. The set is all-time, never pruned on removal (like the totals).
+        if (s.VoiceMode && _wingmanSessions.Add(s.SessionId))
+            changed = true;
+
+        if (s.InputStats?.Buckets is null || s.InputStats.Buckets.Count == 0)
+            return changed;
 
         if (!_highWater.TryGetValue(s.SessionId, out var hw))
         {
@@ -162,7 +190,7 @@ public sealed class GatewayInputStatsAggregator
             _highWater[s.SessionId] = hw;
         }
 
-        var changed = false;
+        long sessionDeltaTurns = 0;
         foreach (var b in s.InputStats.Buckets)
         {
             var key = (b.Modality ?? "", b.Surface ?? "");
@@ -200,11 +228,17 @@ public sealed class GatewayInputStatsAggregator
                     hour.TypedTurns += deltaTurns;
                 hour.Characters += deltaChars;
 
+                sessionDeltaTurns += deltaTurns;
                 changed = true;
             }
 
             hw[key] = new Counters { Turns = b.Turns, Characters = b.Characters };
         }
+
+        // Turns submitted while this session had voice mode on are wingman turns (a subset of the totals).
+        if (s.VoiceMode && sessionDeltaTurns > 0)
+            _wingmanTurns += sessionDeltaTurns;
+
         return changed;
     }
 
@@ -229,6 +263,8 @@ public sealed class GatewayInputStatsAggregator
         public List<InputStatBucketDto> Totals { get; set; } = new();
         public Dictionary<string, List<InputStatBucketDto>> HighWater { get; set; } = new();
         public Dictionary<string, HourTurnsStore> Hourly { get; set; } = new();
+        public long WingmanTurns { get; set; }
+        public List<string> WingmanSessions { get; set; } = new();
     }
 
     private sealed class HourTurnsStore
@@ -273,7 +309,10 @@ public sealed class GatewayInputStatsAggregator
         }
         foreach (var (hour, ht) in parsed.Hourly)
             _hourly[hour] = new HourTurns { VoiceTurns = ht.VoiceTurns, TypedTurns = ht.TypedTurns, Characters = ht.Characters };
-        FileLog.Write($"[GatewayInputStatsAggregator] Load: restored {_totals.Count} total bucket(s), {_highWater.Count} live session(s), {_hourly.Count} hourly bucket(s) from {_path}");
+        _wingmanTurns = parsed.WingmanTurns;
+        foreach (var id in parsed.WingmanSessions)
+            if (!string.IsNullOrEmpty(id)) _wingmanSessions.Add(id);
+        FileLog.Write($"[GatewayInputStatsAggregator] Load: restored {_totals.Count} total bucket(s), {_highWater.Count} live session(s), {_hourly.Count} hourly bucket(s), {_wingmanSessions.Count} wingman session(s)/{_wingmanTurns} wingman turn(s) from {_path}");
     }
 
     private void Quarantine(string reason)
@@ -299,6 +338,8 @@ public sealed class GatewayInputStatsAggregator
                 file.HighWater[sid] = ToDtoLocked(hw).Buckets;
             foreach (var (hour, ht) in _hourly)
                 file.Hourly[hour] = new HourTurnsStore { VoiceTurns = ht.VoiceTurns, TypedTurns = ht.TypedTurns, Characters = ht.Characters };
+            file.WingmanTurns = _wingmanTurns;
+            file.WingmanSessions = _wingmanSessions.ToList();
 
             var json = JsonSerializer.Serialize(file, FileJsonOptions);
             var tmp = _path + ".tmp";
@@ -322,4 +363,13 @@ public sealed class InputHourDto
     public long VoiceTurns { get; set; }
     public long TypedTurns { get; set; }
     public long Characters { get; set; }
+}
+
+/// <summary>All-time wingman usage (owner's definition: a session uses the wingman when it has voice mode
+/// on): the count of turns submitted while a session had voice mode on, and the number of distinct sessions
+/// ever seen with voice mode on.</summary>
+public sealed class WingmanUsageDto
+{
+    public long Turns { get; set; }
+    public int Sessions { get; set; }
 }

--- a/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
+++ b/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
@@ -43,6 +43,9 @@ public static class StatsPageEndpoint
             return Results.Json(new
             {
                 generatedAtUtc = DateTime.UtcNow,
+                // The display time zone the hourly charts render local clock hours in (IANA id).
+                // Auto-defaults to this Gateway machine's own zone; the owner can override it in Settings.
+                timeZone = CcDirector.Core.Configuration.TimeZoneConfig.Get(),
                 buckets = totals.Buckets,
                 // DevThrottle Stats: the "working day" series - turns (by modality) + characters per UTC hour.
                 hourlyTurns = aggregator.HourlyTurns(),

--- a/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
+++ b/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
@@ -49,6 +49,9 @@ public static class StatsPageEndpoint
                 buckets = totals.Buckets,
                 // DevThrottle Stats: the "working day" series - turns (by modality) + characters per UTC hour.
                 hourlyTurns = aggregator.HourlyTurns(),
+                // Wingman usage: turns submitted while a session had voice mode on, and the count of distinct
+                // sessions ever in voice mode ("using the wingman" = voice mode on for that session).
+                wingman = aggregator.WingmanUsage(),
                 // DevThrottle Stats: fleet concurrency (both series: live loaded/running, and actively
                 // working). Null until the aggregator is wired (old callers / tests).
                 concurrency = concurrency?.Snapshot(DateTime.UtcNow),


### PR DESCRIPTION
## What

A ground-up rework of **Your Throttle** so the owner leads with the numbers they actually care about, on both the desktop Cockpit and the phone.

**Desktop (Cockpit)**
- Tabbed page (**Overview / Activity / Breakdown**) instead of one crammed scroll.
- Overview leads with three hero rings: **Voice vs typing**, **Mobile vs desktop**, and **Wingman (voice mode)**, plus a "where you drive from" bar and totals.
- Activity charts got a real, readable **y-axis** (nice ticks + recessive gridlines) and both hourly charts now render **one shared, aligned 24-hour window** (they used to start at different hours).
- Supporting tables + honesty caveats moved to the Breakdown tab.

**Time zone (new Gateway setting)**
- A Gateway-owned display time zone (IANA id) that **auto-defaults to the Gateway machine's own zone**; editable in **Settings > This machine > Time zone**. The hourly charts label hours in it.

**Wingman usage (new)**
- A session "uses the wingman" when it has **voice mode on** (owner's definition). The durable input-stats aggregator now tracks, all-time, the turns submitted while in voice mode and the distinct sessions that used it; exposed on `/stats/data` and shown as the third ring. Forward-looking (counts from deploy onward).

**Mobile (/m)**
- Your Throttle on the phone is now a clean dashboard of the headline stats (three metric rings + surface bar + totals) instead of the old crammed everything-view. The heavy charts/breakdown stay on the desktop.

## Verification

- Gateway builds clean (0 warnings/errors).
- Gateway tests: TimeZoneConfig + wingman aggregator + existing stats/config tests pass.
- client-core + cockpit + mobile typecheck clean; client-core stats-window tests + all 95 cockpit tests pass.
- Every screen rendered headless and eyeballed; ran live as a preview on the owner's Gateway across each step.

Built in an isolated worktree off origin/main; no file overlap with the concurrent work merged since.

Generated with [Claude Code](https://claude.com/claude-code)