### PR TITLE
State slice 3 of 6: the orange dot that lied about your phone for 90 minutes

### DIFF
--- a/docs/new_architecture/session-state.html
+++ b/docs/new_architecture/session-state.html
@@ -441,7 +441,7 @@ so they belong in the inventory. Several are the subject of open defects.</p>
 <tr><td><code>SnoozeExpired</code></td><td>Gateway</td><td>Display-only marker: this session came back on its own because its snooze timer fired. Clients render a distinct "Snooze ended" badge so you know it is a "go and see why it went quiet" item, not a fresh turn-end. Set by the expiry overlay.</td></tr>
 <tr><td><code>SessionRole</code></td><td>Gateway</td><td><code>Standalone</code> / <code>Manager</code> / <code>Worker</code> / <code>Architect</code>. Computed from the WHOLE fleet (it needs to know whether a controller is still alive), which is why only the Gateway can produce it. Drives the slate suppression at ladder position 8. <span class="bad">The role DTO documents three roles; the code produces four - it omits Architect.</span></td></tr>
 <tr><td><code>NeedsYouSince</code></td><td>Gateway</td><td>The clock that orders the "needs you" queue oldest-first. Stamped as the fleet is assembled.</td></tr>
-<tr><td><code>DictationDeliveryState</code></td><td>Gateway (durable, on disk)</td><td><code>Pending</code> / <code>Delivered</code> / <code>Abandoned</code> / <code>Failed</code>. Not a session state, but <code>Pending</code> locks the session and paints it orange - see the dictation lifecycle below, and defect 19.</td></tr>
+<tr><td><code>DictationDeliveryState</code></td><td>Gateway (durable, on disk)</td><td><code>Pending</code> / <code>Delivered</code> / <code>Abandoned</code> / <code>Failed</code>. Not a session state. <code>Pending</code> paints the session orange <em>while the upload is progressing</em> - it does NOT lock the session (issue #1308 removed that), and since 14 July 2026 it does not paint on its own either. See the dictation lifecycle below, and defect 19.</td></tr>
 </table>
 
 <h4>5. Presentation - the colour, the label, the bucket. Owner: the Gateway, and nothing else.</h4>
@@ -560,16 +560,23 @@ separate flags, with three different lifetimes, driving the same colour.</p>
 
 <table>
 <tr><th>Flag</th><th>Set / cleared by</th><th>Can it wedge?</th></tr>
-<tr><td><code>IsTranscribing</code><br><span class="file">desktop dictation</span></td><td><span class="file">BackgroundDictationSend.cs:59, :135</span> - set at start, cleared in a <code>finally</code>.</td><td class="good">No. The <code>finally</code> runs on every path, including a crash mid-transcribe.</td></tr>
+<tr><td><code>IsTranscribing</code><br><span class="file">desktop dictation</span></td><td><span class="file">BackgroundDictationSend.cs:59, :135</span> - set at start, cleared in a <code>finally</code>.</td><td class="good">No - and the <code>finally</code> is the weakest of the three reasons, so do not lean on it. A <code>finally</code> does <em>not</em> run when a process is killed. The reasons that actually hold: (1) the flag is <strong>in-memory Director state</strong> (<span class="file">Session.cs:794</span>, persisted nowhere), so it dies <em>with</em> the process that owns it and a restarted Director reports <code>false</code>; (2) a dead Director's sessions leave the roster <strong>entirely</strong> - <span class="file">PushedSessionStore.cs:244</span> <code>SnapshotFresh</code> requires an active connection AND a fresh cache, so a dark Director contributes nothing to fold orange from. Verified 14 July 2026.</td></tr>
 <tr><td><code>Transcribing</code><br><span class="file">Gateway, active run</span></td><td><span class="file">TranscribingSessions.cs</span> - explicit <code>End()</code> on every terminal outcome, plus a <strong>90-second idle backstop</strong> that clears a mark making no progress.</td><td class="good">No. Bounded to 90 seconds even if the explicit clear is missed entirely.</td></tr>
-<tr><td><code>DictationStatus</code><br>= "Uploading from phone"<br><span class="file">Gateway, durable marker</span></td><td><span class="file">VoiceUploadStore</span> - a durable record on disk. It paints while, and only while, the record is <code>Pending</code>. <code>Pending</code> ends when the record reaches a terminal state: <code>Delivered</code>, <code>Abandoned</code>, or <code>Failed</code>.</td><td class="bad">YES - but only when the record never reaches a terminal state at all.</td></tr>
+<tr><td><code>DictationStatus</code><br>= "Uploading from phone"<br><span class="file">Gateway, durable marker</span></td><td><span class="file">VoiceUploadStore</span> - a durable record on disk. The record is <code>Pending</code> until it reaches a terminal state: <code>Delivered</code>, <code>Abandoned</code>, or <code>Failed</code>. <strong>Since 14 July 2026 the record no longer paints on its own</strong> - the colour is gated on the upload actually making progress (<span class="file">DictationPhase.cs</span>), the same idle rule <code>Transcribing</code> uses.</td><td class="good">Not any more - <strong>this was defect 19, and it is FIXED.</strong> It used to wedge whenever the record reached no terminal state, which was <em>observed</em> to last 1h30m. Bounded now.</td></tr>
 </table>
+
+<p><strong>All three inputs are now bounded, and the reasons are different for each.</strong> That matters: a
+future reader who fixes one and assumes the others follow will be wrong. <code>Transcribing</code> is bounded
+by a 90-second idle backstop; <code>IsTranscribing</code> is bounded by process lifetime and roster freshness;
+<code>DictationStatus</code> is bounded by the progress gate added for defect 19 - while its underlying record
+stays durable and unbounded <em>on purpose</em>.</p>
 
 <p><strong>The three-term lifecycle, stated once, because getting this wrong is what makes people
 believe the wedge is unavoidable:</strong></p>
 
 <ol>
-<li><strong><code>Pending</code> locks and colours.</strong> While the record is Pending, the session is locked (nobody else may type into it) and painted orange. <span class="file">VoiceUploadStore.cs:288-289</span></li>
+<li><strong><code>Pending</code> colours. It does NOT lock.</strong> While the record is Pending the session shows the dictation phase; since 14 July 2026 it does so only while the upload is making progress (<span class="file">DictationPhase.cs</span>). <span class="file">VoiceUploadStore.cs:288-289</span>
+<br><em>This document said "the session is locked (nobody else may type into it)" until 14 July 2026. That was FALSE, and it was load-bearing - it is why the wedge read as far worse than it was.</em> The issue #1188 lock (a 423 on human input while a Pending record stood) was <strong>deliberately removed</strong> by issue #1308, whose own comment gives the reason - this is a single-operator tool, and "a wedged PENDING marker used to falsely block every send for its whole lifetime" (<span class="file">GatewayEndpoints.cs:107-111</span>). Verified 14 July 2026 by looking for consumers, not call sites: the Director's mirror reader is wired at <span class="file">ControlApiHost.cs:390</span> and surfaces as <code>Session.IsDictationLocked</code> (<span class="file">Session.cs:1738</span>), which has <strong>zero consumers anywhere in the codebase</strong> - nothing reads it, so it blocks nothing. Note what this means for the defect's history: the input-blocking half of the wedge was already fixed by #1308. The colour half is what survived, and that is defect 19.</li>
 <li><strong>A terminal tombstone (<code>Delivered</code> / <code>Abandoned</code> / <code>Failed</code>) ends the lock and the colour</strong>, and exists to de-duplicate a re-delivery or support a retry. On the normal path <code>MarkDelivered</code> is written <em>immediately after the session accepts the prompt</em> - <strong>not</strong> when the phone acknowledges. <span class="file">GatewayDictationEndpoint.cs:414-420</span></li>
 <li><strong>The phone's later acknowledgement retires the tombstone only.</strong> It has nothing to do with the lock, which ended at step 2.</li>
 </ol>
@@ -599,20 +606,51 @@ record. The mistake is that <strong>one flag is answering two different question
 <li><em>"Is there an undelivered dictation for this session?"</em> - a durable fact. Must never expire, or the phone loses your words. Today: correct.</li>
 <li><em>"Should this session be painted orange right now?"</em> - a presentation question. Must always be bounded, or a phone that never comes back wedges a session orange until the Gateway restarts.</li>
 </ol>
-<p>The colour is currently driven by the answer to question 1. So any upload that never reaches a terminal
-state leaves the session orange indefinitely, reading "Uploading from phone" about an upload that is not
-happening.</p>
-<p><strong>Which path actually fires in practice is NOT KNOWN, and this document does not guess.</strong>
-Reading the code tells us which paths CAN leave a record non-terminal
-(<span class="file">GatewayDictationEndpoint.cs:277-290</span>: <code>OutOfCredits</code> and any retryable
-error both return without a terminal write; only <code>PermanentError</code> parks the record). It does
-not tell us which one produced any orange dot anyone has actually seen. Nobody has looked at a real
-wedged record yet.</p>
-<p><strong>To diagnose it, look - do not reason.</strong> The durable records are on disk on the Gateway:
-enumerate the <code>Pending</code> ones, read their age and their session id, and check the Gateway log for
-the outcome that was returned when each one completed. That is a five-minute answer from evidence. Any
-claim about the cause that is not backed by one of those records is a guess, and a guess written into this
-document is exactly the disease this document exists to cure.</p>
+<p>The colour used to be driven by the answer to question 1. So any upload that reached no terminal state
+left the session orange indefinitely, reading "Uploading from phone" about an upload that was not
+happening. <strong>Fixed 14 July 2026:</strong> the colour is now gated on the upload making progress
+(<span class="file">DictationPhase.cs</span>, the same idle rule <code>Transcribing</code> uses). The record
+is untouched, never expires, and still delivers whenever the phone returns.</p>
+
+<p><strong>DIAGNOSED 14 July 2026 - by looking, not by reasoning. The cause is the retryable transcription
+error, and here is the evidence.</strong> Log correlation across every Director log on SOREN_NORTH
+(2402 files, 824 distinct upload ids that ever went <code>Pending</code>):</p>
+<ul>
+<li><strong>Upload <code>f13cb4b6d9d0</code>, 12 July 2026, session <code>3eb61028</code>: <code>Pending</code>
+- and therefore orange, reading "Uploading from phone" - from 06:11 to 07:40. One hour and thirty
+minutes.</strong> Its audio had arrived intact and assembled on every attempt (456,755 bytes, one chunk), so
+nothing was "uploading" for any of it. <code>POST /complete</code> returned <strong>502 roughly fifteen
+times</strong>, each after ~33 seconds, each returning without a terminal write. At 07:40 it transcribed and
+delivered <strong>362 characters</strong>.</li>
+<li><strong>It survived FOUR Gateway restarts inside that window.</strong> So the older claim that the wedge
+lasts only "until the Gateway restarts" is <strong>false</strong> - the record is on disk and a restart does
+not touch it.</li>
+<li><strong>Which arm fired:</strong> the exception arm logs (<code>complete ... FAILED:</code>) and has
+fired exactly <strong>once, ever</strong>, on a different id in a different month - so this was not it. The
+assemble succeeded every attempt, so it was not the incomplete or empty-clip arm. What remains is the
+<strong>retryable arm</strong> (<span class="file">GatewayDictationEndpoint.cs</span>), which returned a bare
+502 and <em>logged nothing at all</em> - which is exactly why the log could say when the wedge happened but
+never why. It logs now.</li>
+<li><strong>Out-of-credits is DISPROVEN, not merely unsupported.</strong> Zero <code>OutOfCredits</code> in
+any log, ever, across <strong>846 terminal outcomes</strong> (845 <code>Delivered</code>, 1
+<code>Abandoned</code>, 0 <code>Failed</code>). Independently: the hosted-AI balance was healthy throughout
+the 12 July wedge (<code>[HostedAiReadiness] ... -> Ready</code>, ~24.3 credits). The earlier draft called it
+"almost certainly" the cause and "the everyday way in". It has never happened once.</li>
+<li><strong>Scale:</strong> 6 of 824 uploads (0.7%) stood <code>Pending</code> longer than the 90-second idle
+window would allow; median 4 seconds, p99 56 seconds, max the 1h30m above. Rare, and it lies loudly when it
+fires.</li>
+</ul>
+
+<div class="callout ok">
+<p><strong>A lead that was killed rather than inherited - recorded so nobody re-chases it.</strong> An
+earlier count of <strong>1005 <code>MarkPending</code> versus 846 terminal <code>MarkRecord</code></strong>
+looked like ~159 uploads that went Pending and never resolved. <strong>It is an artefact and the real gap is
+ZERO.</strong> 1005 counts log <em>lines</em>, not uploads: every re-register rewrites the marker for the
+same id (<code>f13cb4b6d9d0</code> alone wrote it 15 times). Deduplicated, 824 distinct ids ever went
+Pending, and <strong>every single one reached a terminal state</strong>. "Reached a terminal state" was never
+the same question as "how long did it stand orange" - the second one is the defect, which is why the
+duration, not the gap, is what found it.</p>
+</div>
 </div>
 
 <p><strong>Today's fix already removes the common case.</strong> The normal dictation path ends with the
@@ -621,20 +659,36 @@ now blue, unconditionally. So a delivered dictation goes orange &rarr; blue on i
 any stale flag says. That is the owner's rule ("transcription pretty much always goes to working")
 falling straight out of the law, with no special case written for it.</p>
 
-<p><strong>What is left is the case where the text never arrives</strong> - out of credits, a retryable
-error, or a phone that never comes back - so the session never works, so nothing knocks the orange off.</p>
+<p><strong>What was left is the case where the text never arrives</strong> - a retryable error (the observed
+one), or a phone that never comes back - so the session never works, so nothing knocks the orange off. That
+is what the fix below closes.</p>
 
 <div class="callout ok">
-<p><strong>DECIDED, 14 July 2026: bound the colour, keep the record.</strong> Paint "Uploading from
-phone" only while the upload is actually making progress - the same idle rule the active-transcription
-mark already uses - and let the session fall back to its true colour when it goes quiet. The durable
-record survives untouched and still delivers whenever the phone returns; the delivery still submits the
-text; the session still goes blue by itself, because working is blue. <strong>Nothing is lost except the
-lie on the dot.</strong></p>
-<p>Fix the two paths that leave the record non-terminal while you are there
-(<span class="file">GatewayDictationEndpoint.cs:277-290</span>): out-of-credits and retryable errors
-should park the record in a state that says what actually happened, so the honest answer is available to
-show. And fix the two comments that claim the pending-derived status "never wedges" - they are why nobody
+<p><strong>DECIDED, 14 July 2026: bound the colour, keep the record. IMPLEMENTED the same day.</strong> Paint
+"Uploading from phone" only while the upload is actually making progress - the same idle rule the
+active-transcription mark already uses - and let the session fall back to its true colour when it goes quiet.
+The durable record survives untouched and still delivers whenever the phone returns; the delivery still
+submits the text; the session still goes blue by itself, because working is blue. <strong>Nothing is lost
+except the lie on the dot.</strong></p>
+<p><strong>Shipped, in two halves</strong> (both needed - the first bounds a phone that goes quiet, the second
+bounds a server that keeps failing while the phone dutifully retries):</p>
+<ol>
+<li><strong>The colour is gated on progress</strong> - <span class="file">DictationPhase.cs</span>, wired at
+<span class="file">GatewayHost.cs</span>. An undelivered record no longer paints on its own.</li>
+<li><strong>Every non-Ok transcription outcome now parks the record <code>Failed</code></strong> -
+<span class="file">GatewayDictationEndpoint.cs</span>. <strong>Parking is not giving up:</strong>
+<code>Failed</code> keeps the staged audio, and the next register/complete clears it back to
+<code>Pending</code> and re-drives. Upload <code>f13cb4b6d9d0</code> would <em>still</em> have delivered its
+362 characters at 07:40 - it simply would not have lied for the ninety minutes first. The client contract is
+deliberately unchanged: retryable stays 502, out-of-credits stays 402, only <code>PermanentError</code> gets
+the 422 stop. The retryable arm also logs now, which it never did.</li>
+</ol>
+<p><strong>Say this plainly, because the mechanism and the cause are not the same thing:</strong> the
+out-of-credits path is real code and is now parked - but it <strong>has never once been observed to
+fire</strong> (0 in 846 outcomes). It is fixed as a mechanism. It is not the cause of anything anyone has
+seen.</p>
+<p>The two comments claiming the pending-derived status "never wedges" are corrected
+(<span class="file">SessionDto.cs</span>, <span class="file">GatewayHost.cs</span>) - they are why nobody
 believed this bug was real.</p>
 </div>
 
@@ -652,7 +706,7 @@ shipped this morning.</p>
 <tr><td>A 12-hour snooze on a session that was NOT working when you pressed it</td><td class="good">Gateway overlays OnHold=false at expiry, returns to red, "Snooze ended" badge</td><td class="good">Unchanged, and correct. The timer survives because the hold landed immediately.</td></tr>
 <tr><td>A snoozed session on a Director that has died</td><td class="bad">Stale OnHold=true in the roster keeps it grey</td><td class="good">The expiry overlay still fires (the Gateway owns the clock). If any fact says working, blue wins.</td></tr>
 <tr><td>You dictate into a session, and the text submits</td><td class="bad">Orange, and could stay orange over the working turn</td><td class="good">Orange while uploading &rarr; text submits &rarr; agent works &rarr; <strong>blue, automatically</strong>.</td></tr>
-<tr><td>You dictate, and the phone dies mid-upload</td><td class="bad">Orange forever</td><td class="bad">Still orange until the Gateway restarts. <strong>Defect 19, open.</strong> Bounded only if the session works for some other reason.</td></tr>
+<tr><td>You dictate, and the phone dies mid-upload</td><td class="bad">Orange forever (and NOT "until the Gateway restarts" - the record is on disk; one observed wedge survived four restarts)</td><td class="good"><strong>Fixed - defect 19.</strong> The progress mark stops being refreshed, so within the idle window the session drops back to its true colour. The record survives untouched: if the phone comes back, it still delivers, still submits the text, and the session goes blue on its own.</td></tr>
 <tr><td>The wingman is reading a finished turn</td><td class="good">Yellow, then red when the brief lands</td><td class="good">Unchanged - it is gated on raw red, so it only ever describes a stopped session.</td></tr>
 <tr><td>A voice-mode session's text-to-speech fails</td><td class="good">Falls to red (fixed 8 July - the <code>VoiceGenerating</code> gate gives it a terminal exit)</td><td class="good">Unchanged.</td></tr>
 <tr><td>A controlled sub-agent is 20 minutes into real work</td><td class="bad">Slate "Sub-agent" - the work was discarded</td><td class="good">Blue "Working". Ownership travels on the role badge, not the colour.</td></tr>
@@ -660,7 +714,8 @@ shipped this morning.</p>
 <tr><td>A sub-agent needs someone but its controller has died</td><td class="good">Red - it surfaces to you (the escape hatch)</td><td class="good">Unchanged.</td></tr>
 <tr><td>A snoozed session exits</td><td class="bad">Reads "Snoozed" forever - the dead session hides behind the label</td><td class="good"><strong>Fixed - defect 21.</strong> The exit edge clears a LANDED hold too, not just a deferred one, so <code>OnHold</code> goes false and the fold falls through to grey <strong>"Exited"</strong>. A dead session never hides behind a Snoozed label.</td></tr>
 <tr><td>The Director restarts while sessions are snoozed</td><td class="bad">Every snooze is forgotten; every deferral is lost</td><td class="good"><strong>Fixed - defect 22.</strong> The hold state is persisted. On restore a <code>Held</code> comes back held; a <code>DeferredHold</code> <strong>lands</strong> (the restart ended the turn it was waiting for); a session that came back working is not held (working always wins); a session that exited drops the hold.</td></tr>
-<tr><td>A dictation reaches no terminal state (any cause)</td><td class="bad">Orange forever, reading "Uploading from phone"</td><td class="bad">Unchanged. <strong>Defect 19, open.</strong> The mechanism is known; which path fires in practice is undiagnosed.</td></tr>
+<tr><td>A dictation reaches no terminal state (any cause)</td><td class="bad">Orange forever, reading "Uploading from phone" - observed at 1h30m (upload <code>f13cb4b6d9d0</code>, 12 July 2026)</td><td class="good"><strong>Fixed - defect 19,</strong> and bounded for EVERY cause at once, including any nobody has thought of: the colour needs progress, not just an undelivered record. Every non-Ok transcription outcome also parks the record <code>Failed</code> now (keeping the audio, retryable), so the record says what happened instead of implying an upload is in flight.</td></tr>
+<tr><td>The server keeps failing to transcribe while your phone dutifully retries</td><td class="bad">Orange the whole time, reading "Uploading from phone" - about audio that arrived intact long ago. <strong>This is the observed defect 19.</strong></td><td class="good">Each attempt shows "Transcribing" while it actually runs; between attempts the record is parked <code>Failed</code>, so the session shows its true colour. The audio is kept and the retry re-drives - when it finally succeeds, the text submits and the session goes blue.</td></tr>
 <tr><td>A session is flagged for deletion</td><td class="bad">Director paints it grey locally; Gateway clients still show red/blue</td><td class="bad">Unchanged. <strong>Defect 23, open</strong> - the fold ignores <code>PendingDeletion</code> and the Director writes a colour it is not allowed to write.</td></tr>
 <tr><td>A session crashes mid-turn</td><td class="bad">Looks identical to a clean exit</td><td class="good"><strong>Fixed - defect 4</strong> (#1562, merged before this mission began; this document had not caught up). Deep red "Crashed", distinct from a clean grey "Exited", on the rail, the Cockpit and the phone.</td></tr>
 </table>
@@ -719,7 +774,7 @@ or its own hold expiry, so it cannot compute its own colour. It must ask.</p>
 <tr><td><strong>22</strong></td><td><span class="good">FIXED 14 July 2026.</span> <strong>The hold state is persisted, so a Director restart no longer silently forgets every snooze.</strong> <code>HoldState</code> was runtime-only - <span class="file">SessionStateStore.cs</span> stored no hold at all - so every <code>Held</code> session came back un-held and every <code>DeferredHold</code> ("park me when this finishes") was forgotten, while the Gateway timer entry lived on pointing at a session that was not held. <strong class="good">THE RULING: persist the hold state, and land the deferral on restart if the session is not working.</strong> That follows from the ruling that the clock starts when the work ends - a Director that died ended the work. If the session exited, the existing rule already applies: drop it, there is no turn to come back to. Restored through <code>Session.RestoreHoldState</code>, which applies the machine's EXISTING edges at restore rather than inventing new ones. <strong>This defect MASKED defect 20</strong> - a restart was the only thing that ever cleared a timer-less permanent snooze - so fixing 22 alone would have made the product WORSE. They landed together. <strong>Two persist sites, and they do not agree in shape:</strong> <span class="file">MainWindow.PersistSessionStateCore</span> is the one that actually runs and writes a SHORT record; <span class="file">SessionManager.BuildPersistedSessions</span> writes a much fuller one and <strong>has no production caller at all</strong> (tests only). The hold is written at BOTH - persisting it only in the fuller one would have been a silent no-op, and a call site is not a caller. That divergence is a real defect of its own; see "Still to do".</td><td><span class="file">SessionStateStore.cs</span> (<code>PersistedSession.HoldState</code>); <span class="file">Session.RestoreHoldState</span>; <span class="file">SessionManager.cs</span>; <span class="file">MainWindow.axaml.cs</span></td></tr>
 <tr><td><strong>21</strong></td><td><span class="good">FIXED 14 July 2026.</span> <strong>A snoozed session that exits now reads "Exited", never "Snoozed".</strong> On exit, <span class="file">Session.cs</span> cleared a <code>DeferredHold</code> with the comment <em>"parking a dead session would just hide it behind a 'Snoozed' label forever"</em> - and did not apply that reasoning to a session that was already <code>Held</code>, which then kept <code>OnHold=true</code>. The fold checks <code>OnHold</code> before the base colour, so the row read "Snoozed" forever: the exact outcome the neighbouring comment forbids. <strong class="good">THE RULING: it reads Exited.</strong> The fix is the one-line generalisation the comment already argued for - the exit edge clears the hold, whatever it is. Done on the DIRECTOR rather than in the fold, because the exit edge is only ever observed by a live Director, so there is no case it misses and the fold needs no new rule above <code>OnHold</code>.</td><td><span class="file">Session.cs</span> (the exit edge)</td></tr>
 <tr><td><strong>20</strong></td><td><span class="good">FIXED 14 July 2026.</span> <strong>A deferred snooze used to lose its timer within 15 seconds, so an agent-requested snooze NEVER EXPIRED.</strong> The most serious defect in this document, and it broke two of the owner's rules at once. Walk it: you (or the agent) press Snooze while the agent is working. The Director correctly enters <code>DeferredHold</code> - "park me when this turn ends" - and <code>DeferredHold</code> reports <code>OnHold=false</code>, because it is not parked yet. The Gateway recorded a 12-hour timer regardless. Fifteen seconds later the expiry sweep asked the Director "is this session held?", was told <em>no</em>, concluded the snooze was over, and <strong>deleted the timer</strong>. The turn then ended, the Director landed <code>DeferredHold &rarr; Held</code>, and the session was snoozed <strong>with no Gateway clock at all</strong>. <em>This is the very feature the owner described - an agent snoozing its own session, which by definition happens while it is working - so it was THE case that failed, not an edge case.</em> <strong>The root cause was defect 12</strong>, the lossy wire. <strong class="good">THE RULING: the clock starts when the work ENDS.</strong> THE FIX, in four parts: (1) the hold state crosses the wire (defect 12); (2) the hold endpoint reads <code>HoldResponse.Pending</code> - which ALWAYS carried this fact and which nothing read - and records a deferral as <strong>a length with no deadline</strong>; (3) the clock starts at the <strong>LANDING</strong>, seen on the Director's own push (<span class="file">SnoozeLandingObserver</span>, via <code>HoldStateChanged</code>, which already fired on <code>DeferredHold &rarr; Held</code>), with the 15-second sweep as the backstop; (4) the sweep clears an entry <strong>only on a true <code>None</code></strong>. <code>SnoozeRegistry.Land</code> is idempotent, so the two landing paths cannot corrupt each other and a running clock is never restarted.</td><td><span class="file">GatewayEndpoints.cs</span> (hold endpoint, reads <code>Pending</code>); <span class="file">SnoozeExpirySweep.cs</span> (tri-state, never clears a deferral); <span class="file">SnoozeRegistry.cs</span> (armed XOR deferred, <code>Land</code>); <span class="file">SnoozeLandingObserver.cs</span> + <span class="file">DirectorHub.cs</span> (the push seam); <span class="file">HoldRequest.cs</span> (<code>Pending</code>, now read)</td></tr>
-<tr><td>19</td><td><strong>A dictation that never reaches a terminal state wedges the session orange.</strong> The durable record paints orange while <code>Pending</code>, and <code>Pending</code> ends only at <code>Delivered</code> / <code>Abandoned</code> / <code>Failed</code>. Two paths never mark it: <strong>OutOfCredits</strong> and any <strong>retryable transcription error</strong> return to the client without a terminal write (only <code>PermanentError</code> parks the record). The session then reads "Uploading from phone" forever - about an upload that is not happening - because the active-transcription mark cleared in its <code>finally</code> and the label degraded back to the upload phase. A phone that dies mid-upload reaches no terminal state either. <strong>WHICH of these actually causes the orange anyone has seen is UNDIAGNOSED - read the pending records on the Gateway before claiming a cause.</strong> <em>One flag answers two questions: the durable record must never expire (correct - an age cut would make a phone out of signal lose its words), but the colour must always be bounded.</em> <strong>Today's fix removes the common case</strong> - a delivered dictation submits text, the agent works, and working is now blue no matter what any stale flag says - but a dictation that never delivers never makes the session work, so nothing knocks the orange off. See "The dictation lifecycle" above.</td><td><span class="file">GatewayDictationEndpoint.cs:277-290</span> (no terminal write on OutOfCredits / retryable), <span class="file">:429-433</span> (label degrades); <span class="file">GatewayHost.cs:1345-1351, :1212-1215</span>; <span class="file">VoiceUploadStore.cs:288-289</span></td></tr>
+<tr><td>19</td><td><span class="good">FIXED 14 July 2026.</span> <strong>A dictation that reached no terminal state wedged the session orange.</strong> The durable record painted while <code>Pending</code>, and <code>Pending</code> ended only at <code>Delivered</code> / <code>Abandoned</code> / <code>Failed</code> - so a dictation that reached none painted forever, reading "Uploading from phone" about an upload that was not happening (the active-transcription mark cleared in its <code>finally</code>, so the label degraded <em>back</em> to the upload phase). <em>One flag was answering two questions: the durable record must never expire (correct - an age cut would make a phone out of signal lose its words), but the colour must always be bounded.</em><br><br><strong>DIAGNOSED, not guessed - the cause is the retryable transcription arm.</strong> Observed: upload <code>f13cb4b6d9d0</code> stood <code>Pending</code> 06:11-07:40 on 12 July 2026 (<strong>1h30m orange</strong>, across <strong>four Gateway restarts</strong>) while <code>complete</code> returned 502 ~15 times from the retryable arm, which returned without a terminal write <em>and logged nothing</em>; its audio had assembled intact every attempt; it then delivered 362 characters. <strong>Out-of-credits is DISPROVEN</strong> (0 in 846 outcomes; balance healthy throughout the wedge) - the earlier draft's "almost certainly out of credits" was invented. 6 of 824 uploads exceeded the 90s idle window; median 4s.<br><br><strong>The fix, in two halves:</strong> (1) the colour is gated on the upload making progress (<span class="file">DictationPhase.cs</span>) - the record is untouched and still never expires; (2) every non-Ok outcome parks the record <code>Failed</code>, which KEEPS the audio and re-enters <code>Pending</code> on retry, so nothing is lost - <code>f13cb4b6d9d0</code> would still have delivered at 07:40. Regression tests fail against the old rule. See "The dictation lifecycle" above.</td><td><span class="file">DictationPhase.cs</span> (the bound); <span class="file">GatewayDictationEndpoint.cs</span> (parks every non-Ok outcome); <span class="file">GatewayHost.cs</span>, <span class="file">SessionDto.cs</span> (the two lying comments, corrected); <span class="file">VoiceUploadStore.cs:288-289</span></td></tr>
 </table>
 
 <h3>The traps - comments that lie to the next agent</h3>
@@ -786,7 +841,7 @@ longer forgets a snooze (defect 22), and a dead session reads Exited (defect 21)
 </div>
 
 <ol>
-<li><strong>Bound the dictation colour without touching the durable record</strong>, and park the out-of-credits and retryable paths in a terminal state. Defect 19 - the wedged orange.</li>
+<li><span class="good">DONE 14 July 2026.</span> <strong>Bound the dictation colour without touching the durable record</strong>, and park the out-of-credits and retryable paths. Defect 19 - the wedged orange. Diagnosed to the retryable transcription arm from a real 1h30m wedge (<code>f13cb4b6d9d0</code>, 12 July 2026); out-of-credits disproven.</li>
 <li><strong>Make the two session-persistence records agree</strong>, and delete the one nothing calls. <span class="file">MainWindow.PersistSessionStateCore</span> is the site that actually runs and writes a SHORT record (id, repo, args, name, colour, agent session, activity, backend, pending prompt, wingman, sort order - plus the hold, as of today). <span class="file">SessionManager.BuildPersistedSessions</span> writes a MUCH fuller one - number, group, controller, explicit role, mission, queued prompts, history - and its two callers (<code>SaveCurrentState</code>, <code>SaveSessionState</code>) are <strong>called by tests and nothing else</strong>. So the fuller record is what the tests prove and the shorter record is what the user gets, and the gap between them is invisible in both. <strong>Found while fixing defect 22</strong>, which had to be written to both sites for the fix to exist at all. <em>Which fields this actually loses on a real restart is UNDIAGNOSED - nobody has read a sessions.json written by a live Director and diffed it against the fuller record. Do that before assuming the difference is only theoretical.</em></li>
 <li><strong>Make pending deletion a badge</strong>, and delete the Director's <code>SetStatusColor</code> call. Defect 23.</li>
 <li><strong>Send the session role down to the desktop</strong> so it stops being the one screen that cannot suppress a worker's red. Until then, desktop and phone disagree by construction.</li>
@@ -833,7 +888,7 @@ implements <em>this</em>, and does not re-open the question.</p>
 <tr><td><strong>You snooze a working session for 12 hours. When does the clock start - when you ask, or when the work ends?</strong></td><td><strong>When the work ends.</strong> "Snooze me for 12 hours when this finishes" means twelve hours of quiet <em>after</em> it finishes. A clock started at request time could expire before the hold has even landed - which is nonsense, and is a second way to produce the same bug.</td><td>Defect 20 - the agent-requested snooze that never expires</td></tr>
 <tr><td><strong>A snoozed session exits. Does it read "Snoozed" or "Exited"?</strong></td><td><strong>Exited.</strong> A dead session must never hide behind a Snoozed label. The code already makes this argument in its own comment for the deferred case; apply it to the landed case too.</td><td>Defect 21</td></tr>
 <tr><td><strong>A session flagged for deletion: colour, or badge?</strong></td><td><strong>A badge. Never a colour.</strong> Pending deletion says nothing about what the agent is <em>doing</em>. If the session is still working it is <strong>blue</strong>, with a badge. The Director's <code>SetStatusColor</code> call in <code>MarkForDeletion</code> is deleted - the Director does not write colours.</td><td>Defect 23</td></tr>
-<tr><td><strong>A dictation that never reaches a terminal state: stay orange until retry, or keep the record durable and bound the colour?</strong></td><td><strong>Bound the colour; keep the record.</strong> The durable record must never expire - a phone out of signal must not lose your words. But the colour must always be bounded. Nothing is lost except the lie on the dot.</td><td>Defect 19 - the wedged orange</td></tr>
+<tr><td><strong>A dictation that never reaches a terminal state: stay orange until retry, or keep the record durable and bound the colour?</strong></td><td><strong>Bound the colour; keep the record.</strong> The durable record must never expire - a phone out of signal must not lose your words. But the colour must always be bounded. Nothing is lost except the lie on the dot. <em>Implemented 14 July 2026, and the observed wedge vindicates both halves: upload <code>f13cb4b6d9d0</code> lied for 1h30m (bound the colour) and then delivered 362 real characters (keep the record).</em></td><td>Defect 19 - the wedged orange</td></tr>
 <tr><td><strong>A Director dies while a snooze is still deferred.</strong></td><td><strong>Persist the hold state, and land the deferral on restart if the session is not working.</strong> This follows from ruling 1: the deferral waits for the work to end, and a Director that died ended the work. If the session exited, the existing rule already applies - drop the deferral, because there is no turn to come back to. <em>This one was inferred from the other rulings rather than stated outright; it is the only entry in this table the owner did not answer word-for-word.</em></td><td>Defect 22 - hold state is not persisted</td></tr>
 </table>
 
@@ -878,6 +933,18 @@ described. A cited defect is checkable. <strong>A fabricated cause is not - it r
 finding, it survives review because it sounds reasonable, and the next agent implements against a world
 that does not exist.</strong> Every disaster in section 1 started this way: a document asserting something
 nobody had checked.</p>
+<p><strong>Someone has now checked, and this is how the story ends - it is worth reading twice.</strong> On
+14 July 2026 the logs were correlated (2402 files, 824 upload ids). Out-of-credits had <strong>never happened
+once</strong> in 846 terminal outcomes; the balance was healthy throughout the very wedge it was invented to
+explain. The real cause was the <em>retryable transcription error</em> - a path the fabricated version
+mentioned only in passing. So the guess was not merely unproven: <strong>it was wrong, and it pointed away
+from the actual cause.</strong> An agent who had "fixed" the credits path would have shipped, closed the
+defect, and left the bug exactly where it was.</p>
+<p><strong>And the correction cuts both ways.</strong> The same investigation carried its own tempting lead -
+a gap of "1005 <code>MarkPending</code> versus 846 terminal writes", read as ~159 wedged records. It was an
+artefact of counting log lines instead of upload ids, and the true gap was <strong>zero</strong>. It was
+killed by the same method that killed the credits story: stop, go and look, count the actual thing. <strong>A
+lead you inherit is not evidence either - not even one written by whoever handed you this document.</strong></p>
 <p><strong>The standard for this document:</strong> a mechanism may be stated from reading the code, and
 must be cited by file and line. <strong>A cause may only be stated from evidence you have actually
 observed</strong> - a log line, a record on disk, a reproduction. If you have not looked, the honest

--- a/src/CcDirector.Gateway.Contracts/SessionDto.cs
+++ b/src/CcDirector.Gateway.Contracts/SessionDto.cs
@@ -393,12 +393,20 @@ public sealed class SessionDto
     /// <summary>
     /// Issue #1181, Task 4: the phone-dictation presentation sub-state - which PHASE an inbound
     /// dictation is in, so a client can show the honest label instead of one blanket "Transcribing...".
-    /// One of: <c>"Uploading from phone"</c> (the phone is still sending the audio up - computed from the
-    /// durable PENDING delivery marker, so it never wedges); <c>"Transcribing"</c> (the audio is up and
-    /// the server is turning it into text - computed from an active transcription run, NOT the 90-second
-    /// idle mark); or <c>null</c> when no dictation is inbound. Stamped by the Gateway aggregator only
-    /// (always null in Director-local responses). Both non-null values drive the orange roster color; the
-    /// clients render this string as the label.
+    /// One of: <c>"Uploading from phone"</c> (the durable PENDING delivery marker stands AND the phone is
+    /// still making progress); <c>"Transcribing"</c> (the audio is up and the server is turning it into
+    /// text - computed from an active transcription run, NOT the 90-second idle mark); or <c>null</c> when
+    /// no dictation is inbound. Stamped by the Gateway aggregator only (always null in Director-local
+    /// responses). Both non-null values drive the orange roster color; the clients render this string as
+    /// the label.
+    ///
+    /// This comment used to say "Uploading from phone" was computed from the durable PENDING marker "so it
+    /// never wedges". That was HALF-TRUE, and the missing half was defect 19: the marker does clear on
+    /// delivery, so the normal path never wedges - but a dictation that reaches no terminal state at all
+    /// never clears it, and the session then read "Uploading from phone" indefinitely about an upload that
+    /// had stopped (observed: 1h30m, upload f13cb4b6d9d0, 12 July 2026). A reader who trusted this comment
+    /// concluded there was no bug, which is exactly why nobody believed the report. The colour is now
+    /// bounded by the progress-idle rule at the Gateway fold; the durable record still never expires.
     /// </summary>
     public string? DictationStatus { get; set; }
 

--- a/src/CcDirector.Gateway.Tests/DictationOrangeBoundTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationOrangeBoundTests.cs
@@ -1,0 +1,117 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// DEFECT 19 - the wedged orange. The regression tests for the rule that bounds the dictation colour
+/// (<see cref="DictationPhase.For"/>), fixed 14 July 2026 by the mission "Session State Truth".
+///
+/// THE DEFECT, OBSERVED - not theorised. Log correlation on SOREN_NORTH, 14 July 2026: upload
+/// f13cb4b6d9d0 registered at 06:11 on 12 July 2026 and stood undelivered until 07:40 - ONE HOUR AND
+/// THIRTY MINUTES - painting its session orange the entire time, reading "Uploading from phone" about an
+/// upload whose audio had already arrived intact (456KB, assembled on every attempt). Its transcription
+/// returned a retryable 502 roughly fifteen times, and each of those returned WITHOUT writing a terminal
+/// state, so the durable PENDING record stood, so the colour stood. It survived four Gateway restarts (the
+/// record is on disk), and at 07:40 it finally transcribed and delivered 362 characters.
+///
+/// Both halves of that matter, and the fix honours both:
+///   - the durable record was RIGHT to keep the words. They landed. It is untouched, and still never expires.
+///   - the colour was LYING for ninety minutes. It is now bounded by actual progress.
+///
+/// THE RULE: "is there an undelivered dictation?" (durable, unbounded, must never expire) is NOT the same
+/// question as "should this session be painted orange right now?" (presentation, must always be bounded).
+/// One flag was answering both. That was the whole defect.
+/// </summary>
+public sealed class DictationOrangeBoundTests
+{
+    // ===== the rule =================================================================================
+
+    [Fact]
+    public void UndeliveredButNotProgressing_DoesNotPaint_ThisIsTheDefect19Fix()
+    {
+        // The phone registered a dictation and went quiet - it died, lost signal, or its transcription is
+        // failing over and over. The durable record still stands (correctly: the words are not lost), but
+        // nothing is happening, so the session must fall back to its TRUE colour.
+        //
+        // THIS IS THE ASSERTION THAT FAILS AGAINST THE OLD RULE. Before the fix this returned
+        // "Uploading from phone" - forever, for as long as the record stood, which for a dictation that
+        // reaches no terminal state is unbounded. That is upload f13cb4b6d9d0's ninety minutes.
+        Assert.Null(DictationPhase.For(activelyTranscribing: false, undelivered: true, progressing: false));
+    }
+
+    [Fact]
+    public void UndeliveredAndProgressing_PaintsUploading()
+    {
+        // The honest case the label exists for: the phone is actively sending. A genuinely slow upload
+        // refreshes its progress mark on every stored chunk, so it keeps this label and is never cut short.
+        Assert.Equal("Uploading from phone",
+            DictationPhase.For(activelyTranscribing: false, undelivered: true, progressing: true));
+    }
+
+    [Fact]
+    public void ActivelyTranscribing_PaintsTranscribing_TheMostSpecificTrueStatement()
+    {
+        Assert.Equal("Transcribing",
+            DictationPhase.For(activelyTranscribing: true, undelivered: true, progressing: true));
+    }
+
+    [Fact]
+    public void ActivelyTranscribing_WinsEvenWhenTheUploadHasGoneQuiet()
+    {
+        // A long server-side transcribe makes no upload progress by definition. The run is bounded by its
+        // own finally, so it may paint regardless - and it is the most specific true statement available.
+        Assert.Equal("Transcribing",
+            DictationPhase.For(activelyTranscribing: true, undelivered: false, progressing: false));
+    }
+
+    [Fact]
+    public void NoDictation_PaintsNothing()
+    {
+        Assert.Null(DictationPhase.For(activelyTranscribing: false, undelivered: false, progressing: false));
+    }
+
+    [Fact]
+    public void Progressing_WithoutAnUndeliveredRecord_PaintsNothing()
+    {
+        // A stale progress mark with no durable record behind it is not a dictation. Both facts are required.
+        Assert.Null(DictationPhase.For(activelyTranscribing: false, undelivered: false, progressing: true));
+    }
+
+    // ===== the rule, joined to the fold that renders it =============================================
+
+    [Fact]
+    public void AQuietUndeliveredDictation_LetsTheSessionShowItsRealColour_InsteadOfWedgingOrange()
+    {
+        // End to end through the shared fold: the session needs the user. Before the fix a quiet
+        // undelivered record painted it orange indefinitely, hiding the fact that it wanted attention.
+        var s = new SessionDto
+        {
+            SessionId = "s1",
+            ActivityState = "WaitingForInput",
+            BriefingState = "None",
+            DictationStatus = DictationPhase.For(activelyTranscribing: false, undelivered: true, progressing: false),
+        };
+
+        Assert.Equal("red", SessionOrdering.EffectiveColor(s));
+        Assert.Equal("Needs you", SessionOrdering.StateLabel(s));
+    }
+
+    [Fact]
+    public void AWorkingSessionWithAWedgedDictationIsBlue_BecauseWorkingIsBlue()
+    {
+        // THE LAW, and the reason the normal dictation path needs no special case: a delivered dictation
+        // submits text, which makes the agent work, and working is blue no matter what any stale flag says.
+        var s = new SessionDto
+        {
+            SessionId = "s1",
+            ActivityState = "Working",
+            BriefingState = "None",
+            DictationStatus = "Uploading from phone",
+        };
+
+        Assert.Equal("blue", SessionOrdering.EffectiveColor(s));
+        Assert.Equal("Working", SessionOrdering.StateLabel(s));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/DictationOrangeProducerTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationOrangeProducerTests.cs
@@ -1,0 +1,198 @@
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Transcription;
+using CcDirector.Gateway.Voice;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// DEFECT 19's PRODUCER - the half that had no test at all, found by phase 5 while auditing what phase 2's
+/// fix was actually protected by.
+///
+/// WHY THIS FILE EXISTS. <see cref="DictationOrangeBoundTests"/> pins the RULE
+/// (<see cref="DictationPhase.For"/>) and pins it well. It does not, and cannot, pin the WIRING that
+/// supplies the rule's three facts: the roster callback appeared in ZERO test files. So you could wire
+/// <c>progressing: true</c> as a constant and the entire Gateway suite stayed green while defect 19 returned
+/// in full - an undelivered record would paint orange forever again, which is precisely the ninety-minute
+/// lie the mission was convened to end. The rule was guarded; the thing that calls it was not.
+///
+/// That is this repository's signature failure and the mission has now found it FOUR times: a live consumer
+/// whose producer is unguarded or absent (the Director's colour computation, the ask-and-wait verb waiting
+/// on a state nothing writes, the auto-drain green for fourteen months on an injected state - and this).
+/// A green suite that guards nothing is the same species as a specification that reads like a finding while
+/// being invented: it is not WRONG, it is PLAUSIBLE, and plausible ships.
+///
+/// SO NOTHING HERE IS HAND-SET. The collaborators are the REAL <see cref="TranscribingSessions"/> and the
+/// REAL <see cref="VoiceUploadStore"/> (on a temporary directory - never the machine's own dictation store),
+/// driven through their real public verbs, and the method under test is the SAME
+/// <c>GatewayHost.DictationStatusFor</c> the live roster calls. The one thing injected is the CLOCK, which
+/// is a legitimate clock advance and not a fabricated fact: without it the idle case takes ninety seconds of
+/// real time to reach.
+///
+/// PROVED TO FAIL, not assumed to: with <c>progressing:</c> hard-wired to <c>true</c> in
+/// <c>GatewayHost.DictationStatusFor</c>, <see cref="AnUndeliveredRecordThatIsNotProgressing_PaintsNothing"/>
+/// and <see cref="AProgressMarkThatGoesIdle_StopsPainting_TheNinetySecondBound"/> both go RED with the
+/// defect's own symptom - an undelivered record painting "Uploading from phone" about an upload that is not
+/// happening - while every other test in the suite stays green. That is the check that makes this file
+/// evidence rather than decoration.
+///
+/// Design: docs/new_architecture/session-state.html, defect 19.
+/// </summary>
+public sealed class DictationOrangeProducerTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "dictation-producer-" + Guid.NewGuid().ToString("N"));
+    private DateTime _now = new(2026, 7, 14, 6, 11, 0, DateTimeKind.Utc); // the hour f13cb4b6d9d0 wedged
+    private readonly TranscribingSessions _marks;
+    private readonly VoiceUploadStore _uploads;
+
+    public DictationOrangeProducerTests()
+    {
+        _marks = new TranscribingSessions(() => _now);
+        _uploads = new VoiceUploadStore(_root);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); }
+        catch (IOException) { /* a temp directory that outlives the test is not a test failure */ }
+    }
+
+    /// <summary>The production seam itself - the exact method the live roster's dictationStatusFor calls.</summary>
+    private string? PhaseFor(string sessionId) => GatewayHost.DictationStatusFor(sessionId, _marks, _uploads);
+
+    /// <summary>
+    /// A real durable PENDING record, written by the real store's real verb, and read back through the real
+    /// disk projection before the test proceeds.
+    ///
+    /// The id is a real GUID because the real store demands one: MarkPending runs NormalizeId and throws
+    /// "invalid upload id" on anything Guid.TryParse rejects. The first version of this file used the literal
+    /// "f13cb4b6d9d0" from the wedge investigation and the store threw - that string is the LOG's truncated
+    /// display of a full upload id, not the id. Worth keeping in the record: a value copied out of a log is
+    /// not the value production handles, and the real component is what caught it.
+    /// </summary>
+    private string ARealUndeliveredDictation(string sessionId)
+    {
+        var uploadId = Guid.NewGuid().ToString("N");
+        _uploads.MarkPending(uploadId, sessionId);
+        Assert.True(_uploads.IsSessionLocked(sessionId), "the durable record must actually stand, or this test proves nothing");
+        return uploadId;
+    }
+
+    // ===================== THE DEFECT =====================
+
+    /// <summary>
+    /// THE DEFECT ITSELF, at the producer. An undelivered record stands - durable, correct, and it must
+    /// never expire - and NOTHING is progressing. Upload f13cb4b6d9d0's audio had arrived intact and its
+    /// transcription was failing; nothing was uploading. The old rule painted "Uploading from phone" anyway,
+    /// for an hour and a half, across four Gateway restarts.
+    ///
+    /// This is the test that goes red if anyone hard-wires the progress fact.
+    /// </summary>
+    [Fact]
+    public void AnUndeliveredRecordThatIsNotProgressing_PaintsNothing()
+    {
+        ARealUndeliveredDictation("wedged");
+
+        Assert.Null(PhaseFor("wedged"));
+    }
+
+    /// <summary>
+    /// THE BOUND, driven through the real idle rule rather than asserted about it. The phone uploads, then
+    /// goes quiet - out of signal, battery dead, whatever. The colour must fall away on its own, and the
+    /// words must NOT: both halves are checked here, because the ruling was "bound the colour, KEEP the
+    /// record", and a fix that dropped the record would pass a colour-only test while losing the user's words.
+    /// </summary>
+    [Fact]
+    public void AProgressMarkThatGoesIdle_StopsPainting_TheNinetySecondBound()
+    {
+        ARealUndeliveredDictation("quiet-phone");
+        _marks.Begin("quiet-phone");
+
+        Assert.Equal(DictationPhase.Uploading, PhaseFor("quiet-phone"));
+
+        _now = _now.AddSeconds(91); // the phone stops sending - the idle window lapses
+
+        Assert.Null(PhaseFor("quiet-phone"));
+        // ...and the words are still there. The record is durable BY DESIGN and this is the half that
+        // vindicated it: f13cb4b6d9d0 delivered 362 real characters at 07:40. Bounding the colour must
+        // never be implemented by throwing the audio away.
+        Assert.True(_uploads.IsSessionLocked("quiet-phone"),
+            "the durable record must survive the colour falling away - an age cut here would make a phone " +
+            "out of signal lose the user's words, which is the one thing the ruling forbids");
+    }
+
+    // ===================== THE POSITIVE CASES =====================
+
+    /// <summary>
+    /// A genuinely slow upload keeps its label and is never cut short - the case that stops the bound from
+    /// being implemented as a crude age cut. Progress refreshes the mark, so the label holds across a window
+    /// far longer than the idle one.
+    /// </summary>
+    [Fact]
+    public void AnUploadThatKeepsMakingProgress_KeepsPainting_HoweverLongItTakes()
+    {
+        ARealUndeliveredDictation("slow-phone");
+        _marks.Begin("slow-phone");
+
+        for (var chunk = 0; chunk < 10; chunk++)
+        {
+            _now = _now.AddSeconds(60);      // slow, but alive
+            _marks.Refresh("slow-phone");    // the real verb the chunk-store path calls
+            Assert.Equal(DictationPhase.Uploading, PhaseFor("slow-phone"));
+        }
+    }
+
+    /// <summary>The server has the audio and is turning it into text: the most specific true statement wins,
+    /// and it is the honest label - "Transcribing", not "Uploading from phone".</summary>
+    [Fact]
+    public void WhileTheServerIsActuallyTranscribing_TheLabelSaysSo()
+    {
+        ARealUndeliveredDictation("transcribing");
+        _marks.MarkActivelyTranscribing("transcribing");
+
+        Assert.Equal(DictationPhase.Transcribing, PhaseFor("transcribing"));
+    }
+
+    /// <summary>
+    /// THE CONTROL. A session with no dictation at all paints nothing - so the tests above are not passing
+    /// because the producer is simply silent about everything.
+    /// </summary>
+    [Fact]
+    public void ASessionWithNoDictation_PaintsNothing()
+    {
+        Assert.Null(PhaseFor("innocent"));
+    }
+
+    /// <summary>
+    /// THE OTHER CONTROL, and the one that matters most: progress WITHOUT an undelivered record must not
+    /// paint either. If it did, the producer would be reading the bounded fact as though it were the durable
+    /// one - the two questions conflated again, in the opposite direction.
+    /// </summary>
+    [Fact]
+    public void AProgressMarkWithNoUndeliveredRecord_PaintsNothing()
+    {
+        _marks.Begin("no-record");
+
+        Assert.False(_uploads.IsSessionLocked("no-record"));
+        Assert.Null(PhaseFor("no-record"));
+    }
+
+    /// <summary>
+    /// THE DELIVERY, end to end through the real store: once the words land, the record is terminal and the
+    /// colour is gone. This is the normal path, and it is why the defect was so hard to believe - the common
+    /// case never wedges, so the two comments claiming "it never wedges" were half-true, and that half was
+    /// load-bearing.
+    /// </summary>
+    [Fact]
+    public void OnceTheWordsAreDelivered_NothingPaints()
+    {
+        var uploadId = ARealUndeliveredDictation("delivering");
+        _marks.Begin("delivering");
+        Assert.Equal(DictationPhase.Uploading, PhaseFor("delivering"));
+
+        _uploads.MarkDelivered(uploadId, submitted: true, movedOn: false, transcript: "the 362 characters");
+
+        Assert.False(_uploads.IsSessionLocked("delivering"));
+        Assert.Null(PhaseFor("delivering"));
+    }
+}

--- a/src/CcDirector.Gateway.Tests/DictationPermanentFailureTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationPermanentFailureTests.cs
@@ -59,31 +59,80 @@ public sealed class DictationPermanentFailureTests : IDisposable
         Assert.Single(Directory.EnumerateFiles(Path.Combine(_root, Guid.Parse(id).ToString("N")), "*.part"));
     }
 
+    // ===== THESE TWO TESTS USED TO ASSERT DEFECT 19. Read this before you "fix" them back. =========
+    //
+    // They were named Guard_*_IsNotMappedToPermanent_AndDoesNotParkTheRecord, and each asserted TWO things
+    // in one breath:
+    //
+    //   (a) a retryable outcome must not be RECLASSIFIED as permanent - it keeps its 502/402 contract so the
+    //       durable queue re-drives it. That half is CORRECT, it is the whole point of issue #1185's guard,
+    //       and it is still asserted below. Do not lose it.
+    //   (b) `Assert.Null(_store.ReadRecord(id))` - the record must be left unparked. THAT HALF WAS THE BUG.
+    //       An unparked record stays PENDING, and PENDING paints the session orange with no bound, so the
+    //       session read "Uploading from phone" about an upload that was going nowhere. OBSERVED: upload
+    //       f13cb4b6d9d0, 12 July 2026, orange for 1h30m across four Gateway restarts before it finally
+    //       delivered 362 characters.
+    //
+    // Parking FAILED does NOT give up on the words: FAILED keeps the staged chunks and the next
+    // register/complete clears it back to PENDING and re-drives. f13cb4b6d9d0 would still have delivered at
+    // 07:40. The only thing parking removes is the lie on the dot between attempts.
+    //
+    // A green test is not proof. These two were green, and they were defending the defect.
+
     [Fact]
-    public void Guard_ProviderError_IsNotMappedToPermanent_AndDoesNotParkTheRecord()
+    public void ProviderError_KeepsItsRetryableContract_ButParksTheRecordSoTheColourIsBounded()
     {
-        // The guard: every non-Ok outcome that is NOT PermanentError keeps its existing behavior. A provider
-        // error stays a retryable 502 and must NOT park the record FAILED.
+        // (a) the CORRECT half, unchanged: a provider error is NOT reclassified as permanent.
         var id = _store.Register(null);
+        _store.MarkPending(id, "session-1");
         var result = GatewayTranscriptionResult.ProviderError("mode", "model", "provider rejected the key");
 
         var outcome = GatewayDictationEndpoint.MapNonOkTranscription(result, id, _store);
 
         Assert.NotNull(outcome);
         Assert.False(outcome!.IsIncomplete);
-        Assert.Null(_store.ReadRecord(id)); // not parked FAILED - still PENDING, so a retry re-runs
+        Assert.False(outcome.Terminal, "a provider error is retryable - the client re-drives it");
+
+        // (b) the INVERTED half - this is the defect-19 fix. The record parks FAILED, so it stops painting.
+        var record = _store.ReadRecord(id);
+        Assert.NotNull(record);
+        Assert.Equal(DictationDeliveryState.Failed, record!.State);
+        Assert.False(_store.IsPending(id), "a parked record must not paint the session 'Uploading from phone'");
+        Assert.False(_store.IsSessionLocked("session-1"), "the wedged orange is exactly this returning true forever");
+
+        // ...and the words are NOT lost: the owning session is preserved and a retry re-enters PENDING.
+        Assert.Equal("session-1", record.SessionId);
+        Assert.True(_store.ClearFailed(id), "the retry must be able to re-drive the parked record");
+        Assert.True(_store.IsPending(id));
     }
 
     [Fact]
-    public void Guard_OutOfCredits_IsNotMappedToPermanent_AndDoesNotParkTheRecord()
+    public async Task OutOfCredits_KeepsIts402Contract_ButParksTheRecordSoTheColourIsBounded()
     {
+        // NOTE: out-of-credits has NEVER been observed to fire - zero OutOfCredits in any log on this
+        // machine, ever, across 846 terminal outcomes. An earlier draft of the specification called it the
+        // "everyday" cause of the wedged orange; that was invented and is disproven. This test asserts the
+        // MECHANISM only. It says nothing about the cause.
         var id = _store.Register(null);
+        await _store.StoreChunkAsync(id, 0, Encoding.UTF8.GetBytes("AAA"), null);
+        _store.MarkPending(id, "session-1");
         var result = GatewayTranscriptionResult.OutOfCredits("mode", "model", "insufficient_credits", "no credits");
 
         var outcome = GatewayDictationEndpoint.MapNonOkTranscription(result, id, _store);
 
+        // (a) the CORRECT half, unchanged: never permanent, so adding credit and retrying still delivers.
         Assert.NotNull(outcome);
-        Assert.Null(_store.ReadRecord(id)); // out-of-credits keeps the recording, never permanent
+        Assert.False(outcome!.Terminal);
+
+        // (b) the INVERTED half: parked, so the session stops claiming an upload is in progress.
+        var record = _store.ReadRecord(id);
+        Assert.NotNull(record);
+        Assert.Equal(DictationDeliveryState.Failed, record!.State);
+        Assert.Equal("out_of_credits", record.Reason);
+        Assert.False(_store.IsSessionLocked("session-1"));
+
+        // The recording is KEPT: adding credit and retrying must still deliver the words.
+        Assert.Single(Directory.EnumerateFiles(Path.Combine(_root, Guid.Parse(id).ToString("N")), "*.part"));
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -266,16 +266,45 @@ internal static class GatewayDictationEndpoint
     }
 
     // Map a NON-Ok transcription result to the dictation outcome, or null when the result is Ok and the
-    // caller should continue to inject (issue #1185). This is where the permanent-failure classification
-    // lives, and the GUARD is exact: ONLY Outcome==PermanentError parks the record FAILED and returns the
-    // 422 stop; out-of-credits stays 402; every OTHER non-Ok outcome (provider error, no-key, no-audio,
-    // transient) keeps its existing retryable 502 behavior and is NOT reclassified as permanent.
+    // caller should continue to inject (issue #1185).
+    //
+    // TWO SEPARATE QUESTIONS, and conflating them is what wedged the orange (defect 19):
+    //
+    //   1. What does the CLIENT get told? Only PermanentError gets the 422 "stop forever" contract.
+    //      Out-of-credits stays 402 and every other non-Ok outcome stays a retryable 502, so the durable
+    //      queue keeps re-driving a failure that might yet succeed. That classification is CORRECT and is
+    //      deliberately unchanged here.
+    //
+    //   2. What state is the RECORD left in? EVERY non-Ok outcome now parks the record FAILED. This is the
+    //      defect-19 fix. Parking is NOT "giving up": FAILED keeps the staged chunk bytes, and the next
+    //      register/complete clears it back to PENDING and re-drives (see the FAILED re-entry at register
+    //      and complete). What it changes is that a record which is going nowhere RIGHT NOW stops claiming
+    //      the session is "Uploading from phone", because IsPending is false while FAILED.
+    //
+    // OBSERVED, not theorised (14 July 2026 log correlation): upload f13cb4b6d9d0 on 12 July stood PENDING
+    // for 1 hour 30 minutes - painting its session orange across four Gateway restarts - while complete
+    // returned 502 roughly fifteen times from THIS retryable arm, which returned without any terminal write.
+    // It then transcribed and delivered 362 characters at 07:40. Both halves matter: the durable record was
+    // right to keep the words (they landed), and the colour was lying for ninety minutes. Parking FAILED
+    // here keeps the words AND ends the lie - that upload would still have delivered at 07:40.
+    //
+    // The retryable arm used to return silently, which is why the log could say WHEN it wedged but never
+    // WHY. It logs now.
     internal static DictationOutcome? MapNonOkTranscription(
         GatewayTranscriptionResult result, string uploadId, VoiceUploadStore uploads)
     {
         if (result.Outcome == TranscriptionOutcome.Ok) return null;
         if (result.Outcome == TranscriptionOutcome.OutOfCredits)
+        {
+            // Park the record so the session stops reading "Uploading from phone" while there is no credit
+            // to transcribe it with; the client still gets 402, and adding credit + retrying re-enters
+            // PENDING and delivers. NOTE: never once observed to fire - zero OutOfCredits in any log on this
+            // machine, ever, across 846 terminal outcomes. The mechanism is real; the cause is not this.
+            uploads.MarkFailed(uploadId, "out_of_credits");
+            FileLog.Write($"[GatewayDictation] complete uploadId={uploadId}: out of credits " +
+                $"code={result.Code}; parked FAILED (chunks retained, retryable)");
             return DictationOutcome.OutOfCredits(HostedAiErrorMapper.MapCode(result.Code));
+        }
         // A genuinely-permanent failure (unsupported/undecodable format, or too large to reduce - issue
         // #1139) can NEVER transcribe, so returning the generic retryable 502 makes the durable queue
         // re-drive it forever. Instead park the record FAILED with the reason code (KEEPING the chunks so an
@@ -287,6 +316,11 @@ internal static class GatewayDictationEndpoint
                 $"code={result.Code}; parked FAILED");
             return DictationOutcome.Permanent(TranslatePermanentReason(result.Code));
         }
+        // The retryable arm - THE ONE THAT ACTUALLY WEDGED (see f13cb4b6d9d0 above). Still a 502 the client
+        // re-drives; now it parks the record so the colour tells the truth between attempts.
+        uploads.MarkFailed(uploadId, result.Code ?? "transcription_error");
+        FileLog.Write($"[GatewayDictation] complete uploadId={uploadId}: retryable transcription failure " +
+            $"code={result.Code} error={result.Error}; parked FAILED (chunks retained, retryable)");
         return DictationOutcome.Error(StatusCodes.Status502BadGateway, result.Error ?? "transcription failed");
     }
 

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1209,13 +1209,39 @@ public sealed class GatewayHost : IAsyncDisposable
             // and transcribed in the background for this session (mobile Speak -> Send).
             transcribingFor: sid => _transcribingSessions.IsTranscribing(sid),
             // Issue #1181, Task 4: the honest phase label. "Transcribing" while the server is actively
-            // turning the uploaded audio into text (a bounded run); otherwise "Uploading from phone" while
-            // the durable PENDING delivery marker stands (the phone is still sending, and this never wedges
-            // because the marker clears only on delivery/abandon); null when no dictation is inbound.
-            dictationStatusFor: sid =>
-                _transcribingSessions.IsActivelyTranscribing(sid) ? "Transcribing"
-                : _dictationUploads.IsSessionLocked(sid) ? "Uploading from phone"
-                : null,
+            // turning the uploaded audio into text (a bounded run); "Uploading from phone" while the durable
+            // PENDING marker stands AND the phone is still making progress; null when no dictation is
+            // inbound.
+            //
+            // ONE FLAG WAS ANSWERING TWO QUESTIONS, and that was defect 19 (fixed 14 July 2026, mission
+            // "Session State Truth"). The durable PENDING marker answers "is there an undelivered dictation
+            // for this session?" - a durable fact that must NEVER expire, or a phone out of signal loses its
+            // words. It was ALSO being used to answer "should this session be painted orange right now?" - a
+            // presentation question that must ALWAYS be bounded. So an upload that stopped progressing left
+            // the session orange indefinitely, reading "Uploading from phone" about an upload that was not
+            // happening.
+            //
+            // The colour is now bounded by the SAME idle rule the transcribing mark already uses
+            // (TranscribingSessions.IdleTimeout): the phone refreshes the mark on every stored chunk and
+            // every completion attempt, so a genuinely slow upload keeps its label and is never cut short,
+            // while one that goes quiet drops back to the session's true colour within the idle window. The
+            // durable record is untouched and still delivers whenever the phone returns - and the delivery
+            // submits text, which makes the agent work, which is blue. Nothing is lost except the lie.
+            //
+            // The earlier comment here claimed this "never wedges because the marker clears only on
+            // delivery/abandon". That was half-true and the half it left out WAS the bug: the marker does
+            // clear on delivery, so the normal path never wedges - but the paths that reach no terminal state
+            // at all never clear it. Observed: upload f13cb4b6d9d0 stood PENDING 1h30m on 12 July 2026,
+            // orange the whole time, across four Gateway restarts (so "it clears on restart" is false too -
+            // the record is on disk), before finally delivering 362 characters.
+            // The rule itself lives in DictationPhase.For so it is testable without a running Gateway; this
+            // supplies the three facts. IsTranscribing() is the progress-idle read (it also drops a stale
+            // mark), and transcribingFor above already calls it for every session, so evaluating it here
+            // costs nothing new.
+            dictationStatusFor: sid => Transcription.DictationPhase.For(
+                activelyTranscribing: _transcribingSessions.IsActivelyTranscribing(sid),
+                undelivered: _dictationUploads.IsSessionLocked(sid),
+                progressing: _transcribingSessions.IsTranscribing(sid)),
             // The mobile Speak flow marks/clears this via POST /sessions/{sid}/transcribing.
             transcribingSessions: _transcribingSessions,
             // Issue #212 W3: enrich the Interrupted sessions list from the durable brief store. Always

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1251,9 +1251,25 @@ public sealed class GatewayHost : IAsyncDisposable
             // The colour is now bounded by the SAME idle rule the transcribing mark already uses
             // (TranscribingSessions.IdleTimeout): the phone refreshes the mark on every stored chunk and
             // every completion attempt, so a genuinely slow upload keeps its label and is never cut short,
-            // while one that goes quiet drops back to the session's true colour within the idle window. The
-            // durable record is untouched and still delivers whenever the phone returns - and the delivery
-            // submits text, which makes the agent work, which is blue. Nothing is lost except the lie.
+            // while one that goes quiet drops back to the session's true colour within the idle window.
+            //
+            // THAT "REFRESHES ON EVERY CHUNK" IS TRUE BY INSPECTION AND UNGUARDED BY ANY TEST. It is
+            // GatewayDictationEndpoint.cs: Begin on register, Refresh in the chunk route, Refresh on the
+            // completion attempt. The producer tests below drive TranscribingSessions directly, so they
+            // prove the RULE reads the mark - they do not prove the ROUTES still write it. Delete the
+            // Refresh in the chunk route and every test in this repository stays green while a slow real
+            // upload stops painting mid-flight. It is the milder cousin of defect 19 (a label that goes
+            // quiet too early, rather than one that never shuts up) and it loses no words, but it is
+            // written here as a known gap rather than left to read as covered: proving it needs an
+            // endpoint-level test that drives the real chunk route, and there is no host harness for these
+            // routes yet. Raised by review of pull request 1588; accepted deliberately, not overlooked.
+            //
+            // The user's AUDIO is retained either way and still delivers whenever the phone returns - the
+            // delivery submits text, which makes the agent work, which is blue. Note the precise claim:
+            // the CHUNKS are kept and the record is never discarded or expired. The record itself is NOT
+            // untouched - a retryable or out-of-credits transcription now parks it Pending -> Failed, and
+            // Failed is a resting state that keeps the audio and re-drives on the next register/complete,
+            // not a terminal one. Nothing is lost except the lie on the dot.
             //
             // The earlier comment here claimed this "never wedges because the marker clears only on
             // delivery/abandon". That was half-true and the half it left out WAS the bug: the marker does

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -358,6 +358,33 @@ public sealed class GatewayHost : IAsyncDisposable
     // terminal tombstone de-dupes the upload id forever until the client acknowledges it - so there is no
     // age sweep for dictation staging (only the unrelated voice-turn staging is age-swept).
     private readonly Voice.VoiceUploadStore _dictationUploads = new(CcDirector.Core.Storage.CcStorage.DictationUploads());
+
+    /// <summary>
+    /// THE PRODUCER of the dictation phase label - the three facts that decide whether a session paints
+    /// orange for a dictation. The roster's <c>dictationStatusFor</c> callback is exactly this method, so
+    /// what a test drives here is what production runs.
+    ///
+    /// WHY IT IS A NAMED METHOD AND NOT AN INLINE LAMBDA. The rule (<see cref="Transcription.DictationPhase.For"/>)
+    /// has regression tests; the WIRING that supplies its three facts had none - the callback appeared in
+    /// zero test files. You could wire <c>progressing: true</c> as a constant and the whole Gateway suite
+    /// stayed green while defect 19 returned in full, because a hard-true progress flag makes any
+    /// undelivered record paint forever, which IS the defect. An unbindable seam is an untestable one, and
+    /// this repository's signature failure is a live consumer with an unguarded producer - the rule pinned,
+    /// the wiring not. Extracting it changes no behaviour and makes the seam bindable;
+    /// <c>DictationOrangeProducerTests</c> binds it with the REAL collaborators and goes red if any of the
+    /// three facts is replaced by a constant.
+    ///
+    /// Read the three facts as the two questions they answer, because conflating them was the whole defect:
+    /// <paramref name="uploads"/> answers the DURABLE one ("are there undelivered words?" - must never
+    /// expire), and <paramref name="marks"/> answers the BOUNDED one ("is anything actually happening right
+    /// now?" - must always expire).
+    /// </summary>
+    internal static string? DictationStatusFor(
+        string sessionId, Transcription.TranscribingSessions marks, Voice.VoiceUploadStore uploads)
+        => Transcription.DictationPhase.For(
+            activelyTranscribing: marks.IsActivelyTranscribing(sessionId),
+            undelivered: uploads.IsSessionLocked(sessionId),
+            progressing: marks.IsTranscribing(sessionId));
     // Issue #629: the durable, bounded, restart-surviving retry queue behind the login-telemetry
     // relay. Constructed here (loads any events a previous run left on disk), wired into the relay
     // endpoint, started flushing in StartAsync, and disposed in StopAsync.
@@ -1234,14 +1261,10 @@ public sealed class GatewayHost : IAsyncDisposable
             // at all never clear it. Observed: upload f13cb4b6d9d0 stood PENDING 1h30m on 12 July 2026,
             // orange the whole time, across four Gateway restarts (so "it clears on restart" is false too -
             // the record is on disk), before finally delivering 362 characters.
-            // The rule itself lives in DictationPhase.For so it is testable without a running Gateway; this
-            // supplies the three facts. IsTranscribing() is the progress-idle read (it also drops a stale
-            // mark), and transcribingFor above already calls it for every session, so evaluating it here
-            // costs nothing new.
-            dictationStatusFor: sid => Transcription.DictationPhase.For(
-                activelyTranscribing: _transcribingSessions.IsActivelyTranscribing(sid),
-                undelivered: _dictationUploads.IsSessionLocked(sid),
-                progressing: _transcribingSessions.IsTranscribing(sid)),
+            // The rule itself lives in DictationPhase.For so it is testable without a running Gateway, and
+            // the WIRING that supplies its three facts lives in DictationStatusFor so it is testable too -
+            // see that method for why an inline lambda here was a hole rather than a style choice.
+            dictationStatusFor: sid => DictationStatusFor(sid, _transcribingSessions, _dictationUploads),
             // The mobile Speak flow marks/clears this via POST /sessions/{sid}/transcribing.
             transcribingSessions: _transcribingSessions,
             // Issue #212 W3: enrich the Interrupted sessions list from the durable brief store. Always

--- a/src/CcDirector.Gateway/Transcription/DictationPhase.cs
+++ b/src/CcDirector.Gateway/Transcription/DictationPhase.cs
@@ -1,0 +1,55 @@
+namespace CcDirector.Gateway.Transcription;
+
+/// <summary>
+/// The Gateway's dictation PHASE label rule - which phase an inbound dictation is in, or null when the
+/// session has no dictation worth painting. This is the single place that answers "should this session be
+/// painted orange for a dictation right now?", and it is deliberately a pure function of three booleans so
+/// the rule itself is testable without a running Gateway. <c>GatewayHost</c> supplies the facts; the
+/// <c>SessionOrdering</c> fold turns a non-null result into the orange dot and the label.
+///
+/// DEFECT 19, fixed 14 July 2026 (mission "Session State Truth"). One flag was answering two questions:
+///
+///   1. "Is there an undelivered dictation for this session?" - a DURABLE fact. It must NEVER expire, or a
+///      phone out of signal loses its words. That is <paramref name="undelivered"/>, and it is correct.
+///   2. "Should this session be painted orange right now?" - a PRESENTATION question. It must ALWAYS be
+///      bounded, or an upload that stopped paints the session orange indefinitely.
+///
+/// The colour used to be driven by the answer to question 1 alone, so any dictation that reached no
+/// terminal state left its session orange forever, reading "Uploading from phone" about an upload that was
+/// not happening. OBSERVED (log correlation, 14 July 2026): upload f13cb4b6d9d0 stood undelivered for
+/// 1 hour 30 minutes on 12 July 2026 - orange the whole time, across four Gateway restarts - while its
+/// transcription failed repeatedly, before finally delivering 362 characters. Both halves of that matter:
+/// the durable record was RIGHT to keep the words, and the colour was lying for ninety minutes.
+///
+/// So the record is untouched and <paramref name="progressing"/> bounds the colour instead: the phone
+/// refreshes its progress mark on every stored chunk and every completion attempt, so a genuinely slow
+/// upload keeps its label and is never cut short, while one that goes quiet drops back to the session's
+/// true colour within the idle window. The dictation still delivers whenever the phone returns - and a
+/// delivery submits text, which makes the agent work, which is blue. Nothing is lost except the lie.
+/// </summary>
+internal static class DictationPhase
+{
+    /// <summary>The phone is still sending the audio up.</summary>
+    public const string Uploading = "Uploading from phone";
+
+    /// <summary>The audio is up and the server is turning it into text.</summary>
+    public const string Transcribing = "Transcribing";
+
+    /// <summary>
+    /// The phase label for a session, or null when no dictation should paint it.
+    /// </summary>
+    /// <param name="activelyTranscribing">A transcription run is in flight for this session (bounded by the
+    /// run itself, cleared in its finally). Wins outright: it is the most specific true statement available.</param>
+    /// <param name="undelivered">A durable PENDING dictation record stands for this session. NEVER expires -
+    /// this is the fact that must not be lost, not the one that may paint.</param>
+    /// <param name="progressing">The upload has made progress within the idle window (a chunk stored, a
+    /// completion attempted). This is what BOUNDS the colour: undelivered alone must never paint, because
+    /// "undelivered" is durable and unbounded by design.</param>
+    public static string? For(bool activelyTranscribing, bool undelivered, bool progressing)
+        => activelyTranscribing ? Transcribing
+        // NOTE the AND. Dropping `progressing` here restores defect 19 exactly: an undelivered record is
+        // durable and unbounded, so it would paint until the record reached a terminal state - which, for
+        // the paths that reach none, is never. If a test ever asks you to remove it, that test is the bug.
+        : undelivered && progressing ? Uploading
+        : null;
+}


### PR DESCRIPTION
## What this fixes

**The orange dot lied about your phone.** A dictation upload that stalled left the session orange, reading "Uploading from phone", while nothing was uploading. One real case stood orange for **an hour and a half**, across four Gateway restarts, before finally delivering.

Orange now requires the upload to be actually making progress. **Your audio is retained and still delivered** either way - the record is never discarded or expired. Only the lie on the dot goes away.

## Diagnosed from evidence, not guessed

The original write-up blamed this on the Gateway running out of credits. That was never observed: zero out-of-credits outcomes across 846 terminal outcomes, with a healthy balance throughout the incident it was invented to explain. The real cause was found by log correlation - the retryable transcription arm returned without a terminal write and logged nothing.

## One change beyond the mission's own work

The mission wired the rule in as an inline lambda and only extracted it into a testable method four commits later. Sliced, that would have put this fix on main with the rule tested and **the wiring unguarded** until slice 6 - the exact hole this repository keeps falling into. The guard is pulled forward so the fix and its protection land together.

## What is proven, and what is not

**Proven:** hard-coding the progress fact to `true` puts defect 19 back in full and turns exactly two producer tests red, 13 green in that class. Verified in this session. Full suite green, all seven projects, zero warnings.

**Not proven, and recorded as such in the code:** the write side. "The phone refreshes the mark on every stored chunk" is true by inspection but no test drives the real chunk route - delete that refresh and the suite stays green while a slow upload stops painting mid-flight. It loses no words and is milder than the bug being fixed, but it is a known gap, accepted deliberately. Closing it needs an endpoint-level host harness that does not exist yet.

**Corrected during review:** an earlier version of this description said "the durable record is untouched". That was too broad - the retryable and out-of-credits arms deliberately move the record from Pending to Failed, which keeps the audio and re-drives on the next attempt. The words are safe; the sentence explaining why was wrong.

Slice 3 of 6.
