### PR TITLE
feat(browsers): per-repository default for Open in Browser (#1112)

### DIFF
--- a/PROOF.md
+++ b/PROOF.md
@@ -1,0 +1,121 @@
+# PROOF - Per-repository default browser+profile (GitHub devthrottle #1112)
+
+Base commit: origin/main `6da36415`. Build: single long session, branch `exp/ctxtax-single`.
+
+## What changed (files)
+
+1. `src/CcDirector.Core/Browsers/BrowserDefaultStore.cs`
+   - Added a second level of default beside the existing application-wide `browser.default`:
+     a per-repository default stored at `browser.repoDefaults[<repoKey>]`, same
+     `{exePath, profileFolder}` shape.
+   - New public methods:
+     - `LoadForRepo(string repoPath)` - the repository's own remembered default, or null.
+     - `SaveForRepo(string repoPath, BrowserDefault value)` - persists it via
+       `CcDirectorConfigService.MergePatch`, so the global default and other repositories'
+       entries are preserved.
+     - `Resolve(string? repoPath)` - the single resolve-order authority: repository default,
+       then application-wide default, then null (meaning "use the operating-system default").
+   - Private helpers: `ReadDefaultObject` (shared parse of an `{exePath, profileFolder}` node,
+     factored out of `Load`) and `NormalizeRepoKey` (unify separators to backslash, trim
+     trailing separators, lowercase on Windows where paths are case-insensitive).
+   - The existing `Load`, `Save`, and `ResolveBrowser` (with its no-fallback throw) are
+     unchanged in behaviour.
+
+2. `src/CcDirector.Terminal.Avalonia/LinkContextMenuBuilder.cs`
+   - A plain click on "Open in Browser" now calls `BrowserDefaultStore.Resolve(context.RepoPath)`
+     instead of `Load()`, so it follows the repo -> global -> OS order. A repo with no
+     repository default is unchanged: `Resolve` falls through to the global default, then the OS
+     default.
+   - The submenu that used to conflate open+save is split so intent is unambiguous. Each profile
+     now expands into explicit choices:
+     - "Open once" - opens in that browser+profile and remembers nothing.
+     - "Set as default for this repository" - opens and saves the repository default (shown only
+       when the link belongs to a repository, i.e. `context.RepoPath` is set).
+     - "Set as application-wide default" - opens and saves the global default (the old
+       profile-click behaviour, now explicit).
+   - The single old `OpenInBrowserProfile` (which both opened and silently saved the global
+     default) is replaced by `OpenInBrowserProfileOnce`, `OpenInBrowserProfileForRepo`, and
+     `OpenInBrowserProfileAppWide`. "System default" is unchanged (one-off, saves nothing).
+
+3. `src/CcDirector.Core.Tests/Browsers/BrowserDefaultStoreTests.cs` (new)
+   - Covers the resolve order and the two-level store against real config.json round-trips in an
+     isolated `CC_DIRECTOR_ROOT`.
+
+## Design decision on the menu interaction
+
+The spec calls out that today a plain profile click BOTH opens and saves the global default, and
+that with a repository level added the user must be able to say WHICH default they are setting.
+
+Chosen design: enumerate installed browsers and their profiles exactly once (as today), but turn
+each profile leaf into a tiny action submenu of explicit intents - "Open once", "Set as default
+for this repository", "Set as application-wide default". This keeps the browser/profile list
+short (listed once, not duplicated per intent), and every click states plainly what it does. The
+repository option is hidden when the link has no owning repository, so it is never offered when it
+could not work. A plain click on the top-level "Open in Browser" remains the fast path and now
+uses the full resolve order. "System default" stays a one-off.
+
+This satisfies the "one-off submenu still works" requirement via "Open once" on every profile and
+the unchanged "System default", while making the set-a-default intent explicit and repository-aware.
+
+## How the resolve order was verified (test output)
+
+`dotnet build cc-director.sln -c Debug` -> Build succeeded, 0 Warning(s), 0 Error(s).
+
+Focused run of the new store tests (`--filter FullyQualifiedName~BrowserDefaultStoreTests`):
+
+```
+Passed CcDirector.Core.Tests.Browsers.BrowserDefaultStoreTests.Resolve_RepoHasOwnDefault_ReturnsRepoDefault
+Passed CcDirector.Core.Tests.Browsers.BrowserDefaultStoreTests.Resolve_RepoHasNoDefault_FallsBackToGlobalDefault
+Passed CcDirector.Core.Tests.Browsers.BrowserDefaultStoreTests.Resolve_NeitherRepoNorGlobal_ReturnsNullForOsDefault
+Passed CcDirector.Core.Tests.Browsers.BrowserDefaultStoreTests.Resolve_NullRepoPath_UsesGlobalDefaultOnly
+Passed CcDirector.Core.Tests.Browsers.BrowserDefaultStoreTests.SaveForRepo_RoundTripsThroughDisk
+Passed CcDirector.Core.Tests.Browsers.BrowserDefaultStoreTests.SaveForRepo_DoesNotDisturbGlobalDefault
+Passed CcDirector.Core.Tests.Browsers.BrowserDefaultStoreTests.SaveForRepo_TwoRepos_KeepBothIndependently
+Passed CcDirector.Core.Tests.Browsers.BrowserDefaultStoreTests.SaveGlobal_DoesNotDisturbExistingRepoDefault
+Passed CcDirector.Core.Tests.Browsers.BrowserDefaultStoreTests.SaveForRepo_PreservesUnrelatedConfigSections
+Passed CcDirector.Core.Tests.Browsers.BrowserDefaultStoreTests.LoadForRepo_NormalizesSeparatorsSlashAndTrailingSlash
+Passed CcDirector.Core.Tests.Browsers.BrowserDefaultStoreTests.LoadForRepo_OnWindowsIsCaseInsensitive
+Passed CcDirector.Core.Tests.Browsers.BrowserDefaultStoreTests.LoadForRepo_UnknownRepo_ReturnsNull
+Passed CcDirector.Core.Tests.Browsers.BrowserDefaultStoreTests.LoadForRepo_BlankPath_ReturnsNull
+Passed CcDirector.Core.Tests.Browsers.BrowserDefaultStoreTests.SaveForRepo_BlankPath_Throws
+Passed CcDirector.Core.Tests.Browsers.BrowserDefaultStoreTests.SaveForRepo_StoresUnderBrowserRepoDefaultsSection
+```
+
+The three resolve-order cases directly prove the Definition-of-Done order:
+- `Resolve_RepoHasOwnDefault_ReturnsRepoDefault` - repo default wins over the global default.
+- `Resolve_RepoHasNoDefault_FallsBackToGlobalDefault` - a repo with no default falls to global.
+- `Resolve_NeitherRepoNorGlobal_ReturnsNullForOsDefault` - neither set -> null -> OS default.
+
+Full Core test suite (`dotnet test` on `CcDirector.Core.Tests`), confirming nothing regressed:
+
+```
+Passed!  - Failed:     0, Passed:  2984, Skipped:     8, Total:  2992, Duration: 3 m 18 s
+```
+
+(The 8 skips are pre-existing environment-gated tests unrelated to this change.)
+
+## Definition of done - mapping
+
+1. Repository can have its own remembered browser+profile, durable, keyed by repository path,
+   without disturbing `browser.default` - `SaveForRepo`/`LoadForRepo`;
+   `SaveForRepo_RoundTripsThroughDisk`, `SaveForRepo_DoesNotDisturbGlobalDefault`.
+2. Plain click from a repo that HAS a repo default opens that default - `Resolve` used by
+   `OpenInBrowserDefault`; `Resolve_RepoHasOwnDefault_ReturnsRepoDefault`.
+3. Repo with NO repo default falls back to global then OS (today's behaviour) -
+   `Resolve_RepoHasNoDefault_FallsBackToGlobalDefault`,
+   `Resolve_NeitherRepoNorGlobal_ReturnsNullForOsDefault`.
+4. User can set a repo default and still set/keep the application-wide default; menu intent is
+   unambiguous - the three explicit profile actions.
+5. One-off submenu still works - "System default" and "Open once" on every profile.
+6. `dotnet build` succeeds, no new warnings - 0 Warning(s).
+7. Unit tests cover the resolve order and existing tests pass - see output above.
+8. This PROOF.md.
+
+## Repo rules honoured
+
+- No fallback programming: a gone browser still throws via the unchanged `ResolveBrowser`; a
+  missing repo/global default returns null meaning "OS default", which is a legitimate state, not
+  a hidden failure. `SaveForRepo` throws on a blank repository path rather than silently no-oping.
+- ASCII only in all new code, logs, and this document.
+- Config writes go through `CcDirectorConfigService.MergePatch` (never hand-written), preserving
+  sibling sections - `SaveForRepo_PreservesUnrelatedConfigSections`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,87 @@
+# Build spec - Per-repository default browser+profile (GitHub devthrottle #1112)
+
+This is the SHARED spec. Both builds - the single long session and the
+architect/manager/workers fleet - get this exact file as their only instruction and
+nothing else. It states WHAT to build and the finish line, and gives the factual code
+pointers both sides start from. It deliberately does NOT prescribe the step-by-step HOW,
+so the two implementations are free to differ (that lets us compare quality honestly).
+
+Base commit (both worktrees): origin/main `6da36415`.
+
+---
+
+## What to build
+
+Add a per-repository "Open in Browser" default that overrides the current application-wide
+default. When a link is opened from a session that belongs to a repository, DevThrottle
+should prefer that repository's chosen browser+profile.
+
+Resolve a plain click on "Open in Browser" in this order:
+
+1. Repository default - the browser+profile remembered for the repository the session
+   belongs to.
+2. Application-wide default - the existing global `browser.default`.
+3. Operating-system default browser - when neither of the above is set.
+
+If a repository has no repository default, behaviour is exactly what it is today.
+
+## Why (context, not instructions)
+
+The user runs multiple browser profiles mapped to different identities (a personal Chrome
+profile, a work Edge profile). Different repositories belong to different identities. Links
+from a work repo should open in the work profile automatically. One global default can't do
+that; a repository-scoped default makes the correct identity automatic per project.
+
+## The user-visible intent problem to solve
+
+Today a plain click on a specific profile in the submenu BOTH opens the link AND saves that
+choice as THE global default (`OpenInBrowserProfile` -> `BrowserDefaultStore.Save`). With a
+repository level added, the user must be able to express which one they are setting: the
+default for THIS repository (the common case) versus the application-wide default. The exact
+menu interaction is yours to design; keep the one-off submenu choices working.
+
+## Factual code pointers (current, verified at the base commit)
+
+- `src/CcDirector.Core/Browsers/BrowserDefaultStore.cs` - static store. `Load()`/`Save()`
+  read/write `config.json` at `browser.default` (`{exePath, profileFolder}`) via
+  `CcDirectorConfigService.ReadRaw()` / `MergePatch()`. `ResolveBrowser(exePath)` maps a
+  stored exe back to an installed `BrowserInfo` and THROWS if it is gone (no silent
+  fallback - keep that behaviour).
+- `src/CcDirector.Terminal.Avalonia/LinkContextMenuBuilder.cs` - the shared menu.
+  `LinkMenuContext.RepoPath` already carries the session's repository path.
+  `BuildOpenInBrowserMenuItem` builds the item; a plain click calls `OpenInBrowserDefault`;
+  a submenu profile click calls `OpenInBrowserProfile` (which is what saves the global
+  default today). This menu is shared by the terminal and the History tab.
+- Config plumbing: `CcDirectorConfigService` (`ReadRaw`, `MergePatch`) preserves other
+  config sections - use it, do not hand-write config.json.
+
+## Repo rules that apply (from the product repo)
+
+- No fallback programming. If a remembered browser is gone, surface a clear error - do not
+  silently open a different one (the existing `ResolveBrowser` throw is the pattern).
+- ASCII only in all output and logs. Keep the existing `FileLog.Write` logging style.
+- Match the surrounding code's conventions.
+
+## Definition of done (both builds must hit ALL of these)
+
+1. A repository can have its own remembered browser+profile, stored durably (survives an app
+   restart) and keyed by repository path, without disturbing the existing global
+   `browser.default`.
+2. A plain click on "Open in Browser" from a session in a repository that HAS a repository
+   default opens the link in that repository default.
+3. A repository with NO repository default falls back to the application-wide default, then
+   the OS default - i.e. today's behaviour is unchanged for repos that never set one.
+4. The user can set a repository default and can still set/keep the application-wide default;
+   the intent is unambiguous in the menu.
+5. The one-off submenu (System default, each installed browser, each profile) still works.
+6. `dotnet build` of the solution succeeds with no new warnings introduced by this change.
+7. Unit test(s) cover the new resolve order (repo default -> global -> OS) against the store,
+   and the existing tests still pass.
+8. A short PROOF.md in the worktree root: what changed (files), how the resolve order was
+   verified (test output pasted), and any design decision made on the menu interaction.
+
+## Out of scope
+
+- Any UI beyond the existing context menu.
+- Syncing the repository default anywhere off the machine.
+- Changing the global-default behaviour for repos that never set a repository default.

--- a/src/CcDirector.Core.Tests/Browsers/BrowserDefaultStoreTests.cs
+++ b/src/CcDirector.Core.Tests/Browsers/BrowserDefaultStoreTests.cs
@@ -1,0 +1,202 @@
+using System.Text.Json;
+using CcDirector.Core.Browsers;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Storage;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Browsers;
+
+/// <summary>
+/// Tests for <see cref="BrowserDefaultStore"/>, focused on the per-repository default added for
+/// GitHub #1112 and the resolve order it introduces: repository default -> application-wide default
+/// -> operating-system default (a null result). Every method runs against an isolated
+/// CC_DIRECTOR_ROOT so it reads and writes a throwaway config.json; xUnit runs a class's methods
+/// sequentially, and the "CcStorageRoot" collection keeps this class from racing the other classes
+/// that redirect the process-wide root.
+/// </summary>
+[Collection("CcStorageRoot")] // serializes all classes that mutate the process-wide CC_DIRECTOR_ROOT
+public sealed class BrowserDefaultStoreTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string? _prevRoot;
+
+    public BrowserDefaultStoreTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-browserdefault-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private const string RepoPath = @"D:\Repos\WorkRepo";
+    private const string OtherRepoPath = @"D:\Repos\PersonalRepo";
+
+    private static BrowserDefault GlobalDefault => new(@"C:\Program Files\Google\Chrome\Application\chrome.exe", "Default");
+    private static BrowserDefault RepoDefault => new(@"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe", "Profile 2");
+
+    // -- Resolve order: repo default -> global default -> OS default (null) --
+
+    [Fact]
+    public void Resolve_RepoHasOwnDefault_ReturnsRepoDefault()
+    {
+        BrowserDefaultStore.Save(GlobalDefault);
+        BrowserDefaultStore.SaveForRepo(RepoPath, RepoDefault);
+
+        var resolved = BrowserDefaultStore.Resolve(RepoPath);
+
+        Assert.Equal(RepoDefault, resolved);
+    }
+
+    [Fact]
+    public void Resolve_RepoHasNoDefault_FallsBackToGlobalDefault()
+    {
+        BrowserDefaultStore.Save(GlobalDefault);
+        // Only OtherRepoPath has a repo default; RepoPath does not.
+        BrowserDefaultStore.SaveForRepo(OtherRepoPath, RepoDefault);
+
+        var resolved = BrowserDefaultStore.Resolve(RepoPath);
+
+        Assert.Equal(GlobalDefault, resolved);
+    }
+
+    [Fact]
+    public void Resolve_NeitherRepoNorGlobal_ReturnsNullForOsDefault()
+    {
+        var resolved = BrowserDefaultStore.Resolve(RepoPath);
+
+        // Null legitimately means "fall through to the operating-system default browser".
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void Resolve_NullRepoPath_UsesGlobalDefaultOnly()
+    {
+        BrowserDefaultStore.Save(GlobalDefault);
+        BrowserDefaultStore.SaveForRepo(RepoPath, RepoDefault);
+
+        // A link with no owning repository never sees any repo default.
+        var resolved = BrowserDefaultStore.Resolve(null);
+
+        Assert.Equal(GlobalDefault, resolved);
+    }
+
+    // -- Durability + isolation between the two levels --
+
+    [Fact]
+    public void SaveForRepo_RoundTripsThroughDisk()
+    {
+        BrowserDefaultStore.SaveForRepo(RepoPath, RepoDefault);
+
+        // LoadForRepo reads fresh from config.json, so this asserts the persisted value.
+        Assert.Equal(RepoDefault, BrowserDefaultStore.LoadForRepo(RepoPath));
+    }
+
+    [Fact]
+    public void SaveForRepo_DoesNotDisturbGlobalDefault()
+    {
+        BrowserDefaultStore.Save(GlobalDefault);
+
+        BrowserDefaultStore.SaveForRepo(RepoPath, RepoDefault);
+
+        // The application-wide default is untouched by a repository write.
+        Assert.Equal(GlobalDefault, BrowserDefaultStore.Load());
+    }
+
+    [Fact]
+    public void SaveForRepo_TwoRepos_KeepBothIndependently()
+    {
+        BrowserDefaultStore.SaveForRepo(RepoPath, RepoDefault);
+        BrowserDefaultStore.SaveForRepo(OtherRepoPath, GlobalDefault);
+
+        Assert.Equal(RepoDefault, BrowserDefaultStore.LoadForRepo(RepoPath));
+        Assert.Equal(GlobalDefault, BrowserDefaultStore.LoadForRepo(OtherRepoPath));
+    }
+
+    [Fact]
+    public void SaveGlobal_DoesNotDisturbExistingRepoDefault()
+    {
+        BrowserDefaultStore.SaveForRepo(RepoPath, RepoDefault);
+
+        BrowserDefaultStore.Save(GlobalDefault);
+
+        Assert.Equal(RepoDefault, BrowserDefaultStore.LoadForRepo(RepoPath));
+    }
+
+    [Fact]
+    public void SaveForRepo_PreservesUnrelatedConfigSections()
+    {
+        var patch = new System.Text.Json.Nodes.JsonObject
+        {
+            ["gateway"] = new System.Text.Json.Nodes.JsonObject { ["url"] = "http://gw.example:7878" },
+        };
+        CcDirectorConfigService.MergePatch(patch);
+
+        BrowserDefaultStore.SaveForRepo(RepoPath, RepoDefault);
+
+        var root = CcDirectorConfigService.ReadRaw();
+        Assert.Equal("http://gw.example:7878", (string?)root["gateway"]?["url"]);
+    }
+
+    // -- Key normalization: the same repo resolves regardless of separator/case/trailing slash --
+
+    [Fact]
+    public void LoadForRepo_NormalizesSeparatorsSlashAndTrailingSlash()
+    {
+        BrowserDefaultStore.SaveForRepo(@"D:\Repos\WorkRepo", RepoDefault);
+
+        // Forward slashes and a trailing slash must map to the same stored entry.
+        Assert.Equal(RepoDefault, BrowserDefaultStore.LoadForRepo("D:/Repos/WorkRepo/"));
+    }
+
+    [Fact]
+    public void LoadForRepo_OnWindowsIsCaseInsensitive()
+    {
+        if (!OperatingSystem.IsWindows())
+            return; // Path case-insensitivity is a Windows property; skip elsewhere.
+
+        BrowserDefaultStore.SaveForRepo(@"D:\Repos\WorkRepo", RepoDefault);
+
+        Assert.Equal(RepoDefault, BrowserDefaultStore.LoadForRepo(@"d:\repos\workrepo"));
+    }
+
+    [Fact]
+    public void LoadForRepo_UnknownRepo_ReturnsNull()
+    {
+        BrowserDefaultStore.SaveForRepo(RepoPath, RepoDefault);
+
+        Assert.Null(BrowserDefaultStore.LoadForRepo(@"D:\Repos\NeverSet"));
+    }
+
+    [Fact]
+    public void LoadForRepo_BlankPath_ReturnsNull()
+    {
+        Assert.Null(BrowserDefaultStore.LoadForRepo(""));
+        Assert.Null(BrowserDefaultStore.LoadForRepo("   "));
+    }
+
+    [Fact]
+    public void SaveForRepo_BlankPath_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => BrowserDefaultStore.SaveForRepo("", RepoDefault));
+    }
+
+    [Fact]
+    public void SaveForRepo_StoresUnderBrowserRepoDefaultsSection()
+    {
+        BrowserDefaultStore.SaveForRepo(RepoPath, RepoDefault);
+
+        var json = File.ReadAllText(CcStorage.ConfigJson());
+        using var doc = JsonDocument.Parse(json);
+        var repoDefaults = doc.RootElement.GetProperty("browser").GetProperty("repoDefaults");
+        // Windows key is the lowercased, backslash-normalized path.
+        var expectedKey = OperatingSystem.IsWindows() ? RepoPath.ToLowerInvariant() : RepoPath;
+        var entry = repoDefaults.GetProperty(expectedKey);
+        Assert.Equal(RepoDefault.ExePath, entry.GetProperty("exePath").GetString());
+        Assert.Equal(RepoDefault.ProfileFolder, entry.GetProperty("profileFolder").GetString());
+    }
+}

--- a/src/CcDirector.Core/Browsers/BrowserDefaultStore.cs
+++ b/src/CcDirector.Core/Browsers/BrowserDefaultStore.cs
@@ -15,28 +15,25 @@ public sealed record BrowserDefault(string ExePath, string ProfileFolder);
 /// Reads and writes the remembered <see cref="BrowserDefault"/> in <c>config.json</c> (via
 /// <see cref="CcDirectorConfigService"/>, so other config sections are preserved), and resolves a
 /// stored exe path back to a live <see cref="BrowserInfo"/>.
+///
+/// Two levels of default are kept: the application-wide default at <c>browser.default</c> and a
+/// per-repository default at <c>browser.repoDefaults[&lt;repoKey&gt;]</c>. A plain "Open in Browser"
+/// resolves in the order repository default -&gt; application-wide default -&gt; operating-system
+/// default (see <see cref="Resolve"/>).
 /// </summary>
 public static class BrowserDefaultStore
 {
     /// <summary>
-    /// Returns the remembered default, or null if the user has never chosen a browser+profile.
-    /// A null result legitimately means "use the OS default" - it is not an error.
+    /// Returns the remembered application-wide default, or null if the user has never chosen a
+    /// browser+profile. A null result legitimately means "use the OS default" - it is not an error.
     /// </summary>
     public static BrowserDefault? Load()
     {
         var root = CcDirectorConfigService.ReadRaw();
-        if (root["browser"]?["default"] is not JsonObject def)
-            return null;
-
-        var exePath = (string?)def["exePath"];
-        var profileFolder = (string?)def["profileFolder"];
-        if (string.IsNullOrWhiteSpace(exePath) || string.IsNullOrWhiteSpace(profileFolder))
-            return null;
-
-        return new BrowserDefault(exePath, profileFolder);
+        return ReadDefaultObject(root["browser"]?["default"]);
     }
 
-    /// <summary>Persists <paramref name="value"/> as the remembered default in config.json.</summary>
+    /// <summary>Persists <paramref name="value"/> as the remembered application-wide default in config.json.</summary>
     public static void Save(BrowserDefault value)
     {
         if (value is null) throw new ArgumentNullException(nameof(value));
@@ -54,6 +51,100 @@ public static class BrowserDefaultStore
             }
         };
         CcDirectorConfigService.MergePatch(patch);
+    }
+
+    /// <summary>
+    /// Returns the browser+profile remembered for <paramref name="repoPath"/>, or null when that
+    /// repository has never set one. Null is not an error - the caller should then fall back to the
+    /// application-wide default (see <see cref="Resolve"/>).
+    /// </summary>
+    public static BrowserDefault? LoadForRepo(string repoPath)
+    {
+        if (string.IsNullOrWhiteSpace(repoPath))
+            return null;
+
+        var root = CcDirectorConfigService.ReadRaw();
+        if (root["browser"]?["repoDefaults"] is not JsonObject repoDefaults)
+            return null;
+
+        return ReadDefaultObject(repoDefaults[NormalizeRepoKey(repoPath)]);
+    }
+
+    /// <summary>
+    /// Persists <paramref name="value"/> as the remembered default for <paramref name="repoPath"/>.
+    /// Uses <see cref="CcDirectorConfigService.MergePatch"/>, so the application-wide default and any
+    /// other repositories' defaults are left untouched.
+    /// </summary>
+    public static void SaveForRepo(string repoPath, BrowserDefault value)
+    {
+        if (string.IsNullOrWhiteSpace(repoPath))
+            throw new ArgumentException("Repository path is required", nameof(repoPath));
+        if (value is null) throw new ArgumentNullException(nameof(value));
+
+        var key = NormalizeRepoKey(repoPath);
+        FileLog.Write($"[BrowserDefaultStore] SaveForRepo: repo={key}, exe={value.ExePath}, profile={value.ProfileFolder}");
+        var patch = new JsonObject
+        {
+            ["browser"] = new JsonObject
+            {
+                ["repoDefaults"] = new JsonObject
+                {
+                    [key] = new JsonObject
+                    {
+                        ["exePath"] = value.ExePath,
+                        ["profileFolder"] = value.ProfileFolder,
+                    }
+                }
+            }
+        };
+        CcDirectorConfigService.MergePatch(patch);
+    }
+
+    /// <summary>
+    /// Resolves the effective "Open in Browser" default for a session in <paramref name="repoPath"/>,
+    /// applying the order: the repository's own default first, then the application-wide default. A
+    /// null result means neither is set, so the caller should open the operating-system default
+    /// browser. <paramref name="repoPath"/> may be null (a link with no owning repository), in which
+    /// case only the application-wide default is consulted.
+    /// </summary>
+    public static BrowserDefault? Resolve(string? repoPath)
+    {
+        if (!string.IsNullOrWhiteSpace(repoPath))
+        {
+            var repoDefault = LoadForRepo(repoPath);
+            if (repoDefault is not null)
+                return repoDefault;
+        }
+
+        return Load();
+    }
+
+    /// <summary>
+    /// Reads an <c>{exePath, profileFolder}</c> object into a <see cref="BrowserDefault"/>, or null
+    /// when the node is absent or either field is missing/blank.
+    /// </summary>
+    private static BrowserDefault? ReadDefaultObject(JsonNode? node)
+    {
+        if (node is not JsonObject def)
+            return null;
+
+        var exePath = (string?)def["exePath"];
+        var profileFolder = (string?)def["profileFolder"];
+        if (string.IsNullOrWhiteSpace(exePath) || string.IsNullOrWhiteSpace(profileFolder))
+            return null;
+
+        return new BrowserDefault(exePath, profileFolder);
+    }
+
+    /// <summary>
+    /// Normalizes a repository path into a stable config.json key: separators unified to backslash and
+    /// trailing separators trimmed, then lowercased on Windows (where paths are case-insensitive) so
+    /// the same repository always maps to the same stored entry regardless of how the path was typed.
+    /// </summary>
+    private static string NormalizeRepoKey(string repoPath)
+    {
+        var normalized = repoPath.Trim().Replace('/', '\\').TrimEnd('\\');
+        return OperatingSystem.IsWindows() ? normalized.ToLowerInvariant() : normalized;
     }
 
     /// <summary>

--- a/src/CcDirector.Core/Browsers/BrowserDefaultStore.cs
+++ b/src/CcDirector.Core/Browsers/BrowserDefaultStore.cs
@@ -30,7 +30,11 @@ public static class BrowserDefaultStore
     public static BrowserDefault? Load()
     {
         var root = CcDirectorConfigService.ReadRaw();
-        return ReadDefaultObject(root["browser"]?["default"]);
+        var value = ReadDefaultObject(root["browser"]?["default"]);
+        FileLog.Write(value is null
+            ? "[BrowserDefaultStore] Load: no application-wide default set"
+            : $"[BrowserDefaultStore] Load: exe={value.ExePath}, profile={value.ProfileFolder}");
+        return value;
     }
 
     /// <summary>Persists <paramref name="value"/> as the remembered application-wide default in config.json.</summary>
@@ -61,13 +65,24 @@ public static class BrowserDefaultStore
     public static BrowserDefault? LoadForRepo(string repoPath)
     {
         if (string.IsNullOrWhiteSpace(repoPath))
+        {
+            FileLog.Write("[BrowserDefaultStore] LoadForRepo: blank repo path, no repository default");
             return null;
+        }
 
+        var key = NormalizeRepoKey(repoPath);
         var root = CcDirectorConfigService.ReadRaw();
         if (root["browser"]?["repoDefaults"] is not JsonObject repoDefaults)
+        {
+            FileLog.Write($"[BrowserDefaultStore] LoadForRepo: no repoDefaults section, repo={key}");
             return null;
+        }
 
-        return ReadDefaultObject(repoDefaults[NormalizeRepoKey(repoPath)]);
+        var value = ReadDefaultObject(repoDefaults[key]);
+        FileLog.Write(value is null
+            ? $"[BrowserDefaultStore] LoadForRepo: no default for repo={key}"
+            : $"[BrowserDefaultStore] LoadForRepo: repo={key}, exe={value.ExePath}, profile={value.ProfileFolder}");
+        return value;
     }
 
     /// <summary>
@@ -109,14 +124,23 @@ public static class BrowserDefaultStore
     /// </summary>
     public static BrowserDefault? Resolve(string? repoPath)
     {
+        FileLog.Write($"[BrowserDefaultStore] Resolve: repo={repoPath ?? "(none)"}");
+
         if (!string.IsNullOrWhiteSpace(repoPath))
         {
             var repoDefault = LoadForRepo(repoPath);
             if (repoDefault is not null)
+            {
+                FileLog.Write("[BrowserDefaultStore] Resolve: using the repository default");
                 return repoDefault;
+            }
         }
 
-        return Load();
+        var global = Load();
+        FileLog.Write(global is null
+            ? "[BrowserDefaultStore] Resolve: nothing remembered, caller uses the OS default browser"
+            : "[BrowserDefaultStore] Resolve: using the application-wide default");
+        return global;
     }
 
     /// <summary>

--- a/src/CcDirector.Terminal.Avalonia/LinkContextMenuBuilder.cs
+++ b/src/CcDirector.Terminal.Avalonia/LinkContextMenuBuilder.cs
@@ -157,9 +157,13 @@ public static class LinkContextMenuBuilder
 
     /// <summary>
     /// Builds the "Open in Browser" menu item for <paramref name="target"/> (a URL or a local file
-    /// path). A plain click reopens the remembered default; hovering expands a submenu of "System
-    /// default" plus each installed browser with its real profiles (re-read from each browser's Local
-    /// State so newly added profiles appear without a restart).
+    /// path). A plain click reopens the resolved default (this repository's default, then the
+    /// application-wide default, then the OS default); hovering expands a submenu of "System default"
+    /// plus each installed browser with its real profiles (re-read from each browser's Local State so
+    /// newly added profiles appear without a restart). Each profile in turn expands into explicit
+    /// intents - "Open once", "Set as default for this repository" (only when the link belongs to a
+    /// repository), and "Set as application-wide default" - so a click is never ambiguous about which
+    /// default, if any, it is setting.
     /// </summary>
     private static MenuItem BuildOpenInBrowserMenuItem(ContextMenu menu, LinkMenuContext context, string target)
     {
@@ -208,14 +212,42 @@ public static class LinkContextMenuBuilder
                         ? profile.DisplayName
                         : $"{profile.DisplayName} ({profile.Account})";
 
-                    var profileItem = new MenuItem { Header = header };
                     var capturedBrowser = browser;
                     var capturedFolder = profile.FolderName;
-                    profileItem.Click += (_, e) =>
+
+                    // Each profile expands into explicit intents so a click is never ambiguous about
+                    // WHAT it sets: open once (remember nothing), remember for THIS repository (the
+                    // common case, only when the link belongs to a repository), or remember as the
+                    // application-wide default.
+                    var profileItem = new MenuItem { Header = header };
+
+                    var openOnceItem = new MenuItem { Header = "Open once" };
+                    openOnceItem.Click += (_, e) =>
                     {
                         e.Handled = true;
-                        OpenInBrowserProfile(context, target, capturedBrowser, capturedFolder);
+                        OpenInBrowserProfileOnce(context, target, capturedBrowser, capturedFolder);
                     };
+                    profileItem.Items.Add(openOnceItem);
+
+                    if (!string.IsNullOrWhiteSpace(context.RepoPath))
+                    {
+                        var repoItem = new MenuItem { Header = "Set as default for this repository" };
+                        repoItem.Click += (_, e) =>
+                        {
+                            e.Handled = true;
+                            OpenInBrowserProfileForRepo(context, target, capturedBrowser, capturedFolder);
+                        };
+                        profileItem.Items.Add(repoItem);
+                    }
+
+                    var appWideItem = new MenuItem { Header = "Set as application-wide default" };
+                    appWideItem.Click += (_, e) =>
+                    {
+                        e.Handled = true;
+                        OpenInBrowserProfileAppWide(context, target, capturedBrowser, capturedFolder);
+                    };
+                    profileItem.Items.Add(appWideItem);
+
                     browserItem.Items.Add(profileItem);
                 }
             }
@@ -230,7 +262,9 @@ public static class LinkContextMenuBuilder
     {
         try
         {
-            var remembered = BrowserDefaultStore.Load();
+            // Resolve order: this repository's default, then the application-wide default, then the OS
+            // default (a null result). A repo with no default behaves exactly as it did before.
+            var remembered = BrowserDefaultStore.Resolve(context.RepoPath);
             if (remembered is null)
             {
                 FileLog.Write($"[LinkContextMenuBuilder] OpenInBrowserDefault: no remembered default, using system default: {target}");
@@ -263,17 +297,52 @@ public static class LinkContextMenuBuilder
         }
     }
 
-    private static void OpenInBrowserProfile(LinkMenuContext context, string target, BrowserInfo browser, string profileFolder)
+    /// <summary>Opens the link in a specific browser+profile once, remembering nothing.</summary>
+    private static void OpenInBrowserProfileOnce(LinkMenuContext context, string target, BrowserInfo browser, string profileFolder)
+    {
+        try
+        {
+            BrowserLauncher.OpenWithProfile(target, browser, profileFolder);
+            FileLog.Write($"[LinkContextMenuBuilder] OpenInBrowserProfileOnce: opened {target} in {browser.DisplayName}/{profileFolder}");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[LinkContextMenuBuilder] OpenInBrowserProfileOnce FAILED: {ex.Message}");
+            context.OnBrowserError?.Invoke($"Could not open in {browser.DisplayName}.\n\n{ex.Message}");
+        }
+    }
+
+    /// <summary>Opens the link and remembers this browser+profile as the owning repository's default.</summary>
+    private static void OpenInBrowserProfileForRepo(LinkMenuContext context, string target, BrowserInfo browser, string profileFolder)
+    {
+        try
+        {
+            BrowserLauncher.OpenWithProfile(target, browser, profileFolder);
+            if (string.IsNullOrWhiteSpace(context.RepoPath))
+                throw new InvalidOperationException("This link has no owning repository, so it has no repository default to set.");
+
+            BrowserDefaultStore.SaveForRepo(context.RepoPath, new BrowserDefault(browser.ExePath, profileFolder));
+            FileLog.Write($"[LinkContextMenuBuilder] OpenInBrowserProfileForRepo: opened {target} in {browser.DisplayName}/{profileFolder}, repo={context.RepoPath}");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[LinkContextMenuBuilder] OpenInBrowserProfileForRepo FAILED: {ex.Message}");
+            context.OnBrowserError?.Invoke($"Could not open in {browser.DisplayName}.\n\n{ex.Message}");
+        }
+    }
+
+    /// <summary>Opens the link and remembers this browser+profile as the application-wide default.</summary>
+    private static void OpenInBrowserProfileAppWide(LinkMenuContext context, string target, BrowserInfo browser, string profileFolder)
     {
         try
         {
             BrowserLauncher.OpenWithProfile(target, browser, profileFolder);
             BrowserDefaultStore.Save(new BrowserDefault(browser.ExePath, profileFolder));
-            FileLog.Write($"[LinkContextMenuBuilder] OpenInBrowserProfile: opened {target} in {browser.DisplayName}/{profileFolder}");
+            FileLog.Write($"[LinkContextMenuBuilder] OpenInBrowserProfileAppWide: opened {target} in {browser.DisplayName}/{profileFolder}");
         }
         catch (Exception ex)
         {
-            FileLog.Write($"[LinkContextMenuBuilder] OpenInBrowserProfile FAILED: {ex.Message}");
+            FileLog.Write($"[LinkContextMenuBuilder] OpenInBrowserProfileAppWide FAILED: {ex.Message}");
             context.OnBrowserError?.Invoke($"Could not open in {browser.DisplayName}.\n\n{ex.Message}");
         }
     }


### PR DESCRIPTION
Closes #1112.

Adds a per-repository "Open in Browser" default that overrides the application-wide one. A plain click resolves in the order: repository default, then application-wide default, then the operating-system browser. A repository with no default behaves exactly as it does today.

It also fixes a long-standing intent problem: today, clicking a profile in the submenu both opens the link AND silently overwrites the global default. Each profile now expands into three explicit choices - "Open once", "Set as default for this repository" (only shown when the link belongs to a repository), and "Set as application-wide default" - so a click is never ambiguous about what it saves.

## Why this branch

This feature was built twice, from the same spec and base commit, as an experiment measuring what a multi-agent fleet costs versus one session (the study is preserved on `research/ctxtax-token-study`). Both arms converged on the same design, the same config schema, and a functionally identical menu.

This branch is the single-session arm, chosen on the code:

- 15 tests versus 11, covering blank paths, unknown repositories, and where the data lands in config.
- The `{exePath, profileFolder}` read is factored into one helper shared by `Load` and `LoadForRepo`, rather than duplicated.
- `NormalizeRepoKey` case-folds only on Windows. The sibling folded case unconditionally, which would collapse two genuinely different repositories into one entry on macOS and Linux - a real defect now that macOS support has landed.

The sibling's one genuine advantage was much heavier logging, which the house rules require. That is ported here in the second commit.

## Storage

Repository defaults live at `browser.repoDefaults[<normalized repo path>]`, separate from the global `browser.default`, written via `MergePatch` so other repositories and unrelated config sections are untouched.

## Verification

- `dotnet build src/CcDirector.Core` - succeeded, 0 warnings, 0 errors.
- `dotnet test --filter BrowserDefaultStore` - 15 passed, 0 failed.

Rebased onto current main; both touched files were untouched on main across the 123 commits since the branch point, so the rebase was clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)