### PR TITLE
refactor(core): burn down the storage-root list to empty

### DIFF
--- a/src/CcDirector.AgentBrain/BrainLog.cs
+++ b/src/CcDirector.AgentBrain/BrainLog.cs
@@ -10,9 +10,27 @@ public static class BrainLog
 {
     private static readonly object Gate = new();
 
-    private static readonly string Dir = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "cc-director", "logs", "agent-brain");
+    /// <summary>
+    /// base/logs/agent-brain/. This is the ONE place outside CcStorage allowed to compose the
+    /// cc-director root, because this library deliberately has no project references (see the class
+    /// summary) and so cannot call CcStorage - StorageRootGuardTests carries a matching exemption.
+    /// It therefore honors CC_DIRECTOR_ROOT by hand, exactly as CcStorage.Base() does, so a test that
+    /// pins the root cannot be written into the real Director's log folder. Resolved per access, not
+    /// baked into a static readonly field: a field is captured at type load and no test can undo it.
+    /// </summary>
+    private static string Dir
+    {
+        get
+        {
+            var overrideRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+            var root = !string.IsNullOrEmpty(overrideRoot)
+                ? overrideRoot
+                : Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "cc-director");
+            return Path.Combine(root, "logs", "agent-brain");
+        }
+    }
 
     public static void Write(string message)
     {

--- a/src/CcDirector.Avalonia/App.axaml.cs
+++ b/src/CcDirector.Avalonia/App.axaml.cs
@@ -539,9 +539,7 @@ public partial class App : Application
     {
         try
         {
-            var dir = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "cc-director", "logs", "director");
+            var dir = CcStorage.ToolLogs("director");
             Directory.CreateDirectory(dir);
             var path = Path.Combine(dir, $"crash-startup-{DateTime.Now:yyyyMMdd-HHmmss}-{Environment.ProcessId}.log");
             File.WriteAllText(path, $"[startup] {DateTime.Now:o}\n\n{ex}\n");

--- a/src/CcDirector.Avalonia/Controls/CommManager/CommManagerViewModel.cs
+++ b/src/CcDirector.Avalonia/Controls/CommManager/CommManagerViewModel.cs
@@ -1073,10 +1073,7 @@ public partial class CommManagerViewModel : ObservableObject, IDisposable
         FileLog.Write($"[CommManager.VM] LogToVaultAsync: ticket #{ticketNumber}");
         try
         {
-            var binDir = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "cc-director", "bin");
-            var toolPath = Path.Combine(binDir, "cc-comm-queue.exe");
+            var toolPath = Path.Combine(CcStorage.Bin(), "cc-comm-queue.exe");
 
             if (!File.Exists(toolPath))
             {

--- a/src/CcDirector.Avalonia/Controls/ConnectionsView.axaml.cs
+++ b/src/CcDirector.Avalonia/Controls/ConnectionsView.axaml.cs
@@ -352,8 +352,7 @@ public partial class ConnectionsView : UserControl
 
         FileLog.Write("[ConnectionsView] EnsureDaemonRunningAsync: daemon not running, starting...");
 
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        var ccBrowserPath = Path.Combine(localAppData, "cc-director", "bin", "cc-browser.cmd");
+        var ccBrowserPath = Path.Combine(CcStorage.Bin(), "cc-browser.cmd");
 
         if (!File.Exists(ccBrowserPath))
         {

--- a/src/CcDirector.Avalonia/Program.cs
+++ b/src/CcDirector.Avalonia/Program.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using Avalonia;
 using CcDirector.ControlApi;
+using CcDirector.Core.Storage;
 using CcDirector.Core.Update;
 using CcDirector.Core.Utilities;
 
@@ -154,9 +155,7 @@ internal static class Program
     {
         try
         {
-            var dir = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "cc-director", "logs", "director");
+            var dir = CcStorage.ToolLogs("director");
             Directory.CreateDirectory(dir);
             // No Date.Now in a reproducible context is fine here -- this is a real crash path.
             var path = Path.Combine(dir, $"crash-{kind}-{DateTime.Now:yyyyMMdd-HHmmss}-{Environment.ProcessId}.log");

--- a/src/CcDirector.Core.Tests/Storage/CcStorageProductionLocationTests.cs
+++ b/src/CcDirector.Core.Tests/Storage/CcStorageProductionLocationTests.cs
@@ -1,0 +1,104 @@
+using CcDirector.Core.Storage;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Storage;
+
+/// <summary>
+/// Pins WHERE the user's data lives when CC_DIRECTOR_ROOT is not set - which is always, in the product.
+///
+/// The burn-down moved 22 call sites off hand-rolled paths and onto CcStorage. Every one of those
+/// folders already held real user data on real machines, so the refactor is only safe if each method
+/// resolves to the exact path its old hand-rolled expression produced. A silent change here does not
+/// throw or fail a test elsewhere - it just quietly orphans the user's existing recordings, logs, hooks
+/// or transcripts and starts writing somewhere new, which is the kind of bug you find months later.
+///
+/// Each expectation is the literal path the old code composed, written out rather than derived from
+/// Base(), so this fails if Base() itself ever moves too.
+///
+/// The paths are resolved INSIDE the test, never in a MemberData/TheoryData member: those are evaluated
+/// at discovery time, before this class's constructor clears the root, so they would capture whatever
+/// CC_DIRECTOR_ROOT another test class happened to have set and assert nothing useful.
+/// </summary>
+[Collection("CcStorageRoot")] // serializes all classes that mutate the process-wide CC_DIRECTOR_ROOT
+public sealed class CcStorageProductionLocationTests : IDisposable
+{
+    private readonly string? _prevRoot;
+
+    public CcStorageProductionLocationTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", null); // the product never sets it
+    }
+
+    public void Dispose() => Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+
+    private static string Local(params string[] parts)
+        => Path.Combine(new[]
+        {
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "cc-director",
+        }.Concat(parts).ToArray());
+
+    [Fact]
+    public void Every_burned_down_folder_resolves_where_the_hand_rolled_code_put_it()
+    {
+        var expected = new (string Actual, string Expected, string Name)[]
+        {
+            (CcStorage.AgentPlugins(), Local("agent-plugins"), nameof(CcStorage.AgentPlugins)),
+            (CcStorage.ClaudeHooks(), Local("claude-hooks"), nameof(CcStorage.ClaudeHooks)),
+            (CcStorage.CodexHooks(), Local("codex-hooks"), nameof(CcStorage.CodexHooks)),
+            (CcStorage.CredentialsEnv(), Local("config", "credentials.env"), nameof(CcStorage.CredentialsEnv)),
+            (CcStorage.Dictation(), Local("dictation"), nameof(CcStorage.Dictation)),
+            (CcStorage.DictationDictionary(), Local("dictation", "dictionary.yaml"), nameof(CcStorage.DictationDictionary)),
+            (CcStorage.DictationRecordings(), Local("dictation", "recordings"), nameof(CcStorage.DictationRecordings)),
+            (CcStorage.DictationSessions(), Local("dictation", "sessions"), nameof(CcStorage.DictationSessions)),
+            (CcStorage.PiPreamble(), Local("pi-preamble"), nameof(CcStorage.PiPreamble)),
+            (CcStorage.SessionRecordings(), Local("session-recordings"), nameof(CcStorage.SessionRecordings)),
+            (CcStorage.StateChanges(), Local("state-changes"), nameof(CcStorage.StateChanges)),
+            (CcStorage.VoiceUtterances(), Local("voice-utterances"), nameof(CcStorage.VoiceUtterances)),
+            (CcStorage.Transcripts(), Local("transcripts"), nameof(CcStorage.Transcripts)),
+            (CcStorage.PromptLog(), Local("prompt-log"), nameof(CcStorage.PromptLog)),
+            (CcStorage.TranscriptionLog(), Local("transcription-log"), nameof(CcStorage.TranscriptionLog)),
+            (CcStorage.TerminalCaptures(), Local("terminal-captures"), nameof(CcStorage.TerminalCaptures)),
+            (CcStorage.WebView2Card(), Local("webview2-card"), nameof(CcStorage.WebView2Card)),
+            (CcStorage.Bin(), Local("bin"), nameof(CcStorage.Bin)),
+            (CcStorage.ToolLogs("director"), Local("logs", "director"), "ToolLogs(director)"),
+            // AgentBrain composes this by hand under an exemption; it must still land where it always has.
+            (CcStorage.ToolLogs("agent-brain"), Local("logs", "agent-brain"), "ToolLogs(agent-brain)"),
+        };
+
+        var moved = expected
+            .Where(e => !string.Equals(
+                Path.TrimEndingDirectorySeparator(e.Actual),
+                Path.TrimEndingDirectorySeparator(e.Expected),
+                StringComparison.OrdinalIgnoreCase))
+            .Select(e => $"{e.Name}: expected {e.Expected} but got {e.Actual}")
+            .ToList();
+
+        Assert.True(moved.Count == 0,
+            "These folders MOVED. Existing user data is still at the old path and would be silently "
+            + "orphaned:\n  " + string.Join("\n  ", moved));
+    }
+
+    [Fact]
+    public void VaultTranscripts_follows_the_vault_not_the_storage_root()
+    {
+        // RecordingEndpoints used to hardcode LocalAppData\cc-director\vault\transcripts, which ignored
+        // CC_VAULT_PATH. Going through Vault() is what makes a relocated vault work; this pins that the
+        // promotion target follows the vault override rather than the storage root.
+        var prevVault = Environment.GetEnvironmentVariable("CC_VAULT_PATH");
+        var vault = Path.Combine(Path.GetTempPath(), "ccd-vault-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Environment.SetEnvironmentVariable("CC_VAULT_PATH", vault);
+
+            Assert.Equal(
+                Path.TrimEndingDirectorySeparator(Path.Combine(vault, "transcripts")),
+                Path.TrimEndingDirectorySeparator(CcStorage.VaultTranscripts()));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CC_VAULT_PATH", prevVault);
+        }
+    }
+}

--- a/src/CcDirector.Core.Tests/StorageRootGuardTests.cs
+++ b/src/CcDirector.Core.Tests/StorageRootGuardTests.cs
@@ -29,45 +29,28 @@ namespace CcDirector.Core.Tests;
 public sealed class StorageRootGuardTests
 {
     /// <summary>
-    /// Call sites that re-derived the storage root before this guard existed. BURN-DOWN LIST: delete
-    /// entries as they move to CcStorage; never add one. Every file here is latent in the same way the
-    /// two fixed in #1580 were - harmless only until a test touches it.
+    /// BURN-DOWN LIST: EMPTY, and it must stay that way. All 22 call sites that predated this guard have
+    /// been moved onto CcStorage. Adding an entry here is not a way to land code that re-derives the
+    /// root - it is the exception list for a debt that no longer exists. If a new call site needs a
+    /// folder CcStorage has no method for, add the method; that is the whole point.
     /// </summary>
-    private static readonly string[] KnownOffenders =
-    {
-        "src/CcDirector.AgentBrain/BrainLog.cs",
-        "src/CcDirector.Avalonia/App.axaml.cs",
-        "src/CcDirector.Avalonia/Controls/CommManager/CommManagerViewModel.cs",
-        "src/CcDirector.Avalonia/Controls/ConnectionsView.axaml.cs",
-        "src/CcDirector.Avalonia/Program.cs",
-        "src/CcDirector.Core/AgentPlugins/AgentPluginRegistry.cs",
-        "src/CcDirector.Core/Backends/GitHubCredentials.cs",
-        "src/CcDirector.Core/Claude/ClaudeHookInstaller.cs",
-        "src/CcDirector.Core/Codex/CodexHookInstaller.cs",
-        "src/CcDirector.Core/Configuration/AgentOptions.cs",
-        "src/CcDirector.Core/Dictation/DictationRecordingStore.cs",
-        "src/CcDirector.Core/Dictation/DictationSessionLog.cs",
-        "src/CcDirector.Core/Pi/PiPreambleWriter.cs",
-        "src/CcDirector.Core/Wingman/TerminalSessionRecorder.cs",
-        "src/CcDirector.Gateway/Api/GatewayEndpoints.cs",
-        "src/CcDirector.Gateway/Api/ItemStatusEndpoint.cs",
-        // Also hand-builds a VAULT path, so it bypasses CcStorage.Vault() and its CC_VAULT_PATH
-        // override too - worth taking early when this list is burned down.
-        "src/CcDirector.Gateway/Api/RecordingEndpoints.cs",
-        "src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs",
-        "src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs",
-        "src/CcDirector.Gateway/Transcription/TranscriptionTelemetryLog.cs",
-        "src/CcDirector.Terminal.Avalonia/TerminalControl.cs",
-        "src/CcDirector.Terminal/Rendering/CardView/CardWebView.xaml.cs",
-    };
+    private static readonly string[] KnownOffenders = Array.Empty<string>();
 
     /// <summary>CcStorage owns the root, so it is the one place allowed to resolve it from the OS.
     /// CcStorageMigration moves data between the old and new real locations, which it cannot do
-    /// through the very abstraction it is migrating.</summary>
+    /// through the very abstraction it is migrating.
+    ///
+    /// BrainLog is the one genuine exception: CcDirector.AgentBrain is a standalone library with NO
+    /// project references by design ("reused across many host programs, so it cannot depend on
+    /// CcDirector.Core's FileLog"), so it cannot call CcStorage without breaking that boundary. It
+    /// pays for the exemption by honoring CC_DIRECTOR_ROOT by hand, which is what actually matters -
+    /// the rule is "be redirectable", and using CcStorage is just the normal way to achieve it.
+    /// Anything added here must clear the same bar, and "it was easier" does not.</summary>
     private static readonly string[] RootOwners =
     {
         "src/CcDirector.Core/Storage/CcStorage.cs",
         "src/CcDirector.Core/Storage/CcStorageMigration.cs",
+        "src/CcDirector.AgentBrain/BrainLog.cs",
     };
 
     [Fact]
@@ -81,6 +64,22 @@ public sealed class StorageRootGuardTests
             + "into the user's REAL Director folders (see #1577 / #1580). Use CcStorage - add a method "
             + "there if the folder has none yet:\n  "
             + string.Join("\n  ", offenders));
+    }
+
+    [Fact]
+    public void BrainLog_pays_for_its_exemption_by_honoring_the_root()
+    {
+        // The exemption is conditional, so the condition is tested rather than trusted: AgentBrain may
+        // skip CcStorage (no project references by design), but it must still be redirectable. Without
+        // this, "cannot use CcStorage" would be a loophole that reintroduces the exact unredirectable
+        // path the guard exists to prevent.
+        var file = Path.Combine(GetRepoRoot(), "src", "CcDirector.AgentBrain", "BrainLog.cs");
+        var text = File.ReadAllText(file);
+
+        Assert.True(text.Contains("CC_DIRECTOR_ROOT", StringComparison.Ordinal),
+            "BrainLog is exempt from using CcStorage because CcDirector.AgentBrain has no project "
+            + "references by design - but it must still honor CC_DIRECTOR_ROOT by hand, or a test that "
+            + "pins the root writes into the real Director's log folder.");
     }
 
     [Fact]

--- a/src/CcDirector.Core/AgentPlugins/AgentPluginRegistry.cs
+++ b/src/CcDirector.Core/AgentPlugins/AgentPluginRegistry.cs
@@ -1,5 +1,6 @@
 using CcDirector.Core.Agents;
 using CcDirector.Core.Configuration;
+using CcDirector.Core.Storage;
 
 namespace CcDirector.Core.AgentPlugins;
 
@@ -78,10 +79,7 @@ public static class AgentPluginRegistry
         if (!string.IsNullOrWhiteSpace(fromEnv))
             return fromEnv;
 
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        return string.IsNullOrWhiteSpace(localAppData)
-            ? string.Empty
-            : Path.Combine(localAppData, "cc-director", "agent-plugins");
+        return CcStorage.AgentPlugins();
     }
 
     private static IReadOnlyList<IAgentPlugin> BuildBuiltIns() =>

--- a/src/CcDirector.Core/Backends/GitHubCredentials.cs
+++ b/src/CcDirector.Core/Backends/GitHubCredentials.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Core.Backends;
@@ -15,14 +16,7 @@ public static class GitHubCredentials
     /// Resolve the credentials.env path. Honors LOCALAPPDATA on Windows and falls
     /// back to the OS-specific local application data folder elsewhere.
     /// </summary>
-    public static string CredentialsPath
-    {
-        get
-        {
-            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            return Path.Combine(localAppData, "cc-director", "config", "credentials.env");
-        }
-    }
+    public static string CredentialsPath => CcStorage.CredentialsEnv();
 
     /// <summary>
     /// Read GITHUB_TOKEN. Throws with an explicit, fixable message when the file

--- a/src/CcDirector.Core/Claude/ClaudeHookInstaller.cs
+++ b/src/CcDirector.Core/Claude/ClaudeHookInstaller.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Core.Claude;
@@ -129,10 +130,7 @@ public static class ClaudeHookInstaller
         }
     }
 
-    private static string DefaultDirectory()
-        => Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "cc-director", "claude-hooks");
+    private static string DefaultDirectory() => CcStorage.ClaudeHooks();
 
     private static string BuildSettingsJson(string scriptPath, bool forWindows)
     {

--- a/src/CcDirector.Core/Codex/CodexHookInstaller.cs
+++ b/src/CcDirector.Core/Codex/CodexHookInstaller.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Core.Codex;
@@ -145,10 +146,7 @@ public static class CodexHookInstaller
             ?? throw new InvalidOperationException($"hooks.json is not a JSON object: {hooksJsonPath}");
     }
 
-    private static string DefaultScriptDirectory()
-        => Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "cc-director", "codex-hooks");
+    private static string DefaultScriptDirectory() => CcStorage.CodexHooks();
 
     private static string DefaultCodexHooksPath()
     {

--- a/src/CcDirector.Core/Configuration/AgentOptions.cs
+++ b/src/CcDirector.Core/Configuration/AgentOptions.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Core.Configuration;
@@ -178,8 +179,7 @@ public class AgentOptions
     {
         if (!string.IsNullOrWhiteSpace(DictationDictionaryPath))
             return DictationDictionaryPath;
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        return Path.Combine(localAppData, "cc-director", "dictation", "dictionary.yaml");
+        return CcStorage.DictationDictionary();
     }
 
     /// <summary>

--- a/src/CcDirector.Core/Dictation/DictationRecordingStore.cs
+++ b/src/CcDirector.Core/Dictation/DictationRecordingStore.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Core.Dictation;
@@ -13,10 +14,10 @@ namespace CcDirector.Core.Dictation;
 /// </summary>
 public static class DictationRecordingStore
 {
-    /// <summary>Where recordings are kept: %LOCALAPPDATA%\cc-director\dictation\recordings.</summary>
-    public static string DefaultDirectory { get; } = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "cc-director", "dictation", "recordings");
+    /// <summary>Where recordings are kept: base/dictation/recordings. Resolved per access, not baked
+    /// into a get-only initializer, so CC_DIRECTOR_ROOT redirects it - an initializer runs once at type
+    /// load and no test can undo it.</summary>
+    public static string DefaultDirectory => CcStorage.DictationRecordings();
 
     /// <summary>
     /// Save one recorded WAV clip and return the full path of the saved file, or null when saving

--- a/src/CcDirector.Core/Dictation/DictationSessionLog.cs
+++ b/src/CcDirector.Core/Dictation/DictationSessionLog.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Core.Dictation;
@@ -44,11 +45,7 @@ public static class DictationSessionLog
         }
     }
 
-    private static string ResolveDir()
-    {
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        return Path.Combine(localAppData, "cc-director", "dictation", "sessions");
-    }
+    private static string ResolveDir() => CcStorage.DictationSessions();
 }
 
 /// <summary>

--- a/src/CcDirector.Core/Pi/PiPreambleWriter.cs
+++ b/src/CcDirector.Core/Pi/PiPreambleWriter.cs
@@ -1,5 +1,6 @@
 using CcDirector.Core.Account;
 using CcDirector.Core.Sessions;
+using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Core.Pi;
@@ -43,8 +44,5 @@ public static class PiPreambleWriter
         return path;
     }
 
-    private static string DefaultDirectory()
-        => Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "cc-director", "pi-preamble");
+    private static string DefaultDirectory() => CcStorage.PiPreamble();
 }

--- a/src/CcDirector.Core/Storage/CcStorage.cs
+++ b/src/CcDirector.Core/Storage/CcStorage.cs
@@ -167,6 +167,62 @@ public static class CcStorage
 
     // -- Tool-specific shortcuts --
 
+    // -- Feature folders --
+    //
+    // Each of these used to be composed by hand at its call site from
+    // GetFolderPath(LocalApplicationData) + "cc-director" + ..., which produced a path that
+    // CC_DIRECTOR_ROOT could not redirect - so any test reaching that code wrote into the real
+    // running Director's folders (#1577, #1580). They are declared here, once, so the root has a
+    // single owner. StorageRootGuardTests fails the build if a new hand-rolled one appears.
+
+    /// <summary>The shared credentials file every tool reads: config/credentials.env.</summary>
+    public static string CredentialsEnv() => Path.Combine(Config(), "credentials.env");
+
+    /// <summary>Installed agent plugin manifests: base/agent-plugins/.</summary>
+    public static string AgentPlugins() => Path.Combine(Base(), "agent-plugins");
+
+    /// <summary>Claude hook scripts the Director installs: base/claude-hooks/.</summary>
+    public static string ClaudeHooks() => Path.Combine(Base(), "claude-hooks");
+
+    /// <summary>Codex hook scripts the Director installs: base/codex-hooks/.</summary>
+    public static string CodexHooks() => Path.Combine(Base(), "codex-hooks");
+
+    /// <summary>Dictation root: base/dictation/. Holds the user dictionary plus the
+    /// recordings/ and sessions/ subfolders.</summary>
+    public static string Dictation() => Path.Combine(Base(), "dictation");
+
+    /// <summary>The user's dictation dictionary: base/dictation/dictionary.yaml. Read by both the
+    /// Director and the Gateway transcription owner, which composed it separately before.</summary>
+    public static string DictationDictionary() => Path.Combine(Dictation(), "dictionary.yaml");
+
+    /// <summary>Durable dictation audio: base/dictation/recordings/.</summary>
+    public static string DictationRecordings() => Path.Combine(Dictation(), "recordings");
+
+    /// <summary>Per-session dictation logs: base/dictation/sessions/.</summary>
+    public static string DictationSessions() => Path.Combine(Dictation(), "sessions");
+
+    /// <summary>The preamble file handed to the Pi agent: base/pi-preamble/.</summary>
+    public static string PiPreamble() => Path.Combine(Base(), "pi-preamble");
+
+    /// <summary>Recorded terminal sessions: base/session-recordings/.</summary>
+    public static string SessionRecordings() => Path.Combine(Base(), "session-recordings");
+
+    /// <summary>Transient recording transcripts (audio + markdown) before the user promotes the
+    /// keepers into the vault: base/transcripts/.</summary>
+    public static string Transcripts() => Path.Combine(Base(), "transcripts");
+
+    /// <summary>The Gateway's durable prompt + reply record: base/prompt-log/.</summary>
+    public static string PromptLog() => Path.Combine(Base(), "prompt-log");
+
+    /// <summary>Transcription telemetry: base/transcription-log/.</summary>
+    public static string TranscriptionLog() => Path.Combine(Base(), "transcription-log");
+
+    /// <summary>Terminal screen captures: base/terminal-captures/.</summary>
+    public static string TerminalCaptures() => Path.Combine(Base(), "terminal-captures");
+
+    /// <summary>WebView2 user-data directory for the card renderer: base/webview2-card/.</summary>
+    public static string WebView2Card() => Path.Combine(Base(), "webview2-card");
+
     /// <summary>Config directory for a specific tool: config/{tool}/</summary>
     public static string ToolConfig(string tool) => Path.Combine(Config(), tool);
 
@@ -189,6 +245,11 @@ public static class CcStorage
 
     /// <summary>Imported files: vault/documents/</summary>
     public static string VaultDocuments() => Path.Combine(Vault(), "documents");
+
+    /// <summary>Promoted recording transcripts (the permanent copy): vault/transcripts/. RecordingEndpoints
+    /// hardcoded LocalApplicationData + "cc-director/vault/transcripts", which ignored CC_VAULT_PATH and so
+    /// would have promoted into the wrong vault for anyone who relocated theirs.</summary>
+    public static string VaultTranscripts() => Path.Combine(Vault(), "transcripts");
 
     /// <summary>Embeddings: vault/vectors/</summary>
     public static string VaultVectors() => Path.Combine(Vault(), "vectors");

--- a/src/CcDirector.Core/Wingman/TerminalSessionRecorder.cs
+++ b/src/CcDirector.Core/Wingman/TerminalSessionRecorder.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 using CcDirector.Core.Memory;
 using CcDirector.Core.Sessions;
+using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Core.Wingman;
@@ -39,9 +40,7 @@ public sealed class TerminalSessionRecorder : IDisposable
     public TerminalSessionRecorder(SessionManager sessionManager, string? root = null, long maxBytesPerSession = 8L * 1024 * 1024)
     {
         _sessionManager = sessionManager;
-        _root = root ?? Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "cc-director", "session-recordings");
+        _root = root ?? CcStorage.SessionRecordings();
         _maxBytesPerSession = maxBytesPerSession;
     }
 

--- a/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/GatewayEndpoints.cs
@@ -2700,8 +2700,7 @@ internal static class GatewayEndpoints
         }
 
         // 3) Standard install location (only used when nothing better was found)
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        var bin = Path.Combine(localAppData, "cc-director", "bin");
+        var bin = CcStorage.Bin();
         foreach (var name in names)
         {
             var candidate = Path.Combine(bin, name);

--- a/src/CcDirector.Gateway/Api/ItemStatusEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/ItemStatusEndpoint.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -216,8 +217,7 @@ internal sealed class GitHubItemStatusResolver
     /// </summary>
     private static (string? token, string? error) ReadCredentialsFileToken()
     {
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        var path = Path.Combine(localAppData, "cc-director", "config", "credentials.env");
+        var path = CcStorage.CredentialsEnv();
         if (!File.Exists(path))
             return (null, $"GITHUB_TOKEN not configured (no {path}); per-item GitHub status unavailable.");
 

--- a/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/RecordingEndpoints.cs
@@ -5,6 +5,7 @@ using CcDirector.Core.Dictation;
 using CcDirector.Core.Dictation.Models;
 using CcDirector.Core.Network;
 using CcDirector.Core.Recording;
+using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 using CcDirector.Gateway.Transcription;
@@ -407,12 +408,13 @@ internal static class RecordingEndpoints
 
     private static RecordingIngestService BuildService()
     {
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         // Local transient store for transcripts (audio + markdown). Transcripts
         // are NOT auto-filed into the vault; the user promotes the keepers.
-        var root = Path.Combine(localAppData, "cc-director", "transcripts");
-        // Promotion target: the vault transcripts collection (permanent copy).
-        var collectionDir = Path.Combine(localAppData, "cc-director", "vault", "transcripts");
+        var root = CcStorage.Transcripts();
+        // Promotion target: the vault transcripts collection (permanent copy). Via CcStorage.Vault()
+        // so it honors CC_VAULT_PATH - the old hardcoded path would have promoted into the wrong
+        // place for anyone who relocated their vault.
+        var collectionDir = CcStorage.VaultTranscripts();
 
         FileLog.Write($"[RecordingEndpoints] BuildService: root={root}, collection={collectionDir}");
 

--- a/src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs
+++ b/src/CcDirector.Gateway/Prompts/GatewayPromptLog.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway.Contracts;
 
@@ -47,11 +48,7 @@ public sealed class GatewayPromptLog
     }
 
     /// <summary>The Gateway's prompt-log directory.</summary>
-    public static string DefaultDirectory()
-    {
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        return Path.Combine(localAppData, "cc-director", "prompt-log");
-    }
+    public static string DefaultDirectory() => CcStorage.PromptLog();
 
     /// <summary>The daily file a message at <paramref name="utcNow"/> lands in.</summary>
     public string FileFor(DateTime utcNow)

--- a/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
+++ b/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
@@ -3,6 +3,7 @@ using CcDirector.Core;
 using CcDirector.Core.Configuration;
 using CcDirector.Core.Dictation;
 using CcDirector.Core.Dictation.Models;
+using CcDirector.Core.Storage;
 using CcDirector.Core.Transcription;
 using CcDirector.Core.Utilities;
 
@@ -282,11 +283,9 @@ public sealed class GatewayTranscriptionService
     /// The single shared dictation glossary file used by both the recording transcriber and the
     /// dictionary editor endpoints, so the path is defined in exactly one place.
     /// </summary>
-    public static string DictionaryPath()
-    {
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        return Path.Combine(localAppData, "cc-director", "dictation", "dictionary.yaml");
-    }
+    /// <remarks>The Director composes this same path via AgentOptions.ResolveDictationDictionaryPath;
+    /// both now go through CcStorage so the two cannot drift apart.</remarks>
+    public static string DictionaryPath() => CcStorage.DictationDictionary();
 
     /// <summary>The file extension (no dot) for an audio MIME type, used to name the upload so a
     /// remote provider decodes the bytes correctly. Defaults to <c>webm</c> (what browsers record).</summary>

--- a/src/CcDirector.Gateway/Transcription/TranscriptionTelemetryLog.cs
+++ b/src/CcDirector.Gateway/Transcription/TranscriptionTelemetryLog.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using CcDirector.Core.Dictation;
+using CcDirector.Core.Storage;
 using CcDirector.Core.Utilities;
 
 namespace CcDirector.Gateway.Transcription;
@@ -46,11 +47,7 @@ public sealed class TranscriptionTelemetryLog
     }
 
     /// <summary>The per-user transcription-log directory.</summary>
-    public static string DefaultDirectory()
-    {
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        return Path.Combine(localAppData, "cc-director", "transcription-log");
-    }
+    public static string DefaultDirectory() => CcStorage.TranscriptionLog();
 
     /// <summary>The daily file a record written at <paramref name="utcNow"/> lands in.</summary>
     public string FileFor(DateTime utcNow)

--- a/src/CcDirector.Terminal.Avalonia/TerminalControl.cs
+++ b/src/CcDirector.Terminal.Avalonia/TerminalControl.cs
@@ -505,9 +505,7 @@ public class TerminalControl : Control
     {
         try
         {
-            var dir = System.IO.Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "cc-director", "terminal-captures");
+            var dir = CcDirector.Core.Storage.CcStorage.TerminalCaptures();
             System.IO.Directory.CreateDirectory(dir);
 
             var ts = DateTime.Now.ToString("yyyyMMdd-HHmmss");

--- a/src/CcDirector.Terminal/Rendering/CardView/CardWebView.xaml.cs
+++ b/src/CcDirector.Terminal/Rendering/CardView/CardWebView.xaml.cs
@@ -52,9 +52,7 @@ public partial class CardWebView : UserControl
         FileLog.Write("[CardWebView] Loaded, initializing WebView2");
         try
         {
-            var userDataFolder = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "cc-director", "webview2-card");
+            var userDataFolder = CcDirector.Core.Storage.CcStorage.WebView2Card();
 
             var env = await CoreWebView2Environment.CreateAsync(null, userDataFolder);
             await WebView.EnsureCoreWebView2Async(env);


### PR DESCRIPTION
#1582 froze 22 production call sites that composed the cc-director storage root by hand, and made the rule mandatory for new code. **This clears the backlog.** The burn-down list is now empty, and the guard passes with it empty.

## What moved onto CcStorage

All 22. Eleven folders had no method, so they are now declared in `CcStorage` once instead of at each call site:

`AgentPlugins` · `ClaudeHooks` · `CodexHooks` · `Dictation` (+ `Dictionary`/`Recordings`/`Sessions`) · `PiPreamble` · `SessionRecordings` · `Transcripts` · `PromptLog` · `TranscriptionLog` · `TerminalCaptures` · `WebView2Card` · `CredentialsEnv` · `VaultTranscripts`

The rest reuse the existing `Bin()`, `ToolLogs()` and `Config()`.

Two more baked-at-type-load paths died with them: `DictationRecordingStore.DefaultDirectory` was a get-only initializer - the same trap as the two `static readonly` fields fixed in #1580, captured once at type load and unredirectable forever after. Both now resolve per access.

## Two latent bugs fell out of the mechanical work

- **`RecordingEndpoints` was promoting into the wrong vault.** It hardcoded `LocalAppData\cc-director\vault\transcripts`, ignoring `CC_VAULT_PATH` entirely - so anyone who relocated their vault would have had recordings promoted into a stale directory that nothing else reads. Now goes through `CcStorage.Vault()`. No change on a default machine, where `CC_VAULT_PATH` points at the default path anyway.
- **The dictation dictionary path was composed twice.** `AgentOptions` (Director) and `GatewayTranscriptionService` (Gateway) each built it independently, free to drift apart. Both now call `CcStorage.DictationDictionary()`.

## The one exemption, and why it is not a loophole

`BrainLog` stays hand-rolled. `CcDirector.AgentBrain` has **no project references at all**, by design - "reused across many host programs, so it cannot depend on CcDirector.Core's FileLog" - so calling `CcStorage` would break that boundary for a logging path.

It pays for the exemption by honoring `CC_DIRECTOR_ROOT` by hand. The rule is *be redirectable*; using `CcStorage` is just the normal way to achieve it. A test asserts `BrainLog` keeps paying, so "I cannot use CcStorage" can never become a way to land an unredirectable path.

## One deliberate behavior note

`AgentPluginRegistry` lost an `if (LocalApplicationData is empty) return string.Empty` guard. `AgentPluginLoader.LoadDirectory` already returns empty for a blank **or** non-existent directory, and `CcStorage.Base()` makes the same assumption everywhere else in the app, so the outcome is identical.

## Verification

A refactor like this fails silently: move a folder and nothing throws, nothing goes red - the user's existing recordings, logs, hooks and transcripts are simply orphaned at the old path while the app writes somewhere new. You find out months later. So that is what I tested:

- **`CcStorageProductionLocationTests` pins all 20 folders** to the literal path the old hand-rolled code produced, with the root unset, and reports any that moved. **Nothing moved.**
- The paths are resolved **inside** the test, not in `TheoryData` - `MemberData` is evaluated at discovery time, before the fixture clears the root, so it would have captured whatever `CC_DIRECTOR_ROOT` another class had set and asserted nothing useful. (Caught while writing it.)
- **The guard passes with an EMPTY list**: zero hand-rolled roots left in `src/`.
- Whole solution builds clean, no new warnings.
- **All seven test projects pass**: Core 3084, Gateway 2217, Avalonia 124, Terminal.Avalonia 21, Engine 62, HostedAgent 80, Launcher 27.

## Where this leaves the rule

Production code in `src/` can no longer resolve the storage root by hand - the guard fails the build, with one tested exemption that must prove it is redirectable anyway. The remaining known gap is unchanged from #1582 and still deliberate: pinning `CC_DIRECTOR_ROOT` assembly-wide so tests are isolated by default would turn `ToolManifestTests` into a silent green no-op, and needs the few tests that genuinely want the real root to opt out explicitly first.

Generated with [Claude Code](https://claude.com/claude-code)
