### PR TITLE
release: v1.3.0 - the release where DevThrottle stops lying

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
   </PropertyGroup>
 </Project>

--- a/docs/public/release-notes/v1.3.0.md
+++ b/docs/public/release-notes/v1.3.0.md
@@ -1,0 +1,31 @@
+## v1.3.0 - July 14, 2026
+
+The release where DevThrottle stops lying to you.
+
+Every change here either removes something that told you an untruth, or makes a failure explain itself. A day was lost to a tool that reported things that were not so: a stale build claiming the same version as a fixed one, a rename answering "not found" with no reason, and a diagnostics panel that broke the very thing it was diagnosing. None of those failures were large. Together they made the tool untrustworthy, and an untrustworthy tool cannot be used to build anything.
+
+### Highlights
+
+- **Opening diagnostics no longer breaks your connection and then blames the Gateway.** On a perfectly healthy Director, pressing "Show diagnostics" turned the connection light from green to red and told you to go and update a Gateway that was already the correct build. The check itself was the thing that failed - it called a route that was deliberately removed weeks ago - and it sent you off to fix something that was never broken. That check is gone. Green now means the connection is up, which is the thing that actually proves it.
+
+- **A command that cannot be delivered now tells you what happened, in words.** If the connection dropped mid-command you got a bare error with no explanation, and most commands were waited on with no time limit at all - on a weak mobile connection that is a silent wait forever. Now you are told which of three things happened: the Director is not connected, it did not answer in time, or the connection dropped while the command was in flight. That last case says plainly that it is not known whether the command was carried out, because that is the truth and guessing would be worse.
+
+- **A session that is working now shows as working.** A session being driven by another session was painted the same grey as one that was on hold or had exited, even while it was minutes deep into real work. You could not tell a busy worker from a parked one. Colour now says what a session is doing; the badge already said who owns it.
+
+- **The Director no longer listens on your network.** In LAN mode it accepted connections on every network interface, even though nothing has dialled it that way since the switch to outbound connections. It now listens only to the machine it runs on, in every mode - and machines already set up that way close themselves when they update.
+
+- **Director Settings in the Cockpit works again.** It answered with a web page instead of your settings, and did so with a success code, so nothing noticed anything was wrong.
+
+- **When writing into an agent's terminal fails, it says so** instead of failing quietly.
+
+- **Every prompt and reply is now logged, for every agent, with where it came from.**
+
+### Also in this release
+
+- The public API reference described the Director as having endpoints it has not had for weeks - the very first example in it returned "not found" when copied. It now lists only what is really there.
+- Five design documents describing systems that were never built have been deleted, along with every link that still pointed at them and lent them authority.
+- Dead code left behind by the move to outbound connections has been removed.
+
+### A note on what we did not change
+
+Three things named in our own cleanup list turned out to be alive and were deliberately left alone. Deleting one of them would have silently stopped the Launcher from connecting - a cleanup that looks successful and quietly breaks remote machine control. In a release about not lying, shipping a silent failure would have been the worst possible outcome, so each was proved by its callers before anything was removed.


### PR DESCRIPTION
## MERGE LAST - this is not ready to merge yet

The notes describe work that is still sitting in **open, unmerged pull requests**. Merging this first would publish claims that are not yet true, which is the exact failure this release exists to remove.

**Merge order:**
1. #1555 - close the inbound port, restore Director Settings, delete the verify handshake
2. The Tier 2 cleanup pull request (dead code, the public API reference, the never-shipped documents)
3. **This one, last**
4. Then the tag is cut on main, and **the owner publishes it**

## What this changes

- `Directory.Build.props` - the single source of truth for the version - 1.2.0 to 1.3.0.
- `docs/public/release-notes/v1.3.0.md` - new.

Nothing else. No product code.

## Accuracy gate

Every claim in the notes was written against merged commits or against work proven on a running build and sitting in an open pull request. Anything not yet true at merge time must be cut from the notes before this lands.

## Note on v1.2.0

**v1.2.0 was never tagged.** It is merged and its notes are on main, but the newest published tag is still v1.1.0, so everything in v1.2.0 has shipped to nobody. That is the owner's decision to make: publish v1.2.0 at `249e9de5` first, or let v1.3.0 carry its contents. Whichever way, it should be decided deliberately rather than by accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)