### PR TITLE
fix(director): resolve a mission name from the Gateway on a local spawn (#1548)

### DIFF
--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -502,6 +502,50 @@ internal static class ControlEndpoints
             if (isLocal)
             {
                 FileLog.Write($"[ControlEndpoints] POST /fleet/spawn: LOCAL, repo={req.RepoPath}, agent={req.Agent}");
+
+                // Issue #1548: a mission-scoped LOCAL spawn resolves the mission NAME against the Gateway's
+                // mission store - the source of truth - before handing the create request to the floor. The
+                // REMOTE leg below already gets this for free: it goes out through the Gateway, whose
+                // POST /machines/{machine}/sessions stamps the name for it. The local leg never touched the
+                // Gateway, so a caller sending only a mission id (which is all the CLI's `session spawn
+                // --mission <id>` can send) fell through to the Director's TEMPORARY local-store bridge and
+                // was rejected against the wrong store - telling the human to create a mission that already
+                // existed. Resolving here makes both legs consult the same store and leaves the floor
+                // stamping only what create carries, which is the documented end state.
+                if (req.MissionId is Guid localMissionId && string.IsNullOrWhiteSpace(req.MissionName))
+                {
+                    var missionGw = gatewayClientProvider?.Invoke();
+                    if (missionGw is { IsEnabled: true })
+                    {
+                        MissionDto? mission;
+                        try
+                        {
+                            mission = await missionGw.GetMissionAsync(localMissionId, ct);
+                        }
+                        catch (Exception ex)
+                        {
+                            // Fail loud. An unreachable Gateway is NOT an unknown mission, and reporting it as
+                            // one is the exact lie this issue is about.
+                            FileLog.Write($"[ControlEndpoints] POST /fleet/spawn: mission lookup {localMissionId} FAILED: {ex.Message}");
+                            return Results.Json(
+                                new { error = $"Cannot attach the new session to mission '{localMissionId}': the Gateway could not be reached to look up its name. {ex.Message}" },
+                                statusCode: StatusCodes.Status502BadGateway);
+                        }
+
+                        if (mission is null)
+                            return Results.BadRequest(new
+                            {
+                                error = $"unknown mission '{localMissionId}'. The Gateway has no mission with that id. "
+                                      + "List the missions with: cc-devthrottle mission list",
+                            });
+
+                        FileLog.Write($"[ControlEndpoints] POST /fleet/spawn: mission {localMissionId} resolved to \"{mission.MissionName}\"");
+                        req.MissionName = mission.MissionName;
+                    }
+                    // No Gateway configured: leave the name blank and let the floor's local-store bridge
+                    // resolve it exactly as it does today. That is the only store a Gateway-less Director has.
+                }
+
                 return await CreateLocalSessionAsync(req);
             }
 

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -468,6 +468,43 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
     }
 
     /// <summary>
+    /// Issue #1548: look a Mission up by id in the GATEWAY's mission store - the source of truth for
+    /// Missions, which are a fleet-level concept spanning Directors and machines. A LOCAL spawn resolves
+    /// the mission name through here so it stamps the create request exactly the way the Gateway already
+    /// stamps a REMOTE spawn in <c>POST /machines/{machine}/sessions</c>, leaving the Director floor to
+    /// stamp only what create carries.
+    ///
+    /// Returns null ONLY when the Gateway genuinely has no mission with that id (404). Throws when the
+    /// Gateway is disabled or unreachable - a missing answer must never be reported as "unknown mission",
+    /// which is the lie this issue is about. Same fail-loud posture as the fleet relays above.
+    /// </summary>
+    public async Task<MissionDto?> GetMissionAsync(Guid missionId, CancellationToken ct = default)
+    {
+        if (!_config.IsEnabled)
+            throw new InvalidOperationException("Gateway is not configured; cannot look up a mission.");
+
+        FileLog.Write($"[GatewayClient] GetMissionAsync: GET /missions/{missionId}");
+        using var resp = await _http.GetAsync($"missions/{missionId}", ct);
+        if (resp.StatusCode == HttpStatusCode.NotFound)
+        {
+            FileLog.Write($"[GatewayClient] GetMissionAsync {missionId}: the Gateway has no such mission");
+            return null;
+        }
+        if (!resp.IsSuccessStatusCode)
+        {
+            var detail = await resp.Content.ReadAsStringAsync(ct);
+            throw new InvalidOperationException(
+                $"Gateway could not look up mission '{missionId}': HTTP {(int)resp.StatusCode} {resp.ReasonPhrase} {detail}".TrimEnd());
+        }
+
+        var mission = await resp.Content.ReadFromJsonAsync<MissionDto>(ct);
+        if (mission is null)
+            throw new InvalidOperationException($"Gateway mission lookup for '{missionId}' returned an unparsable body.");
+        FileLog.Write($"[GatewayClient] GetMissionAsync {missionId}: resolved name=\"{mission.MissionName}\"");
+        return mission;
+    }
+
+    /// <summary>
     /// Snooze Length mission (Phase 3): record or clear a Gateway-owned snooze/hold for a session by
     /// driving the Gateway's <c>POST /sessions/{sid}/hold</c> with the SAME authenticated client (already
     /// pointed at the resolved Gateway address and carrying the fleet token) the other Director-to-Gateway

--- a/src/CcDirector.Gateway.Tests/FleetSpawnMissionAttachTests.cs
+++ b/src/CcDirector.Gateway.Tests/FleetSpawnMissionAttachTests.cs
@@ -1,0 +1,162 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using CcDirector.ControlApi;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Sessions;
+using CcDirector.Core.Storage;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1548, at the endpoint. Reproduces the reported failure exactly: `cc-devthrottle session spawn
+/// &lt;repo&gt; --mission &lt;id&gt;` sends POST /fleet/spawn carrying a mission ID and NOTHING ELSE - the CLI
+/// has no way to send the name - and the spawn was rejected with "unknown mission '&lt;id&gt;'. Create it
+/// first with POST /missions." for a mission that already existed at the Gateway.
+///
+/// The local spawn leg never asked the Gateway, so the request reached the Director floor with the name
+/// blank and fell through to the floor's TEMPORARY local-store bridge, which looked in the Director's own
+/// missions.json - the wrong store. The remote leg never had the bug: it leaves through the Gateway, which
+/// stamps the name on the way out.
+///
+/// This drives the REAL Director Control API against a REAL Gateway stub over a REAL loopback HTTP
+/// connection, so the whole path - endpoint, GatewayClient, wire, floor - runs. Before the fix the first
+/// fact below returns 400 "unknown mission"; after it, the session is born carrying the mission NAME.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class FleetSpawnMissionAttachTests : IAsyncLifetime
+{
+    private static readonly Guid KnownMissionId = Guid.NewGuid();
+    private const string KnownMissionName = "Stable Release";
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private WebApplication _gatewayStub = null!;
+    private ControlApiHost _host = null!;
+    private SessionManager _sm = null!;
+    private HttpClient _client = null!;
+    private string _repoDir = null!;
+
+    public FleetSpawnMissionAttachTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-spawnmission-root-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        // A Gateway stub that knows exactly ONE mission - the source of truth the Director must consult.
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        builder.WebHost.ConfigureKestrel(o => o.Listen(IPAddress.Loopback, 0));
+        _gatewayStub = builder.Build();
+        _gatewayStub.MapGet("/missions/{mid}", (string mid) =>
+            Guid.TryParse(mid, out var id) && id == KnownMissionId
+                ? Results.Json(new MissionDto { MissionId = KnownMissionId, MissionName = KnownMissionName })
+                : Results.NotFound(new { error = "mission not found" }));
+        await _gatewayStub.StartAsync();
+        var gatewayUrl = _gatewayStub.Urls.First();
+
+        // Point this Director at the stub. GatewayConfig.Load reads config.json under CC_DIRECTOR_ROOT, so
+        // this is the same wiring a real install uses - no test-only seam.
+        Directory.CreateDirectory(Path.GetDirectoryName(CcStorage.ConfigJson())!);
+        await File.WriteAllTextAsync(CcStorage.ConfigJson(),
+            "{\"gateway\":{\"url\":\"" + gatewayUrl + "\"}}");
+
+        _repoDir = Path.Combine(Path.GetTempPath(), "ccd-spawnmission-repo-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_repoDir);
+
+        _sm = new SessionManager(new AgentOptions());
+        _host = new ControlApiHost(_sm, "1.0.0-test", () => Task.CompletedTask, useEphemeralPort: true);
+        var port = await _host.StartAsync();
+        _client = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{port}/") };
+        _client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", DirectorAuth.LoadOrCreateToken());
+    }
+
+    public async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _host.StopAsync();
+        _sm.Dispose();
+        await _gatewayStub.StopAsync();
+        try
+        {
+            var f = Path.Combine(InstanceRegistration.InstancesDirectory, $"{_host.DirectorId}.json");
+            if (File.Exists(f)) File.Delete(f);
+        }
+        catch { /* test cleanup, ignore */ }
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+        try { if (Directory.Exists(_repoDir)) Directory.Delete(_repoDir, true); } catch { /* best effort */ }
+    }
+
+    /// <summary>A spawn body shaped exactly like the CLI's: a mission ID, never a name.</summary>
+    private NewSessionRequest CliSpawnBody(Guid missionId) => new()
+    {
+        RepoPath = _repoDir,
+        Agent = "RawCli",
+        Command = "cmd",
+        CommandArgs = "/k",
+        MissionId = missionId,
+    };
+
+    [Fact]
+    public async Task Local_spawn_withMissionIdOnly_resolvesTheNameFromTheGateway_andAttaches()
+    {
+        // The exact #1548 reproduction. This returned 400 "unknown mission" before the fix.
+        var resp = await _client.PostAsJsonAsync("fleet/spawn", CliSpawnBody(KnownMissionId));
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var dto = await resp.Content.ReadFromJsonAsync<SessionDto>();
+        Assert.NotNull(dto);
+        Assert.Equal(KnownMissionId, dto!.MissionId);
+
+        // The point of the whole issue: the session is born carrying the mission NAME, resolved from the
+        // Gateway's store, so it is genuinely bound into the pod rather than rejected against the wrong one.
+        Assert.Equal(KnownMissionName, dto.MissionName);
+
+        if (dto.SessionId is not null)
+            await _client.DeleteAsync($"sessions/{dto.SessionId}");
+    }
+
+    [Fact]
+    public async Task Local_spawn_withMissionUnknownToTheGateway_saysSo_inPlainEnglish()
+    {
+        // A mission the Gateway genuinely does not have still fails - but now it fails against the RIGHT
+        // store, and the message points at the command that lists them instead of telling the human to
+        // create something that may already exist.
+        var resp = await _client.PostAsJsonAsync("fleet/spawn", CliSpawnBody(Guid.NewGuid()));
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("The Gateway has no mission with that id", body);
+        Assert.Contains("cc-devthrottle mission list", body);
+    }
+
+    [Fact]
+    public async Task Local_spawn_withNoMission_isUnaffected()
+    {
+        // The no-mission path must not have acquired a Gateway round-trip.
+        var body = CliSpawnBody(KnownMissionId);
+        body.MissionId = null;
+
+        var resp = await _client.PostAsJsonAsync("fleet/spawn", body);
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var dto = await resp.Content.ReadFromJsonAsync<SessionDto>();
+        Assert.NotNull(dto);
+        Assert.Null(dto!.MissionId);
+        Assert.Null(dto.MissionName);
+
+        if (dto.SessionId is not null)
+            await _client.DeleteAsync($"sessions/{dto.SessionId}");
+    }
+}

--- a/src/CcDirector.Gateway.Tests/GatewayClientMissionLookupTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayClientMissionLookupTests.cs
@@ -1,0 +1,126 @@
+using System.Net;
+using CcDirector.ControlApi;
+using CcDirector.Core.Configuration;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1548: a mission-scoped spawn failed with "unknown mission '&lt;id&gt;'. Create it first with
+/// POST /missions." for a mission that already existed. Missions live at the GATEWAY (the source of truth,
+/// what `cc-devthrottle mission list` reads). The Director's LOCAL spawn leg never consulted it: the CLI can
+/// only send a mission id, so the create request reached the Director floor with the NAME blank, fell through
+/// to the Director's TEMPORARY local-store bridge, and was rejected against the wrong store. The REMOTE leg
+/// never had this bug - it exits through the Gateway, whose POST /machines/{machine}/sessions resolves the
+/// name for it. <see cref="GatewayClient.GetMissionAsync"/> is what closes that asymmetry.
+///
+/// These tests drive the REAL <see cref="GatewayClient"/> over a REAL HTTP connection to a Kestrel stub on a
+/// loopback port (the pattern the token-refresh tests use), so the wire behavior - status codes, the 404, a
+/// server error - is exercised rather than a hand-written fake that is politer than the transport.
+///
+/// The last fact is the point of the whole issue: an unreachable or broken Gateway must THROW, never return
+/// null. Null means "the Gateway answered, and it genuinely has no such mission." Collapsing a transport
+/// failure into null would put the original lie back - telling a human to create a mission that exists.
+/// </summary>
+public sealed class GatewayClientMissionLookupTests
+{
+    /// <summary>
+    /// A Kestrel stub standing in for the Gateway's GET /missions/{mid}, on an OS-assigned loopback port.
+    /// <paramref name="handler"/> returns the response for a requested mission id.
+    /// </summary>
+    private static async Task<(WebApplication app, string url)> StartMissionStubAsync(Func<string, IResult> handler)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        builder.WebHost.ConfigureKestrel(o => o.Listen(IPAddress.Loopback, 0));   // OS-assigned free port
+        var app = builder.Build();
+        app.MapGet("/missions/{mid}", (string mid) => handler(mid));
+        await app.StartAsync();
+        var url = app.Urls.First();
+        return (app, url);
+    }
+
+    private static GatewayClient ClientFor(string gatewayUrl) =>
+        new(new GatewayConfig { Url = gatewayUrl }, Guid.NewGuid().ToString(), 7879, "1.0.0");
+
+    [Fact]
+    public async Task GetMissionAsync_knownMission_resolvesTheName()
+    {
+        var missionId = Guid.NewGuid();
+        var (app, url) = await StartMissionStubAsync(_ => Results.Json(new MissionDto
+        {
+            MissionId = missionId,
+            MissionName = "Stable Release",
+        }));
+
+        try
+        {
+            var mission = await ClientFor(url).GetMissionAsync(missionId);
+
+            Assert.NotNull(mission);
+            Assert.Equal(missionId, mission!.MissionId);
+            Assert.Equal("Stable Release", mission.MissionName);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task GetMissionAsync_unknownMission_returnsNull_soTheCallerCanSayUnknown()
+    {
+        var (app, url) = await StartMissionStubAsync(_ => Results.NotFound(new { error = "mission not found" }));
+
+        try
+        {
+            Assert.Null(await ClientFor(url).GetMissionAsync(Guid.NewGuid()));
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task GetMissionAsync_gatewayError_throws_neverNull_soAFailureIsNotReportedAsUnknownMission()
+    {
+        // The heart of #1548. A 500 means the Gateway could not answer - it does NOT mean the mission is
+        // absent. Returning null here would make the caller say "unknown mission", the exact lie.
+        var (app, url) = await StartMissionStubAsync(_ => Results.StatusCode(500));
+
+        try
+        {
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => ClientFor(url).GetMissionAsync(Guid.NewGuid()));
+            Assert.Contains("could not look up mission", ex.Message);
+        }
+        finally
+        {
+            await app.StopAsync();
+        }
+    }
+
+    [Fact]
+    public async Task GetMissionAsync_unreachableGateway_throws_neverNull()
+    {
+        // Nothing is listening on this port: a transport failure, again not an absent mission.
+        var client = ClientFor("http://127.0.0.1:1");
+
+        await Assert.ThrowsAnyAsync<Exception>(() => client.GetMissionAsync(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public async Task GetMissionAsync_noGatewayConfigured_throws_ratherThanClaimingTheMissionIsUnknown()
+    {
+        var client = new GatewayClient(new GatewayConfig(), Guid.NewGuid().ToString(), 7879, "1.0.0");
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetMissionAsync(Guid.NewGuid()));
+        Assert.Contains("Gateway is not configured", ex.Message);
+    }
+}


### PR DESCRIPTION
Fixes #1548.

## The bug

Spawning a session into a Gateway mission failed with:

```
unknown mission '<id>'. Create it first with POST /missions.
```

for a mission that already existed. `cc-devthrottle session spawn <repo> --mission <id>` could never attach to a Gateway mission. The error is itself the worst part: it tells the human to create something that is already there.

## Why

Missions live at the **Gateway** - the source of truth that `cc-devthrottle mission list` reads.

The **remote** spawn leg never had this bug. It leaves through the Gateway, whose `POST /machines/{machine}/sessions` looks the mission up in the Gateway store and stamps the resolved name onto the create request.

The **local** leg of `POST /fleet/spawn` never consulted the Gateway at all. The CLI can only send a mission id - there is no way for it to send a name - so the create request reached the Director floor with `MissionName` blank. The floor then took its **temporary local-store bridge**, which resolves against the Director's own `missions.json`. That is the wrong store, so a Gateway mission was rejected there.

The two legs disagreed about which store a mission lives in.

## The fix

Resolve the mission name on the local leg too, against the Gateway, so **both legs consult one store** and the Director floor keeps stamping only what the create request carries - the documented end state. The floor's bridge is untouched.

`GatewayClient.GetMissionAsync` returns null **only** on a genuine 404 and **throws** when the Gateway is disabled or unreachable. That distinction is the point of the issue: a Gateway that could not answer is not a mission that does not exist, and reporting one as the other is the original lie. An unreachable Gateway now fails loud naming what actually happened.

**Unchanged:** with no Gateway configured, the local-store bridge resolves exactly as today - that is the only store a Gateway-less Director has. A spawn with no mission acquires no Gateway round-trip (pinned by a test).

## Proof

Tests drive the **real** endpoint and the **real** `GatewayClient` over a **real** loopback HTTP connection to a Kestrel Gateway stub - not a hand-written fake politer than the transport. `FleetSpawnMissionAttachTests` reproduces the report exactly: a spawn body shaped like the CLI's, carrying a mission id and nothing else.

I verified the tests actually catch the bug rather than agreeing with the code. With the endpoint fix reverted:

```
FleetSpawnMissionAttachTests.Local_spawn_withMissionIdOnly_resolvesTheNameFromTheGateway_andAttaches [FAIL]
  Assert.Equal() Failure: Values differ
  Expected: Created
  Actual:   BadRequest
FleetSpawnMissionAttachTests.Local_spawn_withMissionUnknownToTheGateway_saysSo_inPlainEnglish [FAIL]
Failed! - Failed: 2, Passed: 1
```

With the fix, all 8 new tests pass.

**Seven suites green: 5532 passed** (Avalonia 124, Core 3069, Engine 62, Gateway 2163, HostedAgent 80, Launcher 27, Terminal.Avalonia 7). The previous full run was 5524; this adds exactly the 8 new tests.

## Note on the brief

The brief described this as "`MissionId` only -> transitional bridge -> fails", which is accurate, but implied the whole spawn path was broken. It is narrower than that: **only the local leg is affected.** The remote leg already resolves correctly at the Gateway. That is why the fix is a handful of lines at the local branch rather than surgery on the floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
