### PR TITLE
fix(dictation): race-free tail capture on the Car Mode button path; keep the recording when no failure callback exists

### DIFF
--- a/packages/client-core/src/carmode/useCarMode.ts
+++ b/packages/client-core/src/carmode/useCarMode.ts
@@ -953,10 +953,13 @@ export function useCarMode(options: UseCarModeOptions): CarModeView {
     const pauseDetectedAt = prefetched ? prefetched.pauseDetectedAt : performance.now();
 
     // Acquire the raw command audio for BOTH paths (the voice end-phrase path passes the very clip it
-    // transcribed). This is what gets persisted so speech is never lost. The snapshot is FLUSHED:
-    // MediaRecorder's still-buffered tail is forced out first, so the last words before the tap are in
-    // the clip - a bare snapshot() clips up to 100ms off the end, exactly where the final word lands.
-    const clip = prefetched ? prefetched.clip : await rec.snapshotFlushed();
+    // transcribed). This is what gets persisted so speech is never lost. On the button path the
+    // recorder is STOPPED to get the clip - MediaRecorder's stop event fires only after its final
+    // buffered chunk was delivered, so the tail (the last words before the tap) is included with no
+    // race at all; a bare snapshot() clipped up to 100ms off the end, and even a flushed snapshot can
+    // resolve on an already-queued earlier chunk under load. Stopping here is safe: this turn is over
+    // and takeTurn releases the microphone before Thinking anyway (its own stop then no-ops).
+    const clip = prefetched ? prefetched.clip : rec.isRecording ? await rec.stop() : rec.snapshot();
     if (!prefetched && clip.size < MIN_CLIP_BYTES) {
       void takeTurn("", null); // nothing captured: a canned nudge, no server turn, no durable record
       return;

--- a/packages/client-core/src/dictation/recorder.ts
+++ b/packages/client-core/src/dictation/recorder.ts
@@ -125,10 +125,17 @@ export class MicRecorder {
    * A plain snapshot() only sees chunks the recorder has already delivered, so up to CHUNK_MS of the
    * most recent speech (exactly where the final word or the sign-off phrase lands) is missing from it.
    * This variant calls requestData(), which makes MediaRecorder emit its buffered audio as an immediate
-   * dataavailable, and waits for that delivery before assembling the blob - so the last words are in.
-   * Any turn-taking path (Car Mode "Over and out", the end-phrase watch) must use this, never a bare
-   * snapshot(). When the recorder is not actively recording there is nothing buffered to flush and the
-   * plain snapshot is returned as-is.
+   * dataavailable, and waits for a delivery before assembling the blob - so the last words are in.
+   *
+   * RESIDUAL CAVEAT: the wait resolves on the FIRST dataavailable after the call, which under load can
+   * be an earlier timeslice chunk that was already queued - the requestData flush then lands just after
+   * the snapshot was assembled. So this is a large improvement over snapshot(), not an absolute
+   * guarantee. It is the right tool ONLY for the rolling end-phrase watch, where a short miss is
+   * self-correcting: the watch re-ticks every second, and a clip it commits provably contains the
+   * spoken sign-off phrase (that is how the phrase was detected). A path that ENDS the turn must not
+   * rely on this - it stops the recorder instead (stop() resolves only after the final chunk was
+   * delivered, which is race-free). When the recorder is not actively recording there is nothing
+   * buffered to flush and the plain snapshot is returned as-is.
    */
   async snapshotFlushed(): Promise<Blob> {
     const rec = this.recorder;

--- a/src/CcDirector.Avalonia.Tests/BackgroundDictationSendTests.cs
+++ b/src/CcDirector.Avalonia.Tests/BackgroundDictationSendTests.cs
@@ -146,4 +146,22 @@ public sealed class BackgroundDictationSendTests : IDisposable
         Assert.Equal("the words", failedComposed); // the words survive as restorable text...
         Assert.Empty(SavedRecordings()); // ...so the audio copy is not needed and does not pile up
     }
+
+    [Fact]
+    public async Task SubmitFails_WithNoFailureCallback_RecordingIsKept()
+    {
+        // Without an onFailed callback nobody restores the words as text, so the saved WAV is the
+        // only copy of what was said - deleting it here would lose the speech outright. The single
+        // production caller always passes onFailed; this pins the guard for any future caller.
+        var recorder = await NewRecordingRecorderAsync(new byte[] { 1, 2, 3, 4 });
+
+        await BackgroundDictationSend.RunAsync(
+            recorder, prefix: "", NewSession(),
+            new FakeTranscriber { Text = "the words" },
+            submit: _ => throw new InvalidOperationException("composer refused"),
+            onFailed: null,
+            recordingsDirectory: _dir);
+
+        Assert.Single(SavedRecordings());
+    }
 }

--- a/src/CcDirector.Avalonia/Voice/BackgroundDictationSend.cs
+++ b/src/CcDirector.Avalonia/Voice/BackgroundDictationSend.cs
@@ -109,7 +109,16 @@ public static class BackgroundDictationSend
             catch (Exception ex)
             {
                 FileLog.Write($"[BackgroundDictationSend] submit FAILED for session {target.Id} ({DiagnosticState(target)}): {ex.Message}");
-                onFailed?.Invoke(ex.Message, text);
+                if (onFailed is null)
+                {
+                    // No failure callback means nobody restored the words as text - the saved WAV is
+                    // then the only copy of what was said, so it is kept and the log names it. The
+                    // single production caller always passes onFailed; this guards a future caller.
+                    FileLog.Write($"[BackgroundDictationSend] no onFailed callback; keeping savedRecording={savedPath ?? "none"}");
+                    savedPath = null; // kept; do not delete below
+                    return;
+                }
+                onFailed.Invoke(ex.Message, text);
             }
             DictationRecordingStore.TryDelete(savedPath);
             savedPath = null;


### PR DESCRIPTION
Follow-up from the adversarial code review of the merged dictation fixes (#1466, #1467).

## Finding 1 (review): residual race in snapshotFlushed()

`snapshotFlushed()` resolves on the FIRST recorder chunk after the call. Under load that can be an earlier, already-queued timeslice chunk - the flushed tail then lands just after the snapshot was assembled, so the "Over and out" button path could still miss the final words in a narrow race window.

Fix: the button path now **stops the recorder** to get its clip. MediaRecorder's stop event fires only after the final buffered chunk was delivered, which is race-free - and this turn was ending anyway (takeTurn releases the microphone before Thinking; its own stop now no-ops). The rolling end-phrase watch keeps `snapshotFlushed()`, where the residual race is provably harmless: the watch re-ticks every second, and any clip it commits contains the spoken sign-off phrase (that is how the phrase was detected). The method documentation now states the caveat and the intended use.

## Finding 2 (review): failure-callback footgun in the desktop Send

If a future caller passed no `onFailed` callback, a submit failure would have deleted the saved WAV even though nobody restored the words as text - deleting the only copy of the speech. The file is now kept in that case (the single production caller always passes `onFailed`); pinned with a new test.

## Tests

Client-core: 414 passed; workspace typecheck clean. BackgroundDictationSend tests: 4 passed (1 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)