### PR TITLE
feat(sessions): restore the old REST API's session control to the agent surface

### DIFF
--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -577,9 +577,10 @@ internal static class ControlEndpoints
         // POST /sessions/{sid}/role route the tunnel-only cut removed, which left a running session stuck with
         // whatever role it was born with - Architect cannot be derived from the spawn graph, so there was no way
         // to make one after the fact. An unknown role is REJECTED (400) so a mistyped role never silently drops;
-        // an empty role CLEARS the explicit role back to auto-derivation. A remote target fails loud (502): the
-        // Gateway has no role route to relay to, and a silent no-op would be worse than a clear error.
-        app.MapPost("/fleet/role", (FleetRoleRequest req) =>
+        // an empty role CLEARS the explicit role back to auto-derivation. A target this Director does not host
+        // is relayed through the Gateway (POST /sessions/{sid}/role), which routes it to the owning Director
+        // over the tunnel - the same shape as /fleet/rename. Fails loud with no Gateway; never a silent no-op.
+        app.MapPost("/fleet/role", async (FleetRoleRequest req, CancellationToken ct) =>
         {
             if (req is null || string.IsNullOrWhiteSpace(req.ToSessionId))
                 return Results.BadRequest(new { error = "toSessionId is required" });
@@ -594,16 +595,41 @@ internal static class ControlEndpoints
                     error = $"unknown role '{req.Role}'. Valid roles: {string.Join(", ", SessionRoles.All)} (or empty to clear).",
                 });
 
+            var normalized = clearing ? null : SessionRoles.Normalize(req.Role);
+
             var local = sessionManager.GetSession(toGuid);
             if (local is null)
-                return Results.Json(new FleetRoleResponse
-                {
-                    Applied = false, SessionId = req.ToSessionId,
-                    Error = "Session not found on this Director. Setting a role on a session hosted by another "
-                          + "Director is not supported - run this against the Director that owns the session.",
-                }, statusCode: StatusCodes.Status502BadGateway);
+            {
+                // Not ours: relay through the Gateway, which routes it to the owning Director over the tunnel.
+                var gw = gatewayClientProvider?.Invoke();
+                if (gw is not { IsEnabled: true })
+                    return Results.Json(new FleetRoleResponse
+                    {
+                        Applied = false, SessionId = req.ToSessionId,
+                        Error = "Session not found on this Director and no Gateway is configured.",
+                    }, statusCode: StatusCodes.Status404NotFound);
 
-            var normalized = clearing ? null : SessionRoles.Normalize(req.Role);
+                try
+                {
+                    var relayed = await gw.SetRoleFleetAsync(req.ToSessionId, normalized, ct);
+                    return Results.Json(new FleetRoleResponse
+                    {
+                        Applied = true,
+                        SessionId = relayed.SessionId ?? req.ToSessionId,
+                        ExplicitRole = relayed.ExplicitRole,
+                    });
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[ControlEndpoints] /fleet/role relay to {toGuid} FAILED: {ex.Message}");
+                    return Results.Json(new FleetRoleResponse
+                    {
+                        Applied = false, SessionId = req.ToSessionId,
+                        Error = $"Cannot set the role via the Gateway: {ex.Message}",
+                    }, statusCode: StatusCodes.Status502BadGateway);
+                }
+            }
+
             FileLog.Write($"[ControlEndpoints] POST /fleet/role: session={toGuid}, role={normalized ?? "(cleared)"}");
             local.SetExplicitRole(normalized);
 

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -573,6 +573,52 @@ internal static class ControlEndpoints
             }
         });
 
+        // POST /fleet/role - declare a session's EXPLICIT role after birth. Restores the set-role verb off the
+        // POST /sessions/{sid}/role route the tunnel-only cut removed, which left a running session stuck with
+        // whatever role it was born with - Architect cannot be derived from the spawn graph, so there was no way
+        // to make one after the fact. An unknown role is REJECTED (400) so a mistyped role never silently drops;
+        // an empty role CLEARS the explicit role back to auto-derivation. A remote target fails loud (502): the
+        // Gateway has no role route to relay to, and a silent no-op would be worse than a clear error.
+        app.MapPost("/fleet/role", (FleetRoleRequest req) =>
+        {
+            if (req is null || string.IsNullOrWhiteSpace(req.ToSessionId))
+                return Results.BadRequest(new { error = "toSessionId is required" });
+            if (!Guid.TryParse(req.ToSessionId, out var toGuid))
+                return Results.BadRequest(new { error = "invalid toSessionId format" });
+
+            // Blank clears; a non-blank value must be one of the four known roles.
+            var clearing = string.IsNullOrWhiteSpace(req.Role);
+            if (!clearing && !SessionRoles.IsValid(req.Role))
+                return Results.BadRequest(new
+                {
+                    error = $"unknown role '{req.Role}'. Valid roles: {string.Join(", ", SessionRoles.All)} (or empty to clear).",
+                });
+
+            var local = sessionManager.GetSession(toGuid);
+            if (local is null)
+                return Results.Json(new FleetRoleResponse
+                {
+                    Applied = false, SessionId = req.ToSessionId,
+                    Error = "Session not found on this Director. Setting a role on a session hosted by another "
+                          + "Director is not supported - run this against the Director that owns the session.",
+                }, statusCode: StatusCodes.Status502BadGateway);
+
+            var normalized = clearing ? null : SessionRoles.Normalize(req.Role);
+            FileLog.Write($"[ControlEndpoints] POST /fleet/role: session={toGuid}, role={normalized ?? "(cleared)"}");
+            local.SetExplicitRole(normalized);
+
+            // Only the EXPLICIT role is reported back. The effective role folds in Worker/Manager derivation
+            // from the fleet-wide spawn graph, which lives in the Gateway - this Director cannot compute it,
+            // so reporting it here would always be null. Callers read it from the roster.
+            var dto = MapWithIdentity(local, turnSummaryCache);
+            return Results.Json(new FleetRoleResponse
+            {
+                Applied = true,
+                SessionId = dto.SessionId ?? "",
+                ExplicitRole = dto.ExplicitRole,
+            });
+        });
+
         // POST /fleet/done - flag a session anywhere in the fleet for teardown (issue #1490). A local target is
         // flagged directly (its Director's reaper removes it after the grace window); a remote target is relayed
         // through the Gateway (POST /sessions/{sid}/request-deletion). Restores `cc-devthrottle session done` -

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -573,6 +573,157 @@ internal static class ControlEndpoints
             }
         });
 
+        // The session-control verbs below restore what the old REST API offered agents and the tunnel-only cut
+        // took off the loopback surface. They are NOT new logic: a local target is dispatched through the SAME
+        // SessionCommandExecutor the tunnel dispatches into, so the loopback path and the Gateway path run
+        // identical code. A target this Director does not host is relayed through the Gateway, which routes it
+        // to the owning Director over the tunnel. No Gateway and not local is a loud 404 - never a silent no-op.
+
+        // POST /fleet/prompt - send text into a session (the old POST /sessions/{sid}/prompt). Unlike
+        // /fleet/send this does NOT frame the text with a sender: it is a raw prompt, exactly what a human
+        // typing into the session would produce.
+        app.MapPost("/fleet/prompt", async (FleetPromptRequest req, CancellationToken ct) =>
+        {
+            if (req is null || string.IsNullOrWhiteSpace(req.ToSessionId))
+                return Results.BadRequest(new { error = "toSessionId is required" });
+            if (string.IsNullOrEmpty(req.Text))
+                return Results.BadRequest(new { error = "text is required" });
+            if (!Guid.TryParse(req.ToSessionId, out var toGuid))
+                return Results.BadRequest(new { error = "invalid toSessionId format" });
+
+            if (sessionManager.GetSession(toGuid) is not null)
+            {
+                var command = new DirectorCommand
+                {
+                    Verb = "prompt",
+                    SessionId = req.ToSessionId,
+                    PayloadJson = JsonSerializer.Serialize(new PromptRequest { Text = req.Text, AppendEnter = req.AppendEnter }),
+                };
+                var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command, cancellationToken: ct);
+                return CommandResultToHttp(result);
+            }
+
+            var gw = gatewayClientProvider?.Invoke();
+            if (gw is not { IsEnabled: true })
+                return Results.Json(new { error = "Session not found on this Director and no Gateway is configured." },
+                    statusCode: StatusCodes.Status404NotFound);
+            try
+            {
+                await gw.SendPromptToFleetAsync(req.ToSessionId, req.Text, ct);
+                return Results.Json(new { accepted = true, sessionId = req.ToSessionId });
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[ControlEndpoints] /fleet/prompt relay to {toGuid} FAILED: {ex.Message}");
+                return Results.Json(new { error = $"Cannot prompt the target via the Gateway: {ex.Message}" },
+                    statusCode: StatusCodes.Status502BadGateway);
+            }
+        });
+
+        // POST /fleet/interrupt - stop what a session is doing (the old POST /sessions/{sid}/interrupt).
+        app.MapPost("/fleet/interrupt", async (FleetTargetRequest req, CancellationToken ct) =>
+        {
+            if (req is null || string.IsNullOrWhiteSpace(req.ToSessionId))
+                return Results.BadRequest(new { error = "toSessionId is required" });
+            if (!Guid.TryParse(req.ToSessionId, out var toGuid))
+                return Results.BadRequest(new { error = "invalid toSessionId format" });
+
+            if (sessionManager.GetSession(toGuid) is not null)
+            {
+                var command = new DirectorCommand { Verb = "interrupt", SessionId = req.ToSessionId };
+                var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command, cancellationToken: ct);
+                return CommandResultToHttp(result);
+            }
+
+            var gw = gatewayClientProvider?.Invoke();
+            if (gw is not { IsEnabled: true })
+                return Results.Json(new { error = "Session not found on this Director and no Gateway is configured." },
+                    statusCode: StatusCodes.Status404NotFound);
+            try
+            {
+                await gw.InterruptFleetAsync(req.ToSessionId, ct);
+                return Results.Json(new { accepted = true, sessionId = req.ToSessionId });
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[ControlEndpoints] /fleet/interrupt relay to {toGuid} FAILED: {ex.Message}");
+                return Results.Json(new { error = $"Cannot interrupt the target via the Gateway: {ex.Message}" },
+                    statusCode: StatusCodes.Status502BadGateway);
+            }
+        });
+
+        // POST /fleet/hold - park a session, or release it (the old POST /sessions/{sid}/hold). A hold asked
+        // for mid-turn is DEFERRED and applies when the turn settles (see HoldState) - the response's pending
+        // flag says so, which is why it is surfaced rather than swallowed.
+        app.MapPost("/fleet/hold", async (FleetHoldRequest req, CancellationToken ct) =>
+        {
+            if (req is null || string.IsNullOrWhiteSpace(req.ToSessionId))
+                return Results.BadRequest(new { error = "toSessionId is required" });
+            if (!Guid.TryParse(req.ToSessionId, out var toGuid))
+                return Results.BadRequest(new { error = "invalid toSessionId format" });
+
+            if (sessionManager.GetSession(toGuid) is not null)
+            {
+                var command = new DirectorCommand
+                {
+                    Verb = "hold",
+                    SessionId = req.ToSessionId,
+                    PayloadJson = JsonSerializer.Serialize(new HoldRequest { OnHold = req.OnHold, SnoozeMinutes = req.SnoozeMinutes }),
+                };
+                var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command, cancellationToken: ct);
+                return CommandResultToHttp(result);
+            }
+
+            var gw = gatewayClientProvider?.Invoke();
+            if (gw is not { IsEnabled: true })
+                return Results.Json(new { error = "Session not found on this Director and no Gateway is configured." },
+                    statusCode: StatusCodes.Status404NotFound);
+            try
+            {
+                var held = await gw.HoldFleetAsync(req.ToSessionId, req.OnHold, req.SnoozeMinutes, ct);
+                return Results.Json(held);
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[ControlEndpoints] /fleet/hold relay to {toGuid} FAILED: {ex.Message}");
+                return Results.Json(new { error = $"Cannot hold the target via the Gateway: {ex.Message}" },
+                    statusCode: StatusCodes.Status502BadGateway);
+            }
+        });
+
+        // GET /fleet/buffer?sessionId=... - read what a session's terminal is showing (the old GET
+        // /sessions/{sid}/buffer). How a manager sees what a worker is actually doing.
+        app.MapGet("/fleet/buffer", async (string? sessionId, CancellationToken ct) =>
+        {
+            if (string.IsNullOrWhiteSpace(sessionId))
+                return Results.BadRequest(new { error = "sessionId is required" });
+            if (!Guid.TryParse(sessionId, out var toGuid))
+                return Results.BadRequest(new { error = "invalid sessionId format" });
+
+            if (sessionManager.GetSession(toGuid) is not null)
+            {
+                var command = new DirectorCommand { Verb = "buffer", SessionId = sessionId };
+                var result = await SessionCommandExecutor.DispatchAsync(sessionManager, directorId, command, cancellationToken: ct);
+                return CommandResultToHttp(result);
+            }
+
+            var gw = gatewayClientProvider?.Invoke();
+            if (gw is not { IsEnabled: true })
+                return Results.Json(new { error = "Session not found on this Director and no Gateway is configured." },
+                    statusCode: StatusCodes.Status404NotFound);
+            try
+            {
+                var text = await gw.GetBufferFleetAsync(sessionId, ct);
+                return Results.Content(text, "application/json");
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[ControlEndpoints] /fleet/buffer relay to {toGuid} FAILED: {ex.Message}");
+                return Results.Json(new { error = $"Cannot read the target's buffer via the Gateway: {ex.Message}" },
+                    statusCode: StatusCodes.Status502BadGateway);
+            }
+        });
+
         // POST /fleet/role - declare a session's EXPLICIT role after birth. Restores the set-role verb off the
         // POST /sessions/{sid}/role route the tunnel-only cut removed, which left a running session stuck with
         // whatever role it was born with - Architect cannot be derived from the spawn graph, so there was no way
@@ -794,6 +945,21 @@ internal static class ControlEndpoints
         });
 
     }
+
+    /// <summary>
+    /// Map a <see cref="DirectorCommandResult"/> onto the HTTP shape the OLD REST endpoints returned, so a
+    /// caller sees the same status and { error } body it always did: Ok passes the handler's own JSON body
+    /// through, BadRequest/NotFound/Conflict keep their meaning, and anything else is a 500. Shared by every
+    /// /fleet session-control verb so they cannot drift apart from each other or from the tunnel path.
+    /// </summary>
+    private static IResult CommandResultToHttp(DirectorCommandResult result) => result.Status switch
+    {
+        DirectorCommandStatus.Ok => Results.Content(result.BodyJson ?? "{}", "application/json"),
+        DirectorCommandStatus.BadRequest => Results.BadRequest(new { error = result.Error }),
+        DirectorCommandStatus.NotFound => Results.NotFound(new { error = result.Error }),
+        DirectorCommandStatus.Conflict => Results.Json(new { error = result.Error }, statusCode: StatusCodes.Status409Conflict),
+        _ => Results.Json(new { error = result.Error ?? "command failed" }, statusCode: StatusCodes.Status500InternalServerError),
+    };
 
     // Gateway Cleanup CUT RESTORATION (SB-4a): the fleet-directory identity stamp. Restored with the /fleet
     // routes (MapWithIdentity uses it) so a fleet/sessions row carries this Director's machine/user/tailnet

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -259,6 +259,30 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
     }
 
     /// <summary>
+    /// Set a session's EXPLICIT role anywhere in the fleet, through the Gateway's POST
+    /// /sessions/{sid}/role, which routes it to the owning Director over the tunnel. Used by the local
+    /// POST /fleet/role for a target this Director does not host.
+    /// </summary>
+    public async Task<SessionDto> SetRoleFleetAsync(string toSessionId, string? role, CancellationToken ct = default)
+    {
+        if (!_config.IsEnabled)
+            throw new InvalidOperationException("Gateway is not configured; cannot reach a remote session.");
+        if (string.IsNullOrWhiteSpace(toSessionId))
+            throw new ArgumentException("Target session id is required", nameof(toSessionId));
+
+        FileLog.Write($"[GatewayClient] SetRoleFleetAsync: POST /sessions/{toSessionId}/role role={role ?? "(cleared)"}");
+        var body = new SetRoleRequest { Role = role };
+        using var resp = await _http.PostAsJsonAsync($"sessions/{toSessionId}/role", body, ct);
+        if (!resp.IsSuccessStatusCode)
+            throw new InvalidOperationException($"Gateway set-role of {toSessionId} returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+
+        var parsed = await resp.Content.ReadFromJsonAsync<SessionDto>(ct);
+        if (parsed is null)
+            throw new InvalidOperationException("Gateway set-role returned an unparsable body.");
+        return parsed;
+    }
+
+    /// <summary>
     /// Flag a session anywhere in the fleet for teardown via the Gateway's POST /sessions/{sid}/request-deletion,
     /// which routes to the owning Director over the tunnel. Issue #1490: the Director's loopback POST /fleet/done
     /// relays here for a non-local target. Throws when the Gateway is disabled or the call fails.

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -259,6 +259,67 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
     }
 
     /// <summary>
+    /// Interrupt a session anywhere in the fleet, through the Gateway's POST /sessions/{sid}/interrupt,
+    /// which routes it to the owning Director over the tunnel. Used by the local POST /fleet/interrupt for
+    /// a target this Director does not host.
+    /// </summary>
+    public async Task InterruptFleetAsync(string toSessionId, CancellationToken ct = default)
+    {
+        if (!_config.IsEnabled)
+            throw new InvalidOperationException("Gateway is not configured; cannot reach a remote session.");
+        if (string.IsNullOrWhiteSpace(toSessionId))
+            throw new ArgumentException("Target session id is required", nameof(toSessionId));
+
+        FileLog.Write($"[GatewayClient] InterruptFleetAsync: POST /sessions/{toSessionId}/interrupt");
+        using var resp = await _http.PostAsync($"sessions/{toSessionId}/interrupt", content: null, ct);
+        if (!resp.IsSuccessStatusCode)
+            throw new InvalidOperationException($"Gateway interrupt of {toSessionId} returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+    }
+
+    /// <summary>
+    /// Hold (or release) a session anywhere in the fleet, through the Gateway's POST /sessions/{sid}/hold,
+    /// which routes it to the owning Director over the tunnel. Used by the local POST /fleet/hold for a
+    /// target this Director does not host.
+    /// </summary>
+    public async Task<HoldResponse> HoldFleetAsync(string toSessionId, bool onHold, int? snoozeMinutes, CancellationToken ct = default)
+    {
+        if (!_config.IsEnabled)
+            throw new InvalidOperationException("Gateway is not configured; cannot reach a remote session.");
+        if (string.IsNullOrWhiteSpace(toSessionId))
+            throw new ArgumentException("Target session id is required", nameof(toSessionId));
+
+        FileLog.Write($"[GatewayClient] HoldFleetAsync: POST /sessions/{toSessionId}/hold onHold={onHold}");
+        var body = new HoldRequest { OnHold = onHold, SnoozeMinutes = snoozeMinutes };
+        using var resp = await _http.PostAsJsonAsync($"sessions/{toSessionId}/hold", body, ct);
+        if (!resp.IsSuccessStatusCode)
+            throw new InvalidOperationException($"Gateway hold of {toSessionId} returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+
+        var parsed = await resp.Content.ReadFromJsonAsync<HoldResponse>(ct);
+        if (parsed is null)
+            throw new InvalidOperationException("Gateway hold returned an unparsable body.");
+        return parsed;
+    }
+
+    /// <summary>
+    /// Read a session's terminal buffer anywhere in the fleet, through the Gateway's GET
+    /// /sessions/{sid}/buffer, which routes it to the owning Director over the tunnel. Used by the local
+    /// GET /fleet/buffer for a target this Director does not host.
+    /// </summary>
+    public async Task<string> GetBufferFleetAsync(string toSessionId, CancellationToken ct = default)
+    {
+        if (!_config.IsEnabled)
+            throw new InvalidOperationException("Gateway is not configured; cannot reach a remote session.");
+        if (string.IsNullOrWhiteSpace(toSessionId))
+            throw new ArgumentException("Target session id is required", nameof(toSessionId));
+
+        FileLog.Write($"[GatewayClient] GetBufferFleetAsync: GET /sessions/{toSessionId}/buffer");
+        using var resp = await _http.GetAsync($"sessions/{toSessionId}/buffer", ct);
+        if (!resp.IsSuccessStatusCode)
+            throw new InvalidOperationException($"Gateway buffer read of {toSessionId} returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+        return await resp.Content.ReadAsStringAsync(ct);
+    }
+
+    /// <summary>
     /// Set a session's EXPLICIT role anywhere in the fleet, through the Gateway's POST
     /// /sessions/{sid}/role, which routes it to the owning Director over the tunnel. Used by the local
     /// POST /fleet/role for a target this Director does not host.

--- a/src/CcDirector.Gateway.Contracts/FleetMessageRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/FleetMessageRequest.cs
@@ -140,6 +140,47 @@ public sealed class FleetRenameResponse
 }
 
 /// <summary>
+/// Body of POST /fleet/role on the Director. Declares a session's EXPLICIT role after birth - the set-role
+/// verb the tunnel-only cut removed with POST /sessions/{sid}/role, leaving a session stuck with whatever
+/// role it was born with. Architect cannot be derived from the spawn graph, so without this a running
+/// session can never become one.
+/// </summary>
+public sealed class FleetRoleRequest
+{
+    /// <summary>Target session GUID (defaults, at the CLI, to the caller itself).</summary>
+    public string ToSessionId { get; set; } = "";
+
+    /// <summary>
+    /// One of <see cref="SessionRoles.All"/> (case-insensitive). An empty or null value CLEARS the explicit
+    /// role, reverting the session to auto-derivation. An unknown value is REJECTED as a bad request so a
+    /// mistyped role never silently drops.
+    /// </summary>
+    public string? Role { get; set; }
+}
+
+/// <summary>Response from POST /fleet/role.</summary>
+public sealed class FleetRoleResponse
+{
+    /// <summary>True when the explicit role was applied.</summary>
+    public bool Applied { get; set; }
+
+    /// <summary>The target session's GUID.</summary>
+    public string SessionId { get; set; } = "";
+
+    /// <summary>The explicit role after the call, or null when it was cleared.</summary>
+    /// <remarks>
+    /// The EFFECTIVE role is deliberately not returned here. Worker and Manager are derived from the
+    /// fleet-wide spawn graph, which only the Gateway holds - a Director cannot compute it alone, so the
+    /// field would always be null. Read the effective role from the roster (GET /fleet/sessions), which
+    /// relays to the Gateway.
+    /// </remarks>
+    public string? ExplicitRole { get; set; }
+
+    /// <summary>Error message when Applied is false.</summary>
+    public string? Error { get; set; }
+}
+
+/// <summary>
 /// Body of POST /fleet/done on the Director (issue #1490). Flags a session anywhere in the fleet for
 /// asynchronous teardown by its owning Director's deletion reaper: flagged locally when the target lives on
 /// this machine, otherwise relayed through the Gateway (POST /sessions/{sid}/request-deletion). Restores the

--- a/src/CcDirector.Gateway.Contracts/FleetMessageRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/FleetMessageRequest.cs
@@ -140,6 +140,53 @@ public sealed class FleetRenameResponse
 }
 
 /// <summary>
+/// Body of POST /fleet/prompt on the Director: send raw text into a session anywhere in the fleet. Unlike
+/// <see cref="FleetSendRequest"/> this does NOT frame the text with a sender - it is exactly what a human
+/// typing into the session would produce. Restores the old POST /sessions/{sid}/prompt to the loopback
+/// surface the tunnel-only cut removed it from.
+/// </summary>
+public sealed class FleetPromptRequest
+{
+    /// <summary>Target session GUID anywhere in the fleet.</summary>
+    public string ToSessionId { get; set; } = "";
+
+    /// <summary>The text to send. Required.</summary>
+    public string Text { get; set; } = "";
+
+    /// <summary>
+    /// Whether to press Enter after the text. Defaults to true - a prompt normally submits. Named to match
+    /// <see cref="PromptRequest.AppendEnter"/>, which this is passed straight through to.
+    /// </summary>
+    public bool AppendEnter { get; set; } = true;
+}
+
+/// <summary>
+/// Body of a Director fleet verb whose only input is the target session (for example POST
+/// /fleet/interrupt).
+/// </summary>
+public sealed class FleetTargetRequest
+{
+    /// <summary>Target session GUID anywhere in the fleet.</summary>
+    public string ToSessionId { get; set; } = "";
+}
+
+/// <summary>
+/// Body of POST /fleet/hold on the Director: park a session, or release it. Restores the old POST
+/// /sessions/{sid}/hold to the loopback surface.
+/// </summary>
+public sealed class FleetHoldRequest
+{
+    /// <summary>Target session GUID anywhere in the fleet.</summary>
+    public string ToSessionId { get; set; } = "";
+
+    /// <summary>True to hold (the default), false to release.</summary>
+    public bool OnHold { get; set; } = true;
+
+    /// <summary>Optional timed snooze in minutes; null holds until something lifts it.</summary>
+    public int? SnoozeMinutes { get; set; }
+}
+
+/// <summary>
 /// Body of POST /fleet/role on the Director. Declares a session's EXPLICIT role after birth - the set-role
 /// verb the tunnel-only cut removed with POST /sessions/{sid}/role, leaving a session stuck with whatever
 /// role it was born with. Architect cannot be derived from the spawn graph, so without this a running

--- a/src/CcDirector.Gateway.Tests/FleetMessagingTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetMessagingTests.cs
@@ -253,6 +253,67 @@ public sealed class FleetMessagingEndpointTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 
+    // ===== /fleet/role validation (the set-role verb restored to the tunnel-only floor) =====
+
+    // A missing route returns 404, so a 400 from the HANDLER is itself the proof that /fleet/role is
+    // registered - the gap was that POST /sessions/{sid}/role was deleted in the tunnel-only cut, leaving a
+    // running session stuck with the role it was born with.
+    [Fact]
+    public async Task Fleet_role_missing_target_returns_400_provingRouteExists()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/role", new FleetRoleRequest { ToSessionId = "", Role = "Architect" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Fleet_role_bad_guid_returns_400()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/role",
+            new FleetRoleRequest { ToSessionId = "not-a-guid", Role = "Architect" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    // An unknown role must be REJECTED, not silently dropped - a mistyped --role that quietly did nothing is
+    // exactly how a session ends up with the wrong role and nobody notices.
+    [Fact]
+    public async Task Fleet_role_unknown_role_returns_400()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/role",
+            new FleetRoleRequest { ToSessionId = Guid.NewGuid().ToString(), Role = "Overlord" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    // Validation order matters: an unknown role is rejected as a bad request BEFORE the session lookup, so a
+    // typo is reported as a typo rather than as "session not found".
+    [Fact]
+    public async Task Fleet_role_unknown_role_beats_unknown_session_inValidationOrder()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/role",
+            new FleetRoleRequest { ToSessionId = Guid.NewGuid().ToString(), Role = "Overlord" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        Assert.DoesNotContain("not found", await resp.Content.ReadAsStringAsync(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    // A well-formed target this Director does not own: fail loud (502), never a silent no-op. Roles are set on
+    // the owning Director - there is no Gateway route to relay to.
+    [Fact]
+    public async Task Fleet_role_unknown_target_returns_502_notSilentNoOp()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/role",
+            new FleetRoleRequest { ToSessionId = Guid.NewGuid().ToString(), Role = "Architect" });
+        Assert.Equal(HttpStatusCode.BadGateway, resp.StatusCode);
+    }
+
+    // An EMPTY role is the documented "clear it" path, so it must pass validation and reach the session
+    // lookup (502 here) rather than being rejected as a bad request alongside genuine typos.
+    [Fact]
+    public async Task Fleet_role_empty_role_isClearNotReject()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/role",
+            new FleetRoleRequest { ToSessionId = Guid.NewGuid().ToString(), Role = "" });
+        Assert.Equal(HttpStatusCode.BadGateway, resp.StatusCode);
+    }
+
     // ===== /fleet/done validation (issue #1490 - the self-reap route restored to the floor) =====
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/FleetMessagingTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetMessagingTests.cs
@@ -253,6 +253,79 @@ public sealed class FleetMessagingEndpointTests : IAsyncLifetime
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 
+    // ===== the session-control verbs restored to the tunnel-only floor =====
+    // A missing route returns 404 with no body, so a 400 from the HANDLER is itself proof the route is
+    // registered. These pin that each verb exists and validates, which is the gap: the tunnel-only cut took
+    // them off the loopback surface and only rename/done/broadcast (#1490) were ever restored.
+
+    [Fact]
+    public async Task Fleet_prompt_missing_target_returns_400_provingRouteExists()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/prompt", new FleetPromptRequest { ToSessionId = "", Text = "hi" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    // Text is required: a prompt that silently sent nothing would look like it worked.
+    [Fact]
+    public async Task Fleet_prompt_empty_text_returns_400()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/prompt",
+            new FleetPromptRequest { ToSessionId = Guid.NewGuid().ToString(), Text = "" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Fleet_prompt_unknown_target_noGateway_returns_404()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/prompt",
+            new FleetPromptRequest { ToSessionId = Guid.NewGuid().ToString(), Text = "hi" });
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Fleet_interrupt_bad_guid_returns_400_provingRouteExists()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/interrupt", new FleetTargetRequest { ToSessionId = "not-a-guid" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Fleet_interrupt_unknown_target_noGateway_returns_404()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/interrupt",
+            new FleetTargetRequest { ToSessionId = Guid.NewGuid().ToString() });
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Fleet_hold_bad_guid_returns_400_provingRouteExists()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/hold", new FleetHoldRequest { ToSessionId = "not-a-guid" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Fleet_hold_unknown_target_noGateway_returns_404()
+    {
+        var resp = await _client.PostAsJsonAsync("fleet/hold",
+            new FleetHoldRequest { ToSessionId = Guid.NewGuid().ToString(), OnHold = true });
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Fleet_buffer_missing_sessionId_returns_400_provingRouteExists()
+    {
+        var resp = await _client.GetAsync("fleet/buffer");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Fleet_buffer_unknown_target_noGateway_returns_404()
+    {
+        var resp = await _client.GetAsync($"fleet/buffer?sessionId={Guid.NewGuid()}");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
     // ===== /fleet/role validation (the set-role verb restored to the tunnel-only floor) =====
 
     // A missing route returns 404, so a 400 from the HANDLER is itself the proof that /fleet/role is

--- a/src/CcDirector.Gateway.Tests/FleetMessagingTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetMessagingTests.cs
@@ -294,24 +294,24 @@ public sealed class FleetMessagingEndpointTests : IAsyncLifetime
         Assert.DoesNotContain("not found", await resp.Content.ReadAsStringAsync(), StringComparison.OrdinalIgnoreCase);
     }
 
-    // A well-formed target this Director does not own: fail loud (502), never a silent no-op. Roles are set on
-    // the owning Director - there is no Gateway route to relay to.
+    // A well-formed target this Director does not own, with no Gateway to relay through: fail loud (404),
+    // never a silent no-op. Matches /fleet/rename's contract exactly.
     [Fact]
-    public async Task Fleet_role_unknown_target_returns_502_notSilentNoOp()
+    public async Task Fleet_role_unknown_target_noGateway_returns_404()
     {
         var resp = await _client.PostAsJsonAsync("fleet/role",
             new FleetRoleRequest { ToSessionId = Guid.NewGuid().ToString(), Role = "Architect" });
-        Assert.Equal(HttpStatusCode.BadGateway, resp.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 
     // An EMPTY role is the documented "clear it" path, so it must pass validation and reach the session
-    // lookup (502 here) rather than being rejected as a bad request alongside genuine typos.
+    // lookup (404 here, no Gateway) rather than being rejected as a bad request alongside genuine typos.
     [Fact]
     public async Task Fleet_role_empty_role_isClearNotReject()
     {
         var resp = await _client.PostAsJsonAsync("fleet/role",
             new FleetRoleRequest { ToSessionId = Guid.NewGuid().ToString(), Role = "" });
-        Assert.Equal(HttpStatusCode.BadGateway, resp.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
     }
 
     // ===== /fleet/done validation (issue #1490 - the self-reap route restored to the floor) =====

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -21,6 +21,7 @@ from .session_ops import (
     list_sessions,
     mark_done,
     rename_session,
+    set_session_role,
     selftest as run_selftest,
     send_message,
     spawn_session,
@@ -351,6 +352,35 @@ def rename(
         rename_session(None, target_or_name)
     else:
         rename_session(target_or_name, new_name)
+
+
+@session_app.command()
+def role(
+    role_or_target: str = typer.Argument(
+        ...,
+        help="Role for this session (Standalone, Manager, Worker, Architect), or a target when ROLE is "
+             "also provided. Pass 'none' to clear the explicit role.",
+    ),
+    role_value: Optional[str] = typer.Argument(
+        None, help="Role when an explicit target is provided."
+    ),
+) -> None:
+    """Declare a session's explicit role, defaulting to the current session.
+
+    Valid roles: Standalone, Manager, Worker, Architect (case-insensitive). Pass 'none' to clear
+    the explicit role and revert to automatic derivation.
+
+    Worker and Manager are normally derived from the fleet: a controlled session with a live
+    controller is a Worker; a session controlling a live session is a Manager. Architect cannot be
+    inferred from the spawn graph, so declaring it here is the only way to make one after birth.
+    An explicit role is sticky and wins over derivation.
+    """
+    if role_value is None:
+        target, wanted = None, role_or_target
+    else:
+        target, wanted = role_or_target, role_value
+    # "none" is the CLI's way to say "clear it" - the endpoint clears on an empty role.
+    set_session_role(target, "" if wanted.strip().lower() == "none" else wanted)
 
 
 @session_app.command()

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -18,8 +18,12 @@ from . import settings_ops
 from . import setup_ops
 from .session_ops import (
     ask_session,
+    hold_session,
+    interrupt_session,
     list_sessions,
     mark_done,
+    prompt_session,
+    read_session_buffer,
     rename_session,
     set_session_role,
     selftest as run_selftest,
@@ -352,6 +356,61 @@ def rename(
         rename_session(None, target_or_name)
     else:
         rename_session(target_or_name, new_name)
+
+
+@session_app.command()
+def prompt(
+    target: str = typer.Argument(..., help="Session to prompt (id prefix, number, or exact name)."),
+    text: str = typer.Argument(..., help="The text to send."),
+    no_submit: bool = typer.Option(
+        False, "--no-submit", help="Type the text but do not press Enter - leave it in the composer."
+    ),
+) -> None:
+    """Send raw text into a session, as if you had typed it.
+
+    Unlike `message send`, the text is NOT framed with a sender - the session sees exactly what
+    you passed. Use `message send` for agent-to-agent messages, and this to drive a session.
+    """
+    prompt_session(target, text, no_submit=no_submit)
+
+
+@session_app.command()
+def interrupt(
+    target: Optional[str] = typer.Argument(
+        None, help="Session to interrupt. Defaults to THIS session (CC_SESSION_ID)."
+    ),
+) -> None:
+    """Stop what a session is currently doing."""
+    interrupt_session(target)
+
+
+@session_app.command()
+def hold(
+    target: Optional[str] = typer.Argument(
+        None, help="Session to hold. Defaults to THIS session (CC_SESSION_ID)."
+    ),
+    release: bool = typer.Option(False, "--release", help="Release the hold instead of applying one."),
+    minutes: Optional[int] = typer.Option(
+        None, "--minutes", help="Hold for this many minutes, then surface it again."
+    ),
+) -> None:
+    """Park a session so it stops asking for you, or release it.
+
+    A hold asked for while the session is still working is DEFERRED - it applies when the turn
+    finishes, and you are told so. A held session that starts working again always takes itself
+    off hold.
+    """
+    hold_session(target, release=release, minutes=minutes)
+
+
+@session_app.command()
+def buffer(
+    target: Optional[str] = typer.Argument(
+        None, help="Session to read. Defaults to THIS session (CC_SESSION_ID)."
+    ),
+) -> None:
+    """Print what a session's terminal is showing - how you see what a session is actually doing."""
+    read_session_buffer(target)
 
 
 @session_app.command()

--- a/tools/cc-devthrottle/src/session_ops.py
+++ b/tools/cc-devthrottle/src/session_ops.py
@@ -227,6 +227,89 @@ def rename_session(target: Optional[str], new_name: str) -> Dict[str, Any]:
     return resp
 
 
+def prompt_session(target: str, text: str, no_submit: bool = False) -> Dict[str, Any]:
+    """Send raw text into a session - what a human typing into it would produce.
+
+    Unlike `message send`, this does NOT frame the text with a sender. Restores the old
+    POST /sessions/{sid}/prompt.
+    """
+    if not text.strip():
+        console.print("[red]Error:[/red] the prompt text cannot be blank.")
+        raise typer.Exit(1)
+    sid = resolve_target_or_current(target)
+    try:
+        resp = director.post_json(
+            "fleet/prompt", {"toSessionId": sid, "text": text, "appendEnter": not no_submit}
+        )
+    except director.DirectorError as err:
+        console.print(f"[red]Error:[/red] {err}")
+        raise typer.Exit(1)
+    console.print(f"[green]Sent[/green] prompt to {director.short_id(sid)}.")
+    return resp if isinstance(resp, dict) else {}
+
+
+def interrupt_session(target: Optional[str]) -> Dict[str, Any]:
+    """Stop what a session is currently doing. Restores the old POST /sessions/{sid}/interrupt."""
+    sid = resolve_target_or_current(target)
+    try:
+        resp = director.post_json("fleet/interrupt", {"toSessionId": sid})
+    except director.DirectorError as err:
+        console.print(f"[red]Error:[/red] {err}")
+        raise typer.Exit(1)
+    console.print(f"[green]Interrupted[/green] {director.short_id(sid)}.")
+    return resp if isinstance(resp, dict) else {}
+
+
+def hold_session(target: Optional[str], release: bool = False, minutes: Optional[int] = None) -> Dict[str, Any]:
+    """Park a session, or release it. Restores the old POST /sessions/{sid}/hold.
+
+    A hold asked for while the session is still working is DEFERRED: it applies when the turn
+    settles, and the response's pending flag says so. A held session that starts working again
+    always takes itself off hold.
+    """
+    sid = resolve_target_or_current(target)
+    body: Dict[str, Any] = {"toSessionId": sid, "onHold": not release}
+    if minutes is not None:
+        body["snoozeMinutes"] = minutes
+    try:
+        resp = director.post_json("fleet/hold", body)
+    except director.DirectorError as err:
+        console.print(f"[red]Error:[/red] {err}")
+        raise typer.Exit(1)
+
+    short = director.short_id(sid)
+    if release:
+        console.print(f"[green]Released[/green] {short} - no longer held.")
+    elif isinstance(resp, dict) and director.field(resp, "pending", "Pending"):
+        console.print(f"[green]Hold queued[/green] {short} is still working; it parks when it finishes.")
+    else:
+        for_text = f" for {minutes} minutes" if minutes else ""
+        console.print(f"[green]Held[/green] {short}{for_text}.")
+    return resp if isinstance(resp, dict) else {}
+
+
+def read_session_buffer(target: Optional[str]) -> None:
+    """Print what a session's terminal is showing. Restores the old GET /sessions/{sid}/buffer."""
+    sid = resolve_target_or_current(target)
+    try:
+        resp = director.get_json(f"fleet/buffer?sessionId={sid}")
+    except director.DirectorError as err:
+        console.print(f"[red]Error:[/red] {err}")
+        raise typer.Exit(1)
+
+    # The buffer verb returns the terminal text under one of a couple of shapes depending on the
+    # path it came back through; print whichever carries the text rather than guessing one.
+    text = None
+    if isinstance(resp, dict):
+        text = director.field(resp, "text", "Text") or director.field(resp, "buffer", "Buffer")
+    elif isinstance(resp, str):
+        text = resp
+    if text is None:
+        console.print("[red]Error:[/red] the Director did not return the session's buffer.")
+        raise typer.Exit(1)
+    console.print(text)
+
+
 def set_session_role(target: Optional[str], role: Optional[str]) -> Dict[str, Any]:
     """Declare a session's explicit role, defaulting to the current session.
 

--- a/tools/cc-devthrottle/src/session_ops.py
+++ b/tools/cc-devthrottle/src/session_ops.py
@@ -227,6 +227,38 @@ def rename_session(target: Optional[str], new_name: str) -> Dict[str, Any]:
     return resp
 
 
+def set_session_role(target: Optional[str], role: Optional[str]) -> Dict[str, Any]:
+    """Declare a session's explicit role, defaulting to the current session.
+
+    Restores the set-role verb the tunnel-only cut removed with POST /sessions/{sid}/role, which
+    left a running session stuck with the role it was born with. Architect cannot be derived from
+    the spawn graph, so this is the only way to make one after birth. An empty role clears the
+    explicit role and reverts the session to auto-derivation.
+    """
+    sid = resolve_target_or_current(target)
+    wanted = (role or "").strip()
+    try:
+        resp = director.post_json("fleet/role", {"toSessionId": sid, "role": wanted})
+    except director.DirectorError as err:
+        console.print(f"[red]Error:[/red] {err}")
+        raise typer.Exit(1)
+
+    if not isinstance(resp, dict):
+        console.print("[red]Error:[/red] the Director did not return the session's role.")
+        raise typer.Exit(1)
+
+    actual_sid = director.field(resp, "sessionId", "SessionId") or sid
+    explicit = director.field(resp, "explicitRole", "ExplicitRole")
+    short = director.short_id(actual_sid)
+    # Only the explicit role is reported: Worker/Manager derivation needs the fleet-wide spawn graph, which
+    # lives in the Gateway, so the effective role is read from `session list`, not returned here.
+    if explicit:
+        console.print(f"[green]Role set[/green] {short} is now explicitly {explicit}.")
+    else:
+        console.print(f"[green]Role cleared[/green] {short} reverts to automatic role derivation.")
+    return resp
+
+
 def mark_done(target: Optional[str], reason: Optional[str]) -> Dict[str, Any]:
     """Flag a session for deletion, defaulting to the current session.
 


### PR DESCRIPTION
**An agent could start and rename a session but could not drive one.** The tunnel-only cut took the old REST API's session control off the Director's loopback surface. Only rename, done, and broadcast were ever restored (#1490). `cc-devthrottle` offered five session verbs while the Gateway served the whole old API.

## The finding behind this

**Nothing was deleted - it MOVED to the Gateway.** Verified against a real session: the Gateway answers 200 today on `prompt`, `interrupt`, `hold`, `role`, `escape`, `buffer`, and session details, and the effects land. And every verb's logic still lives in `SessionCommandExecutor` - the same code the tunnel dispatches into.

So this restores **doors, not logic**. A local target runs byte-identical code to the Gateway path.

## Restored

| Route | CLI |
|---|---|
| `POST /fleet/prompt` | `session prompt <target> "<text>" [--no-submit]` |
| `POST /fleet/interrupt` | `session interrupt [target]` |
| `POST /fleet/hold` | `session hold [target] [--release] [--minutes N]` |
| `GET /fleet/buffer` | `session buffer [target]` |
| `POST /fleet/role` | `session role [target] <role\|none>` |

Each mirrors `/fleet/rename`: dispatch locally, relay through the Gateway for a session another Director hosts, fail loud (404) when neither - never a silent no-op.

`prompt` is deliberately **not** `/fleet/send`: send **frames** text with its sender, which is right for agent-to-agent messages and wrong for driving a session. `prompt` sends raw text - exactly what a human typing would produce.

## Verified against a live session (slot 6, port 7883)

| verb | result |
|---|---|
| prompt | `accepted: true`, session moved to `Working` |
| buffer | 7180 bytes of real terminal text |
| interrupt | 200 |
| hold | `pending: true` - **deferred** because it was mid-turn; roster then read `onHold: true` |
| release | roster read `onHold: false` |
| role | `explicitRole: Architect`; roster read `sessionRole: Architect` |
| role "Overlord" | rejected, listing the valid roles |

That `pending: true` is the hold state machine (#1537) working as designed - it waits out the turn rather than yanking it.

37 fleet-route tests pass (9 new).

## Corrections I made to my own work here

- The first commit said "the Gateway has no role route to relay to" and failed remote targets with 502. **False** - `POST /sessions/{sid}/role` exists. It now relays.
- The role response originally returned the effective role. It came back null every time: Worker/Manager derivation needs the fleet-wide spawn graph, which only the Gateway holds. Removed rather than ship a permanently-null field.

## Timing worth knowing

A role or hold change reaches the Gateway roster on the next full-snapshot reseed - about **10 seconds**, not instantly. A read at 3 seconds shows the old value and looks like a failure. It is not.

Closes #1514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)