### PR TITLE
docs(skills): correct dev-throttle and fleet-comms for the tunnel-only fleet

### DIFF
--- a/.claude/skills/dev-throttle/SKILL.md
+++ b/.claude/skills/dev-throttle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-throttle
-description: DevThrottle - "Mission Control for Claude Code". A desktop app (binary cc-director.exe) that runs and supervises multiple Claude Code sessions, ships cc-* CLI tools on PATH, and exposes a REST Control API (default port 7879). Triggers on "/dev-throttle", "/devthrottle", "/cc-director", "what cc tools", "list tools", "available tools", "control api", "devthrottle api", "session manager", "mission control".
+description: DevThrottle - "Mission Control for Claude Code". A desktop app (binary cc-director.exe) that runs and supervises multiple Claude Code sessions and ships cc-* CLI tools on PATH. Agents drive the fleet through the cc-devthrottle command, not by calling the Director over HTTP. Triggers on "/dev-throttle", "/devthrottle", "/cc-director", "what cc tools", "list tools", "available tools", "devthrottle api", "session manager", "mission control".
 ---
 
 # Dev Throttle
@@ -13,9 +13,9 @@ Naming note: DevThrottle is the product/brand. The application binary installed 
 
 ## What DevThrottle is, in three parts
 
-1. **Desktop app** - Windows (primary), with experimental Mac/Linux support. Runs and supervises multiple Claude Code sessions, one per repo, with real-time activity tracking, terminal buffers, voice input, and a web Manager UI.
-2. **Control API** - A REST/JSON API embedded in the desktop app, on port range 7879-7898 (default 7879). Lets external callers list sessions, send prompts, interrupt, fetch terminal buffers, perform programmatic handovers, and post voice commands.
-3. **`cc-*` tool suite** - CLI tools installed on PATH when DevThrottle is set up. Each tool supports `--help` for its full command syntax.
+1. **Desktop app (`cc-director.exe`)** - Windows (primary), with experimental Mac/Linux support. Runs and supervises multiple Claude Code sessions, one per repo, with real-time activity tracking, terminal buffers, and voice input.
+2. **The Gateway** - one machine on the fleet runs a Gateway process that every machine's Director connects OUT to over a persistent two-way stream (internally, "the tunnel"). The Gateway is the single front door for the web Cockpit and the phone app, and the coordination point the whole fleet talks through. Individual Directors are never dialled over the network - they dial out to the Gateway, and everything travels down that stream.
+3. **`cc-*` tool suite** - CLI tools installed on PATH when DevThrottle is set up. Each tool supports `--help` for its full command syntax. The fleet command is `cc-devthrottle`.
 
 ## The cc-* tools (installed on PATH)
 
@@ -27,8 +27,8 @@ All tools are on PATH after install. For exact flags and examples, run any tool 
 ### Email
 `cc-gmail`, `cc-outlook` - read, send, and search Gmail and Outlook from the CLI.
 
-### Web and social
-`cc-browser` (cross-session browser automation with persistent connections), `cc-playwright` (Chromium browser + remote-debug + CDP; the default for form fills, sign-in, OTP, and React forms), `cc-reddit` (human-paced Reddit), `cc-crawl4ai` (clean markdown extraction for RAG), `cc-websiteaudit`, `cc-brandingrecommendations`.
+### Web
+`cc-playwright` (Chromium browser + remote-debug + CDP; the default for form fills, sign-in, OTP, and React forms), `cc-crawl4ai` (clean markdown extraction for RAG), `cc-websiteaudit`, `cc-brandingrecommendations`.
 
 ### Desktop automation
 `cc-click` (Windows UI: click, type, screenshot, OCR), `cc-trisight` (3-tier UI element detection: UIA + OCR + pixel), `cc-computer` (AI desktop agent with screenshot-in-the-loop).
@@ -37,7 +37,7 @@ All tools are on PATH after install. For exact flags and examples, run any tool 
 `cc-image`, `cc-voice` (text-to-speech), `cc-whisper` (audio transcription / translation), `cc-video`, `cc-transcribe`, `cc-photos`, `cc-youtube-info`.
 
 ### Data and utilities
-`cc-vault` (contacts, tasks, goals, docs, RAG), `cc-hardware`, `cc-comm-queue` (queue for outbound email / social with approval), `cc-docgen` (C4 architecture diagrams from YAML).
+`cc-vault` (contacts, tasks, goals, docs, RAG), `cc-hardware`, `cc-docgen` (C4 architecture diagrams from YAML).
 
 ### DevThrottle fleet, schedules, and setup
 `cc-devthrottle` is the unified command for fleet/session operations, inter-session messages, settings, Gateway schedules, and setup:
@@ -53,111 +53,93 @@ cc-devthrottle setup status
 
 A handful of tools are registered but not yet built (`cc-twitter`, `cc-facebook`, `cc-youtube`, `cc-posthog`). If a tool isn't on PATH, it likely isn't built yet.
 
-## Control API at a glance
+## How an agent talks to the fleet: use `cc-devthrottle`, not raw HTTP
 
-REST/JSON on Kestrel. Default base URL: `http://localhost:7879` (the app picks a stable port in 7879-7898 if 7879 is taken). When accessed remotely, the API is fronted on the user's Tailscale tailnet rather than localhost.
+The way to list, message, create, rename, and close sessions from inside a session is the
+`cc-devthrottle` command. It already knows how to reach the fleet: every session is launched with
+`CC_DIRECTOR_API` (its own Director's loopback address) and `CC_SESSION_ID` (its own id) in the
+environment, and `cc-devthrottle` reads them automatically. You never need a Gateway URL or token.
 
-Key endpoints:
+Do NOT try to drive sessions by curling the Director's HTTP port. The Director exposes only a small
+LOOPBACK-ONLY floor (see below) - the old "Control API" that let a caller list/prompt/create/delete
+sessions over HTTP was removed when the fleet moved onto the tunnel. Session control now travels the
+tunnel to the owning Director; the agent-facing surface for it is `cc-devthrottle`.
+
+For the full fleet-messaging and session-spawning command reference, see the **fleet-comms** skill.
+
+### The Director's loopback floor
+
+The Director's own HTTP surface is bound to `127.0.0.1` only (never the LAN or Tailscale) and is now
+a minimal floor - not a general control API. It exists for local health checks, the launcher, and the
+agent-lifecycle hooks, not for driving sessions:
 
 | Method | Endpoint | Purpose |
 |---|---|---|
-| GET | `/healthz` | Health, version, director id, session count |
-| GET | `/` | Session list (JSON), or HTML Manager UI for browsers |
-| GET | `/sessions` | List sessions |
-| GET | `/sessions/{sid}` | Session details |
-| GET | `/sessions/{sid}/buffer` | Terminal output (by line range or since-timestamp) |
-| POST | `/sessions/{sid}/prompt` | Send a prompt to a session |
-| POST | `/sessions/{sid}/interrupt` | Send Ctrl+C |
-| GET | `/sessions/{sid}/turns` | Turn history |
-| POST | `/handover` | Programmatic session handover |
-| POST | `/chat` | Manager chat (LLM-powered analysis of sessions) |
-| POST | `/voice/command` | Voice command input |
-| GET | `/repos` | Registered repositories |
-| POST | `/sessions` | Create a new session |
-| POST | `/sessions/{sid}/request-deletion` | Flag a session for graceful async removal (the safe self-close) |
-| DELETE | `/sessions/{sid}/request-deletion` | Cancel a pending deletion during the grace window |
-| DELETE | `/sessions/{sid}` | Kill and remove a session immediately (do NOT use on yourself) |
+| GET | `/healthz` | Health, version, director id, session/director counts |
+| GET | `/fleet/sessions` | Roster the local Director sees (what `cc-devthrottle session list` reads) |
+| POST | `/fleet/send`, `/fleet/ask` | Fleet messaging relay (used by `cc-devthrottle message`) |
+| POST | `/fleet/spawn` | Spawn on another machine, relayed via the Gateway |
+| POST | `/reconnect` | Bounce this Director's outbound tunnel |
+| POST | `/shutdown` | Ask this Director to stop |
+| GET/PUT | `/settings` (+ agents/tools/workspaces/scheduler) | Local config surface (desktop app + cc-settings-api) |
+| GET/POST | `/sessions/{sid}/fleet-preamble`, `/claude-hook` | Agent-lifecycle IPC (the SessionStart hook calls these) |
 
-## Sample API calls
+"Is the app running / what version?" is the one raw call worth knowing:
 
 ```
-# Health check
-curl http://localhost:7879/healthz
-
-# List sessions as JSON
-curl -H "Accept: application/json" http://localhost:7879/sessions
-
-# Send a prompt to a known session
-curl -X POST http://localhost:7879/sessions/<sid>/prompt \
-  -H "Content-Type: application/json" \
-  -d "{\"text\": \"Fix the bug in auth.js\"}"
+curl http://127.0.0.1:7879/healthz
 ```
+
+Everything else an agent needs goes through `cc-devthrottle`.
 
 ## Creating a session correctly (always name it)
 
-When you create a session through `POST /sessions`, do these four things every time. The Control API
-applies NO defaults of its own - it uses exactly what you send - so an underspecified create produces
-a session that is unnamed, blocked on permission prompts, or on the wrong model.
+Create sessions with `cc-devthrottle session spawn`, not a raw HTTP call. Whichever way you create a
+session, get these right every time - an underspecified session is unnamed, blocked on permission
+prompts, or on the wrong model.
 
-1. **Always give it a meaningful Name.** A session is how a human finds work in Mission Control. On a
+1. **Always give it a meaningful name.** A session is how a human finds work in Mission Control. On a
    fleet where many sessions run in the SAME repo, an unnamed session falls back to the bare repo
    folder name (e.g. "devthrottle") and is indistinguishable from every other session in that repo.
-   The `Name` MUST describe what the session is FOR (e.g. "mobile PWA - impl loop #806"), and it must
-   not be blank or equal to the bare repo folder name. Never create a session without a name.
-2. **Carry the normal permission schema and model in `Args`.** The app's normal launch uses the
-   "Automatic (skip permissions)" preset; the Control API does not add it for you. Pass
-   `Args: "--dangerously-skip-permissions --model opus[1m]"` so the session can act without stopping
-   to ask permission for every read/edit/command, and runs on the model + 1M window you expect.
-   Omitting the preset leaves the session stuck at a "Do you want to proceed?" prompt.
-3. **Use `PrePrompt`** for the session's first task (dispatched once the agent is ready). For a long
-   instruction, write it to a file and make `PrePrompt` a short "read and follow <path>" pointer.
-4. **Verify the name persisted; PATCH if empty.** After creating, read the session back and confirm
-   `name` is set. Some running builds do not honor the create-time `Name` - if it came back empty,
-   set it explicitly: `PATCH /sessions/{sid}` with `{ "Name": "<meaningful name>" }`.
+   Pass `--name` (an explicit display name) or `--purpose` (what the session is FOR, e.g.
+   `implement #806`); the name must describe the work and must not be blank or equal to the bare repo
+   folder name. `spawn` warns when you give neither.
+2. **Carry the normal permission preset and model in `--args`.** The desktop New Session dialog uses
+   the "Automatic (skip permissions)" preset. When you pass no `--args`, `spawn` applies the same
+   default. When you DO pass `--args`, you override it entirely, so include the whole line, e.g.
+   `--args "--dangerously-skip-permissions --model opus[1m]"` - otherwise the session can stall at a
+   "Do you want to proceed?" prompt or run on the wrong model/window.
+3. **Use `--prompt`** for the session's first task (dispatched once the agent is ready). For a long
+   instruction, write it to a file and make `--prompt` a short "read and follow <path>" pointer.
 
 ```
-# Create a properly-named, autonomous-ready session (auth header only when the API requires a token)
-curl -X POST http://localhost:7879/sessions \
-  -H "Content-Type: application/json" \
-  -d "{\"RepoPath\":\"D:/Repos/myrepo\",\"Agent\":\"ClaudeCode\",\"Type\":\"Developer\",\"Name\":\"myrepo - fix auth bug #123\",\"Args\":\"--dangerously-skip-permissions --model opus[1m]\",\"PrePrompt\":\"Fix the bug in auth.js\"}"
-
-# Then verify the name, and PATCH it if the running build returned an empty name:
-curl -X PATCH http://localhost:7879/sessions/<sid> \
-  -H "Content-Type: application/json" -d "{\"Name\":\"myrepo - fix auth bug #123\"}"
+# Create a properly-named, autonomous-ready session
+cc-devthrottle session spawn D:\Repos\myrepo \
+  --name "myrepo - fix auth bug #123" \
+  --args "--dangerously-skip-permissions --model opus[1m]" \
+  --prompt "Fix the bug in auth.js"
 ```
+
+The Director names the session at birth and returns the final id and name. See the **fleet-comms**
+skill for the full flag set (`--agent`, `--role`, `--mission`, `--machine`, `--controlled-by`, and the
+display-name convention).
 
 ## Closing a session (including closing yourself)
 
 A session can close itself. When an agent has finished its work and nothing is waiting on the
 user, it should reap its own session rather than leaving an idle entry in Mission Control.
 
-**Use the graceful self-delete: `POST /sessions/{sid}/request-deletion`.** This flags the session
-for asynchronous removal. The owning Director's deletion reaper removes it on its next sweep
-(about every 30 seconds) once a short grace has passed and the session is no longer working. It
-does NOT kill the caller's process mid-request, so the agent can flag itself and then finish its
-turn normally. The request body is optional: `{ "reason": "..." }`.
-
-Every session already knows how to reach its own Director without any Gateway address or token:
-the environment variable `CC_DIRECTOR_API` holds the local Director's base URL (for example
-`http://127.0.0.1:7879`), and `CC_SESSION_ID` holds the session's own id. So to close yourself:
+**Use `cc-devthrottle session done`.** It flags THIS session (via `CC_SESSION_ID`) for graceful
+asynchronous removal: the owning Director's deletion reaper removes it on its next sweep, once a short
+grace has passed and the session is no longer working. It does NOT kill the caller's process
+mid-request, so you can flag yourself and then finish your turn normally.
 
 ```
-# Close THIS session gracefully (run at the very end of your turn)
-curl -X POST "$CC_DIRECTOR_API/sessions/$CC_SESSION_ID/request-deletion" \
-  -H "Content-Type: application/json" \
-  -d "{\"reason\": \"work complete, nothing waiting on the user\"}"
+# Close THIS session gracefully (run at the very end of your turn, on an unattended run)
+cc-devthrottle session done
 ```
 
-The same call works through the Gateway (`POST {gateway}/sessions/{sid}/request-deletion`), which
-forwards it to the owning Director. That matters when the session you want to reap lives on another
-machine; to close your OWN session, going straight to `CC_DIRECTOR_API` is simplest and needs no
-Gateway token.
-
-Two related endpoints:
-- `DELETE /sessions/{sid}/request-deletion` cancels a pending deletion during the grace window (you
-  changed your mind before the reaper ran).
-- `DELETE /sessions/{sid}` kills and removes a session immediately. Do NOT call this on your own
-  session - it tears down your process mid-request. It is for force-removing OTHER sessions.
+To reap a DIFFERENT session, pass its id or name: `cc-devthrottle session done <target>`.
 
 Do not self-close while something still needs the user (a pending decision, an approval, an
 unanswered question). Reap only when the queue is truly empty.
@@ -173,18 +155,17 @@ use the identity the preamble gave you. If no user is named (nobody signed in), 
 ## When this skill is the right thing to consult
 
 - "What cc-* tools do I have for X?" - look in the tool list above; run the tool with `--help` for syntax.
-- "How do I call DevThrottle from a script?" - point at the Control API section.
-- "Is the app running / what version?" - `curl http://localhost:7879/healthz`.
+- "How do I list / message / create / close sessions?" - use `cc-devthrottle` (details in the fleet-comms skill).
+- "Is the app running / what version?" - `curl http://127.0.0.1:7879/healthz`.
 
 ## What this skill does NOT do
 
 - It does not replace `<tool> --help`, which has the authoritative flags and examples for each tool.
-- It does not document every API endpoint; the table above covers the common ones.
+- It does not replace the **fleet-comms** skill, which is the full reference for `cc-devthrottle`.
 
 ---
 
-**Skill Version:** 4.3 (end-user, DevThrottle rebrand)
-**Last Updated:** 2026-07-11
+**Skill Version:** 5.0 (tunnel-only fleet)
+**Last Updated:** 2026-07-13
+**Changes in 5.0:** Rewritten for the tunnel-only fleet (release v1.1.0, the Gateway Cleanup cut). The Director no longer exposes a general HTTP Control API - it binds a small loopback-only floor, and the Gateway is the single front door the fleet connects out to over the tunnel. Removed the deleted session-driving REST endpoints (list/details/buffer/prompt/interrupt/turns/handover/chat/voice/create/request-deletion/delete) and the curl-the-Director examples. Session create / close / rename / message now documented through `cc-devthrottle` (spawn / done / rename / message), which is the agent-facing surface. Dropped retired tools `cc-browser`, `cc-reddit`, and `cc-comm-queue` from the tool list. Note: some `cc-devthrottle` session verbs (rename, done, local spawn, message send all) are tracked as broken on v1.1.0 in issue #1490 pending the CLI's move off the deleted Director routes.
 **Changes in 4.3:** Added "Who the user is" - the session-start preamble names the signed-in DevThrottle user (email + nickname); "me / my account / email me" means that user unless they say otherwise, and identity must not be guessed from usage or the database (issue #1357).
-**Changes in 4.2:** Added "Closing a session (including closing yourself)" - a session can reap itself with `POST /sessions/{sid}/request-deletion` against its own Director (`CC_DIRECTOR_API` + `CC_SESSION_ID`), the graceful self-delete that does not kill the process mid-turn. Documented the Gateway forward of the same call, the cancel-during-grace endpoint, and that immediate `DELETE /sessions/{sid}` must not be used on yourself. Added these three endpoints to the Control API table.
-**Changes in 4.1:** Added "Creating a session correctly (always name it)" - a created session MUST carry a meaningful Name, the normal permission preset + model in Args (--dangerously-skip-permissions --model opus[1m]), a PrePrompt for its first task, and a verify/PATCH of the name afterwards (the Control API applies no defaults; some running builds do not honor create-time Name).

--- a/.claude/skills/fleet-comms/SKILL.md
+++ b/.claude/skills/fleet-comms/SKILL.md
@@ -72,8 +72,11 @@ important lost. Cheaper and sharper, every phase.
 
 At each phase boundary:
 1. Confirm the current Manager is stood down (its tree is clean, nothing in flight).
-2. Reap it: `curl -X DELETE http://127.0.0.1:7878/sessions/<full-session-id>` (the Gateway routes to
-   whichever Director hosts it), or have the user close its tab. This build has no `session done` verb.
+2. Reap it. To reap ANOTHER session (a Manager reaping a Worker, or you reaping the outgoing
+   Manager), call the Gateway front door: `curl -X DELETE http://127.0.0.1:7878/sessions/<full-session-id>`
+   (the Gateway routes it to whichever Director hosts the session over the tunnel), or have the user
+   close its tab. A session reaps ITSELF with `cc-devthrottle session done`, which flags the current
+   session (`CC_SESSION_ID`) for graceful removal without killing it mid-turn.
 3. Spawn a fresh Manager with a tight brief: `session spawn <repo> --name "<Mission> - Manager"`,
    pointing it at the mission document, stating plainly what is DONE and only THIS phase's goal.
 


### PR DESCRIPTION
## What

The Gateway Cleanup cut (release v1.1.0) removed the Director's general HTTP Control API - the Director now binds a small **loopback-only floor**, and all Gateway-to-Director traffic rides the tunnel. The `dev-throttle` skill still documented the deleted REST surface and told agents to curl the Director to drive sessions; every such call returns 404 on v1.1.0.

Verified live against Director `37cea6e2` (v1.1.0, SOREN_NORTH): `GET /sessions`, `POST /sessions`, `PATCH /sessions/{sid}`, `POST /sessions/{sid}/prompt`, `POST /sessions/{sid}/request-deletion`, `DELETE /sessions/{sid}`, `GET /repos` all 404. Only the floor answers (`/healthz`, `/fleet/*`, `/reconnect`, `/shutdown`, `/settings`, the hook routes).

## Changes

- **`dev-throttle` SKILL.md -> v5.0**: reframed around the loopback floor + the Gateway front door; session create / close / rename now go through `cc-devthrottle session spawn` / `session done` instead of raw HTTP; removed the deleted-endpoint table and curl examples; dropped retired tools `cc-browser`, `cc-reddit`, `cc-comm-queue`.
- **`fleet-comms` SKILL.md**: corrected the stale phase-boundary reap note (it claimed there is no `session done` verb); documented self-reap via `cc-devthrottle session done` and reaping another session through the Gateway `DELETE /sessions/{sid}`.

## Related

Filed **#1490** for the deeper bug this surfaced: the shipped `cc-devthrottle` CLI still calls the deleted Director routes for `rename` / `done` / local `spawn` / `message send all`, so those verbs 404 on v1.1.0. This PR is docs-only; #1490 is the code fix.

## Not touched (needs a decision)

- `docs/public/api/01-control-api.md` (customer-facing) documents the entire deleted Director REST surface. Rewriting it is a product-positioning call - do we present the **Gateway** as the programmatic API, `cc-devthrottle`, or "no public HTTP API"? Left for a follow-up once that is decided.
- The CenCon dev-method skills (`product-agent`, `qa-agent`, `developer-agent`, `implementation-loop`) also reference the Control API for driving the app during development - a separate internal-workflow pass.