### PR TITLE
fix(terminal): the browser picker is a dialog, not a four-level submenu (#1571)

### DIFF
--- a/src/CcDirector.Core.Tests/Browsers/BrowserDefaultStoreTests.cs
+++ b/src/CcDirector.Core.Tests/Browsers/BrowserDefaultStoreTests.cs
@@ -199,4 +199,94 @@ public sealed class BrowserDefaultStoreTests : IDisposable
         Assert.Equal(RepoDefault.ExePath, entry.GetProperty("exePath").GetString());
         Assert.Equal(RepoDefault.ProfileFolder, entry.GetProperty("profileFolder").GetString());
     }
+
+    // -- Clearing: how the user takes a default back (picking "System default" in the picker and
+    //    asking to remember it). Without these, a default set once could never be removed.
+
+    [Fact]
+    public void Clear_AfterSave_ResolvesToOperatingSystemDefault()
+    {
+        BrowserDefaultStore.Save(GlobalDefault);
+
+        BrowserDefaultStore.Clear();
+
+        Assert.Null(BrowserDefaultStore.Load());
+        Assert.Null(BrowserDefaultStore.Resolve(null));
+    }
+
+    [Fact]
+    public void Clear_NothingSaved_IsANoOp()
+    {
+        BrowserDefaultStore.Clear();
+
+        Assert.Null(BrowserDefaultStore.Load());
+    }
+
+    [Fact]
+    public void ClearForRepo_AfterSaveForRepo_FallsBackToGlobalDefault()
+    {
+        BrowserDefaultStore.Save(GlobalDefault);
+        BrowserDefaultStore.SaveForRepo(RepoPath, RepoDefault);
+
+        BrowserDefaultStore.ClearForRepo(RepoPath);
+
+        Assert.Null(BrowserDefaultStore.LoadForRepo(RepoPath));
+        Assert.Equal(GlobalDefault, BrowserDefaultStore.Resolve(RepoPath));
+    }
+
+    [Fact]
+    public void ClearForRepo_LeavesOtherRepositoriesAlone()
+    {
+        BrowserDefaultStore.SaveForRepo(RepoPath, RepoDefault);
+        BrowserDefaultStore.SaveForRepo(OtherRepoPath, GlobalDefault);
+
+        BrowserDefaultStore.ClearForRepo(RepoPath);
+
+        Assert.Null(BrowserDefaultStore.LoadForRepo(RepoPath));
+        Assert.Equal(GlobalDefault, BrowserDefaultStore.LoadForRepo(OtherRepoPath));
+    }
+
+    [Fact]
+    public void ClearForRepo_LeavesTheGlobalDefaultAlone()
+    {
+        BrowserDefaultStore.Save(GlobalDefault);
+        BrowserDefaultStore.SaveForRepo(RepoPath, RepoDefault);
+
+        BrowserDefaultStore.ClearForRepo(RepoPath);
+
+        Assert.Equal(GlobalDefault, BrowserDefaultStore.Load());
+    }
+
+    [Fact]
+    public void Clear_LeavesRepositoryDefaultsAlone()
+    {
+        BrowserDefaultStore.Save(GlobalDefault);
+        BrowserDefaultStore.SaveForRepo(RepoPath, RepoDefault);
+
+        BrowserDefaultStore.Clear();
+
+        Assert.Equal(RepoDefault, BrowserDefaultStore.LoadForRepo(RepoPath));
+        Assert.Equal(RepoDefault, BrowserDefaultStore.Resolve(RepoPath));
+    }
+
+    [Fact]
+    public void Clear_PreservesUnrelatedConfigKeys()
+    {
+        CcDirectorConfigService.MergePatch(new System.Text.Json.Nodes.JsonObject
+        {
+            ["someOtherSection"] = new System.Text.Json.Nodes.JsonObject { ["keep"] = "me" }
+        });
+        BrowserDefaultStore.Save(GlobalDefault);
+
+        BrowserDefaultStore.Clear();
+
+        var root = CcDirectorConfigService.ReadRaw();
+        Assert.Equal("me", (string?)root["someOtherSection"]?["keep"]);
+    }
+
+    [Fact]
+    public void ClearForRepo_BlankPath_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => BrowserDefaultStore.ClearForRepo(""));
+    }
 }

--- a/src/CcDirector.Core/Browsers/BrowserDefaultStore.cs
+++ b/src/CcDirector.Core/Browsers/BrowserDefaultStore.cs
@@ -58,6 +58,44 @@ public static class BrowserDefaultStore
     }
 
     /// <summary>
+    /// Forgets the application-wide default, so <see cref="Resolve"/> falls through to the
+    /// operating-system default. This is how the user takes back a default they set: picking
+    /// "System default browser" in the picker and asking to remember it means "stop using a
+    /// remembered browser", which without this would be unsayable once a default existed.
+    /// </summary>
+    public static void Clear()
+    {
+        FileLog.Write("[BrowserDefaultStore] Clear: forgetting the application-wide default");
+        var patch = new JsonObject
+        {
+            ["browser"] = new JsonObject { ["default"] = null }
+        };
+        CcDirectorConfigService.MergePatch(patch);
+    }
+
+    /// <summary>
+    /// Forgets <paramref name="repoPath"/>'s default, so <see cref="Resolve"/> falls through to the
+    /// application-wide default (and then to the operating-system default). Other repositories'
+    /// defaults are untouched.
+    /// </summary>
+    public static void ClearForRepo(string repoPath)
+    {
+        if (string.IsNullOrWhiteSpace(repoPath))
+            throw new ArgumentException("Repository path is required", nameof(repoPath));
+
+        var key = NormalizeRepoKey(repoPath);
+        FileLog.Write($"[BrowserDefaultStore] ClearForRepo: repo={key}");
+        var patch = new JsonObject
+        {
+            ["browser"] = new JsonObject
+            {
+                ["repoDefaults"] = new JsonObject { [key] = null }
+            }
+        };
+        CcDirectorConfigService.MergePatch(patch);
+    }
+
+    /// <summary>
     /// Returns the browser+profile remembered for <paramref name="repoPath"/>, or null when that
     /// repository has never set one. Null is not an error - the caller should then fall back to the
     /// application-wide default (see <see cref="Resolve"/>).

--- a/src/CcDirector.Terminal.Avalonia.Tests/BrowserPickerDialogTests.cs
+++ b/src/CcDirector.Terminal.Avalonia.Tests/BrowserPickerDialogTests.cs
@@ -1,0 +1,118 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.VisualTree;
+using CcDirector.Core.Browsers;
+using CcDirector.Terminal.Avalonia;
+using Xunit;
+
+namespace CcDirector.Terminal.Avalonia.Tests;
+
+/// <summary>
+/// Covers the picker's structure and its choice-building. These run headless, so they assert what
+/// the dialog is made of rather than driving a real click: the point is that every option is one
+/// flat row and that the remember scope resolves to exactly one unambiguous intent.
+/// </summary>
+public class BrowserPickerDialogTests
+{
+    private static BrowserPickerDialog Make(string? repoPath = @"D:\repos\devthrottle")
+        => new("https://example.com/page", repoPath);
+
+    private static IEnumerable<T> Descendants<T>(Control root) where T : Control
+    {
+        foreach (var child in root.GetVisualChildren().OfType<Control>())
+        {
+            if (child is T match)
+                yield return match;
+            foreach (var nested in Descendants<T>(child))
+                yield return nested;
+        }
+    }
+
+    [AvaloniaFact]
+    public void Constructor_DoesNotBlockOnBrowserDetection()
+    {
+        // The window must be constructible without any disk read having happened: detection is
+        // deferred to Opened. If this ever regresses to a synchronous detect, the constructor
+        // starts touching Local State on the UI thread again.
+        var dialog = Make();
+
+        Assert.Null(dialog.Choice);
+        Assert.Equal("Choose browser", dialog.Title);
+    }
+
+    [AvaloniaFact]
+    public void Constructor_WithRepo_OffersBothRememberScopes()
+    {
+        var dialog = Make(@"D:\repos\devthrottle");
+        dialog.Show();
+
+        var radios = Descendants<RadioButton>(dialog).ToList();
+        var scopeLabels = radios
+            .Select(r => (r.Content as TextBlock)?.Text)
+            .Where(t => t is not null)
+            .ToList();
+
+        Assert.Contains(scopeLabels, t => t!.Contains("For this repository (devthrottle)"));
+        Assert.Contains(scopeLabels, t => t! == "For every repository");
+    }
+
+    [AvaloniaFact]
+    public void Constructor_WithoutRepo_HidesTheScopeChoice()
+    {
+        // With no owning repository there is only one place a default can go, so a scope choice
+        // would be a choice of one. The checkbox alone then carries the meaning.
+        var dialog = Make(repoPath: null);
+        dialog.Show();
+
+        var scopeRadio = ScopeRadio(dialog, "For every repository");
+        Assert.False(scopeRadio.IsEffectivelyVisible);
+        Assert.DoesNotContain(Descendants<RadioButton>(dialog),
+            r => ((r.Content as TextBlock)?.Text ?? "").StartsWith("For this repository"));
+    }
+
+    [AvaloniaFact]
+    public void Constructor_WithRepo_ShowsTheScopeChoice()
+    {
+        var dialog = Make(@"D:\repos\devthrottle");
+        dialog.Show();
+
+        Assert.True(ScopeRadio(dialog, "For every repository").IsEffectivelyVisible);
+        Assert.True(ScopeRadio(dialog, "For this repository (devthrottle)").IsEffectivelyVisible);
+    }
+
+    private static RadioButton ScopeRadio(BrowserPickerDialog dialog, string label)
+        => Descendants<RadioButton>(dialog).Single(r => (r.Content as TextBlock)?.Text == label);
+
+    [AvaloniaFact]
+    public void Constructor_RememberUncheckedByDefault()
+    {
+        var dialog = Make();
+        dialog.Show();
+
+        var check = Descendants<CheckBox>(dialog).Single();
+        Assert.False(check.IsChecked);
+    }
+
+    [AvaloniaTheory]
+    [InlineData(BrowserRememberScope.None)]
+    [InlineData(BrowserRememberScope.Repository)]
+    [InlineData(BrowserRememberScope.Application)]
+    public void BrowserChoice_CarriesScopeVerbatim(BrowserRememberScope scope)
+    {
+        var browser = new BrowserInfo(BrowserKind.Chrome, "Google Chrome", @"C:\chrome.exe", @"C:\UserData");
+        var choice = new BrowserChoice(browser, "Profile 1", scope);
+
+        Assert.Equal(scope, choice.Scope);
+        Assert.Equal("Profile 1", choice.ProfileFolder);
+        Assert.Same(browser, choice.Browser);
+    }
+
+    [AvaloniaFact]
+    public void BrowserChoice_NullBrowserMeansSystemDefault()
+    {
+        var choice = new BrowserChoice(null, null, BrowserRememberScope.Application);
+
+        Assert.Null(choice.Browser);
+        Assert.Null(choice.ProfileFolder);
+    }
+}

--- a/src/CcDirector.Terminal.Avalonia.Tests/LinkContextMenuBuilderTests.cs
+++ b/src/CcDirector.Terminal.Avalonia.Tests/LinkContextMenuBuilderTests.cs
@@ -1,0 +1,90 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using CcDirector.Core.Utilities;
+using CcDirector.Terminal.Avalonia;
+using Xunit;
+
+namespace CcDirector.Terminal.Avalonia.Tests;
+
+/// <summary>
+/// Pins the SHAPE of the link context menu. The per-repository default (#1533) shipped its actions
+/// behind a four-level hover chain ("Open in Browser" -> browser -> profile -> intent), which no
+/// pointer could actually traverse: Avalonia's MenuItem has no hover-intent safe area, so moving
+/// diagonally toward a submenu crosses the sibling row and collapses the chain. These tests fail if
+/// anything reintroduces a submenu here.
+/// </summary>
+public class LinkContextMenuBuilderTests
+{
+    private static LinkMenuContext UrlContext(string? repoPath = null) => new()
+    {
+        Link = "https://example.com/page",
+        Type = LinkDetector.LinkType.Url,
+        RepoPath = repoPath,
+        Owner = new Border(),
+    };
+
+    private static IEnumerable<MenuItem> ItemsOf(ContextMenu menu) => menu.Items.OfType<MenuItem>();
+
+    [AvaloniaFact]
+    public void Build_UrlLink_EveryItemIsFlat()
+    {
+        var menu = LinkContextMenuBuilder.Build(UrlContext(@"D:\repos\devthrottle"));
+
+        Assert.NotEmpty(ItemsOf(menu));
+        foreach (var item in ItemsOf(menu))
+            Assert.Empty(item.Items);
+    }
+
+    [AvaloniaFact]
+    public void Build_UrlLink_OffersOpenAndChooseBrowser()
+    {
+        var menu = LinkContextMenuBuilder.Build(UrlContext());
+
+        var headers = ItemsOf(menu).Select(i => i.Header?.ToString()).ToList();
+        Assert.Equal(new[] { "Copy URL", "Open in Browser", "Choose Browser..." }, headers);
+    }
+
+    [AvaloniaFact]
+    public void Build_HtmlPath_OffersOpenAndChooseBrowser()
+    {
+        var menu = LinkContextMenuBuilder.Build(new LinkMenuContext
+        {
+            Link = @"D:\repos\devthrottle\report.html",
+            Type = LinkDetector.LinkType.Path,
+            Owner = new Border(),
+        });
+
+        var headers = ItemsOf(menu).Select(i => i.Header?.ToString()).ToList();
+        Assert.Contains("Open in Browser", headers);
+        Assert.Contains("Choose Browser...", headers);
+        foreach (var item in ItemsOf(menu))
+            Assert.Empty(item.Items);
+    }
+
+    /// <summary>
+    /// The browser items must not read the disk while the menu is being built - detection used to
+    /// run per-browser Local State reads on the UI thread here (CLAUDE.md rule 1). The picker does
+    /// that work in the background instead. This asserts the menu builds with no browser rows in it
+    /// at all, which is what makes the build I/O-free.
+    /// </summary>
+    [AvaloniaFact]
+    public void Build_UrlLink_DoesNotEnumerateBrowsers()
+    {
+        var menu = LinkContextMenuBuilder.Build(UrlContext());
+
+        var headers = ItemsOf(menu).Select(i => i.Header?.ToString() ?? "").ToList();
+        Assert.DoesNotContain(headers, h => h.Contains("Chrome") || h.Contains("Edge"));
+    }
+
+    /// <summary>
+    /// A link with no owning repository still gets the picker; the repository scope simply is not
+    /// offered inside it. Nothing about the menu changes.
+    /// </summary>
+    [AvaloniaFact]
+    public void Build_UrlLinkWithoutRepo_StillOffersChooseBrowser()
+    {
+        var menu = LinkContextMenuBuilder.Build(UrlContext(repoPath: null));
+
+        Assert.Contains(ItemsOf(menu), i => i.Header?.ToString() == "Choose Browser...");
+    }
+}

--- a/src/CcDirector.Terminal.Avalonia/BrowserPickerDialog.cs
+++ b/src/CcDirector.Terminal.Avalonia/BrowserPickerDialog.cs
@@ -1,0 +1,421 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using CcDirector.Core.Browsers;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Terminal.Avalonia;
+
+/// <summary>How long a <see cref="BrowserChoice"/> should be remembered.</summary>
+public enum BrowserRememberScope
+{
+    /// <summary>Open once and remember nothing.</summary>
+    None,
+
+    /// <summary>Remember as the owning repository's default.</summary>
+    Repository,
+
+    /// <summary>Remember as the application-wide default.</summary>
+    Application,
+}
+
+/// <summary>
+/// What the user picked in <see cref="BrowserPickerDialog"/>: a browser+profile (or the operating
+/// system default, when <see cref="Browser"/> is null) and whether to remember it.
+/// </summary>
+public sealed record BrowserChoice(BrowserInfo? Browser, string? ProfileFolder, BrowserRememberScope Scope);
+
+/// <summary>
+/// The "Choose Browser" dialog behind the terminal's and the History tab's link menu. It replaces
+/// the four-level cascading submenu that shipped with the per-repository default (#1533): every
+/// browser+profile is one flat radio row, and remembering the choice is a checkbox next to the
+/// Open button instead of a third and fourth level of hover-only submenu. One pointer press per
+/// decision, and nothing collapses if the pointer moves diagonally.
+///
+/// Browser detection reads each browser's <c>Local State</c> from disk, so it runs in the
+/// background after the window is already on screen (CLAUDE.md rule 1) - the dialog paints
+/// immediately with "Loading browsers..." and fills itself in when the read completes.
+/// </summary>
+public sealed class BrowserPickerDialog : Window
+{
+    private const string GroupName = "browserPickerGroup";
+
+    private readonly string _target;
+    private readonly string? _repoPath;
+    private BrowserDefault? _currentDefault;
+
+    private readonly List<(RadioButton Radio, BrowserInfo? Browser, string? ProfileFolder)> _rows = new();
+
+    private readonly StackPanel _optionsPanel;
+    private readonly TextBlock _statusText;
+    private readonly CheckBox _rememberCheck;
+    private readonly RadioButton _scopeRepoRadio;
+    private readonly RadioButton _scopeAppRadio;
+    private readonly StackPanel _scopePanel;
+    private readonly Button _openButton;
+
+    /// <summary>What the user chose, or null when the dialog was cancelled.</summary>
+    public BrowserChoice? Choice { get; private set; }
+
+    /// <param name="target">The URL or file path being opened, shown so the user knows what they are aiming at.</param>
+    /// <param name="repoPath">The link's owning repository, or null when it has none.</param>
+    public BrowserPickerDialog(string target, string? repoPath)
+    {
+        FileLog.Write($"[BrowserPickerDialog] Constructor: target={target}, repo={repoPath ?? "(none)"}");
+
+        _target = target ?? throw new ArgumentNullException(nameof(target));
+        _repoPath = repoPath;
+
+        Title = "Choose browser";
+        Width = 520;
+        Height = 480;
+        MinWidth = 420;
+        MinHeight = 360;
+        CanResize = true;
+        WindowStartupLocation = WindowStartupLocation.CenterOwner;
+        Background = Brush.Parse("#252526");
+
+        _optionsPanel = new StackPanel { Spacing = 2 };
+        _statusText = new TextBlock
+        {
+            Text = "Loading browsers...",
+            Foreground = Brush.Parse("#888888"),
+            FontSize = 12,
+            FontStyle = FontStyle.Italic,
+            Margin = new Thickness(6, 6, 6, 6),
+        };
+        _optionsPanel.Children.Add(_statusText);
+
+        _rememberCheck = new CheckBox
+        {
+            Content = new TextBlock { Text = "Remember this choice", Foreground = Brush.Parse("#CCCCCC"), FontSize = 13 },
+            Foreground = Brush.Parse("#CCCCCC"),
+        };
+        _rememberCheck.IsCheckedChanged += (_, _) => UpdateScopeEnabled();
+
+        _scopeRepoRadio = MakeScopeRadio(
+            _repoPath is null ? "For this repository" : $"For this repository ({ShortRepoName(_repoPath)})");
+        _scopeAppRadio = MakeScopeRadio("For every repository");
+        _scopeRepoRadio.IsChecked = true;
+
+        _scopePanel = new StackPanel { Spacing = 2, Margin = new Thickness(26, 4, 0, 0) };
+        if (_repoPath is not null)
+            _scopePanel.Children.Add(_scopeRepoRadio);
+        _scopePanel.Children.Add(_scopeAppRadio);
+
+        // With no owning repository there is only one place a default can go, so the checkbox alone
+        // carries the meaning and the scope radios would be a choice of one.
+        if (_repoPath is null)
+        {
+            _scopeAppRadio.IsChecked = true;
+            _scopePanel.IsVisible = false;
+        }
+
+        _openButton = MakeButton("Open", primary: true);
+        _openButton.IsDefault = true;
+        _openButton.Click += (_, _) => Accept();
+
+        var cancelButton = MakeButton("Cancel", primary: false);
+        cancelButton.IsCancel = true;
+        cancelButton.Click += (_, _) =>
+        {
+            FileLog.Write("[BrowserPickerDialog] Cancelled");
+            Choice = null;
+            Close();
+        };
+
+        var buttonRow = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Spacing = 8,
+            Margin = new Thickness(0, 12, 0, 0),
+        };
+        buttonRow.Children.Add(_openButton);
+        buttonRow.Children.Add(cancelButton);
+
+        var grid = new Grid
+        {
+            Margin = new Thickness(16),
+            RowDefinitions = new RowDefinitions("Auto,Auto,*,Auto,Auto"),
+        };
+
+        var header = new TextBlock
+        {
+            Text = "Open in browser",
+            Foreground = Brush.Parse("#CCCCCC"),
+            FontSize = 15,
+            FontWeight = FontWeight.SemiBold,
+        };
+        Grid.SetRow(header, 0);
+        grid.Children.Add(header);
+
+        var targetText = new TextBlock
+        {
+            Text = _target,
+            Foreground = Brush.Parse("#888888"),
+            FontSize = 11,
+            Margin = new Thickness(0, 6, 0, 10),
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            MaxLines = 2,
+            TextWrapping = TextWrapping.Wrap,
+        };
+        ToolTip.SetTip(targetText, _target);
+        Grid.SetRow(targetText, 1);
+        grid.Children.Add(targetText);
+
+        var listBorder = new Border
+        {
+            Background = Brush.Parse("#1E1E1E"),
+            BorderBrush = Brush.Parse("#3C3C3C"),
+            BorderThickness = new Thickness(1),
+            Padding = new Thickness(6),
+            Child = new ScrollViewer
+            {
+                VerticalScrollBarVisibility = ScrollBarVisibility.Visible,
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+                Content = _optionsPanel,
+            },
+        };
+        Grid.SetRow(listBorder, 2);
+        grid.Children.Add(listBorder);
+
+        var rememberPanel = new StackPanel { Spacing = 0, Margin = new Thickness(0, 12, 0, 0) };
+        rememberPanel.Children.Add(_rememberCheck);
+        rememberPanel.Children.Add(_scopePanel);
+        Grid.SetRow(rememberPanel, 3);
+        grid.Children.Add(rememberPanel);
+
+        Grid.SetRow(buttonRow, 4);
+        grid.Children.Add(buttonRow);
+
+        Content = grid;
+
+        UpdateScopeEnabled();
+
+        // Disk I/O off the UI thread; the window is already painted by the time this runs.
+        Opened += async (_, _) => await LoadBrowsersAsync();
+    }
+
+    /// <summary>
+    /// Opens the picker over <paramref name="owner"/> and returns the user's choice, or null when
+    /// they cancelled.
+    /// </summary>
+    public static async Task<BrowserChoice?> ShowAsync(Window owner, string target, string? repoPath)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+
+        var dialog = new BrowserPickerDialog(target, repoPath);
+        await dialog.ShowDialog(owner);
+        return dialog.Choice;
+    }
+
+    /// <summary>
+    /// Reads the installed browsers, their profiles, and the default in force - all disk reads, all
+    /// on one background hop - then rebuilds the option rows. Detection failures are surfaced in the
+    /// list rather than swallowed: the system default row still works, so the dialog stays usable,
+    /// but the user is told what went wrong.
+    /// </summary>
+    private async Task LoadBrowsersAsync()
+    {
+        FileLog.Write("[BrowserPickerDialog] LoadBrowsersAsync");
+
+        List<(BrowserInfo Browser, IReadOnlyList<BrowserProfile> Profiles)> detected = new();
+        string? error = null;
+
+        try
+        {
+            var repoPath = _repoPath;
+            var loaded = await Task.Run(() =>
+            {
+                var browsers = new List<(BrowserInfo, IReadOnlyList<BrowserProfile>)>();
+                foreach (var browser in BrowserLauncher.DetectBrowsers())
+                    browsers.Add((browser, BrowserLauncher.GetProfiles(browser)));
+                return (Browsers: browsers, Current: BrowserDefaultStore.Resolve(repoPath));
+            });
+
+            detected = loaded.Browsers;
+            _currentDefault = loaded.Current;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[BrowserPickerDialog] LoadBrowsersAsync FAILED: {ex.Message}");
+            error = ex.Message;
+        }
+
+        BuildOptions(detected, error);
+        FileLog.Write($"[BrowserPickerDialog] LoadBrowsersAsync: browsers={detected.Count}, rows={_rows.Count}");
+    }
+
+    /// <summary>
+    /// Builds the flat option list: the system default first, then one row per browser+profile. Every
+    /// row is a single radio - there is no nesting and nothing to hover through.
+    /// </summary>
+    private void BuildOptions(
+        IReadOnlyList<(BrowserInfo Browser, IReadOnlyList<BrowserProfile> Profiles)> detected, string? error)
+    {
+        _optionsPanel.Children.Clear();
+        _rows.Clear();
+
+        var systemRadio = MakeOptionRadio("System default browser", "Whatever Windows opens links with today.");
+        _rows.Add((systemRadio, null, null));
+        _optionsPanel.Children.Add(systemRadio);
+
+        foreach (var (browser, profiles) in detected)
+        {
+            if (profiles.Count == 0)
+            {
+                _optionsPanel.Children.Add(new TextBlock
+                {
+                    Text = $"{browser.DisplayName}: no profiles found",
+                    Foreground = Brush.Parse("#666666"),
+                    FontSize = 11,
+                    Margin = new Thickness(6, 6, 6, 2),
+                });
+                continue;
+            }
+
+            foreach (var profile in profiles)
+            {
+                var subtitle = profile.Account is null ? browser.DisplayName : $"{browser.DisplayName} - {profile.Account}";
+                var radio = MakeOptionRadio(profile.DisplayName, subtitle);
+                _rows.Add((radio, browser, profile.FolderName));
+                _optionsPanel.Children.Add(radio);
+            }
+        }
+
+        if (error is not null)
+        {
+            _optionsPanel.Children.Add(new TextBlock
+            {
+                Text = $"Could not read the installed browsers: {error}",
+                Foreground = Brush.Parse("#F59E0B"),
+                FontSize = 11,
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(6, 8, 6, 2),
+            });
+        }
+
+        PreselectCurrentDefault();
+    }
+
+    /// <summary>Checks the row matching the default in force, so the dialog opens on today's answer.</summary>
+    private void PreselectCurrentDefault()
+    {
+        if (_currentDefault is not null)
+        {
+            foreach (var (radio, browser, profileFolder) in _rows)
+            {
+                if (browser is null)
+                    continue;
+
+                if (string.Equals(browser.ExePath, _currentDefault.ExePath, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(profileFolder, _currentDefault.ProfileFolder, StringComparison.Ordinal))
+                {
+                    radio.IsChecked = true;
+                    return;
+                }
+            }
+        }
+
+        // Nothing remembered, or the remembered browser is gone: the system default is the honest
+        // preselection, because it is what a plain "Open in Browser" would do right now.
+        if (_rows.Count > 0)
+            _rows[0].Radio.IsChecked = true;
+    }
+
+    private void Accept()
+    {
+        var scope = BrowserRememberScope.None;
+        if (_rememberCheck.IsChecked == true)
+            scope = _scopeRepoRadio.IsChecked == true && _repoPath is not null
+                ? BrowserRememberScope.Repository
+                : BrowserRememberScope.Application;
+
+        foreach (var (radio, browser, profileFolder) in _rows)
+        {
+            if (radio.IsChecked != true)
+                continue;
+
+            Choice = new BrowserChoice(browser, profileFolder, scope);
+            FileLog.Write($"[BrowserPickerDialog] Accept: browser={browser?.DisplayName ?? "(system default)"}, profile={profileFolder ?? "(none)"}, scope={scope}");
+            Close();
+            return;
+        }
+
+        // The list always contains the system default row and one row is always checked, so reaching
+        // here means the list never loaded. Keep the window open rather than closing on no answer.
+        FileLog.Write("[BrowserPickerDialog] Accept: no row selected, staying open");
+    }
+
+    private void UpdateScopeEnabled()
+    {
+        bool remember = _rememberCheck.IsChecked == true;
+        _scopeRepoRadio.IsEnabled = remember;
+        _scopeAppRadio.IsEnabled = remember;
+        _scopePanel.Opacity = remember ? 1.0 : 0.5;
+    }
+
+    /// <summary>One option row: a bold title over a dimmer subtitle, the whole row clickable.</summary>
+    private static RadioButton MakeOptionRadio(string title, string subtitle)
+    {
+        var content = new StackPanel { Spacing = 2 };
+        content.Children.Add(new TextBlock
+        {
+            Text = title,
+            Foreground = Brush.Parse("#CCCCCC"),
+            FontSize = 13,
+        });
+        content.Children.Add(new TextBlock
+        {
+            Text = subtitle,
+            Foreground = Brush.Parse("#888888"),
+            FontSize = 11,
+            TextWrapping = TextWrapping.Wrap,
+        });
+
+        return new RadioButton
+        {
+            GroupName = GroupName,
+            Content = content,
+            Foreground = Brush.Parse("#CCCCCC"),
+            Padding = new Thickness(6, 6),
+            Margin = new Thickness(0, 1),
+        };
+    }
+
+    private static RadioButton MakeScopeRadio(string title) => new()
+    {
+        GroupName = "browserPickerScopeGroup",
+        Content = new TextBlock { Text = title, Foreground = Brush.Parse("#CCCCCC"), FontSize = 12 },
+        Foreground = Brush.Parse("#CCCCCC"),
+    };
+
+    private static Button MakeButton(string text, bool primary) => new()
+    {
+        Content = text,
+        Height = 30,
+        MinWidth = primary ? 100 : 90,
+        Padding = new Thickness(14, 0),
+        Background = Brush.Parse(primary ? "#007ACC" : "#3C3C3C"),
+        Foreground = Brush.Parse(primary ? "#FFFFFF" : "#CCCCCC"),
+        BorderThickness = new Thickness(0),
+        Cursor = new Cursor(StandardCursorType.Hand),
+        HorizontalContentAlignment = HorizontalAlignment.Center,
+        VerticalContentAlignment = VerticalAlignment.Center,
+    };
+
+    /// <summary>The repository's folder name, which is what the user recognizes it by.</summary>
+    private static string ShortRepoName(string repoPath)
+    {
+        var trimmed = repoPath.Replace('/', '\\').TrimEnd('\\');
+        var lastSlash = trimmed.LastIndexOf('\\');
+        return lastSlash >= 0 && lastSlash < trimmed.Length - 1 ? trimmed[(lastSlash + 1)..] : trimmed;
+    }
+}

--- a/src/CcDirector.Terminal.Avalonia/LinkContextMenuBuilder.cs
+++ b/src/CcDirector.Terminal.Avalonia/LinkContextMenuBuilder.cs
@@ -4,8 +4,6 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia.Controls;
-using Avalonia.Input;
-using Avalonia.Interactivity;
 using CcDirector.Core.Browsers;
 using CcDirector.Core.Utilities;
 
@@ -41,8 +39,12 @@ public sealed class LinkMenuContext
 /// Builds the link context menu shared by the terminal and the History tab (GitHub #735). Both the
 /// terminal's <c>ShowLinkContextMenu</c> and the History bubbles call this single implementation, so
 /// a path or URL offers the exact same actions in either place - there is no divergent copy of the
-/// menu. For a file path: View File (when viewable), Open in Browser (when HTML), Copy Path, Open in
-/// File Manager. For a URL: Copy URL, Open in Browser (with the browser/profile submenu).
+/// menu. For a file path: View File (when viewable), Open in Browser + Choose Browser (when HTML),
+/// Copy Path, Open in File Manager. For a URL: Copy URL, Open in Browser, Choose Browser.
+///
+/// The menu is deliberately FLAT - every item does its thing on one press, and no item opens a
+/// submenu. Picking among browsers and profiles is a dialog (<see cref="BrowserPickerDialog"/>),
+/// not a hover-chain; see <see cref="AddOpenInBrowserItems"/> for why.
 /// </summary>
 public static class LinkContextMenuBuilder
 {
@@ -78,7 +80,7 @@ public static class LinkContextMenuBuilder
             if (FileExtensions.IsHtml(context.Link))
             {
                 string htmlTarget = ResolvePath(context, context.Link).Replace('/', '\\').TrimEnd('\\');
-                menu.Items.Add(BuildOpenInBrowserMenuItem(menu, context, htmlTarget));
+                AddOpenInBrowserItems(menu, context, htmlTarget);
                 addedViewerItem = true;
             }
 
@@ -99,7 +101,7 @@ public static class LinkContextMenuBuilder
             copyItem.Click += (_, _) => _ = CopyLinkToClipboardAsync(context);
             menu.Items.Add(copyItem);
 
-            menu.Items.Add(BuildOpenInBrowserMenuItem(menu, context, context.Link));
+            AddOpenInBrowserItems(menu, context, context.Link);
         }
     }
 
@@ -156,107 +158,131 @@ public static class LinkContextMenuBuilder
     }
 
     /// <summary>
-    /// Builds the "Open in Browser" menu item for <paramref name="target"/> (a URL or a local file
-    /// path). A plain click reopens the resolved default (this repository's default, then the
-    /// application-wide default, then the OS default); hovering expands a submenu of "System default"
-    /// plus each installed browser with its real profiles (re-read from each browser's Local State so
-    /// newly added profiles appear without a restart). Each profile in turn expands into explicit
-    /// intents - "Open once", "Set as default for this repository" (only when the link belongs to a
-    /// repository), and "Set as application-wide default" - so a click is never ambiguous about which
-    /// default, if any, it is setting.
+    /// Adds the two flat "Open in Browser" items for <paramref name="target"/> (a URL or a local
+    /// file path): one that opens the resolved default straight away, and one that opens the
+    /// <see cref="BrowserPickerDialog"/>.
+    ///
+    /// This replaces the cascading submenu that shipped with the per-repository default (#1533),
+    /// where every real action sat four popups deep - "Open in Browser" -&gt; browser -&gt; profile
+    /// -&gt; intent. Avalonia's MenuItem has no hover-intent safe area, so moving the pointer
+    /// diagonally toward a submenu crossed the sibling row and collapsed the chain: the actions were
+    /// unreachable in practice. The picker dialog holds the same three intents (open once, remember
+    /// for this repository, remember everywhere) as one list plus a checkbox, so no action needs a
+    /// submenu at all and every one is a single press.
+    ///
+    /// Both items are pure: neither touches the disk while the menu is being built, so the menu
+    /// pops instantly. Browser detection and default resolution happen inside the dialog, in the
+    /// background, after it is on screen.
     /// </summary>
-    private static MenuItem BuildOpenInBrowserMenuItem(ContextMenu menu, LinkMenuContext context, string target)
+    private static void AddOpenInBrowserItems(ContextMenu menu, LinkMenuContext context, string target)
     {
-        var parent = new MenuItem { Header = "Open in Browser" };
+        var openItem = new MenuItem { Header = "Open in Browser" };
+        openItem.Click += (_, _) => OpenInBrowserDefault(context, target);
+        menu.Items.Add(openItem);
 
-        // A submenu parent does NOT raise Click on its header - pressing the header just expands the
-        // submenu. To make a plain click on the parent reopen the remembered default (while HOVER
-        // still expands the submenu), intercept the header press in the tunnel phase. The tunnel
-        // route also passes through this parent for presses on its OWN submenu leaves (descendants),
-        // so launch the default ONLY when the press lands on the parent's own header rectangle.
-        parent.AddHandler(InputElement.PointerPressedEvent, (_, e) =>
+        var chooseItem = new MenuItem { Header = "Choose Browser..." };
+        chooseItem.Click += (_, _) => _ = ChooseBrowserAsync(context, target);
+        menu.Items.Add(chooseItem);
+    }
+
+    /// <summary>
+    /// Opens the browser picker and acts on what the user chose. Cancelling does nothing at all -
+    /// no launch, no remembered default.
+    /// </summary>
+    private static async Task ChooseBrowserAsync(LinkMenuContext context, string target)
+    {
+        try
         {
-            var pos = e.GetPosition(parent);
-            bool onHeader = pos.X >= 0 && pos.Y >= 0
-                && pos.X <= parent.Bounds.Width && pos.Y <= parent.Bounds.Height;
-            if (!onHeader)
+            if (TopLevel.GetTopLevel(context.Owner) is not Window owner)
+                throw new InvalidOperationException(
+                    "The link menu is not hosted in a window, so the browser picker cannot be opened.");
+
+            var choice = await BrowserPickerDialog.ShowAsync(owner, target, context.RepoPath);
+            if (choice is null)
+            {
+                FileLog.Write("[LinkContextMenuBuilder] ChooseBrowserAsync: cancelled");
+                return;
+            }
+
+            ApplyChoice(context, target, choice);
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[LinkContextMenuBuilder] ChooseBrowserAsync FAILED: {ex.Message}");
+            context.OnBrowserError?.Invoke($"Could not open the browser picker.\n\n{ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Launches the picked browser and persists the picked scope. The launch happens FIRST: if the
+    /// browser will not start, we surface that and never write a default the user would then be
+    /// stuck with.
+    /// </summary>
+    private static void ApplyChoice(LinkMenuContext context, string target, BrowserChoice choice)
+    {
+        try
+        {
+            if (choice.Browser is null)
+                BrowserLauncher.OpenSystemDefault(target);
+            else
+                BrowserLauncher.OpenWithProfile(target, choice.Browser, RequireProfileFolder(choice));
+
+            RememberChoice(context, choice);
+
+            FileLog.Write($"[LinkContextMenuBuilder] ApplyChoice: opened {target} in "
+                + $"{choice.Browser?.DisplayName ?? "the system default browser"}, scope={choice.Scope}");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[LinkContextMenuBuilder] ApplyChoice FAILED: {ex.Message}");
+            var where = choice.Browser?.DisplayName ?? "the system default browser";
+            context.OnBrowserError?.Invoke($"Could not open in {where}.\n\n{ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Writes (or erases) the remembered default for the chosen scope. Choosing the system default
+    /// browser and asking to remember it ERASES the stored default for that scope - that is how a
+    /// default gets taken back, and the store then resolves through to the operating system again.
+    /// </summary>
+    private static void RememberChoice(LinkMenuContext context, BrowserChoice choice)
+    {
+        switch (choice.Scope)
+        {
+            case BrowserRememberScope.None:
                 return;
 
-            e.Handled = true;
-            menu.Close();
-            OpenInBrowserDefault(context, target);
-        }, RoutingStrategies.Tunnel);
+            case BrowserRememberScope.Repository:
+                if (string.IsNullOrWhiteSpace(context.RepoPath))
+                    throw new InvalidOperationException(
+                        "This link has no owning repository, so it has no repository default to set.");
 
-        var systemItem = new MenuItem { Header = "System default" };
-        systemItem.Click += (_, e) =>
-        {
-            e.Handled = true;
-            OpenInBrowserSystemDefault(context, target);
-        };
-        parent.Items.Add(systemItem);
+                if (choice.Browser is null)
+                    BrowserDefaultStore.ClearForRepo(context.RepoPath);
+                else
+                    BrowserDefaultStore.SaveForRepo(
+                        context.RepoPath, new BrowserDefault(choice.Browser.ExePath, RequireProfileFolder(choice)));
+                return;
 
-        foreach (var browser in BrowserLauncher.DetectBrowsers())
-        {
-            var browserItem = new MenuItem { Header = browser.DisplayName };
+            case BrowserRememberScope.Application:
+                if (choice.Browser is null)
+                    BrowserDefaultStore.Clear();
+                else
+                    BrowserDefaultStore.Save(
+                        new BrowserDefault(choice.Browser.ExePath, RequireProfileFolder(choice)));
+                return;
 
-            var profiles = BrowserLauncher.GetProfiles(browser);
-            if (profiles.Count == 0)
-            {
-                browserItem.Items.Add(new MenuItem { Header = "(no profiles found)", IsEnabled = false });
-            }
-            else
-            {
-                foreach (var profile in profiles)
-                {
-                    string header = profile.Account is null
-                        ? profile.DisplayName
-                        : $"{profile.DisplayName} ({profile.Account})";
-
-                    var capturedBrowser = browser;
-                    var capturedFolder = profile.FolderName;
-
-                    // Each profile expands into explicit intents so a click is never ambiguous about
-                    // WHAT it sets: open once (remember nothing), remember for THIS repository (the
-                    // common case, only when the link belongs to a repository), or remember as the
-                    // application-wide default.
-                    var profileItem = new MenuItem { Header = header };
-
-                    var openOnceItem = new MenuItem { Header = "Open once" };
-                    openOnceItem.Click += (_, e) =>
-                    {
-                        e.Handled = true;
-                        OpenInBrowserProfileOnce(context, target, capturedBrowser, capturedFolder);
-                    };
-                    profileItem.Items.Add(openOnceItem);
-
-                    if (!string.IsNullOrWhiteSpace(context.RepoPath))
-                    {
-                        var repoItem = new MenuItem { Header = "Set as default for this repository" };
-                        repoItem.Click += (_, e) =>
-                        {
-                            e.Handled = true;
-                            OpenInBrowserProfileForRepo(context, target, capturedBrowser, capturedFolder);
-                        };
-                        profileItem.Items.Add(repoItem);
-                    }
-
-                    var appWideItem = new MenuItem { Header = "Set as application-wide default" };
-                    appWideItem.Click += (_, e) =>
-                    {
-                        e.Handled = true;
-                        OpenInBrowserProfileAppWide(context, target, capturedBrowser, capturedFolder);
-                    };
-                    profileItem.Items.Add(appWideItem);
-
-                    browserItem.Items.Add(profileItem);
-                }
-            }
-
-            parent.Items.Add(browserItem);
+            default:
+                throw new InvalidOperationException($"Unknown remember scope: {choice.Scope}");
         }
-
-        return parent;
     }
+
+    /// <summary>A choice naming a browser must name the profile to launch it with.</summary>
+    private static string RequireProfileFolder(BrowserChoice choice)
+        => string.IsNullOrWhiteSpace(choice.ProfileFolder)
+            ? throw new InvalidOperationException(
+                $"The choice named {choice.Browser?.DisplayName} but no profile folder.")
+            : choice.ProfileFolder;
 
     private static void OpenInBrowserDefault(LinkMenuContext context, string target)
     {
@@ -280,70 +306,6 @@ public static class LinkContextMenuBuilder
         {
             FileLog.Write($"[LinkContextMenuBuilder] OpenInBrowserDefault FAILED: {ex.Message}");
             context.OnBrowserError?.Invoke($"Could not open in browser.\n\n{ex.Message}");
-        }
-    }
-
-    private static void OpenInBrowserSystemDefault(LinkMenuContext context, string target)
-    {
-        try
-        {
-            BrowserLauncher.OpenSystemDefault(target);
-            FileLog.Write($"[LinkContextMenuBuilder] OpenInBrowserSystemDefault: {target}");
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[LinkContextMenuBuilder] OpenInBrowserSystemDefault FAILED: {ex.Message}");
-            context.OnBrowserError?.Invoke($"Could not open in the system default browser.\n\n{ex.Message}");
-        }
-    }
-
-    /// <summary>Opens the link in a specific browser+profile once, remembering nothing.</summary>
-    private static void OpenInBrowserProfileOnce(LinkMenuContext context, string target, BrowserInfo browser, string profileFolder)
-    {
-        try
-        {
-            BrowserLauncher.OpenWithProfile(target, browser, profileFolder);
-            FileLog.Write($"[LinkContextMenuBuilder] OpenInBrowserProfileOnce: opened {target} in {browser.DisplayName}/{profileFolder}");
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[LinkContextMenuBuilder] OpenInBrowserProfileOnce FAILED: {ex.Message}");
-            context.OnBrowserError?.Invoke($"Could not open in {browser.DisplayName}.\n\n{ex.Message}");
-        }
-    }
-
-    /// <summary>Opens the link and remembers this browser+profile as the owning repository's default.</summary>
-    private static void OpenInBrowserProfileForRepo(LinkMenuContext context, string target, BrowserInfo browser, string profileFolder)
-    {
-        try
-        {
-            BrowserLauncher.OpenWithProfile(target, browser, profileFolder);
-            if (string.IsNullOrWhiteSpace(context.RepoPath))
-                throw new InvalidOperationException("This link has no owning repository, so it has no repository default to set.");
-
-            BrowserDefaultStore.SaveForRepo(context.RepoPath, new BrowserDefault(browser.ExePath, profileFolder));
-            FileLog.Write($"[LinkContextMenuBuilder] OpenInBrowserProfileForRepo: opened {target} in {browser.DisplayName}/{profileFolder}, repo={context.RepoPath}");
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[LinkContextMenuBuilder] OpenInBrowserProfileForRepo FAILED: {ex.Message}");
-            context.OnBrowserError?.Invoke($"Could not open in {browser.DisplayName}.\n\n{ex.Message}");
-        }
-    }
-
-    /// <summary>Opens the link and remembers this browser+profile as the application-wide default.</summary>
-    private static void OpenInBrowserProfileAppWide(LinkMenuContext context, string target, BrowserInfo browser, string profileFolder)
-    {
-        try
-        {
-            BrowserLauncher.OpenWithProfile(target, browser, profileFolder);
-            BrowserDefaultStore.Save(new BrowserDefault(browser.ExePath, profileFolder));
-            FileLog.Write($"[LinkContextMenuBuilder] OpenInBrowserProfileAppWide: opened {target} in {browser.DisplayName}/{profileFolder}");
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[LinkContextMenuBuilder] OpenInBrowserProfileAppWide FAILED: {ex.Message}");
-            context.OnBrowserError?.Invoke($"Could not open in {browser.DisplayName}.\n\n{ex.Message}");
         }
     }
 


### PR DESCRIPTION
Closes #1571.

## The problem

Right-clicking a link offered "Open in Browser", but every action behind it sat **four popups deep**:

```
Copy URL / Open in Browser        <- popup 1
  System default / Google Chrome  <- popup 2
    <profile name>                <- popup 3
      Open once
      Set as default for this repository
      Set as application-wide default   <- popup 4, the only place anything happens
```

Avalonia's `MenuItem` has no hover-intent safe area, so moving the pointer diagonally toward a submenu crossed the sibling row and collapsed the chain. The actions were unreachable in practice.

Worse, the parent item carried a raw `PointerPressed` handler in the **tunnel** phase with `e.Handled = true` and `menu.Close()`. Pressing "Open in Browser" - the obvious move when a submenu will not stay open - closed the whole menu and launched a browser. The item was both "hover me to expand" and "press me to fire an irreversible action".

And building the menu read each browser's `Local State` JSON from disk on the UI thread, on every right-click.

## The change

The per-repository default from #1112 is a good feature; the shape was wrong. Picking a browser and a profile and deciding whether to remember it is a dialog, not a hover-chain.

The menu is now flat - no item opens a submenu:

```
Copy URL
Open in Browser        <- resolved default, one press
Choose Browser...      <- opens the picker
```

`BrowserPickerDialog` lists every browser+profile as one flat row plus "System default browser". "Remember this choice" is a checkbox with a repository/everywhere scope, replacing popups three and four. Detection and default resolution happen in the dialog's background load, so the menu itself does no disk input/output.

`BrowserDefaultStore` gains `Clear` and `ClearForRepo`: picking the system default and asking to remember it now **erases** the stored default for that scope. That is how a default gets taken back - the old menu could only ever write one, so a default set once could never be removed.

## Proof

The dialog rendered through real Skia, reading the real Chrome profiles on the build machine (the preselected row is the default already stored in config):

- One flat scrollable list: "System default browser" first, then each browser+profile with its account.
- "Remember this choice" unticked, scope options greyed until it is ticked.
- Open / Cancel.

Also built to slot 5 and driven by hand: right-click gives three flat items, "Open in Browser" fires on one press, "Choose Browser..." opens the picker and nothing collapses regardless of pointer path.

## Tests

All seven test projects pass (5,595 tests, 0 failures).

- 21 in `Terminal.Avalonia`. The one that matters asserts **every menu item has an empty `Items` collection**, so this fails loudly if anyone reintroduces a submenu here.
- 8 new `BrowserDefaultStore` tests covering clear, scope isolation (clearing a repository default leaves the application-wide default and other repositories alone, and vice versa), and unrelated config keys surviving a clear.
