### PR TITLE
fix(core): stop tests writing into the real Director folder and the repo

### DIFF
--- a/src/CcDirector.Core.Tests/Drivers/SessionAskRunnerTests.cs
+++ b/src/CcDirector.Core.Tests/Drivers/SessionAskRunnerTests.cs
@@ -333,9 +333,13 @@ public class SessionAskRunnerTests : IDisposable
 
     private static void WriteProofLog(IReadOnlyList<string> logged, SessionAskResult result)
     {
-        var repoRoot = FindRepoRoot();
-        if (repoRoot is null) return; // running outside the repo tree (CI artifact dir) - skip the file write
-        var proofDir = Path.Combine(repoRoot, "docs", "cencon", "proof", "issue-509");
+        // Proof generation is OPT-IN, like the sibling proof writers (CC274_PROOF_DIR,
+        // CC300_PROOF_DIR, CC1080_PROOF_DIR): a normal `dotnet test` writes nothing. This used to
+        // locate the repo root and write docs/cencon/proof/issue-509/ask-sequence.log on every run,
+        // which left the file dirty in every worktree. The proof run sets CC509_PROOF_DIR and
+        // commits the artefact; the assertions in the test are what actually prove the behaviour.
+        var proofDir = Environment.GetEnvironmentVariable("CC509_PROOF_DIR");
+        if (string.IsNullOrWhiteSpace(proofDir)) return;
         Directory.CreateDirectory(proofDir);
 
         var sb = new StringBuilder();
@@ -357,18 +361,6 @@ public class SessionAskRunnerTests : IDisposable
     {
         var temp = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
         return line.Replace(temp, "<TEMP>", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static string? FindRepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null)
-        {
-            if (File.Exists(Path.Combine(dir.FullName, "cc-director.sln")))
-                return dir.FullName;
-            dir = dir.Parent;
-        }
-        return null;
     }
 
     private static string Delimited(string answer) =>

--- a/src/CcDirector.Core.Tests/Voice/VoiceUtteranceServiceGateTests.cs
+++ b/src/CcDirector.Core.Tests/Voice/VoiceUtteranceServiceGateTests.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using System.Text;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Sessions;
+using CcDirector.Core.Storage;
 using CcDirector.Core.Voice;
 using Xunit;
 
@@ -13,27 +14,38 @@ namespace CcDirector.Core.Tests.Voice;
 /// (empty capture, missing/zero-byte segment) which return BEFORE any
 /// transcription, so they run without OpenAI or a live session.
 ///
-/// The service stores chunks under a per-user temp root keyed by the utterance
-/// id; each test uses a fresh GUID id and deletes that directory afterward.
+/// CC_DIRECTOR_ROOT is pinned to a temp dir so the chunk staging lands there. This class's
+/// docstring used to call the service's folder "a per-user temp root" - it was not, it was the
+/// REAL %LOCALAPPDATA%\cc-director\voice-utterances of the running Director, baked into a static
+/// readonly field no redirect could reach. Each test still uses a fresh GUID utterance id.
 /// </summary>
+[Collection("CcStorageRoot")] // serializes all classes that mutate the process-wide CC_DIRECTOR_ROOT
 public sealed class VoiceUtteranceServiceGateTests : IDisposable
 {
     private readonly VoiceUtteranceService _svc;
     private readonly string _id = Guid.NewGuid().ToString("N");
     private readonly string _dir;
+    private readonly string _root;
+    private readonly string? _prevRoot;
 
     public VoiceUtteranceServiceGateTests()
     {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-utterance-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+
         var options = new AgentOptions();
         _svc = new VoiceUtteranceService(new SessionManager(options), options);
-        _dir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "cc-director", "voice-utterances", _id);
+        // Ask CcStorage rather than re-deriving the path: the old copy hardcoded %LOCALAPPDATA%
+        // and so followed the production class into the real Director's folder.
+        _dir = Path.Combine(CcStorage.VoiceUtterances(), _id);
     }
 
     public void Dispose()
     {
         try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); } catch { }
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best-effort cleanup */ }
     }
 
     private static string Sha(byte[] b) => Convert.ToHexString(SHA256.HashData(b)).ToLowerInvariant();
@@ -65,5 +77,25 @@ public sealed class VoiceUtteranceServiceGateTests : IDisposable
         Assert.Equal("incomplete", resp.Status);
         Assert.NotNull(resp.Error);
         Assert.Contains("1", resp.Error);
+    }
+
+    [Fact]
+    public async Task StoredChunks_landInTheRedirectedRoot_notTheRealDirectorFolder()
+    {
+        // Asserted, not assumed. Before this, the service baked %LOCALAPPDATA% into a static
+        // readonly field, so these tests staged audio chunks inside the REAL running Director's
+        // voice-utterances folder no matter what root the test set.
+        _svc.Register(_id);
+        var chunk = Encoding.UTF8.GetBytes("voice-chunk-0");
+        await _svc.StoreChunkAsync(_id, 0, chunk, Sha(chunk));
+
+        Assert.StartsWith(_root, _dir, StringComparison.OrdinalIgnoreCase);
+        Assert.True(Directory.Exists(_dir), $"expected the staging dir at {_dir}");
+        Assert.NotEmpty(Directory.GetFiles(_dir));
+
+        var real = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "cc-director", "voice-utterances", _id);
+        Assert.False(Directory.Exists(real), $"a redirected root must not stage into {real}");
     }
 }

--- a/src/CcDirector.Core.Tests/Wingman/StateChangeLogTests.cs
+++ b/src/CcDirector.Core.Tests/Wingman/StateChangeLogTests.cs
@@ -1,5 +1,6 @@
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Sessions;
+using CcDirector.Core.Storage;
 using CcDirector.Core.Wingman;
 using Xunit;
 
@@ -10,9 +11,30 @@ namespace CcDirector.Core.Tests.Wingman;
 /// <see cref="Session"/> (populated by <c>SetActivityState</c> when the detector calls
 /// <c>ApplyTerminalActivityState</c>) and the durable <see cref="StateChangeLog"/>. The
 /// detector's timer wiring itself is timing/async and exercised live, not faked here.
+///
+/// CC_DIRECTOR_ROOT is pinned to a temp dir so the durable log lands there: this test used to
+/// append into the REAL running Director's %LOCALAPPDATA%\cc-director\state-changes folder,
+/// because StateChangeLog baked that path into a static readonly field no redirect could reach.
 /// </summary>
-public sealed class StateChangeLogTests
+[Collection("CcStorageRoot")] // serializes all classes that mutate the process-wide CC_DIRECTOR_ROOT
+public sealed class StateChangeLogTests : IDisposable
 {
+    private readonly string _root;
+    private readonly string? _prevRoot;
+
+    public StateChangeLogTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-statechange-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best-effort cleanup */ }
+    }
+
     [Fact]
     public void State_changes_are_recorded_newest_first()
     {
@@ -96,16 +118,20 @@ public sealed class StateChangeLogTests
     public void StateChangeLog_round_trips_a_record_to_jsonl()
     {
         var sessionId = Guid.NewGuid();
-        var root = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "cc-director", "state-changes");
-        var path = Path.Combine(root, sessionId.ToString("N") + ".jsonl");
+        // Ask CcStorage where the log goes rather than re-deriving the path here: the old copy
+        // hardcoded %LOCALAPPDATA% and so silently followed the production class into the real
+        // Director's folder. Under the pinned root this resolves inside _root.
+        var path = Path.Combine(CcStorage.StateChanges(), sessionId.ToString("N") + ".jsonl");
         var wasEnabled = StateChangeLog.Enabled;
         try
         {
             StateChangeLog.Enabled = true;
             StateChangeLog.Append(sessionId, new StateChangeLog.Record(
                 DateTime.UtcNow.ToString("o"), "Working", "WaitingForInput", "red"));
+
+            // Asserted, not assumed: the append landed in this test's throwaway root, never the
+            // real Director's data directory.
+            Assert.StartsWith(_root, path, StringComparison.OrdinalIgnoreCase);
 
             Assert.True(File.Exists(path));
             var line = File.ReadAllText(path).Trim();

--- a/src/CcDirector.Core/Storage/CcStorage.cs
+++ b/src/CcDirector.Core/Storage/CcStorage.cs
@@ -78,6 +78,24 @@ public static class CcStorage
     public static string Logs() => Path.Combine(Base(), "logs");
 
     /// <summary>
+    /// Durable activity-state transition logs: base/state-changes/&lt;sessionId&gt;.jsonl. The caller creates
+    /// the directory, so this composes the path without touching disk. Resolved here rather than in
+    /// <see cref="Wingman.StateChangeLog"/> so it honors CC_DIRECTOR_ROOT like every other path: that class
+    /// baked %LOCALAPPDATA% into a static readonly field, which no test could redirect - so its test wrote
+    /// into the real running Director's data directory.
+    /// </summary>
+    public static string StateChanges() => Path.Combine(Base(), "state-changes");
+
+    /// <summary>
+    /// Per-utterance resumable voice-chunk staging: base/voice-utterances/&lt;uploadId&gt;/. Transient - the
+    /// service deletes each utterance directory after transcription, and creates them itself, so this
+    /// composes the path without touching disk. Resolved here for the same reason as
+    /// <see cref="StateChanges"/>: <see cref="Voice.VoiceUtteranceService"/> baked %LOCALAPPDATA% into a
+    /// static readonly field that no test could redirect.
+    /// </summary>
+    public static string VoiceUtterances() => Path.Combine(Base(), "voice-utterances");
+
+    /// <summary>
     /// Per-turn voice comparison logs (short retention, auto-purged): base/voice-turn-logs/.
     /// Holds the audio, user transcript, agent reply, and wingman spoken reply for
     /// each voice turn so a meaning divergence can be flagged and compared later.

--- a/src/CcDirector.Core/Voice/VoiceUtteranceService.cs
+++ b/src/CcDirector.Core/Voice/VoiceUtteranceService.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Sessions;
+using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -11,7 +12,7 @@ namespace CcDirector.Core.Voice;
 ///
 /// The browser records with MediaRecorder timeslice, so the audio arrives as an
 /// ordered sequence of webm container fragments. We store each fragment to a
-/// per-utterance temp dir as it lands (SHA256-idempotent, so a retried chunk is a
+/// per-utterance staging dir as it lands (SHA256-idempotent, so a retried chunk is a
 /// no-op), then on <see cref="CompleteAsync"/> concatenate them IN ORDER back into
 /// one webm blob and transcribe it once. A fragment is NOT independently decodable
 /// (only fragment 0 carries the container header), so reassemble-then-transcribe is
@@ -20,13 +21,16 @@ namespace CcDirector.Core.Voice;
 /// Why this exists instead of the single-shot /voice/command: on spotty car LTE a
 /// whole-blob POST that fails near the end re-sends the entire clip. Here, every
 /// chunk that lands stays landed; a dropped connection resumes at the next missing
-/// chunk. Transient only: the temp dir is deleted after transcription. No vault.
+/// chunk. Transient only: the staging dir is deleted after transcription - it lives
+/// under the Director's own storage root, NOT the machine temp dir, whatever the
+/// wording here used to claim. No vault.
 /// </summary>
 public sealed class VoiceUtteranceService
 {
-    private static readonly string Root = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "cc-director", "voice-utterances");
+    /// <summary>Resolved per access (not a static readonly field) so CC_DIRECTOR_ROOT redirects it: a
+    /// baked field is captured at type load, which no test can undo - and this class's gate test wrote
+    /// into the real Director's data directory as a result. Same folder in production.</summary>
+    private static string Root => CcStorage.VoiceUtterances();
 
     private readonly SessionManager _sessionManager;
     private readonly AgentOptions _options;

--- a/src/CcDirector.Core/Wingman/StateChangeLog.cs
+++ b/src/CcDirector.Core/Wingman/StateChangeLog.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Core.Wingman;
@@ -22,9 +23,11 @@ public static class StateChangeLog
 {
     private static readonly object Gate = new();
     private static readonly JsonSerializerOptions Json = new() { WriteIndented = false };
-    private static readonly string Root = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "cc-director", "state-changes");
+
+    /// <summary>Resolved per access (not a static readonly field) so CC_DIRECTOR_ROOT redirects it: a
+    /// baked field is captured at type load, which no test can undo - and this class's own test wrote
+    /// into the real Director's data directory as a result. Same folder in production.</summary>
+    private static string Root => CcStorage.StateChanges();
 
     /// <summary>Disabled by setting <c>CC_DIRECTOR_STATE_LOG=0</c> at startup; the in-memory
     /// ring and the Wingman tab still work without the durable log.</summary>

--- a/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
@@ -15,7 +15,8 @@ namespace CcDirector.Gateway.Tests;
 /// the mechanical guarantees (faithful carry-through, context cleared every turn, fail-loud
 /// on a broken contract, speech cleanup, and that the only dependency is a real-session
 /// brain - never a <c>--print</c> process). Human judgement of summary quality comes from
-/// the HTML QA report this file also emits.
+/// the HTML QA report this file emits when <c>CC531_PROOF_DIR</c> names an output directory;
+/// a normal test run writes no files.
 /// </summary>
 public sealed class WingmanTranslatorTests
 {
@@ -504,21 +505,19 @@ public sealed class WingmanTranslatorTests
             Assert.False(string.IsNullOrWhiteSpace(r.Spoken)); // a non-empty reply yields a non-empty translation
         }
 
-        var outDir = Path.Combine(FindRepoRoot(), "docs", "proof", "issue-531");
+        // Proof generation is OPT-IN, like the sibling proof writers (CC274_PROOF_DIR,
+        // CC300_PROOF_DIR, CC1080_PROOF_DIR): a normal `dotnet test` writes nothing. This used
+        // to write docs/proof/issue-531/wingman-text-qa.html unconditionally, rewriting a
+        // git-tracked file on every Gateway run and leaving every worktree dirty. The
+        // assertions above are the test; the report is an artefact the proof run collects.
+        var outDir = Environment.GetEnvironmentVariable("CC531_PROOF_DIR");
+        if (string.IsNullOrWhiteSpace(outDir)) return;
+
         Directory.CreateDirectory(outDir);
         var outPath = Path.Combine(outDir, "wingman-text-qa.html");
         File.WriteAllText(outPath, WingmanQaReport.Render(rows, live: false), Encoding.UTF8);
 
         _out.WriteLine($"QA report written: {outPath}");
         Assert.True(File.Exists(outPath));
-    }
-
-    private static string FindRepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "CcDirector.sln"))
-               && !Directory.Exists(Path.Combine(dir.FullName, ".git")))
-            dir = dir.Parent;
-        return dir?.FullName ?? AppContext.BaseDirectory;
     }
 }


### PR DESCRIPTION
Follow-up to #1577. That fixed one test leaking a junk file into the owner's real screenshots gallery. This audits all **14** test projects for the same shape and fixes what it found.

## The pattern

The repo already has the right conventions. Three proof writers gate themselves and write nothing on a normal run. Two screenshot tests pin their folder to temp. The problem is that every one of those conventions is **opt-in**, and nothing enforces any of them - so a test that forgets writes somewhere real and passes anyway. That is now the third independent instance. The one place isolation was made mandatory (`CC_DIRECTOR_INSTANCES_DIR`, pinned assembly-wide in `TestEnvironment`) is the one place that has never leaked.

## Writing into the running Director's data directory

Two production classes resolved the user's folder themselves, bypassing `CcStorage`, each baking `%LOCALAPPDATA%` into a `static readonly` field captured at type load. `CC_DIRECTOR_ROOT` could not redirect them at any point, so their tests appended into the **live Director's own folders**:

| Class | Wrote into |
|---|---|
| `StateChangeLog` | `cc-director/state-changes` |
| `VoiceUtteranceService` | `cc-director/voice-utterances` |

Both now resolve per access via new `CcStorage.StateChanges()` / `CcStorage.VoiceUtterances()`, matching how every other subfolder in that file is defined. **Production behavior is identical** - `CcStorage.Base()` is `%LOCALAPPDATA%/cc-director` when no root is set, which is exactly what these two hardcoded.

`VoiceUtteranceService`'s own doc comment called the folder "a temp dir" and its test docstring called it "a per-user temp root". It was neither. That is the same false belief that caused the original screenshots leak, written down twice more, so the wording is corrected rather than left to mislead the next reader.

## Rewriting git-tracked files on every run

| Test | Rewrote |
|---|---|
| `WingmanTranslatorTests` | `docs/proof/issue-531/wingman-text-qa.html` |
| `SessionAskRunnerTests` | `docs/cencon/proof/issue-509/ask-sequence.log` |

Both unconditional, no cleanup, both **git-tracked**, and both dirty in the shared checkout when this was written - they are why every worktree shows modified proof files after a test run.

Three sibling proof writers already do this correctly (`CC274_PROOF_DIR`, `CC300_PROOF_DIR`, `CC1080_PROOF_DIR`):

```csharp
var dir = Environment.GetEnvironmentVariable("CC274_PROOF_DIR");
if (string.IsNullOrWhiteSpace(dir)) return;
```

These two now follow it via `CC531_PROOF_DIR` / `CC509_PROOF_DIR`. **The artefacts are unchanged and still generated on demand** - proof generation is preserved, not removed, so the CenCon proof-to-branch flow still works; it just no longer fires on every unrelated test run. Their now-unused `FindRepoRoot` helpers are deleted.

## Verification

- **Both new isolation assertions FAIL against the old baked roots** - confirmed by reverting the two production classes and watching them go red. The guards catch the real bug rather than passing alongside it.
- **A full Core run and a full Gateway run each leave the repo clean.** Both dirtied a tracked file before this change.
- Opt-in proof generation confirmed still working: setting the env vars emits both `ask-sequence.log` and `wingman-text-qa.html` unchanged.
- Core: 3075 passed, 0 failed. Gateway: 2217 passed, 0 failed. No new warnings.

## Deliberately not addressed

`SessionLogWriterTests` writes the real production path **on purpose**; its comment explains a `CC_DIRECTOR_ROOT` override "would race against other test classes that read `CcStorage.Root()`". That is a real constraint and it names the deeper problem: the root is process-wide global state, so isolating one test can break another. Patching it would trade a leak for flakes. It needs the wider design change.

Also found and left alone, documented here so they are not lost:

- `CcStorage.Output()` still resolves to the real `Documents\cc-director` and ignores the root - **latent**, no test reaches it today (only `QuickActionService` calls it, and nothing tests that).
- `DirectorIdStore.DirectoryPath` is statically cached and safe today only by call ordering. If a future test boots a `ControlApiHost` with `useEphemeralPort: false` and no `directorId` first, it would overwrite the user's **real Director identity file**.
- `CockpitReactAppServingTests` unconditionally deletes its test-output `wwwroot/c` and leaves fakes behind - build output, not a user folder, but destructive and order-dependent.
- Two installer tests create a real Windows scheduled task and a real HKCU uninstall entry. GUID-named and cleaned up, and in no solution, so CI never runs them; only a hard kill mid-test orphans them.
- `NulFileWatcherTests` deletes a `nul` file from the user's home directory.
- `TelemetryConsentConfigTests` and `GatewayConsentAckTests` mutate the process-wide root outside the collection meant to serialize it - a flake hazard, not a leak.

Generated with [Claude Code](https://claude.com/claude-code)
