### PR TITLE
docs(reviews): add the two independent tunnel-only migration reviews

### DIFF
--- a/docs/reviews/tunnel-only-review-claude-2026-07-14.md
+++ b/docs/reviews/tunnel-only-review-claude-2026-07-14.md
@@ -1,0 +1,194 @@
+# Tunnel-Only Migration Review - Independent Assessment
+
+- Date: 2026-07-14
+- Reviewer: Claude (independent review session "Tunnel Review - Claude fable", machine SOREN_NORTH)
+- Reviewed commit: origin/main at `ff7a571a` ("refactor(gateway-cleanup): remove the dead verify-before-advertise machinery (tunnel-only)", pull request #1511, merged 2026-07-14)
+- Method: read-only review of a detached worktree checked out at origin/main. Five parallel research passes (migration completeness, dead code, connection resilience, documentation, repository hygiene), every load-bearing claim re-verified by hand against the worktree. No product code was changed and no pull request was opened.
+
+**Important note on method:** the working checkout at `D:\ReposFred\devthrottle` was **52 commits behind origin/main** when this review started. The actual tunnel-only cut (pull requests #1486, #1488, release v1.1.0 in #1489) landed inside that gap. Every conclusion below was re-verified against a fresh worktree at `ff7a571a`; conclusions drawn from the stale checkout would have been badly wrong (for example, it still contained the full HTTP fallback paths). The stale checkout is itself a finding - see section 5.
+
+---
+
+## Summary of top findings
+
+1. **The tunnel-only cut is real and holds on the Director leg.** The Gateway never dials a Director: the HTTP client class was deleted, every session verb rides the tunnel, and a Director that is not tunnel-connected produces an explicit 502. Verified by hand (details in section 1).
+2. **The Launcher leg was never migrated.** The Gateway still dials cc-launcher over plain HTTP across the network when the launcher has no stream connection (`src/CcDirector.Gateway/Api/MachineEndpoints.cs:204,302,360-369`). "The Gateway never dials out" is only true for Directors.
+3. **LAN addressing mode still binds the Director Control API to all interfaces** (`0.0.0.0`) when configured (`src/CcDirector.ControlApi/ControlApiHost.cs:264-272`), directly contradicting the cut's stated invariant that the inbound port stays closed on every machine. Nothing dials it anymore, so it is pure attack surface.
+4. **A mid-flight tunnel drop during a command surfaces as a raw HTTP 500, and most hot-path commands are awaited with no timeout at all.** For the driving-on-mobile use case this is the single highest-value resilience fix (section 3, finding R1).
+5. **The public Control API reference documents an endpoint surface that no longer exists.** `docs/public/api/01-control-api.md` still describes sessions, prompts, buffers, git, and handover endpoints on the Director; the Director floor actually has about a dozen routes. Five other documents describe worlds that never shipped and should be deleted outright (section 4).
+6. **Concrete dead code is ready to delete today:** the register/heartbeat cluster inside `GatewayClient.cs`, `DirectorForwarding.cs` plus the unused YARP forwarder registration, the orphaned `DispatchContracts.cs`, the `CockpitWsUrls`/`CockpitShotUrls` contracts, the now-inert `streamMode` configuration key, and the never-assigned `_serveProvisioner` field with its dependent branches (section 2).
+7. **The desktop "Verify now" button can no longer ever succeed** - it still posts to a Gateway verify endpoint that was deleted in the cut (section 1, finding M5).
+
+---
+
+## Section 1 - Tunnel-only migration review
+
+### What is genuinely done (verified against code, not documents)
+
+- **The Gateway has no HTTP path to a Director.** `src/CcDirector.Gateway/Discovery/DirectorEndpointClient.cs` (the HTTP wrapper the Gateway used to call Directors) is deleted. A repository-wide search for `client.<something>Async(director.ControlEndpoint)` call shapes returns zero hits. `src/CcDirector.Gateway/Api/DirectorCommandRouter.cs:13-16` states the new contract plainly: a null result means the Director is not tunnel-connected and the command is unroutable - the endpoint returns 502, never an HTTP dial. Spot-checked on the prompt endpoint (`src/CcDirector.Gateway/Api/GatewayEndpoints.cs:1281-1301`, error text "director not connected to the tunnel") and the buffer endpoint (`GatewayEndpoints.cs:1240-1256`).
+- **The stream-mode flag is gone.** `src/CcDirector.Gateway/GatewayHost.cs:455`: the tunnel is mandatory; the parameter is retained only for existing test call sites. On the Director, `GatewayStreamClient` runs whenever a Gateway is configured.
+- **The Director floor is genuinely small.** `src/CcDirector.ControlApi/ControlEndpoints.cs` (1,158 lines) maps twelve routes: `/healthz`, `/shutdown`, seven `/fleet/*` routes (sessions, send, ask, spawn, rename, done, broadcast), `/sessions/{sid}/fleet-preamble`, `/sessions/{sid}/fleet-preamble-hook-output`, and `/sessions/{sid}/claude-hook`. The old session-driving surface (list, prompt, interrupt, buffer, patch, handover, repositories, and so on) is gone from the Director.
+- **The default bind is loopback only** (`ControlApiHost.cs:266,291,302` - `IPAddress.Loopback`), and at startup the Director proactively **tears down** any Tailscale Serve mapping a previous build left behind (`ControlApiHost.cs:516-524`), so upgraded machines self-heal to a closed inbound port.
+- **Registration rides the tunnel.** The Director no longer posts to register or heartbeat over HTTP (`src/CcDirector.ControlApi/GatewayClient.cs:497-515` - "do NOT register, heartbeat, or run the two-way verify handshake"). The tunnel Hello carries the identity and the hub upserts the registry with `Source="stream"` and an empty control endpoint (`src/CcDirector.Gateway/Streaming/DirectorHub.cs:59-83`, `src/CcDirector.Gateway/Discovery/DirectorRegistry.cs:116-142`).
+- **Two real hardening fixes are in place on the tunnel:** MessagePack framing so binary frames do not inflate by a third and trip the size limit, and a 32-megabyte ceiling for one-shot command replies (`src/CcDirector.Gateway.Contracts/DirectorUpStreamMessages.cs:78,118,126-128`, wired at `GatewayHost.cs:1016-1026`) so large turn or buffer reads no longer kill the connection (pull request #1496).
+- **Web clients only ever talk to the Gateway.** The cockpit, the mobile app, and the phone client all call Gateway routes (`/directors/{id}/...` proxies that now resolve over the tunnel); none dials a Director port directly.
+
+### What is inconsistent, half-migrated, or wrong
+
+**M1. The Launcher leg still dials out over HTTP - and part of that path is already unreachable.** `src/CcDirector.Gateway/Api/MachineEndpoints.cs` tries the launcher stream first (`LauncherCommandRouter.TrySendAsync`, lines 193 and 290) and then falls back to building an `HttpClient` against `http://<networkAddress>:<port>/` across the network (lines 204, 302, and `BuildLauncherClient` at 360-369). This is the exact stream-first-with-HTTP-fallback pattern the Director leg just eliminated. It gets worse: the launcher's own web host now binds loopback only (`src/CcDirector.Launcher/LauncherHost.cs:74` - `o.Listen(IPAddress.Loopback, _port)`), so the remote-address arm of that fallback can never connect to a cross-machine launcher - it is dead code that still reads as a live network path. Meanwhile the launcher runs both legs at once: it still HTTP-registers and heartbeats (`src/CcDirector.Launcher/GatewayRegistrationClient.cs:121-158`, mapped at `MachineEndpoints.cs:70`) and also dials the launcher stream (`src/CcDirector.Launcher/LauncherCore.cs:64,72` start both clients). Comments at `MachineEndpoints.cs:182,280` still say "When stream mode is on", a gate that no longer exists. **Recommendation:** give the launcher the same cut the Director got - tunnel-only commands, registration on the stream, delete the HTTP fallback (its remote arm is provably unreachable already) - or write the exception down explicitly so "the Gateway never dials out" stops being true only with an asterisk.
+
+**M2. LAN addressing mode contradicts the cut - and users can still switch it on.** `src/CcDirector.ControlApi/ControlApiHost.cs:264-272` still binds the Control API to `0.0.0.0` when `addressing_mode` is "lan" in config.json (`src/CcDirector.Core/Configuration/AddressingModeConfig.cs:8` still parses it), and the mode is still settable at runtime through the Gateway settings endpoint (`src/CcDirector.Gateway/Api/SettingsEndpoints.cs:216-229`) and the cockpit settings page (`apps/cockpit/src/settings/SettingsView.tsx`, the addressing chooser). The comment at `ControlApiHost.cs:511-515` says the whole point of the cut is that "the inbound port stays CLOSED on every client machine" - yet this mode opens it on every interface, and since the Gateway never dials Directors anymore, **no shipped caller exists for that open port**. The #1511 commit message says this is deliberately kept for a later slice. **Recommendation:** prioritize that slice, and hide the cockpit chooser in the meantime. This is not just dead code; it is a user-reachable switch whose only remaining effect is opening an unneeded network listener.
+
+**M3. The Gateway still accepts HTTP Director registration nobody sends.** `POST /directors/register` and `POST /directors/{id}/heartbeat` are still mapped (`src/CcDirector.Gateway/Api/GatewayEndpoints.cs:424,439`), and `DirectorRegistry.Upsert` keeps the whole `Source="http"` path with `ControlEndpoint = req.TailnetEndpoint` (`DirectorRegistry.cs:79-109`). Current Directors never call these; only pre-v1.1.0 Directors would. **Recommendation:** keep them through a short compatibility window if older Directors may still be running, then delete the endpoints and the "http" source path together, with the registry sweeper simplification that follows. Record the intended removal date on an issue so it does not silently become permanent.
+
+**M4. `GatewayClient` on the Director is now mostly a fossil.** The file still opens with a class comment describing the five-step register/heartbeat/verify lifecycle (`GatewayClient.cs:15-25`) that `Start()` explicitly no longer performs. The class survives only as the outbound caller for fleet operations plus candidate-address selection. Large parts of it are unreachable (detailed in section 2, finding D1). **Recommendation:** delete the dead members and rewrite the class comment to describe what it actually is now.
+
+**M5. The desktop "Verify now" button can never succeed.** `GatewayClient.VerifyAsync` (`GatewayClient.cs:846`) is still reachable from the desktop Gateway panel (`src/CcDirector.Avalonia/.../GatewayConnectionPanel.axaml.cs:284` via `ControlApiHost.VerifyGatewayNowAsync:156`), but the Gateway endpoint it posts to (`POST /directors/{id}/verify`) was deleted in the cut (only a tombstone comment remains at `GatewayEndpoints.cs:505`). Every press now ends in a failure branch. **Recommendation:** remove the button or repoint it at a meaningful tunnel-health check (the tunnel state that `GatewayConnectionMonitor` already tracks is the honest signal).
+
+**M6. Stale statements inside the code contradict the new reality.** The `ControlApiHost` class comment (`ControlApiHost.cs:19-31`) and several inline comments (lines 277-283, and the startup log line at 463: "loopback only; remote access via Tailscale Serve") still describe Tailscale Serve as the live remote path. Misleading for anyone reading the file cold. **Recommendation:** update the comments and the log line in the next touch of this file.
+
+**M7. The Gateway-side `TailscaleServeProvisioner` still runs.** It is instantiated and started (`GatewayHost.cs:289,463`). Its Director-mapping function is obsolete (Directors no longer accept inbound traffic), though it may still serve the Gateway's own HTTPS front door. **Recommendation:** review what it still maps in practice; strip the Director-mapping logic (`src/CcDirector.Gateway/Tailscale/TailscaleServeProvisioner.cs:329-364` handles per-Director mappings) and keep only whatever fronts the Gateway itself.
+
+**M8. The stream-mode configuration key is parsed but changes nothing.** `src/CcDirector.Core/Configuration/GatewayConfig.cs:107,169` still reads `streamMode` from config.json, but the gate that consumed it is gone: `src/CcDirector.ControlApi/GatewayStreamClient.cs:101` is now `IsEnabled => _config.IsEnabled`, and `GatewayHost.cs:455` ignores the parameter (retained only for test call sites). The XML comments in both files still describe "stream mode off" behavior that cannot happen. **Recommendation:** delete the config key and the stale comments; update the test call sites.
+
+### Verdict
+
+The migration is complete where it matters most - the Director command plane - and the cut was done with discipline (explicit 502 semantics, registration moved onto the Hello, proactive serve-mapping teardown, floor restores in #1498/#1509 when the cut broke fleet verbs). It is **not** complete as a system-wide statement: the launcher leg, the LAN addressing mode, the HTTP registration surface, and the verify remnants are all still standing. None of them breaks the product today; all of them will confuse the next person who reads the code and is told "tunnel-only".
+
+---
+
+## Section 2 - Leftover Director REST cleanup
+
+Verdicts: **DELETE NOW** (statically unreachable or zero production references at `ff7a571a`), **DECIDE** (referenced, but the referencing path is inert or scheduled), **KEEP** (genuinely live).
+
+### DELETE NOW
+
+**D1. The register/heartbeat cluster in `src/CcDirector.ControlApi/GatewayClient.cs`.**
+`Start()` (lines 497-515) no longer enters this code, and the heartbeat timer is never constructed (`_heartbeat` is only ever assigned null; there is no `new Timer` in the file).
+- `SelectActiveUrlThenRegisterAsync` (line 563) - zero callers.
+- `HeartbeatTick` (line 699) - only called by the never-created timer.
+- `MaybeReRegisterOnIdentityChange` (line 792) - only called from `HeartbeatTick`.
+- `MaybeKickVerify` (line 821) - only called from `HeartbeatTick`.
+- The `_heartbeat` field and the `StopAsync` unregister branch guarded by `_registered` (lines 528-544) - `_registered` can never become true because `RegisterLoop` is the only place that sets it and it is no longer entered on any live path.
+- The class comment at lines 15-25 describing the old lifecycle.
+Reason: all unreachable from the three live roots (`Start`, `NotifySessionState`, `VerifyAsync`).
+
+**D2. `src/CcDirector.Gateway/DirectorForwarding.cs` (whole file), plus the dead forwarder registration.** Two static constants whose consumers (`DirectorEndpointClient`, the old WebSocket proxy dial) were deleted by the cut. A repository-wide search for member access `DirectorForwarding.` finds zero hits; the only mentions left are a stale comment at `GatewayHost.cs:997` and a project-file comment. In the same breath, `GatewayHost.cs:998` still registers the YARP HTTP forwarder (`builder.Services.AddHttpForwarder()`) and nothing in the Gateway consumes `IHttpForwarder` anymore. Delete the file, the comments, and the registration (and the package reference if nothing else needs it).
+
+**D2a. `src/CcDirector.Gateway.Contracts/DispatchContracts.cs` (whole file).** The cut deleted the Director's `/dispatch` endpoint (`DispatchEndpoint.cs` no longer exists) and no "dispatch" tunnel verb was ever created, but the contract types (`DispatchRequest`, `DispatchResultDto`) were left behind with zero references outside their own file. Delete.
+
+**D3. `src/CcDirector.Gateway.Contracts/CockpitWsUrls.cs` and `CockpitShotUrls.cs`.** Zero production references; only their own definitions, their two dedicated test files, and one string entry in `NoCrossMachineLoopbackGuardTests.cs`. Superseded by same-origin proxying. Delete both classes, both test files, and fix the guard-list string.
+
+**D4. The never-assigned serve-provisioner field in `src/CcDirector.ControlApi/ControlApiHost.cs`.** The `_serveProvisioner` field (line 101) is never assigned - the teardown at line 521 uses a throwaway local. Therefore the `ServeProvisioner` property (line 149) is always null, the `StopAsync` branch at lines 890-894 is dead, and the three desktop-panel rungs that read it are inert (`GatewayConnectionPanel.axaml.cs:299,387,454` - the troubleshooter auto-fix rung can never fire). Delete the field, the property, the dead branch, and the inert panel rungs. Note: keep the line-521 teardown local - that is the deliberate self-heal.
+
+### DECIDE (inert or scheduled - do not delete blindly, do decide on an issue)
+
+- **`RegisterLoop` / `TryRegisterAsync` / `BuildRegistrationRequest`** (`GatewayClient.cs:618,656` and below): statically reachable only from `VerifyAsync`'s 410-Gone branch (line 863), which can no longer fire because the Gateway verify endpoint is deleted. Effectively dead; classified here rather than DELETE NOW only because the reachability argument is behavioral, not static. Goes away naturally with M5.
+- **`VerifyAsync` and the desktop "Verify now" button** - see M5. Removing them also unblocks deleting the `DirectorVerification` contract types (`src/CcDirector.Gateway.Contracts/DirectorVerification.cs`), which after the cut are referenced only by this inert flow.
+- **`TailscaleServeSelfProvisioner`** (`src/CcDirector.ControlApi/TailscaleServeSelfProvisioner.cs`, 227 lines): only `RemoveOwnMapping` is live (the startup teardown). `EnsureMappingAsync`, `LastError`, and the reconcile logic are reachable only through the dead field of D4 and tests. Shrink the class to the teardown, or fold the teardown into a small helper and delete the rest.
+- **`GatewayConnectivitySelfTest`** (301 lines): still wired to the desktop panel troubleshooter (`GatewayConnectionPanel.axaml.cs:298`), and it still checks `TailscaleServeSelfProvisioner.StatusHasMapping` (`GatewayConnectivitySelfTest.cs:137`) - a mapping the Director now never creates, so that rung will always report "no mapping" as if it were a problem. Review and rebuild the troubleshooter around tunnel health, or remove it.
+- **`AddressingMode.Lan`** - see M2. Removing the mode deletes the `0.0.0.0` bind branch, the LAN resolver arm in `GatewayClient.cs:150`, and the settings plumbing in `src/CcDirector.Gateway/Api/SettingsEndpoints.cs`.
+- **Gateway HTTP registration surface** (`POST /directors/register`, `POST /directors/{id}/heartbeat`, the `Source="http"` registry path) - see M3. Compatibility window, then delete together.
+- **`tools/cc-director-setup-engine/TailnetResolver.cs`**: installer tooling for the Gateway tray HTTPS URL, not Director runtime. Live where it is; fold into the general de-Tailscaling only when the installer story changes.
+
+### KEEP (checked and genuinely live)
+
+`GatewayStreamClient`, `DirectorUpStreamHandler`, `DirectorStreamProducers` (the tunnel itself, now always on); `GatewayConnectionMonitor` (repurposed - the tunnel drives the desktop connectivity light); `GatewayEnrollmentClient` (device enrollment from the desktop panel); `InstanceRegistration` (loopback instance discovery on the same machine); `DirectorReachabilityDto`, `DoorbellRequest`, `HoldRequest` (all have live call sites); every endpoint file currently mapped by `ControlApiHost`; all web-client call sites (they target Gateway proxy routes that still exist).
+
+---
+
+## Section 3 - Connection resilience on bad internet
+
+Context assessed: the owner drives while using the mobile web app over a weak phone network; the Director sits at home behind the tunnel. Three legs: phone to Gateway, Director to Gateway, and command round-trips spanning both.
+
+### What is already good (verified)
+
+- **Director tunnel reconnect is sound.** Automatic reconnect at 0, 2, 5, and 10 seconds (`src/CcDirector.ControlApi/GatewayStreamClient.cs:156-159`), then a supervise loop that re-dials every 5 seconds forever (line 60 and the loop at 228-239). A multi-hour Gateway outage self-heals without a Director restart. On every reconnect the Director re-sends Hello plus a full snapshot, and a quiet session's cache is kept fresh by a re-push every 10 seconds (half the 20-second staleness window, `GatewayStreamClient.cs:90,116`).
+- **The tunnel got two real hardening fixes:** MessagePack framing and the 32-megabyte command-reply ceiling (section 1). Both remove classes of spurious tunnel drops under load.
+- **Car Mode is now durable and idempotent** (this was rebuilt in the missing 52 commits; the pre-cut tree lost voice commands on any blip). Spoken commands are written to IndexedDB before any network work (`packages/client-core/src/carmode/pendingTurnStore.ts:24-47`), retried with exponential backoff capped at 15 seconds for the first hour and then every 5 minutes (`packages/client-core/src/carmode/turnRetry.ts:12-15`), carry an idempotency key so a re-drive acts at most once (`packages/client-core/src/carmode/carModeApi.ts:104-114`), and turns older than 30 minutes are surfaced to the owner instead of auto-fired (`turnRetry.ts:20,34-37`). The states are spoken honestly ("holding", "connection down", "Back online").
+- **Dictation remains the gold standard** (durable, chunked, resumable, idempotent - `packages/client-core/src/dictation/backgroundSend.ts`), and the terminal view never blanks during an outage; it shows "reconnecting" and repaints only after a successful reopen (`packages/client-core/src/terminal/stream.ts:50,384-402`).
+- **A foreground keep-warm ping** (`packages/client-core/src/net/useKeepWarm.ts:11`, every 25 seconds) keeps the direct network path warm, with an honest status pill and server-side drift detection behind it. Note this is a path warmer and an observability feature, not a liveness heartbeat - it does not detect or shorten anything about drops.
+
+### Where it breaks, ranked by impact on the driving scenario
+
+**R1. A mid-flight tunnel drop during a command surfaces as a raw HTTP 500, and hot-path commands have no timeout.** `GatewayHost.SendCommandAsync` (`src/CcDirector.Gateway/GatewayHost.cs:1758-1771`) awaits the hub invocation with whatever token the endpoint passed and no internal deadline and no exception boundary. The hottest endpoints pass `CancellationToken.None`: prompt (`GatewayEndpoints.cs:1281`), kill (1025), patch (1222), create (953 and 1503), interrupt (1344), escape (1358) - 19 call sites in the file. Two concrete failure modes:
+  - Director drops while the command is in flight: the invocation faults, nothing catches it, the phone receives status 500 and shows "The Gateway rejected the request (error 500)" (`packages/client-core/src/api/client.ts:319-323`) - indistinguishable from a Gateway bug, and not the friendly copy that a 502 gets.
+  - Director connected but wedged: with no deadline, the request hangs until the transport-level timeout (about 30 seconds by default) while the driver stares at a spinner.
+  **Fix:** wrap the hub invocation in a bounded timeout (a few seconds for fire-and-forget verbs, longer for create) plus a try/catch that converts the fault into the same typed 502 the not-connected case already returns. One method, one change, every verb benefits.
+
+**R2. Phone write calls have no timeout, so a half-open connection hangs them silently.** Only the repeating poll reads carry the 10-second cap (`client.ts:324` and the call sites at 384, 413, 905, 1069, 1101). Writes - `sendPrompt` (431), hold, kill, the queue verbs - pass no `timeoutMs`, which means on a weak network exactly the wrong calls can hang: the user-initiated ones. Worse, a hung write never flips the connection-health banner (`packages/client-core/src/connection/health.ts` only reacts to completed failures), so the app looks healthy while the send is stuck. **Fix:** give every write a timeout (15 to 20 seconds) so the failure becomes visible and the banner flips. Pair with an idempotency key (R6) before ever adding automatic retry.
+
+**R3. The terminal WebSocket reconnects every 1.2 seconds forever, with no backoff, jitter, or cap** (`packages/client-core/src/terminal/stream.ts:39,429-433`), and has no heartbeat of its own. On a long drive through a dead zone this is the most battery- and data-hungry loop in the app, and every eventual success replays the full history from byte zero (line 397-402, full reset plus replay - correct, but expensive to do fifty times). **Fix:** exponential backoff to a ceiling of 10 to 15 seconds with jitter, reset to fast on visibility change or the health store flipping good.
+
+**R4. Both sides of the tunnel run on default keep-alive timings.** Neither `GatewayStreamClient.cs:149-165` nor the hub options at `GatewayHost.cs:1016-1026` set keep-alive or client-timeout intervals, so the Gateway can take up to about 30 seconds to notice a silently dead Director. Combined with the 20-second cache staleness window (`src/CcDirector.Core/Configuration/GatewayConfig.cs:118`), a phone can spend half a minute sending commands that 502 one by one before the roster shows the truth. **Fix:** set explicit, slightly tighter values (for example 10-second keep-alive, 20-second client timeout) so detection roughly matches the staleness window, and consider surfacing "Director unreachable since [time]" rather than a bare 502 error string.
+
+**R5. Car Mode attempts still have no per-attempt deadline.** The transcribe, speech, and brain-turn calls route through `gatewayFetch` (good - they now feed the health banner) but pass no `timeoutMs` (`carModeApi.ts:27,49,109`); the abort controller fires only on stop or interrupt. The durable retry (above) rescues the outcome, but a single half-open attempt can still sit in "thinking" until the driver notices. **Fix:** per-attempt timeout of 20 to 30 seconds; the existing retry machinery already handles what happens next.
+
+**R6. Command verbs carry no idempotency key.** `DirectorCommandRouter.TrySendAsync` mints a fresh command id per attempt (`DirectorCommandRouter.cs:35-41`). Today nothing auto-retries commands, so exposure is limited to a human re-tapping after an ambiguous timeout - but that is precisely what a driver does. A re-tapped prompt double-submits. Dictation and Car Mode already solved this pattern (client-supplied idempotency key, server dedupe). **Fix:** thread a client-generated idempotency key through prompt at minimum, before implementing R1/R2 retry advice.
+
+**R7. Structural: when the tunnel is down, sessions become unaddressable with no queue.** By design there is no fallback anymore; after the 20-second window a command gets a 502 and the roster honestly marks staleness. That is the right call versus the old silent HTTP dial, but nothing offers the driver "will retry when the Director comes back" for anything except Car Mode turns. Low urgency; worth considering a lightweight held-command pattern for prompt only, reusing the Car Mode machinery.
+
+---
+
+## Section 4 - Outdated documentation
+
+Judged against the code at `ff7a571a`. The skills were partly fixed in pull request #1491; the documents below were not.
+
+### DELETE (describe worlds that never shipped or are fully dead; no salvage value)
+
+| Document | What is wrong |
+|---|---|
+| `docs/PRD-RemoteControl.md` | Describes a Supabase + Vercel + Next.js paid cloud relay with Postgres tables and WPF dialogs. None of it shipped; the product is Gateway plus tunnel, and the desktop moved to Avalonia long ago. |
+| `docs/Implementation-RemoteControl.md` | The build plan for the same dead product; admits at lines 13-16 that the prototype was removed. Points at nothing recoverable. |
+| `docs/CC_Gateway_Design.md` | A "Gateway" that is a Discord bot on `http://localhost:5555/api/` talking to the Director over named pipes. Shares only the name with the real Gateway. Also cross-referenced as the "original design" by `docs/architecture/gateway/GATEWAY_DIRECTOR_ARCHITECTURE.md:12`, which lends it false authority - sever that link when deleting. |
+| `docs/Gateway_Dashboard.md` | A third, different "Gateway": a scheduled-jobs dashboard on `http://localhost:6060/` started by a `cc_director_service` binary that does not exist. Name-collision landmine; cross-referenced at `GATEWAY_DIRECTOR_ARCHITECTURE.md:13`. |
+| `docs/plans/phase1-https-via-tailscale.md` | A plan to make Tailscale Serve the mandatory remote path - the exact opposite of what shipped - and it links to a `REMOTE_ACCESS.md` that does not exist anywhere in the tree. |
+
+### UPDATE (living documents with confirmed-wrong sections)
+
+**U1 (highest priority). `docs/public/api/01-control-api.md`** - the public reference linked from `docs/README.md:36`. Line 3 claims every Director hosts "the programmatic surface for everything the desktop UI can do: sessions, prompts, terminal buffers, git, handovers, repositories, settings" and that "the Cockpit, the phone clients, and agents all drive Directors through this API". Lines 27-71 document `GET/POST/DELETE/PATCH /sessions`, prompt, interrupt, buffer, git, handovers, repositories, settings, tools, dispatch, scheduler, wingman, and a WebSocket stream. The real Director floor is twelve routes (section 1). Rewrite around the floor plus "clients drive sessions through the Gateway"; the environment-variable section (lines 5-21, `CC_DIRECTOR_API` and friends) is still correct and worth keeping.
+
+**U2. `docs/architecture/gateway/GATEWAY_DIRECTOR_ARCHITECTURE.md`** - stamped "Status: CURRENT" (line 3) and aimed at anyone touching the code, yet its thesis is the dead proxy model: "talk to each other over plain HTTP" (line 21), "proxies session-specific calls to the owning Director" (line 26), a whole proxy table (lines 98-208), "exposes that aggregate over Tailscale to your browser" (line 54). Meanwhile the correct target-state documents (`GATEWAY_DIRECTOR_TARGET.md` beside it, and `docs/architecture/DIRECTOR_DUMB_WRAPPER_TARGET.md`) describe what actually shipped. A wrong document stamped CURRENT sitting next to a right document stamped TARGET is the single most misleading state in the tree. Rewrite the transport sections around the tunnel, keep the still-true structural facts (two executables, port ranges, source layout), remove the two dead cross-references, and make it the one canonical architecture page.
+
+**U3. `docs/public/getting-started/02-installation.md`** - line 185 says the Director "opens its own Tailscale Serve front door for remote access, and verifies its advertised address actually answers before registering"; line 189 says the single remote path is "a Tailscale Serve HTTPS mapping ... which each Director now provisions and self-heals for itself". Both false: the Director only tears mappings down (`ControlApiHost.cs:516-524`) and the verify machinery was deleted (#1511). The "Tailscale (optional) - remote access" rows at lines 7 and 15 are also misleading now that Tailscale confers no remote-access benefit (pull request #1506 already removed it from the installer preflights).
+
+**U4. `docs/remote-experience/remote-experience-plan.md`** - the transport premise throughout (lines 5-19) is per-Director and per-session Tailscale Serve URLs, which no longer exist; clients reach the Gateway and the Gateway relays over the tunnel. The three-modes product vision (desktop, mobile supervisor, car voice - lines 22-30) is still good; update the transport framing. Review the sibling `your-suggestions.md` at the same time - it shares the premise.
+
+**U5. `.claude/skills/cc-settings-api/SKILL.md`** - lines 56-72 still teach the advertised-address model: pass `--advertised http://THIS-HOST:7879` because "the gateway cannot call back" to loopback, plus "the Tailscale auto-detection is Windows-only". The Gateway never calls back at all now. Rewrite the "connect this Director to a Gateway" section around dial-out; the settings mechanics in the rest of the skill are fine. (For contrast, `.claude/skills/dev-throttle/SKILL.md` was already corrected by #1491 and now matches the code; its only blemish is a changelog caveat about verbs #1490 broke, which #1498/#1509 have since restored.)
+
+**U6. Code-comment rot (small but worth a sweep):** the `ControlApiHost` class comment and startup log line still name Tailscale Serve as the remote path (section 1, M6), and `GatewayClient.cs:15-25` still describes the deleted register/heartbeat lifecycle.
+
+### Pattern: mission scratch notes intermixed with living architecture
+
+`docs/architecture/` mixes durable reference with dated one-run mission and handover notes (`gateway-cleanup-mission-2026-07-11.md`, `gateway-cleanup-phase0-execution-plan.md`, `gateway-cleanup-phase0-tunnel-protocol.md`, `network-diagnostics-mission-2026-07-13.md`, `car-mode-mission-2026-07-11.md`, `cockpit-improvement-mission-2026-07-10.md`, and more), plus the whole `docs/new_architecture/` phase tree. These were the working papers of the migration - valuable as history, wrong as reference. Move dated mission, phase, and handover notes into `docs/archive/` and leave exactly one authoritative tunnel-only architecture page (U2). `docs/SessionIntercommunication.md` (a design for issue #705) appears superseded by the shipped fleet messaging and deserves a status stamp.
+
+---
+
+## Section 5 - Repository cleanup
+
+### Committed on origin/main (act via pull request)
+
+1. **`tools/cc-browser-archived/` - DELETE.** 51 tracked files. Not in `tools/registry.json`; its only inbound reference is the to-do at `tools/cc-browser/docs/PRD-browser-connections.md:1056` ("Remove cc-browser-archived after confidence period"). The confidence period is over.
+2. **`OVERNIGHT-CHARTER.md` (repository root) - ARCHIVE or DELETE.** A one-time overnight-run instruction sheet hard-coding a throwaway worktree path, a feature branch, and a session id. Nothing references it. Root-level clutter.
+3. **Retired tools, paired registry decision:** `tools/cc-comm-queue/` (its own registry entry at line 247 says "RETIRED - no longer shipped"), `tools/cc-reddit/` (depends on the retired cc-browser), and `tools/cc-browser/` itself (superseded by cc-playwright per registry line 87). Each is dormant-but-catalogued; remove the directory and the `registry.json` entry together, or deliberately keep them listed. Do not delete the directories alone - that creates registry drift.
+4. **`phone/` (the native phone client) - make the retirement decision explicit.** The project decision was to retire the native app in favor of the mobile web app, but the repository shows no trace of that: 181 tracked files, its own solution file, `scripts/deploy-phone.ps1`, and `.github/workflows/docs-drift.yml` still watches `phone/CcDirectorClient/**`. Either delete the directory plus its script and workflow trigger, or record in the tree that it is frozen. Right now a contributor cannot tell.
+5. **Repository weight (note, not urgent):** the largest tracked files are test fixtures - `src/CcDirector.Core.Tests/TestData/claude-stray-today.expected.json` at 19.7 megabytes, plus two more at 13.2 and 12.2 megabytes (about 45 megabytes of expected-output JSON), and `claude-stray-today.bin` is byte-identical to `claude-session-huge-50.bin`. Candidates for trimming or generating; also `docs/features/voice-mode/REPORT.html` at 3.2 megabytes.
+6. Confirmed clean: no `nul` files anywhere, no tracked `bin/`, `obj/`, `dist/`, or publish output, no tracked `.orig`/`.bak`/`.tmp` files, and `.gitignore` coverage is thorough. `docs/archive/`, `docs/spikes/`, `docs/problems/`, and `docs/mockups/` are small, intentional, and fine to keep. The root `package.json` and `eslint.config.js` are a legitimate npm workspace root, not clutter.
+
+### The live working checkout on this machine (local cleanup, no pull request)
+
+7. **The checkout was 52 commits behind origin/main** at review start, with two modified tracked files and 14 untracked documents sitting in `docs/architecture/`. Under the project's own convergence rule the resting state is checkout equal to origin/main and clean. Recommend a `git pull` and a sweep.
+8. **`docs/architecture/car-mode-mission-2026-07-11.md.local-bak` - DELETE.** An editor backup file.
+9. **13 untracked mission and cleanup scratch documents** (`gateway-cleanup-phase2-repoint-design.md`, `gateway-cleanup-phase1-*`, `*-mission-2026-07-11.md`, and others): commit the ones worth keeping (several are the best record of how the migration was designed) or delete them. Today they are neither tracked nor ignored, so they pollute the status of every session on this machine.
+10. **Local-only directories never committed and already ignored** - safe to sweep for disk space: `artifacts/` (about 40 one-time test-run captures), root `mobile/` (a local debugging harness superseded by `apps/mobile` - do not confuse the two), `playground/`, `scheduler/`, `mcps/`, `tools/__pycache__/`, `tools/.pytest_cache/`, and stale numbered executables in `local_builds/` (about 190 megabytes).
+
+---
+
+## Suggested order of work
+
+1. R1 and R2 (command timeout plus typed error, phone write timeouts) - small changes, largest effect on the driving experience.
+2. Delete list D1-D4 plus the M5 verify remnants - one focused cleanup pull request, all statically safe.
+3. U1 and U2 (the public API reference and the CURRENT-stamped architecture page) - the two documents actively misleading people today.
+4. M2 (LAN addressing mode) and M3 (HTTP registration surface) - close the remaining inbound-surface questions with explicit decisions.
+5. The five document deletions, the scratch-note archive sweep, and the repository cleanup items 1-4.
+6. R3-R6 as a mobile-resilience follow-up mission.

--- a/docs/reviews/tunnel-only-review-codex-2026-07-14.md
+++ b/docs/reviews/tunnel-only-review-codex-2026-07-14.md
@@ -1,0 +1,157 @@
+# Tunnel Only Review
+
+Review target: origin/main on 2026-07-14.
+
+## 1. Tunnel Only Migration Review
+
+### Finding 1.1: The main Gateway to Director command path is tunnel only.
+
+Evidence: `src/CcDirector.Gateway/Api/DirectorCommandRouter.cs:12` to `src/CcDirector.Gateway/Api/DirectorCommandRouter.cs:16` says the old Director client is deleted and a null tunnel send means the Director is not connected. The router only constructs a `DirectorCommand` and calls the injected tunnel sender at `src/CcDirector.Gateway/Api/DirectorCommandRouter.cs:35` to `src/CcDirector.Gateway/Api/DirectorCommandRouter.cs:44`. The sender in `src/CcDirector.Gateway/GatewayHost.cs:1758` to `src/CcDirector.Gateway/GatewayHost.cs:1771` resolves the active SignalR connection and invokes the command over that connection.
+
+Recommendation: Keep this architecture. Add a focused test or static check that fails if a new Gateway to Director Hypertext Transfer Protocol client is introduced.
+
+### Finding 1.2: The Director still has a nontrivial local Hypertext Transfer Protocol floor, and one mode can still bind it to every network interface.
+
+Evidence: the default branch binds loopback at `src/CcDirector.ControlApi/ControlApiHost.cs:276` to `src/CcDirector.ControlApi/ControlApiHost.cs:287`, but local area network mode binds `IPAddress.Any` at `src/CcDirector.ControlApi/ControlApiHost.cs:264` to `src/CcDirector.ControlApi/ControlApiHost.cs:272`. The code maps local routes for settings, agents, tools, workspaces, and scheduler at `src/CcDirector.ControlApi/ControlApiHost.cs:436` to `src/CcDirector.ControlApi/ControlApiHost.cs:443`. The comment says these are local floor routes, but also says remote configuration editing still needs tunnel verbs later at `src/CcDirector.ControlApi/ControlApiHost.cs:428` to `src/CcDirector.ControlApi/ControlApiHost.cs:435`.
+
+Recommendation: Keep only if local area network mode is still an explicit supported deployment. If the migration goal is strict loopback only, remove the `IPAddress.Any` branch or guard it behind a development only setting. Also either complete the configuration tunnel verbs or clearly mark the current local floor as the final supported local only surface.
+
+### Finding 1.3: The Gateway still exposes old Director registration and heartbeat routes.
+
+Evidence: `POST /directors/register` is still mapped at `src/CcDirector.Gateway/Api/GatewayEndpoints.cs:424` to `src/CcDirector.Gateway/Api/GatewayEndpoints.cs:437`; `POST /directors/{id}/heartbeat` is still mapped at `src/CcDirector.Gateway/Api/GatewayEndpoints.cs:439` to `src/CcDirector.Gateway/Api/GatewayEndpoints.cs:470`; `DELETE /directors/{id}/registration` is still mapped at `src/CcDirector.Gateway/Api/GatewayEndpoints.cs:510` to `src/CcDirector.Gateway/Api/GatewayEndpoints.cs:516`. Current Director startup says it no longer registers or heartbeats over Hypertext Transfer Protocol at `src/CcDirector.ControlApi/GatewayClient.cs:517` to `src/CcDirector.ControlApi/GatewayClient.cs:524`. Tunnel registration happens in `src/CcDirector.Gateway/Streaming/DirectorHub.cs:77` to `src/CcDirector.Gateway/Streaming/DirectorHub.cs:83`.
+
+Recommendation: Delete the registration and heartbeat routes after confirming there is no supported old Director compatibility requirement. Keep `POST /directors/{id}/doorbell` for now because current Director code still sends it at `src/CcDirector.ControlApi/GatewayClient.cs:803` to `src/CcDirector.ControlApi/GatewayClient.cs:815`.
+
+### Finding 1.4: The migration is functionally ahead of its comments.
+
+Evidence: `src/CcDirector.Gateway/GatewayHost.cs:1755` to `src/CcDirector.Gateway/GatewayHost.cs:1756` still says callers fall back to the old command path, while `src/CcDirector.Gateway/Api/DirectorCommandRouter.cs:13` to `src/CcDirector.Gateway/Api/DirectorCommandRouter.cs:16` says there is no fallback. Many route comments still describe a pre-cut fallback, for example `src/CcDirector.Gateway/Api/GatewayEndpoints.cs:1040` to `src/CcDirector.Gateway/Api/GatewayEndpoints.cs:1043`, `src/CcDirector.Gateway/Api/GatewayEndpoints.cs:1071` to `src/CcDirector.Gateway/Api/GatewayEndpoints.cs:1074`, and `src/CcDirector.Gateway/Api/GatewayEndpoints.cs:1090` to `src/CcDirector.Gateway/Api/GatewayEndpoints.cs:1095`.
+
+Recommendation: Update these comments now. They are not harmless because future changes will copy the old fallback rule back into new code.
+
+### Finding 1.5: The old phone client still uses Director addresses after creating or selecting a session.
+
+Evidence: after a session is created through the Gateway, the phone client stamps the Director endpoint onto the session at `phone/CcDirectorClient/Voice/GatewayClient.cs:253` to `phone/CcDirectorClient/Voice/GatewayClient.cs:285`. The fleet parser falls back from `tailnetEndpoint` to `controlEndpoint` at `phone/CcDirectorClient/Voice/FleetParser.cs:40` to `phone/CcDirectorClient/Voice/FleetParser.cs:52`. Raw terminal HTML is built against a Director base address at `phone/CcDirectorClient/Voice/RawTerminalPage.cs:36` to `phone/CcDirectorClient/Voice/RawTerminalPage.cs:43`.
+
+Recommendation: Either delete the old phone project if the React mobile application is the only supported phone experience, or migrate every phone operation to same origin Gateway routes. Keeping this client in the repository makes the migration look incomplete.
+
+## 2. Leftover Director Representational State Transfer Cleanup
+
+### Finding 2.1: Delete dead registration and heartbeat implementation in `GatewayClient`.
+
+Evidence: `GatewayClient.Start` says the old register, heartbeat, and verify loop is gone at `src/CcDirector.ControlApi/GatewayClient.cs:517` to `src/CcDirector.ControlApi/GatewayClient.cs:524`. The timer field remains but is never assigned; references are only declarations and disposal in `src/CcDirector.ControlApi/GatewayClient.cs:62`, `src/CcDirector.ControlApi/GatewayClient.cs:544`, `src/CcDirector.ControlApi/GatewayClient.cs:567`, and the uncalled `HeartbeatTick` at `src/CcDirector.ControlApi/GatewayClient.cs:733`. `RegisterLoop`, `TryRegisterAsync`, `HeartbeatTick`, and related helpers remain at `src/CcDirector.ControlApi/GatewayClient.cs:634` to `src/CcDirector.ControlApi/GatewayClient.cs:818`.
+
+Recommendation: Delete the old registration, heartbeat, and verification code from `GatewayClient`. Keep the active on-demand outbound calls such as doorbell and session number allocation.
+
+### Finding 2.2: Delete or isolate old Gateway registration routes.
+
+Evidence: the old `DirectorRegistry.Upsert` path still builds an entry with `Source = "http"` and a dialable control endpoint at `src/CcDirector.Gateway/Discovery/DirectorRegistry.cs:79` to `src/CcDirector.Gateway/Discovery/DirectorRegistry.cs:110`. The tunnel registration path builds an entry with empty control endpoint at `src/CcDirector.Gateway/Discovery/DirectorRegistry.cs:120` to `src/CcDirector.Gateway/Discovery/DirectorRegistry.cs:143`.
+
+Recommendation: Delete `Upsert` and the Gateway route that calls it if old Directors are not supported. If old compatibility is required, move it behind a named legacy setting and keep it out of the normal tunnel-only path.
+
+### Finding 2.3: Delete `DirectorForwarding` and the unused forwarding package.
+
+Evidence: `src/CcDirector.Gateway/DirectorForwarding.cs:3` to `src/CcDirector.Gateway/DirectorForwarding.cs:20` describes direct proxying to Director control endpoints. The only code reference is a stale comment at `src/CcDirector.Gateway/GatewayHost.cs:997`. The Gateway project still references `Yarp.ReverseProxy` at `src/CcDirector.Gateway/CcDirector.Gateway.csproj:25` to `src/CcDirector.Gateway/CcDirector.Gateway.csproj:27`, but the only code hits for Yarp are this package reference and obsolete documentation.
+
+Recommendation: Delete `DirectorForwarding.cs`, remove `builder.Services.AddHttpForwarder()` at `src/CcDirector.Gateway/GatewayHost.cs:997` to `src/CcDirector.Gateway/GatewayHost.cs:998`, and remove the package reference if no other branch needs the one address proxy.
+
+### Finding 2.4: Delete or rewrite verification contracts.
+
+Evidence: `DirectorVerification.cs` describes a Gateway callback to the Director at `src/CcDirector.Gateway.Contracts/DirectorVerification.cs:3` to `src/CcDirector.Gateway.Contracts/DirectorVerification.cs:8` and a WebSocket callback leg at `src/CcDirector.Gateway.Contracts/DirectorVerification.cs:50` to `src/CcDirector.Gateway.Contracts/DirectorVerification.cs:63`. The Gateway route comment says that callback handshake is deleted at `src/CcDirector.Gateway/Api/GatewayEndpoints.cs:505` to `src/CcDirector.Gateway/Api/GatewayEndpoints.cs:508`. Current `VerifyAsync` still posts to `/directors/{id}/verify` at `src/CcDirector.ControlApi/GatewayClient.cs:880` to `src/CcDirector.ControlApi/GatewayClient.cs:912`, but no Gateway route for that path remains.
+
+Recommendation: Delete `VerifyAsync`, `DirectorVerifyRequest`, `DirectorVerifyResultDto`, and `VerifyCallbackDto`, or replace them with a tunnel health check that does not dial a Director.
+
+### Finding 2.5: Keep the Director doorbell route, but fix the wording.
+
+Evidence: current Director code still sends `POST /directors/{id}/doorbell` at `src/CcDirector.ControlApi/GatewayClient.cs:803` to `src/CcDirector.ControlApi/GatewayClient.cs:815`; the Gateway consumes it at `src/CcDirector.Gateway/Api/GatewayEndpoints.cs:479` to `src/CcDirector.Gateway/Api/GatewayEndpoints.cs:490`. The contract says the Gateway pulls truth over Director representational state transfer after the ping at `src/CcDirector.Gateway.Contracts/DoorbellRequest.cs:3` to `src/CcDirector.Gateway.Contracts/DoorbellRequest.cs:10`, which no longer matches the tunnel push model.
+
+Recommendation: Keep the route as an outbound Director to Gateway notification until it is replaced by a tunnel upstream event. Update the contract comment to say the periodic tunnel snapshot reconciles missed pings.
+
+## 3. Connection Resilience On Bad Internet
+
+### Finding 3.1: Tunnel reconnect is reasonable, but the fixed long-outage retry is too aggressive for weak mobile networks.
+
+Evidence: the Director tunnel client uses automatic reconnect delays of zero, two, five, and ten seconds at `src/CcDirector.ControlApi/GatewayStreamClient.cs:156` to `src/CcDirector.ControlApi/GatewayStreamClient.cs:159`. After that gives up, the supervise loop redials every five seconds at `src/CcDirector.ControlApi/GatewayStreamClient.cs:228` to `src/CcDirector.ControlApi/GatewayStreamClient.cs:239`.
+
+Recommendation: Keep the fast first ladder, then change the long-outage loop to randomized increasing delay with a maximum around thirty to sixty seconds. Reset it after a successful reseed. This reduces repeated failed connection attempts on a weak phone hotspot without making normal brief drops slower.
+
+### Finding 3.2: State recovery after reconnect is good for roster state.
+
+Evidence: on reconnect the client sends `Hello` and a full snapshot at `src/CcDirector.ControlApi/GatewayStreamClient.cs:275` to `src/CcDirector.ControlApi/GatewayStreamClient.cs:292`. The pushed store treats each connection as a new generation at `src/CcDirector.Gateway/Streaming/PushedSessionStore.cs:47` to `src/CcDirector.Gateway/Streaming/PushedSessionStore.cs:68`, drops stale sequence messages at `src/CcDirector.Gateway/Streaming/PushedSessionStore.cs:12` to `src/CcDirector.Gateway/Streaming/PushedSessionStore.cs:24`, and keeps quiet sessions fresh with periodic full repush at `src/CcDirector.ControlApi/GatewayStreamClient.cs:111` to `src/CcDirector.ControlApi/GatewayStreamClient.cs:136`.
+
+Recommendation: Keep this. It is the strongest part of the migration.
+
+### Finding 3.3: Live streams are torn down correctly, but user work in in-flight commands is not replayed.
+
+Evidence: the tunnel client cancels all upstream producers during reconnect and close at `src/CcDirector.ControlApi/GatewayStreamClient.cs:167` to `src/CcDirector.ControlApi/GatewayStreamClient.cs:178`. The browser terminal reopens the stream and replays terminal history on the next connection at `packages/client-core/src/terminal/interactive.ts:376` to `packages/client-core/src/terminal/interactive.ts:403`. However, command writes such as prompt, escape, and interrupt are one-shot requests at `packages/client-core/src/api/client.ts:423` to `packages/client-core/src/api/client.ts:465`. They use `gatewayFetch` without a timeout or durable retry; the fetch helper says one-shot writes pass no timeout at `packages/client-core/src/api/client.ts:264` to `packages/client-core/src/api/client.ts:270`.
+
+Recommendation: Add a command request shape that is safe to repeat for user-submitted prompts and destructive controls, or at least add a visible pending and retry state for writes that fail while the tunnel is down. Dictation already uses stronger durability; normal typed commands should not be weaker.
+
+### Finding 3.4: The mobile read-only terminal reconnects every one point two seconds forever.
+
+Evidence: the read-only terminal has a fixed reconnect delay of one point two seconds at `packages/client-core/src/terminal/stream.ts:39`, and its close handler always schedules another connection with that same delay at `packages/client-core/src/terminal/stream.ts:420` to `packages/client-core/src/terminal/stream.ts:434`. The interactive terminal is better: it uses thirty fast attempts and then a fifteen second slow probe at `packages/client-core/src/terminal/interactive.ts:56` to `packages/client-core/src/terminal/interactive.ts:61` and `packages/client-core/src/terminal/interactive.ts:461` to `packages/client-core/src/terminal/interactive.ts:481`.
+
+Recommendation: Give the mobile terminal the same slow keepalive behavior as the interactive terminal. On weak mobile internet, a permanent one point two second loop wastes battery and radio time.
+
+### Finding 3.5: Dictation upload is the best current model for weak connections.
+
+Evidence: dictation upload registers with an idempotency key at `packages/client-core/src/api/client.ts:1495` to `packages/client-core/src/api/client.ts:1508`, stores the audio locally before chunk planning at `packages/client-core/src/api/client.ts:1535` to `packages/client-core/src/api/client.ts:1538`, resumes missing chunks at `packages/client-core/src/api/client.ts:1560` to `packages/client-core/src/api/client.ts:1599`, and treats a swept server staging area as retryable at `packages/client-core/src/api/client.ts:1601` to `packages/client-core/src/api/client.ts:1605`.
+
+Recommendation: Use this pattern for other user work that must survive a tunnel or phone network drop.
+
+## 4. Outdated Documentation
+
+### Finding 4.1: `docs/architecture/cockpit/COCKPIT_DESIGN.md` should be updated or archived.
+
+Evidence: it says to lift a typed client from `DirectorEndpointClient` at `docs/architecture/cockpit/COCKPIT_DESIGN.md:81` to `docs/architecture/cockpit/COCKPIT_DESIGN.md:85`. It says the terminal opens a direct WebSocket to the owning Director at `docs/architecture/cockpit/COCKPIT_DESIGN.md:105` to `docs/architecture/cockpit/COCKPIT_DESIGN.md:108` and again at `docs/architecture/cockpit/COCKPIT_DESIGN.md:117` to `docs/architecture/cockpit/COCKPIT_DESIGN.md:122`.
+
+Recommendation: Update if this is still the Cockpit architecture page. Otherwise move it to an archive folder and put a short replacement that says the browser talks to the Gateway and the Gateway reaches Directors through the tunnel.
+
+### Finding 4.2: `docs/architecture/gateway/GATEWAY_DIRECTOR_ARCHITECTURE.md` should be updated.
+
+Evidence: it lists `DirectorEndpointClient` as the per-Director client at `docs/architecture/gateway/GATEWAY_DIRECTOR_ARCHITECTURE.md:77` to `docs/architecture/gateway/GATEWAY_DIRECTOR_ARCHITECTURE.md:83`, and says there is no cache of session data and every `/sessions` call fans out live at `docs/architecture/gateway/GATEWAY_DIRECTOR_ARCHITECTURE.md:89`.
+
+Recommendation: Update. This is a general architecture document, so stale content here will mislead new work.
+
+### Finding 4.3: `docs/architecture/gateway/DIRECTOR_LIVENESS_PLAN.md` should be deleted or marked historical.
+
+Evidence: it is built around heartbeat expiry and probing Director control endpoints at `docs/architecture/gateway/DIRECTOR_LIVENESS_PLAN.md:11` to `docs/architecture/gateway/DIRECTOR_LIVENESS_PLAN.md:19`, and still points to `DirectorEndpointClient` at `docs/architecture/gateway/DIRECTOR_LIVENESS_PLAN.md:58` to `docs/architecture/gateway/DIRECTOR_LIVENESS_PLAN.md:63`.
+
+Recommendation: Delete if no one needs the history. Otherwise move it under an archive folder and mark it as pre-tunnel.
+
+### Finding 4.4: `docs/new_architecture/phase-1-full-bidirectional-spec.md` should be archived.
+
+Evidence: it tells implementers to keep the old fallback path at `docs/new_architecture/phase-1-full-bidirectional-spec.md:86` to `docs/new_architecture/phase-1-full-bidirectional-spec.md:93`, which is no longer true.
+
+Recommendation: Archive as a completed phase document. Do not leave it in an active architecture folder.
+
+### Finding 4.5: `docs/new_architecture/OVERNIGHT-STATUS.md` should be archived.
+
+Evidence: it describes the old flag-gated and fallback world repeatedly, including preserved fallback at `docs/new_architecture/OVERNIGHT-STATUS.md:15` to `docs/new_architecture/OVERNIGHT-STATUS.md:17` and a routing helper that falls back to `DirectorEndpointClient` at `docs/new_architecture/OVERNIGHT-STATUS.md:73` to `docs/new_architecture/OVERNIGHT-STATUS.md:77`.
+
+Recommendation: Archive. It is useful history, but it should not be an active status source after the cut.
+
+## 5. Repository Cleanup
+
+### Finding 5.1: Remove checked-in backup files.
+
+Evidence: `phone/CcDirectorClient/TalkPage.xaml.cs.fixbak` and `phone/CcDirectorClient/TalkPage.xaml.fixbak` are tracked. They are duplicate backup files, and the main phone code also contains stale direct Director paths.
+
+Recommendation: Delete both backup files.
+
+### Finding 5.2: Clean up proof output that is not durable documentation.
+
+Evidence: tracked proof output includes logs, test output, generated spreadsheets, and audio files such as `docs/cencon/proof/issue-509/ask-sequence.log`, `docs/cencon/proof/issue-887/live-transcription/tts-clip.wav`, `docs/theme-gallery/test-repro-output.xlsx`, and multiple `test-output.txt` and `summary.json` files under `docs/cencon/proof`.
+
+Recommendation: Move large proof artifacts to external storage or an archive package, and keep only short written proof summaries in the repository.
+
+### Finding 5.3: Remove unused one address forwarding dependency if the proxy is gone.
+
+Evidence: the project still references `Yarp.ReverseProxy` at `src/CcDirector.Gateway/CcDirector.Gateway.csproj:25` to `src/CcDirector.Gateway/CcDirector.Gateway.csproj:27`, and still calls `AddHttpForwarder` at `src/CcDirector.Gateway/GatewayHost.cs:997` to `src/CcDirector.Gateway/GatewayHost.cs:998`. No live code uses the forwarder after the tunnel cut.
+
+Recommendation: Delete the dependency and service registration together with `DirectorForwarding.cs`.
+
+### Finding 5.4: Decide whether the old `phone` tree is still shipped.
+
+Evidence: the solution file does not list `CcDirectorClient`, while the phone tree still has direct Director endpoint code and backup files. The current web mobile application uses same-origin Gateway calls through `packages/client-core/src/api/client.ts:380` and nearby routes, while the phone tree keeps its own transport model.
+
+Recommendation: If the web mobile application is the supported phone surface, archive or delete the old `phone/CcDirectorClient` tree. If it is still shipped, migrating it to Gateway-only routes should be treated as part of finishing the tunnel-only cut.


### PR DESCRIPTION
Adds the two independent tunnel-only migration review documents produced on 2026-07-14.

## Why this needs to be on main

Issues thefrederiksen/devthrottle_internal#785 through thefrederiksen/devthrottle_internal#799, and tracking issue thefrederiksen/devthrottle_internal#800, were filed from these reviews and every one of them references the documents by path (`docs/reviews/tunnel-only-review-claude-2026-07-14.md` and `docs/reviews/tunnel-only-review-codex-2026-07-14.md`). Until now those files existed only as untracked files in one shared working checkout, so the evidence trail behind sixteen issues resolved for nobody else - and a routine hygiene sweep of that shared tree would have deleted them.

## What they are

Two reviewers examined origin/main independently, with no knowledge of each other's work: one Claude Code on the fable model, one Codex. Both covered the same five areas - the tunnel-only migration itself, leftover Director HTTP cleanup, connection resilience on a weak mobile network while driving, outdated documentation, and repository cleanup.

Both converged on the same headline: the tunnel-only cut is real and holds on the Director command path - the Gateway genuinely never dials a Director. The remaining gaps are the unmigrated launcher leg, resilience on weak connections, leftover dead code, and documentation that still describes the pre-cut world.

Documents only. No product code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
