### PR TITLE
release: v1.1.0 - tunnel-only DevThrottle

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.0.9</Version>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Bumps the product version to 1.1.0 for the first tunnel-only release (Gateway never dials Directors; inbound port closed). After merge, tag v1.1.0 triggers the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)