### PR TITLE
fix(conpty): make the write into the agent's terminal say when it fails

### DIFF
--- a/src/CcDirector.Core/ConPty/ProcessHost.cs
+++ b/src/CcDirector.Core/ConPty/ProcessHost.cs
@@ -243,28 +243,51 @@ public sealed class ProcessHost : IDisposable
         });
     }
 
-    /// <summary>Write raw bytes to the process input.</summary>
+    /// <summary>
+    /// Write raw bytes to the process input - the ONLY door bytes take from the Director into the
+    /// agent's terminal.
+    ///
+    /// EVERY exit from this method is logged, and that is the whole point (issue #1551). On
+    /// 2026-07-14 a 1031-character phone dictation never reached Claude Code's composer. The
+    /// terminal's OUTPUT is recorded byte-for-byte (session-logs/&lt;id&gt;/raw.jsonl), so we could
+    /// prove the text was absent from the composer - but this direction recorded NOTHING, so we
+    /// could not tell whether the bytes failed to leave here or left and were dropped by the TUI.
+    /// Those two causes need opposite fixes and the evidence to separate them did not exist.
+    ///
+    /// The failure paths used <see cref="System.Diagnostics.Debug.WriteLine"/>, which is
+    /// [Conditional("DEBUG")] and therefore compiled out of the shipped build entirely: a write that
+    /// threw was silent on disk, in the exact place a lost prompt would go missing.
+    ///
+    /// SILENCE HERE NOW MEANS SUCCESS. FileStream.Write either writes every byte or throws, so a
+    /// send with no line from this method is proof the bytes left the Director - which points the
+    /// next investigation at the TUI instead of at us. That inference only holds while every
+    /// non-success path below stays loud; do not quiet one.
+    ///
+    /// Success is deliberately NOT logged: every keystroke goes through here, and per-write lines
+    /// would bury the failures this exists to surface.
+    /// </summary>
     public void Write(byte[] data)
     {
         if (_disposed || _inputStream == null)
         {
-            System.Diagnostics.Debug.WriteLine($"[ConPTY Write] SKIPPED — disposed={_disposed}, stream null={_inputStream == null}");
+            FileLog.Write($"[ProcessHost] Write SKIPPED: pid={ProcessId}, bytes={data.Length}, " +
+                          $"disposed={_disposed}, streamNull={_inputStream == null} - the bytes never left the Director");
             return;
         }
         try
         {
-            System.Diagnostics.Debug.WriteLine($"[ConPTY Write] {data.Length} bytes: [{string.Join(", ", data.Select(b => $"0x{b:X2}"))}] \"{System.Text.Encoding.UTF8.GetString(data).Replace("\r", "\\r").Replace("\n", "\\n")}\"");
             _inputStream.Write(data, 0, data.Length);
             _inputStream.Flush();
-            System.Diagnostics.Debug.WriteLine($"[ConPTY Write] Flushed OK");
         }
         catch (IOException ex)
         {
-            System.Diagnostics.Debug.WriteLine($"[ConPTY Write] IOException: {ex.Message}");
+            FileLog.Write($"[ProcessHost] Write FAILED: pid={ProcessId}, bytes={data.Length}: " +
+                          $"{ex.GetType().Name}: {ex.Message} - the bytes never left the Director");
         }
         catch (ObjectDisposedException ex)
         {
-            System.Diagnostics.Debug.WriteLine($"[ConPTY Write] ObjectDisposedException: {ex.Message}");
+            FileLog.Write($"[ProcessHost] Write FAILED: pid={ProcessId}, bytes={data.Length}: " +
+                          $"{ex.GetType().Name}: {ex.Message} - the bytes never left the Director");
         }
     }
 


### PR DESCRIPTION
## Why

A 1031-character phone dictation never reached Claude Code's composer on 2026-07-14. The dictation transcribed fine; the words simply never landed.

We can prove the text was absent, because the terminal's **output** is recorded byte-for-byte in `session-logs/<id>/raw.jsonl`. The full-screen repaint at 18:50:51 shows the input box holding an empty prompt and three blank lines - three of the submit watchdog's own Enters - and nothing else. The user's manual re-send produced 1034 characters (three newlines plus the 1031), confirming nothing was already sitting there.

What we could **not** tell is where the text went. Two candidates, opposite fixes, no evidence on disk to separate them:

1. the bytes never left the Director, or
2. they left and the terminal user interface dropped them.

`ProcessHost.Write` is the only door bytes take from the Director into the agent's terminal, and it recorded nothing. Its failure paths used `Debug.WriteLine`, which is `[Conditional("DEBUG")]` and so is compiled out of the shipped build:

```csharp
catch (IOException ex)
{
    System.Diagnostics.Debug.WriteLine($"[ConPTY Write] IOException: {ex.Message}");
}
```

A write that threw was silent on disk, in the exact place a lost prompt would go missing.

## What this does

Every non-success exit from `Write` now goes to `FileLog`.

Because `FileStream.Write` either writes every byte or throws, **silence from this method is now itself evidence**: a send with no line from here proves the bytes left the Director, and points the next investigation at the terminal user interface instead of at us.

Success stays unlogged on purpose - every keystroke goes through here, and per-write lines would bury the failures this exists to surface.

## What this deliberately does NOT do

It does not fix the underlying loss. The cause is not known. Guessing at it would mean shipping code we may not need, so this adds the one missing witness and nothing else. The next occurrence names its own cause, and then we fix the real thing.

Scope note: `ProcessHost.WriteAsync` has the same empty-catch trap but has no callers - left alone rather than widened into this change.

## Proof

- Full solution builds clean in Release: 0 warnings, 0 errors.
- `CcDirector.Core.Tests`: **3036 passed, 0 failed**, 8 skipped.
- No behaviour change - logging only.

Refs #1551

🤖 Generated with [Claude Code](https://claude.com/claude-code)