### PR TITLE
release: v1.2.0 - session rename and close work again

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
   </PropertyGroup>
 </Project>

--- a/docs/public/release-notes/v1.2.0.md
+++ b/docs/public/release-notes/v1.2.0.md
@@ -1,0 +1,21 @@
+## v1.2.0 - July 14, 2026
+
+Repairs the session controls that v1.1.0 broke: you can rename, close, and message your sessions again, and voice, History, and the phone roster stop failing on longer replies.
+
+### Highlights
+
+- Renaming, closing, and messaging your whole team work again. In v1.1.0 these answered "not found" and there was no way around it. If you are on v1.1.0, this is the release you want.
+- Voice, History, and the phone's session list no longer break on longer replies. A size limit on the connection between your computers was cutting off anything large, which took these features down with it.
+- Tailscale is no longer needed to install or run DevThrottle. Your computers reach each other by dialling out, so nothing has to be installed or opened up first. It stays available as an option if you want to reach the Cockpit from outside your own machine.
+- DevThrottle installs and runs on a Mac. The installer places a proper Mac application, starts the launcher, and sets up the command line tools.
+- The desktop and the phone now agree on what a session is doing. Snoozed sessions were showing red "Your Turn" on the desktop with a nagging clock while the phone correctly showed them grey - on this fleet, six sessions in thirteen disagreed at the same moment. Both now read the same answer from one place.
+- Every prompt you send is checked to have actually gone in, not just the long ones.
+
+### Also in this release
+
+- Links can open in a different browser and profile per repository, so work links land in your work profile automatically. Picking a profile now asks what you meant - open it once, set it for this repository, or set it everywhere - instead of silently changing your default.
+- A session held while it is still working now stays held once it finishes, instead of quietly coming off hold. A held session that starts working again always takes itself off hold.
+- You can snooze a session for a length of time you choose.
+- Starting a session from the Cockpit lets you pick which agent to run.
+- Clearing screenshots now deletes the files from disk, after warning you.
+- The version number is correct again. v1.1.0 shipped without its version being raised, so a fixed build and a broken one both reported the same number and there was no way to tell them apart.


### PR DESCRIPTION
Repairs what v1.1.0 broke. **No new product code** - everything in these notes is already on main. This is the version bump plus the notes.

## Why the bump matters on its own

v1.1.0 shipped without `Directory.Build.props` being raised. So a fixed build from main and the broken shipped build **both report `"version":"1.1.0"`** - proven today by running them side by side:

| Director | `/fleet/spawn` | `/fleet/rename` | `/fleet/done` | reports |
|---|---|---|---|---|
| installed v1.1.0 (port 7879) | **201** | **404** | **404** | `1.1.0` |
| build from main (port 7880) | 201 | works | works | `1.1.0` |
| (control) fake route | - | 404 | 404 | - |

There was no way to tell which build you were running. 1.2.0 makes that answerable again - and it is the root of a full day of misdiagnosis, including my own.

## What v1.1.0 actually broke

Measured, not assumed: **starting sessions worked**; renaming and closing them did not. Earlier guidance (including mine, in thefrederiksen/devthrottle#1535) said the whole session surface was down. That was wrong, and thefrederiksen/devthrottle#1540 corrected it.

## Verification

All three operations proven end-to-end on a build from main (slot 5, port 7880):

- **start** - HTTP 201, session created
- **rename** - roster name changed from `devthrottle / 0e5a` to `Proof - Renamed OK`, confirmed by re-reading the roster rather than trusting the response
- **close** - reaper log: `Reaping session 0e5ac661 flagged for deletion (proof run complete)`, roster count back to 0

A rename issued at one Director travelled out to the Gateway, down the tunnel to the Director hosting the session, and took effect - so the tunnel path itself is proven, not just the route.

## Accuracy gate

Step 4 of the release-manager run-book changed one claim. The commit for thefrederiksen/devthrottle#1506 says Tailscale was "removed from install preflights", but `TailscalePreflight.Run()` is still invoked from `PrerequisiteChecker.cs:271`. It is now an **optional gateway-role row**, and the workstation checklist has no Tailscale row at all. The notes therefore say "no longer needed to install or run" rather than "removed". Every other headline was checked against running code.

## After merge

The tag is published by the human, from main, at the merged bump commit. Pushing the tag triggers the Release workflow, which builds and attaches the executable.

Known, not blocking: thefrederiksen/devthrottle_internal#801 (flaky tunnel backpressure test - fails on a slow runner, not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)