### PR TITLE
fix(gateway-cleanup): restore session rename and done to the tunnel-only Director floor (#1490)

### DIFF
--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -526,6 +526,96 @@ internal static class ControlEndpoints
             }
         });
 
+        // POST /fleet/rename - rename a session anywhere in the fleet (issue #1490). A local target is renamed
+        // directly; a remote target is relayed through the Gateway (PATCH /sessions/{sid}), which routes the
+        // rename to the owning Director over the tunnel. Restores the CLI `session rename` off the PATCH
+        // /sessions/{sid} route the tunnel-only cut removed from the Director floor. Fails loud (404) for an
+        // unknown target with no Gateway - never a silent no-op.
+        app.MapPost("/fleet/rename", async (FleetRenameRequest req, CancellationToken ct) =>
+        {
+            if (req is null || string.IsNullOrWhiteSpace(req.ToSessionId))
+                return Results.BadRequest(new { error = "toSessionId is required" });
+            if (!Guid.TryParse(req.ToSessionId, out var toGuid))
+                return Results.BadRequest(new { error = "invalid toSessionId format" });
+
+            var local = sessionManager.GetSession(toGuid);
+            if (local is not null)
+            {
+                if (!sessionManager.RenameSession(toGuid, req.Name))
+                    return Results.Json(
+                        new FleetRenameResponse { Renamed = false, SessionId = req.ToSessionId, Error = "rename failed" },
+                        statusCode: StatusCodes.Status500InternalServerError);
+                var dto = MapWithIdentity(local, turnSummaryCache);
+                return Results.Json(new FleetRenameResponse { Renamed = true, SessionId = dto.SessionId ?? "", Name = dto.Name ?? "" });
+            }
+
+            var gw = gatewayClientProvider?.Invoke();
+            if (gw is not { IsEnabled: true })
+                return Results.Json(new FleetRenameResponse
+                {
+                    Renamed = false, SessionId = req.ToSessionId,
+                    Error = "Session not found on this Director and no Gateway is configured.",
+                }, statusCode: StatusCodes.Status404NotFound);
+
+            try
+            {
+                var dto = await gw.RenameFleetAsync(req.ToSessionId, req.Name, ct);
+                return Results.Json(new FleetRenameResponse { Renamed = true, SessionId = dto.SessionId ?? "", Name = dto.Name ?? "" });
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[ControlEndpoints] /fleet/rename relay to {toGuid} FAILED: {ex.Message}");
+                return Results.Json(new FleetRenameResponse
+                {
+                    Renamed = false, SessionId = req.ToSessionId,
+                    Error = $"Cannot rename the target via the Gateway: {ex.Message}",
+                }, statusCode: StatusCodes.Status502BadGateway);
+            }
+        });
+
+        // POST /fleet/done - flag a session anywhere in the fleet for teardown (issue #1490). A local target is
+        // flagged directly (its Director's reaper removes it after the grace window); a remote target is relayed
+        // through the Gateway (POST /sessions/{sid}/request-deletion). Restores `cc-devthrottle session done` -
+        // how an unattended run tears ITSELF down - off the route the tunnel-only cut removed. Fails loud (404)
+        // for an unknown target with no Gateway.
+        app.MapPost("/fleet/done", async (FleetDoneRequest req, CancellationToken ct) =>
+        {
+            if (req is null || string.IsNullOrWhiteSpace(req.ToSessionId))
+                return Results.BadRequest(new { error = "toSessionId is required" });
+            if (!Guid.TryParse(req.ToSessionId, out var toGuid))
+                return Results.BadRequest(new { error = "invalid toSessionId format" });
+
+            var local = sessionManager.GetSession(toGuid);
+            if (local is not null)
+            {
+                local.MarkForDeletion(req.Reason);
+                return Results.Json(new FleetDoneResponse { Accepted = true });
+            }
+
+            var gw = gatewayClientProvider?.Invoke();
+            if (gw is not { IsEnabled: true })
+                return Results.Json(new FleetDoneResponse
+                {
+                    Accepted = false,
+                    Error = "Session not found on this Director and no Gateway is configured.",
+                }, statusCode: StatusCodes.Status404NotFound);
+
+            try
+            {
+                await gw.RequestDeletionFleetAsync(req.ToSessionId, req.Reason, ct);
+                return Results.Json(new FleetDoneResponse { Accepted = true });
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[ControlEndpoints] /fleet/done relay to {toGuid} FAILED: {ex.Message}");
+                return Results.Json(new FleetDoneResponse
+                {
+                    Accepted = false,
+                    Error = $"Cannot reach the target via the Gateway: {ex.Message}",
+                }, statusCode: StatusCodes.Status502BadGateway);
+            }
+        });
+
     }
 
     // Gateway Cleanup CUT RESTORATION (SB-4a): the fleet-directory identity stamp. Restored with the /fleet

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -250,6 +250,50 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
     }
 
     /// <summary>
+    /// Rename a session anywhere in the fleet via the Gateway's PATCH /sessions/{sid}, which routes the
+    /// rename to the owning Director over the tunnel and returns the updated <see cref="SessionDto"/>.
+    /// Issue #1490: the Director's loopback POST /fleet/rename relays here for a non-local target. Throws
+    /// when the Gateway is disabled or the call fails.
+    /// </summary>
+    public async Task<SessionDto> RenameFleetAsync(string toSessionId, string? name, CancellationToken ct = default)
+    {
+        if (!_config.IsEnabled)
+            throw new InvalidOperationException("Gateway is not configured; cannot reach a remote session.");
+        if (string.IsNullOrWhiteSpace(toSessionId))
+            throw new ArgumentException("Target session id is required", nameof(toSessionId));
+
+        FileLog.Write($"[GatewayClient] RenameFleetAsync: PATCH /sessions/{toSessionId}");
+        var body = new SessionUpdateRequest { Name = name };
+        using var resp = await _http.PatchAsJsonAsync($"sessions/{toSessionId}", body, ct);
+        if (!resp.IsSuccessStatusCode)
+            throw new InvalidOperationException($"Gateway rename of {toSessionId} returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+
+        var parsed = await resp.Content.ReadFromJsonAsync<SessionDto>(ct);
+        if (parsed is null)
+            throw new InvalidOperationException("Gateway rename returned an unparsable body.");
+        return parsed;
+    }
+
+    /// <summary>
+    /// Flag a session anywhere in the fleet for teardown via the Gateway's POST /sessions/{sid}/request-deletion,
+    /// which routes to the owning Director over the tunnel. Issue #1490: the Director's loopback POST /fleet/done
+    /// relays here for a non-local target. Throws when the Gateway is disabled or the call fails.
+    /// </summary>
+    public async Task RequestDeletionFleetAsync(string toSessionId, string? reason, CancellationToken ct = default)
+    {
+        if (!_config.IsEnabled)
+            throw new InvalidOperationException("Gateway is not configured; cannot reach a remote session.");
+        if (string.IsNullOrWhiteSpace(toSessionId))
+            throw new ArgumentException("Target session id is required", nameof(toSessionId));
+
+        FileLog.Write($"[GatewayClient] RequestDeletionFleetAsync: POST /sessions/{toSessionId}/request-deletion");
+        var body = new SessionDeletionRequest { Reason = reason };
+        using var resp = await _http.PostAsJsonAsync($"sessions/{toSessionId}/request-deletion", body, ct);
+        if (!resp.IsSuccessStatusCode)
+            throw new InvalidOperationException($"Gateway deletion request for {toSessionId} returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+    }
+
+    /// <summary>
     /// Ask a question to a session anywhere in the fleet and wait for its answer (issue #717), via
     /// the Gateway's POST /sessions/{sid}/prompt with WaitForIdle=true. The Gateway holds the
     /// response open until the target returns to Idle (or the timeout), then returns the captured

--- a/src/CcDirector.Gateway.Contracts/FleetMessageRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/FleetMessageRequest.cs
@@ -107,3 +107,59 @@ public sealed class FleetAskResponse
     /// <summary>Error or timeout message when Answered is false.</summary>
     public string? Error { get; set; }
 }
+
+/// <summary>
+/// Body of POST /fleet/rename on the Director (issue #1490). A session asks its own Director to rename a
+/// session anywhere in the fleet: renamed locally when the target lives on this machine, otherwise relayed
+/// through the Gateway (PATCH /sessions/{sid}), so the fleet token never reaches the calling agent. The
+/// tunnel-only floor restores this off the PATCH /sessions/{sid} route the cut removed from the Director.
+/// </summary>
+public sealed class FleetRenameRequest
+{
+    /// <summary>Target session GUID anywhere in the fleet.</summary>
+    public string ToSessionId { get; set; } = "";
+
+    /// <summary>New custom display name, or empty/null to clear it back to the default (repo folder name).</summary>
+    public string? Name { get; set; }
+}
+
+/// <summary>Response from POST /fleet/rename.</summary>
+public sealed class FleetRenameResponse
+{
+    /// <summary>True when the rename was applied.</summary>
+    public bool Renamed { get; set; }
+
+    /// <summary>The renamed session's GUID.</summary>
+    public string SessionId { get; set; } = "";
+
+    /// <summary>The session's resolved display name after the rename.</summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>Error message when Renamed is false.</summary>
+    public string? Error { get; set; }
+}
+
+/// <summary>
+/// Body of POST /fleet/done on the Director (issue #1490). Flags a session anywhere in the fleet for
+/// asynchronous teardown by its owning Director's deletion reaper: flagged locally when the target lives on
+/// this machine, otherwise relayed through the Gateway (POST /sessions/{sid}/request-deletion). Restores the
+/// CLI self-reap (`cc-devthrottle session done`) off the route the tunnel-only cut removed from the Director.
+/// </summary>
+public sealed class FleetDoneRequest
+{
+    /// <summary>Target session GUID anywhere in the fleet (usually the caller flagging itself).</summary>
+    public string ToSessionId { get; set; } = "";
+
+    /// <summary>Short human reason for the teardown, surfaced while the session winds down. Optional.</summary>
+    public string? Reason { get; set; }
+}
+
+/// <summary>Response from POST /fleet/done.</summary>
+public sealed class FleetDoneResponse
+{
+    /// <summary>True when the session was flagged for deletion.</summary>
+    public bool Accepted { get; set; }
+
+    /// <summary>Error message when Accepted is false.</summary>
+    public string? Error { get; set; }
+}

--- a/src/CcDirector.Gateway.Tests/FleetMessagingTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetMessagingTests.cs
@@ -225,4 +225,55 @@ public sealed class FleetMessagingEndpointTests : IAsyncLifetime
             new NewSessionRequest { RepoPath = @"D:\ReposFred\devthrottle", Machine = "some-other-machine" });
         Assert.Equal(HttpStatusCode.BadGateway, resp.StatusCode);
     }
+
+    // ===== /fleet/rename validation (issue #1490 - route restored to the tunnel-only floor) =====
+
+    // A missing route returns 404, so a 400 from the HANDLER is itself the proof that /fleet/rename is
+    // registered again - the exact gap #1490 was: the CLI's rename 404'd because the route was gone.
+    [Fact]
+    public async Task Fleet_rename_missing_target_returns_400_provingRouteExists()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/rename", new FleetRenameRequest { ToSessionId = "", Name = "x" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Fleet_rename_bad_guid_returns_400()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/rename", new FleetRenameRequest { ToSessionId = "not-a-guid", Name = "x" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Fleet_rename_unknown_target_noGateway_returns_404()
+    {
+        // A well-formed target this Director does not own, with no Gateway: fail loud (404), never a silent no-op.
+        var resp = await _client.PostAsJsonAsync("fleet/rename",
+            new FleetRenameRequest { ToSessionId = Guid.NewGuid().ToString(), Name = "x" });
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    // ===== /fleet/done validation (issue #1490 - the self-reap route restored to the floor) =====
+
+    [Fact]
+    public async Task Fleet_done_missing_target_returns_400_provingRouteExists()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/done", new FleetDoneRequest { ToSessionId = "" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Fleet_done_bad_guid_returns_400()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/done", new FleetDoneRequest { ToSessionId = "not-a-guid" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Fleet_done_unknown_target_noGateway_returns_404()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/done",
+            new FleetDoneRequest { ToSessionId = Guid.NewGuid().ToString() });
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
 }

--- a/tools/cc-devthrottle/src/session_ops.py
+++ b/tools/cc-devthrottle/src/session_ops.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import platform
 import sys
 import tempfile
 import time
@@ -210,7 +209,10 @@ def rename_session(target: Optional[str], new_name: str) -> Dict[str, Any]:
 
     sid = resolve_target_or_current(target)
     try:
-        resp = director.patch_json(f"sessions/{sid}", {"name": name})
+        # Tunnel-only floor (#1490): rename goes through the Director's loopback POST /fleet/rename, which
+        # renames a local session directly or relays a remote one via the Gateway over the tunnel. The old
+        # PATCH /sessions/{sid} route was removed from the Director in the tunnel-only cut.
+        resp = director.post_json("fleet/rename", {"toSessionId": sid, "name": name})
     except director.DirectorError as err:
         console.print(f"[red]Error:[/red] {err}")
         raise typer.Exit(1)
@@ -234,11 +236,14 @@ def mark_done(target: Optional[str], reason: Optional[str]) -> Dict[str, Any]:
     nothing left for the user, instead of lingering as a dead session in the fleet.
     """
     sid = resolve_target_or_current(target)
-    body: Dict[str, Any] = {}
+    body: Dict[str, Any] = {"toSessionId": sid}
     if reason and reason.strip():
         body["reason"] = reason.strip()
     try:
-        resp = director.post_json(f"sessions/{sid}/request-deletion", body)
+        # Tunnel-only floor (#1490): self-reap goes through the Director's loopback POST /fleet/done, which
+        # flags a local session directly or relays a remote one via the Gateway. The old
+        # POST /sessions/{sid}/request-deletion route was removed from the Director in the tunnel-only cut.
+        resp = director.post_json("fleet/done", body)
     except director.DirectorError as err:
         console.print(f"[red]Error:[/red] {err}")
         raise typer.Exit(1)
@@ -424,23 +429,16 @@ def spawn_session(
     if mission:
         body["missionId"] = mission
 
-    # "Start a session on another computer": with no --machine, or a --machine that names THIS machine,
-    # keep the unchanged LOCAL spawn (POST /sessions on the local Director). A remote machine name routes
-    # the spawn through the local Director's POST /fleet/spawn, which forwards it via the Gateway to a
-    # Director on that machine (first available, auto-launched if none is running). An off/unreachable
-    # machine fails loudly (DirectorError -> red error + exit 1) with NO local fallback.
+    # "Start a session on another computer": both local and remote spawns now go through the Director's
+    # loopback POST /fleet/spawn (issue #1490). With no --machine (or a --machine naming THIS machine) the
+    # floor spawns LOCALLY (CreateLocalSessionAsync); a remote machine name is forwarded via the Gateway to a
+    # Director on that machine (first available, auto-launched if none is running). An off/unreachable machine
+    # fails loudly (DirectorError -> red error + exit 1) with NO local fallback. The old POST /sessions route
+    # was removed from the Director floor in the tunnel-only cut.
     target_machine = machine.strip() if machine else ""
-    is_local = (
-        not target_machine
-        or target_machine.lower() == "local"
-        or target_machine.lower() == platform.node().lower()
-    )
 
     try:
-        if is_local:
-            resp = director.post_json("sessions", body)
-        else:
-            resp = director.post_json("fleet/spawn", {"machine": target_machine, **body})
+        resp = director.post_json("fleet/spawn", {"machine": target_machine, **body})
     except director.DirectorError as err:
         console.print(f"[red]Error:[/red] {err}")
         raise typer.Exit(1)


### PR DESCRIPTION
Closes #1490.

## The problem
The tunnel-only cut (v1.1.0) removed the Director's session-write REST routes, but the shipped `cc-devthrottle` command-line tool still called them, so several everyday fleet verbs returned **"HTTP 404 from the Director"**:

- `session rename` - hit the deleted `PATCH /sessions/{sid}`
- `session done` - hit the deleted `POST /sessions/{sid}/request-deletion`; this also broke how unattended and scheduled runs tear themselves down (the documented self-reap)
- `session spawn` (local) - hit the deleted `POST /sessions`

## The fix
Restore them the same way the working fleet verbs (`send` / `ask` / `sessions` / `spawn`) were restored: the command-line tool calls a **loopback-only** route on the local Director, which acts directly for a local target or **relays through the Gateway over the tunnel** for a remote one. No Director listens on a network port; nothing dials a Director directly.

- **ControlEndpoints.cs** - new loopback `POST /fleet/rename` and `POST /fleet/done` (local session acted on directly; remote relayed via the Gateway; unknown target with no Gateway fails loud with 404 - never a silent no-op).
- **GatewayClient.cs** - `RenameFleetAsync` (`PATCH /sessions/{sid}`) and `RequestDeletionFleetAsync` (`POST /sessions/{sid}/request-deletion`) relay methods.
- **FleetMessageRequest.cs** - request/response contracts.
- **session_ops.py** - `rename` -> `/fleet/rename`, `done` -> `/fleet/done`, local `spawn` unified onto `/fleet/spawn`; removed the now-unused `platform` import.
- **FleetMessagingTests.cs** - six regression tests. The 400-validation tests prove the routes now *exist* (a missing route returns 404) - the exact gap that made the verbs 404.

## Deferred (follow-up)
`message send all` (`/fleet/broadcast`, Hub-gated per #1229) and `selftest` - both need the team-broadcast path, so they get their own small change.

## Verification
- Clean build.
- Full `CcDirector.Gateway.Tests`: **2129 passed, 0 failed** (pre-rebase); fleet endpoint suite 17/17 green on the rebased tree.
- Python compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)