### PR TITLE
fix(setup): Tailscale is not a product requirement - remove it from install preflights

### DIFF
--- a/tools/cc-director-setup-cli/Commands.cs
+++ b/tools/cc-director-setup-cli/Commands.cs
@@ -92,9 +92,12 @@ internal static class Commands
 
     public static int Prereqs(bool json)
     {
+        // Tailscale is deliberately NOT checked: it is not a product requirement. The
+        // tunnel-only architecture means the Director and launcher dial OUT to the Gateway
+        // and no inbound port is ever opened, so nothing on this machine needs a mesh
+        // network, a VPN, or a firewall change.
         var statuses = FrameworkDetector.DetectAll();
         var anyFound = statuses.Any(s => s.Found);
-        var tailscale = TailscalePreflight.Run();
 
         if (json)
         {
@@ -102,13 +105,6 @@ internal static class Commands
             {
                 satisfied = anyFound,
                 frameworks = statuses.Select(s => new { name = s.Name, found = s.Found, location = s.Location }),
-                // Informational (issue #197): remote access needs Tailscale on this machine,
-                // but a local-only Director is legitimate, so this never flips `satisfied`.
-                tailscale = new
-                {
-                    remoteAccessReady = TailscalePreflight.AllOk(tailscale),
-                    checks = tailscale.Select(c => new { check = c.Check, ok = c.Ok, detail = c.Detail, remedy = c.Remedy }),
-                },
             });
             return anyFound ? Ok : PrereqMissing;
         }
@@ -116,12 +112,6 @@ internal static class Commands
         Console.WriteLine("Agent framework check:");
         foreach (var s in statuses)
             Console.WriteLine($"  {s.Name,-8} {(s.Found ? $"found ({s.Location})" : "not found")}");
-
-        Console.WriteLine();
-        Console.WriteLine("Remote access check (Tailscale - needed for the Gateway/Cockpit to reach this machine):");
-        Console.WriteLine(TailscalePreflight.Summary(tailscale));
-        if (!TailscalePreflight.AllOk(tailscale))
-            Console.WriteLine("  Note: without Tailscale the Director still works locally; it just won't appear on a remote Gateway.");
 
         if (!anyFound)
         {
@@ -156,20 +146,6 @@ internal static class Commands
                 if (json) Program.WriteJson(new { mode = "install", role = "gateway", failed = preflight });
                 else Console.Error.WriteLine(preflight);
                 return Error;
-            }
-        }
-
-        // Tailscale preflight (issue #197): detection-only, NEVER blocks. A local-only install is
-        // legitimate; this just tells the user up front - with the exact fix per failed leg - why
-        // the machine would not be reachable from a remote Gateway/Cockpit.
-        if (installMode && !args.HasFlag("dry-run") && !json)
-        {
-            var ts = TailscalePreflight.Run();
-            if (!TailscalePreflight.AllOk(ts))
-            {
-                Console.WriteLine("Remote access (Tailscale) preflight - this machine will NOT be reachable from a remote Gateway until fixed:");
-                Console.WriteLine(TailscalePreflight.Summary(ts));
-                Console.WriteLine();
             }
         }
 

--- a/tools/cc-director-setup-engine/TailscalePreflight.cs
+++ b/tools/cc-director-setup-engine/TailscalePreflight.cs
@@ -7,13 +7,13 @@ namespace CcDirector.Setup.Engine;
 public sealed record TailscaleCheckResult(string Check, bool Ok, string Detail, string? Remedy);
 
 /// <summary>
-/// Detection-only Tailscale preflight for installs (issue #197). A Director is reachable
-/// from the Gateway/Cockpit ONLY through a tailscale serve mapping on its own machine, so
-/// the deployment story is: install Tailscale, install cc-director, set gateway.url - done.
-/// This preflight tells the user up front which of those legs is missing and exactly how
-/// to fix it. It never installs anything and never blocks: a local-only Director (no
-/// Tailscale) is a legitimate state; the Director itself refuses to advertise an endpoint
-/// that does not answer (verify-before-advertise).
+/// Detection-only Tailscale status check, used ONLY by the setup wizard's optional
+/// gateway-role row. Tailscale is NOT a product requirement: the tunnel-only architecture
+/// means every Director and launcher dials OUT to the Gateway and no inbound port is ever
+/// opened, so workstations never need this check at all. On the gateway machine it is an
+/// optional convenience - phones and browsers reaching the Cockpit off-machine need a
+/// secure (HTTPS) address, which Tailscale can provide. It never installs anything and
+/// never blocks.
 ///
 /// Checks, in dependency order (later checks are skipped once one fails):
 ///   1. CLI installed   - tailscale.exe at the standard install path.

--- a/tools/cc-director-setup/Services/PrerequisiteChecker.cs
+++ b/tools/cc-director-setup/Services/PrerequisiteChecker.cs
@@ -7,22 +7,15 @@ public static class PrerequisiteChecker
 {
     public static List<PrerequisiteInfo> CreateChecklist(CcDirector.Setup.Engine.InstallRole role)
     {
-        // Tailscale stays optional and never blocks the install. Only the WHY differs by role:
-        // on the gateway it is what lets a phone or another computer reach this machine securely
-        // (browsers require HTTPS off localhost, and Tailscale supplies that certificate for free);
-        // on a workstation it only matters when the machine leaves the gateway's local network.
-        // Everything runs on this machine at localhost over plain HTTP with no Tailscale, because
-        // browsers treat localhost as already secure.
-        var tailscaleDescription = role == CcDirector.Setup.Engine.InstallRole.Gateway
-            ? "Optional but needed for your phone and other computers to reach this gateway. The "
-              + "mobile app and the Cockpit run in a browser, which requires a secure (HTTPS) "
-              + "connection off this machine - Tailscale provides that automatically and for free. "
-              + "Everything still works on this machine at localhost without it."
-            : "Optional: only needed if you use this machine away from your gateway's local "
-              + "network. On the same network it reaches the gateway directly, with no Tailscale.";
-
-        return
-        [
+        // Tailscale is NOT a product requirement on a workstation - the tunnel-only
+        // architecture means every Director and launcher dials OUT to the Gateway and no
+        // inbound port is ever opened, so a workstation shows no Tailscale row at all.
+        // The one optional use left is on the GATEWAY machine itself: phones and browsers
+        // reaching the Cockpit off-machine need a secure (HTTPS) address, which Tailscale
+        // can provide for free. Everything on the gateway machine itself works at
+        // localhost over plain HTTP without it.
+        var checklist = new List<PrerequisiteInfo>
+        {
             new PrerequisiteInfo
             {
                 Name = ".NET 10 Runtime",
@@ -53,16 +46,26 @@ public static class PrerequisiteChecker
                 IsRequired = true,
                 InstallUrl = "https://nodejs.org/"
             },
-            new PrerequisiteInfo
+        };
+
+        if (role == CcDirector.Setup.Engine.InstallRole.Gateway)
+        {
+            checklist.Add(new PrerequisiteInfo
             {
                 Name = "Tailscale",
-                Description = tailscaleDescription,
+                Description = "Optional, gateway machine only: lets your phone and browsers on "
+                    + "other computers reach this gateway's Cockpit over a secure (HTTPS) "
+                    + "connection. Directors and launchers connect to the gateway on their own "
+                    + "and never need Tailscale. Everything on this machine works at localhost "
+                    + "without it.",
                 IsRequired = false,
                 CanAutoInstall = true,
                 WingetId = "tailscale.Tailscale",
                 InstallUrl = "https://tailscale.com/download"
-            },
-        ];
+            });
+        }
+
+        return checklist;
     }
 
     public static async Task CheckAllAsync(List<PrerequisiteInfo> items)
@@ -258,17 +261,17 @@ public static class PrerequisiteChecker
     }
 
     /// <summary>
-    /// Tailscale preflight (issue #197): remote reachability needs the CLI installed, the
-    /// daemon running/logged in, AND a MagicDNS name. The shared engine check supplies the
-    /// per-leg result with the exact fix; the checklist row shows the first failing leg so
-    /// the user knows WHAT to do, not just that something is off.
+    /// Tailscale status for the OPTIONAL gateway-role row (the workstation checklist has no
+    /// Tailscale row - the tunnel-only architecture needs none). The shared engine check
+    /// supplies the per-leg result; the row shows the first failing leg so the user knows
+    /// what to do if they WANT off-machine Cockpit access.
     /// </summary>
     private static void CheckTailscale(PrerequisiteInfo item)
     {
         var results = CcDirector.Setup.Engine.TailscalePreflight.Run();
         if (CcDirector.Setup.Engine.TailscalePreflight.AllOk(results))
         {
-            // The last check carries the MagicDNS name - the address Directors advertise.
+            // The last check carries the MagicDNS name - the HTTPS address for the Cockpit.
             item.Version = results[^1].Detail;
             item.Status = "Found";
             item.IsFound = true;


### PR DESCRIPTION
Owner directive: Tailscale has nothing to do with the product any more. The tunnel-only architecture means Directors and launchers dial OUT to the Gateway; the Gateway never dials in; no inbound ports are opened anywhere. That zero-network-prerequisite property is the headline benefit of the cutover, and the installers were actively contradicting it.

- Command line installer: the install-time warning ("this machine will NOT be reachable from a remote Gateway until fixed") and the prereqs Tailscale check are gone entirely.
- Windows wizard: the optional Tailscale row now appears ONLY for the Gateway role, reworded as what it really is - an optional convenience so phones and browsers can reach the Cockpit off-machine over HTTPS. Workstation installs see no Tailscale mention at all.
- TailscalePreflight keeps existing for that one optional gateway row, with its obsolete direct-dial architecture claim rewritten.

Verified: CLI builds and is Tailscale-free (one deliberate explanatory comment), WPF wizard builds under EnableWindowsTargeting, CLI tests at the pre-existing baseline (2 Windows-shaped failures, unrelated).

Director-side Tailscale code in src/ (TailscaleServeSelfProvisioner and friends) is the gateway-cleanup mission's dead-code territory and is being flagged to that Architect separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)