### PR TITLE
docs(architecture): land the mission documents stranded in the main checkout

### DIFF
--- a/docs/architecture/auto-network-switching-mission-2026-07-11.md
+++ b/docs/architecture/auto-network-switching-mission-2026-07-11.md
@@ -1,0 +1,254 @@
+# Mission Brief: Automatic Network Switching (home = direct, away = Tailscale)
+
+Status: research + design, written 2026-07-11 on machine SOREN_NORTH. This is a research
+brief and an Architect handover in progress. It captures what the code actually does today,
+the one hard constraint that reshapes the whole mission, and the design fork the owner must
+settle before the Manager starts building. It covers ONLY the two browser apps - the mobile
+PWA (`/m`) and the Cockpit - plus their shared library `packages/client-core`. The desktop
+Avalonia app is out of scope (it already does multi-address probing, issue #1233).
+
+## The mission, in the owner's words
+
+"When I use my phone at home, I do not want to go through the Tailscale network. If I am on
+my normal home network, go straight to the computer. If I am away from the network the
+gateway is on, switch to Tailscale." Automatic. No toggle to remember. Just for the phone
+PWA and the Cockpit.
+
+## DECISION (v1, settled by the owner 2026-07-12)
+
+**Tailscale is a hard requirement for anyone who wants to use the Cockpit or the mobile app.**
+It is optional in the code today; v1 makes it required. This stands until we find a different
+way to solve the same problem (an alternatives review is explicitly deferred, not abandoned).
+
+Why this is the decision, not a compromise:
+- Tailscale is required for remote access anyway - only it punches through home routers. We
+  cannot replace that ourselves without running tunnel infrastructure.
+- Tailscale automatically gives the gateway a free, trusted TLS certificate for its
+  `<machine>.<tailnet>.ts.net` name. That certificate IS the HTTPS the browsers demand. So
+  requiring Tailscale erases the entire "run our own certificate service for thousands of
+  users" problem - no wildcard DNS, no Let's Encrypt pipeline, no name-to-IP table to operate.
+- There is genuinely no easy alternative: browsers require a publicly-trusted certificate for
+  the powerful features below on any non-localhost address, and self-signed certificates do not
+  work (scary full-page warning every visit, and the features stay blocked even after the user
+  clicks through; iOS Safari is the strictest). This is not our quirk - every self-hosted
+  product accessed from a phone (Plex, Home Assistant) solves it the same way.
+
+Precise scope of the requirement:
+- The **phone always** needs Tailscale (it is a browser on another device).
+- A user running everything on ONE machine and using the Cockpit only at `http://localhost`
+  does NOT technically need Tailscale (`localhost` is already a secure context). v1 may still
+  require it uniformly for a single setup path; this is the one case that would otherwise work
+  without it.
+- Our **backend and CLI never need it**: the Director Control API (`http://127.0.0.1:787x`),
+  the Gateway (`http://0.0.0.0:7878`), and the Director-to-Gateway REST + SignalR tunnel are
+  all plain HTTP and have no HTTPS/Tailscale dependency. Only a browser loading the app from a
+  non-localhost address needs HTTPS.
+
+Strategic note: this takes a hard third-party dependency and adds an onboarding step (install
+Tailscale + sign in). Keep a mental escape hatch for later (our own cert pipeline, or a
+self-hosted Tailscale control server) - not built now.
+
+### The browser features that require HTTPS and therefore force this decision
+
+Verified live on the gateway 2026-07-12 by loading `/m` over plain `http://SOREN_NORTH:7878`:
+
+| Browser capability | What it powers for us | On plain HTTP |
+|---|---|---|
+| Microphone (`getUserMedia`) | Dictation, Car Mode, mobile Speak | dead |
+| Service worker | PWA install to home screen, offline cache | dead |
+| Web Push (needs a service worker) | The "needs you" phone notification/badge | dead |
+| Camera (`getUserMedia`) | Any future QR/photo capture | dead |
+| `crypto.randomUUID` / `crypto.subtle` | Sign-in / device enrollment, client crypto | broken (randomUUID code-fixable; subtle not) |
+
+Works on plain HTTP anyway: live terminal (WebSocket), typed input, `localStorage`. So voice
+and notifications - the two things that make the phone useful - are exactly the casualties.
+
+### Follow-on work (deferred, tracked here)
+
+1. Installer/runtime gate that makes Tailscale required with a clear, actionable error when it
+   is absent (today it silently runs without remote HTTPS).
+2. Close the half-wired local-first gap found in research: the Director's REST client already
+   prefers the local address (issue #1233), but the **SignalR tunnel** (`GatewayStreamClient`
+   -> `/director-stream`) and the **cc-launcher** still dial the single configured `gateway.url`
+   and do not do the candidate walk - so an on-LAN machine can still ride Tailscale for those.
+3. The alternatives review the owner asked for: revisit ways to get browser-trusted HTTPS on a
+   self-hosted LAN server without requiring Tailscale.
+
+## What actually happens today (verified against the working tree 2026-07-11)
+
+Read this before designing anything. It is why this mission is not the simple app-layer
+change it first sounds like.
+
+1. **The browser apps are hard-wired to same-origin.** Every API call in the shared client
+   is root-relative - `fetch("/sessions")`, `fetch("/healthz")`, `fetch("/m/enroll")`
+   (`packages/client-core/src/api/client.ts`). The live terminal WebSocket is built from
+   `window.location.host` (`packages/client-core/src/terminal/stream.ts:42-44` and
+   `interactive.ts:71-73`). There is NO configurable base URL, no candidate list, and no
+   reachability probe. The app talks to whatever host served the page - full stop. So "which
+   gateway path" is decided entirely by "which URL loaded the app," not by any runtime logic
+   the app owns today.
+
+2. **The phone reaches the Gateway ONLY over the Tailscale HTTPS front door.** The Gateway
+   is plain HTTP on `0.0.0.0:7878` and terminates no TLS of its own
+   (`src/CcDirector.Gateway/GatewayHost.cs:871-876`). HTTPS is provided entirely by Tailscale
+   Serve mapping `443 -> localhost:7878`, provisioned automatically by
+   `TailscaleServeProvisioner` (`src/CcDirector.Gateway/Tailscale/TailscaleServeProvisioner.cs`).
+   So the working phone URL is `https://<machine>.<tailnet>.ts.net/m` - the tailnet front door.
+
+3. **On the raw LAN there is HTTP only. No LAN HTTPS exists anywhere in the code.** Searches
+   for `UseHttps`, `X509`, certificate, pfx, mkcert, self-signed TLS termination return
+   nothing. `LanIdentity.BuildLanUrlForPort` yields `http://192.168.1.x:7878` and
+   `TailscaleIdentity.BuildMachineNameUrl` yields `http://SOREN_NORTH:7878` - both plain HTTP
+   (`src/CcDirector.Core/Network/`). The Gateway simply cannot serve HTTPS on the LAN today.
+
+4. **A browser will not let a PWA use those LAN addresses - two separate hard walls.**
+   - *Secure-context wall.* The PWA needs a secure context for `crypto.randomUUID`, the
+     service worker, and enrollment. We already learned the hard way that plain HTTP on a
+     non-localhost host is NOT a secure context, so Sign In and dictation die silently
+     (memory `mobile-pwa-url-and-deploy`). `http://SOREN_NORTH:7878/m` breaks the app.
+   - *Mixed-content wall.* Even if we did nothing but health-check, a page loaded over
+     `https://...ts.net/m` is forbidden by the browser from making any `fetch` or WebSocket
+     to an `http://` address. So the C# client's trick - "load once, then probe candidates
+     and switch the base URL" - is illegal in a browser when the candidate is plain HTTP.
+
+5. **Client identity is origin-scoped, so "home" and "away" cannot be two casual origins.**
+   The per-device key and install id live in `localStorage` (`cc.deviceKey`, `cc.installId`
+   in `packages/client-core/src/auth/deviceKey.ts`), which is scoped to the exact origin. If
+   the home path and the away path are different origins, they are two separate enrollments,
+   two device keys, and for the installed PWA, effectively two apps. Switching origins is not
+   transparent - it means re-enrolling.
+
+**The consequence.** Automatic network switching in the browser is not blocked in the app
+layer - it is blocked in the transport layer. The app cannot prefer a direct-local path until
+there IS a direct-local path the browser will accept, and today the only browser-acceptable
+path is the Tailscale HTTPS front door. The real mission is: *give the home network a path
+the browser trusts, then teach the app to choose it.* The second half is easy; the first half
+is the whole decision.
+
+## One fact the owner should weigh first
+
+When the phone is on the same physical network as the gateway AND Tailscale is running on the
+phone, Tailscale already connects **directly over the LAN** - a peer-to-peer path, not a relay
+out to the internet. So "going through Tailscale" at home is not an internet round-trip today;
+the packets already travel straight across the home WiFi. The genuine thing the owner gains by
+this mission is **not needing Tailscale running on the phone at all when home** (and a snappier,
+more robust local path when the tailnet itself is flaky). That is the requirement that decides
+whether we build anything - and how much.
+
+## The design fork (owner decides - everything downstream hangs on this)
+
+The app-layer piece is the same in every case: a small startup connection resolver in
+`client-core` that health-checks a home candidate and an away candidate and locks onto the
+best reachable one, plus a visible "Home (direct) / Away (Tailscale)" indicator and a manual
+override. What differs - and what the owner must pick - is HOW the home network gets an
+HTTPS path the browser will accept without Tailscale.
+
+- **Option A - Do nothing new; keep Tailscale on the phone.** Accept that Tailscale already
+  routes direct on the LAN. Zero build. Fails the "do not depend on Tailscale on the phone"
+  goal. Listed for honesty; not recommended if the goal stands.
+
+- **Option B - LAN HTTPS via a locally-trusted certificate (recommended).** Teach the
+  Gateway to also serve real TLS on the LAN under a stable name (a bound `https://` endpoint
+  or a small local reverse step), using a certificate the phone trusts. The phone installs
+  the local certificate authority ONCE. Then there are two HTTPS origins that both work:
+  `https://<home-name>/m` (home, no Tailscale) and the existing tailnet front door (away).
+  The app health-checks the home origin at startup and prefers it when reachable. Costs:
+  certificate generation and trust on the phone (one-time), a stable home address (DHCP
+  reservation - see the Orbi router notes), and handling the origin-scoped identity so the
+  two origins do not force a double enrollment.
+
+- **Option C - One stable HTTPS name, split-horizon DNS (best UX, heaviest infra).** A single
+  real domain name with a publicly valid certificate on the Gateway, where the home router
+  answers that name with the gateway's LAN IP at home and the tailnet path answers it away.
+  ONE origin means ONE device key and truly transparent switching - the app changes nothing;
+  the network underneath does. Costs: a real certificate on the Gateway with auto-renewal, and
+  split-horizon DNS configured on the home router - home-network-specific, does not generalize
+  to arbitrary users' networks.
+
+Recommendation: **Option B.** It meets the stated goal (home works with Tailscale off),
+keeps the away path exactly as it is today, and its costs are one-time and local. Option C is
+a cleaner end state but front-loads real-cert and router-DNS infrastructure that is not worth
+it for a one-machine, one-owner setup right now. Option A is only right if, on reflection, the
+owner is fine keeping Tailscale on the phone at home.
+
+## The app-layer design (identical regardless of A/B/C, built only if B or C is chosen)
+
+A startup **connection resolver** in `client-core`, sitting in front of the same-origin
+client. Given a home candidate origin and the away (tailnet) origin, it:
+
+1. Fires a short-timeout `GET /healthz` at the home candidate. If it answers within, say, one
+   second, home is reachable -> use it. If not, fall back to away. (Mirrors the C# client's
+   `GatewayEndpointSelector` from #1233/#1236, but browser-side and HTTPS-only.)
+2. Locks onto the chosen path for the session and re-walks on a hard connection failure, so
+   walking out the door mid-session fails over to away without a manual step.
+3. Surfaces the chosen path in the UI - a small, quiet "Home (direct)" vs "Away (Tailscale)"
+   indicator - and offers a manual override for when the automatic choice is wrong. A manual
+   choice wins until cleared. Never fail silently: if neither path answers, say so loudly
+   (consistent with the mobile fail-loud rule).
+
+Two subtleties the Manager must design against, not paper over:
+
+- *Origin-scoped identity.* Under Option B the two origins each carry their own device key.
+  The resolver must not present a signed-in home app as signed-out just because the away
+  origin was where enrollment happened (or vice versa). Either enroll both origins as part of
+  one flow, or make the app aware it may load from either front door and keep the identities
+  reconciled. This is the sharpest design question in the app layer and must be settled before
+  Phase 1 of the app work.
+- *Same-origin assumption is everywhere.* The WebSocket builder, the cookie mirror
+  (`ensureGatewayCookie`), the 401 redirect, and every `fetch` assume same-origin. If the
+  resolver ever points the app at a different origin than the one that served the page, all of
+  those must go through the resolved base, not `window.location`. Cleanest is to keep the app
+  served from, and talking to, ONE origin at a time (whichever front door loaded it) rather
+  than cross-origin calling - which again favors Option C's single-origin end state and makes
+  Option B's two-origin reconciliation the real work.
+
+## Decisions already implied - confirm, do not re-litigate
+
+1. Scope is the two browser apps and `client-core` only. The desktop app is out of scope.
+2. The away path stays exactly as it is today: the Tailscale HTTPS front door. This mission
+   adds a home path and a chooser; it does not touch remote access.
+3. Switching is automatic (health-check driven) with a manual override and a visible
+   indicator. No silent failure - if nothing is reachable, the app says so.
+4. ASCII only, plain English, no fallback programming. If the home certificate is not trusted
+   or the home path is misconfigured, fail with a clear instruction - never silently limp on a
+   broken secure context (that is the exact failure that made Sign In "do nothing" before).
+
+## Open questions for the owner (blocking)
+
+1. **Which option - A, B, or C?** This decides whether we build the transport half at all and
+   how much. Recommendation above is B.
+2. If B: is a one-time "install this certificate on your phone" step acceptable? (It is the
+   price of LAN HTTPS the browser trusts.)
+3. What is the stable home address to trust - a reserved DHCP IP, the machine name, or a
+   chosen local hostname? (Feeds the certificate's name and the health-check candidate.)
+
+## The work, in phases (only if B is chosen - restated for C on request)
+
+Each phase ships alone: implemented, merged to origin/main per the trunk rule, deployed to the
+real Gateway, and owner-verifiable on the real phone before the next begins.
+
+- **Phase 0 - LAN HTTPS on the Gateway.** Give the Gateway a trusted TLS path on the LAN under
+  the chosen stable name; document the one-time phone trust step. Proof: on the real phone,
+  with Tailscale turned OFF, load `https://<home-name>/m`, sign in, and run dictation - all
+  working over the direct LAN path.
+- **Phase 1 - The browser connection resolver.** Add the startup health-check chooser to
+  `client-core`, the "Home (direct) / Away (Tailscale)" indicator, and the manual override.
+  Settle the origin-scoped identity question first. Proof: on the real phone, home path is
+  chosen automatically at home; walking off the home network fails over to the tailnet path;
+  the indicator reflects the live choice; the override works.
+- **Phase 2 - Cockpit parity and hardening.** Bring the same resolver and indicator to the
+  Cockpit, confirm the WebSocket/terminal path honors the resolved base, and prove the
+  failure messaging is loud when neither path answers. Proof: Cockpit chooses correctly on the
+  home LAN and away; a deliberately broken home path shows a clear error, never a silent hang.
+
+## Definition of done
+
+1. On the home network with Tailscale OFF on the phone, the PWA loads, signs in, streams a
+   terminal, and dictates - over the direct LAN path, automatically, with no manual step.
+2. Away from home, the app is unchanged - it uses the Tailscale front door exactly as today,
+   automatically.
+3. The switch is automatic, has a visible Home/Away indicator and a manual override, and fails
+   loudly (never silently) when no path is reachable.
+4. Both the mobile PWA and the Cockpit behave identically. The desktop app is untouched.
+5. A verification report (HTML, in docs/reviews/) with real-phone screenshots: home-direct
+   with Tailscale off, automatic failover to away, the indicator, and the loud no-path error.

--- a/docs/architecture/car-mode-mission-2026-07-11.md
+++ b/docs/architecture/car-mode-mission-2026-07-11.md
@@ -237,6 +237,32 @@ The owner must be able to tell the two apart without looking. Keep them short an
     Kit can drive open-source OpenAI-compatible models fine. If a framework is later wanted, it is
     the .NET-native Microsoft Agent Framework, in-process, not the OpenAI one.
 
+## A responsive interface is everything (load-bearing principle, owner, 2026-07-12)
+
+Car Mode is used eyes-nearly-free and hands-free, so the single most important quality after
+"it works" is that the owner is never left staring at a screen that has not changed, wondering
+whether his action registered. The owner stated this plainly: waiting for the voice, the model,
+or the network is completely acceptable - as long as he can see and hear that he is waiting. A
+silent, unchanged screen during that wait is the defect, not the wait itself.
+
+The rule, applied everywhere in Car Mode: the instant anything happens - a tap, a recognized
+"over and out", a recognized "stop" - change the visible state first, synchronously, before any
+asynchronous work begins. Do not run the transcription, the brain, or the text-to-speech and then
+update the screen; flip the screen into its next state (for example Thinking) as the very first
+thing, and only then start the asynchronous pipeline. The audible acknowledgement cue must fire on
+the same synchronous beat.
+
+While the assistant is thinking or waiting, play a soft, low-volume ambient cue in the background
+so the owner hears, without looking, that work is in progress - the pattern other good voice
+assistants use (a gentle, quiet, recurring sound, not a loud one-shot). This cue must use the soft
+water-droplet sound from dictation (`readyCue.ts`), not a harsh tone; the owner finds the current
+tone harsh and wants the whole experience to move toward the gentle water sound. Stop the ambient
+cue the moment the reply audio starts.
+
+This principle sits above the individual fixes: every state Car Mode can be in must show and sound
+like what it is doing, and every transition must be immediate on the screen even when the real work
+behind it takes seconds.
+
 ## The work, in phases
 
 Each phase ships alone: implemented, merged to origin/main per the trunk rule, deployed to the

--- a/docs/architecture/carmode-stopword-research-2026-07-12.md
+++ b/docs/architecture/carmode-stopword-research-2026-07-12.md
@@ -1,0 +1,176 @@
+# Car Mode stop-word detection - research and settled design (issue #1411)
+
+Status: research settled by the Car Mode Architect, 2026-07-12. This is the agreed approach the
+Manager implements. Child of the Car Mode epic (#1410); worked before the system-prompt issue (#1412).
+
+## The problem, precisely
+
+Car Mode is a walkie-talkie. The owner cuts the assistant off mid-reply by saying a **stop word**.
+Detecting that spoken word **while the assistant's own voice is playing out of the phone speaker**
+(barge-in), fast enough to feel instant, is the one unsolved unknown in the mission.
+
+Current shipped state (verified against `origin/main` @ `0910530a`, v5 - NOT the working tree):
+- The browser's built-in speech recognizer was removed (pull request #1358): flaky on Android and
+  untestable with fake audio.
+- The end phrase "over and out" is caught by pause-triggered Gateway transcription; that path works.
+- There is **no spoken interrupt during playback at all** today. The only interrupt while the
+  assistant speaks is the on-screen **STOP button**. Spoken "stop" during playback was removed in v3
+  because listening during playback re-opened the microphone and ducked the reply audio to silence.
+- `micReacquiredDuringPlayback` in the telemetry is a **hardcoded `false` assertion** ("kept to
+  prove it"), not a live measurement. If any new approach re-adds a microphone tap during playback,
+  that flag must be turned back into a real measurement and the mobile duck re-checked before shipping.
+
+So this issue is about bringing the spoken stop word back, reliably, without re-triggering the duck.
+
+## Why the cloud-transcription approach cannot be the answer
+
+Sending rolling audio windows to the Gateway to be transcribed and scanned for "stop" has two fatal
+problems for an interrupt: a cloud round-trip is far too slow for something that must feel instant
+(hundreds of milliseconds to seconds), and to hear the owner over the reply it must keep the
+microphone open during playback - the exact thing that ducks the audio. An interrupt has to be
+detected **on the device, on the stream we already control, with no round-trip.**
+
+## The candidates evaluated
+
+| Option | In-browser | Latency | Custom words | License / cost | Verdict |
+|---|---|---|---|---|---|
+| **TensorFlow.js Speech Commands** | Yes (WebGL + WebAudio FFT) | Near-instant, warm-up-able | Fixed 18-word vocab out of the box (includes **"stop"**); custom via in-browser transfer learning (record ~8 samples) | Apache-2.0, free, no key | **CHOSEN** |
+| Picovoice Porcupine | Yes (WASM, fully offline) | Excellent | Arbitrary, typed-in phrase | Free tier = single device + watermarked; custom words need Enterprise; commercial from **$6,000/year** | **Rejected** - conflicts with MIT / free / pay-only-for-services |
+| openWakeWord | Possible (onnxruntime-web) | Good | Needs ML training | Open source | Fallback only if TF.js accuracy is insufficient |
+| Gateway rolling transcription (today) | No (round-trip) | Too slow; ducks audio | Any word | n/a | Rejected for interrupt |
+
+## The decision
+
+**Use TensorFlow.js Speech Commands (`@tensorflow-models/speech-commands`).** It runs entirely in the
+phone browser on the microphone stream we already echo-cancel, needs no server round-trip, no
+access key, and its built-in model already recognizes **"stop"** - the natural default. It warms up
+the same way our keep-warm pattern already does for the model and text-to-speech.
+
+Porcupine is technically the strongest but its licensing (single-device free tier, Enterprise-gated
+custom words, $6,000/year floor) is incompatible with DevThrottle being open source and free. We do
+not take a $6,000/year dependency for one control word.
+
+### User-configurable stop word (the Settings requirement)
+
+Two tiers, shipped in order:
+
+1. **Pick from the known vocabulary (ship first).** The built-in model recognizes a fixed set
+   ("stop", "go", "up", "down", "yes", "no", "left", "right", "on", "off", the digits). Let the user
+   choose their stop word from the subset that makes sense as a "cut it off" word. Zero training,
+   instant, reliable. Default = "stop".
+2. **Custom word via transfer learning (later).** For a word not in the vocabulary, TF.js supports
+   in-browser transfer learning: the user records a handful of samples and a tiny model is trained on
+   the device. The Settings Test button flow (below) doubles as the sample-collection UI. This is a
+   follow-up enhancement, not required for the first ship.
+
+## The offline test harness (build this first - the iteration loop)
+
+The owner's hard requirement: evaluate stop-word detection **outside the app, with no phone deploy**.
+
+Design - drive the **real** on-device path headlessly so results transfer to the phone:
+
+- A tiny HTML page loads `@tensorflow-models/speech-commands`, warms up, calls `listen()`, and logs
+  every detection with a high-resolution timestamp and score.
+- Playwright launches Chromium with `--use-file-for-fake-audio-capture=<clip>.wav`,
+  `--use-fake-device-for-media-stream`, and an autoplay-permissive policy, so **WebAudio's real FFT**
+  processes each clip exactly as it would a live microphone on the phone. This is the same fake-audio
+  technique the mission already proved for `MicRecorder`; it is why the numbers transfer.
+- For each labelled clip the runner records: detected (yes/no), the score, and the latency from clip
+  start to detection.
+- Scorecard aggregates: **detection rate** on true positives, **false-fire rate** on negatives, and
+  **median / p95 latency**.
+
+### Test corpus (labelled clips)
+
+- True positives: "stop", "stop stop", "please stop", spoken at different speeds/volumes.
+- Near-misses that must NOT fire: "stopwatch", "stopping", "nonstop", "the bus stop", "top", "shop".
+- The barge-in case: the assistant's own reply audio playing, with a spoken "stop" mixed over it at
+  realistic speaker/mic levels (the hardest and most important case).
+- Environment: quiet, background noise, simulated in-car noise.
+- Seed the corpus synthetically via the Gateway voice (`POST /wingman/tts`) plus a few real phone
+  recordings captured over `chrome://inspect`; mix the assistant-under-owner clips programmatically.
+
+The harness lives outside the product (a research tool, not shipped code) and is the loop we iterate
+the detector and thresholds on before anything touches the phone.
+
+## What "done" looks like for the detector choice
+
+Measured evidence from the harness that TF.js Speech Commands, on the echo-cancelled stream:
+- detects "stop" reliably, including **while the assistant's reply is playing**, at low latency; and
+- does not false-fire on the near-miss and assistant-reply-only clips.
+
+If (and only if) the harness shows TF.js cannot clear the barge-in case, escalate to openWakeWord on
+the same harness before considering any paid engine. Prove first; do not assume.
+
+## First measured findings (2026-07-12, harness built, synthetic corpus)
+
+The offline harness is built and running (Playwright + Chromium `--use-file-for-fake-audio-capture`
+driving the real TF.js Speech Commands + WebAudio FFT path; corpus synthesized from the Gateway
+voice). First three passes, synthetic (text-to-speech) audio only - real human recordings still to come:
+
+- **Specificity is excellent.** Seven distinct near-misses that do not contain the word "stop"
+  (shop, top, hop, drop, pop, "start the tests", "the server crashed") every one scored below 0.10.
+  The model does not confuse similar-sounding words. False-fire rate on these = 0.
+- **Sensitivity to a clearly-spoken "stop" is good but not yet perfect on synthetic audio.** Repeated
+  "stop" clips peaked at 0.99+; a couple were weak (a "stop now" clip peaked 0.28). At a single-frame
+  threshold overall detection was ~0.83. Single short utterances swing run-to-run because a ~1 second
+  model window may miss one brief word - repeating the word removes that lottery; real human
+  recordings and threshold tuning are needed for a trustworthy sensitivity number.
+- **THE LOAD-BEARING FINDING: the assistant's own voice can self-trigger the detector.** A
+  full-volume assistant reply containing no "stop" scored 0.99 and false-fired. This is the barge-in
+  risk made concrete: if the stop detector runs during playback and hears the assistant's own speech,
+  it may self-interrupt. In this test the assistant was at full volume (the worst case, no echo
+  cancellation). The realistic case is the residual the microphone hears AFTER echo cancellation
+  (heavily attenuated) - so the decisive next test is a negative clip of attenuated assistant audio
+  only (no owner "stop"), across several different replies, to see whether the residual stays below
+  threshold. If attenuated assistant speech still self-triggers, the detector cannot run naively
+  during playback and needs a gate (for example: suppress detection on the frequencies/known audio the
+  assistant is currently producing, or accept "stop" only when its score clears the assistant-voice
+  floor), or barge-in stays button-only while Speaking with the spoken stop working only in Listening.
+
+**The decisive test is now run, and the answer is that attenuation does NOT save us.** Two real
+assistant replies (the actual nova Gateway voice), each tested at full volume and attenuated to 0.35
+(the residual after echo cancellation), with no "stop" spoken:
+- Reply 1 scored **1.0 even at 0.35 attenuation**, sustained across frames - so neither a higher
+  threshold nor a longer debounce suppresses it.
+- Reply 2 was borderline (0.98 full, 0.69 attenuated).
+
+Conclusion: **the generic TF.js Speech Commands "stop" class cannot safely run a spoken interrupt
+during playback.** It is specific against distinct standalone words (all seven near-misses silent),
+but the coarse "stop" classifier is triggered at 1.0 by segments of ordinary connected speech,
+including the assistant's own voice, independent of volume. A spoken interrupt built on it would
+self-cut certain replies. Echo-cancellation loudness reduction is not a reliable fix because the
+model is largely volume-robust.
+
+### Revised recommendation
+
+- **Spoken barge-in (interrupt while the assistant is speaking) needs a purpose-trained wake-word
+  model, not the generic 18-word classifier.** A model trained to fire ONLY on the chosen word, with
+  general speech (and ideally the assistant's own voice) as negatives, is far more specific. The
+  open-source, self-hostable option is **openWakeWord** (custom words via training); Picovoice
+  Porcupine's purpose-trained words are excellent but its licensing is still out. This is a larger
+  build (train + host a small model) and is the real path if spoken barge-in during playback is
+  wanted.
+- **The generic TF.js model is still useful where the assistant is NOT speaking** - but in the
+  Listening phase the turn is already ended by "over and out", so a stop word there adds little. The
+  value of the stop word is barge-in, which is exactly the case the generic model fails.
+- **Interim shipping option:** keep today's v5 behaviour - the STOP button is the interrupt during
+  playback (reliable, zero risk) - and treat spoken barge-in as its own tracked piece pending the
+  purpose-trained model. The configurable-stop-word Settings tab and Test button still make sense,
+  built on whichever detector we land on.
+
+Still to do regardless of path: real human "stop" recordings captured over `chrome://inspect` (the
+owner-side audio here is text-to-speech, a weak proxy), and re-running the harness against the chosen
+detector. The harness itself is the durable asset - it now evaluates any detector against the same
+corpus with no phone deploy.
+
+## Implementation order (after the harness proves the detector)
+
+1. Offline test harness + corpus, detector chosen and thresholds tuned on measured numbers.
+2. A `useStopWord` detector in `packages/client-core/src/carmode/` wrapping the chosen engine on the
+   single `MicRecorder` stream, live during Speaking. If it taps the mic during playback, convert
+   `micReacquiredDuringPlayback` back to a live measurement and re-check the mobile duck on a real
+   phone before shipping.
+3. A Cockpit Settings tab to choose the stop word, with a Test button that runs the same detector so
+   the user can confirm capture (and, later, collect transfer-learning samples).
+4. Wire the chosen stop word into Car Mode's interrupt path; owner-verify on the real phone.

--- a/docs/architecture/devthrottle-stats-mission-2026-07-11.md
+++ b/docs/architecture/devthrottle-stats-mission-2026-07-11.md
@@ -1,0 +1,334 @@
+# Mission Brief: DevThrottle Stats (prove where the work happens, then gamify it)
+
+Status: active mission. Written 2026-07-11 by the Architect session ("DevThrottle Stats -
+Architect", session c991c09e, machine SOREN_NORTH). This document is the Architect's handover to
+the Manager session. The Manager owns execution from here; the Architect settles the design and
+then lets the Manager drive. It replaces the intake seed of the same name; every claim below was
+verified against the working tree on 2026-07-11 and carries file and line citations.
+
+## The mission
+
+The owner wants hard proof of where his development actually happens, and then wants to turn that
+proof into a game other people play too. After shipping mobile voice mode, working by voice from
+his phone became his preferred way to build; he goes to the computer only when he genuinely needs
+to click around a screen and see what the app looks like. He wants to PROVE - to himself and,
+publicly, to the market - that most of his real development is done by voice, from his phone.
+
+Two halves, in order, and the order is the whole point:
+
+1. Instrument and measure (the real reason). Track, across the whole fleet, how the owner is
+   actually driving development: how much of his input is spoken (voice dictation) versus typed on
+   a keyboard, and how much comes from the phone (the mobile `/m` app), the cc-director desktop
+   app, or the cockpit. The measurement is always available on the Gateway - a page he can open any
+   time and see the breakdown, with no cloud round-trip needed to see his own numbers.
+
+2. Gamify and share (the marketing wrapper). Let a person opt in to publish their stats online,
+   turning it into a friendly competition - "what share of your development do you do from your
+   phone?" More than one public leaderboard. Real DevThrottle credits are paid to winners. The
+   boards are seeded so they look populated at launch.
+
+The instrumentation is the point; the leaderboard is how that proof becomes a marketing story.
+Everything below serves "show, with data, where the work happens" - and it must show it
+**honestly**, because a phone-share number the owner will publish is worthless if the measurement
+quietly flatters the phone.
+
+## The core finding - the honest counting seam is the Director, not the Gateway
+
+Verified against the working tree on 2026-07-11. Read this before starting; it changes the
+shape of the whole mission and corrects the intake seed's leading guess.
+
+1. Every input into a session funnels through exactly two methods on the local `Session` object,
+   and they are already the enforced, tested choke point. `Session.SendInput(byte[])`
+   (`src/CcDirector.Core/Sessions/Session.cs:1532`) takes raw keystrokes and writes them to the
+   PTY (`_backend.Write(data)`, line 1536). `Session.SendTextAsync(string, SendSource)`
+   (`src/CcDirector.Core/Sessions/Session.cs:1619`) takes a submitted turn (a whole message that
+   ends with Enter). There is no third door: a regression test,
+   `src/CcDirector.Core.Tests/TerminalPromptInjectionChokepointTests.cs`, already pins these two
+   methods as the only way text reaches a session. This pair is where the counting lives.
+
+2. Desktop-local input never touches the Gateway - it calls the local `Session` in-process. When
+   the owner types in the desktop terminal, `TerminalControl.OnTextInput`/`OnKeyDown`
+   (`src/CcDirector.Terminal.Avalonia/TerminalControl.cs:1305` and `:1288`) call `_session.SendInput(bytes)`
+   directly on the live in-process `Session`. The desktop composer calls
+   `_activeSession.Session.SendTextAsync(text)` (`src/CcDirector.Avalonia/MainWindow.axaml.cs:4953`
+   and `:3080`); desktop dictation lands on the same `SendTextAsync` via `BackgroundDictationSend`
+   (`MainWindow.axaml.cs:3001`) and the voice-mode/FIFO controllers
+   (`src/CcDirector.Core/Voice/Controllers/VoiceModeController.cs`,
+   `src/CcDirector.Avalonia/FifoWindow.axaml.cs:401`). None of these serialize out to the Gateway.
+   **This is the finding that decides the architecture: if we counted only at the Gateway, we
+   would miss 100% of desktop-local typing, and the owner's published phone/voice share would be
+   silently and dishonestly inflated - the one outcome we cannot ship.** The count must happen at
+   the Director choke point, which is the only place that sees desktop-local input.
+
+3. Remote input (cockpit and phone) converges onto the same two `Session` methods. Remote
+   keystrokes ride the terminal WebSocket and land at
+   `TerminalStreamEndpoint.ForwardClientInputAsync` -> `SendInput(bytes)`
+   (`src/CcDirector.ControlApi/TerminalStreamEndpoint.cs:217`). Remote composer/prompt submits hit
+   the Director's `POST /sessions/{sid}/prompt` (`src/CcDirector.ControlApi/ControlEndpoints.cs:2266-2298`)
+   -> `SessionCommandExecutor.SendPromptAsync` (`src/CcDirector.ControlApi/SessionCommandExecutor.cs:112`),
+   which branches at lines 122-125: `AppendEnter == true` -> `SendTextAsync` (a submitted turn),
+   `AppendEnter == false` -> `SendInput` (raw typing). So the same two methods cover desktop,
+   cockpit, and phone.
+
+4. The seed's leading guess - "`POST /wingman/transcribe` is the clean voice-versus-typed seam" -
+   is wrong, and this matters. There IS one transcription service, `GatewayTranscriptionService`
+   (`src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs:33`), reached by several
+   HTTP front doors (`POST /wingman/transcribe`,
+   `src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs:339`; the chunked
+   `/wingman/utterance/.../complete`, `:143`; the durable
+   `POST /dictation/{uploadId}/complete`, `src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs:130`).
+   But the one-shot transcribe endpoints return `{ transcript }` to the CLIENT (`:372`), which then
+   re-submits it as an ordinary message; by the time it reaches the session it is a plain `{ Text }`
+   with no voice marker, and the voice-turn endpoint's own doc says the text tab and the voice tab
+   are the identical request (`GatewayWingmanVoiceEndpoint.cs:38-40`). `PromptRequest`
+   (`src/CcDirector.Gateway.Contracts/PromptRequest.cs:6-22`) has no origin field. So a transcribed
+   input is NOT distinguishable from typed once it reaches the session today. Voice-versus-typed is
+   a tag we must ADD, threaded from the entry points into the choke point.
+
+5. `SendSource` exists but is not the tag we need. `SendSource`
+   (`src/CcDirector.Core/Sessions/SendSource.cs:18-28`) has `UserInput`, `Delivery`, `Internal`,
+   and its documented purpose is the dictation-lock exemption, not statistics; its own doc calls it
+   "diagnostic only" (`Session.cs:1612-1617`). It does not encode surface, and "voice" is spread
+   across `Internal` (desktop voice-mode/FIFO, Gateway voice-turn) and `UserInput` (re-submitted
+   wingman transcripts, desktop dictation composer). The single real origin signal that exists is
+   the `X-Dictation-Delivery` header on the Director prompt endpoint
+   (`ControlEndpoints.cs:2274-2275`), set only by the Gateway's durable dictation delivery -> mapped
+   to `SendSource.Delivery`. That covers exactly one voice path (phone durable dictation) and
+   nothing else. We reuse it as one input, but it is not sufficient.
+
+6. Surface (phone vs cockpit vs desktop) is not on requests today, but the device key already
+   proves it. Auth is one boolean check: `AuthMiddleware.HasValidToken`
+   (`src/CcDirector.Gateway/Util/AuthMiddleware.cs:181`) accepts a valid per-device key via
+   `DeviceRegistry.IsValidDeviceKey` (`src/CcDirector.Gateway/Pairing/DeviceRegistry.cs:156`), which
+   returns `true`/`false` and throws away WHICH device matched. But each device record already
+   carries a recorded `DeviceType` (`DeviceRegistry.cs:248`; constants and mapping at `:29`, and
+   `MobileDeviceEnrollmentService.DeviceTypeForPlatform`,
+   `src/CcDirector.Gateway/Account/MobileDeviceEnrollmentService.cs:48-58`): a phone enrolls as
+   `phone`, the cockpit as `browser`, the local machine as `workstation`/`gateway`. No client sends
+   any distinguishing header - `authHeaders()` in `packages/client-core/src/api/client.ts:71-74`
+   emits only `Authorization: Bearer <key>`, and the desktop C# client
+   (`src/CcDirector.ControlApi/GatewayClient.cs:165`) likewise sends only the Bearer. So the surface
+   is knowable from the verified key with no client change; it is simply discarded at the auth check
+   today.
+
+7. The Director already reports its roster up to the Gateway on a live channel - stats ride the
+   same rails. `GatewayStreamClient` (`src/CcDirector.ControlApi/GatewayStreamClient.cs`) dials the
+   Gateway's `director-stream` SignalR hub and pushes `List<SessionDto>` snapshots and per-session
+   deltas (`PushSnapshot`/`PushDelta`/`RemoveSession`, lines 206-241), reconciled by a heartbeat
+   floor. The Gateway aggregates these into `GET /sessions`
+   (`src/CcDirector.Gateway/Api/GatewayEndpoints.cs`), which is the always-available roster today.
+   Per-session stat counters flow up most naturally as new fields on the pushed snapshot/delta or a
+   sibling hub method - no new transport.
+
+8. The Gateway already has the durable-store pattern and the web surface a private dashboard needs.
+   Durable state is one JSON file per store, atomic temp-write + rename, reloaded on boot, corrupt
+   files quarantined - the `CronJobStore` precedent
+   (`src/CcDirector.Gateway/CronJobStore.cs:315-340` save, `:248-308` load/quarantine), written
+   under `CcStorage.Root()` = `%LOCALAPPDATA%\cc-director`
+   (`src/CcDirector.Core/Storage/CcStorage.cs:30-38`). The Gateway is a Kestrel host that already
+   serves the cockpit React app at `/c` (`src/CcDirector.Gateway/Cockpit/CockpitReactApp.cs`) and
+   the mobile PWA at `/m` (`src/CcDirector.Gateway/Mobile/MobileApp.cs`), plus a self-contained
+   static login page (`src/CcDirector.Gateway/Web/login.html`). Important nuance: the React apps
+   are only built into `wwwroot` in RELEASE builds; a plain dev build 404s those routes. An
+   "always available" page must therefore not depend on the React build.
+
+9. The cloud side already exists and is the model for publishing. This repo never touches Supabase
+   directly for app data; it calls a cloud REST API at `devthrottle.com` with the account token -
+   e.g. `AccountCreditsClient` reads `GET /api/v1/account/credits`
+   (`src/CcDirector.Core/Account/AccountCreditsClient.cs:35,65-113`) and the Gateway proxies it
+   token-free at `/account/credits` (`src/CcDirector.Gateway/Api/AccountCreditsEndpoint.cs:39`). The
+   accounts, members, and credits tables live in the sibling repo `D:\ReposFred\devthrottle_internal`
+   on Supabase project `ompujpfrglgqvqprilxa`. A "publish my stats" push mirrors `AccountCreditsClient`:
+   a new `POST https://devthrottle.com/api/v1/...` client here plus a new Vercel route and Supabase
+   table there. The public leaderboard endpoints do not exist yet in either repo - they must be
+   built cloud-side.
+
+10. Credits can only be granted server-side, by the cloud, and only manually today. Balance is read
+    here (`AccountCreditsClient`); the 402/insufficient-credits gate lives in the cloud
+    (`devthrottle_internal/website/api/v1/chat.js:264`, `_lib/credits.js`). The one "add credits to
+    a member" primitive is the Supabase RPC `grant_topup_credit(member, micros, ref, note)`
+    (`devthrottle_internal/website/supabase/migrations/20260702150000_stripe_topup_grant.sql:26-88`),
+    which is `SECURITY DEFINER` with execute granted ONLY to `service_role`. No app, client, or admin
+    UI here can grant credits. A leaderboard payout is a server-side action in the internal repo
+    reusing that RPC with a unique idempotency `ref`.
+
+## The two things that are genuinely new - build these; everything else is reuse
+
+### New build A - origin tagging at the Director choke point, and a per-session tally
+
+This is the heart of the mission and the honest measurement. Two dimensions per input:
+modality = `voice | typed`, surface = `phone | cockpit | desktop`.
+
+- Thread a small origin descriptor into the two choke-point methods. `SendInput`
+  (`Session.cs:1532`) takes only bytes today and must gain an origin argument; `SendTextAsync`
+  (`Session.cs:1619`) carries `SendSource`, which is the wrong axis and must be joined by a real
+  `(modality, surface)` origin. Set it at each entry point, where the origin is actually known:
+  - Desktop typed terminal (`TerminalControl.cs:1288/1305`): surface = `desktop`, modality = `typed`
+    - by construction, because this is the local app calling in-process.
+  - Desktop composer (`MainWindow.axaml.cs:4953/3080`): surface = `desktop`, modality = `typed`.
+  - Desktop dictation (`MainWindow.axaml.cs:3001` / `FifoWindow.axaml.cs:401` /
+    `VoiceModeController.cs`): surface = `desktop`, modality = `voice`.
+  - Remote keystrokes (`TerminalStreamEndpoint.cs:217`): modality = `typed`; surface from the
+    Gateway (below).
+  - Remote prompt (`ControlEndpoints.cs:2266` -> `SendPromptAsync`, `SessionCommandExecutor.cs:122-125`):
+    surface from the Gateway; modality = `voice` when the durable-dictation marker is present
+    (`X-Dictation-Delivery` -> `SendSource.Delivery`, `ControlEndpoints.cs:2274-2275`), else `typed`.
+- Carry surface from the Gateway to the Director for remote input. Resolve the surface from the
+  verified device key (change `DeviceRegistry.IsValidDeviceKey`, `DeviceRegistry.cs:156`, to return
+  the matched record's `DeviceType`, and have `AuthMiddleware.HasValidToken`, `AuthMiddleware.cs:181`,
+  stash it on the request) - this is trustworthy and needs no client change (decision 3). The Gateway
+  then stamps that surface onto the requests it already proxies to the Director - a new header on
+  `POST /sessions/{sid}/prompt` and on the terminal-stream leg, exactly the way `X-Dictation-Delivery`
+  is already carried. Desktop-local input needs no header: it is `desktop` by construction.
+  - Honest caveat to record: voice from the PHONE that goes through the one-shot
+    `/wingman/transcribe` path (rather than durable `/dictation`) re-enters as a normal message and
+    currently looks typed. Phase 1 must either route the owner's phone voice through the durable
+    dictation delivery (which already carries the marker) or add the same modality marker to the
+    wingman voice-turn submit (`GatewayWingmanVoiceEndpoint.cs:249,297`). Do not ship a phone-voice
+    count that silently misses the wingman path - state which path is instrumented.
+- Tally per session, on the Director. Keep counters keyed by `(modality, surface)`: number of
+  submitted turns (a `SendTextAsync` with AppendEnter, or a dictation/voice-turn delivery) and the
+  character volume of the text. Do NOT synthesize a "turn" from each `SendInput` keystroke - raw
+  terminal keystrokes are counted as typed CHARACTER volume for their surface, never as turns.
+  Persist locally with the `CronJobStore` pattern (`CronJobStore.cs:315-340`) so the tally survives
+  a Director restart.
+- Flow the tally up to the Gateway on the existing `director-stream` channel
+  (`GatewayStreamClient.cs:206-241`) - new counter fields on the pushed snapshot/delta, aggregated
+  into a Gateway-side `stats.json` store (same `CronJobStore` pattern, `CcStorage.Root()`).
+
+### New build B - the always-available private Gateway dashboard
+
+- One page the owner opens any time on the Gateway showing HIS breakdown: voice vs typed and phone
+  vs desktop vs cockpit, with the headline share (see "The unit" below) front and center. It reads
+  the Gateway's aggregated `stats.json`; it needs zero cloud dependency.
+- Serve it as a self-contained static page (the `Web/login.html` model), NOT as a React route,
+  because the React apps only exist in release builds (core finding 8) and this page must be always
+  available - including on a plain dev build. Mount it in `GatewayHost.cs` alongside the existing
+  `MobileApp.Map`/`CockpitReactApp.Map` registrations.
+- Loud empty and not-captured states, per the no-fallback rule: a metric that cannot be captured
+  (for example the wingman-path phone-voice caveat above, if that path is not yet instrumented) is
+  shown as "not captured," never faked, estimated, or silently zeroed.
+
+## The unit of "how much" - settled
+
+Report both a count-based and a character-based view; make the count-based view the headline.
+
+- Headline (count): share of submitted TURNS that were spoken vs typed, and share of submitted
+  turns from phone vs desktop vs cockpit. A turn is one submitted message (`SendTextAsync` with
+  AppendEnter, or a dictation/voice-turn delivery). This is the fair, comparable unit: one spoken
+  utterance and one typed message each count as one turn, so neither modality is inflated by its
+  mechanics.
+- Secondary (characters): character volume by modality and surface, as an honest cross-check.
+  Dictation tends to produce more characters per turn; typing in bursts produces many turns; showing
+  both keeps either from being misread.
+- Explicitly NOT time-in-mode. There is no clean per-mode timer at the choke point, and time favors
+  slow voice; inventing a time metric would violate the no-fallback rule. If a defensible time
+  signal appears later it can be added, but v1 does not fabricate one.
+- The one genuinely awkward case, stated not hidden: a person working directly in a terminal TUI
+  produces typed characters but few or no "turns." That is why characters are reported alongside
+  turns; the dashboard labels raw-keystroke volume as typed character activity, distinct from turns.
+
+## Decisions already made - do not re-litigate
+
+1. Measurement first (private, always on the Gateway), then the public leaderboard/gamification on
+   top. The measurement is the point; the game is the wrapper. (Owner.)
+2. Three surfaces to distinguish - phone (`/m`), cc-director desktop, cockpit - and one input split
+   that matters most: spoken vs typed. (Owner.)
+3. Count on the Director at the `SendInput`/`SendTextAsync` choke point, never only at the Gateway,
+   because desktop-local input never reaches the Gateway (core findings 1-2). Surface for remote
+   input is resolved from the verified device key and forwarded to the Director; desktop is `desktop`
+   by construction. (Architect, 2026-07-11.)
+4. The private dashboard is always available on the Gateway with zero cloud round-trip, served as a
+   self-contained static page so it works even on a non-release build. (Owner + Architect.)
+5. Publishing to public leaderboards is strictly opt-in and reversible (stop sharing, remove me).
+   Only counts and ratios ever leave the machine - never the text of anything said or typed. This is
+   firm. (Owner + Architect.)
+6. There are several leaderboard categories. Launch set proposed below (owner confirms the final
+   set). (Owner.)
+7. Real DevThrottle credits are paid to winners, manual-first: a server-side grant in the internal
+   repo via the `grant_topup_credit` service-role RPC with an idempotent ref (core finding 10). Do
+   NOT build automated payout in an early phase. (Owner + Architect.)
+8. The boards are seeded so they look populated at launch, under the honesty stance below (owner
+   rules on it with eyes open). (Owner.)
+9. Plain English everywhere, ASCII only in code and output. No fallback programming: a metric that
+   cannot be captured is stated as not-captured, never faked or estimated silently. Fire-and-forget
+   is banned; every captured signal is real or explicitly absent. (Project rule.)
+
+## Two decisions the owner must make with eyes open (carried, not decided by the Architect)
+
+### Seeded demo users - DEFERRED, do not build yet (owner decision, 2026-07-11)
+
+The owner has decided: build the leaderboard PAGES; do NOT generate any seed/demo data yet, and do
+not decide the honesty stance now. Whether the boards are ever populated with invented users is a
+later call. So the Throttle Boards ship rendering real opted-in data (which may be just the owner at
+first, or empty), with clean, loud empty states - not a wall of fake users. When and if seed data is
+revisited, the standing recommendation holds: keep any seed rows CLEARLY SEPARABLE with an `is_seed`
+flag and never present fabricated users as verified real customers. But that is out of scope for now
+- do not implement seed-data generation in this mission unless the owner asks for it.
+
+### The public name - DECIDED
+
+The public, competitive/leaderboard side is **"Throttle Boards"** (owner decision, 2026-07-11) -
+on-brand with DevThrottle. Use this name in shipped, user-visible copy for the leaderboards. The
+private per-person view is simply "your stats" or "your throttle." The headline hook that carries
+the owner's thesis is a phone/voice share metric - a "Mobile share" or "Voice share" percentage.
+
+## Leaderboard categories - proposed launch set (owner confirms)
+
+- Highest phone share (the headline board - the owner's thesis). Ships first, in Phase 2.
+- Highest voice share. Phase 3.
+- Most sessions driven (raw volume). Phase 3.
+- Longest hands-free streak (stretch, only if the streak signal is cleanly capturable; do not fake
+  it). Phase 3 or deferred.
+
+## The work, in phases
+
+Each phase ships alone: implemented, merged to origin/main per the trunk rule, deployed to the real
+Gateway, and verified by the owner before the next phase begins. Phase 1 alone delivers the thing
+the owner actually wants - the proof.
+
+- Phase 1 - Instrumentation and the private Gateway dashboard. Add the `(modality, surface)` origin
+  tag at the Director choke point (`SendInput`/`SendTextAsync`), threaded from every entry point
+  (New build A); resolve surface for remote input from the verified device key and forward it; tally
+  per session on the Director and persist it (`CronJobStore` pattern); flow the tally up the existing
+  `director-stream` channel; aggregate into a Gateway `stats.json`; serve one always-available
+  self-contained page showing the owner's breakdown with the headline share (New build B). Instrument
+  the phone-voice path explicitly and state which path (durable dictation vs wingman) is counted.
+  Proof: the owner drives sessions by voice from the phone and by keyboard from the desktop, opens
+  the Gateway page, and watches the voice/typed and phone/desktop/cockpit split move correctly.
+  Unit tests for the tally math.
+
+- Phase 2 - Opt-in publish and one public leaderboard. Add the reversible opt-in that pushes a
+  counts-only summary to the cloud (a new `devthrottle.com/api/v1/...` client here mirroring
+  `AccountCreditsClient`, plus a new Vercel route and Supabase table in `devthrottle_internal`), and
+  render one public leaderboard - the phone-share board, the owner's headline thesis. Only counts and
+  ratios leave the machine (decision 5). Proof: the owner opts in, appears on a live public board,
+  opts back out, and disappears completely.
+
+- Phase 3 - Multiple boards and the name. Add the remaining leaderboard categories and land the
+  confirmed public name "Throttle Boards" in the copy. No seed/demo data - the boards render real
+  opted-in data with clean empty states (owner deferred seed data, 2026-07-11). Proof: several boards
+  render from real data; opting out still works; the name in user-visible copy is "Throttle Boards".
+
+- Phase 4 - Credits payout and hardening. Wire the manual-first credits payout: a server-side action
+  in `devthrottle_internal` that grants a winner credits via `grant_topup_credit` with an idempotent
+  ref (core finding 10). Add loud/clear empty, not-captured, and error states everywhere; tests for
+  the aggregation math and the origin tagging; and the final report. Proof: a winner is granted
+  credits and the balance reflects it.
+
+## Definition of done for the mission
+
+1. All phases merged to origin/main, each verified by the owner on the real Gateway and, for the
+   phone-share signal, on the real phone.
+2. The owner can open one always-available Gateway page and see, from real usage, how much of his
+   development is voice vs typing and how much is phone vs desktop vs cockpit - and the numbers move
+   correctly when he changes how he works. The count is taken at the Director choke point so
+   desktop-local typing is included; the phone/voice share is honest, not inflated by a missing
+   surface.
+3. A person can opt in to publish, appear on public leaderboards, and opt back out completely; only
+   counts and ratios ever leave the machine, never content.
+4. The leaderboards render populated (with the owner-approved honesty stance on seed data), the public
+   name and copy are the owner's confirmed choice, and manual credits payout to a winner works.
+5. A final verification report (HTML, in `docs/reviews/`) with screenshots of the private dashboard
+   and the public boards, showing the phone-and-voice share the owner set out to prove, and stating
+   plainly which input paths are instrumented and which (if any) are not-captured.

--- a/docs/architecture/gateway-cleanup-handover-verification-2026-07-13.md
+++ b/docs/architecture/gateway-cleanup-handover-verification-2026-07-13.md
@@ -1,0 +1,53 @@
+# Gateway Cleanup - Verification Handover (2026-07-13)
+
+You are a FRESH verification session, started on the NEW tunnel-only cc-director (v1.1.0). Your job: independently VERIFY that the Gateway Cleanup mission was completed correctly and end-to-end, surface anything missing or broken, and drive the one known live issue (the mobile app "blinking" / sessions appearing and disappearing) to a root cause. Do NOT trust prior reports - confirm each item with your own eyes (the prior Architect caught several report-vs-reality discrepancies during the ship). Never say something works without a proof you ran yourself.
+
+## The mission in one line
+The Gateway must NEVER dial a cc-director over the network. ALL Gateway<->Director traffic rides "the tunnel" (the two-way SignalR stream; DirectorHub `/director-stream` + GatewayStreamClient). WHY: (1) kills the phone "reconnecting to this session's computer" bug (the old Gateway dialed the Director's advertised Tailscale endpoint even on the same LAN, hit a 2s timeout + circuit breaker); (2) closes the inbound network port on every client machine (the Director dials OUT, nothing dials IN).
+
+## What was shipped (confirm each)
+- **PR #1486** (squash 398c4e4a) - the destructive cut: the Gateway no longer dials Directors (DirectorEndpointClient + the whole HTTP reverse-proxy DELETED), the tunnel is MANDATORY (streamMode gate removed), Director REST cut to a small loopback floor, plus the two restorations that were folded in (repos/handover management verbs; the fleet-messaging CLI floor on the Director loopback) and the floor-only real-exe proof (all 5 points passed live, inbound port confirmed closed).
+- **PR #1488** (f7032070) - Director made 100% tunnel-only: removed the streamMode gate on the Director side, RETIRED the /verify handshake (this killed a FALSE "Cannot reach the Gateway" banner), the tunnel Hello now REGISTERS the Director (RegisterFromStream), inbound Tailscale port for the Director closed.
+- **PR #1489** (880255b5) - version bump to 1.1.0.
+- **Release v1.1.0** - published as a STABLE release (Soren directly ordered a real release over a prerelease recommendation). /releases/latest should be v1.1.0, isPrerelease=false, ~16 assets, signed.
+- Test state at ship: Gateway.Tests ~2123-2133 green, Core.Tests 3010 pass / 8 env-skips / 0 fail. Re-run to confirm on the current main.
+
+## Current fleet state (measured at ship - RE-VERIFY, it may have moved)
+- **Gateway 7878 = v1.1.0 tunnel-only** (it auto-updated itself when the stable release published; was PID 26616, version 1.1.0+880255b5). This is the single fleet Gateway, hosted on SOREN_NORTH.
+- **A cut Director (id 37cea6e2, SOREN_NORTH, v1.1.0, source=stream)** is tunnel-connected to the Gateway and served a live tunnel command (repos-list 200). This is the working tunnel-only Director - likely the machine you are running on.
+- **Old Director 7881 (id 5edf0787) = cc-director2.exe, v1.0.7, a LOCAL DEV BUILD with the auto-updater OFF** - it did NOT and will NOT auto-update (that is why it stayed v1.0.7 for ~38h while v1.0.9 was latest). It is roster-only behind the cut Gateway (pre-cut, so session verbs fail for it) but ALIVE, still hosting the prior mission drivers (Architect b8231814 + Manager b549044e) + ~9 other-mission sessions. Soren's ONE hard rule this whole ship was: do NOT kill 7881. Its sessions still need to be migrated/drained onto the tunnel-only stack, then it can be retired.
+- SORENLAPTOP + the Mac: installed-from-release Directors auto-update to v1.1.0 on their poll cadence; Soren deprioritized them during the ship.
+
+## PRIORITY ISSUE TO INVESTIGATE - mobile app "blinking" (sessions appear then disappear)
+Soren reports the mobile app roster is flickering - sessions keep coming on and disappearing. This is the top thing to root-cause. Strong hypotheses, in order:
+1. **Mixed fleet roster churn.** The cut Gateway builds its roster from pushed snapshots (PushedSessions / stream source). The pre-cut 7881 (source=file, roster-only) and the cut Directors (source=stream) may be racing - e.g. 7881's sessions flap in/out as different push/reconcile paths disagree, or a session shows under two Directors. Check whether the blink correlates with the pre-cut 7881 being present; test whether draining+retiring 7881 stops it.
+2. **Roster push/reconnect timing.** #1488 changed registration to tunnel-Hello (RegisterFromStream). If Directors reconnect/re-Hello periodically and the Gateway rebuilds/expires roster entries, sessions blink. Look at the PushedSessions staleness/expiry window vs the push cadence, and any roster-rebuild-on-reconnect.
+3. **Duplicate Director identity on SOREN_NORTH.** Two Directors on one machine (7881 pre-cut + the cut 37cea6e2) may collide on machine identity / session numbering, causing entries to alternate.
+Reproduce on the phone, watch the Gateway roster (GET /healthz counts + the directors/sessions listing) live while it blinks, correlate with Gateway logs (DirectorHub Hello/disconnect, GatewayStreamRegistry, PushedSessions). This is the #1480 "always-current Gateway picture" territory - related design notes in memory [[gateway-live-picture-1480]].
+
+## Verification checklist (confirm each yourself)
+1. **Gateway is tunnel-only v1.1.0**: GET http://127.0.0.1:7878/healthz -> version 1.1.0. /m/ -> 200.
+2. **THE SECURITY WIN - inbound port closed on a cut Director**: `netstat -ano | findstr :<cutDirPort>` shows LISTENING only on 127.0.0.1 (NOT 0.0.0.0 / [::]); `tailscale serve status` shows NO mapping for the Director port (only the 7878 front door). Contrast a pre-cut Director (7881) which still listens on its control port.
+3. **THE PHONE WIN - reconnecting bug gone**: from the phone, on Tailscale (away) AND home LAN, open a session that lives on a CUT Director. Confirm NO "reconnecting to this session's computer" banner, and turns/prompt/voice/file all work over the tunnel.
+4. **Whole surface over the tunnel**: turns, buffer, prompt (round-trip), resize, terminal stream, file view, screenshots, upload-image, voice, the restored repos/overview + repos-management verbs. All should work with zero HTTP-dial fallback (there is none - the client is deleted).
+5. **Director loopback floor intact**: healthz, shutdown, reconnect, claude-hook, fleet-preamble(+hook-output), the Phase-4-deferred loopback config surface + the restored /fleet/send|ask|sessions|spawn (so `cc-devthrottle` still works locally).
+6. **Release integrity**: gh api repos/thefrederiksen/devthrottle/releases/latest -> v1.1.0, isPrerelease=false, assets present + signed.
+7. **Tests green on current origin/main**: Gateway.Tests + Core.Tests.
+
+## Known caveats / follow-ups (not blockers, but log/verify)
+- **Stale wwwroot assets**: the live Gateway swap used a Copy-Item MERGE (a Remove-Item hook blocked a clean replace), so old hashed assets may linger beside the cut ones. Harmless (hashed = content-addressed; the cut index.html governs what loads) but a clean wwwroot is owed.
+- **File byte-Range reads** are whole-file-only over the up-stream (minor video-seek/large-PDF degradation) - tracked follow-up **#1481**.
+- **Disk**: D: hit 100% full during the ship (caused a first gateway-swap attempt to fail + likely the earlier Gateway roster degradation); ~13GB was freed. Confirm D: has healthy headroom and stays clear.
+- **Migrate + retire 7881**: move the prior mission sessions off the pre-cut dev-build 7881 onto the tunnel-only stack, then retire it (this also likely resolves the mobile blink if hypothesis 1 holds). Do NOT force-kill it while it hosts sessions.
+- **Old mission worktrees to clean up**: `D:\ReposFred\devthrottle-cutprep` and `D:\ReposFred\devthrottle-gwcleanup-phase2`; plus `D:\cc-proof-root` + `local_builds\_gwbuild-cut` / `_dir-v1.1.0-cut` / `_rollback-v1.0.9` residue.
+
+## Where the full state lives
+- Mission memory: `C:\Users\soren\.claude\projects\D--ReposFred-devthrottle\memory\gateway-cleanup-mission.md` (seat-by-seat history, every ruling, every PR).
+- Design docs: `docs/architecture/gateway-cleanup-phase2-repoint-design.md`, `gateway-cleanup-phase1-deletion-checkpoint.md`, `gateway-cleanup-phase1-manager-plan.md`, `gateway-cleanup-mission-2026-07-11.md`.
+- The cutover runbook + evidence tables were in the prior Manager session's scratchpad (session df57f396: `cutover-plan.md`, `cutover-runbook-FINAL.md`, `sb4-evidence/EVIDENCE-TABLE.md`).
+- The prior mission drivers still reachable on the old 7881 loopback (Architect b8231814, Manager b549044e) via `POST http://127.0.0.1:7881/fleet/send` if you need their context before they are retired.
+
+## Rollback (if something is badly wrong)
+- Gateway: a reserved v1.0.9 exe is staged (`...\cc-director\gateway\devthrottle-gateway-v1.0.9.exe`) - swap back + relaunch via the gateway-launch scheduled task.
+- Directors: `.old` backups + a SHA-verified v1.0.9 asset in `local_builds\_rollback-v1.0.9`. To stop the fleet auto-updating, re-mark v1.1.0 as a prerelease (but note a v1.0.7 machine would then pull v1.0.9 = still a restart).
+- Rollback is only coherent if the Gateway AND the Directors revert together (the incompatibility is bidirectional).

--- a/docs/architecture/gateway-cleanup-phase1-deletion-checkpoint.md
+++ b/docs/architecture/gateway-cleanup-phase1-deletion-checkpoint.md
@@ -1,0 +1,399 @@
+# Gateway Cleanup - Phase 0 to Phase 1 Deletion Checkpoint
+
+Status: assembled 2026-07-12 by the Manager (session 432d5006). This is the go/no-go package for the
+Architect (session 51f1898e) to review and carry to Soren. It is presented BEFORE any deletion, build, or
+launch. Nothing in the deletion program has been started; this document is the gate.
+
+Phase 0 is complete and merged to origin/main: every unary-shaped Director read and write now rides the
+tunnel dispatch (the spine plus waves 1, 2, and 3), the up-stream primitive and the four connection-bound
+stream verbs are in, and the eight Director-local verbs stay in-process by design. All additive, no
+deletions. This checkpoint covers the deletion program (Phase 1 Director floor, then the Gateway-side
+removals in Phases 2 and 3) that the mission now unlocks.
+
+The package has five parts, in the order the Architect requested.
+
+## 0-RESOLVED. Wave 4 closed both findings; Phase 1 is now clear to cut (2026-07-12)
+
+UPDATE after the Architect's ruling and Wave 4: both findings below are RESOLVED and merged to main, so the
+deletion is unblocked (still behind Soren's gate). Kept below for the record.
+
+- FINDING A is adopted: the floor is SIX (fleet-preamble-hook-output kept, ratified by the Architect).
+- FINDING B is closed: the ten orphans are handled - Wave 4a (#1437, merged 65a87d12) added tunnel verbs for
+  the seven clear-cut ones (handovers-list, handovers-content, repo-delete, interrupted-dismiss,
+  interrupted-remove, backfill-numbers, screenshot-delete); Wave 4b (#1435, merged 867d71c1) made missions
+  GATEWAY-NATIVE (Gateway mission store + endpoints + the create MissionName plumbing + the cc-devthrottle
+  re-point), so the Director /missions routes are now a clean DELETE (their function lives at the Gateway).
+  Nothing a real client or the Gateway needs is orphaned anymore.
+
+So the deletion inventory below now has ZERO risk items: every DELETE route maps to a tunnel verb, an
+up-stream primitive, the pushed store, a Gateway-native surface, a documented drop, or the Phase-4 config
+deferral. Phase 1 (the Director floor deletion) is clear to proceed on slot 5 per Section 4, pending Soren's
+go/no-go which the Architect carries.
+
+## 0. TWO FINDINGS THAT NEEDED A DECISION BEFORE PHASE 1 (surfaced by the coverage proof) - now RESOLVED above
+
+The exact inventory (re-verified against current code; the mission-brief appendix had drifted and
+undercounted) turned up two things that changed the plan, and both were the Architect's/Soren's call:
+
+- FINDING A - the floor is SIX items, not five. The inventory found a 6th agent-lifecycle route the
+  appendix missed: `GET /sessions/{sid}/fleet-preamble-hook-output` (ControlEndpoints.cs:299), which the
+  installed Claude hook (the bash/curl variant) calls at `ClaudeHookInstaller.cs:86` - it returns the
+  preamble wrapped in Claude's `hookSpecificOutput` envelope. It is Director-local agent IPC exactly like
+  `fleet-preamble` and belongs on the floor. RECOMMENDATION: keep it (floor becomes six).
+
+- FINDING B - TEN routes are BLOCKERS. Ten routes have a real remote consumer (a Gateway
+  `DirectorEndpointClient` method, a web client, or a command-line tool) but NO tunnel verb yet and no
+  documented drop. Phase 1 cannot delete them until each gets a verb or a conscious drop decision:
+  1. `DELETE /screenshots/file` (:2387) - web client deletes a screenshot; no verb.
+  2. `DELETE /repos` (:2499) - Gateway `DeleteRepoAsync`; no verb.
+  3. `GET /handovers` (:2677) - Gateway `ListHandoversAsync` (the saved-handover-docs list, distinct from
+     the per-session `handover` info verb); no verb.
+  4. `GET /handovers/content` (:2744) - Gateway `GetHandoverContentAsync`; no verb.
+  5. `DELETE /interrupted/{deadDirectorId}/{deadPid}` (:2935) - Gateway `DismissInterruptedAsync`; no verb
+     (the interrupted READ is covered by `interrupted-list`; only its two DELETE mutations are orphaned).
+  6. `DELETE /interrupted/{deadDirectorId}/{deadPid}/sessions/{sessionId}` (:2945) - Gateway
+     `RemoveInterruptedSessionAsync`; no verb.
+  7. `POST /missions` (:1184), `GET /missions` (:1198), `GET /missions/{mid}` (:1206) - the `cc-devthrottle`
+     tool uses these; Director-local MissionStore, no verb, and the Gateway-native mission store is not yet
+     defined.
+  8. `POST /admin/backfill-numbers` (:2964) - the Gateway proxies to it via `/directors/{id}/backfill-numbers`;
+     no verb.
+  RECOMMENDATION: a small WAVE 4 that adds tunnel verbs for the clear-cut ones (screenshot-delete, repo-delete,
+  handovers-list, handovers-content, interrupted-dismiss, interrupted-remove, backfill-numbers) and a design
+  decision on the missions trio (Gateway-native mission store vs a Director verb) - all still additive, no
+  deletions - THEN Phase 1. This is exactly the orphan the coverage proof exists to catch before we cut.
+
+## 1. Exact deletion inventory (file:line)
+
+The full re-verified inventory (146 routes total; Director routes classified KEEP-FLOOR / DELETE-with-verb /
+DIRECTOR-LOCAL / DROP / RISK; DirectorEndpointClient and every call site; the catch-all and the nine HTTP
+fallbacks; the dialing machinery with front-door 443 explicitly kept) is in the Appendix at the end of this
+document. Summary of the Director floor that REMAINS (everything else on the Director HTTP surface is deleted):
+
+1. `GET /healthz` (ControlEndpoints.cs:87) - liveness for the launcher and local operator.
+2. `POST /shutdown` (:2974) - graceful self-shutdown (the launcher's DirectorSupervisor and the test teardown).
+3. `POST /reconnect` - NEW in Phase 1 (does not exist yet): force the Director to bounce the tunnel.
+4. `POST /sessions/{sid}/claude-hook` (:2228) - the installed agent hook posts lifecycle events here.
+5. `GET /sessions/{sid}/fleet-preamble` (:268) - the installed agent hook reads its preamble here.
+6. `GET /sessions/{sid}/fleet-preamble-hook-output` (:299) - FINDING A: the Claude bash-hook variant reads
+   the preamble here; Director-local agent IPC, kept on the floor.
+
+## 2. Re-confirm grep result: wingman-act and recovery-prompt
+
+The Architect flagged these two (their names suggested a possible driver consumer we could have missed). I
+re-ran the consumer grep across client-core, the Gateway (DirectorEndpointClient and any dial), the
+command-line tools, and Director-internal/driver source.
+
+RESULT - NO CONSUMER FOUND for either, in any source:
+
+- `POST /wingman/act` (`/wingman/act`): zero matches in packages/client-core/src, src/CcDirector.Gateway,
+  tools, or src/CcDirector.Core / src/CcDirector.ControlApi source. No client fetch, no DirectorEndpointClient
+  method, no command-line call, no internal caller of the route.
+- `POST /recovery-prompt` (`/recovery-prompt`): zero SOURCE matches in the same set. The only matches are
+  inside compiled `.dll` build artifacts under bin/ and obj/ (the embedded string constant), which are not
+  consumers.
+
+Conclusion: both are confirmed Director-local. Their ROUTES are safe to delete in Phase 1; their handler
+methods stay in-process for the desktop app / any internal direct call (deleting a route registration does
+not remove the handler or the feature). No remote consumer is orphaned.
+
+## 3. Coverage proof (nothing a real client or the Gateway needs is orphaned)
+
+The coverage cross-check (full table in the Appendix) maps every DELETE route to its replacement:
+
+- COVERED: the 14 session reads, 7 catalog reads, 23 session/director writes, 12 queue/git verbs, 2 unary
+  byte verbs, 3 streams (up-stream primitive), the roster (up-tunnel pushed store), the 5 fleet-messaging
+  routes (Gateway-native), and the 8 Director-local verbs (route dropped, handler kept). Every one of these
+  was exercised with per-verb parity tests in the Phase 0 waves, so the replacements are verified, not assumed.
+- DROP (documented, no consumer): the local desktop UI (`/`, `/login`, `/logout`, `/view`, `/fanout-local`),
+  the xterm/dictate static assets, the local voice-engine routes, the Gateway-native `/tts` + `/voice-turn`
+  duplicates, and the verify/verify-ws handshake (deleted in Phase 3, coordinated with registration).
+- DROP (added 2026-07-13, Phase 2 PR E-B): the Director SSE endpoint `POST /sessions/{sid}/voice-turn`
+  (`CcDirector.ControlApi/VoiceTurnEndpoint.cs`, issue #351). Its ONLY driver was the Gateway async voice-turn
+  surface (`GatewayVoiceTurnEndpoint`), which is client-dead (only the retired native MAUI client called it;
+  cockpit + mobile use `/wingman/voice-turn`) and was RETIRED + deleted in PR E-B. The Director route now has
+  zero callers, so it is a clean DROP at the cut - not on the floor, not given a tunnel verb.
+- DEFERRED to Phase 4 (not a Phase 1 delete): the settings / agents / tools / workspaces / scheduler config
+  surface (28 routes) - reached today via the `/directors/{id}/settings` proxy and the `cc-settings-api` skill.
+- NOT COVERED = the 10 RISK routes in Section 0, Finding B. These are the only orphans, and they are the
+  gate: Phase 1 must not delete them until each has a verb or a conscious drop. Everything else is clean.
+
+So the honest coverage answer is: the main read/write surface is fully covered and verified; ten routes with
+real consumers are NOT yet covered and are blockers; the rest are documented drops or Phase-4 deferrals.
+
+## 4. Slot-5 verification plan (Phase 1 Director floor)
+
+The big-bang cut is proven on ONE test Director on slot 5, never on the user's Directors. Per CLAUDE.md
+rule 0b, the test Director is launched ONLY via the Windows Task Scheduler, never from this agent's process
+tree (a nested pseudo-console kills grandchild agents).
+
+Build and launch:
+
+1. Build the stripped Director to slot 5: `scripts/local-build-avalonia.ps1 -Slot 5` (produces
+   `local_builds/cc-director5.exe`). Slot 5+ is reserved for agent test Directors; the user's main build and
+   slots 1-4 are never touched or killed.
+2. Point the `cc-director-launch` scheduled task at `cc-director5.exe` with its WorkingDirectory set (the
+   idempotent one-time registration in CLAUDE.md 0b), then `Start-ScheduledTask -TaskName "cc-director-launch"`.
+   It boots under svchost (outside the agent ConPty), so any agent sessions it spawns have clean stdio.
+3. Read the allocated Control API port from the slot-5 Director log line
+   `[ControlApiHost] Kestrel listening on http://0.0.0.0:<port>`.
+
+End-to-end proof - ALL of this driven THROUGH THE TUNNEL (the browser/Gateway path), with the slot-5
+Director exposing ONLY the five-item floor:
+
+- Roster: the Gateway `/sessions` aggregation shows the slot-5 Director's sessions from the pushed store
+  (no HTTP pull to the Director).
+- Terminal stream: open the terminal WebSocket to the Gateway; frames arrive via the Director up-stream.
+- A prompt: send a prompt through the Gateway; it rides the `prompt` tunnel verb.
+- A read: fetch `turns` through the Gateway; it rides the `turns` tunnel verb.
+- A file view: open a session file through the Gateway; it rides the `read-file` up-stream.
+- Floor-only proof: curl each DELETED route on the slot-5 Director loopback and confirm 404 (the route is
+  gone), while `healthz` / `shutdown` / `reconnect` / `claude-hook` / `fleet-preamble` still answer.
+
+Teardown: `POST /shutdown` to the slot-5 Director (graceful, so it leaves no phantom crash-journal entry);
+never force-kill. Only ever kill a process whose path is the slot-5 exe, and only as a last resort.
+
+## 5. Blast radius and rollback
+
+Blast radius:
+
+- The deletions live in the shared codebase, but only the slot-5 test Director is BUILT and RUN from the
+  post-deletion code for this proof. The user's daily-driver Director (main build) and slots 1-4 keep
+  running the pre-deletion build and are unaffected until the explicit fleet rollout (a separately gated
+  step, Phase 6 / "each rollout to real machines").
+- The browser-facing and phone-facing contracts do not change; only the hidden Gateway-to-Director leg
+  changes. The Gateway front-door 443 mapping is explicitly kept.
+- The Gateway-side removals (DirectorEndpointClient, the catch-all, the dialing machinery) are Phases 2 and
+  3; each has its own proof (cockpit and mobile drive slot 5 with no Director HTTP dial anywhere, verified
+  by log and by grep for the removed client), and none of it rolls to production without the rollout gate.
+
+Rollback:
+
+- Pre-merge: the deletions are built on a branch; if the slot-5 proof fails, the branch is abandoned with
+  zero production impact.
+- Post-merge, pre-rollout: production Directors were never rebuilt, so they are unaffected; a revert of the
+  deletion pull requests restores the routes on main. Because the cut is big-bang, a revert is all-or-nothing
+  per phase, which is why each phase is proven on slot 5 before the next begins.
+- The rollout to the user's real machines is its own hard gate (Architect to Soren) and is not part of this
+  checkpoint.
+
+## Recommendation
+
+Phase 0 (the additive verb migration) is complete and verified. But the coverage proof did its job and
+surfaced TEN routes with real consumers that are not yet covered (Section 0, Finding B), so Phase 1 is NOT
+clear to start as-is. Recommended sequence, all still additive before any deletion:
+
+1. A small WAVE 4 (additive, no deletions): add tunnel verbs for the seven clear-cut orphans (screenshot-delete,
+   repo-delete, handovers-list, handovers-content, interrupted-dismiss, interrupted-remove, backfill-numbers),
+   and settle the missions trio with the Architect (Gateway-native mission store vs a Director verb).
+2. Adopt the six-item floor (Finding A: keep `fleet-preamble-hook-output`).
+3. THEN Phase 1 (the Director floor deletion) on slot 5 with the end-to-end proof in Section 4, returning for
+   the Architect's review of the slot-5 result before the Gateway-side removals (Phases 2 and 3).
+
+No deletion, build, or launch happens until the Architect reviews this package and carries Soren's go/no-go
+back. This is Soren's gate.
+
+## Architect review - SETTLED 2026-07-12 (session 51f1898e)
+
+Reviewed. The checkpoint is thorough and the coverage proof did exactly its job: it caught real orphans BEFORE
+any deletion. Rulings below. Net: Phase 1 is NOT clear to cut yet; one small additive WAVE 4 closes the
+orphans first, then the Phase 1 deletion itself returns as Soren's gate.
+
+FINDING A - RATIFIED. `fleet-preamble-hook-output` stays on the floor; the floor is SIX, not five. It is the
+same Director-local agent-lifecycle IPC as `fleet-preamble` (the installed Claude bash-hook reads its preamble
+here in Claude's hookSpecificOutput envelope, ClaudeHookInstaller.cs:86), so it falls squarely under the
+already-approved Open Decision 1 (the hook endpoints are Director-local by nature and stay on the loopback
+floor). Deleting it would break Claude session startup via the bash hook. No Soren decision needed - it is
+inside the approved floor rationale, just a sixth endpoint the appendix missed.
+
+FINDING B - the ten orphans:
+- The SEVEN clear-cut orphans (screenshot-delete, repo-delete, handovers-list, handovers-content,
+  interrupted-dismiss, interrupted-remove, backfill-numbers) each have a real remote consumer and fit the
+  unary tunnel shape. APPROVED: give each a tunnel verb in an additive WAVE 4, exactly like the Phase 0 lifts
+  (lift-not-rewrite, the REST route and the verb share one core, per-verb parity tests). Additive, so under the
+  Option A commit policy the Manager builds and merges it without a per-commit relay.
+- The MISSIONS trio (POST /missions, GET /missions, GET /missions/{mid}) - DESIGN RULING: missions are a
+  FLEET-level concept (a mission spans sessions across Directors and machines - one mission's Architect,
+  Manager, and workers can be on different machines; missions nest), so they belong GATEWAY-NATIVE, the same
+  category as fleet messaging and scheduling. They must NOT become a Director tunnel verb - that would entrench
+  a fleet concept as Director-local, the exact "easy path that never heals" anti-pattern the brief warns
+  against, and it contradicts the mission's own Definition of Done ("the command-line tools go through the
+  Gateway"). So: build a Gateway-native mission store plus its endpoints and re-point the `cc-devthrottle`
+  mission verbs at the Gateway (additive, part of Wave 4 / the Phase 4 command-line re-point); the Director's
+  /missions routes are then DROPPED in Phase 1 (not floor, not a Director verb), once the Gateway store exists
+  so nothing is orphaned. This is REQUIRED by the Definition of Done, not scope creep - the brief already
+  commits command-line tools to the Gateway; missions were simply under-specified in the appendix. (Soren
+  informed; he may veto in favour of a temporary /missions floor exception if he wants to defer the Gateway
+  store, but the recommended and DoD-required end state is Gateway-native.)
+  - MISSIONS attach mechanism (Wave 4b design nuance, SETTLED 2026-07-12): making missions Gateway-native
+    breaks spawn-into-mission, because the Director create verb today resolves the mission NAME from the
+    Director-local MissionStore and rejects an unknown mission. Ruling: Option A. The GATEWAY (the source of
+    truth) resolves AND validates the mission before spawn and passes BOTH MissionId and MissionName on the
+    create command - add an optional MissionName to NewSessionRequest / the create verb. The Director stamps
+    session.AttachToMission(id, name) DIRECTLY from the passed name with NO local-store lookup on the Gateway
+    path; mission-existence validation (reject unknown -> BadRequest) MOVES to the Gateway where the store
+    lives. Option B (overlay the name only during roster aggregation, no Director change) is rejected: it would
+    leave the Director's own session record and desktop UI without the mission name. A local-store lookup when
+    MissionName is absent is allowed ONLY as an explicitly transitional bridge for old Director-store missions
+    during Wave 4 -> Phase 1, and is REMOVED when Phase 1 drops /missions and the MissionStore. End state
+    (post-Phase-1): the Director never resolves a mission name locally - it only stamps what the create command
+    carries. No permanent fallback.
+
+SEQUENCE - APPROVED: WAVE 4 (additive - the seven orphan tunnel verbs, plus the Gateway-native mission store
+and the cc-devthrottle mission re-point) and adopt the six-item floor, THEN Phase 1 on slot 5. No deletions in
+Wave 4. The Phase 1 DELETION itself (and the slot-5 build and launch) remains SOREN'S GATE under Option A: the
+Manager brings the completed Wave 4 plus the now-unblocked Phase 1 plan back to the Architect, who carries the
+deletion go/no-go to Soren before any route is deleted or any slot-5 build or launch happens.
+
+The rest of the package is sound and approved as the Phase 1 approach: the deletion inventory, the
+wingman-act / recovery-prompt CLEAN re-confirm, the slot-5 plan (build to slot 5, launch ONLY via the
+cc-director-launch scheduled task, the end-to-end tunnel proof plus the floor-only 404 check), and the
+blast-radius / rollback. Proceed with Wave 4 now.
+
+---
+
+## Appendix: full inventory pass output (file:line, re-verified against current origin/main)
+
+The following is the exhaustive inventory. Line numbers were re-verified against the current code (the
+mission-brief appendix had drifted +20 to +60 lines and undercounted the route total as 118; the true count
+is 146).
+
+### A1 - Director routes (src/CcDirector.ControlApi/), 146 total Map* registrations
+
+Composition root wires them at ControlApiHost.cs:419-455. No MapFallback / MapMethods / static-file
+middleware, so this is exhaustive. Per-file counts: ControlEndpoints.cs 104, AgentsEndpoint 11,
+SettingsEndpoint 6, ToolsEndpoint 5, DictationEndpoint 4, TerminalStreamEndpoint 4, WorkspacesEndpoint 3,
+SchedulerEndpoint 2, and 1 each in FactsEndpoint / DispatchEndpoint / ClaudeTranscriptsEndpoint /
+SessionHistoryEndpoint / SessionContextEndpoint / SessionUsageEndpoint / VoiceTurnEndpoint.
+
+FLOOR (keep): GET /healthz (ControlEndpoints.cs:87); POST /shutdown (:2974); POST /sessions/{sid}/claude-hook
+(:2228); GET /sessions/{sid}/fleet-preamble (:268); GET /sessions/{sid}/fleet-preamble-hook-output (:299,
+emitted by the installed Claude hook at ClaudeHookInstaller.cs:86); plus NEW POST /reconnect (not present today).
+
+DELETE -> SessionReadExecutor verbs: GET /sessions/{sid} (:245) snapshot; /buffer (:1277); /buffer/html (:1304);
+/turns (:1325); /summary (:1341); /recap (:1544); /turn-summaries (:1892); /usage (SessionUsageEndpoint.cs:22);
+/context (SessionContextEndpoint.cs:25); /history (SessionHistoryEndpoint.cs:29); /github-urls (:1039);
+/wingman (:1105) wingman-view; /wingman/explain (:877) wingman-explain; /handover (:1365) handover.
+
+DELETE -> CatalogReadExecutor verbs: GET /sessions/{sid}/git (:1753) git-status; /coaching/categories (:2644);
+/claude-sessions (:2660); /interrupted (:2922) interrupted-list; /fs/list (:2769) fs-list; /facts
+(FactsEndpoint.cs:32); /repos (:2485) repos-list.
+
+DELETE -> SessionWriteExecutor verbs: POST /sessions/{sid}/prompt (:2011); /interrupt (:2139); /escape (:2161);
+/hold (:964); DELETE /sessions/{sid} (:2834) kill; POST /sessions (:2787) create; /wingman/goal (:1123);
+/role (:1159) set-role; /mission (:1222) attach-mission; /resize (:2261); /clear-context (:2204);
+/history-picker (:2182); /mobile-mode (:897); /voice-mode (:932); /wingman-enabled (:1004); /relink (:1806);
+/request-deletion (:2873) + DELETE /request-deletion (:2898) cancel-deletion; /execute-action (:3005);
+POST /handover (:1975) handover-generate; /wingman/ask (:786) wingman-ask; /recap (:1564) recap-generate.
+(PATCH /sessions/{sid} patch has NO Director route today - cockpit reaches it via the catch-all;
+terminal-input has no REST route - it is the Phase-2 keystroke pump.)
+
+DELETE -> QueueGitExecutor verbs: GET /sessions/{sid}/queue (:2072) queue-read; POST /queue (:2075) queue-add;
+DELETE /queue/{itemId} (:2081) queue-remove; POST /queue/{itemId}/move-up (:2094); move-down (:2100);
+DELETE /queue (:2106) queue-clear; POST /queue/{itemId}/send (:2116); POST /git/stage (:1794) /unstage (:1796)
+/discard (:1798) /commit (:1800); POST /sessions/github (:2807) create-from-github. (queue-update PATCH has
+no Director route - reached via the catch-all.)
+
+DELETE -> SessionByteExecutor verbs: GET /screenshots (:2349) screenshots-list; POST /sessions/{sid}/upload-image
+(:2292) upload-image.
+
+DELETE -> up-stream primitive: GET /sessions/{sid}/stream WS (TerminalStreamEndpoint.cs:56) open-terminal-stream;
+GET /sessions/{sid}/file (:1086) read-file; GET /screenshots/file (:2369) screenshot-file.
+
+DELETE -> up-tunnel pushed store: GET /sessions roster (:230) - served by PushSnapshot/PushDelta, no unary verb.
+
+DELETE -> Gateway-native fleet messaging: GET /fleet/sessions (:351); POST /fleet/send (:379); /fleet/broadcast
+(:455); /fleet/ask (:635); /fleet/spawn (:739).
+
+DIRECTOR-LOCAL (route deleted, handler kept) - the 8 confirmed-local: POST /sessions/{sid}/wingman/act (:822);
+GET /brief (:1386); POST /chat (:1704); GET /handover-context (:1496); POST /turn-summaries (:1911);
+/rule-violations (:1728); /recovery-prompt (:1825); /state-vote (:1929).
+
+DROP (local UI / static / handshake / dead legacy - no client, no Gateway caller): GET / (:157); /login (:168);
+POST /login (:178); GET /logout (:208); /sessions/{sid}/view (:214); POST /fanout-local (:2398, only
+Web/manager.html:792); GET /verify/{nonce} (:106) + /verify-ws/{nonce} (:122, Phase 3, breaks registration -
+coordinate); xterm.js/css/canvas (TerminalStreamEndpoint.cs:49/51/53); dictate.html/worklet/overlay
+(DictationEndpoint.cs:70/76/82); GET /dictate WS (DictationEndpoint.cs:90); POST /voice/command (:1605) +
+/voice/status (:1626) + /voice/utterance (:1636) + PUT chunk (:1647) + complete (:1667); POST /tts (:1839) +
+/tts/status (:1873); POST /sessions/{sid}/voice-turn (VoiceTurnEndpoint.cs:50); POST /repos (:2512);
+GET /repos/overview (:2563); POST /handovers (:2699); DELETE /handovers (:2724); GET /claude-transcripts
+(ClaudeTranscriptsEndpoint.cs:21); POST /dispatch (DispatchEndpoint.cs:26).
+
+PHASE-4 config surface (NOT a Phase 1 delete - listed so it is not mistaken for one): SettingsEndpoint.cs
+GET/PUT /settings (37/39) + detect/test (56/70/84/97); AgentsEndpoint.cs 11 routes (110/117/126/185/198/214/
+242/275/299/335); ToolsEndpoint.cs 5 (35/46/61/77/114); WorkspacesEndpoint.cs 3 (25/31/39); SchedulerEndpoint.cs
+2 (24/38).
+
+RISK - real caller, NO tunnel verb, NO documented drop (the Phase 1 blockers, Section 0 Finding B):
+DELETE /screenshots/file (:2387, web client); DELETE /repos (:2499, Gateway DeleteRepoAsync);
+GET /handovers (:2677, Gateway ListHandoversAsync); GET /handovers/content (:2744, Gateway GetHandoverContentAsync);
+DELETE /interrupted/{d}/{p} (:2935, Gateway DismissInterruptedAsync); DELETE /interrupted/{d}/{p}/sessions/{s}
+(:2945, Gateway RemoveInterruptedSessionAsync); POST /missions (:1184) + GET /missions (:1198) + GET /missions/{mid}
+(:1206, cc-devthrottle); POST /admin/backfill-numbers (:2964, Gateway proxy).
+
+### A2 - Gateway dialing machinery (src/CcDirector.Gateway/)
+
+DirectorEndpointClient (Discovery/DirectorEndpointClient.cs, whole file, class :14, ctor :21) - DELETE. Methods:
+VerifyCallbackAsync(65), VerifyStreamCallbackAsync(110), GetHealthAsync(165), GetHealthDetailedAsync(183),
+ListSessionsAsync(206), ListSessionsWithStatusAsync(227), GetSessionAsync(248), GetWingmanAsync(263),
+AskWingmanAsync(283), SetWingmanGoalAsync(310), SetRoleAsync(334), SetHoldAsync(358), KillSessionAsync(385),
+RequestSessionDeletionAsync(408), CancelSessionDeletionAsync(435), PatchSessionAsync(457), GetBufferAsync(481),
+GetTurnsAsync(505), GetHistoryTurnsAsync(~528, NOT in the appendix), PostPromptAsync(602), PostInterruptAsync(629),
+PostEscapeAsync(643), UploadImageAsync(662), ListReposAsync(698), DeleteRepoAsync(711), GetFactsAsync(728),
+ListCoachingCategoriesAsync(741), ListClaudeSessionsAsync(754), ListHandoversAsync(767), GetHandoverContentAsync(780),
+ListDirectoryAsync(793), CreateGitHubSessionAsync(809), CreateSessionAsync(829), GetSummaryAsync(849),
+GetGitAsync(865), GetHandoverAsync(883), PostHandoverAsync(896), GetRecapAsync(916), PostRecapAsync(929),
+GetInterruptedAsync(962), DismissInterruptedAsync(976), RemoveInterruptedSessionAsync(995), PostShutdownAsync(1011).
+Call sites (re-point at DirectorCommandRouter.TrySendAsync / up-stream): GatewayHost.cs:276/427; WingmanVoiceService.cs:39/68;
+WingmanTrainingStore.cs:54; Briefing/TurnEndWatcher.cs:48/59; Running/MachineSessionSpawner.cs:34;
+Running/DirectorImplSessionDriver.cs:16/23; Discovery/AdvertisedEndpointMonitor.cs:37; Api/ExesEndpoints.cs:34;
+Api/GatewayDictationEndpoint.cs:63/313/430/445; Api/GatewayEndpoints.cs:44/2050; Api/GatewayVoiceTurnEndpoint.cs:59/380/579;
+Api/GatewayWingmanVoiceEndpoint.cs:61/506/520/623/667/676/684; Api/SessionWsProxyEndpoints.cs:50/198/288;
+Api/WorkListRunnerEndpoints.cs:35.
+
+Catch-all + SessionWsForwarder (Api/SessionWsProxyEndpoints.cs, Map :50): browser-facing STAY (GET /sessions/{sid}/stream :55;
+/dictate :61; /screenshots/file :77; /screenshots :88; /directors/{id}/settings :131 config; POST /directors/{id}/backfill-numbers
+:164 - see RISK). DELETE the catch-all /sessions/{sid}/{**rest} :101 (ProxyAsync dispatch :123). The Director-dialing leg
+to delete: ProxyAsync :197, LocateOwningDirectorAsync :288, ForwardDestination :321, class SessionWsForwarder (ForwardAsync
+:407, ForwardWebSocketAsync :416, PumpAsync :457, ForwardHttpAsync :487).
+
+9 tunnel-verb HTTP fallbacks become stream-only (Api/GatewayEndpoints.cs, TrySendAsync anchor per verb; the HTTP else-branch
+after each dies): kill :963, wingman-goal :1042, set-role :1060, hold :1086, patch :1148, prompt :1205, interrupt :1265,
+escape :1281, create :1357. Router DirectorCommandRouter (Api/DirectorCommandRouter.cs, TrySendAsync/ReadBody/DescribeFailure)
+is the KEEP path; wired when _streamMode on (GatewayHost.cs field :98, set :419, passed :1172/1505/1432). SendCommandAsync
+(GatewayHost.cs:1646) is the tunnel dispatch (keep). Phase 6 removes the _streamMode flag.
+
+Reachability circuit breaker (Discovery/DirectorRegistry.cs) - DELETE: consts MaxConsecutiveFailures :47,
+UnreachableCooldown :50, UnreachableEvictAfter :53; class Reachability :60-66, _reach :69; ShouldProbe :227,
+RecordReachable :238, WasEverReachable :251, RecordUnreachable :337; verify-state MarkTwoWayVerified :259,
+MarkStreamVerified :275, RecordEndpointProbeResult :301; sweeper evict :458-473. Consumers: TurnEndWatcher.cs:136/143/146;
+GatewayEndpoints.cs:419/498/500/509/511/771. DO NOT TOUCH the DIFFERENT class FleetRosterCache.cs:64/91
+(RecordReachable/Unreachable) - its call sites GatewayEndpoints.cs:534/562 stay (only ~25 lines from the registry ones -
+distinguish registry.* vs rosterCache.*).
+
+AdvertisedEndpointMonitor (Discovery/AdvertisedEndpointMonitor.cs, whole file, ctor :37) - DELETE. Refs: GatewayHost.cs
+field :343, construction :889 (only two now, not the appendix's five).
+
+verify / verify-ws trio - DELETE: POST /directors/{id}/verify (GatewayEndpoints.cs:378, calls VerifyCallbackAsync :392 /
+VerifyStreamCallbackAsync :404); client methods DirectorEndpointClient.cs:65/110; registry MarkTwoWayVerified (:259) /
+MarkStreamVerified (:275).
+
+Director control-endpoint advertisement (TailnetEndpoint/ControlEndpoint selection) - DELETE: GatewayHost.cs:535
+(d.TailnetEndpoint ?? d.ControlEndpoint), :793 ((d.ControlEndpoint ?? d.TailnetEndpoint ?? "")), :1109
+(Registry.Get(directorId)?.ControlEndpoint); SessionWsProxyEndpoints.cs:321 ForwardDestination; GatewayEndpoints.cs
+DeriveDirectorBaseUrl (~:2050-2061). DirectorDto.ControlEndpoint/TailnetEndpoint/AdvertisedEndpoint* fields die with it.
+
+TailscaleServeProvisioner (Tailscale/TailscaleServeProvisioner.cs): KEEP front-door 443 - FrontDoorHttpsPort const :53,
+FrontDoorWatchInterval :73, _frontDoorTimer :82, front-door serve :122, timer init :142, WatchFrontDoorCore :285,
+reconcile branches :189-196/:307-310/:256-261, ReconcileActions :276, Dispose :426. DELETE per-Director-port mappings -
+DirectorPortMin/Max :65-66, _portsById :80, OnDirectorAdded/Removed subscriptions :117-118 (+ unsubscribe :427-428),
+HandleAdded loop :130 + per-director ShouldMap :170, HandleAdded :323, HandleRemoved :337, ShouldMap :351.
+(LegacyCockpitPort :60 is a separate legacy concern - leave for its own decision.)
+
+### A3 - Coverage summary
+COVERED (verified by Phase 0 parity tests): 14 session reads, 7 catalog reads, 23 writes, 12 queue/git, 2 unary bytes,
+3 streams (up-stream), roster (pushed store), 5 fleet messaging (Gateway-native), 8 Director-local (handler kept).
+DROP: the local UI/static/voice/handshake set above. DEFERRED: the Phase-4 config surface. NOT COVERED = the 10 RISK
+routes (Section 0 Finding B) - the only orphans, and the Phase 1 blockers.
+
+

--- a/docs/architecture/gateway-cleanup-phase1-manager-plan.md
+++ b/docs/architecture/gateway-cleanup-phase1-manager-plan.md
@@ -1,0 +1,170 @@
+# Gateway Cleanup - Phase 1 Manager execution plan (for the Architect, before any cut)
+
+Author: Manager session d1286c9f ("Gateway Cleanup - Manager"), 2026-07-12, machine SOREN_NORTH.
+Status: PRESENTED TO THE ARCHITECT (51f1898e) FOR A SEQUENCING RULING. No worktree created, no branch cut,
+no route deleted, no build, no launch. This is the plan and one design fork that must be settled first.
+
+## 1. State confirmed (nothing lost in the phase-boundary reset)
+
+- All additive work is merged to origin/main. Local main is 867d71c1; origin/main tip is ffbc45bb (a few
+  intervening commits from other missions sit on top of Wave 4b - I will branch off origin/main, not local).
+- Wave 4a (#1437, 65a87d12) and Wave 4b (#1435, 867d71c1) are in: the seven orphan verbs are tunnelled and
+  missions are Gateway-native. The deletion checkpoint is 0-RESOLVED (both findings closed).
+- The floor is SIX (Finding A ratified): GET /healthz, POST /shutdown, POST /reconnect (NEW), POST
+  /sessions/{sid}/claude-hook, GET /sessions/{sid}/fleet-preamble, GET /sessions/{sid}/fleet-preamble-hook-output.
+- Soren's GO for BUILDING and PROVING Phase 1 on slot 5 is given; the deletion MERGE stays his gate through you.
+
+## 2. THE FORK (must be settled before I structure the deletion): the Gateway does NOT yet read/stream through the tunnel
+
+I re-verified the current Gateway code against the slot-5 proof. The proof as written in the checkpoint
+(Section 4) presupposes the Gateway serves the browser-facing legs THROUGH THE TUNNEL. It does not yet.
+
+Evidence (current origin/main Gateway):
+
+- Only NINE verbs ride the tunnel on the GATEWAY side, all writes/commands, via
+  DirectorCommandRouter.TrySendAsync(sendCommand, ...): kill, wingman-goal, set-role, hold, patch, prompt,
+  interrupt, escape, create (GatewayEndpoints.cs:1005/1084/1102/1128/1190/1247/1307/1323/1399). sendCommand is
+  non-null only when streamMode is on (GatewayHost.cs:1198), and streamMode is OFF in production
+  (GatewayHost.cs:1208 comment: "which is off in production").
+- Every READ (turns, buffer, git-status, usage, context, history, summary, handover, ...), the terminal
+  WebSocket stream, the screenshot bytes, and the file view are served by SessionWsForwarder, which DIALS the
+  owning Director's HTTP/WS endpoint. The terminal stream (SessionWsProxyEndpoints.cs:55), dictate (:61),
+  screenshots (:77/:88), and the generic catch-all /sessions/{sid}/{**rest} (:101 -> ProxyAsync ->
+  ForwardDestination) are NOT gated by streamMode and do NOT touch the up-stream.
+- The up-stream primitive (DirectorStreamFrame, StreamUp hub, GatewayStreamRegistry, the four connection-bound
+  stream verbs) is built, hub-wired, and unit-tested (Phase 0, #1414), but NO browser-facing Gateway leg
+  consumes GatewayStreamRegistry. Grep for StreamUp/GatewayStreamRegistry hits only GatewayHost, DirectorHub,
+  GatewayStreamRegistry, IStreamSink - no terminal/file endpoint. Wiring the browser legs onto the up-stream and
+  the read verbs is Phase 2, and Phase 2 is not built.
+
+Consequence: a floor-only slot-5 Director driven through the Gateway would pass ONLY roster (served from the
+Director push cache - up-tunnel, real) and prompt (tunnel verb). turns (read), the terminal stream, and the
+file view would 404, because the Gateway would dial the Director HTTP routes that Phase 1 just deleted. So the
+five-part end-to-end proof in the checkpoint cannot run against today's Gateway. The mission's own invariant -
+"the new path is in place before the old path is deleted" - is only half-satisfied: Phase 0 put the new path on
+the DIRECTOR (verbs + up-stream primitive) but left the GATEWAY still dialing HTTP for reads/streams. Deleting
+the Director HTTP surface now removes a road the Gateway still drives on.
+
+## 3. Options and my recommendation
+
+- OPTION A (RECOMMENDED) - re-point the Gateway onto the tunnel FIRST, then delete the Director floor. Do the
+  Phase 2 browser-leg re-point (terminal stream -> up-stream; reads -> tunnel read verbs; file/screenshot ->
+  up-stream; replace the /sessions/{sid}/{**rest} catch-all's Director-dial with the explicit tunnel dispatch),
+  all ADDITIVE under streamMode (streamMode on = tunnel, off = HTTP - both paths coexist, nothing on main
+  breaks, production stays HTTP until the rollout gate). Prove on slot 5 with a FULL-surface Director + a
+  streamMode Gateway that the tunnel actually carries roster + terminal + prompt + turns + file. THEN Phase 1
+  deletes the Director's now-unused HTTP surface and RE-proves floor-only (the same proof, now with the routes
+  gone and every deleted route 404ing). Rationale: this is the only order where the floor-only proof is
+  runnable, and it honors the invariant (new road carries traffic before the old road is removed). It swaps the
+  1<->2 order, or equivalently recognizes the checkpoint's slot-5 proof as a Phase-2-then-Phase-1 proof.
+- OPTION B - bundle Phase 1 + the minimal Phase 2 wiring on ONE branch: delete the Director routes AND wire the
+  Gateway browser legs onto the tunnel, prove floor-only end-to-end in one shot. Matches the checkpoint's proof
+  literally, but mixes additive Gateway work with the destructive Director cut inside one gated merge, and is a
+  larger single blast radius. Under Option A that Gateway work is a separate additive merge I can land without a
+  gate, keeping the destructive cut small and clean.
+- OPTION C - scope the Phase 1 proof down to what the tunnel carries TODAY (roster push + prompt); accept that
+  turns/terminal/file are NOT proven until Phase 2. REJECTED as a real proof: it would merge a Director that
+  breaks terminal and reads through any streamMode Gateway, and it does not exercise the mission's headline
+  (terminal + file via the up-stream). A weak proof is worse than none here.
+
+Recommendation: OPTION A. Please rule on the sequence. Everything below is the mechanics, unchanged by the
+ruling except for which branch carries the deletion.
+
+## 4. Deletion structure (Phase 1 proper, once sequence is settled)
+
+- Own worktree off origin/main (git worktree add, a fresh branch e.g. gateway-cleanup-phase1-director-floor).
+  NEVER checkout -b on the shared tree; NEVER git add -A; stage only my own files by name. The shared tree
+  currently holds another mission's uncommitted CarMode work - I will not touch it.
+- Scope of the cut (from the checkpoint inventory, Appendix A1):
+  - KEEP the six floor routes; ADD POST /reconnect (bounce the tunnel; the only new thing on the Director).
+  - DELETE every other Director route registration EXCEPT the Phase-4 config surface, which the checkpoint
+    explicitly DEFERS (Settings/Agents/Tools/Workspaces/Scheduler, 28 routes, reached via /directors/{id}/settings
+    and the cc-settings-api skill). CONFIRM WITH YOU: Phase 1 leaves that config surface in place (so slot 5
+    answers the 6 floor routes PLUS the 28 config routes); the 404 proof targets the Phase-1-DELETED routes, not
+    the config surface. The checkpoint says so (Section 3 + Appendix), but it is worth an explicit yes.
+  - DIRECTOR-LOCAL (route deleted, handler kept in-process): the 8 confirmed-local verbs (wingman-act, brief,
+    chat, handover-context, turn-summaries-generate, rule-violations, recovery-prompt, state-vote). Re-confirm
+    wingman-act and recovery-prompt have no remote consumer at the cut (cheap insurance, already done once).
+  - DROP (no consumer): local desktop UI, xterm/dictate static assets, local voice-engine routes, the
+    Gateway-native /tts + /voice-turn duplicates. The verify/verify-ws handshake is coordinated with Phase 3
+    (it breaks registration) - I will NOT delete verify/verify-ws in Phase 1 unless you want it folded in.
+  - The in-process executor cores (Phase 0) stay; deleting a Map* registration does not remove the feature, it
+    removes the network door. The tunnel verb already calls the same core.
+- Likely ONE deletion pull request for the Director floor (it is mechanical route-registration removal in a few
+  endpoint files), unless it proves large enough to want a small chain by endpoint file. I will keep it a single
+  reviewable cut if I can.
+- Build discipline before merge: PR up-to-date-with-main, AND audit-read-aware - an intervening commit that
+  edits a file a source-audit test READS can red main even without touching my files (the
+  TerminalPromptInjectionChokepointTests lesson). I re-check the merged state before merging.
+
+## 5. Slot-5 build, launch, and proof (mechanics, unchanged by the ruling)
+
+1. Build from the branch to slot 5: scripts/local-build-avalonia.ps1 -Slot 5 -> local_builds/cc-director5.exe.
+   Slot 5+ only; the user's main build and slots 1-4 are never built to, never killed.
+2. Launch ONLY via the cc-director-launch Windows scheduled task (CLAUDE.md rule 0b): point the task at
+   cc-director5.exe with its WorkingDirectory, Start-ScheduledTask. It boots under svchost, outside my ConPty,
+   so any agent session it spawns has clean stdio. I never spawn cc-director5.exe from my own process tree.
+3. Read the Control API port from the slot-5 log line "[ControlApiHost] Kestrel listening on http://0.0.0.0:<port>".
+4. End-to-end proof through the Gateway (a streamMode Gateway, per the ruling): roster (push) + terminal stream
+   (up-stream) + prompt (tunnel verb) + turns (read verb) + file view (read-file up-stream).
+5. Floor-only proof: curl each DELETED route on the slot-5 loopback -> 404; the 6 floor routes + POST /reconnect
+   still answer.
+6. Teardown: POST /shutdown to the slot-5 Director (graceful, leaves no phantom crash-journal entry). Never
+   force-kill; if I ever must, only a process whose path is cc-director5.exe, confirmed first, last resort only.
+
+## 6. Gate and stop point
+
+I do NOT merge the destructive deletion until the slot-5 proof PASSES. When it passes I STOP and bring you the
+proof result (the e2e run + the 404s on deleted routes + the floor-only confirmation) so you carry Soren's
+OK-to-merge. If the proof FAILS I abandon the branch (zero production impact) and bring you the failure. The
+additive Gateway re-point under Option A I can merge autonomously (Option A commit policy); only the Director
+deletion is the gate.
+
+## 7. The one question for you
+
+Rule on the sequence in Section 3 (I recommend Option A: Gateway re-point first, then Director floor), and
+confirm the Section 4 scope point (Phase 1 leaves the Phase-4 config surface in place; the 404 proof targets the
+Phase-1-deleted routes). On your ruling I create the worktree and begin - the additive Gateway re-point first if
+Option A, or the deletion branch directly if you want B/C.
+
+## Architect ruling (sequencing fork) - SETTLED 2026-07-12 (session 51f1898e)
+
+OPTION A - APPROVED. Excellent catch. The finding is correct and consistent with the Phase 0 deliverable: Phase
+0 put the new path on the DIRECTOR (the verb dispatch + the up-stream primitive) but explicitly left the
+up-stream UNWIRED into the browser-facing Gateway legs (that swap is Phase 2, stated in the phase0 protocol
+doc). The Gateway still dials the Director over HTTP for every read, the terminal stream, and the
+file/screenshot bytes (SessionWsForwarder + the catch-all; streamMode is off in production; only nine write
+verbs ride the tunnel). So a floor-only slot-5 Director would 404 turns/terminal/file - the mission's own
+invariant ("the new path is in place before the old path is deleted") is only half-satisfied, and deleting the
+Director HTTP surface now would remove a road the Gateway still drives on.
+
+Corrected sequence:
+1. FIRST (additive, under the existing streamMode flag - both paths coexist, production stays on HTTP, nothing
+   on main breaks): re-point the Gateway's browser-facing legs onto the tunnel - terminal stream onto the
+   up-stream, reads onto the tunnel read verbs, file/screenshot onto the up-stream, and replace the
+   /sessions/{sid}/{**rest} catch-all's Director-dial with the explicit tunnel dispatch. Prove on a FULL-surface
+   slot-5 Director + a streamMode Gateway that the tunnel actually carries roster + terminal + prompt + turns +
+   file. This is additive, so under the Option A commit policy you build and merge it WITHOUT a gate.
+2. THEN (destructive, Soren's gate through me): delete the Director REST surface to the six-item floor and
+   RE-prove floor-only (every deleted route 404s; the six floor routes + POST /reconnect answer). Bring me the
+   slot-5 proof BEFORE merging the deletion.
+
+This honors the invariant (the new road carries traffic before the old road is removed), keeps the destructive
+cut small and clean (separate from the additive re-point), and is the only order in which the floor-only proof
+is runnable. It effectively splits the original Phase 2 into an additive-wire part (done now, before the Phase 1
+deletion) and a destructive delete-the-dialing-machinery part (later). Option B (bundle additive + destructive
+on one branch) is rejected as a larger single blast radius that folds autonomous additive work into a gated
+destructive merge; Option C (scope the proof down to roster+prompt) is rejected as a weak proof - agreed on both.
+
+Scope confirmations:
+- Phase 1 LEAVES the Phase-4 config surface (Settings / Agents / Tools / Workspaces / Scheduler, 28 routes) in
+  place - CONFIRMED. Slot 5 answers the six floor routes + POST /reconnect + the 28 config routes; the 404 proof
+  targets ONLY the Phase-1-deleted routes, never the config surface.
+- verify / verify-ws stays for PHASE 3 - CONFIRMED. Do NOT fold it into Phase 1; it breaks Director-to-Gateway
+  registration and must be removed in lockstep with the Gateway-side verify call (Phase 3).
+- Re-confirm wingman-act + recovery-prompt have no remote consumer at the moment of the cut - yes, cheap
+  insurance (already clean once).
+
+Proceed: build the additive Gateway re-point first (own worktree off origin/main), prove tunnel-carries-all on a
+full-surface slot 5, merge it (additive, autonomous), THEN cut the Director floor on its own branch and bring me
+the floor-only proof for Soren's OK-to-merge.

--- a/docs/architecture/gateway-cleanup-phase2-repoint-design.md
+++ b/docs/architecture/gateway-cleanup-phase2-repoint-design.md
@@ -162,6 +162,88 @@ These four turn the proof from "it works" into "it works under the exact conditi
 Fold them into the slot-5 run, and where cheap into PR A's integration tests. Everything else in the plan stands
 - proceed.
 
+## Architect ruling (tunnel wire protocol = MessagePack) - SETTLED 2026-07-12 (session 51f1898e)
+
+The mechanism proof did exactly its job: the under-load additions (rulings 1 and 2) caught a REAL Phase 0 gap
+before Phase 1 built on it. Root cause: the tunnel SignalR connection was left on the DEFAULT JSON protocol,
+which base64-encodes a byte[] frame (+33%). A full-cap 48 KB Binary frame inflates to ~64 KB and exceeds the hub
+MaximumReceiveMessageSize (~52 KB = MaxBinaryFrameBytes 48 KB + 4 KB envelope), aborting the connection
+(confirmed empirically: a 30 KB sub-cap frame passes, a 48 KB full-cap frame disconnects). Ruling 2's size
+accounting ASSUMED binary framing; the connection was never switched to a binary protocol - that is the gap.
+
+RULING: OPTION A - add MessagePack on BOTH ends (.AddMessagePackProtocol() on the Gateway DirectorHub, the
+Director's HubConnectionBuilder, and the test client; the Microsoft.AspNetCore.SignalR.Protocols.MessagePack
+package). This is the ROOT-CAUSE fix and it completes ruling 2: with binary framing a 48 KB byte[] is ~48 KB on
+the wire (not ~64 KB base64), so the existing MaxBinaryFrameBytes + FrameEnvelopeAllowanceBytes (~52 KB) limit
+is CORRECT and the DirectorStreamLimits constants stay as-is. It also removes the 33% base64 bandwidth + CPU tax
+on ALL tunnel traffic - directly serving the slow-phone-link case this mission exists to fix.
+
+Options B (raise MaximumReceiveMessageSize to cover base64) and C (lower the frame cap so base64 fits) are
+REJECTED: both keep JSON's permanent 33% bandwidth + CPU tax, which is counter to the mission's whole purpose,
+and merely patch around the broken assumption instead of fixing it (the no-fallback rule: fix the root cause).
+
+Implementation notes:
+- The tunnel connection also carries roster push and the existing nine write verbs, so the switch affects ALL
+  tunnel traffic. Validate that the existing verbs + roster push still round-trip under MessagePack (the DTOs -
+  DirectorCommand / DirectorCommandResult, DirectorStreamFrame - are simple string / byte[] / int / enum shapes,
+  MessagePack-friendly).
+- ROLLOUT COORDINATION (folds into the Phase 6 rollout gate): both ends of a stream-serving connection must
+  speak MessagePack. The hub can ADD MessagePack while KEEPING JSON (an un-updated Director still connects via
+  JSON), but a JSON Director still hits the base64 bug on large frames, so any Director serving streams MUST be
+  on MessagePack. In the big-bang the fleet updates together; do not assume a mixed (JSON-Director) fleet can
+  serve large streams.
+- Validation: re-run the mechanism proof; the three red cases (large file, concurrency, backpressure) MUST go
+  green with MessagePack (the 48 KB full-cap frame no longer inflates past the limit). Then finish C and D.
+
+## Architect ruling (upload-image chunking + slow-LLM verbs) - SETTLED 2026-07-13 (session 51f1898e)
+
+- upload-image (large payload DOWN the tunnel): OPTION 1 - CHUNK. The Director HubConnection
+  (GatewayStreamClient.cs:132) had NO MaximumReceiveMessageSize (SignalR default 32 KB), so a real photo is
+  rejected. Set it to the SAME bounded value as the hub (MaxBinaryFrameBytes + FrameEnvelopeAllowanceBytes,
+  ~52 KB) - symmetric up/down and bounded. CHUNK the image at MaxBinaryFrameBytes across unary commands keyed by
+  an uploadId (begin / chunk / complete), reassembled on the Director, then the existing upload-image handler
+  runs on the reassembled bytes. Option 2 (raise the down-limit to a few MB) is REJECTED: a multi-MB single
+  message monopolizes the one shared tunnel connection (against ruling 2) and raises the limit for ALL traffic -
+  the no-fallback rule (fix the root cause, do not patch around it).
+  - UPDATE 2026-07-13 (implementation reality, SETTLED): the "raise the Director-client MaximumReceiveMessageSize
+    to a symmetric ~52 KB + 48 KB binary chunks" mechanism was REVISED after the Manager found the constraints.
+    The SignalR CLIENT (the Director HubConnection) exposes NO clean public MaximumReceiveMessageSize setter
+    (only the server HubOptions does), and adding a byte[] field to DirectorCommand would CHANGE the FROZEN
+    envelope. So the settled mechanism is: keep the chunk bytes BASE64 in the existing DirectorCommand.PayloadJson
+    string carrier at 20 KB raw (~27 KB on the wire) - comfortably under the SignalR client ~32 KB default, so no
+    client-limit change is needed and the frozen envelope is respected. This still fully satisfies ruling 2
+    (bounded, no single message monopolizes the tunnel), and the base64 tax is negligible because upload-image is
+    infrequent and small (unlike the high-volume up-stream, where MessagePack binary framing was worth it). This
+    is the RIGHT PERMANENT answer, not a stopgap - no binary follow-up needed. Everything else is option 1
+    exactly: begin/chunk/complete keyed by uploadId, a 25 MB fail-loud ceiling, a 2-minute abandoned-upload sweep,
+    fail-loud on out-of-order / size-mismatch / bad-base64, and the SAME save core as the single-shot path
+    (shared SaveImageBytes) - proven byte-for-byte (a 50 KB image over the tunnel in 3 chunks, 11/11 green).
+
+## Architect ruling (Phase 2 completeness gate = zero DirectorEndpointClient callers) - SETTLED 2026-07-13
+
+The invariant that governs which re-points belong in Phase 2 vs later: EVERY Gateway call site that HTTP-dials
+the Director (via DirectorEndpointClient or any other direct dial) MUST be re-pointed onto the tunnel in PHASE 2
+(additive, under streamMode) BEFORE the destructive cut, because (a) the pre-deletion whole-surface proof must
+cover it, and (b) deleting DirectorEndpointClient in Phase 3 STRANDS any un-re-pointed caller (it will not
+compile / it breaks). Consequences settled 2026-07-13:
+- wingman-voice + voice-turn Gateway endpoints (which call DirectorEndpointClient.GetTurns / PostPrompt /
+  GetBuffer / GetSession directly, bypassing TrySendAsync) are re-pointed in PHASE 2 (a small PR E after PR D),
+  NOT deferred to Phase 3.
+- The three director-level mutations (repo-delete / interrupted-dismiss / interrupted-remove - Wave-4a verbs
+  already exist) are folded into PR D so the /directors surface is uniformly tunnel-carried.
+- COMPLETENESS GATE: before the whole-surface proof, sweep every remaining DirectorEndpointClient call site
+  (mission brief Appendix B lists them) and re-point each in Phase 2, then VERIFY DirectorEndpointClient has
+  ZERO callers left (grep - only its own definition remains). That zero-callers check IS the definition of "the
+  tunnel carries everything", it makes the Phase 3 deletion of DirectorEndpointClient a clean no-op-caller
+  removal, and together with the whole-surface real-exe proof it is what the Architect clears the destructive
+  cut on.
+- wingman-ask + recap-generate (slow LLM): plain SYNCHRONOUS unary threading the caller CancellationToken, NO
+  trigger-and-ack. This resolves the earlier Phase-2 caution: SignalR client-results have NO per-invocation
+  timeout, the connection keep-alive pings sustain a long await, and the caller ct mirrors the HTTP
+  RequestAborted exactly - so the synchronous unary preserves the existing synchronous browser contract
+  byte-identically (the browser contract must not change). VERIFY in the whole-surface real-exe proof: a
+  genuinely-slow call (over 30 seconds, past ClientTimeoutInterval) over the tunnel COMPLETES without a
+  connection drop - confirm the keep-alive pings sustain it. That closes the only residual risk.
 ## PR C - the explicit GatewayEndpoints session routes - SETTLED 2026-07-13 (session 51f1898e)
 
 PRs A/B1/B2 moved the browser stream legs + the catch-all read/write dispatch onto the tunnel. But the

--- a/docs/architecture/headless-gateway-mission-2026-07-14.md
+++ b/docs/architecture/headless-gateway-mission-2026-07-14.md
@@ -1,0 +1,265 @@
+# Mission: Headless Gateway
+
+Mission id: f39c439c-3752-4631-9c0c-bb48290e507b
+Architect: Headless Gateway - Architect (session 6b58543b), SOREN_NORTH
+Written: 2026-07-14. Verified against origin/main at fe00dc25.
+
+## The WHY
+
+The Gateway has a user interface of its own - a tray application, a flyout, a pairing
+window, a consent window. Every one of those is a second place where Gateway state can be
+read and changed, and a second place for it to get out of sync. That split is the disease.
+
+Today it produced a provable, owner-visible failure: the Gateway cannot sign in to a
+DevThrottle account, so it cannot enroll any new browser or phone as a device. We fix that
+by deleting the Gateway's user interface and moving every human interaction to the Cockpit,
+which becomes the one and only user interface for the Gateway.
+
+Scope limit from the owner: we are NOT turning the Gateway into a Windows service. That is
+later. This mission is headless plus move-the-interaction-to-the-Cockpit, nothing more.
+
+## What I verified with my own eyes
+
+The shared checkout at D:\ReposFred\devthrottle was 55 commits behind origin/main. All code
+findings below come from a clean worktree off origin/main (fe00dc25), not that checkout.
+
+### The live failure, confirmed and timed
+
+- `GET /account/status` on the running Gateway returns `{"signedIn":false}`.
+- The credential blob `config\gateway\devthrottle-credential.bin` does not exist.
+- `config\gateway\devthrottle-auth-events.jsonl` ends with
+  `{"Kind":"logout","At":"2026-07-14T11:40:38Z"}` = 07:40:38 local. The Gateway had been
+  signed in continuously since 2026-07-08.
+- The Gateway process (pid 27920) started at 07:51:09 local, AFTER that logout - so it
+  booted signed-out.
+- A loopback login callback is still live right now, over an hour later:
+  `netsh http show servicestate` reports request queue
+  `HTTP://127.0.0.1:57455:127.0.0.1/DEVTHROTTLE-LOGIN-CALLBACK/` State: Active.
+  (It shows as pid 4 in netstat because HttpListener registers with the kernel http.sys.)
+
+That is the deadlock: boot signed-out -> auto-fire a sign-in -> open a loopback listener and
+wait with NO timeout -> hold the single-flight lock forever -> every later Sign in click is
+swallowed.
+
+### Corrections to the mission brief
+
+The brief was right about the disease and the shape of the deadlock. Four details are wrong,
+and two of them change the plan materially.
+
+1. **Port 57455 is not hardcoded.** `git grep 57455` over origin/main returns nothing.
+   `LoopbackLoginListener` asks the OS for an ephemeral free port
+   (`FindFreeLoopbackPort()`, binds TcpListener to port 0 and reads back the assignment).
+   57455 is just what this boot happened to get. The load-bearing fact is not the port - it
+   is that the wait has **no timeout at all**.
+
+2. **`FirstRunLoginCoordinator` does not auto-fire and does not hold the lock.** It is a
+   passive class. The auto-fire is `GatewayTrayController.PromptSignInIfNeeded`
+   (src/CcDirector.GatewayApp/GatewayTrayController.cs:513, issue #637), called right after
+   `host.StartAsync()`. The single-flight lock is `GatewaySignInService._singleFlight`
+   (src/CcDirector.Gateway/Account/GatewaySignInService.cs:31), and the
+   "already in flight - ignoring" message is at GatewaySignInService.cs:106 and
+   GatewayTrayController.cs:593.
+
+3. **The Gateway library is ALREADY headless.** There are two projects, and the brief treats
+   them as one:
+   - `src/CcDirector.Gateway` - the library plus a console host. `OutputType=Exe`,
+     `net10.0`, **zero UI packages**. Its `Program.cs` is already a clean generic-host
+     worker. Its csproj already says "The Gateway serves NO UI (one-URL plan)".
+   - `src/CcDirector.GatewayApp` - the shipped `devthrottle-gateway.exe`. `WinExe`,
+     `net10.0-windows`, Avalonia. This holds 100% of the UI.
+   The headless skeleton we are supposedly building already exists. This mission is mostly
+   "delete GatewayApp, move the shipped exe name onto CcDirector.Gateway, rehome the
+   lifecycle logic the tray controller happens to own."
+
+4. **The replacement is not half-built - it is built, merged, and LIVE right now.** The
+   brief calls the remote-vs-loopback redirect mechanics "the backbone" and "a separate
+   follow-up". They landed in `bd6119fc` (Fix #1080, pull request #1105) and are present in
+   the running build ff7a571a. I proved it against the live Gateway:
+
+   ```
+   POST https://soren-north.taildb08ed.ts.net/account/sign-in-start
+   -> 302 Location: https://devthrottle.com/signin
+        ?redirect_uri=https%3A%2F%2Fsoren-north.taildb08ed.ts.net%2Faccount%2Fsign-in-callback
+   GET  /account/sign-in-callback -> 200 (public, no credential)
+   GET  /account/sign-in-start    -> 200, a real "Sign in with DevThrottle" page
+   ```
+
+   A routable https callback, no loopback, no host browser. The doc comment in
+   `AccountSignInStartEndpoint` that calls this "a separate follow-up (epic #1069, issue 0b)"
+   is **stale** - the code beneath it already has the branch.
+
+### The finding that reframes the mission
+
+The Cockpit already has a "Sign in to DevThrottle" button
+(`apps/cockpit/src/account/AccountView.tsx:360`). It calls `POST /account/sign-in`
+(`packages/client-core/src/account/accountClient.ts:144`), and that endpoint
+(`src/CcDirector.Gateway/Api/AccountSignInEndpoint.cs:76`) fires
+`RunSignInAsync()` - **the dead loopback flow**.
+
+So the Cockpit's Sign in button is broken for exactly the same reason the tray's is: it
+opens a browser on the Gateway's desktop and waits on a loopback a remote browser can never
+reach, behind a lock that is currently held forever. The Cockpit shows
+"Waiting for your browser..." indefinitely.
+
+The single highest-value change in this mission is small: **repoint the Cockpit's existing
+Sign in button from `/account/sign-in` (loopback) to `/account/sign-in-start` (remote).**
+The working flow already exists; the only user interface that is supposed to survive is
+wired to the wrong one.
+
+## What the Cockpit already has (the capability gap is small)
+
+| Tray surface | Cockpit home today | Gap |
+|---|---|---|
+| Open Cockpit | the Cockpit itself | none |
+| Sign in to DevThrottle | `/account` button exists | **wired to the dead flow** |
+| Settings | `/settings`, 4 tabs | none |
+| Start on login | `/settings` -> `PUT /gateway/autostart` | none |
+| Status (version, uptime, Directors, port) | `/about`, `/settings` machine tab | none |
+| Add a device | `/account` "Your devices"; `/signin` + `/device-callback` | verify vs PairingWindow |
+| Restart Gateway | nothing | **real gap** |
+| Logs folder / Config folder | nothing | **real gap, and local-only by nature** |
+| Consent window (#650) | nothing | **real gap** |
+
+The Cockpit has **no onboarding wizard** of any kind. The only wizard in the repo is Avalonia
+desktop (`src/CcDirector.Avalonia/OnboardingWizardDialog.axaml`, issue #370), whose UI-free
+logic is already extracted to `src/CcDirector.Core/Onboarding/OnboardingModel.cs`. That
+extraction is the natural seam to reuse.
+
+## The plan
+
+### Phase 0 - Unblock the owner today. No code.
+
+Open `https://soren-north.taildb08ed.ts.net/account/sign-in-start` in any browser and click
+Sign in. The Gateway signs in; device enrollment works again.
+
+WHY: the owner is blocked right now and the fix is already deployed. It also proves the
+replacement flow end-to-end BEFORE we delete the thing it replaces, which de-risks every
+later phase. Nothing in this mission should be built on an unproven assumption that the
+remote flow works.
+
+### Phase 1 - Point the Cockpit at the working flow, and kill the deadlock.
+
+Remove the GATEWAY's use of the loopback sign-in. Do NOT remove the mechanism itself - see
+"the loopback is not the villain" below.
+
+- Repoint the Cockpit Sign in button to `/account/sign-in-start`.
+- Delete the startup auto-fire (`PromptSignInIfNeeded`, #637).
+- Delete `GatewaySignInService.RunSignInAsync` and the single-flight lock that exists only to
+  guard it, `POST /account/sign-in`, and the same-machine loopback branch in
+  `/account/sign-in-start` (AccountSignInStartEndpoint.cs:221).
+- Extract `FirstRunLoginCoordinator`'s URL statics (`ResolveSignInBaseUrl`, `BuildSignInUrl`,
+  `DefaultSignInBaseUrl`) to a new home BEFORE touching the class. They are pure URL helpers
+  with nothing to do with loopback, and the flow we are KEEPING depends on them
+  (`RemoteSignInRouting.cs:85`), as do both installers.
+
+WHY: this is precisely what broke today. The deadlock - no timeout, a permanent lock, a
+browser on the wrong desktop - dies here, in the smallest possible change, and it shrinks
+what Phase 3 has to delete. The Gateway's only sign-in becomes the one that already works
+from anywhere.
+
+#### The loopback is not the villain - the headless Gateway is the wrong host for it
+
+The brief says `FirstRunLoginCoordinator`, `BrowserLauncher.OpenSystemDefault` and
+`LoopbackLoginListener` are "all on the chopping block". That is too broad, and following it
+literally would break two shipping things:
+
+- **The installer stands up its own `LoopbackLoginListener`.**
+  `tools\cc-director-setup\Services\SignInRunner.cs:73` and
+  `tools\cc-director-setup-engine\GatewayAccountEnrollRunner.cs:462` drive it directly, for
+  the installer's sign-in step and Gateway-connect step. That is a **legitimate** use: an
+  installer is a desktop program, running at the machine, with a human in front of it.
+  Opening the local browser and catching the callback on loopback is exactly right there.
+  Loopback is only wrong for a process with no desktop. Deleting the mechanism deletes the
+  installer's sign-in.
+- **`BrowserLauncher.OpenSystemDefault` has non-sign-in callers.** The terminal's link
+  context menu uses it (`LinkContextMenuBuilder.cs:237` and `:256`, including the explicit
+  "Open in system default browser" item). Remove only the sign-in caller
+  (`FirstRunLoginCoordinator.cs:84`); keep the method.
+- **`CredentialHandbackPage` survives.** It is shared with the remote front-door callback
+  (`AccountSignInCallbackEndpoint.cs:140/159`), which is the flow we are keeping. It exists
+  (issue #1082, absorbing security issue #877) precisely to be shared by both.
+
+Build-breaking landmine: `src\CcDirector.Core.Tests\NoCrossMachineLoopbackGuardTests.cs:53`
+allowlists `LoopbackLoginListener.cs`, and its `Allowlist_has_no_stale_entries` test fails if
+the file stops existing. Any commit that removes the file must remove that line too.
+
+Also note issue **#651** is the standing ticket to finish removing the account/credential
+types that #664 left behind - the Manager should read it before deleting anything in
+`CcDirector.Core/Account`.
+
+### Phase 2 - The Cockpit gains what the tray still owns.
+
+Close the three real gaps: Restart Gateway, logs and config access, first-run consent. Verify
+device-add parity against PairingWindow.
+
+WHY: no capability may be lost when the tray dies. This lands BEFORE deletion so there is
+never a window where the owner can do less than before.
+
+### Phase 3 - Delete the Gateway's user interface.
+
+Delete `src/CcDirector.GatewayApp` entirely (GatewayTrayController, PairingWindow,
+GatewayConsentWindow, App.axaml, Avalonia, the icons). Move the `devthrottle-gateway`
+assembly name onto `CcDirector.Gateway`. Rehome the non-UI logic the tray controller happens
+to own: GatewayHost lifecycle, the `/shutdown` self-update hook and its #880 watchdog,
+`SettingsHooks`, the `--managed` update loop, autostart registration, port-conflict
+diagnostics. Update the installer (`GatewayTrayInstaller`), scripts, and docs.
+
+Do NOT delete `CcDirector.TrayUi` - the Launcher shares it
+(src/CcDirector.Launcher/CcDirector.Launcher.csproj:44).
+
+WHY: the UI is the disease. The library is already headless and its Program.cs is already a
+generic-host worker, so this is a move, not a rewrite.
+
+### Phase 4 - The Cockpit onboarding wizard.
+
+Walk a fresh install through: reach the Gateway -> sign the GATEWAY in -> enroll THIS browser
+as a device -> confirm it actually works.
+
+WHY: the centerpiece. A fresh install has no guided path today, and the two sign-ins below
+are not something a new user can be expected to reason about unaided.
+
+## Things the Manager must not get wrong
+
+**There are TWO different sign-ins.** They are easy to conflate and the wizard depends on the
+order:
+1. **The Gateway signs in** to the cloud account (`/account/sign-in-start` ->
+   credential blob). This is the prerequisite.
+2. **A browser or phone enrolls** as a device (`/signin` -> devthrottle.com -> 
+   `/device-callback` -> `POST /m/enroll` -> device key in localStorage).
+A signed-out Gateway cannot do (2). That is exactly today's failure.
+
+**The bootstrap constraint.** The Cockpit is served BY the Gateway from `wwwroot/c`, and its
+whole router sits behind `RequireDeviceKey` except `/signin` and `/device-callback`. Anything
+the wizard must do before a device key exists has to be on the `AuthMiddleware` public
+allow-list, next to the existing `/account/sign-in-start`.
+
+**The Cockpit only builds in Release.** `RunCockpitBuild` is gated to
+`Configuration == Release` or `BuildCockpit == true`. On a Debug build `wwwroot/c` does not
+exist and the Cockpit answers 404.
+
+**Cross-repo dependency, flagged in-tree (#1081).** `packages/client-core/src/auth/
+enrollRequest.ts` notes that devthrottle.com pins `/m/device-callback` and hard-rejects any
+platform other than `android`/`ios`. Browser enrollment with `platform: "browser"` may need a
+site-side change. Phase 4 must confirm this before designing around it.
+
+**Seven test projects, not two.** Running only Core plus Gateway tests is a false green. The
+installer has its own tests (`tools\cc-director-setup.Tests\SignInRunnerTests.cs`, 290 lines,
+entirely about the loopback runner) and they are directly in this mission's blast radius.
+
+**Process rules.** Build from your own git worktree off origin/main - never switch branches in
+the shared checkout, never `git add -A` there. The shared checkout lags; verify against
+origin/main. Redeploy with `scripts\redeploy-gateway.ps1`. Never kill a cc-director process.
+
+## Open design questions for the owner
+
+1. **Who starts and restarts a headless Gateway?** With no tray and no service yet, if the
+   Gateway stops, nothing brings it back, and "Restart Gateway" has no home. The natural
+   answer is `cc-launcher` - it already exists, already has a tray, and already shares
+   `CcDirector.TrayUi`. Making the Launcher the Gateway's supervisor keeps the "no service
+   yet" limit intact. Needs the owner's call.
+
+2. **Logs and Config folders.** The tray opens local folders; a Cockpit on another machine
+   cannot. Drop them, serve logs in the Cockpit (`/about` already shows diagnostics), or
+   leave them to a CLI?
+
+3. **First-run consent (#650).** Into the Phase 4 wizard, or does it die?

--- a/docs/architecture/local-files-mission-2026-07-11.md
+++ b/docs/architecture/local-files-mission-2026-07-11.md
@@ -1,0 +1,195 @@
+# Mission Brief: Local Files (remote file viewer)
+
+Status: active mission. Written 2026-07-11 by the Architect session ("Local Files - Architect",
+session c5c299d0, machine SOREN_NORTH). This document is the Architect's handover to the Manager
+session. The Manager owns execution from here; the Architect does not gate the Manager.
+
+## The mission
+
+When a local file path appears in a session's terminal output or in its chat - an image, an
+HTML page, a Markdown file, a PDF, a text or code file - the remote clients (the cockpit React
+app and the mobile phone app at /m) must show it as a clickable link, and clicking it must open
+that file in a viewer, rendered in place, streamed from the machine the session runs on. Today
+those paths are dead text: on mobile and cockpit chat a detected file path renders as an inert
+"copy path" label, and in the terminal nothing is clickable at all. A person driving a session
+from their phone or from the cockpit cannot see the picture, the report, or the document the
+agent just produced without walking over to the machine. This mission closes that gap.
+
+The shape is: the path is on a specific machine; the client never talks to that machine
+directly; the request rides the Gateway to the owning session's Director, which reads the bytes
+off its own disk and streams them back. This is the same path the screenshot viewer already
+uses - we are generalizing it from "one screenshot image" to "any local file, rendered by type."
+
+## The core finding - most of this already exists
+
+The Architect verified the following against the working tree on 2026-07-11. Read it before
+starting; it is why this is a small mission, not a large one.
+
+1. The Director ALREADY serves local files over HTTP. `GET /file?path=<absolute path>` at
+   `src/CcDirector.ControlApi/ControlEndpoints.cs:1010-1036` streams any local file INLINE
+   with a correct content-type already mapped for html, pdf, png, jpg/jpeg, gif, svg, css, js,
+   json, csv, md, txt, log, and an octet-stream fallback. A code comment on it (lines 1002-1009)
+   calls it the "mobile view-links" feature and explicitly notes it has no sandbox - the tailnet
+   is the only gate. Someone started this feature; it is half-built. The two gaps: it is NOT
+   reachable through the Gateway (only loopback-direct or that machine's own Tailscale Serve
+   front door), and it is a top-level route, not session-scoped, so the Gateway's per-session
+   proxy does not forward it.
+
+2. The exact remote request path we need is already proven by the screenshot-bytes viewer.
+   Client calls the Gateway same-origin at `GET /sessions/{sid}/screenshots/file`; the Gateway
+   resolves the session's owning Director and streams the bytes back unchanged. Blueprint files:
+   `src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs` (the proxy legs and the generic
+   per-session catch-all `app.Map("/sessions/{sid}/{**rest}")` at line 101 that forwards any
+   remaining verb to the owning Director), and `screenshotFileUrl()` in
+   `packages/client-core/src/api/client.ts:595`. The Director side is
+   `GET /screenshots/file` at `ControlEndpoints.cs:2642` using
+   `Results.File(full, contentType, enableRangeProcessing: true)`.
+
+3. Link DETECTION already exists and is already wired into CHAT on both apps.
+   `extractLinks(body)` in `packages/client-core/src/history/historyLinks.ts:48` detects
+   absolute Windows paths (`C:\...`, `C:/...`), `/c/...` Unix-style paths, http/https URLs, and
+   `file://` URLs (converted to a local path). It is a TS port of
+   `src/CcDirector.Core/Utilities/LinkDetector.cs`. Chat already renders the detected links: the
+   cockpit chat at `apps/cockpit/src/sessions/ChatTab.tsx:92-116` and the mobile chat at
+   `apps/mobile/src/pages/Chat.tsx:139-163` both split each link into a real anchor for URLs and
+   an INERT copy-only span for file paths. That inert span is the exact spot the viewer plugs
+   into. The terminal (cockpit `packages/client-core/src/terminal/interactive.ts`, mobile
+   `packages/client-core/src/terminal/stream.ts`) has NO link handling at all - that is new work.
+
+4. Markdown rendering already exists. `marked` is a dependency
+   (`packages/client-core/package.json`) and `markdownToHtml(text)` in
+   `packages/client-core/src/history/historyMarkdown.ts:71` is a sanitized, XSS-safe renderer
+   (GFM on, raw HTML escaped, href scheme allow-list) that both chat views already trust. The
+   Markdown viewer reuses it directly.
+
+5. There is NO viewer / lightbox / modal file component today. The cockpit screenshots panel
+   just opens raw bytes in a new browser tab. The reusable cockpit modal shell is
+   `apps/cockpit/src/components/ConfirmDialog.tsx` (the `ui-modal-backdrop` convention). Mobile
+   has no modal component and uses full routes/pages (`apps/mobile/src/components/ViewTabs.tsx`).
+   The viewer is built from scratch in each app.
+
+## The request path we are building
+
+Client viewer (cockpit or /m) issues a same-origin GET to the Gateway:
+`GET /sessions/{sid}/file?path=<url-encoded absolute path>`.
+-> The global Gateway auth middleware admits it on the caller's enrolled per-device key
+   (`AuthMiddleware.HasValidToken(ctx, Token, Devices)`; browser `<img>`/`<iframe>` src carry
+   the `cc-gateway-token` cookie exactly as screenshots do).
+-> The Gateway's per-session catch-all proxy resolves the session's owning Director and forwards
+   the request, presenting the shared fleet Bearer token, to that Director at the SAME path.
+-> The Director reads the file off ITS OWN disk and streams the bytes back with the right
+   content-type and range support. Because the session lives on that machine, an absolute path
+   emitted by that session's terminal or chat is always a path on that same machine - correct by
+   construction, no machine-selection needed.
+
+The client is viewing a specific session, so it always has the session id; session-scoping is
+purely the routing vehicle that reaches the right machine and reuses all existing auth and
+proxy plumbing. It is NOT a sandbox - see decision 2.
+
+## Decisions already made - do not re-litigate
+
+1. Reuse the screenshot request path, session-scoped. Add `GET /sessions/{sid}/file` on the
+   Director (a session-scoped sibling of the existing top-level `/file`), so the Gateway's
+   existing `/sessions/{sid}/{**rest}` catch-all forwards it for free. Do NOT add new Gateway
+   proxy plumbing and do NOT try to reach the top-level `/file` from the Gateway.
+
+2. NO path sandbox. Any absolute path the caller asks for is served if it exists (404 if not).
+   This is a settled product decision by the owner (2026-07-11): the trust boundary is Tailscale
+   network membership plus an enrolled device key. Anyone who is on the tailnet and holds a valid
+   device key is already trusted with the machine. Do not add allowed-roots, repo-anchoring, or
+   proof-of-mention checks. This matches the existing `/file` behavior.
+
+3. One exception to "we harden nothing," and it is mandatory: the HTML viewer must render the
+   file in a SANDBOXED iframe (a `sandbox` attribute WITHOUT `allow-same-origin`). The file is
+   served from the Gateway origin, so an HTML file containing script would otherwise run with the
+   Gateway's ambient cookie authority and could call Gateway APIs as the user. A sandboxed iframe
+   runs the page in a null origin, which removes that authority. This is a safety property of the
+   viewer, not a restriction on what files can be read. Additionally set
+   `X-Content-Type-Options: nosniff` on the file response. Images, PDF, Markdown, and text do not
+   execute and do not need the sandbox, but the HTML case does.
+
+4. Viewer type is decided client-side by file extension, and the client picks the render mode:
+   - image (png, jpg, jpeg, gif, svg, webp, bmp): `<img src=fileUrl>`
+   - pdf: `<iframe src=fileUrl>` (browser native PDF viewer)
+   - html, htm: sandboxed `<iframe src=fileUrl>` (decision 3)
+   - md, markdown: fetch the text, render with `markdownToHtml()`
+   - text/code (txt, log, json, csv, and any other textual extension): fetch the text, `<pre>`
+   - anything else / unknown / binary: do not guess - show the file name, size, and a Download
+     button (a plain link to `fileUrl` with a download attribute). Fail loud, no fallback render.
+
+5. Detection reuses `extractLinks()` unchanged for what it already finds; extend it (or a thin
+   wrapper) only to classify a detected path into one of the viewer types above by extension, so
+   the click knows which mode to open. Do not rewrite the detector or add relative-path guessing
+   (it deliberately avoids relative paths to prevent false positives).
+
+6. The viewer lives in each app; client-core stays app-agnostic. The terminal link provider in
+   client-core must not import app UI. It takes an `onFileLink(path)` callback the app supplies;
+   the app's handler opens that app's viewer. Same for chat: the render lives in the app.
+
+7. Plain English everywhere, ASCII only in code and output. No fallback programming: a missing
+   file is a loud 404 with a clear message in the viewer, never a silent blank or a guess.
+
+8. Windows first: build and human-verify every phase on SOREN_NORTH driving the real Gateway and
+   a real phone. The Mac gets a verification pass at the end (one Avalonia/React codebase, no
+   porting step; #125 already tracks embedded-WebView file viewing on macOS - link it, do not
+   solve it here).
+
+## Known limitation to state, not solve, in v1
+
+HTML files that reference sibling assets by relative path (a separate .css, an external image)
+will not resolve those assets, because the viewer loads a single file by query string, not a
+directory. Self-contained HTML - which is what the repo's own document tooling (cc-html) emits,
+inlining CSS/JS/images - renders correctly, and that is the primary case (generated reports).
+Do not build a directory-serving or asset-rewriting proxy in this mission. If it proves needed,
+it is a follow-up. State the limitation in the Phase 4 report.
+
+## The work, in phases
+
+Each phase ships alone: implemented, merged to origin/main per the trunk rule, deployed to a real
+machine, and clickable by the owner before the next phase begins.
+
+- Phase 1 - Server and API foundation. Add `GET /sessions/{sid}/file` on the Director
+  (`ControlEndpoints.cs`), reusing the existing `/file` content-type map and adding
+  `enableRangeProcessing: true` and `X-Content-Type-Options: nosniff`. Confirm the Gateway's
+  per-session catch-all forwards it (no Gateway code should be needed; verify, do not assume).
+  Add `sessionFileUrl(sid, path)` and `fetchSessionFileText(sid, path)` to
+  `packages/client-core/src/api/client.ts` next to `screenshotFileUrl`. Add a small
+  `classifyFile(path)` helper (extension -> viewer type) in client-core.
+  Proof: a real remote GET through the Gateway returns an image's bytes and a text file's bytes
+  from another machine's session; a round-trip test modeled on
+  `src/CcDirector.Gateway.Tests/ScreenshotProxyRoundTripTests.cs`.
+
+- Phase 2 - Cockpit viewer, chat links, terminal links. Build the cockpit `FileViewerModal`
+  (modeled on `ConfirmDialog`) that renders each type per decision 4. Turn the inert chat path
+  span (`ChatTab.tsx`) into a clickable control that opens the viewer (keep the copy button).
+  Add an xterm link provider in `packages/client-core/src/terminal/interactive.ts` that runs
+  `extractLinks` over rendered line text and calls the app's `onFileLink` handler on click.
+  Proof: from the cockpit, click a file path in chat AND in the terminal for an image, a PDF, a
+  Markdown file, an HTML report, and a text file; screenshots of each rendering.
+
+- Phase 3 - Mobile (/m) viewer, chat links, terminal links. Build the mobile viewer as a
+  full-screen route (per `ViewTabs` conventions); wire the mobile chat path links
+  (`apps/mobile/src/pages/Chat.tsx`) and a terminal link provider in
+  `packages/client-core/src/terminal/stream.ts`. Reuse the client-core classify/URL helpers and
+  the same viewer logic; only the shell differs.
+  Proof: on the real phone at /m, open each of the five file types from chat and from the
+  terminal; screenshots from the phone.
+
+- Phase 4 - Hardening and polish. Download button for unknown/binary types; loud, specific
+  error and permission states (file not found, session offline -> the Gateway's 503); large-file
+  and range behavior for big PDFs/images; the HTML relative-asset limitation written into the
+  report; unit tests for `classifyFile` and the terminal link provider; the macOS verification
+  pass (link #125). No new capability - correctness, tests, and the edges.
+
+## Definition of done for the mission
+
+1. All four phases merged to origin/main, each human-verified on this Windows machine against the
+   real Gateway, and Phase 3 verified on the real phone.
+2. From the cockpit AND from the phone, a file path in the terminal and in the chat is clickable
+   and opens the file rendered by type - image, PDF, HTML, Markdown, and text all proven.
+3. No path sandbox exists (decision 2); the HTML viewer is sandboxed (decision 3); a missing file
+   fails loud with a clear message.
+4. Round-trip and unit tests exist and pass; the screenshot round-trip test is the model.
+5. A final verification report (HTML, in docs/reviews/) showing every file type opened from both
+   clients, from both the terminal and chat, with screenshots from the running cockpit and the
+   real phone. The HTML relative-asset limitation is stated in it.

--- a/docs/architecture/mission-screen-mission-2026-07-11.md
+++ b/docs/architecture/mission-screen-mission-2026-07-11.md
@@ -1,0 +1,147 @@
+# Mission: Mission Screen
+
+- Date opened: 2026-07-12
+- GitHub issue: #1405
+- Architect: session #106 "Mission Screen - Architect" (id 3457ddcf)
+- Manager: session "Mission Screen - Manager" (spawned on the same Director)
+- Mockup: https://claude.ai/code/artifact/37e81651-5243-47a3-8901-b67292563589
+
+---
+
+## WHY (mandatory - this comes first)
+
+When many agents are running at once, the owner loses track of what is being built and why.
+Holding every mission in your head does not scale past a handful of sessions, so missions drift
+and low-value "because it's cool" work sneaks in. The Mission Screen gives one place that shows
+every mission - **with its WHY front and center** - grouped by the unit of work the owner actually
+thinks in (the mission, not the session), plus (later) something to talk to about "what should we
+do next." It keeps the owner oriented and keeps us honest about what deserves to be worked on.
+
+**Rule this mission also establishes for ALL missions:** every mission must state a clear WHY, and
+that WHY is shown front and center on the Mission Screen. A mission with no WHY is a red flag the
+screen makes obvious. This is dogfooded here: the section you are reading is that WHY.
+
+---
+
+## What we are building
+
+A new **Missions** page in the Cockpit (a left-rail nav destination under "Fleet"). Same live fleet
+data as the Fleet Map, seen a different way: sessions grouped into **missions**, alphabetical, with a
+**Standalone** group for sessions that are not part of a mission. Each mission is a card showing its
+name, its WHY, its repo, a status summary, and one row per session that links to open that session.
+Later, a chat panel ("Mission Control") to reason about the missions.
+
+Principle: **code builds the map, the LLM reasons over it.** The list is deterministic and needs no
+model; the chat (a later phase) is where judgment lives.
+
+---
+
+## Phases
+
+- **Phase 1a (Manager's job NOW): the grouped mission list + linking.** Pure client. Ships today.
+- **Phase 1b (right after 1a, same mission): the WHY** - a durable, shared store for each mission's
+  WHY, shown on every card, editable inline, with a loud "No why set" flag when missing.
+- **Phase 2 (later): the chat panel** - a Car-Mode-style tool-calling brain over the fleet tools.
+- **Phase 3 (later): first-class mission objects + an API** so Car Mode can query the Mission Screen.
+
+Prove each phase in the running Cockpit before starting the next (see Working rules).
+
+---
+
+## Phase 1a - concrete scope (do this first)
+
+Build a read-only **Missions** page that groups the live fleet by mission and links into sessions.
+
+Acceptance (prove in the running Cockpit, with a screenshot in the PR):
+1. New nav item **"Missions"** under the Fleet section; route `/missions` renders the page.
+2. The page reads the ONE shared roster store (no new poll, no Director address).
+3. Sessions are grouped into missions, **alphabetical**, **Standalone** group last.
+4. Each mission is a card: mission name, repo(s), session count, a status summary, and a **WHY slot**
+   (Phase 1a shows "No why set - add one" until 1b wires the store).
+5. Each session renders as a row: number badge, role, machine, live state (reuse the shared color +
+   label rule), and clicking it opens the session (`/session/:id`) - this is the linking.
+6. Loading / empty / error states handled like the Fleet Map.
+7. New CSS file for the page; follow `docs/VisualStyle.md` (the Cockpit dark palette).
+
+### How to derive the mission (important)
+
+The Cockpit's `SessionDto` (from the Gateway roster) does **NOT** carry `missionName` / `sessionRole`
+- those exist in the `cc-devthrottle session list` CLI view but are not in the Cockpit schema
+(`packages/client-core/src/api/schema.ts`, the generated `SessionDto`). So for Phase 1 derive the
+mission from the session **name**, which follows the convention **"<Mission> - <Role>"** (dash, role
+second - roles seen: Architect, Manager, Worker):
+
+- If the name matches `"<something> - <Role>"`, the mission is `<something>` and the role is `<Role>`.
+- Otherwise the session goes in **Standalone** (its own group), shown by its own name.
+- Group case-insensitively; display the mission name as first seen.
+
+Do NOT add backend fields for Phase 1a. (Exposing `missionName`/`sessionRole` on the Cockpit
+`SessionDto`, or making missions first-class Gateway objects, is a Phase 3 decision - bring it to the
+Architect, do not decide it solo.)
+
+## Phase 1b - the WHY store (right after 1a)
+
+The WHY must be **durable and shared** (not per-browser localStorage - every client and the future
+chat/API must read the same WHY). Recommended smallest form: a Gateway **mission-notes** store keyed
+by mission name (GET to read all, PUT `{mission, why}` to set one), surfaced on the card and editable
+inline. A missing WHY renders as a loud flag, never silently blank. **Confirm this shape with the
+Architect before building the endpoint** - it is the first toe into "missions as real objects."
+
+---
+
+## Codebase pointers (verified 2026-07-12)
+
+- **Nav + shell:** `apps/cockpit/src/AppShell.tsx` - `NAV_SECTIONS`, add `{ to: "/missions", label:
+  "Missions" }` under the "Fleet" section.
+- **Routes:** `apps/cockpit/src/main.tsx` - register the `/missions` route and import the new view +
+  its CSS (follow how `FleetMapView` / `fleetmap.css` are wired).
+- **The data + patterns to copy:** `apps/cockpit/src/fleet/FleetMapView.tsx` - reads
+  `useSharedRoster()` from `@devthrottle/client-core/fleet/rosterStore` (sessions, machineErrors,
+  directors, error). It already groups the fleet by pivots (machine/repo/agent) and links cards via
+  `navigate('/session/:id')`. The Missions page is the same idea with a "by mission" grouping and a
+  card-per-mission layout. Reuse it as the template; do not re-invent the roster plumbing.
+- **Shared color + label:** `dotColor`, `effectiveColor`, `stateLabel` from
+  `@devthrottle/client-core/sessions/ordering` - use these so a status dot matches every other surface.
+- **Types:** `SessionDto` from `@devthrottle/client-core/api/client` (generated in
+  `packages/client-core/src/api/schema.ts`). Fields you have: `name`, `number`, `repoPath`,
+  `machineName`, `directorId`, `sessionId`, `groupId`, `groupRole`, `effectiveColor`,
+  `lastStatusReason`, `lastActivityAt`, `createdAt`, `agent`. (No mission/role field - derive from name.)
+- **CSS reference:** `apps/cockpit/src/fleet/fleetmap.css` for the card / lane look; `docs/VisualStyle.md`
+  for the palette (panel #1E1E1E, sidebar/card #252526, accent #007ACC, red = needs you, blue = working).
+- **Format helpers:** `apps/cockpit/src/fleet/format.ts` (`repoBasename`, `relativeTime`).
+
+---
+
+## Design decisions already made by the Architect (do not re-litigate)
+
+1. Grouping is **derived from the session name** for now (no backend change in Phase 1a).
+2. Phase 1a ships the mission **list full width** - NO empty chat pane. The two-pane (chat left,
+   list right) layout arrives with the chat in Phase 2. Do not ship a placeholder chat pane.
+3. Reuse the shared roster store and the shared color/label rule - never a second poll or a Director
+   address, never a private color mapping.
+4. The WHY is a first-class slot on every card from Phase 1a (shown empty with a flag until 1b).
+
+## Bring these to the Architect (design questions - not the user)
+
+- The WHY store shape (Phase 1b) before building any endpoint.
+- Whether/when to make missions first-class Gateway objects and expose mission/role on the Cockpit
+  `SessionDto` (Phase 3).
+- Any layout question about how the chat and list share the page in Phase 2.
+
+The Architect (session #106) settles design; you drive the build. Ping the Architect at each
+milestone, decision, or block - do not stall silently.
+
+---
+
+## Working rules (fleet standards)
+
+- Trunk-based: build on a branch in your **own git worktree** off `origin/main` (never `checkout -b`
+  in the shared tree), open a pull request, drive it to **merged on origin/main** - that is the only
+  "done". Delete the branch and worktree on merge.
+- Stage only the files you created/changed **by name** - never `git add -A` in the shared tree.
+- Commit only when the owner asks; but once a phase is approved, finish it to a merged PR.
+- Prove it in the running Cockpit (screenshot in the PR) before calling a phase done. Do not
+  "merge-for-hours-then-test".
+- Plain English, no abbreviations. **No unicode / emoji anywhere** (ASCII only) - this repo is strict.
+- Enterprise standards apply (`CLAUDE.md`, `docs/CodingStyle.md`, `docs/VisualStyle.md`): responsive
+  UI, logging, no fallback programming, tests for logic (the mission-derivation parser needs unit tests).

--- a/docs/architecture/mobile-resilience-mission-2026-07-11.md
+++ b/docs/architecture/mobile-resilience-mission-2026-07-11.md
@@ -1,0 +1,246 @@
+# Mission Brief: Mobile bad-connection resilience (never clear good data)
+
+Status: active mission. Written 2026-07-11 by the Architect session ("Mobile Resilience -
+Architect", session c3095612, machine SOREN_NORTH). This document is the Architect's handover to
+the Manager session. The Manager owns execution from here; the Architect settled the design,
+stays available for design questions through the mission, and escalates product calls to the
+owner.
+
+Verification note: everything below was verified against origin/main at commit e235e76c on
+2026-07-11. The SHARED checkout in D:\ReposFred\devthrottle lags origin/main (it was 25 commits
+behind when this was written) - always read and branch from origin/main, never trust the shared
+working tree to show the latest merged state. In particular, the shipped voice fix (PR #1334) is
+visible only on origin/main, not in the stale checkout.
+
+## The mission
+
+The owner travels a lot - the cottage, driving - through areas with bad internet, and the mobile
+app at /m is the surface he uses the most on the road. Today, when the connection goes bad, the
+app clears things out: the session list (the roster, his most-used screen) disappears, and voice
+mode disappears. That makes the app unusable exactly when he depends on it.
+
+The principle he wants applied everywhere: **never clear out good data just because the
+connection is bad.** Every mobile surface keeps showing the last-known content, and one small
+"bad connection" indicator at the top of the screen tells him why nothing is updating - so he
+knows it is the network, not the fleet. The surfaces to cover: the session list (roster), voice
+mode, chat, and the terminal. Beyond those four, the app should generally be a lot more
+resilient in bad-internet areas.
+
+Two distinct legs can go bad, and both must obey the rule:
+
+- The phone-to-Gateway leg (the cottage / driving case): the phone's own requests fail or hang.
+  On this leg a fetch THROWS, so the client knows directly.
+- The Gateway-to-Director leg (a machine at home briefly unreachable while he is away): the
+  Gateway answers the phone with HTTP 200 but the list it returns is SHRUNKEN, because an owning
+  Director did not answer the fan-out. On this leg the failure is invisible in a flat list - the
+  client needs the reachability data the Gateway already computes (see finding 4).
+
+## The core finding - most of the keep-last-known machinery already exists
+
+Read this before starting; it is why the new work is small and targeted, not a rewrite.
+
+1. The pattern to generalize has already shipped once, for voice. PR #1334 (issue #1333, merged
+   2026-07-11) in `packages/client-core/src/voice/useVoiceMode.ts`: a session merely ABSENT from
+   a SUCCESSFUL `/sessions` poll is treated as a transient gap - the screen keeps the last-known
+   session and whatever is playing and shows a soft "Reconnecting to this session's computer..."
+   note - and only an authoritative `voiceMode=false` (the session IS reported, with voice off)
+   turns voice off. That one fix is the whole philosophy of this mission: absence is not
+   authority; only an answer is. The open follow-ups #1325 (the Gateway should stamp one
+   authoritative voice phase) and #1326 (voice client hardening) are adjacent but SEPARATE - this
+   mission builds on #1334 as shipped and does not touch voice-phase derivation.
+
+2. The roster already keeps last-known on a THROWN poll. `apps/mobile/src/pages/Home.tsx`:
+   `load()`'s catch keeps the existing `sessions` state and shows "Offline - showing last-known
+   roster". So the primary cottage case (the phone cannot reach the Gateway at all) is already
+   half-handled on the roster - the content stays; what is missing is the app-wide indicator and
+   the same guarantee on every other screen. The remaining roster gap is the degraded 200
+   (finding 3 and 4).
+
+3. The Gateway already absorbs BRIEF server-side misses. `FleetRosterCache`
+   (`src/CcDirector.Gateway/Discovery/FleetRosterCache.cs`, issue #1215): when a Director's poll
+   fails, the Gateway serves that Director's last-known-good snapshot (state "Wobbly") for up to
+   3 consecutive failed poll cycles, then declares it "Offline" and drops its sessions from the
+   flat `GET /sessions` response. So a one-tick blink no longer shrinks the list - but a longer
+   unreachable stretch still makes sessions silently vanish from the flat response, and the flat
+   response carries no way to tell "vanished because killed" from "vanished because unreachable".
+
+4. The per-machine reachability truth is already exposed, and already has a typed shared client.
+   `GET /sessions?envelope=true` returns `{ sessions, machineErrors, directors }`, where
+   `directors` is the per-Director reachability (Online / Wobbly / Offline, last-seen time and
+   age, error text) - see `GatewayEndpoints.cs` around line 725 and `DirectorReachabilityDto`.
+   Shared client-core already has `getSessionsEnvelope()`
+   (`packages/client-core/src/fleet/fleetClient.ts`) and a polling store with a hook
+   (`packages/client-core/src/fleet/rosterStore.ts`, `useSharedRoster()`), consumed today by the
+   Cockpit fleet views. The MOBILE app does not use any of it - its roster calls the flat
+   `listSessions` (`packages/client-core/src/api/client.ts`), which throws on a non-2xx (hard
+   failures handled) but cannot see WHY a session is missing from a 200. Reuse the envelope; do
+   not invent a second reachability channel.
+
+5. Chat content already keeps last-known. `packages/client-core/src/history/useSessionChat.ts`:
+   a failed history poll sets `loadFailed` and KEEPS the rendered bubbles; the mobile Chat page
+   (`apps/mobile/src/pages/Chat.tsx`) shows its "Could not read this session's history right now.
+   Retrying..." note only when there are no bubbles at all. With bubbles on screen, a failing
+   poll is currently SILENT - the reader has no idea the conversation is stale. That silence is
+   exactly what the global banner exists to fix; the data handling itself is already right. The
+   header name label is a best-effort one-shot that never clears a known name - fine as is.
+
+6. The terminal is a live WebSocket mirror with auto-reconnect ALREADY BUILT - but it clears the
+   buffer at the wrong moment. `packages/client-core/src/terminal/stream.ts` (`TerminalMirror`):
+   reconnect at ~1200 ms is in (`RECONNECT_DELAY_MS`), and xterm keeps its own buffer (this is a
+   byte stream, not polling). BUT `connect()` calls `term.reset()` BEFORE opening the new socket.
+   On a bad connection, the retry loop therefore wipes the screen on every FAILED attempt, so
+   the terminal sits blank the whole time the network is down - a direct violation of the
+   keep-good-data principle. The root cause is the reset's position: it belongs at successful
+   socket open (the stream replays full history from byte 0 on each new connection, so resetting
+   right before that replay is correct; resetting before a connection that never opens is the
+   bug). There is also no visible "reconnecting" state anywhere on the screen.
+
+7. One shared unreachable-classification already exists - reuse it. `GATEWAY_UNREACHABLE_MESSAGE`
+   and `gatewayErrorMessage()` in `packages/client-core/src/api/client.ts` (issue #1028) already
+   separate "the request never reached a healthy backend" (fetch TypeError, status 0/502/503/504)
+   from a reachable Gateway answering with an application error (400/404/409/500). The
+   connection-health signal must be fed by THIS classification, not a second taxonomy.
+
+8. There is NO global connection indicator in the mobile app today, and the mount point for one
+   already exists: `GatedLayout` in `apps/mobile/src/main.tsx` wraps every gated page, stays
+   mounted across navigations, and already owns app-wide concerns (the screen wake lock, the
+   dictation resume). That layout is the natural single home for the banner.
+
+9. Dictation is already resilient - verify, do not rebuild. The durable store-and-forward send
+   path (issues #1006/#1182, `dictation/backgroundSend.ts` and the chunked upload in
+   `api/client.ts`) survives connection loss by design and shows honest held/parked states on
+   the roster and the status strip. This mission's Phase 4 exercises it under real flaky
+   conditions but must not re-architect it.
+
+## What is genuinely new - build these, everything else is reuse
+
+### New build A - the shared connection-health signal
+
+A small client-core module (for example `packages/client-core/src/connection/health.ts`): one
+store that every Gateway contact reports into - success or failure, classified by the existing
+unreachable logic (finding 7) - holding a derived state (good / bad) and the time of the last
+successful contact. It is fed at the transport CHOKE POINTS, never wired page by page: the fetch
+calls in `api/client.ts` (which every poll on every screen already goes through) and the terminal
+WebSocket's open/close events. A `useConnectionHealth()` hook exposes it to React. The pattern to
+mirror is the dictation status store (`packages/client-core/src/dictation/status.ts`): a
+module-level store with a subscriber hook, already proven in this codebase.
+
+### New build B - the one global banner
+
+A mobile component mounted ONCE in `GatedLayout`: hidden while the connection is good; when it
+goes bad, a small strip pinned at the top of every screen - plain English, for example "Bad
+connection - showing last known information", adding how stale things are ("updated 40s ago")
+once the gap is long enough to matter. This banner REPLACES the roster's own per-page offline
+strip so the condition has exactly one voice in the whole app.
+
+### New build C - the don't-degrade rule for the roster (removal requires authority)
+
+Move the mobile roster from the flat `listSessions` to the envelope (`getSessionsEnvelope`,
+already in client-core). The rule: a session leaves the list ONLY when its owning Director
+ANSWERED and no longer reports it. When a Director reads Wobbly or Offline, its last-known
+sessions STAY on the roster, visually marked unreachable (grayed dot plus a short plain note
+naming the machine), for as long as the machine stays unreachable. When the machine answers
+again, the live read replaces them in place. This is the #1334 rule generalized with better
+data: unreachable is a state you SHOW, not data you DELETE. The client keeps its own last-known
+copy per Director so that even after the Gateway's 3-cycle grace window expires (finding 3) the
+phone still shows the cards - the envelope's per-Director state is what lets it do that honestly.
+
+### New build D - the terminal that never blanks
+
+Fix `TerminalMirror`: no reset on a failed reconnect attempt - `term.reset()` moves to the
+successful socket open, immediately before the byte-0 history replay. Report the socket's state
+into the health signal (so the banner also covers a dead stream when plain polls still succeed),
+and show a small reconnecting note on the terminal screen while the stream is down.
+
+## Decisions locked - do not re-litigate
+
+1. One banner, mounted once in `GatedLayout`. No per-page connection banners; the roster's
+   existing "Offline - showing last-known roster" strip folds into it. Pages keep their content;
+   the banner is the single explanation.
+2. The health signal lives in shared client-core and is fed at the transport choke points (the
+   `api/client.ts` fetches and the terminal WebSocket), never hand-wired per page. Its
+   classification reuses the issue #1028 unreachable logic; inventing a second taxonomy is a
+   defect.
+3. Removal requires authority. No mobile surface may replace good data with empty or shrunken
+   data because of unreachability. A session is removed from the roster only when its owning
+   Director answered without it; voice turns off only on an authoritative `voiceMode=false`
+   (already shipped, #1334); the terminal buffer is cleared only when a new stream actually
+   opens and replays.
+4. No shrink heuristics. The envelope's per-Director reachability is the truth - use it. Any
+   client-side guess of the form "the list shrank suspiciously, ignore it" is fallback
+   programming and banned in this codebase.
+5. Sessions on an unreachable machine stay visible and marked, indefinitely, until their machine
+   answers again. They gray out with the machine name and "unreachable"; they do not fade out on
+   a timer and they do not vanish. (Owner's principle applied directly; if he finds long-dead
+   machines cluttering the roster in practice, that is a product adjustment to bring back to
+   him, not a design change to make silently.)
+6. Scope is the mobile app under /m. The Cockpit already consumes the envelope in its fleet
+   views; giving the Cockpit the same banner is a natural follow-up but NOT this mission. The
+   desktop app is untouched.
+7. Voice-phase authority (#1325) and voice client hardening (#1326) remain separate issues.
+   This mission must not re-derive voice state or overlap those changes.
+8. Plain English, ASCII only, fail loud. A bad connection is NAMED on screen by the banner -
+   never a silent stall, and nothing pretends to be live when it is stale (the banner's staleness
+   age is the honesty mechanism).
+9. Trunk rules. Each phase is built in its OWN isolated git worktree off origin/main (the shared
+   checkout is used by other sessions and lags main - never build there), merged to origin/main
+   (the only "done"), deployed with `scripts/redeploy-gateway.ps1` (which self-verifies the
+   running Gateway reports the deployed commit), and verified by the owner on the real phone
+   before the next phase starts. No commits until the owner explicitly asks.
+
+## The work, in phases
+
+Each phase ships alone: implemented, merged to origin/main, deployed to the phone via
+`scripts/redeploy-gateway.ps1`, and verified by the owner on the real phone before the next
+phase begins.
+
+- Phase 1 - the connection-health signal and the one banner (the biggest visible win). New
+  builds A and B: the client-core health store fed from the `api/client.ts` choke points, the
+  `useConnectionHealth()` hook, the banner mounted in `GatedLayout`, and the roster's own offline
+  strip retired in its favor. Proof, on the phone: turn on airplane mode while on the roster, in
+  chat, in voice, and in the terminal - the content stays put on all four screens, one small
+  banner at the top names the bad connection, and it clears by itself within a poll tick of the
+  network coming back.
+
+- Phase 2 - the don't-degrade rule for the list surfaces. New build C: the mobile roster moves
+  to the envelope; sessions of Wobbly/Offline machines are kept and marked; only an
+  authoritative Director answer removes a session. Verify (and leave alone) that the voice, chat,
+  and terminal header labels never clear a known name. Proof, on the phone, against a real
+  second machine: stop the test machine's Director (or pull its network) - its sessions stay on
+  the roster, grayed, named unreachable; kill a session on a reachable Director - it leaves the
+  roster promptly; restart the stopped Director - its cards return to live in place.
+
+- Phase 3 - the streams: terminal reconnect without buffer loss. New build D: no reset on a
+  failed attempt, reset only at successful open before the replay, socket state feeding the
+  health signal, a reconnecting note on the terminal screen. Confirm chat keeps its bubbles
+  under a dropped connection and that a failing history poll now surfaces through the banner
+  (it is silent today). Proof, on the phone: airplane mode mid-stream - the terminal keeps
+  showing the last content (never blank), the banner shows, and on reconnect the terminal
+  replays and is live again with no user action; the chat keeps its bubbles throughout.
+
+- Phase 4 - the real-world drive (hardening). The general "a lot more resilient" pass under
+  genuinely flaky conditions, not clean on/off toggles: a timeout on the poll fetches so a hung
+  request cannot stall a poll cycle; banner debounce so one lost packet does not flash it;
+  voice playback and the dictation review under drops (the durable dictation send path already
+  covers this by design - exercise it, do not rebuild it); unit tests for the health store and
+  the roster keep-and-mark merge rule. Proof: the owner uses the app on a real drive or at the
+  cottage and reports that the roster, chat, terminal, and voice all stayed populated and
+  honest, with the banner the only sign of trouble.
+
+## Definition of done for the mission
+
+1. All phases merged to origin/main, each deployed via `scripts/redeploy-gateway.ps1` and
+   verified by the owner on the real phone before the next began.
+2. The rule holds everywhere: no mobile surface ever replaces good data with empty or degraded
+   data because of a bad connection - roster, voice, chat, and terminal all keep their
+   last-known content through an outage.
+3. One small banner at the top of the screen is the single, global bad-connection indicator: it
+   appears on trouble, names it plainly (including how stale the data is), and disappears on its
+   own when the connection recovers - on every screen.
+4. Sessions on an unreachable machine stay visible and marked until their machine answers again,
+   while a genuinely removed session still leaves the roster promptly.
+5. The terminal survives connection loss without ever blanking, shows that it is reconnecting,
+   and recovers by itself.
+6. The health store and the roster merge rule have unit tests, and a final verification report
+   (HTML, in docs/reviews/) shows phone screenshots of each phase's proof, including the
+   airplane-mode walk-through of all four surfaces.

--- a/docs/architecture/snooze-length-mission-2026-07-11.md
+++ b/docs/architecture/snooze-length-mission-2026-07-11.md
@@ -1,0 +1,249 @@
+# Mission Brief: Snooze Length (snooze that always comes back)
+
+Status: active mission. Written 2026-07-11 by the Architect session ("Snooze Length - Architect",
+machine SOREN_NORTH). This document is the Architect's handover to the Manager. The Manager owns
+execution from here; the Architect settles the design and stays available for design questions but
+does not gate the Manager.
+
+## The mission
+
+Today, snoozing a session is open-ended. You tap Snooze, the session drops out of the "needs you"
+rotation and goes grey, and it stays that way until *something new happens* to it. That is the bug:
+when a session dies or an agent misbehaves and goes quiet, nothing new ever happens, so the snooze
+never lifts. The session silently falls off the radar forever. This actually happened - an
+enrichment session went wrong, nothing surfaced it, and the owner had no way to know it needed him.
+
+This mission turns snooze into a **time-bounded hold with a guaranteed return**. When you snooze a
+session it is held for a fixed period (default one hour). When that period expires, the session is
+thrown back into "needs you" on its own - even if the session or its whole Director has died in the
+meantime. The worst case becomes: every snoozed session comes back. You can no longer lose a
+session by snoozing it. It is a dead-man's switch, not just a hide button.
+
+The one hard requirement that shapes the whole design: **the timer must live on the Gateway.** The
+entire point is to catch a session whose Director is dead or unresponsive. A timer that lives on the
+Director would die with it. The Gateway is the only place that survives to raise the alarm.
+
+## The core finding - most of this already exists
+
+The Architect verified all of the following against the working tree on 2026-07-11. Read it before
+starting; it is why this is a focused mission, not a large one.
+
+1. **Snooze today is the Director-owned `OnHold` boolean.** It is a property on the live `Session`
+   object at `src/CcDirector.Core/Sessions/Session.cs:572`. It is set by
+   `POST /sessions/{sid}/hold` on the Director (`src/CcDirector.ControlApi/ControlEndpoints.cs:909`;
+   body is `HoldRequest { OnHold=true }`, empty body defaults to true). It is reported to every
+   client as `SessionDto.OnHold`. There is NO timer anywhere - it is a plain flag.
+
+2. **The Director already clears `OnHold` the moment the session comes back to life.** Issue #470:
+   `Session.cs:1546` and `Session.cs:1642` clear the hold when a new turn starts or the user enters
+   something ("stale Hold deferral no longer reflects intent -- clear it"). This is exactly the
+   "if it comes back before the hour, the snooze just clears" behavior the owner wants, and it
+   already exists on the Director side. We mirror this clear into the Gateway registry.
+
+3. **The Gateway does NOT own hold today - it just forwards it.** The Gateway has no dedicated hold
+   handler; `hold` rides the generic per-session catch-all proxy
+   (`src/CcDirector.Gateway/Api/SessionWsProxyEndpoints.cs:96` lists "hold" among the forwarded
+   verbs). So the snooze timer is genuinely new Gateway-owned state. We add a dedicated Gateway
+   handler for `POST /sessions/{sid}/hold` that records the snooze-until AND forwards to the
+   Director exactly as today (the same pattern the Local Files mission used: a specific route in
+   front of the catch-all).
+
+4. **The fold that decides "needs you" is one shared function, and snooze already sits in it.**
+   `SessionOrdering.Classify` (`src/CcDirector.Gateway.Contracts/SessionOrdering.cs:216`) buckets a
+   session as `OnHold`, `NeedsYou`, or `Active`. An `OnHold` session is pulled OUT of `NeedsYou`
+   (`Classify` returns `OnHold` first), renders grey (`EffectiveColor`, line 96), and labels
+   "Snoozed" (`StateLabel`, line 187). This is the single fold every client AND the Gateway's own
+   push notifier share. To make a snooze expire, we make the session read as NOT on hold again -
+   and `Classify` puts it straight back into `NeedsYou`. No new classification logic is needed.
+
+5. **The phone already buzzes when the `NeedsYou` count rises - for free.**
+   `src/CcDirector.Gateway/Push/WebPushNeedsYouNotifier.cs` polls the Gateway's own aggregated
+   roster every 8 seconds (while a device is subscribed) and pushes the app-icon dot on the rising
+   edge of `CountNeedsYou` (line 157 - the count of `Classify == NeedsYou`). This is the mechanism
+   that makes an expired snooze reach the owner's phone an hour later: the moment expiry flips the
+   session back into `NeedsYou`, this existing notifier pushes the dot. We do not build a new
+   notification path.
+
+6. **The roster survives a dead Director.** `FleetRosterCache` (`GatewayHost.cs:60`, issue #1215)
+   keeps the last-known-good roster so a transient Director poll failure does not evict its
+   sessions. This is what lets the Gateway still hold, and still surface, a snoozed session whose
+   Director has gone silent - the dead-Director case that is the whole reason for the mission.
+
+7. **There is one settings surface already.** `src/CcDirector.Gateway/Api/SettingsEndpoints.cs`
+   backs the single Cockpit Settings page with `GET/PUT /gateway/*` actions
+   (`packages/client-core/src/settings/settingsClient.ts`,
+   `apps/cockpit/src/settings/SettingsView.tsx`). The default snooze length is one more setting
+   here. Because every one of the owner's devices talks to their one Gateway, a Gateway-owned
+   setting IS "one value across all the user's devices" - no cloud-account round-trip needed for v1.
+
+## The design
+
+**Snooze becomes: Director `OnHold` (as today) plus a Gateway-owned expiry timestamp.**
+
+Gateway snooze registry: a persisted map `sessionId -> SnoozeUntilUtc` (absolute UTC time),
+written to disk so a Gateway restart re-arms every pending snooze. Any entry already past its time
+at startup fires immediately (surfaces as needs-you) rather than being lost or all firing at once.
+
+Set (user taps Snooze): the new Gateway `POST /sessions/{sid}/hold` handler records
+`SnoozeUntilUtc = now + defaultSnoozeMinutes`, then forwards the hold to the Director exactly as
+today. Snooze and hold are set together; the Director still drops the session from the voice
+rotation and still reports `OnHold=true`. Nothing about the existing hold behavior changes.
+
+Early return (it comes back on its own): the Director clears `OnHold` on new activity (#470, already
+built) and reports `OnHold=false`. The Gateway's aggregation sees a session that has a registry
+entry flip to `OnHold=false` and clears the registry entry. The snooze-until "just clears," exactly
+as the owner described. A genuinely new turn or a user keystroke therefore breaks through the snooze
+immediately - the timer is a floor (guaranteed return by the hour), never a ceiling that gags a
+session.
+
+Manual unsnooze (user taps Unsnooze): `POST .../hold` with `OnHold=false` clears the registry entry
+and forwards, as today.
+
+Expiry (the watchdog): a Gateway background sweep - ride the existing 8-second notifier cadence or a
+sibling timer - checks the registry for entries whose `SnoozeUntilUtc <= now`. On expiry the Gateway
+(a) clears the registry entry, (b) stamps the aggregated `SessionDto` as no-longer-held so
+`Classify` returns it to `NeedsYou`, and (c) if the Director is alive, forwards a `hold=false` so the
+Director's own state agrees and its voice rotation resumes. If the Director is dead, step (b) alone
+surfaces it from the cached roster - which is the case that matters most.
+
+The returning-from-snooze marker: expiry also stamps a new display-only DTO field (e.g.
+`SnoozeExpired: true`) that the clients render as a small "Snooze ended" badge, distinct from a
+normal turn-complete, so the owner knows this is a *go investigate why nothing happened* item. This
+marker is metadata on the roster/notification only. **Nothing is injected into the session's
+conversation.** The push copy for an expired snooze should read differently from an ordinary
+needs-you ("Snooze ended - still waiting on you") so a phone buzz is self-explanatory.
+
+## Decisions already made - do not re-litigate
+
+1. **No per-snooze duration.** There is exactly ONE snooze length - the user default. Snoozing a
+   session always uses that length. Do NOT build a duration picker, a long-press menu, a
+   split-button, or any per-session override. (The owner explicitly cut this; it can be a later
+   improvement.)
+
+2. **The default length is a per-user setting, default one hour, one value across all devices.** It
+   lives on the Gateway settings surface (`SettingsEndpoints.cs`, `settingsClient.ts`, the Cockpit
+   Settings page). Because all of the owner's devices read from their one Gateway, that is
+   automatically "same snooze everywhere." Mobile reads the same value; mobile does not get its own.
+
+3. **The timer is Gateway-owned and Director-independent, persisted to disk.** This is the whole
+   point of the mission. It must fire even when the owning Director is offline or the session is
+   dead. It must survive a Gateway restart.
+
+4. **Re-snooze is not a special case - it is just snoozing again.** Like an alarm clock: when a
+   session is not currently snoozed you can snooze it, and you can do that as many times as you want.
+   There is no escalation, no cap, no "second snooze is different." Do not build any re-snooze logic;
+   there is nothing to build - each snooze is an independent set of the same one-hour timer.
+
+5. **Coming out of snooze re-raises "needs you"; it does not touch the conversation.** On expiry the
+   session re-enters the `NeedsYou` bucket (which drives the roster, the ordering, and the existing
+   phone push) and carries a "Snooze ended" marker. We do NOT write anything into the session's
+   terminal or chat. The distinction lives in roster/notification metadata only.
+
+6. **Reuse the existing fold and the existing push notifier.** Do not add a second notification
+   path or a second triage classifier. Expiry works by making `SessionOrdering.Classify` see the
+   session as un-held again; everything downstream (roster order, grey-vs-red, the app-icon dot)
+   follows for free. Keep the Gateway as the single fold (issue #1177) - the cleanest implementation
+   overrides `OnHold` on the aggregated DTO copy at the Gateway rather than teaching `SessionOrdering`
+   about snooze expiry.
+
+7. **Snooze ALWAYS goes through the Gateway - no local fallback (settled by the owner 2026-07-11).**
+   Every snooze button - the cockpit session menu (`apps/cockpit/src/sessions/SessionMenu.tsx:207`),
+   the cockpit roster (`apps/cockpit/src/sessions/SessionRoster.tsx`), the mobile manage bar
+   (`apps/mobile/src/components/SessionManageBar.tsx:114`), AND the desktop Avalonia menus
+   (`MainWindow.axaml.cs`, `FifoWindow.axaml.cs`) - must set the hold through the Gateway
+   `POST /sessions/{sid}/hold` endpoint, so every snooze gets the registry timer. The desktop today
+   sets `Session.OnHold=true` IN-PROCESS on the local Director and never calls the Gateway; that is a
+   BUG to remove in Phase 3, not a second valid path. A Director may run without a Gateway, but it is
+   then CRIPPLED for snooze: pressing Snooze with no Gateway connection does NOT snooze locally - it
+   tells the user "you need to be connected to a Gateway to use snooze" and sets no hold at all. No
+   local timer, no in-process hold, no silent degrade. This supersedes the earlier "stated
+   limitation" framing (a Gateway-less Director does not get a weaker snooze - it gets none, loudly).
+
+8. Plain English everywhere, ASCII only in code and output. No fallback programming: if the registry
+   cannot be persisted, fail loud with a clear error - never silently run a snooze that will not
+   survive a restart.
+
+9. Verify agent-driven; do NOT route the owner through hands-on testing for this feature (settled
+   2026-07-11 - the owner will not hand-test a simple feature, and is right). Prove the server logic
+   with in-process end-to-end integration tests (boot a `GatewayHost` on an ephemeral port, drive the
+   real endpoints, dispose and re-create to prove persistence). Never spin a standalone test Gateway
+   that binds the tailscale/443 front door (the leftover-test-gateway hazard that once broke prod),
+   and never touch the owner's production Gateway. Reserve any owner or real-hardware check for
+   something that genuinely needs his eyes or his real phone - not this.
+
+## A subtlety to confirm, not solve blindly
+
+A session that is genuinely still *working* will have cleared its own `OnHold` via #470 the moment it
+produced activity, so it will not still be snoozed at the one-hour mark. The only sessions that reach
+expiry still snoozed are ones that went quiet - which is exactly the stuck/dead population the
+watchdog exists to surface. So "still snoozed at the hour -> raise needs-you" is correct. The Manager
+must confirm precisely which activity triggers the #470 clear on the Director, and hook the Gateway's
+"clear the snooze-until" mirror to the same observed transition (`OnHold` reported false), so the
+early-return clear and the Director's own clear never disagree.
+
+## The work, in phases
+
+Each phase ships alone: implemented, merged to origin/main per the trunk rule, and agent-verified
+(in-process end-to-end tests, not owner hand-testing) before the next phase begins.
+
+- **Phase 1 - Gateway snooze registry, timer, and the setting.** Add the persisted
+  `sessionId -> SnoozeUntilUtc` registry and the dedicated Gateway `POST /sessions/{sid}/hold`
+  handler that records it and forwards. Add the expiry sweep that clears the entry and flips the
+  session back into `NeedsYou` on the aggregated roster. Add the early-return clear (registry entry
+  cleared when a held session reports `OnHold=false`). Add the `GET/PUT /gateway/snooze-default`
+  setting (default 60 minutes) and re-arm from disk on Gateway startup, firing any already-past
+  entry immediately.
+  Proof: unit tests for the sweep (future/expired/cleared-early), plus an in-process end-to-end
+  integration test - boot a `GatewayHost` on an ephemeral port, drive the real
+  `POST /sessions/{sid}/hold`, set the default to a few seconds, let the sweep run, assert the
+  `/sessions` fold returns the session to `NeedsYou` on its own, then dispose and re-create the host
+  to prove the registry re-arms from the on-disk file (the survives-restart property). No live
+  Gateway, no owner hand-testing.
+
+- **Phase 2 - The returning-from-snooze marker and the phone push.** Add the display-only
+  `SnoozeExpired` DTO field, render it as a distinct "Snooze ended" badge on the cockpit roster and
+  the mobile roster, and give `WebPushNeedsYouNotifier` distinct copy for a snooze-expiry rise so the
+  phone buzz reads "Snooze ended - still waiting on you." A newly-expired snooze buzzes PROMPTLY with
+  that distinct copy even when the needs-you dot is already showing (it is new, actionable news), but
+  the push edge is keyed to a NEWLY-expired snooze the notifier has not yet announced - NOT to
+  `snoozeExpired > 0`. A dead-Director expired snooze persists in `NeedsYou` indefinitely, so buzzing
+  on a count would re-buzz every poll forever; instead announce each newly-expired session ONCE, then
+  it folds into the existing silent dot/heartbeat. Extend `DotState` to remember the announced set;
+  keep every existing anti-buzz guarantee.
+  Proof: an automated test asserting the notifier emits the distinct snooze-expiry copy when an
+  expired snooze raises the `NeedsYou` count, and the mobile PWA rendered via the existing Playwright
+  harness (mobile-pwa-proof-via-playwright) showing the "Snooze ended" badge. A real-phone push check
+  is welcome but is NOT a gate and is NOT the owner's to run.
+
+- **Phase 3 - Desktop routed through the Gateway, the dead-Director case, and the settings UI.**
+  Make the desktop Avalonia snooze (`MainWindow.axaml.cs`, `FifoWindow.axaml.cs`) call the Gateway
+  `POST /sessions/{sid}/hold` path instead of setting `Session.OnHold` in-process, so a desktop
+  snooze gets the same registry timer as phone and cockpit. When the Director has no Gateway
+  connection the desktop Snooze must be blocked with a clear "you need to be connected to a Gateway
+  to use snooze" message and set NO local hold (decision #7 - no fallback). Verify end to end that a
+  snooze on a session whose Director then goes offline still returns to "needs you" from the cached
+  roster at expiry (the enrichment-session scenario) and does not present as a live session. Add the
+  default-snooze-length control to the Cockpit Settings page (confirm mobile reads the same value).
+  Proof: a desktop snooze coming back on its own through the Gateway timer; the no-Gateway Snooze
+  showing the connect message and setting no hold; a graceful-stopped Director's snooze still firing
+  (the approved graceful path, never a blind force-kill of the user's Directors); screenshots of the
+  settings control and every snooze surface.
+
+## Definition of done for the mission
+
+1. All three phases merged to origin/main, each agent-verified by in-process end-to-end tests (no
+   owner hand-testing, no production Gateway).
+2. Snoozing any session holds it for the user-default length (default one hour) and then returns it
+   to "needs you" on its own - proven both for a live session gone quiet AND for a session whose
+   Director has died.
+3. A session that comes back on its own before the timer clears its snooze immediately (early return
+   works); re-snoozing works any number of times with no special behavior.
+4. The returned-from-snooze item is visibly distinct ("Snooze ended") on the roster and in the phone
+   push, and nothing is written into the session's conversation.
+5. The default length is a single per-user setting on the Gateway, editable in Settings, the same
+   across every device; the registry survives a Gateway restart.
+6. A final verification report (HTML, in docs/reviews/) showing the passing end-to-end tests: a
+   snooze returning on its own, an early return clearing the snooze, a dead-Director snooze still
+   firing, a snooze surviving a host restart (re-armed from disk), the distinct badge and push copy,
+   the no-Gateway "connect to snooze" behavior, and the settings control - with cockpit/PWA
+   screenshots from the Playwright harness. No step requires the owner or his production Gateway.


### PR DESCRIPTION
Eleven mission and research documents were sitting untracked in the main checkout - which is 56 commits behind origin/main - existing on one machine's disk and nowhere else. A second crash would have taken them.

Most were a straight copy. Two were not.

## The owner principle in car-mode-mission

The local copy carries 26 lines recorded nowhere else: an owner-stated, load-bearing principle from 2026-07-12. Car Mode is used hands-free, so waiting for the voice, the model, or the network is acceptable - **a silent, unchanged screen during that wait is the defect, not the wait**. The rule: flip the visible state synchronously the instant anything happens, before any async work begins.

## gateway-cleanup-phase2-repoint-design had genuinely diverged

Not stale - diverged. Two sessions edited it; one committed, one did not. Each version holds sections the other lacks, so neither supersedes the other and a plain pull would have silently kept main's and dropped the rest.

Recovered from the uncommitted copy:

- **The MessagePack wire-protocol ruling** (2026-07-12). This one shipped - `AddMessagePackProtocol` is on main today - and the doc is the only record of *why*: the tunnel was left on the default JSON protocol, which base64-encodes byte frames (+33%), so a full-cap 48 KB frame inflated past the hub receive limit and aborted the connection. It also records why the two alternatives were rejected: both keep JSON's permanent bandwidth and CPU tax and patch around the broken assumption instead of fixing the root cause.
- The upload-image chunking and slow-LLM verbs ruling (2026-07-13).
- The Phase 2 completeness gate (zero DirectorEndpointClient callers, 2026-07-13).

Main's eight later sections (PR C through E-B3, the voice-turn retirement, the three cut restorations) are all retained. Result is 18 headings: main's 15 plus the 3 rescued.

## Deliberately not included

- `carmode-help-mode-proposal` - already on main, byte-identical.
- `session-state-machine-2026-07-14.html` - the local copy is a 525-line snapshot; a newer 594-line version with a "Decisions taken, and why" section is on `feat/unified-hold-state` and arrives with that work.
- `car-mode-mission-2026-07-11.md.local-bak` - a scratch backup of the pre-edit file.
- A line-endings-only change to `docs/proof/issue-531/wingman-text-qa.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)