### PR TITLE
fix(gateway-cleanup): restore "message send all" (/fleet/broadcast) to the Director floor (#1490)

### DIFF
--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -616,6 +616,111 @@ internal static class ControlEndpoints
             }
         });
 
+        // POST /fleet/broadcast - "message send all": one message to the sender's whole TEAM, or (with
+        // Everyone + a human grant + reason) the whole fleet (issue #1229). The Director narrows the recipients
+        // to the sender's team HERE using the SHARED BroadcastScope - the same definition the Gateway enforces
+        // as the authority, so the two cannot drift - then relays to the Gateway's /fanout. Standalone (no
+        // Gateway) it delivers to the in-team sessions this Director can see. Restores `message send all`,
+        // which the CLI already calls but which had no Director route on the tunnel-only floor (issue #1490).
+        app.MapPost("/fleet/broadcast", async (FleetBroadcastRequest req, CancellationToken ct) =>
+        {
+            if (req is null || string.IsNullOrWhiteSpace(req.Text))
+                return Results.BadRequest(new { error = "text is required" });
+            if (string.IsNullOrWhiteSpace(req.FromSessionId))
+                return Results.BadRequest(new { error = "fromSessionId is required to resolve your team" });
+
+            var framed = FrameForSender(req.FromSessionId, req.Text);
+            var gw = gatewayClientProvider?.Invoke();
+
+            // The candidate fleet: the aggregated fleet via the Gateway, or - standalone - this Director's
+            // own live sessions mapped to the same shape so one scope filter serves both paths.
+            List<SessionDto> fleet;
+            if (gw is { IsEnabled: true })
+            {
+                try
+                {
+                    fleet = await gw.ListFleetSessionsAsync(ct);
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[ControlEndpoints] /fleet/broadcast list FAILED: {ex.Message}");
+                    return Results.Json(new FleetSendResponse { Accepted = false, Error = $"Cannot reach the Gateway: {ex.Message}" },
+                        statusCode: StatusCodes.Status502BadGateway);
+                }
+            }
+            else
+            {
+                fleet = sessionManager.ListSessions()
+                    .Where(s => s.ActivityState != ActivityState.Exited)
+                    .Select(s => MapWithIdentity(s, turnSummaryCache))
+                    .ToList();
+            }
+
+            var sender = fleet.FirstOrDefault(s => string.Equals(s.SessionId, req.FromSessionId, StringComparison.OrdinalIgnoreCase));
+            if (sender is null)
+                return Results.Json(new FleetSendResponse
+                {
+                    Accepted = false,
+                    Error = "The broadcasting session was not found in the fleet, so its team cannot be resolved.",
+                }, statusCode: StatusCodes.Status404NotFound);
+
+            var senderScope = BroadcastScope.FromAggregatedSession(sender);
+            var targetIds = fleet
+                .Where(s => !string.Equals(s.SessionId, req.FromSessionId, StringComparison.OrdinalIgnoreCase)
+                            && (req.Everyone || senderScope.Includes(BroadcastScope.FromAggregatedSession(s))))
+                .Select(s => s.SessionId)
+                .ToList();
+
+            if (targetIds.Count == 0)
+                return Results.Json(new FleetSendResponse
+                {
+                    Accepted = true,
+                    DeliveredCount = 0,
+                    Warning = req.Everyone ? "No other sessions in the fleet." : "No other sessions on your team.",
+                });
+
+            if (gw is { IsEnabled: true })
+            {
+                try
+                {
+                    // A plain team broadcast passes no reason/grant (every target is in scope). Everyone carries
+                    // the reason + human grant the Hub requires to reach beyond the team.
+                    var resp = await gw.FanoutToFleetAsync(targetIds, framed, req.FromSessionId,
+                        req.Everyone ? req.Reason : null, req.Everyone ? req.GrantId : null, ct);
+                    if (resp.Denied)
+                        return Results.Json(new FleetSendResponse { Accepted = false, Error = resp.DeniedReason ?? "The broadcast was refused on scope grounds." });
+                    var delivered = resp.Results.Count(r => r.Error is null);
+                    return Results.Json(new FleetSendResponse { Accepted = true, DeliveredCount = delivered });
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[ControlEndpoints] /fleet/broadcast relay FAILED: {ex.Message}");
+                    return Results.Json(new FleetSendResponse { Accepted = false, Error = $"Cannot broadcast via the Gateway: {ex.Message}" },
+                        statusCode: StatusCodes.Status502BadGateway);
+                }
+            }
+
+            // Standalone: the targets are all local sessions on this Director; deliver directly. Per-session
+            // failures are logged and counted out, never silently dropped, and never abort the whole broadcast.
+            var count = 0;
+            foreach (var tid in targetIds)
+            {
+                if (Guid.TryParse(tid, out var tguid) && sessionManager.GetSession(tguid) is { } local)
+                {
+                    try
+                    {
+                        await local.SendTextAsync(framed, SendSource.Internal);
+                        count++;
+                    }
+                    catch (Exception ex)
+                    {
+                        FileLog.Write($"[ControlEndpoints] /fleet/broadcast local deliver to {tid} FAILED: {ex.Message}");
+                    }
+                }
+            }
+            return Results.Json(new FleetSendResponse { Accepted = true, DeliveredCount = count });
+        });
+
     }
 
     // Gateway Cleanup CUT RESTORATION (SB-4a): the fleet-directory identity stamp. Restored with the /fleet

--- a/src/CcDirector.Gateway.Tests/FleetMessagingTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetMessagingTests.cs
@@ -276,4 +276,36 @@ public sealed class FleetMessagingEndpointTests : IAsyncLifetime
             new FleetDoneRequest { ToSessionId = Guid.NewGuid().ToString() });
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
+
+    // ===== /fleet/broadcast validation (issue #1490 - "message send all", route was never built) =====
+
+    // A 400 from the handler proves the route now exists (a missing route 404s) - the gap that made
+    // `message send all` 404.
+    [Fact]
+    public async Task Fleet_broadcast_missing_text_returns_400_provingRouteExists()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/broadcast",
+            new FleetBroadcastRequest { Text = "", FromSessionId = Guid.NewGuid().ToString() });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Fleet_broadcast_missing_sender_returns_400_soTheTeamCanBeResolved()
+    {
+        // Without the sender's id the team cannot be resolved, so a broadcast that would otherwise reach
+        // "everyone" is refused up front rather than guessing.
+        var resp = await _client.PostAsJsonAsync("fleet/broadcast",
+            new FleetBroadcastRequest { Text = "hi", FromSessionId = "" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Fleet_broadcast_senderNotInFleet_returns_404()
+    {
+        // Standalone Director with no sessions: the sender is not in the (empty) fleet, so its team cannot
+        // be resolved - fail loud (404), never broadcast to a guessed set.
+        var resp = await _client.PostAsJsonAsync("fleet/broadcast",
+            new FleetBroadcastRequest { Text = "hi", FromSessionId = Guid.NewGuid().ToString() });
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
 }


### PR DESCRIPTION
Part 2 of the #1490 tunnel-only CLI restore (after #1498, which fixed rename/done/local-spawn).

## The problem
`cc-devthrottle message send all` - the team broadcast every session's preamble tells it to use - returned **"HTTP 404 from the Director"**. The CLI has always POSTed `/fleet/broadcast`, but that route was **never built** on the Director floor (`GatewayClient.FanoutToFleetAsync` had no caller) - a Phase-4 completion gap.

## The fix
Add the loopback `POST /fleet/broadcast` handler. It narrows recipients to the sender's **team** here, using the **shared `BroadcastScope`** from the Contracts assembly - the exact type the Gateway enforces as the authority (#1229), so the Director's narrowing and the Gateway's enforcement cannot drift - then relays the in-team set to the Gateway's `/fanout`.

- A plain broadcast carries no reason/grant (every target is in scope → `AllowedInScope`).
- `Everyone` carries the reason + human grant the Hub requires to reach beyond the team; a refusal comes back as a clear "not delivered".
- Standalone (no Gateway) delivers to the in-team local sessions this Director can see; per-session failures are logged and counted out, never a silent drop.

**C#-only** - the CLI already calls `/fleet/broadcast`, and `FleetBroadcastRequest` + `FanoutToFleetAsync` already existed. Only the Director route was missing.

- `ControlEndpoints.cs` - the `POST /fleet/broadcast` handler.
- `FleetMessagingTests.cs` - three regression tests (the 400 ones prove the route now exists).

## Still deferred
`selftest` - needs a **synchronous-kill** floor route for its throwaway-session teardown (the deferred `/fleet/done` is grace-window async), so it gets its own final small change.

## Verification
- Clean build.
- Full `CcDirector.Gateway.Tests`: **2135 passed, 0 failed**; fleet endpoint suite 20/20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)