### PR TITLE
fix(sessions): a crashed session is deep red again, not a clean exit (#959)

### DIFF
--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -1184,6 +1184,11 @@ internal static class ControlEndpoints
             RepoPath = s.RepoPath,
             Status = s.Status.ToString(),
             ActivityState = s.ActivityState.ToString(),
+            // Issue #959: the raw crash fact. ActivityState says only "Exited", so without this the fold
+            // cannot tell a crash from a clean exit. This ONE mapper feeds both the Gateway wire and the
+            // desktop rail's own fold input, so stamping it here restores the deep-red on the rail, the
+            // Cockpit and the phone together.
+            Crashed = s.Crashed,
             // SessionDto.AssessedState is intentionally left null (defaults null): the Gateway-pushed
             // "assessed state" display annotation (issue #186) was retired with the Director's overlay
             // fold (issue #1177, Phase 2.3). Readers still do "AssessedState ?? ActivityState", so a null

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -124,6 +124,23 @@ public sealed class SessionDto
     public string StatusColor { get; set; } = "unknown";
 
     /// <summary>
+    /// True when the agent process ended UNEXPECTEDLY - a crash (issue #959). Mirrors
+    /// <c>Session.Crashed</c> on the owning Director, which decides it from the exit code AND whether the
+    /// session dropped out while working (some crashes exit 0, so the code alone is not enough).
+    ///
+    /// This is a RAW fact and the fold reads it directly. It exists because a crash was NEVER modelled in
+    /// <see cref="ActivityState"/> - a crashed session is <c>Exited</c> like any other - so without it the
+    /// wire could not tell a crash from a clean exit and every client rendered both as the same grey. That
+    /// is precisely what happened: the Director kept setting its deep-red Error colour, and the fold, which
+    /// reads only raw facts, had no raw fact to read.
+    ///
+    /// Deliberately NOT inferred from <see cref="Status"/> == "Failed". The two coincide today only because
+    /// the one other writer of Failed (a create-time failure) disposes the session before it ever reaches
+    /// the roster. Reading the producer's own fact keeps that coincidence from becoming a dependency.
+    /// </summary>
+    public bool Crashed { get; set; }
+
+    /// <summary>
     /// Short human-readable reason for the current <see cref="StatusColor"/>
     /// (e.g. "session created", "working", "waiting for input"). Surfaced as a
     /// tooltip on the dot so the user can see WHY the color is what it is.

--- a/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionOrdering.cs
@@ -159,9 +159,16 @@ public static class SessionOrdering
 
     /// <summary>The pure activity-state color. Starting/Working -&gt; blue; Waiting/Idle -&gt; red;
     /// Exited -&gt; "grey" (Phase 2.3, owner-approved: an exited session shows the SAME grey string as an
-    /// OnHold one, so clients render it identically). This deliberately DIVERGES from the Director's
-    /// standalone <c>ColorFromActivityState</c>, which keeps exited as "unknown" - the Gateway is the single
-    /// source of truth for the fold. Any unrecognized state -&gt; "unknown".</summary>
+    /// OnHold one, so clients render it identically), EXCEPT a crashed one -&gt; "error" (issue #959: the
+    /// deep red #B91C1C, deliberately darker than the bright "needs you" red, so a session that DIED is
+    /// never mistaken for one that finished). This deliberately DIVERGES from the Director's standalone
+    /// <c>ColorFromActivityState</c>, which keeps exited as "unknown" - the Gateway is the single source of
+    /// truth for the fold. Any unrecognized state -&gt; "unknown".
+    ///
+    /// The crash arm reads <see cref="SessionDto.Crashed"/>, NOT the activity state: a crash was never
+    /// modelled in ActivityState (a crashed session is "Exited" like any other), which is exactly how the
+    /// deep red went missing for two releases - this fold reads raw facts, and the crash fact was not on
+    /// the wire to read.</summary>
     private static string RawActivityColor(SessionDto s) => s.ActivityState switch
     {
         "Starting" => "blue",
@@ -169,7 +176,7 @@ public static class SessionOrdering
         "WaitingForInput" => "red",
         "WaitingForPerm" => "red",
         "Idle" => "red",
-        "Exited" => "grey",
+        "Exited" => s.Crashed ? "error" : "grey",
         _ => "unknown",
     };
 
@@ -206,6 +213,7 @@ public static class SessionOrdering
             "blue" => "Working",
             "red" => "Needs you",
             "grey" => "Exited",              // Phase 2.3: an exited session's grey base (see RawActivityColor)
+            "error" => "Crashed",            // issue #959: died, not finished - never reads as a clean "Exited"
             _ => "Idle",
         };
     }

--- a/src/CcDirector.Gateway.Tests/CrashedSessionColorTests.cs
+++ b/src/CcDirector.Gateway.Tests/CrashedSessionColorTests.cs
@@ -1,0 +1,131 @@
+using CcDirector.ControlApi;
+using CcDirector.Core.Backends;
+using CcDirector.Core.Memory;
+using CcDirector.Core.Sessions;
+using CcDirector.Gateway.Contracts;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #959, re-broken and now restored. A crashed session must show the deep red #B91C1C - deliberately
+/// darker than the bright "needs you" red - so a session that DIED is never mistaken for one that finished.
+/// It had been rendering as an ordinary grey "Exited", byte-identical to a clean exit, on every surface.
+///
+/// The mechanism, because it is not the obvious one: a crash was NEVER modelled in ActivityState - a crashed
+/// session is "Exited" like any other. It lives on Session.Crashed, and the PRODUCER never stopped working.
+/// What broke was the transport and the fold. SessionDto carried no crash fact, and SessionOrdering computes
+/// colour from RAW facts only ("the Gateway is the single fold and reads the Director's cooked StatusColor
+/// for NOTHING"), so there was simply no crash fact on the wire for it to read. Two independent regressions
+/// of the same behaviour: #1177 took it from the Cockpit and the phone, #1537 took it from the desktop rail
+/// when the rail joined the shared fold. ErrorStatusBrush, the "error" switch arm and the #B91C1C palette
+/// entry all survived as orphans, which is why the support still LOOKED present.
+///
+/// These tests drive the REAL producer - a backend raising a real process exit into
+/// Session.OnBackendProcessExited - then the REAL wire mapper, then the REAL fold. Nothing sets Crashed by
+/// hand, so the tests cannot pass on a fact production never emits.
+/// </summary>
+public sealed class CrashedSessionColorTests
+{
+    /// <summary>A backend whose process exit can be driven, so the real crash decision runs.</summary>
+    private sealed class ExitableBackend : ISessionBackend
+    {
+        public int ProcessId => 4321;
+        public string Status => "Exitable";
+        public bool IsRunning => !_exited;
+        public bool HasExited => _exited;
+        public CircularTerminalBuffer? Buffer => null;
+        private bool _exited;
+
+#pragma warning disable CS0067 // required by the interface, unused here
+        public event Action<string>? StatusChanged;
+#pragma warning restore CS0067
+        public event Action<int>? ProcessExited;
+
+        public void RaiseExit(int code)
+        {
+            _exited = true;
+            ProcessExited?.Invoke(code);
+        }
+
+        public void Start(string executable, string args, string workingDir, short cols, short rows, Dictionary<string, string>? environmentVars = null) { }
+        public void Write(byte[] data) { }
+        public Task SendTextAsync(string text) => Task.CompletedTask;
+        public Task SendEnterAsync() => Task.CompletedTask;
+        public void Resize(short cols, short rows) { }
+        public Task GracefulShutdownAsync(int timeoutMs = 5000) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// Runs a session to a real process exit and returns what the wire carries - the exact SessionDto the
+    /// Gateway aggregates AND the desktop rail folds (both go through ControlEndpoints.Map).
+    /// </summary>
+    private static SessionDto ExitedSessionOnTheWire(int exitCode, ActivityState stateBeforeExit)
+    {
+        var backend = new ExitableBackend();
+        var session = new Session(
+            Guid.NewGuid(), @"C:\test\repo", @"C:\test\repo", null,
+            backend, SessionBackendType.ConPty);
+        session.MarkRunning();
+        session.ApplyTerminalActivityState(stateBeforeExit);
+
+        backend.RaiseExit(exitCode);   // the real producer decides crash-vs-clean
+
+        return ControlEndpoints.Map(session, directorId: "");
+    }
+
+    [Fact]
+    public void Crash_withNonZeroExit_foldsToTheDeepRed_notGrey()
+    {
+        var dto = ExitedSessionOnTheWire(exitCode: 1, stateBeforeExit: ActivityState.WaitingForInput);
+
+        Assert.True(dto.Crashed);                                  // the fact reached the wire
+        Assert.Equal("Exited", dto.ActivityState);                 // ...and ActivityState still cannot say it
+        Assert.Equal("error", SessionOrdering.EffectiveColor(dto));
+        Assert.Equal("Crashed", SessionOrdering.StateLabel(dto));
+    }
+
+    [Fact]
+    public void Crash_withExitZero_whileWorking_foldsToTheDeepRed()
+    {
+        // Some crashes exit 0, so the exit code alone is not enough - dropping out mid-work is the tell.
+        var dto = ExitedSessionOnTheWire(exitCode: 0, stateBeforeExit: ActivityState.Working);
+
+        Assert.True(dto.Crashed);
+        Assert.Equal("error", SessionOrdering.EffectiveColor(dto));
+        Assert.Equal("Crashed", SessionOrdering.StateLabel(dto));
+    }
+
+    [Fact]
+    public void CleanExit_isUnchanged_stillGreyAndStillReadsExited()
+    {
+        // The other half of the contract: a session that finished on purpose must NOT gain a crash colour.
+        var dto = ExitedSessionOnTheWire(exitCode: 0, stateBeforeExit: ActivityState.WaitingForInput);
+
+        Assert.False(dto.Crashed);
+        Assert.Equal("grey", SessionOrdering.EffectiveColor(dto));
+        Assert.Equal("Exited", SessionOrdering.StateLabel(dto));
+    }
+
+    [Fact]
+    public void Crash_andCleanExit_areDistinguishable_theWholePointOf959()
+    {
+        var crashed = ExitedSessionOnTheWire(exitCode: 1, stateBeforeExit: ActivityState.WaitingForInput);
+        var clean = ExitedSessionOnTheWire(exitCode: 0, stateBeforeExit: ActivityState.WaitingForInput);
+
+        Assert.NotEqual(SessionOrdering.EffectiveColor(clean), SessionOrdering.EffectiveColor(crashed));
+        Assert.NotEqual(SessionOrdering.StateLabel(clean), SessionOrdering.StateLabel(crashed));
+    }
+
+    [Fact]
+    public void Crash_doesNotBecomeNeedsYou_theDeepRedStaysDistinctFromTheBrightRed()
+    {
+        // #959 chose a SEPARATE deep red on purpose. If a crash folded to plain "red" it would be
+        // indistinguishable from a session waiting on the human - a different lie, not a fix.
+        var dto = ExitedSessionOnTheWire(exitCode: 1, stateBeforeExit: ActivityState.Working);
+
+        Assert.NotEqual("red", SessionOrdering.EffectiveColor(dto));
+        Assert.Equal(SessionOrdering.TriageBucket.Active, SessionOrdering.Classify(dto));   // triage is unchanged
+    }
+}


### PR DESCRIPTION
Restores thefrederiksen/devthrottle#959.

This started as an **unverified claim** ("a crashed session is indistinguishable from an exited one, a regression from thefrederiksen/devthrottle#1537"). The claim is **real** - but the mechanism it gives is wrong, and the wrong mechanism is worth recording, because it is the one a reader would naturally believe.

## What was claimed

That `ActivityState` lost its `Crashed` member.

## What is actually true

**There never was one.** A crash was never modelled in `ActivityState` - a crashed session is `Exited` like any other. Nothing was removed from that enum, and thefrederiksen/devthrottle#1537 did not touch it.

The crash lives on `Session.Crashed`, and **the producer never stopped working**. `OnBackendProcessExited` still decides crash-vs-clean correctly (non-zero exit code **or** dropping out while working - some crashes exit 0), still sets `Crashed`, `Status = Failed`, and still stamps the deep-red Error colour with a reason.

**The transport and the fold are what broke.** `SessionDto` carried no crash fact at all, and `SessionOrdering` computes colour from RAW facts only - its own comment says the fold "reads the Director's cooked StatusColor for **NOTHING**". So `EffectiveColor` had no crash fact to read and **could never return `"error"`**, no matter what the Director knew. A crashed session folded to `Exited -> "grey"`, identical to a clean exit.

**Two independent regressions of the same behaviour, not one:**

| Surface | Broke at | What changed |
|---|---|---|
| Cockpit + phone | thefrederiksen/devthrottle_internal#722 | the Gateway stopped passing the Director's `StatusColor` through and computed colour from `ActivityState` instead |
| Desktop rail | thefrederiksen/devthrottle#1537 | the rail joined the shared fold; before it, it switched on `Session.StatusColor`, which **does** carry `"error"` (verified by diffing `db1a509c^`) |

`ErrorStatusBrush`, the `"error"` switch arm, and the `error: "#B91C1C"` palette entry all survived as **orphaned call sites with no caller that could reach them**. That is why crash support still *looks* present in the code.

## The fix

Fix the **transport and the fold**, not the three clients: carry the raw crash fact on `SessionDto`, and let the fold read it.

`ControlEndpoints.Map` is the one mapper feeding **both** the Gateway wire **and** the desktop rail's own fold input, and the TypeScript clients are deliberately dumb - they render the Gateway-stamped `effectiveColor` and already hold `#B91C1C`. So this restores the rail, the Cockpit and the phone **together, with no client change**.

Two deliberate choices:

- **`Crashed` is read from the producer's own fact, not inferred from `Status == "Failed"`.** The two coincide today only because the one other writer of `Failed` (a create-time failure) disposes the session before it ever reaches the roster. That coincidence should not become a dependency.
- **Triage is unchanged.** A crash stays out of "needs you" - that separation is the entire reason thefrederiksen/devthrottle#959 chose a distinct colour rather than reusing the bright red. A test pins it.

## Proof

Tests drive the **real producer** - a backend raising a real process exit into `Session.OnBackendProcessExited` - then the real mapper, then the real fold. **Nothing sets `Crashed` by hand**, so these cannot pass on a fact production never emits.

Verified they catch the bug rather than agreeing with the code. With the fold arm reverted (transport still carrying the fact):

```
CrashedSessionColorTests.Crash_withNonZeroExit_foldsToTheDeepRed_notGrey [FAIL]
CrashedSessionColorTests.Crash_withExitZero_whileWorking_foldsToTheDeepRed [FAIL]
CrashedSessionColorTests.Crash_andCleanExit_areDistinguishable_theWholePointOf959 [FAIL]
Failed! - Failed: 3, Passed: 2
```

The two clean-exit facts stayed green, which is the control: they prove the suite is not simply colouring everything red.

**Seven suites green: 5537 passed** (Avalonia 124, Core 3069, Engine 62, Gateway 2168, HostedAgent 80, Launcher 27, Terminal.Avalonia 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
