### PR TITLE
fix(client-core): green the build - cast the Gateway-stamped stateLabel literals

### DIFF
--- a/packages/client-core/src/sessions/ordering.test.ts
+++ b/packages/client-core/src/sessions/ordering.test.ts
@@ -87,13 +87,15 @@ describe("Gateway-stamped session presentation state", () => {
 
   it("contextLine renders the Gateway's stamped label instead of re-deriving one", () => {
     // The row's words come from the same fold as its dot, so they cannot contradict it.
-    expect(contextLine(session({ effectiveColor: "blue", stateLabel: "Working", onHold: true })))
+    // stateLabel is Gateway-stamped and not in the generated schema, so each literal needs the same
+    // cast the stateLabel tests above use.
+    expect(contextLine(session({ effectiveColor: "blue", stateLabel: "Working", onHold: true } as Partial<SessionDto>)))
       .toBe("Working");
-    expect(contextLine(session({ effectiveColor: "grey", stateLabel: "Snoozed", onHold: true })))
+    expect(contextLine(session({ effectiveColor: "grey", stateLabel: "Snoozed", onHold: true } as Partial<SessionDto>)))
       .toBe("Snoozed");
     // A working session with dictation in flight reads "Working", not "Transcribing...": the local
     // ladder that produced a blue dot beside the word "Snoozed" is gone.
-    expect(contextLine(session({ effectiveColor: "blue", stateLabel: "Working", transcribing: true })))
+    expect(contextLine(session({ effectiveColor: "blue", stateLabel: "Working", transcribing: true } as Partial<SessionDto>)))
       .toBe("Working");
   });
 });


### PR DESCRIPTION
## Main is red and has been for five commits

Every `Build & Test (.NET)` run on main since the `contextLine` test landed has failed with the same error:

```
src/sessions/ordering.test.ts(90,58): error TS2353: Object literal may only specify
known properties, and 'stateLabel' does not exist in type 'Partial<...>'
```

The Gateway project runs `npm run typecheck --workspaces` as a build target, so a TypeScript error in `client-core` fails the entire solution build. Nothing merges green until this is fixed.

## The fix

`stateLabel` is a Gateway-stamped field that is not in the generated schema - exactly like `triageBucket`. The `stateLabel` tests thirty lines above the break already work around this and explain it in a comment:

```ts
// stateLabel is a Gateway-stamped field not yet in the generated schema (like triageBucket above),
// so the literal is cast the same way; the accessor reads it through the GatewayStampedSession cast.
expect(stateLabel(session({ stateLabel: "Needs you" } as Partial<SessionDto>))).toBe("Needs you");
```

Three literals in the `contextLine` test simply missed that cast. This adds it. Same cast, same reason, same file.

**Test-file only** - no shipping code changes.

## Why it reached main

`dotnet build` only runs the typecheck target if `node_modules` is present. In a fresh worktree it is not, so the local build passes and CI does not. Worth knowing; not fixed here.

## Verification

- `npm run typecheck --workspaces` - client-core, cockpit and mobile all clean.
- `npm test` in client-core - 40 files, 431 tests, all pass.
