### PR TITLE
fix(repo): stop agents reading stale checkouts - guard, hook, and rule zero

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File \"${CLAUDE_PROJECT_DIR}\\scripts\\check-tree-freshness.ps1\" -MaxBehind 0 -Quiet"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,39 @@ This is **enterprise-level software** requiring robust error handling, comprehen
 
 ## Critical Rules
 
+### 00. NEVER READ OR WORK FROM A STALE CHECKOUT - THIS IS RULE ZERO
+
+**A checkout that is behind origin/main is a lie. Reading it and reporting what you find as fact is the single most expensive mistake we make. Verify freshness BEFORE you read a single file.**
+
+This has already cost real time, repeatedly, in one day:
+
+- A session read `GatewayEndpoints.cs` in a tree 53 commits behind, concluded a shipped feature "was never merged or was reverted", and escalated. It had shipped days earlier.
+- Another session read `session_ops.py` in a tree 55 commits behind, concluded a fixed file was still broken, and wrote that into a GitHub issue comment as evidence. The fix was already on main.
+
+Both sessions were confident. Both were wrong. Both were caught only because a third party double-checked. **Do not rely on being double-checked.**
+
+**The rule:**
+
+1. **Before reading code to answer a question, check the tree.** The `SessionStart` hook runs `scripts/check-tree-freshness.ps1` and fails loud when this tree is behind origin/main. If you see that banner, believe it. Run it yourself any time you are unsure:
+   ```
+   powershell -NoProfile -File scripts\check-tree-freshness.ps1
+   ```
+2. **To READ shipped code, read origin/main directly - never the working tree:**
+   ```
+   git fetch origin
+   git show origin/main:path/to/file.cs
+   git grep <pattern> origin/main
+   ```
+3. **To WORK - edit, build, open a pull request - cut a worktree from origin/main.** Never work in the shared checkout, and never `git checkout -b` in it:
+   ```
+   git fetch origin
+   git worktree add ../<repo>-<task> -b <branch-name> origin/main
+   ```
+4. **Never `git pull` the shared checkout to "fix" staleness.** Other sessions and agents are working in it; pulling underneath them breaks them. Cut a worktree instead.
+5. **A branch is stale the moment origin/main moves past it.** Rebase onto origin/main or cut a fresh worktree. Do not build on a base you fetched hours ago.
+
+**When you state a fact about the code, it must come from origin/main or a worktree cut from it.** If you cannot say which, you do not know the fact - go and check. Saying "the code says X" when X came from a stale tree is reporting fiction as evidence.
+
 ### 0a. WRITE IN PLAIN ENGLISH - NO ABBREVIATIONS
 
 **Never use abbreviations, acronyms, initialisms, or jargon. Write out the full words in plain English, everywhere.**

--- a/scripts/check-tree-freshness.ps1
+++ b/scripts/check-tree-freshness.ps1
@@ -1,0 +1,118 @@
+<#
+.SYNOPSIS
+    Fail loud when this checkout is behind origin/main.
+
+.DESCRIPTION
+    A checkout that lags origin/main makes every file in it a lie. An agent that reads
+    such a tree draws confident conclusions from code that shipped, changed, or was
+    deleted weeks ago, and reports them as fact. This has caused repeated wrong calls:
+    a merged feature reported as never merged, and a fixed file reported as still broken.
+
+    This script is the guard. It fetches, compares HEAD to origin/main, and fails with a
+    non-zero exit code when the gap exceeds the allowed threshold. It is wired into the
+    SessionStart hook (.claude/settings.json) so every agent session is told the truth
+    about its tree before it reads a single file.
+
+    NO FALLBACK: this does not auto-pull. A shared checkout may have other sessions and
+    other agents working in it, and pulling underneath them is destructive. The script
+    reports the exact problem and the exact fix; a human or agent decides.
+
+.PARAMETER MaxBehind
+    How many commits behind origin/main is tolerated before failing. Default 0.
+
+.PARAMETER Quiet
+    Print nothing when the tree is current. Used by the SessionStart hook so a healthy
+    tree adds no noise to the session.
+
+.EXAMPLE
+    powershell -NoProfile -File scripts\check-tree-freshness.ps1
+    powershell -NoProfile -File scripts\check-tree-freshness.ps1 -MaxBehind 5 -Quiet
+#>
+[CmdletBinding()]
+param(
+    [int] $MaxBehind = 0,
+    [switch] $Quiet
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Section {
+    param([string] $Text)
+    Write-Output $Text
+}
+
+# Resolve the repository root from this script's location so the check works from any
+# working directory (hooks do not guarantee one).
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+
+Push-Location $repoRoot
+try {
+    $insideRepo = & git rev-parse --is-inside-work-tree 2>$null
+    if ($LASTEXITCODE -ne 0 -or $insideRepo -ne "true") {
+        Write-Output "STALE-CHECK: not a git working tree at $repoRoot - skipping."
+        exit 0
+    }
+
+    # Fetch quietly. A failure here is NOT fatal: offline is a legitimate state, but the
+    # comparison below is then made against whatever origin/main we last saw, and we say so.
+    $fetchFailed = $false
+    & git fetch origin --quiet 2>$null
+    if ($LASTEXITCODE -ne 0) { $fetchFailed = $true }
+
+    & git rev-parse --verify --quiet origin/main > $null 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Output "STALE-CHECK: origin/main not found - skipping."
+        exit 0
+    }
+
+    $behind = [int](& git rev-list --count HEAD..origin/main 2>$null)
+    $branch = & git rev-parse --abbrev-ref HEAD 2>$null
+    $head = & git rev-parse --short HEAD 2>$null
+
+    if ($behind -le $MaxBehind) {
+        if (-not $Quiet) {
+            Write-Output "STALE-CHECK: OK - $branch ($head) is $behind commit(s) behind origin/main."
+        }
+        exit 0
+    }
+
+    # Behind the threshold. Fail loud, and say exactly what to do about it.
+    Write-Section ""
+    Write-Section "=============================================================================="
+    Write-Section " STOP - THIS CHECKOUT IS STALE. DO NOT TRUST WHAT YOU READ IN IT."
+    Write-Section "=============================================================================="
+    Write-Section ""
+    Write-Section "  Tree:      $repoRoot"
+    Write-Section "  Branch:    $branch ($head)"
+    Write-Section "  Behind:    $behind commit(s) behind origin/main"
+    if ($fetchFailed) {
+        Write-Section "  WARNING:   git fetch FAILED - the real gap may be larger than $behind."
+    }
+    Write-Section ""
+    Write-Section "  Every file in this tree may be out of date. Reading it and reporting what"
+    Write-Section "  you find as fact is how we have shipped wrong conclusions before: a merged"
+    Write-Section "  feature reported as never merged, a fixed file reported as still broken."
+    Write-Section ""
+    Write-Section "  THE RULE: never read code from a stale tree. Read shipped code, or work in"
+    Write-Section "  a worktree cut from origin/main."
+    Write-Section ""
+    Write-Section "  To READ shipped code without touching this tree:"
+    Write-Section "      git fetch origin"
+    Write-Section "      git show origin/main:path/to/file.cs"
+    Write-Section "      git grep <pattern> origin/main"
+    Write-Section ""
+    Write-Section "  To WORK (build, edit, open a pull request), cut a worktree off origin/main:"
+    Write-Section "      git fetch origin"
+    Write-Section "      git worktree add ../<repo>-<task> -b <branch-name> origin/main"
+    Write-Section ""
+    Write-Section "  Do NOT git pull this tree without checking who else is working in it -"
+    Write-Section "  it is shared, and pulling underneath a live session breaks that session."
+    Write-Section ""
+    Write-Section "=============================================================================="
+    Write-Section ""
+
+    exit 1
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## The problem

A checkout behind `origin/main` is a lie, and reporting what you read in one as fact is the most expensive recurring mistake we make. It happened **twice in one day** on 2026-07-14, in the shared checkout, from two different sessions:

- A session read `GatewayEndpoints.cs` in a tree **53 commits behind**, concluded a shipped feature "was never merged or was reverted", and escalated. It had shipped days earlier.
- Another session read `session_ops.py` in a tree **55 commits behind**, concluded a fixed file was still broken, and wrote that into a comment on #1514 as evidence. The fix had already landed on main in #1498.

Both sessions were confident. Both were wrong. Both were caught only because a third party double-checked. Asking agents to keep repositories clean and stay off old branches had already been said, and it did not hold - so this makes it **enforced rather than remembered**.

## The fix

**`scripts/check-tree-freshness.ps1`** - fetches, compares HEAD to `origin/main`, fails loud with a non-zero exit code when the tree is behind. It deliberately does **not** auto-pull: the shared checkout has live sessions in it, and pulling underneath them is destructive. It reports the exact gap and the exact fix, and lets a human or agent decide.

**`.claude/settings.json`** - runs the guard as a `SessionStart` hook, so every agent session is told the truth about its tree before it reads a single file. Silent when the tree is current; loud when it is not.

**`CLAUDE.md` Critical Rule 00** - read shipped code with `git show origin/main:<path>`, work only in worktrees cut from `origin/main`, never pull the shared tree, and know which tree any claim about the code came from.

## Verification

Tested both directions:

- Worktree cut from `origin/main`: silent, exit 0.
- The real shared checkout, 55 commits behind: full banner, exit 1.

```
==============================================================================
 STOP - THIS CHECKOUT IS STALE. DO NOT TRUST WHAT YOU READ IN IT.
==============================================================================
  Tree:      D:\ReposFred\devthrottle
  Branch:    main (867d71c1)
  Behind:    55 commit(s) behind origin/main
```

No product code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
