### PR TITLE
fix(desktop): Clear All screenshots deletes files on disk after a warning (#1494)

### DIFF
--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -127,6 +127,9 @@ public partial class MainWindow : Window
     private FileSystemWatcher? _screenshotWatcher;
     private DispatcherTimer? _screenshotDebounceTimer;
     private string? _screenshotsDirectory;
+    // The image file types the Screenshots panel loads and clears. Kept in one place so listing
+    // (LoadScreenshotViewModels) and Clear All (DeleteAllScreenshots) agree on what a screenshot is.
+    private static readonly string[] ScreenshotExtensions = { ".png", ".jpg", ".jpeg", ".bmp", ".gif" };
 
     public MainWindow()
     {
@@ -4975,13 +4978,30 @@ public partial class MainWindow : Window
 
     private static List<ScreenshotViewModel> LoadScreenshotViewModels(string directory)
     {
-        var extensions = new[] { ".png", ".jpg", ".jpeg", ".bmp", ".gif" };
         return Directory.GetFiles(directory)
-            .Where(f => extensions.Contains(Path.GetExtension(f).ToLowerInvariant()))
+            .Where(f => ScreenshotExtensions.Contains(Path.GetExtension(f).ToLowerInvariant()))
             .OrderByDescending(f => File.GetLastWriteTime(f))
             .Take(50)
             .Select(f => new ScreenshotViewModel(f))
             .ToList();
+    }
+
+    // Deletes every screenshot image file in the folder from disk and returns how many were removed.
+    // Clear All must delete the files, not just empty the in-memory list: the folder watcher re-reads
+    // the directory on the next change and any surviving file reappears in the panel (issue #1494).
+    private static int DeleteAllScreenshots(string directory)
+    {
+        var files = Directory.GetFiles(directory)
+            .Where(f => ScreenshotExtensions.Contains(Path.GetExtension(f).ToLowerInvariant()))
+            .ToList();
+
+        var deleted = 0;
+        foreach (var file in files)
+        {
+            File.Delete(file);
+            deleted++;
+        }
+        return deleted;
     }
 
     private void OnScreenshotFileChanged(object sender, FileSystemEventArgs e)
@@ -5012,11 +5032,34 @@ public partial class MainWindow : Window
         _ = RefreshScreenshots();
     }
 
-    private void BtnClearScreenshots_Click(object? sender, RoutedEventArgs e)
+    private async void BtnClearScreenshots_Click(object? sender, RoutedEventArgs e)
     {
         FileLog.Write("[MainWindow] BtnClearScreenshots_Click");
-        // Clear from UI only (not from disk)
-        _screenshots.Clear();
+        try
+        {
+            if (_screenshotsDirectory == null)
+                return;
+
+            // Deleting the files is permanent, so warn before destroying data (issue #1494).
+            var confirm = new ConfirmDialog(
+                "Clear all screenshots?",
+                "This permanently deletes every screenshot in this Director's screenshots folder from disk. This cannot be undone.",
+                confirmLabel: "Delete All");
+            if (await confirm.ShowDialog<bool>(this) != true)
+                return;
+
+            var deleted = await Task.Run(() => DeleteAllScreenshots(_screenshotsDirectory));
+            FileLog.Write($"[MainWindow] BtnClearScreenshots_Click: deleted {deleted} file(s)");
+
+            // Re-read from disk so the panel reflects the now-empty folder even if the watcher's
+            // debounced refresh has not fired yet.
+            await RefreshScreenshots();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[MainWindow] BtnClearScreenshots_Click FAILED: {ex.Message}");
+            await new MessageDialog("Cannot Clear Screenshots", ex.Message).ShowDialog<bool?>(this);
+        }
     }
 
     private async void ScreenshotItem_PointerPressed(object? sender, global::Avalonia.Input.PointerPressedEventArgs e)


### PR DESCRIPTION
Fixes #1494.

## Problem

On the desktop Screenshots panel, **Clear All** only emptied the in-memory list; the screenshot files were left on disk. The folder's `FileSystemWatcher` re-read the directory on the next change and the whole list reappeared (as empty rows). The only working delete was the per-item **Del** button.

## Fix

- **Clear All now warns, then deletes.** It shows the existing `ConfirmDialog` ("Clear all screenshots?" / **Delete All** / Cancel, worded as permanent and undoable). On confirm it permanently deletes every screenshot image file in the Director's screenshots folder from disk, then refreshes. Since the files are gone, the watcher no longer brings them back.
- **New `DeleteAllScreenshots` helper** does the disk deletion on a background thread; failures surface loudly in a `MessageDialog` rather than being swallowed.
- **Hoisted the file-extension list** into a shared `ScreenshotExtensions` field so listing (`LoadScreenshotViewModels`) and clearing agree on what counts as a screenshot.

## Testing

- Built to a slot-5 test Director; owner confirmed Clear All now shows the warning and permanently deletes the screenshots (they no longer reappear on refresh). Cancel leaves them untouched.
- `dotnet build` of `CcDirector.Avalonia` against current origin/main: 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)