### PR TITLE
Log every prompt and reply, for all agents, with where it came from (#1551)

### DIFF
--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -174,6 +174,7 @@ public sealed class ControlApiHost : IAsyncDisposable
     private TransientErrorAutoResume? _transientErrorAutoResume;
     private TerminalSessionRecorder? _sessionRecorder;
     private Core.Storage.TurnReviewLogger? _turnReviewLogger;
+    private Core.Storage.ConversationIngestor? _conversationIngestor;
     private Core.Storage.SessionLogManager? _sessionLogManager;
     // Resolved lazily at request time: the scheduler is created AFTER the Control API host
     // (StartControlApi runs before StartScheduler), so we capture an accessor, not the instance.
@@ -616,6 +617,12 @@ public sealed class ControlApiHost : IAsyncDisposable
         // retention. See CcStorage.TurnReviewLogs().
         _turnReviewLogger = new Core.Storage.TurnReviewLogger(_sessionManager);
         _turnReviewLogger.Start();
+
+        // Durable prompt + reply record (issue #1551): on the same turn-end trigger, copy each
+        // session's conversation out of the agent's own transcript into our own log, with the origin
+        // of each prompt joined on from InputOriginLog. The foundation for the weekly review.
+        _conversationIngestor = new Core.Storage.ConversationIngestor(_sessionManager);
+        _conversationIngestor.Start();
     }
 
     /// <summary>
@@ -882,6 +889,8 @@ public sealed class ControlApiHost : IAsyncDisposable
         _transientErrorAutoResume = null;
         _turnReviewLogger?.Dispose();
         _turnReviewLogger = null;
+        _conversationIngestor?.Dispose();
+        _conversationIngestor = null;
         _sessionRecorder?.Dispose();
         _sessionRecorder = null;
         _proactiveExplain?.Dispose();

--- a/src/CcDirector.Core.Tests/Gemini/GeminiPromptLogReaderTests.cs
+++ b/src/CcDirector.Core.Tests/Gemini/GeminiPromptLogReaderTests.cs
@@ -1,0 +1,100 @@
+using CcDirector.Core.Gemini;
+using CcDirector.Core.History;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Gemini;
+
+/// <summary>
+/// Tests for <see cref="GeminiPromptLogReader"/> (issue #1551) - reading Gemini's own logs.json so the
+/// durable record gets real prompts with real timestamps, instead of the untimestamped terminal
+/// scrollback blob the History tab uses.
+/// </summary>
+public sealed class GeminiPromptLogReaderTests
+{
+    /// <summary>
+    /// The directory scheme, pinned: Gemini keys its per-project temp dir by the lowercase hex SHA-256
+    /// of the project path. This expected value was taken from a live ~/.gemini/tmp on Windows - if
+    /// Gemini ever changes the scheme, this test is the thing that notices.
+    /// </summary>
+    [Fact]
+    public void HashRepoPath_matches_the_scheme_gemini_actually_uses()
+    {
+        var hash = GeminiPromptLogReader.HashRepoPath(@"D:\ReposFred\devthrottle");
+
+        Assert.StartsWith("dd33f065e1e15649", hash);
+        Assert.Equal(64, hash.Length);
+        Assert.Equal(hash.ToLowerInvariant(), hash);
+    }
+
+    [Fact]
+    public void ResolvePath_returns_null_for_a_repo_gemini_has_never_run_in()
+    {
+        Assert.Null(GeminiPromptLogReader.ResolvePath(@"D:\definitely\not\a\real\repo\" + Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void ResolvePath_of_a_blank_repo_is_null_rather_than_throwing()
+    {
+        Assert.Null(GeminiPromptLogReader.ResolvePath(""));
+        Assert.Null(GeminiPromptLogReader.ResolvePath("   "));
+    }
+
+    [Fact]
+    public void Read_of_a_repo_with_no_gemini_log_is_empty_rather_than_throwing()
+    {
+        var history = GeminiPromptLogReader.Read(@"D:\definitely\not\a\real\repo\" + Guid.NewGuid());
+
+        Assert.Same(ConversationHistory.Empty, history);
+    }
+
+    /// <summary>
+    /// The real payoff: a live logs.json on this machine parses into real user prompts carrying real
+    /// timestamps - which is what makes the origin join possible for Gemini at all. Skipped when the
+    /// machine has never run Gemini, so this cannot fail on a clean box.
+    /// </summary>
+    [Fact]
+    public void Read_of_a_real_on_disk_log_yields_timestamped_user_prompts()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var tmp = Path.Combine(home, ".gemini", "tmp");
+        if (!Directory.Exists(tmp)) return; // Gemini never ran here - nothing to verify against.
+
+        var log = Directory.GetFiles(tmp, "logs.json", SearchOption.AllDirectories)
+            .FirstOrDefault(f => new FileInfo(f).Length > 100);
+        if (log is null) return;
+
+        // Drive the reader through its real resolver by naming the repo whose hash owns this dir.
+        var owningDir = Path.GetFileName(Path.GetDirectoryName(log)!);
+        var history = ReadByDirectoryHash(owningDir, log);
+
+        Assert.NotEmpty(history.Messages);
+        Assert.All(history.Messages, m => Assert.Equal(ConversationRole.User, m.Role));
+        Assert.All(history.Messages, m => Assert.NotEmpty(m.Parts));
+        // The whole reason this source beats the scrollback: real timestamps.
+        Assert.Contains(history.Messages, m => m.Timestamp.HasValue);
+    }
+
+    /// <summary>
+    /// Drive the real Read() over a known logs.json by recreating the exact layout it resolves -
+    /// ~/.gemini/tmp/&lt;hash of repo&gt;/logs.json - under a home directory we control. This exercises
+    /// the resolver AND the parser, which is the part that breaks when Gemini changes its format.
+    /// </summary>
+    private static ConversationHistory ReadByDirectoryHash(string _, string logPath)
+    {
+        var temp = Path.Combine(Path.GetTempPath(), "gemini-read-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(temp);
+        try
+        {
+            var repo = Path.Combine(temp, "repo");
+            var geminiDir = Path.Combine(temp, ".gemini", "tmp", GeminiPromptLogReader.HashRepoPath(repo));
+            Directory.CreateDirectory(geminiDir);
+            File.Copy(logPath, Path.Combine(geminiDir, "logs.json"));
+
+            return GeminiPromptLogReader.Read(repo, homeDirectory: temp);
+        }
+        finally
+        {
+            try { Directory.Delete(temp, recursive: true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/src/CcDirector.Core.Tests/Storage/ConversationIngestorTests.cs
+++ b/src/CcDirector.Core.Tests/Storage/ConversationIngestorTests.cs
@@ -1,0 +1,296 @@
+using System.Text.Json;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Tests.Wingman; // BufferOnlyBackend (internal test stub)
+using Xunit;
+
+namespace CcDirector.Core.Tests.Storage;
+
+/// <summary>
+/// Tests for <see cref="ConversationIngestor"/> (issue #1551): copying an agent's own transcript into
+/// the durable <see cref="ConversationLog"/>, dropping tool calls, and joining each user message to
+/// the origin event recorded at the Session choke point.
+///
+/// The session is pointed at a Claude-format transcript this test writes, via the same public pointer
+/// the SessionStart hook uses - so the real SessionHistoryReader path is exercised, not a stub.
+/// </summary>
+[Collection("CcStorageRoot")] // serializes all classes that mutate the process-wide CC_DIRECTOR_ROOT
+public sealed class ConversationIngestorTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string? _prevRoot;
+
+    public ConversationIngestorTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-ingest-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private static Session NewSession()
+    {
+        var manager = new SessionManager(new AgentOptions { ClaudePath = TestShell.Path });
+        return manager.CreateEmbeddedSession(Path.GetTempPath(), null, new BufferOnlyBackend());
+    }
+
+    /// <summary>Write a Claude-format transcript and point the session at it.</summary>
+    private string WriteTranscript(Session session, params string[] jsonlLines)
+    {
+        var path = Path.Combine(_root, $"transcript-{Guid.NewGuid():N}.jsonl");
+        File.WriteAllLines(path, jsonlLines);
+        session.UpdateClaudeSessionPointer("claude-session-id", path, "test");
+        return path;
+    }
+
+    private static string TextLine(string type, string role, string text, DateTime ts) =>
+        JsonSerializer.Serialize(new
+        {
+            type,
+            timestamp = ts.ToString("O"),
+            message = new { role, content = new[] { new { type = "text", text } } },
+        });
+
+    private static string UserLine(string text, DateTime ts) => TextLine("user", "user", text, ts);
+
+    private static string AssistantLine(string text, DateTime ts) => TextLine("assistant", "assistant", text, ts);
+
+    private static string AssistantToolLine(string toolName, DateTime ts) =>
+        JsonSerializer.Serialize(new
+        {
+            type = "assistant",
+            timestamp = ts.ToString("O"),
+            message = new
+            {
+                role = "assistant",
+                content = new[] { new { type = "tool_use", id = "t1", name = toolName, input = new { a = 1 } } },
+            },
+        });
+
+    private static IReadOnlyList<ConversationRecord> Recorded()
+        => ConversationLog.Read(DateTime.UtcNow.Date.AddDays(-2), DateTime.UtcNow.Date.AddDays(1));
+
+    [Fact]
+    public void Ingest_copies_both_the_prompt_and_the_reply()
+    {
+        var session = NewSession();
+        var ts = DateTime.UtcNow;
+        WriteTranscript(session, UserLine("fix the login bug", ts), AssistantLine("Fixed it.", ts.AddSeconds(5)));
+
+        using var ingestor = new ConversationIngestor(new SessionManager(new AgentOptions { ClaudePath = TestShell.Path }));
+        ingestor.Ingest(session);
+
+        var records = Recorded();
+        Assert.Equal(2, records.Count);
+        Assert.Equal("user", records[0].Role);
+        Assert.Equal("fix the login bug", records[0].Text);
+        Assert.Equal("assistant", records[1].Role);
+        Assert.Equal("Fixed it.", records[1].Text);
+    }
+
+    [Fact]
+    public void Ingest_drops_tool_calls()
+    {
+        var session = NewSession();
+        var ts = DateTime.UtcNow;
+        WriteTranscript(session,
+            UserLine("read the file", ts),
+            AssistantToolLine("Read", ts.AddSeconds(1)),
+            AssistantLine("Here is what it says.", ts.AddSeconds(2)));
+
+        using var ingestor = new ConversationIngestor(new SessionManager(new AgentOptions { ClaudePath = TestShell.Path }));
+        ingestor.Ingest(session);
+
+        var records = Recorded();
+        // The tool_use message carries no Text part, so it is not recorded at all.
+        Assert.Equal(2, records.Count);
+        Assert.DoesNotContain(records, r => r.Text.Contains("tool_use"));
+        Assert.Equal(new[] { "read the file", "Here is what it says." }, records.Select(r => r.Text));
+    }
+
+    [Fact]
+    public void Ingest_is_idempotent_and_does_not_double_append()
+    {
+        var session = NewSession();
+        var ts = DateTime.UtcNow;
+        WriteTranscript(session, UserLine("only once", ts));
+
+        using var ingestor = new ConversationIngestor(new SessionManager(new AgentOptions { ClaudePath = TestShell.Path }));
+        ingestor.Ingest(session);
+        ingestor.Ingest(session);
+        ingestor.Ingest(session);
+
+        Assert.Single(Recorded());
+    }
+
+    [Fact]
+    public void Ingest_picks_up_only_the_new_message_when_the_transcript_grows()
+    {
+        var session = NewSession();
+        var ts = DateTime.UtcNow;
+        var path = WriteTranscript(session, UserLine("first", ts));
+
+        using var ingestor = new ConversationIngestor(new SessionManager(new AgentOptions { ClaudePath = TestShell.Path }));
+        ingestor.Ingest(session);
+
+        File.AppendAllLines(path, new[] { AssistantLine("reply", ts.AddSeconds(2)) });
+        ingestor.Ingest(session);
+
+        Assert.Equal(new[] { "first", "reply" }, Recorded().Select(r => r.Text));
+    }
+
+    // ===== the origin join =====
+
+    [Fact]
+    public void A_user_message_is_joined_to_the_origin_event_recorded_at_the_choke_point()
+    {
+        var session = NewSession();
+        var ts = DateTime.UtcNow;
+
+        // The submission crosses the choke point, writing an origin event...
+        InputOriginLog.Write(new InputOriginRecord
+        {
+            TsUtc = ts,
+            SessionId = session.Id.ToString(),
+            Modality = "voice",
+            Surface = "phone",
+            CharCount = 9,
+        });
+        // ...and the agent records the same prompt in its transcript a moment later.
+        WriteTranscript(session, UserLine("say hello", ts.AddSeconds(1)));
+
+        using var ingestor = new ConversationIngestor(new SessionManager(new AgentOptions { ClaudePath = TestShell.Path }));
+        ingestor.Ingest(session);
+
+        var only = Assert.Single(Recorded());
+        Assert.Equal("voice", only.Modality);
+        Assert.Equal("phone", only.Surface);
+    }
+
+    [Fact]
+    public void A_user_message_with_no_origin_event_is_unknown_not_guessed()
+    {
+        var session = NewSession();
+        WriteTranscript(session, UserLine("typed straight into the terminal", DateTime.UtcNow));
+
+        using var ingestor = new ConversationIngestor(new SessionManager(new AgentOptions { ClaudePath = TestShell.Path }));
+        ingestor.Ingest(session);
+
+        var only = Assert.Single(Recorded());
+        Assert.Equal("unknown", only.Surface);
+        Assert.Null(only.Modality);
+    }
+
+    [Fact]
+    public void An_origin_event_far_away_in_time_is_not_matched()
+    {
+        var session = NewSession();
+        var ts = DateTime.UtcNow;
+
+        // An unrelated submission an hour earlier must not be claimed as this prompt's origin.
+        InputOriginLog.Write(new InputOriginRecord
+        {
+            TsUtc = ts.AddHours(-1),
+            SessionId = session.Id.ToString(),
+            Modality = "voice",
+            Surface = "phone",
+            CharCount = 5,
+        });
+        WriteTranscript(session, UserLine("a different prompt", ts));
+
+        using var ingestor = new ConversationIngestor(new SessionManager(new AgentOptions { ClaudePath = TestShell.Path }));
+        ingestor.Ingest(session);
+
+        Assert.Equal("unknown", Assert.Single(Recorded()).Surface);
+    }
+
+    [Fact]
+    public void An_origin_event_from_another_session_is_never_matched()
+    {
+        var session = NewSession();
+        var ts = DateTime.UtcNow;
+
+        InputOriginLog.Write(new InputOriginRecord
+        {
+            TsUtc = ts,
+            SessionId = Guid.NewGuid().ToString(), // a different session, same instant
+            Modality = "voice",
+            Surface = "phone",
+            CharCount = 5,
+        });
+        WriteTranscript(session, UserLine("my own prompt", ts));
+
+        using var ingestor = new ConversationIngestor(new SessionManager(new AgentOptions { ClaudePath = TestShell.Path }));
+        ingestor.Ingest(session);
+
+        Assert.Equal("unknown", Assert.Single(Recorded()).Surface);
+    }
+
+    [Fact]
+    public void An_assistant_reply_carries_no_origin()
+    {
+        var session = NewSession();
+        var ts = DateTime.UtcNow;
+
+        InputOriginLog.Write(new InputOriginRecord
+        {
+            TsUtc = ts,
+            SessionId = session.Id.ToString(),
+            Modality = "typed",
+            Surface = "desktop",
+            CharCount = 5,
+        });
+        WriteTranscript(session, AssistantLine("I replied.", ts));
+
+        using var ingestor = new ConversationIngestor(new SessionManager(new AgentOptions { ClaudePath = TestShell.Path }));
+        ingestor.Ingest(session);
+
+        var only = Assert.Single(Recorded());
+        // The reply is near an origin event in time, but a reply has no origin - it must not borrow one.
+        Assert.Null(only.Surface);
+        Assert.Null(only.Modality);
+    }
+
+    /// <summary>
+    /// Two Director sessions pointed at the SAME transcript must not each record it. Claude keeps a
+    /// transcript per agent session so this is rare, but Copilot, OpenCode and Gemini resolve their
+    /// history by repo out of one shared store, where two sessions on one repo read the identical
+    /// conversation - so the dedupe is scoped to the source, not to the Director session.
+    /// </summary>
+    [Fact]
+    public void Two_sessions_reading_the_same_transcript_record_it_once()
+    {
+        var ts = DateTime.UtcNow;
+        var sessionA = NewSession();
+        var path = WriteTranscript(sessionA, UserLine("shared conversation", ts));
+
+        // A second Director session pointed at the very same transcript file.
+        var sessionB = NewSession();
+        sessionB.UpdateClaudeSessionPointer("claude-session-id", path, "test");
+
+        using var ingestor = new ConversationIngestor(new SessionManager(new AgentOptions { ClaudePath = TestShell.Path }));
+        ingestor.Ingest(sessionA);
+        ingestor.Ingest(sessionB);
+
+        Assert.Single(Recorded());
+    }
+
+    [Fact]
+    public void A_real_agent_timestamp_is_marked_as_the_agents_own()
+    {
+        var session = NewSession();
+        WriteTranscript(session, UserLine("stamped by claude", DateTime.UtcNow));
+
+        using var ingestor = new ConversationIngestor(new SessionManager(new AgentOptions { ClaudePath = TestShell.Path }));
+        ingestor.Ingest(session);
+
+        Assert.True(Assert.Single(Recorded()).TimestampFromAgent);
+    }
+}

--- a/src/CcDirector.Core.Tests/Storage/ConversationIngestorTests.cs
+++ b/src/CcDirector.Core.Tests/Storage/ConversationIngestorTests.cs
@@ -50,17 +50,20 @@ public sealed class ConversationIngestorTests : IDisposable
         return path;
     }
 
-    private static string TextLine(string type, string role, string text, DateTime ts) =>
+    private static string TextLine(string type, string role, string text, DateTime ts, string? contextId = null) =>
         JsonSerializer.Serialize(new
         {
             type,
             timestamp = ts.ToString("O"),
+            sessionId = contextId,
             message = new { role, content = new[] { new { type = "text", text } } },
         });
 
-    private static string UserLine(string text, DateTime ts) => TextLine("user", "user", text, ts);
+    private static string UserLine(string text, DateTime ts, string? contextId = null)
+        => TextLine("user", "user", text, ts, contextId);
 
-    private static string AssistantLine(string text, DateTime ts) => TextLine("assistant", "assistant", text, ts);
+    private static string AssistantLine(string text, DateTime ts, string? contextId = null)
+        => TextLine("assistant", "assistant", text, ts, contextId);
 
     private static string AssistantToolLine(string toolName, DateTime ts) =>
         JsonSerializer.Serialize(new
@@ -302,6 +305,68 @@ public sealed class ConversationIngestorTests : IDisposable
         Assert.Equal(
             new[] { "an old prompt", "an old reply", "a later prompt" },
             Recorded().Select(r => r.Text));
+    }
+
+    // ===== the context id: replaying one conversation, and resetting on /clear =====
+
+    [Fact]
+    public void Every_message_of_one_conversation_carries_the_same_context_id()
+    {
+        var session = NewSession();
+        var ts = DateTime.UtcNow;
+        WriteTranscript(session,
+            UserLine("first", ts, "ctx-abc"),
+            AssistantLine("reply", ts.AddSeconds(2), "ctx-abc"),
+            UserLine("second", ts.AddSeconds(9), "ctx-abc"));
+
+        using var ingestor = new ConversationIngestor(new SessionManager(new AgentOptions { ClaudePath = TestShell.Path }));
+        ingestor.Ingest(session);
+
+        var records = Recorded();
+        Assert.Equal(3, records.Count);
+        Assert.All(records, r => Assert.Equal("ctx-abc", r.ContextId));
+        // The whole point: one group key reloads the whole back-and-forth.
+        Assert.Equal(3, records.Count(r => r.ContextId == "ctx-abc"));
+    }
+
+    [Fact]
+    public void Clearing_the_context_starts_a_new_context_id_under_the_same_session()
+    {
+        var session = NewSession();
+        var ts = DateTime.UtcNow;
+
+        // A conversation, then /clear - Claude mints a new context id AND a new transcript file, and
+        // the SessionStart hook repoints the session at it.
+        WriteTranscript(session, UserLine("before the clear", ts, "ctx-one"));
+        using var ingestor = new ConversationIngestor(new SessionManager(new AgentOptions { ClaudePath = TestShell.Path }));
+        ingestor.Ingest(session);
+
+        WriteTranscript(session, UserLine("after the clear", ts.AddMinutes(1), "ctx-two"));
+        ingestor.Ingest(session);
+
+        var records = Recorded();
+        Assert.Equal(2, records.Count);
+        Assert.Equal("ctx-one", records[0].ContextId);
+        Assert.Equal("ctx-two", records[1].ContextId);
+        // ...while the Director session id spans both, so the workstream stays joined up.
+        Assert.All(records, r => Assert.Equal(session.Id.ToString(), r.SessionId));
+    }
+
+    [Fact]
+    public void A_context_id_is_recorded_as_absent_rather_than_invented()
+    {
+        var session = NewSession();
+        // A transcript whose lines carry no sessionId at all.
+        WriteTranscript(session, UserLine("no context id on this line", DateTime.UtcNow));
+
+        using var ingestor = new ConversationIngestor(new SessionManager(new AgentOptions { ClaudePath = TestShell.Path }));
+        ingestor.Ingest(session);
+
+        // Falls back to the transcript file's own name - which for a file-per-context agent IS the
+        // context identity - rather than borrowing the Director session id and pretending.
+        var only = Assert.Single(Recorded());
+        Assert.NotNull(only.ContextId);
+        Assert.NotEqual(session.Id.ToString(), only.ContextId);
     }
 
     [Fact]

--- a/src/CcDirector.Core.Tests/Storage/ConversationIngestorTests.cs
+++ b/src/CcDirector.Core.Tests/Storage/ConversationIngestorTests.cs
@@ -282,6 +282,28 @@ public sealed class ConversationIngestorTests : IDisposable
         Assert.Single(Recorded());
     }
 
+    /// <summary>
+    /// Backfill for a live session is automatic and needs no separate pass: the first ingest reads the
+    /// WHOLE transcript, so history written before the feature existed is copied on the next turn end.
+    /// </summary>
+    [Fact]
+    public void First_ingest_backfills_the_whole_existing_conversation()
+    {
+        var session = NewSession();
+        var ts = DateTime.UtcNow.AddHours(-3);
+        WriteTranscript(session,
+            UserLine("an old prompt", ts),
+            AssistantLine("an old reply", ts.AddSeconds(2)),
+            UserLine("a later prompt", ts.AddMinutes(30)));
+
+        using var ingestor = new ConversationIngestor(new SessionManager(new AgentOptions { ClaudePath = TestShell.Path }));
+        ingestor.Ingest(session);
+
+        Assert.Equal(
+            new[] { "an old prompt", "an old reply", "a later prompt" },
+            Recorded().Select(r => r.Text));
+    }
+
     [Fact]
     public void A_real_agent_timestamp_is_marked_as_the_agents_own()
     {

--- a/src/CcDirector.Core.Tests/Storage/PromptLogTests.cs
+++ b/src/CcDirector.Core.Tests/Storage/PromptLogTests.cs
@@ -1,0 +1,222 @@
+using CcDirector.Core.Configuration;
+using CcDirector.Core.History;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Storage;
+using CcDirector.Core.Tests.Wingman; // BufferOnlyBackend (internal test stub)
+using Xunit;
+
+namespace CcDirector.Core.Tests.Storage;
+
+/// <summary>
+/// Tests for the durable prompt + reply record (issue #1551): the origin sidecar
+/// (<see cref="InputOriginLog"/>), the content log (<see cref="ConversationLog"/>), and the join
+/// between them. All methods share an isolated CC_DIRECTOR_ROOT, set in the constructor; xUnit runs
+/// the methods of one class sequentially so the shared env var is safe within the class.
+/// </summary>
+[Collection("CcStorageRoot")] // serializes all classes that mutate the process-wide CC_DIRECTOR_ROOT
+public sealed class PromptLogTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string? _prevRoot;
+
+    public PromptLogTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-promptlog-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    // ===== the content log =====
+
+    private static ConversationRecord Sample(DateTime ts, string text, string role = "user") => new()
+    {
+        TsUtc = ts,
+        SessionId = "session-1",
+        SessionName = "devthrottle / abcd",
+        RepoPath = @"D:\ReposFred\devthrottle",
+        Agent = "ClaudeCode",
+        Role = role,
+        Modality = role == "user" ? "typed" : null,
+        Surface = role == "user" ? "desktop" : null,
+        TimestampFromAgent = true,
+        CharCount = text.Length,
+        WordCount = text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Length,
+        Text = text,
+    };
+
+    [Fact]
+    public void ConversationLog_round_trips_a_message()
+    {
+        var ts = new DateTime(2026, 7, 14, 9, 30, 0, DateTimeKind.Utc);
+        ConversationLog.Write(Sample(ts, "fix the login bug"));
+
+        var only = Assert.Single(ConversationLog.Read(ts, ts));
+        Assert.Equal("fix the login bug", only.Text);
+        Assert.Equal("user", only.Role);
+        Assert.Equal("typed", only.Modality);
+        Assert.Equal("desktop", only.Surface);
+        Assert.Equal(4, only.WordCount);
+    }
+
+    [Fact]
+    public void ConversationLog_appends_rather_than_overwriting()
+    {
+        var ts = new DateTime(2026, 7, 14, 9, 30, 0, DateTimeKind.Utc);
+        ConversationLog.Write(Sample(ts, "first"));
+        ConversationLog.Write(Sample(ts.AddMinutes(1), "second", "assistant"));
+        ConversationLog.Write(Sample(ts.AddMinutes(2), "third"));
+
+        var read = ConversationLog.Read(ts, ts);
+
+        Assert.Equal(new[] { "first", "second", "third" }, read.Select(r => r.Text));
+        Assert.Equal(new[] { "user", "assistant", "user" }, read.Select(r => r.Role));
+    }
+
+    [Fact]
+    public void ConversationLog_spans_days_and_returns_oldest_first()
+    {
+        var day1 = new DateTime(2026, 7, 14, 9, 0, 0, DateTimeKind.Utc);
+        var day3 = new DateTime(2026, 7, 16, 9, 0, 0, DateTimeKind.Utc);
+        ConversationLog.Write(Sample(day1, "monday"));
+        ConversationLog.Write(Sample(day3, "wednesday"));
+
+        Assert.Equal(new[] { "monday", "wednesday" }, ConversationLog.Read(day1, day3).Select(r => r.Text));
+    }
+
+    [Fact]
+    public void ConversationLog_read_of_an_absent_day_is_empty_rather_than_throwing()
+    {
+        var ts = new DateTime(2026, 7, 14, 9, 0, 0, DateTimeKind.Utc);
+        Assert.Empty(ConversationLog.Read(ts, ts));
+    }
+
+    [Fact]
+    public void ConversationLog_skips_a_corrupt_line_and_still_returns_the_good_ones()
+    {
+        var ts = new DateTime(2026, 7, 14, 9, 0, 0, DateTimeKind.Utc);
+        ConversationLog.Write(Sample(ts, "good one"));
+        File.AppendAllText(ConversationLog.FileFor(ts), "{ this is not json" + Environment.NewLine);
+        ConversationLog.Write(Sample(ts.AddMinutes(1), "good two"));
+
+        Assert.Equal(new[] { "good one", "good two" }, ConversationLog.Read(ts, ts).Select(r => r.Text));
+    }
+
+    [Fact]
+    public void ConversationLog_preserves_a_multi_line_message_as_one_record()
+    {
+        var ts = new DateTime(2026, 7, 14, 9, 0, 0, DateTimeKind.Utc);
+        var text = "line one\nline two\nline three";
+        ConversationLog.Write(Sample(ts, text));
+
+        Assert.Equal(text, Assert.Single(ConversationLog.Read(ts, ts)).Text);
+    }
+
+    // ===== the origin sidecar, written at the Session choke points =====
+
+    private static IReadOnlyList<InputOriginRecord> OriginsToday()
+        => InputOriginLog.Read(DateTime.UtcNow.Date, DateTime.UtcNow.Date.AddDays(1));
+
+    private static Session NewSession()
+    {
+        var manager = new SessionManager(new AgentOptions { ClaudePath = TestShell.Path });
+        return manager.CreateEmbeddedSession(Path.GetTempPath(), null, new BufferOnlyBackend());
+    }
+
+    [Fact]
+    public async Task SendTextAsync_records_where_the_prompt_came_from()
+    {
+        var session = NewSession();
+
+        await session.SendTextAsync("make the button blue", SendSource.UserInput, InputOrigin.DesktopTyped);
+
+        var only = Assert.Single(OriginsToday());
+        Assert.Equal(session.Id.ToString(), only.SessionId);
+        Assert.Equal("typed", only.Modality);
+        Assert.Equal("desktop", only.Surface);
+        Assert.Equal(20, only.CharCount);
+    }
+
+    [Fact]
+    public async Task SendTextAsync_records_the_origin_it_was_given()
+    {
+        var session = NewSession();
+
+        await session.SendTextAsync("spoken from the phone", SendSource.UserInput, InputOrigin.Voice(InputSurface.Phone));
+
+        var only = Assert.Single(OriginsToday());
+        Assert.Equal("voice", only.Modality);
+        Assert.Equal("phone", only.Surface);
+    }
+
+    [Fact]
+    public async Task SendTextAsync_without_an_origin_is_framework_internal_and_is_not_recorded()
+    {
+        var session = NewSession();
+
+        await session.SendTextAsync("handover framing text", SendSource.UserInput, origin: null);
+
+        Assert.Empty(OriginsToday());
+    }
+
+    [Fact]
+    public async Task SendTextAsync_with_blank_text_records_nothing()
+    {
+        var session = NewSession();
+
+        await session.SendTextAsync("", SendSource.UserInput, InputOrigin.DesktopTyped);
+
+        Assert.Empty(OriginsToday());
+    }
+
+    [Fact]
+    public void Terminal_typing_records_one_origin_event_on_submit_not_one_per_keystroke()
+    {
+        var session = NewSession();
+
+        // Typing "hi" at the terminal grid: one keystroke at a time, then Enter.
+        session.SendInput(new[] { (byte)'h' }, InputOrigin.DesktopTyped);
+        session.SendInput(new[] { (byte)'i' }, InputOrigin.DesktopTyped);
+        session.SendInput(new byte[] { 0x0D }, InputOrigin.DesktopTyped);
+
+        var only = Assert.Single(OriginsToday());
+        Assert.Equal("typed", only.Modality);
+        Assert.Equal("desktop", only.Surface);
+        // The whole line's size, not just the final keystroke's.
+        Assert.Equal(2, only.CharCount);
+    }
+
+    [Fact]
+    public void Terminal_typing_without_a_submit_records_nothing_yet()
+    {
+        var session = NewSession();
+
+        session.SendInput(new[] { (byte)'h' }, InputOrigin.DesktopTyped);
+        session.SendInput(new[] { (byte)'i' }, InputOrigin.DesktopTyped);
+
+        // Still composing - no submission has happened, so there is no prompt to attribute.
+        Assert.Empty(OriginsToday());
+    }
+
+    [Fact]
+    public void Terminal_typing_starts_a_fresh_count_after_each_submit()
+    {
+        var session = NewSession();
+
+        session.SendInput(new[] { (byte)'a' }, InputOrigin.DesktopTyped);
+        session.SendInput(new byte[] { 0x0D }, InputOrigin.DesktopTyped);
+        session.SendInput(new[] { (byte)'b' }, InputOrigin.DesktopTyped);
+        session.SendInput(new[] { (byte)'c' }, InputOrigin.DesktopTyped);
+        session.SendInput(new byte[] { 0x0D }, InputOrigin.DesktopTyped);
+
+        var events = OriginsToday();
+        Assert.Equal(2, events.Count);
+        Assert.Equal(1, events[0].CharCount);
+        Assert.Equal(2, events[1].CharCount); // not 3 - the first line's chars are not carried over
+    }
+}

--- a/src/CcDirector.Core/Claude/ClaudeTranscriptReader.cs
+++ b/src/CcDirector.Core/Claude/ClaudeTranscriptReader.cs
@@ -115,7 +115,14 @@ public static class ClaudeTranscriptReader
                 && DateTimeOffset.TryParse(ts.GetString(), out var parsed))
                 timestamp = parsed;
 
-            return new ConversationMessage(role, parts, timestamp);
+            // Claude stamps every line with the id of the context it belongs to, and mints a new one on
+            // /clear and on auto-compaction - so this is what groups the messages that truly shared a
+            // context window (issue #1551).
+            string? contextId = null;
+            if (root.TryGetProperty("sessionId", out var sid) && sid.ValueKind == JsonValueKind.String)
+                contextId = sid.GetString();
+
+            return new ConversationMessage(role, parts, timestamp, contextId);
         }
     }
 

--- a/src/CcDirector.Core/Gemini/GeminiPromptLogReader.cs
+++ b/src/CcDirector.Core/Gemini/GeminiPromptLogReader.cs
@@ -93,10 +93,17 @@ public static class GeminiPromptLogReader
                     && DateTimeOffset.TryParse(tsEl.GetString(), out var parsed))
                     ts = parsed;
 
+                // This file is per REPO and accumulates every Gemini context ever run there, so the
+                // per-entry sessionId is the only thing separating one context from the next.
+                string? contextId = null;
+                if (entry.TryGetProperty("sessionId", out var sidEl) && sidEl.ValueKind == JsonValueKind.String)
+                    contextId = sidEl.GetString();
+
                 messages.Add(new ConversationMessage(
                     ConversationRole.User,
                     new[] { new ConversationPart(ConversationPartKind.Text, text) },
-                    ts));
+                    ts,
+                    contextId));
             }
 
             return new ConversationHistory(messages);

--- a/src/CcDirector.Core/Gemini/GeminiPromptLogReader.cs
+++ b/src/CcDirector.Core/Gemini/GeminiPromptLogReader.cs
@@ -1,0 +1,110 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core.History;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Gemini;
+
+/// <summary>
+/// Reads Gemini's own prompt log (issue #1551): the user's prompts, with real timestamps.
+///
+/// This is NOT the same source as <see cref="GeminiTerminalHistory"/>, and the difference matters.
+/// The History TAB wants the whole conversation as a human reads it, so it scrapes the terminal
+/// scrollback - the only place Gemini's REPLIES exist. The durable record wants structured, stably
+/// identified messages, and the scrollback is neither: it is one ever-growing unstructured blob with
+/// no timestamps, so copying it on each turn would append the entire conversation again every time.
+///
+/// Gemini does persist the user's half, at
+/// <c>~/.gemini/tmp/&lt;sha256 of the repo path&gt;/logs.json</c> - a JSON array of
+/// <c>{ sessionId, messageId, type, message, timestamp }</c>. Real prompt text, real timestamps, so
+/// the origin join works exactly as it does for the other agents.
+///
+/// The honest limit: Gemini records the user's prompts ONLY, never the model's responses. So a Gemini
+/// session yields prompts and no replies. That is a real gap in what Gemini persists, not something
+/// we can parse our way out of - and it is recorded as absent rather than filled in from the
+/// scrollback, which cannot be attributed to a turn.
+/// </summary>
+public static class GeminiPromptLogReader
+{
+    /// <summary>
+    /// The logs.json path for a repo, or null when Gemini has never run there.
+    /// </summary>
+    /// <param name="repoPath">The session's repo path - what Gemini hashes to key its temp directory.</param>
+    /// <param name="homeDirectory">Override the user profile directory. Tests only; null resolves the
+    /// real one. (Note the real lookup is the Windows shell API, which the USERPROFILE environment
+    /// variable does NOT influence - hence an explicit parameter rather than an env override.)</param>
+    public static string? ResolvePath(string repoPath, string? homeDirectory = null)
+    {
+        if (string.IsNullOrWhiteSpace(repoPath)) return null;
+        try
+        {
+            var home = homeDirectory ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var path = Path.Combine(home, ".gemini", "tmp", HashRepoPath(repoPath), "logs.json");
+            return File.Exists(path) ? path : null;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GeminiPromptLogReader] ResolvePath failed for {repoPath}: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Gemini keys its per-project temp directory by the SHA-256 of the project path, lowercase hex.
+    /// Verified against a live ~/.gemini/tmp on Windows: the input is the path exactly as the OS gives
+    /// it, backslashes included.
+    /// </summary>
+    internal static string HashRepoPath(string repoPath)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(repoPath));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// The user prompts Gemini recorded for this repo, oldest first. Returns an empty history when
+    /// Gemini has not run there or its log cannot be read. Never throws.
+    /// </summary>
+    public static ConversationHistory Read(string repoPath, string? homeDirectory = null)
+    {
+        var path = ResolvePath(repoPath, homeDirectory);
+        if (path is null) return ConversationHistory.Empty;
+
+        try
+        {
+            // Gemini rewrites this file as it appends; read shared so a live session cannot lock us out.
+            using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var doc = JsonDocument.Parse(fs);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array) return ConversationHistory.Empty;
+
+            var messages = new List<ConversationMessage>();
+            foreach (var entry in doc.RootElement.EnumerateArray())
+            {
+                if (entry.ValueKind != JsonValueKind.Object) continue;
+                // Gemini writes only user entries today; anything else is not ours to interpret.
+                if (!entry.TryGetProperty("type", out var type) || type.GetString() != "user") continue;
+                if (!entry.TryGetProperty("message", out var msg) || msg.ValueKind != JsonValueKind.String) continue;
+
+                var text = msg.GetString();
+                if (string.IsNullOrWhiteSpace(text)) continue;
+
+                DateTimeOffset? ts = null;
+                if (entry.TryGetProperty("timestamp", out var tsEl) && tsEl.ValueKind == JsonValueKind.String
+                    && DateTimeOffset.TryParse(tsEl.GetString(), out var parsed))
+                    ts = parsed;
+
+                messages.Add(new ConversationMessage(
+                    ConversationRole.User,
+                    new[] { new ConversationPart(ConversationPartKind.Text, text) },
+                    ts));
+            }
+
+            return new ConversationHistory(messages);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GeminiPromptLogReader] Read failed for {path}: {ex.Message}");
+            return ConversationHistory.Empty;
+        }
+    }
+}

--- a/src/CcDirector.Core/History/ConversationHistory.cs
+++ b/src/CcDirector.Core/History/ConversationHistory.cs
@@ -44,10 +44,17 @@ public sealed record ConversationPart(
 /// <param name="Role">Who produced the message.</param>
 /// <param name="Parts">The message's content parts, in order.</param>
 /// <param name="Timestamp">When the message was recorded, if the source carries it.</param>
+/// <param name="ContextId">The agent's OWN id for the context this message belongs to, when the source
+/// carries one; null otherwise. This is the CONTEXT's identity, not the Director session's: agents mint
+/// a new one whenever the context restarts (Claude does so on /clear and on auto-compaction), so it is
+/// what groups messages that actually shared a context window. Distinct from the Director session id,
+/// which spans every context in one window. A source holding several contexts in one file (Gemini's
+/// logs.json) carries it per message, which is why it lives here rather than on the history.</param>
 public sealed record ConversationMessage(
     ConversationRole Role,
     IReadOnlyList<ConversationPart> Parts,
-    DateTimeOffset? Timestamp = null);
+    DateTimeOffset? Timestamp = null,
+    string? ContextId = null);
 
 /// <summary>
 /// An agent-agnostic, normalized view of a session's conversation. Every agent provider

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -2,6 +2,7 @@ using CcDirector.Core.Agents;
 using CcDirector.Core.Backends;
 using CcDirector.Core.Claude;
 using CcDirector.Core.Memory;
+using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 using CcDirector.Core.Wingman;
 using CcDirector.Terminal.Core;
@@ -1606,19 +1607,37 @@ public sealed class Session : IDisposable
     /// <summary>Send raw bytes to the backend. <paramref name="origin"/> tags this input for the
     /// DevThrottle Stats tally as typed CHARACTER volume for its surface (never a turn - a bare keystroke
     /// is the user composing, not a submitted turn). Null origin = framework-internal, not counted.</summary>
+    /// <summary>Printable characters typed at the terminal since the last submission, accumulated so
+    /// the origin event written on Enter carries the size of the whole line rather than of the final
+    /// keystroke. Reset at each submission. See <see cref="RecordOrigin"/>.</summary>
+    private int _pendingOriginChars;
+
     public void SendInput(byte[] data, InputOrigin? origin = null)
     {
         if (_disposed || Status is SessionStatus.Exited or SessionStatus.Failed) return;
         FileLog.Write($"[Session] SendInput: session={Id}, bytes={data.Length}, firstByte=0x{(data.Length > 0 ? data[0].ToString("X2") : "00")}");
         _backend.Write(data);
         if (origin is InputOrigin o)
+        {
             InputStats.RecordCharacters(o, CountPrintable(data));
+            _pendingOriginChars += CountPrintable(data);
+        }
         // Only promote to Working when the write contains an actual submission
         // (CR or LF). A bare keystroke is the user composing at the prompt --
         // Claude Code hasn't received a turn yet. Treating every byte as Working
         // flickered the sidebar dot blue on every character typed.
         if (ContainsSubmit(data))
         {
+            // A submission is the moment to note the origin (issue #1551). Terminal typing arrives
+            // here one keystroke at a time, so the prompt TEXT cannot be reconstructed from these
+            // bytes - backspace, arrow-key edits, history recall, paste and the agent's own
+            // autocomplete all mutate the line invisibly, and replaying keystrokes would silently
+            // record prompts the user never sent. Only the provenance is recorded here; the text is
+            // read back from the agent's own transcript by the conversation ingest and joined to
+            // this event by timestamp.
+            if (origin is InputOrigin so)
+                RecordOrigin(so, _pendingOriginChars);
+            _pendingOriginChars = 0;
             IsBrandNew = false;
             // A real submission means the user is driving this session again, so neither a hold nor a
             // not-yet-landed deferral reflects intent any more - both are superseded (issue #470).
@@ -1739,7 +1758,33 @@ public sealed class Session : IDisposable
         // volume) for the tagged origin. Null origin = framework-internal (handover, queue drain) - not
         // counted, even though it still submits a turn to the agent.
         if (origin is InputOrigin o)
+        {
             InputStats.RecordTurn(o, text?.Length ?? 0);
+            RecordOrigin(o, text?.Length ?? 0);
+        }
+    }
+
+    /// <summary>
+    /// Note WHERE this submission came from in the <see cref="InputOriginLog"/> (issue #1551). Carries
+    /// no text: the conversation ingest reads the text back from the agent's own transcript and joins
+    /// this event to it by session + nearest timestamp. This choke point is the only place the origin
+    /// is ever known.
+    ///
+    /// Gated on the same non-null origin as the stats tally, so framework-internal sends (handover
+    /// text, queue drain, framing) stay out for the same reason they stay out of the counts: they carry
+    /// no human keystrokes and no spoken words.
+    /// </summary>
+    private void RecordOrigin(InputOrigin origin, int charCount)
+    {
+        if (charCount <= 0) return;
+        InputOriginLog.Write(new InputOriginRecord
+        {
+            TsUtc = DateTime.UtcNow,
+            SessionId = Id.ToString(),
+            Modality = origin.ModalityToken,
+            Surface = origin.SurfaceToken,
+            CharCount = charCount,
+        });
     }
 
     /// <summary>Send text followed by Enter (sync wrapper). See

--- a/src/CcDirector.Core/Storage/ConversationIngestor.cs
+++ b/src/CcDirector.Core/Storage/ConversationIngestor.cs
@@ -1,0 +1,316 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using CcDirector.Core.Agents;
+using CcDirector.Core.Gemini;
+using CcDirector.Core.History;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Storage;
+
+/// <summary>
+/// Copies each session's conversation into the durable <see cref="ConversationLog"/> (issue #1551).
+///
+/// Trigger: the same one <see cref="TurnReviewLogger"/> uses - a session flipping to
+/// <see cref="ActivityState.WaitingForInput"/>, i.e. our own detector deciding "the agent is done and
+/// needs the user". That is exactly when new messages exist to copy, so there is no polling.
+///
+/// Source: <see cref="SessionHistoryReader"/>, the agent-neutral facade over all supported agents. We
+/// keep only <see cref="ConversationPartKind.Text"/> parts - tool calls and their results are dropped
+/// (they are most of the volume and not the signal), and thinking blocks with them.
+///
+/// Watermarking: agents rewrite and compact their transcripts, so "how many did I read last time" is
+/// not durable. Instead each written message's identity (timestamp + role + text hash) is remembered
+/// per session and persisted, so re-reading the same transcript cannot double-append. State lives at
+/// base/prompt-log/ingest-state.json.
+///
+/// Read-only over sessions and fail-safe throughout: ingest must never break a turn.
+/// </summary>
+public sealed class ConversationIngestor : IDisposable
+{
+    private readonly SessionManager _sessionManager;
+    private readonly ConcurrentDictionary<Guid, Action<ActivityState, ActivityState>> _handlers = new();
+    private readonly IngestState _state = IngestState.Load();
+    private bool _started;
+    private int _disposed;
+
+    public ConversationIngestor(SessionManager sessionManager) => _sessionManager = sessionManager;
+
+    public void Start()
+    {
+        if (_started) return;
+        _started = true;
+        FileLog.Write("[ConversationIngestor] Start");
+        _sessionManager.OnSessionCreated += WireSession;
+        _sessionManager.OnSessionRemoved += UnwireSession;
+        foreach (var s in _sessionManager.ListSessions())
+            WireSession(s);
+    }
+
+    private void WireSession(Session session)
+    {
+        if (_handlers.ContainsKey(session.Id)) return;
+
+        Action<ActivityState, ActivityState> handler = (_, @new) =>
+        {
+            // The single trigger: the agent just finished a turn, so new messages exist to copy.
+            if (@new != ActivityState.WaitingForInput) return;
+            // Off the event thread - reading a transcript is disk work and must not stall the UI.
+            Task.Run(() => Ingest(session));
+        };
+        _handlers[session.Id] = handler;
+        session.OnActivityStateChanged += handler;
+    }
+
+    private void UnwireSession(Session session)
+    {
+        if (_handlers.TryRemove(session.Id, out var h))
+            session.OnActivityStateChanged -= h;
+        // Deliberately keep this session's seen-set: a session can be removed and restored, and its
+        // transcript survives, so forgetting here would re-append everything it ever said.
+    }
+
+    /// <summary>
+    /// Copy any not-yet-recorded messages for this session. Public so a backfill can drive it directly.
+    /// Never throws.
+    /// </summary>
+    public void Ingest(Session session)
+    {
+        try
+        {
+            if (!SessionHistoryReader.IsSupported(session)) return;
+
+            var history = ReadForRecord(session);
+            if (history.Messages.Count == 0) return;
+
+            var scope = ScopeKey(session);
+
+            var origins = LoadOriginsFor(session, history);
+            var toWrite = new List<ConversationRecord>();
+
+            foreach (var message in history.Messages)
+            {
+                var text = TextOf(message);
+                if (string.IsNullOrWhiteSpace(text)) continue;
+
+                // Gemini carries no timestamps (its history is scraped from the terminal buffer), so
+                // there is nothing real to stamp with. Record ingest time and mark it as ours, rather
+                // than letting an inferred time read as a measured one.
+                var fromAgent = message.Timestamp.HasValue;
+                var ts = message.Timestamp?.UtcDateTime ?? DateTime.UtcNow;
+
+                if (_state.AlreadyWritten(scope, ts, message.Role, text, fromAgent)) continue;
+
+                var isUser = message.Role == ConversationRole.User;
+                var origin = isUser ? MatchOrigin(origins, ts, fromAgent) : null;
+
+                toWrite.Add(new ConversationRecord
+                {
+                    TsUtc = ts,
+                    SessionId = session.Id.ToString(),
+                    SessionName = session.CustomName,
+                    RepoPath = session.RepoPath,
+                    Agent = session.AgentKind.ToString(),
+                    MissionName = session.MissionName,
+                    Role = isUser ? "user" : "assistant",
+                    Modality = origin?.Modality,
+                    // A user message we could not attribute is "unknown", never a guess. An assistant
+                    // reply has no origin at all, so it stays null.
+                    Surface = isUser ? (origin?.Surface ?? "unknown") : null,
+                    TimestampFromAgent = fromAgent,
+                    CharCount = text.Length,
+                    WordCount = text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Length,
+                    Text = text,
+                });
+
+                _state.MarkWritten(scope, ts, message.Role, text, fromAgent);
+            }
+
+            if (toWrite.Count == 0) return;
+
+            ConversationLog.WriteMany(toWrite);
+            _state.Save();
+            FileLog.Write($"[ConversationIngestor] session={session.Id} wrote {toWrite.Count} message(s)");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[ConversationIngestor] Ingest FAILED (swallowed) session={session.Id}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// What the dedupe is scoped to: the SOURCE we read, not the Director session that triggered the
+    /// read. These are not the same thing, and assuming they were is a duplication bug.
+    ///
+    /// Claude, Codex, Pi and Grok keep a transcript per agent session, so the source is that file and
+    /// scoping by Director session happens to agree. But Copilot and OpenCode resolve their
+    /// conversation by REPO out of one shared SQLite store, and Gemini's logs.json is keyed by repo
+    /// too - so two Director sessions on one repo read the SAME conversation. Scoped by session, each
+    /// would keep its own seen-set and write every message twice. Scoped by source, they share one.
+    /// </summary>
+    private static string ScopeKey(Session session) => session.AgentKind switch
+    {
+        AgentKind.Gemini => $"gemini|{session.RepoPath}",
+        AgentKind.Copilot => $"copilot|{session.RepoPath}",
+        AgentKind.OpenCode => $"opencode|{session.RepoPath}",
+        // Per-session transcript agents: the file itself is the identity. Fall back to the session id
+        // only if the path cannot be resolved, which is the narrowest honest scope available.
+        _ => SessionHistoryReader.ResolveTranscriptPath(session) ?? session.Id.ToString(),
+    };
+
+    /// <summary>
+    /// The conversation to copy for this session. Normally the agent-neutral
+    /// <see cref="SessionHistoryReader"/> facade - with ONE deliberate exception.
+    ///
+    /// Gemini persists no transcript, so the facade builds its history by scraping the terminal
+    /// scrollback into a single unstructured, untimestamped blob. That is right for the History tab
+    /// (it is the only place Gemini's replies exist) and wrong here: the blob grows every turn, so it
+    /// is a different message each time and copying it would append the whole conversation again on
+    /// every turn, forever. Gemini's own logs.json has the user's prompts with real timestamps, which
+    /// is what a durable record needs - so the record reads that instead, and honestly has no Gemini
+    /// replies rather than a re-appended screen dump. See <see cref="GeminiPromptLogReader"/>.
+    /// </summary>
+    private static ConversationHistory ReadForRecord(Session session)
+        => session.AgentKind == AgentKind.Gemini
+            ? GeminiPromptLogReader.Read(session.RepoPath)
+            : SessionHistoryReader.Read(session);
+
+    /// <summary>Concatenate a message's Text parts. Tool calls, tool results, and thinking are dropped.</summary>
+    private static string TextOf(ConversationMessage message)
+    {
+        var parts = message.Parts
+            .Where(p => p.Kind == ConversationPartKind.Text)
+            .Select(p => p.Text)
+            .Where(t => !string.IsNullOrWhiteSpace(t));
+        return string.Join("\n", parts).Trim();
+    }
+
+    /// <summary>
+    /// The origin events that could plausibly belong to this session's messages: the days the history
+    /// spans. Read once per ingest rather than per message.
+    /// </summary>
+    private static List<InputOriginRecord> LoadOriginsFor(Session session, ConversationHistory history)
+    {
+        var stamps = history.Messages.Where(m => m.Timestamp.HasValue)
+            .Select(m => m.Timestamp!.Value.UtcDateTime).ToList();
+        var from = stamps.Count > 0 ? stamps.Min().Date : DateTime.UtcNow.Date;
+        var to = stamps.Count > 0 ? stamps.Max().Date : DateTime.UtcNow.Date;
+        var id = session.Id.ToString();
+        return InputOriginLog.Read(from, to).Where(o => o.SessionId == id).ToList();
+    }
+
+    /// <summary>
+    /// The closest origin event in time to this message, or null when none is close enough. The join is
+    /// deliberately tight: an origin event is written the instant a submission crosses a choke point,
+    /// and the agent stamps the message on receipt, so a real pair is seconds apart. Anything further
+    /// out is not evidence, and an unmatched message is honestly "unknown".
+    /// </summary>
+    private static InputOriginRecord? MatchOrigin(List<InputOriginRecord> origins, DateTime ts, bool timestampFromAgent)
+    {
+        // Without a real agent timestamp there is nothing to join on - we would be matching our own
+        // ingest clock against submission times, which is not a measurement.
+        if (!timestampFromAgent || origins.Count == 0) return null;
+
+        InputOriginRecord? best = null;
+        var bestDelta = TimeSpan.MaxValue;
+        foreach (var o in origins)
+        {
+            var delta = (o.TsUtc - ts).Duration();
+            if (delta < bestDelta) { bestDelta = delta; best = o; }
+        }
+        return bestDelta <= MatchWindow ? best : null;
+    }
+
+    /// <summary>How far apart a submission and its transcript message may be and still be the same event.</summary>
+    private static readonly TimeSpan MatchWindow = TimeSpan.FromSeconds(30);
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        _sessionManager.OnSessionCreated -= WireSession;
+        _sessionManager.OnSessionRemoved -= UnwireSession;
+        foreach (var s in _sessionManager.ListSessions())
+            UnwireSession(s);
+        _handlers.Clear();
+        _state.Save();
+    }
+}
+
+/// <summary>
+/// Which messages have already been copied, per SOURCE (see ConversationIngestor.ScopeKey - a
+/// transcript file, or a repo for the agents whose history is repo-resolved). Identity is timestamp +
+/// role + text hash - NOT a message index, because agents rewrite and compact their transcripts and an
+/// index would slide. Persisted so a Director restart cannot re-append a whole history.
+/// </summary>
+internal sealed class IngestState
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<string, HashSet<string>> _seen = new();
+
+    private static string Path_ => System.IO.Path.Combine(ConversationLog.Directory(), "ingest-state.json");
+
+    private static string Key(DateTime ts, ConversationRole role, string text, bool tsFromAgent)
+    {
+        // A message with no agent timestamp is stamped with OUR clock, which differs on every read -
+        // so its key must not include the time or nothing would ever dedupe. Text + role is what we
+        // genuinely have for those agents.
+        var timePart = tsFromAgent ? ts.ToString("O") : "no-ts";
+        return $"{timePart}|{(int)role}|{text.GetHashCode()}";
+    }
+
+    public bool AlreadyWritten(string scope, DateTime ts, ConversationRole role, string text, bool tsFromAgent)
+    {
+        lock (_gate)
+        {
+            return _seen.TryGetValue(scope, out var set)
+                && set.Contains(Key(ts, role, text, tsFromAgent));
+        }
+    }
+
+    public void MarkWritten(string scope, DateTime ts, ConversationRole role, string text, bool tsFromAgent)
+    {
+        lock (_gate)
+        {
+            if (!_seen.TryGetValue(scope, out var set))
+                _seen[scope] = set = new HashSet<string>();
+            set.Add(Key(ts, role, text, tsFromAgent));
+        }
+    }
+
+    public static IngestState Load()
+    {
+        var state = new IngestState();
+        try
+        {
+            if (!File.Exists(Path_)) return state;
+            var json = File.ReadAllText(Path_);
+            var loaded = JsonSerializer.Deserialize<Dictionary<string, HashSet<string>>>(json);
+            if (loaded is not null)
+                foreach (var kv in loaded) state._seen[kv.Key] = kv.Value;
+        }
+        catch (Exception ex)
+        {
+            // A lost watermark means re-appending, not data loss. Log it and start clean rather than
+            // failing the Director over a state file.
+            FileLog.Write($"[ConversationIngestor] ingest-state load FAILED, starting clean: {ex.Message}");
+        }
+        return state;
+    }
+
+    public void Save()
+    {
+        try
+        {
+            lock (_gate)
+            {
+                var tmp = Path_ + ".tmp";
+                File.WriteAllText(tmp, JsonSerializer.Serialize(_seen));
+                File.Move(tmp, Path_, overwrite: true);
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[ConversationIngestor] ingest-state save FAILED (swallowed): {ex.Message}");
+        }
+    }
+}

--- a/src/CcDirector.Core/Storage/ConversationIngestor.cs
+++ b/src/CcDirector.Core/Storage/ConversationIngestor.cs
@@ -108,6 +108,7 @@ public sealed class ConversationIngestor : IDisposable
                 {
                     TsUtc = ts,
                     SessionId = session.Id.ToString(),
+                    ContextId = ContextIdFor(session, message),
                     SessionName = session.CustomName,
                     RepoPath = session.RepoPath,
                     Agent = session.AgentKind.ToString(),
@@ -136,6 +137,39 @@ public sealed class ConversationIngestor : IDisposable
         {
             FileLog.Write($"[ConversationIngestor] Ingest FAILED (swallowed) session={session.Id}: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Which agent CONTEXT a message belonged to - what you group by to replay one conversation as the
+    /// agent saw it, and what resets when the context is cleared (issue #1551).
+    ///
+    /// Prefer the id the source itself stamped on the message: Claude and Gemini both carry one, and
+    /// only a per-message value is correct for a source that holds several contexts in one file. Fall
+    /// back to the transcript file's own name, which for the file-per-context agents (Codex, Pi, Grok)
+    /// IS the context's identity - a new context means a new file.
+    ///
+    /// Null when the agent exposes no context identity at all (Copilot and OpenCode resolve out of a
+    /// shared store by repo). Recorded as absent rather than invented; the Director session id still
+    /// groups the work.
+    /// </summary>
+    private static string? ContextIdFor(Session session, ConversationMessage message)
+    {
+        if (!string.IsNullOrWhiteSpace(message.ContextId)) return message.ContextId;
+
+        return session.AgentKind switch
+        {
+            // These resolve out of one shared per-repo store and expose no context identity we can read.
+            AgentKind.Copilot or AgentKind.OpenCode => null,
+            _ => TranscriptStem(session),
+        };
+    }
+
+    /// <summary>The transcript file's name without extension - the context identity for the agents that
+    /// keep one file per context. Null when no transcript path resolves.</summary>
+    private static string? TranscriptStem(Session session)
+    {
+        var path = SessionHistoryReader.ResolveTranscriptPath(session);
+        return string.IsNullOrWhiteSpace(path) ? null : Path.GetFileNameWithoutExtension(path);
     }
 
     /// <summary>

--- a/src/CcDirector.Core/Storage/ConversationLog.cs
+++ b/src/CcDirector.Core/Storage/ConversationLog.cs
@@ -115,7 +115,18 @@ public static class ConversationLog
 public sealed record ConversationRecord
 {
     [JsonPropertyName("ts")] public required DateTime TsUtc { get; init; }
+    /// <summary>The DIRECTOR session (the window/slot). Stable for its whole life - it does NOT reset
+    /// when the context is cleared - so it groups every context in one workstream.</summary>
     [JsonPropertyName("sessionId")] public required string SessionId { get; init; }
+    /// <summary>
+    /// The AGENT's own id for the context this message belonged to. Resets whenever the context does:
+    /// Claude mints a new one on /clear AND on auto-compaction. This is what to group by to replay one
+    /// conversation exactly as the agent saw it - everything that shared a context window.
+    ///
+    /// Null when the agent exposes no context identity of its own. Never invented: an absent context id
+    /// is recorded as absent, and the Director session id above still groups the work.
+    /// </summary>
+    [JsonPropertyName("contextId")] public string? ContextId { get; init; }
     [JsonPropertyName("sessionName")] public string? SessionName { get; init; }
     [JsonPropertyName("repoPath")] public string? RepoPath { get; init; }
     [JsonPropertyName("agent")] public string? Agent { get; init; }

--- a/src/CcDirector.Core/Storage/ConversationLog.cs
+++ b/src/CcDirector.Core/Storage/ConversationLog.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Storage;
+
+/// <summary>
+/// The durable record of what was actually said (issue #1551): every prompt the operator sent and
+/// every reply the agent sent back, for every agent, with the origin of each prompt joined on.
+/// This is the foundation the weekly review reads back (devthrottle_internal#358).
+///
+/// One JSON line per message in a daily file: base/prompt-log/conversation-yyyyMMdd.jsonl.
+///
+/// Source: the agent's OWN transcript, read through the agent-neutral SessionHistoryReader facade and
+/// copied here by <see cref="ConversationIngestor"/>. That is ground truth - what the agent actually
+/// received, after all the line editing - rather than our reconstruction of what the user probably
+/// typed. Agents read on demand and nothing persists them, so if an agent compacts or cleans up its
+/// transcript the history is gone; copying it here is the whole point.
+///
+/// Retention is deliberately unbounded. The point is looking back across weeks and months, and this
+/// text is small. (Contrast <see cref="TurnReviewLog"/>, which holds terminal SCREENS and expires at
+/// 7 days.) Nothing prunes this. If that changes it becomes a stated setting, not a silent sweep.
+///
+/// Fail-safe: every write is wrapped, so a logging error can never break a turn.
+/// </summary>
+public static class ConversationLog
+{
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private static readonly object _gate = new();
+
+    /// <summary>The prompt-log directory, shared with <see cref="InputOriginLog"/>.</summary>
+    public static string Directory() => CcStorage.Ensure(Path.Combine(CcStorage.Root(), "prompt-log"));
+
+    /// <summary>The daily file a message at <paramref name="utcNow"/> lands in.</summary>
+    public static string FileFor(DateTime utcNow)
+        => Path.Combine(Directory(), $"conversation-{utcNow:yyyyMMdd}.jsonl");
+
+    /// <summary>Append one message. Never throws.</summary>
+    public static void Write(ConversationRecord record)
+    {
+        try
+        {
+            var line = JsonSerializer.Serialize(record, JsonOpts);
+            var path = FileFor(record.TsUtc);
+            lock (_gate)
+            {
+                File.AppendAllText(path, line + Environment.NewLine);
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[ConversationLog] Write FAILED (swallowed) for session={record.SessionId}: {ex.Message}");
+        }
+    }
+
+    /// <summary>Append several messages in one lock. Never throws.</summary>
+    public static void WriteMany(IEnumerable<ConversationRecord> records)
+    {
+        foreach (var record in records)
+            Write(record);
+    }
+
+    /// <summary>
+    /// Read every message in the inclusive UTC day range, oldest first. Skips unparseable lines rather
+    /// than failing the whole read, so one bad line cannot hide a month of work.
+    /// </summary>
+    public static IReadOnlyList<ConversationRecord> Read(DateTime fromUtc, DateTime toUtc)
+    {
+        var results = new List<ConversationRecord>();
+        for (var day = fromUtc.Date; day <= toUtc.Date; day = day.AddDays(1))
+        {
+            var path = FileFor(day);
+            if (!File.Exists(path)) continue;
+            string[] lines;
+            try
+            {
+                lock (_gate) { lines = File.ReadAllLines(path); }
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[ConversationLog] Read FAILED for {path}: {ex.Message}");
+                continue;
+            }
+            foreach (var line in lines)
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                try
+                {
+                    var record = JsonSerializer.Deserialize<ConversationRecord>(line, JsonOpts);
+                    if (record is not null) results.Add(record);
+                }
+                catch (JsonException ex)
+                {
+                    FileLog.Write($"[ConversationLog] Skipping unparseable line in {Path.GetFileName(path)}: {ex.Message}");
+                }
+            }
+        }
+        return results;
+    }
+}
+
+/// <summary>
+/// One message in the durable record. <see cref="Text"/> is the whole message as the agent saw it.
+///
+/// The origin fields (<see cref="Modality"/>, <see cref="Surface"/>) are joined from
+/// <see cref="InputOriginLog"/> at ingest and are meaningful only for a user message; an assistant
+/// reply has no origin and leaves them null. When a user message cannot be matched to an origin event
+/// the surface is recorded as "unknown" rather than guessed - InputOrigin.cs defines Unknown for
+/// exactly this, "recorded honestly, but never presented as a real surface share".
+/// </summary>
+public sealed record ConversationRecord
+{
+    [JsonPropertyName("ts")] public required DateTime TsUtc { get; init; }
+    [JsonPropertyName("sessionId")] public required string SessionId { get; init; }
+    [JsonPropertyName("sessionName")] public string? SessionName { get; init; }
+    [JsonPropertyName("repoPath")] public string? RepoPath { get; init; }
+    [JsonPropertyName("agent")] public string? Agent { get; init; }
+    [JsonPropertyName("missionName")] public string? MissionName { get; init; }
+    /// <summary>"user" or "assistant".</summary>
+    [JsonPropertyName("role")] public required string Role { get; init; }
+    /// <summary>"typed" or "voice"; null for an assistant reply or an unmatched user message.</summary>
+    [JsonPropertyName("modality")] public string? Modality { get; init; }
+    /// <summary>"desktop" / "cockpit" / "phone" / "unknown"; null for an assistant reply.</summary>
+    [JsonPropertyName("surface")] public string? Surface { get; init; }
+    /// <summary>True when the source agent supplied a real timestamp; false when we stamped it at
+    /// ingest because the agent carries none (Gemini). Keeps an inferred time from reading as measured.</summary>
+    [JsonPropertyName("tsFromAgent")] public required bool TimestampFromAgent { get; init; }
+    [JsonPropertyName("charCount")] public required int CharCount { get; init; }
+    [JsonPropertyName("wordCount")] public required int WordCount { get; init; }
+    [JsonPropertyName("text")] public required string Text { get; init; }
+}

--- a/src/CcDirector.Core/Storage/InputOriginLog.cs
+++ b/src/CcDirector.Core/Storage/InputOriginLog.cs
@@ -1,0 +1,111 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Storage;
+
+/// <summary>
+/// The provenance half of the prompt record (issue #1551): where each submitted prompt came from -
+/// typed or spoken, desktop or cockpit or phone.
+///
+/// This exists because the two halves are knowable in two different places and NOWHERE else:
+/// - WHAT was said is the agent's own business, read back from its transcript
+///   (<see cref="ConversationLog"/> ingests it via SessionHistoryReader).
+/// - WHERE IT CAME FROM is ONLY ever known here, at the Session choke points. By the time a prompt
+///   reaches a transcript, one spoken on the phone and one typed at the terminal are identical.
+///
+/// So this log deliberately holds NO text - just a small event per submission that the conversation
+/// ingest joins to a message by session + nearest timestamp. One JSON line per submission in a daily
+/// file: base/prompt-log/origin-yyyyMMdd.jsonl.
+///
+/// Fail-safe: every write is wrapped, so a disk error can never break a turn.
+/// </summary>
+public static class InputOriginLog
+{
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private static readonly object _gate = new();
+
+    /// <summary>The prompt-log directory, shared with <see cref="ConversationLog"/>.</summary>
+    public static string Directory() => CcStorage.Ensure(Path.Combine(CcStorage.Root(), "prompt-log"));
+
+    /// <summary>The daily file an event at <paramref name="utcNow"/> lands in.</summary>
+    public static string FileFor(DateTime utcNow)
+        => Path.Combine(Directory(), $"origin-{utcNow:yyyyMMdd}.jsonl");
+
+    /// <summary>Append one origin event. Never throws.</summary>
+    public static void Write(InputOriginRecord record)
+    {
+        try
+        {
+            var line = JsonSerializer.Serialize(record, JsonOpts);
+            var path = FileFor(record.TsUtc);
+            lock (_gate)
+            {
+                File.AppendAllText(path, line + Environment.NewLine);
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[InputOriginLog] Write FAILED (swallowed) for session={record.SessionId}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Read every origin event in the inclusive UTC day range, oldest first. Skips unparseable lines
+    /// rather than failing the whole read.
+    /// </summary>
+    public static IReadOnlyList<InputOriginRecord> Read(DateTime fromUtc, DateTime toUtc)
+    {
+        var results = new List<InputOriginRecord>();
+        for (var day = fromUtc.Date; day <= toUtc.Date; day = day.AddDays(1))
+        {
+            var path = FileFor(day);
+            if (!File.Exists(path)) continue;
+            string[] lines;
+            try
+            {
+                lock (_gate) { lines = File.ReadAllLines(path); }
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[InputOriginLog] Read FAILED for {path}: {ex.Message}");
+                continue;
+            }
+            foreach (var line in lines)
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                try
+                {
+                    var record = JsonSerializer.Deserialize<InputOriginRecord>(line, JsonOpts);
+                    if (record is not null) results.Add(record);
+                }
+                catch (JsonException ex)
+                {
+                    FileLog.Write($"[InputOriginLog] Skipping unparseable line in {Path.GetFileName(path)}: {ex.Message}");
+                }
+            }
+        }
+        return results;
+    }
+}
+
+/// <summary>
+/// One submission crossing a Session choke point: when, which session, and how the operator produced
+/// it. Deliberately carries no prompt text - the conversation log holds the text, and this is joined
+/// to it by session + nearest timestamp.
+/// </summary>
+public sealed record InputOriginRecord
+{
+    [JsonPropertyName("ts")] public required DateTime TsUtc { get; init; }
+    [JsonPropertyName("sessionId")] public required string SessionId { get; init; }
+    /// <summary>"typed" or "voice".</summary>
+    [JsonPropertyName("modality")] public required string Modality { get; init; }
+    /// <summary>"desktop", "cockpit", "phone", or "unknown".</summary>
+    [JsonPropertyName("surface")] public required string Surface { get; init; }
+    /// <summary>Characters submitted. A size hint only - the authoritative text is in the conversation log.</summary>
+    [JsonPropertyName("charCount")] public required int CharCount { get; init; }
+}


### PR DESCRIPTION
Closes #1551. Foundation for devthrottle_internal#358 (the honest weekly picture).

## What this does

Records every prompt sent and every reply received, for all seven agents, with the origin of each
prompt attached. Nothing durable recorded prompt text before this.

**Two thin records, joined on session + time.**

| | source | holds |
|---|---|---|
| `ConversationLog` | the agent's own transcript, via `SessionHistoryReader` | what was said (user + assistant) |
| `InputOriginLog` | the Session choke points | where it came from (typed/voice, desktop/cockpit/phone) |

The history knows *what* and can never know *where from* - by the time a prompt is in a transcript, one
spoken on the phone and one typed at the terminal are identical. Only the choke points ever knew. So
the origin log carries no text, and the ingest joins it to a message by session + nearest timestamp
(30s window).

Reading the agent's own transcript means all seven agents work with no per-agent code, and we get the
assistant's replies for free - "did that prompt work" is not answerable from the prompt alone. Tool
calls are dropped by filtering `ConversationPartKind`, which is most of the volume.

## Decisions worth reviewing

**Prompts are not reconstructed from keystrokes.** Terminal typing reaches `SendInput` one byte at a
time. Buffering and flushing on Enter looks easy but is wrong: backspace, arrow-key edits, history
recall, paste and slash-command autocomplete all mutate the line invisibly. We would be reimplementing
a line editor and silently recording prompts the user never sent - the worst outcome for a feature
whose job is telling the truth about the week, and against the stats mission rule that an uncapturable
metric is stated as not-captured, never estimated. `SendInput` records provenance only, on submit.

**Unmatched origin is "unknown", never guessed.** `InputSurface.Unknown` already exists for exactly
this.

**Retention is unbounded.** The point is looking back across months and the text is small. Contrast
`TurnReviewLog`, which holds terminal screens and expires at 7 days.

**Fail-open throughout.** Logging can never break a turn - same contract as `TranscriptionTelemetryLog`.

## Two bugs this found and fixed

- **Gemini would have re-appended its whole conversation every turn.** Its History-tab source is a
  scrape of the terminal scrollback: one ever-growing, untimestamped blob, so it is a different message
  on every read. The record now reads Gemini's own `logs.json` instead - real prompts, real timestamps,
  so the origin join works. Gemini persists no replies, so it honestly yields prompts only.
- **Repo-resolved agents would have double-recorded.** Copilot, OpenCode and Gemini resolve history by
  *repo*, not per session, so two Director sessions on one repo read the same conversation. Dedupe is
  now scoped to the source, not the Director session.

## Proof

29 new tests. They drive the **real** `Session` choke points and **real** Claude-format transcripts
through the **real** `SessionHistoryReader` - not stubs. Covered: round-trip, append-not-overwrite,
multi-day reads, a corrupt line not taking down the day, tool-call filtering, idempotent re-ingest,
the origin join, cross-session and far-in-time non-matching, replies borrowing no origin, terminal
typing recording once per submit rather than per keystroke, and two sessions on one transcript
recording once.

Full Core suite: **3065 passed, 0 failed**.

## Not in this PR

Weekly review UI, work-category attribution (marketing vs development), effectiveness analysis, naming.
All downstream on devthrottle_internal#358.

🤖 Generated with [Claude Code](https://claude.com/claude-code)