### PR TITLE
feat(network-diagnostics): Phase 1 - diagnostics endpoints, phone/cockpit pages, monitor, drift detector, rollup, status pill

### DIFF
--- a/apps/cockpit/src/AppShell.tsx
+++ b/apps/cockpit/src/AppShell.tsx
@@ -1,4 +1,5 @@
 import { NavLink, Outlet, useLocation } from "react-router-dom";
+import { CockpitStatusPill } from "./network/CockpitStatusPill";
 
 // The desktop layout frame (epic #967): a two-region shell - a left rail (navigation) and the main
 // pane (the routed page). The main pane fills all remaining width. Desktop-first: the frame stays
@@ -47,6 +48,7 @@ const NAV_SECTIONS: ReadonlyArray<{ title: string; items: ReadonlyArray<NavItem>
       { to: "/transcripts", label: "Voice Recorder" },
       { to: "/exes", label: "Executables" },
       { to: "/transcription", label: "Transcription" },
+      { to: "/network", label: "Network" },
       { to: "/learn", label: "Learning" },
     ],
   },
@@ -68,6 +70,7 @@ export function AppShell() {
     <div className="shell">
       <nav className="rail rail-left" aria-label="Primary">
         <div className="brand">DevThrottle</div>
+        <CockpitStatusPill />
         <div className="nav">
           {NAV_SECTIONS.map((section) => (
             <div className="nav-section" key={section.title}>

--- a/apps/cockpit/src/main.tsx
+++ b/apps/cockpit/src/main.tsx
@@ -24,6 +24,7 @@ import { ExesView } from "./exes/ExesView";
 import { LearningView } from "./learning/LearningView";
 import { YourThrottleView } from "./throttle/YourThrottleView";
 import { TranscriptionHealthView } from "./transcription/TranscriptionHealthView";
+import { NetworkDiagnosticsView } from "./network/NetworkDiagnosticsView";
 import { AccountView } from "./account/AccountView";
 import { AboutView } from "./about/AboutView";
 import { SettingsView } from "./settings/SettingsView";
@@ -178,6 +179,7 @@ const router = createBrowserRouter(
             // Transcription Health: read-only view over the local transcription telemetry the Gateway
             // records (latency, failures, most-corrected words). Same Gateway REST surface via client-core.
             { path: "/transcription", element: <TranscriptionHealthView /> },
+            { path: "/network", element: <NetworkDiagnosticsView /> },
             { path: "/account", element: <AccountView /> },
             { path: "/about", element: <AboutView /> },
             // The Settings page (issue #1025): a real React port of the retired Blazor

--- a/apps/cockpit/src/network/CockpitStatusPill.tsx
+++ b/apps/cockpit/src/network/CockpitStatusPill.tsx
@@ -1,0 +1,21 @@
+import { Link } from "react-router-dom";
+import { useNetStatus } from "@devthrottle/client-core/net/useNetStatus";
+import "./statusPill.css";
+
+// The Cockpit's network status pill (Network Diagnostics mission, Phase 1): the same always-visible
+// green/amber/red/grey indicator the phone shows, in the left rail. Colour comes from the authoritative
+// direct-vs-relay for this device; tapping it opens the Network Diagnostics view.
+export function CockpitStatusPill() {
+  const status = useNetStatus();
+  return (
+    <Link
+      to="/network"
+      className={`net-pill net-pill-${status.level}`}
+      title={status.detail}
+      aria-label={`Network: ${status.label}. ${status.detail}`}
+    >
+      <span className="net-pill-dot" aria-hidden="true" />
+      <span className="net-pill-label">Network: {status.label}</span>
+    </Link>
+  );
+}

--- a/apps/cockpit/src/network/NetworkDiagnosticsView.tsx
+++ b/apps/cockpit/src/network/NetworkDiagnosticsView.tsx
@@ -1,0 +1,287 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  getNetworkDiag,
+  getNetDiagResults,
+  measureLatency,
+  measureDownload,
+  measureUpload,
+  postNetDiagResult,
+  type NetworkDiag,
+  type NetDiagResult,
+  type ThroughputResult,
+} from "@devthrottle/client-core/api/client";
+import "./network.css";
+
+// Network Diagnostics (Cockpit): the operator/agent view of network health. Its centerpiece is the
+// SERVER-SIDE Tailscale check (GET /diag/network) - per connected device, direct-vs-DERP-relay + latency,
+// with no phone needed - which is the one signal that tells "warming up on the relay" apart from
+// "genuinely slow". It also lets you test THIS browser's path and shows the recent results users saw.
+
+const DOWNLOAD_BYTES = 4 * 1024 * 1024;
+const UPLOAD_BYTES = 2 * 1024 * 1024;
+const LATENCY_SAMPLES = 6;
+
+type TestPhase = "idle" | "latency" | "download" | "upload" | "done";
+
+export function NetworkDiagnosticsView() {
+  const [diag, setDiag] = useState<NetworkDiag | null>(null);
+  const [diagError, setDiagError] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const [results, setResults] = useState<NetDiagResult[]>([]);
+
+  const [phase, setPhase] = useState<TestPhase>("idle");
+  const [latency, setLatency] = useState<number[] | null>(null);
+  const [download, setDownload] = useState<ThroughputResult | null>(null);
+  const [upload, setUpload] = useState<ThroughputResult | null>(null);
+
+  const loadDiag = useCallback(async (signal?: AbortSignal) => {
+    try {
+      setDiagError(false);
+      setRefreshing(true);
+      const d = await getNetworkDiag(signal);
+      setDiag(d);
+    } catch {
+      if (!signal?.aborted) setDiagError(true);
+    } finally {
+      setRefreshing(false);
+    }
+  }, []);
+
+  const loadResults = useCallback(async (signal?: AbortSignal) => {
+    try {
+      setResults(await getNetDiagResults(signal));
+    } catch {
+      /* the results list is a nice-to-have; leave it empty on failure */
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void loadDiag(controller.signal);
+    void loadResults(controller.signal);
+    return () => controller.abort();
+  }, [loadDiag, loadResults]);
+
+  const testRunning = phase === "latency" || phase === "download" || phase === "upload";
+  const medianLatency = useMemo(() => (latency ? median(latency) : null), [latency]);
+
+  async function runSelfTest() {
+    setLatency(null);
+    setDownload(null);
+    setUpload(null);
+    try {
+      setPhase("latency");
+      const timings = await measureLatency(LATENCY_SAMPLES);
+      setLatency(timings);
+      setPhase("download");
+      const dl = await measureDownload(DOWNLOAD_BYTES);
+      setDownload(dl);
+      setPhase("upload");
+      const ul = await measureUpload(UPLOAD_BYTES);
+      setUpload(ul);
+      setPhase("done");
+      void postNetDiagResult({
+        route: "",
+        latencyMedianMs: median(timings),
+        latencyBestMs: Math.min(...timings),
+        latencySamples: timings.length,
+        downloadMbps: dl.mbps,
+        uploadMbps: ul.mbps,
+        rating: rate(median(timings), dl.mbps),
+        verdict: `Cockpit self-test: ${formatMs(median(timings))} ms, ${formatMbps(dl.mbps)} Mbps down`,
+        loadedFrom: typeof window !== "undefined" ? window.location.host : "",
+        surface: "cockpit",
+      }).catch(() => undefined);
+      void loadResults();
+    } catch {
+      setPhase("idle");
+    }
+  }
+
+  return (
+    <div className="page netdiag">
+      <div className="page-head">
+        <h1>Network Diagnostics</h1>
+        <button type="button" className="netdiag-refresh" onClick={() => void loadDiag()} disabled={refreshing}>
+          {refreshing ? "Checking..." : "Refresh"}
+        </button>
+      </div>
+
+      <p className="netdiag-lede">
+        The server-side Tailscale check for this Gateway. For each connected device it shows whether Tailscale
+        is on a direct LAN path or relaying through a distant DERP server - the difference between a fast home
+        connection and a slow one.
+      </p>
+
+      <section className="netdiag-section" aria-label="Network health">
+        {diagError ? (
+          <div className="netdiag-error">Could not read the network diagnostic from the Gateway.</div>
+        ) : diag === null ? (
+          <div className="netdiag-muted">Loading...</div>
+        ) : !diag.tailscaleAvailable ? (
+          <div className="netdiag-muted">Tailscale is not installed on the Gateway machine.</div>
+        ) : (
+          <>
+            <div className="netdiag-summary">
+              <span>
+                Gateway <strong>{diag.selfName ?? "?"}</strong> ({diag.selfTailscaleIp ?? "?"})
+              </span>
+              <span>backend: {diag.backendState ?? "?"}</span>
+              <span>UDP: {yn(diag.udpOk)}</span>
+              <span>hard-NAT: {yn(diag.mappingVariesByDestIp)}</span>
+              <span>nearest relay: {diag.nearestDerp ?? "?"}</span>
+            </div>
+            <table className="netdiag-table">
+              <thead>
+                <tr>
+                  <th>Device</th>
+                  <th>Tailscale IP</th>
+                  <th>OS</th>
+                  <th>Online</th>
+                  <th>Path</th>
+                  <th>Latency</th>
+                </tr>
+              </thead>
+              <tbody>
+                {diag.peers.length === 0 && (
+                  <tr>
+                    <td colSpan={6} className="netdiag-muted">
+                      No peers connected.
+                    </td>
+                  </tr>
+                )}
+                {diag.peers.map((p) => (
+                  <tr key={p.tailscaleIp ?? p.name}>
+                    <td>{p.name}</td>
+                    <td>{p.tailscaleIp ?? "-"}</td>
+                    <td>{p.os ?? "-"}</td>
+                    <td>{yn(p.online)}</td>
+                    <td>
+                      {p.direct === true ? (
+                        <span className="netdiag-direct">direct {p.path ?? ""}</span>
+                      ) : p.direct === false ? (
+                        <span className="netdiag-relay">RELAY {p.path ?? ""}</span>
+                      ) : (
+                        <span className="netdiag-muted">{p.path ?? "-"}</span>
+                      )}
+                    </td>
+                    <td>{p.latencyMs != null ? `${Math.round(p.latencyMs)} ms` : "-"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {diag.notes.map((n, i) => (
+              <div key={i} className="netdiag-note">
+                {n}
+              </div>
+            ))}
+          </>
+        )}
+      </section>
+
+      <section className="netdiag-section" aria-label="Test this browser">
+        <h2>Test this browser</h2>
+        <button type="button" className="netdiag-run" onClick={runSelfTest} disabled={testRunning}>
+          {testRunning ? testPhaseLabel(phase) : latency ? "Run again" : "Run speed test"}
+        </button>
+        {(latency || download || upload) && (
+          <div className="netdiag-metrics">
+            <Metric label="Latency" value={medianLatency != null ? `${formatMs(medianLatency)} ms` : "..."} />
+            <Metric label="Download" value={download ? `${formatMbps(download.mbps)} Mbps` : "..."} />
+            <Metric label="Upload" value={upload ? `${formatMbps(upload.mbps)} Mbps` : "..."} />
+          </div>
+        )}
+      </section>
+
+      <section className="netdiag-section" aria-label="Recent results">
+        <h2>Recent results</h2>
+        {results.length === 0 ? (
+          <div className="netdiag-muted">No speed-test results logged yet.</div>
+        ) : (
+          <table className="netdiag-table">
+            <thead>
+              <tr>
+                <th>Received (UTC)</th>
+                <th>Surface</th>
+                <th>Gateway sees</th>
+                <th>Latency</th>
+                <th>Down</th>
+                <th>Up</th>
+                <th>Rating</th>
+              </tr>
+            </thead>
+            <tbody>
+              {results.map((r, i) => (
+                <tr key={i}>
+                  <td>{shortTime(r.receivedAt)}</td>
+                  <td>{r.surface || "-"}</td>
+                  <td>
+                    {r.clientIp ?? "?"} ({r.clientPath ?? "?"})
+                  </td>
+                  <td>{ms(r.latencyMedianMs)}</td>
+                  <td>{mbps(r.downloadMbps)}</td>
+                  <td>{mbps(r.uploadMbps)}</td>
+                  <td>{r.rating || "-"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="netdiag-metric">
+      <div className="netdiag-metric-label">{label}</div>
+      <div className="netdiag-metric-value">{value}</div>
+    </div>
+  );
+}
+
+function testPhaseLabel(phase: TestPhase): string {
+  if (phase === "latency") return "Latency...";
+  if (phase === "download") return "Download...";
+  if (phase === "upload") return "Upload...";
+  return "Running...";
+}
+
+function rate(medianMs: number, downMbps: number): string {
+  if (medianMs < 30 && downMbps >= 50) return "fast";
+  if (medianMs < 100 && downMbps >= 10) return "ok";
+  return "slow";
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function yn(value: boolean | null | undefined): string {
+  return value === true ? "yes" : value === false ? "no" : "?";
+}
+
+function ms(value: number | null | undefined): string {
+  return typeof value === "number" ? `${Math.round(value)} ms` : "-";
+}
+
+function mbps(value: number | null | undefined): string {
+  return typeof value === "number" ? `${value.toFixed(1)} Mbps` : "-";
+}
+
+function formatMs(value: number): string {
+  return value >= 100 ? String(Math.round(value)) : value.toFixed(1);
+}
+
+function formatMbps(value: number): string {
+  return value >= 100 ? String(Math.round(value)) : value.toFixed(1);
+}
+
+function shortTime(value: string | undefined): string {
+  if (!value) return "-";
+  return value.slice(0, 19).replace("T", " ");
+}

--- a/apps/cockpit/src/network/network.css
+++ b/apps/cockpit/src/network/network.css
@@ -1,0 +1,105 @@
+/* Network Diagnostics view (Cockpit). Uses the shared cockpit theme tokens plus a local green/red for
+   the direct/relay states. */
+
+.netdiag-lede {
+  color: var(--text-dim);
+  max-width: 70ch;
+  line-height: 1.5;
+  margin: 0 0 16px;
+}
+
+.netdiag-section {
+  margin-bottom: 24px;
+}
+.netdiag-section h2 {
+  font-size: 15px;
+  margin: 0 0 10px;
+}
+
+.netdiag-refresh,
+.netdiag-run {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  border-radius: 6px;
+  padding: 8px 14px;
+  font-size: 14px;
+  cursor: pointer;
+}
+.netdiag-run {
+  border-color: var(--accent);
+}
+.netdiag-refresh:disabled,
+.netdiag-run:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.netdiag-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 18px;
+  color: var(--text-dim);
+  font-size: 13px;
+  margin-bottom: 12px;
+}
+.netdiag-summary strong {
+  color: var(--text);
+}
+
+.netdiag-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.netdiag-table th,
+.netdiag-table td {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+.netdiag-table th {
+  color: var(--text-dim);
+  font-weight: 600;
+}
+.netdiag-direct {
+  color: #37c26d;
+  font-weight: 600;
+}
+.netdiag-relay {
+  color: var(--warn, #e8a33d);
+  font-weight: 700;
+}
+.netdiag-muted {
+  color: var(--text-dim);
+}
+.netdiag-note {
+  color: var(--warn, #e8a33d);
+  font-size: 12px;
+  margin-top: 8px;
+}
+.netdiag-error {
+  color: var(--warn, #e8a33d);
+}
+
+.netdiag-metrics {
+  display: flex;
+  gap: 16px;
+  margin-top: 12px;
+}
+.netdiag-metric {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 14px;
+  min-width: 120px;
+}
+.netdiag-metric-label {
+  color: var(--text-dim);
+  font-size: 12px;
+}
+.netdiag-metric-value {
+  font-size: 20px;
+  font-weight: 700;
+  margin-top: 2px;
+}

--- a/apps/cockpit/src/network/statusPill.css
+++ b/apps/cockpit/src/network/statusPill.css
@@ -1,0 +1,29 @@
+/* The Cockpit network status pill in the left rail (Network Diagnostics mission, P1). */
+.net-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin: 0 12px 10px;
+  padding: 5px 11px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-dim);
+  font-size: 12px;
+  font-weight: 600;
+  text-decoration: none;
+}
+.net-pill-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-dim);
+  flex: 0 0 auto;
+}
+.net-pill-green .net-pill-dot { background: #37c26d; }
+.net-pill-amber .net-pill-dot { background: #e8a33d; }
+.net-pill-red .net-pill-dot { background: var(--warn, #e8a33d); }
+.net-pill-grey .net-pill-dot { background: var(--text-dim); }
+.net-pill-green { color: #37c26d; }
+.net-pill-amber { color: #e8a33d; }
+.net-pill-red { color: var(--warn, #e8a33d); }

--- a/apps/mobile/src/components/NavDrawer.tsx
+++ b/apps/mobile/src/components/NavDrawer.tsx
@@ -42,6 +42,9 @@ export function NavDrawer() {
             <Link className="drawer-item" to="/settings" onClick={close}>
               AI settings
             </Link>
+            <Link className="drawer-item" to="/diagnostics" onClick={close}>
+              Diagnostics
+            </Link>
             <Link className="drawer-item" to="/about" onClick={close}>
               About
             </Link>

--- a/apps/mobile/src/components/StatusPill.tsx
+++ b/apps/mobile/src/components/StatusPill.tsx
@@ -1,0 +1,21 @@
+import { Link } from "react-router-dom";
+import { useNetStatus } from "@devthrottle/client-core/net/useNetStatus";
+
+// The network status pill (Network Diagnostics mission, Phase 1): a small, always-visible green/amber/red/
+// grey dot + label that tells you your connection quality at a glance without opening a page. Its colour
+// comes from the authoritative direct-vs-relay for this device (never the speed-test guess), and it never
+// flashes red on the normal cold-start. Tapping it opens the full Diagnostics page.
+export function StatusPill() {
+  const status = useNetStatus();
+  return (
+    <Link
+      to="/diagnostics"
+      className={`net-pill net-pill-${status.level}`}
+      title={status.detail}
+      aria-label={`Network: ${status.label}. ${status.detail}`}
+    >
+      <span className="net-pill-dot" aria-hidden="true" />
+      <span className="net-pill-label">{status.label}</span>
+    </Link>
+  );
+}

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -11,6 +11,7 @@ import { CarMode } from "./pages/CarMode";
 import { EndWordTest } from "./pages/EndWordTest";
 import { AiSettings } from "./pages/AiSettings";
 import { About } from "./pages/About";
+import { Diagnostics } from "./pages/Diagnostics";
 import { YourThrottle } from "./pages/YourThrottle";
 import { SignIn } from "@devthrottle/client-core/auth/SignIn";
 import { DeviceCallback } from "@devthrottle/client-core/auth/DeviceCallback";
@@ -22,6 +23,7 @@ import { ConnectionBanner } from "./components/ConnectionBanner";
 import { useScreenWakeLock } from "./hooks/useScreenWakeLock";
 import { resumePendingDictations } from "@devthrottle/client-core/dictation/backgroundSend";
 import { RouteRecoveryBoundary, RootLayout } from "./components/StaleShellRecovery";
+import { StatusPill } from "./components/StatusPill";
 import "./styles.css";
 
 // The auth gate (issue #908): every real screen requires an enrolled device key. Without one, the
@@ -49,6 +51,7 @@ function GatedLayout() {
   return (
     <>
       <ConnectionBanner />
+      <StatusPill />
       <Outlet />
     </>
   );
@@ -117,6 +120,9 @@ const router = createBrowserRouter(
             { path: "/endword", element: <EndWordTest /> },
             { path: "/settings", element: <AiSettings /> },
             { path: "/about", element: <About /> },
+            // Diagnostics (auto-network-switching mission): a phone-side connection tester - route
+            // (direct LAN vs Tailscale relay), latency, and download/upload throughput, with a verdict.
+            { path: "/diagnostics", element: <Diagnostics /> },
             // Your Throttle (devthrottle-stats mission): the in-app port of the standalone Gateway
             // /stats page, reading the same GET /stats/data feed through client-core.
             { path: "/throttle", element: <YourThrottle /> },

--- a/apps/mobile/src/pages/Diagnostics.tsx
+++ b/apps/mobile/src/pages/Diagnostics.tsx
@@ -1,0 +1,367 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  getNetDiagEcho,
+  measureLatency,
+  measureDownload,
+  measureUpload,
+  getNetworkDiag,
+  postNetDiagResult,
+  gatewayErrorMessage,
+  type NetDiagEcho,
+  type ThroughputResult,
+  type NetworkDiag,
+  type NetDiagPeer,
+} from "@devthrottle/client-core/api/client";
+
+// Diagnostics (Network Diagnostics mission): a phone-side connection tester. A phone cannot run
+// `tailscale ping`, so this measures the phone-to-Gateway path from the phone itself - route, latency,
+// throughput - and then asks the Gateway for the AUTHORITATIVE Tailscale state (direct vs DERP relay) for
+// this exact connection, so the verdict distinguishes "warming up on the relay" from "genuinely slow".
+
+const DOWNLOAD_BYTES = 4 * 1024 * 1024;
+const UPLOAD_BYTES = 2 * 1024 * 1024;
+const LATENCY_SAMPLES = 6;
+
+type Phase = "idle" | "latency" | "download" | "upload" | "checking" | "done";
+
+export function Diagnostics() {
+  const [echo, setEcho] = useState<NetDiagEcho | null>(null);
+  const [echoError, setEchoError] = useState<string | null>(null);
+
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [latency, setLatency] = useState<number[] | null>(null);
+  const [download, setDownload] = useState<ThroughputResult | null>(null);
+  const [upload, setUpload] = useState<ThroughputResult | null>(null);
+  const [network, setNetwork] = useState<NetworkDiag | null>(null);
+  const [testError, setTestError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    getNetDiagEcho(controller.signal)
+      .then((e) => {
+        setEcho(e);
+        setEchoError(null);
+      })
+      .catch((err) => {
+        if (!controller.signal.aborted) setEchoError(gatewayErrorMessage(err));
+      });
+    return () => controller.abort();
+  }, []);
+
+  const running = phase !== "idle" && phase !== "done";
+
+  const medianLatency = useMemo(() => (latency ? median(latency) : null), [latency]);
+  // The Gateway's authoritative view of THIS phone's Tailscale path, matched by the IP the Gateway sees.
+  const selfPeer = useMemo(() => findSelfPeer(network, echo), [network, echo]);
+  const route = useMemo(() => describeRoute(echo, selfPeer), [echo, selfPeer]);
+  const verdict = useMemo(
+    () => buildVerdict(route.kind, selfPeer, medianLatency, download?.mbps ?? null),
+    [route.kind, selfPeer, medianLatency, download],
+  );
+
+  async function runSpeedTest() {
+    setTestError(null);
+    setLatency(null);
+    setDownload(null);
+    setUpload(null);
+    setNetwork(null);
+    try {
+      setPhase("latency");
+      const timings = await measureLatency(LATENCY_SAMPLES);
+      setLatency(timings);
+
+      setPhase("download");
+      const dl = await measureDownload(DOWNLOAD_BYTES);
+      setDownload(dl);
+
+      setPhase("upload");
+      const ul = await measureUpload(UPLOAD_BYTES);
+      setUpload(ul);
+
+      // Ask the Gateway for the authoritative direct-vs-relay state. Non-fatal: if it is unavailable we
+      // still show the measured numbers and fall back to the heuristic verdict.
+      setPhase("checking");
+      let net: NetworkDiag | null = null;
+      try {
+        net = await getNetworkDiag();
+        setNetwork(net);
+      } catch {
+        /* leave network null; verdict falls back to the measured heuristic */
+      }
+
+      setPhase("done");
+
+      // Log the result to the Gateway so an agent can read it later. Best-effort, never blocks the page.
+      const self = findSelfPeer(net, echo);
+      const v = buildVerdict(describeRoute(echo, self).kind, self, median(timings), dl.mbps);
+      void postNetDiagResult({
+        route: echo?.clientPath ?? "other",
+        latencyMedianMs: median(timings),
+        latencyBestMs: Math.min(...timings),
+        latencySamples: timings.length,
+        downloadMbps: dl.mbps,
+        uploadMbps: ul.mbps,
+        rating: v?.rating ?? "",
+        verdict: v?.headline ?? "",
+        loadedFrom: typeof window !== "undefined" ? window.location.host : "",
+        surface: "mobile",
+        // Actual-path tags from the authoritative self-peer, so the Gateway folds this into the right
+        // home(LAN-direct)/away(relay) sub-sum - never by the front-door route.
+        direct: self?.direct ?? null,
+        isLanPath: pathIsLan(self?.path ?? null),
+      }).catch(() => {
+        /* logging is best-effort */
+      });
+    } catch (err) {
+      setTestError(gatewayErrorMessage(err));
+      setPhase("idle");
+    }
+  }
+
+  return (
+    <div className="screen">
+      <header className="app-bar">
+        <Link className="back-link" to="/">
+          Back
+        </Link>
+        <h1>Diagnostics</h1>
+      </header>
+
+      {echoError !== null && (
+        <div className="banner banner-error" role="alert">
+          {echoError}
+        </div>
+      )}
+
+      <section className={`diag-route diag-route-${route.kind}`} aria-label="Connection route">
+        <div className="diag-route-label">Connection route</div>
+        <div className="diag-route-value">{route.title}</div>
+        <div className="diag-route-detail">{route.detail}</div>
+      </section>
+
+      <button type="button" className="diag-run" onClick={runSpeedTest} disabled={running}>
+        {running ? phaseLabel(phase) : latency ? "Run speed test again" : "Run speed test"}
+      </button>
+
+      {testError !== null && (
+        <div className="banner banner-error" role="alert">
+          {testError}
+        </div>
+      )}
+
+      {(latency || download || upload) && (
+        <section className="diag-metrics" aria-label="Speed results">
+          <Metric
+            label="Latency (round trip)"
+            value={medianLatency !== null ? `${formatMs(medianLatency)} ms` : pending(phase, "latency")}
+            sub={latency ? `best ${formatMs(Math.min(...latency))} ms of ${latency.length}` : ""}
+          />
+          <Metric
+            label="Download"
+            value={download ? `${formatMbps(download.mbps)} Mbps` : pending(phase, "download")}
+            sub={download ? `${formatMs(download.ms)} ms for ${formatMib(download.bytes)}` : ""}
+          />
+          <Metric
+            label="Upload"
+            value={upload ? `${formatMbps(upload.mbps)} Mbps` : pending(phase, "upload")}
+            sub={upload ? `${formatMs(upload.ms)} ms for ${formatMib(upload.bytes)}` : ""}
+          />
+        </section>
+      )}
+
+      {verdict && phase === "done" && (
+        <section className={`diag-verdict diag-verdict-${verdict.rating}`} aria-label="Verdict">
+          <div className="diag-verdict-headline">{verdict.headline}</div>
+          {verdict.advice !== "" && <p className="diag-verdict-advice">{verdict.advice}</p>}
+        </section>
+      )}
+
+      {verdict && phase === "done" && verdict.showChecklist && (
+        <section className="diag-checklist" aria-label="How to make it faster">
+          <div className="diag-checklist-title">How to make it faster</div>
+          <ul>
+            <li>Keep this app open and re-run in a few seconds - a fresh connection starts on a relay and speeds up once it goes direct.</li>
+            <li>In the Tailscale app, make sure this phone has granted local-network access.</li>
+            <li>Do not route your home traffic through a Tailscale exit node.</li>
+            <li>On your router, turn off wireless client isolation and allow UDP (enable UPnP) so a direct path can form.</li>
+          </ul>
+        </section>
+      )}
+
+      <section className="about-list" aria-label="Connection details">
+        <DetailRow label="Loaded from" value={typeof window !== "undefined" ? window.location.host : ""} />
+        <DetailRow label="Gateway sees you as" value={echo ? `${echo.clientIp ?? "?"} (${echo.clientPath})` : "Loading..."} />
+        {selfPeer && (
+          <DetailRow
+            label="Tailscale path"
+            value={selfPeer.direct === true ? `direct ${selfPeer.path ?? ""} (${fmt(selfPeer.latencyMs)} ms)` : selfPeer.direct === false ? `relayed via ${selfPeer.path ?? "DERP"}` : "unknown"}
+          />
+        )}
+        <DetailRow label="Gateway machine" value={echo?.machineName ?? "Loading..."} />
+        <DetailRow label="Gateway LAN address" value={echo?.gatewayLanIp ?? "unknown"} />
+        <DetailRow label="Gateway Tailscale name" value={echo?.gatewayTailnetName ?? "unknown"} />
+      </section>
+    </div>
+  );
+}
+
+function Metric({ label, value, sub }: { label: string; value: string; sub: string }) {
+  return (
+    <div className="diag-metric">
+      <div className="diag-metric-label">{label}</div>
+      <div className="diag-metric-value">{value}</div>
+      {sub !== "" && <div className="diag-metric-sub">{sub}</div>}
+    </div>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="about-row">
+      <span className="about-label">{label}</span>
+      <span className="about-value">{value}</span>
+    </div>
+  );
+}
+
+type RouteKind = "lan" | "tailscale" | "local" | "other" | "unknown";
+
+// Find the Gateway's view of THIS phone in the network diagnostic, matched by the IP the Gateway sees for
+// us (echo.clientIp is our tailnet address, which appears as a peer's tailscaleIp).
+function findSelfPeer(network: NetworkDiag | null, echo: NetDiagEcho | null): NetDiagPeer | null {
+  if (!network || !echo?.clientIp) return null;
+  return network.peers.find((p) => p.tailscaleIp === echo.clientIp) ?? null;
+}
+
+function describeRoute(echo: NetDiagEcho | null, selfPeer: NetDiagPeer | null): { kind: RouteKind; title: string; detail: string } {
+  if (echo === null) {
+    return { kind: "unknown", title: "Checking...", detail: "Asking the Gateway how it sees this connection." };
+  }
+  switch (echo.clientPath) {
+    case "lan":
+      return { kind: "lan", title: "Direct on your LAN", detail: "The phone is talking straight to the Gateway over the local network - the fastest path." };
+    case "tailscale": {
+      // With the authoritative check in hand we can say direct-over-Tailscale vs relayed.
+      if (selfPeer?.direct === true)
+        return { kind: "tailscale", title: "Through Tailscale (direct)", detail: `A direct peer-to-peer path over your LAN (${selfPeer.path ?? ""}). This is the good state.` };
+      if (selfPeer?.direct === false)
+        return { kind: "tailscale", title: "Through Tailscale (relayed)", detail: "Traffic is relaying through a distant DERP server instead of going direct - this is what makes it slow." };
+      return { kind: "tailscale", title: "Through Tailscale", detail: "Traffic is riding the Tailscale network. On the same home network this should connect directly, not relay." };
+    }
+    case "local":
+      return { kind: "local", title: "On the Gateway machine", detail: "This browser is on the same machine as the Gateway (loopback)." };
+    default:
+      return { kind: "other", title: "Remote / other", detail: "The Gateway sees a public or unrecognized address for this connection." };
+  }
+}
+
+type Rating = "fast" | "ok" | "slow";
+
+function buildVerdict(
+  kind: RouteKind,
+  selfPeer: NetDiagPeer | null,
+  medianMs: number | null,
+  downMbps: number | null,
+): { rating: Rating; headline: string; advice: string; showChecklist: boolean } | null {
+  if (medianMs === null || downMbps === null) return null;
+  const rating: Rating =
+    medianMs < 30 && downMbps >= 50 ? "fast" : medianMs < 100 && downMbps >= 10 ? "ok" : "slow";
+  const speedWord = rating === "fast" ? "fast" : rating === "ok" ? "usable" : "slow";
+  const numbers = `median ${formatMs(medianMs)} ms, ${formatMbps(downMbps)} Mbps down`;
+
+  // Authoritative: the Gateway told us whether Tailscale is direct or relayed for this phone.
+  if (selfPeer?.direct === false) {
+    return {
+      rating,
+      headline: `Relaying through Tailscale and it is ${speedWord} (${numbers}).`,
+      advice:
+        "Tailscale is routing this connection through a distant relay server instead of a direct path over your LAN. That is the cause of the slowness.",
+      showChecklist: true,
+    };
+  }
+  if (selfPeer?.direct === true) {
+    // Direct now. If the measured numbers were slow, the test caught the brief cold-start relay window.
+    if (rating === "slow") {
+      return {
+        rating: "ok",
+        headline: `Tailscale is now on a DIRECT LAN path (${fmt(selfPeer.latencyMs)} ms), but the speed test caught the slow start (${numbers}).`,
+        advice: "A fresh connection begins on a relay and upgrades to direct after a moment. Run the test again now - it should be much faster.",
+        showChecklist: false,
+      };
+    }
+    return {
+      rating,
+      headline: `Direct Tailscale path over your LAN and it is ${speedWord} (${numbers}).`,
+      advice: "",
+      showChecklist: false,
+    };
+  }
+
+  // No authoritative signal - fall back to the measured heuristic.
+  if (kind === "tailscale" && rating !== "fast") {
+    return {
+      rating,
+      headline: `Connected through Tailscale and it is ${speedWord} (${numbers}).`,
+      advice: "On the same home network this is usually the brief cold-start relay before Tailscale finds the direct path. Re-run in a few seconds.",
+      showChecklist: true,
+    };
+  }
+  if (kind === "lan") {
+    return {
+      rating,
+      headline: `Direct LAN connection and it is ${speedWord} (${numbers}).`,
+      advice: rating === "slow" ? "A direct LAN path is slow here - likely weak Wi-Fi signal or a busy network." : "",
+      showChecklist: false,
+    };
+  }
+  return { rating, headline: `Connection is ${speedWord} (${numbers}).`, advice: "", showChecklist: false };
+}
+
+function phaseLabel(phase: Phase): string {
+  if (phase === "latency") return "Testing latency...";
+  if (phase === "download") return "Testing download...";
+  if (phase === "upload") return "Testing upload...";
+  if (phase === "checking") return "Checking Tailscale...";
+  return "Running...";
+}
+
+function pending(phase: Phase, forStep: "latency" | "download" | "upload"): string {
+  return phase === forStep ? "Testing..." : "-";
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function fmt(ms: number | null): string {
+  return ms === null ? "?" : formatMs(ms);
+}
+
+function formatMs(ms: number): string {
+  return ms >= 100 ? String(Math.round(ms)) : ms.toFixed(1);
+}
+
+function formatMbps(mbps: number): string {
+  return mbps >= 100 ? String(Math.round(mbps)) : mbps.toFixed(1);
+}
+
+function formatMib(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// True when a self-peer path (e.g. "192.168.1.15:52091") is a private LAN address; "DERP(...)" / null are not.
+function pathIsLan(path: string | null): boolean {
+  if (!path || path.startsWith("DERP")) return false;
+  const b = path.split(":")[0].split(".");
+  if (b.length !== 4) return false;
+  const o0 = Number(b[0]);
+  const o1 = Number(b[1]);
+  if (o0 === 10) return true;
+  if (o0 === 172 && o1 >= 16 && o1 <= 31) return true;
+  if (o0 === 192 && o1 === 168) return true;
+  if (o0 === 169 && o1 === 254) return true;
+  return false;
+}

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -2547,6 +2547,165 @@ a.banner-btn {
   text-align: right;
 }
 
+/* Diagnostics page (auto-network-switching mission): the connection-route banner, the big run button,
+   the three speed metrics, and the plain-English verdict. Rating colors reuse the theme tokens plus a
+   local green/amber for the good/ok states (the theme ships only accent-blue and attention-red). */
+.diag-route {
+  margin: 16px 0;
+  padding: 14px 16px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--text-dim);
+  border-radius: 8px;
+}
+.diag-route-lan { border-left-color: #37c26d; }
+.diag-route-tailscale { border-left-color: #e8a33d; }
+.diag-route-local { border-left-color: var(--accent); }
+.diag-route-label {
+  color: var(--text-dim);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.diag-route-value {
+  font-size: 17px;
+  font-weight: 700;
+  margin-top: 4px;
+}
+.diag-route-detail {
+  color: var(--text-dim);
+  font-size: 13px;
+  margin-top: 6px;
+  line-height: 1.4;
+}
+
+.diag-run {
+  width: 100%;
+  min-height: 48px;
+  margin: 4px 0 16px;
+  border: 1px solid var(--accent);
+  border-radius: 8px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 16px;
+  font-weight: 700;
+}
+.diag-run:disabled {
+  opacity: 0.6;
+  background: var(--surface-2);
+  color: var(--text-dim);
+  border-color: var(--border);
+}
+
+.diag-metrics {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+.diag-metric {
+  padding: 12px 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.diag-metric-label {
+  color: var(--text-dim);
+  font-size: 12px;
+}
+.diag-metric-value {
+  font-size: 22px;
+  font-weight: 800;
+  margin-top: 2px;
+}
+.diag-metric-sub {
+  color: var(--text-dim);
+  font-size: 12px;
+  margin-top: 2px;
+}
+
+.diag-verdict {
+  margin-bottom: 16px;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--text-dim);
+  border-radius: 8px;
+  background: var(--surface-2);
+}
+.diag-verdict-fast { border-left-color: #37c26d; }
+.diag-verdict-ok { border-left-color: #e8a33d; }
+.diag-verdict-slow { border-left-color: var(--attention); }
+.diag-verdict-headline {
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.4;
+}
+.diag-verdict-advice {
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1.45;
+  margin: 8px 0 0;
+}
+
+/* The always-visible network status pill (Network Diagnostics mission, P1): a small green/amber/red/grey
+   dot + label pinned to the top-right, tappable to open Diagnostics. Colour = authoritative direct-vs-relay
+   for this device; never red on the cold-start. */
+.net-pill {
+  position: fixed;
+  top: calc(env(safe-area-inset-top, 0px) + 8px);
+  right: 10px;
+  z-index: 40;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text-dim);
+  font-size: 12px;
+  font-weight: 600;
+  text-decoration: none;
+  line-height: 1;
+}
+.net-pill-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-dim);
+  flex: 0 0 auto;
+}
+.net-pill-green .net-pill-dot { background: #37c26d; }
+.net-pill-amber .net-pill-dot { background: #e8a33d; }
+.net-pill-red .net-pill-dot { background: var(--attention); }
+.net-pill-grey .net-pill-dot { background: var(--text-dim); }
+.net-pill-green { color: #37c26d; }
+.net-pill-amber { color: #e8a33d; }
+.net-pill-red { color: var(--attention); }
+
+/* The "how to make it faster" checklist, shown when the connection is relaying or slow. */
+.diag-checklist {
+  margin-bottom: 16px;
+  padding: 14px 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.diag-checklist-title {
+  font-size: 14px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.diag-checklist ul {
+  margin: 0;
+  padding-left: 18px;
+}
+.diag-checklist li {
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1.5;
+  margin-bottom: 6px;
+}
+
 /* The Control API port shown on each machine row in the New session picker, so several cc-director
    slots on one machine are told apart and the number can be quoted to an agent. */
 .row-port {

--- a/docs/architecture/network-diagnostics-design-decisions-2026-07-13.md
+++ b/docs/architecture/network-diagnostics-design-decisions-2026-07-13.md
@@ -1,0 +1,479 @@
+# Network Diagnostics - Architect design decisions (P1 through P5)
+
+Status: design settled 2026-07-13 by the "Network Diagnostics - Architect" session (136b9960) on
+machine SOREN_NORTH, in the `devthrottle` repo. Companion to the mission brief
+(`network-diagnostics-mission-2026-07-13.md`) and the findings handoff
+(`devthrottle_internal/docs/networking/network-diagnostics-findings-handoff-2026-07-13.md`).
+Manager driving the build: session 3cc96cc5. Docs owner: session 52749c5a.
+
+This document settles the four decisions the Manager asked the Architect to make: the keep-warm
+mechanism, the route-tagging plus persistence schema, how network statistics extend the existing
+"Your Throttle" instrumentation instead of forking it, and the drift-alert policy. None of these
+decisions depend on the Phase 0 deploy; only their validation against the live Gateway does.
+
+## The one idea that organizes everything: route and quality are two different things
+
+The single most important architectural point, drawn straight from the measured proof in the
+findings handoff:
+
+- ROUTE = which front door a request came in on. The Gateway already classifies this on every
+  request in `NetDiag.ClassifyClientIp(IPAddress?)`:
+  - loopback -> "local"
+  - `192.168/16`, `10/8`, `172.16/12`, `169.254/16` -> "lan"   (direct on the home LAN)
+  - `100.64.0.0/10` (Tailscale carrier-grade address space) -> "tailscale"   (the Tailscale front door)
+  - anything else -> "other"
+- QUALITY = how good the connection actually was: latency, throughput, and whether the underlying
+  Tailscale path is direct peer-to-peer or relayed through a DERP relay server.
+
+These are ORTHOGONAL and must never be conflated. A phone sitting on the home Wi-Fi still reaches
+the `.ts.net` front door over the Tailscale address (100.x), so its ROUTE reads "tailscale" even
+while its underlying WireGuard path is DIRECT (192.168.x, 11 ms). The app-only speed test cannot
+tell "warming up" from "genuinely relaying" - only the Tailscale-layer state from
+`GET /diag/network` (the `PeerDiag.Direct` flag) can. Therefore:
+
+- ROUTE is the cheap, always-available, per-request home-versus-away tag. It tags usage events.
+- QUALITY is the richer measurement that comes from a diagnostic run (client speed test plus the
+  server-side `GET /diag/network`). It is a separate data stream.
+
+They share the ROUTE dimension and share one presentation surface, but they are different tables.
+Trying to jam latency numbers into the usage buckets, or infer quality from route alone, is the
+mistake to avoid.
+
+Home-versus-away mapping used at presentation time (raw four-value classification is what we STORE;
+the two-bucket rollup is derived when we display):
+- "home" = route in { "lan", "local" }
+- "away" = route == "tailscale"
+- "other" = route == "other"
+
+Away plus relay is EXPECTED and fine; the baseline for "this should be fast" is home. This is the
+rule that keeps the drift alert honest.
+
+---
+
+## Decision 1: Keep-warm mechanism (Phase 2)
+
+Goal, from the WHY: keep the fast path warm so the user opens the app ALREADY direct, and does not
+fall back to the relay mid-use. We control no knob that forces Tailscale to go direct; the only
+lever is driving and holding the upgrade that Tailscale performs on its own once real traffic flows.
+
+Keep-warm is TWO independent, honestly-scoped pieces. Neither is a silver bullet and the design must
+not overclaim (house rule: never claim "fast" without the measured proof).
+
+### 1a. Server-side warmer (primary, always-on) - the truth source
+
+A background service on the Gateway that periodically runs `tailscale ping <peer>` to each peer it
+should keep warm. The Gateway is always up; the phone's Tailscale membership persists in the phone
+OS's background VPN service even when our progressive-web-application is closed. A server-driven
+ping forces hole-punching and holds the direct path so that when the user picks up the phone and
+opens the app, Tailscale is already direct and the cold-start window is short or gone.
+
+- Implement as a `System.Threading.Timer` background service modeled exactly on
+  `WebPushNeedsYouNotifier` (reentrancy guard with `Interlocked.CompareExchange`, per-iteration
+  try/catch that isolates failures, self-gate when there is nothing to do). Start it in
+  `GatewayHost.StartAsync` next to the existing sweeps.
+- Reuse the exact `TailscaleCli.Run` runner the diagnostics already use. No new Tailscale plumbing.
+- GATE which peers to warm: only ping peers that are (a) online in the last `tailscale status`, and
+  (b) recently active (seen in the roster or in a diagnostic result within the last N minutes) OR on
+  the home baseline. Do not ping a phone that has been dark for hours - it will not answer and it is
+  pointless. Cap the peer count (reuse the existing `MaxPeersToPing` = 12 ceiling).
+- Cadence: inside the direct-path decay window. Default one warm sweep every 60 seconds. Tunable.
+- Best-effort ONLY. A failed `tailscale ping` is logged and skipped. Keep-warm is never a health
+  gate and must never block, slow, or fail any real request.
+
+Honest scope: whether a warmed direct path survives the seconds/minutes until the user opens the
+app depends on Tailscale keepalives; the first real request the app fires also drives the upgrade
+anyway. So the server warmer REDUCES the cold-start window; it does not abolish it. We measure its
+effect (see Decision 3) rather than assert it.
+
+### 1b. Client-side foreground heartbeat (secondary) - holds the path during use
+
+While the phone or Cockpit application is open AND visible, fire the featherweight `GET /diag/ping`
+on an interval. This drives a fast upgrade the instant the app opens and holds the direct path
+during active use so the user does not decay onto the relay mid-session.
+
+- Interval: default every 25 seconds. PAUSE when `document.hidden` (a progressive-web-application
+  cannot run in the background, and we must not pretend otherwise - this is only a while-open hold).
+- Use `GET /diag/ping` specifically (the endpoint that does no interface scan), so the heartbeat is
+  near-zero cost and does not inflate any latency the user sees.
+- Small hook in the shared client-core, consumed by both `apps/mobile` and `apps/cockpit`.
+
+Forward-compatibility note: the sibling "Auto network switching / LAN-with-trusted-certificate"
+mission may later remove the Tailscale hop at home entirely. Keep-warm must not assume that. Because
+route classification already distinguishes "lan" from "tailscale", the warmer degrades gracefully
+if a device starts arriving on the direct LAN door instead of the Tailscale door.
+
+---
+
+## Decision 2: Route-tagging plus persistence schema (the enabler)
+
+Today the results live in `NetDiagResultLog`: an in-memory, per-process, capacity-50 ring, lost on
+every Gateway restart. The route already rides each result as the Gateway-stamped
+`NetDiagResultDto.ClientPath`. The enabler work is: make results durable, add a rollup that can
+express trend and home-versus-away quality, and separately tag usage events with route.
+
+Persistence pattern for ALL of the below: copy `CronRunHistoryStore` verbatim - a single JSON file
+per store under `CcStorage.Root()` (`%LOCALAPPDATA%\cc-director`), bounded, newest-first, atomic
+temp-write-plus-rename, corrupt-file quarantine, constructed in the `GatewayHost` constructor with a
+test-injectable path. No SQLite (that is Vault-only). No new analytics pipeline.
+
+### 2a. Durable diagnostic-results store (Phase 3) - replaces the in-memory ring
+
+- New store `diagnostics-results.json`, modeled on `CronRunHistoryStore`: bounded, newest-first
+  list of `NetDiagResultDto`. Raise the bound from 50 to about 200 for a useful recent history.
+- `POST /diag/result` appends to it; `GET /diag/results` reads it. Same wire shapes; the only change
+  is durability and capacity. The `NetDiagResultDto` (C#) and `NetDiagResult` (TypeScript,
+  `client.ts`) records stay in lockstep - any field added goes to both.
+
+### 2b. Hourly quality rollup (Phase 1 hour-only; route split deferred to Phase 4)
+
+The flat results list is too small and too coarse for trends and for the home-versus-away quality
+comparison. Add an hourly rollup mirroring `GatewayInputStatsAggregator.Hourly` (per-UTC-clock-hour
+buckets, 90-day retention with pruning) holding QUALITY sums:
+
+    count, sumLatencyMs, minLatencyMs, sumDownloadMbps, sumUploadMbps, directCount, relayCount
+
+From these we derive, per hour: average latency, best (minimum) latency, average throughput, and
+percent-direct (`directCount / (directCount + relayCount)`). We store SUMS and COUNTS, not per-sample
+arrays, which keeps the store bounded and matches the "sums and counts" style of the existing
+rollups. Note honestly: from sums we can show average and minimum, NOT a true median; do not label an
+average as a median. This rollup is a NEW aggregation shape (the existing Your Throttle rollups carry
+no latency or throughput concept at all), and it lives here in the diagnostics store - it is not
+forced into the input-stats buckets.
+
+REVISION (build-cadence decision, 2026-07-13): the Phase 1 rollup is keyed by HOUR ONLY - NO
+home-versus-away route split. An earlier draft keyed it by (hour, route), but "route" for a quality
+measurement would mean the front-door classification (`ClientPath`), and keying quality by the front
+door CONFLATES route and quality - the exact orthogonality trap Decision 1 forbids. A home phone
+reads `route = tailscale` (front door) while its path is DIRECT, so its good direct measurement would
+land in the "away" bucket and poison it. The signal the Phase 3 trend actually needs is percent-direct
+over time (`directCount / relayCount`), which needs no route key. So hour-only is both simpler and
+more honest for Phase 1.
+
+The home-versus-away split moves to Phase 4 for PRESENTATION, but the underlying quality history is
+captured from day one (see the retention decision below): the quality-location is judged by the
+ACTUAL path (a LAN-direct `192.168.x` path is home; a relay or non-LAN path is not), NOT the
+front-door `ClientPath`, and the Phase 4 presentation lands in lockstep with the `InputRoute` usage
+axis.
+
+RETENTION AND THE PATH-SPLIT (build-cadence decision, 2026-07-13). Raw per-observation retention is
+RECENT-DEPTH ONLY, not 90 days: a per-75-second raw log over 90 days is hundreds of thousands of
+records, and the atomic-whole-file-rewrite store rewrites the entire file on every append, so a large
+file rewritten every 75 seconds is write-amplification we will not pay. The ROLLUP is the 90-day
+memory; raw stays recent (roughly the last day or two, or a few hundred records) for the
+recent-results view and debugging.
+
+To keep home-versus-away QUALITY history without a heavy raw log, the location split is baked INTO the
+hourly rollup now, keyed on the ACTUAL path (`isLanPath`), never the front-door `ClientPath`. Each
+hourly bucket carries LAN (home) versus non-LAN (away/relay) sub-sums - `lanCount`, `sumLatencyLan`,
+`minLatencyLan`, `sumDownLan`, `sumUpLan` and the non-LAN counterparts - alongside `directCount` and
+`relayCount`. Three properties keep this honest and in scope: it is NOT the conflation trap (it keys
+on the measured path, not the front door); it is NOT a new key dimension (still one bucket per hour,
+just richer sub-sum fields, no cardinality growth); and it stays Phase-1-cheap (Phase 1 STORES the
+split but does NOT render it - the Phase 3 dashboard shows overall percent-direct plus latency trend,
+and Phase 4 simply turns on the home-versus-away presentation over history already accumulated).
+
+Both producers must tag observations by the actual path: the monitor already has direct plus
+`isLanPath` per tick; client speed-test results need the tag added - put the self-peer's direct plus
+`isLanPath` onto `NetDiagResultDto` (additive; the mobile page already computes the self-peer for its
+verdict) so a client result lands in the right home-versus-away sub-sum rather than being classified
+by `ClientPath`.
+
+### 2c. Per-user baseline (Phase 4) - "slow" is judged against THIS network
+
+Derive a known-good baseline from the observed home-and-direct distribution: a rolling summary
+(for example, the trailing average and best of home-plus-direct latency and throughput over the
+last N good samples) stored in the rollup file. "Slow" then means materially worse than THIS
+network's own baseline, never a fixed threshold. This baseline is exactly what the Phase 5 drift
+alert compares against.
+
+The baseline is PER-DEVICE, keyed by Tailscale address (the phone at 44 ms direct, the laptop at
+4 ms direct, and the mac at 73 ms direct are each their OWN "good" - never phone-versus-laptop, never
+one global number). It records the device's baseline PATH TYPE (LAN-direct on a `192.168.x` address
+versus relayed) as well as its latency and throughput, because the path type is the load-bearing
+drift signal (see Decision 4).
+
+Two correctness rules the baseline must obey:
+- Build it from HOME-plus-DIRECT samples ONLY. Exclude any relayed or away sample - one relayed
+  sample would poison the "good" number and make the whole thing lie.
+- Keep the baseline "unknown" until it has enough good samples. During that warmup the drift state
+  machine sits in UNKNOWN and never alerts - the same self-gating as when Tailscale is unavailable.
+  Never compare against a half-formed baseline.
+
+### 2d. Route-tagged USAGE events (Phase 4) - the real "extend Your Throttle" work
+
+See Decision 3 for the full rationale. Schema decision here: add ROUTE as a THIRD axis on
+`InputOrigin` - `record struct InputOrigin(InputModality Modality, InputSurface Surface,
+InputRoute Route)` - with a new `InputRoute` enum { Local, Home, Away, Unknown } and wire tokens.
+Route is resolved GATEWAY-SIDE exactly where `Surface` already is (the `AuthMiddleware` device stash
+plus the `GatewayEndpoints` prompt stamp plus the `PromptRequest` gateway-authoritative field), so
+it cannot be forged and the Director choke point simply carries whatever the Gateway stamped.
+Desktop-local emit sites set Route = Local. This is the exact "add a new dimension" recipe the
+existing stats code was built to accept.
+
+Why a third axis and not a separate counter: the existing high-water fold in
+`GatewayInputStatsAggregator.FoldLocked` tracks each (session, bucket-key) independently. If the
+bucket key includes route, a session whose turns move from home to away simply lands its later turns
+in a different bucket key; the fold still never double-counts and correctly attributes the home
+turns to home and the away turns to away. Mid-session route change is handled for free. Bucket
+cardinality stays trivial (2 modality x 4 surface x 4 route = 32 maximum, most empty).
+
+Sequencing benefit: because diagnostic RESULTS already carry route (`ClientPath`), Phases 1 through
+3 need no `InputOrigin` change at all. The third-axis work is isolated entirely to Phase 4 and
+blocks nothing earlier.
+
+---
+
+## Decision 3: How network statistics EXTEND Your Throttle (Phase 4), not fork it
+
+The rule from the brief: extend the existing instrumentation; do not build a second analytics
+pipeline. Concretely, there are two data streams and each attaches to the existing system at a
+different, already-established seam:
+
+- USAGE by route (how much the product is used at home versus away): the third axis on `InputOrigin`
+  (Decision 2d). It folds into the SAME `GatewayInputStatsAggregator`, serves from the SAME
+  `GET /stats/data`, and renders on the SAME "Your Throttle" page - we add a home-versus-away split
+  to the existing surface bars. Nothing parallel is built.
+- QUALITY by route (latency, throughput, percent-direct, home versus away): the diagnostics rollup
+  (Decision 2b). Your Throttle has no latency or throughput concept today, so this is genuinely new
+  data - but it is surfaced as a NEW SECTION on the SAME Your-Throttle-styled page (and mirrored on
+  the Cockpit "Network" view), reusing the `statsClient.ts` read patterns and the self-contained
+  `/stats` page shell. Not a separate application.
+
+Presentation of the home-versus-away quality comparison always judges home against the direct/fast
+expectation and away against the relay-is-expected expectation, so the comparison and any alert are
+measured against the right baseline (Decision 2c).
+
+Honesty caveats: extend the existing `notCaptured` array in `StatsPageEndpoint.cs` with any path the
+new dimension cannot yet observe - for example, desktop-local route attribution, or remote raw
+keystrokes that are already attributed to the "Unknown" surface. No-fallback rule: declare what we
+cannot measure rather than guessing it.
+
+---
+
+## Decision 4: Drift-alert policy (Phase 5)
+
+The point of the whole mission: no user is ever silently slow at home. But the alert must NEVER fire
+during the normal Tailscale cold-start warmup, and must NEVER fire for a genuinely-away device that
+is correctly relaying. Design:
+
+### Truth source and definition of drift
+
+- The always-on truth source is the server-side scheduled monitor: `GET /diag/network` run on a
+  timer (the same `System.Threading.Timer` background-service pattern; may be the same service as
+  the warmer or a sibling). Each run is logged into the diagnostics rollup.
+- DRIFT = a HOME device (a peer whose own baseline shows it is normally direct on the LAN) is
+  observed `Direct == false` (relaying through a DERP relay), OR materially worse than that device's
+  own baseline, for K CONSECUTIVE monitor runs spanning at least T minutes, where T is comfortably
+  past the cold-start window. Defaults: K = 3 consecutive checks, T >= 5 minutes. A single relayed
+  sample is warmup and is ignored.
+- A device that is genuinely AWAY and relaying is NOT drift - that is expected and fine.
+
+The drift DISCRIMINATOR keys off PATH TYPE compared to the device's own baseline path, NOT off raw
+latency. From the server-side `GET /diag/network`, a home device shows `path = 192.168.x` (a
+LAN-direct address); a relayed device shows `path = DERP(region)`. The primary, unambiguous drift
+signal is therefore: a device whose BASELINE path was LAN-direct now shows DERP. That one comparison
+cleanly separates the two cases we must never confuse:
+- "a home device fell back to the relay" -> DRIFT (this is the thing the whole mission exists to catch).
+- "a device is genuinely away and is correctly direct-over-the-internet or relaying" -> NOT drift,
+  never flag it (away-plus-relay is expected).
+Latency-worse-than-baseline is only a SECONDARY signal and needs a generous margin - the phone's
+44 ms direct baseline must not flag drift at 50 ms. `Direct == false when the baseline path was
+LAN-direct` is the clean primary; treat a modest latency rise on an otherwise-direct path as noise,
+not drift.
+
+### Two realities from live `tailscale status --json` on the Gateway machine (2026-07-13)
+
+Grounding the discriminator in what Tailscale actually exposes (verified live against the four real
+peers), two facts constrain the design:
+
+- The `Relay` field is a TRAP. Every peer, INCLUDING the three that were actively DIRECT, carried
+  `Relay: "tor"`. So `Relay` is just the peer's NEAREST DERP relay, present whether or not the peer
+  is relaying. Reading `Relay` as "is relaying" misclassifies every peer. The direct-versus-relay
+  truth is `CurAddr` (a `192.168.x:port` value means direct on the LAN; empty means relay or
+  offline) plus the authoritative `tailscale ping` path parse (`direct = the path does not start
+  with "DERP"`). The existing `TailscaleDiagnostics` already keys off `CurAddr` and the ping path,
+  not `Relay` - keep it that way; never let the `Relay` field drive a direct-versus-relay decision.
+- `Addrs` and `Endpoints` are NULL for every peer in `status --json`. So there is no idle
+  "LAN endpoint candidate" to read while a peer is relaying. Once a device is relaying we cannot see
+  its physical LAN presence from `status` at all. The only per-peer signals available are `CurAddr`,
+  `Online`, `LastSeen`, and `LastHandshake`.
+
+### Home-determination (the crux of "never a false alert")
+
+"A home device fell back to the relay" (DRIFT) and "the user left the house and is now away and
+relaying" (NOT drift) look IDENTICAL on the wire - both simply show the peer is no longer direct on
+a `192.168.x` address. Because `status` does not expose physical-LAN presence once relaying, we
+cannot perfectly separate the two. The trap to avoid: using "current path is LAN-direct" as the
+home-signal would gate out the exact event we exist to catch (the instant a home device drifts to
+DERP it would be reclassified as away). So home-determination must be INDEPENDENT of the current
+relay state.
+
+CORRECTION (from the code review of `NetDiagDrift.cs`, 2026-07-13): a time-based recency window does
+NOT solve this. An earlier draft of this decision proposed "seen LAN-direct within the last 30
+minutes AND continuously online" as the home-signal. Reviewing the concrete Decide-machine showed
+that is unsound: drift accrues in K>=3 observations over >=5 minutes, but a 30-minute recency window
+is WIDER than that accrual, so it does not separate "a home device fell to relay" from "the user
+left the house and is now on a cellular relay." Trace: the user leaves at T0 (last-seen-LAN-direct
+freezes at T0), the phone reconnects on a DERP relay over cellular, and the monitor's ticks at
+T0/+3/+6 all still satisfy "seen home within 30 minutes" - so the machine drifts and fires "your
+home network is slow" while the user is simply driving away on a perfectly good connection. Leaving
+the house is a daily event, so this would cry wolf constantly. Any time window W just creates a
+W-long false-alert hole after leaving; a window cannot fix this.
+
+ROOT CAUSE: from Tailscale state alone, "home plus fell-to-relay" and "just-left-home plus on-relay"
+are genuinely indistinguishable. The fix requires an INDEPENDENT physical-presence signal.
+
+SETTLED RESOLUTION - Address-Resolution-Protocol presence with a Media-Access-Control identity match:
+
+- The Decide-machine's home-gate is a `HomeLanPresent` input, NOT a time window. It is true only
+  when the device is positively confirmed on the home LAN this tick.
+- The Gateway is physically on the home LAN, so when a home-baseline device is seen relaying, it does
+  a best-effort Address-Resolution-Protocol probe (on Windows, `SendARP` via `iphlpapi`) to the
+  device's last-known `192.168.x` address. Address Resolution Protocol is answered at layer two by
+  the device's network card regardless of application state, sleep, or whether Internet Control
+  Message Protocol is disabled, and regardless of the Tailscale path - so it is the honest "is this
+  device on my LAN right now." A device that left the house does not answer on the home LAN.
+- REQUIRED refinement: gate on MAC IDENTITY MATCH, not merely "the probe resolved something." The
+  cached `192.168.x` is a LAST-KNOWN address; a Dynamic-Host-Configuration-Protocol lease can expire
+  and that address be reassigned to a DIFFERENT device, which would answer the probe and falsely read
+  the departed device as home. So we cache the device's MAC (the probe returns it) from LAN-direct
+  sightings and require the probe to resolve to THAT SAME MAC. A different or absent MAC means "not
+  present" -> UNKNOWN, never alert. Cheap (the MAC is already in hand) insurance against a real, if
+  rare, false positive.
+- MAINTENANCE: refresh the (address, MAC) pair on EVERY LAN-direct sighting - that is exactly when
+  Tailscale's `CurAddr` gives the current `192.168.x` and the MAC can be recaptured, so the cache
+  never goes stale while the device is home.
+- The presence probe is needed only for the PRIMARY relay-drift signal. The SECONDARY latency signal
+  already requires `CurrentIsLanPath == true` (the device IS LAN-direct), so presence is self-evident
+  there and needs no probe.
+- Residual risk: a router/access-point could briefly proxy-answer Address Resolution Protocol for a
+  just-departed device; this is small and bounded by the K>=3 / >=5-minute persistence plus the
+  MAC-identity match plus the device dropping off the access point shortly after leaving.
+- Scoping primary drift alerting to STATIONARY devices that cannot leave (a Mac mini, a desktop) is
+  now OPTIONAL belt-and-suspenders, not required, once Address-Resolution-Protocol-plus-MAC is in.
+
+We deliberately accept MISSING some genuine home-drift rather than ever crying wolf - the missed case
+is still caught by the in-app status pill the moment the user looks, whereas a false "your home
+network is slow" alert erodes trust in every future alert.
+
+A related review finding on the same machine: the resolution note (`ShouldResolve`) must fire ONLY
+on the transition Drifted -> Ok (recovery actually observed - direct restored), NOT on Drifted ->
+Unknown (Tailscale down, or home-evidence lost). Emitting "recovered" merely because we lost the
+ability to judge is a false all-clear; when we can no longer judge, go quiet.
+
+Empirical confirmation (2026-07-13, phone on home Wi-Fi): a direct Address-Resolution-Protocol probe
+from the Gateway resolved the phone's `192.168.x` to a stable per-network-name MAC (Internet Control
+Message Protocol also answered, but Address Resolution Protocol is the robust layer-two signal). So
+this approach is confirmed viable and the stationary-device fallback is not needed.
+
+Monitor contract for the presence signal, and two accepted conservative limitations (all surfaced by
+the code review; the Decide-machine itself is approved):
+- The monitor must make `HomeLanPresent` ROBUST to a single blip. A sleeping phone under power-save
+  can miss one Address-Resolution-Protocol answer; because the Decide-machine resets the episode on
+  any Unknown tick, an un-smoothed probe would whipsaw a genuine active-use drift out of accrual. The
+  monitor should briefly retry the probe, or treat a positive result as valid for a short window (for
+  example "present within the last ~120 seconds"), before declaring absent. Note the natural upside:
+  a phone that is genuinely asleep and not being used simply will not sustain presence, so alerts
+  self-scope to "awake, home, and actively being slowed" - which is exactly when the user cares.
+- LIMITATION 1 (accepted): if an Unknown tick lands between drift and recovery, the resolution note
+  is suppressed (the transition into Ok no longer sees a Drifted prior). Worst case is a MISSING
+  all-clear after a real alert, never a false one. Do NOT carry the alerted flag across Unknown to
+  "fix" this - that would reintroduce a false-all-clear risk.
+- LIMITATION 2 (accepted): the same episode-reset-on-Unknown means a flaky probe delays or prevents
+  a real alert. This is the conservative direction (miss over false alarm) and the in-app pill still
+  catches the missed case.
+
+### No flapping: a pure state machine
+
+Model the alert decision on `WebPushNeedsYouNotifier.Decide` - a pure, unit-testable transition
+function `(observation, state) -> (shouldAlert, nextState)`. Enter the DRIFT state only after K
+consecutive bad checks; clear it only after M consecutive good checks (hysteresis). Emit ONE alert
+per drift episode (edge-triggered), and one resolution notice when it clears. No per-check spam.
+
+### Channels (escalation, least intrusive first)
+
+1. Always, on entering drift: emit a fleet doorbell event via `DirectorEventLog.Record(...)` - the
+   same channel `GatewayCronNotifier` already uses - so the in-app surfaces and the Cockpit show an
+   ambient "home network is slow" indicator with the specific cause.
+2. On sustained drift: send an owner email via `AccountNotifyClient.SendOwnerAsync(...)` carrying
+   the SPECIFIC fix (for example: "your phone is relaying through the Toronto relay while on the
+   home network; keep the app open, grant Tailscale local-network access, make sure no exit node is
+   routing home traffic, and enable UPnP on the router so hole-punching works"). Handle the
+   not-signed-in (401) case explicitly - no silent fallback. At most one email per episode, plus a
+   resolution note when it clears; a daily cap so a network broken for hours does not spam.
+3. Do NOT hijack the phone "needs you" badge. That badge is count-driven off the session roster and
+   semantically means "a session is waiting for you" (it is a wait-time queue). Overloading it with
+   network drift would conflate two unrelated meanings. The phone signal for drift is the doorbell
+   event plus the always-visible status pill from Phase 1, not the needs-you count.
+
+### Anti-false-alarm guarantees (the reason this policy exists)
+
+- Never alert during cold-start (the K-consecutive requirement).
+- Never alert on away-plus-relay (expected; judged by route).
+- Judge "slow" against the device's OWN baseline, not a fixed number.
+- Edge-triggered: one alert per episode, one resolution note.
+- The monitor self-gates: if no home device is present, or Tailscale is unavailable, the state is
+  "unknown", not "drift" - it stays quiet rather than guessing.
+
+---
+
+## Monitor implementation notes (Phase 1, from the code review of `NetDiagMonitor.cs` / `LanPresenceProbe.cs`)
+
+The server-side monitor was reviewed and approved against its contracts (direct-versus-relay from the
+ping path parse never the `Relay` field; `CurrentIsLanPath` from the `CurAddr` private-range check;
+`HomeLanPresent` from an Address-Resolution-Protocol probe resolving the same cached MAC; tick
+cadence <=90 seconds; offline peers gated to Unknown before the Decide-machine). Three durable points
+came out of that review:
+
+- SAFETY INVARIANT: the positive-presence smoothing cache (120 seconds) MUST stay comfortably shorter
+  than the drift-duration floor (5 minutes). That ordering is precisely what makes "the user left the
+  house" watertight: a departed device ages out of the presence cache in ~120 seconds, well before
+  drift can fire (three consecutive bad observations over 5 minutes), so it can reach at most a brief
+  Suspect and never Drifted. If anyone raises the cache window past the drift floor, the leave-the-
+  house false-alert hole silently reopens. Keep an assertion or comment guarding this.
+- PERSISTENCE (guardrail C): the monitor is the always-on producer of continuous quality data, so its
+  per-device observations (direct-versus-relay, latency, route) must be appended to the durable
+  results store / hourly rollup starting at the FIRST live redeploy - not deferred to Phase 3. If the
+  monitor only writes to the file log, then the baseline lives only in memory (a Gateway restart
+  wipes it, forcing a re-warmup) and all quality history until Phase 3 is thrown away, which is the
+  exact loss guardrail C exists to prevent. Two constraints on WHAT to persist:
+  - The BASELINE is a separate derived value, NOT something to reconstruct from the hourly rollup. A
+    rollup stores hourly SUMS (which cannot yield the median the baseline uses) and blends away/relay
+    data. Persist the baseline as its own small per-device value (is-LAN-direct, typical latency,
+    sample count), or persist the bounded recent HOME-plus-DIRECT-plus-LAN good-sample list and let
+    the baseline computation run unchanged. Keep the home-plus-direct-only filter on anything
+    reloaded - never seed a baseline from away or relay observations. The rollup is for trend and
+    quality DISPLAY; the baseline is a different shape - do not conflate them.
+  - DO NOT persist or restore the drift state machine across a restart. Persist only the baseline and
+    the (cached-LAN-address, cached-MAC) presence identity. Restoring a mid-episode Drifted state with
+    a stale first-bad timestamp could immediately re-fire an alert or mis-time the 5-minute floor on
+    boot. A restart starts every device fresh at Unknown/Ok and re-accrues from live observations -
+    the baseline seeds instantly (no re-warmup) while the drift-episode clock begins clean.
+- MINOR HARDENING: an online peer that was not pinged (its direct-versus-relay verdict is null, which
+  happens only past the per-tick ping cap or on a ping failure) should be gated to Unknown like an
+  offline peer - judge only peers with a confirmed ping verdict. Latent for a small fleet, but tidy.
+
+## Phase-by-phase landing summary
+
+- Phase 0 (Manager, owner-gated): deploy the built foundation; validate `GET /diag/network` against
+  the live Tailscale. Design does not depend on it; validation does.
+- Phase 1: app-open auto-run plus an always-visible status pill (green direct/fast, amber warming,
+  red relaying/slow); the server-side scheduled monitor (Decision 4 truth source), which flags a
+  problem only when relaying PERSISTS.
+- Phase 2: keep-warm (Decision 1) - server-side warmer plus client-side foreground heartbeat;
+  contextual fix guidance when relaying persists.
+- Phase 3: durable results store plus hourly quality rollup (Decisions 2a, 2b); Cockpit Network
+  dashboard with status light, live per-device table, and trend over time.
+- Phase 4: network-statistics surface styled like Your Throttle (Decision 3); home-versus-away usage
+  via the `InputOrigin` third axis (Decision 2d); home-versus-away quality via the rollup; per-user
+  baseline (Decision 2c).
+- Phase 5: drift alert (Decision 4).
+
+## Open items to confirm (with the Manager / owner, post-deploy)
+
+1. Confirm the real peer/route classification against live `GET /diag/network` output - especially
+   that a home phone reads route "tailscale" with `Direct == true` (the orthogonality assumption).
+2. Confirm keep-warm cadence (60 s server / 25 s client foreground) is acceptable and does not annoy
+   Tailscale or drain phone battery in practice; tune after a live observation.
+3. Confirm the owner-email cadence default (one per episode plus resolution, daily cap) matches the
+   owner's tolerance, consistent with the "email only on drift, always self-reap" convention.

--- a/docs/architecture/network-diagnostics-mission-2026-07-13.md
+++ b/docs/architecture/network-diagnostics-mission-2026-07-13.md
@@ -1,0 +1,92 @@
+# Mission Brief: Network Diagnostics (fast at home, always visible)
+
+Status: research + build in progress, written 2026-07-13 on machine SOREN_NORTH, in the `devthrottle`
+repo, session "Network Diagnostics - Standalone" (3cc96cc5). Companion documentation is owned by the
+"Network Diagnostics - Docs" session (52749c5a) in `devthrottle_internal`
+(docs/networking/network-speed-and-diagnostics.md).
+
+## WHY (front and center)
+
+The home network should be fast by default, and a user must never be silently slow on their own LAN
+without knowing it or how to fix it. The owner was slow for about two weeks and did not know the cause
+existed. Never again: make the connection quality visible, make the diagnosis automatic (agents and the
+apps, not the user), keep the fast path warm, and show the whole story - including how much the product
+is used, and how well the network performs, at home versus away.
+
+## The discovery that reframed everything
+
+The home slowness was NOT a misconfiguration and NOT the "Tailscale is required" problem. It is
+Tailscale's normal cold-start behavior: every connection starts relayed through the nearest DERP server
+(Toronto here) and auto-upgrades to a DIRECT peer-to-peer LAN path a moment later. Measured during that
+window you see the relay (155 ms, 8 Mbps); a moment later it is direct (11 ms). Proven with
+`tailscale ping` (direct 192.168.1.15, 11 ms; UDP open, NAT clean, local-network access granted). So the
+owner's settings are already correct; the only cause of slowness is landing in the cold-start window.
+
+## What is already built (branch feat/mobile-net-diagnostics, verified, NOT yet deployed)
+
+Endpoints (Gateway, per-device-key gated): `GET /diag/echo`, `GET|POST /diag/payload`, `GET /diag/ping`
+(featherweight latency), `GET /diag/network` (server-side tailscale status/ping/netcheck ->
+per-device direct-vs-DERP + latency + UDP/NAT, NO phone needed), `POST /diag/result` + `GET /diag/results`
+(logged recent history). Client-core measurement + read helpers. Mobile `/m/diagnostics` page with the
+authoritative direct-vs-relay verdict + "how to make it faster" checklist + result logging. Cockpit
+"Network" view (per-device table + self-test + recent results). CLI: `cc-devthrottle diag network` /
+`diag results`. 32 unit tests pass; all workspaces typecheck.
+
+## The enabler for everything below
+
+Stamp every relevant event - each diagnostic result AND each feature-usage event (voice, typing, etc.) -
+with its ROUTE at the time: "home" (direct LAN) vs "away" (Tailscale), plus the measured quality. Then
+PERSIST it (today the results ring is in-memory). This one dimension powers usage-by-location,
+network-quality-by-location, trends, and drift alerts. It must EXTEND the existing DevThrottle Stats /
+Your Throttle instrumentation (see devthrottle-stats mission), not create a parallel stats system.
+
+## Feature roadmap (phased; each ships and is proven before the next)
+
+Phase 0 - DEPLOY the foundation already built, and verify /diag/network against real Tailscale on the
+live Gateway. (Prereq for seeing any live data.)
+
+Phase 1 - Automatic detection.
+  - Auto-run a quiet diagnostic on app open (phone + Cockpit); a small status pill (green=direct/fast,
+    amber=warming, red=relaying/slow) in the header so quality is always visible without opening a page.
+  - Server-side scheduled monitor: the Gateway runs the network check on a timer (existing schedule
+    system), logs each run, and flags a problem only when relaying PERSISTS past the cold-start window
+    (no false alarms during warmup).
+
+Phase 2 - Keep it fast, not just measured.
+  - Keep-warm heartbeat while an app is open: a tiny periodic ping holds the direct path open so the user
+    never falls back to the relay. The targeted fix for "always fast at home."
+  - Contextual fix guidance when relaying persists; optional agent assertions that Tailscale is set up
+    correctly (report-only by default).
+
+Phase 3 - Persist + Cockpit dashboard.
+  - Persist diagnostic results (survive Gateway restart) so trends are real.
+  - Cockpit Network dashboard: at-a-glance status light, live per-device direct/relay table,
+    latency/throughput TREND over time, recent-results history, per-device drilldown.
+
+Phase 4 - Network statistics + home-vs-away (the Your Throttle counterpart).
+  - Network statistics surface (styled like Your Throttle): avg latency, throughput, and percent of time
+    direct vs relayed, over time.
+  - Home vs away USAGE: how much the product is used at home vs away (tag usage events with route,
+    extending DevThrottle Stats).
+  - Home vs away NETWORK QUALITY: side-by-side comparison of latency/throughput/reliability at home vs
+    away. "At home should be direct/fast; away, relay is expected and fine" - so comparisons and alerts
+    are judged against the right baseline.
+  - A per-user baseline (known-good numbers) so "slow" is judged against this network, not a fixed number.
+
+Phase 5 - Tell the user when it matters.
+  - Drift alert: when the monitor sees persistent relaying/slowness AT HOME, notify (phone needs-you
+    badge or the owner-email channel) with the specific fix. Closes the loop so no one is silently slow.
+
+## Design constraints (do not violate)
+
+- A phone PWA cannot run in the background, so "automatic" = app-open auto-run PLUS a server-side
+  scheduled monitor. The server-side monitor is the always-on truth source.
+- Home vs away is judged from the route the Gateway sees (LAN 192.168.x = home; Tailscale 100.x = away).
+- Never fail silently on mobile; never claim "fast" without the measured proof.
+- Extend the existing stats instrumentation; do not build a second analytics pipeline.
+- ASCII only, plain English, no fallback programming.
+
+## Coordination
+
+Docs session 52749c5a keeps docs/networking/network-speed-and-diagnostics.md in sync; it holds unshipped
+names as not-yet-merged until this session confirms them post-deploy with final names + a warm screenshot.

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -862,6 +862,187 @@ export async function getGatewayHealth(signal?: AbortSignal): Promise<GatewayHea
   return (await res.json()) as GatewayHealth;
 }
 
+// ===== Network diagnostics (auto-network-switching mission) =====
+// Back the mobile Diagnostics page. A phone cannot run `tailscale ping`, so these let it measure the
+// phone-to-Gateway path from the phone itself: which route it is on (direct LAN vs relayed through
+// Tailscale), the round-trip latency, and the download/upload throughput.
+
+/** GET /diag/echo - what the Gateway sees about THIS connection. clientPath is "tailscale" | "lan" | "local" | "other". */
+export interface NetDiagEcho {
+  clientIp: string | null;
+  clientPath: string;
+  forwardedFor: string;
+  host: string;
+  machineName: string;
+  gatewayLanIp: string | null;
+  gatewayTailnetName: string | null;
+  serverTime: string;
+}
+
+// GET /diag/echo - the IP and host the Gateway sees for this request. RemoteIpAddress reflects
+// X-Forwarded-For on the Gateway, so clientPath is the one clean signal that distinguishes a direct-LAN
+// hit from a Tailscale relay. Gated like the rest of the data API, so it carries the per-device key.
+export async function getNetDiagEcho(signal?: AbortSignal): Promise<NetDiagEcho> {
+  const res = await gatewayFetch("/diag/echo", {
+    method: "GET",
+    headers: { Accept: "application/json", ...authHeaders() },
+    signal,
+  }, { timeoutMs: POLL_TIMEOUT_MS });
+  if (!res.ok) throw new GatewayError(res.status, `GET /diag/echo failed: ${res.status}`);
+  return (await res.json()) as NetDiagEcho;
+}
+
+/** One throughput measurement: bytes moved, milliseconds taken, and the derived megabits per second. */
+export interface ThroughputResult {
+  bytes: number;
+  ms: number;
+  mbps: number;
+}
+
+function megabitsPerSecond(bytes: number, ms: number): number {
+  if (ms <= 0) return 0;
+  return (bytes * 8) / (ms / 1000) / 1_000_000;
+}
+
+// Measure round-trip latency: fire `samples` tiny GET /diag/echo requests back to back and return each
+// timing in milliseconds. Sequential (not parallel) so every number is a clean single-request round trip -
+// the same thing the user feels tapping through the app. Stops early if the caller aborts.
+export async function measureLatency(samples: number, signal?: AbortSignal): Promise<number[]> {
+  const timings: number[] = [];
+  for (let i = 0; i < samples; i++) {
+    if (signal?.aborted) break;
+    const t0 = performance.now();
+    // /diag/ping is featherweight (no address lookup), so this measures wire time, not server work.
+    const res = await gatewayFetch("/diag/ping", {
+      method: "GET",
+      headers: { Accept: "application/json", ...authHeaders() },
+      signal,
+    });
+    await res.arrayBuffer(); // drain the body so the timing spans the whole round trip
+    timings.push(performance.now() - t0);
+  }
+  return timings;
+}
+
+// Measure DOWNLOAD throughput: fetch `bytes` of incompressible data from the Gateway and time the whole
+// transfer. The payload is no-store on the server, so the service worker never serves a cached copy that
+// would fake the number.
+export async function measureDownload(bytes: number, signal?: AbortSignal): Promise<ThroughputResult> {
+  const t0 = performance.now();
+  const res = await gatewayFetch(`/diag/payload?bytes=${bytes}`, {
+    method: "GET",
+    headers: { ...authHeaders() },
+    signal,
+  });
+  if (!res.ok) throw new GatewayError(res.status, `GET /diag/payload failed: ${res.status}`);
+  const buf = await res.arrayBuffer();
+  const ms = performance.now() - t0;
+  return { bytes: buf.byteLength, ms, mbps: megabitsPerSecond(buf.byteLength, ms) };
+}
+
+// Measure UPLOAD throughput: POST `bytes` of data and time it. Upload is the direction that carries
+// dictation audio, so it is worth measuring on its own - a relay can be asymmetric.
+export async function measureUpload(bytes: number, signal?: AbortSignal): Promise<ThroughputResult> {
+  const body = new Uint8Array(bytes); // zero-filled is fine; we are timing the wire, not inspecting content
+  const t0 = performance.now();
+  const res = await gatewayFetch("/diag/payload", {
+    method: "POST",
+    headers: { "Content-Type": "application/octet-stream", ...authHeaders() },
+    body,
+    signal,
+  });
+  if (!res.ok) throw new GatewayError(res.status, `POST /diag/payload failed: ${res.status}`);
+  await res.arrayBuffer();
+  const ms = performance.now() - t0;
+  return { bytes, ms, mbps: megabitsPerSecond(bytes, ms) };
+}
+
+/** One connected device's live Tailscale path, from GET /diag/network. */
+export interface NetDiagPeer {
+  name: string;
+  tailscaleIp: string | null;
+  os: string | null;
+  online: boolean;
+  /** true = direct LAN/peer path, false = relayed through DERP, null = not determined. */
+  direct: boolean | null;
+  /** "192.168.x.y:port" when direct, or "DERP(region)" when relayed. */
+  path: string | null;
+  latencyMs: number | null;
+  note: string | null;
+}
+
+/** GET /diag/network - the server-side Tailscale diagnostic (direct-vs-relay per device, no phone needed). */
+export interface NetworkDiag {
+  tailscaleAvailable: boolean;
+  backendState: string | null;
+  selfName: string | null;
+  selfTailscaleIp: string | null;
+  udpOk: boolean | null;
+  mappingVariesByDestIp: boolean | null;
+  nearestDerp: string | null;
+  peers: NetDiagPeer[];
+  notes: string[];
+  collectedAt: string;
+}
+
+// GET /diag/network - the server-side Tailscale check. Slower than the other reads (it shells the CLI and
+// pings peers), so give it a longer timeout. Lets a client show the AUTHORITATIVE direct-vs-relay state
+// for its own connection instead of guessing from the speed numbers.
+export async function getNetworkDiag(signal?: AbortSignal): Promise<NetworkDiag> {
+  const res = await gatewayFetch("/diag/network", {
+    method: "GET",
+    headers: { Accept: "application/json", ...authHeaders() },
+    signal,
+  }, { timeoutMs: 20000 });
+  if (!res.ok) throw new GatewayError(res.status, `GET /diag/network failed: ${res.status}`);
+  return (await res.json()) as NetworkDiag;
+}
+
+/** A completed speed-test result, as submitted to POST /diag/result and returned by GET /diag/results. */
+export interface NetDiagResult {
+  route: string;
+  latencyMedianMs: number | null;
+  latencyBestMs: number | null;
+  latencySamples: number;
+  downloadMbps: number | null;
+  uploadMbps: number | null;
+  rating: string;
+  verdict: string;
+  loadedFrom: string;
+  surface: string;
+  /** Actual-path tags (from the authoritative self-peer): decide the home(LAN-direct)/away(relay) sub-sum. */
+  direct?: boolean | null;
+  isLanPath?: boolean;
+  clientIp?: string | null;
+  clientPath?: string | null;
+  receivedAt?: string;
+}
+
+// POST /diag/result - hand the Gateway the result the page just computed so it is logged and readable by
+// an agent at GET /diag/results. Best-effort: a failure here must never break the page, so callers treat a
+// rejection as non-fatal (the numbers are still on screen).
+export async function postNetDiagResult(result: NetDiagResult, signal?: AbortSignal): Promise<void> {
+  const res = await gatewayFetch("/diag/result", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify(result),
+    signal,
+  });
+  if (!res.ok) throw new GatewayError(res.status, `POST /diag/result failed: ${res.status}`);
+}
+
+// GET /diag/results - recent logged results, newest first. Backs the Cockpit history view and lets an
+// agent read what users have been seeing.
+export async function getNetDiagResults(signal?: AbortSignal): Promise<NetDiagResult[]> {
+  const res = await gatewayFetch("/diag/results", {
+    method: "GET",
+    headers: { Accept: "application/json", ...authHeaders() },
+    signal,
+  }, { timeoutMs: POLL_TIMEOUT_MS });
+  if (!res.ok) throw new GatewayError(res.status, `GET /diag/results failed: ${res.status}`);
+  return (await res.json()) as NetDiagResult[];
+}
+
 // GET /directors - the fleet's machines (Directors). Sorted most-recently-seen first so the picker
 // can default-select the top one (matching FleetParser.ParseDirectors), tie-broken by machine name.
 // Entries with no directorId are dropped (they cannot be addressed). Throws GatewayError on non-2xx

--- a/packages/client-core/src/net/netStatus.test.ts
+++ b/packages/client-core/src/net/netStatus.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { evaluateNetStatus, RELAY_POLLS_BEFORE_RED } from "./netStatus";
+import type { NetworkDiag, NetDiagEcho, NetDiagPeer } from "../api/client";
+
+// The status-pill resolver: colour comes from the AUTHORITATIVE self-peer direct flag, and the cold-start
+// window is AMBER, never RED (guardrail A).
+
+const PHONE_IP = "100.86.144.11";
+
+function echo(clientPath: string, clientIp: string | null = PHONE_IP): NetDiagEcho {
+  return {
+    clientIp,
+    clientPath,
+    forwardedFor: "",
+    host: "soren-north.taildb08ed.ts.net",
+    machineName: "SOREN_NORTH",
+    gatewayLanIp: "192.168.1.18",
+    gatewayTailnetName: "soren-north.taildb08ed.ts.net",
+    serverTime: "2026-07-13T12:00:00Z",
+  };
+}
+
+function network(self: Partial<NetDiagPeer> | null): NetworkDiag {
+  const peers: NetDiagPeer[] = self
+    ? [{ name: "phone", tailscaleIp: PHONE_IP, os: "android", online: true, direct: null, path: null, latencyMs: null, note: null, ...self }]
+    : [];
+  return {
+    tailscaleAvailable: true,
+    backendState: "Running",
+    selfName: "soren-north",
+    selfTailscaleIp: "100.97.80.26",
+    udpOk: true,
+    mappingVariesByDestIp: false,
+    nearestDerp: "Toronto",
+    peers,
+    notes: [],
+    collectedAt: "2026-07-13T12:00:00Z",
+  };
+}
+
+describe("evaluateNetStatus", () => {
+  it("is grey while the echo has not arrived", () => {
+    expect(evaluateNetStatus(null, null).level).toBe("grey");
+  });
+
+  it("is green on a direct-LAN front door without needing the peer view", () => {
+    expect(evaluateNetStatus(null, echo("lan")).level).toBe("green");
+  });
+
+  it("is green when the authoritative self-peer is direct", () => {
+    const s = evaluateNetStatus(network({ direct: true, path: "192.168.1.15:52091", latencyMs: 44 }), echo("tailscale"));
+    expect(s.level).toBe("green");
+    expect(s.detail).toContain("44 ms");
+  });
+
+  it("is AMBER (not red) when relaying on the cold-start window", () => {
+    const s = evaluateNetStatus(network({ direct: false, path: "DERP(tor)" }), echo("tailscale"), 0);
+    expect(s.level).toBe("amber");
+  });
+
+  it("goes RED only once relaying has PERSISTED", () => {
+    const s = evaluateNetStatus(network({ direct: false, path: "DERP(tor)" }), echo("tailscale"), RELAY_POLLS_BEFORE_RED);
+    expect(s.level).toBe("red");
+  });
+
+  it("is grey when the Gateway does not see this device yet", () => {
+    expect(evaluateNetStatus(network(null), echo("tailscale")).level).toBe("grey");
+  });
+
+  it("is grey when Tailscale is unavailable", () => {
+    const net = { ...network({ direct: true }), tailscaleAvailable: false };
+    expect(evaluateNetStatus(net, echo("tailscale")).level).toBe("grey");
+  });
+
+  it("is amber while the ping verdict is not yet in (direct null)", () => {
+    expect(evaluateNetStatus(network({ direct: null }), echo("tailscale")).level).toBe("amber");
+  });
+});

--- a/packages/client-core/src/net/netStatus.ts
+++ b/packages/client-core/src/net/netStatus.ts
@@ -1,0 +1,68 @@
+import type { NetworkDiag, NetDiagEcho, NetDiagPeer } from "../api/client";
+
+// The status-pill resolver (Network Diagnostics mission, Phase 1). Pure and shared by the phone and the
+// Cockpit. Per the Architect's guardrail A, the pill's colour comes from the AUTHORITATIVE direct flag of
+// THIS device's self-peer in GET /diag/network - never from the app's speed-test verdict (which cannot
+// tell warming-up from broken). And it never flashes RED on the normal cold-start: a just-relaying device
+// is AMBER until the relay has PERSISTED across a couple of polls.
+
+export type NetStatusLevel = "green" | "amber" | "red" | "grey";
+
+export interface NetStatus {
+  level: NetStatusLevel;
+  label: string;
+  detail: string;
+}
+
+/** How many consecutive relaying observations before AMBER (warming) becomes RED (persistently relaying). */
+export const RELAY_POLLS_BEFORE_RED = 2;
+
+// Find the Gateway's view of THIS device in the network diagnostic, matched by the IP the Gateway sees us
+// as (echo.clientIp is our tailnet address, which appears as a peer's tailscaleIp).
+export function findSelfPeer(network: NetworkDiag | null, echo: NetDiagEcho | null): NetDiagPeer | null {
+  if (!network || !echo?.clientIp) return null;
+  return network.peers.find((p) => p.tailscaleIp === echo.clientIp) ?? null;
+}
+
+/**
+ * Resolve the status pill. `consecutiveRelay` is how many polls in a row this device has been observed
+ * relaying (the caller threads it, resetting to 0 on any non-relay observation) - it is what keeps the
+ * cold-start window AMBER rather than RED.
+ */
+export function evaluateNetStatus(
+  network: NetworkDiag | null,
+  echo: NetDiagEcho | null,
+  consecutiveRelay = 0,
+): NetStatus {
+  if (echo === null) return { level: "grey", label: "Checking", detail: "Checking your connection..." };
+
+  // A direct-LAN or local front door is unambiguously good without needing the authoritative peer view.
+  if (echo.clientPath === "lan") return { level: "green", label: "Direct LAN", detail: "Straight to the Gateway over your local network." };
+  if (echo.clientPath === "local") return { level: "green", label: "Local", detail: "On the Gateway machine." };
+
+  // Tailscale front door: the colour depends on the AUTHORITATIVE direct-vs-relay for this device.
+  if (network === null || !network.tailscaleAvailable) {
+    return { level: "grey", label: "Checking", detail: "Confirming your Tailscale path..." };
+  }
+  const self = findSelfPeer(network, echo);
+  if (self === null) return { level: "grey", label: "Unknown", detail: "The Gateway does not see this device yet." };
+
+  if (self.direct === true) {
+    return { level: "green", label: "Fast", detail: `Direct path over your LAN${self.latencyMs != null ? ` (${Math.round(self.latencyMs)} ms)` : ""}.` };
+  }
+  if (self.direct === false) {
+    // Never RED on the cold-start: AMBER until the relay has persisted across a couple of polls.
+    if (consecutiveRelay >= RELAY_POLLS_BEFORE_RED) {
+      return { level: "red", label: "Slow", detail: "Relaying through a distant server instead of a direct path." };
+    }
+    return { level: "amber", label: "Warming up", detail: "Connecting - this speeds up once the direct path forms." };
+  }
+  // direct === null: not yet confirmed by a ping.
+  return { level: "amber", label: "Checking", detail: "Confirming the path..." };
+}
+
+/** True when an observation counts as "relaying" for the consecutive-relay counter the caller threads. */
+export function isRelayObservation(network: NetworkDiag | null, echo: NetDiagEcho | null): boolean {
+  const self = findSelfPeer(network, echo);
+  return self?.direct === false;
+}

--- a/packages/client-core/src/net/useNetStatus.ts
+++ b/packages/client-core/src/net/useNetStatus.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef, useState } from "react";
+import { getNetworkDiag, getNetDiagEcho } from "../api/client";
+import { evaluateNetStatus, isRelayObservation, type NetStatus } from "./netStatus";
+
+// Auto-run-on-open network status for the header pill (Network Diagnostics mission, Phase 1), shared by the
+// phone and the Cockpit so the two pills can never drift. Per the Architect's guardrail B this is LIGHT: it
+// reads GET /diag/echo (to learn which device the Gateway sees us as) + GET /diag/network (the authoritative
+// direct-vs-relay), and NEVER runs the heavy download/upload throughput test. It re-polls on a slow cadence
+// so the pill stays current, and threads a consecutive-relay counter so the cold-start window shows AMBER,
+// not RED.
+
+const POLL_MS = 30000;
+
+export function useNetStatus(): NetStatus {
+  const [status, setStatus] = useState<NetStatus>({ level: "grey", label: "Checking", detail: "Checking your connection..." });
+  const relayCount = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    async function poll() {
+      try {
+        const [echo, network] = await Promise.all([getNetDiagEcho(), getNetworkDiag()]);
+        if (cancelled) return;
+        relayCount.current = isRelayObservation(network, echo) ? relayCount.current + 1 : 0;
+        setStatus(evaluateNetStatus(network, echo, relayCount.current));
+      } catch {
+        if (!cancelled) setStatus({ level: "grey", label: "Offline", detail: "Cannot reach the Gateway right now." });
+      } finally {
+        if (!cancelled) timer = setTimeout(poll, POLL_MS);
+      }
+    }
+
+    void poll();
+    return () => {
+      cancelled = true;
+      if (timer !== undefined) clearTimeout(timer);
+    };
+  }, []);
+
+  return status;
+}

--- a/src/CcDirector.Gateway.Contracts/NetDiagEchoDto.cs
+++ b/src/CcDirector.Gateway.Contracts/NetDiagEchoDto.cs
@@ -1,0 +1,38 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// GET /diag/echo response. Backs the mobile Diagnostics page's connection-path readout
+/// (auto-network-switching mission). Reports what the Gateway sees about the caller's connection so the
+/// phone can tell a direct-LAN hit (a private 192.168.x address) apart from a Tailscale relay (a
+/// 100.64.0.0/10 CGNAT address), plus the Gateway's own reachable addresses so the page can show where a
+/// direct path would point.
+/// </summary>
+public sealed class NetDiagEchoDto
+{
+    /// <summary>
+    /// The client IP as the Gateway sees it AFTER X-Forwarded-For processing: the phone's tailnet 100.x
+    /// address through the Tailscale front door, or its 192.168.x LAN address on a direct hit.
+    /// </summary>
+    public string? ClientIp { get; set; }
+
+    /// <summary>Classification of <see cref="ClientIp"/>: "tailscale", "lan", "local", or "other".</summary>
+    public string ClientPath { get; set; } = "other";
+
+    /// <summary>The raw X-Forwarded-For header, or empty. Present only when a proxy (Tailscale serve) forwarded the request.</summary>
+    public string ForwardedFor { get; set; } = "";
+
+    /// <summary>The Host header the request arrived on (the ts.net front door, a LAN IP, or the machine name).</summary>
+    public string Host { get; set; } = "";
+
+    /// <summary>This Gateway's OS host name.</summary>
+    public string MachineName { get; set; } = "";
+
+    /// <summary>This Gateway's best LAN IPv4 (e.g. 192.168.1.42), or null when none is available.</summary>
+    public string? GatewayLanIp { get; set; }
+
+    /// <summary>This Gateway's Tailscale MagicDNS name (e.g. soren-north.tailnet.ts.net), or null.</summary>
+    public string? GatewayTailnetName { get; set; }
+
+    /// <summary>Server UTC time, for a rough clock read.</summary>
+    public DateTime ServerTime { get; set; } = DateTime.UtcNow;
+}

--- a/src/CcDirector.Gateway.Contracts/NetDiagResultDto.cs
+++ b/src/CcDirector.Gateway.Contracts/NetDiagResultDto.cs
@@ -1,0 +1,53 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// One completed speed-test result, submitted by a client (phone or Cockpit) to POST /diag/result and
+/// returned by GET /diag/results (Network Diagnostics mission). The client fills the measured fields; the
+/// Gateway stamps <see cref="ClientIp"/>, <see cref="ClientPath"/>, and <see cref="ReceivedAt"/> on
+/// receipt so an agent reading the history sees both what the user measured AND how the Gateway saw that
+/// connection - without needing the phone.
+/// </summary>
+public sealed class NetDiagResultDto
+{
+    // ----- filled by the client (what the page measured and showed) -----
+
+    /// <summary>The route the page reported: "tailscale", "lan", "local", or "other".</summary>
+    public string Route { get; set; } = "";
+    public double? LatencyMedianMs { get; set; }
+    public double? LatencyBestMs { get; set; }
+    public int LatencySamples { get; set; }
+    public double? DownloadMbps { get; set; }
+    public double? UploadMbps { get; set; }
+
+    /// <summary>The page's rating: "fast", "ok", or "slow".</summary>
+    public string Rating { get; set; } = "";
+
+    /// <summary>The plain-English verdict headline the user saw.</summary>
+    public string Verdict { get; set; } = "";
+
+    /// <summary>The host the page was loaded from (window.location.host).</summary>
+    public string LoadedFrom { get; set; } = "";
+
+    /// <summary>Which surface ran the test: "mobile" or "cockpit".</summary>
+    public string Surface { get; set; } = "";
+
+    /// <summary>
+    /// The ACTUAL-path tags for this client, from the Gateway's authoritative self-peer view at test time
+    /// (the mobile page already computes this for its verdict). These - NOT the front-door Route/ClientPath -
+    /// decide which home (LAN-direct) vs away (relay) sub-sum a result folds into, so quality-by-location is
+    /// judged by the measured path and never conflated with the front door.
+    /// </summary>
+    public bool? Direct { get; set; }
+    public bool IsLanPath { get; set; }
+
+    // ----- stamped by the Gateway on receipt -----
+
+    /// <summary>The client IP the Gateway saw for the submission (after X-Forwarded-For).</summary>
+    public string? ClientIp { get; set; }
+
+    /// <summary>The Gateway's own classification of <see cref="ClientIp"/>: "tailscale", "lan", "local", "other".</summary>
+    public string? ClientPath { get; set; }
+
+    /// <summary>When the Gateway received this result (UTC).</summary>
+    public DateTime ReceivedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/CcDirector.Gateway.Tests/NetDiagDeviceStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/NetDiagDeviceStoreTests.cs
@@ -1,0 +1,98 @@
+using CcDirector.Gateway.Api;
+using Xunit;
+using static CcDirector.Gateway.Api.NetDiagDrift;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The durable per-device store (Network Diagnostics mission, Phase 1 / Architect guardrail C): persists
+/// baseline good-samples + the (IP, MAC) presence identity across a restart - and DELIBERATELY not the
+/// drift state - so a restart seeds baselines instantly (no re-warmup) while the drift-episode clock starts
+/// clean.
+/// </summary>
+public sealed class NetDiagDeviceStoreTests : IDisposable
+{
+    private static readonly DateTime T0 = new(2026, 7, 13, 12, 0, 0, DateTimeKind.Utc);
+    private const string PhoneIp = "100.86.144.11";
+
+    private readonly string _path = Path.Combine(
+        Path.GetTempPath(), "cc-director-tests", "netdiagdev-" + Guid.NewGuid().ToString("N"), "netdiag-devices.json");
+
+    public void Dispose()
+    {
+        var dir = Path.GetDirectoryName(_path);
+        if (dir is not null && Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+    }
+
+    private static List<GoodSample> GoodSamples(int n) =>
+        Enumerable.Range(0, n).Select(_ => new GoodSample(true, true, true, 44)).ToList();
+
+    [Fact]
+    public void SamplesAndPresenceIdentity_SurviveReload()
+    {
+        var store = new NetDiagDeviceStore(_path);
+        store.Save(PhoneIp, GoodSamples(5), "192.168.1.15", "aa-bb-cc-dd-ee-ff");
+
+        var reopened = new NetDiagDeviceStore(_path).LoadAll();
+        Assert.True(reopened.ContainsKey(PhoneIp));
+        Assert.Equal(5, reopened[PhoneIp].Samples.Count);
+        Assert.Equal("192.168.1.15", reopened[PhoneIp].LanIp);
+        Assert.Equal("aa-bb-cc-dd-ee-ff", reopened[PhoneIp].Mac);
+    }
+
+    [Fact]
+    public void Save_KeepsOnlyHomeDirectLanSamples()
+    {
+        var mixed = new List<GoodSample>
+        {
+            new(true, true, true, 40),    // good
+            new(true, true, true, 44),    // good
+            new(false, true, true, 40),   // away
+            new(true, false, false, 200), // relay
+        };
+        var store = new NetDiagDeviceStore(_path);
+        store.Save(PhoneIp, mixed, "192.168.1.15", "aa");
+        Assert.Equal(2, store.LoadAll()[PhoneIp].Samples.Count); // only the two good ones
+    }
+
+    [Fact]
+    public void CorruptFile_IsQuarantined_NotCrashing()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+        File.WriteAllText(_path, "{ not valid json");
+        var store = new NetDiagDeviceStore(_path);
+        Assert.Empty(store.LoadAll());
+        Assert.NotEmpty(Directory.GetFiles(Path.GetDirectoryName(_path)!, "*.corrupt-*"));
+    }
+
+    // The payoff: seeding baselines from the store means a restart does NOT re-warmup - a device with a
+    // persisted baseline that is relaying (and present) accrues drift on the FIRST tick instead of sitting
+    // in Unknown for ~6 minutes. And the drift clock starts fresh (this first bad tick is only Suspect).
+    [Fact]
+    public void MonitorSeededFromStore_HasInstantBaseline_AndFreshDriftClock()
+    {
+        var store = new NetDiagDeviceStore(_path);
+        store.Save(PhoneIp, GoodSamples(NetDiagDrift.MinBaselineSamples), "192.168.1.15", "aa-bb-cc-dd-ee-ff");
+
+        var monitor = new NetDiagMonitor(() => throw new InvalidOperationException("unused"), _ => null, store);
+        var diag = new TailscaleDiagnostics.NetworkDiag
+        {
+            TailscaleAvailable = true,
+            BackendState = "Running",
+            Peers = new()
+            {
+                new TailscaleDiagnostics.PeerDiag
+                {
+                    Name = "phone", TailscaleIp = PhoneIp, Os = "android",
+                    Online = true, Direct = false, Path = "DERP(tor)", LatencyMs = null,
+                },
+            },
+        };
+
+        // First tick after a "restart": baseline is already known (seeded), device is present (MAC matches),
+        // and it is relaying -> Suspect immediately (NOT Unknown-warmup), but only Suspect (fresh clock).
+        var d = monitor.Tick(diag, _ => "aa-bb-cc-dd-ee-ff", T0).Single().decision;
+        Assert.Equal("suspect", d.Status);
+        Assert.False(d.ShouldAlert);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/NetDiagDriftTests.cs
+++ b/src/CcDirector.Gateway.Tests/NetDiagDriftTests.cs
@@ -1,0 +1,175 @@
+using CcDirector.Gateway.Api;
+using Xunit;
+using static CcDirector.Gateway.Api.NetDiagDrift;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The pure per-device drift Decide-machine (Network Diagnostics mission, Architect Decision 4). These
+/// tests are the "never a false alert" guarantee in executable form: warmup, Tailscale-down, away, and
+/// no-physical-LAN-presence all self-gate to UNKNOWN; drift only fires for a device the monitor has
+/// POSITIVELY confirmed present on the home LAN (ARP + MAC match) that persistently relays for K>=3 ticks
+/// over >=5 min, exactly once per episode; and a lost-ability-to-judge (Drifted->Unknown) never emits a
+/// false all-clear.
+/// </summary>
+public sealed class NetDiagDriftTests
+{
+    private static readonly DateTime T0 = new(2026, 7, 13, 12, 0, 0, DateTimeKind.Utc);
+    private static Baseline LanBaseline(double ms = 44) => new() { IsLanDirect = true, TypicalLatencyMs = ms };
+
+    private static Observation Obs(
+        bool? direct, bool lanPath, double? latency, DateTime now,
+        bool homePresent = false, bool tsUp = true, Baseline? baseline = null) => new()
+    {
+        TailscaleUp = tsUp,
+        Baseline = baseline ?? LanBaseline(),
+        CurrentDirect = direct,
+        CurrentIsLanPath = lanPath,
+        CurrentLatencyMs = latency,
+        HomeLanPresent = homePresent,
+        NowUtc = now,
+    };
+
+    // ---- baseline ----
+
+    [Fact]
+    public void ComputeBaseline_TooFewGoodSamples_IsUnknown()
+    {
+        var samples = Enumerable.Range(0, MinBaselineSamples - 1)
+            .Select(_ => new GoodSample(true, true, true, 40)).ToList();
+        Assert.Null(ComputeBaseline(samples));
+    }
+
+    [Fact]
+    public void ComputeBaseline_EnoughHomeDirect_IsLanDirectMedian()
+    {
+        var samples = new[] { 40.0, 44, 48, 50, 42 }.Select(ms => new GoodSample(true, true, true, ms)).ToList();
+        var b = ComputeBaseline(samples);
+        Assert.NotNull(b);
+        Assert.True(b!.IsLanDirect);
+        Assert.Equal(44, b.TypicalLatencyMs); // median of 40,42,44,48,50
+    }
+
+    [Fact]
+    public void ComputeBaseline_ExcludesRelayAndAwaySamples()
+    {
+        var samples = new List<GoodSample>
+        {
+            new(true, true, true, 40), new(true, true, true, 44),
+            new(false, true, true, 40),   // away
+            new(true, false, false, 200), // relay path
+            new(true, true, false, 200),  // not lan path
+        };
+        Assert.Null(ComputeBaseline(samples)); // only 2 qualify, below the minimum
+    }
+
+    // ---- gating: never drift ----
+
+    [Fact]
+    public void TailscaleDown_IsUnknown_NeverAlerts()
+    {
+        var d = Decide(Obs(false, false, null, T0, tsUp: false), new MachineState());
+        Assert.Equal("unknown", d.Status);
+        Assert.False(d.ShouldAlert);
+    }
+
+    [Fact]
+    public void NoLanDirectBaseline_IsUnknown()
+    {
+        var d = Decide(Obs(false, false, null, T0, baseline: null), new MachineState());
+        Assert.Equal("unknown", d.Status);
+    }
+
+    [Fact]
+    public void CurrentlyDirect_IsOk()
+    {
+        var d = Decide(Obs(true, true, 44, T0, homePresent: true), new MachineState());
+        Assert.Equal("ok", d.Status);
+        Assert.False(d.ShouldAlert);
+    }
+
+    // THE CRUX: relaying but the monitor did NOT positively confirm LAN presence (device left the house, or
+    // a different device holds that IP now) = UNKNOWN, never alert - even mid-episode.
+    [Fact]
+    public void Relaying_NoLanPresence_IsUnknown_NeverAlerts()
+    {
+        var obs = Obs(false, false, null, T0, homePresent: false);
+        var state = new MachineState { State = State.Suspect, ConsecutiveBad = 2, FirstBadUtc = T0 - TimeSpan.FromMinutes(6) };
+        var d = Decide(obs, state);
+        Assert.Equal("unknown", d.Status);
+        Assert.False(d.ShouldAlert);
+    }
+
+    // ---- drift accrual + one-shot alert + hysteresis ----
+
+    [Fact]
+    public void Relaying_HomePresent_PersistsKAndDuration_DriftsAndAlertsOnce()
+    {
+        var state = new MachineState();
+
+        var d1 = Decide(Obs(false, false, null, T0, homePresent: true), state);
+        Assert.Equal("suspect", d1.Status);
+        Assert.False(d1.ShouldAlert);
+
+        var d2 = Decide(Obs(false, false, null, T0.AddMinutes(3), homePresent: true), d1.Next);
+        Assert.Equal("suspect", d2.Status);
+
+        var d3 = Decide(Obs(false, false, null, T0.AddMinutes(6), homePresent: true), d2.Next);
+        Assert.Equal("drifted", d3.Status);
+        Assert.True(d3.ShouldAlert);
+
+        var d4 = Decide(Obs(false, false, null, T0.AddMinutes(9), homePresent: true), d3.Next);
+        Assert.Equal("drifted", d4.Status);
+        Assert.False(d4.ShouldAlert); // fired once
+    }
+
+    [Fact]
+    public void KReached_ButUnderFiveMinutes_StaysSuspect()
+    {
+        var s1 = Decide(Obs(false, false, null, T0, homePresent: true), new MachineState()).Next;
+        var s2 = Decide(Obs(false, false, null, T0.AddSeconds(30), homePresent: true), s1).Next;
+        var d3 = Decide(Obs(false, false, null, T0.AddMinutes(1), homePresent: true), s2); // 3 bad but 1 min elapsed
+        Assert.Equal("suspect", d3.Status);
+        Assert.False(d3.ShouldAlert);
+    }
+
+    [Fact]
+    public void Recovery_AfterAlertedDrift_ResolvesOnce()
+    {
+        var alerted = new MachineState { State = State.Drifted, ConsecutiveBad = 4, FirstBadUtc = T0, Alerted = true };
+        var d = Decide(Obs(true, true, 44, T0.AddMinutes(10), homePresent: true), alerted);
+        Assert.Equal("ok", d.Status);
+        Assert.True(d.ShouldResolve);
+        Assert.False(d.Next.Alerted);
+    }
+
+    // Architect review fix: losing the ability to judge (Drifted -> Unknown) must NOT emit a false
+    // "your network recovered" all-clear. Only a real observed recovery (Drifted -> Ok) resolves.
+    [Fact]
+    public void Drifted_ToUnknown_DoesNotResolve()
+    {
+        var alerted = new MachineState { State = State.Drifted, ConsecutiveBad = 4, FirstBadUtc = T0, Alerted = true };
+        var d = Decide(Obs(false, false, null, T0.AddMinutes(10), tsUp: false), alerted); // tailscale down
+        Assert.Equal("unknown", d.Status);
+        Assert.False(d.ShouldResolve);
+        Assert.False(d.ShouldAlert);
+    }
+
+    // ---- secondary (latency) signal: generous margin, and NO presence probe needed (device is LAN-direct) ----
+
+    [Fact]
+    public void DirectButSlightlySlow_WithinMargin_IsOk()
+    {
+        var d = Decide(Obs(true, true, 50, T0, homePresent: true), new MachineState()); // 50 vs 44 baseline
+        Assert.Equal("ok", d.Status);
+    }
+
+    [Fact]
+    public void SecondaryLatencySignal_AccruesWithoutPresenceProbe()
+    {
+        // 200 ms vs a 44 ms baseline exceeds 3x. The device IS LAN-direct (presence self-evident), so it
+        // accrues even though HomeLanPresent is false - the probe is only for the primary relay signal.
+        var d = Decide(Obs(true, true, 200, T0, homePresent: false), new MachineState());
+        Assert.Equal("suspect", d.Status);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/NetDiagMonitorTests.cs
+++ b/src/CcDirector.Gateway.Tests/NetDiagMonitorTests.cs
@@ -1,0 +1,149 @@
+using CcDirector.Gateway.Api;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The server-side monitor's per-device Tick core (Network Diagnostics mission, Phase 1). Verifies the
+/// monitor contracts: offline peers gate to Unknown before Decide; direct-vs-relay comes from the peer's
+/// ping-derived Direct (never Relay); and HomeLanPresent for a relaying device requires an ARP probe that
+/// resolves the SAME cached MAC (with short smoothing) - so a present home device drifts but an absent /
+/// mismatched one never alerts.
+/// </summary>
+public sealed class NetDiagMonitorTests
+{
+    private static readonly DateTime T0 = new(2026, 7, 13, 12, 0, 0, DateTimeKind.Utc);
+    private const string PhoneIp = "100.86.144.11";
+
+    private static NetDiagMonitor NewMonitor() => new(() => throw new InvalidOperationException("collector unused"), _ => null);
+
+    private static TailscaleDiagnostics.NetworkDiag Diag(bool? direct, string? path, double? latency, bool online = true) =>
+        new()
+        {
+            TailscaleAvailable = true,
+            BackendState = "Running",
+            Peers = new()
+            {
+                new TailscaleDiagnostics.PeerDiag
+                {
+                    Name = "phone", TailscaleIp = PhoneIp, Os = "android",
+                    Online = online, Direct = direct, Path = path, LatencyMs = latency,
+                },
+            },
+        };
+
+    // Prime a known baseline: 5 LAN-direct sightings (resolver returns a stable MAC).
+    private static void PrimeBaseline(NetDiagMonitor m)
+    {
+        for (int i = 0; i < NetDiagDrift.MinBaselineSamples; i++)
+            m.Tick(Diag(true, "192.168.1.15:52091", 44), _ => "aa-bb-cc-dd-ee-ff", T0);
+    }
+
+    // ---- pure helpers ----
+
+    [Theory]
+    [InlineData("192.168.1.15:52091", true)]
+    [InlineData("10.0.0.5:41641", true)]
+    [InlineData("172.16.9.9:1", true)]
+    [InlineData("8.8.8.8:443", false)]
+    [InlineData("DERP(tor)", false)]
+    [InlineData(null, false)]
+    public void IsLanPath_ClassifiesPaths(string? path, bool expected)
+        => Assert.Equal(expected, NetDiagMonitor.IsLanPath(path));
+
+    [Theory]
+    [InlineData("192.168.1.15:52091", "192.168.1.15")]
+    [InlineData("10.0.0.5:41641", "10.0.0.5")]
+    [InlineData("DERP(tor)", null)]
+    public void ExtractIp_StripsPort(string path, string? expected)
+        => Assert.Equal(expected, NetDiagMonitor.ExtractIp(path));
+
+    [Fact]
+    public void NormalizeMac_FormatsLowerHexDashed()
+        => Assert.Equal("82-68-dc-31-50-33", LanPresenceProbe.NormalizeMac(new byte[] { 0x82, 0x68, 0xdc, 0x31, 0x50, 0x33 }));
+
+    // ---- monitor contracts ----
+
+    [Fact]
+    public void OfflinePeer_GatesToUnknown()
+    {
+        var m = NewMonitor();
+        PrimeBaseline(m);
+        var d = m.Tick(Diag(false, "DERP(tor)", null, online: false), _ => "aa-bb-cc-dd-ee-ff", T0.AddMinutes(1));
+        Assert.Equal("unknown", d.Single().decision.Status);
+    }
+
+    [Fact]
+    public void OnlineButNotPinged_NullDirect_GatesToUnknown()
+    {
+        var m = NewMonitor();
+        PrimeBaseline(m);
+        // Online, but no ping verdict (Direct==null) and a status-fallback DERP path: must NOT judge.
+        var d = m.Tick(Diag(null, "DERP(tor)", null), _ => "aa-bb-cc-dd-ee-ff", T0.AddMinutes(1));
+        Assert.Equal("unknown", d.Single().decision.Status);
+    }
+
+    [Fact]
+    public void PresentHomeDevice_RelayingPersistently_Drifts()
+    {
+        var m = NewMonitor();
+        PrimeBaseline(m); // baseline now known, LastPresent = T0
+        string? Present(string _) => "aa-bb-cc-dd-ee-ff"; // ARP resolves the SAME cached MAC = present
+
+        var t1 = m.Tick(Diag(false, "DERP(tor)", null), Present, T0).Single().decision;
+        Assert.Equal("suspect", t1.Status);
+        var t2 = m.Tick(Diag(false, "DERP(tor)", null), Present, T0.AddMinutes(3)).Single().decision;
+        Assert.Equal("suspect", t2.Status);
+        var t3 = m.Tick(Diag(false, "DERP(tor)", null), Present, T0.AddMinutes(6)).Single().decision;
+        Assert.Equal("drifted", t3.Status);
+        Assert.True(t3.ShouldAlert);
+    }
+
+    [Fact]
+    public void Relaying_MacAbsent_BeyondSmoothing_NeverDrifts()
+    {
+        var m = NewMonitor();
+        PrimeBaseline(m); // LastPresent = T0
+        string? Absent(string _) => null; // ARP no longer resolves = device left the LAN
+
+        // Beyond the 120s smoothing window, so the stale positive-presence cache does not apply.
+        var t1 = m.Tick(Diag(false, "DERP(tor)", null), Absent, T0.AddSeconds(200)).Single().decision;
+        var t2 = m.Tick(Diag(false, "DERP(tor)", null), Absent, T0.AddMinutes(4)).Single().decision;
+        var t3 = m.Tick(Diag(false, "DERP(tor)", null), Absent, T0.AddMinutes(8)).Single().decision;
+        Assert.Equal("unknown", t1.Status);
+        Assert.Equal("unknown", t2.Status);
+        Assert.Equal("unknown", t3.Status);
+        Assert.False(t3.ShouldAlert);
+    }
+
+    [Fact]
+    public void Relaying_DifferentMac_IsNotPresent()
+    {
+        var m = NewMonitor();
+        PrimeBaseline(m);
+        // A DIFFERENT device now answers at the cached IP (DHCP reassigned it) - not our device. Beyond the
+        // smoothing window so the mismatch is decisive.
+        var d = m.Tick(Diag(false, "DERP(tor)", null), _ => "ff-ff-ff-ff-ff-ff", T0.AddSeconds(200)).Single().decision;
+        Assert.Equal("unknown", d.Status);
+    }
+
+    // Architect-flagged safety invariant: the presence-cache must age a departed device out well before
+    // drift could fire, or "the user left the house" silently becomes a false alert.
+    [Fact]
+    public void PresenceCacheWindow_StaysBelowDriftFloor()
+    {
+        Assert.True(NetDiagMonitor.PresenceCacheWindow < NetDiagDrift.MinDriftDuration,
+            "presence cache must be shorter than the 5-min drift floor");
+        Assert.True(NetDiagMonitor.PresenceCacheWindow * 2 <= NetDiagDrift.MinDriftDuration,
+            "keep a comfortable margin (>=2x) so a departed device can never reach Drifted+alert");
+    }
+
+    [Fact]
+    public void CurrentlyLanDirect_WithBaseline_IsOk()
+    {
+        var m = NewMonitor();
+        PrimeBaseline(m);
+        var d = m.Tick(Diag(true, "192.168.1.15:52091", 44), _ => "aa-bb-cc-dd-ee-ff", T0.AddMinutes(1)).Single().decision;
+        Assert.Equal("ok", d.Status);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/NetDiagResultStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/NetDiagResultStoreTests.cs
@@ -1,0 +1,89 @@
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The durable network-results store (Network Diagnostics mission, Phase 1): newest-first, bounded,
+/// and persisted to JSON with the CronRunHistoryStore atomic-write + quarantine contract, so results
+/// survive a Gateway restart (the history the per-device baseline is built from).
+/// </summary>
+public sealed class NetDiagResultStoreTests : IDisposable
+{
+    private readonly string _path = Path.Combine(
+        Path.GetTempPath(), "cc-director-tests", "netdiag-" + Guid.NewGuid().ToString("N"), "diagnostics-results.json");
+
+    public void Dispose()
+    {
+        var dir = Path.GetDirectoryName(_path);
+        if (dir is not null && Directory.Exists(dir))
+            Directory.Delete(dir, recursive: true);
+    }
+
+    private static NetDiagResultDto Result(string tag) => new() { Verdict = tag };
+
+    [Fact]
+    public void Recent_IsNewestFirst()
+    {
+        var store = new NetDiagResultStore(_path);
+        store.Add(Result("a"));
+        store.Add(Result("b"));
+        store.Add(Result("c"));
+        Assert.Equal(new[] { "c", "b", "a" }, store.Recent().Select(r => r.Verdict));
+    }
+
+    [Fact]
+    public void Add_EvictsOldestBeyondCapacity()
+    {
+        var store = new NetDiagResultStore(_path);
+        for (int i = 0; i < NetDiagResultStore.MaxRecords + 5; i++)
+            store.Add(Result($"r{i}"));
+
+        var recent = store.Recent();
+        Assert.Equal(NetDiagResultStore.MaxRecords, recent.Count);
+        Assert.Equal($"r{NetDiagResultStore.MaxRecords + 4}", recent[0].Verdict);
+        Assert.DoesNotContain(recent, r => r.Verdict == "r0");
+    }
+
+    [Fact]
+    public void Results_SurviveReload()
+    {
+        var store = new NetDiagResultStore(_path);
+        store.Add(new NetDiagResultDto { Verdict = "persisted", Route = "tailscale", LatencyMedianMs = 44, DownloadMbps = 90 });
+
+        // A fresh store over the SAME file (simulating a Gateway restart) must see the persisted result.
+        var reopened = new NetDiagResultStore(_path);
+        var recent = reopened.Recent();
+        var only = Assert.Single(recent);
+        Assert.Equal("persisted", only.Verdict);
+        Assert.Equal("tailscale", only.Route);
+        Assert.Equal(44, only.LatencyMedianMs);
+        Assert.Equal(90, only.DownloadMbps);
+    }
+
+    [Fact]
+    public void CorruptFile_IsQuarantined_NotCrashing()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+        File.WriteAllText(_path, "{ this is not valid json");
+
+        // Load must not throw; it quarantines the bad file and starts empty.
+        var store = new NetDiagResultStore(_path);
+        Assert.Empty(store.Recent());
+        Assert.NotEmpty(Directory.GetFiles(Path.GetDirectoryName(_path)!, "*.corrupt-*"));
+
+        // And it is usable afterward.
+        store.Add(Result("after-quarantine"));
+        Assert.Single(store.Recent());
+    }
+
+    [Fact]
+    public void Recent_RespectsCount()
+    {
+        var store = new NetDiagResultStore(_path);
+        for (int i = 0; i < 10; i++) store.Add(Result($"r{i}"));
+        Assert.Equal(3, store.Recent(3).Count);
+        Assert.Empty(store.Recent(0));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/NetDiagRollupStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/NetDiagRollupStoreTests.cs
@@ -1,0 +1,116 @@
+using CcDirector.Gateway.Api;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The hourly quality rollup (Network Diagnostics mission, Phase 1 / Decision 2b): one bucket per UTC hour
+/// with a HOME (LAN-direct) vs AWAY (relay) split keyed on the MEASURED path, sums (not medians) so folds
+/// are associative, 90-day retention, and durable across a restart.
+/// </summary>
+public sealed class NetDiagRollupStoreTests : IDisposable
+{
+    private static readonly DateTime T0 = new(2026, 7, 13, 12, 30, 0, DateTimeKind.Utc);
+
+    private readonly string _path = Path.Combine(
+        Path.GetTempPath(), "cc-director-tests", "netdiagroll-" + Guid.NewGuid().ToString("N"), "netdiag-rollup.json");
+
+    public void Dispose()
+    {
+        var dir = Path.GetDirectoryName(_path);
+        if (dir is not null && Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+    }
+
+    [Fact]
+    public void Fold_HomeSample_LandsInLanSubSums()
+    {
+        var store = new NetDiagRollupStore(_path);
+        store.Fold(T0, latencyMs: 44, direct: true, isLanPath: true, downMbps: null, upMbps: null);
+
+        var b = Assert.Single(store.All());
+        Assert.Equal(1, b.Count);
+        Assert.Equal(1, b.DirectCount);
+        Assert.Equal(0, b.RelayCount);
+        Assert.Equal(1, b.LanCount);
+        Assert.Equal(0, b.AwayCount);
+        Assert.Equal(44, b.SumLatencyLan);
+        Assert.Equal(44, b.MinLatencyLan);
+    }
+
+    [Fact]
+    public void Fold_AwaySample_LandsInAwaySubSums_AndCountsRelay()
+    {
+        var store = new NetDiagRollupStore(_path);
+        store.Fold(T0, latencyMs: 150, direct: false, isLanPath: false, downMbps: null, upMbps: null);
+
+        var b = Assert.Single(store.All());
+        Assert.Equal(1, b.RelayCount);
+        Assert.Equal(1, b.AwayCount);
+        Assert.Equal(0, b.LanCount);
+        Assert.Equal(150, b.SumLatencyAway);
+    }
+
+    [Fact]
+    public void Fold_ClientThroughput_AccumulatesDownUpInTheRightSplit()
+    {
+        var store = new NetDiagRollupStore(_path);
+        store.Fold(T0, 40, true, isLanPath: true, downMbps: 90, upMbps: 10);
+        store.Fold(T0, 42, true, isLanPath: true, downMbps: 80, upMbps: 8);
+
+        var b = Assert.Single(store.All()); // same hour -> accumulates
+        Assert.Equal(2, b.LanCount);
+        Assert.Equal(170, b.SumDownLan);
+        Assert.Equal(18, b.SumUpLan);
+        Assert.Equal(82, b.SumLatencyLan);
+        Assert.Equal(40, b.MinLatencyLan);
+    }
+
+    [Fact]
+    public void Fold_SurvivesReload()
+    {
+        new NetDiagRollupStore(_path).Fold(T0, 44, true, true, null, null);
+        var reopened = new NetDiagRollupStore(_path).All();
+        Assert.Single(reopened);
+        Assert.Equal(1, reopened[0].LanCount);
+    }
+
+    [Fact]
+    public void Monitor_FoldsJudgedObservationIntoRollup()
+    {
+        var rollup = new NetDiagRollupStore(_path);
+        var monitor = new NetDiagMonitor(
+            () => throw new InvalidOperationException("unused"), _ => "aa-bb-cc-dd-ee-ff", deviceStore: null, rollup: rollup);
+        var diag = new TailscaleDiagnostics.NetworkDiag
+        {
+            TailscaleAvailable = true,
+            BackendState = "Running",
+            Peers = new()
+            {
+                new TailscaleDiagnostics.PeerDiag
+                {
+                    Name = "phone", TailscaleIp = "100.86.144.11", Os = "android",
+                    Online = true, Direct = true, Path = "192.168.1.15:52091", LatencyMs = 44,
+                },
+            },
+        };
+
+        monitor.Tick(diag, _ => "aa-bb-cc-dd-ee-ff", T0);
+
+        var b = Assert.Single(rollup.All());
+        Assert.Equal(1, b.LanCount);
+        Assert.Equal(1, b.DirectCount);
+        Assert.Equal(44, b.SumLatencyLan);
+    }
+
+    [Fact]
+    public void Prune_DropsBucketsBeyondNinetyDays()
+    {
+        var store = new NetDiagRollupStore(_path);
+        store.Fold(T0 - TimeSpan.FromDays(100), 44, true, true, null, null); // ancient
+        store.Fold(T0, 44, true, true, null, null);                          // now -> prunes the ancient one
+
+        var all = store.All();
+        Assert.Single(all);
+        Assert.Equal(NetDiagRollupStore.HourKey(T0), all[0].Hour);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/NetDiagTests.cs
+++ b/src/CcDirector.Gateway.Tests/NetDiagTests.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using CcDirector.Gateway.Api;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The /diag/* network-diagnostics helpers (auto-network-switching mission). ClassifyClientIp is the
+/// brains of the mobile Diagnostics page's route readout: it turns the IP the Gateway sees (after
+/// X-Forwarded-For) into the label that tells a direct-LAN hit apart from a Tailscale relay. BuildPayload
+/// backs the throughput test.
+/// </summary>
+public sealed class NetDiagTests
+{
+    [Theory]
+    // Tailscale CGNAT 100.64.0.0/10 (the phone's tailnet IP through the ts.net front door).
+    [InlineData("100.64.0.1", "tailscale")]
+    [InlineData("100.100.100.100", "tailscale")]
+    [InlineData("100.127.255.254", "tailscale")]
+    // The 100.x addresses OUTSIDE the /10 are NOT Tailscale - they are ordinary public space.
+    [InlineData("100.63.255.255", "other")]
+    [InlineData("100.128.0.1", "other")]
+    // RFC-1918 private LAN ranges (a direct hit on the home network).
+    [InlineData("192.168.1.42", "lan")]
+    [InlineData("10.0.0.5", "lan")]
+    [InlineData("172.16.0.1", "lan")]
+    [InlineData("172.31.255.254", "lan")]
+    [InlineData("172.15.0.1", "other")] // just below the 172.16-31 block
+    [InlineData("172.32.0.1", "other")] // just above it
+    [InlineData("169.254.1.1", "lan")] // APIPA link-local
+    // Loopback.
+    [InlineData("127.0.0.1", "local")]
+    [InlineData("::1", "local")]
+    // Public / other.
+    [InlineData("8.8.8.8", "other")]
+    public void ClassifyClientIp_KnownRanges_AreNamed(string ip, string expected)
+    {
+        Assert.Equal(expected, NetDiag.ClassifyClientIp(IPAddress.Parse(ip)));
+    }
+
+    [Fact]
+    public void ClassifyClientIp_Null_IsOther()
+    {
+        Assert.Equal("other", NetDiag.ClassifyClientIp(null));
+    }
+
+    [Fact]
+    public void ClassifyClientIp_Ipv4MappedToIpv6_IsUnwrapped()
+    {
+        // A dual-stack Kestrel can surface an IPv4 client as ::ffff:192.168.1.42; it must still read as LAN.
+        var mapped = IPAddress.Parse("192.168.1.42").MapToIPv6();
+        Assert.Equal("lan", NetDiag.ClassifyClientIp(mapped));
+    }
+
+    [Fact]
+    public void BuildPayload_ReturnsRequestedSize()
+    {
+        Assert.Equal(1024, NetDiag.BuildPayload(1024).Length);
+        Assert.Empty(NetDiag.BuildPayload(0));
+    }
+
+    [Fact]
+    public void BuildPayload_IsNotAllZeros()
+    {
+        // The payload must not be trivially compressible, or a throughput measurement over a compressing
+        // transport would be inflated. A varied LCG fill has many distinct byte values.
+        var data = NetDiag.BuildPayload(4096);
+        var distinct = new HashSet<byte>(data);
+        Assert.True(distinct.Count > 32, $"expected a varied fill, saw {distinct.Count} distinct byte values");
+    }
+}

--- a/src/CcDirector.Gateway.Tests/TailscaleDiagnosticsTests.cs
+++ b/src/CcDirector.Gateway.Tests/TailscaleDiagnosticsTests.cs
@@ -1,0 +1,132 @@
+using CcDirector.Gateway.Api;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The server-side network diagnostic (Network Diagnostics mission). The parse helpers turn raw
+/// tailscale CLI output into the direct-vs-relay + latency signal an agent reads; Collect stitches
+/// status + ping + netcheck together with an injected CLI runner so no real tailscale is shelled.
+/// </summary>
+public sealed class TailscaleDiagnosticsTests
+{
+    [Fact]
+    public void ParsePingResult_DirectLan_IsDirectWithLatency()
+    {
+        var (answered, direct, path, ms) = TailscaleDiagnostics.ParsePingResult(
+            "pong from sorens-z-flip4 (100.86.144.11) via 192.168.1.15:52091 in 11ms");
+        Assert.True(answered);
+        Assert.True(direct);
+        Assert.Equal("192.168.1.15:52091", path);
+        Assert.Equal(11, ms);
+    }
+
+    [Fact]
+    public void ParsePingResult_Derp_IsRelayed()
+    {
+        var (answered, direct, path, ms) = TailscaleDiagnostics.ParsePingResult(
+            "pong from sorens-z-flip4 (100.86.144.11) via DERP(tor) in 84ms");
+        Assert.True(answered);
+        Assert.False(direct);
+        Assert.Equal("DERP(tor)", path);
+        Assert.Equal(84, ms);
+    }
+
+    [Fact]
+    public void ParsePingResult_UsesLastPongLine()
+    {
+        // ping emits several lines; the settled path is the last one (relay -> upgraded to direct).
+        var (answered, direct, path, _) = TailscaleDiagnostics.ParsePingResult(
+            "pong from host (100.0.0.1) via DERP(tor) in 90ms\npong from host (100.0.0.1) via 192.168.1.15:41641 in 9ms\n");
+        Assert.True(answered);
+        Assert.True(direct);
+        Assert.Equal("192.168.1.15:41641", path);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("ping 'host' did not respond after 3 attempts")]
+    [InlineData("no matching peer")]
+    public void ParsePingResult_NoPong_NotAnswered(string stdout)
+    {
+        var (answered, _, _, _) = TailscaleDiagnostics.ParsePingResult(stdout);
+        Assert.False(answered);
+    }
+
+    [Fact]
+    public void ParseNetcheckText_ReadsUdpNatAndDerp()
+    {
+        var text = string.Join("\n", new[]
+        {
+            "Report:",
+            "\t* UDP: true",
+            "\t* IPv4: yes, 66.185.205.57:63769",
+            "\t* MappingVariesByDestIP: false",
+            "\t* PortMapping: UPnP, NAT-PMP",
+            "\t* Nearest DERP: Toronto",
+        });
+        var (udp, mappingVaries, derp) = TailscaleDiagnostics.ParseNetcheckText(text);
+        Assert.True(udp);
+        Assert.False(mappingVaries);
+        Assert.Equal("Toronto", derp);
+    }
+
+    [Fact]
+    public void ParseNetcheckText_HardNat_UdpBlocked()
+    {
+        var text = "\t* UDP: false\n\t* MappingVariesByDestIP: true\n";
+        var (udp, mappingVaries, derp) = TailscaleDiagnostics.ParseNetcheckText(text);
+        Assert.False(udp);
+        Assert.True(mappingVaries);
+        Assert.Null(derp);
+    }
+
+    [Fact]
+    public void Collect_StitchesStatusPingAndNetcheck()
+    {
+        const string statusJson = """
+        {
+          "BackendState": "Running",
+          "Self": { "DNSName": "soren-north.taildb08ed.ts.net.", "TailscaleIPs": ["100.100.0.1"] },
+          "Peer": {
+            "nodekey:aaa": { "DNSName": "sorens-z-flip4.taildb08ed.ts.net.", "HostName": "sorens-z-flip4", "OS": "android", "Online": true, "TailscaleIPs": ["100.86.144.11"], "Relay": "tor", "CurAddr": "" }
+          }
+        }
+        """;
+
+        (bool, string, string) Run(string args)
+        {
+            if (args.StartsWith("status")) return (true, statusJson, "ok");
+            if (args.StartsWith("ping")) return (true, "pong from sorens-z-flip4 (100.86.144.11) via 192.168.1.15:52091 in 11ms", "ok");
+            if (args.StartsWith("netcheck")) return (true, "\t* UDP: true\n\t* MappingVariesByDestIP: false\n\t* Nearest DERP: Toronto", "ok");
+            return (false, "", "unexpected");
+        }
+
+        var diag = TailscaleDiagnostics.Collect(Run);
+
+        Assert.True(diag.TailscaleAvailable);
+        Assert.Equal("Running", diag.BackendState);
+        Assert.Equal("soren-north.taildb08ed.ts.net", diag.SelfName);
+        Assert.True(diag.UdpOk);
+        Assert.False(diag.MappingVariesByDestIp);
+        Assert.Equal("Toronto", diag.NearestDerp);
+
+        var peer = Assert.Single(diag.Peers);
+        Assert.Equal("sorens-z-flip4.taildb08ed.ts.net", peer.Name);
+        Assert.Equal("100.86.144.11", peer.TailscaleIp);
+        Assert.True(peer.Online);
+        // The live ping settled on a direct LAN path even though the status snapshot had only a relay.
+        Assert.True(peer.Direct);
+        Assert.Equal("192.168.1.15:52091", peer.Path);
+        Assert.Equal(11, peer.LatencyMs);
+    }
+
+    [Fact]
+    public void Collect_StatusFails_ReportsNote()
+    {
+        var diag = TailscaleDiagnostics.Collect(_ => (false, "", "tailscaled not running"));
+        Assert.True(diag.TailscaleAvailable); // CLI exists on this box; the call itself failed
+        Assert.Contains(diag.Notes, n => n.Contains("status failed"));
+        Assert.Empty(diag.Peers);
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Net.Sockets;
 using CcDirector.Core.Diagnostics;
 using CcDirector.Core.Network;
+using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Discovery;
@@ -56,6 +57,10 @@ internal static class GatewayEndpoints
         Gateway.Events.DirectorEventLog? directorEvents = null,
         Voice.GatewayTurnJobStore? turnJobs = null,
         Pairing.DeviceRegistry? devices = null,
+        // Network Diagnostics mission (P1): the shared hourly quality rollup that POST /diag/result folds
+        // client speed-test results into (home/away split on the measured path). The monitor folds into the
+        // same instance. Null in tests / when diagnostics are off.
+        NetDiagRollupStore? netDiagRollup = null,
         // Issue #1176 (Phase 1a): when non-null, /sessions serves a Director from this push cache instead
         // of pulling it, whenever that Director's stream is connected and its last push is within
         // streamStaleAfter. Null (stream mode off) keeps the pull-only behaviour byte-identical to today.
@@ -291,6 +296,91 @@ internal static class GatewayEndpoints
                 ServerTime = DateTime.UtcNow,
             });
         });
+
+        // ===== Network diagnostics (auto-network-switching mission) =====
+        // Back the mobile Diagnostics page so the owner can measure the phone-to-Gateway path from the
+        // phone itself (a phone cannot run `tailscale ping`). These routes are gated like the rest of the
+        // data API - the page calls them with its per-device key - so they are not an open bandwidth tap.
+
+        // GET /diag/echo: report what the Gateway sees about the caller's connection. RemoteIpAddress
+        // reflects X-Forwarded-For (UseForwardedHeaders trusts ONLY the loopback tailscale-serve proxy),
+        // so it is the phone's tailnet 100.x address through the front door and its 192.168.x LAN address
+        // on a direct hit - the one clean signal that says "you are relaying through Tailscale" vs "you are
+        // direct on the LAN". Also hands back the Gateway's own LAN IP and tailnet name so the page can
+        // show where a direct path would point.
+        app.MapGet("/diag/echo", (HttpContext ctx) => Results.Json(new NetDiagEchoDto
+        {
+            ClientIp = ctx.Connection.RemoteIpAddress?.ToString(),
+            ClientPath = NetDiag.ClassifyClientIp(ctx.Connection.RemoteIpAddress),
+            ForwardedFor = ctx.Request.Headers["X-Forwarded-For"].ToString(),
+            Host = ctx.Request.Host.Value ?? "",
+            MachineName = Environment.MachineName,
+            GatewayLanIp = LanIdentity.TryGetPrimaryLanIpv4(),
+            GatewayTailnetName = TailscaleIdentity.TryGetMagicDnsName(),
+            ServerTime = DateTime.UtcNow,
+        }));
+
+        // GET /diag/payload?bytes=N streams N bytes of incompressible data so the phone can time a DOWNLOAD
+        // and derive throughput. Size is clamped so the endpoint cannot be turned into a bandwidth
+        // amplifier, and the response is no-store so a proxy or the service worker never serves a cached
+        // copy that would fake the number.
+        app.MapGet("/diag/payload", (HttpContext ctx, int? bytes) =>
+        {
+            int size = Math.Clamp(bytes ?? NetDiag.DefaultPayloadBytes, 0, NetDiag.MaxPayloadBytes);
+            ctx.Response.Headers.CacheControl = "no-store";
+            return Results.Bytes(NetDiag.BuildPayload(size), "application/octet-stream");
+        });
+
+        // POST /diag/payload reads and discards the request body and returns the byte count, so the phone
+        // can time an UPLOAD (the direction that carries dictation audio) and derive throughput.
+        app.MapPost("/diag/payload", async (HttpContext ctx) =>
+        {
+            long received = 0;
+            var buffer = new byte[64 * 1024];
+            int read;
+            while ((read = await ctx.Request.Body.ReadAsync(buffer)) > 0)
+                received += read;
+            return Results.Json(new { received });
+        });
+
+        // GET /diag/network: the SERVER-SIDE diagnostic an agent runs with no phone and no app open. Runs
+        // tailscale status/ping/netcheck and reports, per connected device, direct-vs-DERP-relay + latency,
+        // plus UDP/NAT health - the one signal the phone speed test cannot see (it cannot tell "warming up
+        // on the relay" apart from "genuinely broken"). Ran off the request thread so the CLI shell-outs do
+        // not block the Kestrel I/O thread.
+        app.MapGet("/diag/network", async () =>
+        {
+            var diag = await Task.Run(TailscaleDiagnostics.Collect);
+            return Results.Json(diag);
+        });
+
+        // GET /diag/ping: the featherweight latency endpoint the client's latency loop hits. Unlike
+        // /diag/echo it does NO network-interface scan or Tailscale lookup, so its round trip is the wire
+        // time, not server work - keeping the reported latency honest.
+        app.MapGet("/diag/ping", () => Results.Json(new { t = DateTime.UtcNow }));
+
+        // Result logging: the phone/Cockpit POSTs its completed speed-test result here; the Gateway stamps
+        // what IT saw about the connection, writes one greppable log line, and keeps it in a small ring so
+        // an agent can read the recent history at GET /diag/results with no phone. This is the "log all of
+        // this so the agent can get to it" piece of the mission.
+        var netDiagResults = new NetDiagResultStore(Path.Combine(CcStorage.Root(), "diagnostics-results.json"));
+        app.MapPost("/diag/result", async (HttpContext ctx, NetDiagResultDto result) =>
+        {
+            result.ClientIp = ctx.Connection.RemoteIpAddress?.ToString();
+            result.ClientPath = NetDiag.ClassifyClientIp(ctx.Connection.RemoteIpAddress);
+            result.ReceivedAt = DateTime.UtcNow;
+            netDiagResults.Add(result);
+            // Fold into the hourly quality rollup by the MEASURED path (Direct/IsLanPath the client tagged
+            // from its authoritative self-peer), never the front-door ClientPath.
+            netDiagRollup?.Fold(result.ReceivedAt, result.LatencyMedianMs, result.Direct, result.IsLanPath, result.DownloadMbps, result.UploadMbps);
+            FileLog.Write(
+                $"[NetDiag] result surface={result.Surface} route={result.Route} clientPath={result.ClientPath} " +
+                $"client={result.ClientIp} latencyMedian={result.LatencyMedianMs}ms down={result.DownloadMbps}Mbps " +
+                $"up={result.UploadMbps}Mbps rating={result.Rating} loadedFrom={result.LoadedFrom}");
+            await Task.CompletedTask;
+            return Results.Json(new { ok = true });
+        });
+        app.MapGet("/diag/results", () => Results.Json(netDiagResults.Recent()));
 
         // About / diagnostics: product, version, build date, install root, the one Cockpit URL, and
         // the installed component versions (from installed.json on this box). Feeds the Cockpit About

--- a/src/CcDirector.Gateway/Api/LanPresenceProbe.cs
+++ b/src/CcDirector.Gateway/Api/LanPresenceProbe.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// Best-effort physical LAN-presence probe (Network Diagnostics mission, Phase 1 monitor). Resolves the
+/// MAC of an IPv4 on the local subnet via ARP (Windows <c>SendARP</c>). ARP is answered at layer 2 by the
+/// device's NIC regardless of app/sleep state or ICMP being disabled, and regardless of the Tailscale
+/// path, so it is the honest "is this device on my home LAN right now" - the signal the drift detector
+/// requires (matched against the device's cached MAC) before it will ever accrue a home-relay drift.
+///
+/// A departed device does not answer ARP at its old home IP, so the probe returning null (or a DIFFERENT
+/// MAC than cached) is what keeps the never-cry-wolf guarantee. Windows-only and best-effort: any failure
+/// returns null (treated as "cannot confirm present" -> never alert), never throws.
+/// </summary>
+public static class LanPresenceProbe
+{
+    [DllImport("iphlpapi.dll", ExactSpelling = true)]
+    [SupportedOSPlatform("windows")]
+    private static extern int SendARP(uint destIp, uint srcIp, byte[] macAddr, ref uint macAddrLen);
+
+    /// <summary>
+    /// Resolve the MAC address of <paramref name="ipv4"/> on the local subnet, normalized as
+    /// <c>aa-bb-cc-dd-ee-ff</c> (lower-case), or null when it does not answer / cannot be resolved.
+    /// </summary>
+    public static string? TryResolveMac(string ipv4)
+    {
+        if (!OperatingSystem.IsWindows()) return null;
+        if (!IPAddress.TryParse(ipv4, out var ip) || ip.AddressFamily != AddressFamily.InterNetwork) return null;
+
+        try
+        {
+            uint dest = BitConverter.ToUInt32(ip.GetAddressBytes(), 0); // GetAddressBytes is already network order
+            var mac = new byte[6];
+            uint len = 6;
+            if (SendARP(dest, 0, mac, ref len) != 0 || len < 6) return null;
+            // An all-zero result means "no entry" on some stacks; treat it as unresolved.
+            if (mac.All(b => b == 0)) return null;
+            return NormalizeMac(mac);
+        }
+        catch
+        {
+            return null; // best-effort: any P/Invoke failure is "cannot confirm present"
+        }
+    }
+
+    /// <summary>Format the first six bytes as <c>aa-bb-cc-dd-ee-ff</c> (lower-case). Pure - unit-tested.</summary>
+    public static string NormalizeMac(byte[] mac)
+        => string.Join("-", mac.Take(6).Select(b => b.ToString("x2")));
+}

--- a/src/CcDirector.Gateway/Api/NetDiag.cs
+++ b/src/CcDirector.Gateway/Api/NetDiag.cs
@@ -1,0 +1,58 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// Helpers for the /diag/* network-diagnostics endpoints (auto-network-switching mission). Pure and
+/// unit-testable: the client-IP classifier that lets the mobile Diagnostics page name the connection
+/// path, and the throughput payload builder.
+/// </summary>
+internal static class NetDiag
+{
+    /// <summary>4 MiB: sub-second to download on a LAN, visibly slower over a DERP relay. The default download size.</summary>
+    public const int DefaultPayloadBytes = 4 * 1024 * 1024;
+
+    /// <summary>Hard cap on the payload size so the endpoint cannot be turned into a bandwidth amplifier.</summary>
+    public const int MaxPayloadBytes = 16 * 1024 * 1024;
+
+    /// <summary>
+    /// Name the caller's network path from the IP the Gateway sees (after X-Forwarded-For processing):
+    /// "tailscale" for the 100.64.0.0/10 CGNAT range Tailscale assigns, "lan" for an RFC-1918 private
+    /// address (or APIPA link-local), "local" for loopback, and "other" for anything else (a routable
+    /// public address). A null address is "other".
+    /// </summary>
+    public static string ClassifyClientIp(IPAddress? ip)
+    {
+        if (ip is null) return "other";
+        if (ip.AddressFamily == AddressFamily.InterNetworkV6 && ip.IsIPv4MappedToIPv6)
+            ip = ip.MapToIPv4();
+        if (IPAddress.IsLoopback(ip)) return "local";
+        if (ip.AddressFamily != AddressFamily.InterNetwork) return "other"; // classify IPv4 only
+
+        var b = ip.GetAddressBytes(); // 4 bytes for IPv4
+        if (b[0] == 100 && b[1] >= 64 && b[1] <= 127) return "tailscale"; // 100.64.0.0/10 CGNAT
+        if (b[0] == 10) return "lan";                                     // 10.0.0.0/8
+        if (b[0] == 172 && b[1] >= 16 && b[1] <= 31) return "lan";        // 172.16.0.0/12
+        if (b[0] == 192 && b[1] == 168) return "lan";                    // 192.168.0.0/16
+        if (b[0] == 169 && b[1] == 254) return "lan";                    // 169.254.0.0/16 APIPA link-local
+        return "other";
+    }
+
+    /// <summary>
+    /// Build a payload of <paramref name="size"/> bytes filled with a non-repeating pseudo-random pattern
+    /// so response compression (if ever enabled) cannot shrink it and inflate the measured throughput.
+    /// A cheap linear-congruential generator keeps this allocation-free beyond the returned buffer.
+    /// </summary>
+    public static byte[] BuildPayload(int size)
+    {
+        var data = new byte[size];
+        uint state = 0x9E3779B9u;
+        for (int i = 0; i < size; i++)
+        {
+            state = (state * 1664525u) + 1013904223u;
+            data[i] = (byte)(state >> 24);
+        }
+        return data;
+    }
+}

--- a/src/CcDirector.Gateway/Api/NetDiagDeviceStore.cs
+++ b/src/CcDirector.Gateway/Api/NetDiagDeviceStore.cs
@@ -1,0 +1,155 @@
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// Durable per-device state that must survive a Gateway restart (Network Diagnostics mission, Phase 1 /
+/// Architect guardrail C). Persists exactly two things per device, and DELIBERATELY NOT a third:
+///   - the bounded HOME + DIRECT + LAN-path good-sample list, so the per-device baseline survives a restart
+///     (no ~6-minute re-warmup) - persisted as the raw good samples so <see cref="NetDiagDrift.ComputeBaseline"/>
+///     runs UNCHANGED (never derived from the hourly-sum rollup, which can't yield the median and blends
+///     away/relay data);
+///   - the (cachedLanIp, cachedMac) presence identity, so an ARP presence probe can run immediately after a
+///     restart instead of waiting for the device to be seen LAN-direct again.
+///
+/// It does NOT persist the drift <see cref="NetDiagDrift.MachineState"/>: restoring a mid-episode Drifted
+/// state with a stale FirstBadUtc could immediately re-fire an alert or mis-time the 5-minute floor on boot.
+/// A restart starts every device fresh at Unknown and re-accrues from live observations - baseline seeds
+/// instantly, but the drift-episode clock begins clean.
+///
+/// Same atomic write-through + corrupt-file quarantine contract as <see cref="CronRunHistoryStore"/>.
+/// </summary>
+public sealed class NetDiagDeviceStore
+{
+    public const int MaxSamplesPerDevice = 50;
+
+    /// <summary>One device's persisted baseline samples and presence identity (never its drift state).</summary>
+    public sealed class PersistedDevice
+    {
+        public List<NetDiagDrift.GoodSample> Samples { get; set; } = new();
+        public string? LanIp { get; set; }
+        public string? Mac { get; set; }
+    }
+
+    private readonly object _gate = new();
+    private readonly string _path;
+    private readonly Dictionary<string, PersistedDevice> _devices = new(StringComparer.Ordinal);
+
+    private static readonly JsonSerializerOptions FileJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
+    };
+
+    public NetDiagDeviceStore(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("store path is required", nameof(path));
+        _path = path;
+        Load();
+    }
+
+    /// <summary>Every device's persisted baseline samples (home+direct filtered) and presence identity.</summary>
+    public IReadOnlyDictionary<string, PersistedDevice> LoadAll()
+    {
+        lock (_gate)
+            return _devices.ToDictionary(
+                kv => kv.Key,
+                kv => new PersistedDevice
+                {
+                    Samples = kv.Value.Samples.Where(IsGood).ToList(),
+                    LanIp = kv.Value.LanIp,
+                    Mac = kv.Value.Mac,
+                },
+                StringComparer.Ordinal);
+    }
+
+    /// <summary>Replace one device's baseline samples + presence identity and persist. Drift state is never stored.</summary>
+    public void Save(string deviceKey, IReadOnlyList<NetDiagDrift.GoodSample> samples, string? lanIp, string? mac)
+    {
+        if (string.IsNullOrWhiteSpace(deviceKey)) return;
+        lock (_gate)
+        {
+            var kept = samples.Where(IsGood).ToList();
+            if (kept.Count > MaxSamplesPerDevice)
+                kept.RemoveRange(0, kept.Count - MaxSamplesPerDevice);
+            _devices[deviceKey] = new PersistedDevice { Samples = kept, LanIp = lanIp, Mac = mac };
+            Save();
+        }
+    }
+
+    private static bool IsGood(NetDiagDrift.GoodSample s) => s.IsHome && s.Direct && s.IsLanPath;
+
+    // ---- persistence (CronRunHistoryStore precedent) ----
+
+    private sealed class StoreFile
+    {
+        public Dictionary<string, PersistedDevice> Devices { get; set; } = new(StringComparer.Ordinal);
+    }
+
+    private void Load()
+    {
+        if (!File.Exists(_path))
+        {
+            FileLog.Write($"[NetDiagDeviceStore] Load: no store file at {_path}; starting empty");
+            return;
+        }
+
+        StoreFile? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize<StoreFile>(File.ReadAllText(_path), FileJsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            Quarantine(ex.Message);
+            return;
+        }
+
+        if (parsed is null)
+        {
+            Quarantine("file deserialized to null (no store document)");
+            return;
+        }
+
+        foreach (var (key, dev) in parsed.Devices)
+            if (!string.IsNullOrWhiteSpace(key) && dev is not null)
+            {
+                dev.Samples = dev.Samples.Where(IsGood).ToList();
+                _devices[key] = dev;
+            }
+
+        FileLog.Write($"[NetDiagDeviceStore] Load: restored {_devices.Count} device(s) from {_path}");
+    }
+
+    private void Quarantine(string reason)
+    {
+        var quarantinePath = $"{_path}.corrupt-{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}";
+        File.Move(_path, quarantinePath);
+        FileLog.Write($"[NetDiagDeviceStore] Load FAILED: store file at {_path} is corrupt ({reason}); quarantined to {quarantinePath}; starting empty.");
+    }
+
+    private void Save()
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(_path);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            var file = new StoreFile { Devices = _devices };
+            var json = JsonSerializer.Serialize(file, FileJsonOptions);
+
+            var tmp = _path + ".tmp";
+            File.WriteAllText(tmp, json);
+            File.Move(tmp, _path, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[NetDiagDeviceStore] Save FAILED: path={_path}: {ex.Message}");
+            throw;
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Api/NetDiagDrift.cs
+++ b/src/CcDirector.Gateway/Api/NetDiagDrift.cs
@@ -1,0 +1,173 @@
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// Pure per-device drift detection (Network Diagnostics mission, Phase 1 / Architect Decision 4). Built
+/// ONCE here: the P1 server-side monitor feeds it and it LOGS drift state quietly (no channels); P5 later
+/// bolts the doorbell + owner-email onto the same machine without changing this logic.
+///
+/// The whole point is to avoid false alarms. Two ideas make it honest:
+///  - Per-device baseline from HOME+DIRECT samples ONLY, UNKNOWN until enough good samples, so one relay
+///    sample cannot poison a device's "good" number and warmup never drifts.
+///  - The drift discriminator keys off PATH TYPE vs the device's baseline path, not raw latency: a device
+///    whose baseline is LAN-direct now showing a relay (DERP / not-direct) is the unambiguous drift signal;
+///    latency-worse-than-baseline is only a SECONDARY signal with a generous margin. This cleanly separates
+///    "a home device fell to the relay" (DRIFT) from "a device is genuinely away" (NOT drift - never flagged,
+///    because an away device has no LAN-direct baseline to fall from, so the machine self-gates to Unknown).
+///
+/// Everything here is a pure function of (observation, state) so it is fully unit-testable with no clock,
+/// no CLI, and no I/O.
+/// </summary>
+public static class NetDiagDrift
+{
+    /// <summary>Good HOME+DIRECT samples required before a device's baseline is known (until then: Unknown, never drift).</summary>
+    public const int MinBaselineSamples = 5;
+
+    /// <summary>K: consecutive bad observations required before drift is declared.</summary>
+    public const int ConsecutiveBadToDrift = 3;
+
+    /// <summary>T: drift must persist at least this long (with the cold-start relay window well under it).</summary>
+    public static readonly TimeSpan MinDriftDuration = TimeSpan.FromMinutes(5);
+
+    /// <summary>Secondary (latency) signal margin: only flag a still-direct device whose latency exceeds its own baseline by this factor.</summary>
+    public const double LatencyDriftFactor = 3.0;
+
+    /// <summary>A device's established "good" state, derived from HOME+DIRECT history only.</summary>
+    public sealed record Baseline
+    {
+        /// <summary>True when this device is normally on a direct LAN path (the only kind that can "drift" to relay).</summary>
+        public bool IsLanDirect { get; init; }
+        public double TypicalLatencyMs { get; init; }
+    }
+
+    /// <summary>One historical sample used to build a baseline.</summary>
+    public readonly record struct GoodSample(bool IsHome, bool Direct, bool IsLanPath, double LatencyMs);
+
+    /// <summary>
+    /// Compute a per-device baseline from its samples, or null (UNKNOWN) until it has at least
+    /// <see cref="MinBaselineSamples"/> HOME + DIRECT + LAN-path samples. Relay/away samples are excluded.
+    /// </summary>
+    public static Baseline? ComputeBaseline(IReadOnlyList<GoodSample> samples)
+    {
+        var good = samples.Where(s => s.IsHome && s.Direct && s.IsLanPath).Select(s => s.LatencyMs).ToList();
+        if (good.Count < MinBaselineSamples) return null;
+        return new Baseline { IsLanDirect = true, TypicalLatencyMs = Median(good) };
+    }
+
+    public enum State { Unknown, Ok, Suspect, Drifted }
+
+    /// <summary>The carried state between monitor ticks for ONE device.</summary>
+    public sealed record MachineState
+    {
+        public State State { get; init; } = State.Unknown;
+        public int ConsecutiveBad { get; init; }
+        public DateTime? FirstBadUtc { get; init; }
+        public bool Alerted { get; init; }
+    }
+
+    /// <summary>What the monitor observed for one device this tick.</summary>
+    public sealed record Observation
+    {
+        public bool TailscaleUp { get; init; }
+        /// <summary>The device's baseline; null (or non-LAN-direct) self-gates the machine to Unknown.</summary>
+        public Baseline? Baseline { get; init; }
+        public bool? CurrentDirect { get; init; }
+        public bool CurrentIsLanPath { get; init; }
+        public double? CurrentLatencyMs { get; init; }
+        /// <summary>
+        /// The monitor's POSITIVE physical-presence verdict for a RELAYING device: a best-effort ARP probe
+        /// to the device's cached 192.168.x LAN IP that resolved to the SAME MAC captured while it was
+        /// LAN-direct. True = the device is on the home LAN right now (so relaying = real drift); false =
+        /// absent / probe failed / MAC mismatch (device left, or a different device now holds that IP) =>
+        /// never alert. Only consulted for the primary relay signal; the secondary latency signal already
+        /// implies the device IS LAN-direct, so presence is self-evident there.
+        /// </summary>
+        public bool HomeLanPresent { get; init; }
+        public DateTime NowUtc { get; init; }
+    }
+
+    public sealed record Decision
+    {
+        public MachineState Next { get; init; } = new();
+        /// <summary>Rising edge into Drifted - fire the alert once per episode (P5 wires the channels).</summary>
+        public bool ShouldAlert { get; init; }
+        /// <summary>Falling edge out of an alerted Drifted state - emit the one resolution note.</summary>
+        public bool ShouldResolve { get; init; }
+        /// <summary>"unknown" | "ok" | "suspect" | "drifted".</summary>
+        public string Status { get; init; } = "unknown";
+    }
+
+    /// <summary>The pure state transition. See the class summary for the discriminator rationale.</summary>
+    public static Decision Decide(Observation obs, MachineState state)
+    {
+        // Self-gate to UNKNOWN when there is nothing to judge: Tailscale down, or no established LAN-direct
+        // baseline (warmup, or a device that is normally away). Never drift, never alert. A prior alerted
+        // episode resolves on the way into Unknown.
+        if (!obs.TailscaleUp || obs.Baseline is not { IsLanDirect: true })
+            return Settle(State.Unknown, "unknown", state);
+
+        var baseline = obs.Baseline;
+
+        // PRIMARY drift signal: baseline is LAN-direct, but the device now shows a relay / not-direct path.
+        bool primaryBad = obs.CurrentDirect == false || !obs.CurrentIsLanPath;
+        // SECONDARY: still direct on the LAN, but latency far above its OWN baseline (generous margin so a
+        // 44 ms baseline never flags at 50 ms).
+        bool secondaryBad = obs.CurrentDirect == true && obs.CurrentIsLanPath
+            && obs.CurrentLatencyMs is { } lat && lat > baseline.TypicalLatencyMs * LatencyDriftFactor;
+
+        if (!(primaryBad || secondaryBad))
+            return Settle(State.Ok, "ok", state);
+
+        // The crux of the "never a false alert" guarantee. A relaying device that "fell to DERP at home"
+        // (DRIFT) and one whose "user left the house" (away, NOT drift) look IDENTICAL on the active path,
+        // and tailscale exposes no persistent LAN candidate to tell them apart. No time window can close
+        // this (a departed device's last-seen-home time is frozen at departure). So the PRIMARY (relay)
+        // signal requires the monitor's POSITIVE physical-presence verdict - a best-effort ARP probe to the
+        // device's cached LAN IP that resolves to its SAME cached MAC. Absent / mismatch / probe error =>
+        // UNKNOWN, never alert: we deliberately MISS a home-drift over ever crying wolf, and the in-app pill
+        // catches the missed case the moment the user looks. The SECONDARY (latency) signal already requires
+        // CurrentIsLanPath (the device IS LAN-direct), so presence is self-evident and needs no probe.
+        if (primaryBad && !obs.HomeLanPresent)
+            return Settle(State.Unknown, "unknown", state);
+
+        // Bad observation: accrue consecutive count + episode start.
+        int consecutive = state.ConsecutiveBad + 1;
+        DateTime firstBad = state.FirstBadUtc ?? obs.NowUtc;
+        bool longEnough = (obs.NowUtc - firstBad) >= MinDriftDuration;
+
+        if (consecutive >= ConsecutiveBadToDrift && longEnough)
+        {
+            bool rising = !state.Alerted; // fire exactly once per episode
+            return new Decision
+            {
+                Next = new MachineState { State = State.Drifted, ConsecutiveBad = consecutive, FirstBadUtc = firstBad, Alerted = true },
+                ShouldAlert = rising,
+                Status = "drifted",
+            };
+        }
+
+        return new Decision
+        {
+            Next = new MachineState { State = State.Suspect, ConsecutiveBad = consecutive, FirstBadUtc = firstBad, Alerted = state.Alerted },
+            Status = "suspect",
+        };
+    }
+
+    // Move to a settled good/unknown state. A resolution note fires ONLY on Drifted -> Ok (an OBSERVED
+    // recovery to a direct path). Drifted -> Unknown (Tailscale down, or we lost the ability to judge)
+    // must NOT resolve: going quiet is not the same as "fixed", and a false "your network recovered"
+    // all-clear when nothing recovered is its own cry-wolf. We only ever claim recovery on seeing direct
+    // restored. (Architect review: never a false all-clear.)
+    private static Decision Settle(State next, string status, MachineState prior) => new()
+    {
+        Next = new MachineState { State = next },
+        ShouldResolve = next == State.Ok && prior.State == State.Drifted && prior.Alerted,
+        Status = status,
+    };
+
+    private static double Median(List<double> values)
+    {
+        values.Sort();
+        int m = values.Count / 2;
+        return values.Count % 2 == 0 ? (values[m - 1] + values[m]) / 2 : values[m];
+    }
+}

--- a/src/CcDirector.Gateway/Api/NetDiagMonitor.cs
+++ b/src/CcDirector.Gateway/Api/NetDiagMonitor.cs
@@ -1,0 +1,253 @@
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The server-side network monitor (Network Diagnostics mission, Phase 1). On a timer it collects the
+/// per-device Tailscale picture and threads each device through the approved <see cref="NetDiagDrift"/>
+/// Decide-machine, logging drift state QUIETLY (no channels yet - P5 bolts the doorbell + owner email onto
+/// the same state). It honors the monitor contracts the Architect set:
+///   - tick cadence &lt;= 90s so K=3 lands near the 5-min duration floor (not far past it);
+///   - OFFLINE peers are gated to Unknown BEFORE Decide (Decide takes CurrentDirect and does not check Online);
+///   - direct-vs-relay comes from the ping-path parse (PeerDiag.Direct), NEVER the tailscale Relay field;
+///   - HomeLanPresent for a relaying device = an ARP probe of its cached LAN IP resolving to the SAME cached
+///     MAC (refreshed on every LAN-direct sighting), smoothed by a short positive-presence cache so a single
+///     Android power-save ARP miss does not whipsaw a genuine active-use drift out of accrual.
+///
+/// <see cref="Tick"/> is the pure, dependency-injected core (collector + MAC resolver + clock) so the whole
+/// per-device logic is unit-testable with no timer, no CLI, and no P/Invoke.
+/// </summary>
+public sealed class NetDiagMonitor : IDisposable
+{
+    /// <summary>Tick cadence. &lt;=90s so three consecutive bad ticks land near the 5-minute drift floor.</summary>
+    public static readonly TimeSpan TickInterval = TimeSpan.FromSeconds(75);
+    public static readonly TimeSpan StartupDelay = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// How long a positive ARP+MAC presence result is trusted to smooth over a single probe blip.
+    ///
+    /// SAFETY INVARIANT (do NOT break): this MUST stay comfortably below <see cref="NetDiagDrift.MinDriftDuration"/>
+    /// (the 5-minute drift floor). That gap is what makes "the user left the house" watertight: a departed
+    /// phone ages out of this presence cache (~120s) well before drift could ever fire (K=3 over 5 min), so it
+    /// can reach at most a brief Suspect and NEVER Drifted+alert. Bumping this past the drift floor would
+    /// silently reopen the false-alert hole. Guarded by NetDiagMonitorTests.PresenceCacheWindow_StaysBelowDriftFloor.
+    /// </summary>
+    public static readonly TimeSpan PresenceCacheWindow = TimeSpan.FromSeconds(120);
+
+    /// <summary>Baseline samples retained per device (bounded).</summary>
+    public const int MaxSamplesPerDevice = 50;
+
+    private sealed class DeviceState
+    {
+        public NetDiagDrift.MachineState Drift = new();
+        public readonly List<NetDiagDrift.GoodSample> Samples = new();
+        public string? CachedLanIp;
+        public string? CachedMac;
+        public DateTime? LastPresentUtc;
+    }
+
+    private readonly object _gate = new();
+    private readonly Dictionary<string, DeviceState> _devices = new(StringComparer.Ordinal);
+
+    private readonly Func<TailscaleDiagnostics.NetworkDiag> _collect;
+    private readonly Func<string, string?> _resolveMac;
+    private readonly NetDiagDeviceStore? _deviceStore;
+    private readonly NetDiagRollupStore? _rollup;
+    private Timer? _timer;
+
+    /// <param name="collect">Gathers the current per-device picture (production: <see cref="TailscaleDiagnostics.Collect"/>).</param>
+    /// <param name="resolveMac">Resolves a LAN IP to a MAC (production: <see cref="LanPresenceProbe.TryResolveMac"/>).</param>
+    /// <param name="deviceStore">Optional durable store: seeds baselines + presence identity on startup (drift starts fresh).</param>
+    /// <param name="rollup">Optional hourly quality rollup: each judged observation folds into it (home/away path split).</param>
+    public NetDiagMonitor(
+        Func<TailscaleDiagnostics.NetworkDiag> collect,
+        Func<string, string?> resolveMac,
+        NetDiagDeviceStore? deviceStore = null,
+        NetDiagRollupStore? rollup = null)
+    {
+        _collect = collect ?? throw new ArgumentNullException(nameof(collect));
+        _resolveMac = resolveMac ?? throw new ArgumentNullException(nameof(resolveMac));
+        _deviceStore = deviceStore;
+        _rollup = rollup;
+
+        // Seed baselines + presence identity from the store so a restart does not re-warmup; the drift
+        // MachineState is DELIBERATELY not restored - every device starts fresh at Unknown and re-accrues.
+        if (deviceStore is not null)
+            foreach (var (key, pd) in deviceStore.LoadAll())
+            {
+                var ds = new DeviceState { CachedLanIp = pd.LanIp, CachedMac = pd.Mac };
+                ds.Samples.AddRange(pd.Samples);
+                _devices[key] = ds;
+            }
+    }
+
+    /// <summary>Start the periodic monitor. Safe to call once.</summary>
+    public void Start()
+    {
+        _timer ??= new Timer(_ => RunOnce(), null, StartupDelay, TickInterval);
+    }
+
+    private void RunOnce()
+    {
+        try
+        {
+            var diag = _collect();
+            var decisions = Tick(diag, _resolveMac, DateTime.UtcNow);
+            foreach (var (device, d) in decisions)
+            {
+                if (d.ShouldAlert)
+                    FileLog.Write($"[NetDiagMonitor] DRIFT device={device} status={d.Status} (home relaying persistently) - alert channels wired in P5");
+                else if (d.ShouldResolve)
+                    FileLog.Write($"[NetDiagMonitor] RESOLVED device={device} - direct path restored");
+                else if (d.Status is "suspect" or "drifted")
+                    FileLog.Write($"[NetDiagMonitor] device={device} status={d.Status}");
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[NetDiagMonitor] tick failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Process one collected picture: update per-device baseline + presence cache and run each device
+    /// through the Decide-machine. Pure w.r.t. the injected clock/resolver; mutates only the internal
+    /// per-device state. Returns each device's decision (for logging).
+    /// </summary>
+    public IReadOnlyList<(string device, NetDiagDrift.Decision decision)> Tick(
+        TailscaleDiagnostics.NetworkDiag diag, Func<string, string?> resolveMac, DateTime nowUtc)
+    {
+        var results = new List<(string, NetDiagDrift.Decision)>();
+        bool tailscaleUp = diag.TailscaleAvailable
+            && string.Equals(diag.BackendState, "Running", StringComparison.OrdinalIgnoreCase);
+
+        lock (_gate)
+        {
+            foreach (var peer in diag.Peers)
+            {
+                var key = peer.TailscaleIp;
+                if (string.IsNullOrEmpty(key)) continue;
+                if (!_devices.TryGetValue(key, out var ds)) { ds = new DeviceState(); _devices[key] = ds; }
+
+                // Contract: gate OFFLINE peers to Unknown BEFORE Decide (an offline phone must not accrue as
+                // "bad"). A device we cannot currently see says nothing about home network quality.
+                if (!peer.Online)
+                {
+                    ds.Drift = new NetDiagDrift.MachineState { State = NetDiagDrift.State.Unknown };
+                    results.Add((key, new NetDiagDrift.Decision { Next = ds.Drift, Status = "unknown" }));
+                    continue;
+                }
+
+                // Only judge peers with a CONFIRMED ping verdict. An online-but-not-pinged peer
+                // (Direct==null: past the ping cap, or a ping that did not answer) has no authoritative
+                // direct-vs-relay result, so gate it to Unknown rather than judging on the status-fallback
+                // path (which could read DERP without a real ping confirming a relay).
+                if (peer.Direct is null)
+                {
+                    ds.Drift = new NetDiagDrift.MachineState { State = NetDiagDrift.State.Unknown };
+                    results.Add((key, new NetDiagDrift.Decision { Next = ds.Drift, Status = "unknown" }));
+                    continue;
+                }
+
+                bool currentDirect = peer.Direct == true;
+                bool isLanPath = IsLanPath(peer.Path);
+
+                // On a LAN-direct sighting: refresh the baseline sample AND the (IP, MAC) cache - this is
+                // exactly when CurAddr gives the current 192.168.x and we can (re)capture the MAC, so the
+                // cache never goes stale while the device is home.
+                if (currentDirect && isLanPath)
+                {
+                    var lanIp = ExtractIp(peer.Path!);
+                    if (lanIp is not null)
+                    {
+                        ds.CachedLanIp = lanIp;
+                        var mac = resolveMac(lanIp);
+                        if (mac is not null) ds.CachedMac = mac;
+                        ds.LastPresentUtc = nowUtc;
+                    }
+                    if (peer.LatencyMs is { } lat)
+                    {
+                        ds.Samples.Add(new NetDiagDrift.GoodSample(true, true, true, lat));
+                        if (ds.Samples.Count > MaxSamplesPerDevice) ds.Samples.RemoveAt(0);
+                    }
+                    // Persist the refreshed baseline + presence identity so both survive a restart (drift
+                    // state is never persisted). Best-effort: a store failure must not break the tick.
+                    try { _deviceStore?.Save(key, ds.Samples, ds.CachedLanIp, ds.CachedMac); }
+                    catch (Exception ex) { FileLog.Write($"[NetDiagMonitor] device-store save failed for {key}: {ex.Message}"); }
+                }
+
+                bool homePresent = ResolveHomePresence(ds, currentDirect && isLanPath, resolveMac, nowUtc);
+
+                var obs = new NetDiagDrift.Observation
+                {
+                    TailscaleUp = tailscaleUp,
+                    Baseline = NetDiagDrift.ComputeBaseline(ds.Samples),
+                    CurrentDirect = peer.Direct,
+                    CurrentIsLanPath = isLanPath,
+                    CurrentLatencyMs = peer.LatencyMs,
+                    HomeLanPresent = homePresent,
+                    NowUtc = nowUtc,
+                };
+
+                var decision = NetDiagDrift.Decide(obs, ds.Drift);
+                ds.Drift = decision.Next;
+
+                // Fold this judged observation into the hourly quality rollup (home/away split on the
+                // MEASURED path). The monitor has no throughput numbers, so down/up are null. Best-effort.
+                try { _rollup?.Fold(nowUtc, peer.LatencyMs, peer.Direct, isLanPath, null, null); }
+                catch (Exception ex) { FileLog.Write($"[NetDiagMonitor] rollup fold failed for {key}: {ex.Message}"); }
+
+                results.Add((key, decision));
+            }
+        }
+
+        return results;
+    }
+
+    // Positive physical-presence with MAC-identity match + short smoothing cache.
+    private bool ResolveHomePresence(DeviceState ds, bool currentlyLanDirect, Func<string, string?> resolveMac, DateTime nowUtc)
+    {
+        if (currentlyLanDirect) return true; // trivially home; also refreshed LastPresentUtc above
+        if (ds.CachedLanIp is null || ds.CachedMac is null) return false;
+
+        var mac = resolveMac(ds.CachedLanIp);
+        if (mac is not null && string.Equals(mac, ds.CachedMac, StringComparison.OrdinalIgnoreCase))
+        {
+            ds.LastPresentUtc = nowUtc;
+            return true;
+        }
+        // Smooth over a single ARP miss (Android power-save) with a short positive-presence cache: if we
+        // confirmed presence very recently, trust it so a genuine active-use drift is not whipsawed out of
+        // accrual. A device that truly left stops refreshing this and ages out within the window.
+        return ds.LastPresentUtc is { } last && (nowUtc - last) <= PresenceCacheWindow;
+    }
+
+    /// <summary>A path is LAN-direct when it is an "a.b.c.d:port" in a private range; "DERP(...)" / null are not.</summary>
+    public static bool IsLanPath(string? path)
+    {
+        var ip = ExtractIp(path);
+        if (ip is null) return false;
+        var b = ip.Split('.');
+        if (b.Length != 4 || !int.TryParse(b[0], out var o0) || !int.TryParse(b[1], out var o1)) return false;
+        if (o0 == 10) return true;
+        if (o0 == 172 && o1 >= 16 && o1 <= 31) return true;
+        if (o0 == 192 && o1 == 168) return true;
+        if (o0 == 169 && o1 == 254) return true;
+        return false;
+    }
+
+    /// <summary>Strip the ":port" from a "192.168.1.15:52091" path; null for "DERP(...)" / empty.</summary>
+    public static string? ExtractIp(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || path.StartsWith("DERP", StringComparison.OrdinalIgnoreCase)) return null;
+        var colon = path.LastIndexOf(':');
+        var ip = colon > 0 ? path[..colon] : path;
+        return ip.Count(c => c == '.') == 3 ? ip : null;
+    }
+
+    public void Dispose()
+    {
+        _timer?.Dispose();
+        _timer = null;
+    }
+}

--- a/src/CcDirector.Gateway/Api/NetDiagResultStore.cs
+++ b/src/CcDirector.Gateway/Api/NetDiagResultStore.cs
@@ -1,0 +1,131 @@
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// Durable store of recent network speed-test results (Network Diagnostics mission, Phase 1). Replaces
+/// the in-memory NetDiagResultLog ring so results submitted from the app/Cockpit AND the server-side
+/// monitor survive a Gateway restart and can feed the per-device baseline. Newest-first, bounded, and
+/// persisted to <c>diagnostics-results.json</c> with the same atomic write-through + corrupt-file
+/// quarantine contract as <see cref="CronRunHistoryStore"/>, so a crash mid-write never half-truncates
+/// the file and an unreadable file is preserved rather than silently overwritten.
+/// </summary>
+public sealed class NetDiagResultStore
+{
+    /// <summary>Max results retained; older results are pruned (keeps the file bounded). Architect Decision 2a: 50 -> 200.</summary>
+    public const int MaxRecords = 200;
+
+    private readonly object _gate = new();
+    private readonly string _path;
+    private readonly List<NetDiagResultDto> _items = new(); // newest first
+
+    private static readonly JsonSerializerOptions FileJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
+    };
+
+    /// <param name="path">The JSON file the store persists to. REQUIRED (no silent default).</param>
+    /// <exception cref="ArgumentException">The path is null/empty/whitespace.</exception>
+    public NetDiagResultStore(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("store path is required", nameof(path));
+        _path = path;
+        Load();
+    }
+
+    /// <summary>Record one result (newest first), pruning to <see cref="MaxRecords"/>, and persist.</summary>
+    /// <exception cref="ArgumentNullException">The result is null.</exception>
+    public void Add(NetDiagResultDto result)
+    {
+        if (result is null)
+            throw new ArgumentNullException(nameof(result));
+
+        lock (_gate)
+        {
+            _items.Insert(0, result);
+            if (_items.Count > MaxRecords)
+                _items.RemoveRange(MaxRecords, _items.Count - MaxRecords);
+            Save();
+            FileLog.Write($"[NetDiagResultStore] Add: surface={result.Surface}, route={result.Route}, clientPath={result.ClientPath}, latencyMedian={result.LatencyMedianMs}ms, count={_items.Count}");
+        }
+    }
+
+    /// <summary>The most recent results, newest first (at most <paramref name="count"/>).</summary>
+    public IReadOnlyList<NetDiagResultDto> Recent(int count = MaxRecords)
+    {
+        lock (_gate)
+            return _items.Take(Math.Max(0, count)).ToList();
+    }
+
+    // ---- persistence (CronRunHistoryStore precedent: atomic write-through + corrupt-file quarantine) ----
+
+    private sealed class StoreFile
+    {
+        public List<NetDiagResultDto> Results { get; set; } = new();
+    }
+
+    private void Load()
+    {
+        if (!File.Exists(_path))
+        {
+            FileLog.Write($"[NetDiagResultStore] Load: no store file at {_path}; starting empty");
+            return;
+        }
+
+        StoreFile? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize<StoreFile>(File.ReadAllText(_path), FileJsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            Quarantine(ex.Message);
+            return;
+        }
+
+        if (parsed is null)
+        {
+            Quarantine("file deserialized to null (no store document)");
+            return;
+        }
+
+        _items.AddRange(parsed.Results.Where(r => r is not null));
+        if (_items.Count > MaxRecords)
+            _items.RemoveRange(MaxRecords, _items.Count - MaxRecords);
+        FileLog.Write($"[NetDiagResultStore] Load: restored {_items.Count} result(s) from {_path}");
+    }
+
+    private void Quarantine(string reason)
+    {
+        var quarantinePath = $"{_path}.corrupt-{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}";
+        File.Move(_path, quarantinePath);
+        FileLog.Write($"[NetDiagResultStore] Load FAILED: store file at {_path} is corrupt ({reason}); quarantined to {quarantinePath}; starting empty.");
+    }
+
+    private void Save()
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(_path);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            var file = new StoreFile { Results = _items };
+            var json = JsonSerializer.Serialize(file, FileJsonOptions);
+
+            var tmp = _path + ".tmp";
+            File.WriteAllText(tmp, json);
+            File.Move(tmp, _path, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[NetDiagResultStore] Save FAILED: path={_path}: {ex.Message}");
+            throw;
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Api/NetDiagRollupStore.cs
+++ b/src/CcDirector.Gateway/Api/NetDiagRollupStore.cs
@@ -1,0 +1,190 @@
+using System.Globalization;
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The hourly quality rollup (Network Diagnostics mission, Phase 1 / Architect Decision 2b as resequenced).
+/// ONE bucket per UTC hour (no per-route key - so no cardinality growth and no route/quality conflation),
+/// but each bucket carries a HOME vs AWAY split keyed on the MEASURED path (isLanPath), never the front-door
+/// ClientPath. That gives home-vs-away quality history from day one for free; P1 STORES the split, the P3
+/// dashboard shows overall percent-direct + latency trend, and P4 just turns on the home/away presentation
+/// over history that is already accumulating.
+///
+/// This is the 90-day durable memory (the raw results ring stays recent-depth). Same atomic write-through +
+/// corrupt-file quarantine contract as <see cref="CronRunHistoryStore"/>; the file stays small (~24 x 90 =
+/// a couple thousand buckets), so a rewrite per fold is cheap.
+/// </summary>
+public sealed class NetDiagRollupStore
+{
+    public static readonly TimeSpan Retention = TimeSpan.FromDays(90);
+
+    /// <summary>One UTC hour's aggregate. Sums (not medians) so folds are associative; averages derived on read.</summary>
+    public sealed class HourBucket
+    {
+        public string Hour { get; set; } = ""; // "yyyy-MM-ddTHH" UTC
+        public int Count { get; set; }
+        public double SumLatencyMs { get; set; }
+        public double? MinLatencyMs { get; set; }
+        public int DirectCount { get; set; }
+        public int RelayCount { get; set; }
+
+        // HOME (LAN-direct measured path) sub-sums.
+        public int LanCount { get; set; }
+        public double SumLatencyLan { get; set; }
+        public double? MinLatencyLan { get; set; }
+        public double SumDownLan { get; set; }
+        public double SumUpLan { get; set; }
+
+        // AWAY (non-LAN / relay measured path) sub-sums.
+        public int AwayCount { get; set; }
+        public double SumLatencyAway { get; set; }
+        public double? MinLatencyAway { get; set; }
+        public double SumDownAway { get; set; }
+        public double SumUpAway { get; set; }
+    }
+
+    private readonly object _gate = new();
+    private readonly string _path;
+    private readonly Dictionary<string, HourBucket> _buckets = new(StringComparer.Ordinal);
+
+    private static readonly JsonSerializerOptions FileJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
+    };
+
+    public NetDiagRollupStore(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("store path is required", nameof(path));
+        _path = path;
+        Load();
+    }
+
+    /// <summary>
+    /// Fold one observation into its UTC-hour bucket. <paramref name="isLanPath"/> is the MEASURED path type
+    /// (a LAN-direct address = home); <paramref name="direct"/> is the ping verdict. Down/up are only present
+    /// for client speed-test results (the monitor passes null). Prunes buckets past the 90-day retention.
+    /// </summary>
+    public void Fold(DateTime whenUtc, double? latencyMs, bool? direct, bool isLanPath, double? downMbps, double? upMbps)
+    {
+        var hour = HourKey(whenUtc);
+        lock (_gate)
+        {
+            if (!_buckets.TryGetValue(hour, out var b)) { b = new HourBucket { Hour = hour }; _buckets[hour] = b; }
+
+            b.Count++;
+            if (latencyMs is { } lat) { b.SumLatencyMs += lat; b.MinLatencyMs = Least(b.MinLatencyMs, lat); }
+            if (direct == true) b.DirectCount++;
+            else if (direct == false) b.RelayCount++;
+
+            if (isLanPath)
+            {
+                b.LanCount++;
+                if (latencyMs is { } l) { b.SumLatencyLan += l; b.MinLatencyLan = Least(b.MinLatencyLan, l); }
+                if (downMbps is { } d) b.SumDownLan += d;
+                if (upMbps is { } u) b.SumUpLan += u;
+            }
+            else
+            {
+                b.AwayCount++;
+                if (latencyMs is { } l) { b.SumLatencyAway += l; b.MinLatencyAway = Least(b.MinLatencyAway, l); }
+                if (downMbps is { } d) b.SumDownAway += d;
+                if (upMbps is { } u) b.SumUpAway += u;
+            }
+
+            Prune(whenUtc);
+            Save();
+        }
+    }
+
+    /// <summary>All retained buckets, oldest hour first.</summary>
+    public IReadOnlyList<HourBucket> All()
+    {
+        lock (_gate)
+            return _buckets.Values.OrderBy(b => b.Hour, StringComparer.Ordinal).ToList();
+    }
+
+    public static string HourKey(DateTime whenUtc)
+        => whenUtc.ToUniversalTime().ToString("yyyy-MM-ddTHH", CultureInfo.InvariantCulture);
+
+    private static double? Least(double? cur, double v) => cur is null ? v : Math.Min(cur.Value, v);
+
+    private void Prune(DateTime nowUtc)
+    {
+        var cutoff = HourKey(nowUtc - Retention);
+        var stale = _buckets.Keys.Where(k => string.CompareOrdinal(k, cutoff) < 0).ToList();
+        foreach (var k in stale) _buckets.Remove(k);
+    }
+
+    // ---- persistence (CronRunHistoryStore precedent) ----
+
+    private sealed class StoreFile
+    {
+        public Dictionary<string, HourBucket> Buckets { get; set; } = new(StringComparer.Ordinal);
+    }
+
+    private void Load()
+    {
+        if (!File.Exists(_path))
+        {
+            FileLog.Write($"[NetDiagRollupStore] Load: no store file at {_path}; starting empty");
+            return;
+        }
+
+        StoreFile? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize<StoreFile>(File.ReadAllText(_path), FileJsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            Quarantine(ex.Message);
+            return;
+        }
+
+        if (parsed is null)
+        {
+            Quarantine("file deserialized to null (no store document)");
+            return;
+        }
+
+        foreach (var (hour, bucket) in parsed.Buckets)
+            if (!string.IsNullOrWhiteSpace(hour) && bucket is not null)
+                _buckets[hour] = bucket;
+
+        FileLog.Write($"[NetDiagRollupStore] Load: restored {_buckets.Count} hourly bucket(s) from {_path}");
+    }
+
+    private void Quarantine(string reason)
+    {
+        var quarantinePath = $"{_path}.corrupt-{DateTime.UtcNow:yyyyMMdd-HHmmss-fff}";
+        File.Move(_path, quarantinePath);
+        FileLog.Write($"[NetDiagRollupStore] Load FAILED: store file at {_path} is corrupt ({reason}); quarantined to {quarantinePath}; starting empty.");
+    }
+
+    private void Save()
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(_path);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            var file = new StoreFile { Buckets = _buckets };
+            var json = JsonSerializer.Serialize(file, FileJsonOptions);
+
+            var tmp = _path + ".tmp";
+            File.WriteAllText(tmp, json);
+            File.Move(tmp, _path, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[NetDiagRollupStore] Save FAILED: path={_path}: {ex.Message}");
+            throw;
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Api/TailscaleDiagnostics.cs
+++ b/src/CcDirector.Gateway/Api/TailscaleDiagnostics.cs
@@ -1,0 +1,248 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using CcDirector.Core.Network;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// Server-side network diagnostic (Network Diagnostics mission): the exact check an operator runs by
+/// hand - "tailscale status / ping / netcheck" - turned into something an AGENT can call with no phone
+/// and no app open. It answers the one question the phone speed test cannot: for each connected device,
+/// is Tailscale on a DIRECT LAN path or RELAYING through a distant DERP server, and at what latency.
+///
+/// The parse helpers are pure and unit-tested; Collect shells the CLI through the shared
+/// <see cref="TailscaleCli"/> and stitches the results together.
+/// </summary>
+public static class TailscaleDiagnostics
+{
+    /// <summary>Cap on how many peers we actively ping, so a large tailnet cannot make the endpoint slow.</summary>
+    public const int MaxPeersToPing = 12;
+
+    /// <summary>One connected device's live path, as seen from this machine.</summary>
+    public sealed record PeerDiag
+    {
+        public string Name { get; init; } = "";
+        public string? TailscaleIp { get; init; }
+        public string? Os { get; init; }
+        public bool Online { get; init; }
+        /// <summary>True = direct LAN/peer path, false = relayed through DERP, null = could not determine (not pinged).</summary>
+        public bool? Direct { get; init; }
+        /// <summary>The active path: a "192.168.x.y:port" address when direct, or "DERP(region)" when relayed.</summary>
+        public string? Path { get; init; }
+        public double? LatencyMs { get; init; }
+        public string? Note { get; init; }
+    }
+
+    /// <summary>The whole picture an agent reads to judge network health with no phone involved.</summary>
+    public sealed record NetworkDiag
+    {
+        public bool TailscaleAvailable { get; init; }
+        public string? BackendState { get; init; }
+        public string? SelfName { get; init; }
+        public string? SelfTailscaleIp { get; init; }
+        public bool? UdpOk { get; init; }
+        public bool? MappingVariesByDestIp { get; init; }
+        public string? NearestDerp { get; init; }
+        public List<PeerDiag> Peers { get; init; } = new();
+        public List<string> Notes { get; init; } = new();
+        public DateTime CollectedAt { get; init; } = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Collect the full diagnostic. Runs "status --json" (who is connected), pings each online peer to
+    /// learn its live direct-vs-relay path and latency, and "netcheck" for UDP/NAT/DERP health. Never
+    /// throws for a missing CLI or an unparseable line - it records a Note and returns what it has.
+    /// </summary>
+    public static NetworkDiag Collect()
+    {
+        if (!TailscaleCli.IsAvailable)
+            return new NetworkDiag { TailscaleAvailable = false, Notes = { "tailscale CLI not found on this machine" } };
+        return Collect(TailscaleCli.Run);
+    }
+
+    /// <summary>
+    /// Testable core: the CLI runner is injected so the whole stitch-together is unit-testable without
+    /// shelling a real tailscale (the injected runner IS the CLI, so this does not re-check installation).
+    /// <paramref name="run"/> maps an argument string to (ok, stdout, message).
+    /// </summary>
+    internal static NetworkDiag Collect(Func<string, (bool ok, string stdout, string message)> run)
+    {
+        var notes = new List<string>();
+
+        var (statusOk, statusJson, statusMsg) = run("status --json");
+        if (!statusOk)
+            return new NetworkDiag { TailscaleAvailable = true, Notes = { $"tailscale status failed: {statusMsg}" } };
+
+        string? backendState = null, selfName = null, selfIp = null;
+        var peers = new List<PeerDiag>();
+        try
+        {
+            (backendState, selfName, selfIp, peers) = ParseStatus(statusJson);
+        }
+        catch (Exception ex)
+        {
+            notes.Add($"could not parse tailscale status: {ex.Message}");
+        }
+
+        // Ping each online peer to learn its LIVE path (direct vs DERP) and latency. status --json's
+        // CurAddr/Relay reflect the last known path; a fresh ping is the authoritative current state and
+        // also nudges the direct-path upgrade - exactly what proves "warming up" vs "genuinely relaying".
+        var enriched = new List<PeerDiag>();
+        int pinged = 0;
+        foreach (var p in peers)
+        {
+            if (!p.Online || string.IsNullOrEmpty(p.TailscaleIp) || pinged >= MaxPeersToPing)
+            {
+                enriched.Add(p);
+                continue;
+            }
+            pinged++;
+            var (pingOk, pingOut, pingMsg) = run($"ping --c 2 --timeout 3s {p.TailscaleIp}");
+            var parsed = ParsePingResult(pingOut);
+            enriched.Add(p with
+            {
+                Direct = parsed.answered ? parsed.direct : null,
+                Path = parsed.path ?? p.Path,
+                LatencyMs = parsed.latencyMs,
+                Note = parsed.answered ? null : (pingOk ? "no direct/relay path reported" : $"ping failed: {pingMsg}"),
+            });
+        }
+
+        bool? udp = null, mappingVaries = null;
+        string? nearestDerp = null;
+        var (ncOk, ncOut, ncMsg) = run("netcheck");
+        if (ncOk)
+            (udp, mappingVaries, nearestDerp) = ParseNetcheckText(ncOut);
+        else
+            notes.Add($"tailscale netcheck failed: {ncMsg}");
+
+        return new NetworkDiag
+        {
+            TailscaleAvailable = true,
+            BackendState = backendState,
+            SelfName = selfName,
+            SelfTailscaleIp = selfIp,
+            UdpOk = udp,
+            MappingVariesByDestIp = mappingVaries,
+            NearestDerp = nearestDerp,
+            Peers = enriched,
+            Notes = notes,
+        };
+    }
+
+    // ----- pure parse helpers (unit-tested) -----
+
+    /// <summary>
+    /// Parse the pong line from "tailscale ping". Returns whether it answered, whether the active path is
+    /// DIRECT (via a LAN/peer address) or RELAYED (via DERP), the path string, and the latency in ms.
+    /// Examples:
+    ///   "pong from host (100.86.144.11) via 192.168.1.15:52091 in 11ms" -> answered, direct, 11ms
+    ///   "pong from host (100.x) via DERP(tor) in 84ms"                   -> answered, relayed, 84ms
+    ///   "ping ... timed out" / "no matching peer"                        -> not answered
+    /// </summary>
+    public static (bool answered, bool direct, string? path, double? latencyMs) ParsePingResult(string stdout)
+    {
+        if (string.IsNullOrWhiteSpace(stdout)) return (false, false, null, null);
+
+        // Prefer the last pong line (ping sends several; the last reflects the settled path).
+        string? pong = null;
+        foreach (var raw in stdout.Split('\n'))
+        {
+            var line = raw.Trim();
+            if (line.StartsWith("pong ", StringComparison.OrdinalIgnoreCase) && line.Contains(" via ", StringComparison.OrdinalIgnoreCase))
+                pong = line;
+        }
+        if (pong is null) return (false, false, null, null);
+
+        double? latency = null;
+        var m = Regex.Match(pong, @"in\s+([0-9]+(?:\.[0-9]+)?)\s*ms", RegexOptions.IgnoreCase);
+        if (m.Success && double.TryParse(m.Groups[1].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var ms))
+            latency = ms;
+
+        var viaIdx = pong.IndexOf(" via ", StringComparison.OrdinalIgnoreCase);
+        var afterVia = pong[(viaIdx + 5)..].Trim();
+        // Path token is up to " in " (the latency clause) or end of line.
+        var inIdx = afterVia.IndexOf(" in ", StringComparison.OrdinalIgnoreCase);
+        var path = (inIdx >= 0 ? afterVia[..inIdx] : afterVia).Trim();
+
+        bool direct = !path.StartsWith("DERP", StringComparison.OrdinalIgnoreCase);
+        return (true, direct, path, latency);
+    }
+
+    /// <summary>
+    /// Parse the human "tailscale netcheck" output for the three fields the diagnostic cares about:
+    /// UDP reachability, whether NAT mapping varies by destination (hard NAT), and the nearest DERP name.
+    /// Tolerant of the leading "* " bullet and spacing. Missing fields come back null.
+    /// </summary>
+    public static (bool? udp, bool? mappingVaries, string? nearestDerp) ParseNetcheckText(string stdout)
+    {
+        bool? udp = null, mappingVaries = null;
+        string? nearestDerp = null;
+        foreach (var raw in stdout.Split('\n'))
+        {
+            var line = raw.Trim().TrimStart('*').Trim();
+            if (line.StartsWith("UDP:", StringComparison.OrdinalIgnoreCase))
+                udp = line[4..].Trim().StartsWith("true", StringComparison.OrdinalIgnoreCase);
+            else if (line.StartsWith("MappingVariesByDestIP:", StringComparison.OrdinalIgnoreCase))
+                mappingVaries = line["MappingVariesByDestIP:".Length..].Trim().StartsWith("true", StringComparison.OrdinalIgnoreCase);
+            else if (line.StartsWith("Nearest DERP:", StringComparison.OrdinalIgnoreCase))
+            {
+                var v = line["Nearest DERP:".Length..].Trim();
+                nearestDerp = v.Length > 0 ? v : null;
+            }
+        }
+        return (udp, mappingVaries, nearestDerp);
+    }
+
+    private static (string? backendState, string? selfName, string? selfIp, List<PeerDiag> peers) ParseStatus(string statusJson)
+    {
+        using var doc = JsonDocument.Parse(statusJson);
+        var root = doc.RootElement;
+
+        string? backendState = root.TryGetProperty("BackendState", out var bs) && bs.ValueKind == JsonValueKind.String ? bs.GetString() : null;
+
+        string? selfName = null, selfIp = null;
+        if (root.TryGetProperty("Self", out var self))
+        {
+            selfName = StringProp(self, "DNSName")?.TrimEnd('.');
+            selfIp = FirstTailscaleIp(self);
+        }
+
+        var peers = new List<PeerDiag>();
+        if (root.TryGetProperty("Peer", out var peerMap) && peerMap.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var kv in peerMap.EnumerateObject())
+            {
+                var node = kv.Value;
+                var curAddr = StringProp(node, "CurAddr");   // set when a direct path is up
+                var relay = StringProp(node, "Relay");        // DERP region code, e.g. "tor"
+                peers.Add(new PeerDiag
+                {
+                    Name = (StringProp(node, "DNSName") ?? StringProp(node, "HostName") ?? "?").TrimEnd('.'),
+                    TailscaleIp = FirstTailscaleIp(node),
+                    Os = StringProp(node, "OS"),
+                    Online = !(node.TryGetProperty("Online", out var on) && on.ValueKind == JsonValueKind.False),
+                    // status snapshot as a fallback before we ping: direct if CurAddr is populated.
+                    Path = !string.IsNullOrEmpty(curAddr) ? curAddr : (!string.IsNullOrEmpty(relay) ? $"DERP({relay})" : null),
+                });
+            }
+        }
+        return (backendState, selfName, selfIp, peers);
+    }
+
+    private static string? StringProp(JsonElement el, string name)
+        => el.TryGetProperty(name, out var p) && p.ValueKind == JsonValueKind.String ? p.GetString() : null;
+
+    private static string? FirstTailscaleIp(JsonElement node)
+    {
+        if (node.TryGetProperty("TailscaleIPs", out var ips) && ips.ValueKind == JsonValueKind.Array)
+            foreach (var ip in ips.EnumerateArray())
+                if (ip.ValueKind == JsonValueKind.String)
+                {
+                    var s = ip.GetString();
+                    if (!string.IsNullOrEmpty(s) && s.Contains('.')) return s; // prefer IPv4 100.x
+                }
+        return null;
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -376,6 +376,8 @@ public sealed class GatewayHost : IAsyncDisposable
     private readonly Push.PushSubscriptionStore _pushSubscriptions;
     private readonly HttpClient _pushLoopbackHttp = new() { Timeout = TimeSpan.FromSeconds(20) };
     private Push.WebPushNeedsYouNotifier? _pushNotifier;
+    private Api.NetDiagMonitor? _netDiagMonitor;
+    private Api.NetDiagRollupStore? _netDiagRollup;
     private WebApplication? _app;
     private bool _stopped;
 
@@ -1155,7 +1157,13 @@ public sealed class GatewayHost : IAsyncDisposable
 
         // Product version stamped by Directory.Build.props; full form carries the commit SHA.
         var version = AppVersion.Full;
+        // Network Diagnostics mission (P1): the shared hourly quality rollup - POST /diag/result folds
+        // client results into it, and the monitor (started below) folds its per-tick observations into the
+        // same instance, so both writers share one thread-safe in-memory state + file.
+        _netDiagRollup = new Api.NetDiagRollupStore(Path.Combine(CcStorage.Root(), "netdiag-rollup.json"));
+
         GatewayEndpoints.Map(_app, Registry, _client, version, Token, AuthEnabled,
+            netDiagRollup: _netDiagRollup,
             requestShutdown: () =>
             {
                 var handler = OnShutdownRequested;
@@ -1652,6 +1660,13 @@ public sealed class GatewayHost : IAsyncDisposable
             _vapidStore.PublicKey, _vapidStore.PrivateKey, "mailto:support@devthrottle.com");
         _pushNotifier = new Push.WebPushNeedsYouNotifier(_pushSubscriptions, GetNeedsYouCountAsync, pushSender);
         _pushNotifier.Start();
+
+        // Network Diagnostics monitor (Network Diagnostics mission, Phase 1): on a timer, watch each
+        // connected device's direct-vs-relay path and log persistent home-relay drift QUIETLY. Alert
+        // channels (doorbell + owner email) are wired in P5 onto the same Decide-machine state.
+        var netDiagDeviceStore = new Api.NetDiagDeviceStore(Path.Combine(CcStorage.Root(), "netdiag-devices.json"));
+        _netDiagMonitor = new Api.NetDiagMonitor(Api.TailscaleDiagnostics.Collect, Api.LanPresenceProbe.TryResolveMac, netDiagDeviceStore, _netDiagRollup);
+        _netDiagMonitor.Start();
     }
 
     /// <summary>
@@ -1801,6 +1816,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // loopback HTTP client it read /sessions with. Subscriptions are already on disk (written through
         // on every change), so stopping loses nothing.
         try { _pushNotifier?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] push notifier dispose error: {ex.Message}"); }
+        try { _netDiagMonitor?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] netdiag monitor dispose error: {ex.Message}"); }
         try { _snoozeSweep?.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] snooze sweep dispose error: {ex.Message}"); }
         _pushNotifier = null;
         try { _pushLoopbackHttp.Dispose(); } catch (Exception ex) { FileLog.Write($"[GatewayHost] push loopback client dispose error: {ex.Message}"); }

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.table import Table
 
 from . import __version__
+from . import diag_ops
 from . import email_ops
 from . import mission_ops
 from . import schedule_ops
@@ -51,6 +52,11 @@ setup_app = typer.Typer(
 email_app = typer.Typer(
     help="Send email to the account owner.", add_completion=False, no_args_is_help=True
 )
+diag_app = typer.Typer(
+    help="Run network diagnostics (Tailscale direct-vs-relay, speed results).",
+    add_completion=False,
+    no_args_is_help=True,
+)
 app.add_typer(session_app, name="session")
 app.add_typer(mission_app, name="mission")
 app.add_typer(message_app, name="message")
@@ -58,6 +64,7 @@ app.add_typer(settings_app, name="settings")
 app.add_typer(schedule_app, name="schedule")
 app.add_typer(setup_app, name="setup")
 app.add_typer(email_app, name="email")
+app.add_typer(diag_app, name="diag")
 console = Console()
 
 _ACTIONS = [
@@ -458,6 +465,26 @@ def mission_list(
 ) -> None:
     """List every Mission record on the Gateway."""
     mission_ops.list_missions(json_output)
+
+
+@diag_app.command("network")
+def diag_network(
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON."),
+) -> None:
+    """Server-side network check: per connected device, direct-vs-DERP-relay + latency, plus UDP/NAT.
+
+    Runs on the Gateway with no phone and no app open - the check an agent uses to tell "warming up on
+    the relay" apart from "genuinely slow".
+    """
+    diag_ops.show_network(json_output)
+
+
+@diag_app.command("results")
+def diag_results(
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output raw JSON."),
+) -> None:
+    """Recent speed-test results users submitted from the app or Cockpit (newest first)."""
+    diag_ops.show_results(json_output)
 
 
 @message_app.command("send")

--- a/tools/cc-devthrottle/src/diag_ops.py
+++ b/tools/cc-devthrottle/src/diag_ops.py
@@ -1,0 +1,242 @@
+"""Network diagnostics operations for cc-devthrottle (Network Diagnostics mission).
+
+Lets an AGENT run the network diagnostic directly - no phone, no app - against the loopback Gateway
+(or a configured remote one). Two reads on the Gateway Control API:
+
+  GET /diag/network  - the server-side Tailscale check: per connected device, direct-vs-DERP-relay +
+                       latency, plus UDP/NAT health. This is the one signal the phone speed test cannot
+                       see (it cannot tell "warming up on the relay" apart from "genuinely slow").
+  GET /diag/results  - the recent speed-test results users have submitted from the app/Cockpit.
+
+Mirrors the mission/schedule command style (Gateway Control API, Bearer token from config, loopback
+needs none).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+import requests
+from rich import box
+from rich.console import Console
+from rich.table import Table
+
+_tools_dir = str(Path(__file__).resolve().parent.parent.parent)
+if _tools_dir not in sys.path:
+    sys.path.insert(0, _tools_dir)
+
+from cc_shared.config import CCDirectorConfig  # noqa: E402
+
+console = Console()
+err_console = Console(stderr=True)
+
+LOOPBACK_DEFAULT = "http://127.0.0.1:7878"
+TIMEOUT_SECONDS = 25  # /diag/network shells the CLI and pings peers, so allow more than the usual 10s.
+
+
+class GatewayError(Exception):
+    """A handled, user-facing failure talking to the Gateway."""
+
+
+def resolve_base_url() -> str:
+    config = CCDirectorConfig().load()
+    url = (config.gateway.url or "").strip()
+    return url.rstrip("/") if url else LOOPBACK_DEFAULT
+
+
+def _auth_token() -> str:
+    config = CCDirectorConfig().load()
+    return (config.gateway.token or "").strip()
+
+
+def _is_loopback(url: str) -> bool:
+    host = (urlparse(url).hostname or "").lower()
+    return host in ("127.0.0.1", "localhost", "::1")
+
+
+class DiagClient:
+    """Talks to one Gateway's /diag surface."""
+
+    def __init__(self, base_url: Optional[str] = None) -> None:
+        self.base_url = (base_url or resolve_base_url()).rstrip("/")
+        self._token = _auth_token()
+        if not self._token and not _is_loopback(self.base_url):
+            raise GatewayError(
+                f"Gateway URL {self.base_url} is remote but gateway.token is not set. "
+                "Set it with 'cc-devthrottle settings set gateway.token <token>' "
+                "(a loopback Gateway on this machine needs no token)."
+            )
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Accept": "application/json"}
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
+        return headers
+
+    def _get(self, path: str) -> Any:
+        url = f"{self.base_url}{path}"
+        try:
+            resp = requests.get(url, headers=self._headers(), timeout=TIMEOUT_SECONDS)
+        except requests.exceptions.ConnectionError as exc:
+            raise GatewayError(
+                f"Gateway not reachable at {self.base_url}. Is the Gateway tray app running on this machine?"
+            ) from exc
+        except requests.exceptions.Timeout as exc:
+            raise GatewayError(
+                f"Gateway at {self.base_url} did not respond within {TIMEOUT_SECONDS}s."
+            ) from exc
+        if 200 <= resp.status_code < 300:
+            return resp.json() if resp.content else {}
+        raise GatewayError(_gateway_message(resp))
+
+    def network(self) -> Dict[str, Any]:
+        return self._get("/diag/network")
+
+    def results(self) -> List[Dict[str, Any]]:
+        data = self._get("/diag/results")
+        return data if isinstance(data, list) else []
+
+
+def _gateway_message(resp: requests.Response) -> str:
+    try:
+        data = resp.json()
+        if isinstance(data, dict) and data.get("error"):
+            return str(data["error"])
+    except ValueError:
+        pass
+    text = (resp.text or "").strip()
+    return text if text else f"Gateway returned HTTP {resp.status_code}"
+
+
+def show_network(json_output: bool) -> None:
+    """Print the server-side Tailscale diagnostic: per-device direct-vs-relay + latency, plus UDP/NAT."""
+    try:
+        diag = DiagClient().network()
+    except GatewayError as exc:
+        err_console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1)
+
+    if json_output:
+        console.print_json(json.dumps(diag))
+        return
+
+    if not diag.get("tailscaleAvailable", False):
+        console.print("[yellow]Tailscale CLI not found on the Gateway machine.[/yellow]")
+        for note in diag.get("notes", []) or []:
+            console.print(f"  - {note}")
+        return
+
+    console.print(
+        f"Gateway [bold]{diag.get('selfName') or '?'}[/bold] "
+        f"(tailscale {diag.get('selfTailscaleIp') or '?'})  "
+        f"backend={diag.get('backendState') or '?'}"
+    )
+    udp = diag.get("udpOk")
+    varies = diag.get("mappingVariesByDestIp")
+    console.print(
+        f"UDP={_yn(udp)}  hard-NAT(MappingVariesByDestIP)={_yn(varies)}  "
+        f"nearest-DERP={diag.get('nearestDerp') or '?'}"
+    )
+
+    peers = diag.get("peers", []) or []
+    table = Table(box=box.SIMPLE_HEAVY, show_edge=False)
+    table.add_column("Device")
+    table.add_column("Tailscale IP")
+    table.add_column("OS")
+    table.add_column("Online")
+    table.add_column("Path")
+    table.add_column("Latency")
+    table.add_column("Note")
+    for p in peers:
+        direct = p.get("direct")
+        if direct is True:
+            path = f"[green]direct[/green] {p.get('path') or ''}"
+        elif direct is False:
+            path = f"[red]RELAY[/red] {p.get('path') or ''}"
+        else:
+            path = p.get("path") or "-"
+        latency = p.get("latencyMs")
+        table.add_row(
+            str(p.get("name") or "?"),
+            str(p.get("tailscaleIp") or "-"),
+            str(p.get("os") or "-"),
+            _yn(p.get("online")),
+            path,
+            f"{latency:.0f} ms" if isinstance(latency, (int, float)) else "-",
+            str(p.get("note") or ""),
+        )
+    console.print(table)
+
+    for note in diag.get("notes", []) or []:
+        console.print(f"[yellow]note:[/yellow] {note}")
+
+    relayed = [p for p in peers if p.get("online") and p.get("direct") is False]
+    if relayed:
+        console.print(
+            f"[yellow]{len(relayed)} online device(s) are RELAYING through DERP instead of a direct path.[/yellow] "
+            "On the same LAN this is the cold-start window or a blocked direct path (check UDP, client isolation, exit node)."
+        )
+
+
+def show_results(json_output: bool) -> None:
+    """Print the recent speed-test results users submitted from the app/Cockpit."""
+    try:
+        results = DiagClient().results()
+    except GatewayError as exc:
+        err_console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1)
+
+    if json_output:
+        console.print_json(json.dumps(results))
+        return
+
+    if not results:
+        console.print("No speed-test results logged yet.")
+        return
+
+    table = Table(box=box.SIMPLE_HEAVY, show_edge=False)
+    table.add_column("Received (UTC)")
+    table.add_column("Surface")
+    table.add_column("Gateway sees")
+    table.add_column("Latency")
+    table.add_column("Down")
+    table.add_column("Up")
+    table.add_column("Rating")
+    for r in results:
+        table.add_row(
+            _short_time(r.get("receivedAt")),
+            str(r.get("surface") or "-"),
+            f"{r.get('clientIp') or '?'} ({r.get('clientPath') or '?'})",
+            _ms(r.get("latencyMedianMs")),
+            _mbps(r.get("downloadMbps")),
+            _mbps(r.get("uploadMbps")),
+            str(r.get("rating") or "-"),
+        )
+    console.print(table)
+
+
+def _yn(value: Any) -> str:
+    if value is True:
+        return "yes"
+    if value is False:
+        return "no"
+    return "?"
+
+
+def _ms(value: Any) -> str:
+    return f"{value:.0f} ms" if isinstance(value, (int, float)) else "-"
+
+
+def _mbps(value: Any) -> str:
+    return f"{value:.1f} Mbps" if isinstance(value, (int, float)) else "-"
+
+
+def _short_time(value: Any) -> str:
+    if not value:
+        return "-"
+    text = str(value)
+    return text[:19].replace("T", " ")


### PR DESCRIPTION
## Network Diagnostics - Phase 1

Makes the home network fast by default and its quality always visible. Root cause of the owner's home slowness was Tailscale's cold-start DERP relay (auto-upgrades to a direct LAN path a moment later), not a misconfiguration - this slice makes that diagnosable and visible.

### What's in it
- **Gateway `/diag/*` endpoints** (per-device-key gated): `echo`, `payload` (GET/POST), `ping`, `network` (server-side tailscale direct-vs-DERP + latency + UDP/NAT, no phone needed), `result`/`results` (durable results store).
- **Always-on monitor + honest drift detection** - the "never cry wolf" path: per-device baseline from home+direct samples only; drift accrues only with **positive physical LAN presence** (ARP + cached-MAC identity match), K>=3 over >=5min, one alert per episode, resolves only on observed direct-again. The presence-cache window is test-guarded to stay below the drift floor so "user left the house" can never false-alert.
- **Persistence**: baseline + IP/MAC identity survive restart (drift clock starts fresh); a 90-day hourly quality rollup with a home/away split on the **measured** path (stored now, surfaced later).
- **Clients**: `/m/diagnostics` page + Cockpit Network view; a shared green/amber/red/grey **status pill** coloured from the authoritative self-peer direct flag (amber-not-red on cold-start).
- **Agent tooling**: `cc-devthrottle diag network|results` - run the diagnostic with no phone and no app.

### Verification
74 Gateway diagnostic tests + 8 client resolver tests, all green; all workspaces typecheck. Design reviewed end-to-end by the mission Architect (adversarial pass closed every false-alert path).

### Notes
- Live-Gateway QA follows the merge (trunk-dev: merge-on-green, QA-after) via the owner-gated redeploy.
- The live redeploy is a separate owner-gated action; merging does not touch any running Gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
