### PR TITLE
docs(architecture): record the Stable Release mission brief and Phase 1 plan

### DIFF
--- a/docs/architecture/stable-release-architect-seed.md
+++ b/docs/architecture/stable-release-architect-seed.md
@@ -1,0 +1,86 @@
+# You are the Architect of Mission: Stable Release
+
+Mission id: `ac6883bb-09e2-4b5a-96bf-df3eae8d9f63`
+Target: DevThrottle **v1.3.0**, released today.
+
+## Read this first
+
+`D:\ReposFred\devthrottle\docs\architecture\stable-release-mission-2026-07-14.html`
+
+That document is your brief. It holds the WHY, the finish line, the tiers, what is
+deliberately deferred, the mission rules, the fleet table, and the release mechanics. Do not
+re-derive any of it. Do not re-open a Tier 3 decision - they were settled deliberately.
+
+The two independent reviews the plan came from:
+
+- `docs/reviews/tunnel-only-review-codex-2026-07-14.md`
+- `docs/reviews/tunnel-only-review-claude-2026-07-14.md`
+
+## Why this mission exists
+
+Yesterday cost the owner a full day of work he could not do, because DevThrottle told him
+things that were not true. A stale build reported the same version as a fixed one. Rename
+answered "not found" with no explanation. Agents read a skill documenting an interface deleted
+weeks earlier. **v1.3.0 is the release where DevThrottle stops lying.** Every item either
+removes something that misleads, or makes a failure explain itself.
+
+## How you work
+
+You are the **Architect**. You settle design questions and you do NOT gate the Manager - the
+Manager drives the work and does not wait on you for permission to proceed.
+
+- Spawn a **Manager** per phase, briefed on that phase only:
+  `cc-devthrottle session spawn D:\ReposFred\devthrottle --mission ac6883bb-09e2-4b5a-96bf-df3eae8d9f63 --role Manager --name "Stable Release - Manager"`
+- **Retire the Manager at each phase boundary and spawn a fresh one.** A Manager carrying three
+  phases of context makes worse decisions than a new one with a tight brief.
+- Re-seat yourself at clean boundaries too, for the same reason.
+- Workers are spawned by the Manager, on disjoint files, and report to it.
+- Session naming is **Mission - Role**, with a dash, mission first.
+
+## The rules that are not negotiable
+
+1. **Verify before you claim.** Check `origin/main`, never a commit message, never a memory, never
+   a working tree that may be behind. Read shipped code with `git show origin/main:<path>` or
+   `git grep <pattern> origin/main`. Work in a worktree cut from `origin/main`.
+2. **Probe the route, never the version.** `/healthz` cannot tell a fixed build from a broken one -
+   `Directory.Build.props` sat at 1.1.0 through both. Probe the real route against a deliberately
+   fake one: both 404 means the route is absent; the real one answering anything else means it is
+   there. **Never probe `POST /fleet/spawn`** - it returns 201 and creates a real session.
+3. **Proof is a running build, not a green test.** Demonstrate every Tier 1 item on a slot Director.
+4. **No fallbacks.** Fix the root cause or fail loudly with a clear message.
+5. **Plain English, ASCII only.** No abbreviations, no jargon, no emoji, anywhere.
+6. **Do not commit without the owner asking**, and **the owner publishes the tag** - never you.
+7. Ask the owner ONE question at a time, in plain words, and never cite issue or pull request
+   numbers at him.
+
+## The fleet
+
+| Director | Port | Use |
+|---|---|---|
+| slot 2 | 7884 | **Permanent. You run here.** v1.2.0, all restored verbs. |
+| slot 6 | 7883 | Testing. Throwaway proof runs. |
+| slot 1 | 7881 | Older build, hosts another session. Leave it alone. |
+| installed app | 7879 | v1.1.0, the broken build. Do not test against it. |
+
+Each slot needs its OWN scheduled task (`cc-director-launch-slot<n>`). A shared task kills
+whichever Director it launched last - this already killed slot 1 once today.
+
+Build a slot with:
+`powershell -ExecutionPolicy Bypass -File scripts\local-build-avalonia.ps1 -Slot 6`
+
+## Order of work
+
+1. Tier 1 item 1 - the command timeout and typed error. Largest effect, smallest change.
+2. Tier 1 items 2 to 4, each proven on a running slot.
+3. Tier 2 item 5 - one focused deletion pull request, statically safe.
+4. Tier 2 items 6 and 7 - the documents that mislead today.
+5. Cut v1.3.0 per the `release-manager` skill. Bump `Directory.Build.props` (the version lives in
+   exactly one file). `scripts/new-release.ps1` does NOT work - it direct-pushes main, which is
+   branch-protected. The bump reaches main through an ordinary pull request; the owner then
+   publishes the tag.
+
+## First act
+
+Read the mission document, confirm the plan still matches `origin/main` (things merged today),
+then report to the owner in plain words: what you are starting with and what you need from him,
+if anything. Then start - do not wait for permission to begin Tier 1.

--- a/docs/architecture/stable-release-mission-2026-07-14.html
+++ b/docs/architecture/stable-release-mission-2026-07-14.html
@@ -1,0 +1,285 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Mission: Stable Release - DevThrottle v1.3.0</title>
+<style>
+  :root {
+    --ink:#1a1f2b; --mute:#5b6675; --line:#d8dee8; --bg:#ffffff; --panel:#f6f8fb;
+    --red:#ef4444; --blue:#3b82f6; --grey:#9ca3af; --slate:#64748b;
+    --green:#16a34a; --amber:#f0b848; --accent:#2563eb;
+  }
+  * { box-sizing:border-box; }
+  body {
+    margin:0; padding:0 24px 80px; background:var(--bg); color:var(--ink);
+    font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  }
+  .wrap { max-width:920px; margin:0 auto; }
+  header { border-bottom:3px solid var(--ink); padding:48px 0 20px; margin-bottom:36px; }
+  h1 { font-size:32px; line-height:1.2; margin:0 0 8px; letter-spacing:-0.02em; }
+  .sub { color:var(--mute); font-size:15px; margin:0; }
+  h2 {
+    font-size:23px; margin:52px 0 14px; padding-top:22px; border-top:1px solid var(--line);
+    letter-spacing:-0.01em;
+  }
+  h3 { font-size:17px; margin:30px 0 8px; }
+  p { margin:0 0 14px; }
+  .lede { font-size:18px; line-height:1.6; }
+  .why {
+    background:#fff8e6; border:2px solid var(--amber); border-radius:8px;
+    padding:22px 24px; margin:28px 0 8px;
+  }
+  .why h2 { margin:0 0 10px; padding:0; border:0; font-size:21px; }
+  .why p:last-child { margin-bottom:0; }
+  .callout {
+    background:var(--panel); border-left:4px solid var(--accent);
+    padding:16px 18px; margin:20px 0; border-radius:0 6px 6px 0;
+  }
+  .callout.warn { border-left-color:var(--red); background:#fef2f2; }
+  .callout.good { border-left-color:var(--green); background:#f0fdf4; }
+  .callout p:last-child { margin-bottom:0; }
+  table { border-collapse:collapse; width:100%; margin:18px 0; font-size:15px; }
+  th, td { text-align:left; padding:10px 12px; border-bottom:1px solid var(--line); vertical-align:top; }
+  th { background:var(--panel); font-weight:600; }
+  code {
+    background:var(--panel); border:1px solid var(--line); border-radius:4px;
+    padding:1px 5px; font:13px/1.4 ui-monospace,SFMono-Regular,Consolas,monospace;
+  }
+  .tier { display:inline-block; padding:2px 9px; border-radius:999px; font-size:12px; font-weight:700; color:#fff; }
+  .t1 { background:var(--red); }
+  .t2 { background:var(--blue); }
+  .t3 { background:var(--grey); }
+  ul, ol { margin:0 0 14px; padding-left:22px; }
+  li { margin:0 0 7px; }
+  .meta { font-size:14px; color:var(--mute); }
+  .done { color:var(--green); font-weight:600; }
+  footer { margin-top:56px; padding-top:20px; border-top:1px solid var(--line); font-size:14px; color:var(--mute); }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header>
+  <h1>Mission: Stable Release</h1>
+  <p class="sub">DevThrottle v1.3.0 &middot; Mission <code>ac6883bb-09e2-4b5a-96bf-df3eae8d9f63</code> &middot; 2026-07-14</p>
+</header>
+
+<div class="why">
+  <h2>Why this mission exists</h2>
+  <p class="lede">
+    Yesterday cost the owner a full day of work he could not do, because DevThrottle told him
+    things that were not true.
+  </p>
+  <p>
+    A stale executable reported the same version number as a fixed one, so nobody could tell which
+    build they were running. Session rename answered "not found" with no explanation. Agents were
+    reading a skill that documented an interface deleted weeks earlier. Each failure was small.
+    Together they made the tool untrustworthy, and an untrustworthy tool cannot be used to build
+    anything.
+  </p>
+  <p>
+    <strong>v1.3.0 is not a feature release. It is the release where DevThrottle stops lying.</strong>
+    Every item below either removes something that misleads, or makes a failure explain itself.
+  </p>
+</div>
+
+<h2>The finish line</h2>
+
+<p>
+  v1.3.0 is published, and on a bad mobile connection in a moving car the tool either works or says
+  plainly what went wrong. No raw 500s. No silent hangs. No document or skill describing an
+  interface that does not exist. No open inbound port that nothing dials.
+</p>
+
+<div class="callout good">
+  <p>
+    <strong>Already banked in v1.2.0 (merged, awaiting its tag).</strong> Session rename and close
+    repaired; the full session-control surface restored to agents (prompt, interrupt, hold, buffer,
+    role); the tunnel large-reply fix; Tailscale made optional; macOS support; one hold state machine
+    shared by desktop and phone; and the version number made honest again.
+  </p>
+</div>
+
+<h2>Where the work comes from</h2>
+
+<p>
+  Two independent reviews of the tunnel-only migration, done separately and without sight of each
+  other, then reconciled:
+</p>
+
+<ul>
+  <li><code>docs/reviews/tunnel-only-review-codex-2026-07-14.md</code> - Codex</li>
+  <li><code>docs/reviews/tunnel-only-review-claude-2026-07-14.md</code> - Claude</li>
+</ul>
+
+<p>
+  They agree on the substance. Their three most serious claims were re-verified against the code
+  before this plan was written, rather than taken on trust:
+</p>
+
+<table>
+  <tr><th>Claim</th><th>Verified</th></tr>
+  <tr>
+    <td>LAN addressing mode still binds the Control API to every interface</td>
+    <td><code>o.Listen(IPAddress.Any, Port)</code> - <code>ControlApiHost.cs</code>. Confirmed.</td>
+  </tr>
+  <tr>
+    <td>The Gateway still dials the launcher over plain HTTP</td>
+    <td><code>PostAsync($"/director/{verb}")</code> - <code>MachineEndpoints.cs:305</code>. Confirmed.</td>
+  </tr>
+  <tr>
+    <td>The public API reference documents endpoints that no longer exist</td>
+    <td>9 references to deleted session endpoints. Confirmed.</td>
+  </tr>
+</table>
+
+<h2><span class="tier t1">Tier 1</span> &nbsp;Stability - these ship</h2>
+
+<h3>1. A dropped command must explain itself</h3>
+<p>
+  A tunnel drop mid-command surfaces as a raw HTTP 500, and most hot-path commands are awaited with
+  <strong>no timeout at all</strong>. On a weak mobile link that is an indefinite hang with no
+  explanation. Both reviews rank this the single highest-value fix for the driving case. Add a
+  command timeout and a typed error that names what happened.
+</p>
+
+<h3>2. Close the open inbound port</h3>
+<p>
+  LAN addressing mode binds the Director to <code>0.0.0.0</code>, directly contradicting the
+  tunnel-only cut's stated invariant that the inbound port stays closed. Nothing dials it anymore,
+  so it is pure attack surface with no user.
+</p>
+
+<h3>3. Cockpit Director Settings is broken (#1508)</h3>
+<p>
+  <code>/directors/{id}/settings</code> returns an HTML shell. The same disease as rename: a caller
+  left pointing at something the cut moved.
+</p>
+
+<h3>4. "Verify now" can never succeed</h3>
+<p>
+  The desktop button still posts to a Gateway verify endpoint deleted in the cut. A button that
+  cannot work is worse than no button.
+</p>
+
+<h2><span class="tier t2">Tier 2</span> &nbsp;Cleanup - statically safe, no behaviour change</h2>
+
+<h3>5. Delete the dead code both reviews name</h3>
+<p>
+  The register and heartbeat cluster inside <code>GatewayClient</code>; <code>DirectorForwarding</code>
+  and the unused forwarder registration; the orphaned <code>DispatchContracts</code>; the
+  <code>CockpitWsUrls</code> and <code>CockpitShotUrls</code> contracts; the now-inert
+  <code>streamMode</code> configuration key; and the never-assigned <code>_serveProvisioner</code>
+  field with its dependent branches.
+</p>
+
+<h3>6. Fix the public API reference</h3>
+<p>
+  <code>docs/public/api/01-control-api.md</code> still describes sessions, prompts, buffers, git and
+  handover endpoints on the Director. The Director floor has about a dozen routes. This document is
+  public and is actively misleading anyone reading it today - it is the same failure mode that cost
+  the owner yesterday, still live.
+</p>
+
+<h3>7. Delete the documents describing worlds that never shipped</h3>
+<p>
+  Five architecture documents describe designs that were never built or are fully dead. They have no
+  salvage value and every one of them is a trap for the next reader.
+</p>
+
+<h2><span class="tier t3">Tier 3</span> &nbsp;Deliberately NOT in v1.3.0</h2>
+
+<p>Named here so nobody re-opens the question mid-flight:</p>
+
+<table>
+  <tr><th>Deferred</th><th>Why not now</th></tr>
+  <tr>
+    <td>Mobile resilience (#1181, #1187, #1139, #1326, #1325)</td>
+    <td>Its own mission. Real work, not a couple of hours.</td>
+  </tr>
+  <tr>
+    <td>Cockpit regression (#1296)</td>
+    <td>Fixes sit unmerged on <code>backup/issue-1215-cockpit-local-2026-07-11</code>. Needs its own session and a decision on that branch.</td>
+  </tr>
+  <tr>
+    <td>Flaky tests (#1541, #1221)</td>
+    <td>Real but not user-facing. They fail a run, not a person.</td>
+  </tr>
+  <tr>
+    <td>The Gateway dialling the launcher over HTTP</td>
+    <td>A genuine hole in "the Gateway never dials out", but changing the launcher leg is not a two-hour job. Record it, decide it deliberately.</td>
+  </tr>
+</table>
+
+<h2>Rules for this mission</h2>
+
+<ol>
+  <li>
+    <strong>Verify before you claim.</strong> Every finding here was checked against
+    <code>origin/main</code>, not a commit message and not a memory. A checkout, a CLI, and a running
+    Director can each lag main and contradict the code.
+  </li>
+  <li>
+    <strong>Probe the route, never the version.</strong> <code>/healthz</code> cannot tell a fixed
+    build from a broken one. Probe the real route against a deliberately fake one. Never probe
+    <code>/fleet/spawn</code> - it returns 201 and creates a real session.
+  </li>
+  <li>
+    <strong>Proof is a running build, not a green test.</strong> Every Tier 1 item is demonstrated on
+    a slot Director before it is called done.
+  </li>
+  <li><strong>No fallbacks.</strong> Fix the root cause or fail loudly with a clear message.</li>
+  <li><strong>Plain English, ASCII only.</strong> No abbreviations, no jargon, no emoji.</li>
+  <li>
+    <strong>The human publishes the tag.</strong> Everything is prepared; the final irreversible
+    click is the owner's.
+  </li>
+</ol>
+
+<h2>The fleet for this mission</h2>
+
+<table>
+  <tr><th>Director</th><th>Port</th><th>Role</th></tr>
+  <tr><td>slot 2</td><td>7884</td><td><strong>Permanent.</strong> v1.2.0, all restored verbs. The mission runs here.</td></tr>
+  <tr><td>slot 6</td><td>7883</td><td>Testing. v1.2.0. Throwaway proof runs.</td></tr>
+  <tr><td>slot 1</td><td>7881</td><td>Older build. Hosts <code>cc-consult - GU</code>; rebuild when that session parks.</td></tr>
+  <tr><td>installed app</td><td>7879</td><td>v1.1.0, the broken build. Fixed only when the v1.2.0 tag is published.</td></tr>
+</table>
+
+<div class="callout warn">
+  <p>
+    <strong>Each slot needs its own scheduled task.</strong> A shared task kills whichever Director it
+    launched last - this already killed slot 1 once today. Use
+    <code>cc-director-launch-slot&lt;n&gt;</code>, one per slot.
+  </p>
+</div>
+
+<h2>Order of work</h2>
+
+<ol>
+  <li>Tier 1 item 1 - the command timeout and typed error. Largest effect, smallest change.</li>
+  <li>Tier 1 items 2 to 4 - each proven on a running slot.</li>
+  <li>Tier 2 item 5 - one focused deletion pull request, statically safe.</li>
+  <li>Tier 2 items 6 and 7 - the documents that mislead today.</li>
+  <li>Cut v1.3.0: bump <code>Directory.Build.props</code>, write the notes, accuracy-gate them, open the release pull request. The owner publishes the tag.</li>
+</ol>
+
+<div class="callout">
+  <p>
+    <strong>Release mechanics, so nobody rediscovers them.</strong> The version lives in exactly one
+    file, <code>Directory.Build.props</code>. <code>scripts/new-release.ps1</code> does not work -
+    it direct-pushes <code>main</code>, which is branch-protected (#1133). The bump reaches main
+    through an ordinary pull request; the tag is then cut on main at the merged commit, and pushing
+    it triggers the Release workflow. Full run-book: the <code>release-manager</code> skill.
+  </p>
+</div>
+
+<footer>
+  Mission <code>ac6883bb-09e2-4b5a-96bf-df3eae8d9f63</code> &middot; Stable Release &middot;
+  attach a session with <code>cc-devthrottle session spawn &lt;repo&gt; --mission ac6883bb-09e2-4b5a-96bf-df3eae8d9f63</code>
+</footer>
+
+</div>
+</body>
+</html>

--- a/docs/architecture/stable-release-phase1-manager-brief.md
+++ b/docs/architecture/stable-release-phase1-manager-brief.md
@@ -1,0 +1,117 @@
+# Phase 1 Manager brief - Stable Release (DevThrottle v1.3.0)
+
+Mission id: `ac6883bb-09e2-4b5a-96bf-df3eae8d9f63`
+You are the **Manager** for Phase 1 only. The Architect is session `2eef41a3` ("Stable Release - Architect").
+
+Read the mission brief first: `docs/architecture/stable-release-mission-2026-07-14.html`
+It holds the WHY. Do not re-derive it. Do not re-open a Tier 3 decision.
+
+## Your scope: Tier 1 item 1 only
+
+**A dropped command must explain itself.** Nothing else. Items 2 to 4 belong to later Managers.
+
+## What the Architect verified against origin/main (do not re-derive; build on it)
+
+The whole Gateway-to-Director command path funnels through ONE chokepoint:
+
+- `src/CcDirector.Gateway/Api/DirectorCommandRouter.cs` -> `TrySendAsync(...)`
+  Every command verb routes through here. It calls the injected `sendCommand` delegate with only the
+  caller's cancellation token and no timeout of its own.
+- That delegate is `GatewayHost.SendCommandAsync` (`src/CcDirector.Gateway/GatewayHost.cs:1758`), which
+  ends in:
+  `await hub.Clients.Client(connectionId).InvokeAsync<DirectorCommandResult>("Command", command, ct)`
+
+Two proven failure modes, both live today:
+
+1. **Indefinite hang.** If the Director stays tunnel-connected but never answers the command, that
+   `InvokeAsync` never completes. There is no timeout anywhere on the path. On a weak mobile link this is
+   a silent forever-wait.
+2. **Raw HTTP 500.** When the tunnel drops mid-command `InvokeAsync` throws. No caller on the path
+   catches it - `SessionVerbClient` and the command endpoints have no try/catch - so it escapes as an
+   unhandled exception and the caller sees a raw 500 with no explanation.
+
+Today `TrySendAsync` has exactly one non-success outcome: it returns null when the Director is not
+tunnel-connected, and the endpoint surfaces that as a 502. Timeout and mid-command drop are NOT
+distinguishable from each other or from anything else.
+
+**Stale comment, fix it while you are there:** `GatewayHost.SendCommandAsync`'s documentation comment says a
+null return means the caller "falls back to the HTTP command path". That path was deleted in the cut. The
+comment is one of the lies this release exists to remove. `DirectorCommandRouter`'s own comment already has
+it right.
+
+## The design (settled by the Architect - implement it, do not redesign it)
+
+- **The timeout goes in `DirectorCommandRouter.TrySendAsync`, and nowhere else.** It is the one chokepoint;
+  putting it there means it cannot diverge across verbs. Do not scatter timeouts into individual callers.
+- **Three outcomes must be distinguishable to the caller**, each with a plain-English message that names
+  what actually happened:
+  1. Director not tunnel-connected (unroutable) - the existing null/502. Unchanged.
+  2. **Command timed out** - the Director is connected but did not answer in time.
+  3. **Tunnel dropped mid-command** - `InvokeAsync` threw. Catch it at the chokepoint.
+- **Default timeout: 30 seconds**, as a named constant, with an optional per-call override parameter on
+  `TrySendAsync` defaulting to that constant. Rationale: it must bound the hang without breaking
+  legitimately slow verbs. If you find a verb that genuinely needs longer (session create is the likely
+  candidate), give that call site an explicit override - do not raise the global default. If evidence says
+  30 seconds is wrong, bring it to the Architect rather than changing it silently.
+- **No fallback and no retry.** A timeout fails loudly with a message that says so. Do not retry, do not
+  degrade, do not swallow.
+- **The message is for a human in a moving car.** "The Director on SOREN_NORTH did not answer within 30
+  seconds" - not a status code, not a stack trace, not jargon.
+- Use a linked cancellation token so the caller's own token still cancels promptly.
+
+## The rules that are not negotiable
+
+1. **Verify before you claim.** Read shipped code with `git show origin/main:<path>` or
+   `git grep <pattern> origin/main`. Never a commit message, never a memory, never a tree that may be
+   behind.
+2. **Work in a worktree cut from origin/main.** Never `git checkout -b` in the shared checkout - other
+   sessions are working in it. `git worktree add ../devthrottle-<task> -b <branch> origin/main`
+3. **Probe the route, never the version.** `/healthz` cannot tell a fixed build from a broken one. Probe
+   the real route against a deliberately fake one. **Never probe `POST /fleet/spawn`** - it returns 201
+   and creates a real session.
+4. **Proof is a running build, not a green test.** Demonstrate the timeout and each typed error on a
+   running slot Director before calling it done. A green test alone is not proof.
+5. **No fallbacks.** Fix the root cause or fail loudly with a clear message.
+6. **Plain English, ASCII only.** No abbreviations, no jargon, no emoji, anywhere - code, comments, logs,
+   messages, pull request text.
+7. **Do not commit without the owner asking.** Do not merge. Do not tag.
+8. Do not message the owner. Report to the Architect.
+
+## Testing
+
+There are **seven** test projects, not two. Core plus Gateway alone is a false green - `HostedAgent` has
+its own fake backend. Run the full set.
+
+## The fleet
+
+| Director | Port | Use |
+|---|---|---|
+| slot 6 | 7883 | **Testing. Yours.** Throwaway proof runs. |
+| slot 2 | 7884 | Permanent. The Architect runs here. Do not disturb. |
+| slot 1 | 7881 | Older build, hosts another session. Leave it alone. |
+| installed app | 7879 | v1.1.0, the broken build. Never test against it. |
+
+Each slot needs its OWN scheduled task (`cc-director-launch-slot<n>`). A shared task kills whichever
+Director it launched last - this already killed slot 1 once today.
+
+Build a slot: `powershell -ExecutionPolicy Bypass -File scripts\local-build-avalonia.ps1 -Slot 6`
+
+Never kill a `cc-director*.exe` you did not launch. Shut your own test Director down cleanly with
+`POST http://127.0.0.1:<port>/shutdown` - a force-kill leaves a phantom session in the fleet.
+
+## How you work
+
+- Spawn Workers on **disjoint files**; they report to you.
+- **Ping the Architect at every milestone** - design question settled, worker landed, proof captured,
+  blocked. Never stall silently.
+- Fleet messages are ONE line - `send` truncates at the first newline.
+- You do not wait on the Architect for permission to proceed. Bring design questions, not approvals.
+
+## Definition of done for Phase 1
+
+1. A command that hangs is bounded by the timeout and returns a typed error naming the timeout.
+2. A command interrupted by a tunnel drop returns a typed error naming the drop - never a raw 500.
+3. The Director-not-connected case still behaves as it does today.
+4. All three demonstrated on a running slot Director, with the evidence captured.
+5. The stale "falls back to the HTTP command path" comment is gone.
+6. A pull request is open and green. You do not merge it.


### PR DESCRIPTION
## What

Puts the three documents driving Mission: Stable Release (DevThrottle v1.3.0) on main.

- `stable-release-architect-seed.md` - the Architect's seat and order of work.
- `stable-release-mission-2026-07-14.html` - the mission brief: why the release exists, the finish line, the tiers, what is deliberately deferred, the mission rules, the fleet, and the release mechanics.
- `stable-release-phase1-manager-brief.md` - the Phase 1 Manager brief for Tier 1 item 1, carrying the verified chokepoint findings and the settled design.

## Why

They existed only as untracked files in a shared checkout - a single copy, on disk, with nothing behind it. Today already proved that is how work gets lost. The owner asked for them to be committed.

## Risk

None. Documents only - no product code, no behaviour change, no test touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)