### PR TITLE
feat(gateway-cleanup): add shutdown + handover-context tunnel verbs, re-point the last two HTTP callers

### DIFF
--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -668,12 +668,38 @@ public sealed class ControlApiHost : IAsyncDisposable
             // Gateway Cleanup mission, Phase 0 (wave 3): also carry the Director version and the repository
             // registry so the director-level reads that stamp/read them (facts, handover, repos-list) serve the
             // same value over the tunnel that their REST route served.
-            cmd => SessionCommandExecutor.DispatchAsync(_sessionManager, DirectorId, cmd,
-                new SessionCommandServices { ProactiveExplain = _proactiveExplain, TurnSummaryCache = _turnSummaryCache, MissionStore = _missionStore, DirectorVersion = _version, Repositories = _repositoryRegistry }),
+            cmd => DispatchTunnelCommandAsync(cmd),
             // Gateway Cleanup mission, Phase 0 (up-stream): pass the SessionManager so the four connection-bound
             // stream verbs work - their terminal/file producers read session and file state from it and stream
             // frames up this same connection.
             sessionManager: _sessionManager);
+    }
+
+    /// <summary>
+    /// The Director-side dispatcher for a command that arrived over the tunnel. Almost every verb runs through
+    /// the shared <see cref="SessionCommandExecutor"/> so it is byte-identical to its HTTP route. The one
+    /// exception is <c>shutdown</c> (Gateway Cleanup mission): stopping the whole Director is a HOST concern,
+    /// not a session-command concern - it has no place in a session executor and needs the host's shutdown hook -
+    /// so it is handled here. <c>POST /shutdown</c> stays on the loopback floor for the local launcher; this is
+    /// the Gateway-initiated REMOTE stop (<c>DELETE /directors/{id}</c>) taking the same in-process self-shutdown
+    /// path, fired-and-forgotten (like the REST route) so the Ok result flushes before Kestrel and the stream tear down.
+    /// </summary>
+    private Task<DirectorCommandResult> DispatchTunnelCommandAsync(DirectorCommand cmd)
+    {
+        if (string.Equals(cmd.Verb, "shutdown", StringComparison.Ordinal))
+        {
+            FileLog.Write("[ControlApiHost] tunnel 'shutdown' command received; self-shutting-down");
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(100);
+                try { await _requestShutdownAsync(); }
+                catch (Exception ex) { FileLog.Write($"[ControlApiHost] tunnel shutdown FAILED: {ex.Message}"); }
+            });
+            return Task.FromResult(DirectorCommandResult.Success());
+        }
+
+        return SessionCommandExecutor.DispatchAsync(_sessionManager, DirectorId, cmd,
+            new SessionCommandServices { ProactiveExplain = _proactiveExplain, TurnSummaryCache = _turnSummaryCache, MissionStore = _missionStore, DirectorVersion = _version, Repositories = _repositoryRegistry });
     }
 
     /// <summary>

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1493,46 +1493,29 @@ internal static class ControlEndpoints
             }
         });
 
-        app.MapGet("/sessions/{sid}/handover-context", (string sid, string? extraContext) =>
+        // Return the plain-text prompt that would be sent to a target session on POST /handover. Useful for
+        // clients (skills, UI) that want to preview or edit the context before dispatching. Gateway Cleanup Phase 0:
+        // the read runs through the shared SessionReadExecutor core (handover-context verb) so this REST path and
+        // the Gateway stream down-channel are identical and cannot drift. Phase 1 deletes this route.
+        app.MapGet("/sessions/{sid}/handover-context", async (string sid, string? extraContext) =>
         {
-            // Return the plain-text prompt that would be sent to a target session on
-            // POST /handover. Useful for clients (skills, UI) that want to preview or
-            // edit the context before dispatching.
-            if (!Guid.TryParse(sid, out var guid))
-                return Results.BadRequest(new { error = "invalid session id format" });
-
-            var session = sessionManager.GetSession(guid);
-            if (session is null)
-                return Results.NotFound(new { error = "session not found" });
-
-            SessionSummaryDto summary;
-            if (string.IsNullOrEmpty(session.ClaudeSessionId))
+            var command = new DirectorCommand
             {
-                summary = new SessionSummaryDto
-                {
-                    SessionId = sid, DirectorId = directorId,
-                    Agent = session.AgentKind.ToString(),
-                    RepoPath = session.RepoPath,
-                    ActivityState = session.ActivityState.ToString(),
-                    CreatedAt = session.CreatedAt.UtcDateTime,
-                };
-            }
-            else
-            {
-                var jsonl = ClaudeSessionReader.GetJsonlPath(session.ClaudeSessionId, session.RepoPath);
-                summary = File.Exists(jsonl)
-                    ? SummaryBuilder.Build(StreamMessageParser.ParseFile(jsonl))
-                    : new SessionSummaryDto();
-                summary.SessionId = sid;
-                summary.DirectorId = directorId;
-                summary.Agent = session.AgentKind.ToString();
-                summary.RepoPath = session.RepoPath;
-                summary.ActivityState = session.ActivityState.ToString();
-                summary.CreatedAt = session.CreatedAt.UtcDateTime;
-            }
+                Verb = "handover-context",
+                SessionId = sid,
+                PayloadJson = SessionCommandExecutor.Serialize(new HandoverContextRequest { ExtraContext = extraContext }),
+            };
+            var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command);
 
-            var text = SummaryBuilder.FormatAsHandoverPrompt(summary, extraContext);
-            return Results.Text(text, "text/plain; charset=utf-8");
+            return result.Status switch
+            {
+                DirectorCommandStatus.Ok => Results.Text(
+                    SessionCommandExecutor.Deserialize<HandoverContextResponse>(result.BodyJson)?.Text ?? "",
+                    "text/plain; charset=utf-8"),
+                DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+                DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+                _ => Results.Problem(result.Error ?? "handover-context command failed"),
+            };
         });
 
         // ===== REST: Recap (cheap claude --print side-call, cached) =====

--- a/src/CcDirector.ControlApi/SessionReadExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionReadExecutor.cs
@@ -44,6 +44,7 @@ internal sealed class SessionReadExecutor : ISessionCommandArea
         "wingman-view",
         "wingman-explain",
         "handover",
+        "handover-context",
     };
 
     public Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken)
@@ -65,6 +66,7 @@ internal sealed class SessionReadExecutor : ISessionCommandArea
             "wingman-view" => WingmanView(context, command),
             "wingman-explain" => WingmanExplain(sessionManager, command),
             "handover" => Handover(sessionManager, context.DirectorId, context.Services?.DirectorVersion, command),
+            "handover-context" => HandoverContext(sessionManager, context.DirectorId, command),
             _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the session read area"),
         };
         return Task.FromResult(result);
@@ -635,5 +637,56 @@ internal sealed class SessionReadExecutor : ISessionCommandArea
             MachineName = Environment.MachineName,
             Version = version ?? string.Empty,
         }));
+    }
+
+    /// <summary>
+    /// The <c>handover-context</c> verb: the plain-text prompt that would be sent to a target session on a
+    /// handover. Mirrors the Director's <c>GET /sessions/{sid}/handover-context</c> lambda verbatim - invalid id
+    /// -&gt; BadRequest, missing session -&gt; NotFound - building the same <see cref="SessionSummaryDto"/> and
+    /// running it through <see cref="SummaryBuilder.FormatAsHandoverPrompt"/> with the optional extra context.
+    /// The text is wrapped in a <see cref="HandoverContextResponse"/> so the tunnel body is valid JSON; the
+    /// re-pointed REST route unwraps it back to <c>text/plain</c>. Gateway Cleanup mission: the cross-Director
+    /// handover reads this over the tunnel before spawning the continuation on the target Director.
+    /// </summary>
+    internal static DirectorCommandResult HandoverContext(SessionManager sessionManager, string directorId, DirectorCommand command)
+    {
+        FileLog.Write($"[SessionReadExecutor] handover-context: sid={command.SessionId}");
+        if (!Guid.TryParse(command.SessionId, out var guid))
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "invalid session id format");
+
+        var session = sessionManager.GetSession(guid);
+        if (session is null)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
+
+        var extraContext = SessionCommandExecutor.Deserialize<HandoverContextRequest>(command.PayloadJson)?.ExtraContext;
+
+        SessionSummaryDto summary;
+        if (string.IsNullOrEmpty(session.ClaudeSessionId))
+        {
+            summary = new SessionSummaryDto
+            {
+                SessionId = command.SessionId, DirectorId = directorId,
+                Agent = session.AgentKind.ToString(),
+                RepoPath = session.RepoPath,
+                ActivityState = session.ActivityState.ToString(),
+                CreatedAt = session.CreatedAt.UtcDateTime,
+            };
+        }
+        else
+        {
+            var jsonl = ClaudeSessionReader.GetJsonlPath(session.ClaudeSessionId, session.RepoPath);
+            summary = File.Exists(jsonl)
+                ? SummaryBuilder.Build(StreamMessageParser.ParseFile(jsonl))
+                : new SessionSummaryDto();
+            summary.SessionId = command.SessionId;
+            summary.DirectorId = directorId;
+            summary.Agent = session.AgentKind.ToString();
+            summary.RepoPath = session.RepoPath;
+            summary.ActivityState = session.ActivityState.ToString();
+            summary.CreatedAt = session.CreatedAt.UtcDateTime;
+        }
+
+        var text = SummaryBuilder.FormatAsHandoverPrompt(summary, extraContext);
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(new HandoverContextResponse { Text = text }));
     }
 }

--- a/src/CcDirector.Gateway.Contracts/SessionReadContracts.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionReadContracts.cs
@@ -69,3 +69,23 @@ public sealed class WingmanExplainResponse
     public string? ClaudeVerbatim { get; set; }
     public string? Say { get; set; }
 }
+
+/// <summary>
+/// GET /sessions/{sid}/handover-context request. Carries the optional <c>extraContext</c> query argument the
+/// old REST route took (it has no home on <see cref="DirectorCommand"/>, so it rides in the command payload).
+/// Gateway Cleanup mission: the cross-Director handover reads this over the tunnel before spawning the target.
+/// </summary>
+public sealed class HandoverContextRequest
+{
+    public string? ExtraContext { get; set; }
+}
+
+/// <summary>
+/// GET /sessions/{sid}/handover-context response - the plain-text handover prompt the old REST route returned
+/// as <c>text/plain</c>. Wrapped in a typed body (like <c>buffer-html</c>) so the tunnel verb serializes valid
+/// JSON; the re-pointed REST route unwraps it back to <c>Results.Text</c>, byte-identical.
+/// </summary>
+public sealed class HandoverContextResponse
+{
+    public string Text { get; set; } = "";
+}

--- a/src/CcDirector.Gateway.Tests/SessionReadExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionReadExecutorTests.cs
@@ -478,4 +478,54 @@ public sealed class SessionReadExecutorTests
         }
         finally { sm.Dispose(); }
     }
+
+    // ---------- handover-context (Gateway Cleanup mission: cross-Director handover reads this over the tunnel) ----------
+
+    [Fact]
+    public async Task DispatchAsync_HandoverContext_InvalidSessionId_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("handover-context", "not-a-guid"));
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_HandoverContext_MissingSession_ReturnsNotFound()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("handover-context", Guid.NewGuid().ToString()));
+            Assert.Equal(DirectorCommandStatus.NotFound, result.Status);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_HandoverContext_ExistingSession_ReturnsTheHandoverPromptText()
+    {
+        var (sm, session, _) = NewSession();
+        try
+        {
+            var command = new DirectorCommand
+            {
+                CommandId = "r1",
+                Verb = "handover-context",
+                SessionId = session.Id.ToString(),
+                PayloadJson = SessionCommandExecutor.Serialize(new HandoverContextRequest { ExtraContext = "carry this note" }),
+            };
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", command);
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var body = JsonSerializer.Deserialize<HandoverContextResponse>(result.BodyJson ?? "", Json);
+            Assert.NotNull(body);
+            Assert.False(string.IsNullOrWhiteSpace(body!.Text)); // the formatted handover prompt
+            Assert.Contains("carry this note", body.Text);       // the extra context rode the payload into the prompt
+        }
+        finally { sm.Dispose(); }
+    }
 }

--- a/src/CcDirector.Gateway.Tests/TunnelShutdownHandoverProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelShutdownHandoverProofTests.cs
@@ -1,0 +1,191 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection; // AddMessagePackProtocol (client)
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Gateway Cleanup mission, Phase 2 (final pre-cut re-point): the two Gateway paths that dialed a Director over
+/// HTTP with NO tunnel path now ride the tunnel via the two NEW verbs this PR adds:
+///   - DELETE /directors/{id}  -> the "shutdown" director-level verb (POST /shutdown stays on the loopback floor
+///     for the local launcher; this is the Gateway-initiated REMOTE stop).
+///   - POST /handover          -> same-Director via the existing "handover-generate" verb; cross-Director reads
+///     the source context via the new "handover-context" read verb, then creates the target via "create".
+///
+/// TUNNEL-BY-CONSTRUCTION: both Directors register with DELIBERATELY UNREACHABLE control endpoints, so a success
+/// can only have ridden the tunnel; each test asserts the exact verb(s) the Gateway sent down.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class TunnelShutdownHandoverProofTests : IAsyncLifetime
+{
+    private const string Token = "test-token-shutdown-handover";
+    private const string SourceDir = "dir-source";
+    private const string TargetDir = "dir-target";
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _instancesDir = Path.Combine(Path.GetTempPath(), "cc-shutho-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private HubConnection _sourceConn = null!;
+    private HubConnection _targetConn = null!;
+    private SessionManager _sm = null!;
+    private Session _session = null!;
+    private string _sid = "";
+
+    private readonly List<DirectorCommand> _sourceCommands = new();
+    private readonly List<DirectorCommand> _targetCommands = new();
+    private static readonly JsonSerializerOptions WebJson = new(JsonSerializerDefaults.Web);
+
+    public TunnelShutdownHandoverProofTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-shutho-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            streamMode: true);
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+
+        _sm = new SessionManager(new AgentOptions());
+        _session = _sm.CreateEmbeddedSession(Path.GetTempPath(), null, new ExecuteActionTestBackend());
+        _sid = _session.Id.ToString();
+
+        foreach (var id in new[] { SourceDir, TargetDir })
+            _gateway.Registry.Upsert(new DirectorRegistrationRequest
+            {
+                DirectorId = id,
+                TailnetEndpoint = "http://127.0.0.1:59920/", // nothing listens here
+                MachineName = "shutho-machine",
+                Pid = 1,
+                Version = "test",
+                StartedAt = DateTime.UtcNow,
+            });
+
+        _sourceConn = await ConnectAsync(SourceDir, _sourceCommands);
+        _targetConn = await ConnectAsync(TargetDir, _targetCommands);
+
+        // The source session is pushed so the Gateway resolves SourceDir as its owner (TryLocate) via the tunnel.
+        await _sourceConn.InvokeAsync("PushSnapshot", 1L, new[]
+        {
+            new SessionDto { SessionId = _sid, ActivityState = "WaitingForInput" },
+        });
+    }
+
+    private async Task<HubConnection> ConnectAsync(string directorId, List<DirectorCommand> sink)
+    {
+        var conn = new HubConnectionBuilder()
+            .WithUrl($"http://127.0.0.1:{_gateway.Port}/director-stream", o => o.AccessTokenProvider = () => Task.FromResult<string?>(Token))
+            .AddMessagePackProtocol()
+            .Build();
+        conn.On<DirectorCommand, DirectorCommandResult>("Command", cmd => Dispatch(directorId, cmd, sink));
+        await conn.StartAsync();
+        await conn.InvokeAsync("Hello", new DirectorStreamHello { DirectorId = directorId, Version = "test" });
+        return conn;
+    }
+
+    private static DirectorCommandResult Dispatch(string directorId, DirectorCommand cmd, List<DirectorCommand> sink)
+    {
+        sink.Add(cmd);
+        return cmd.Verb switch
+        {
+            "shutdown" => DirectorCommandResult.Success(),
+            "handover-generate" => DirectorCommandResult.Success(JsonSerializer.Serialize(
+                new HandoverResponse { Accepted = true, TargetSession = new SessionDto { SessionId = "ho-target", ActivityState = "Working" } }, WebJson)),
+            "handover-context" => DirectorCommandResult.Success(JsonSerializer.Serialize(
+                new HandoverContextResponse { Text = "the source handover context" }, WebJson)),
+            "create" => DirectorCommandResult.Success(JsonSerializer.Serialize(
+                new SessionDto { SessionId = "xdir-target", ActivityState = "Working" }, WebJson)),
+            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}"),
+        };
+    }
+
+    public async Task DisposeAsync()
+    {
+        try { await _sourceConn.DisposeAsync(); } catch { /* best effort */ }
+        try { await _targetConn.DisposeAsync(); } catch { /* best effort */ }
+        _sm.Dispose();
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        foreach (var dir in new[] { _instancesDir, _root })
+            try { if (Directory.Exists(dir)) Directory.Delete(dir, true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task DeleteDirector_ridesTheTunnel_asTheShutdownVerb()
+    {
+        // TargetDir has no pushed sessions, so the live-session gate is skipped and the remote stop proceeds.
+        using var req = new HttpRequestMessage(HttpMethod.Delete, $"directors/{TargetDir}")
+        {
+            Content = JsonContent.Create(new { reason = "proof: remote stop over the tunnel" }),
+        };
+        var resp = await _http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode); // an HTTP dial to the unreachable Director would have failed
+
+        Assert.Contains(_targetCommands, c => c.Verb == "shutdown");
+        Assert.All(_targetCommands.Where(c => c.Verb == "shutdown"), c => Assert.Equal("", c.SessionId)); // director-level
+    }
+
+    [Fact]
+    public async Task Handover_sameDirector_ridesTheTunnel_asHandoverGenerate()
+    {
+        var resp = await _http.PostAsJsonAsync("handover", new HandoverRequest
+        {
+            FromSessionId = _sid,
+            ToRepoPath = Path.GetTempPath(), // same-Director (no toDirectorId) => the handover-generate proxy
+        });
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<HandoverResponse>();
+        Assert.True(body?.Accepted);
+        Assert.Equal("ho-target", body?.TargetSession?.SessionId);
+        Assert.Equal(SourceDir, body?.TargetSession?.DirectorId); // the Gateway stamps the source director id
+
+        Assert.Contains(_sourceCommands, c => c.Verb == "handover-generate");
+    }
+
+    [Fact]
+    public async Task Handover_crossDirector_ridesTheTunnel_asHandoverContextThenCreate()
+    {
+        var resp = await _http.PostAsJsonAsync("handover", new HandoverRequest
+        {
+            FromSessionId = _sid,
+            ToDirectorId = TargetDir,          // cross-Director
+            ToRepoPath = Path.GetTempPath(),
+        });
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<HandoverResponse>();
+        Assert.True(body?.Accepted);
+        Assert.Equal("xdir-target", body?.TargetSession?.SessionId);
+        Assert.Equal(TargetDir, body?.TargetSession?.DirectorId);
+        Assert.Equal("the source handover context", body?.ContextSent);
+
+        Assert.Contains(_sourceCommands, c => c.Verb == "handover-context"); // read from the source over the tunnel
+        Assert.Contains(_targetCommands, c => c.Verb == "create");           // spawn on the target over the tunnel
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -1792,7 +1792,14 @@ internal static class GatewayEndpoints
                 FileLog.Write($"[GatewayEndpoints] DELETE director: id={id} live-session count UNKNOWN (director unreachable); session gate skipped");
             }
 
-            var ok = await client.PostShutdownAsync(director.ControlEndpoint);
+            // Gateway Cleanup Phase 2: the Gateway-initiated REMOTE stop rides the tunnel (shutdown verb,
+            // director-level so SessionId is ""), tunnel-first; a null return falls back to the byte-identical
+            // HTTP dial. POST /shutdown stays on the Director loopback floor for the local launcher; this tunnel
+            // verb triggers the same in-process self-shutdown. Post-cut the HTTP arm is removed.
+            var shutdownSr = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "shutdown", "", null, CancellationToken.None);
+            var ok = shutdownSr is not null
+                ? shutdownSr.Ok
+                : await client.PostShutdownAsync(director.ControlEndpoint);
             if (ok)
             {
                 FileLog.Write($"[GatewayEndpoints] DELETE director: id={id} pid={director.Pid} graceful shutdown accepted");
@@ -1974,9 +1981,22 @@ internal static class GatewayEndpoints
 
             if (targetDirector is null)
             {
-                // Same-Director: proxy the entire request.
-                var (ok, body, err) = await client.PostHandoverAsync(sourceDirector.ControlEndpoint, req);
-                if (!ok || body is null)
+                // Same-Director: proxy the entire request. Gateway Cleanup Phase 2: ride the tunnel first
+                // (handover-generate verb, director-level so SessionId is ""); a null return falls back to the
+                // byte-identical HTTP proxy. A non-Ok stream result collapses to 502 exactly as the HTTP null did.
+                HandoverResponse? body; string? err;
+                var hgSr = await DirectorCommandRouter.TrySendAsync(sendCommand, sourceDirector.DirectorId, "handover-generate", "", req, CancellationToken.None);
+                if (hgSr is not null)
+                {
+                    body = hgSr.Ok ? DirectorCommandRouter.ReadBody<HandoverResponse>(hgSr) : null;
+                    err = hgSr.Ok ? null : DirectorCommandRouter.DescribeFailure(hgSr);
+                }
+                else
+                {
+                    var http = await client.PostHandoverAsync(sourceDirector.ControlEndpoint, req);
+                    body = http.body; err = http.error;
+                }
+                if (body is null)
                     return Results.Problem(err ?? "handover failed", statusCode: StatusCodes.Status502BadGateway);
                 if (body.TargetSession is not null) body.TargetSession.DirectorId = sourceDirector.DirectorId;
                 return Results.Json(body, statusCode: 201);
@@ -1988,18 +2008,31 @@ internal static class GatewayEndpoints
             if (string.IsNullOrEmpty(req.ToRepoPath))
                 return Results.BadRequest(new { error = "toRepoPath is required for cross-director handover" });
 
+            // Gateway Cleanup Phase 2: read the source session's handover context over the tunnel
+            // (handover-context verb), falling back to the byte-identical HTTP GET when the source has no stream.
             string contextText;
-            try
+            var ctxSr = await DirectorCommandRouter.TrySendAsync(sendCommand, sourceDirector.DirectorId, "handover-context",
+                req.FromSessionId, new HandoverContextRequest { ExtraContext = req.ExtraContext }, CancellationToken.None);
+            if (ctxSr is not null)
             {
-                var ctxUrl = $"{sourceDirector.ControlEndpoint}/sessions/{req.FromSessionId}/handover-context";
-                if (!string.IsNullOrEmpty(req.ExtraContext))
-                    ctxUrl += "?extraContext=" + Uri.EscapeDataString(req.ExtraContext);
-                using var ctxHttp = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
-                contextText = await ctxHttp.GetStringAsync(ctxUrl);
+                if (!ctxSr.Ok)
+                    return Results.Problem("failed to read handover-context from source director: " + DirectorCommandRouter.DescribeFailure(ctxSr), statusCode: 502);
+                contextText = DirectorCommandRouter.ReadBody<HandoverContextResponse>(ctxSr)?.Text ?? "";
             }
-            catch (Exception ex)
+            else
             {
-                return Results.Problem("failed to read handover-context from source director: " + ex.Message, statusCode: 502);
+                try
+                {
+                    var ctxUrl = $"{sourceDirector.ControlEndpoint}/sessions/{req.FromSessionId}/handover-context";
+                    if (!string.IsNullOrEmpty(req.ExtraContext))
+                        ctxUrl += "?extraContext=" + Uri.EscapeDataString(req.ExtraContext);
+                    using var ctxHttp = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+                    contextText = await ctxHttp.GetStringAsync(ctxUrl);
+                }
+                catch (Exception ex)
+                {
+                    return Results.Problem("failed to read handover-context from source director: " + ex.Message, statusCode: 502);
+                }
             }
 
             var spawnReq = new NewSessionRequest
@@ -2008,14 +2041,27 @@ internal static class GatewayEndpoints
                 Agent = req.ToAgent,
                 PrePrompt = contextText,
             };
-            using var spawnHttp = new HttpClient { Timeout = TimeSpan.FromSeconds(20) };
-            var spawnResp = await spawnHttp.PostAsJsonAsync($"{targetDirector.ControlEndpoint}/sessions", spawnReq);
-            if (!spawnResp.IsSuccessStatusCode)
+            // Gateway Cleanup Phase 2: create the target over the tunnel (create verb, director-level), tunnel-first;
+            // the dedicated 20s HTTP client is the fallback pre-cut (the tunnel unary has no 2s aggregate timeout).
+            SessionDto? newSession;
+            var spawnSr = await DirectorCommandRouter.TrySendAsync(sendCommand, targetDirector.DirectorId, "create", "", spawnReq, CancellationToken.None);
+            if (spawnSr is not null)
             {
-                var body = await spawnResp.Content.ReadAsStringAsync();
-                return Results.Problem($"target director returned {(int)spawnResp.StatusCode}: {body}", statusCode: 502);
+                if (!spawnSr.Ok)
+                    return Results.Problem($"target director returned {DirectorCommandRouter.DescribeFailure(spawnSr)}", statusCode: 502);
+                newSession = DirectorCommandRouter.ReadBody<SessionDto>(spawnSr);
             }
-            var newSession = await spawnResp.Content.ReadFromJsonAsync<SessionDto>();
+            else
+            {
+                using var spawnHttp = new HttpClient { Timeout = TimeSpan.FromSeconds(20) };
+                var spawnResp = await spawnHttp.PostAsJsonAsync($"{targetDirector.ControlEndpoint}/sessions", spawnReq);
+                if (!spawnResp.IsSuccessStatusCode)
+                {
+                    var body = await spawnResp.Content.ReadAsStringAsync();
+                    return Results.Problem($"target director returned {(int)spawnResp.StatusCode}: {body}", statusCode: 502);
+                }
+                newSession = await spawnResp.Content.ReadFromJsonAsync<SessionDto>();
+            }
             if (newSession is not null) newSession.DirectorId = targetDirector.DirectorId;
 
             return Results.Json(new HandoverResponse


### PR DESCRIPTION
## What

The second and final pre-cut additive re-point for the Gateway Cleanup mission. It closes the two Gateway paths the definitive `DirectorEndpointClient` grep found with **no tunnel path**, each of which needed a NEW director verb:

1. **`DELETE /directors/{id}`** (remote Director stop - used by the Cockpit exes page, `exesClient.ts`) dialed `POST /shutdown` over HTTP. Added a director-level **`shutdown` tunnel verb** handled at the host (`ControlApiHost.DispatchTunnelCommandAsync`) - it fires the SAME in-process self-shutdown `POST /shutdown` uses, fire-and-forget so the `Ok` flushes before Kestrel/the stream tear down. `POST /shutdown` **stays on the loopback floor** for the local launcher; this is only the Gateway-initiated remote stop. The route now rides the verb tunnel-first (HTTP fallback pre-cut).

2. **`POST /handover`** dialed the source/target Directors over HTTP. Same-Director now rides the existing **`handover-generate`** verb; cross-Director (exercised by the `/move-session` skill's "move to another Director" path, field-verified) reads the source context via a NEW **`handover-context`** read verb, then creates the continuation via the **`create`** verb. All tunnel-first, byte-identical HTTP dial kept as the fallback (removed at the cut).

## How

`handover-context` lifts the `GET /sessions/{sid}/handover-context` REST body into a shared `SessionReadExecutor` core (like the other read verbs); the REST route now dispatches to it, so the two callers cannot drift. New `HandoverContextRequest`/`HandoverContextResponse` contracts. Additive - no deletions.

## Proof

`TunnelShutdownHandoverProofTests` drives `DELETE /directors/{id}` + same-Director and cross-Director `POST /handover` against a REAL streamMode Gateway with BOTH Directors registered **UNREACHABLE** (two MessagePack SignalR connections; tunnel-by-construction), asserting the exact verbs sent (`shutdown` / `handover-generate` / `handover-context` + `create`). `SessionReadExecutorTests` gains `handover-context` parity (bad id -> BadRequest, missing -> NotFound, real -> the prompt text with the extra context folded in). Full Gateway suite **2153/2153**; source-audit guards green.

With PR #1474 (strays 1-3) already merged, this completes the additive tunnel re-point. After merge, the definitive `DirectorEndpointClient` grep is re-run and brought to the Architect for the final destructive-cut clearance. The Director-side `shutdown` self-stop is exercised end to end by the upcoming floor-only real-exe proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)