### PR TITLE
fix(core): stop the tests writing junk into the user's real screenshots folder

### DIFF
--- a/src/CcDirector.Core.Tests/Storage/CcStorageScreenshotsTests.cs
+++ b/src/CcDirector.Core.Tests/Storage/CcStorageScreenshotsTests.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+using CcDirector.Core.Storage;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Storage;
+
+/// <summary>
+/// Tests for <see cref="CcStorage.Screenshots"/> - specifically that a test which redirects
+/// CC_DIRECTOR_ROOT cannot write into the user's REAL Pictures\Screenshots folder.
+///
+/// The regression: the chunked upload-image proof set CC_DIRECTOR_ROOT to a temp dir and trusted that to
+/// sandbox its 50 KB fake "photo.png". Screenshots() ignored the root, fell through to
+/// MyPictures\Screenshots, and every run of that suite left an undrawable date-only entry in the owner's
+/// screenshots gallery. Setting the root LOOKS like it sandboxes everything, so the next author will assume
+/// it too - these tests make the assumption true and keep it true.
+/// </summary>
+[Collection("CcStorageRoot")] // serializes all classes that mutate the process-wide CC_DIRECTOR_ROOT
+public sealed class CcStorageScreenshotsTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string? _prevRoot;
+
+    public CcStorageScreenshotsTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-shots-storage-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void Screenshots_withRedirectedRoot_andNoConfig_staysInsideTheRoot()
+    {
+        var dir = CcStorage.Screenshots();
+
+        Assert.StartsWith(_root, dir, StringComparison.OrdinalIgnoreCase);
+        Assert.True(Directory.Exists(dir), "Screenshots() must create the folder it returns");
+    }
+
+    [Fact]
+    public void Screenshots_withRedirectedRoot_andNoConfig_neverReturnsTheUsersPicturesFolder()
+    {
+        var pictures = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
+        var real = Path.Combine(pictures, "Screenshots");
+
+        var dir = CcStorage.Screenshots();
+
+        Assert.False(
+            string.Equals(Path.TrimEndingDirectorySeparator(dir), Path.TrimEndingDirectorySeparator(real), StringComparison.OrdinalIgnoreCase),
+            $"a redirected root must not resolve to the user's real screenshots folder, but got {dir}");
+    }
+
+    [Fact]
+    public void Screenshots_configuredSourceDirectory_stillWins_overTheRoot()
+    {
+        // The product's own override: a user who points the gallery at a real folder keeps it, root or not.
+        var configured = Path.Combine(_root, "a-configured-folder");
+        WriteConfig(new { screenshots = new { source_directory = configured } });
+
+        var dir = CcStorage.Screenshots();
+
+        Assert.Equal(Path.TrimEndingDirectorySeparator(configured), Path.TrimEndingDirectorySeparator(dir));
+    }
+
+    private void WriteConfig(object config)
+    {
+        var configDir = Path.Combine(_root, "config");
+        Directory.CreateDirectory(configDir);
+        File.WriteAllText(Path.Combine(configDir, "config.json"), JsonSerializer.Serialize(config));
+    }
+}

--- a/src/CcDirector.Core/Storage/CcStorage.cs
+++ b/src/CcDirector.Core/Storage/CcStorage.cs
@@ -201,6 +201,17 @@ public static class CcStorage
         if (!string.IsNullOrWhiteSpace(configured))
             return Ensure(configured);
 
+        // No configured folder. When CC_DIRECTOR_ROOT is set the caller has pinned storage to a throwaway
+        // location (only tests do this - the product never sets it), so keep the screenshots folder inside
+        // that root rather than falling through to the user's REAL Pictures\Screenshots. Without this a test
+        // that redirects the root still wrote into the user's own screenshots folder, where the gallery listed
+        // the leftovers as undrawable date-only entries; the leak shipped because setting the root LOOKS like
+        // it sandboxes everything. Mirrors CC_DIRECTOR_INSTANCES_DIR (issue #322) in keeping test artefacts out
+        // of the user's real environment.
+        var overrideRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        if (!string.IsNullOrEmpty(overrideRoot))
+            return Ensure(Path.Combine(overrideRoot, "screenshots"));
+
         if (OperatingSystem.IsMacOS())
             return Ensure(Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory));
 

--- a/src/CcDirector.Gateway.Tests/TunnelExplicitRouteProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/TunnelExplicitRouteProofTests.cs
@@ -279,6 +279,12 @@ public sealed class TunnelExplicitRouteProofTests : IAsyncLifetime
         var saved = await File.ReadAllBytesAsync(savedPath!);
         Assert.Equal(image, saved);
         Assert.EndsWith(".png", savedPath);
+
+        // The save landed INSIDE this test's throwaway root, not in the user's real Pictures\Screenshots.
+        // Asserted, not assumed: this test set CC_DIRECTOR_ROOT and trusted that to sandbox the write, but
+        // CcStorage.Screenshots() ignored the root and fell through to the user's own screenshots folder, so
+        // every run of this suite left a 50 KB undrawable "photo.png" in their gallery.
+        Assert.StartsWith(_root, savedPath!, StringComparison.OrdinalIgnoreCase);
     }
 
     // -------------------------------------------------------------------------------------- helpers ----


### PR DESCRIPTION
## What was happening

The owner's screenshots gallery showed entries with a date and no picture. They were not screenshots. They were test artefacts from our own suite, written into his real Pictures folder.

Two files on disk, byte-identical, exactly 51200 bytes each, no PNG signature (`07 26 45 64`, not `89 50 4E 47`). The contents were a synthetic pattern, `byte[i] = (i * 31 + 7) % 251` - the exact generator in `TunnelExplicitRouteProofTests.cs:261`. The size matches that test's fake image precisely: `UploadChunkRawBytes * 2 + 10 KB` = 20480 + 20480 + 10240 = 51200.

The gallery listed them because the save path validates only the file extension, never the content. Nothing drawable, so: a date and an empty box.

## Why they escaped into the real folder

`TunnelExplicitRouteProofTests` sets `CC_DIRECTOR_ROOT` to a temp dir and deletes it on dispose. Its comment claims "a real file is written under the test's screenshots folder." That was wrong. `CcStorage.Screenshots()` never consulted the root - it read `screenshots.source_directory` from `config.json` and, finding none under the throwaway root, fell through to `MyPictures\Screenshots`. OneDrive has moved that known folder, so it resolved to the owner's real gallery.

Setting the root actually made it worse: it hid the real config and dropped the test onto the known-folder fallback.

Two sibling tests (`SessionByteExecutorTests`, `ScreenshotEndpointsTests`) get this right - they write a `config.json` pinning the folder into their temp root, with comments saying "so nothing touches the user's real Pictures\Screenshots folder". This test did half the setup. It passed, so nobody found out. The owner's Pictures folder was the only place the failure was visible.

Landed in c10cfee3 (#1459) on 2026-07-13. Every Gateway suite run since has left one behind, on every machine that runs it.

## The fix

`CcStorage.Screenshots()` now keeps the folder inside `CC_DIRECTOR_ROOT` when that is set and nothing is configured - making the assumption the test author already made a true one. Isolation was opt-in per test and depended on each author knowing the ritual; a convention is not a boundary.

Product resolution is unchanged. The product never sets `CC_DIRECTOR_ROOT`; a configured `source_directory` still wins; the `Pictures\Screenshots` fallback still applies. `Bin()` had this identical bug fixed the same way ("previously this hardcoded %LOCALAPPDATA%\cc-director\bin and silently ignored the override"), and `CC_DIRECTOR_INSTANCES_DIR` (#322) exists for the same class of leak.

The proof test now asserts its saved path is under its own root, so a regression fails the test rather than the owner's gallery.

## Verification

- The new assertion **fails** without the `Screenshots()` change - confirmed by reverting it and watching the test go red. The guard is real, not vacuous.
- A **full Gateway suite run added zero files** to the real folder. Before the fix, every run added one.
- New `CcStorageScreenshotsTests` covers all three legs: redirected root stays inside the root, never resolves to the user's Pictures, and a configured `source_directory` still wins.
- Core: 3066 passed, 0 failed. Gateway: 2217 passed, 0 failed.
- The leftover junk files have been deleted from the owner's folder.

## Not addressed here

While running the suite, `docs/cencon/proof/issue-509/ask-sequence.log` was modified by the tests - another test writing into the repo working tree. Same family of problem, out of scope for this fix, left for a follow-up.

Generated with [Claude Code](https://claude.com/claude-code)
