### PR TITLE
fix(network-diagnostics): P5 hardening - drift is relay-by-construction (no misleading direct-but-slow alert)

### DIFF
--- a/src/CcDirector.Gateway.Tests/NetDiagDriftTests.cs
+++ b/src/CcDirector.Gateway.Tests/NetDiagDriftTests.cs
@@ -155,21 +155,15 @@ public sealed class NetDiagDriftTests
         Assert.False(d.ShouldAlert);
     }
 
-    // ---- secondary (latency) signal: generous margin, and NO presence probe needed (device is LAN-direct) ----
+    // ---- a STILL-DIRECT device is NEVER drift, whatever its latency (P5 hardening: drift == relay only) ----
 
     [Fact]
-    public void DirectButSlightlySlow_WithinMargin_IsOk()
+    public void DirectDevice_IsOk_RegardlessOfLatency()
     {
-        var d = Decide(Obs(true, true, 50, T0, homePresent: true), new MachineState()); // 50 vs 44 baseline
-        Assert.Equal("ok", d.Status);
-    }
-
-    [Fact]
-    public void SecondaryLatencySignal_AccruesWithoutPresenceProbe()
-    {
-        // 200 ms vs a 44 ms baseline exceeds 3x. The device IS LAN-direct (presence self-evident), so it
-        // accrues even though HomeLanPresent is false - the probe is only for the primary relay signal.
-        var d = Decide(Obs(true, true, 200, T0, homePresent: false), new MachineState());
-        Assert.Equal("suspect", d.Status);
+        // Direct on the LAN but slow (200 ms vs a 44 ms baseline) is NOT drift: a relay-framed alert for a
+        // direct device would be a misleading diagnosis (wrong cause + wrong fix). "Direct but slow" shows on
+        // the dashboard's latency trend, never as a drift / relay alert. The machine keys only on path type.
+        Assert.Equal("ok", Decide(Obs(true, true, 200, T0, homePresent: false), new MachineState()).Status);
+        Assert.Equal("ok", Decide(Obs(true, true, 50, T0, homePresent: true), new MachineState()).Status);
     }
 }

--- a/src/CcDirector.Gateway/Api/NetDiagDrift.cs
+++ b/src/CcDirector.Gateway/Api/NetDiagDrift.cs
@@ -28,9 +28,6 @@ public static class NetDiagDrift
     /// <summary>T: drift must persist at least this long (with the cold-start relay window well under it).</summary>
     public static readonly TimeSpan MinDriftDuration = TimeSpan.FromMinutes(5);
 
-    /// <summary>Secondary (latency) signal margin: only flag a still-direct device whose latency exceeds its own baseline by this factor.</summary>
-    public const double LatencyDriftFactor = 3.0;
-
     /// <summary>A device's established "good" state, derived from HOME+DIRECT history only.</summary>
     public sealed record Baseline
     {
@@ -72,6 +69,7 @@ public static class NetDiagDrift
         public Baseline? Baseline { get; init; }
         public bool? CurrentDirect { get; init; }
         public bool CurrentIsLanPath { get; init; }
+        /// <summary>Carried for context/logging only - the drift decision keys on PATH TYPE, never latency (P5 hardening: a direct-but-slow device is not drift). Latency lives in the dashboard trend.</summary>
         public double? CurrentLatencyMs { get; init; }
         /// <summary>
         /// The monitor's POSITIVE physical-presence verdict for a RELAYING device: a best-effort ARP probe
@@ -105,28 +103,26 @@ public static class NetDiagDrift
         if (!obs.TailscaleUp || obs.Baseline is not { IsLanDirect: true })
             return Settle(State.Unknown, "unknown", state);
 
-        var baseline = obs.Baseline;
+        // Drift is RELAY by construction (Architect P5-hardening): a device whose baseline is LAN-direct now
+        // shows a relay / not-direct path. Latency degradation on a STILL-DIRECT device is deliberately NOT
+        // drift - a relay-framed alert (owner email AND the NetworkDrift doorbell) for a direct device is a
+        // MISLEADING diagnosis, wrong cause + wrong fix, which for this mission is as bad as a false one. So
+        // the machine keys ONLY on path type, never latency; "direct but slow" is shown honestly on the
+        // dashboard's latency trend, where the framing is right, and never triggers a relay alert.
+        bool relaying = obs.CurrentDirect == false || !obs.CurrentIsLanPath;
 
-        // PRIMARY drift signal: baseline is LAN-direct, but the device now shows a relay / not-direct path.
-        bool primaryBad = obs.CurrentDirect == false || !obs.CurrentIsLanPath;
-        // SECONDARY: still direct on the LAN, but latency far above its OWN baseline (generous margin so a
-        // 44 ms baseline never flags at 50 ms).
-        bool secondaryBad = obs.CurrentDirect == true && obs.CurrentIsLanPath
-            && obs.CurrentLatencyMs is { } lat && lat > baseline.TypicalLatencyMs * LatencyDriftFactor;
-
-        if (!(primaryBad || secondaryBad))
+        if (!relaying)
             return Settle(State.Ok, "ok", state);
 
         // The crux of the "never a false alert" guarantee. A relaying device that "fell to DERP at home"
         // (DRIFT) and one whose "user left the house" (away, NOT drift) look IDENTICAL on the active path,
         // and tailscale exposes no persistent LAN candidate to tell them apart. No time window can close
-        // this (a departed device's last-seen-home time is frozen at departure). So the PRIMARY (relay)
-        // signal requires the monitor's POSITIVE physical-presence verdict - a best-effort ARP probe to the
-        // device's cached LAN IP that resolves to its SAME cached MAC. Absent / mismatch / probe error =>
-        // UNKNOWN, never alert: we deliberately MISS a home-drift over ever crying wolf, and the in-app pill
-        // catches the missed case the moment the user looks. The SECONDARY (latency) signal already requires
-        // CurrentIsLanPath (the device IS LAN-direct), so presence is self-evident and needs no probe.
-        if (primaryBad && !obs.HomeLanPresent)
+        // this (a departed device's last-seen-home time is frozen at departure). So we require the monitor's
+        // POSITIVE physical-presence verdict - a best-effort ARP probe to the device's cached LAN IP that
+        // resolves to its SAME cached MAC. Absent / mismatch / probe error => UNKNOWN, never alert: we
+        // deliberately MISS a home-drift over ever crying wolf, and the in-app pill catches the missed case
+        // the moment the user looks.
+        if (!obs.HomeLanPresent)
             return Settle(State.Unknown, "unknown", state);
 
         // Bad observation: accrue consecutive count + episode start.


### PR DESCRIPTION
Removes the secondary latency signal from drift accrual, so drift now means an actual relay by construction: a still-direct-but-slow device (noisy Wi-Fi) can never reach the drift state and can never fire the relay-framed owner email or the NetworkDrift doorbell. 'Direct but slow' still shows on the dashboard latency trend. Architect-verified in the Decide code; invariant holds by construction. 81 diag tests green. Follows #1485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)