### PR TITLE
fix(cockpit): give the signed-out Gateway a way out instead of a loop

### DIFF
--- a/packages/client-core/src/api/enroll.test.ts
+++ b/packages/client-core/src/api/enroll.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { GATEWAY_NOT_SIGNED_IN, isGatewayNotSignedIn } from "./enroll";
+import { GatewayError } from "./client";
+
+// There are TWO different sign-ins in this product and they are easy to conflate:
+//
+//   1. the PERSON signs in at devthrottle.com (this is what the Sign in button does), and
+//   2. the GATEWAY signs in to a DevThrottle account (without this it has no account to enroll onto).
+//
+// A device cannot enroll until BOTH have happened, and a fresh install has only ever done (1). The
+// Gateway reports that as 409 from POST /m/enroll. Before this existed, the callback screen treated it
+// as a generic error and offered only "Try again" - which returns to the sign-in screen and fails again
+// for exactly the same reason, a loop with no exit. So 409 must stay distinguishable from every other
+// enrollment failure, or that dead end comes straight back.
+//
+// Note this is the pure classification only. client-core has no DOM test tooling (no jsdom, no
+// testing-library), so the screen that consumes it is not rendered here.
+
+describe("isGatewayNotSignedIn", () => {
+  it("recognises the Gateway-not-signed-in conflict", () => {
+    expect(isGatewayNotSignedIn(new GatewayError(GATEWAY_NOT_SIGNED_IN, "not signed in"))).toBe(true);
+  });
+
+  it("is 409, the status the Gateway actually answers with", () => {
+    expect(GATEWAY_NOT_SIGNED_IN).toBe(409);
+  });
+
+  it("does not swallow the other enrollment failures, which the person cannot fix by signing the Gateway in", () => {
+    // 403 = this device is not on the Gateway's account; 502 = the cloud was unreachable. Neither is
+    // fixed by signing the Gateway in, so neither may reach that screen.
+    expect(isGatewayNotSignedIn(new GatewayError(403, "wrong account"))).toBe(false);
+    expect(isGatewayNotSignedIn(new GatewayError(502, "cloud unreachable"))).toBe(false);
+    expect(isGatewayNotSignedIn(new GatewayError(400, "bad request"))).toBe(false);
+  });
+
+  it("does not mistake a plain error or a non-error for the conflict", () => {
+    expect(isGatewayNotSignedIn(new Error("boom"))).toBe(false);
+    expect(isGatewayNotSignedIn({ status: 409 })).toBe(false);
+    expect(isGatewayNotSignedIn(null)).toBe(false);
+    expect(isGatewayNotSignedIn(undefined)).toBe(false);
+  });
+});

--- a/packages/client-core/src/api/enroll.ts
+++ b/packages/client-core/src/api/enroll.ts
@@ -9,6 +9,25 @@
 import { GatewayError } from "./client";
 
 /**
+ * The Gateway answers POST /m/enroll with 409 when THE GATEWAY ITSELF is not signed in to a DevThrottle
+ * account, so it has no account to enroll this device onto.
+ *
+ * This is not really a failure - on a fresh install it is the expected state - and it is the one
+ * enrollment outcome the person can fix themselves, by signing the Gateway in. Callers must therefore be
+ * able to tell it apart from a genuine error (403 wrong account, 502 cloud unreachable) and offer that
+ * action instead of a "try again" that would fail identically.
+ */
+export const GATEWAY_NOT_SIGNED_IN = 409;
+
+/**
+ * Whether an enrollment failure is "the GATEWAY is not signed in" (as opposed to the person not being
+ * signed in, which is a different thing entirely - see GATEWAY_NOT_SIGNED_IN).
+ */
+export function isGatewayNotSignedIn(err: unknown): err is GatewayError {
+  return err instanceof GatewayError && err.status === GATEWAY_NOT_SIGNED_IN;
+}
+
+/**
  * Exchange the cloud device key for a local Gateway device key.
  * @returns the local per-device key the app must store and send as its Bearer.
  * @throws GatewayError on any non-2xx, carrying the server's reason (403 = not on this Gateway's

--- a/packages/client-core/src/auth/DeviceCallback.tsx
+++ b/packages/client-core/src/auth/DeviceCallback.tsx
@@ -10,10 +10,20 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getInstallId, setDeviceKey } from "./deviceKey";
 import { enrollmentProfile, takeEnrollState, takeEnrollNext } from "./enrollRequest";
-import { enrollDevice } from "../api/enroll";
+import { enrollDevice, isGatewayNotSignedIn } from "../api/enroll";
 import { ensureGatewayCookie } from "../api/client";
+import { beginSignIn } from "../account/accountClient";
 
-type Phase = "working" | "denied" | "error";
+// "gatewaySignedOut" is the Gateway itself not being signed in to a DevThrottle account (HTTP 409 from
+// /m/enroll). It is deliberately NOT an error phase: on a fresh install it is the EXPECTED state - the
+// Gateway has to join an account before it can enroll anything onto that account.
+//
+// It needs its own phase because the generic error phase strands the person. The Gateway's message says
+// "sign the Gateway in and try again", but the only action offered was "Try again", which returns to the
+// sign-in screen and fails again for exactly the same reason - a loop with no exit. The two sign-ins are
+// easy to conflate: the person HAS signed themselves in at devthrottle.com; it is the GATEWAY that has
+// not. So this phase says which one is missing and offers the action that fixes it.
+type Phase = "working" | "denied" | "error" | "gatewaySignedOut";
 
 export function DeviceCallback() {
   const navigate = useNavigate();
@@ -68,6 +78,11 @@ export function DeviceCallback() {
         navigate(landing, { replace: true });
       } catch (err) {
         if (cancelled) return;
+        if (isGatewayNotSignedIn(err)) {
+          setPhase("gatewaySignedOut");
+          setMessage(err.message);
+          return;
+        }
         setPhase("error");
         setMessage(err instanceof Error ? err.message : "Could not connect this device. Please try again.");
       }
@@ -79,6 +94,11 @@ export function DeviceCallback() {
 
   const container = { maxWidth: 420, margin: "0 auto", padding: "2.5rem 1.25rem", textAlign: "center" as const };
 
+  const button = {
+    padding: "0.8rem 1.25rem", fontSize: "1rem", fontWeight: 600,
+    borderRadius: 10, border: "none", cursor: "pointer",
+  } as const;
+
   if (phase === "working") {
     return (
       <div style={container}>
@@ -88,15 +108,31 @@ export function DeviceCallback() {
     );
   }
 
+  // The Gateway has no account yet. The person is signed in; the GATEWAY is not - so name that
+  // difference plainly and give them the one action that resolves it, rather than a "Try again" that
+  // would fail identically. beginSignIn navigates to the Gateway's public sign-in front door, which
+  // sends this browser to devthrottle.com and hands it back to the Gateway's own callback.
+  if (phase === "gatewaySignedOut") {
+    return (
+      <div style={container}>
+        <h1>This Gateway is not signed in yet</h1>
+        <p style={{ opacity: 0.8, marginBottom: "1.5rem" }}>{message}</p>
+        <button type="button" onClick={() => beginSignIn()} style={button}>
+          Sign the Gateway in
+        </button>
+        <p style={{ opacity: 0.7, marginTop: "1.25rem", fontSize: "0.9rem" }}>
+          You are signed in already - it is the Gateway that needs to join your account before it can
+          connect this {profile.deviceLabel}. Once it has, sign in here again.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div style={container}>
       <h1>{phase === "denied" ? "Sign-in declined" : "Something went wrong"}</h1>
       <p style={{ opacity: 0.8, marginBottom: "1.5rem" }}>{message}</p>
-      <button
-        type="button"
-        onClick={() => navigate(profile.signInPath, { replace: true })}
-        style={{ padding: "0.8rem 1.25rem", fontSize: "1rem", fontWeight: 600, borderRadius: 10, border: "none", cursor: "pointer" }}
-      >
+      <button type="button" onClick={() => navigate(profile.signInPath, { replace: true })} style={button}>
         Try again
       </button>
     </div>


### PR DESCRIPTION
Last gap of the headless Gateway work: a fresh install could reach a dead end with no way forward.

## The dead end

There are **two** sign-ins, and they are easy to conflate:

1. the **person** signs in at devthrottle.com, and
2. the **Gateway** signs in to a DevThrottle account.

A device cannot enroll until both have happened, and a fresh install has only ever done the first. The Gateway handles this correctly - `POST /m/enroll` answers `409` with a clear message: *"This Gateway is not signed in to a DevThrottle account... Sign the Gateway in and try again."*

So it was **explained, but not actionable**. `DeviceCallback` treated the 409 as a generic error: heading *"Something went wrong"*, and one button - **"Try again"** - which returns to the sign-in screen and fails again for exactly the same reason. A loop with no exit. And the person cannot tell which sign-in is missing: they *just signed in*.

## The fix

409 now gets its own state. It names which sign-in is missing - the **Gateway's** - and offers **"Sign the Gateway in"**, which navigates to the public `/account/sign-in-start` front door (#1597). It is not framed as an error, because on a fresh install it is the expected state.

`403` (device not on this account) and `502` (cloud unreachable) keep the generic error path - signing the Gateway in fixes neither, so they must not reach the new screen.

`DeviceCallback` is shared by both shells, so the phone's `/m/device-callback` gets the same exit.

## No new public surface

An earlier plan for this step added a public "is the Gateway signed in" probe, because `/account/status` is gated and a fresh browser cannot read it. That turned out to be **unnecessary**: the 409 the Gateway already returns carries everything needed. No new endpoint, no new attack surface.

## Proof

- client-core **438 tests pass**, 4 new. Verified they **fail on purpose**: blinding the classifier to 409 turns it red on exactly the loop it exists to prevent.
- Cockpit and client-core typecheck clean; Release build runs the Cockpit build clean

## Known limit

The pure classification is tested; **the screen is not rendered in a test**. client-core has no DOM test tooling (no jsdom, no testing-library), and adding it was out of scope here. Stating it rather than implying coverage I do not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)