### PR TITLE
refactor(gateway-cleanup): remove the dead verify-before-advertise machinery (tunnel-only)

### DIFF
--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -619,29 +619,13 @@ public sealed class ControlApiHost : IAsyncDisposable
     }
 
     /// <summary>
-    /// Construct the Gateway client and, when this Director self-provisions its serve
-    /// mapping, wire verify-before-advertise (issue #197): every register attempt first
-    /// asserts the own-port mapping, then probes the advertised URL from the outside-in.
-    /// The PROBE is the gate - a registration only happens for an endpoint that
-    /// demonstrably answers; the mapping step is best-effort-but-loud, so an exotic
-    /// setup (hand-run reverse proxy via gateway.tailnetEndpoint) that answers without
-    /// our mapping still registers truthfully.
+    /// Construct the Gateway client. Tunnel-only: the Director dials OUT and is reached only down that
+    /// stream, so there is no inbound endpoint to verify-before-advertise anymore. The old issue #197
+    /// own-port probe was already dead once the Director stopped self-provisioning a serve front door
+    /// (the wiring here was gated on a serve provisioner this Director never creates), so it is removed.
     /// </summary>
     private GatewayClient BuildGatewayClient(GatewayConfig gatewayConfig)
-    {
-        var client = new GatewayClient(gatewayConfig, DirectorId, Port, _version, SnapshotSessionStates, GatewayMonitor);
-        if (_serveProvisioner is { } provisioner)
-        {
-            client.EndpointVerifier = async (endpoint, ct) =>
-            {
-                var (mapped, mapError) = await provisioner.EnsureMappingAsync(ct);
-                var probeError = await GatewayClient.ProbeAdvertisedEndpointAsync(endpoint, ct);
-                if (probeError is null) return null;
-                return mapped ? probeError : $"{probeError} (serve mapping: {mapError})";
-            };
-        }
-        return client;
-    }
+        => new(gatewayConfig, DirectorId, Port, _version, SnapshotSessionStates, GatewayMonitor);
 
     /// <summary>
     /// Issue #1176 (Phase 1a): build the push-stream client, or null when stream mode is off / no Gateway

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -97,22 +97,6 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
     internal Func<TailnetEndpointResolution> ResolveAdvertisedEndpoint { get; set; }
 
     /// <summary>
-    /// Verify-before-advertise (issue #197): called with the advertised endpoint before
-    /// every register POST. Returns null when the endpoint is confirmed reachable from
-    /// the outside; otherwise a human-readable reason, which SKIPS the registration -
-    /// a dead endpoint is never advertised, and <see cref="RegisterLoop"/>'s backoff
-    /// retries later (covering the first-serve TLS cert issuance window and a Tailscale
-    /// daemon that comes up after the Director). Null (the default) disables verification:
-    /// direct constructions (tests, ephemeral-port hosts) register exactly as before;
-    /// ControlApiHost wires it for real fixed-port Directors.
-    /// </summary>
-    public Func<string, CancellationToken, Task<string?>>? EndpointVerifier { get; set; }
-
-    /// <summary>Reason the last register attempt refused to advertise, or null when the
-    /// endpoint verified (or verification is disabled). Surfaced for diagnostics.</summary>
-    public string? LastVerifyError { get; private set; }
-
-    /// <summary>
     /// The gateway address currently in use (issue #1233): <see cref="GatewayConfig.Url"/> until
     /// <see cref="Start"/> narrows it to the first reachable entry of
     /// <see cref="GatewayConfig.CandidateUrls"/>. Exposed for tests and diagnostics.
@@ -698,24 +682,6 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
             return false;
         }
 
-        // Verify-before-advertise (issue #197): never register an endpoint that does not
-        // demonstrably answer. The verifier (composed in ControlApiHost) asserts the
-        // Director's own tailscale serve mapping and probes the advertised URL from the
-        // outside-in. On failure the precise reason lands in THIS machine's log - the one
-        // place someone can act on it - instead of an eternal unreachable flap on the Gateway.
-        if (EndpointVerifier is not null)
-        {
-            var reason = await EndpointVerifier(req.TailnetEndpoint, ct);
-            if (reason is not null)
-            {
-                LastVerifyError = reason;
-                FileLog.Write($"[GatewayClient] NOT registering {req.TailnetEndpoint}: {reason}");
-                _monitor?.ReportRegistrationFailure($"This Director's own front door failed verification: {reason}");
-                return false;
-            }
-            LastVerifyError = null;
-        }
-
         FileLog.Write($"[GatewayClient] POST /directors/register: endpoint={req.TailnetEndpoint}");
         var resp = await _http.PostAsJsonAsync("directors/register", req, ct);
         if (resp.IsSuccessStatusCode)
@@ -989,30 +955,5 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
             Version = _version,
             StartedAt = System.Diagnostics.Process.GetCurrentProcess().StartTime.ToUniversalTime(),
         };
-    }
-
-    /// <summary>
-    /// One outside-in probe of an advertised Director endpoint: GET &lt;endpoint&gt;/healthz
-    /// through the real HTTPS front door (the tailscale serve mapping + tailnet cert), NOT
-    /// loopback. Returns null when it answers 2xx, else the reason. Deliberately a single
-    /// short attempt: <see cref="RegisterLoop"/>'s exponential backoff supplies the long
-    /// retry horizon (first-ever serve on a node can take seconds to get its TLS cert).
-    /// </summary>
-    public static async Task<string?> ProbeAdvertisedEndpointAsync(string endpoint, CancellationToken ct = default)
-    {
-        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
-        try
-        {
-            var resp = await http.GetAsync($"{endpoint.TrimEnd('/')}/healthz", ct);
-            return resp.IsSuccessStatusCode ? null : $"healthz answered HTTP {(int)resp.StatusCode}";
-        }
-        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
-        {
-            return "healthz probe timed out after 5s";
-        }
-        catch (Exception ex)
-        {
-            return $"healthz probe failed: {ex.Message}";
-        }
     }
 }


### PR DESCRIPTION
Tunnel-only cleanup, **Slice 1** of the Tailscale/direct-dial dead-code removal.

## Why it's dead
The Director dials **out** to the Gateway and is reached only down that stream, so the old "verify my own inbound endpoint before advertising it" path (#197) has no purpose. It was already **provably inert**: the wiring is gated on a serve provisioner this Director never creates (`_serveProvisioner` is only ever assigned `null`), so `EndpointVerifier` was never set and the registration-time probe never ran.

## Removed (no behavior change)
- `GatewayClient`: `EndpointVerifier` + `LastVerifyError` properties, the registration-time verify-before-advertise block, and `ProbeAdvertisedEndpointAsync` (its only live caller was the dead block).
- `ControlApiHost.BuildGatewayClient`: the `_serveProvisioner`-gated `EndpointVerifier` wiring — it now just constructs the client.

## Deliberately KEPT (still live — not dead)
`VerifyAsync` + the desktop "Verify now" button; the graceful-shutdown serve-mapping teardown / self-heal; `TailscaleServeSelfProvisioner` (used by the teardown and the connectivity self-test); `TailnetResolver` (the gateway-role Cockpit HTTPS URL); `AddressingMode.Lan`; the `TailnetEndpoint` display field. These come out — where they're actually dead — in later, more surgical slices.

## Verification
- ControlApi + Avalonia desktop build clean.
- Full `CcDirector.Gateway.Tests`: **2135 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)