### PR TITLE
feat(network-diagnostics): P4 Task 1 - direct-vs-relayed quality split on the Cockpit dashboard

### DIFF
--- a/apps/cockpit/src/network/NetworkDiagnosticsView.tsx
+++ b/apps/cockpit/src/network/NetworkDiagnosticsView.tsx
@@ -98,6 +98,27 @@ export function NetworkDiagnosticsView() {
     return withThroughput ?? null;
   }, [results]);
 
+  // Home-vs-away quality (P4 Task 1) from the rollup's measured-path sub-sums, over the selected window.
+  // Honestly derivable per side: average latency + share-of-time. (Per-side percent-direct and average
+  // throughput are NOT derivable from the current schema - see the note to the Architect - so we don't fake
+  // them.) Framing per Decision 2c: home is judged against fast/direct; away is EXPECTED to relay.
+  const homeAway = useMemo(() => {
+    const recent = rollup.slice(-trendHours);
+    let hCount = 0, hLat = 0, hMin: number | null = null;
+    let aCount = 0, aLat = 0, aMin: number | null = null;
+    for (const b of recent) {
+      hCount += b.lanCount; hLat += b.sumLatencyLan;
+      if (b.minLatencyLan != null) hMin = hMin == null ? b.minLatencyLan : Math.min(hMin, b.minLatencyLan);
+      aCount += b.awayCount; aLat += b.sumLatencyAway;
+      if (b.minLatencyAway != null) aMin = aMin == null ? b.minLatencyAway : Math.min(aMin, b.minLatencyAway);
+    }
+    const total = hCount + aCount;
+    return {
+      home: { count: hCount, avg: hCount ? hLat / hCount : null, min: hMin, share: total ? (hCount / total) * 100 : null },
+      away: { count: aCount, avg: aCount ? aLat / aCount : null, min: aMin, share: total ? (aCount / total) * 100 : null },
+    };
+  }, [rollup, trendHours]);
+
   const testRunning = phase === "latency" || phase === "download" || phase === "upload";
   const medianLatency = useMemo(() => (latency ? median(latency) : null), [latency]);
 
@@ -173,6 +194,52 @@ export function NetworkDiagnosticsView() {
             <span className="netdiag-muted"> - throughput is measured only when a speed test runs, so it is not a continuous trend.</span>
           </div>
         )}
+      </section>
+
+      <section className="netdiag-section" aria-label="Direct versus relayed quality">
+        <h2>Direct vs relayed</h2>
+        <p className="netdiag-muted netdiag-homeaway-sub">
+          Quality by measured path over the selected window. A direct path on your LAN is your fast home
+          connection; a relayed path is normal when you are away. (A home device briefly relaying also lands
+          on the relayed side - the status pill and drift alerts, which check physical LAN presence, are the
+          authoritative "home is slow" signal; this split is the coarse trend.)
+        </p>
+        <div className="netdiag-homeaway">
+          <div className="netdiag-side netdiag-side-home">
+            <div className="netdiag-side-title">Direct on your LAN</div>
+            {homeAway.home.count === 0 ? (
+              <div className="netdiag-muted">No direct-LAN data yet.</div>
+            ) : (
+              <div className="netdiag-side-stats">
+                <div className="netdiag-side-stat">
+                  <span className="netdiag-side-num">{formatMs(homeAway.home.avg ?? 0)} ms</span>
+                  <span className="netdiag-side-lbl">average latency{homeAway.home.min != null ? ` (best ${Math.round(homeAway.home.min)})` : ""}</span>
+                </div>
+                <div className="netdiag-side-stat">
+                  <span className="netdiag-side-num">{Math.round(homeAway.home.share ?? 0)}%</span>
+                  <span className="netdiag-side-lbl">of the time</span>
+                </div>
+              </div>
+            )}
+          </div>
+          <div className="netdiag-side netdiag-side-away">
+            <div className="netdiag-side-title">Relayed / remote</div>
+            {homeAway.away.count === 0 ? (
+              <div className="netdiag-muted">No relayed connections yet - you have been direct on your LAN.</div>
+            ) : (
+              <div className="netdiag-side-stats">
+                <div className="netdiag-side-stat">
+                  <span className="netdiag-side-num">{formatMs(homeAway.away.avg ?? 0)} ms</span>
+                  <span className="netdiag-side-lbl">average latency{homeAway.away.min != null ? ` (best ${Math.round(homeAway.away.min)})` : ""}</span>
+                </div>
+                <div className="netdiag-side-stat">
+                  <span className="netdiag-side-num">{Math.round(homeAway.away.share ?? 0)}%</span>
+                  <span className="netdiag-side-lbl">of the time - relaying is normal when you are away</span>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
       </section>
 
       <section className="netdiag-section" aria-label="Network health">

--- a/apps/cockpit/src/network/network.css
+++ b/apps/cockpit/src/network/network.css
@@ -172,3 +172,28 @@
 .netdiag-chart-latest { color: var(--text); font-weight: 600; }
 .netdiag-chart-empty { padding: 28px 0; text-align: center; }
 .netdiag-throughput-note { margin-top: 12px; font-size: 13px; }
+
+/* P4 Task 1: home-vs-away quality side-by-side. Home rail = green (fast/direct expectation), away rail =
+   neutral (relay is EXPECTED, not framed as worse). */
+.netdiag-homeaway-sub { max-width: 70ch; margin: 0 0 12px; line-height: 1.5; }
+.netdiag-homeaway {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+@media (max-width: 720px) {
+  .netdiag-homeaway { grid-template-columns: 1fr; }
+}
+.netdiag-side {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px 16px;
+  background: var(--surface);
+}
+.netdiag-side-home { border-left: 4px solid #37c26d; }
+.netdiag-side-away { border-left: 4px solid var(--text-dim); }
+.netdiag-side-title { font-weight: 700; font-size: 14px; margin-bottom: 10px; }
+.netdiag-side-stats { display: flex; gap: 24px; flex-wrap: wrap; }
+.netdiag-side-stat { display: flex; flex-direction: column; }
+.netdiag-side-num { font-size: 22px; font-weight: 800; }
+.netdiag-side-lbl { color: var(--text-dim); font-size: 12px; }


### PR DESCRIPTION
P4 Task 1: home-vs-away QUALITY view on the Cockpit Network dashboard over the rollup's already-stored measured-path sub-sums (pure read/frontend, no store/fold change). Per side: avg latency + share of time, 24h/7d window. Labeled by measured path (Direct on your LAN / Relayed / remote) - the pill + P5 drift alert stay the authoritative home-slow signal. Decision-2c framing, honest empty state. Follows #1478; trunk merge-on-green, live pass after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)