### PR TITLE
fix(core): make the storage-root rule enforced, not remembered

### DIFF
--- a/src/CcDirector.Core.Tests/Storage/CcStorageOutputTests.cs
+++ b/src/CcDirector.Core.Tests/Storage/CcStorageOutputTests.cs
@@ -1,0 +1,72 @@
+using CcDirector.Core.Storage;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Storage;
+
+/// <summary>
+/// Tests for <see cref="CcStorage.Output"/> honoring CC_DIRECTOR_ROOT. Output() resolved the user's real
+/// Documents\cc-director and ignored the override - the last path in CcStorage that did, after Bin() and
+/// Screenshots() were fixed the same way. No test reached it (only QuickActionService calls it, and
+/// nothing tests that), so it was latent rather than leaking; these tests keep it that way.
+/// </summary>
+[Collection("CcStorageRoot")] // serializes all classes that mutate the process-wide CC_DIRECTOR_ROOT
+public sealed class CcStorageOutputTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string? _prevRoot;
+
+    public CcStorageOutputTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-output-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best-effort cleanup */ }
+    }
+
+    [Fact]
+    public void Output_withRedirectedRoot_staysInsideTheRoot()
+    {
+        var dir = CcStorage.Output();
+
+        Assert.StartsWith(_root, dir, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Output_withRedirectedRoot_neverReturnsTheUsersDocumentsFolder()
+    {
+        var real = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "cc-director");
+
+        var dir = CcStorage.Output();
+
+        Assert.False(
+            string.Equals(Path.TrimEndingDirectorySeparator(dir), Path.TrimEndingDirectorySeparator(real), StringComparison.OrdinalIgnoreCase),
+            $"a redirected root must not resolve to the user's real Documents folder, but got {dir}");
+    }
+
+    [Fact]
+    public void ToolOutput_withRedirectedRoot_staysInsideTheRoot()
+    {
+        // The reachable one: QuickActionService's constructor calls CcStorage.Ensure(ToolOutput(...)),
+        // so the first test to touch that class would otherwise create a folder in the real Documents.
+        var dir = CcStorage.ToolOutput("quick-actions");
+
+        Assert.StartsWith(_root, dir, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Output_withNoRoot_isTheUsersDocumentsFolder()
+    {
+        // The product never sets CC_DIRECTOR_ROOT, so its location must not move.
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", null);
+        var expected = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "cc-director");
+
+        var dir = CcStorage.Output();
+
+        Assert.Equal(Path.TrimEndingDirectorySeparator(expected), Path.TrimEndingDirectorySeparator(dir));
+    }
+}

--- a/src/CcDirector.Core.Tests/StorageRootGuardTests.cs
+++ b/src/CcDirector.Core.Tests/StorageRootGuardTests.cs
@@ -1,0 +1,162 @@
+using Xunit;
+
+namespace CcDirector.Core.Tests;
+
+/// <summary>
+/// Architecture fitness function: production code must not re-derive the cc-director storage root by
+/// hand. Composing <c>GetFolderPath(LocalApplicationData) + "cc-director"</c> (or the MyDocuments
+/// equivalent) yourself produces a path that CC_DIRECTOR_ROOT cannot redirect - so any test that reaches
+/// that code writes into the REAL running Director's folders, and no amount of care in the test can stop
+/// it. Ask <see cref="Storage.CcStorage"/> instead; it owns the root and honors the override.
+///
+/// This is not hypothetical. It has now cost real time four times:
+///   - Screenshots: CcStorage.Screenshots() ignored the root, so the chunked upload proof left a 50 KB
+///     undrawable file in the owner's Pictures gallery on every Gateway run for over a day (#1577).
+///   - StateChangeLog + VoiceUtteranceService: both baked the root into a static readonly field, so their
+///     tests appended into the live Director's own data directory (#1580).
+///   - Tailscale serve: test hosts clobbered the production serve table every fixture - the long-standing
+///     "#179/#200 mystery clobberer" - until TestEnvironment pinned it off process-wide.
+/// Each was written by someone being careful. Care is not the control; this test is.
+///
+/// The rule is enforced for NEW code. <see cref="KnownOffenders"/> freezes the call sites that already
+/// existed when the guard landed: the guard fails the moment a new one appears, and each entry burned
+/// down is deleted from the list, never added to. A file only earns a place here by predating the guard.
+///
+/// Deliberately scoped to src/. The installers under tools/cc-director-setup* are excluded because they
+/// DEFINE the install root rather than consume it - they are the code that creates the folder CcStorage
+/// later reads, and they must target the real machine to install onto it.
+/// </summary>
+public sealed class StorageRootGuardTests
+{
+    /// <summary>
+    /// Call sites that re-derived the storage root before this guard existed. BURN-DOWN LIST: delete
+    /// entries as they move to CcStorage; never add one. Every file here is latent in the same way the
+    /// two fixed in #1580 were - harmless only until a test touches it.
+    /// </summary>
+    private static readonly string[] KnownOffenders =
+    {
+        "src/CcDirector.AgentBrain/BrainLog.cs",
+        "src/CcDirector.Avalonia/App.axaml.cs",
+        "src/CcDirector.Avalonia/Controls/CommManager/CommManagerViewModel.cs",
+        "src/CcDirector.Avalonia/Controls/ConnectionsView.axaml.cs",
+        "src/CcDirector.Avalonia/Program.cs",
+        "src/CcDirector.Core/AgentPlugins/AgentPluginRegistry.cs",
+        "src/CcDirector.Core/Backends/GitHubCredentials.cs",
+        "src/CcDirector.Core/Claude/ClaudeHookInstaller.cs",
+        "src/CcDirector.Core/Codex/CodexHookInstaller.cs",
+        "src/CcDirector.Core/Configuration/AgentOptions.cs",
+        "src/CcDirector.Core/Dictation/DictationRecordingStore.cs",
+        "src/CcDirector.Core/Dictation/DictationSessionLog.cs",
+        "src/CcDirector.Core/Pi/PiPreambleWriter.cs",
+        "src/CcDirector.Core/Wingman/TerminalSessionRecorder.cs",
+        "src/CcDirector.Gateway/Api/GatewayEndpoints.cs",
+        "src/CcDirector.Gateway/Api/ItemStatusEndpoint.cs",
+        // Also hand-builds a VAULT path, so it bypasses CcStorage.Vault() and its CC_VAULT_PATH
+        // override too - worth taking early when this list is burned down.
+        "src/CcDirector.Gateway/Api/RecordingEndpoints.cs",
+        "src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs",
+        "src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs",
+        "src/CcDirector.Gateway/Transcription/TranscriptionTelemetryLog.cs",
+        "src/CcDirector.Terminal.Avalonia/TerminalControl.cs",
+        "src/CcDirector.Terminal/Rendering/CardView/CardWebView.xaml.cs",
+    };
+
+    /// <summary>CcStorage owns the root, so it is the one place allowed to resolve it from the OS.
+    /// CcStorageMigration moves data between the old and new real locations, which it cannot do
+    /// through the very abstraction it is migrating.</summary>
+    private static readonly string[] RootOwners =
+    {
+        "src/CcDirector.Core/Storage/CcStorage.cs",
+        "src/CcDirector.Core/Storage/CcStorageMigration.cs",
+    };
+
+    [Fact]
+    public void Production_code_does_not_rederive_the_storage_root()
+    {
+        var offenders = ScanForRootRederivation(out _);
+
+        Assert.True(offenders.Count == 0,
+            "These files compose the cc-director storage root by hand instead of asking CcStorage. "
+            + "The result cannot be redirected by CC_DIRECTOR_ROOT, so any test reaching this code writes "
+            + "into the user's REAL Director folders (see #1577 / #1580). Use CcStorage - add a method "
+            + "there if the folder has none yet:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    [Fact]
+    public void Burn_down_list_has_no_stale_entries()
+    {
+        // Keeps the list honest: a file that no longer re-derives the root must be removed, so the list
+        // only ever shrinks and cannot quietly become a permanent excuse.
+        ScanForRootRederivation(out var seen);
+        var stale = KnownOffenders.Where(k => !seen.Contains(k)).ToList();
+
+        Assert.True(stale.Count == 0,
+            "These entries no longer re-derive the storage root - delete them from KnownOffenders so the "
+            + "guard keeps protecting them:\n  " + string.Join("\n  ", stale));
+    }
+
+    /// <summary>Find every production file that resolves a real user folder and pins "cc-director" under
+    /// it - the shape that bypasses CcStorage. Returns non-allowlisted offenders; reports all matches via
+    /// <paramref name="allMatches"/>.</summary>
+    private static List<string> ScanForRootRederivation(out HashSet<string> allMatches)
+    {
+        var root = GetRepoRoot();
+        var offenders = new List<string>();
+        allMatches = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var file in Directory.EnumerateFiles(Path.Combine(root, "src"), "*.cs", SearchOption.AllDirectories))
+        {
+            var rel = Relative(root, file);
+            if (rel.Contains("/bin/") || rel.Contains("/obj/")) continue;
+            if (IsTestProject(rel)) continue;
+            if (RootOwners.Contains(rel, StringComparer.OrdinalIgnoreCase)) continue;
+
+            if (!RederivesRoot(File.ReadAllText(file))) continue;
+
+            allMatches.Add(rel);
+            if (!KnownOffenders.Contains(rel, StringComparer.OrdinalIgnoreCase))
+                offenders.Add(rel);
+        }
+
+        return offenders;
+    }
+
+    /// <summary>
+    /// True when the text resolves LocalApplicationData/MyDocuments and names "cc-director" within a few
+    /// lines of it - i.e. builds our own root rather than reading someone else's folder. Deliberately
+    /// narrow: production legitimately resolves real folders for OTHER things (~/.claude, ~/.codex,
+    /// Program Files browsers, the Start Menu), and banning that outright would be wrong.
+    /// </summary>
+    private static bool RederivesRoot(string text)
+    {
+        var lines = text.Split('\n');
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (!lines[i].Contains("SpecialFolder.LocalApplicationData", StringComparison.Ordinal)
+                && !lines[i].Contains("SpecialFolder.MyDocuments", StringComparison.Ordinal))
+                continue;
+
+            // The folder name usually lands on the same line or the next few (Path.Combine wraps).
+            var window = string.Join('\n', lines.Skip(i).Take(4));
+            if (window.Contains("\"cc-director\"", StringComparison.Ordinal))
+                return true;
+        }
+        return false;
+    }
+
+    private static bool IsTestProject(string rel)
+        => rel.Contains(".Tests/", StringComparison.OrdinalIgnoreCase);
+
+    private static string Relative(string root, string full)
+        => Path.GetRelativePath(root, full).Replace('\\', '/');
+
+    private static string GetRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "cc-director.sln")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+}

--- a/src/CcDirector.Core/Storage/CcStorage.cs
+++ b/src/CcDirector.Core/Storage/CcStorage.cs
@@ -67,9 +67,19 @@ public static class CcStorage
         return Path.Combine(Config(), "director", "instances");
     }
 
-    /// <summary>Generated files: PDFs, reports, transcripts, exports.</summary>
+    /// <summary>
+    /// Generated files: PDFs, reports, transcripts, exports. Lives in the user's Documents folder by
+    /// design - these are files the user opens - but honors CC_DIRECTOR_ROOT when set so a test that
+    /// pins the root cannot write into the real Documents\cc-director. The product never sets the root,
+    /// so its location is unchanged. Same fix already applied to <see cref="Bin"/> and
+    /// <see cref="Screenshots"/>; this was the last path here that ignored the override.
+    /// </summary>
     public static string Output()
     {
+        var overrideRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        if (!string.IsNullOrEmpty(overrideRoot))
+            return Path.Combine(overrideRoot, "output");
+
         var docs = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
         return Path.Combine(docs, "cc-director");
     }


### PR DESCRIPTION
Third follow-up to #1577 / #1580. Those fixed the leaks that had tests pointed at them. This makes the rule **enforced instead of remembered**.

## What the audit actually found

The two classes fixed in #1580 were not aberrations. **22 production files in `src/` compose the cc-director storage root by hand.** It is the house style. Every one of them is unredirectable by `CC_DIRECTOR_ROOT`, and so writes into the user's real folders the moment a test reaches it. The two that leaked were simply the two that had tests.

Convention has now failed four times:

| When | What |
|---|---|
| #1577 | Screenshots upload proof left a 50 KB undrawable file in the owner's gallery every Gateway run |
| #1580 | `StateChangeLog` + `VoiceUtteranceService` appended into the live Director's data directory |
| #179 / #200 | Test hosts clobbered the **production Tailscale serve table** every fixture - the long-standing "mystery clobberer", invisible to CI |

Each was written by someone being careful. Care is not a control.

## The guard

`StorageRootGuardTests` is an architecture fitness function in the shape this repo already uses for banned patterns (`GatewayOnlyTranscriptionGuardTests`, `PrintBanAuditTests`, and friends). It fails the build when production code resolves `LocalApplicationData`/`MyDocuments` and pins `"cc-director"` under it instead of asking `CcStorage`.

It is deliberately narrow. Production legitimately resolves real folders for **other** things - `~/.claude`, `~/.codex`, Program Files browser discovery, the Start Menu - and banning `SpecialFolder` outright would be wrong (~130 call sites, most of them the product doing its job). The installers under `tools/cc-director-setup*` are out of scope because they **define** the install root rather than consume it: they are the code that creates the folder `CcStorage` later reads.

The 22 existing call sites are frozen in a `KnownOffenders` burn-down list. The rule is mandatory for new code **today**, and the backlog is visible in source rather than living as folklore. A second test fails if an entry that no longer offends is left in the list, so it can only ever shrink.

The guard found two call sites my own manual grep missed - `AgentPluginRegistry` and `RecordingEndpoints`. That is the argument for automating it rather than trusting a careful reader. `RecordingEndpoints` also hand-builds a **vault** path, bypassing `CcStorage.Vault()` and its `CC_VAULT_PATH` override; it is flagged in the list for early burn-down.

## CcStorage.Output()

Now honors `CC_DIRECTOR_ROOT` - the last path in `CcStorage` that ignored it, after `Bin()` and `Screenshots()`. No test reaches it today (only `QuickActionService` calls it), so this closes it while it is still latent rather than after it bites. `Documents\cc-director` is unchanged in production, which the fourth test pins explicitly.

## Verification

- **The guard fails on a planted new offender and names the file.** I added a fake hand-rolled root, watched the guard go red pointing at it, and removed it.
- **The `Output()` tests fail against the old resolution** - checked by reverting the fix. The test asserting the production location still passes, so the change is provably invisible to the product.
- Core: 3081 passed, 0 failed. Gateway: 2217 passed, 0 failed. Repo clean after both runs.

## Deliberately NOT done

Pinning `CC_DIRECTOR_ROOT` assembly-wide so tests are isolated by default - the other half of "mandatory".

`ToolManifestTests` reads the **real** `CcStorage.Bin()` and early-returns when the folder is absent:

```csharp
var binDir = CcStorage.Bin();
if (!Directory.Exists(binDir)) return; // nothing built - nothing to verify
```

Under a blanket pin that resolves to an empty temp dir, so the test silently becomes a permanent green no-op instead of failing loudly. That is worse than the leak it would prevent: a test that stopped testing without telling anyone. Gateway's `TestEnvironment` already declined the same idea **in writing**, for the same reason ("the whole storage root is left alone, so tests that read other real storage are unaffected").

Inverting that default is the right end state, but it requires the handful of tests that genuinely need the real root to opt OUT explicitly first. That is a design change, not a patch, and it should not ride along here.

Generated with [Claude Code](https://claude.com/claude-code)
