### PR TITLE
fix(cockpit): point Sign in at the front door that works from another machine

### DIFF
--- a/apps/cockpit/src/account/AccountView.tsx
+++ b/apps/cockpit/src/account/AccountView.tsx
@@ -4,7 +4,7 @@ import {
   logoutAccount,
   getAccountDevices,
   removeAccountDevice,
-  startSignIn,
+  beginSignIn,
   type AccountStatus,
   type AccountDevice,
   type AccountDevicesResponse,
@@ -15,18 +15,14 @@ import { ErrorBanner, LoadingState, PageHeader } from "../components";
 // The Account page (issue #978, epic #967) - the React port of the Blazor Cockpit Account.razor
 // (#853/#648/#854). A pure client of the Gateway account endpoints: the credential lives on the
 // Gateway and the raw token is NEVER fetched, stored, or displayed (security rule DT-05).
-//   - signed-out: a real "Sign in" action that starts the Gateway browser loopback sign-in via
-//     POST /account/sign-in, then polls GET /account/status for completion;
+//   - signed-out: a real "Sign in" action that NAVIGATES to the Gateway's public sign-in front door
+//     (POST /account/sign-in-start), which redirects a remote browser on to devthrottle.com and hands
+//     it back to the Gateway's own callback - so this page just leaves and is re-entered signed in;
 //   - signed-in: identity + Log out (POST /account/logout) AND a "Your devices" list from
 //     GET /account/devices with a per-device Remove (DELETE /account/devices/{id}).
 // Responsive (CodingStyle.md): the page renders immediately with a loading state and loads the status +
 // device list asynchronously. On any failure it shows an explicit error state, never a fabricated
 // signed-out or empty-devices view (the no-fallback rule).
-
-/** How long the page waits for the browser sign-in to complete before it stops polling. */
-const SIGN_IN_POLL_TIMEOUT_MS = 5 * 60 * 1000;
-/** How often the page re-reads the Gateway status while a sign-in is in flight. */
-const SIGN_IN_POLL_INTERVAL_MS = 2000;
 
 function Row({ label, value }: { label: string; value: string }) {
   return (
@@ -66,7 +62,6 @@ export function AccountView() {
   const [loggedOut, setLoggedOut] = useState(false);
 
   // Sign-in (signed-out state).
-  const [signInInProgress, setSignInInProgress] = useState(false);
   const [signInError, setSignInError] = useState<string | null>(null);
 
   // Devices (signed-in state).
@@ -166,64 +161,14 @@ export function AccountView() {
     }
   };
 
-  // Poll the Gateway status while the browser sign-in runs, until the Gateway reports signed-in or the
-  // poll window elapses. The token hand-back happens on the Gateway (#637); this page only observes the
-  // resulting status - it never sees the credential.
-  const pollUntilSignedIn = useCallback(async () => {
-    pollAbortRef.current?.abort();
-    const controller = new AbortController();
-    pollAbortRef.current = controller;
-    const signal = controller.signal;
-    const deadline = Date.now() + SIGN_IN_POLL_TIMEOUT_MS;
-
-    while (Date.now() < deadline) {
-      await new Promise((resolve) => setTimeout(resolve, SIGN_IN_POLL_INTERVAL_MS));
-      if (signal.aborted) return;
-      let next: AccountStatus;
-      try {
-        next = await getAccountStatus(signal);
-      } catch {
-        // A transient status read failure during sign-in is expected (the Gateway is busy with the
-        // hand-off); keep polling until the deadline rather than aborting the sign-in.
-        continue;
-      }
-      if (next.signedIn) {
-        setStatus(next);
-        setSignInInProgress(false);
-        await loadDevices(signal);
-        return;
-      }
-    }
-
-    // The poll window elapsed without a signed-in status: report it explicitly so the person can retry
-    // rather than leaving the button stuck on "waiting".
-    if (!signal.aborted) {
-      setSignInInProgress(false);
-      setSignInError("Sign-in did not complete. Finish it in your browser, then try again.");
-    }
-  }, [loadDevices]);
-
-  const startSignInFlow = async () => {
-    if (signInInProgress) return;
+  // Sign the GATEWAY in to its DevThrottle account. This NAVIGATES away to the Gateway's public
+  // sign-in front door, which redirects a remote browser on to devthrottle.com and hands it back to
+  // the Gateway's own callback - so there is nothing to await and nothing to poll here. The page is
+  // simply re-entered signed in.
+  const startSignInFlow = () => {
     setSignInError(null);
     setLoggedOut(false);
-    try {
-      const result = await startSignIn();
-      if (result.alreadySignedIn) {
-        await loadStatus();
-        return;
-      }
-      if (!result.started) {
-        setSignInError(result.error ?? "Sign-in could not be started.");
-        return;
-      }
-      // Show "waiting for your browser" immediately and poll in the background (responsive UI).
-      setSignInInProgress(true);
-      void pollUntilSignedIn();
-    } catch (err) {
-      setSignInInProgress(false);
-      setSignInError(gatewayErrorMessage(err));
-    }
+    beginSignIn();
   };
 
   return (
@@ -357,19 +302,13 @@ export function AccountView() {
             This Gateway is not signed in to DevThrottle. Sign in to register this device and manage your
             account.
           </p>
-          <button className="acct-btn signin" onClick={() => void startSignInFlow()} disabled={signInInProgress}>
-            {signInInProgress ? "Waiting for your browser..." : "Sign in to DevThrottle"}
+          <button className="acct-btn signin" onClick={startSignInFlow}>
+            Sign in to DevThrottle
           </button>
           <p className="acct-note acct-signin-note">
-            Opens your web browser to finish signing in with Google, GitHub, or email.
+            Takes you to DevThrottle to sign in with Google, GitHub, or email, then brings you back here.
           </p>
 
-          {signInInProgress && (
-            <div className="acct-signin-progress">
-              Finish signing in in the browser window that opened. This page updates automatically once
-              you are signed in.
-            </div>
-          )}
           {signInError !== null && <div className="acct-signin-error">{signInError}</div>}
         </div>
       )}

--- a/packages/client-core/src/account/accountClient.test.ts
+++ b/packages/client-core/src/account/accountClient.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { SIGN_IN_START_PATH, beginSignIn } from "./accountClient";
+
+// Signing the Gateway in from the Cockpit has two load-bearing properties, and both are easy to regress
+// into a version that hangs forever with no visible error:
+//
+//  1. It must target /account/sign-in-start, NOT the old POST /account/sign-in. The old endpoint always
+//     runs the Gateway's browser LOOPBACK sign-in - a browser on the GATEWAY HOST's desktop waiting on
+//     127.0.0.1 - which a Cockpit on any other machine can never reach. That was the live bug.
+//  2. It must NAVIGATE via a form submission, not fetch. The endpoint answers a remote caller with a 302
+//     to devthrottle.com; only a navigation lets the browser follow it and show the person the sign-in
+//     page. A fetch would follow the redirect invisibly in the background.
+//
+// Both failures look identical to a user - the button never completes - so they are pinned here. The
+// fake document keeps this a pure unit test: client-core has no jsdom, and this needs no real DOM.
+
+function fakeDom() {
+  const form = { method: "", action: "", submit: vi.fn() };
+  const appended: unknown[] = [];
+  const doc = {
+    createElement: vi.fn(() => form),
+    body: { appendChild: (n: unknown) => appended.push(n) },
+  } as unknown as Document;
+  return { doc, form, appended };
+}
+
+describe("beginSignIn", () => {
+  it("submits a form POST to the public sign-in start front door", () => {
+    const { doc, form, appended } = fakeDom();
+
+    beginSignIn(doc);
+
+    expect(form.method).toBe("POST");
+    expect(form.action).toBe(SIGN_IN_START_PATH);
+    expect(form.submit).toHaveBeenCalledOnce();
+    // The form must be in the document before submit(); a detached form does not navigate.
+    expect(appended).toEqual([form]);
+  });
+
+  it("does not target the loopback sign-in endpoint", () => {
+    const { doc, form } = fakeDom();
+
+    beginSignIn(doc);
+
+    expect(form.action).not.toBe("/account/sign-in");
+  });
+
+  it("navigates rather than fetching, so the browser can follow the 302 to the cloud", () => {
+    const { doc } = fakeDom();
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    beginSignIn(doc);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+});

--- a/packages/client-core/src/account/accountClient.ts
+++ b/packages/client-core/src/account/accountClient.ts
@@ -42,13 +42,9 @@ export interface AccountDevicesResponse {
   devices?: AccountDevice[] | null;
 }
 
-/** The POST /account/sign-in result: whether a browser sign-in flow is now in flight, whether the
- *  Gateway was already signed in, and a user-safe reason when it could not start. Token-free. */
-export interface SignInStartResult {
-  started: boolean;
-  alreadySignedIn: boolean;
-  error?: string | null;
-}
+/** The Gateway's public sign-in START front door (epic #1069, issues #1076/#1080). Public on the
+ *  AuthMiddleware allow-list, so a browser with no Gateway credential can reach it. */
+export const SIGN_IN_START_PATH = "/account/sign-in-start";
 
 async function gatewayErrorFrom(res: Response, label: string): Promise<GatewayError> {
   let detail = `${res.status}`;
@@ -136,21 +132,27 @@ export async function removeAccountDevice(deviceId: string, signal?: AbortSignal
   if (!res.ok) throw await gatewayErrorFrom(res, `DELETE /account/devices/${deviceId}`);
 }
 
-// POST /account/sign-in - start the Gateway's browser loopback sign-in (the #637 flow). The sign-in
-// runs in the background on the Gateway; this returns as soon as it is kicked off (or reports it was
-// already signed in / not available). After a started result the caller polls getAccountStatus to
-// observe completion. Throws with the server error on transport failure.
-export async function startSignIn(signal?: AbortSignal): Promise<SignInStartResult> {
-  const res = await fetch("/account/sign-in", {
-    method: "POST",
-    headers: { Accept: "application/json", ...authHeaders() },
-    signal,
-  });
-  if (!res.ok) throw await gatewayErrorFrom(res, "POST /account/sign-in");
-  const body = (await res.json()) as Partial<SignInStartResult> | null;
-  return {
-    started: Boolean(body?.started),
-    alreadySignedIn: Boolean(body?.alreadySignedIn),
-    error: body?.error ?? null,
-  };
+// Begin signing the GATEWAY in to its DevThrottle account by NAVIGATING this browser to the Gateway's
+// public sign-in START front door.
+//
+// This must be a real form navigation, not a fetch. POST /account/sign-in-start answers a remote caller
+// with a 302 to devthrottle.com carrying a redirect_uri back to the Gateway's own /account/sign-in-callback
+// (AccountSignInStartEndpoint, epic #1069). Only a navigation lets the browser FOLLOW that redirect, sign
+// in on the cloud page, and be handed back - a fetch would follow it in the background, where the person
+// can never see or use the sign-in page.
+//
+// It deliberately does NOT use the old POST /account/sign-in: that endpoint always runs the Gateway's
+// browser LOOPBACK sign-in, which opens a browser on the GATEWAY HOST's desktop and waits on 127.0.0.1.
+// A Cockpit on any other machine can never reach that loopback, so the button appeared to hang forever.
+//
+// The browser leaves this page and returns via the callback, so there is nothing to poll and nothing to
+// await - this function does not return.
+//
+// `doc` exists only so a unit test can assert the method and target without a DOM; callers pass nothing.
+export function beginSignIn(doc: Document = document): void {
+  const form = doc.createElement("form");
+  form.method = "POST";
+  form.action = SIGN_IN_START_PATH;
+  doc.body.appendChild(form);
+  form.submit();
 }


### PR DESCRIPTION
The Cockpit's "Sign in to DevThrottle" button was wired to the one sign-in flow a Cockpit can never complete. Found while preparing the tray cut.

## The bug

`POST /account/sign-in` always runs the Gateway's browser **loopback** sign-in: it opens a browser on the **Gateway host's own desktop** and waits on `127.0.0.1`. Used from the Cockpit on any other machine - the normal case - there is no browser to open and no loopback to reach. The button sat on *"Waiting for your browser..."* forever.

## The fix

The working flow already exists and is already public. `POST /account/sign-in-start` branches on the caller (`AccountSignInStartEndpoint.cs:195`): a **remote** request gets a `302` to devthrottle.com carrying a `redirect_uri` back to the Gateway's own routable `/account/sign-in-callback` (epic thefrederiksen/devthrottle_internal#675, issues thefrederiksen/devthrottle#1076/#1080). Both routes are already on the `AuthMiddleware` public allow-list, so a browser with no Gateway credential can reach them.

The button now **navigates** there via a real form POST rather than fetching. A fetch would follow the 302 in the background, where the person can never see the sign-in page; only a navigation hands the browser to the cloud page and back. The browser leaves and returns via the callback, so the status polling this page used to do is gone with it.

## Why this lands before the tray cut

The tray flyout's own "Sign in to DevThrottle" button is currently **the only one that works**. Deleting the flyout first would have left no way to sign the Gateway in at all. Same goal, safe order.

## Proof

- client-core **434 tests pass**, 3 new. Verified they **fail on purpose**: pointing the form back at `/account/sign-in` turns them red on exactly the reported symptom, green again when fixed.
- Cockpit and client-core typecheck clean
- Release build runs the Cockpit build clean

## Noted, not touched

- The docstring on `AccountSignInStartEndpoint` describes only the loopback behaviour and is **stale** - the remote branch is right below it at line 195.
- `POST /account/sign-in` now has **no callers**. It dies with the tray's sign-in action in the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)