### PR TITLE
feat(devthrottle-stats): private Repos page - per-repository input split

### DIFF
--- a/apps/cockpit/src/AppShell.tsx
+++ b/apps/cockpit/src/AppShell.tsx
@@ -57,6 +57,7 @@ const NAV_SECTIONS: ReadonlyArray<{ title: string; items: ReadonlyArray<NavItem>
     items: [
       { to: "/account", label: "Account" },
       { to: "/your-throttle", label: "Your Throttle" },
+      { to: "/repos", label: "Repos" },
       { to: "/settings", label: "Settings" },
       { to: "/about", label: "About" },
     ],

--- a/apps/cockpit/src/main.tsx
+++ b/apps/cockpit/src/main.tsx
@@ -22,6 +22,7 @@ import { TranscriptsView } from "./transcripts/TranscriptsView";
 import { ExesView } from "./exes/ExesView";
 import { LearningView } from "./learning/LearningView";
 import { YourThrottleView } from "./throttle/YourThrottleView";
+import { ReposView } from "./throttle/ReposView";
 import { TranscriptionHealthView } from "./transcription/TranscriptionHealthView";
 import { NetworkDiagnosticsView } from "./network/NetworkDiagnosticsView";
 import { AccountView } from "./account/AccountView";
@@ -175,6 +176,11 @@ const router = createBrowserRouter(
             // /stats page. Reads the same GET /stats/data feed through client-core so the user sees
             // their throttle in the app rather than at a bare URL.
             { path: "/your-throttle", element: <YourThrottleView /> },
+            // Repos (devthrottle-stats mission): the PRIVATE per-repo split. Its own route + rail entry,
+            // deliberately separate from Your Throttle so which codebases take the owner's time is never
+            // on-screen alongside the shareable throttle. Reads the same GET /stats/data feed (repos ride
+            // on it) through client-core.
+            { path: "/repos", element: <ReposView /> },
             // Transcription Health: read-only view over the local transcription telemetry the Gateway
             // records (latency, failures, most-corrected words). Same Gateway REST surface via client-core.
             { path: "/transcription", element: <TranscriptionHealthView /> },

--- a/apps/cockpit/src/throttle/ReposView.tsx
+++ b/apps/cockpit/src/throttle/ReposView.tsx
@@ -1,0 +1,277 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  getThrottle,
+  summarizeRepos,
+  formatShare,
+  type ThrottleData,
+  type RepoStat,
+  type RepoSummary,
+} from "@devthrottle/client-core/stats/statsClient";
+import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
+
+// The private "Repos" page (devthrottle-stats mission): where the owner's development actually happens -
+// how driving splits across the codebases worked in, ranked by submitted turns. Deliberately a SEPARATE
+// page from Your Throttle (its own route + rail entry), because - unlike the voice/surface splits, which
+// the owner may share to talk about how the fleet is driven - which repos take his time is private and
+// must never ride along on-screen when the throttle is shown.
+//
+// Reads the same GET /stats/data feed as Your Throttle (repos ride on it now), so there is no new
+// endpoint and the same owner-only auth applies. Renders immediately with a loading state, loads
+// asynchronously, shows an explicit error banner on failure (no-fallback rule), and auto-refreshes so
+// the split visibly moves as the owner keeps driving. Counts only - never any message text.
+
+const REFRESH_MS = 10_000;
+
+// The three honest metrics the system actually measures per repo. Tokens are intentionally absent: the
+// tally counts turns and characters, never tokens, and this page never fabricates a number.
+type Metric = "turns" | "characters" | "sessions";
+const METRIC_LABEL: Record<Metric, string> = {
+  turns: "Turns",
+  characters: "Characters",
+  sessions: "Sessions",
+};
+const METRIC_WORD: Record<Metric, string> = {
+  turns: "turns",
+  characters: "characters",
+  sessions: "sessions",
+};
+
+function metricValue(r: RepoStat, metric: Metric): number {
+  return metric === "turns" ? r.turns : metric === "characters" ? r.characters : r.sessions;
+}
+
+function formatValue(value: number, metric: Metric): string {
+  return metric === "characters" ? compactNumber(value) : value.toLocaleString();
+}
+
+/** Compact large character counts (e.g. 48200 -> "48.2K", 1_200_000 -> "1.2M"); plain below 1,000. */
+function compactNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+/** A big headline metric card. */
+function HeadlineCard({ label, value, sub }: { label: string; value: string; sub: string }) {
+  return (
+    <div className="thr-card">
+      <div className="thr-card-value">{value}</div>
+      <div className="thr-card-label">{label}</div>
+      <div className="thr-card-sub">{sub}</div>
+    </div>
+  );
+}
+
+/** One ranked repository row: rank, name + full path, a proportional bar (voice/typed split on the turns
+ * metric, single accent otherwise), and the active metric's value with its share of the total. */
+function RepoRow({
+  rank,
+  repo,
+  metric,
+  max,
+  total,
+}: {
+  rank: number;
+  repo: RepoStat;
+  metric: Metric;
+  max: number;
+  total: number;
+}) {
+  const value = metricValue(repo, metric);
+  const width = max > 0 ? (value / max) * 100 : 0;
+  const share = total > 0 ? Math.round((value / total) * 100) : 0;
+  const voicePct = repo.turns > 0 ? Math.round((repo.voiceTurns / repo.turns) * 100) : 0;
+  const showSplit = metric === "turns" && repo.turns > 0;
+
+  // The secondary facts on the meta line depend on which metric is the headline, so the row never just
+  // repeats the big number - it shows the other two honest measures alongside it.
+  const meta =
+    metric === "turns"
+      ? `${compactNumber(repo.characters)} chars - ${repo.sessions} session${repo.sessions === 1 ? "" : "s"} - ${voicePct}% voice`
+      : metric === "characters"
+        ? `${repo.turns.toLocaleString()} turns - ${repo.sessions} session${repo.sessions === 1 ? "" : "s"}`
+        : `${repo.turns.toLocaleString()} turns - ${compactNumber(repo.characters)} chars`;
+
+  return (
+    <div className="repo-row">
+      <div className="repo-rank">{rank}</div>
+      <div className="repo-main">
+        <div className="repo-top">
+          <span className="repo-name">{repo.repoName}</span>
+          {repo.repo && repo.repo !== repo.repoName && <span className="repo-path">{repo.repo}</span>}
+        </div>
+        <div className="repo-meta">{meta}</div>
+        <div className="repo-bar-track" title={`${formatValue(value, metric)} ${METRIC_WORD[metric]}`}>
+          {showSplit ? (
+            <>
+              <div className="repo-bar-voice" style={{ width: `${(width * voicePct) / 100}%` }} />
+              <div className="repo-bar-typed" style={{ width: `${(width * (100 - voicePct)) / 100}%` }} />
+            </>
+          ) : (
+            <div className="repo-bar-voice" style={{ width: `${width}%` }} />
+          )}
+        </div>
+      </div>
+      <div className="repo-val">
+        <div className="repo-val-num">{formatValue(value, metric)}</div>
+        <div className="repo-val-share">{share}%</div>
+      </div>
+    </div>
+  );
+}
+
+export function ReposView() {
+  const [data, setData] = useState<ThrottleData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [metric, setMetric] = useState<Metric>("turns");
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const tick = async () => {
+      try {
+        const fresh = await getThrottle(controller.signal);
+        if (controller.signal.aborted) return;
+        setData(fresh);
+        setError(null);
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setError(gatewayErrorMessage(err));
+      } finally {
+        if (!controller.signal.aborted) timer = setTimeout(() => void tick(), REFRESH_MS);
+      }
+    };
+    void tick();
+
+    return () => {
+      controller.abort();
+      if (timer !== undefined) clearTimeout(timer);
+    };
+  }, []);
+
+  const repos = data?.repos ?? [];
+  const summary: RepoSummary | null = data === null ? null : summarizeRepos(repos);
+
+  // Rank by the active metric (the feed arrives ranked by turns; re-sort so switching to characters or
+  // sessions re-orders the list honestly).
+  const ranked = useMemo(
+    () => [...repos].sort((a, b) => metricValue(b, metric) - metricValue(a, metric)),
+    [repos, metric],
+  );
+  const max = ranked.length > 0 ? metricValue(ranked[0], metric) : 0;
+  const total = ranked.reduce((t, r) => t + metricValue(r, metric), 0);
+
+  return (
+    <div className="page thr repos">
+      <div className="page-head">
+        <div className="repos-private" title="This page is only ever shown to you">
+          <span className="repos-lock" aria-hidden="true" />
+          Private - only you
+        </div>
+        <h1>Repos</h1>
+        <p className="page-sub">
+          Where your development actually happens: how your driving splits across the codebases you work
+          in, ranked by {METRIC_WORD[metric]}. All-time, counted at the Director so desktop typing is
+          included. Kept on its own page - never shown alongside Your Throttle - because which repos take
+          your time is just for you.
+        </p>
+      </div>
+
+      {error !== null && (
+        <div className="thr-banner" role="alert">
+          {error}
+        </div>
+      )}
+
+      {summary === null && error === null && <div className="thr-loading">Loading...</div>}
+
+      {summary !== null && !summary.hasData && (
+        <div className="thr-empty">
+          No input counted yet. Drive a session in any repo - by voice, from the phone, or typed on the
+          desktop - and the repos you work in will appear here, ranked.
+        </div>
+      )}
+
+      {summary !== null && summary.hasData && (
+        <>
+          <div className="thr-cards">
+            <HeadlineCard
+              label="Repos worked in"
+              value={String(summary.repoCount)}
+              sub={`${summary.totalSessions} session${summary.totalSessions === 1 ? "" : "s"} in total`}
+            />
+            <HeadlineCard
+              label="Total turns"
+              value={summary.totalTurns.toLocaleString()}
+              sub={`${compactNumber(summary.totalCharacters)} characters`}
+            />
+            <HeadlineCard
+              label="Busiest repo"
+              value={formatShare(summary.topShare)}
+              sub={summary.topRepoName !== null ? `${summary.topRepoName} leads` : "of your turns"}
+            />
+            <HeadlineCard
+              label="Voice-driven"
+              value={formatShare(summary.totalTurns > 0 ? summary.voiceTurns / summary.totalTurns : null)}
+              sub="of turns spoken, not typed"
+            />
+          </div>
+
+          <div className="repos-controls">
+            <span className="repos-controls-label">Rank by</span>
+            <div className="repos-seg" role="tablist" aria-label="Rank repositories by">
+              {(["turns", "characters", "sessions"] as Metric[]).map((m) => (
+                <button
+                  key={m}
+                  type="button"
+                  role="tab"
+                  aria-selected={metric === m}
+                  className={metric === m ? "repos-seg-btn on" : "repos-seg-btn"}
+                  onClick={() => setMetric(m)}
+                >
+                  {METRIC_LABEL[m]}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="thr-section">
+            <h2>By repository</h2>
+            <div className="repo-rows">
+              {ranked.map((r, i) => (
+                <RepoRow key={r.repo} rank={i + 1} repo={r} metric={metric} max={max} total={total} />
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+
+      <div className="thr-caveats">
+        <h2>What this does and doesn't count</h2>
+        <ul>
+          <li>
+            A <strong>turn</strong> is one submitted message - one spoken utterance and one typed message
+            each count once. On the turns view, the amber part of each bar is the share driven by voice.
+          </li>
+          <li>
+            Repos are grouped by the session's working directory. Time is deliberately not shown: an idle
+            hour looks the same as a heads-down hour, so it would lie. Turns and characters track what you
+            actually pushed through.
+          </li>
+          <li>
+            Tokens are not shown - the tally counts turns and characters, never tokens, and this page
+            never fabricates a number it did not measure.
+          </li>
+        </ul>
+        {data !== null && data.notCaptured.length > 0 && (
+          <ul>
+            {data.notCaptured.map((c, i) => (
+              <li key={i}>{c}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/cockpit/src/throttle/throttle.css
+++ b/apps/cockpit/src/throttle/throttle.css
@@ -445,6 +445,184 @@
   background: color-mix(in srgb, var(--accent) 32%, transparent);
 }
 
+/* ============================================================================
+   Repos page (private per-person view) - reuses the throttle tokens and card /
+   section / caveat styles above, and adds the ranked repository list, the
+   private badge, and the metric toggle.
+   ============================================================================ */
+
+/* The "private - only you" badge sits above the title so the page announces, at a glance, that it is
+   not for sharing (unlike the shareable Your Throttle splits). */
+.repos-private {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 32%, transparent);
+  border-radius: 999px;
+  padding: 4px 10px;
+  margin-bottom: 10px;
+}
+.repos-lock {
+  width: 9px;
+  height: 8px;
+  border: 1.5px solid currentColor;
+  border-radius: 1px 1px 2px 2px;
+  position: relative;
+  margin-top: 3px;
+}
+.repos-lock::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: -6px;
+  width: 6px;
+  height: 6px;
+  border: 1.5px solid currentColor;
+  border-bottom: none;
+  border-radius: 4px 4px 0 0;
+  transform: translateX(-50%);
+}
+
+/* Metric toggle (Turns / Characters / Sessions) */
+.repos-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+.repos-controls-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.repos-seg {
+  display: inline-flex;
+  gap: 2px;
+  padding: 3px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 9px;
+}
+.repos-seg-btn {
+  appearance: none;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-dim);
+  padding: 5px 13px;
+  border-radius: 6px;
+}
+.repos-seg-btn:hover {
+  color: var(--text);
+}
+.repos-seg-btn.on {
+  background: var(--surface);
+  color: var(--accent);
+}
+
+/* Ranked repository list */
+.repo-rows {
+  display: flex;
+  flex-direction: column;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.repo-row {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) 88px;
+  align-items: center;
+  gap: 14px;
+  padding: 13px 16px;
+  border-top: 1px solid var(--border);
+}
+.repo-row:first-child {
+  border-top: none;
+}
+.repo-rank {
+  font-size: 13px;
+  color: var(--text-dim);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.repo-main {
+  min-width: 0;
+}
+.repo-top {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  margin-bottom: 4px;
+  flex-wrap: wrap;
+}
+.repo-name {
+  font-weight: 600;
+  font-size: 14px;
+}
+.repo-path {
+  font-size: 11px;
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+.repo-meta {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-bottom: 7px;
+  font-variant-numeric: tabular-nums;
+}
+.repo-bar-track {
+  height: 10px;
+  background: var(--surface-2);
+  border-radius: 5px;
+  overflow: hidden;
+  display: flex;
+}
+.repo-bar-voice {
+  height: 100%;
+  background: var(--accent);
+}
+.repo-bar-typed {
+  height: 100%;
+  background: color-mix(in srgb, var(--text-dim) 45%, transparent);
+}
+.repo-val {
+  text-align: right;
+}
+.repo-val-num {
+  font-size: 15px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.repo-val-share {
+  font-size: 11px;
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 560px) {
+  .repo-row {
+    grid-template-columns: 22px minmax(0, 1fr) 72px;
+    gap: 10px;
+    padding: 12px;
+  }
+}
+
 /* ---- Honesty caveats ----------------------------------------------------------------------------- */
 .thr-caveats {
   background: var(--surface-2);

--- a/apps/mobile/src/components/NavDrawer.tsx
+++ b/apps/mobile/src/components/NavDrawer.tsx
@@ -38,6 +38,9 @@ export function NavDrawer() {
             <Link className="drawer-item" to="/throttle" onClick={close}>
               Your Throttle
             </Link>
+            <Link className="drawer-item" to="/repos" onClick={close}>
+              Repos
+            </Link>
             <div className="drawer-sep" />
             <Link className="drawer-item" to="/settings" onClick={close}>
               AI settings

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -13,6 +13,7 @@ import { AiSettings } from "./pages/AiSettings";
 import { About } from "./pages/About";
 import { Diagnostics } from "./pages/Diagnostics";
 import { YourThrottle } from "./pages/YourThrottle";
+import { Repos } from "./pages/Repos";
 import { SignIn } from "@devthrottle/client-core/auth/SignIn";
 import { DeviceCallback } from "@devthrottle/client-core/auth/DeviceCallback";
 import { hasDeviceKey } from "@devthrottle/client-core/auth/deviceKey";
@@ -129,6 +130,9 @@ const router = createBrowserRouter(
             // Your Throttle (devthrottle-stats mission): the in-app port of the standalone Gateway
             // /stats page, reading the same GET /stats/data feed through client-core.
             { path: "/throttle", element: <YourThrottle /> },
+            // Repos (devthrottle-stats mission): the PRIVATE per-repo split, its own page separate from
+            // Your Throttle. Reads the same GET /stats/data feed (repos ride on it) through client-core.
+            { path: "/repos", element: <Repos /> },
             { path: "/new", element: <NewSession /> },
             { path: "/session/:sessionId", element: <Chat /> },
             { path: "/session/:sessionId/chat", element: <Chat /> },

--- a/apps/mobile/src/pages/Repos.tsx
+++ b/apps/mobile/src/pages/Repos.tsx
@@ -1,0 +1,210 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  getThrottle,
+  summarizeRepos,
+  formatShare,
+  type ThrottleData,
+  type RepoStat,
+  type RepoSummary,
+} from "@devthrottle/client-core/stats/statsClient";
+import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
+
+// The private "Repos" page for the phone (devthrottle-stats mission): where the owner's development
+// actually happens - how driving splits across the codebases worked in, ranked by submitted turns. Its
+// own page, deliberately separate from Your Throttle, because which repos take the owner's time is
+// private (unlike the shareable voice/surface splits). Reads the same GET /stats/data feed (repos ride
+// on it now) as the Cockpit Repos page, so both shells show one identical, single-source view. Renders
+// immediately with a loading state, loads asynchronously, shows an explicit error banner on failure
+// (no-fallback rule), and auto-refreshes. Counts only - never any message text.
+
+const REFRESH_MS = 10_000;
+
+type Metric = "turns" | "characters" | "sessions";
+const METRIC_LABEL: Record<Metric, string> = { turns: "Turns", characters: "Characters", sessions: "Sessions" };
+const METRIC_WORD: Record<Metric, string> = { turns: "turns", characters: "characters", sessions: "sessions" };
+
+function metricValue(r: RepoStat, metric: Metric): number {
+  return metric === "turns" ? r.turns : metric === "characters" ? r.characters : r.sessions;
+}
+
+/** Compact large counts (48200 -> "48.2K", 1_200_000 -> "1.2M"); plain below 1,000. */
+function compactNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function formatValue(value: number, metric: Metric): string {
+  return metric === "characters" ? compactNumber(value) : value.toLocaleString();
+}
+
+export function Repos() {
+  const [data, setData] = useState<ThrottleData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [metric, setMetric] = useState<Metric>("turns");
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const tick = async () => {
+      try {
+        const fresh = await getThrottle(controller.signal);
+        if (controller.signal.aborted) return;
+        setData(fresh);
+        setError(null);
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setError(gatewayErrorMessage(err));
+      } finally {
+        if (!controller.signal.aborted) timer = setTimeout(() => void tick(), REFRESH_MS);
+      }
+    };
+    void tick();
+
+    return () => {
+      controller.abort();
+      if (timer !== undefined) clearTimeout(timer);
+    };
+  }, []);
+
+  const repos = data?.repos ?? [];
+  const summary: RepoSummary | null = data === null ? null : summarizeRepos(repos);
+
+  const ranked = useMemo(
+    () => [...repos].sort((a, b) => metricValue(b, metric) - metricValue(a, metric)),
+    [repos, metric],
+  );
+  const max = ranked.length > 0 ? metricValue(ranked[0], metric) : 0;
+  const total = ranked.reduce((t, r) => t + metricValue(r, metric), 0);
+
+  return (
+    <div className="screen">
+      <header className="app-bar">
+        <Link className="back-link" to="/">
+          Back
+        </Link>
+        <h1>Repos</h1>
+      </header>
+
+      <div className="repos-private">
+        <span className="repos-lock" aria-hidden="true" />
+        Private - only you
+      </div>
+
+      {error !== null && (
+        <div className="banner banner-error" role="alert">
+          {error}
+        </div>
+      )}
+
+      {summary === null && error === null && <div className="thr-note">Loading...</div>}
+
+      {summary !== null && !summary.hasData && (
+        <div className="thr-note">
+          No input counted yet. Drive a session in any repo and the codebases you work in will appear here,
+          ranked.
+        </div>
+      )}
+
+      {summary !== null && summary.hasData && (
+        <>
+          <section className="thr-cards" aria-label="Repo headlines">
+            <div className="thr-card">
+              <div className="thr-card-value">{summary.repoCount}</div>
+              <div className="thr-card-label">Repos</div>
+            </div>
+            <div className="thr-card">
+              <div className="thr-card-value">{summary.totalTurns.toLocaleString()}</div>
+              <div className="thr-card-label">Turns</div>
+            </div>
+            <div className="thr-card">
+              <div className="thr-card-value">{formatShare(summary.topShare)}</div>
+              <div className="thr-card-label">Busiest</div>
+            </div>
+          </section>
+
+          <div className="thr-caption">
+            {summary.topRepoName !== null && (
+              <>
+                {summary.topRepoName} leads;{" "}
+              </>
+            )}
+            {summary.totalSessions} session{summary.totalSessions === 1 ? "" : "s"},{" "}
+            {compactNumber(summary.totalCharacters)} characters in total.
+          </div>
+
+          <div className="repos-seg" role="tablist" aria-label="Rank repositories by">
+            {(["turns", "characters", "sessions"] as Metric[]).map((m) => (
+              <button
+                key={m}
+                type="button"
+                role="tab"
+                aria-selected={metric === m}
+                className={metric === m ? "repos-seg-btn on" : "repos-seg-btn"}
+                onClick={() => setMetric(m)}
+              >
+                {METRIC_LABEL[m]}
+              </button>
+            ))}
+          </div>
+
+          <section className="thr-list" aria-label="By repository">
+            <div className="thr-list-title">By {METRIC_WORD[metric]}</div>
+            {ranked.map((r, i) => {
+              const value = metricValue(r, metric);
+              const width = max > 0 ? (value / max) * 100 : 0;
+              const share = total > 0 ? Math.round((value / total) * 100) : 0;
+              const voicePct = r.turns > 0 ? Math.round((r.voiceTurns / r.turns) * 100) : 0;
+              const showSplit = metric === "turns" && r.turns > 0;
+              return (
+                <div className="repo-item" key={r.repo}>
+                  <div className="repo-item-top">
+                    <span className="repo-item-rank">{i + 1}</span>
+                    <span className="repo-item-name">{r.repoName}</span>
+                    <span className="repo-item-val">
+                      {formatValue(value, metric)}
+                      <span className="repo-item-share"> - {share}%</span>
+                    </span>
+                  </div>
+                  <div className="repo-item-bar">
+                    {showSplit ? (
+                      <>
+                        <span className="repo-item-voice" style={{ width: `${(width * voicePct) / 100}%` }} />
+                        <span className="repo-item-typed" style={{ width: `${(width * (100 - voicePct)) / 100}%` }} />
+                      </>
+                    ) : (
+                      <span className="repo-item-voice" style={{ width: `${width}%` }} />
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </section>
+        </>
+      )}
+
+      <section className="thr-caveats" aria-label="What this does and doesn't count">
+        <div className="thr-list-title">What this does and doesn't count</div>
+        <ul>
+          <li>
+            A turn is one submitted message; the amber part of each bar is the share driven by voice.
+            Repos are grouped by the session's working directory.
+          </li>
+          <li>
+            Time is not shown (an idle hour looks like a busy one), and tokens are not shown - the tally
+            counts turns and characters, never tokens. Nothing here is fabricated.
+          </li>
+        </ul>
+        {data !== null && data.notCaptured.length > 0 && (
+          <ul>
+            {data.notCaptured.map((c, i) => (
+              <li key={i}>{c}</li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -3313,6 +3313,121 @@ a.banner-btn {
   margin-bottom: 6px;
 }
 
+/* ===== Repos page (private per-person view) - reuses the throttle cards/list/caveats above ===== */
+.repos-private {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 34%, transparent);
+  border-radius: 999px;
+  padding: 4px 10px;
+  margin: 12px 14px 0;
+}
+.repos-lock {
+  width: 9px;
+  height: 8px;
+  border: 1.5px solid currentColor;
+  border-radius: 1px 1px 2px 2px;
+  position: relative;
+  margin-top: 3px;
+}
+.repos-lock::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: -6px;
+  width: 6px;
+  height: 6px;
+  border: 1.5px solid currentColor;
+  border-bottom: none;
+  border-radius: 4px 4px 0 0;
+  transform: translateX(-50%);
+}
+.repos-seg {
+  display: flex;
+  gap: 2px;
+  margin: 14px 14px 0;
+  padding: 3px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 9px;
+}
+.repos-seg-btn {
+  appearance: none;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font: inherit;
+  flex: 1 1 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-dim);
+  padding: 7px 8px;
+  border-radius: 6px;
+}
+.repos-seg-btn.on {
+  background: var(--surface);
+  color: var(--accent);
+}
+.repo-item {
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+}
+.repo-item-top {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.repo-item-rank {
+  font-size: 12px;
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+  min-width: 16px;
+}
+.repo-item-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.repo-item-val {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+.repo-item-share {
+  color: var(--text-dim);
+  font-weight: 400;
+}
+.repo-item-bar {
+  height: 9px;
+  background: var(--surface-2);
+  border-radius: 5px;
+  overflow: hidden;
+  display: flex;
+  margin-left: 24px;
+}
+.repo-item-voice {
+  height: 100%;
+  background: var(--accent);
+}
+.repo-item-typed {
+  height: 100%;
+  background: color-mix(in srgb, var(--text-dim) 45%, transparent);
+}
+
 /* 24-hour concurrency bar chart */
 .thr-chart {
   display: flex;

--- a/packages/client-core/src/stats/statsClient.test.ts
+++ b/packages/client-core/src/stats/statsClient.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   summarizeThrottle,
+  summarizeRepos,
   formatShare,
   last24HourKeys,
   windowSeries,
@@ -8,6 +9,7 @@ import {
   localHourLabel,
   safeTimeZone,
   type ThrottleData,
+  type RepoStat,
   type InputHour,
 } from "./statsClient";
 
@@ -22,8 +24,13 @@ function data(buckets: ThrottleData["buckets"]): ThrottleData {
     hourlyTurns: [],
     concurrency: null,
     wingman: { turns: 0, sessions: 0 },
+    repos: [],
     notCaptured: [],
   };
+}
+
+function repo(repoName: string, turns: number, voiceTurns: number, characters: number, sessions: number): RepoStat {
+  return { repo: `D:/${repoName}`, repoName, turns, voiceTurns, typedTurns: turns - voiceTurns, characters, sessions };
 }
 
 describe("summarizeThrottle", () => {
@@ -62,6 +69,32 @@ describe("summarizeThrottle", () => {
     expect(s.totalCharacters).toBe(42);
     expect(s.voiceShare).toBeNull();
     expect(s.hasData).toBe(true);
+  });
+});
+
+describe("summarizeRepos", () => {
+  it("totals turns, characters and distinct sessions, and finds the top repo's share", () => {
+    const s = summarizeRepos([
+      repo("devthrottle", 8, 6, 640, 2),
+      repo("mindzieWeb", 2, 0, 60, 1),
+    ]);
+    expect(s.repoCount).toBe(2);
+    expect(s.totalTurns).toBe(10);
+    expect(s.totalCharacters).toBe(700);
+    expect(s.totalSessions).toBe(3);
+    expect(s.voiceTurns).toBe(6);
+    expect(s.topRepoName).toBe("devthrottle");
+    expect(s.topShare).toBeCloseTo(0.8);
+    expect(s.hasData).toBe(true);
+  });
+
+  it("reports a null top share (not 0%) when nothing is counted yet", () => {
+    const s = summarizeRepos([]);
+    expect(s.repoCount).toBe(0);
+    expect(s.totalTurns).toBe(0);
+    expect(s.topShare).toBeNull();
+    expect(s.topRepoName).toBeNull();
+    expect(s.hasData).toBe(false);
   });
 });
 

--- a/packages/client-core/src/stats/statsClient.ts
+++ b/packages/client-core/src/stats/statsClient.ts
@@ -67,6 +67,26 @@ export interface InputHour {
   characters: number;
 }
 
+/** One repository's all-time input tally for the private Repos page: how much development landed in this
+ * codebase, in submitted turns (total + voice/typed split), character volume, and distinct sessions.
+ * Mirrors the Gateway RepoStatBucketDto. Counts only - never any message text. */
+export interface RepoStat {
+  /** Full repository / working-directory path the sessions ran in (the grouping key). */
+  repo: string;
+  /** Display leaf of the path (its last segment), e.g. "devthrottle". */
+  repoName: string;
+  /** Total submitted turns into this repo (voice + typed). */
+  turns: number;
+  /** Submitted turns driven by voice. */
+  voiceTurns: number;
+  /** Submitted turns driven by typing. */
+  typedTurns: number;
+  /** Total character volume of input into this repo. */
+  characters: number;
+  /** Distinct sessions that drove counted input into this repo. */
+  sessions: number;
+}
+
 /** The GET /stats/data body: the fleet-wide aggregated tally plus the honesty caveats. */
 export interface ThrottleData {
   /** When the Gateway generated this snapshot (ISO 8601 UTC), or "" when absent. */
@@ -81,6 +101,8 @@ export interface ThrottleData {
   concurrency: ConcurrencyStats | null;
   /** Wingman usage (a session "uses the wingman" when it has voice mode on). */
   wingman: WingmanUsage;
+  /** Per-repository all-time tally, ranked most-driven first (the private Repos page). */
+  repos: RepoStat[];
   /** Plain-English caveats about what the numbers do and do not include. */
   notCaptured: string[];
 }
@@ -159,10 +181,12 @@ export async function getThrottle(signal?: AbortSignal): Promise<ThrottleData> {
     hourlyTurns?: unknown;
     concurrency?: unknown;
     wingman?: unknown;
+    repos?: unknown;
     notCaptured?: unknown;
   } | null;
   const buckets = Array.isArray(body?.buckets) ? body!.buckets.map(normalizeBucket) : [];
   const hourlyTurns = Array.isArray(body?.hourlyTurns) ? body!.hourlyTurns.map(normalizeInputHour) : [];
+  const repos = Array.isArray(body?.repos) ? body!.repos.map(normalizeRepo) : [];
   const notCaptured = Array.isArray(body?.notCaptured)
     ? body!.notCaptured.filter((x): x is string => typeof x === "string")
     : [];
@@ -173,6 +197,7 @@ export async function getThrottle(signal?: AbortSignal): Promise<ThrottleData> {
     hourlyTurns,
     concurrency: normalizeConcurrency(body?.concurrency),
     wingman: normalizeWingman(body?.wingman),
+    repos,
     notCaptured,
   };
 }
@@ -180,6 +205,19 @@ export async function getThrottle(signal?: AbortSignal): Promise<ThrottleData> {
 function normalizeWingman(raw: unknown): WingmanUsage {
   const w = (raw ?? {}) as { turns?: unknown; sessions?: unknown };
   return { turns: num(w.turns), sessions: num(w.sessions) };
+}
+
+function normalizeRepo(raw: unknown): RepoStat {
+  const r = (raw ?? {}) as Partial<Record<keyof RepoStat, unknown>>;
+  return {
+    repo: String(r.repo ?? ""),
+    repoName: String(r.repoName ?? ""),
+    turns: num(r.turns),
+    voiceTurns: num(r.voiceTurns),
+    typedTurns: num(r.typedTurns),
+    characters: num(r.characters),
+    sessions: num(r.sessions),
+  };
 }
 
 function normalizeInputHour(raw: unknown): InputHour {
@@ -257,6 +295,55 @@ export function summarizeThrottle(data: ThrottleData): ThrottleSummary {
     voiceShare: share(voiceTurns),
     turnsBySurface,
     phoneShare: share(turnsBySurface.phone),
+    hasData: totalTurns > 0 || totalCharacters > 0,
+  };
+}
+
+/** A derived, presentation-ready summary of the per-repo tally for the Repos page headline cards. */
+export interface RepoSummary {
+  /** How many repos have any counted input. */
+  repoCount: number;
+  /** Total submitted turns across every repo. */
+  totalTurns: number;
+  /** Total character volume across every repo. */
+  totalCharacters: number;
+  /** Total distinct sessions across every repo (a session belongs to exactly one repo, so summing the
+   * per-repo distinct counts is itself a distinct total). */
+  totalSessions: number;
+  /** Total voice-driven turns across every repo. */
+  voiceTurns: number;
+  /** The most-driven repo's share of all turns, or null when no turns are counted yet. */
+  topShare: number | null;
+  /** The most-driven repo's display name, or null when there is no data. */
+  topRepoName: string | null;
+  hasData: boolean;
+}
+
+/** Derive the Repos-page headline summary from the per-repo tally. Shares are null (never a fabricated
+ * 0%) when there are no counted turns yet. */
+export function summarizeRepos(repos: RepoStat[]): RepoSummary {
+  let totalTurns = 0;
+  let totalCharacters = 0;
+  let totalSessions = 0;
+  let voiceTurns = 0;
+  let top: RepoStat | null = null;
+
+  for (const r of repos) {
+    totalTurns += r.turns;
+    totalCharacters += r.characters;
+    totalSessions += r.sessions;
+    voiceTurns += r.voiceTurns;
+    if (top === null || r.turns > top.turns) top = r;
+  }
+
+  return {
+    repoCount: repos.length,
+    totalTurns,
+    totalCharacters,
+    totalSessions,
+    voiceTurns,
+    topShare: totalTurns > 0 && top !== null ? top.turns / totalTurns : null,
+    topRepoName: top !== null ? top.repoName : null,
     hasData: totalTurns > 0 || totalCharacters > 0,
   };
 }

--- a/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
@@ -44,6 +44,17 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
         return dto;
     }
 
+    private static SessionDto SessionInRepo(string id, string repoPath, params (string modality, string surface, long turns, long chars)[] buckets)
+    {
+        var dto = Session(id, buckets);
+        dto.RepoPath = repoPath;
+        return dto;
+    }
+
+    private static RepoStatBucketDto? Repo(GatewayInputStatsAggregator agg, string repoName) =>
+        agg.RepoTotals().FirstOrDefault(r => r.RepoName == repoName);
+
+
     private static long Turns(InputStatsDto dto, string modality, string surface) =>
         dto.Buckets.FirstOrDefault(b => b.Modality == modality && b.Surface == surface)?.Turns ?? 0;
 
@@ -228,5 +239,50 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
         b.Observe(VoiceSession("s1", ("voice", "phone", 3, 120)));
         Assert.Equal(3, b.WingmanUsage().Turns);
         Assert.Equal(1, b.WingmanUsage().Sessions);
+    }
+
+    [Fact]
+    public void RepoTotals_AttributeTurnsToRepo_SplitByModality_AndRankByTurns()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        // Two repos drive input; devthrottle gets more, so it must rank first.
+        agg.Observe(SessionInRepo("s1", @"D:\ReposFred\devthrottle", ("voice", "phone", 6, 600)));
+        agg.Observe(SessionInRepo("s2", @"D:\ReposFred\devthrottle", ("typed", "desktop", 2, 40)));
+        agg.Observe(SessionInRepo("s3", @"C:\repos\mindzieWeb", ("typed", "cockpit", 3, 90)));
+
+        var ranked = agg.RepoTotals();
+        Assert.Equal(2, ranked.Count);
+        Assert.Equal("devthrottle", ranked[0].RepoName);     // 8 turns - ranked first
+        Assert.Equal("mindzieWeb", ranked[1].RepoName);      // 3 turns
+
+        var dt = ranked[0];
+        Assert.Equal(8, dt.Turns);
+        Assert.Equal(6, dt.VoiceTurns);
+        Assert.Equal(2, dt.TypedTurns);
+        Assert.Equal(640, dt.Characters);
+        Assert.Equal(2, dt.Sessions);                         // two distinct sessions drove it
+        Assert.Equal(@"D:\ReposFred\devthrottle", dt.Repo);   // full path preserved
+    }
+
+    [Fact]
+    public void RepoTotals_DistinctSessions_NoDoubleCountAcrossRepush_AndSurviveRestart()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        agg.Observe(SessionInRepo("s1", @"D:\repos\app", ("voice", "phone", 3, 120)));
+        agg.Observe(SessionInRepo("s1", @"D:\repos\app", ("voice", "phone", 3, 120))); // re-push, no change
+        agg.Observe(SessionInRepo("s1", @"D:\repos\app", ("voice", "phone", 5, 200))); // grew by 2
+
+        var app = Repo(agg, "app");
+        Assert.NotNull(app);
+        Assert.Equal(5, app!.Turns);
+        Assert.Equal(1, app.Sessions); // the same session id must count once, not three times
+
+        // Gateway restart: the per-repo tally (and its distinct-session set) reload from disk.
+        var reloaded = new GatewayInputStatsAggregator(_path);
+        var app2 = Repo(reloaded, "app");
+        Assert.NotNull(app2);
+        Assert.Equal(5, app2!.Turns);
+        Assert.Equal(200, app2.Characters);
+        Assert.Equal(1, app2.Sessions);
     }
 }

--- a/src/CcDirector.Gateway.Tests/StatsPageEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/StatsPageEndpointTests.cs
@@ -124,6 +124,40 @@ public sealed class StatsPageEndpointTests : IDisposable
     }
 
     [Fact]
+    public async Task StatsData_RanksRepos_ByTurns()
+    {
+        var agg = new GatewayInputStatsAggregator(Path.Combine(_dir, "s.json"));
+        agg.Observe(new SessionDto
+        {
+            SessionId = "s1",
+            RepoPath = @"D:\ReposFred\devthrottle",
+            InputStats = new InputStatsDto { Buckets = { new InputStatBucketDto { Modality = "voice", Surface = "phone", Turns = 6, Characters = 600 } } },
+        });
+        agg.Observe(new SessionDto
+        {
+            SessionId = "s2",
+            RepoPath = @"C:\repos\mindzieWeb",
+            InputStats = new InputStatsDto { Buckets = { new InputStatBucketDto { Modality = "typed", Surface = "desktop", Turns = 2, Characters = 40 } } },
+        });
+
+        var (app, http) = await StartAsync(agg, authEnabled: false);
+        try
+        {
+            using var doc = JsonDocument.Parse(await (await http.GetAsync("/stats/data")).Content.ReadAsStringAsync());
+            var repos = doc.RootElement.GetProperty("repos");
+            Assert.Equal(2, repos.GetArrayLength());
+
+            var first = repos[0];
+            Assert.Equal("devthrottle", first.GetProperty("repoName").GetString()); // most turns ranks first
+            Assert.Equal(6, first.GetProperty("turns").GetInt64());
+            Assert.Equal(6, first.GetProperty("voiceTurns").GetInt64());
+            Assert.Equal(1, first.GetProperty("sessions").GetInt32());
+            Assert.Equal("mindzieWeb", repos[1].GetProperty("repoName").GetString());
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    [Fact]
     public async Task AuthEnabled_NoToken_Returns401_AndWithToken_Returns200()
     {
         var agg = new GatewayInputStatsAggregator(Path.Combine(_dir, "s.json"));

--- a/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
+++ b/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
@@ -48,11 +48,28 @@ public sealed class GatewayInputStatsAggregator
     private long _wingmanTurns;
     private readonly HashSet<string> _wingmanSessions = new(StringComparer.Ordinal);
 
+    // Per-repository all-time tally, keyed by the session's RepoPath (working directory). Accumulated from
+    // the SAME high-water deltas as the totals: when a session's counted input grows, that increase is also
+    // attributed to the session's repo. Feeds the private Repos page ("where your development actually
+    // happens"). All-time, like the totals - never pruned. Only counts travel; never any message text.
+    private readonly Dictionary<string, RepoTally> _repos = new(StringComparer.OrdinalIgnoreCase);
+
     private sealed class HourTurns
     {
         public long VoiceTurns;
         public long TypedTurns;
         public long Characters;
+    }
+
+    private sealed class RepoTally
+    {
+        public long VoiceTurns;
+        public long TypedTurns;
+        public long Characters;
+        // The distinct session ids that drove counted input into this repo, so "sessions" is a true
+        // distinct count that never double-counts across a re-push or a Gateway restart (the set is
+        // persisted and re-adding a known id is a no-op).
+        public readonly HashSet<string> Sessions = new(StringComparer.Ordinal);
     }
 
     private sealed class Counters
@@ -151,6 +168,50 @@ public sealed class GatewayInputStatsAggregator
         }
     }
 
+    /// <summary>The per-repository all-time tally (turns by modality, character volume, distinct sessions),
+    /// ranked most-driven first, for the private Repos page. Repos with no counted turns are omitted.</summary>
+    public IReadOnlyList<RepoStatBucketDto> RepoTotals()
+    {
+        lock (_lock)
+        {
+            var list = new List<RepoStatBucketDto>(_repos.Count);
+            foreach (var kvp in _repos)
+            {
+                var t = kvp.Value;
+                list.Add(new RepoStatBucketDto
+                {
+                    Repo = kvp.Key,
+                    RepoName = RepoLeaf(kvp.Key),
+                    Turns = t.VoiceTurns + t.TypedTurns,
+                    VoiceTurns = t.VoiceTurns,
+                    TypedTurns = t.TypedTurns,
+                    Characters = t.Characters,
+                    Sessions = t.Sessions.Count,
+                });
+            }
+            // Rank by turns (the headline metric), then characters, then name, so the order is stable.
+            list.Sort((a, b) =>
+            {
+                var byTurns = b.Turns.CompareTo(a.Turns);
+                if (byTurns != 0) return byTurns;
+                var byChars = b.Characters.CompareTo(a.Characters);
+                return byChars != 0 ? byChars : string.CompareOrdinal(a.RepoName, b.RepoName);
+            });
+            return list;
+        }
+    }
+
+    // The display leaf of a repository path: the last path segment of the working directory, so
+    // "D:\ReposFred\devthrottle" reads as "devthrottle". Handles both slash styles across machines (the
+    // Gateway aggregates repos from Windows and Unix Directors alike). Empty path reads as "(unknown)".
+    private static string RepoLeaf(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return "(unknown)";
+        var trimmed = path.TrimEnd('/', '\\');
+        var idx = trimmed.LastIndexOfAny(new[] { '/', '\\' });
+        return idx >= 0 && idx < trimmed.Length - 1 ? trimmed[(idx + 1)..] : trimmed;
+    }
+
     private static string HourKey(DateTime utc) =>
         utc.ToUniversalTime().ToString(HourFormat, System.Globalization.CultureInfo.InvariantCulture);
 
@@ -214,6 +275,8 @@ public sealed class GatewayInputStatsAggregator
                 total.Turns += deltaTurns;
                 total.Characters += deltaChars;
 
+                var isVoice = string.Equals(key.Item1, "voice", StringComparison.OrdinalIgnoreCase);
+
                 // Attribute this increase to the hour it was observed (the "working day" series). Turns are
                 // split by modality; characters are summed. Surface is not split here - the hourly log is
                 // about WHEN work happened, not from where.
@@ -222,13 +285,31 @@ public sealed class GatewayInputStatsAggregator
                     hour = new HourTurns();
                     _hourly[hourKey] = hour;
                 }
-                if (string.Equals(key.Item1, "voice", StringComparison.OrdinalIgnoreCase))
+                if (isVoice)
                     hour.VoiceTurns += deltaTurns;
                 else
                     hour.TypedTurns += deltaTurns;
                 hour.Characters += deltaChars;
 
                 sessionDeltaTurns += deltaTurns;
+
+                // Attribute the SAME increase to the session's repository (the private Repos page): which
+                // codebase the work landed in. Turns split by modality, characters summed, and the session
+                // id remembered so a repo's distinct-session count is honest.
+                var repoKey = s.RepoPath ?? "";
+                if (!_repos.TryGetValue(repoKey, out var repo))
+                {
+                    repo = new RepoTally();
+                    _repos[repoKey] = repo;
+                }
+                if (isVoice)
+                    repo.VoiceTurns += deltaTurns;
+                else
+                    repo.TypedTurns += deltaTurns;
+                repo.Characters += deltaChars;
+                if (!string.IsNullOrEmpty(s.SessionId))
+                    repo.Sessions.Add(s.SessionId);
+
                 changed = true;
             }
 
@@ -265,6 +346,7 @@ public sealed class GatewayInputStatsAggregator
         public Dictionary<string, HourTurnsStore> Hourly { get; set; } = new();
         public long WingmanTurns { get; set; }
         public List<string> WingmanSessions { get; set; } = new();
+        public Dictionary<string, RepoTallyStore> Repos { get; set; } = new();
     }
 
     private sealed class HourTurnsStore
@@ -272,6 +354,14 @@ public sealed class GatewayInputStatsAggregator
         public long VoiceTurns { get; set; }
         public long TypedTurns { get; set; }
         public long Characters { get; set; }
+    }
+
+    private sealed class RepoTallyStore
+    {
+        public long VoiceTurns { get; set; }
+        public long TypedTurns { get; set; }
+        public long Characters { get; set; }
+        public List<string> Sessions { get; set; } = new();
     }
 
     private void Load()
@@ -312,7 +402,13 @@ public sealed class GatewayInputStatsAggregator
         _wingmanTurns = parsed.WingmanTurns;
         foreach (var id in parsed.WingmanSessions)
             if (!string.IsNullOrEmpty(id)) _wingmanSessions.Add(id);
-        FileLog.Write($"[GatewayInputStatsAggregator] Load: restored {_totals.Count} total bucket(s), {_highWater.Count} live session(s), {_hourly.Count} hourly bucket(s), {_wingmanSessions.Count} wingman session(s)/{_wingmanTurns} wingman turn(s) from {_path}");
+        foreach (var (repoKey, rt) in parsed.Repos)
+        {
+            var tally = new RepoTally { VoiceTurns = rt.VoiceTurns, TypedTurns = rt.TypedTurns, Characters = rt.Characters };
+            foreach (var sid in rt.Sessions) tally.Sessions.Add(sid);
+            _repos[repoKey] = tally;
+        }
+        FileLog.Write($"[GatewayInputStatsAggregator] Load: restored {_totals.Count} total bucket(s), {_highWater.Count} live session(s), {_hourly.Count} hourly bucket(s), {_wingmanSessions.Count} wingman session(s)/{_wingmanTurns} wingman turn(s), {_repos.Count} repo(s) from {_path}");
     }
 
     private void Quarantine(string reason)
@@ -340,6 +436,14 @@ public sealed class GatewayInputStatsAggregator
                 file.Hourly[hour] = new HourTurnsStore { VoiceTurns = ht.VoiceTurns, TypedTurns = ht.TypedTurns, Characters = ht.Characters };
             file.WingmanTurns = _wingmanTurns;
             file.WingmanSessions = _wingmanSessions.ToList();
+            foreach (var (repoKey, rt) in _repos)
+                file.Repos[repoKey] = new RepoTallyStore
+                {
+                    VoiceTurns = rt.VoiceTurns,
+                    TypedTurns = rt.TypedTurns,
+                    Characters = rt.Characters,
+                    Sessions = rt.Sessions.ToList(),
+                };
 
             var json = JsonSerializer.Serialize(file, FileJsonOptions);
             var tmp = _path + ".tmp";
@@ -371,5 +475,32 @@ public sealed class InputHourDto
 public sealed class WingmanUsageDto
 {
     public long Turns { get; set; }
+    public int Sessions { get; set; }
+}
+
+/// <summary>One repository's all-time input tally for the private Repos page: how much development landed
+/// in this codebase, measured in submitted TURNS (total and split voice vs typed), CHARACTER volume, and
+/// the count of distinct SESSIONS that drove input into it. Only counts ever travel - never message text.</summary>
+public sealed class RepoStatBucketDto
+{
+    /// <summary>The full repository / working-directory path the sessions ran in (the grouping key).</summary>
+    public string Repo { get; set; } = "";
+
+    /// <summary>The display leaf of <see cref="Repo"/> (its last path segment), e.g. "devthrottle".</summary>
+    public string RepoName { get; set; } = "";
+
+    /// <summary>Total submitted turns into this repo (voice + typed).</summary>
+    public long Turns { get; set; }
+
+    /// <summary>Submitted turns driven by voice.</summary>
+    public long VoiceTurns { get; set; }
+
+    /// <summary>Submitted turns driven by typing.</summary>
+    public long TypedTurns { get; set; }
+
+    /// <summary>Total character volume of input into this repo.</summary>
+    public long Characters { get; set; }
+
+    /// <summary>Distinct sessions that drove counted input into this repo.</summary>
     public int Sessions { get; set; }
 }

--- a/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
+++ b/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
@@ -55,6 +55,11 @@ public static class StatsPageEndpoint
                 // DevThrottle Stats: fleet concurrency (both series: live loaded/running, and actively
                 // working). Null until the aggregator is wired (old callers / tests).
                 concurrency = concurrency?.Snapshot(DateTime.UtcNow),
+                // DevThrottle Stats (private Repos page): the per-repository all-time tally, ranked
+                // most-driven first, so the owner can see where development actually happens. Same
+                // owner-only auth as the rest of this feed; rendered on a SEPARATE page from Your Throttle
+                // so it never rides along when the throttle is shared.
+                repos = aggregator.RepoTotals(),
                 notCaptured = NotCaptured,
             });
         });


### PR DESCRIPTION
## What

A new, **separate** "Repos" page in both the Cockpit and the mobile app: where the owner's development actually happens, ranked by submitted turns. It is deliberately its own page (own route + menu entry), kept apart from **Your Throttle**, because which codebases take the owner's time is private and must never ride along when the shareable throttle is shown.

## How

- **Backend:** `GatewayInputStatsAggregator` now keeps a per-repository all-time tally (turns split voice/typed, character volume, distinct sessions), folded from the *same* high-water deltas as the existing totals - so it never double-counts across a re-push or a Gateway restart - and persisted. Exposed as `repos` on the existing `GET /stats/data` feed (same owner-only auth); no new endpoint.
- **Clients:** a Repos route + menu entry in the Cockpit (System rail) and the mobile nav drawer, reading the shared feed through client-core. Adds a `RepoStat` type and a `summarizeRepos` helper both pages use. A **Turns / Characters / Sessions** toggle re-ranks live; each bar's voice share is shown.

## Honest-only by design

No tokens (never measured - not fabricated) and no time window (the tally is all-time, like the rest of Your Throttle).

## Verification

- Gateway tests: **18 pass** (per-repo attribution, distinct-session dedup, restart survival, `/stats/data` ranking - coexisting with the wingman-usage tests that landed on main).
- client-core: **13 pass** (added `summarizeRepos` math).
- All three web workspaces typecheck clean.
- Rendered both pages live (dev server + stubbed feed) and confirmed the ranked bars and the metric toggle re-ordering.

Rebased cleanly onto the latest `origin/main`, preserving the wingman-usage + time-zone work that merged into the same files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)