### PR TITLE
feat(network-diagnostics): P5 - drift alert (owner email + doorbell)

### DIFF
--- a/src/CcDirector.Gateway.Contracts/DoorbellRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/DoorbellRequest.cs
@@ -54,6 +54,15 @@ public static class DoorbellEvents
     /// the same per-Director event ring so the fleet's existing notification channel carries it.
     /// The accompanying state is the run's infra-status (started / not-started / catch-up / ...).</summary>
     public const string CronRunCompleted = "cron-run-completed";
+
+    /// <summary>A home device has been PERSISTENTLY relaying (drift) instead of a direct LAN path
+    /// (Network Diagnostics mission, P5). Originates in the Gateway's network monitor, rides the same
+    /// event ring as an ambient "your home network is slow" indicator. The accompanying state is the
+    /// drifted device name.</summary>
+    public const string NetworkDrift = "network-drift";
+
+    /// <summary>A previously-drifted home device is back on a direct LAN path (observed recovery).</summary>
+    public const string NetworkRecovered = "network-recovered";
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway.Tests/NetDiagAlertServiceTests.cs
+++ b/src/CcDirector.Gateway.Tests/NetDiagAlertServiceTests.cs
@@ -1,0 +1,132 @@
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Events;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The P5 drift-alert delivery (Network Diagnostics mission). The detector guarantees no false alert; these
+/// tests guard the DELIVERY safety the Architect flagged: the 401 (not-signed-in) path sends no email, the
+/// daily cap prevents spam and resets per day, a "recovered" email only goes to a device we actually warned
+/// about, and the message names the device with the specific fix. The email send is injected so no real
+/// send happens; the fake completes synchronously so the fire-and-forget is deterministic.
+/// </summary>
+public sealed class NetDiagAlertServiceTests
+{
+    private readonly List<(string token, string subject, string body)> _sent = new();
+
+    private NetDiagAlertService Make(string? token = "tok", int cap = 3, Func<DateTime>? now = null) =>
+        new(
+            new DirectorEventLog(),
+            () => token,
+            (t, s, b) => { _sent.Add((t, s, b)); return Task.FromResult(true); },
+            dailyEmailCap: cap,
+            nowUtc: now);
+
+    // ----- message content -----
+
+    [Fact]
+    public void DriftMessage_NamesDeviceAndCarriesTheFixSteps()
+    {
+        Assert.Contains("Phone", NetDiagAlertService.DriftSubject("Phone"));
+        var body = NetDiagAlertService.DriftBodyText("Phone");
+        Assert.Contains("Phone", body);
+        Assert.Contains("local-network access", body);
+        Assert.Contains("exit node", body);
+        Assert.Contains("UPnP", body);
+    }
+
+    [Fact]
+    public void RecoveryMessage_NamesDevice()
+    {
+        Assert.Contains("Phone", NetDiagAlertService.RecoverySubject("Phone"));
+        Assert.Contains("Phone", NetDiagAlertService.RecoveryBodyText("Phone"));
+    }
+
+    // ----- delivery safety -----
+
+    [Fact]
+    public void OnDrift_SignedInUnderCap_SendsOneEmail()
+    {
+        Make().OnDrift("Phone");
+        var one = Assert.Single(_sent);
+        Assert.Contains("Phone", one.subject);
+    }
+
+    [Fact]
+    public void OnDrift_NotSignedIn_SendsNoEmail()
+    {
+        Make(token: null).OnDrift("Phone");
+        Assert.Empty(_sent); // 401-explicit: doorbell only, never a fabricated send
+    }
+
+    // Architect finding 1 regression: a not-signed-in drift must not burn the cap OR mark the device warned,
+    // or a later sign-in + resolve would email a false "recovered" for a drift the owner never received.
+    [Fact]
+    public void OnDrift_NotSignedIn_BurnsNoCapAndMarksNoEpisode()
+    {
+        string? token = null;
+        var s = new NetDiagAlertService(
+            new DirectorEventLog(), () => token,
+            (t, su, b) => { _sent.Add((t, su, b)); return Task.FromResult(true); },
+            dailyEmailCap: 1);
+
+        s.OnDrift("Phone"); // not signed in -> doorbell only
+        Assert.Empty(_sent);
+
+        // (a) episode NOT marked: sign in, resolve -> NO false 'recovered'
+        token = "tok";
+        s.OnResolve("Phone");
+        Assert.Empty(_sent);
+
+        // (b) cap NOT burned: a real signed-in drift still sends under the cap of 1
+        s.OnDrift("Laptop");
+        var one = Assert.Single(_sent);
+        Assert.Contains("Laptop", one.subject);
+    }
+
+    [Fact]
+    public void DailyCap_LimitsEmailsPerDay()
+    {
+        var s = Make(cap: 2);
+        s.OnDrift("A");
+        s.OnDrift("B");
+        s.OnDrift("C"); // over the cap
+        Assert.Equal(2, _sent.Count);
+    }
+
+    [Fact]
+    public void DailyCap_ResetsTheNextDay()
+    {
+        var now = new DateTime(2026, 7, 13, 10, 0, 0, DateTimeKind.Utc);
+        var s = new NetDiagAlertService(
+            new DirectorEventLog(), () => "tok",
+            (t, su, b) => { _sent.Add((t, su, b)); return Task.FromResult(true); },
+            dailyEmailCap: 1, nowUtc: () => now);
+
+        s.OnDrift("A"); // day 1: sends
+        s.OnDrift("B"); // day 1: cap hit, no send
+        Assert.Single(_sent);
+
+        now = now.AddDays(1);
+        s.OnDrift("C"); // day 2: reset, sends
+        Assert.Equal(2, _sent.Count);
+    }
+
+    [Fact]
+    public void OnResolve_OnlyEmailsADeviceWeWarned()
+    {
+        var s = Make();
+
+        s.OnResolve("Phone"); // never warned -> no unsolicited "recovered"
+        Assert.Empty(_sent);
+
+        s.OnDrift("Phone"); // 1 drift email
+        s.OnResolve("Phone"); // recovery email, because we warned
+        Assert.Equal(2, _sent.Count);
+        Assert.Contains("recovered", _sent[1].subject);
+
+        s.OnResolve("Phone"); // episode already closed -> no second recovery email
+        Assert.Equal(2, _sent.Count);
+    }
+}

--- a/src/CcDirector.Gateway/Api/NetDiagAlertService.cs
+++ b/src/CcDirector.Gateway/Api/NetDiagAlertService.cs
@@ -1,0 +1,149 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Events;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The drift-alert channels (Network Diagnostics mission, P5). It delivers the monitor's Decide-machine
+/// outputs - which the machine already emits correctly and false-alert-proof - to two channels:
+///   - an ambient DOORBELL event (an in-app/Cockpit "your home network is slow" indicator), and
+///   - an OWNER EMAIL with the specific fix, naming the drifted device.
+///
+/// Safety, because this is the one place a mistake would put a false "your home is slow" in front of the
+/// owner: it adds NO detection of its own (the machine is the sole source of truth); it is 401-EXPLICIT
+/// (when not signed in there is no account to email from, so the doorbell still fires but NO email is sent
+/// and nothing is fabricated); it caps owner emails per day so a broken-for-hours network cannot spam; it
+/// fires one drift email per EPISODE (the machine's rising edge is already one-shot); and it sends a
+/// "recovered" email ONLY to a device it actually warned about. It never touches the needs-you badge.
+/// Plain English, ASCII, names the device, no fabrication.
+/// </summary>
+public sealed class NetDiagAlertService
+{
+    public const int DefaultDailyEmailCap = 3;
+
+    // A fixed ring key for these gateway-originated network events (they are not tied to a Director/session).
+    private const string RingKey = "network";
+
+    private readonly DirectorEventLog _events;
+    private readonly Func<string, string, string, Task<bool>> _sendEmail; // (token, subject, bodyText) -> sent?
+    private readonly Func<string?> _getToken;
+    private readonly int _dailyEmailCap;
+    private readonly Func<DateTime> _nowUtc;
+
+    private readonly object _gate = new();
+    private DateOnly _emailDay;
+    private int _emailsToday;
+    private readonly HashSet<string> _emailedEpisode = new(StringComparer.Ordinal);
+
+    /// <param name="sendEmail">Sends an owner email (token, subject, bodyText) and returns whether it sent. Production closes over AccountNotifyClient.SendOwnerAsync; tests inject a fake.</param>
+    public NetDiagAlertService(
+        DirectorEventLog events, Func<string?> getToken, Func<string, string, string, Task<bool>> sendEmail,
+        int? dailyEmailCap = null, Func<DateTime>? nowUtc = null)
+    {
+        _events = events ?? throw new ArgumentNullException(nameof(events));
+        _getToken = getToken ?? throw new ArgumentNullException(nameof(getToken));
+        _sendEmail = sendEmail ?? throw new ArgumentNullException(nameof(sendEmail));
+        _dailyEmailCap = dailyEmailCap ?? DefaultDailyEmailCap;
+        _nowUtc = nowUtc ?? (() => DateTime.UtcNow);
+    }
+
+    /// <summary>Persistent home drift for <paramref name="deviceName"/>: doorbell always; owner email if signed in + under the daily cap.</summary>
+    public void OnDrift(string deviceName)
+    {
+        try { _events.Record(RingKey, "", DoorbellEvents.NetworkDrift, deviceName); }
+        catch (Exception ex) { FileLog.Write($"[NetDiagAlert] doorbell drift failed: {ex.Message}"); }
+
+        // 401 FIRST, before touching the cap or the episode set. If not signed in we send only the doorbell
+        // and must NOT burn the daily cap or mark the device "warned" - otherwise a later sign-in + resolve
+        // would email a false "recovered" for a drift the owner never received (Architect review finding 1).
+        var token = _getToken();
+        if (string.IsNullOrEmpty(token))
+        {
+            FileLog.Write($"[NetDiagAlert] drift for {deviceName}: not signed in - doorbell only, no email");
+            return;
+        }
+
+        bool underCap;
+        lock (_gate)
+        {
+            RollDay();
+            underCap = _emailsToday < _dailyEmailCap;
+            if (underCap) _emailsToday++;
+        }
+        if (!underCap)
+        {
+            FileLog.Write($"[NetDiagAlert] drift for {deviceName}: daily email cap ({_dailyEmailCap}) reached - doorbell only");
+            return;
+        }
+
+        // Mark the device "warned" only when the email actually SENDS (inside SendAsync), so
+        // resolve-only-if-warned holds even if the cloud send fails.
+        _ = SendAsync(token, DriftSubject(deviceName), DriftBodyText(deviceName), markWarnedDevice: deviceName);
+    }
+
+    /// <summary>Observed recovery for <paramref name="deviceName"/>: doorbell always; a "recovered" email ONLY if we emailed a drift for it.</summary>
+    public void OnResolve(string deviceName)
+    {
+        try { _events.Record(RingKey, "", DoorbellEvents.NetworkRecovered, deviceName); }
+        catch (Exception ex) { FileLog.Write($"[NetDiagAlert] doorbell recovered failed: {ex.Message}"); }
+
+        bool weWarned;
+        lock (_gate) { weWarned = _emailedEpisode.Remove(deviceName); }
+        if (!weWarned) return; // never send an unsolicited "recovered" - only close the loop we opened
+
+        var token = _getToken();
+        if (string.IsNullOrEmpty(token)) return;
+
+        _ = SendAsync(token, RecoverySubject(deviceName), RecoveryBodyText(deviceName), markWarnedDevice: null);
+    }
+
+    // Sends the owner email; on success, marks markWarnedDevice as "warned" so a later resolve emails a
+    // recovery only for a drift the owner actually received (null for the recovery email itself).
+    private async Task SendAsync(string token, string subject, string bodyText, string? markWarnedDevice)
+    {
+        try
+        {
+            var sent = await _sendEmail(token, subject, bodyText).ConfigureAwait(false);
+            if (sent)
+            {
+                if (markWarnedDevice is not null)
+                    lock (_gate) { _emailedEpisode.Add(markWarnedDevice); }
+                FileLog.Write("[NetDiagAlert] owner email sent to the account owner.");
+            }
+            else
+            {
+                FileLog.Write("[NetDiagAlert] owner email was not sent (cloud declined).");
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[NetDiagAlert] owner email failed: {ex.Message}");
+        }
+    }
+
+    private void RollDay()
+    {
+        var today = DateOnly.FromDateTime(_nowUtc());
+        if (today != _emailDay) { _emailDay = today; _emailsToday = 0; }
+    }
+
+    // ----- pure message content (unit-tested) -----
+
+    public static string DriftSubject(string deviceName) => $"DevThrottle: your home network is slow ({deviceName})";
+
+    public static string DriftBodyText(string deviceName) =>
+        $"{deviceName} has been relaying through a distant server instead of a direct connection on your home network for several minutes.\r\n\r\n" +
+        "This only fires when it persists - a brief slow start when you open the app is normal and is not reported.\r\n\r\n" +
+        "To get back to a fast, direct connection:\r\n" +
+        $"- Keep the DevThrottle app open on {deviceName}.\r\n" +
+        "- In the Tailscale app on that device, make sure it has local-network access.\r\n" +
+        "- Make sure no Tailscale exit node is routing your home traffic.\r\n" +
+        "- On your router, enable UPnP and do not isolate wireless clients, so a direct path can form.\r\n\r\n" +
+        "You will get a follow-up when it is back on a direct path.";
+
+    public static string RecoverySubject(string deviceName) => $"DevThrottle: home network recovered ({deviceName})";
+
+    public static string RecoveryBodyText(string deviceName) =>
+        $"{deviceName} is back on a direct connection on your home network. No action needed.";
+}

--- a/src/CcDirector.Gateway/Api/NetDiagMonitor.cs
+++ b/src/CcDirector.Gateway/Api/NetDiagMonitor.cs
@@ -53,22 +53,30 @@ public sealed class NetDiagMonitor : IDisposable
     private readonly Func<string, string?> _resolveMac;
     private readonly NetDiagDeviceStore? _deviceStore;
     private readonly NetDiagRollupStore? _rollup;
+    private readonly Action<string>? _onDrift;
+    private readonly Action<string>? _onResolve;
     private Timer? _timer;
 
     /// <param name="collect">Gathers the current per-device picture (production: <see cref="TailscaleDiagnostics.Collect"/>).</param>
     /// <param name="resolveMac">Resolves a LAN IP to a MAC (production: <see cref="LanPresenceProbe.TryResolveMac"/>).</param>
     /// <param name="deviceStore">Optional durable store: seeds baselines + presence identity on startup (drift starts fresh).</param>
     /// <param name="rollup">Optional hourly quality rollup: each judged observation folds into it (home/away path split).</param>
+    /// <param name="onDrift">P5: invoked with the device NAME on the rising edge into Drifted (persistent home relay).</param>
+    /// <param name="onResolve">P5: invoked with the device NAME on observed recovery (Drifted -> Ok).</param>
     public NetDiagMonitor(
         Func<TailscaleDiagnostics.NetworkDiag> collect,
         Func<string, string?> resolveMac,
         NetDiagDeviceStore? deviceStore = null,
-        NetDiagRollupStore? rollup = null)
+        NetDiagRollupStore? rollup = null,
+        Action<string>? onDrift = null,
+        Action<string>? onResolve = null)
     {
         _collect = collect ?? throw new ArgumentNullException(nameof(collect));
         _resolveMac = resolveMac ?? throw new ArgumentNullException(nameof(resolveMac));
         _deviceStore = deviceStore;
         _rollup = rollup;
+        _onDrift = onDrift;
+        _onResolve = onResolve;
 
         // Seed baselines + presence identity from the store so a restart does not re-warmup; the drift
         // MachineState is DELIBERATELY not restored - every device starts fresh at Unknown and re-accrues.
@@ -93,14 +101,27 @@ public sealed class NetDiagMonitor : IDisposable
         {
             var diag = _collect();
             var decisions = Tick(diag, _resolveMac, DateTime.UtcNow);
+            var nameByIp = diag.Peers
+                .Where(p => !string.IsNullOrEmpty(p.TailscaleIp))
+                .GroupBy(p => p.TailscaleIp!, StringComparer.Ordinal)
+                .ToDictionary(g => g.Key, g => g.First().Name, StringComparer.Ordinal);
             foreach (var (device, d) in decisions)
             {
+                var name = nameByIp.TryGetValue(device, out var n) && !string.IsNullOrEmpty(n) ? n : device;
                 if (d.ShouldAlert)
-                    FileLog.Write($"[NetDiagMonitor] DRIFT device={device} status={d.Status} (home relaying persistently) - alert channels wired in P5");
+                {
+                    FileLog.Write($"[NetDiagMonitor] DRIFT device={name} (home relaying persistently) - firing alert channels");
+                    try { _onDrift?.Invoke(name); } catch (Exception ex) { FileLog.Write($"[NetDiagMonitor] onDrift failed for {name}: {ex.Message}"); }
+                }
                 else if (d.ShouldResolve)
-                    FileLog.Write($"[NetDiagMonitor] RESOLVED device={device} - direct path restored");
+                {
+                    FileLog.Write($"[NetDiagMonitor] RESOLVED device={name} - direct path restored");
+                    try { _onResolve?.Invoke(name); } catch (Exception ex) { FileLog.Write($"[NetDiagMonitor] onResolve failed for {name}: {ex.Message}"); }
+                }
                 else if (d.Status is "suspect" or "drifted")
-                    FileLog.Write($"[NetDiagMonitor] device={device} status={d.Status}");
+                {
+                    FileLog.Write($"[NetDiagMonitor] device={name} status={d.Status}");
+                }
             }
         }
         catch (Exception ex)

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1663,7 +1663,21 @@ public sealed class GatewayHost : IAsyncDisposable
         // connected device's direct-vs-relay path and log persistent home-relay drift QUIETLY. Alert
         // channels (doorbell + owner email) are wired in P5 onto the same Decide-machine state.
         var netDiagDeviceStore = new Api.NetDiagDeviceStore(Path.Combine(CcStorage.Root(), "netdiag-devices.json"));
-        _netDiagMonitor = new Api.NetDiagMonitor(Api.TailscaleDiagnostics.Collect, Api.LanPresenceProbe.TryResolveMac, netDiagDeviceStore, _netDiagRollup);
+        // P5: deliver the monitor's drift/resolve to the doorbell + owner email. The alert service owns the
+        // 401-explicit "not signed in" path, the daily email cap, and one-email-per-episode; the monitor
+        // just hands it the device name on the machine's rising/falling edges.
+        var netDiagNotify = new Core.Account.AccountNotifyClient(new HttpClient { Timeout = TimeSpan.FromSeconds(30) });
+        var netDiagAlerts = new Api.NetDiagAlertService(
+            DirectorEvents,
+            () => Account?.GetAccessTokenForForwarding(),
+            async (token, subject, bodyText) =>
+            {
+                var r = await netDiagNotify.SendOwnerAsync(token, subject, bodyText, null, null, default).ConfigureAwait(false);
+                return r.Sent;
+            });
+        _netDiagMonitor = new Api.NetDiagMonitor(
+            Api.TailscaleDiagnostics.Collect, Api.LanPresenceProbe.TryResolveMac, netDiagDeviceStore, _netDiagRollup,
+            netDiagAlerts.OnDrift, netDiagAlerts.OnResolve);
         _netDiagMonitor.Start();
     }
 


### PR DESCRIPTION
P5 wires the monitor's Decide-machine ShouldAlert/ShouldResolve to an owner email (naming the device + the specific fix) and a doorbell event, closing the mission WHY: no one silently slow at home. Delivery-only on the watertight detector. Safety: 401-explicit (doorbell only when not signed in, no side effects), daily cap with UTC reset, one email per episode, 'warned' recorded only on a successful send (no false 'recovered'). 8 unit tests; Architect-reviewed (caught+fixed a false-recovered edge). Completes P0-P5; Task 2 deliberately deferred. Follows #1483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)