### PR TITLE
fix(sessions): one hold state machine, and the desktop rail joins the shared fold

### DIFF
--- a/docs/architecture/session-state-machine-2026-07-14.html
+++ b/docs/architecture/session-state-machine-2026-07-14.html
@@ -503,7 +503,76 @@
   release and becomes something the structure will not let us break.</p>
 </div>
 
-<h2>8. Coordination</h2>
+<h2>8. Decisions taken, and why</h2>
+
+<p>
+  Recorded so the next reader does not have to re-litigate them, and so a future change that breaks one of
+  them does it knowingly.
+</p>
+
+<h3>Who owns which fact</h3>
+<p>
+  Not "which component is authoritative" - that question has no single answer, which is what made this hard.
+  The split is per <em>fact</em>:
+</p>
+<div class="scroll">
+<table>
+  <thead><tr><th>Fact</th><th>Owner</th><th>Consequence</th></tr></thead>
+  <tbody>
+    <tr><td>Activity (Working / needs you)</td><td>The terminal, on the Director</td>
+        <td>Nothing may override Working. Pushed up. Only the Director sees the instant work stops.</td></tr>
+    <tr><td>Hold intent</td><td>The Gateway</td>
+        <td>No client invents it; no Gateway means no snooze (already enforced, and it fails loudly).</td></tr>
+    <tr><td>Session role</td><td>The Gateway</td>
+        <td>Needs the whole fleet - "is this session's controller alive?" is unanswerable from one Director.</td></tr>
+  </tbody>
+</table>
+</div>
+<p>
+  The desktop is a <em>producer</em> of the first and a <em>cache</em> of the other two, at the same time.
+  That is why "is the desktop a producer or a dumb cache?" had no answer: it depends which fact.
+</p>
+
+<h3>The Gateway owns the deferred hold; the Director applies it</h3>
+<p>
+  The Gateway records the intent and the timer. The Director applies it at the settle. If the Gateway
+  applied it, the sequence would be: session settles, pushes up, Gateway notices, sends the hold down,
+  Director holds, pushes up - and for that entire round trip the session reads red "needs you" on every
+  screen, a spurious nag for a session you already snoozed. Only the Director is fast enough to act without
+  that flash. The Gateway stays the source of truth; the Director is its hands.
+</p>
+
+<h3>Opening a snoozed session's terminal lifts its hold</h3>
+<p>
+  Accepted deliberately. Attaching a terminal can resize it, a resize reflows the screen, and those bytes
+  read as work. It takes a human deliberately opening that session (a resize no-ops on an unchanged size,
+  and only an attached terminal resizes at all - background sessions never trip it). The alternative,
+  suppressing resize-induced activity, is timing-based fragility, which is a worse defect than the surprise.
+  And it fails <strong>safe</strong>: the disease being cured is a session hidden behind "Snoozed" while it
+  works. An unwanted un-snooze is visible and one tap to undo; a hidden working session is neither.
+</p>
+
+<h3>Two existing tests deleted</h3>
+<p>
+  <code>CosmeticRepaint_OnHeldIdleSession_KeepsHold</code> and
+  <code>TurnEndingAtIdle_ConsumesArming_SoLaterRepaintCannotLiftHold</code> both asserted that a byte-blip to
+  Working must leave a hold intact - the exact opposite of the rule. Their premise is periodic Claude
+  repaints, and that premise is false: measured on the live fleet, a held idle session was byte-silent for
+  <strong>34 minutes</strong>. The noise they feared is already filtered inside the detector before it ever
+  reports Working.
+</p>
+
+<h2>9. Captured, not built</h2>
+<div class="callout">
+  <p><strong>Snooze a session whose Director is offline.</strong> Today this is impossible and fails
+  honestly: the hold endpoint forwards over the tunnel, a disconnected Director yields a 502, and the snooze
+  timer is armed only after a successful forward - so nothing is half-recorded. Making it work means moving
+  hold intent to the Gateway <em>durably</em> and making the Director a follower that reconciles on
+  reconnect. That is a real capability and a real architecture change, and it is its own later phase - not a
+  reconciliation step bolted onto this one. Noted here so it is not lost.</p>
+</div>
+
+<h2>10. Coordination</h2>
 <ul>
   <li><strong>Gateway Cleanup (11e753a3)</strong> - parked. Pull request #1512 stays open and unmerged;
       no mobile snooze work started. It agreed the latch is the wrong signal.</li>

--- a/docs/architecture/session-state-machine-2026-07-14.html
+++ b/docs/architecture/session-state-machine-2026-07-14.html
@@ -1,0 +1,525 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>DevThrottle Session State - Design for Approval</title>
+<style>
+  :root {
+    --ink:#1a1f2b; --mute:#5b6675; --line:#d8dee8; --bg:#ffffff; --panel:#f6f8fb;
+    --red:#ef4444; --blue:#3b82f6; --grey:#9ca3af; --slate:#64748b;
+    --green:#16a34a; --amber:#f0b848; --accent:#2563eb;
+  }
+  * { box-sizing:border-box; }
+  body {
+    margin:0; padding:0 24px 80px; background:var(--bg); color:var(--ink);
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  }
+  .wrap { max-width:920px; margin:0 auto; }
+  header { border-bottom:3px solid var(--ink); padding:48px 0 20px; margin-bottom:36px; }
+  h1 { font-size:32px; line-height:1.2; margin:0 0 8px; letter-spacing:-0.02em; }
+  .sub { color:var(--mute); font-size:15px; margin:0; }
+  h2 {
+    font-size:23px; margin:52px 0 14px; padding-top:22px; border-top:1px solid var(--line);
+    letter-spacing:-0.01em;
+  }
+  h3 { font-size:17px; margin:30px 0 8px; }
+  p { margin:0 0 14px; }
+  .lede { font-size:18px; line-height:1.6; }
+  .callout {
+    background:var(--panel); border-left:4px solid var(--accent);
+    padding:16px 18px; margin:20px 0; border-radius:0 6px 6px 0;
+  }
+  .callout.warn { border-left-color:var(--red); }
+  .callout.ok { border-left-color:var(--green); }
+  .callout p:last-child { margin-bottom:0; }
+  table { border-collapse:collapse; width:100%; margin:18px 0; font-size:14px; }
+  th, td { border-bottom:1px solid var(--line); padding:9px 10px; text-align:left; vertical-align:top; }
+  th { background:var(--panel); font-weight:600; font-size:12px; text-transform:uppercase;
+       letter-spacing:.06em; color:var(--mute); }
+  code { font:13px/1.4 "SF Mono",Consolas,"Liberation Mono",monospace;
+         background:var(--panel); padding:1px 5px; border-radius:3px; }
+  .dot { display:inline-block; width:9px; height:9px; border-radius:50%; margin-right:6px;
+         vertical-align:middle; }
+  .d-red{background:var(--red)} .d-blue{background:var(--blue)} .d-grey{background:var(--grey)}
+  .d-slate{background:var(--slate)}
+  .bad { color:var(--red); font-weight:600; }
+  .good { color:var(--green); font-weight:600; }
+  figure { margin:26px 0; }
+  figure svg { width:100%; height:auto; display:block; }
+  figcaption { color:var(--mute); font-size:13px; margin-top:10px; text-align:center; }
+  .scroll { overflow-x:auto; }
+  ul { margin:0 0 14px; padding-left:22px; }
+  li { margin-bottom:7px; }
+  .file { font:12.5px/1.4 "SF Mono",Consolas,monospace; color:var(--mute); }
+  footer { margin-top:60px; padding-top:20px; border-top:1px solid var(--line);
+           color:var(--mute); font-size:13px; }
+  @media (prefers-color-scheme: dark) {
+    :root { --ink:#e8ecf3; --mute:#9aa7b8; --line:#2b3340; --bg:#12161d; --panel:#1a1f28; }
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header>
+  <h1>DevThrottle Session State</h1>
+  <p class="sub">Design for approval &middot; 14 July 2026 &middot; prepared by session "Dev Throttle State" (3a2239de)</p>
+</header>
+
+<p class="lede">
+  Right now your desktop and your phone show <strong>different states for the same session</strong>. I measured
+  it on your live fleet this morning: six of thirteen sessions disagreed. This document explains why,
+  proposes one state machine and one place where state is decided, and asks for your approval before
+  any code is written.
+</p>
+
+<div class="callout warn">
+  <p><strong>The short version.</strong> There is no single answer to "what is this session doing?".
+  The Gateway computes one answer for your phone and the Cockpit. The desktop computes three
+  different answers of its own. Nobody reconciles them. On top of that, the hold flag is built on a
+  latch that a slow command destroys, so a snoozed session can keep working and never come back.</p>
+</div>
+
+<h2>1. The evidence</h2>
+
+<p>
+  The Gateway's session list carries both colors at once: <code>statusColor</code> (what your desktop
+  paints) and <code>effectiveColor</code> (what your phone paints). That let me compare the two views
+  of the same session at the same instant, on the running fleet. Six rows disagreed.
+</p>
+
+<div class="scroll">
+<table>
+  <thead>
+    <tr><th>Session</th><th>Really doing</th><th>Desktop shows</th><th>Phone shows</th><th>Cause</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Enrichment Facade Eval - Architect</td><td>Waiting, snoozed</td>
+        <td><span class="dot d-red"></span><span class="bad">"Your Turn", waiting 10h</span></td>
+        <td><span class="dot d-grey"></span>"Snoozed"</td><td>Label ignores hold</td></tr>
+    <tr><td>cc-consult - Perry</td><td>Waiting, snoozed</td>
+        <td><span class="dot d-red"></span><span class="bad">"Your Turn", waiting 10h</span></td>
+        <td><span class="dot d-grey"></span>"Snoozed"</td><td>Label ignores hold</td></tr>
+    <tr><td>mindzieWeb - james template</td><td>Waiting, snoozed</td>
+        <td><span class="dot d-red"></span><span class="bad">"Your Turn"</span></td>
+        <td><span class="dot d-grey"></span>"Snoozed"</td><td>Label ignores hold</td></tr>
+    <tr><td>mindzieWeb - James</td><td>Waiting, snoozed</td>
+        <td><span class="dot d-red"></span><span class="bad">"Your Turn", waiting 10h</span></td>
+        <td><span class="dot d-grey"></span>"Snoozed"</td><td>Label ignores hold</td></tr>
+    <tr><td>devthrottle - snooze longer</td><td>Waiting, snoozed</td>
+        <td><span class="dot d-red"></span><span class="bad">"Your Turn"</span></td>
+        <td><span class="dot d-grey"></span>"Snoozed"</td><td>Label ignores hold</td></tr>
+    <tr><td><strong>Tunnel-Only Review - Reviewer 2 (Codex)</strong></td><td>Waiting, is a Worker</td>
+        <td><span class="dot d-red"></span><span class="bad">"Your Turn"</span></td>
+        <td><span class="dot d-slate"></span>"Sub-agent"</td><td>Desktop cannot see roles</td></tr>
+  </tbody>
+</table>
+</div>
+
+<p>
+  That last row is the Codex session you spotted. It is a Worker, and the Gateway deliberately keeps
+  Workers quiet so they nag their manager instead of you. The desktop does not know the session is a
+  Worker, so it nags you anyway. Both halves of what you saw are real, and they have two different
+  causes.
+</p>
+
+<h2>2. Why the hold breaks</h2>
+
+<p>
+  Hold is meant to lift itself when a turn ends. Whether it is allowed to lift depends on a private
+  latch called <code>_turnInFlight</code>. That latch is armed only when you press Enter, and it is
+  destroyed by <strong>any ten seconds of terminal silence</strong> - because the detector treats ten
+  seconds of quiet as "the turn is over", with no attempt to tell a finished turn apart from a slow
+  build. Almost every real turn contains such a gap.
+</p>
+
+<figure>
+<svg viewBox="0 0 880 250" xmlns="http://www.w3.org/2000/svg" role="img"
+     aria-label="Timeline showing the turn latch destroyed by a ten second quiet gap mid-turn">
+  <defs>
+    <marker id="ar" markerWidth="9" markerHeight="9" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#5b6675"/>
+    </marker>
+  </defs>
+  <line x1="40" y1="60" x2="840" y2="60" stroke="#d8dee8" stroke-width="2"/>
+
+  <rect x="40"  y="46" width="150" height="28" fill="#3b82f6" opacity=".85" rx="3"/>
+  <rect x="190" y="46" width="120" height="28" fill="#f6f8fb" stroke="#d8dee8" rx="3"/>
+  <rect x="310" y="46" width="260" height="28" fill="#3b82f6" opacity=".85" rx="3"/>
+  <rect x="570" y="46" width="270" height="28" fill="#3b82f6" opacity=".85" rx="3"/>
+
+  <text x="115" y="65" font-size="12" fill="#fff" text-anchor="middle" font-family="sans-serif">agent working</text>
+  <text x="250" y="65" font-size="12" fill="#5b6675" text-anchor="middle" font-family="sans-serif">slow build (quiet)</text>
+  <text x="440" y="65" font-size="12" fill="#fff" text-anchor="middle" font-family="sans-serif">agent working again</text>
+  <text x="705" y="65" font-size="12" fill="#fff" text-anchor="middle" font-family="sans-serif">still working</text>
+
+  <line x1="40" y1="30" x2="40" y2="46" stroke="#5b6675" stroke-width="1.5"/>
+  <text x="40" y="24" font-size="11.5" fill="#1a1f2b" text-anchor="middle" font-family="sans-serif">you press Enter</text>
+  <text x="40" y="94" font-size="11" fill="#16a34a" text-anchor="middle" font-family="sans-serif">latch ARMED</text>
+
+  <line x1="310" y1="30" x2="310" y2="46" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="310" y="24" font-size="11.5" fill="#ef4444" text-anchor="middle" font-family="sans-serif">10s of quiet elapses</text>
+  <text x="310" y="94" font-size="11" fill="#ef4444" text-anchor="middle" font-family="sans-serif" font-weight="bold">latch DESTROYED</text>
+  <text x="310" y="110" font-size="10.5" fill="#5b6675" text-anchor="middle" font-family="sans-serif">(detector assumes the turn ended)</text>
+
+  <line x1="570" y1="30" x2="570" y2="46" stroke="#5b6675" stroke-width="1.5"/>
+  <text x="570" y="24" font-size="11.5" fill="#1a1f2b" text-anchor="middle" font-family="sans-serif">you press Snooze</text>
+  <text x="570" y="94" font-size="11" fill="#1a1f2b" text-anchor="middle" font-family="sans-serif">held = true</text>
+
+  <line x1="840" y1="30" x2="840" y2="46" stroke="#5b6675" stroke-width="1.5"/>
+  <text x="840" y="24" font-size="11.5" fill="#1a1f2b" text-anchor="end" font-family="sans-serif">turn really ends</text>
+
+  <rect x="300" y="150" width="560" height="76" fill="#fdecec" stroke="#ef4444" rx="5"/>
+  <text x="316" y="172" font-size="13" fill="#ef4444" font-family="sans-serif" font-weight="bold">The hold never lifts.</text>
+  <text x="316" y="192" font-size="12.5" fill="#1a1f2b" font-family="sans-serif">The turn-end lift is gated on a latch that the quiet gap already threw away,</text>
+  <text x="316" y="210" font-size="12.5" fill="#1a1f2b" font-family="sans-serif">so the session runs to completion still marked "Snoozed".</text>
+
+  <path d="M570,110 C570,140 430,120 430,150" stroke="#5b6675" stroke-width="1.2" fill="none" marker-end="url(#ar)"/>
+</svg>
+<figcaption>Today: one ordinary slow command mid-turn silently disables the hold's ability to lift itself.</figcaption>
+</figure>
+
+<div class="callout">
+  <p>This is also why a mid-turn snooze does not stick, and why the fix on the open pull request
+  #1512 - which reads the same latch to decide whether to defer - would inherit the same bug in a new
+  place. That pull request is parked pending this design.</p>
+</div>
+
+<h2>3. The proposed state machine</h2>
+
+<p>
+  Hold is currently three variables that can disagree: the public flag, the fragile latch, and a
+  pending flag on the unmerged branch. Replace all three with <strong>one field, three states</strong>,
+  owned by the Director's session object. The only other thing it reads is whether the session is
+  working right now - which the terminal detector already decides.
+</p>
+
+<figure>
+<svg viewBox="0 0 880 420" xmlns="http://www.w3.org/2000/svg" role="img"
+     aria-label="State diagram with three states: None, Held, and Deferred Hold">
+  <defs>
+    <marker id="a2" markerWidth="10" markerHeight="10" refX="9" refY="3.2" orient="auto">
+      <path d="M0,0 L0,6.4 L9,3.2 z" fill="#5b6675"/>
+    </marker>
+    <marker id="a3" markerWidth="10" markerHeight="10" refX="9" refY="3.2" orient="auto">
+      <path d="M0,0 L0,6.4 L9,3.2 z" fill="#16a34a"/>
+    </marker>
+  </defs>
+
+  <circle cx="62" cy="127" r="7" fill="#1a1f2b"/>
+  <path d="M70,127 L112,127" stroke="#5b6675" stroke-width="1.6" marker-end="url(#a2)"/>
+
+  <rect x="120" y="96" width="180" height="62" rx="31" fill="#f6f8fb" stroke="#1a1f2b" stroke-width="2"/>
+  <text x="210" y="123" font-size="17" text-anchor="middle" font-family="sans-serif" font-weight="600">None</text>
+  <text x="210" y="142" font-size="11.5" fill="#5b6675" text-anchor="middle" font-family="sans-serif">not held</text>
+
+  <rect x="580" y="96" width="180" height="62" rx="31" fill="#f1f3f7" stroke="#9ca3af" stroke-width="2.5"/>
+  <text x="670" y="123" font-size="17" text-anchor="middle" font-family="sans-serif" font-weight="600">Held</text>
+  <text x="670" y="142" font-size="11.5" fill="#5b6675" text-anchor="middle" font-family="sans-serif">"Snoozed"</text>
+
+  <rect x="110" y="300" width="200" height="66" rx="33" fill="#eef4ff" stroke="#3b82f6" stroke-width="2.5"/>
+  <text x="210" y="327" font-size="16" text-anchor="middle" font-family="sans-serif" font-weight="600">DeferredHold</text>
+  <text x="210" y="347" font-size="11" fill="#5b6675" text-anchor="middle" font-family="sans-serif">"Working, snoozing when done"</text>
+
+  <path d="M670,96 C670,36 210,36 210,94" stroke="#16a34a" stroke-width="2.8" fill="none" marker-end="url(#a3)"/>
+  <text x="440" y="20" font-size="13.5" fill="#16a34a" text-anchor="middle" font-family="sans-serif" font-weight="bold">it starts working -&gt; the hold lifts, always</text>
+  <text x="440" y="36" font-size="11" fill="#5b6675" text-anchor="middle" font-family="sans-serif">(and the snooze timer is cancelled, whatever its length)</text>
+
+  <path d="M300,113 L576,113" stroke="#5b6675" stroke-width="1.6" marker-end="url(#a2)"/>
+  <text x="438" y="105" font-size="12" fill="#1a1f2b" text-anchor="middle" font-family="sans-serif">Snooze pressed while idle</text>
+
+  <path d="M578,141 L304,141" stroke="#5b6675" stroke-width="1.6" marker-end="url(#a2)"/>
+  <text x="440" y="158" font-size="12" fill="#1a1f2b" text-anchor="middle" font-family="sans-serif">Unsnooze pressed</text>
+
+  <path d="M180,158 L180,296" stroke="#5b6675" stroke-width="1.6" marker-end="url(#a2)"/>
+  <text x="168" y="216" font-size="12" fill="#1a1f2b" text-anchor="end" font-family="sans-serif">Snooze pressed</text>
+  <text x="168" y="232" font-size="12" fill="#1a1f2b" text-anchor="end" font-family="sans-serif">while working</text>
+
+  <path d="M248,298 L248,162" stroke="#5b6675" stroke-width="1.6" fill="none" stroke-dasharray="5,4" marker-end="url(#a2)"/>
+  <text x="262" y="216" font-size="11.5" fill="#5b6675" font-family="sans-serif">you send a new prompt</text>
+  <text x="262" y="232" font-size="11.5" fill="#5b6675" font-family="sans-serif">(supersedes the deferral)</text>
+
+  <path d="M312,338 C500,338 640,300 664,164" stroke="#5b6675" stroke-width="1.6" fill="none" marker-end="url(#a2)"/>
+  <text x="452" y="392" font-size="12" fill="#1a1f2b" text-anchor="middle" font-family="sans-serif">it stops working -&gt; the deferral lands</text>
+</svg>
+<figcaption>Three states. The green edge is your rule: a held session that starts working comes off hold, every time.</figcaption>
+</figure>
+
+<h3>The whole machine as a table</h3>
+
+<div class="scroll">
+<table>
+  <thead>
+    <tr><th>From state</th><th>It starts working</th><th>It stops working</th><th>You send a prompt</th>
+        <th>You press Snooze</th><th>You press Unsnooze</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>None</strong></td>
+      <td>None</td><td>None</td><td>None</td>
+      <td>working? <strong>DeferredHold</strong><br>idle? <strong>Held</strong></td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td><strong>Held</strong></td>
+      <td class="good">None - the rule</td><td>Held</td><td class="good">None</td>
+      <td>Held</td><td>None</td>
+    </tr>
+    <tr>
+      <td><strong>DeferredHold</strong></td>
+      <td>DeferredHold</td><td class="good">Held - lands</td><td class="good">None - superseded</td>
+      <td>DeferredHold</td><td>None</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+<div class="callout ok">
+  <p><strong>Why this is simpler, not just renamed.</strong> Today the question "should I defer this
+  hold?" and the question "may I lift this hold?" are answered by two different signals that fall out
+  of step with each other. In the new machine both read the same authoritative fact - is it working
+  right now - so they cannot disagree. The fragile latch disappears entirely.</p>
+</div>
+
+<h3>Timed snoozes</h3>
+<p>
+  A snooze can carry its own length (a caller passes minutes, anywhere from one minute to seven days;
+  the account setting is only the fallback when none is given). Your rule applies to those too:
+  <strong>when a session starts working, the hold lifts and its timer is cancelled</strong>, whether it
+  was set for twelve hours or twenty-four. An alarm for a session you are already back working on is
+  noise.
+</p>
+
+<h2>4. One place decides state</h2>
+
+<p>
+  The state machine fixes what is true. This fixes whether all three screens agree about it.
+</p>
+
+<p>
+  The Gateway already has one function that decides color and label together from raw facts, and every
+  browser client just renders its output. That was the intent all along. The desktop never joined - it
+  hand-rolls three folds of its own, each reading different fields with different rules. Two of them
+  have never heard of hold, which is precisely why you get a grey strip and a red "Your Turn" on the
+  same row.
+</p>
+
+<figure>
+<svg viewBox="0 0 880 380" xmlns="http://www.w3.org/2000/svg" role="img"
+     aria-label="Diagram comparing three desktop folds today against one shared fold after the change">
+  <defs>
+    <marker id="a4" markerWidth="9" markerHeight="9" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#5b6675"/>
+    </marker>
+  </defs>
+
+  <text x="16" y="22" font-size="14" font-family="sans-serif" font-weight="bold" fill="#ef4444">TODAY - four folds, nobody reconciles them</text>
+
+  <rect x="16" y="40" width="120" height="112" rx="5" fill="#f6f8fb" stroke="#d8dee8"/>
+  <text x="76" y="62" font-size="12" text-anchor="middle" font-family="sans-serif" font-weight="600">raw facts</text>
+  <text x="76" y="83" font-size="11" text-anchor="middle" font-family="sans-serif" fill="#5b6675">activity state</text>
+  <text x="76" y="101" font-size="11" text-anchor="middle" font-family="sans-serif" fill="#5b6675">hold flag</text>
+  <text x="76" y="119" font-size="11" text-anchor="middle" font-family="sans-serif" fill="#5b6675">session role</text>
+  <text x="76" y="137" font-size="11" text-anchor="middle" font-family="sans-serif" fill="#5b6675">status color</text>
+
+  <path d="M138,70  L196,58"  stroke="#5b6675" stroke-width="1.3" marker-end="url(#a4)"/>
+  <path d="M138,92  L196,100" stroke="#5b6675" stroke-width="1.3" marker-end="url(#a4)"/>
+  <path d="M138,114 L196,142" stroke="#5b6675" stroke-width="1.3" marker-end="url(#a4)"/>
+  <path d="M138,136 L196,196" stroke="#5b6675" stroke-width="1.3" marker-end="url(#a4)"/>
+
+  <rect x="198" y="42" width="176" height="32" rx="4" fill="#fdecec" stroke="#ef4444"/>
+  <text x="286" y="63" font-size="11.5" text-anchor="middle" font-family="sans-serif">desktop strip (knows hold)</text>
+  <rect x="198" y="84" width="176" height="32" rx="4" fill="#fdecec" stroke="#ef4444"/>
+  <text x="286" y="105" font-size="11.5" text-anchor="middle" font-family="sans-serif" fill="#ef4444">desktop label (no hold)</text>
+  <rect x="198" y="126" width="176" height="32" rx="4" fill="#fdecec" stroke="#ef4444"/>
+  <text x="286" y="147" font-size="11.5" text-anchor="middle" font-family="sans-serif" fill="#ef4444">desktop "waiting 10h" (no hold)</text>
+  <rect x="198" y="180" width="176" height="32" rx="4" fill="#eef4ff" stroke="#3b82f6"/>
+  <text x="286" y="201" font-size="11.5" text-anchor="middle" font-family="sans-serif">Gateway fold (knows all)</text>
+
+  <path d="M376,58  L440,84"  stroke="#5b6675" stroke-width="1.3" marker-end="url(#a4)"/>
+  <path d="M376,100 L440,94"  stroke="#5b6675" stroke-width="1.3" marker-end="url(#a4)"/>
+  <path d="M376,142 L440,104" stroke="#5b6675" stroke-width="1.3" marker-end="url(#a4)"/>
+  <path d="M376,196 L440,180" stroke="#5b6675" stroke-width="1.3" marker-end="url(#a4)"/>
+
+  <rect x="442" y="76" width="120" height="36" rx="4" fill="#fff" stroke="#ef4444" stroke-width="2"/>
+  <text x="502" y="99" font-size="12" text-anchor="middle" font-family="sans-serif" font-weight="600">DESKTOP</text>
+  <rect x="442" y="164" width="120" height="36" rx="4" fill="#fff" stroke="#3b82f6" stroke-width="2"/>
+  <text x="502" y="187" font-size="12" text-anchor="middle" font-family="sans-serif" font-weight="600">phone + Cockpit</text>
+
+  <text x="590" y="100" font-size="13" font-family="sans-serif" fill="#ef4444" font-weight="bold">"Your Turn"</text>
+  <text x="590" y="120" font-size="11.5" font-family="sans-serif" fill="#5b6675">red, waiting 10h</text>
+  <text x="590" y="188" font-size="13" font-family="sans-serif" fill="#5b6675" font-weight="bold">"Snoozed"</text>
+  <text x="590" y="208" font-size="11.5" font-family="sans-serif" fill="#5b6675">grey, recessed</text>
+  <text x="590" y="146" font-size="12" font-family="sans-serif" fill="#ef4444" font-weight="bold">same session, two answers</text>
+
+  <line x1="16" y1="248" x2="864" y2="248" stroke="#d8dee8" stroke-width="1"/>
+  <text x="16" y="278" font-size="14" font-family="sans-serif" font-weight="bold" fill="#16a34a">AFTER - one fold, three screens</text>
+
+  <rect x="16" y="296" width="120" height="60" rx="5" fill="#f6f8fb" stroke="#d8dee8"/>
+  <text x="76" y="322" font-size="12" text-anchor="middle" font-family="sans-serif" font-weight="600">raw facts</text>
+  <text x="76" y="341" font-size="11" text-anchor="middle" font-family="sans-serif" fill="#5b6675">(unchanged)</text>
+
+  <path d="M138,326 L242,326" stroke="#5b6675" stroke-width="1.4" marker-end="url(#a4)"/>
+
+  <rect x="244" y="302" width="190" height="48" rx="5" fill="#e9f7ee" stroke="#16a34a" stroke-width="2.5"/>
+  <text x="339" y="323" font-size="13" text-anchor="middle" font-family="sans-serif" font-weight="600">SessionOrdering</text>
+  <text x="339" y="341" font-size="11" text-anchor="middle" font-family="sans-serif" fill="#5b6675">the one fold</text>
+
+  <path d="M436,318 L516,300" stroke="#16a34a" stroke-width="1.4" marker-end="url(#a4)"/>
+  <path d="M436,326 L516,326" stroke="#16a34a" stroke-width="1.4" marker-end="url(#a4)"/>
+  <path d="M436,334 L516,352" stroke="#16a34a" stroke-width="1.4" marker-end="url(#a4)"/>
+
+  <rect x="518" y="284" width="110" height="32" rx="4" fill="#fff" stroke="#16a34a" stroke-width="1.6"/>
+  <text x="573" y="305" font-size="12" text-anchor="middle" font-family="sans-serif">desktop</text>
+  <rect x="518" y="310" width="110" height="32" rx="4" fill="#fff" stroke="#16a34a" stroke-width="1.6"/>
+  <text x="573" y="331" font-size="12" text-anchor="middle" font-family="sans-serif">Cockpit</text>
+  <rect x="518" y="336" width="110" height="32" rx="4" fill="#fff" stroke="#16a34a" stroke-width="1.6"/>
+  <text x="573" y="357" font-size="12" text-anchor="middle" font-family="sans-serif">phone</text>
+
+  <text x="654" y="322" font-size="13" font-family="sans-serif" fill="#16a34a" font-weight="bold">one answer</text>
+  <text x="654" y="342" font-size="11.5" font-family="sans-serif" fill="#5b6675">agreement is structural</text>
+</svg>
+<figcaption>The desktop already references the project the shared fold lives in. It can call the identical function and delete its private copies.</figcaption>
+</figure>
+
+<div class="callout">
+  <p><strong>One open question for you.</strong> Suppressing a Worker's red needs to know the session
+  is a Worker, and that is worked out by the Gateway from the whole fleet - the Director does not know
+  it. Either the Gateway sends the role back down so the desktop can read it (my recommendation: one
+  place still decides, at the cost of the rail being briefly unaware right after a restart), or the
+  desktop works the role out locally (instant and works offline, but that is a second derivation that
+  can drift - the exact disease we are curing).</p>
+</div>
+
+<h2>5. Near real-time</h2>
+
+<p>
+  Your Director already dials out to the Gateway and pushes its sessions the instant anything changes,
+  plus every ten seconds regardless. That part works. But it only announces <em>activity</em> changes.
+  <strong>Nobody announces a hold change.</strong> The hold flag has exactly one listener in the whole
+  product, and it is the desktop rail sitting in the same process.
+</p>
+
+<p>
+  So when you press Snooze on your phone, the Director sets the flag, answers your phone, and tells
+  the Gateway nothing. The news waits for the next ten-second heartbeat, then the receiving screen's
+  own refresh. Every <em>other</em> screen is wrong for up to fifteen seconds - and because the
+  Gateway works out the color and the sort order from that flag, the session also sits in the wrong
+  part of the list for that whole window.
+</p>
+
+<figure>
+<svg viewBox="0 0 880 260" xmlns="http://www.w3.org/2000/svg" role="img"
+     aria-label="Timeline comparing the current fifteen second blind window against instant push after the fix">
+  <line x1="150" y1="66" x2="840" y2="66" stroke="#d8dee8" stroke-width="2"/>
+  <line x1="150" y1="186" x2="840" y2="186" stroke="#d8dee8" stroke-width="2"/>
+
+  <text x="16" y="46" font-size="13" font-family="sans-serif" font-weight="bold" fill="#ef4444">TODAY</text>
+  <text x="16" y="70" font-size="11.5" font-family="sans-serif" fill="#5b6675">you press</text>
+  <text x="16" y="86" font-size="11.5" font-family="sans-serif" fill="#5b6675">Snooze on phone</text>
+
+  <circle cx="150" cy="66" r="6" fill="#1a1f2b"/>
+  <rect x="150" y="52" width="450" height="28" fill="#fdecec" stroke="#ef4444" stroke-dasharray="4,3" rx="3"/>
+  <text x="375" y="71" font-size="12" fill="#ef4444" text-anchor="middle" font-family="sans-serif" font-weight="bold">desktop + Cockpit still show the OLD state</text>
+  <circle cx="600" cy="66" r="6" fill="#5b6675"/>
+  <text x="600" y="42" font-size="11.5" fill="#5b6675" text-anchor="middle" font-family="sans-serif">10s heartbeat</text>
+  <rect x="600" y="52" width="130" height="28" fill="#f6f8fb" stroke="#d8dee8" rx="3"/>
+  <text x="665" y="71" font-size="11.5" fill="#5b6675" text-anchor="middle" font-family="sans-serif">their refresh</text>
+  <circle cx="730" cy="66" r="6" fill="#16a34a"/>
+  <text x="748" y="71" font-size="12" fill="#16a34a" font-family="sans-serif" font-weight="bold">agree</text>
+  <text x="440" y="104" font-size="12.5" fill="#ef4444" text-anchor="middle" font-family="sans-serif" font-weight="bold">up to 15 seconds of disagreement</text>
+
+  <text x="16" y="166" font-size="13" font-family="sans-serif" font-weight="bold" fill="#16a34a">AFTER</text>
+  <text x="16" y="190" font-size="11.5" font-family="sans-serif" fill="#5b6675">you press</text>
+  <text x="16" y="206" font-size="11.5" font-family="sans-serif" fill="#5b6675">Snooze on phone</text>
+
+  <circle cx="150" cy="186" r="6" fill="#1a1f2b"/>
+  <rect x="150" y="172" width="34" height="28" fill="#e9f7ee" stroke="#16a34a" rx="3"/>
+  <circle cx="184" cy="186" r="6" fill="#16a34a"/>
+  <text x="230" y="191" font-size="12" fill="#16a34a" font-family="sans-serif" font-weight="bold">every screen agrees</text>
+  <text x="167" y="160" font-size="11" fill="#16a34a" text-anchor="middle" font-family="sans-serif">push</text>
+  <text x="440" y="224" font-size="12.5" fill="#16a34a" text-anchor="middle" font-family="sans-serif">the hold change announces itself, like activity already does</text>
+</svg>
+<figcaption>The fix is to announce hold changes on the same channel activity changes already use.</figcaption>
+</figure>
+
+<p>
+  Being honest about the remaining limit: the last hop, Gateway to browser, is still a poll - the
+  Cockpit asks every 2 seconds, the phone every 5. So "near real-time" after this change means about
+  <strong>2 seconds on the Cockpit and 5 on the phone</strong>, down from up to 15, with the desktop
+  instant. Pushing that last hop is a known follow-on and deliberately out of scope here; I would
+  rather land the truth first and shorten the last hop separately.
+</p>
+
+<h2>6. What changes</h2>
+
+<div class="scroll">
+<table>
+  <thead><tr><th>Change</th><th>Where</th><th>Why</th></tr></thead>
+  <tbody>
+    <tr><td>One <code>HoldState</code> replacing the flag, the latch, and the pending flag</td>
+        <td class="file">Core/Sessions/Session.cs</td>
+        <td>The machine in section 3</td></tr>
+    <tr><td>Working lifts a hold; snooze timer cancelled with it</td>
+        <td class="file">Core/Sessions/Session.cs, Gateway/Snooze</td>
+        <td>Your rule</td></tr>
+    <tr><td>Announce hold changes to the Gateway</td>
+        <td class="file">ControlApi/ControlApiHost.cs</td>
+        <td>Closes the 15-second window</td></tr>
+    <tr><td>Desktop calls the shared fold; delete its three private folds</td>
+        <td class="file">Avalonia/SessionViewModel.cs</td>
+        <td>Screens cannot disagree</td></tr>
+    <tr><td>Add the "snoozing when done" label; hold no longer hides working</td>
+        <td class="file">Gateway.Contracts/SessionOrdering.cs</td>
+        <td>Labels stop lying</td></tr>
+    <tr><td>Report a deferred hold back to the button</td>
+        <td class="file">Gateway.Contracts/HoldRequest.cs</td>
+        <td>The button can say what it did</td></tr>
+    <tr><td>Fix the mobile double-tap race</td>
+        <td class="file">apps/mobile/.../SessionManageBar.tsx</td>
+        <td>Button releases before the refresh lands</td></tr>
+    <tr><td>Correct two doc comments that describe behavior we no longer have</td>
+        <td class="file">Core/Configuration/SnoozeDefaultConfig.cs, Gateway/Api/SettingsEndpoints.cs</td>
+        <td>They say per-snooze duration does not exist. It does. They misled me today.</td></tr>
+  </tbody>
+</table>
+</div>
+
+<h2>7. How we prove it</h2>
+
+<p>
+  Not by me saying it works. The same measurement that found the problem becomes the test: read your
+  live fleet and assert that <strong>every session's desktop answer equals its phone answer</strong>.
+  Today that check reports six failures. When it reports zero, and keeps reporting zero, the job is
+  done. Alongside that go unit tests for every cell of the table in section 3, including the five
+  already written for the deferred hold on pull request #1512, which I will lift and credit.
+</p>
+
+<div class="callout ok">
+  <p><strong>The end state.</strong> One field says what a session is doing. One function turns that
+  into a color and a label. Three screens render it. A held session that starts working comes back on
+  its own, every time, whatever its timer said. Agreement stops being something we re-check each
+  release and becomes something the structure will not let us break.</p>
+</div>
+
+<h2>8. Coordination</h2>
+<ul>
+  <li><strong>Gateway Cleanup (11e753a3)</strong> - parked. Pull request #1512 stays open and unmerged;
+      no mobile snooze work started. It agreed the latch is the wrong signal.</li>
+  <li><strong>snooze longer (fb3582a6)</strong> - clear. Nothing snooze is open; it handed over the
+      snooze registry, the hold endpoint, and the shared fold. It also caught that my checkout was 53
+      commits behind, which is how the stale doc comments got into this document's scope.</li>
+  <li>No fleet-wide broadcasts were sent - three targeted messages only.</li>
+</ul>
+
+<footer>
+  <p>Prepared for approval before any code is written. Open questions: the state machine as designed;
+  the desktop fold rewrite; how the desktop learns a session's role (section 4); and whether I
+  implement or hand this to 11e753a3.</p>
+  <p>Saved at <span class="file">docs/architecture/session-state-machine-2026-07-14.html</span></p>
+</footer>
+
+</div>
+</body>
+</html>

--- a/src/CcDirector.Avalonia/SessionViewModel.cs
+++ b/src/CcDirector.Avalonia/SessionViewModel.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Avalonia.Media;
 using Avalonia.Threading;
+using CcDirector.ControlApi;
 using CcDirector.Core.Agents;
 using CcDirector.Core.Claude;
 using CcDirector.Core.Sessions;
@@ -111,37 +112,52 @@ public class SessionViewModel : INotifyPropertyChanged
     }
 
     /// <summary>
-    /// Phase 4d: the sidebar color strip's brush. Reads <see cref="Session.StatusColor"/>
-    /// written by the SessionStatusWingman. Desktop and Gateway use the same field
-    /// so the same session shows the same color in both windows.
+    /// The live session projected into the wire DTO the shared presentation fold reads, via the ONE mapper
+    /// that already builds it for the Gateway - so the rail folds exactly the same inputs the phone does.
     ///
-    /// Exception: when the user has parked the session on hold (<see cref="Session.OnHold"/>),
-    /// the strip shows a light gray so held sessions recede and read as "set aside" at a glance.
-    /// OnHold is an orthogonal user override that sits on top of the wingman's color.
+    /// Deliberately NOT cached. Map is pure property reads with no I/O, and the rail re-reads only when a
+    /// change event raises a property, not in a loop. A cache here would buy nothing measurable and would
+    /// add an invalidation obligation across nine change handlers, where missing one means the rail quietly
+    /// shows stale state - the precise failure this whole change exists to remove.
     /// </summary>
-    public ISolidColorBrush StatusColorBrush
+    private SessionDto FoldInput => ControlEndpoints.Map(Session, directorId: "");
+
+    /// <summary>
+    /// The ONE presentation fold, shared with the Gateway and therefore with the Cockpit and the phone
+    /// (<see cref="SessionOrdering"/> lives in CcDirector.Gateway.Contracts, which this app references).
+    ///
+    /// The desktop used to hand-roll three separate folds of its own - the strip read the hold flag, while
+    /// the label and the "waiting" clock read the activity state and the wingman colour and had never heard
+    /// of hold. That is why a snoozed session showed a grey strip next to a red "Your Turn" and a nagging
+    /// hours-long clock, while the phone correctly showed "Snoozed": four readings of the same session, and
+    /// nothing reconciled them. Calling the same function the other screens call makes agreement structural
+    /// instead of something we re-verify every release.
+    ///
+    /// Known gap (Phase 2b): SessionRole is derived by the Gateway from the WHOLE fleet - the Director
+    /// cannot know whether a controlled session's controller is alive on another machine - so it is absent
+    /// here until the Gateway pushes it down. Until then a live Worker's red is suppressed on the Cockpit
+    /// and the phone but still surfaces on this rail.
+    /// </summary>
+    private string EffectiveColor => SessionOrdering.EffectiveColor(FoldInput);
+
+    /// <summary>
+    /// The sidebar colour strip's brush: the shared fold's colour, mapped to this app's palette. Hold,
+    /// dictation, briefing and the activity colour are all folded by <see cref="SessionOrdering"/> - this
+    /// only picks the brush.
+    /// </summary>
+    public ISolidColorBrush StatusColorBrush => EffectiveColor switch
     {
-        get
-        {
-            if (Session.OnHold) return OnHoldStatusBrush;
-            // Issue #1181, Task 3b: a session receiving a dictation from the phone shows ORANGE, so the
-            // "a dictation is arriving" state is obvious at a glance in the rail (it overrides the base
-            // red "needs you", which would otherwise hide the fact that input is temporarily locked).
-            if (Session.IsReceivingDictation) return OrangeStatusBrush;
-            return (Session.StatusColor?.ToLowerInvariant()) switch
-            {
-                "green"  => GreenStatusBrush,
-                "blue"   => BlueStatusBrush,
-                "yellow" => YellowStatusBrush,
-                "red"    => RedStatusBrush,
-                "purple" => PurpleStatusBrush,
-                "orange" => OrangeStatusBrush,
-                "supporting" => SupportingStatusBrush,
-                "error"  => ErrorStatusBrush,
-                _        => UnknownStatusBrush,
-            };
-        }
-    }
+        "grey"       => Session.OnHold ? OnHoldStatusBrush : UnknownStatusBrush,
+        "green"      => GreenStatusBrush,
+        "blue"       => BlueStatusBrush,
+        "yellow"     => YellowStatusBrush,
+        "red"        => RedStatusBrush,
+        "purple"     => PurpleStatusBrush,
+        "orange"     => OrangeStatusBrush,
+        "supporting" => SupportingStatusBrush,
+        "error"      => ErrorStatusBrush,
+        _            => UnknownStatusBrush,
+    };
 
     /// <summary>True when the user has parked this session on hold. Drives the menu toggle
     /// label and the light-gray strip color.</summary>
@@ -190,9 +206,11 @@ public class SessionViewModel : INotifyPropertyChanged
 
     /// <summary>How long this session has been waiting on you, shown in the list only when red,
     /// so you can see at a glance WHICH needs-you session is the most stale and triage it first.
-    /// Proxied from the last briefing time (generated at turn-end, when the session goes red).</summary>
+    /// Proxied from the last briefing time (generated at turn-end, when the session goes red).
+    /// Reads the shared fold, NOT the raw wingman colour: a snoozed session is not red and must not nag
+    /// with an hours-long clock - that mismatch is exactly what this change removes.</summary>
     public bool HasWaitingDuration =>
-        string.Equals(Session.StatusColor, "red", StringComparison.OrdinalIgnoreCase)
+        string.Equals(EffectiveColor, "red", StringComparison.OrdinalIgnoreCase)
         && Session.CachedExplainAt is not null;
 
     public string WaitingDurationLabel
@@ -274,8 +292,12 @@ public class SessionViewModel : INotifyPropertyChanged
         }
     }
 
-    public string ActivityLabel =>
-        ActivityLabels.TryGetValue(Session.ActivityState, out var label) ? label : "Unknown";
+    /// <summary>
+    /// The session's state in words. The shared fold's label - the SAME string the Cockpit and the phone
+    /// render - so a session cannot read "Your Turn" here and "Snoozed" there. This used to read the raw
+    /// activity state and therefore had no idea the session was held.
+    /// </summary>
+    public string ActivityLabel => SessionOrdering.StateLabel(FoldInput);
 
     public ISolidColorBrush ActivityBrush =>
         ActivityBrushes.TryGetValue(Session.ActivityState, out var brush) ? brush : Brushes.Gray;

--- a/src/CcDirector.ControlApi/CcDirector.ControlApi.csproj
+++ b/src/CcDirector.ControlApi/CcDirector.ControlApi.csproj
@@ -27,6 +27,13 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="CcDirector.Gateway.Tests" />
+    <!-- The desktop rail renders the SAME presentation fold (SessionOrdering) the Gateway serves to the
+         Cockpit and the phone, so all three screens cannot disagree about a session's colour and label.
+         The fold takes a SessionDto, and ControlEndpoints.Map is the ONE mapper that builds one from a live
+         Session - the desktop reuses it rather than hand-rolling a second projection, which is exactly the
+         drift this change removes. See docs/architecture/session-state-machine-2026-07-14.html. -->
+    <!-- The desktop app's ASSEMBLY name, not its project name (see its AssemblyName property). -->
+    <InternalsVisibleTo Include="cc-director" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -724,7 +724,8 @@ public sealed class ControlApiHost : IAsyncDisposable
     private void WireDoorbellPush()
     {
         void Attach(Core.Sessions.Session session)
-            => session.OnActivityStateChanged += (_, newState) =>
+        {
+            session.OnActivityStateChanged += (_, newState) =>
             {
                 var eventName = newState switch
                 {
@@ -738,6 +739,16 @@ public sealed class ControlApiHost : IAsyncDisposable
                 // Issue #1176 (Phase 1a): push the changed session up the stream as a delta.
                 _streamClient?.NotifyDelta(ControlEndpoints.Map(session, DirectorId));
             };
+            // A hold change is a state change like any other, so it pushes like any other. Without this the
+            // Director set the flag, answered the caller, and told the Gateway NOTHING: a hold toggle that
+            // rode no activity change stayed invisible to every OTHER screen until the next 10-second
+            // re-push - and because the Gateway derives each session's color and triage bucket from this
+            // flag when it serves the roster, the session also sorted into the wrong bucket for that whole
+            // window. Fires on every HoldState transition, including None <-> DeferredHold, which leaves
+            // OnHold untouched but does change the label clients render.
+            session.HoldStateChanged += _ =>
+                _streamClient?.NotifyDelta(ControlEndpoints.Map(session, DirectorId));
+        }
 
         _sessionManager.OnSessionCreated += session =>
         {

--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -293,9 +293,17 @@ internal static class SessionCommandExecutor
         if (session is null)
             return DirectorCommandResult.Fail(DirectorCommandStatus.NotFound, "session not found");
 
-        session.OnHold = onHold;
-        FileLog.Write($"[SessionCommandExecutor] hold: session={guid} onHold={onHold}");
-        return DirectorCommandResult.Success(Serialize(new HoldResponse { OnHold = session.OnHold }));
+        // RequestHold runs the hold state machine rather than poking a flag: a hold that arrives while the
+        // agent is working is DEFERRED and lands when the work stops ("hold my session when it finishes"),
+        // instead of parking a session that is visibly still running. An immediate hold / un-hold is
+        // unchanged. See docs/architecture/session-state-machine-2026-07-14.html.
+        var outcome = session.RequestHold(onHold);
+        FileLog.Write($"[SessionCommandExecutor] hold: session={guid} onHold={onHold} outcome={outcome} state={session.HoldState}");
+        return DirectorCommandResult.Success(Serialize(new HoldResponse
+        {
+            OnHold = session.OnHold,
+            Pending = outcome == Session.HoldOutcome.Pending,
+        }));
     }
 
     /// <summary>

--- a/src/CcDirector.Core.Tests/SessionInteractiveTests.cs
+++ b/src/CcDirector.Core.Tests/SessionInteractiveTests.cs
@@ -46,14 +46,73 @@ public sealed class SessionInteractiveTests
         Assert.Equal(new byte[] { 0x1b, (byte)'[', (byte)'A' }, backend.Writes[0]);
     }
 
-    // ---- #470 typing into a held session takes it off Hold ----
+    // ================= the hold state machine =================
+    // One field, three states: None / Held / DeferredHold. Design and diagram:
+    // docs/architecture/session-state-machine-2026-07-14.html. These tests walk every cell of the
+    // transition table in that document. Credit: the five deferred-hold cases come from pull request
+    // #1512 (session "Gateway Cleanup - Tunnel-Only Migration"), re-pointed at the live ActivityState.
+
+    // ---- THE RULE: a held session that starts working comes off hold, every time ----
+
+    [Fact]
+    public void HeldSession_ThatStartsWorking_LiftsTheHold()
+    {
+        var backend = new RecordingBackend();
+        using var s = NewSession(backend, ActivityState.Idle);
+        s.RequestHold(true);
+        Assert.True(s.OnHold);
+
+        // The agent comes back to life on its own - a background task landed, a sub-agent reported,
+        // the model resumed. Nobody submitted anything.
+        s.ApplyTerminalActivityState(ActivityState.Working);
+
+        Assert.False(s.OnHold);                       // it cannot be parked and working at once
+        Assert.Equal(HoldState.None, s.HoldState);
+    }
+
+    [Fact]
+    public void HeldSession_ThatStartsWorking_LiftsEvenWithNoSubmissionBehindIt()
+    {
+        // THE REGRESSION THIS MACHINE EXISTS TO KILL. Before, the lift was gated on a turn latch that
+        // was armed only by Enter and destroyed by any 10 seconds of terminal quiet - so an ordinary
+        // slow command mid-turn left the session able to work forever while still reading "Snoozed".
+        var backend = new RecordingBackend();
+        using var s = NewSession(backend, ActivityState.Working);
+
+        s.ApplyTerminalActivityState(ActivityState.WaitingForInput); // a 10s quiet gap MID-turn
+        s.ApplyTerminalActivityState(ActivityState.Working);         // output resumes
+        s.RequestHold(true);                                         // user snoozes it -> deferred
+        s.ApplyTerminalActivityState(ActivityState.WaitingForInput); // the turn really ends -> parks
+        Assert.True(s.OnHold);
+
+        s.ApplyTerminalActivityState(ActivityState.Working);         // it wakes up again
+        Assert.False(s.OnHold);                                      // and comes back. Every time.
+    }
+
+    [Fact]
+    public void HeldSession_LeftAlone_StaysHeld()
+    {
+        // The other half of the rule: silence is not work. A held session with no output sits held -
+        // measured on the live fleet, an idle Claude Code session is byte-silent for tens of minutes,
+        // so it never reaches Working and never lifts.
+        var backend = new RecordingBackend();
+        using var s = NewSession(backend, ActivityState.WaitingForInput);
+        s.RequestHold(true);
+
+        s.ApplyTerminalActivityState(ActivityState.Idle); // settling around, no work
+        Assert.True(s.OnHold);
+        s.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+        Assert.True(s.OnHold);
+    }
+
+    // ---- #470: a fresh submission supersedes any hold ----
 
     [Fact]
     public async Task SendTextAsync_OnHeldSession_ClearsOnHold()
     {
         var backend = new RecordingBackend();
-        using var s = NewSession(backend, ActivityState.Working);
-        s.OnHold = true;
+        using var s = NewSession(backend, ActivityState.Idle);
+        s.RequestHold(true);
 
         await s.SendTextAsync("hello");
 
@@ -64,8 +123,8 @@ public sealed class SessionInteractiveTests
     public void SendInput_WithSubmitByte_ClearsOnHold()
     {
         var backend = new RecordingBackend();
-        using var s = NewSession(backend, ActivityState.Working);
-        s.OnHold = true;
+        using var s = NewSession(backend, ActivityState.Idle);
+        s.RequestHold(true);
 
         s.SendInput(new byte[] { (byte)'h', (byte)'i', 0x0D }); // text + CR (Enter)
 
@@ -76,8 +135,8 @@ public sealed class SessionInteractiveTests
     public void SendInput_BareKeystroke_LeavesOnHold()
     {
         var backend = new RecordingBackend();
-        using var s = NewSession(backend, ActivityState.Working);
-        s.OnHold = true;
+        using var s = NewSession(backend, ActivityState.Idle);
+        s.RequestHold(true);
 
         s.SendInput(new byte[] { (byte)'h', (byte)'i' }); // composing - no CR/LF
 
@@ -88,8 +147,8 @@ public sealed class SessionInteractiveTests
     public async Task SendTextAsync_OnHeldSession_RaisesOnHoldChangedOnceWithFalse()
     {
         var backend = new RecordingBackend();
-        using var s = NewSession(backend, ActivityState.Working);
-        s.OnHold = true;
+        using var s = NewSession(backend, ActivityState.Idle);
+        s.RequestHold(true);
         var events = new List<bool>();
         s.OnHoldChanged += value => events.Add(value);
 
@@ -99,70 +158,113 @@ public sealed class SessionInteractiveTests
         Assert.False(events[0]);        // with value false
     }
 
-    // ---- Hold auto-lift on turns: the OUT-of-a-turn edge ----
-    // A snoozed session must come off hold when the agent FINISHES a real turn and lands at a
-    // "needs you" settle - so a session parked mid-work cannot silently sit there needing the user.
-    // The lift is anchored to a real submission, so the periodic cosmetic terminal repaints (which
-    // reach WaitingForInput with no submission behind them) never break the hold.
+    // ---- DeferredHold: "hold my session when it finishes what it is doing" (credit: #1512) ----
 
     [Fact]
-    public async Task TurnEnd_AfterMidWorkSnooze_LiftsHold()
+    public async Task RequestHold_MidTurn_IsDeferred_ThenAppliesDurablyAtRedSettle()
     {
         var backend = new RecordingBackend();
         using var s = NewSession(backend, ActivityState.Working);
 
-        await s.SendTextAsync("do the thing"); // real submission arms the turn (also clears hold on the way in)
-        s.OnHold = true;                        // user snoozes WHILE it is still working
+        await s.SendTextAsync("do the thing");
+        var outcome = s.RequestHold(true);      // user says "hold this" WHILE it is working
 
-        s.ApplyTerminalActivityState(ActivityState.WaitingForInput); // agent finishes -> needs you
+        Assert.Equal(Session.HoldOutcome.Pending, outcome);
+        Assert.Equal(HoldState.DeferredHold, s.HoldState);
+        Assert.False(s.OnHold);                 // not parked yet - it is still visibly working
 
-        Assert.False(s.OnHold); // the completed turn took it off hold
+        s.ApplyTerminalActivityState(ActivityState.WaitingForInput); // turn ends -> red "needs you"
+        Assert.True(s.OnHold);                  // the deferral landed
+        Assert.Equal(HoldState.Held, s.HoldState);
     }
 
     [Fact]
-    public async Task TurnEnd_WaitingForPerm_LiftsHold()
+    public async Task RequestHold_MidTurn_AppliesAtIdleSettleToo()
     {
         var backend = new RecordingBackend();
         using var s = NewSession(backend, ActivityState.Working);
 
-        await s.SendTextAsync("run it");
-        s.OnHold = true;
+        await s.SendTextAsync("go");
+        s.RequestHold(true);
 
-        s.ApplyTerminalActivityState(ActivityState.WaitingForPerm); // agent stops to ask permission
-
-        Assert.False(s.OnHold);
+        s.ApplyTerminalActivityState(ActivityState.Idle); // turn ends at ready, not "needs you"
+        Assert.True(s.OnHold);                            // still parks held
     }
 
     [Fact]
-    public void CosmeticRepaint_OnHeldIdleSession_KeepsHold()
+    public void RequestHold_WhenSettled_HoldsImmediately()
     {
         var backend = new RecordingBackend();
         using var s = NewSession(backend, ActivityState.Idle);
-        s.OnHold = true; // parked while idle - no turn in flight
 
-        // A periodic Claude repaint: a byte blip to Working, then settling straight back to needs-you.
-        s.ApplyTerminalActivityState(ActivityState.Working);
-        s.ApplyTerminalActivityState(ActivityState.WaitingForInput);
-
-        Assert.True(s.OnHold); // no real submission behind it -> the hold survives the repaint
+        var outcome = s.RequestHold(true); // not working
+        Assert.Equal(Session.HoldOutcome.Held, outcome);
+        Assert.True(s.OnHold);
     }
 
     [Fact]
-    public async Task TurnEndingAtIdle_ConsumesArming_SoLaterRepaintCannotLiftHold()
+    public async Task RequestHold_False_ReleasesAndClearsAPendingDefer()
     {
         var backend = new RecordingBackend();
         using var s = NewSession(backend, ActivityState.Working);
 
-        await s.SendTextAsync("go"); // arms the turn
-        s.OnHold = true;
+        await s.SendTextAsync("go");
+        s.RequestHold(true);                          // deferred
+        var outcome = s.RequestHold(false);           // user changes their mind before it lands
 
-        s.ApplyTerminalActivityState(ActivityState.Idle); // quiet return to ready - not a "needs you" settle
-        Assert.True(s.OnHold);       // a turn ending at ready does not surface a held session
+        Assert.Equal(Session.HoldOutcome.Released, outcome);
+        Assert.Equal(HoldState.None, s.HoldState);
 
-        // The arming was consumed at the Idle settle, so a later cosmetic repaint cannot pose as a turn-end.
-        s.ApplyTerminalActivityState(ActivityState.Working);
-        s.ApplyTerminalActivityState(ActivityState.WaitingForInput);
-        Assert.True(s.OnHold);
+        s.ApplyTerminalActivityState(ActivityState.WaitingForInput); // turn ends
+        Assert.False(s.OnHold); // the cleared deferral is NOT resurrected
+    }
+
+    [Fact]
+    public async Task RequestHold_PendingDefer_IsSupersededByANewSubmission()
+    {
+        var backend = new RecordingBackend();
+        using var s = NewSession(backend, ActivityState.Working);
+
+        await s.SendTextAsync("first");
+        s.RequestHold(true);             // deferred
+        await s.SendTextAsync("second"); // a fresh submission - the user is driving again
+
+        s.ApplyTerminalActivityState(ActivityState.WaitingForInput); // that turn ends
+        Assert.False(s.OnHold); // the superseded deferral did not apply
+    }
+
+    [Fact]
+    public async Task RequestHold_Deferred_IsDroppedIfTheSessionExits()
+    {
+        // A deferral has nothing to come back to once the agent is gone; parking a dead session would
+        // just hide it behind a "Snoozed" label forever.
+        var backend = new RecordingBackend();
+        using var s = NewSession(backend, ActivityState.Working);
+
+        await s.SendTextAsync("go");
+        s.RequestHold(true);
+
+        s.ApplyTerminalActivityState(ActivityState.Exited);
+        Assert.False(s.OnHold);
+        Assert.Equal(HoldState.None, s.HoldState);
+    }
+
+    [Fact]
+    public void RequestHold_WhileWorking_DoesNotRaiseOnHoldChanged_ButDoesRaiseHoldStateChanged()
+    {
+        // None -> DeferredHold parks nothing, so the "is it parked?" listeners (rail strip, FIFO
+        // conductor) must not fire. The push to the Gateway must, because the LABEL changes.
+        var backend = new RecordingBackend();
+        using var s = NewSession(backend, ActivityState.Working);
+        var parked = new List<bool>();
+        var states = new List<HoldState>();
+        s.OnHoldChanged += v => parked.Add(v);
+        s.HoldStateChanged += st => states.Add(st);
+
+        s.RequestHold(true);
+
+        Assert.Empty(parked);
+        Assert.Equal(new[] { HoldState.DeferredHold }, states);
     }
 
     // ---- #5 PTY resize guard ----
@@ -204,10 +306,13 @@ public sealed class SessionInteractiveTests
     {
         var backend = new RecordingBackend();
         using var s = NewSession(backend, ActivityState.Working);
-        s.OnHold = true;
+        s.RequestHold(true); // asked for while working -> deferred, lands at the Idle settle below
         s.PromptQueue.Enqueue("held");
 
+        // The deferral must land BEFORE the drain check on this same transition, or a session the user
+        // just parked would immediately fire the next queued prompt at it.
         s.ApplyTerminalActivityState(ActivityState.Idle);
+        Assert.True(s.OnHold);
 
         await Task.Delay(250);
         Assert.Empty(backend.SentTexts);

--- a/src/CcDirector.Core/Sessions/HoldState.cs
+++ b/src/CcDirector.Core/Sessions/HoldState.cs
@@ -1,0 +1,44 @@
+namespace CcDirector.Core.Sessions;
+
+/// <summary>
+/// Where a session sits in the hold ("Snooze") state machine - the user's "I do not want to deal with
+/// this one right now". Design and diagram: docs/architecture/session-state-machine-2026-07-14.html.
+///
+/// The whole machine, driven by two things: what the user pressed, and whether the agent is working
+/// (<see cref="ActivityState"/>, the authoritative live fact - never a latch):
+///
+/// <code>
+///                      +---------------- it starts working ----------------+
+///                      v                                                   |
+///   [None] --- Snooze pressed while settled -------------------------> [Held]
+///     ^                                                                    ^
+///     |--- Unsnooze pressed ---------------------------------------------- |
+///     |                                                                    |
+///     |--- you send a prompt (supersedes) ---+                             |
+///     |                                      |                             |
+///     +--- Snooze pressed while working -> [DeferredHold] --- it stops ----+
+/// </code>
+///
+/// The load-bearing edge is Held + it starts working -> None: a held session that comes back to life
+/// takes itself off hold, every time, and its snooze timer is cancelled with it. A session can never be
+/// simultaneously held and working - that combination is unreachable by construction, which is the point.
+/// </summary>
+public enum HoldState
+{
+    /// <summary>Not held. The session's own activity state is the whole story.</summary>
+    None = 0,
+
+    /// <summary>
+    /// Parked by the user: shown as "Snoozed", sunk to the bottom of the roster, skipped by the FIFO
+    /// conductor, and never raised as "needs you". Left the instant the agent starts working again.
+    /// </summary>
+    Held = 1,
+
+    /// <summary>
+    /// The user pressed Snooze while the agent was working: "hold this one when it finishes". NOT parked
+    /// yet - the session is still working and still reads as working on every screen - but it parks
+    /// (-&gt; <see cref="Held"/>) the moment the work stops. Superseded by a fresh prompt, and dropped if
+    /// the session exits (there is no turn left to come back to).
+    /// </summary>
+    DeferredHold = 2,
+}

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -560,40 +560,98 @@ public sealed class Session : IDisposable
     public bool VoiceMode => ViewMode == MobileViewMode.Voice;
 
     /// <summary>
-    /// True when the user has explicitly parked this session in the FIFO voice queue:
-    /// "I do not want to deal with this one right now." A user override that is
-    /// ORTHOGONAL to <see cref="ActivityState"/> and <see cref="StatusColor"/> - the
-    /// terminal-state detector keeps reporting the true underlying state, and this flag
-    /// sits on top of it so the FIFO conductor can skip held sessions without the
-    /// detector ever clobbering the intent. Cleared when the user takes it off hold.
-    /// Runtime-only (not persisted across a Director restart): it tracks what the user
-    /// is currently choosing to defer, not durable session state. Off by default.
+    /// Where this session sits in the hold state machine: the user's "I do not want to deal with this one
+    /// right now". Design and diagram: docs/architecture/session-state-machine-2026-07-14.html.
+    ///
+    /// This ONE field replaces what used to be three that could disagree (a public OnHold flag, a private
+    /// turn-in-flight latch gating the auto-lift, and a private pending-hold flag). Both questions the hold
+    /// has to answer - "should this hold be deferred?" and "may this hold lift?" - now read the same
+    /// authoritative fact, <see cref="ActivityState"/>, so they cannot fall out of step with each other.
+    ///
+    /// Runtime-only (not persisted across a Director restart): it tracks what the user is currently
+    /// choosing to defer, not durable session state.
     /// </summary>
-    public bool OnHold
+    public HoldState HoldState
     {
-        get => _onHold;
-        set
+        get => _holdState;
+        private set
         {
-            if (_onHold == value) return;
-            _onHold = value;
-            OnHoldChanged?.Invoke(value);
+            if (_holdState == value) return;
+            var wasOnHold = OnHold;
+            _holdState = value;
+            // OnHoldChanged is the "is it parked?" signal (rail strip, FIFO conductor), so it fires only
+            // when that answer actually flips - None <-> DeferredHold does not park anything.
+            if (OnHold != wasOnHold) OnHoldChanged?.Invoke(OnHold);
+            // HoldStateChanged fires on EVERY transition: a client's label distinguishes DeferredHold
+            // ("Working, snoozing when done") from None, so it must hear about that edge too.
+            HoldStateChanged?.Invoke(value);
         }
     }
-    private bool _onHold;
+    private HoldState _holdState;
 
     /// <summary>
-    /// True while a genuine, submitted turn is underway: set when a real submission enters the session
-    /// (a human Enter, or a delivered prompt/message), and cleared the moment the session settles again.
-    /// It is the anchor that lets a turn-END lift the Hold (the agent finishing a turn takes the session
-    /// off hold) WITHOUT the cosmetic terminal repaints - which flicker Working -> WaitingForInput with no
-    /// submission behind them - ever clearing it. Runtime-only, same lifetime semantics as <see cref="OnHold"/>.
+    /// True when the session is parked right now. Derived from <see cref="HoldState"/>; a DeferredHold is
+    /// NOT parked yet - the user asked for it while the agent was working and it lands when the work stops.
+    /// Read-only: every transition goes through <see cref="RequestHold"/> or the machine in
+    /// <see cref="SetActivityState"/>, so no caller can put the state machine into a state it cannot reach.
     /// </summary>
-    private bool _turnInFlight;
+    public bool OnHold => _holdState == HoldState.Held;
+
+    /// <summary>True when the agent is producing output right now. The single authoritative input to the
+    /// hold machine: it decides both whether an incoming hold defers and whether a held session lifts.
+    /// Starting counts as working - a session that has not settled yet has a turn ahead of it.</summary>
+    private bool IsWorking => ActivityState is ActivityState.Working or ActivityState.Starting;
 
     /// <summary>Fires when <see cref="OnHold"/> changes. Arg: new value. The desktop
-    /// session list subscribes so the color strip can repaint dark blue (held) without
+    /// session list subscribes so the color strip can repaint (held) without
     /// the wingman touching <see cref="StatusColor"/>; OnHold sits on top of it.</summary>
     public event Action<bool>? OnHoldChanged;
+
+    /// <summary>Fires on EVERY <see cref="HoldState"/> transition, including ones that leave
+    /// <see cref="OnHold"/> unchanged (None &lt;-&gt; DeferredHold). The Control API subscribes so a hold
+    /// change is pushed to the Gateway the instant it happens, exactly as an activity change already is -
+    /// without it, a hold toggle is invisible to every other screen until the next 10-second heartbeat.</summary>
+    public event Action<HoldState>? HoldStateChanged;
+
+    /// <summary>Outcome of a <see cref="RequestHold"/> call.</summary>
+    public enum HoldOutcome
+    {
+        /// <summary>The hold was applied immediately (the session was not working).</summary>
+        Held,
+        /// <summary>The session was working, so the hold was DEFERRED and lands when the work stops.</summary>
+        Pending,
+        /// <summary>The session was taken OFF hold, clearing any pending deferral too.</summary>
+        Released,
+    }
+
+    /// <summary>
+    /// Request an EXPLICIT hold / un-hold - the user pressing Snooze. Un-hold clears the hold and any
+    /// pending deferral at once. A hold requested while the agent is WORKING is deferred (the user's "hold
+    /// this one when it finishes"); a hold requested while it is settled applies immediately. Returns which
+    /// of those happened so the caller's button can say what it did.
+    ///
+    /// The defer decision reads <see cref="IsWorking"/> - the live state - deliberately NOT a turn latch.
+    /// The old latch was armed only by a submitted turn and destroyed by any 10 seconds of terminal quiet
+    /// (see TerminalStateDetector.QuietThreshold), which an ordinary slow command produces mid-turn, so a
+    /// hold requested after such a gap read as "no turn in flight" and was applied immediately instead of
+    /// deferred - and could then never lift itself.
+    /// </summary>
+    public HoldOutcome RequestHold(bool onHold)
+    {
+        if (!onHold)
+        {
+            HoldState = HoldState.None;
+            return HoldOutcome.Released;
+        }
+        if (IsWorking)
+        {
+            FileLog.Write($"[Session] Hold requested while working - deferring until it stops: session={Id}");
+            HoldState = HoldState.DeferredHold;
+            return HoldOutcome.Pending;
+        }
+        HoldState = HoldState.Held;
+        return HoldOutcome.Held;
+    }
 
     /// <summary>
     /// Whether this session participates in the Wingman experience: the auto-explain
@@ -1562,12 +1620,10 @@ public sealed class Session : IDisposable
         if (ContainsSubmit(data))
         {
             IsBrandNew = false;
-            // A real submission means the user is driving this session again, so a
-            // stale Hold deferral no longer reflects intent -- clear it (issue #470).
-            // The OnHold setter no-ops + skips OnHoldChanged when already false.
-            OnHold = false;
-            // A real turn is now underway; arm the turn-END hold lift (see SetActivityState).
-            _turnInFlight = true;
+            // A real submission means the user is driving this session again, so neither a hold nor a
+            // not-yet-landed deferral reflects intent any more - both are superseded (issue #470).
+            // The HoldState setter no-ops when already None.
+            HoldState = HoldState.None;
             SetActivityState(ActivityState.Working);
         }
     }
@@ -1674,12 +1730,10 @@ public sealed class Session : IDisposable
             await _backend.SendTextAsync(text);
         }
         IsBrandNew = false;
-        // A SendTextAsync is always a submitted turn -- the user is driving this
-        // session again, so clear any stale Hold deferral (issue #470). The OnHold
-        // setter no-ops + skips OnHoldChanged when already false.
-        OnHold = false;
-        // A real turn is now underway; arm the turn-END hold lift (see SetActivityState).
-        _turnInFlight = true;
+        // A SendTextAsync is always a submitted turn -- the user is driving this session again, so both a
+        // hold and a not-yet-landed deferral are superseded (issue #470). The HoldState setter no-ops when
+        // already None.
+        HoldState = HoldState.None;
         SetActivityState(ActivityState.Working);
         // DevThrottle Stats: a SendTextAsync is exactly one submitted turn. Count it (plus its character
         // volume) for the tagged origin. Null origin = framework-internal (handover, queue drain) - not
@@ -1795,24 +1849,45 @@ public sealed class Session : IDisposable
         var old = ActivityState;
         if (old == newState) return;
         ActivityState = newState;
-        // Hold auto-lift on turns: a genuine turn boundary takes a snoozed session OFF hold so it can
-        // never silently change state under the user. The INTO-a-turn edge is handled at the submission
-        // sites (SendInput / SendTextAsync clear OnHold as the turn starts, so the user sees it go blue
-        // right away); this is the OUT-of-a-turn edge - the agent finishing a real turn and landing at a
-        // "needs you" settle. It is gated on _turnInFlight so the periodic cosmetic repaints (which reach
-        // WaitingForInput with no submission behind them) never lift the hold. _turnInFlight is consumed on
-        // ANY settle, including a quiet return to Idle, so a stale flag cannot let a later repaint pose as a
-        // turn-end.
-        if (newState is ActivityState.WaitingForInput or ActivityState.WaitingForPerm
-            or ActivityState.Idle or ActivityState.Exited)
+        // ===== The hold state machine's activity edges (docs/architecture/session-state-machine-2026-07-14.html).
+        // ActivityState has already been assigned above, so IsWorking below reads the NEW state.
+        if (IsWorking)
         {
-            if (_turnInFlight && newState is ActivityState.WaitingForInput or ActivityState.WaitingForPerm)
+            // THE RULE: a held session that starts working takes itself off hold, every time, with no
+            // condition attached. A session cannot be both held and working - the user would see a parked
+            // session quietly doing work, which is exactly the lie this machine exists to make impossible.
+            //
+            // This is safe against cosmetic repaints - the concern the old turn-latch was built to handle -
+            // because the detector no longer reports cosmetic Working. Both of its paths filter noise before
+            // they get here: for a byte-silent-idle agent a byte IS real output, and for an agent with an
+            // animated idle footer the continuous-idle path diffs the screen BODY and stays silent on
+            // footer-only repaints (see TerminalStateDetector). The GitHubActions backend's ActivitySink is
+            // authoritative run status. So reaching Working means real work, on every path.
+            if (HoldState == HoldState.Held)
             {
-                if (OnHold)
-                    FileLog.Write($"[Session] Turn ended ({newState}) - lifting hold: session={Id}");
-                OnHold = false;
+                FileLog.Write($"[Session] Session started working - lifting hold: session={Id}");
+                HoldState = HoldState.None;
             }
-            _turnInFlight = false;
+            // A DeferredHold deliberately survives here: it is WAITING for this work to stop.
+        }
+        else if (newState is ActivityState.Exited)
+        {
+            // Exited: a deferral can never land - there is no turn to come back to, and parking a dead
+            // session would just hide it behind a "Snoozed" label forever.
+            if (HoldState == HoldState.DeferredHold)
+                HoldState = HoldState.None;
+        }
+        else
+        {
+            // Settled (WaitingForInput / WaitingForPerm / Idle): a deferred hold lands DURABLY. There is no
+            // turn-end auto-lift any more - the lift edge moved to "starts working" above, which is both
+            // earlier (the user sees it go blue immediately) and immune to the quiet-gap problem that made
+            // the old turn-end lift unreachable after any slow command.
+            if (HoldState == HoldState.DeferredHold)
+            {
+                FileLog.Write($"[Session] Deferred hold landed at settle ({newState}): session={Id}");
+                HoldState = HoldState.Held;
+            }
         }
         // A real activity change ends any Wingman "running in the background" overlay: once the
         // terminal produces output again (Working), or the session otherwise leaves the parked

--- a/src/CcDirector.Gateway.Contracts/HoldRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/HoldRequest.cs
@@ -27,4 +27,12 @@ public sealed class HoldRequest
 public sealed class HoldResponse
 {
     public bool OnHold { get; set; }
+
+    /// <summary>
+    /// True when an explicit hold was DEFERRED because the agent was working: the session is not held yet
+    /// (<see cref="OnHold"/> is still false), but it parks the moment the work stops. Lets the caller's
+    /// button say "it'll hold when it finishes what it's doing" instead of implying it is already held.
+    /// False for an immediate hold, an un-hold, or a Director that predates this field.
+    /// </summary>
+    public bool Pending { get; set; }
 }

--- a/src/CcDirector.Gateway.Tests/DesktopGatewayFoldAgreementTests.cs
+++ b/src/CcDirector.Gateway.Tests/DesktopGatewayFoldAgreementTests.cs
@@ -1,0 +1,92 @@
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// The regression that started this work: the desktop rail and the phone showed DIFFERENT states for the
+/// same session at the same instant - six of thirteen sessions disagreed when measured on the live fleet
+/// on 14 July 2026. The desktop hand-rolled three private folds, and two of them had never heard of the
+/// hold flag, so a snoozed session rendered a grey strip next to a red "Your Turn" and an hours-long
+/// nagging clock, while the phone correctly showed "Snoozed".
+///
+/// The rows below are the ACTUAL diverging sessions from that measurement. Both screens now call the SAME
+/// fold (<see cref="SessionOrdering"/>), so the only honest assertion is that one function yields one
+/// answer per session. Anything that re-introduces a second reading fails here.
+///
+/// Design: docs/architecture/session-state-machine-2026-07-14.html
+/// </summary>
+public sealed class DesktopGatewayFoldAgreementTests
+{
+    /// <summary>A snoozed session as the Director reports it: the wingman's raw colour still says "red"
+    /// (the session genuinely IS at a turn end), which is exactly what the old rail read.</summary>
+    private static SessionDto Snoozed(string activityState) => new()
+    {
+        SessionId = "s",
+        ActivityState = activityState,
+        OnHold = true,
+        StatusColor = "red",
+    };
+
+    [Theory]
+    [InlineData("WaitingForInput")] // "Enrichment Facade Eval - Architect", "cc-consult - Perry", ...
+    [InlineData("WaitingForPerm")]
+    [InlineData("Idle")]
+    public void ASnoozedSession_ReadsSnoozed_AndIsNotRed_OnEveryScreen(string activityState)
+    {
+        var s = Snoozed(activityState);
+
+        // The raw fact the old rail folded on its own, and got wrong:
+        Assert.Equal("red", s.StatusColor);
+
+        // The one fold every screen now calls - one answer.
+        Assert.Equal("Snoozed", SessionOrdering.StateLabel(s));
+        Assert.Equal("grey", SessionOrdering.EffectiveColor(s));
+        Assert.Equal(SessionOrdering.TriageBucket.OnHold, SessionOrdering.Classify(s));
+
+        // ...and because the "waiting 10h" nag is gated on the FOLD being red rather than the raw colour,
+        // a snoozed session no longer nags. This is the assertion that pins the rail's third fold.
+        Assert.NotEqual("red", SessionOrdering.EffectiveColor(s));
+    }
+
+    [Fact]
+    public void ALiveWorker_IsRecessive_NotRed_OnEveryScreen()
+    {
+        // The "Tunnel-Only Review - Reviewer 2 (Codex)" row: a Worker parked at a turn end. The Gateway
+        // keeps Workers quiet so they surface to their manager rather than the human; the rail painted it
+        // red because it cannot see the role. Phase 2b pushes the role down so the rail reaches this same
+        // answer - this test pins what that answer must be.
+        var codex = new SessionDto
+        {
+            SessionId = "codex",
+            ActivityState = "WaitingForInput",
+            StatusColor = "red",
+            IsControlled = true,
+            ControllerSessionId = "manager",
+            SessionRole = SessionRoles.Worker,
+        };
+
+        Assert.Equal("supporting", SessionOrdering.EffectiveColor(codex));
+        Assert.Equal("Sub-agent", SessionOrdering.StateLabel(codex));
+    }
+
+    [Fact]
+    public void AWorkingSession_ReadsWorking_OnEveryScreen()
+    {
+        var s = new SessionDto { SessionId = "s", ActivityState = "Working", StatusColor = "blue" };
+
+        Assert.Equal("Working", SessionOrdering.StateLabel(s));
+        Assert.Equal("blue", SessionOrdering.EffectiveColor(s));
+    }
+
+    [Fact]
+    public void AHeldSession_CanNeverAlsoReadWorking()
+    {
+        // The invariant the hold state machine makes unreachable on the Director, asserted here at the
+        // presentation layer too: there is no input for which a screen shows a parked session working.
+        // (A session the user snoozed WHILE working is DeferredHold - not held - and reads as working,
+        // which is correct: it is still working.)
+        var held = Snoozed("Working"); // a state the machine cannot produce - belt and braces
+        Assert.NotEqual("Working", SessionOrdering.StateLabel(held));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/SessionCommandExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/SessionCommandExecutorTests.cs
@@ -283,7 +283,7 @@ public sealed class SessionCommandExecutorTests
         var (sm, session, _) = NewSession();
         try
         {
-            session.OnHold = true; // start held
+            session.RequestHold(true); // start held
             var command = new DirectorCommand
             {
                 Verb = "hold",


### PR DESCRIPTION
Follow-up to #1512, which made a deferred hold stick. That fix was correct but left the hold rules spread across several places that disagreed with each other. This unifies them.

Recovered work: these two commits were sitting on this machine's disk after the crash, committed but on no remote. They are pushed now regardless of when this merges.

## One hold state machine

Introduces `HoldState` (`None` / `Held` / `DeferredHold`) as the single type for "I do not want to deal with this one right now", driven by two inputs: what the user pressed, and whether the agent is actually working - the live fact, never a latch.

The load-bearing rule: **Held plus it starts working always collapses to None**. A held session that comes back to life takes itself off hold every time, and its snooze timer is cancelled with it. Held-and-working is unreachable by construction, which is the point.

`DeferredHold` keeps #1512's behaviour: pressing Snooze mid-turn parks the session when the work stops, is superseded by a fresh prompt, and drops if the session exits.

## The rail joins the shared fold

Measured on the live fleet: **six of thirteen sessions showed a different state on the desktop than on the phone at the same instant**. Five were snoozed sessions the rail painted red "Your Turn" with an hours-long nagging clock, while the phone correctly showed grey "Snoozed".

The Gateway has one fold (`SessionOrdering`) that decides colour and label together, and every browser client renders it. The desktop never joined - it hand-rolled three folds of its own, each reading different raw fields under different rules, and two had never heard of the hold flag:

| the colour strip | checked hold, then the wingman colour | knew about hold |
| the label | read the activity state alone | did not |
| the "waiting 10h" clock | read the wingman colour alone | did not |

One session, three readings, nothing reconciling them - hence a grey strip beside a red "Your Turn" in the same row. `SessionOrdering` already lives in `CcDirector.Gateway.Contracts`, which the desktop can reference, so the rail now calls the one shared fold and its three private ones are deleted. A new agreement test pins desktop and Gateway to the same answer.

## Verification

- `dotnet build src/CcDirector.Core` - succeeded, 0 warnings, 0 errors.
- `dotnet test --filter Hold|Snooze|Fold` - 48 passed, 0 failed.
- Full suite left to CI.

Design and diagram: `docs/architecture/session-state-machine-2026-07-14.html` (the 594-line version arrives with this branch; a stale 525-line snapshot was deliberately left out of #1536).

🤖 Generated with [Claude Code](https://claude.com/claude-code)