### PR TITLE
Close the inbound port, restore Director Settings, and delete the verify handshake that could only lie

### DIFF
--- a/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/GatewayConnectionPanel.axaml.cs
@@ -119,7 +119,7 @@ public partial class GatewayConnectionPanel : UserControl
         var status = host?.GatewayMonitor?.Status;
 
         // A proven handshake opens on the signed-in view (Step 2 vs Done settles from account status).
-        if (status == GatewayConnectionStatus.Verified)
+        if (status == GatewayConnectionStatus.Connected)
             return new GatewayConnectionPanel(GatewayPanelStep.Done, repairMode: false);
 
         // A prior failure (or a lost tailnet identity) opens Step 1 in REPAIR mode (Phase 5): the failing
@@ -240,12 +240,12 @@ public partial class GatewayConnectionPanel : UserControl
                 (monitor.FailureSummary ?? "Start Tailscale on this machine, or set the Director public URL under Advanced.")
                 + " Once Tailscale is up this heals automatically; you can also pick your Gateway below to reconnect.");
 
-        var callbackFailed = monitor.LastResult is { CallbackOk: false };
+        // The callback-leg branch is gone with the handshake (tunnel-only): there is no Gateway->Director
+        // dial any more, so "the callback leg failed" is not a thing that can happen. The monitor's own
+        // summary says why the tunnel is not up.
         var wasWorking = monitor.LastVerifiedAt is not null;
         var title = wasWorking ? "Your Gateway became unreachable" : "Could not connect to your Gateway";
-        var summary = callbackFailed
-            ? "The Gateway could not reach this Director back (the callback leg). It may have moved - pick its current address below to reconnect. Show diagnostics for the full check."
-            : (monitor.FailureSummary ?? "The connection could not be completed.")
+        var summary = (monitor.FailureSummary ?? "The connection could not be completed.")
               + " It may have moved - pick its current address below to reconnect. Show diagnostics for the full check.";
         return (title, summary);
     }
@@ -261,8 +261,15 @@ public partial class GatewayConnectionPanel : UserControl
     }
 
     // Reuse the troubleshooter's diagnostic engine INLINE (spec section 8: the dialog-as-destination is
-    // gone, the logic is reused): re-run the handshake, then walk GatewayConnectivitySelfTest's ladder and
-    // render each rung. No new verification is built here.
+    // gone, the logic is reused): report the live connection state, then walk GatewayConnectivitySelfTest's
+    // ladder and render each rung. No new verification is built here.
+    //
+    // Gateway Cleanup mission (tunnel-only): opening this used to RUN the two-way handshake first
+    // (host.VerifyGatewayNowAsync). That handshake's Gateway route was deleted at the cut, so the call could
+    // only ever 404 - and on the 404 it wrote "the Gateway does not support the verify handshake - update the
+    // Gateway" into the monitor as a FAILURE. The result: opening diagnostics on a perfectly healthy,
+    // tunnel-connected Director flipped its light from green to red and told the owner to go update a Gateway
+    // that was already correct. Diagnostics now REPORT the connection state; they do not manufacture one.
     private async Task RunDiagnosticsAsync()
     {
         var host = (global::Avalonia.Application.Current as App)?.ControlApiHost;
@@ -278,20 +285,18 @@ public partial class GatewayConnectionPanel : UserControl
 
         DiagnosticsHost.Children.Clear();
         DiagnosticsRunning.IsVisible = true;
-        DiagnosticsVerdict.Text = "Running the two-way handshake and the diagnostic ladder...";
+        DiagnosticsVerdict.Text = "Running the diagnostic ladder...";
         try
         {
-            await host.VerifyGatewayNowAsync(ct);
             DiagnosticsVerdict.Text = DiagnosticsVerdictText(host.GatewayMonitor);
 
-            var monitor = host.GatewayMonitor;
             var port = host.Port;
             var (gatewayUrl, endpoint) = await Task.Run(() =>
             {
                 var cfg = GatewayConfig.Load();
-                var ep = monitor.LastResult?.CallbackEndpoint;
-                if (string.IsNullOrEmpty(ep))
-                    ep = TailscaleIdentity.TryGetMagicDnsName() is { } dns ? $"https://{dns}:{port}" : cfg.TailnetEndpoint;
+                // The callback endpoint the deleted handshake used to report is gone with it; resolve this
+                // machine's advertised address the same way it did when no verdict had been recorded yet.
+                var ep = TailscaleIdentity.TryGetMagicDnsName() is { } dns ? $"https://{dns}:{port}" : cfg.TailnetEndpoint;
                 return (cfg.IsEnabled ? cfg.Url : null, ep);
             }, ct);
 
@@ -320,10 +325,10 @@ public partial class GatewayConnectionPanel : UserControl
 
     private static string DiagnosticsVerdictText(GatewayConnectionMonitor m) => m.Status switch
     {
-        GatewayConnectionStatus.Verified => "Two-way verification PASSED - the Gateway and this Director can each reach the other.",
-        GatewayConnectionStatus.Failed => $"Two-way verification FAILED - {m.FailureSummary}",
+        GatewayConnectionStatus.Connected => "CONNECTED - this Director's tunnel to the Gateway is up, which is what lets the two reach each other.",
+        GatewayConnectionStatus.Failed => $"NOT CONNECTED - {m.FailureSummary}",
         GatewayConnectionStatus.NoTailnetIdentity => $"No tailnet identity - {m.FailureSummary}",
-        GatewayConnectionStatus.Connecting => "Still verifying - the handshake is in flight. Re-open diagnostics in a few seconds.",
+        GatewayConnectionStatus.Connecting => "Connecting - the tunnel is dialing. Re-open diagnostics in a few seconds.",
         _ => "No Gateway is configured.",
     };
 
@@ -857,7 +862,7 @@ public partial class GatewayConnectionPanel : UserControl
 
         switch (monitor.Status)
         {
-            case GatewayConnectionStatus.Verified:
+            case GatewayConnectionStatus.Connected:
                 OnHandshakeVerified();
                 break;
             case GatewayConnectionStatus.Failed:
@@ -891,7 +896,7 @@ public partial class GatewayConnectionPanel : UserControl
         if (attempt != _attemptId || !_connecting) return; // superseded or already settled
 
         var monitor = _monitor;
-        if (monitor?.Status == GatewayConnectionStatus.Verified)
+        if (monitor?.Status == GatewayConnectionStatus.Connected)
         {
             OnHandshakeVerified();
             return;

--- a/src/CcDirector.Avalonia/FifoWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/FifoWindow.axaml.cs
@@ -228,7 +228,7 @@ public partial class FifoWindow : Window
         // records the snooze-until AND forwards the hold back down to this Director (which sets OnHold),
         // so OnHold is already set when we Advance - no optimistic local set.
         var host = (global::Avalonia.Application.Current as App)?.ControlApiHost;
-        if (host?.GatewayMonitor.Status != GatewayConnectionStatus.Verified || host.GatewayHold is null)
+        if (host?.GatewayMonitor.Status != GatewayConnectionStatus.Connected || host.GatewayHold is null)
         {
             // No Gateway -> no snooze (owner rule, no-fallback). Do NOT advance, set NO local hold.
             SetStatus("Connect to a Gateway to snooze.", Red);

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -629,19 +629,20 @@ public partial class MainWindow : Window
             Account: _boxAccount);
     }
 
-    // Map the monitor's raw status onto the resolver's connection verification plus the failing leg. A
-    // Failed handshake with a recorded callback verdict is the callback leg; without one, the outbound
-    // reach never got that far. NoTailnetIdentity is a local identity failure named generically here (the
-    // panel names it precisely in Step 1 repair).
+    // Map the monitor's raw status onto the resolver's connection verification plus the failing leg.
+    // Gateway Cleanup mission (tunnel-only): a failure is always the OUTBOUND reach now - this Director could
+    // not get its tunnel up. The Callback leg (the Gateway dialing this Director back) no longer exists, so it
+    // is never reported: the handshake that used to distinguish the two legs is gone with the dial-back it
+    // measured. NoTailnetIdentity is a local identity failure named generically here (the panel names it
+    // precisely in Step 1 repair).
     private static (GatewayConnectionVerification, GatewayConnectionFailedLeg) MapMonitor(GatewayConnectionMonitor? m)
     {
         if (m is null) return (GatewayConnectionVerification.Unknown, GatewayConnectionFailedLeg.None);
         return m.Status switch
         {
-            GatewayConnectionStatus.Verified => (GatewayConnectionVerification.Connected, GatewayConnectionFailedLeg.None),
+            GatewayConnectionStatus.Connected => (GatewayConnectionVerification.Connected, GatewayConnectionFailedLeg.None),
             GatewayConnectionStatus.Connecting => (GatewayConnectionVerification.Verifying, GatewayConnectionFailedLeg.None),
-            GatewayConnectionStatus.Failed => (GatewayConnectionVerification.Failed,
-                m.LastResult is { CallbackOk: false } ? GatewayConnectionFailedLeg.Callback : GatewayConnectionFailedLeg.OutboundReach),
+            GatewayConnectionStatus.Failed => (GatewayConnectionVerification.Failed, GatewayConnectionFailedLeg.OutboundReach),
             GatewayConnectionStatus.NoTailnetIdentity => (GatewayConnectionVerification.Failed, GatewayConnectionFailedLeg.None),
             _ => (GatewayConnectionVerification.Unknown, GatewayConnectionFailedLeg.None),
         };
@@ -1247,7 +1248,7 @@ public partial class MainWindow : Window
         if (_lastHomeStatus is not { } status) return;
 
         var healthy = status.AllReady && !_gatewayError;
-        var summary = _gatewayMonitor?.Status == GatewayConnectionStatus.Verified
+        var summary = _gatewayMonitor?.Status == GatewayConnectionStatus.Connected
             ? "Gateway connected - ready to work"
             : "Ready to start a session";
         // When all tools pass, show the count (and any optional not-installed) quietly here rather than
@@ -2185,7 +2186,7 @@ public partial class MainWindow : Window
 
         // No Gateway -> no snooze (owner rule, no-fallback): require a VERIFIED connection, which proves
         // BOTH legs the round-trip needs (Director->Gateway to record, Gateway->Director to forward back).
-        if (host?.GatewayMonitor.Status != GatewayConnectionStatus.Verified || host.GatewayHold is null)
+        if (host?.GatewayMonitor.Status != GatewayConnectionStatus.Connected || host.GatewayHold is null)
         {
             ShowNotification("You need to be connected to a Gateway to use snooze.");
             return;

--- a/src/CcDirector.Avalonia/OnboardingWizardDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/OnboardingWizardDialog.axaml.cs
@@ -149,7 +149,7 @@ public partial class OnboardingWizardDialog : Window
     {
         var host = (global::Avalonia.Application.Current as App)?.ControlApiHost;
         var connected = _gatewayConnected
-            || host?.GatewayMonitor?.Status == CcDirector.ControlApi.GatewayConnectionStatus.Verified;
+            || host?.GatewayMonitor?.Status == CcDirector.ControlApi.GatewayConnectionStatus.Connected;
         if (!connected)
         {
             FileLog.Write("[OnboardingWizardDialog] AdvanceFromGateway: not connected yet, nudging");

--- a/src/CcDirector.ControlApi/ControlApiHost.cs
+++ b/src/CcDirector.ControlApi/ControlApiHost.cs
@@ -125,10 +125,9 @@ public sealed class ControlApiHost : IAsyncDisposable
     internal bool SuppressServeProvisioning { get; set; }
 
     /// <summary>
-    /// The one home of this Director's Gateway-connection truth (issues #223/#224).
-    /// Host-owned so it survives GatewayClient replacement on settings changes; the
-    /// desktop indicator subscribes to its Changed event, the /verify/{nonce} endpoint
-    /// records callback receipts in it.
+    /// The one home of this Director's Gateway-connection truth. Host-owned so it survives
+    /// GatewayClient replacement on settings changes; the desktop indicator subscribes to its
+    /// Changed event and the Gateway tunnel marks itself connected/reconnecting in it.
     /// </summary>
     public GatewayConnectionMonitor GatewayMonitor { get; } = new();
 
@@ -138,7 +137,7 @@ public sealed class ControlApiHost : IAsyncDisposable
     /// instead of setting <c>Session.OnHold</c> in-process. Backed by the live <see cref="GatewayClient"/>
     /// (which already holds the resolved Gateway address + fleet token), so it reuses the Director's
     /// existing Gateway connection. Null while the Gateway is not configured (no client) - the desktop
-    /// gates the Snooze button on <see cref="GatewayMonitor"/> being Verified anyway.
+    /// gates the Snooze button on <see cref="GatewayMonitor"/> being Connected anyway.
     /// </summary>
     public IGatewayHold? GatewayHold => _gatewayClient;
 
@@ -147,14 +146,6 @@ public sealed class ControlApiHost : IAsyncDisposable
     /// provisioner's LastError explains WHY a mapping is missing. Null on ephemeral-port
     /// hosts (tests, hosted agents), which never self-provision.</summary>
     public TailscaleServeSelfProvisioner? ServeProvisioner => _serveProvisioner;
-
-    /// <summary>
-    /// On-demand two-way handshake (issues #223/#224) for the troubleshooter's Re-test
-    /// button. Null result when no Gateway is configured or a handshake is already in
-    /// flight; the verdict also lands in <see cref="GatewayMonitor"/> either way.
-    /// </summary>
-    public Task<Gateway.Contracts.DirectorVerifyResultDto?> VerifyGatewayNowAsync(CancellationToken ct = default)
-        => _gatewayClient?.VerifyAsync(ct) ?? Task.FromResult<Gateway.Contracts.DirectorVerifyResultDto?>(null);
 
     /// <summary>
     /// Fetch the latest Gateway turn brief for a session - the desktop Wingman tab's source.
@@ -243,9 +234,11 @@ public sealed class ControlApiHost : IAsyncDisposable
         var gatewayConfig = Core.Configuration.GatewayConfig.Load();
         var addressingMode = gatewayConfig.AddressingMode;
 
-        // LAN mode puts the Control API on a routable interface, so it MUST be authenticated -
-        // auto-enable auth (the tailnet trust boundary is gone). This is why LAN "just works"
-        // without a separate toggle: choosing LAN turns on auth.
+        // LAN mode auto-enables auth. This began (issue #457) because LAN mode put the Control API on a
+        // routable interface, which MUST be authenticated. The bind is now loopback in every mode, so this
+        // no longer guards a routable interface - it is kept because a LAN-mode Director has required the
+        // fleet token since #457, and quietly dropping auth on upgrade would WEAKEN a running install. It
+        // costs a local caller nothing it was not already paying.
         if (addressingMode == Core.Configuration.AddressingMode.Lan && !_authEnabled)
         {
             _authEnabled = true;
@@ -262,22 +255,18 @@ public sealed class ControlApiHost : IAsyncDisposable
         {
             builder.WebHost.ConfigureKestrel(o => o.Listen(IPAddress.Loopback, 0));
         }
-        else if (addressingMode == Core.Configuration.AddressingMode.Lan)
-        {
-            // LAN addressing mode (issue #457): the Director must be reachable on its real LAN
-            // IP, so the Control API binds to ALL interfaces - there is no Tailscale Serve
-            // fronting it in this mode. Auth was auto-enabled above so the raw port is not open;
-            // the fleet token (gateway.token) is required on every call.
-            Port = PortAllocator.Allocate(DirectorId);
-            FileLog.Write($"[ControlApiHost] LAN addressing mode: binding Control API to 0.0.0.0:{Port} (auth enabled)");
-            builder.WebHost.ConfigureKestrel(o => o.Listen(IPAddress.Any, Port));
-        }
         else
         {
-            // Loopback ONLY. The raw port is never exposed on the LAN or the Tailscale
-            // interface; the sole remote path is Tailscale Serve (HTTPS), which the
-            // Gateway's TailscaleServeProvisioner maps as https://<host>:<port> ->
-            // http://localhost:<port>. This kills the plain-HTTP-on-raw-port surface.
+            // Loopback ONLY, in EVERY addressing mode. The tunnel-only cut made the Director dial
+            // OUT to the Gateway and be reached only down that stream, so no caller anywhere needs
+            // this port from off-machine: the Gateway creates sessions and drains work lists over
+            // the tunnel (SessionVerbClient / DirectorImplSessionDriver carry no HTTP client), and
+            // the two-way verify handshake that used to dial back was deleted with its route.
+            // Binding a routable interface would therefore open an inbound port with no user at
+            // all - pure attack surface - and break the cut's invariant that the inbound port stays
+            // CLOSED on every client machine. LAN addressing mode used to bind IPAddress.Any here
+            // (issue #457) for a Gateway->Director dial that no longer exists; it no longer changes
+            // the bind interface.
             int? allocated = PortAllocationOverride is not null
                 ? PortAllocationOverride(DirectorId)
                 : (PortAllocator.TryAllocate(DirectorId, out var p) ? p : (int?)null);
@@ -459,9 +448,7 @@ public sealed class ControlApiHost : IAsyncDisposable
         // "listening" line) and release the reservation so a restart picks a different port.
         if (await SelfProbeControlApiAsync(Port))
         {
-            FileLog.Write(addressingMode == Core.Configuration.AddressingMode.Lan
-                ? $"[ControlApiHost] Kestrel listening on http://0.0.0.0:{Port} (LAN addressing mode; reachable on this machine's LAN IP)"
-                : $"[ControlApiHost] Kestrel listening on http://127.0.0.1:{Port} (loopback only; remote access via Tailscale Serve)");
+            FileLog.Write($"[ControlApiHost] Kestrel listening on http://127.0.0.1:{Port} (loopback only; the inbound port is closed - remote access is the outbound tunnel to the Gateway)");
         }
         else
         {
@@ -504,17 +491,16 @@ public sealed class ControlApiHost : IAsyncDisposable
         _registration = new InstanceRegistration(DirectorId, Port, _version, _instancesDirectory);
         _registration.Register();
 
-        // Issue #197: this Director owns its own Tailscale Serve front door. Only real
-        // fixed-range Directors self-provision; ephemeral-port hosts (tests, hosted
-        // agents) are reached through the Gateway and must not churn the serve table
-        // (the #179 lesson). Issue #457: LAN addressing mode has no Serve front door at all -
-        // the Director is reached directly on its LAN IP - so it never provisions a mapping.
         // Gateway Cleanup mission (tunnel-only): the Director NO LONGER opens an inbound Tailscale Serve
         // front door on its control port. It dials OUT to the Gateway over the tunnel and is reached ONLY
         // down that stream, so there is nothing inbound to publish - the whole point of the cut is that the
         // inbound port stays CLOSED on every client machine. Any Serve mapping a previous build left for this
-        // port is proactively torn down so an upgraded Director self-heals to closed.
-        if (!_useEphemeralPort && addressingMode != Core.Configuration.AddressingMode.Lan && !SuppressServeProvisioning)
+        // port is proactively torn down so an upgraded Director self-heals to closed. This runs in EVERY
+        // addressing mode: a Director that was on tailscale mode when an older build published a mapping, and
+        // has since been switched to LAN mode, must still have that stale inbound mapping torn down. Only
+        // ephemeral-port hosts (tests, hosted agents) are skipped - they never published one to begin with,
+        // and must not churn the serve table (the #179 lesson).
+        if (!_useEphemeralPort && !SuppressServeProvisioning)
         {
             var portToClose = Port;
             _ = Task.Run(() =>
@@ -688,7 +674,7 @@ public sealed class ControlApiHost : IAsyncDisposable
         }
 
         return SessionCommandExecutor.DispatchAsync(_sessionManager, DirectorId, cmd,
-            new SessionCommandServices { ProactiveExplain = _proactiveExplain, TurnSummaryCache = _turnSummaryCache, MissionStore = _missionStore, DirectorVersion = _version, Repositories = _repositoryRegistry });
+            new SessionCommandServices { ProactiveExplain = _proactiveExplain, TurnSummaryCache = _turnSummaryCache, MissionStore = _missionStore, DirectorVersion = _version, Repositories = _repositoryRegistry, ReapplyGatewayAsync = ReapplyGatewayAsync });
     }
 
     /// <summary>

--- a/src/CcDirector.ControlApi/DirectorConfigExecutor.cs
+++ b/src/CcDirector.ControlApi/DirectorConfigExecutor.cs
@@ -1,0 +1,101 @@
+using System.Text.Json.Nodes;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Contracts;
+
+namespace CcDirector.ControlApi;
+
+/// <summary>
+/// Gateway Cleanup CUT RESTORATION: the Director-level CONFIG area of the tunnel command surface - the
+/// settings read and write behind the Cockpit's Director Settings editor.
+///
+/// The cut dropped the Gateway's HTTP reverse-proxy leg for <c>/directors/{id}/settings</c> and deferred
+/// remote config editing to Phase 4, but the Cockpit's caller was never removed with it. With no route
+/// mapped, the Gateway's single-page-app fallback answered the Cockpit's GET with the HTML shell at status
+/// 200 - so the editor silently loaded a web page where the settings were meant to be, and the client could
+/// not even tell it had failed (it only checks <c>res.ok</c>). These two verbs give the surface the proper
+/// tunnel legs the cut always intended it to have, instead of leaving the caller pointing at nothing.
+///
+/// Each core reproduces the Director's own <see cref="SettingsEndpoint"/> lambda verbatim - the SAME
+/// <see cref="CcDirectorConfigService"/> calls, guards, and return shapes - so the loopback floor route and
+/// this tunnel verb share one behaviour and cannot drift. The config surface itself stays on the loopback
+/// floor for LOCAL callers exactly as before; this only restores the REMOTE read/write path.
+/// </summary>
+internal sealed class DirectorConfigExecutor : ISessionCommandArea
+{
+    public IReadOnlyCollection<string> Verbs { get; } = new[]
+    {
+        "settings-get",
+        "settings-put",
+    };
+
+    public async Task<DirectorCommandResult> ExecuteAsync(SessionCommandContext context, DirectorCommand command, CancellationToken cancellationToken)
+    {
+        return command.Verb switch
+        {
+            "settings-get" => SettingsGet(),
+            "settings-put" => await SettingsPut(context.Services?.ReapplyGatewayAsync, command),
+            _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"verb '{command.Verb}' is not handled by the director config area"),
+        };
+    }
+
+    /// <summary>
+    /// The <c>settings-get</c> verb (director-level, no session): the full config.json as a JSON object.
+    /// Mirrors the Director's <c>GET /settings</c> lambda - a read of
+    /// <see cref="CcDirectorConfigService.ReadRaw"/>, always a 200. The body is the config object itself
+    /// (an opaque object the Director owns), which the Gateway forwards to the Cockpit verbatim.
+    /// </summary>
+    internal static DirectorCommandResult SettingsGet()
+    {
+        FileLog.Write("[DirectorConfigExecutor] settings-get");
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(CcDirectorConfigService.ReadRaw()));
+    }
+
+    /// <summary>
+    /// The <c>settings-put</c> verb (director-level, no session): deep-merge a partial patch into config.json
+    /// and return the merged result. Mirrors the Director's <c>PUT /settings</c> lambda - a non-object body is
+    /// a BadRequest with the same wording, the merge is the same
+    /// <see cref="CcDirectorConfigService.MergePatch"/> call, and a patch touching the <c>gateway</c> block
+    /// re-applies the Gateway live exactly as the route does (everything else is read on next use).
+    ///
+    /// The re-apply hook is the one dependency the tunnel command surface did not carry; it rides in
+    /// <see cref="SessionCommandServices.ReapplyGatewayAsync"/>. Unlike the optional side-effect services, a
+    /// MISSING hook is not skipped quietly: the REST route always has one, so its absence here means the host
+    /// wired the stream client wrong, and silently merging gateway settings that never take effect would be
+    /// precisely the "looks like it worked" failure this restoration exists to remove. It fails loudly instead,
+    /// BEFORE writing anything, so the config on disk never disagrees with the running Director.
+    /// </summary>
+    internal static async Task<DirectorCommandResult> SettingsPut(Func<Task>? reapplyGatewayAsync, DirectorCommand command)
+    {
+        var request = SessionCommandExecutor.Deserialize<SettingsPutRequest>(command.PayloadJson);
+        if (request?.Settings is not JsonObject patch)
+            return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "request body must be a JSON object");
+
+        FileLog.Write($"[DirectorConfigExecutor] settings-put: keys={string.Join(",", patch.Select(kv => kv.Key))}");
+
+        var touchesGateway = patch.ContainsKey("gateway");
+        if (touchesGateway && reapplyGatewayAsync is null)
+        {
+            FileLog.Write("[DirectorConfigExecutor] settings-put REFUSED: gateway patch with no re-apply hook wired");
+            return DirectorCommandResult.Fail(DirectorCommandStatus.Error,
+                "This Director cannot apply a gateway settings change over the tunnel: its re-apply hook is not wired. Nothing was written.");
+        }
+
+        var merged = CcDirectorConfigService.MergePatch(patch);
+
+        if (touchesGateway)
+            await reapplyGatewayAsync!();
+
+        return DirectorCommandResult.Success(SessionCommandExecutor.Serialize(merged));
+    }
+}
+
+/// <summary>
+/// The <c>settings-put</c> payload: the raw settings patch the Cockpit typed, carried verbatim as an opaque
+/// JSON object. It is wrapped in a property rather than sent bare so the payload stays a well-formed command
+/// envelope the executor can deserialize like every other verb.
+/// </summary>
+internal sealed class SettingsPutRequest
+{
+    public JsonNode? Settings { get; set; }
+}

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -35,14 +35,6 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
     /// <summary>Max delay between failed register/heartbeat retries.</summary>
     public static TimeSpan MaxBackoff { get; } = TimeSpan.FromSeconds(60);
 
-    /// <summary>
-    /// How often a VERIFIED two-way connection re-proves itself (issues #223/#224). While
-    /// unverified or failed, re-verification instead rides every heartbeat tick (15s) so
-    /// recovery is fast; once green, this slower cadence keeps the proof fresh without
-    /// dialing the callback loop four times a minute.
-    /// </summary>
-    public static TimeSpan ReverifyInterval { get; } = TimeSpan.FromSeconds(60);
-
     private readonly GatewayConfig _config;
     private readonly string _directorId;
     private readonly int _port;
@@ -55,9 +47,6 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
     // Start() to the first reachable entry of _config.CandidateUrls (machine name -> Tailscale -> IP).
     // volatile: read by the fleet-relay one-off clients on other threads.
     private volatile string _activeUrl = "";
-
-    private DateTime _lastVerifyStartedUtc = DateTime.MinValue;
-    private int _verifying; // re-entrancy guard: never stack a second handshake on a slow one
 
     private Timer? _heartbeat;
     private CancellationTokenSource? _cts;
@@ -710,13 +699,9 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
                 if (await TryRegisterAsync(ct))
                 {
                     _registered = true;
-                    // Registration only proves leg 1. Run the two-way handshake right away
-                    // (issues #223/#224) so the indicator earns its green - or names the
-                    // broken return leg - within seconds of connecting, not at the next tick.
-                    // A flagged no-endpoint registration (issue #324) has nothing the Gateway
-                    // could call back, so the handshake is skipped until identity heals.
-                    if (!string.IsNullOrEmpty(_advertisedEndpoint))
-                        _ = Task.Run(() => VerifyAsync(ct), ct);
+                    // The post-registration verify kick is gone with the handshake (tunnel-only): the
+                    // indicator's green is earned by the live tunnel, not by a callback the Gateway no
+                    // longer makes.
                     return;
                 }
             }
@@ -801,11 +786,8 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
                 // heartbeat, no restart.
                 MaybeReRegisterOnIdentityChange();
 
-                // Issues #223/#224: keep the two-way proof fresh. Re-verifies every
-                // ReverifyInterval while green, every tick while failed/unverified - so
-                // killing the return path flips the indicator red within one cycle and
-                // a repaired path flips it back green within one heartbeat.
-                MaybeKickVerify();
+                // The per-heartbeat verify kick is gone with the handshake (tunnel-only): the tunnel's
+                // own connected/reconnecting transitions drive the indicator now, within one cycle.
 
                 // The per-session state snapshot rides the heartbeat (issue #186): it lets
                 // the Gateway reconcile any doorbell ping it missed. Old Gateways ignore
@@ -902,112 +884,15 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
         });
     }
 
-    /// <summary>Kick a background handshake when one is due (see <see cref="ReverifyInterval"/>).</summary>
-    private void MaybeKickVerify()
-    {
-        if (_monitor is null) return;
-        // A flagged no-endpoint registration (issue #324) has nothing the Gateway could call
-        // back; a handshake would only overwrite the precise identity-failure message with a
-        // generic callback error. The heartbeat identity re-resolve restores verification
-        // the moment a real endpoint registers.
-        if (string.IsNullOrEmpty(_advertisedEndpoint)) return;
-        if (_monitor.Status == GatewayConnectionStatus.Verified
-            && _lastVerifyStartedUtc + ReverifyInterval > DateTime.UtcNow)
-            return;
-        var cts = _cts;
-        if (cts is null || cts.IsCancellationRequested) return;
-        _ = Task.Run(() => VerifyAsync(cts.Token));
-    }
-
-    /// <summary>
-    /// Run ONE two-way handshake (issues #223/#224): POST a fresh nonce to the Gateway's
-    /// /directors/{id}/verify (this call arriving proves leg 1), which makes the Gateway
-    /// dial GET /verify/{nonce} back on the advertised endpoint (leg 2). The verdict -
-    /// including the cross-check that the callback actually landed HERE - goes to the
-    /// <see cref="GatewayConnectionMonitor"/>; the return value is for on-demand callers
-    /// (the troubleshooting dialog's Re-test). Null when verification is disabled, a
-    /// handshake is already in flight, or the verdict never round-tripped.
-    /// </summary>
-    public async Task<DirectorVerifyResultDto?> VerifyAsync(CancellationToken ct = default)
-    {
-        if (!_config.IsEnabled || _monitor is null || _disposed) return null;
-        if (Interlocked.CompareExchange(ref _verifying, 1, 0) != 0) return null;
-        var nonce = _monitor.BeginHandshake();
-        try
-        {
-            _lastVerifyStartedUtc = DateTime.UtcNow;
-            var resp = await _http.PostAsJsonAsync($"directors/{_directorId}/verify", new DirectorVerifyRequest { Nonce = nonce }, ct);
-
-            if (resp.StatusCode == HttpStatusCode.Gone)
-            {
-                // Same contract as the heartbeat: the Gateway forgot us, re-register first.
-                _monitor.CompleteHandshake(nonce, null, "Gateway no longer knows this Director - re-registering");
-                _registered = false;
-                var cts = _cts;
-                if (cts is not null && !cts.IsCancellationRequested)
-                    _ = Task.Run(() => RegisterLoop(cts.Token));
-                return null;
-            }
-            if (resp.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.MethodNotAllowed)
-            {
-                _monitor.CompleteHandshake(nonce, null,
-                    $"The Gateway at {_activeUrl} does not support the verify handshake - update the Gateway");
-                return null;
-            }
-            if (!resp.IsSuccessStatusCode)
-            {
-                _monitor.CompleteHandshake(nonce, null, $"Gateway verify returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
-                return null;
-            }
-
-            var result = await resp.Content.ReadFromJsonAsync<DirectorVerifyResultDto>(cancellationToken: ct);
-            if (result is null)
-            {
-                _monitor.CompleteHandshake(nonce, null, "Gateway verify answered 2xx with an unparsable body");
-                return null;
-            }
-
-            string? summary = null;
-            if (!result.Verified)
-            {
-                // The leg that broke in #197/#223: heartbeats land, callbacks die.
-                summary = $"The Gateway cannot call this Director back: {result.CallbackError}";
-            }
-            else if (!_monitor.CallbackReceived(nonce))
-            {
-                // The nonce correlation earning its keep: the Gateway believes its callback
-                // succeeded, but it never arrived here - whatever answered the advertised
-                // URL was not this process. One leg alone can never fake a green.
-                result.Verified = false;
-                summary = $"The Gateway's callback was answered by something that is not this Director (at {result.CallbackEndpoint})";
-            }
-            // Stream leg (the Cockpit terminal path): HTTP control can be fully verified while the
-            // WebSocket UPGRADE the terminal needs is dead. Don't flip Verified (the advertise gate
-            // is HTTP-based, issue #197) - but record it loudly. result is stored as LastResult, so
-            // any director UI reading the monitor sees StreamOk/StreamError too.
-            if (result.Verified && !result.StreamOk && result.StreamError is not null)
-                FileLog.Write($"[GatewayClient] verify: HTTP callback OK but TERMINAL STREAM leg failed: {result.StreamError}");
-
-            _monitor.CompleteHandshake(nonce, result, summary);
-            return result;
-        }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
-        {
-            _monitor.AbandonHandshake(nonce); // shutdown: no verdict, no state flip
-            return null;
-        }
-        catch (Exception ex)
-        {
-            // Includes the HttpClient timeout (TaskCanceledException without ct signaled):
-            // leg 1 itself is down or crawling.
-            _monitor.CompleteHandshake(nonce, null, $"Cannot reach the Gateway at {_activeUrl}: {ex.Message}");
-            return null;
-        }
-        finally
-        {
-            Interlocked.Exchange(ref _verifying, 0);
-        }
-    }
+    // Gateway Cleanup mission (tunnel-only): the two-way verify handshake is GONE from this client.
+    // MaybeKickVerify and VerifyAsync used to POST directors/{id}/verify and ask the Gateway to dial this
+    // Director back on its advertised endpoint. The Gateway deleted that route - and its whole dial-back -
+    // at the cut ("Liveness is now the tunnel connection itself"), and the Director's own GET /verify/{nonce}
+    // callback door went with it, so the handshake could never pass again by two independent counts. What it
+    // could still do was LIE: on the 404 it told the owner "the Gateway does not support the verify handshake
+    // - update the Gateway", which sent him to fix a Gateway that was already correct, and flipped a healthy
+    // green light to red for doing nothing but opening diagnostics. Liveness is the tunnel: GatewayStreamClient
+    // marks the monitor connected/reconnecting directly.
 
     // Stamped by BuildRegistrationRequest: true while the last resolution found no tailnet
     // identity. RegisterLoop reads it to keep identity retries at heartbeat cadence (#324).

--- a/src/CcDirector.ControlApi/GatewayConnectionMonitor.cs
+++ b/src/CcDirector.ControlApi/GatewayConnectionMonitor.cs
@@ -3,19 +3,25 @@ using CcDirector.Gateway.Contracts;
 
 namespace CcDirector.ControlApi;
 
-/// <summary>Connection states of the Director &lt;-&gt; Gateway two-way handshake (issues #223/#224).</summary>
+/// <summary>Connection states of this Director's link to its Gateway.</summary>
 public enum GatewayConnectionStatus
 {
     /// <summary>No gateway.url configured - a legitimate local-only Director (gray, not an error).</summary>
     NotConfigured,
 
-    /// <summary>Gateway configured; registration or verification pending or in flight (yellow).</summary>
+    /// <summary>Gateway configured; the tunnel is dialing or reconnecting (yellow).</summary>
     Connecting,
 
-    /// <summary>The last handshake proved BOTH legs (green). Earned, never assumed.</summary>
-    Verified,
+    /// <summary>
+    /// The outbound tunnel to the Gateway is UP (green). Gateway Cleanup mission (tunnel-only): this was
+    /// <c>Verified</c>, the verdict of the two-way nonce handshake (issues #223/#224). That handshake is
+    /// gone - the Gateway deleted its half at the cut because it no longer dials the Director back - so the
+    /// state is named for what now proves it: a live tunnel. Still earned, never assumed; the connection
+    /// itself IS the proof, which is why the handshake was redundant as well as broken.
+    /// </summary>
+    Connected,
 
-    /// <summary>The last handshake failed; <see cref="GatewayConnectionMonitor.FailureSummary"/> names the failing leg (red).</summary>
+    /// <summary>The connection could not be established; <see cref="GatewayConnectionMonitor.FailureSummary"/> says why (red).</summary>
     Failed,
 
     /// <summary>
@@ -30,41 +36,38 @@ public enum GatewayConnectionStatus
 }
 
 /// <summary>
-/// The one home of this Director's Gateway-connection truth (issues #223/#224).
+/// The one home of this Director's Gateway-connection truth.
 ///
 /// Owned by ControlApiHost - NOT by GatewayClient - so it survives the client being
-/// replaced on a settings change (ReapplyGatewayAsync). Three writers, one reader model:
-///   - GatewayClient begins handshakes and records verdicts here.
-///   - The Control API's GET /verify/{nonce} endpoint records callback receipts here.
-///   - The desktop indicator and the troubleshooting dialog read state and subscribe
+/// replaced on a settings change (ReapplyGatewayAsync). Two writers, one reader model:
+///   - The Gateway tunnel (GatewayStreamClient) marks itself connected/reconnecting here.
+///   - The desktop indicator and the connection panel read state and subscribe
 ///     to <see cref="Changed"/>.
 ///
-/// Green is EARNED: only a completed nonce handshake (both legs proven, nonce correlated
-/// on this side too) sets <see cref="GatewayConnectionStatus.Verified"/>. Heartbeats
-/// succeeding is NOT "connected" - that exact lie hid the EXAMPLE-PC outage for days
-/// while the Gateway could not call back.
+/// Green is EARNED: only a LIVE tunnel sets <see cref="GatewayConnectionStatus.Connected"/>.
+/// The original lesson stands - the EXAMPLE-PC outage hid for days behind an indicator that
+/// called succeeding heartbeats "connected" while the Gateway could not actually reach the
+/// Director - but the proof is now the connection itself. The Gateway reaches this Director
+/// ONLY down this stream, so a live stream is not evidence OF reachability, it IS reachability.
+///
+/// Gateway Cleanup mission (tunnel-only): the two-way nonce handshake that used to earn green
+/// (issues #223/#224) is GONE. The Gateway deleted its half at the cut - it no longer dials the
+/// Director back - so this side's half could never pass again, and the "handshake" writers here
+/// (BeginHandshake / CompleteHandshake / RecordCallback) went with it.
 /// </summary>
 public sealed class GatewayConnectionMonitor
 {
     private readonly object _lock = new();
 
-    // Nonce -> whether the Gateway's callback arrived for it. Entries live only for the
-    // duration of one handshake attempt; CompleteHandshake removes them.
-    private readonly Dictionary<string, bool> _pending = new(StringComparer.Ordinal);
-
     public GatewayConnectionStatus Status { get; private set; } = GatewayConnectionStatus.NotConfigured;
 
-    /// <summary>UTC time of the last PASSING handshake. Survives later failures so the UI
-    /// can show "verified until HH:mm" next to a red X.</summary>
+    /// <summary>UTC time the tunnel last came up. Survives a later drop so the UI can show
+    /// "connected until HH:mm" next to a red X.</summary>
     public DateTime? LastVerifiedAt { get; private set; }
 
-    /// <summary>One human-readable line naming the failing leg while <see cref="Status"/> is
+    /// <summary>One human-readable line saying why while <see cref="Status"/> is
     /// <see cref="GatewayConnectionStatus.Failed"/>; null otherwise.</summary>
     public string? FailureSummary { get; private set; }
-
-    /// <summary>Full Gateway verdict of the last COMPLETED handshake (per-leg detail for the
-    /// troubleshooting dialog). Null until one handshake round-trips, and after Reset.</summary>
-    public DirectorVerifyResultDto? LastResult { get; private set; }
 
     /// <summary>Raised after every state change. May fire on any thread - UI subscribers dispatch.</summary>
     public event Action? Changed;
@@ -78,11 +81,9 @@ public sealed class GatewayConnectionMonitor
     {
         lock (_lock)
         {
-            _pending.Clear();
             Status = gatewayConfigured ? GatewayConnectionStatus.Connecting : GatewayConnectionStatus.NotConfigured;
             LastVerifiedAt = null;
             FailureSummary = null;
-            LastResult = null;
         }
         FileLog.Write($"[GatewayConnectionMonitor] Reset: status={Status}");
         Changed?.Invoke();
@@ -100,8 +101,8 @@ public sealed class GatewayConnectionMonitor
         lock (_lock)
         {
             if (Status == GatewayConnectionStatus.NotConfigured) return;
-            if (Status == GatewayConnectionStatus.Verified) return; // no churn
-            Status = GatewayConnectionStatus.Verified;
+            if (Status == GatewayConnectionStatus.Connected) return; // no churn
+            Status = GatewayConnectionStatus.Connected;
             LastVerifiedAt = DateTime.UtcNow;
             FailureSummary = null;
         }
@@ -168,77 +169,4 @@ public sealed class GatewayConnectionMonitor
         Changed?.Invoke();
     }
 
-    /// <summary>Open a handshake attempt: returns the fresh nonce to send to the Gateway.</summary>
-    public string BeginHandshake()
-    {
-        var nonce = Guid.NewGuid().ToString("N");
-        lock (_lock)
-        {
-            _pending[nonce] = false;
-        }
-        return nonce;
-    }
-
-    /// <summary>
-    /// Record the Gateway's callback arriving (GET /verify/{nonce}). Returns true when the
-    /// nonce matches a handshake currently in flight - echoed to the Gateway as "Known".
-    /// </summary>
-    public bool RecordCallback(string nonce)
-    {
-        if (string.IsNullOrEmpty(nonce)) return false;
-        lock (_lock)
-        {
-            if (!_pending.ContainsKey(nonce)) return false;
-            _pending[nonce] = true;
-            return true;
-        }
-    }
-
-    /// <summary>Whether the callback for this in-flight handshake has arrived on this side.</summary>
-    public bool CallbackReceived(string nonce)
-    {
-        lock (_lock)
-        {
-            return _pending.TryGetValue(nonce, out var received) && received;
-        }
-    }
-
-    /// <summary>Retire an in-flight nonce without a verdict (shutdown mid-handshake).
-    /// No state flip, no event - the attempt simply never happened.</summary>
-    public void AbandonHandshake(string nonce)
-    {
-        lock (_lock)
-        {
-            _pending.Remove(nonce);
-        }
-    }
-
-    /// <summary>
-    /// Close a handshake attempt with its verdict. <paramref name="failureSummary"/> null
-    /// means PASS -> Verified; otherwise -> Failed with that summary. Either way the nonce
-    /// is retired and <see cref="Changed"/> fires.
-    /// </summary>
-    public void CompleteHandshake(string nonce, DirectorVerifyResultDto? result, string? failureSummary)
-    {
-        lock (_lock)
-        {
-            _pending.Remove(nonce);
-            LastResult = result;
-            if (failureSummary is null)
-            {
-                Status = GatewayConnectionStatus.Verified;
-                LastVerifiedAt = DateTime.UtcNow;
-                FailureSummary = null;
-            }
-            else
-            {
-                Status = GatewayConnectionStatus.Failed;
-                FailureSummary = failureSummary;
-            }
-        }
-        FileLog.Write(failureSummary is null
-            ? "[GatewayConnectionMonitor] Handshake PASSED: two-way connection verified"
-            : $"[GatewayConnectionMonitor] Handshake FAILED: {failureSummary}");
-        Changed?.Invoke();
-    }
 }

--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -44,6 +44,15 @@ internal sealed class SessionCommandServices
     /// returned when no registry was wired).
     /// </summary>
     public RepositoryRegistry? Repositories { get; init; }
+
+    /// <summary>
+    /// Gateway Cleanup CUT RESTORATION: the live "re-apply the Gateway settings now" hook, so the
+    /// <c>settings-put</c> verb makes a gateway change take effect immediately exactly as the Director's own
+    /// <c>PUT /settings</c> route does. This is the one service that is NOT an optional side effect: the REST
+    /// route always holds one, so a null here means the host wired the stream client wrong, and the verb
+    /// refuses a gateway patch outright rather than writing settings that never take effect.
+    /// </summary>
+    public Func<Task>? ReapplyGatewayAsync { get; init; }
 }
 
 /// <summary>
@@ -74,6 +83,7 @@ internal static class SessionCommandExecutor
         new SessionWriteExecutor(),
         new QueueGitExecutor(),
         new SessionByteExecutor(),
+        new DirectorConfigExecutor(),
     };
 
     /// <summary>

--- a/src/CcDirector.Gateway.Tests/DirectorConfigExecutorTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorConfigExecutorTests.cs
@@ -1,0 +1,207 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using CcDirector.ControlApi;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Storage;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Gateway Cleanup CUT RESTORATION: parity tests for the Director-level CONFIG verbs
+/// (<see cref="DirectorConfigExecutor"/>) behind the Cockpit's Director Settings editor. The cut dropped the
+/// Gateway's leg for <c>/directors/{id}/settings</c> but left the Cockpit calling it, so the request fell
+/// through to the single-page-app fallback and the editor was handed the HTML shell at status 200.
+///
+/// Each verb is exercised through the real <see cref="SessionCommandExecutor.DispatchAsync"/> path (verb map
+/// -&gt; area -&gt; core), the same way the Gateway stream down-channel reaches it, and asserts the behaviour
+/// the Director's own <see cref="SettingsEndpoint"/> route has: the read returns the config verbatim, the
+/// write deep-merges without dropping sibling sections, a non-object body is refused with the route's exact
+/// wording, and a gateway patch re-applies the Gateway live.
+///
+/// Every method runs under an isolated CC_DIRECTOR_ROOT set in the constructor, so a test can never read or
+/// write the real config.json on this machine.
+/// </summary>
+[Collection("DirectorRoot")] // serializes the classes that mutate the process-wide CC_DIRECTOR_ROOT
+public sealed class DirectorConfigExecutorTests : IDisposable
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+
+    public DirectorConfigExecutorTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-dircfg-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    private static DirectorCommand Cmd(string verb, string payloadJson = "") =>
+        new() { CommandId = "cfg", Verb = verb, SessionId = "", PayloadJson = payloadJson };
+
+    /// <summary>The settings-put payload envelope: the patch travels as an opaque object under "settings".</summary>
+    private static string PutPayload(string settingsJson) =>
+        $"{{\"settings\":{settingsJson}}}";
+
+    private static void SeedConfig(string json)
+    {
+        var path = CcStorage.ConfigJson();
+        var dir = Path.GetDirectoryName(path);
+        Assert.NotNull(dir);
+        Directory.CreateDirectory(dir!);
+        File.WriteAllText(path, json);
+    }
+
+    private static string ReadConfigOnDisk() => File.ReadAllText(CcStorage.ConfigJson());
+
+    // ---------- settings-get ----------
+
+    [Fact]
+    public async Task DispatchAsync_SettingsGet_ReturnsTheConfigOnDisk()
+    {
+        SeedConfig("""{ "addressing_mode": "lan", "gateway": { "url": "http://gw.example:7878" } }""");
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-cfg", Cmd("settings-get"));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var body = JsonNode.Parse(result.BodyJson ?? "")!.AsObject();
+            Assert.Equal("lan", body["addressing_mode"]!.GetValue<string>());
+            Assert.Equal("http://gw.example:7878", body["gateway"]!["url"]!.GetValue<string>());
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // ---------- settings-put ----------
+
+    [Fact]
+    public async Task DispatchAsync_SettingsPut_MergesPatchAndPreservesSiblingSections()
+    {
+        // The data-loss guard the Director's own PUT /settings route has: a targeted patch must never drop a
+        // block it did not mention.
+        SeedConfig("""{ "gateway": { "url": "http://gw.example:7878" }, "screenshots": { "source_directory": "C:/old" } }""");
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-cfg",
+                Cmd("settings-put", PutPayload("""{ "screenshots": { "source_directory": "D:/new" } }""")));
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            var merged = JsonNode.Parse(result.BodyJson ?? "")!.AsObject();
+            Assert.Equal("D:/new", merged["screenshots"]!["source_directory"]!.GetValue<string>());
+            Assert.Equal("http://gw.example:7878", merged["gateway"]!["url"]!.GetValue<string>());
+
+            // and it actually landed on disk, not just in the reply
+            var onDisk = JsonNode.Parse(ReadConfigOnDisk())!.AsObject();
+            Assert.Equal("D:/new", onDisk["screenshots"]!["source_directory"]!.GetValue<string>());
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_SettingsPut_NonObjectBody_ReturnsBadRequestWithTheRoutesWording()
+    {
+        SeedConfig("""{ "gateway": { "url": "http://gw.example:7878" } }""");
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-cfg",
+                Cmd("settings-put", PutPayload("[1,2,3]")));
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+            Assert.Equal("request body must be a JSON object", result.Error);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_SettingsPut_MissingPayload_ReturnsBadRequest()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-cfg", Cmd("settings-put"));
+
+            Assert.Equal(DirectorCommandStatus.BadRequest, result.Status);
+            Assert.Equal("request body must be a JSON object", result.Error);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_SettingsPut_GatewayPatch_ReAppliesTheGatewayLive()
+    {
+        // A gateway change must take effect immediately, exactly as the Director's route re-applies it.
+        SeedConfig("""{ "gateway": { "url": "http://old.example:7878" } }""");
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var reapplied = 0;
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-cfg",
+                Cmd("settings-put", PutPayload("""{ "gateway": { "url": "http://new.example:7878" } }""")),
+                new SessionCommandServices
+                {
+                    ReapplyGatewayAsync = () => { reapplied++; return Task.CompletedTask; },
+                });
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal(1, reapplied);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_SettingsPut_NonGatewayPatch_DoesNotReApplyTheGateway()
+    {
+        // Only a gateway patch re-registers; everything else is read on next use. Mirrors the route's guard.
+        SeedConfig("""{ "gateway": { "url": "http://gw.example:7878" } }""");
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var reapplied = 0;
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-cfg",
+                Cmd("settings-put", PutPayload("""{ "screenshots": { "source_directory": "D:/new" } }""")),
+                new SessionCommandServices
+                {
+                    ReapplyGatewayAsync = () => { reapplied++; return Task.CompletedTask; },
+                });
+
+            Assert.Equal(DirectorCommandStatus.Ok, result.Status);
+            Assert.Equal(0, reapplied);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_SettingsPut_GatewayPatchWithNoReApplyHook_FailsLoudlyAndWritesNothing()
+    {
+        // The one place this verb refuses rather than degrading: with no re-apply hook wired, a gateway change
+        // would be written to disk but never take effect - the running Director would disagree with its own
+        // config and the person would be told it worked. It must fail BEFORE writing, leaving the file untouched.
+        var seed = """{ "gateway": { "url": "http://old.example:7878" } }""";
+        SeedConfig(seed);
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        try
+        {
+            var result = await SessionCommandExecutor.DispatchAsync(sm, "dir-cfg",
+                Cmd("settings-put", PutPayload("""{ "gateway": { "url": "http://new.example:7878" } }""")),
+                new SessionCommandServices()); // no ReapplyGatewayAsync
+
+            Assert.Equal(DirectorCommandStatus.Error, result.Status);
+            Assert.Contains("Nothing was written", result.Error ?? "", StringComparison.Ordinal);
+
+            var onDisk = JsonNode.Parse(ReadConfigOnDisk())!.AsObject();
+            Assert.Equal("http://old.example:7878", onDisk["gateway"]!["url"]!.GetValue<string>());
+        }
+        finally { sm.Dispose(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/GatewayConnectionMonitorTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayConnectionMonitorTests.cs
@@ -1,13 +1,17 @@
 using CcDirector.ControlApi;
-using CcDirector.Gateway.Contracts;
 using Xunit;
 
 namespace CcDirector.Gateway.Tests;
 
 /// <summary>
-/// The Director-side home of the handshake truth (issues #223/#224): green is earned by a
-/// completed nonce handshake only; NotConfigured is a legitimate gray, never red; a stale
-/// LastVerifiedAt survives later failures so the UI can say "was verified until HH:mm".
+/// The Director-side home of the Gateway-connection truth: green is earned by a LIVE TUNNEL only;
+/// NotConfigured is a legitimate gray, never red; a stale LastVerifiedAt survives later failures so the UI
+/// can say "was connected until HH:mm".
+///
+/// Gateway Cleanup mission (tunnel-only): the two-way nonce handshake these tests were written against
+/// (issues #223/#224) is gone - the Gateway deleted its half at the cut, so it could never pass again and its
+/// only remaining effect was to paint a lie over a healthy connection. The behaviours it used to guard are
+/// re-asserted here against the tunnel writers, which now earn the green.
 /// </summary>
 public sealed class GatewayConnectionMonitorTests
 {
@@ -33,62 +37,69 @@ public sealed class GatewayConnectionMonitorTests
     {
         var m = new GatewayConnectionMonitor();
         m.Reset(gatewayConfigured: true);
-        var n = m.BeginHandshake();
-        m.CompleteHandshake(n, new DirectorVerifyResultDto { Verified = true }, null);
+        m.MarkTunnelConnected();
 
         m.Reset(gatewayConfigured: false);
         Assert.Equal(GatewayConnectionStatus.NotConfigured, m.Status);
-        Assert.Null(m.LastVerifiedAt); // a verification against the old gateway says nothing now
-        Assert.Null(m.LastResult);
+        Assert.Null(m.LastVerifiedAt); // a connection to the old gateway says nothing now
     }
 
     [Fact]
-    public void RecordCallback_KnownNonce_True_UnknownNonce_False()
+    public void MarkTunnelConnected_GoesConnected_AndStamps()
     {
         var m = new GatewayConnectionMonitor();
         m.Reset(gatewayConfigured: true);
-        var nonce = m.BeginHandshake();
 
-        Assert.True(m.RecordCallback(nonce));
-        Assert.True(m.CallbackReceived(nonce));
-        Assert.False(m.RecordCallback("never-issued"));
-        Assert.False(m.RecordCallback(""));
-    }
+        m.MarkTunnelConnected();
 
-    [Fact]
-    public void CompleteHandshake_Pass_GoesVerified_AndStamps()
-    {
-        var m = new GatewayConnectionMonitor();
-        m.Reset(gatewayConfigured: true);
-        var nonce = m.BeginHandshake();
-        var result = new DirectorVerifyResultDto { Verified = true, Nonce = nonce };
-
-        m.CompleteHandshake(nonce, result, failureSummary: null);
-
-        Assert.Equal(GatewayConnectionStatus.Verified, m.Status);
+        Assert.Equal(GatewayConnectionStatus.Connected, m.Status);
         Assert.NotNull(m.LastVerifiedAt);
         Assert.Null(m.FailureSummary);
-        Assert.Same(result, m.LastResult);
-        Assert.False(m.CallbackReceived(nonce)); // nonce retired
     }
 
     [Fact]
-    public void CompleteHandshake_Fail_GoesFailed_KeepsOlderVerifiedStamp()
+    public void MarkTunnelConnected_NeverGoesGreenFromNotConfigured()
+    {
+        // Gray is sticky: a local-only Director with no gateway.url never lights up.
+        var m = new GatewayConnectionMonitor();
+
+        m.MarkTunnelConnected();
+
+        Assert.Equal(GatewayConnectionStatus.NotConfigured, m.Status);
+        Assert.Null(m.LastVerifiedAt);
+    }
+
+    [Fact]
+    public void TunnelDrop_GoesConnecting_AndKeepsOlderConnectedStamp()
     {
         var m = new GatewayConnectionMonitor();
         m.Reset(gatewayConfigured: true);
 
-        var n1 = m.BeginHandshake();
-        m.CompleteHandshake(n1, new DirectorVerifyResultDto { Verified = true }, null);
-        var verifiedAt = m.LastVerifiedAt;
-        Assert.NotNull(verifiedAt);
+        m.MarkTunnelConnected();
+        var connectedAt = m.LastVerifiedAt;
+        Assert.NotNull(connectedAt);
 
-        var n2 = m.BeginHandshake();
-        m.CompleteHandshake(n2, new DirectorVerifyResultDto { Verified = false }, "The Gateway cannot call this Director back: TCP timeout");
+        m.MarkTunnelConnecting(); // the tunnel dropped and is redialing
+
+        Assert.Equal(GatewayConnectionStatus.Connecting, m.Status);
+        Assert.Equal(connectedAt, m.LastVerifiedAt); // "was connected until HH:mm" survives
+    }
+
+    [Fact]
+    public void RegistrationFailureAfterConnected_GoesFailed_KeepsOlderConnectedStamp()
+    {
+        var m = new GatewayConnectionMonitor();
+        m.Reset(gatewayConfigured: true);
+
+        m.MarkTunnelConnected();
+        var connectedAt = m.LastVerifiedAt;
+        Assert.NotNull(connectedAt);
+
+        m.ReportRegistrationFailure("Cannot reach the Gateway at http://gw:7878: connection refused");
 
         Assert.Equal(GatewayConnectionStatus.Failed, m.Status);
-        Assert.Contains("cannot call this Director back", m.FailureSummary);
-        Assert.Equal(verifiedAt, m.LastVerifiedAt); // "was verified until HH:mm" survives
+        Assert.Contains("connection refused", m.FailureSummary);
+        Assert.Equal(connectedAt, m.LastVerifiedAt); // "was connected until HH:mm" survives
     }
 
     [Fact]
@@ -149,22 +160,9 @@ public sealed class GatewayConnectionMonitorTests
         m.ReportRegistrationFailure("reason A");        // 2
         m.ReportRegistrationFailure("reason A");        // suppressed (no churn)
         m.ReportRegistrationFailure("reason B");        // 3
-        var n = m.BeginHandshake();                     // no event (no state change yet)
-        m.CompleteHandshake(n, null, null);             // 4
+        m.MarkTunnelConnected();                        // 4
+        m.MarkTunnelConnected();                        // suppressed (no churn)
 
         Assert.Equal(4, fired);
-    }
-
-    [Fact]
-    public void AbandonHandshake_RetiresNonce_WithoutStateFlip()
-    {
-        var m = new GatewayConnectionMonitor();
-        m.Reset(gatewayConfigured: true);
-        var nonce = m.BeginHandshake();
-
-        m.AbandonHandshake(nonce);
-
-        Assert.Equal(GatewayConnectionStatus.Connecting, m.Status);
-        Assert.False(m.RecordCallback(nonce)); // no longer pending
     }
 }

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
 using System.Net.Http.Json;
 using System.Net.Sockets;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using CcDirector.Core.Diagnostics;
 using CcDirector.Core.Network;
 using CcDirector.Core.Storage;
@@ -1493,6 +1495,63 @@ internal static class GatewayEndpoints
             return TunnelFailure(null, d.MachineName);
         });
 
+        // Gateway Cleanup CUT RESTORATION: the Cockpit's Director Settings editor
+        // (apps/cockpit/src/fleet/DirectorDetailView.tsx -> client-core getDirectorSettings/putDirectorSettings).
+        // The cut dropped the HTTP reverse-proxy leg that used to serve these two and deferred remote config
+        // editing to Phase 4, but the CALLER was left pointing here. With nothing mapped, the request fell
+        // through to the single-page-app fallback, which answered the Cockpit's GET with the HTML shell at
+        // status 200 - and the client only checks res.ok, so it loaded a web page into the settings editor and
+        // called it settings. These legs ride the tunnel like every director-level verb above; the settings body
+        // is an OPAQUE object the Director owns, so it is forwarded VERBATIM in both directions rather than
+        // being modelled here (the Gateway must not become a second definition of the Director's config).
+        app.MapGet("/directors/{id}/settings", async (string id, CancellationToken ct) =>
+        {
+            var d = registry.Get(id);
+            if (d is null) return Results.NotFound(new { error = "director not found" });
+
+            var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, id, "settings-get", "", null, ct, machineName: d.MachineName);
+            if (sr is null || !sr.Ok) return DirectorAnswerFailure(sr, d.MachineName);
+
+            // The verb's body IS the config object; forward the exact bytes the Director sent.
+            return Results.Content(sr.BodyJson ?? "{}", "application/json");
+        });
+
+        app.MapPut("/directors/{id}/settings", async (string id, HttpContext ctx, CancellationToken ct) =>
+        {
+            var d = registry.Get(id);
+            if (d is null) return Results.NotFound(new { error = "director not found" });
+
+            string raw;
+            using (var reader = new StreamReader(ctx.Request.Body))
+                raw = await reader.ReadToEndAsync(ct);
+
+            // Parse only far enough to know it is a JSON object - the Director owns what the keys MEAN. A
+            // malformed edit is rejected HERE, naming the fault, rather than travelling to the Director to
+            // fail there or, worse, being written as garbage.
+            JsonNode? patch;
+            try
+            {
+                patch = JsonNode.Parse(raw);
+            }
+            catch (JsonException ex)
+            {
+                return Results.Json(new { error = $"The settings you sent are not valid JSON: {ex.Message}" },
+                    statusCode: StatusCodes.Status400BadRequest);
+            }
+            if (patch is not JsonObject)
+                return Results.Json(new { error = "request body must be a JSON object" },
+                    statusCode: StatusCodes.Status400BadRequest);
+
+            FileLog.Write($"[GatewayEndpoints] PUT /directors/{id}/settings: machine={d.MachineName}");
+
+            var sr = await DirectorCommandRouter.TrySendAsync(sendCommand, id, "settings-put", "",
+                new SettingsPutPayload { Settings = patch }, ct, machineName: d.MachineName);
+            if (sr is null || !sr.Ok) return DirectorAnswerFailure(sr, d.MachineName);
+
+            // The merged config the Director actually stored, forwarded verbatim.
+            return Results.Content(sr.BodyJson ?? "{}", "application/json");
+        });
+
         app.MapPost("/directors/{id}/sessions", async (string id, NewSessionRequest req) =>
         {
             var d = registry.Get(id);
@@ -2423,6 +2482,34 @@ internal static class GatewayEndpoints
     //   - any other status  -> the exact bare 502 it returns today, byte-for-byte
     // Deliberately NOT MapDirectorFailure: that maps BadRequest/NotFound to 400/404, and these call sites ship
     // a 502 for those today. Changing that is a contract change and belongs to a different piece of work.
+    /// <summary>
+    /// The settings legs' failure mapping. <see cref="TunnelFailure"/> words the two GATEWAY-synthesized
+    /// outcomes (no tunnel, timeout, mid-command drop) well, so those are handed straight to it. What it does
+    /// NOT do is carry a DIRECTOR-sent failure's message: its default branch collapses every one to a bare 502
+    /// with no body. That is exactly the trap item 1 paid for - a command that computes a perfect explanation
+    /// which no endpoint ever shows a human. The settings verbs return real, actionable messages ("request body
+    /// must be a JSON object"; a refused gateway patch saying nothing was written), so these legs map the
+    /// Director's own status to its HTTP equivalent and carry its words through to the person who typed the
+    /// edit. Scoped to these two routes deliberately: the other legs' bare-502 behaviour is not this item's to
+    /// change.
+    /// </summary>
+    private static IResult DirectorAnswerFailure(DirectorCommandResult? sr, string? machineName)
+    {
+        if (sr is null
+            || sr.Status is DirectorCommandStatus.Timeout or DirectorCommandStatus.TunnelDropped)
+            return TunnelFailure(sr, machineName);
+
+        var status = sr.Status switch
+        {
+            DirectorCommandStatus.BadRequest => StatusCodes.Status400BadRequest,
+            DirectorCommandStatus.NotFound => StatusCodes.Status404NotFound,
+            DirectorCommandStatus.Conflict => StatusCodes.Status409Conflict,
+            DirectorCommandStatus.Locked => StatusCodes.Status423Locked,
+            _ => StatusCodes.Status502BadGateway,
+        };
+        return Results.Json(new { error = sr.Error }, statusCode: status);
+    }
+
     private static IResult TunnelFailure(DirectorCommandResult? sr, string? machineName = null)
     {
         if (sr is null)
@@ -2642,5 +2729,15 @@ internal static class GatewayEndpoints
         if (string.IsNullOrEmpty(s)) return "";
         var oneLine = s.Replace('\r', ' ').Replace('\n', ' ');
         return oneLine.Length <= 200 ? oneLine : oneLine[..200] + "...";
+    }
+
+    /// <summary>
+    /// The <c>settings-put</c> verb payload. Mirrors the Director-side <c>SettingsPutRequest</c>: the settings
+    /// patch travels as an opaque JSON object under one property, so the command envelope stays well-formed
+    /// without the Gateway modelling the Director's config keys.
+    /// </summary>
+    private sealed class SettingsPutPayload
+    {
+        public JsonNode? Settings { get; set; }
     }
 }


### PR DESCRIPTION
Stable Release Tier 1, items 2, 3 and 4. Three places where the tunnel-only cut moved something and left a caller, a port, or a button pointing at where it used to be.

**Do not merge without the owner's word.** Opened for review only, at his instruction.

## 2. The inbound port is closed in every addressing mode

LAN addressing mode bound the Control API to `IPAddress.Any` for a Gateway-to-Director dial that no longer exists. I checked who dials it before cutting: the Gateway creates sessions and drains work lists over the tunnel (`SessionVerbClient` carries no `HttpClient`, and `ICronWorkListDrainLauncher.cs:39` already says "the endpoint argument is ignored post-cut"), and the verify route is deleted. The open port had **no caller at all** — pure attack surface, contradicting the cut's own invariant.

The Serve teardown also no longer skips LAN mode, so a machine **already out there** self-heals to closed. A fix that only protected fresh installs would have left the port open on the only machine that matters.

The LAN auth auto-enable is **kept deliberately**: it no longer guards a routable interface, but dropping it would silently weaken a running install on upgrade.

## 3. Director Settings answers with settings, not a web page

`GET/PUT /directors/{id}/settings` is mapped again, riding the tunnel via two new verbs in a new `DirectorConfigExecutor`. The cut dropped the reverse-proxy leg and deferred remote config editing, but the Cockpit's caller stayed.

With no route mapped, the request fell through to the single-page-app fallback, which answers an extensionless GET with `index.html` **at status 200** — and the client only checks `res.ok`, so the editor loaded the HTML shell and presented it as the Director's settings. The 200-not-404 is why the Cockpit could not tell it was broken.

Each verb's core mirrors the Director's own `SettingsEndpoint` lambda verbatim, so the loopback floor and the tunnel cannot drift into two answers. These legs also map the Director's status and carry its message, because the shared `TunnelFailure` helper collapses Director-sent failures to a bodyless 502.

## 4. The verify handshake is deleted

Its Gateway route was removed at the cut ("Liveness is now the tunnel connection itself") and the Director's own `GET /verify/{nonce}` callback door went with it, so it could never pass again by two independent counts. What it could still do was lie: on the 404 it told the owner *"the Gateway does not support the verify handshake - update the Gateway"* and flipped the light from green to red.

It fires from `RunDiagnosticsAsync` — the **"Show diagnostics" toggle**. So opening diagnostics on a healthy Director broke the indicator and blamed a Gateway that was already the correct build. The diagnostic tool broke the thing it was diagnosing, then lied about the cause.

`GatewayConnectionStatus.Verified` is now `Connected`: green means the tunnel is up, which is the thing that actually proves liveness.

## Proof — running builds, not green tests

- **Item 2:** a slot Director in LAN mode logs `Kestrel listening on http://127.0.0.1` and refuses its own LAN IP, while a control listener on `0.0.0.0` answers on that same IP at the same moment — so the refusal is the bind, not a firewall. The log line `LAN addressing mode: auth auto-enabled` proves LAN mode was genuinely active, so it is not a pass for the wrong reason.
- **Item 3:** against a live Gateway with a tunnel-connected Director, the fixed route returns `200 application/json` while an unmapped sibling returns `200 text/html` — the shell. PUT proven too: a valid patch merges and lands on disk, malformed JSON is a 400 naming the fault, a non-object is a 400.
- **Item 4:** the real `GatewayClient` against the real Gateway went `Verified` -> `Failed` with the exact "update the Gateway" text. Afterwards the harness that reproduced it **no longer compiles**, because `VerifyAsync` does not exist. You cannot regress what is not there.

All seven suites green on the rebased code: **5580 passed, 0 failed**.

## Left alone deliberately

`GatewayClient`'s `RegisterLoop` / `TryRegisterAsync` / heartbeat cluster is already unreachable (nothing calls `SelectActiveUrlThenRegisterAsync`) and keeps its own focused deletion; only the two dead calls **into** the handshake are removed here.

Newly orphaned for that sweep: `Gateway.Contracts/DirectorVerification.cs` (zero users) and `DirectorDto.TwoWayVerifiedAt` (declared, written nowhere, serialises null forever).

**Reviewer note - that dead code is deliberately still here, not an oversight.** Those two are orphaned *by this branch*. On `origin/main` today they still have live users, precisely because this branch has not landed: `DirectorVerification.cs` is used by the very `VerifyAsync` this pull request deletes. The Tier 2 cleanup has therefore correctly **held** those deletions until this merges - deleting them first would break `origin/main`. The ordering is: this lands, and only then are they safely deletable. Please do not read their continued presence as something missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


