### PR TITLE
docs(cockpit): record the three settled decisions that survived nowhere on main

### DIFF
--- a/docs/architecture/cockpit-improvement-mission-2026-07-10.md
+++ b/docs/architecture/cockpit-improvement-mission-2026-07-10.md
@@ -43,6 +43,13 @@ machine-errors envelope; effective color and triage bucket are already stamped o
 5. The browser talks ONLY to the Gateway with relative addresses.
 6. No fallback programming; fail loudly with a clear message.
 7. Plain English everywhere - no abbreviations, no jargon. ASCII only in code and output.
+8. Fleet search filters by session TITLE only. Searching what sessions are actually doing
+   (terminal output or transcript content) is a noted follow-on, deliberately not in scope.
+9. Remote screen capture is OUT OF SCOPE for the Cockpit. Agents capture their own machine's
+   screen with their own tools (AgentEyes). The Cockpit only ever uploads an image from the
+   device the browser runs on.
+10. "Open in Explorer" and "Open in VS Code" are desktop-only actions and are NOT added to the
+    Cockpit session menu - the session may run on a remote machine.
 
 ## The one open dependency: the pull-request stack 1217 to 1226
 


### PR DESCRIPTION
Three lines, rescued from a branch that was about to be deleted.

## What happened

The approved six-phase Cockpit improvement plan exists only on `wip/shared-tree-snapshot-2026-07-10` - the same branch that claims, in its own commit message, that its contents are "proven duplicates of merged work". They are not.

All six phases are merged, deployed, and their issues closed, so the 214-line plan is a finished work order. It is deliberately **not** landed. But three of its settled decisions exist nowhere on main, and a memory instructs agents to read that plan before any Cockpit work - pointing at a file that is not there.

## The three

- **Fleet search is title-only.** Searching terminal output or transcript content is a deferred follow-on, not an oversight.
- **Remote screen capture is out of scope for the Cockpit.** Agents capture their own machine with AgentEyes; the Cockpit only uploads an image from the device the browser runs on.
- **Open in Explorer and Open in VS Code stay desktop-only.** The session may run on a remote machine.

Each is a "why doesn't the Cockpit just..." question waiting to be re-decided by someone who never saw the answer. That is exactly what a do-not-re-litigate list is for.

## Where they went

Appended to the existing do-not-re-litigate list in the mission brief, which is the document on main that the next agent will actually open. The plan's other three decisions (the Fleet page dying into the Fleet Map, the terminal staying plain, Chat and Voice as literal ports) are already covered by item 2 there, so they are not duplicated.

Verified pure ASCII, per the house rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)