### PR TITLE
feat(network-diagnostics): Phase 2+3 - keep-warm heartbeat + Cockpit quality-trend dashboard

### DIFF
--- a/apps/cockpit/src/AppShell.tsx
+++ b/apps/cockpit/src/AppShell.tsx
@@ -1,4 +1,5 @@
 import { NavLink, Outlet, useLocation } from "react-router-dom";
+import { useKeepWarm } from "@devthrottle/client-core/net/useKeepWarm";
 import { CockpitStatusPill } from "./network/CockpitStatusPill";
 
 // The desktop layout frame (epic #967): a two-region shell - a left rail (navigation) and the main
@@ -65,6 +66,8 @@ const NAV_SECTIONS: ReadonlyArray<{ title: string; items: ReadonlyArray<NavItem>
 
 export function AppShell() {
   const location = useLocation();
+  // Keep-warm heartbeat (P2): hold the direct LAN path open during active use.
+  useKeepWarm();
 
   return (
     <div className="shell">

--- a/apps/cockpit/src/network/NetworkDiagnosticsView.tsx
+++ b/apps/cockpit/src/network/NetworkDiagnosticsView.tsx
@@ -1,15 +1,18 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import {
   getNetworkDiag,
   getNetDiagResults,
+  getNetDiagRollup,
   measureLatency,
   measureDownload,
   measureUpload,
   postNetDiagResult,
   type NetworkDiag,
   type NetDiagResult,
+  type NetDiagRollupBucket,
   type ThroughputResult,
 } from "@devthrottle/client-core/api/client";
+import { useNetStatus } from "@devthrottle/client-core/net/useNetStatus";
 import "./network.css";
 
 // Network Diagnostics (Cockpit): the operator/agent view of network health. Its centerpiece is the
@@ -29,6 +32,9 @@ export function NetworkDiagnosticsView() {
   const [refreshing, setRefreshing] = useState(false);
 
   const [results, setResults] = useState<NetDiagResult[]>([]);
+  const [rollup, setRollup] = useState<NetDiagRollupBucket[]>([]);
+  const [trendHours, setTrendHours] = useState<24 | 168>(24);
+  const status = useNetStatus(); // same authoritative signal as the header pill, so the light always agrees
 
   const [phase, setPhase] = useState<TestPhase>("idle");
   const [latency, setLatency] = useState<number[] | null>(null);
@@ -56,12 +62,41 @@ export function NetworkDiagnosticsView() {
     }
   }, []);
 
+  const loadRollup = useCallback(async (signal?: AbortSignal) => {
+    try {
+      setRollup(await getNetDiagRollup(signal));
+    } catch {
+      /* the trend is a nice-to-have; leave it empty on failure */
+    }
+  }, []);
+
   useEffect(() => {
     const controller = new AbortController();
     void loadDiag(controller.signal);
     void loadResults(controller.signal);
+    void loadRollup(controller.signal);
     return () => controller.abort();
-  }, [loadDiag, loadResults]);
+  }, [loadDiag, loadResults, loadRollup]);
+
+  // Derive the trend points from the hourly rollup for the selected window (newest buckets), skipping
+  // hours with no data so gaps do not draw a misleading flat line. Percent-direct is the headline; average
+  // latency (honestly "average", not median) is secondary.
+  const trend = useMemo(() => {
+    const recent = rollup.slice(-trendHours);
+    const directPct: number[] = [];
+    const avgLatency: number[] = [];
+    for (const b of recent) {
+      const judged = b.directCount + b.relayCount;
+      if (judged > 0) directPct.push((b.directCount / judged) * 100);
+      if (b.count > 0 && b.sumLatencyMs > 0) avgLatency.push(b.sumLatencyMs / b.count);
+    }
+    return { directPct, avgLatency };
+  }, [rollup, trendHours]);
+
+  const recentThroughput = useMemo(() => {
+    const withThroughput = results.find((r) => r.downloadMbps != null || r.uploadMbps != null);
+    return withThroughput ?? null;
+  }, [results]);
 
   const testRunning = phase === "latency" || phase === "download" || phase === "upload";
   const medianLatency = useMemo(() => (latency ? median(latency) : null), [latency]);
@@ -113,6 +148,32 @@ export function NetworkDiagnosticsView() {
         is on a direct LAN path or relaying through a distant DERP server - the difference between a fast home
         connection and a slow one.
       </p>
+
+      <section className="netdiag-trend" aria-label="Network health trend">
+        <div className="netdiag-light-row">
+          <span className={`netdiag-light netdiag-light-${status.level}`} aria-hidden="true" />
+          <span className="netdiag-light-label">{status.label}</span>
+          <span className="netdiag-light-detail">{status.detail}</span>
+          <div className="netdiag-window" role="group" aria-label="Trend window">
+            <button type="button" className={trendHours === 24 ? "on" : ""} onClick={() => setTrendHours(24)}>24h</button>
+            <button type="button" className={trendHours === 168 ? "on" : ""} onClick={() => setTrendHours(168)}>7d</button>
+          </div>
+        </div>
+        <div className="netdiag-trend-grid">
+          <TrendCard title="Direct connections" subtitle="percent of the time on a direct path - higher is better">
+            <TrendChart values={trend.directPct} yMin={0} yMax={100} color="var(--accent)" unit="%" prominent />
+          </TrendCard>
+          <TrendCard title="Average latency" subtitle="hourly average round trip - lower is better">
+            <TrendChart values={trend.avgLatency} yMin={0} yMax={Math.max(50, ...trend.avgLatency)} color="#e8a33d" unit="ms" />
+          </TrendCard>
+        </div>
+        {recentThroughput && (
+          <div className="netdiag-throughput-note">
+            Latest speed test: {fmtMbps(recentThroughput.downloadMbps)} down / {fmtMbps(recentThroughput.uploadMbps)} up
+            <span className="netdiag-muted"> - throughput is measured only when a speed test runs, so it is not a continuous trend.</span>
+          </div>
+        )}
+      </section>
 
       <section className="netdiag-section" aria-label="Network health">
         {diagError ? (
@@ -231,6 +292,48 @@ export function NetworkDiagnosticsView() {
       </section>
     </div>
   );
+}
+
+function TrendCard({ title, subtitle, children }: { title: string; subtitle: string; children: ReactNode }) {
+  return (
+    <div className="netdiag-trend-card">
+      <div className="netdiag-trend-title">{title}</div>
+      <div className="netdiag-trend-sub">{subtitle}</div>
+      {children}
+    </div>
+  );
+}
+
+// A minimal, theme-aware, dependency-free line chart. Values are evenly spaced in time (oldest first). The
+// stroke colour is passed in (an accessible, colourblind-safe hue chosen by the caller); the line reads in
+// both light and dark because it uses the caller's token/hex and non-scaling stroke. Honest empty state.
+function TrendChart({
+  values, yMin, yMax, color, unit, prominent = false,
+}: { values: number[]; yMin: number; yMax: number; color: string; unit: string; prominent?: boolean }) {
+  if (values.length < 2) return <div className="netdiag-muted netdiag-chart-empty">Not enough data yet.</div>;
+  const w = 600, h = 90, pad = 6;
+  const span = yMax - yMin || 1;
+  const x = (i: number) => pad + (i / (values.length - 1)) * (w - 2 * pad);
+  const y = (v: number) => h - pad - ((Math.max(yMin, Math.min(yMax, v)) - yMin) / span) * (h - 2 * pad);
+  const d = values.map((v, i) => `${i === 0 ? "M" : "L"}${x(i).toFixed(1)},${y(v).toFixed(1)}`).join(" ");
+  const last = values[values.length - 1];
+  return (
+    <div className="netdiag-chart-wrap">
+      <svg className="netdiag-chart" viewBox={`0 0 ${w} ${h}`} preserveAspectRatio="none" role="img"
+        aria-label={`Trend over the selected window; latest ${Math.round(last)} ${unit}`}>
+        <path d={d} fill="none" stroke={color} strokeWidth={prominent ? 2.5 : 1.75} vectorEffect="non-scaling-stroke" strokeLinejoin="round" />
+      </svg>
+      <div className="netdiag-chart-axis">
+        <span>{Math.round(yMin)}{unit}</span>
+        <span className="netdiag-chart-latest">latest {Math.round(last)}{unit}</span>
+        <span>{Math.round(yMax)}{unit}</span>
+      </div>
+    </div>
+  );
+}
+
+function fmtMbps(v: number | null | undefined): string {
+  return typeof v === "number" ? `${v.toFixed(1)} Mbps` : "-";
 }
 
 function Metric({ label, value }: { label: string; value: string }) {

--- a/apps/cockpit/src/network/network.css
+++ b/apps/cockpit/src/network/network.css
@@ -103,3 +103,72 @@
   font-weight: 700;
   margin-top: 2px;
 }
+
+/* P3 trend dashboard: status light + window toggle + two dependency-free line charts. Theme-aware (uses
+   the cockpit tokens) and colourblind-safe (percent-direct = accent, latency = amber, distinct hues). */
+.netdiag-trend {
+  margin-bottom: 24px;
+}
+.netdiag-light-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+.netdiag-light {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--text-dim);
+  flex: 0 0 auto;
+}
+.netdiag-light-green { background: #37c26d; }
+.netdiag-light-amber { background: #e8a33d; }
+.netdiag-light-red { background: var(--warn, #e8a33d); }
+.netdiag-light-grey { background: var(--text-dim); }
+.netdiag-light-label { font-weight: 700; }
+.netdiag-light-detail { color: var(--text-dim); font-size: 13px; }
+.netdiag-window {
+  margin-left: auto;
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.netdiag-window button {
+  border: none;
+  background: var(--surface);
+  color: var(--text-dim);
+  padding: 5px 12px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.netdiag-window button.on { background: var(--accent); color: #fff; }
+.netdiag-trend-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+@media (max-width: 720px) {
+  .netdiag-trend-grid { grid-template-columns: 1fr; }
+}
+.netdiag-trend-card {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+  background: var(--surface);
+}
+.netdiag-trend-title { font-weight: 700; font-size: 14px; }
+.netdiag-trend-sub { color: var(--text-dim); font-size: 12px; margin-bottom: 10px; }
+.netdiag-chart { width: 100%; height: 90px; display: block; }
+.netdiag-chart-axis {
+  display: flex;
+  justify-content: space-between;
+  color: var(--text-dim);
+  font-size: 11px;
+  margin-top: 4px;
+}
+.netdiag-chart-latest { color: var(--text); font-weight: 600; }
+.netdiag-chart-empty { padding: 28px 0; text-align: center; }
+.netdiag-throughput-note { margin-top: 12px; font-size: 13px; }

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -21,6 +21,7 @@ import { ensurePushSubscribed } from "@devthrottle/client-core/push/register";
 import { CreditsNotice } from "./components/CreditsNotice";
 import { ConnectionBanner } from "./components/ConnectionBanner";
 import { useScreenWakeLock } from "./hooks/useScreenWakeLock";
+import { useKeepWarm } from "@devthrottle/client-core/net/useKeepWarm";
 import { resumePendingDictations } from "@devthrottle/client-core/dictation/backgroundSend";
 import { RouteRecoveryBoundary, RootLayout } from "./components/StaleShellRecovery";
 import { StatusPill } from "./components/StatusPill";
@@ -40,6 +41,8 @@ function RequireDeviceKey() {
 // routes, the lock is acquired once (a single sentinel), not once per page.
 function GatedLayout() {
   useScreenWakeLock();
+  // Keep-warm heartbeat (P2): hold the direct LAN path open during active use so it never idles back to the relay.
+  useKeepWarm();
   // Resume any recorded-but-unsent dictation once the phone is enrolled (issue #1006): a clip whose
   // upload was interrupted by a refresh / crash / dropped connection is re-driven to the session here.
   React.useEffect(() => {

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -985,6 +985,19 @@ export interface NetworkDiag {
   collectedAt: string;
 }
 
+// Keep-warm heartbeat (Network Diagnostics mission, P2): a lightweight GET /diag/ping that keeps the
+// WireGuard direct path from idling out during active foreground use (an idle path silently drops back to
+// the relay until Tailscale re-establishes direct on the next request). Best-effort - a failure is ignored,
+// this is NOT a reachability signal and must never surface an error.
+export async function keepWarmPing(signal?: AbortSignal): Promise<void> {
+  try {
+    const res = await gatewayFetch("/diag/ping", { method: "GET", headers: { ...authHeaders() }, signal });
+    await res.arrayBuffer();
+  } catch {
+    /* best-effort: keep-warm never reports failure */
+  }
+}
+
 // GET /diag/network - the server-side Tailscale check. Slower than the other reads (it shells the CLI and
 // pings peers), so give it a longer timeout. Lets a client show the AUTHORITATIVE direct-vs-relay state
 // for its own connection instead of guessing from the speed numbers.
@@ -1041,6 +1054,38 @@ export async function getNetDiagResults(signal?: AbortSignal): Promise<NetDiagRe
   }, { timeoutMs: POLL_TIMEOUT_MS });
   if (!res.ok) throw new GatewayError(res.status, `GET /diag/results failed: ${res.status}`);
   return (await res.json()) as NetDiagResult[];
+}
+
+/** One UTC-hour quality bucket from GET /diag/rollup, with the home(LAN)/away(relay) sub-sums. */
+export interface NetDiagRollupBucket {
+  hour: string;
+  count: number;
+  sumLatencyMs: number;
+  minLatencyMs: number | null;
+  directCount: number;
+  relayCount: number;
+  lanCount: number;
+  sumLatencyLan: number;
+  minLatencyLan: number | null;
+  sumDownLan: number;
+  sumUpLan: number;
+  awayCount: number;
+  sumLatencyAway: number;
+  minLatencyAway: number | null;
+  sumDownAway: number;
+  sumUpAway: number;
+}
+
+// GET /diag/rollup - the hourly quality trend (oldest first) for the Cockpit dashboard. Sums, not
+// averages: derive percent-direct = directCount/(directCount+relayCount) and avg latency = sum/count on read.
+export async function getNetDiagRollup(signal?: AbortSignal): Promise<NetDiagRollupBucket[]> {
+  const res = await gatewayFetch("/diag/rollup", {
+    method: "GET",
+    headers: { Accept: "application/json", ...authHeaders() },
+    signal,
+  }, { timeoutMs: POLL_TIMEOUT_MS });
+  if (!res.ok) throw new GatewayError(res.status, `GET /diag/rollup failed: ${res.status}`);
+  return (await res.json()) as NetDiagRollupBucket[];
 }
 
 // GET /directors - the fleet's machines (Directors). Sorted most-recently-seen first so the picker

--- a/packages/client-core/src/net/useKeepWarm.ts
+++ b/packages/client-core/src/net/useKeepWarm.ts
@@ -1,0 +1,43 @@
+import { useEffect } from "react";
+import { keepWarmPing } from "../api/client";
+
+// Keep-warm heartbeat (Network Diagnostics mission, P2), shared by the phone and the Cockpit. While the app
+// is FOREGROUNDED it sends a lightweight GET /diag/ping every ~25s so the WireGuard direct path stays active
+// during use - an idle path silently drops back to the relay, which is the cold-start slowness this fixes.
+// It PAUSES while the document is hidden (battery/data), and pings once immediately on becoming visible so
+// the path is warm the moment you look. Best-effort: keepWarmPing never throws. This is the "measure, don't
+// assert" half's warmer - the effect shows up in the rollup's percent-direct trend, we don't claim it here.
+
+export const KEEP_WARM_MS = 25000;
+
+export function useKeepWarm(): void {
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      // Non-DOM env (SSR/tests): a plain interval with no visibility gating.
+      const timer = setInterval(() => void keepWarmPing(), KEEP_WARM_MS);
+      return () => clearInterval(timer);
+    }
+
+    let timer: ReturnType<typeof setInterval> | undefined;
+
+    const start = () => {
+      if (timer !== undefined) return;
+      void keepWarmPing(); // warm immediately on (re)foreground
+      timer = setInterval(() => void keepWarmPing(), KEEP_WARM_MS);
+    };
+    const stop = () => {
+      if (timer === undefined) return;
+      clearInterval(timer);
+      timer = undefined;
+    };
+    const onVisibility = () => (document.visibilityState === "visible" ? start() : stop());
+
+    if (document.visibilityState === "visible") start();
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      stop();
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, []);
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -382,6 +382,10 @@ internal static class GatewayEndpoints
         });
         app.MapGet("/diag/results", () => Results.Json(netDiagResults.Recent()));
 
+        // GET /diag/rollup: the hourly quality trend (one bucket per UTC hour, oldest first) for the
+        // Cockpit dashboard - percent-direct over time, latency trend, and the stored home/away split.
+        app.MapGet("/diag/rollup", () => Results.Json(netDiagRollup?.All() ?? new List<NetDiagRollupStore.HourBucket>()));
+
         // About / diagnostics: product, version, build date, install root, the one Cockpit URL, and
         // the installed component versions (from installed.json on this box). Feeds the Cockpit About
         // page; loopback-reachable like the rest of the read API.

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1099,6 +1099,9 @@ public sealed class GatewayHost : IAsyncDisposable
                 var path = ctx.Request.Path.Value ?? "";
                 if (!path.Equals("/healthz", StringComparison.OrdinalIgnoreCase)
                     && !path.Equals("/favicon.ico", StringComparison.OrdinalIgnoreCase)
+                    // The keep-warm heartbeat (P2) hits /diag/ping every ~25s per client - warming traffic,
+                    // not a request worth logging; skip it so it does not flood the access log.
+                    && !path.Equals("/diag/ping", StringComparison.OrdinalIgnoreCase)
                     // The React Cockpit's hashed static assets would flood the log.
                     && !path.StartsWith("/assets/", StringComparison.OrdinalIgnoreCase))
                 {


### PR DESCRIPTION
P2 keep-warm (client /diag/ping heartbeat while foregrounded; monitor already warms server-side) + P3 Cockpit dashboard (status light matching the pill, percent-direct + avg-latency trends over 24h/7d from GET /diag/rollup, recent throughput value). No home/away split yet (P4). Gateway builds, all workspaces typecheck, Cockpit bundles. Follows P1 (#1477); trunk merge-on-green, live pass after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)