### PR TITLE
fix(gateway): carry the Director's error message to the human

### DIFF
--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Text.Json;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Network;
 using CcDirector.Core.Utilities;
@@ -167,6 +168,45 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
         }
     }
 
+    /// <summary>
+    /// Turn a failed Gateway relay response into the exception the /fleet/* endpoint will word for the human,
+    /// CARRYING the Gateway's own message instead of throwing it away.
+    ///
+    /// This is the second of two places the same explanation used to die. The Gateway's TunnelFailure dropped
+    /// a Director-sent failure into a bodyless 502; these relays then threw "returned HTTP 502 Bad Gateway"
+    /// without ever reading the body, so even once the Gateway carried the words, the Director discarded them
+    /// one hop before the person who typed the command. Fixing either alone lands nowhere - the CLI's own
+    /// error path already parses an "error" key and already tolerates an empty body, so with both legs carried
+    /// the Director's real explanation reaches the terminal with no client change at all.
+    ///
+    /// Falls back to the status line ONLY when there genuinely is no message to show - an empty or non-JSON
+    /// body. That is not papering over a failure; it is reporting the only fact available.
+    /// </summary>
+    private static async Task<InvalidOperationException> RelayFailureAsync(
+        HttpResponseMessage resp, string what, CancellationToken ct)
+    {
+        string? message = null;
+        try
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            if (!string.IsNullOrWhiteSpace(body))
+            {
+                using var doc = JsonDocument.Parse(body);
+                if (doc.RootElement.ValueKind == JsonValueKind.Object
+                    && doc.RootElement.TryGetProperty("error", out var err)
+                    && err.ValueKind == JsonValueKind.String)
+                {
+                    message = err.GetString();
+                }
+            }
+        }
+        catch (JsonException) { /* not JSON - fall through to the status line below */ }
+
+        var statusLine = $"Gateway {what} returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}".TrimEnd();
+        FileLog.Write($"[GatewayClient] {what} FAILED: {(string.IsNullOrWhiteSpace(message) ? statusLine : message)}");
+        return new InvalidOperationException(string.IsNullOrWhiteSpace(message) ? statusLine : message);
+    }
+
     // ===== Fleet relay (issue #705) =====
     // A session can only reach its OWN Director (it is given CC_DIRECTOR_API, never the
     // Gateway URL or the fleet token). These three methods let the Director relay a session's
@@ -188,7 +228,7 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
         FileLog.Write("[GatewayClient] ListFleetSessionsAsync: GET /sessions");
         using var resp = await _http.GetAsync("sessions", ct);
         if (!resp.IsSuccessStatusCode)
-            throw new InvalidOperationException($"Gateway GET /sessions returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+            throw await RelayFailureAsync(resp, "GET /sessions", ct);
 
         var list = await resp.Content.ReadFromJsonAsync<List<SessionDto>>(ct);
         if (list is null)
@@ -214,7 +254,7 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
         var body = new PromptRequest { Text = text, AppendEnter = true, WaitForIdle = false };
         using var resp = await _http.PostAsJsonAsync($"sessions/{toSessionId}/prompt", body, ct);
         if (!resp.IsSuccessStatusCode)
-            throw new InvalidOperationException($"Gateway prompt to {toSessionId} returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+            throw await RelayFailureAsync(resp, $"prompt to {toSessionId}", ct);
 
         var parsed = await resp.Content.ReadFromJsonAsync<PromptResponse>(ct);
         if (parsed is null)
@@ -239,7 +279,7 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
         var body = new SessionUpdateRequest { Name = name };
         using var resp = await _http.PatchAsJsonAsync($"sessions/{toSessionId}", body, ct);
         if (!resp.IsSuccessStatusCode)
-            throw new InvalidOperationException($"Gateway rename of {toSessionId} returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+            throw await RelayFailureAsync(resp, $"rename of {toSessionId}", ct);
 
         var parsed = await resp.Content.ReadFromJsonAsync<SessionDto>(ct);
         if (parsed is null)
@@ -262,7 +302,7 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
         FileLog.Write($"[GatewayClient] InterruptFleetAsync: POST /sessions/{toSessionId}/interrupt");
         using var resp = await _http.PostAsync($"sessions/{toSessionId}/interrupt", content: null, ct);
         if (!resp.IsSuccessStatusCode)
-            throw new InvalidOperationException($"Gateway interrupt of {toSessionId} returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+            throw await RelayFailureAsync(resp, $"interrupt of {toSessionId}", ct);
     }
 
     /// <summary>
@@ -281,7 +321,7 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
         var body = new HoldRequest { OnHold = onHold, SnoozeMinutes = snoozeMinutes };
         using var resp = await _http.PostAsJsonAsync($"sessions/{toSessionId}/hold", body, ct);
         if (!resp.IsSuccessStatusCode)
-            throw new InvalidOperationException($"Gateway hold of {toSessionId} returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+            throw await RelayFailureAsync(resp, $"hold of {toSessionId}", ct);
 
         var parsed = await resp.Content.ReadFromJsonAsync<HoldResponse>(ct);
         if (parsed is null)
@@ -304,7 +344,7 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
         FileLog.Write($"[GatewayClient] GetBufferFleetAsync: GET /sessions/{toSessionId}/buffer");
         using var resp = await _http.GetAsync($"sessions/{toSessionId}/buffer", ct);
         if (!resp.IsSuccessStatusCode)
-            throw new InvalidOperationException($"Gateway buffer read of {toSessionId} returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+            throw await RelayFailureAsync(resp, $"buffer read of {toSessionId}", ct);
         return await resp.Content.ReadAsStringAsync(ct);
     }
 
@@ -324,7 +364,7 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
         var body = new SetRoleRequest { Role = role };
         using var resp = await _http.PostAsJsonAsync($"sessions/{toSessionId}/role", body, ct);
         if (!resp.IsSuccessStatusCode)
-            throw new InvalidOperationException($"Gateway set-role of {toSessionId} returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+            throw await RelayFailureAsync(resp, $"set-role of {toSessionId}", ct);
 
         var parsed = await resp.Content.ReadFromJsonAsync<SessionDto>(ct);
         if (parsed is null)
@@ -348,7 +388,7 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
         var body = new SessionDeletionRequest { Reason = reason };
         using var resp = await _http.PostAsJsonAsync($"sessions/{toSessionId}/request-deletion", body, ct);
         if (!resp.IsSuccessStatusCode)
-            throw new InvalidOperationException($"Gateway deletion request for {toSessionId} returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+            throw await RelayFailureAsync(resp, $"deletion request for {toSessionId}", ct);
     }
 
     /// <summary>
@@ -379,7 +419,7 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
         var body = new PromptRequest { Text = text, AppendEnter = true, WaitForIdle = true, TimeoutMs = timeoutMs };
         using var resp = await http.PostAsJsonAsync($"sessions/{toSessionId}/prompt", body, ct);
         if (!resp.IsSuccessStatusCode)
-            throw new InvalidOperationException($"Gateway ask to {toSessionId} returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+            throw await RelayFailureAsync(resp, $"ask to {toSessionId}", ct);
 
         var parsed = await resp.Content.ReadFromJsonAsync<PromptResponse>(ct);
         if (parsed is null)
@@ -415,7 +455,7 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
         };
         using var resp = await _http.PostAsJsonAsync("fanout", body, ct);
         if (!resp.IsSuccessStatusCode)
-            throw new InvalidOperationException($"Gateway fanout returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+            throw await RelayFailureAsync(resp, "fanout", ct);
 
         var parsed = await resp.Content.ReadFromJsonAsync<FanoutResponse>(ct);
         if (parsed is null)
@@ -527,7 +567,7 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
         var body = new HoldRequest { OnHold = onHold };
         using var resp = await _http.PostAsJsonAsync($"sessions/{sessionId}/hold", body, ct);
         if (!resp.IsSuccessStatusCode)
-            throw new InvalidOperationException($"Gateway hold for {sessionId} returned HTTP {(int)resp.StatusCode} {resp.ReasonPhrase}");
+            throw await RelayFailureAsync(resp, $"hold for {sessionId}", ct);
     }
 
     // ===== Fleet session numbers (issue #1292) =====

--- a/src/CcDirector.Gateway.Tests/DirectorErrorMessageReachesTheHumanTests.cs
+++ b/src/CcDirector.Gateway.Tests/DirectorErrorMessageReachesTheHumanTests.cs
@@ -1,0 +1,201 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Text.Json;
+using CcDirector.ControlApi;
+using CcDirector.Core.Configuration;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// A Director computes a real, actionable explanation when a command fails. It used to be thrown away TWICE
+/// before any human could read it, and fixing either leg alone lands nowhere:
+///
+///   LEG 1, the Gateway: <c>TunnelFailure</c>'s default branch collapsed every DIRECTOR-SENT failure
+///   (BadRequest / NotFound / Conflict / Locked / Failed) into a BODYLESS 502. Its Gateway-SYNTHESIZED
+///   branches - no tunnel, Timeout, TunnelDropped - already carried their words; the Director-sent default
+///   never did.
+///
+///   LEG 2, the Director's own relay: the ~11 fleet methods on <see cref="GatewayClient"/> threw
+///   "returned HTTP 502 Bad Gateway" without ever reading the response body, so even a Gateway that DID send
+///   the words had them discarded one hop before the person who typed the command.
+///
+/// These tests pin both legs against real transports, because that is the only way to know the message
+/// actually arrives. Leg 1 rides a REAL SignalR tunnel to a REAL GatewayHost whose Director is registered at
+/// a DELIBERATELY UNREACHABLE endpoint, so the answer can only have come over the tunnel. Leg 2 drives the
+/// REAL GatewayClient over a REAL loopback HTTP connection.
+///
+/// Deliberately NOT pinned: any status change. Every status here stays exactly what it ships today.
+/// </summary>
+public sealed class DirectorErrorMessageReachesTheHumanTests
+{
+    // ===================== LEG 1: the Gateway carries the Director's words =====================
+
+    [Collection("DirectorRoot")]
+    public sealed class GatewayLeg : IAsyncLifetime
+    {
+        private const string Token = "test-token-director-error-words";
+        private const string DirectorId = "dir-error-words";
+
+        /// <summary>The Director's own explanation - the thing a human needs and used to never see.</summary>
+        private const string DirectorWords = "that repository is already open in another session on this machine";
+
+        private readonly string _root;
+        private readonly string? _prevRoot;
+        private readonly string _instancesDir = Path.Combine(Path.GetTempPath(), "cc-errwords-" + Guid.NewGuid().ToString("N"));
+
+        private GatewayHost _gateway = null!;
+        private HttpClient _http = null!;
+        private FakeTunnelDirector _director = null!;
+
+        public GatewayLeg()
+        {
+            _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+            _root = Path.Combine(Path.GetTempPath(), "ccd-errwords-" + Guid.NewGuid().ToString("N"));
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+        }
+
+        public async Task InitializeAsync()
+        {
+            _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+                instancesDirectory: _instancesDir,
+                workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+                streamMode: true);
+            await _gateway.StartAsync();
+            _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+            _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+
+            // Every verb fails the way a real Director fails: a DIRECTOR-SENT status carrying real words.
+            // This is the branch that used to drop them.
+            _director = await FakeTunnelDirector.StartAsync(_gateway, Token, DirectorId,
+                dispatch: _ => DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, DirectorWords));
+        }
+
+        public async Task DisposeAsync()
+        {
+            await _director.DisposeAsync();
+            _http.Dispose();
+            await _gateway.StopAsync();
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+            foreach (var dir in new[] { _instancesDir, _root })
+                try { if (Directory.Exists(dir)) Directory.Delete(dir, true); } catch { /* best effort */ }
+        }
+
+        [Fact]
+        public async Task DirectorSentFailure_carriesTheDirectorsWords_andKeepsTheSame502()
+        {
+            var resp = await _http.GetAsync($"directors/{DirectorId}/repos");
+
+            // The status is UNCHANGED. A Director BadRequest ships as 502 on this leg today, and mapping it to
+            // 400 would move a shipped contract - this change carries the words and nothing else.
+            Assert.Equal(HttpStatusCode.BadGateway, resp.StatusCode);
+
+            var body = await resp.Content.ReadAsStringAsync();
+            Assert.False(string.IsNullOrWhiteSpace(body), "a bodyless 502 is the bug: the human gets a bare status they cannot act on");
+
+            using var doc = JsonDocument.Parse(body);
+            Assert.Equal(DirectorWords, doc.RootElement.GetProperty("error").GetString());
+        }
+
+        private static int AllocateFreePort()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+    }
+
+    // ============ LEG 2: the Director's relay surfaces them instead of discarding them ============
+
+    public sealed class DirectorRelayLeg
+    {
+        private const string GatewayWords = "session 4c81 is on hold; take it off hold before sending to it";
+
+        /// <summary>A Gateway stub that fails exactly the way the fixed leg 1 above now fails.</summary>
+        private static async Task<(WebApplication app, string url)> StartFailingGatewayAsync(
+            int statusCode, string? jsonBody)
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            builder.WebHost.ConfigureKestrel(o => o.Listen(IPAddress.Loopback, 0));
+            var app = builder.Build();
+            app.MapPost("/sessions/{sid}/interrupt", () => jsonBody is null
+                ? Results.StatusCode(statusCode)
+                : Results.Content(jsonBody, "application/json", statusCode: statusCode));
+            await app.StartAsync();
+            return (app, app.Urls.First());
+        }
+
+        private static GatewayClient ClientFor(string url) =>
+            new(new GatewayConfig { Url = url }, Guid.NewGuid().ToString(), 7879, "1.0.0");
+
+        [Fact]
+        public async Task Relay_surfacesTheGatewaysMessage_ratherThanABareStatusLine()
+        {
+            var (app, url) = await StartFailingGatewayAsync(502, $$"""{"error":"{{GatewayWords}}"}""");
+
+            try
+            {
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => ClientFor(url).InterruptFleetAsync(Guid.NewGuid().ToString()));
+
+                // The whole point: the human reads WHY, not "returned HTTP 502 Bad Gateway".
+                Assert.Equal(GatewayWords, ex.Message);
+                Assert.DoesNotContain("returned HTTP", ex.Message);
+            }
+            finally
+            {
+                await app.StopAsync();
+            }
+        }
+
+        [Fact]
+        public async Task Relay_withNoBody_stillReportsTheStatus_ratherThanSayingNothing()
+        {
+            // No message to carry is not a reason to say nothing: report the only fact there is.
+            var (app, url) = await StartFailingGatewayAsync(502, jsonBody: null);
+
+            try
+            {
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => ClientFor(url).InterruptFleetAsync(Guid.NewGuid().ToString()));
+
+                Assert.Contains("returned HTTP 502", ex.Message);
+            }
+            finally
+            {
+                await app.StopAsync();
+            }
+        }
+
+        [Fact]
+        public async Task Relay_withNonJsonBody_doesNotThrowParsingIt()
+        {
+            // A proxy or crash can put HTML in front of us. That must degrade to the status line, not blow up
+            // with a JSON parse error that buries the real failure.
+            var (app, url) = await StartFailingGatewayAsync(502, "<html>502 Bad Gateway</html>");
+
+            try
+            {
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => ClientFor(url).InterruptFleetAsync(Guid.NewGuid().ToString()));
+
+                Assert.Contains("returned HTTP 502", ex.Message);
+            }
+            finally
+            {
+                await app.StopAsync();
+            }
+        }
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -2525,7 +2525,16 @@ internal static class GatewayEndpoints
                 statusCode: StatusCodes.Status504GatewayTimeout),
             DirectorCommandStatus.TunnelDropped => Results.Json(new { error = sr.Error },
                 statusCode: StatusCodes.Status502BadGateway),
-            _ => Results.StatusCode(StatusCodes.Status502BadGateway),
+            // A DIRECTOR-SENT failure (BadRequest / NotFound / Conflict / Locked / a plain Failed). The
+            // Director computed a real explanation and this branch used to drop it on the floor, returning a
+            // bodyless 502 - the human got a bare status they could not act on, and the words that would have
+            // told them what to do were discarded one hop from being shown.
+            //
+            // The STATUS stays 502, byte-identical, for every one of these. That is deliberate: these legs
+            // ship a 502 for a Director BadRequest/NotFound today, and mapping them to 400/404 (what
+            // MapDirectorFailure does) would change a shipped contract. This carries the words and moves
+            // nothing else.
+            _ => Results.Json(new { error = sr.Error }, statusCode: StatusCodes.Status502BadGateway),
         };
     }
 


### PR DESCRIPTION
Leg 3 filed as thefrederiksen/devthrottle_internal#807.

A Director computes a real, actionable explanation when a command fails - "that repository is already open in another session on this machine". It was thrown away **twice** before any human could read it.

The brief for this item named **one** of those two. Following it literally would have shipped a fix that changed what a human sees on **no surface they actually use**.

## The three legs, and who actually reads the message

| Leg | Where the message dies | Fixed here |
|---|---|---|
| 1 | **Gateway**: `TunnelFailure`'s default branch returns a **bodyless** 502 | yes |
| 2 | **The Director's own relay**: `GatewayClient`'s ~11 fleet methods throw `returned HTTP 502 Bad Gateway` **without ever reading the body** | yes |
| 3 | **client-core**: never reads the body on these legs, **and** force-collapses any 502 to `"Can't reach the Gateway - retrying."` | **no** - filed as thefrederiksen/devthrottle_internal#807 |

**Leg 2 is why leg 1 alone lands nowhere.** We could have fixed the Gateway perfectly and still shown the human nothing, because the Director discards the words one hop before the person who typed the command. That is also why both are in one pull request: either alone is a no-op.

Had only leg 1 shipped, the message would have surfaced on exactly **one leg of the MAUI phone app** - deprecated, last touched 9 June. The Cockpit, the mobile PWA and the CLI would all have been unchanged, with the item closed. A closed item nobody sees the effect of is worse than an open one, because it stops the next person looking.

## A correction to the brief

The brief said to "carry the body only for the Gateway-synthesized outcomes". **That work is already done** - the no-tunnel, `Timeout` and `TunnelDropped` branches already carry their words. The real gap is the **Director-sent default**, which the brief never mentions.

`DirectorAnswerFailure`'s own doc comment already named it:

> its default branch collapses every one to a bare 502 with no body. That is exactly the trap item 1 paid for - a command that computes a perfect explanation which no endpoint ever shows a human.

The code told us where the bug was.

## What is deliberately unchanged

- **Every status is byte-identical.** A Director `BadRequest` still ships as 502 on these legs. Mapping it to 400/404 (what `MapDirectorFailure` does) would move a shipped contract. This carries words and moves nothing else.
- **Leg 2 changes only an exception message.**
- **Leg 3 stays out.** The 502 collapse in `client-core` is a deliberate decision pinned by a passing test (`gatewayError.test.ts:33`). Reversing someone's design under cover of an error-message cleanup - with their own test as the evidence it was deliberate - is exactly how a quiet regression ships. thefrederiksen/devthrottle_internal#807 names the decision it would reverse and the real design question underneath it: a 502 *carrying a body* means "the Gateway is fine, a Director refused you, retrying will not help", which is a different animal from "can't reach the Gateway", and the status cannot currently tell them apart.

## Blast radius: proven, not asserted

Nothing breaks by adding a body to a 502:

- No test anywhere asserts an empty 502 body.
- The Python CLI already `try`/`except`s the parse and already falls back on an empty body.
- The TypeScript reader guards `if (!text.trim()) return undefined;`.
- The MAUI extractor guards null and catches `JsonException`.

One cosmetic wart, reported not hidden: the MAUI repos leg interpolates the **raw** body, so it will render literal JSON. Ugly, on a deprecated app, versus a human on the CLI finally seeing why their command failed.

## Proof

Both legs are pinned against **real transports**, not fakes:

- **Leg 1** boots a real `GatewayHost` and rides a **real SignalR tunnel** to a Director registered at a **deliberately unreachable endpoint** - so the answer can only have come over the tunnel.
- **Leg 2** drives the real `GatewayClient` over a **real loopback HTTP** connection, including the non-JSON-body and no-body cases.

Each leg was reverted **independently** to prove its test catches its own bug:

```
LEG 1 REVERTED (bodyless 502 restored):
  GatewayLeg.DirectorSentFailure_carriesTheDirectorsWords_andKeepsTheSame502 [FAIL]
  Failed! - Failed: 1, Passed: 0

LEG 2 REVERTED (leg 1 restored):
  DirectorRelayLeg.Relay_surfacesTheGatewaysMessage_ratherThanABareStatusLine [FAIL]
  Failed! - Failed: 1, Passed: 2      <-- the other two stayed green: the control
```

**Seven suites green: 5577 passed** (Avalonia 124, Core 3074, Engine 62, Gateway 2203, HostedAgent 80, Launcher 27, Terminal.Avalonia 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
