### PR TITLE
feat(snooze): honor a caller-specified snooze duration on the hold endpoint (#1500)

### DIFF
--- a/src/CcDirector.Gateway.Contracts/HoldRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/HoldRequest.cs
@@ -8,6 +8,16 @@ namespace CcDirector.Gateway.Contracts;
 public sealed class HoldRequest
 {
     public bool OnHold { get; set; } = true;
+
+    /// <summary>
+    /// Optional per-call snooze length in whole minutes (issue #1500). When a caller holds a session
+    /// (<see cref="OnHold"/> = true) and supplies a value here, the Gateway arms its snooze timer for
+    /// exactly this many minutes instead of the per-user default (<c>snooze_default_minutes</c>). Null
+    /// keeps the existing behaviour - the Gateway uses the default - so the field is backward
+    /// compatible. Read and validated (1..10080) ONLY by the Gateway hold endpoint; the Director never
+    /// reads it, so this is a Gateway-only capability and needs no Director change.
+    /// </summary>
+    public int? SnoozeMinutes { get; set; }
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway.Tests/SnoozeEndToEndTests.cs
+++ b/src/CcDirector.Gateway.Tests/SnoozeEndToEndTests.cs
@@ -133,6 +133,48 @@ public sealed class SnoozeEndToEndTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Hold_with_an_explicit_duration_records_that_duration_not_the_default()
+    {
+        // Issue #1500: the per-user default is short (1 minute), but the caller asks for a 12-hour snooze.
+        // The Gateway must arm the timer for the REQUESTED length, not the default.
+        await SetDefaultMinutes(1);
+        var fake = await StartFakeAsync("s6", onHold: false);
+
+        var holdResp = await _http.PostAsJsonAsync(
+            "sessions/s6/hold", new HoldRequest { OnHold = true, SnoozeMinutes = 12 * 60 });
+        Assert.Equal(HttpStatusCode.OK, holdResp.StatusCode);
+
+        // The hold still rode the tunnel to the Director, and the recorded snooze-until is ~12 hours out -
+        // clearly the requested length, not the 1-minute default.
+        Assert.True(fake.CurrentOnHold("s6"));
+        var entry = Assert.Single(_gw.SnoozeRegistry.Entries());
+        Assert.Equal("s6", entry.SessionId);
+        var until = entry.SnoozeUntilUtc - DateTime.UtcNow;
+        Assert.InRange(until.TotalMinutes, 12 * 60 - 2, 12 * 60 + 1); // 12 hours, generous tolerance
+    }
+
+    [Fact]
+    public async Task Hold_with_an_out_of_range_duration_is_rejected_and_arms_nothing()
+    {
+        // Issue #1500: a bad length fails loudly (400) and leaves NO side effect - the session is not held
+        // and no timer is armed (no fallback / no silent clamp). MaxMinutes is 7 days (10080).
+        await SetDefaultMinutes(1);
+        var fake = await StartFakeAsync("s7", onHold: false);
+
+        var tooLong = await _http.PostAsJsonAsync(
+            "sessions/s7/hold", new HoldRequest { OnHold = true, SnoozeMinutes = 10081 });
+        Assert.Equal(HttpStatusCode.BadRequest, tooLong.StatusCode);
+
+        var tooShort = await _http.PostAsJsonAsync(
+            "sessions/s7/hold", new HoldRequest { OnHold = true, SnoozeMinutes = 0 });
+        Assert.Equal(HttpStatusCode.BadRequest, tooShort.StatusCode);
+
+        // Neither the Director nor the registry saw anything.
+        Assert.False(fake.CurrentOnHold("s7"));
+        Assert.Empty(_gw.SnoozeRegistry.Entries());
+    }
+
+    [Fact]
     public async Task Watchdog_nudges_the_live_director_off_hold_and_clears_once_confirmed()
     {
         await SetDefaultMinutes(1);

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -1143,6 +1143,20 @@ internal static class GatewayEndpoints
             if (session is null || director is null)
                 return Results.NotFound(new { error = "session not found across any director" });
             var holdReq = req ?? new HoldRequest();
+            // Issue #1500: an explicit per-call snooze length. Validate it BEFORE forwarding the hold, so
+            // a bad value fails loudly (no fallback / no silent clamp) and never parks the session. Null =
+            // use the per-user default (unchanged behaviour). Only the Gateway reads this - the Director
+            // gets the same plain hold it always did, so this stays a Gateway-only capability.
+            if (holdReq.OnHold && holdReq.SnoozeMinutes is int requested
+                && !Core.Configuration.SnoozeDefaultConfig.IsValid(requested))
+            {
+                return Results.BadRequest(new
+                {
+                    error = $"snoozeMinutes must be a whole number of minutes between "
+                            + $"{Core.Configuration.SnoozeDefaultConfig.MinMinutes} and "
+                            + $"{Core.Configuration.SnoozeDefaultConfig.MaxMinutes}"
+                });
+            }
             // Post-cut: tunnel-only. The Ok result's body IS the { onHold } JSON; a null result (Director not
             // connected) or a non-Ok result collapses to 502.
             var streamResult = await DirectorCommandRouter.TrySendAsync(sendCommand, director.DirectorId, "hold", sid, holdReq, ct);
@@ -1154,9 +1168,10 @@ internal static class GatewayEndpoints
             {
                 if (holdReq.OnHold)
                 {
-                    // One snooze length for everyone (the per-user Gateway default) - read now so a
-                    // Settings change applies to the next snooze. No per-snooze duration by design.
-                    var minutes = Core.Configuration.SnoozeDefaultConfig.Get();
+                    // Issue #1500: honour a per-call snooze length when the caller passed one (already
+                    // validated above); otherwise fall back to the per-user default (snooze_default_minutes),
+                    // read now so a Settings change applies to the next snooze.
+                    var minutes = holdReq.SnoozeMinutes ?? Core.Configuration.SnoozeDefaultConfig.Get();
                     snoozeRegistry.Snooze(sid, DateTime.UtcNow.AddMinutes(minutes), director.DirectorId);
                 }
                 else


### PR DESCRIPTION
Closes #1500.

## What

Lets a caller snooze a session for an explicit duration (e.g. 12 hours) instead of only the single per-user default. **Gateway-only change** - no Director change and no cc-director redeploy.

- `HoldRequest` gains an optional nullable `SnoozeMinutes`. Only the Gateway reads it; the Director gets the same plain hold it always did, and unknown JSON members are ignored on deserialize, so an old (un-redeployed) Director is unaffected.
- `POST /sessions/{sid}/hold` validates the value up front (`1..10080` via `SnoozeDefaultConfig.IsValid`) and returns **400** on out-of-range - no silent clamp, no fallback - so a bad value never parks the session. When valid it arms `SnoozeRegistry` for that many minutes; when absent it falls back to the default exactly as before.

Everything else is unchanged: the timer still lives on the Gateway (survives a dead Director), the expiry sweep still returns the session on its own, and the hold is still forwarded to the owning Director over the tunnel.

## How it's called

Any client that already calls the hold endpoint just adds the field:

```
POST /sessions/{sid}/hold   { "onHold": true, "snoozeMinutes": 720 }
```

The user-facing trigger (CLI verb / Car Mode voice / menu picker) is a separate follow-up, per the issue.

## Tests

`SnoozeEndToEndTests` (real `GatewayHost` + fake tunnel Director driving the real endpoint):
- an explicit 12-hour hold records ~12h, not the 1-minute default;
- an out-of-range length (`0` and `10081`) returns 400 and arms nothing.

All 7 snooze end-to-end tests pass locally.