### PR TITLE
fix(setup-cli): full macOS support - Mac assets, .app bundle placement, launcher start, tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,24 @@ jobs:
           path: artifacts-mac/cc-director-setup-mac-arm64.zip
           if-no-files-found: error
 
+      # The headless CLI ships for macOS too, so an agent (or a user over ssh) can install and
+      # update every component from the command line without the graphical wizard (issue #1445).
+      # No EnableCompressionInSingleFile on macOS - memory corruption, issue #1442.
+      - name: Publish self-contained setup CLI for macOS arm64
+        run: >
+          dotnet publish tools/cc-director-setup-cli/CcDirector.Setup.Cli.csproj
+          -c Release -r osx-arm64 --self-contained true
+          -p:PublishSingleFile=true
+          -p:IncludeNativeLibrariesForSelfExtract=true
+          --nologo
+
+      - name: Upload macOS setup CLI artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: setup-cli-mac
+          path: tools/cc-director-setup-cli/bin/Release/net10.0/osx-arm64/publish/cc-director-setup-cli
+          if-no-files-found: error
+
   # ---------------------------------------------------------------
   # Job 1c: Build the CC Gateway tray app (Windows)
   # ---------------------------------------------------------------
@@ -647,6 +665,9 @@ jobs:
           # Windows setup CLI (the wizard downloads this to run the elevated Gateway install)
           cp release-artifacts/setup-cli-win/cc-director-setup-cli.exe "$RELEASE_DIR/devthrottle-setup-cli-win-x64.exe"
 
+          # macOS setup CLI (issue #1445: command line install/update on the Mac)
+          cp release-artifacts/setup-cli-mac/cc-director-setup-cli "$RELEASE_DIR/devthrottle-setup-cli-mac-arm64"
+
           echo ""
           echo "Release files:"
           ls -lh "$RELEASE_DIR/"
@@ -669,6 +690,7 @@ jobs:
             cc-launcher-mac-arm64
             devthrottle-setup-win-x64.exe
             devthrottle-setup-cli-win-x64.exe
+            devthrottle-setup-cli-mac-arm64
             cc-python-win-x64.zip
             cc-tools-pyenv-win-x64.zip
             cc-python-macos-arm64.tar.gz

--- a/tools/cc-director-setup-cli.Tests/InstallScopeTests.cs
+++ b/tools/cc-director-setup-cli.Tests/InstallScopeTests.cs
@@ -12,13 +12,13 @@ public class InstallScopeTests
     [Fact]
     public void InstallsPythonTools_GatewayInstall_True()
     {
-        Assert.True(InstallScope.InstallsPythonTools(InstallRole.Gateway, installMode: true, dryRun: false, isWindows: true));
+        Assert.True(InstallScope.InstallsPythonTools(InstallRole.Gateway, installMode: true, dryRun: false));
     }
 
     [Fact]
     public void InstallsPythonTools_WorkstationInstall_True()
     {
-        Assert.True(InstallScope.InstallsPythonTools(InstallRole.Workstation, installMode: true, dryRun: false, isWindows: true));
+        Assert.True(InstallScope.InstallsPythonTools(InstallRole.Workstation, installMode: true, dryRun: false));
     }
 
     [Theory]
@@ -27,17 +27,17 @@ public class InstallScopeTests
     public void InstallsPythonTools_BothRolesAgree(InstallRole role)
     {
         // Role-independent by design: whatever Workstation does, Gateway does too.
-        var gateway = InstallScope.InstallsPythonTools(InstallRole.Gateway, installMode: true, dryRun: false, isWindows: true);
-        var workstation = InstallScope.InstallsPythonTools(InstallRole.Workstation, installMode: true, dryRun: false, isWindows: true);
+        var gateway = InstallScope.InstallsPythonTools(InstallRole.Gateway, installMode: true, dryRun: false);
+        var workstation = InstallScope.InstallsPythonTools(InstallRole.Workstation, installMode: true, dryRun: false);
         Assert.Equal(workstation, gateway);
         // The parameterized role still resolves to the same decision.
-        Assert.True(InstallScope.InstallsPythonTools(role, installMode: true, dryRun: false, isWindows: true));
+        Assert.True(InstallScope.InstallsPythonTools(role, installMode: true, dryRun: false));
     }
 
     [Fact]
     public void InstallsPythonTools_DryRun_False()
     {
-        Assert.False(InstallScope.InstallsPythonTools(InstallRole.Gateway, installMode: true, dryRun: true, isWindows: true));
+        Assert.False(InstallScope.InstallsPythonTools(InstallRole.Gateway, installMode: true, dryRun: true));
     }
 
     [Fact]
@@ -45,13 +45,15 @@ public class InstallScopeTests
     {
         // A plain `update` pass (installMode: false) refreshes apps/tools already present; it does not
         // run the full bundle install step.
-        Assert.False(InstallScope.InstallsPythonTools(InstallRole.Gateway, installMode: false, dryRun: false, isWindows: true));
+        Assert.False(InstallScope.InstallsPythonTools(InstallRole.Gateway, installMode: false, dryRun: false));
     }
 
     [Fact]
-    public void InstallsPythonTools_NonWindows_False()
+    public void InstallsPythonTools_PlatformIndependent_TrueOnInstall()
     {
-        // The shared-venv bundle path here is Windows-only (macOS has its own placement).
-        Assert.False(InstallScope.InstallsPythonTools(InstallRole.Workstation, installMode: true, dryRun: false, isWindows: false));
+        // The decision is platform-independent: PythonToolsInstaller selects the right bundle
+        // assets per platform itself, and the release ships macOS bundles. The old Windows-only
+        // gate silently skipped the cc-* tools on a macOS install (issue #1445).
+        Assert.True(InstallScope.InstallsPythonTools(InstallRole.Workstation, installMode: true, dryRun: false));
     }
 }

--- a/tools/cc-director-setup-cli/Commands.cs
+++ b/tools/cc-director-setup-cli/Commands.cs
@@ -44,13 +44,14 @@ internal static class Commands
     public static int Components(CliArgs args, InstallLayout layout, bool json)
     {
         var components = ScopedComponents(args);
+        var macOs = OperatingSystem.IsMacOS();
         if (json)
         {
             Program.WriteJson(components.Select(c => new
             {
                 id = c.Id,
                 kind = c.Kind.ToString(),
-                asset = c.WindowsAsset,
+                asset = c.AssetFor(macOs),
                 path = layout.PathFor(c),
                 roles = c.Roles.Select(r => r.ToString()).OrderBy(s => s),
             }));
@@ -59,7 +60,7 @@ internal static class Commands
 
         Console.WriteLine($"Components for role '{Role(args)}':");
         foreach (var c in components)
-            Console.WriteLine($"  {c.Id,-14} {c.Kind,-9} {c.WindowsAsset}");
+            Console.WriteLine($"  {c.Id,-14} {c.Kind,-9} {c.AssetFor(macOs) ?? "(no macOS build)"}");
         return Ok;
     }
 
@@ -191,12 +192,44 @@ internal static class Commands
 
         var source = new ReleaseSource();
 
-        var result = new UpdateRunResult { Results = Array.Empty<ApplyResult>() };
+        // macOS: the Director ships as a .app-bundle zip (cc-director-mac-arm64.zip) that the
+        // generic single-file runner cannot place. Route it through MacAppPlacer - the exact step
+        // the setup wizard uses - and hand the rest of the plan to the generic runner. Before this
+        // split the CLI downloaded the WINDOWS Director exe onto macOS (issue #1445).
+        PlanItem? macDirectorItem = null;
+        if (OperatingSystem.IsMacOS())
+        {
+            macDirectorItem = plan.Items.FirstOrDefault(i =>
+                i.ComponentId.Equals(ComponentRegistry.Director.Id, StringComparison.OrdinalIgnoreCase)
+                && i.Kind is PlanItemKind.Install or PlanItemKind.Update);
+            if (macDirectorItem is not null)
+                plan = new UpdatePlan { Items = plan.Items.Where(i => !ReferenceEquals(i, macDirectorItem)).ToList() };
+        }
+
+        var applied = new List<ApplyResult>();
         if (plan.HasWork)
         {
             var runner = new UpdateRunner(layout, components,
                 (item, ct) => source.DownloadAssetAsync(item.AssetName, release.DownloadUrls, ct));
-            result = await runner.ApplyAsync(plan);
+            var runResult = await runner.ApplyAsync(plan);
+            applied.AddRange(runResult.Results);
+        }
+
+        if (macDirectorItem is not null)
+        {
+            var placed = await PlaceMacDirectorAsync(layout, release, source, json);
+            applied.Add(new ApplyResult(
+                ComponentRegistry.Director.Id,
+                placed.Success
+                    ? (macDirectorItem.Kind == PlanItemKind.Update ? ApplyStatus.Updated : ApplyStatus.Installed)
+                    : ApplyStatus.Failed,
+                macDirectorItem.FromVersion, placed.Version ?? macDirectorItem.ToVersion,
+                placed.Success ? null : placed.Message, null));
+        }
+
+        var result = new UpdateRunResult { Results = applied };
+        if (applied.Count > 0)
+        {
             PrintRun(result, installMode, json);
         }
         else if (!isGatewayInstall && !(installMode && Role(args) == InstallRole.Workstation))
@@ -237,7 +270,7 @@ internal static class Commands
         // old workstation-only gate dated from when the Gateway was an elevated Windows service that
         // ran as admin while the venv belonged in the logged-in user's profile; that model is retired.
         var toolsInstalled = false;
-        if (InstallScope.InstallsPythonTools(Role(args), installMode, args.HasFlag("dry-run"), OperatingSystem.IsWindows()))
+        if (InstallScope.InstallsPythonTools(Role(args), installMode, args.HasFlag("dry-run")))
         {
             var py = await new PythonToolsInstaller(layout).InstallAsync(release, source);
             if (json)
@@ -268,6 +301,13 @@ internal static class Commands
                 Console.WriteLine(shortcut ? "Start Menu shortcut: created" : "Start Menu shortcut: skipped (Director not installed)");
             }
         }
+        else if (perUserTouched && OperatingSystem.IsMacOS())
+        {
+            // Wizard parity: make sure ~/.local/bin (the cc-* tool shims) is on the login PATH.
+            var pathChanged = InstallFinalizer.EnsureMacUserBinOnPath();
+            if (!json)
+                Console.WriteLine(pathChanged ? "PATH: added ~/.local/bin (open a new terminal to use the tools)" : "PATH: already set");
+        }
 
         // The Launcher tray app ships to BOTH roles. The generic runner PLACES its exe but never
         // starts it (so a fresh install leaves it dormant and its autostart Run key unwritten). Start
@@ -279,23 +319,47 @@ internal static class Commands
         // the self-update loop on start. Idempotent: an already-running launcher just keeps serving. If
         // the launcher's OWN install failed its exe is absent and we skip (counted in result.Failed below).
         var launcherExe = layout.PathFor(ComponentRegistry.Launcher);
-        if (installMode && OperatingSystem.IsWindows() && File.Exists(launcherExe))
+        if (installMode && File.Exists(launcherExe))
         {
-            var launcherInstaller = new LauncherTrayInstaller(layout);
-            var launcherTray = await launcherInstaller.InstallAsync();
+            // Same contract both platforms: the exe/binary is already placed; this step starts it
+            // and verifies health + autostart registration (Run key on Windows, launch agent on
+            // macOS, where a kickstart hands a running launcher over to the newly placed binary).
+            LauncherInstallResult launcherStart;
+            if (OperatingSystem.IsWindows())
+                launcherStart = await new LauncherTrayInstaller(layout).InstallAsync();
+            else if (OperatingSystem.IsMacOS())
+                launcherStart = await new LauncherMacInstaller(layout).InstallAsync();
+            else
+                throw new PlatformNotSupportedException("The launcher install step supports Windows and macOS only.");
+
             if (json)
-                Program.WriteJson(new { launcherTray = new { success = launcherTray.Success, message = launcherTray.Message, steps = launcherTray.Steps } });
+                Program.WriteJson(new { launcherTray = new { success = launcherStart.Success, message = launcherStart.Message, steps = launcherStart.Steps } });
             else
             {
                 Console.WriteLine();
-                Console.WriteLine(launcherTray.Success ? "Launcher tray app:" : "Launcher tray app FAILED:");
-                foreach (var s in launcherTray.Steps) Console.WriteLine($"  {s}");
-                Console.WriteLine($"  {launcherTray.Message}");
+                Console.WriteLine(launcherStart.Success ? "Launcher tray app:" : "Launcher tray app FAILED:");
+                foreach (var s in launcherStart.Steps) Console.WriteLine($"  {s}");
+                Console.WriteLine($"  {launcherStart.Message}");
             }
-            if (!launcherTray.Success) return Error;
+            if (!launcherStart.Success) return Error;
         }
 
         return result.Failed > 0 ? Error : Ok;
+    }
+
+    /// <summary>
+    /// Place the macOS Director .app bundle via <see cref="MacAppPlacer"/> (download, SHA-256
+    /// verify, ditto-extract, swap into ~/Applications, de-quarantine). Fresh install and update
+    /// are the same operation; the placer records the installed version for the planner.
+    /// </summary>
+    private static async Task<MacAppResult> PlaceMacDirectorAsync(
+        InstallLayout layout, ResolvedRelease release, ReleaseSource source, bool json)
+    {
+        if (!OperatingSystem.IsMacOS())
+            throw new InvalidOperationException("PlaceMacDirectorAsync is macOS-only.");
+        if (!json) Console.WriteLine("Placing CC Director.app:");
+        return await MacAppPlacer.PlaceAsync(layout, release, source,
+            log: m => { if (!json) Console.WriteLine($"  {m}"); });
     }
 
     /// <summary>

--- a/tools/cc-director-setup-cli/InstallScope.cs
+++ b/tools/cc-director-setup-cli/InstallScope.cs
@@ -10,15 +10,17 @@ public static class InstallScope
 {
     /// <summary>
     /// Whether this pass installs the per-user Python tools bundle (the shared venv that carries
-    /// every cc-* tool). True for an install of EITHER role on Windows: the Gateway is a per-user
-    /// tray app (no elevation), so a Gateway install is a true SUPERSET of a Workstation install
-    /// and must include the tools too (INSTALLATION.md section 1). It is deliberately role-INDEPENDENT;
-    /// <paramref name="role"/> is kept in the signature to document and lock that fact (the old
-    /// workstation-only gate dated from when the Gateway was an elevated Windows service).
+    /// every cc-* tool). True for an install of EITHER role on either platform: the Gateway is a
+    /// per-user tray app (no elevation), so a Gateway install is a true SUPERSET of a Workstation
+    /// install and must include the tools too (INSTALLATION.md section 1), and the release ships
+    /// macOS bundles (cc-python-macos-arm64 / cc-tools-pyenv-macos-arm64) that the platform-aware
+    /// PythonToolsInstaller consumes - the old Windows-only gate silently skipped the tools on a
+    /// macOS install (issue #1445). It is deliberately role-INDEPENDENT; <paramref name="role"/>
+    /// is kept in the signature to document and lock that fact.
     /// </summary>
-    public static bool InstallsPythonTools(InstallRole role, bool installMode, bool dryRun, bool isWindows)
+    public static bool InstallsPythonTools(InstallRole role, bool installMode, bool dryRun)
     {
         _ = role; // role-independent by design (see summary); both roles get the tools bundle.
-        return installMode && !dryRun && isWindows;
+        return installMode && !dryRun;
     }
 }

--- a/tools/cc-director-setup-engine.Tests/InstalledStateReaderTests.cs
+++ b/tools/cc-director-setup-engine.Tests/InstalledStateReaderTests.cs
@@ -1,0 +1,46 @@
+using CcDirector.Setup.Engine;
+using Xunit;
+
+namespace CcDirector.Setup.Engine.Tests;
+
+public class InstalledStateReaderTests
+{
+    [Fact]
+    public void DefaultExists_File_True()
+    {
+        var file = Path.Combine(Path.GetTempPath(), $"reader-test-{Guid.NewGuid():N}.bin");
+        File.WriteAllText(file, "x");
+        try
+        {
+            Assert.True(InstalledStateReader.DefaultExists(file));
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public void DefaultExists_Directory_True()
+    {
+        // The macOS Director installs as a .app BUNDLE, which is a directory. Presence
+        // detection must accept it; File.Exists alone reported it "not installed" (issue #1445).
+        var dir = Path.Combine(Path.GetTempPath(), $"reader-test-{Guid.NewGuid():N}.app");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            Assert.True(InstalledStateReader.DefaultExists(dir));
+        }
+        finally
+        {
+            Directory.Delete(dir);
+        }
+    }
+
+    [Fact]
+    public void DefaultExists_Missing_False()
+    {
+        Assert.False(InstalledStateReader.DefaultExists(
+            Path.Combine(Path.GetTempPath(), $"reader-test-{Guid.NewGuid():N}")));
+    }
+}

--- a/tools/cc-director-setup-engine.Tests/OrchestratorTests.cs
+++ b/tools/cc-director-setup-engine.Tests/OrchestratorTests.cs
@@ -59,7 +59,7 @@ public class OrchestratorTests : IDisposable
             var copy = Path.Combine(_dir, "dl-" + Guid.NewGuid().ToString("N"));
             File.Copy(staged, copy);
             return Task.FromResult(copy);
-        });
+        }, macOs: false);
 
         Assert.False(result.NoWork);
         Assert.Equal(1, result.Run!.Installed);

--- a/tools/cc-director-setup-engine.Tests/UpdatePlannerTests.cs
+++ b/tools/cc-director-setup-engine.Tests/UpdatePlannerTests.cs
@@ -42,7 +42,7 @@ public class UpdatePlannerTests
         var manifest = Manifest(
             ("cc-director-win-x64.exe", "0.4.0"),
             ("cc-pdf-win-x64.exe", "1.0.0"));
-        var plan = UpdatePlanner.Plan(components, Installed(), manifest);
+        var plan = UpdatePlanner.Plan(components, Installed(), manifest, macOs: false);
 
         Assert.All(plan.Items.Where(i => i.ComponentId is "director" or "cc-pdf"),
             i => Assert.Equal(PlanItemKind.Install, i.Kind));
@@ -62,7 +62,7 @@ public class UpdatePlannerTests
             ("cc-pdf", "1.1.0"),   // behind -> update
             ("cc-html", "1.1.0")); // current -> up to date
 
-        var plan = UpdatePlanner.Plan(components, installed, manifest);
+        var plan = UpdatePlanner.Plan(components, installed, manifest, macOs: false);
 
         Assert.Equal(PlanItemKind.UpToDate, plan.Items.Single(i => i.ComponentId == "director").Kind);
         Assert.Equal(PlanItemKind.Update, plan.Items.Single(i => i.ComponentId == "cc-pdf").Kind);
@@ -79,7 +79,7 @@ public class UpdatePlannerTests
     {
         var components = ComponentRegistry.Build(["cc-pdf"]);
         var manifest = Manifest(("cc-director-win-x64.exe", "0.4.0")); // no cc-pdf asset
-        var plan = UpdatePlanner.Plan(components, Installed(("director", "0.4.0")), manifest);
+        var plan = UpdatePlanner.Plan(components, Installed(("director", "0.4.0")), manifest, macOs: false);
 
         // cc-pdf has no asset, and (in this minimal manifest) neither do gateway/cockpit.
         Assert.Equal(PlanItemKind.MissingAsset, plan.Items.Single(i => i.ComponentId == "cc-pdf").Kind);
@@ -99,7 +99,7 @@ public class UpdatePlannerTests
         var pins = new UpdatePins();
         pins.Pin("cc-pdf", "1.2.0"); // rolled back from 1.2.0
 
-        var plan = UpdatePlanner.Plan(components, installed, manifest, pins);
+        var plan = UpdatePlanner.Plan(components, installed, manifest, pins, macOs: false);
 
         Assert.Equal(PlanItemKind.Pinned, plan.Items.Single(i => i.ComponentId == "cc-pdf").Kind);
         Assert.Empty(plan.ToUpdate);
@@ -119,7 +119,7 @@ public class UpdatePlannerTests
         var manifest = Manifest(("devthrottle-gateway-win-x64.exe", "0.6.6"));
         var installed = InstalledWithFileVersion("gateway", recordedVersion: "9.9.9", fileVersion: "0.6.5");
 
-        var plan = UpdatePlanner.Plan(components, installed, manifest);
+        var plan = UpdatePlanner.Plan(components, installed, manifest, macOs: false);
 
         var item = plan.Items.Single(i => i.ComponentId == "gateway");
         Assert.NotEqual(PlanItemKind.UpToDate, item.Kind);
@@ -137,7 +137,7 @@ public class UpdatePlannerTests
         var manifest = Manifest(("devthrottle-gateway-win-x64.exe", "0.6.6"));
         var installed = InstalledWithFileVersion("gateway", recordedVersion: "9.9.9", fileVersion: "0.6.6");
 
-        var plan = UpdatePlanner.Plan(components, installed, manifest);
+        var plan = UpdatePlanner.Plan(components, installed, manifest, macOs: false);
 
         var item = plan.Items.Single(i => i.ComponentId == "gateway");
         Assert.Equal(PlanItemKind.UpToDate, item.Kind);
@@ -153,7 +153,7 @@ public class UpdatePlannerTests
         var manifest = Manifest(("devthrottle-gateway-win-x64.exe", "0.6.6"));
         var installed = InstalledWithFileVersion("gateway", recordedVersion: "9.9.9", fileVersion: null);
 
-        var plan = UpdatePlanner.Plan(components, installed, manifest);
+        var plan = UpdatePlanner.Plan(components, installed, manifest, macOs: false);
 
         var item = plan.Items.Single(i => i.ComponentId == "gateway");
         Assert.Equal(PlanItemKind.Update, item.Kind);
@@ -168,10 +168,60 @@ public class UpdatePlannerTests
         var manifest = Manifest(("devthrottle-gateway-win-x64.exe", "0.6.6"));
         var installed = InstalledWithFileVersion("gateway", recordedVersion: "0.6.6", fileVersion: "0.6.6");
 
-        var plan = UpdatePlanner.Plan(components, installed, manifest);
+        var plan = UpdatePlanner.Plan(components, installed, manifest, macOs: false);
 
         var item = plan.Items.Single(i => i.ComponentId == "gateway");
         Assert.Equal(PlanItemKind.UpToDate, item.Kind);
         Assert.Equal("0.6.6", item.FromVersion);
+    }
+
+    // --- Issue #1445: platform-aware asset selection (the macOS install planned Windows exes) ---
+
+    [Fact]
+    public void Plan_MacOs_SelectsMacAssets()
+    {
+        // On macOS the Director is judged against its .app-bundle zip and the launcher against its
+        // mac binary - never the Windows exes. Before the macOs parameter existed, a macOS install
+        // downloaded cc-director-win-x64.exe onto the Mac (issue #1445).
+        var components = new[] { ComponentRegistry.Director, ComponentRegistry.Launcher };
+        var manifest = Manifest(
+            ("cc-director-win-x64.exe", "1.1.0"),
+            ("cc-director-mac-arm64.zip", "1.1.0"),
+            ("cc-launcher-win-x64.exe", "1.1.0"),
+            ("cc-launcher-mac-arm64", "1.1.0"));
+
+        var plan = UpdatePlanner.Plan(components, Installed(), manifest, macOs: true);
+
+        Assert.Equal("cc-director-mac-arm64.zip", plan.Items.Single(i => i.ComponentId == "director").AssetName);
+        Assert.Equal("cc-launcher-mac-arm64", plan.Items.Single(i => i.ComponentId == "cc-launcher").AssetName);
+        Assert.All(plan.Items, i => Assert.Equal(PlanItemKind.Install, i.Kind));
+    }
+
+    [Fact]
+    public void Plan_MacOs_ComponentWithoutMacBuild_BecomesMissingAsset()
+    {
+        // The Gateway has no macOS build (MacAsset is null): on macOS it must plan as
+        // MissingAsset, never fall back to the Windows exe that happens to be in the release.
+        var components = new[] { ComponentRegistry.Gateway };
+        var manifest = Manifest(("devthrottle-gateway-win-x64.exe", "1.1.0"));
+
+        var plan = UpdatePlanner.Plan(components, Installed(), manifest, macOs: true);
+
+        Assert.Equal(PlanItemKind.MissingAsset, plan.Items.Single(i => i.ComponentId == "gateway").Kind);
+    }
+
+    [Fact]
+    public void Plan_PresentWithUnknownVersion_ReappliesInsteadOfUpToDate()
+    {
+        // A hand-placed binary (or a macOS single-file build with no readable version stamp) is
+        // present but of unknown version. Claiming UpToDate would be a fallback that hides the
+        // unknown; the planner re-applies the release so the version gets recorded.
+        var components = new[] { ComponentRegistry.Launcher };
+        var manifest = Manifest(("cc-launcher-mac-arm64", "1.1.0"));
+        var installed = Installed(("cc-launcher", null));
+
+        var plan = UpdatePlanner.Plan(components, installed, manifest, macOs: true);
+
+        Assert.Equal(PlanItemKind.Update, plan.Items.Single(i => i.ComponentId == "cc-launcher").Kind);
     }
 }

--- a/tools/cc-director-setup-engine/Component.cs
+++ b/tools/cc-director-setup-engine/Component.cs
@@ -26,4 +26,12 @@ public sealed record Component(
     string? MacAsset = null)
 {
     public bool InRole(InstallRole role) => Roles.Contains(role);
+
+    /// <summary>
+    /// The release-asset filename for the requested platform: <see cref="MacAsset"/> on macOS
+    /// (null when the component has no macOS build), <see cref="WindowsAsset"/> otherwise.
+    /// The platform is a parameter, not read from the environment, so planning stays pure and
+    /// testable on any development machine.
+    /// </summary>
+    public string? AssetFor(bool macOs) => macOs ? MacAsset : WindowsAsset;
 }

--- a/tools/cc-director-setup-engine/InstalledStateReader.cs
+++ b/tools/cc-director-setup-engine/InstalledStateReader.cs
@@ -3,8 +3,9 @@ namespace CcDirector.Setup.Engine;
 /// <summary>
 /// Reads the installed state (present? which version?) of components from disk.
 /// File existence and version reading are injectable so the logic is testable
-/// without a real filesystem; the default wiring uses <see cref="File.Exists"/>
-/// and the Windows file-version stamp.
+/// without a real filesystem; the default wiring accepts files and directories
+/// (the macOS .app bundle is a directory) and reads the Windows file-version
+/// stamp or the macOS bundle Info.plist version.
 /// </summary>
 public sealed class InstalledStateReader
 {
@@ -20,10 +21,17 @@ public sealed class InstalledStateReader
         InstalledManifest? installed = null)
     {
         _layout = layout ?? throw new ArgumentNullException(nameof(layout));
-        _fileExists = fileExists ?? File.Exists;
+        _fileExists = fileExists ?? DefaultExists;
         _readVersion = readVersion ?? DefaultReadVersion;
         _installed = installed ?? InstalledManifest.Load(layout);
     }
+
+    /// <summary>
+    /// Default presence check. A component can be a single file (every Windows exe, the macOS
+    /// launcher) or a DIRECTORY (the macOS "CC Director.app" bundle), so presence must accept
+    /// both; File.Exists alone reported an installed .app bundle as "not installed".
+    /// </summary>
+    internal static bool DefaultExists(string path) => File.Exists(path) || Directory.Exists(path);
 
     /// <summary>Inspect one component.</summary>
     public InstalledComponent Read(Component component)
@@ -55,23 +63,38 @@ public sealed class InstalledStateReader
     }
 
     /// <summary>
-    /// Default version reader: the Windows product-version stamp on the exe. Only
-    /// meaningful on Windows; returns null elsewhere (the engine treats a null
-    /// version as "present but version unknown", which the planner handles).
+    /// Default version reader: the Windows product-version stamp on the exe, or the
+    /// CFBundleShortVersionString of a macOS .app bundle. A macOS single-file binary
+    /// carries neither, so it reads as null ("present but version unknown", which the
+    /// planner answers by re-applying the release so the version gets recorded).
     /// </summary>
     private static string? DefaultReadVersion(string path)
     {
-        if (!OperatingSystem.IsWindows())
-            return null;
-        try
+        if (OperatingSystem.IsWindows())
         {
-            var info = System.Diagnostics.FileVersionInfo.GetVersionInfo(path);
-            return info.ProductVersion;
+            try
+            {
+                var info = System.Diagnostics.FileVersionInfo.GetVersionInfo(path);
+                return info.ProductVersion;
+            }
+            catch (Exception ex)
+            {
+                EngineLog.Write($"[InstalledStateReader] version read FAILED for {path}: {ex.Message}");
+                return null;
+            }
         }
-        catch (Exception ex)
+
+        // macOS .app bundle: the version lives in Contents/Info.plist. plutil is part of macOS.
+        var plist = Path.Combine(path, "Contents", "Info.plist");
+        if (!OperatingSystem.IsMacOS() || !File.Exists(plist))
+            return null;
+        var (exit, output) = ProcessRunner.Run(
+            "/usr/bin/plutil", $"-extract CFBundleShortVersionString raw \"{plist}\"");
+        if (exit != 0 || string.IsNullOrWhiteSpace(output))
         {
-            EngineLog.Write($"[InstalledStateReader] version read FAILED for {path}: {ex.Message}");
+            EngineLog.Write($"[InstalledStateReader] bundle version read FAILED for {plist} (plutil exit {exit})");
             return null;
         }
+        return output.Trim();
     }
 }

--- a/tools/cc-director-setup-engine/Orchestrator.cs
+++ b/tools/cc-director-setup-engine/Orchestrator.cs
@@ -30,20 +30,23 @@ public sealed class Orchestrator
     /// <summary>
     /// Plan the given components against the manifest and apply any actionable
     /// items. Returns the plan plus the run result (null when there was no work).
+    /// <paramref name="macOs"/> selects which platform's release assets are planned
+    /// (null = the platform this process runs on); tests pin it to stay hermetic.
     /// </summary>
     public async Task<OrchestratorResult> RunAsync(
         IReadOnlyList<Component> components,
         ReleaseManifest manifest,
         UpdateRunner.Downloader downloader,
         UpdatePins? pins = null,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        bool? macOs = null)
     {
         ArgumentNullException.ThrowIfNull(components);
         ArgumentNullException.ThrowIfNull(manifest);
         ArgumentNullException.ThrowIfNull(downloader);
 
         var installed = _reader.ReadAll(components);
-        var plan = UpdatePlanner.Plan(components, installed, manifest, pins);
+        var plan = UpdatePlanner.Plan(components, installed, manifest, pins, macOs);
 
         EngineLog.Write($"[Orchestrator] RunAsync: {components.Count} components, {plan.Actionable.Count} actionable.");
         if (!plan.HasWork)

--- a/tools/cc-director-setup-engine/UpdatePlanner.cs
+++ b/tools/cc-director-setup-engine/UpdatePlanner.cs
@@ -13,25 +13,32 @@ public static class UpdatePlanner
     /// <summary>
     /// Build a plan. <paramref name="installed"/> is keyed by component id; a
     /// component missing from the map is treated as not present.
+    /// <paramref name="macOs"/> selects which platform's release asset each component is judged
+    /// against (null = the platform this process runs on). Passing it explicitly keeps the
+    /// planner pure for tests; before this parameter existed the planner always used the
+    /// Windows asset, which made a macOS install download Windows executables (issue #1445).
     /// </summary>
     public static UpdatePlan Plan(
         IEnumerable<Component> components,
         IReadOnlyDictionary<string, InstalledComponent> installed,
         ReleaseManifest manifest,
-        UpdatePins? pins = null)
+        UpdatePins? pins = null,
+        bool? macOs = null)
     {
         ArgumentNullException.ThrowIfNull(components);
         ArgumentNullException.ThrowIfNull(installed);
         ArgumentNullException.ThrowIfNull(manifest);
         pins ??= new UpdatePins();
+        var mac = macOs ?? OperatingSystem.IsMacOS();
 
         var items = new List<PlanItem>();
         foreach (var c in components)
         {
-            var asset = manifest.TryGetAsset(c.WindowsAsset);
+            var assetName = c.AssetFor(mac);
+            var asset = assetName is null ? null : manifest.TryGetAsset(assetName);
             if (asset is null)
             {
-                items.Add(new PlanItem(c.Id, PlanItemKind.MissingAsset, c.WindowsAsset, null, null, ""));
+                items.Add(new PlanItem(c.Id, PlanItemKind.MissingAsset, assetName ?? c.WindowsAsset, null, null, ""));
                 continue;
             }
 
@@ -74,6 +81,12 @@ public static class UpdatePlanner
             else if (poisonedInstalledVersion && string.IsNullOrWhiteSpace(fromVersion))
                 // Poisoned record AND no readable exe stamp to trust: never report UpToDate on a
                 // version we just discarded - re-apply the released build to correct the state.
+                kind = PlanItemKind.Update;
+            else if (string.IsNullOrWhiteSpace(fromVersion))
+                // Present but no recorded version and no readable stamp (a hand-placed binary, or a
+                // macOS single-file build that carries no Windows version resource): we cannot claim
+                // it matches the release, so re-apply the released build. The apply records the
+                // version in installed.json, so this heals to a normal UpToDate on the next plan.
                 kind = PlanItemKind.Update;
             else
                 kind = PlanItemKind.UpToDate;


### PR DESCRIPTION
Fixes the command line installer on macOS (issue #1445, part of making the Mac fully self-sufficient).

## What was broken

Running `install --role workstation` on macOS downloaded the WINDOWS Director executable and wrote it as a flat file at the .app path; an installed CC Director.app bundle read as "not installed" (File.Exists on a directory); the launcher start step and the Python tools bundle were gated to Windows; and a component present with an unknown version was reported "up to date" - a fallback that hid the unknown.

## The fix

- Platform-aware asset selection: Component.AssetFor(macOs) plus a macOs parameter on UpdatePlanner.Plan and Orchestrator.RunAsync (default: the ambient platform; tests pin it to stay hermetic).
- The CLI routes the macOS Director through MacAppPlacer and starts the launcher via LauncherMacInstaller - the same engine steps the graphical wizard uses, so the two cannot drift.
- InstalledStateReader accepts .app bundle directories and reads the bundle's Info.plist version.
- Present-with-unknown-version now re-applies the release (recording the version) instead of claiming up to date.
- Python tools bundle installs on macOS; ~/.local/bin PATH finalization.
- The release now ships devthrottle-setup-cli-mac-arm64 (added to the completeness guard).

## Proof - live on Sorens-Mac-mini (Apple M4, macOS 26.5)

- plan: director UpToDate (1.1.0, version read from Info.plist - no wasteful re-download), cc-launcher present-with-unknown-version -> Update.
- install --role workstation: launcher Updated (SHA-256 verified, rename-based swap of the RUNNING launcher, launchctl kickstart hand-over, health OK, launch agent verified), 9 Python tools installed from the macOS bundles, ~/.local/bin added to PATH.
- Second plan run: everything UpToDate, Actionable: 0 - idempotent.
- Tests: 3 new planner tests, InstalledStateReader tests, InstallScope platform-independence; existing Windows-fixture tests pinned with macOs: false. Zero new failures against the main baseline on macOS (the ~27 pre-existing Windows-shaped failures in the engine suite are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)