### PR TITLE
fix(sessions): delete the prompt-queue auto-drain that never ran (#1564)

### DIFF
--- a/src/CcDirector.Core.Tests/SessionInteractiveTests.cs
+++ b/src/CcDirector.Core.Tests/SessionInteractiveTests.cs
@@ -9,8 +9,10 @@ namespace CcDirector.Core.Tests;
 /// Behavior tests for the final-build session features:
 ///   #3 terminal input  -> SendInput forwards raw bytes to the backend (the exact path the
 ///                          /stream WebSocket now drives).
-///   #4 queue auto-drain -> the next queued prompt is sent when the session goes Idle, gated
-///                          by OnHold and never on WaitingForInput.
+///   #4 the prompt queue  -> a MANUAL holding list: it never auto-sends, whatever the activity
+///                          state. The auto-drain this line used to describe was gated on a
+///                          transition to Idle, which no producer has ever emitted, so it never
+///                          ran in a real session and is now deleted (issue #1564).
 ///   #5 PTY resize       -> Resize no-ops on an unchanged size (the repaint-loop guard).
 /// </summary>
 public sealed class SessionInteractiveTests
@@ -284,52 +286,74 @@ public sealed class SessionInteractiveTests
         Assert.Equal((120, 30), backend.Resizes[1]);
     }
 
-    // ---- #4 queue auto-drain ----
+    // ---- the prompt queue is a MANUAL holding list, and always has been ----
 
-    [Fact]
-    public async Task Queue_auto_drains_one_item_when_session_goes_idle()
+    // These replace three tests that certified an auto-drain which has never run in a real session. They
+    // passed for fourteen months by calling ApplyTerminalActivityState(ActivityState.Idle) directly - a state
+    // NOTHING in the product has ever assigned, so the transition they relied on could not occur outside the
+    // test. The old gate is deleted (see Session.SetActivityState), and what is pinned here is the behaviour
+    // users actually have and the product actually describes: a queue you send from explicitly.
+
+    /// <summary>
+    /// The queue never auto-sends, on ANY activity state. Deliberately a theory over EVERY member of the
+    /// enum rather than the one state the detector happens to emit today: that makes the guarantee immune to
+    /// the producer changing which state it reports at a turn end - the exact coupling that let the original
+    /// drain sit dead behind a state no producer emitted, with a green test in front of it.
+    /// </summary>
+    [Theory]
+    [InlineData(ActivityState.Starting)]
+    [InlineData(ActivityState.Idle)]
+    [InlineData(ActivityState.Working)]
+    [InlineData(ActivityState.WaitingForInput)]
+    [InlineData(ActivityState.WaitingForPerm)]
+    [InlineData(ActivityState.Exited)]
+    public async Task Queue_neverAutoSends_onAnyActivityState(ActivityState state)
     {
         var backend = new RecordingBackend();
         using var s = NewSession(backend, ActivityState.Working);
-        s.PromptQueue.Enqueue("first");
-        s.PromptQueue.Enqueue("second");
+        s.PromptQueue.Enqueue("queued work");
 
-        s.ApplyTerminalActivityState(ActivityState.Idle); // transition triggers the drain
+        s.ApplyTerminalActivityState(state);
 
-        await WaitUntil(() => backend.SentTexts.Count >= 1);
-        Assert.Equal("first", backend.SentTexts[0]); // FIFO
-        Assert.Equal(1, s.PromptQueue.Count);          // exactly one drained per Idle
+        await Task.Delay(250);
+        Assert.Empty(backend.SentTexts);          // nothing was fired at the session
+        Assert.Equal(1, s.PromptQueue.Count);     // and the item is still there, waiting to be sent
     }
 
+    /// <summary>
+    /// The turn end specifically. This is the moment a queued prompt would have gone out, and the moment it
+    /// must not: the detector reports WaitingForInput for BOTH "finished cleanly" and "blocked on a question"
+    /// and explicitly refuses to tell them apart, so an auto-send here could answer a question the agent
+    /// asked with unrelated text - a silent wrong action. Auto-send needs a real turn-end classifier first
+    /// (issue #1564).
+    /// </summary>
     [Fact]
-    public async Task Queue_does_not_drain_when_on_hold()
+    public async Task Queue_doesNotAutoSend_atATurnEnd_whichCouldAnswerTheAgentsOwnQuestion()
     {
         var backend = new RecordingBackend();
         using var s = NewSession(backend, ActivityState.Working);
-        s.RequestHold(true); // asked for while working -> deferred, lands at the Idle settle below
-        s.PromptQueue.Enqueue("held");
+        s.PromptQueue.Enqueue("also update the README");
 
-        // The deferral must land BEFORE the drain check on this same transition, or a session the user
-        // just parked would immediately fire the next queued prompt at it.
-        s.ApplyTerminalActivityState(ActivityState.Idle);
-        Assert.True(s.OnHold);
+        s.ApplyTerminalActivityState(ActivityState.WaitingForInput);
 
         await Task.Delay(250);
         Assert.Empty(backend.SentTexts);
         Assert.Equal(1, s.PromptQueue.Count);
     }
 
+    /// <summary>The queue still does what it is for: the user sends an item, explicitly, whenever they want.</summary>
     [Fact]
-    public async Task Queue_does_not_drain_on_waiting_for_input()
+    public async Task Queue_itemIsSentWhenTheUserSendsIt()
     {
         var backend = new RecordingBackend();
         using var s = NewSession(backend, ActivityState.Working);
-        s.PromptQueue.Enqueue("answer?");
+        var item = s.PromptQueue.Enqueue("first");
+        s.PromptQueue.Enqueue("second");
 
-        s.ApplyTerminalActivityState(ActivityState.WaitingForInput); // Claude is asking - do NOT auto-answer
+        await s.SendTextAsync(item.Text);
+        s.PromptQueue.Remove(item.Id);
 
-        await Task.Delay(250);
-        Assert.Empty(backend.SentTexts);
+        Assert.Equal("first", backend.SentTexts[0]);
         Assert.Equal(1, s.PromptQueue.Count);
     }
 

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -1949,35 +1949,26 @@ public sealed class Session : IDisposable
         // Log the transition (blue<->red) to the in-memory ring the Wingman tab renders.
         RecordStateChange(old, newState);
         OnActivityStateChanged?.Invoke(old, newState);
-
-        // Auto-drain the prompt queue when the session returns to Idle (ready at the prompt).
-        if (newState == ActivityState.Idle)
-            TryDrainQueue();
     }
 
-    /// <summary>
-    /// When the session goes Idle and isn't on hold, send the next queued prompt - so the
-    /// queue means "auto-send when Claude is ready", not a manual holding list. One item per
-    /// Idle transition; SendText -> Working -> Idle drains the rest in FIFO order. We never
-    /// drain on WaitingForInput/WaitingForPerm: a queued prompt must not answer Claude's own
-    /// question. The send is scheduled off the current stack to avoid re-entering
-    /// SetActivityState (SendText synchronously flips to Working).
-    /// </summary>
-    private void TryDrainQueue()
-    {
-        if (OnHold || !PromptQueue.HasItems) return;
-        if (Status is SessionStatus.Exited or SessionStatus.Failed) return;
-
-        var next = PromptQueue.Items[0];
-        PromptQueue.Remove(next.Id); // remove first so a double Idle can't send it twice
-        FileLog.Write($"[Session] Queue auto-drain: session={Id}, remaining={PromptQueue.Count}");
-
-        _ = Task.Run(async () =>
-        {
-            try { await SendTextAsync(next.Text); }
-            catch (Exception ex) { FileLog.Write($"[Session] Queue auto-drain FAILED: session={Id}: {ex.Message}"); }
-        });
-    }
+    // The prompt queue does NOT auto-send, and never has. A "TryDrainQueue" used to hang here, gated on
+    // a transition to ActivityState.Idle - a state NOTHING has ever assigned. It went in with the auto-drain
+    // itself in May 2026 and shipped dead: the terminal detector emits WaitingForInput at a turn end,
+    // deliberately ("we do not try to tell 'finished cleanly' apart from 'blocked on a question'"), and Idle
+    // is not even the enum's zero value (Starting is), so it could not arrive by default or deserialization
+    // either. The only assignments of Idle in the whole repository were, and are, in tests - which is why the
+    // drain's own tests passed for fourteen months by calling ApplyTerminalActivityState(Idle) directly and
+    // injecting a state production never emits.
+    //
+    // It is deleted rather than repaired because the queue that users actually have is the one the product
+    // describes: PromptQueue is "prompts the user wants to send later... sent in any order", the desktop
+    // offers only "Add to prompt queue", and there is an explicit send verb (queue-send). NOTHING
+    // user-facing has ever promised auto-send. Switching it on now would make DevThrottle fire prompts into
+    // sessions by itself for the first time ever, at the exact moment it cannot tell a finished turn from a
+    // question it would be answering with unrelated text.
+    //
+    // Auto-send is a real feature and needs a real turn-end classifier that can separate "finished cleanly"
+    // from "blocked on a question" - the thing the detector explicitly refuses to do. See issue #1564.
 
     /// <summary>
     /// Set ActivityState from the <c>TerminalStateDetector</c> in terminal-driven mode.

--- a/src/CcDirector.Gateway.Tests/DirectorSurfaceEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorSurfaceEndpointTests.cs
@@ -14,7 +14,7 @@ namespace CcDirector.Gateway.Tests;
 /// Wiring + validation tests for the final-build Director surface: #5 resize, and the #6
 /// endpoints (relink, git writes, scheduler, workspaces/history). No live session is needed -
 /// these prove the routes exist, validate input, and 404/503 correctly. The behavior of
-/// resize/auto-drain/git lives in the Core unit tests.
+/// resize/prompt-queue/git lives in the Core unit tests.
 /// </summary>
 [Collection("DirectorRoot")]
 public sealed class DirectorSurfaceEndpointTests : IAsyncLifetime


### PR DESCRIPTION
Follow-up feature filed as thefrederiksen/devthrottle_internal#806.

This started as an **unverified claim** ("the prompt queue can never auto-drain, gated on `ActivityState.Idle` which nothing writes"). The claim is **real**, and the truth turned out to be worse than the claim.

## It has never worked. Not once, in any version.

The gate went in **with the auto-drain itself**, in May 2026 - commit `2c12a04b`, whose own message reads *"#4 prompt queue auto-drains when the session goes Idle"*. At **that very commit**, the only assignments of `ActivityState.Idle` in the entire repository were already in tests.

There has never been a producer:

- `TerminalStateDetector` emits `WaitingForInput` at a turn end, **deliberately**: *"we do not try to tell 'finished cleanly' apart from 'blocked on a question'; a long silence means 'needs you'."*
- `Idle` is **not** the enum's zero value (`Starting` is), so no default-initialization or deserialization could ever produce it either. The one escape hatch a reader would check is closed.
- `AssessedState` - the Gateway brain that could refute quiet with "Idle" - never existed on `Session`. It was only ever a display annotation on the DTO.

So this is **not a regression**. It shipped dead and stayed dead for fourteen months, behind three green tests that called `ApplyTerminalActivityState(ActivityState.Idle)` **directly** - injecting a state production never emits.

## Why it is deleted, not switched on

**Nothing user-facing has ever promised auto-send.** `PromptQueue`'s own class doc: *"prompts the user wants to send later... sent in any order"* - a manual holding list. The desktop offers only "Add to prompt queue" and "No queued prompts". There is an explicit send verb (`queue-send`). No string in any client, on any surface, has ever claimed the queue sends by itself.

So users have always had exactly the queue the product describes, and **nobody is missing a feature**. `TryDrainQueue`'s comment - "the queue means auto-send when Claude is ready, not a manual holding list" - was the lie. It was never the spec.

Which makes switching it on the wrong move, and not a close call:

> Turning auto-send on now would make DevThrottle fire prompts into every user's sessions **by itself, for the first time ever**, at the one moment it explicitly cannot tell a finished turn from a question it would be answering with unrelated text.

That is a **new silent wrong action**, introduced by the release whose entire purpose is killing them. A visible non-action (a queue you send from) beats a silent wrong one every time.

Auto-send is a real feature and needs a real turn-end classifier - the exact thing the detector refuses to do. Filed as **#1564** with what it actually requires, including "never drain on `WaitingForPerm`", where the failure mode is answering "do you want to allow this?" with unrelated text.

## What changed

**Zero behaviour change.** The dead gate and `TryDrainQueue` are gone; the manual queue is untouched.

The three tests that certified the fiction are replaced by tests that pin what users actually have:

- `Queue_neverAutoSends_onAnyActivityState` - a theory over **every** member of the enum, not just the state the detector happens to emit today. That makes the guarantee immune to the producer changing which state it reports at a turn end, which is the exact coupling that let the drain sit dead behind a state no producer emitted with a green test in front of it.
- `Queue_doesNotAutoSend_atATurnEnd_whichCouldAnswerTheAgentsOwnQuestion` - the moment that matters.
- `Queue_itemIsSentWhenTheUserSendsIt` - the queue still does its job.

Stale comments claiming the drain are corrected, including the test class's own header, which described the auto-drain as live.

## Proof

**Seven suites green: 5542 passed** (Avalonia 124, Core 3074, Engine 62, Gateway 2168, HostedAgent 80, Launcher 27, Terminal.Avalonia 7).

One caveat, reported rather than smoothed over: on the first Gateway run a single test failed, and I did not capture its name. It passed on a clean re-run (2168/2168), and this change touches Core, not the Gateway - the only Gateway-side edit here is a comment. I am calling it flaky (there are known flaky tests on file, thefrederiksen/devthrottle_internal#801 and thefrederiksen/devthrottle_internal#734), but I did not identify it, so it is not proven flaky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
