### PR TITLE
fix(gateway-tunnel): admit large command replies (fixes voice/wingman, History, and mobile roster blinking)

### DIFF
--- a/src/CcDirector.Gateway.Contracts/DirectorUpStreamMessages.cs
+++ b/src/CcDirector.Gateway.Contracts/DirectorUpStreamMessages.cs
@@ -101,6 +101,32 @@ public static class DirectorStreamLimits
     /// infrequent, so the extra chunks are free; the invariant that matters is bounded, no-monopoly framing.
     /// </summary>
     public const int UploadChunkRawBytes = 20 * 1024;
+
+    /// <summary>
+    /// The maximum bytes in a single unary command REPLY (a <see cref="DirectorCommandResult"/> carried back
+    /// over the tunnel as a SignalR client result via InvokeAsync). Unlike the up-stream - which is chunked at
+    /// <see cref="MaxBinaryFrameBytes"/> - a command reply is ONE message: some read verbs (turns, full
+    /// buffer/html) legitimately return the whole structure at once, and for a long-running session that is far
+    /// larger than a single stream frame. The hub's MaximumReceiveMessageSize must therefore admit the LARGER of
+    /// a framed up-stream message and this value; otherwise a big reply tears down the shared tunnel connection
+    /// ("The maximum message size ... was exceeded"), which both 500s the read (voice/explain, History/turns,
+    /// full buffer) AND drops the Director's roster registration - the mobile "blinking". Raising the receive cap
+    /// does NOT weaken streaming backpressure: the up-stream producer still chunks at <see cref="MaxBinaryFrameBytes"/>
+    /// and <see cref="StreamBufferCapacity"/> is unchanged. 32 MB is a generous ceiling for a realistic
+    /// full-history turns or whole-buffer reply while still bounding a single message's memory.
+    /// </summary>
+    public const int MaxCommandReplyBytes = 32 * 1024 * 1024;
+
+    /// <summary>
+    /// The hub's MaximumReceiveMessageSize: the LARGER of a framed up-stream message
+    /// (<see cref="MaxBinaryFrameBytes"/> + <see cref="FrameEnvelopeAllowanceBytes"/>) and a unary command reply
+    /// (<see cref="MaxCommandReplyBytes"/>). One knob bounds every inbound message on the shared tunnel. Kept as
+    /// a single derived constant so the hub option and any future producer share one source of truth.
+    /// </summary>
+    public const int MaxInboundMessageBytes =
+        MaxBinaryFrameBytes + FrameEnvelopeAllowanceBytes > MaxCommandReplyBytes
+            ? MaxBinaryFrameBytes + FrameEnvelopeAllowanceBytes
+            : MaxCommandReplyBytes;
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1017,7 +1017,12 @@ public sealed class GatewayHost : IAsyncDisposable
             .AddMessagePackProtocol()
             .AddHubOptions<Streaming.DirectorHub>(o =>
             {
-                o.MaximumReceiveMessageSize = Contracts.DirectorStreamLimits.MaxBinaryFrameBytes + Contracts.DirectorStreamLimits.FrameEnvelopeAllowanceBytes;
+                // The receive cap must admit the LARGER of a framed up-stream message (chunked at
+                // MaxBinaryFrameBytes) and a single unary command REPLY (turns / full buffer can be MBs, sent as
+                // one client-result message). Using only the frame size tore the tunnel down on any large read
+                // ("maximum message size ... exceeded"), which 500'd voice/History and dropped the roster. The
+                // up-stream producer still chunks at MaxBinaryFrameBytes, so backpressure is unchanged.
+                o.MaximumReceiveMessageSize = Contracts.DirectorStreamLimits.MaxInboundMessageBytes;
                 o.StreamBufferCapacity = Contracts.DirectorStreamLimits.StreamBufferCapacity;
             });
         builder.Services.AddSingleton(PushedSessions);


### PR DESCRIPTION
## Root cause (one bug, proven live)

The tunnel-only cut moved session read verbs (`turns`, full `buffer/html`) onto the SignalR **command-reply** path, but the `DirectorHub` receive limit was still sized for a single up-stream frame: `MaxBinaryFrameBytes` (48K) + envelope = **53,248 bytes**. A command reply is a *single* message, so any real session's `turns`/full `buffer` exceeds it and SignalR closes the whole tunnel connection:

```
[DirectorHub] disconnected ... The maximum message size of 53248B was exceeded.
```

That single connection drop caused **both** live symptoms:
1. `GET /sessions/{sid}/turns` and `POST .../wingman/explain` → **500** → mobile **voice/wingman dead** (explain reads the turns).
2. The dropped Director registration made `FleetRosterCache` go **WOBBLY** → the mobile roster **"blinking."**

Verified against the live v1.1.0 Gateway with real cut-Director sessions: `buffer?lines=5` (small) works; full `buffer` and `turns` (large) 500 with the size-exceeded disconnect in the log.

## Fix

Decouple the command-reply size from the streaming-frame size:
- New `MaxCommandReplyBytes` (32MB) bounds a single unary reply.
- `MaximumReceiveMessageSize` = larger of a framed up-stream message and a command reply (`MaxInboundMessageBytes`).
- The up-stream producer still chunks at `MaxBinaryFrameBytes` and `StreamBufferCapacity` is unchanged, so streaming backpressure is untouched.

## Files
- `src/CcDirector.Gateway.Contracts/DirectorUpStreamMessages.cs` — new constants.
- `src/CcDirector.Gateway/GatewayHost.cs` — hub receive cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)