### PR TITLE
fix(gateway-cleanup): re-point the 3 stray HTTP callers found by the definitive grep onto the tunnel

### DIFF
--- a/src/CcDirector.Gateway.Tests/TunnelIdleWaitFanoutRestoreProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelIdleWaitFanoutRestoreProofTests.cs
@@ -1,0 +1,209 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection; // AddMessagePackProtocol (client)
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 2 (final pre-cut re-point): the THREE stray caller clusters the definitive
+/// DirectorEndpointClient grep surfaced - each dialed the owning Director over HTTP with NO tunnel branch - now
+/// ride the tunnel under stream mode. The re-points reuse EXISTING registered verbs
+/// (snapshot / buffer / prompt / create / patch / interrupted-remove):
+///   1. POST /sessions/{sid}/prompt WaitForIdle poll (was GetSession + GetBuffer HTTP)
+///   2. POST /fanout fleet broadcast delivery + poll (was PostPrompt + GetSession + GetBuffer HTTP)
+///   3. POST /interrupted/{dir}/{pid}/restore create + rename + journal cleanup (was raw spawn + PatchSession
+///      + RemoveInterruptedSession HTTP)
+///
+/// TUNNEL-BY-CONSTRUCTION: the Director registers with a DELIBERATELY UNREACHABLE control endpoint, so an HTTP
+/// dial cannot succeed - a 200/201 with the expected body can ONLY have ridden the tunnel. Each test asserts the
+/// exact verbs the Gateway sent DOWN the tunnel, so a leg that silently stayed on HTTP fails loudly.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class TunnelIdleWaitFanoutRestoreProofTests : IAsyncLifetime
+{
+    private const string Token = "test-token-idlewait-fanout-restore";
+    private const string DirectorId = "dir-idlewait";
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _instancesDir = Path.Combine(Path.GetTempPath(), "cc-idlewait-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private HubConnection _conn = null!;
+    private SessionManager _sm = null!;
+    private Session _session = null!;
+    private string _sid = "";
+
+    // Every command the Director saw over the tunnel, in order, so a test can assert the exact verb sequence.
+    private readonly List<DirectorCommand> _commands = new();
+    private static readonly JsonSerializerOptions WebJson = new(JsonSerializerDefaults.Web);
+
+    public TunnelIdleWaitFanoutRestoreProofTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-idlewait-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+
+        _sm = new SessionManager(new AgentOptions());
+        _session = _sm.CreateEmbeddedSession(Path.GetTempPath(), null, new ExecuteActionTestBackend());
+        _sid = _session.Id.ToString();
+
+        // UNREACHABLE endpoint: a working route can only have ridden the tunnel.
+        _gateway.Registry.Upsert(new DirectorRegistrationRequest
+        {
+            DirectorId = DirectorId,
+            TailnetEndpoint = "http://127.0.0.1:59919/", // nothing listens here
+            MachineName = "idlewait-machine",
+            Pid = 1,
+            Version = "test",
+            StartedAt = DateTime.UtcNow,
+        });
+
+        _conn = new HubConnectionBuilder()
+            .WithUrl($"http://127.0.0.1:{_gateway.Port}/director-stream", o => o.AccessTokenProvider = () => Task.FromResult<string?>(Token))
+            .AddMessagePackProtocol()
+            .Build();
+        _conn.On<DirectorCommand, DirectorCommandResult>("Command", Dispatch);
+        await _conn.StartAsync();
+        await _conn.InvokeAsync("Hello", new DirectorStreamHello { DirectorId = DirectorId, Version = "test" });
+        await _conn.InvokeAsync("PushSnapshot", 1L, new[]
+        {
+            new SessionDto { SessionId = _sid, ActivityState = "WaitingForInput" },
+        });
+    }
+
+    public async Task DisposeAsync()
+    {
+        try { await _conn.DisposeAsync(); } catch { /* best effort */ }
+        _sm.Dispose();
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        foreach (var dir in new[] { _instancesDir, _root })
+            try { if (Directory.Exists(dir)) Directory.Delete(dir, true); } catch { /* best effort */ }
+    }
+
+    // Canned per-verb responses so each flow completes; every command is recorded for verb-sequence assertions.
+    private DirectorCommandResult Dispatch(DirectorCommand cmd)
+    {
+        _commands.Add(cmd);
+        return cmd.Verb switch
+        {
+            // prompt / fanout delivery: accepted, still Working so the WaitForIdle poll actually runs.
+            "prompt" => DirectorCommandResult.Success(JsonSerializer.Serialize(
+                new PromptResponse { Accepted = true, ActivityState = "Working", BufferCursor = 3 }, WebJson)),
+            // the idle poll: report Idle on the first read so the loop exits promptly.
+            "snapshot" => DirectorCommandResult.Success(JsonSerializer.Serialize(
+                new SessionDto { SessionId = cmd.SessionId, ActivityState = "Idle" }, WebJson)),
+            // the output diff.
+            "buffer" => DirectorCommandResult.Success(JsonSerializer.Serialize(
+                new BufferResponse { SessionId = cmd.SessionId, Text = "new output", NewCursor = 9 }, WebJson)),
+            // restore: journal re-read, continuation create, rename, journal cleanup.
+            "interrupted-list" => DirectorCommandResult.Success(JsonSerializer.Serialize(
+                new List<CrashJournalDto>
+                {
+                    new()
+                    {
+                        DirectorId = "dead-dir",
+                        Pid = 999,
+                        Sessions = new List<CrashJournalSessionDto>
+                        {
+                            new() { SessionId = "dead-sess", Name = "Dead One", RepoPath = Path.GetTempPath(), Agent = "ClaudeCode" },
+                        },
+                    },
+                }, WebJson)),
+            "create" => DirectorCommandResult.Success(JsonSerializer.Serialize(
+                new SessionDto { SessionId = "new-sess", ActivityState = "Working" }, WebJson)),
+            "patch" => DirectorCommandResult.Success(JsonSerializer.Serialize(
+                new SessionDto { SessionId = "new-sess", Name = "Dead One" }, WebJson)),
+            "interrupted-remove" => DirectorCommandResult.Success(),
+            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
+        };
+    }
+
+    [Fact]
+    public async Task PromptWaitForIdle_pollAndBufferRideTheTunnel()
+    {
+        var resp = await _http.PostAsJsonAsync($"sessions/{_sid}/prompt",
+            new PromptRequest { Text = "hi", WaitForIdle = true, TimeoutMs = 5000 });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode); // an HTTP dial to the unreachable Director would have failed
+        var body = await resp.Content.ReadFromJsonAsync<PromptResponse>();
+        Assert.Equal("idle", body?.WaitStatus);
+        Assert.Equal("new output", body?.Output);
+
+        // Delivery, the idle poll, and the output diff all rode the tunnel.
+        var verbs = _commands.Select(c => c.Verb).ToList();
+        Assert.Contains("prompt", verbs);
+        Assert.Contains("snapshot", verbs);   // the poll (was client.GetSessionAsync)
+        Assert.Contains("buffer", verbs);     // the diff (was client.GetBufferAsync)
+    }
+
+    [Fact]
+    public async Task Fanout_deliveryPollAndBufferRideTheTunnel()
+    {
+        // Sender == target => the broadcast stays in the sender's own team (in-scope, free) so the governor allows it.
+        var resp = await _http.PostAsJsonAsync("fanout", new FanoutRequest
+        {
+            SessionIds = new List<string> { _sid },
+            Text = "team heads-up",
+            FromSessionId = _sid,
+            WaitForIdle = true,
+            TimeoutMs = 5000,
+        });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var node = await resp.Content.ReadFromJsonAsync<JsonNode>();
+        Assert.NotEqual(true, node?["denied"]?.GetValue<bool>());
+
+        var verbs = _commands.Select(c => c.Verb).ToList();
+        Assert.Contains("prompt", verbs);     // delivery (was client.PostPromptAsync)
+        Assert.Contains("snapshot", verbs);   // the poll (was client.GetSessionAsync)
+        Assert.Contains("buffer", verbs);     // the diff (was client.GetBufferAsync)
+    }
+
+    [Fact]
+    public async Task RestoreInterrupted_createRenameAndCleanupRideTheTunnel()
+    {
+        var resp = await _http.PostAsJsonAsync("interrupted/dead-dir/999/restore",
+            new RestoreInterruptedRequest { SessionId = "dead-sess", Via = DirectorId });
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode); // 201; an HTTP dial to the unreachable Director would have failed
+        var body = await resp.Content.ReadFromJsonAsync<RestoreInterruptedResponse>();
+        Assert.True(body?.Restored);
+        Assert.Equal("new-sess", body?.TargetSession?.SessionId);
+
+        var verbs = _commands.Select(c => c.Verb).ToList();
+        Assert.Contains("interrupted-list", verbs);   // journal re-read (already tunnel-first)
+        Assert.Contains("create", verbs);             // continuation (was raw spawnHttp.PostAsJsonAsync)
+        Assert.Contains("patch", verbs);              // rename (was client.PatchSessionAsync)
+        Assert.Contains("interrupted-remove", verbs); // journal cleanup (was client.RemoveInterruptedSessionAsync)
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -962,15 +962,30 @@ internal static class GatewayEndpoints
             // exists but never gets renamed or journal-cleaned). Dedicated 20s client,
             // same as the cross-director handover's spawn leg above.
             var targetEp = (target.ControlEndpoint ?? "").TrimEnd('/');
-            SessionDto? created;
-            using (var spawnHttp = new HttpClient { Timeout = TimeSpan.FromSeconds(20) })
+            var spawnReq = new NewSessionRequest
             {
-                var spawnResp = await spawnHttp.PostAsJsonAsync($"{targetEp}/sessions", new NewSessionRequest
-                {
-                    RepoPath = row.RepoPath,
-                    Agent = row.Agent,
-                    PrePrompt = context,
-                });
+                RepoPath = row.RepoPath,
+                Agent = row.Agent,
+                PrePrompt = context,
+            };
+            // Gateway Cleanup Phase 2: create the continuation over the tunnel (create verb, director-level so
+            // SessionId is ""), tunnel-first. The tunnel unary has no 2s aggregate timeout - keep-alive sustains
+            // a multi-second spawn - so the orphan risk the dedicated 20s HttpClient guarded against does not
+            // apply on the tunnel path; the HTTP fallback keeps that dedicated client. Post-cut the HTTP arm goes.
+            SessionDto? created;
+            var createSr = await DirectorCommandRouter.TrySendAsync(sendCommand, target.DirectorId, "create", "", spawnReq, CancellationToken.None);
+            if (createSr is not null)
+            {
+                created = createSr.Ok ? DirectorCommandRouter.ReadBody<SessionDto>(createSr) : null;
+                if (created is null)
+                    return Results.Problem(
+                        $"target director failed to create the continuation session: {DirectorCommandRouter.DescribeFailure(createSr)}",
+                        statusCode: StatusCodes.Status502BadGateway);
+            }
+            else
+            {
+                using var spawnHttp = new HttpClient { Timeout = TimeSpan.FromSeconds(20) };
+                var spawnResp = await spawnHttp.PostAsJsonAsync($"{targetEp}/sessions", spawnReq);
                 if (!spawnResp.IsSuccessStatusCode)
                 {
                     var body = await spawnResp.Content.ReadAsStringAsync();
@@ -990,16 +1005,33 @@ internal static class GatewayEndpoints
             var restoredName = string.IsNullOrWhiteSpace(row.Name) ? null : row.Name;
             if (restoredName is not null)
             {
-                var (patched, body, patchErr) = await client.PatchSessionAsync(targetEp, created.SessionId,
-                    new SessionUpdateRequest { Name = restoredName });
-                if (patched && body is not null) { body.DirectorId = target.DirectorId; created = body; }
+                // Gateway Cleanup Phase 2: rename over the tunnel (patch verb, tunnel-first, HTTP fallback pre-cut).
+                var renameReq = new SessionUpdateRequest { Name = restoredName };
+                SessionDto? renamed; string? patchErr;
+                var patchSr = await DirectorCommandRouter.TrySendAsync(sendCommand, target.DirectorId, "patch", created.SessionId, renameReq, CancellationToken.None);
+                if (patchSr is not null)
+                {
+                    renamed = patchSr.Ok ? DirectorCommandRouter.ReadBody<SessionDto>(patchSr) : null;
+                    patchErr = patchSr.Ok ? null : DirectorCommandRouter.DescribeFailure(patchSr);
+                }
+                else
+                {
+                    var http = await client.PatchSessionAsync(targetEp, created.SessionId, renameReq);
+                    renamed = http.body; patchErr = http.error;
+                }
+                if (renamed is not null) { renamed.DirectorId = target.DirectorId; created = renamed; }
                 else FileLog.Write($"[GatewayEndpoints] restore: rename failed (continuing): {patchErr}");
             }
 
             // Pull the restored session out of the Interrupted sessions list. Best-effort too - the
             // user can still Dismiss the row by hand if this leg fails.
-            var cleaned = await client.RemoveInterruptedSessionAsync(
-                (reporter.ControlEndpoint ?? "").TrimEnd('/'), deadDirectorId, deadPid, row.SessionId);
+            // Gateway Cleanup Phase 2: journal cleanup over the tunnel (interrupted-remove verb on the reporting
+            // Director, tunnel-first, HTTP fallback pre-cut).
+            var removeReq = new InterruptedRemoveRequest { DeadDirectorId = deadDirectorId, DeadPid = deadPid, SessionId = row.SessionId };
+            var removeSr = await DirectorCommandRouter.TrySendAsync(sendCommand, reporter.DirectorId, "interrupted-remove", "", removeReq, CancellationToken.None);
+            var cleaned = removeSr is not null
+                ? removeSr.Ok
+                : await client.RemoveInterruptedSessionAsync((reporter.ControlEndpoint ?? "").TrimEnd('/'), deadDirectorId, deadPid, row.SessionId);
             if (!cleaned)
                 FileLog.Write($"[GatewayEndpoints] restore: journal cleanup failed for {row.SessionId} (row stays in the Interrupted sessions list)");
 
@@ -1350,16 +1382,18 @@ internal static class GatewayEndpoints
             while (DateTime.UtcNow < deadline)
             {
                 await Task.Delay(750);
-                var cur = await client.GetSessionAsync(director.ControlEndpoint, sid);
+                // Gateway Cleanup Phase 2: the idle poll rides the tunnel too (snapshot verb, tunnel-first);
+                // a null return falls back to the byte-identical HTTP dial. Post-cut the HTTP arm is removed.
+                var cur = await SnapshotTunnelFirstAsync(sendCommand, client, director, sid, CancellationToken.None);
                 if (cur is null) { finalState = "Exited"; break; }
                 finalState = cur.ActivityState;
                 if (finalState is "Idle" or "WaitingForInput" or "Exited" or "Failed") break;
             }
             sw.Stop();
 
-            // Fetch new output since prompt was sent
+            // Fetch new output since prompt was sent. Gateway Cleanup Phase 2: buffer verb, tunnel-first.
             string output = "";
-            var buf = await client.GetBufferAsync(director.ControlEndpoint, sid, lines: 500, raw: false, since: body.BufferCursor);
+            var buf = await BufferTunnelFirstAsync(sendCommand, client, director, sid, 500, body.BufferCursor, CancellationToken.None);
             if (buf is not null) output = buf.Text;
 
             body.WaitStatus = finalState switch
@@ -2097,7 +2131,20 @@ internal static class GatewayEndpoints
                 }
 
                 var promptReq = new PromptRequest { Text = req.Text, AppendEnter = req.AppendEnter };
-                var (ok, body, err) = await client.PostPromptAsync(director.ControlEndpoint, sid, promptReq);
+                // Gateway Cleanup Phase 2: fanout delivery rides the tunnel (prompt verb, tunnel-first);
+                // a null return falls back to the byte-identical HTTP dial. Post-cut the HTTP arm is removed.
+                bool ok; PromptResponse? body; string? err;
+                var deliverSr = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "prompt", sid, promptReq, CancellationToken.None);
+                if (deliverSr is not null)
+                {
+                    ok = deliverSr.Ok;
+                    body = deliverSr.Ok ? DirectorCommandRouter.ReadBody<PromptResponse>(deliverSr) : null;
+                    err = deliverSr.Ok ? null : DirectorCommandRouter.DescribeFailure(deliverSr);
+                }
+                else
+                {
+                    (ok, body, err) = await client.PostPromptAsync(director.ControlEndpoint, sid, promptReq);
+                }
                 if (!ok || body is null)
                 {
                     sw.Stop();
@@ -2124,20 +2171,20 @@ internal static class GatewayEndpoints
                     };
                 }
 
-                // Poll for idle
+                // Poll for idle. Gateway Cleanup Phase 2: snapshot verb, tunnel-first (HTTP fallback pre-cut).
                 var deadline = DateTime.UtcNow.AddMilliseconds(req.TimeoutMs);
                 string finalState = body.ActivityState;
                 while (DateTime.UtcNow < deadline)
                 {
                     await Task.Delay(750);
-                    var cur = await client.GetSessionAsync(director.ControlEndpoint, sid);
+                    var cur = await SnapshotTunnelFirstAsync(sendCommand, client, director, sid, CancellationToken.None);
                     if (cur is null) { finalState = "Exited"; break; }
                     finalState = cur.ActivityState;
                     if (finalState is "Idle" or "WaitingForInput" or "Exited" or "Failed") break;
                 }
 
-                // Get the diff
-                var buf = await client.GetBufferAsync(director.ControlEndpoint, sid, lines: 500, raw: false, since: body.BufferCursor);
+                // Get the diff. Gateway Cleanup Phase 2: buffer verb, tunnel-first (HTTP fallback pre-cut).
+                var buf = await BufferTunnelFirstAsync(sendCommand, client, director, sid, 500, body.BufferCursor, CancellationToken.None);
                 var output = buf?.Text ?? "";
 
                 sw.Stop();
@@ -2343,6 +2390,31 @@ internal static class GatewayEndpoints
     {
         var machine = string.IsNullOrWhiteSpace(session.MachineName) ? (director.MachineName ?? "") : session.MachineName;
         return new BroadcastScope(session.MissionId?.ToString(), session.GroupId, session.RepoPath, machine);
+    }
+
+    // Gateway Cleanup mission, Phase 2: the idle-wait poll (single prompt AND fanout broadcast) reads the
+    // owning session snapshot / terminal buffer over the tunnel FIRST (snapshot / buffer verbs), falling back
+    // to the byte-identical HTTP dial only when the Director has no stream. Post-cut the HTTP arm is removed.
+    // Shared by both poll sites so there is one tunnel-branch to prove.
+    private static async Task<SessionDto?> SnapshotTunnelFirstAsync(
+        DirectorCommandRouter.SendDirectorCommandAsync? sendCommand, DirectorEndpointClient client,
+        DirectorDto director, string sid, CancellationToken ct)
+    {
+        var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "snapshot", sid, null, ct);
+        if (sr is not null)
+            return sr.Ok ? DirectorCommandRouter.ReadBody<SessionDto>(sr) : null;
+        return await client.GetSessionAsync(director.ControlEndpoint, sid, ct);
+    }
+
+    private static async Task<BufferResponse?> BufferTunnelFirstAsync(
+        DirectorCommandRouter.SendDirectorCommandAsync? sendCommand, DirectorEndpointClient client,
+        DirectorDto director, string sid, int lines, long? since, CancellationToken ct)
+    {
+        var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "buffer", sid,
+            new BufferRequest { Lines = lines, Raw = false, Since = since }, ct);
+        if (sr is not null)
+            return sr.Ok ? DirectorCommandRouter.ReadBody<BufferResponse>(sr) : null;
+        return await client.GetBufferAsync(director.ControlEndpoint, sid, lines, raw: false, since: since, ct);
     }
 
     // Gateway Cleanup mission, Phase 2 (PR E-B): internal so the voice / dictation cluster endpoints reuse


### PR DESCRIPTION
## What

The final pre-cut completeness check for the Gateway Cleanup mission ran the DEFINITIVE `DirectorEndpointClient` caller sweep (grep-verified, not the prior A-D classification, per the Architect's ruling). It found THREE caller clusters that still dialed the owning Director over HTTP with **no tunnel branch** - each would 404 after the destructive cut removes `DirectorEndpointClient`:

1. **`POST /sessions/{sid}/prompt` WaitForIdle poll** - the idle poll (`GetSessionAsync`) and output diff (`GetBufferAsync`) were unconditional HTTP even though prompt delivery was already tunnel-first. (This is the finding the whole-surface real-exe proof surfaced.)
2. **`POST /fanout` fleet broadcast** - the whole send (`PostPromptAsync`) + idle poll (`GetSessionAsync`) + output diff (`GetBufferAsync`) were HTTP.
3. **`POST /interrupted/{dir}/{pid}/restore`** - the continuation create (raw `spawnHttp.PostAsJsonAsync`), rename (`PatchSessionAsync`), and journal cleanup (`RemoveInterruptedSessionAsync`) were HTTP.

## How

All re-pointed **tunnel-first with the byte-identical HTTP dial kept as the fallback** (removed at the destructive cut), reusing the EXISTING registered Director verbs `snapshot` / `buffer` / `prompt` / `create` / `patch` / `interrupted-remove`. The two idle-poll sites share `SnapshotTunnelFirstAsync` + `BufferTunnelFirstAsync` so there is one tunnel branch to prove. Additive - no deletions.

## Proof

`TunnelIdleWaitFanoutRestoreProofTests` drives each flow end to end against a REAL streamMode Gateway + REAL MessagePack SignalR client with the Director registered **UNREACHABLE** (tunnel-by-construction), asserting the exact verb sequence each re-pointed leg sent down the tunnel. 3/3 green; full Gateway suite 2147/2147.

Part of the Gateway Cleanup mission (kill the Director remote REST surface; everything Gateway<->Director over the tunnel). This is one of two final pre-cut additive re-point PRs; a follow-up adds the `shutdown` + `handover-context` verbs. After both merge, the definitive grep is re-run for the Architect's final destructive-cut clearance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)