### PR TITLE
fix(sessions): make an explicit "hold my session" during a live turn stick (deferred hold)

### DIFF
--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -293,9 +293,16 @@ internal static class SessionCommandExecutor
         if (session is null)
             return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
 
-        session.OnHold = onHold;
-        FileLog.Write($"[SessionCommandExecutor] hold: session={guid} onHold={onHold}");
-        return DirectorCommandResult.Success(Serialize(new HoldResponse { OnHold = session.OnHold }));
+        // RequestHold defers an EXPLICIT hold that arrives mid-turn so it applies durably when the turn
+        // ends, instead of being bounced by the turn-END auto-lift (the "put my session on hold while it is
+        // still working" case). An immediate hold / un-hold behaves as before.
+        var outcome = session.RequestHold(onHold);
+        FileLog.Write($"[SessionCommandExecutor] hold: session={guid} onHold={onHold} outcome={outcome}");
+        return DirectorCommandResult.Success(Serialize(new HoldResponse
+        {
+            OnHold = session.OnHold,
+            Pending = outcome == Session.HoldOutcome.Pending,
+        }));
     }
 
     /// <summary>

--- a/src/CcDirector.Core.Tests/SessionInteractiveTests.cs
+++ b/src/CcDirector.Core.Tests/SessionInteractiveTests.cs
@@ -165,6 +165,86 @@ public sealed class SessionInteractiveTests
         Assert.True(s.OnHold);
     }
 
+    // ---- explicit "put my session on hold" (RequestHold): a hold asked for mid-turn is DEFERRED and
+    // applied durably at the turn end, instead of being bounced by the turn-END auto-lift ----
+
+    [Fact]
+    public async Task RequestHold_MidTurn_IsDeferred_ThenAppliesDurablyAtRedSettle()
+    {
+        var backend = new RecordingBackend();
+        using var s = NewSession(backend, ActivityState.Working);
+
+        await s.SendTextAsync("do the thing"); // real submission arms the turn
+        var outcome = s.RequestHold(true);      // user says "put my session on hold" WHILE it is working
+
+        Assert.Equal(Session.HoldOutcome.Pending, outcome);
+        Assert.False(s.OnHold); // not held yet - it finishes the current turn first
+
+        s.ApplyTerminalActivityState(ActivityState.WaitingForInput); // turn ends -> red "needs you"
+        Assert.True(s.OnHold); // the deferred hold applied at the settle
+
+        // ...and it STICKS: the turn boundary that would auto-lift an ordinary snooze does not bounce it,
+        // and later cosmetic repaints leave it held.
+        s.ApplyTerminalActivityState(ActivityState.Working);
+        s.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+        Assert.True(s.OnHold);
+    }
+
+    [Fact]
+    public async Task RequestHold_MidTurn_AppliesAtIdleSettleToo()
+    {
+        var backend = new RecordingBackend();
+        using var s = NewSession(backend, ActivityState.Working);
+
+        await s.SendTextAsync("go");
+        s.RequestHold(true);
+
+        s.ApplyTerminalActivityState(ActivityState.Idle); // turn ends at ready, not "needs you"
+        Assert.True(s.OnHold); // still parks held
+    }
+
+    [Fact]
+    public void RequestHold_WhenSettled_HoldsImmediately()
+    {
+        var backend = new RecordingBackend();
+        using var s = NewSession(backend, ActivityState.Idle);
+
+        var outcome = s.RequestHold(true); // no turn in flight
+        Assert.Equal(Session.HoldOutcome.Held, outcome);
+        Assert.True(s.OnHold);
+    }
+
+    [Fact]
+    public async Task RequestHold_False_ReleasesAndClearsAPendingDefer()
+    {
+        var backend = new RecordingBackend();
+        using var s = NewSession(backend, ActivityState.Working);
+
+        await s.SendTextAsync("go");
+        s.RequestHold(true);                          // pending
+        var outcome = s.RequestHold(false);           // user changes their mind before it applies
+
+        Assert.Equal(Session.HoldOutcome.Released, outcome);
+        Assert.False(s.OnHold);
+
+        s.ApplyTerminalActivityState(ActivityState.WaitingForInput); // turn ends
+        Assert.False(s.OnHold); // the cleared deferral is NOT resurrected
+    }
+
+    [Fact]
+    public async Task RequestHold_PendingDefer_IsSupersededByANewSubmission()
+    {
+        var backend = new RecordingBackend();
+        using var s = NewSession(backend, ActivityState.Working);
+
+        await s.SendTextAsync("first");
+        s.RequestHold(true);            // pending
+        await s.SendTextAsync("second"); // a fresh submission - the user is driving again
+
+        s.ApplyTerminalActivityState(ActivityState.WaitingForInput); // that turn ends
+        Assert.False(s.OnHold); // the superseded deferral did not apply
+    }
+
     // ---- #5 PTY resize guard ----
 
     [Fact]

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -590,6 +590,52 @@ public sealed class Session : IDisposable
     /// </summary>
     private bool _turnInFlight;
 
+    /// <summary>
+    /// An EXPLICIT "hold this session" that arrived WHILE a real turn was in flight, deferred until the
+    /// turn ends. The problem it solves: "put my session on hold" set OnHold immediately, but the very
+    /// turn that was underway then ended and the turn-END auto-lift cleared it - so the hold never stuck.
+    /// When the session next settles, this is applied as a DURABLE hold (OnHold goes true and is NOT lifted
+    /// by that same turn boundary, unlike the automatic snooze). Set only via <see cref="RequestHold"/>;
+    /// cleared when applied, when the session exits, or when a new submission supersedes it. Runtime-only.
+    /// </summary>
+    private bool _pendingHold;
+
+    /// <summary>Outcome of a <see cref="RequestHold"/> call.</summary>
+    public enum HoldOutcome
+    {
+        /// <summary>The hold was applied immediately (the session was already settled).</summary>
+        Held,
+        /// <summary>A turn was in flight, so the hold was deferred and will apply when the turn ends.</summary>
+        Pending,
+        /// <summary>The session was taken OFF hold (onHold=false), clearing any pending deferral too.</summary>
+        Released,
+    }
+
+    /// <summary>
+    /// Request an EXPLICIT hold / un-hold of this session - the user's "put my session on hold". Un-hold
+    /// (<paramref name="onHold"/> false) clears the hold and any pending deferral at once. A hold requested
+    /// while a real turn is in flight is DEFERRED: it applies durably when the turn ends, so the very turn
+    /// boundary that auto-lifts an ordinary snooze does not bounce it. A hold requested while the session is
+    /// settled applies immediately. Returns which of those happened.
+    /// </summary>
+    public HoldOutcome RequestHold(bool onHold)
+    {
+        if (!onHold)
+        {
+            _pendingHold = false;
+            OnHold = false;
+            return HoldOutcome.Released;
+        }
+        if (_turnInFlight)
+        {
+            _pendingHold = true;
+            FileLog.Write($"[Session] Hold requested during an active turn - deferring until it ends: session={Id}");
+            return HoldOutcome.Pending;
+        }
+        OnHold = true;
+        return HoldOutcome.Held;
+    }
+
     /// <summary>Fires when <see cref="OnHold"/> changes. Arg: new value. The desktop
     /// session list subscribes so the color strip can repaint dark blue (held) without
     /// the wingman touching <see cref="StatusColor"/>; OnHold sits on top of it.</summary>
@@ -1566,6 +1612,7 @@ public sealed class Session : IDisposable
             // stale Hold deferral no longer reflects intent -- clear it (issue #470).
             // The OnHold setter no-ops + skips OnHoldChanged when already false.
             OnHold = false;
+            _pendingHold = false; // a fresh submission supersedes a not-yet-applied deferred hold
             // A real turn is now underway; arm the turn-END hold lift (see SetActivityState).
             _turnInFlight = true;
             SetActivityState(ActivityState.Working);
@@ -1678,6 +1725,7 @@ public sealed class Session : IDisposable
         // session again, so clear any stale Hold deferral (issue #470). The OnHold
         // setter no-ops + skips OnHoldChanged when already false.
         OnHold = false;
+        _pendingHold = false; // a fresh submission supersedes a not-yet-applied deferred hold
         // A real turn is now underway; arm the turn-END hold lift (see SetActivityState).
         _turnInFlight = true;
         SetActivityState(ActivityState.Working);
@@ -1806,12 +1854,23 @@ public sealed class Session : IDisposable
         if (newState is ActivityState.WaitingForInput or ActivityState.WaitingForPerm
             or ActivityState.Idle or ActivityState.Exited)
         {
-            if (_turnInFlight && newState is ActivityState.WaitingForInput or ActivityState.WaitingForPerm)
+            if (_pendingHold && newState is not ActivityState.Exited)
+            {
+                // A deferred EXPLICIT hold (RequestHold while a turn was in flight): the turn the user asked
+                // to hold during has now finished, so apply it DURABLY. This WINS over the turn-END auto-lift
+                // below - an explicit hold sticks; it is not cleared by the very turn boundary it was waiting
+                // for. The session parks held (red or idle) until the user comes back to it.
+                if (!OnHold)
+                    FileLog.Write($"[Session] Deferred hold applied at turn end ({newState}): session={Id}");
+                OnHold = true;
+            }
+            else if (_turnInFlight && newState is ActivityState.WaitingForInput or ActivityState.WaitingForPerm)
             {
                 if (OnHold)
                     FileLog.Write($"[Session] Turn ended ({newState}) - lifting hold: session={Id}");
                 OnHold = false;
             }
+            _pendingHold = false;
             _turnInFlight = false;
         }
         // A real activity change ends any Wingman "running in the background" overlay: once the

--- a/src/CcDirector.Gateway.Contracts/HoldRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/HoldRequest.cs
@@ -27,4 +27,12 @@ public sealed class HoldRequest
 public sealed class HoldResponse
 {
     public bool OnHold { get; set; }
+
+    /// <summary>
+    /// True when an EXPLICIT hold was DEFERRED because a real turn was in flight: the session is not held
+    /// yet (<see cref="OnHold"/> is still false), but it will park held the moment the current turn ends.
+    /// Lets the caller tell the user "it'll hold when it finishes what it's doing" instead of implying it
+    /// is already held. False for an immediate hold, an un-hold, or a Gateway that predates this field.
+    /// </summary>
+    public bool Pending { get; set; }
 }


### PR DESCRIPTION
## The bug
Asking to put a session **on hold while it is still working** didn't stick. `OnHold` was set immediately, but the very turn that was in flight then ended, and the turn-END auto-lift (which surfaces an ordinary snooze at the next "needs you") cleared the hold right back off. Net: "put my session on hold" appeared to do nothing.

## The fix — a deferred, durable hold
`Session.RequestHold(onHold)`:
- **un-hold** clears the hold and any pending deferral at once;
- a hold requested **while a real turn is in flight** is **deferred** (a new `_pendingHold` flag) instead of set now;
- a hold requested while the session is already settled applies **immediately** (unchanged).

When the session next settles, `SetActivityState` applies the deferred hold **durably** — `OnHold` goes true and, unlike the automatic snooze, is **not** lifted by that same turn boundary. It parks the session held (red or idle) until the user comes back to it. A fresh submission before it applies **supersedes** the deferral (the user is driving again).

The hold command executor routes through `RequestHold`, and `HoldResponse` gains a `Pending` flag so a caller can tell the user "it'll hold when it finishes what it's doing" rather than implying it's already held.

## Safety
The existing turn-END auto-lift (for a snooze already in place *before* the turn) is **unchanged** — the new path is purely additive, so the prior hold tests pass untouched.

## Verification
- Core + ControlApi + Gateway build clean.
- Full `CcDirector.Core.Tests`: **3016 passed, 8 skipped, 0 failed** (incl. 5 new deferred-hold tests: defer-then-apply at red and idle settles, immediate hold when settled, release-clears-pending, superseded-by-submit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)