### PR TITLE
feat(cockpit): New Session picks the agent, not the model (#1497)

### DIFF
--- a/apps/cockpit/src/sessions/NewSessionDialog.tsx
+++ b/apps/cockpit/src/sessions/NewSessionDialog.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   createSession,
+  getAgents,
   getDirectors,
   getRepos,
   gatewayErrorMessage,
+  type AgentChoice,
   type DirectorInfo,
   type RepoInfo,
 } from "@devthrottle/client-core/api/client";
@@ -14,10 +16,15 @@ import {
 // contract the mobile NewSession flow uses - getDirectors / getRepos / createSession - so both shells
 // create sessions through the one Gateway front door (POST /directors/{id}/sessions).
 //
-// The flow mirrors the mobile two-step:
-//   1. Pick a MACHINE from GET /directors (default-select the most-recently-seen so repos load with
-//      one fewer click).
+// The flow mirrors the desktop New Session dialog:
+//   1. Pick a MACHINE from GET /directors (default-select the most-recently-seen so repos+agents load
+//      with one fewer click).
 //   2. Pick a REPOSITORY from GET /directors/{id}/repos (newest-used first) OR type a path.
+//   3. LAUNCH OPTIONS: pick the AGENT from GET /directors/{id}/agents (that machine's configured,
+//      enabled agents), and choose the permission mode. There is deliberately NO model picker - the
+//      model comes from the chosen agent's own configured default, exactly like the desktop dialog
+//      (issue #1497). The client sends only the agent kind and the Bypass-permissions choice; the
+//      Director applies that agent's configured default model and permission preset.
 // On success the parent is told the new session id so it can refresh the roster and open it.
 
 export interface NewSessionDialogProps {
@@ -27,60 +34,39 @@ export interface NewSessionDialogProps {
   onCreated: (sessionId: string) => void;
 }
 
-// A launch choice: the value we remember (key), what the user reads (label), and the exact command-line
-// fragment it contributes (arg - empty string means "add nothing", which is the Director's own default).
-interface LaunchChoice {
+// Permission choices, mapped to the desktop dialog's "Bypass permission prompts" checkbox. "Skip
+// permission prompts" is the desktop default (the checkbox defaults to ON), so it is first / pre-selected.
+// Neither adds a command-line argument on the client: the choice is sent as a structured flag and the
+// Director resolves the agent's configured launch line accordingly, so the model is unaffected either way.
+interface PermissionChoice {
   key: string;
   label: string;
-  arg: string;
+  bypass: boolean;
 }
-
-// Model choices. "Default" adds no argument, so the Director launches the agent's built-in default model;
-// the others pass "--model <name>" exactly (issue #1243).
-const MODEL_CHOICES: LaunchChoice[] = [
-  { key: "default", label: "Default", arg: "" },
-  { key: "opus", label: "Opus", arg: "--model opus" },
-  { key: "sonnet", label: "Sonnet", arg: "--model sonnet" },
+const PERMISSION_CHOICES: PermissionChoice[] = [
+  { key: "skip", label: "Skip permission prompts", bypass: true },
+  { key: "ask", label: "Ask for permissions", bypass: false },
 ];
 
-// Permission choices. "Ask for permissions" adds no argument (the agent stops for each permission prompt);
-// "Skip permission prompts" passes --dangerously-skip-permissions so the session starts working at once.
-// We do not steer the user toward either - the default selection is simply their last-used choice.
-const PERMISSION_CHOICES: LaunchChoice[] = [
-  { key: "ask", label: "Ask for permissions", arg: "" },
-  { key: "skip", label: "Skip permission prompts", arg: "--dangerously-skip-permissions" },
-];
-
-const MODEL_STORAGE_KEY = "cockpit.newSession.model";
+const AGENT_STORAGE_KEY = "cockpit.newSession.agent";
 const PERMISSION_STORAGE_KEY = "cockpit.newSession.permission";
 
-// Read the last-used choice key from localStorage, falling back to the first choice when nothing was
-// stored or the stored key no longer matches a known choice.
-function loadChoiceKey(storageKey: string, choices: LaunchChoice[]): string {
+// Read a remembered string from localStorage, or null when unavailable/absent (private mode is fine).
+function loadStored(storageKey: string): string | null {
   try {
-    const saved = window.localStorage.getItem(storageKey);
-    if (saved && choices.some((c) => c.key === saved)) return saved;
+    return window.localStorage.getItem(storageKey);
   } catch {
-    /* localStorage can be unavailable (private mode); fall back to the first choice */
+    return null;
   }
-  return choices[0].key;
 }
 
-// Save the chosen key so the next open of the dialog pre-selects it.
-function saveChoiceKey(storageKey: string, key: string): void {
+// Save a chosen value so the next open pre-selects it. Best-effort (private mode may reject it).
+function saveStored(storageKey: string, value: string): void {
   try {
-    window.localStorage.setItem(storageKey, key);
+    window.localStorage.setItem(storageKey, value);
   } catch {
     /* localStorage can be unavailable (private mode); remembering the choice is best-effort */
   }
-}
-
-// Assemble the launch-argument string from the two chosen fragments, dropping the empty ("default")
-// ones. Returns "" when both are default, so createSession sends no "args" at all.
-function buildLaunchArgs(modelKey: string, permissionKey: string): string {
-  const model = MODEL_CHOICES.find((c) => c.key === modelKey);
-  const permission = PERMISSION_CHOICES.find((c) => c.key === permissionKey);
-  return [model?.arg ?? "", permission?.arg ?? ""].filter((a) => a.length > 0).join(" ");
 }
 
 function directorLabel(d: DirectorInfo): string {
@@ -94,6 +80,15 @@ function repoLabel(r: RepoInfo): string {
   return parts.length ? parts[parts.length - 1] : r.path;
 }
 
+// The one-line summary of what will launch, e.g. "Claude Code . Opus 4.8 . skips permission prompts".
+// Mirrors the desktop dialog telling you the agent and the model it will use (issue #1497).
+function launchSummary(agent: AgentChoice | null, bypass: boolean): string {
+  if (agent === null) return "Pick an agent above.";
+  const model = agent.modelLabel.trim() || "its default model";
+  const permission = bypass ? "skips permission prompts" : "asks for permissions";
+  return `${agent.displayName} . ${model} . ${permission}`;
+}
+
 export function NewSessionDialog({ onClose, onCreated }: NewSessionDialogProps) {
   const [directors, setDirectors] = useState<DirectorInfo[] | null>(null);
   const [directorsError, setDirectorsError] = useState<string | null>(null);
@@ -102,23 +97,32 @@ export function NewSessionDialog({ onClose, onCreated }: NewSessionDialogProps) 
   const [repos, setRepos] = useState<RepoInfo[] | null>(null);
   const [reposStatus, setReposStatus] = useState("Pick a machine first.");
 
+  // The selected machine's configured agents (issue #1497), loaded like the repos when the machine
+  // changes. `agentsStatus` carries the loading / empty / error line for the agent picker.
+  const [agents, setAgents] = useState<AgentChoice[] | null>(null);
+  const [agentsStatus, setAgentsStatus] = useState<string | null>(null);
+  const [selectedAgentType, setSelectedAgentType] = useState<string | null>(null);
+
   const [manualPath, setManualPath] = useState("");
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
 
-  // Launch options, pre-selected from the last-used choice (issue #1243). Lazy initial state reads
-  // localStorage exactly once.
-  const [modelKey, setModelKey] = useState(() => loadChoiceKey(MODEL_STORAGE_KEY, MODEL_CHOICES));
-  const [permissionKey, setPermissionKey] = useState(() =>
-    loadChoiceKey(PERMISSION_STORAGE_KEY, PERMISSION_CHOICES),
-  );
-  const launchArgs = buildLaunchArgs(modelKey, permissionKey);
+  // Permission mode, pre-selected from the last-used choice (default: Skip, matching the desktop
+  // Bypass-permissions checkbox default of ON).
+  const [permissionKey, setPermissionKey] = useState(() => {
+    const saved = loadStored(PERMISSION_STORAGE_KEY);
+    return saved && PERMISSION_CHOICES.some((c) => c.key === saved) ? saved : PERMISSION_CHOICES[0].key;
+  });
+  const permission = PERMISSION_CHOICES.find((c) => c.key === permissionKey) ?? PERMISSION_CHOICES[0];
 
-  // Guards against a stale repo response landing after the user switched machines.
+  const selectedAgent = agents?.find((a) => a.type === selectedAgentType) ?? null;
+
+  // Guards against a stale repo/agent response landing after the user switched machines.
   const reposReqRef = useRef(0);
+  const agentsReqRef = useRef(0);
 
   // Step 1: load the machines once, default-selecting the most-recently-seen (directors[0]) so the
-  // repos load immediately (mobile NewSession / Android OpenNewSessionPanelAsync parity).
+  // repos and agents load immediately (desktop New Session parity).
   useEffect(() => {
     const controller = new AbortController();
     getDirectors(controller.signal)
@@ -154,9 +158,38 @@ export function NewSessionDialog({ onClose, onCreated }: NewSessionDialogProps) 
       .catch((err) => {
         if (controller.signal.aborted || reqId !== reposReqRef.current) return;
         setRepos([]);
-        setReposStatus(
-          `Could not load repos: ${gatewayErrorMessage(err)}`,
-        );
+        setReposStatus(`Could not load repos: ${gatewayErrorMessage(err)}`);
+      });
+    return () => controller.abort();
+  }, [selectedId]);
+
+  // Step 3: whenever the selected machine changes, load THAT machine's configured agents (issue #1497).
+  // Default-select the last-used agent when it is still offered, else the first - mirroring the desktop
+  // dialog, which pre-selects the first enabled agent.
+  useEffect(() => {
+    if (!selectedId) return;
+    const controller = new AbortController();
+    const reqId = ++agentsReqRef.current;
+    setAgents(null);
+    setSelectedAgentType(null);
+    setAgentsStatus("Loading agents...");
+    getAgents(selectedId, controller.signal)
+      .then((list) => {
+        if (reqId !== agentsReqRef.current) return; // a newer selection superseded this one
+        setAgents(list);
+        if (list.length === 0) {
+          setAgentsStatus("No agents configured on this machine.");
+          return;
+        }
+        setAgentsStatus(null);
+        const remembered = loadStored(AGENT_STORAGE_KEY);
+        const pick = list.find((a) => a.type === remembered) ?? list[0];
+        setSelectedAgentType(pick.type);
+      })
+      .catch((err) => {
+        if (controller.signal.aborted || reqId !== agentsReqRef.current) return;
+        setAgents([]);
+        setAgentsStatus(`Could not load agents: ${gatewayErrorMessage(err)}`);
       });
     return () => controller.abort();
   }, [selectedId]);
@@ -182,13 +215,24 @@ export function NewSessionDialog({ onClose, onCreated }: NewSessionDialogProps) 
         setCreateError("Enter a repo path, or click a recent repo above.");
         return;
       }
+      // The agent is required when the machine offers a list; fall back to Claude Code only when the
+      // list could not be loaded, so the dialog still works if the agents read failed.
+      if (agents !== null && agents.length > 0 && !selectedAgentType) {
+        setCreateError("Pick an agent below.");
+        return;
+      }
+      const agentType = selectedAgentType ?? "ClaudeCode";
       setCreating(true);
       setCreateError(null);
-      // Remember the choices so the next open pre-selects them (issue #1243).
-      saveChoiceKey(MODEL_STORAGE_KEY, modelKey);
-      saveChoiceKey(PERMISSION_STORAGE_KEY, permissionKey);
+      // Remember the choices so the next open pre-selects them.
+      saveStored(AGENT_STORAGE_KEY, agentType);
+      saveStored(PERMISSION_STORAGE_KEY, permissionKey);
       try {
-        const session = await createSession(selectedId, path, launchArgs);
+        const session = await createSession(selectedId, path, {
+          agent: agentType,
+          bypassPermissions: permission.bypass,
+          signal: undefined,
+        });
         const sid = session.sessionId;
         if (!sid) throw new Error("The created session had no id.");
         onCreated(sid);
@@ -199,7 +243,7 @@ export function NewSessionDialog({ onClose, onCreated }: NewSessionDialogProps) 
         setCreating(false);
       }
     },
-    [creating, selectedId, onCreated, launchArgs, modelKey, permissionKey],
+    [creating, selectedId, agents, selectedAgentType, permission.bypass, permissionKey, onCreated],
   );
 
   return (
@@ -297,27 +341,31 @@ export function NewSessionDialog({ onClose, onCreated }: NewSessionDialogProps) 
             </div>
           </div>
 
-          {/* Step 3: launch options (model and permission mode), remembered across uses */}
+          {/* Step 3: launch options (agent and permission mode), remembered across uses. No model
+              picker - the model comes from the chosen agent's own configured default (issue #1497). */}
           <div className="newsess-step">
             <div className="newsess-step-label">3. Launch options</div>
 
-            <div className="newsess-opt-label" id="newsess-model-label">
-              Model
+            <div className="newsess-opt-label" id="newsess-agent-label">
+              Agent
             </div>
-            <div className="newsess-seg" role="group" aria-labelledby="newsess-model-label">
-              {MODEL_CHOICES.map((c) => (
-                <button
-                  key={c.key}
-                  type="button"
-                  className={`newsess-seg-btn${c.key === modelKey ? " sel" : ""}`}
-                  aria-pressed={c.key === modelKey}
-                  disabled={creating}
-                  onClick={() => setModelKey(c.key)}
-                >
-                  {c.label}
-                </button>
-              ))}
-            </div>
+            {agentsStatus !== null && <div className="newsess-status">{agentsStatus}</div>}
+            {agents !== null && agents.length > 0 && (
+              <div className="newsess-seg" role="group" aria-labelledby="newsess-agent-label">
+                {agents.map((a) => (
+                  <button
+                    key={a.type}
+                    type="button"
+                    className={`newsess-seg-btn${a.type === selectedAgentType ? " sel" : ""}`}
+                    aria-pressed={a.type === selectedAgentType}
+                    disabled={creating}
+                    onClick={() => setSelectedAgentType(a.type)}
+                  >
+                    {a.displayName}
+                  </button>
+                ))}
+              </div>
+            )}
 
             <div className="newsess-opt-label" id="newsess-permission-label">
               Permission mode
@@ -337,9 +385,9 @@ export function NewSessionDialog({ onClose, onCreated }: NewSessionDialogProps) 
               ))}
             </div>
 
-            <div className="newsess-opt-label">Arguments passed to the session</div>
+            <div className="newsess-opt-label">This session will start as</div>
             <div className="newsess-args mono" aria-live="polite">
-              {launchArgs.length > 0 ? launchArgs : "(none - default model, asks for permissions)"}
+              {launchSummary(selectedAgent, permission.bypass)}
             </div>
           </div>
 

--- a/packages/client-core/src/api/client.ts
+++ b/packages/client-core/src/api/client.ts
@@ -59,6 +59,21 @@ export interface RepoInfo {
   lastUsed: string;
 }
 
+// One selectable agent on a Director, projected from GET /directors/{id}/agents (issue #1497): the
+// machine's configured, enabled agents, one per kind - the remote counterpart of the desktop New
+// Session dialog's agent radios. Not in the OpenAPI schema; read with this narrow local shape.
+export interface AgentChoice {
+  /** The agent kind to launch, sent verbatim as the create request's `agent` (e.g. "ClaudeCode"). */
+  type: string;
+  /** The configured display name shown to the user. */
+  displayName: string;
+  /** The configured default model id, or empty when the agent uses its own built-in default. */
+  defaultModel: string;
+  /** A friendly label for the default model (e.g. "Opus 4.8"), or empty - shown so the user sees which
+   *  model the agent will use. The desktop shape: pick the agent, the model comes from its default. */
+  modelLabel: string;
+}
+
 // The app's credential is the per-device key it obtained at enrollment (issue #908/#1088), read from
 // the device-key store - NOT a token injected into the page (the shell carries no secret). Empty until
 // this device has enrolled, in which case the caller (the auth gate) routes to the Sign in screen.
@@ -1145,31 +1160,66 @@ export async function getRepos(directorId: string, signal?: AbortSignal): Promis
   return list;
 }
 
-// POST /directors/{id}/sessions - create a new session in repoPath. Agent is hardcoded "ClaudeCode"
-// and wingmanEnabled=false, type omitted, exactly like the Android NewSessionPanel
-// (FleetParser.BuildCreateBody). Returns the created SessionDto so the caller can open it. The
-// Gateway answers 201 on success; throws GatewayError on non-2xx with the server's reason.
-//
-// launchArgs is the exact command-line argument string the Director passes to the agent (for example
-// "--model opus --dangerously-skip-permissions"). Session launch applies no defaults, so a session
-// created with no launchArgs comes up on the default model and blocked on a permission prompt - the
-// caller decides. An empty or whitespace-only launchArgs sends no "args" at all, matching the
-// historic behavior; callers that do not care (the mobile NewSession flow) simply omit it.
+// GET /directors/{id}/agents - a machine's configured, enabled agents (one per kind) for the New
+// Session dialog's agent picker (issue #1497). The Director already de-duplicates by kind and orders by
+// the configured order, so the list is used as-is. Entries with no type are dropped. Throws GatewayError
+// on non-2xx (e.g. 502 when the Director is not connected), which the dialog surfaces inline.
+export async function getAgents(directorId: string, signal?: AbortSignal): Promise<AgentChoice[]> {
+  const id = encodeURIComponent(directorId);
+  const res = await gatewayFetch(`/directors/${id}/agents`, {
+    method: "GET",
+    headers: { Accept: "application/json", ...authHeaders() },
+    signal,
+  });
+  if (!res.ok) {
+    throw new GatewayError(res.status, `GET /directors/${directorId}/agents failed: ${res.status}`);
+  }
+  const raw = (await res.json()) as Array<Record<string, unknown>>;
+  return raw
+    .map((a) => ({
+      type: String(a.type ?? ""),
+      displayName: String(a.displayName ?? ""),
+      defaultModel: String(a.defaultModel ?? ""),
+      modelLabel: String(a.modelLabel ?? ""),
+    }))
+    .filter((a) => a.type.length > 0);
+}
+
+// Options for createSession, mirroring the desktop New Session dialog's launch controls (issue #1497):
+// pick the AGENT (the model is the agent's own configured default - there is no model override), and the
+// per-session Bypass-permissions choice. No command-line arguments are composed on the client; the
+// Director applies the agent's configured default launch line (its model and permission preset) exactly
+// as the desktop dialog does.
+export interface CreateSessionOptions {
+  /** The agent kind to launch (e.g. "ClaudeCode", "Codex", "Gemini"). Defaults to "ClaudeCode". */
+  agent?: string;
+  /** The desktop "Bypass permission prompts" checkbox (default ON). When omitted, the Director applies
+   *  its default (true). True launches the agent's configured model AND its permission-bypass flag;
+   *  false launches the same model but stops for each permission prompt. */
+  bypassPermissions?: boolean;
+  signal?: AbortSignal;
+}
+
+// POST /directors/{id}/sessions - create a new session in repoPath. Sends the chosen agent kind and the
+// Bypass-permissions choice ONLY; it never composes an args string, so the Director applies that agent's
+// configured default model and permission preset - identical to the desktop New Session dialog (issue
+// #1497). Returns the created SessionDto so the caller can open it. The Gateway answers 201 on success;
+// throws GatewayError on non-2xx with the server's reason. Callers that pass nothing (the mobile
+// NewSession flow) get Claude Code with its configured defaults, exactly as before.
 export async function createSession(
   directorId: string,
   repoPath: string,
-  launchArgs?: string | null,
-  signal?: AbortSignal,
+  options?: CreateSessionOptions,
 ): Promise<SessionDto> {
   const id = encodeURIComponent(directorId);
-  const body: NewSessionRequest = { repoPath: repoPath.trim(), agent: "ClaudeCode", wingmanEnabled: false };
-  const trimmedArgs = (launchArgs ?? "").trim();
-  if (trimmedArgs.length > 0) body.args = trimmedArgs;
+  const agent = options?.agent?.trim() || "ClaudeCode";
+  const body: NewSessionRequest = { repoPath: repoPath.trim(), agent, wingmanEnabled: false };
+  if (options?.bypassPermissions !== undefined) body.bypassPermissions = options.bypassPermissions;
   const res = await gatewayFetch(`/directors/${id}/sessions`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
     body: JSON.stringify(body),
-    signal,
+    signal: options?.signal,
   });
   if (!res.ok) {
     let detail = `${res.status}`;

--- a/packages/client-core/src/api/schema.ts
+++ b/packages/client-core/src/api/schema.ts
@@ -5184,6 +5184,7 @@ export interface components {
             purpose?: null | string;
             agent?: string;
             args?: null | string;
+            bypassPermissions?: boolean | null;
             command?: null | string;
             commandArgs?: null | string;
             type?: null | string;

--- a/src/CcDirector.ControlApi/CatalogReadExecutor.cs
+++ b/src/CcDirector.ControlApi/CatalogReadExecutor.cs
@@ -1,3 +1,5 @@
+using CcDirector.Core.AgentPlugins;
+using CcDirector.Core.Agents;
 using CcDirector.Core.Claude;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Diagnostics;
@@ -48,6 +50,9 @@ internal sealed class CatalogReadExecutor : ISessionCommandArea
         "fs-list",
         "facts",
         "repos-list",
+        // Issue #1497: the machine's configured, enabled agents (one per kind) for the Cockpit New
+        // Session dialog's agent picker - the remote counterpart of the desktop dialog's agent radios.
+        "agents-list",
         // Gateway Cleanup CUT RESTORATION (SB-4a): the enriched per-repo overview the Repositories page reads.
         // Migrated late (the cut deleted the un-migrated leftover); it reads the live registry AND aggregates
         // live/history/claude/handover activity per repo. The core reproduces the old REST lambda verbatim so
@@ -72,6 +77,7 @@ internal sealed class CatalogReadExecutor : ISessionCommandArea
             "fs-list" => FsList(command),
             "facts" => Facts(context.DirectorId, context.Services?.DirectorVersion),
             "repos-list" => ReposList(context.Services?.Repositories),
+            "agents-list" => AgentsList(context.SessionManager.Options),
             "repos-overview" => ReposOverview(context.SessionManager, context.Services?.Repositories),
             "handovers-list" => HandoversList(command),
             "handovers-content" => HandoversContent(command),
@@ -138,6 +144,54 @@ internal sealed class CatalogReadExecutor : ISessionCommandArea
             .OrderByDescending(r => r.LastUsed ?? DateTime.MinValue)
             .ToList();
         return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(repos));
+    }
+
+    /// <summary>
+    /// The <c>agents-list</c> verb (director-level, no session): this machine's configured, ENABLED agents,
+    /// one per kind, for the Cockpit New Session dialog's agent picker (issue #1497). This is the remote
+    /// counterpart of the desktop New Session dialog, which shows a radio per enabled configured agent and
+    /// launches it with that agent's own default model - there is no model picker. Reads the same configured
+    /// library the desktop dialog reads (<see cref="AgentEntryStore.LoadEntries"/>, first-run seeded by tool
+    /// detection), keeps only enabled entries, and de-duplicates by kind because the create request selects an
+    /// agent by KIND (<see cref="NewSessionRequest.Agent"/>) and the Director launches the first enabled entry
+    /// of that kind - so a second entry of the same kind is a choice create cannot honor. Each choice carries a
+    /// friendly model label resolved from the driver's known-models list, so the Cockpit can show which model
+    /// the agent will use. Always a 200 (an empty list is a valid answer). Ordered by the configured order.
+    /// </summary>
+    internal static DirectorCommandResult AgentsList(AgentOptions options)
+    {
+        FileLog.Write("[CatalogReadExecutor] agents-list");
+        var choices = new List<AgentChoiceDto>();
+        var seenKinds = new HashSet<AgentKind>();
+        foreach (var entry in AgentEntryStore.LoadEntries(options))
+        {
+            if (!entry.Enabled) continue;
+            if (!seenKinds.Add(entry.Type)) continue; // one row per kind: create launches the first enabled of a kind
+            choices.Add(new AgentChoiceDto
+            {
+                Type = entry.Type.ToString(),
+                DisplayName = string.IsNullOrWhiteSpace(entry.DisplayName) ? entry.Type.ToString() : entry.DisplayName,
+                DefaultModel = entry.DefaultModel ?? "",
+                ModelLabel = ResolveModelLabel(entry.Type, entry.DefaultModel),
+            });
+        }
+        FileLog.Write($"[CatalogReadExecutor] agents-list: {choices.Count} enabled agent kind(s)");
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(choices));
+    }
+
+    /// <summary>
+    /// A friendly one-line label for a configured default model id, resolved from the kind's driver
+    /// known-models list (e.g. "opus" -&gt; "Opus 4.8"). Falls back to the raw id when the driver does not
+    /// list it, and to an empty string when no model is configured (the agent uses its own built-in default).
+    /// </summary>
+    private static string ResolveModelLabel(AgentKind kind, string? modelId)
+    {
+        if (string.IsNullOrWhiteSpace(modelId)) return "";
+        if (!AgentPluginRegistry.Contains(kind)) return modelId;
+        var driver = AgentPluginRegistry.Get(kind).Driver;
+        if (driver is null) return modelId;
+        var match = driver.KnownModels.FirstOrDefault(m => string.Equals(m.Id, modelId, StringComparison.OrdinalIgnoreCase));
+        return match?.DisplayName ?? modelId;
     }
 
     /// <summary>

--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -450,9 +450,12 @@ internal static class SessionCommandExecutor
         string? effectiveArgs = req.Args;
         if (req.Args is null && kind != AgentKind.RawCli)
         {
-            var resolvedDefault = AgentLaunchDefaults.ResolveDefaultArgs(kind, sessionManager.Options);
+            // Issue #1497: honor the caller's Bypass-permissions choice (the desktop dialog's checkbox,
+            // default ON). Null keeps the historic default of true, so callers that omit it are unchanged.
+            var bypassPermissions = req.BypassPermissions ?? true;
+            var resolvedDefault = AgentLaunchDefaults.ResolveDefaultArgs(kind, sessionManager.Options, bypassPermissions);
             effectiveArgs = string.IsNullOrWhiteSpace(resolvedDefault) ? null : resolvedDefault;
-            FileLog.Write($"[SessionCommandExecutor] create: no args supplied; applied default agent settings for {kind}: \"{effectiveArgs ?? "(empty)"}\"");
+            FileLog.Write($"[SessionCommandExecutor] create: no args supplied; applied default agent settings for {kind} (bypassPermissions={bypassPermissions}): \"{effectiveArgs ?? "(empty)"}\"");
         }
 
         // Issue #800: enforce a meaningful name at birth. An EXPLICIT name that is blank or equal to the

--- a/src/CcDirector.Core.Tests/Configuration/AgentLaunchDefaultsTests.cs
+++ b/src/CcDirector.Core.Tests/Configuration/AgentLaunchDefaultsTests.cs
@@ -111,6 +111,29 @@ public sealed class AgentLaunchDefaultsTests : IDisposable
     }
 
     [Fact]
+    public void ResolveDefaultArgs_BypassPermissionsFalse_KeepsModelDropsBypass()
+    {
+        // Issue #1497: when the caller clears the Bypass-permissions checkbox, the session keeps the
+        // agent's configured model but is launched WITHOUT the permission-bypass flag, so it stops for
+        // each permission prompt - exactly as the desktop dialog launches with the checkbox cleared.
+        SeedConfig("""
+        {
+          "agent": {
+            "entries": [
+              { "type": "ClaudeCode", "enabled": true, "executable_path": "C:/tools/claude.cmd",
+                "preset_id": "Standard", "default_model": "opus[1m]", "launch_mode": "Guided" }
+            ]
+          }
+        }
+        """);
+
+        var args = AgentLaunchDefaults.ResolveDefaultArgs(AgentKind.ClaudeCode, new AgentOptions(), bypassPermissions: false);
+
+        Assert.Contains("--model opus[1m]", args);
+        Assert.DoesNotContain(ClaudeSkip, args);
+    }
+
+    [Fact]
     public void ResolveDefaultArgs_MultipleClaudeEntries_PicksFirstEnabled()
     {
         // The New Session dialog pre-selects the first ENABLED entry of the kind; ResolveDefaultArgs

--- a/src/CcDirector.Core/Configuration/AgentLaunchDefaults.cs
+++ b/src/CcDirector.Core/Configuration/AgentLaunchDefaults.cs
@@ -37,8 +37,13 @@ public static class AgentLaunchDefaults
     ///     entry configured with the "Automatic" preset is not doubled.
     /// Returns an empty string for a kind with no catalog plugin (e.g. <see cref="AgentKind.RawCli"/>),
     /// whose command line is supplied explicitly by the caller and has nothing to inherit.
+    ///
+    /// <paramref name="bypassPermissions"/> mirrors the dialog's Bypass-permissions checkbox: <c>true</c>
+    /// (the default, matching the checkbox's default-ON) appends the bypass flag as described above;
+    /// <c>false</c> resolves the SAME entry preset and model but WITHOUT the bypass flag, exactly as the
+    /// desktop dialog launches when the user clears the checkbox (issue #1497).
     /// </summary>
-    public static string ResolveDefaultArgs(AgentKind agentKind, AgentOptions options)
+    public static string ResolveDefaultArgs(AgentKind agentKind, AgentOptions options, bool bypassPermissions = true)
     {
         if (options is null) throw new ArgumentNullException(nameof(options));
 
@@ -56,7 +61,14 @@ public static class AgentLaunchDefaults
         // launches with the permission-bypass flag on top of the preset. Replicate that default so a
         // spawned session has the SAME permission profile and is usable without hand-fixing
         // permissions. Add only when absent so an "Automatic" preset that already carries the flag is
-        // not doubled.
+        // not doubled. When the caller cleared the checkbox (bypassPermissions=false), skip this layer
+        // entirely so the session keeps the configured model but stops for each permission prompt.
+        if (!bypassPermissions)
+        {
+            FileLog.Write($"[AgentLaunchDefaults] ResolveDefaultArgs: {agentKind} bypass cleared; preset/model only -> \"{baseArgs}\"");
+            return baseArgs;
+        }
+
         var bypassArg = PermissionBypassArgFor(agentKind);
         if (bypassArg is not null && !baseArgs.Contains(bypassArg, StringComparison.Ordinal))
         {

--- a/src/CcDirector.Gateway.Contracts/AgentChoiceDto.cs
+++ b/src/CcDirector.Gateway.Contracts/AgentChoiceDto.cs
@@ -1,0 +1,32 @@
+namespace CcDirector.Gateway.Contracts;
+
+/// <summary>
+/// One selectable agent for a remote New Session dialog (issue #1497): the machine's configured,
+/// enabled agents, one per kind, as returned by the Director's <c>agents-list</c> tunnel verb and the
+/// Gateway's <c>GET /directors/{id}/agents</c> proxy leg. This is the remote counterpart of the desktop
+/// New Session dialog's agent radios - the Cockpit shows the agent's name (and the model it will use)
+/// and launches it by <see cref="Type"/>, with no per-session model picker, exactly like the desktop
+/// (which chooses the agent, and the model comes from that agent's configured default).
+///
+/// Deduplicated by kind on the Director side, because the create request selects an agent by kind
+/// (<see cref="NewSessionRequest.Agent"/>), and the Director launches the FIRST enabled entry of that
+/// kind - so returning two entries of the same kind would be a choice the create path cannot honor.
+/// </summary>
+public sealed class AgentChoiceDto
+{
+    /// <summary>The agent kind, sent verbatim as <see cref="NewSessionRequest.Agent"/> to launch it
+    /// (e.g. "ClaudeCode", "Codex", "Gemini").</summary>
+    public string Type { get; set; } = "";
+
+    /// <summary>The configured display name of the agent (the entry's DisplayName), shown to the user.</summary>
+    public string DisplayName { get; set; } = "";
+
+    /// <summary>The configured default model id for this agent, or empty when the agent uses its own
+    /// built-in default (no explicit model configured).</summary>
+    public string DefaultModel { get; set; } = "";
+
+    /// <summary>A friendly one-line label for the default model (e.g. "Opus 4.8"), resolved from the
+    /// driver's known-models list; falls back to the raw model id, or empty when no model is configured.
+    /// Purely informational - the Cockpit shows it so the user sees which model the agent will use.</summary>
+    public string ModelLabel { get; set; } = "";
+}

--- a/src/CcDirector.Gateway.Contracts/NewSessionRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/NewSessionRequest.cs
@@ -36,6 +36,17 @@ public sealed class NewSessionRequest
     public string? Args { get; set; }
 
     /// <summary>
+    /// Optional per-session permission-bypass choice, mirroring the desktop New Session dialog's
+    /// "Bypass permission prompts" checkbox (issue #1497). Consulted ONLY when <see cref="Args"/> is
+    /// null (no explicit command-line override): <c>true</c> (the desktop default) launches the agent's
+    /// configured default model AND its permission-bypass flag; <c>false</c> launches the same configured
+    /// model but WITHOUT the bypass flag, so the agent stops for each permission prompt. When
+    /// <see cref="Args"/> is supplied, that explicit line wins and this is ignored. Null defaults to
+    /// <c>true</c> (the desktop default), so callers that omit it are unaffected.
+    /// </summary>
+    public bool? BypassPermissions { get; set; }
+
+    /// <summary>
     /// For <see cref="Agent"/> = "RawCli": the executable to run (e.g. "pwsh", "aider",
     /// or an absolute path). Resolved against PATH+PATHEXT before spawning; a path that
     /// cannot be resolved fails loudly at launch. Ignored for all other agent kinds.

--- a/src/CcDirector.Gateway.Tests/CatalogReadExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/CatalogReadExecutorTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text.Json;
 using CcDirector.ControlApi;
 using CcDirector.Core.Sessions;
@@ -286,6 +287,82 @@ public sealed class CatalogReadExecutorTests
             try { if (File.Exists(registryFile)) File.Delete(registryFile); } catch { /* best effort */ }
             try { if (Directory.Exists(repoDir)) Directory.Delete(repoDir, true); } catch { /* best effort */ }
         }
+    }
+
+    // ---------- agents-list (issue #1497: the machine's configured, enabled agents for the Cockpit New
+    // Session dialog's agent picker). Pins CC_DIRECTOR_ROOT into a temp dir and seeds a controlled
+    // config.json so the read is deterministic and never touches the user's real agent library.
+
+    [Fact]
+    public async Task DispatchAsync_AgentsList_ReturnsEnabledAgentsDedupedByKind()
+    {
+        var (root, prev) = PinDirectorRoot();
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            // Two Claude entries (only the first should survive the by-kind dedupe), one Codex, one
+            // DISABLED Gemini (must be excluded). The create request selects an agent by kind, so a second
+            // entry of the same kind is a choice create cannot honor - hence one row per kind.
+            SeedConfig("""
+            {
+              "agent": {
+                "entries": [
+                  { "type": "ClaudeCode", "enabled": true, "display_name": "Claude Code",
+                    "default_model": "opus", "preset_id": "Standard", "launch_mode": "Guided" },
+                  { "type": "ClaudeCode", "enabled": true, "display_name": "Claude Two",
+                    "preset_id": "Standard", "launch_mode": "Guided" },
+                  { "type": "Codex", "enabled": true, "display_name": "Codex",
+                    "preset_id": "Standard", "launch_mode": "Guided" },
+                  { "type": "Gemini", "enabled": false, "display_name": "Gemini",
+                    "preset_id": "Standard", "launch_mode": "Guided" }
+                ]
+              }
+            }
+            """);
+
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-A", Cmd("agents-list"));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var agents = JsonSerializer.Deserialize<List<AgentChoiceDto>>(result.BodyJson ?? "", Json);
+            Assert.NotNull(agents);
+            // Enabled-only: the disabled Gemini is excluded.
+            Assert.DoesNotContain(agents!, a => a.Type == "Gemini");
+            // Deduped by kind: exactly one ClaudeCode row, and it is the FIRST enabled entry.
+            Assert.Equal(1, agents!.Count(a => a.Type == "ClaudeCode"));
+            var claude = agents!.First(a => a.Type == "ClaudeCode");
+            Assert.Equal("Claude Code", claude.DisplayName);
+            // Its configured model resolves to a friendly label from the driver's known-models list.
+            Assert.False(string.IsNullOrEmpty(claude.ModelLabel));
+            // Codex is offered too.
+            Assert.Contains(agents!, a => a.Type == "Codex");
+        }
+        finally { sm.Dispose(); RestoreDirectorRoot(root, prev); }
+    }
+
+    // Pin CC_DIRECTOR_ROOT into a fresh temp dir so config.json (the agent library the agents-list verb
+    // reads) is a controlled file that never touches the user's real config. Returns the pinned root and
+    // the previous value so RestoreDirectorRoot can put it back and delete the temp tree.
+    private static (string root, string? prev) PinDirectorRoot()
+    {
+        var prev = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        var root = Path.Combine(Path.GetTempPath(), "ccd-agentslist-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", root);
+        return (root, prev);
+    }
+
+    private static void RestoreDirectorRoot(string root, string? prev)
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", prev);
+        try { if (Directory.Exists(root)) Directory.Delete(root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private static void SeedConfig(string json)
+    {
+        var path = CcStorage.ConfigJson();
+        var dir = Path.GetDirectoryName(path);
+        Assert.NotNull(dir);
+        Directory.CreateDirectory(dir!);
+        File.WriteAllText(path, json);
     }
 
     // ---------- handovers-list / handovers-content (Gateway Cleanup Phase 0 Wave 4a: the saved-handover

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -1453,6 +1453,24 @@ internal static class GatewayEndpoints
             return Results.StatusCode(StatusCodes.Status502BadGateway);
         });
 
+        // Issue #1497: the target Director's configured, enabled agents (one per kind) for the Cockpit New
+        // Session dialog's agent picker. Rides the tunnel (agents-list verb, director-level), mirroring the
+        // facts/repos-list read legs above; a null result (Director not connected) collapses to 502.
+        app.MapGet("/directors/{id}/agents", async (string id, CancellationToken ct) =>
+        {
+            var d = registry.Get(id);
+            if (d is null) return Results.NotFound(new { error = "director not found" });
+
+            var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, id, "agents-list", "", null, ct);
+            if (sr is not null)
+            {
+                if (!sr.Ok) return Results.StatusCode(StatusCodes.Status502BadGateway);
+                return Results.Json(DirectorCommandRouter.ReadBody<List<AgentChoiceDto>>(sr) ?? new List<AgentChoiceDto>());
+            }
+
+            return Results.StatusCode(StatusCodes.Status502BadGateway);
+        });
+
         app.MapPost("/directors/{id}/sessions", async (string id, NewSessionRequest req) =>
         {
             var d = registry.Get(id);


### PR DESCRIPTION
Closes #1497.

## What changed
The Cockpit "Start a new session" dialog now matches the desktop Director: you pick the **agent** to launch, and the **model comes from that agent's own configured default**. The model picker is gone — the desktop shape the request asked for.

## Behaviour
- Step 3 "Launch options" now shows the selected machine's configured, **enabled** agents (one per kind), with the model each will use as a caption, instead of Default/Opus/Sonnet buttons.
- The chosen agent is sent as the create request's agent kind. **No command-line arguments are composed on the client**, so the Director applies that agent's configured default model and permission preset — exactly as the desktop New Session dialog does (`AgentLaunchDefaults.ResolveDefaultArgs`).
- The permission mode maps to the desktop's "Bypass permission prompts" checkbox (default on): the new structured `BypassPermissions` flag turns the bypass on/off **without** losing the configured model.

## Plumbing (Cockpit → Gateway → Director)
- **Director floor:** new `agents-list` tunnel read verb (`CatalogReadExecutor`) — enabled agents, deduped by kind, with a friendly default-model label from the driver's known models.
- **Gateway:** new `GET /directors/{id}/agents` proxy leg, mirroring the existing `facts` / `repos-list` legs.
- **Contracts:** `AgentChoiceDto`; `NewSessionRequest.BypassPermissions`.
- **client-core:** `getAgents()`; `createSession()` now takes `{ agent, bypassPermissions }` and never composes an args string. The mobile flow (calls it with no options) is unchanged.

## Tests
- `AgentLaunchDefaults` with the bypass cleared → keeps the model, drops the bypass flag.
- `agents-list` verb → enabled-only, deduped by kind, friendly model label.
- All web workspaces typecheck; the Cockpit builds; the two affected .NET test suites pass (11 + 20).

## Note
The screenshot dialog lives at `apps/cockpit/src/sessions/NewSessionDialog.tsx` (React Cockpit `/c`), which is on `origin/main` but was ahead of the local checkout — this branch is cut from `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)