### PR TITLE
release: fold the session-control restoration into the v1.2.0 notes

### DIFF
--- a/docs/public/release-notes/v1.2.0.md
+++ b/docs/public/release-notes/v1.2.0.md
@@ -1,21 +1,23 @@
 ## v1.2.0 - July 14, 2026
 
-Repairs the session controls that v1.1.0 broke: you can rename, close, and message your sessions again, and voice, History, and the phone roster stop failing on longer replies.
+Puts back the session controls that v1.1.0 broke, and gives agents back the full set of things they can do to a session. If you are on v1.1.0, this is the release you want.
 
 ### Highlights
 
-- Renaming, closing, and messaging your whole team work again. In v1.1.0 these answered "not found" and there was no way around it. If you are on v1.1.0, this is the release you want.
+- Renaming, closing, and messaging your whole team work again. In v1.1.0 these answered "not found" and there was no way around it.
+- Agents can drive a session again, not just start one. Sending a prompt into a session, interrupting it, putting it on hold or releasing it, reading what its terminal is showing, and setting its role are all back on the command line. In v1.1.0 an agent could open a session and rename it but could do nothing else to it - which meant a session could never change its role after it was created, so it could never be made an Architect.
 - Voice, History, and the phone's session list no longer break on longer replies. A size limit on the connection between your computers was cutting off anything large, which took these features down with it.
-- Tailscale is no longer needed to install or run DevThrottle. Your computers reach each other by dialling out, so nothing has to be installed or opened up first. It stays available as an option if you want to reach the Cockpit from outside your own machine.
+- Tailscale is no longer needed to install or run DevThrottle. Your computers reach each other by dialling out, so nothing has to be installed or opened up first. It stays available if you want to reach the Cockpit from outside your own machine.
 - DevThrottle installs and runs on a Mac. The installer places a proper Mac application, starts the launcher, and sets up the command line tools.
-- The desktop and the phone now agree on what a session is doing. Snoozed sessions were showing red "Your Turn" on the desktop with a nagging clock while the phone correctly showed them grey - on this fleet, six sessions in thirteen disagreed at the same moment. Both now read the same answer from one place.
+- The desktop and the phone now agree on what a session is doing. Snoozed sessions were showing red "Your Turn" on the desktop with a nagging clock while the phone correctly showed them grey - on one fleet, six sessions in thirteen disagreed at the same moment. Both now read the same answer from one place.
 - Every prompt you send is checked to have actually gone in, not just the long ones.
 
 ### Also in this release
 
 - Links can open in a different browser and profile per repository, so work links land in your work profile automatically. Picking a profile now asks what you meant - open it once, set it for this repository, or set it everywhere - instead of silently changing your default.
-- A session held while it is still working now stays held once it finishes, instead of quietly coming off hold. A held session that starts working again always takes itself off hold.
-- You can snooze a session for a length of time you choose.
+- A session put on hold while it is still working now stays held once it finishes, instead of quietly coming off hold. A held session that starts working again always takes itself off hold.
+- You can put a session on hold for a length of time you choose.
+- Your Throttle gains a Repos tab.
 - Starting a session from the Cockpit lets you pick which agent to run.
 - Clearing screenshots now deletes the files from disk, after warning you.
 - The version number is correct again. v1.1.0 shipped without its version being raised, so a fixed build and a broken one both reported the same number and there was no way to tell them apart.


### PR DESCRIPTION
The v1.2.0 notes were written before thefrederiksen/devthrottle#1543 merged, so they promised only the rename/close repair. **The tag is not cut yet**, so the release absorbs the rest rather than shipping a partial v1.2.0 followed immediately by a v1.3.0.

No version change - `Directory.Build.props` already reads 1.2.0.

## The headline that was missing

> **Agents can drive a session again, not just start one.** Sending a prompt into a session, interrupting it, putting it on hold or releasing it, reading what its terminal is showing, and setting its role are all back on the command line. In v1.1.0 an agent could open a session and rename it but could do nothing else to it - which meant a session could never change its role after it was created, so it could never be made an Architect.

That is the fix most worth having for anyone driving a fleet, and the notes said nothing about it.

## Also picked up

The Cockpit Repos tab (#1546), which merged after the notes were written.

## Accuracy gate

Per the run-book's step 4, verified against main rather than trusting commit subjects: `/fleet/prompt`, `/fleet/interrupt`, `/fleet/hold`, `/fleet/buffer` and `/fleet/role` are all mapped in `ControlEndpoints.cs`, and the matching `prompt` / `interrupt` / `hold` / `buffer` / `role` commands exist in the CLI.

The earlier accuracy pass on this file still holds: the Tailscale line says "no longer needed to install or run" rather than "removed", because `TailscalePreflight` is still invoked - it is now an optional gateway-role row, and the workstation checklist has no Tailscale row at all.

## After merge

The tag is published by the human, from main, at the merged commit. Pushing the tag triggers the Release workflow, which builds and attaches the executable. Do not use `scripts/new-release.ps1` - it direct-pushes main and branch protection blocks it (#1133).

🤖 Generated with [Claude Code](https://claude.com/claude-code)