### PR TITLE
refactor(gateway): move the lifecycle out of the tray and into the service

### DIFF
--- a/src/CcDirector.Core.Tests/NoCrossMachineLoopbackGuardTests.cs
+++ b/src/CcDirector.Core.Tests/NoCrossMachineLoopbackGuardTests.cs
@@ -39,14 +39,13 @@ public sealed class NoCrossMachineLoopbackGuardTests
         // loopback-guarded HTTP reverse-proxy was deleted, it is a tunnel-dispatch-only file now) were
         // removed from this allowlist because they no longer carry a loopback literal.
         ["src/CcDirector.Gateway/GatewayHost.cs"] = "Local loopback bind / same-machine wiring.",
-        ["src/CcDirector.Gateway/GatewayWorker.cs"] = "Same-machine worker wiring.",
+        ["src/CcDirector.Gateway/GatewayService.cs"] = "Probes THIS process's own Gateway port on loopback to diagnose a failed start (is the port taken by our own gateway, another app, or nothing?). Same machine by definition - it is asking about its own bind - and it moved here unchanged from GatewayTrayController when the lifecycle left the tray app.",
         ["src/CcDirector.Gateway/Tailscale/TailscaleServeProvisioner.cs"] = "Maps the tailnet front door to local loopback backends.",
         ["src/CcDirector.Gateway/Api/RecordingEndpoints.cs"] = "Local recording paths.",
         ["src/CcDirector.Gateway/Api/MachineEndpoints.cs"] = "Same-machine relay/launcher wiring.",
         ["src/CcDirector.Gateway/Running/IDirectorLauncher.cs"] = "RelayDirectorLauncher posts to the local Gateway's own loopback port to relay a Director start request (same-machine self-call to the Gateway's own /machines/{machine}/director/start endpoint).",
         ["src/CcDirector.Gateway/CarMode/LoopbackCarModeFleet.cs"] = "The Car Mode brain's fleet tools call THIS Gateway's own endpoints over http://127.0.0.1:{port} (same-machine self-call), the same pattern the Web Push needs-you notifier uses to read its own /sessions - so the brain sees the identical aggregated roster every client sees with no re-implementation.",
         ["src/CcDirector.GatewayApp/Program.cs"] = "Local Gateway bootstrap.",
-        ["src/CcDirector.GatewayApp/GatewayTrayController.cs"] = "Probes its own Gateway port on loopback (same machine); the Cockpit is served in-process by that Gateway.",
         ["src/CcDirector.Launcher/DirectorSupervisor.cs"] = "Supervises a local Director over loopback.",
         ["src/CcDirector.Launcher/LauncherHost.cs"] = "Local launcher loopback bind.",
         ["src/CcDirector.Launcher/Program.cs"] = "Self-update helper POSTs /shutdown + probes /healthz on the launcher's own loopback (same machine).",

--- a/src/CcDirector.Gateway.Tests/HeadlessGatewayGuardTests.cs
+++ b/src/CcDirector.Gateway.Tests/HeadlessGatewayGuardTests.cs
@@ -28,6 +28,29 @@ namespace CcDirector.Gateway.Tests;
 /// </summary>
 public class HeadlessGatewayGuardTests
 {
+    // The lifecycle now LIVES in the library (GatewayService), rather than in the tray app with the
+    // library merely not referencing it. That is the difference between "the shim could be deleted" as a
+    // claim and as a fact: a host supplies a port, a mode and how to exit, and gets a complete Gateway.
+    //
+    // This constructs the service with NO host of any kind - no tray, no Avalonia, no desktop - which is
+    // exactly the situation a Windows service will be in. If the lifecycle ever drifts back into the shim,
+    // this stops compiling or stops passing.
+    [Fact]
+    public void TheGatewayLifecycleIsUsableWithNoHostAtAll()
+    {
+        using var service = new GatewayService(new GatewayServiceOptions
+        {
+            Port = 7999,
+            Managed = false,
+            RegisterAutostart = false,
+            ModeLabel = "dev",
+        });
+
+        Assert.Equal(7999, service.Port);
+        Assert.Equal(GatewayServiceState.Stopped, service.State);
+        Assert.Null(service.Host);
+    }
+
     private static Assembly GatewayLibrary => typeof(GatewayHost).Assembly;
 
     [Fact]

--- a/src/CcDirector.Gateway/GatewayService.cs
+++ b/src/CcDirector.Gateway/GatewayService.cs
@@ -1,0 +1,368 @@
+using System.Net.Http;
+using System.Net.Sockets;
+using CcDirector.Core.Utilities;
+using CcDirector.HostedAgent;
+using CcDirector.Setup.Engine;
+
+namespace CcDirector.Gateway;
+
+/// <summary>The lifecycle state of the Gateway, as a service control would report it.</summary>
+public enum GatewayServiceState { Starting, Running, Stopped, Failed }
+
+/// <summary>
+/// The few facts about the PROCESS that the service itself cannot know: which port to serve, whether it
+/// is a managed install that self-updates, and what to write into the autostart Run key. A host supplies
+/// these; everything else the service decides for itself.
+/// </summary>
+public sealed class GatewayServiceOptions
+{
+    /// <summary>The port to serve on.</summary>
+    public int Port { get; init; } = GatewayHost.DefaultPort;
+
+    /// <summary>Run the periodic self-update loop (managed installs only; never the dev console loop).</summary>
+    public bool Managed { get; init; }
+
+    /// <summary>Register the per-user autostart Run key at start.</summary>
+    public bool RegisterAutostart { get; init; }
+
+    /// <summary>The arguments to bake into the autostart Run key, or null for none.</summary>
+    public string? AutostartArguments { get; init; }
+
+    /// <summary>The run-mode string the Cockpit Settings page shows ("managed" / "dev").</summary>
+    public string ModeLabel { get; init; } = "dev";
+}
+
+/// <summary>
+/// The Gateway, as a service: it owns the <see cref="GatewayHost"/> lifecycle, the managed self-update
+/// loop, autostart registration, the Cockpit's settings hooks, port-conflict diagnostics, and the issue
+/// #880 shutdown watchdog. Start and stop are its only verbs, because they are the only verbs a Windows
+/// service has.
+///
+/// WHY THIS CLASS EXISTS. All of the above used to live in GatewayTrayController - inside the tray app's
+/// user interface, tangled up with a flyout. That, not the existence of screens, was what actually
+/// blocked the Gateway from becoming a service: its lifecycle was a property of its window. Deleting the
+/// screens did not fix it; moving the lifecycle here does.
+///
+/// It is deliberately HEADLESS: no Avalonia, no Dispatcher, no windowing type of any kind
+/// (HeadlessGatewayGuardTests pins that). It reports state through <see cref="StateChanged"/> and asks to
+/// be shut down through <see cref="ShutdownRequested"/>; how a host renders state, or ends the process,
+/// is the host's business and not this class's.
+///
+/// Two hosts drive it, which is the point: the tray shim (CcDirector.GatewayApp), and the console host in
+/// this project's Program.cs. They differ only in how they render and how they exit. When the Gateway
+/// becomes a real Windows service, that is a third host - and nothing here changes.
+/// </summary>
+public sealed class GatewayService : IDisposable
+{
+    private enum PortProbe { Nothing, OurGateway, OtherListener }
+
+    // Issue #880: how long a /shutdown-initiated graceful stop gets before the watchdog hard-exits the
+    // process. Must stay well under the self-update helper's 20-second wait for the exe to unlock, so a
+    // wedged stop can never strand an update on the old build.
+    private static readonly TimeSpan ShutdownWatchdogGrace = TimeSpan.FromSeconds(10);
+
+    private readonly GatewayServiceOptions _options;
+    private readonly CancellationTokenSource _lifetime = new();
+    private GatewayHost? _host;
+    private bool _disposed;
+
+    public GatewayService(GatewayServiceOptions options)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    /// <summary>The port the Gateway serves on.</summary>
+    public int Port => _options.Port;
+
+    /// <summary>When this service was constructed.</summary>
+    public DateTime StartedAtUtc { get; } = DateTime.UtcNow;
+
+    /// <summary>The running host, or null while stopped/starting.</summary>
+    public GatewayHost? Host => _host;
+
+    /// <summary>
+    /// The Gateway's in-process brain (issue #184): a warm claude.exe the host owns - no Director
+    /// dependency. Null while the host is stopped/starting.
+    /// </summary>
+    public BrainSupervisor? Brain => _host?.Brain;
+
+    /// <summary>The lifecycle state.</summary>
+    public GatewayServiceState State { get; private set; } = GatewayServiceState.Stopped;
+
+    /// <summary>
+    /// A human-readable one-liner for the current state, including the diagnosed reason when a start
+    /// failed (for example "Port 7900 in use by another app"). A host may show this verbatim.
+    /// </summary>
+    public string StatusText { get; private set; } = "Gateway stopped";
+
+    /// <summary>Raised whenever <see cref="State"/> or <see cref="StatusText"/> changes. May fire on any thread.</summary>
+    public event Action? StateChanged;
+
+    /// <summary>
+    /// Raised when the Gateway has stopped in response to a <c>/shutdown</c> request (the self-update
+    /// helper) and the PROCESS should now end. The host decides how - Avalonia's Shutdown, or
+    /// Environment.Exit. The issue #880 watchdog hard-exits regardless if the host does not, so a host
+    /// that ignores this cannot strand a self-update on the old build.
+    /// </summary>
+    public event Action? ShutdownRequested;
+
+    /// <summary>Start the Gateway. Safe to call again after a stop; a fresh host is built each time.</summary>
+    public async Task StartAsync()
+    {
+        if (_host is not null)
+        {
+            FileLog.Write("[GatewayService] StartAsync: already running - ignoring");
+            return;
+        }
+
+        RegisterAutostartSafe();
+        SetState(GatewayServiceState.Starting, "Gateway starting...");
+
+        try
+        {
+            // A fresh host each start: StopAsync disposes the registry and Tailscale provisioner, so a
+            // restart needs a new instance rather than reusing a torn-down one.
+            var host = new GatewayHost(_options.Port);
+            host.OnShutdownRequested = OnHostShutdownRequested;
+            host.SettingsHooks = BuildSettingsHooks();
+            await host.StartAsync();
+            _host = host;
+            SetState(GatewayServiceState.Running, $"Gateway running on :{_options.Port}");
+            FileLog.Write($"[GatewayService] running on :{_options.Port}");
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayService] StartAsync FAILED: {ex.Message}");
+            await DiagnoseStartFailureAsync();
+        }
+    }
+
+    /// <summary>Stop the Gateway. The service can be started again afterwards.</summary>
+    public async Task StopAsync()
+    {
+        await StopHostAsync();
+        SetState(GatewayServiceState.Stopped, "Gateway stopped");
+    }
+
+    /// <summary>
+    /// Start the background work a long-running host wants: the managed self-update loop. Separate from
+    /// <see cref="StartAsync"/> so a test (or a one-shot host) can run the Gateway without it.
+    /// </summary>
+    public void StartBackgroundWork()
+    {
+        if (_options.Managed)
+            _ = RunUpdateLoopAsync(_lifetime.Token);
+    }
+
+    /// <summary>
+    /// The self-update helper POSTs /shutdown to make this process exit so the exe unlocks and can be
+    /// swapped.
+    /// </summary>
+    private void OnHostShutdownRequested()
+    {
+        FileLog.Write("[GatewayService] shutdown requested via /shutdown (self-update)");
+        // Issue #880: /shutdown must ALWAYS end this process - the self-update swap waits (bounded) for
+        // the exe to unlock, and a graceful stop wedged behind a stuck host or a frozen host thread would
+        // strand it on the old build. The watchdog hard-exits after the grace period; every store the
+        // Gateway owns is written through on mutation, so a hard exit at shutdown time loses nothing.
+        var watchdog = new Thread(() =>
+        {
+            Thread.Sleep(ShutdownWatchdogGrace);
+            FileLog.Write($"[GatewayService] graceful stop did not finish within {ShutdownWatchdogGrace.TotalSeconds:0}s of /shutdown -> hard process exit (issue #880 watchdog)");
+            Environment.Exit(0);
+        })
+        { IsBackground = true, Name = "shutdown-watchdog" };
+        watchdog.Start();
+        _ = ShutdownAsync();
+    }
+
+    private async Task ShutdownAsync()
+    {
+        FileLog.Write("[GatewayService] ShutdownAsync");
+        _lifetime.Cancel();
+        // Issue #880: the host stop (which also gracefully stops the host-owned brain) must never run
+        // with a host's UI context captured, or a slow brain stop freezes that host and wedges the exit.
+        // Task.Run gives the chain a context-free thread.
+        await Task.Run(StopHostAsync);
+        ShutdownRequested?.Invoke();
+    }
+
+    /// <summary>
+    /// Back the Cockpit Settings page with the bits only this PROCESS knows: its run mode, and the
+    /// per-user autostart Run key (which needs this exe's path and its launch arguments). These hooks are
+    /// optional by design - GatewaySettingsHooks degrades to "unknown"/"unsupported" when they are null.
+    /// </summary>
+    private Api.GatewaySettingsHooks BuildSettingsHooks() => new()
+    {
+        Mode = () => _options.ModeLabel,
+        AutostartEnabled = () =>
+            OperatingSystem.IsWindows() ? GatewayAutostart.IsRegistered() : (bool?)null,
+        SetAutostart = enable =>
+        {
+            if (!OperatingSystem.IsWindows()) return false;
+            if (enable)
+            {
+                var exe = Environment.ProcessPath
+                          ?? throw new InvalidOperationException("Could not resolve own exe path");
+                GatewayAutostart.EnsureRegistered(exe, _options.AutostartArguments);
+                return true;
+            }
+            GatewayAutostart.Unregister();
+            return false;
+        },
+    };
+
+    private async Task StopHostAsync()
+    {
+        if (_host is null) return;
+        try
+        {
+            await _host.StopAsync();
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[GatewayService] StopHostAsync error: {ex.Message}");
+        }
+        finally
+        {
+            _host = null;
+        }
+    }
+
+    /// <summary>
+    /// Periodic machine-tier auto-update (managed mode only): check for a newer Gateway and, if found,
+    /// launch the detached self-update helper (it POSTs /shutdown -> swap -> relaunch -> health ->
+    /// auto-rollback). The Cockpit picks up its own update on the relaunch. Failures only log.
+    /// </summary>
+    private static async Task RunUpdateLoopAsync(CancellationToken ct)
+    {
+        var layout = InstallLayout.Default();
+        // Let the gateway settle before the first check; never compete with startup.
+        try { await Task.Delay(TimeSpan.FromMinutes(2), ct); } catch (OperationCanceledException) { return; }
+
+        while (!ct.IsCancellationRequested)
+        {
+            var cfg = AutoUpdateConfig.Load(layout);
+            if (cfg.Enabled && OperatingSystem.IsWindows())
+            {
+                try
+                {
+                    var source = new ReleaseSource();
+                    var release = await source.FetchLatestAsync(ct);
+                    var version = await new GatewayUpdater(layout).CheckStageAndLaunchAsync(release, source, ct);
+                    if (version is not null)
+                    {
+                        FileLog.Write($"[GatewayService] launched Gateway self-update to {version}; this process will be asked to exit");
+                        return; // the detached helper POSTs /shutdown, swaps, and relaunches us
+                    }
+                }
+                catch (Exception ex)
+                {
+                    FileLog.Write($"[GatewayService] update check failed: {ex.Message}");
+                }
+            }
+            try { await Task.Delay(cfg.Enabled ? cfg.Interval : TimeSpan.FromHours(1), ct); }
+            catch (OperationCanceledException) { break; }
+        }
+    }
+
+    // A bare "FAILED" is a silent dead-end. The overwhelmingly common cause is the port already being
+    // taken, so probe it and say what is actually there. The service stays alive either way, so Start
+    // can retry.
+    private async Task DiagnoseStartFailureAsync()
+    {
+        var probe = await ProbePortAsync();
+        var status = probe switch
+        {
+            PortProbe.OurGateway => $"Another gateway already on :{_options.Port}",
+            PortProbe.OtherListener => $"Port {_options.Port} in use by another app",
+            _ => "Gateway FAILED - see logs",
+        };
+        FileLog.Write($"[GatewayService] DiagnoseStartFailure: probe={probe}, status=\"{status}\"");
+        SetState(GatewayServiceState.Failed, status);
+    }
+
+    // Distinguish "our own gateway is already there" (a benign double-start) from "some other app holds
+    // the port" (a real conflict) from "nothing listening" (the bind failed for another reason entirely).
+    private async Task<PortProbe> ProbePortAsync()
+    {
+        try
+        {
+            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
+            var resp = await http.GetAsync($"http://127.0.0.1:{_options.Port}/healthz");
+            var body = await resp.Content.ReadAsStringAsync();
+            if (body.Contains("\"status\":\"ok\"") || body.Contains("\"directors\""))
+                return PortProbe.OurGateway;
+            return PortProbe.OtherListener; // answered HTTP, but not our gateway shape
+        }
+        catch
+        {
+            // Not HTTP (or refused). A raw TCP connect tells us whether anything is listening at all.
+            return await CanConnectAsync() ? PortProbe.OtherListener : PortProbe.Nothing;
+        }
+    }
+
+    private async Task<bool> CanConnectAsync()
+    {
+        try
+        {
+            using var tcp = new TcpClient();
+            var connect = tcp.ConnectAsync("127.0.0.1", _options.Port);
+            var done = await Task.WhenAny(connect, Task.Delay(TimeSpan.FromSeconds(1)));
+            return done == connect && tcp.Connected;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private void RegisterAutostartSafe()
+    {
+        if (!_options.RegisterAutostart)
+        {
+            FileLog.Write("[GatewayService] Autostart registration skipped (not requested)");
+            return;
+        }
+        // The autostart Run key is a Windows concept. The tray app never needed this guard because it
+        // targets net10.0-windows; this library targets net10.0 and runs anywhere, so the platform check
+        // is real, not ceremony (issue #1095 builds the account stack on non-Windows hosts).
+        if (!OperatingSystem.IsWindows())
+        {
+            FileLog.Write("[GatewayService] Autostart registration skipped (not Windows)");
+            return;
+        }
+
+        try
+        {
+            var exePath = Environment.ProcessPath
+                          ?? throw new InvalidOperationException("Could not resolve own exe path for autostart");
+            GatewayAutostart.EnsureRegistered(exePath, _options.AutostartArguments);
+        }
+        catch (Exception ex)
+        {
+            // Autostart is a convenience, not a hard dependency of running right now. Log truthfully and
+            // keep running rather than failing the whole service.
+            FileLog.Write($"[GatewayService] Autostart registration FAILED: {ex.Message}");
+        }
+    }
+
+    private void SetState(GatewayServiceState state, string status)
+    {
+        State = state;
+        StatusText = status;
+        StateChanged?.Invoke();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _lifetime.Cancel();
+        // Synchronous best-effort stop on shutdown (also gracefully stops the host-owned brain).
+        try { _host?.StopAsync().GetAwaiter().GetResult(); }
+        catch (Exception ex) { FileLog.Write($"[GatewayService] Dispose stop error: {ex.Message}"); }
+        _host = null;
+        _lifetime.Dispose();
+    }
+}

--- a/src/CcDirector.Gateway/GatewayWorker.cs
+++ b/src/CcDirector.Gateway/GatewayWorker.cs
@@ -4,36 +4,46 @@ using Microsoft.Extensions.Hosting;
 namespace CcDirector.Gateway;
 
 /// <summary>
-/// Hosts the Gateway's Kestrel host inside the generic host for the DEV console loop
-/// (<c>dotnet run</c>, Ctrl+C to stop). The shipped Gateway is the tray app
-/// (CcDirector.GatewayApp), which owns self-update in managed mode; this host deliberately has
-/// neither. The React Cockpit is served in-process by <see cref="GatewayHost"/> - there is no
-/// separate Cockpit process to supervise (issue #979 retired the Blazor Server Cockpit).
+/// Hosts the Gateway inside the generic host for the dev console loop (<c>dotnet run</c>, Ctrl+C to stop).
+///
+/// It drives the SAME <see cref="GatewayService"/> the shipped tray app drives - not a parallel,
+/// slightly-different copy of the lifecycle, which is what this used to be. That matters beyond tidiness:
+/// the tray app is a shim that must be deletable, and the only way to KNOW it is deletable is for a second
+/// host with no user interface at all to run the identical service. This is that host.
+///
+/// The differences from the tray app are exactly the two a host is allowed to have: it does not render
+/// state (there is nothing to render to), and it ends the process with Environment.Exit rather than
+/// Avalonia's Shutdown. Self-update and autostart are off - those belong to a managed install, never to
+/// the dev loop.
 /// </summary>
 public sealed class GatewayWorker : BackgroundService
 {
-    private readonly int _port;
-    private GatewayHost? _host;
+    private readonly GatewayService _service;
 
     public GatewayWorker(int port)
     {
-        _port = port;
+        _service = new GatewayService(new GatewayServiceOptions
+        {
+            Port = port,
+            Managed = false,
+            RegisterAutostart = false,
+            ModeLabel = "dev",
+        });
+        // /shutdown support, so the self-update flow is testable against a dev console gateway. The
+        // service has already stopped the Gateway by the time this fires; ending the process is all that
+        // is left, and only a host knows how.
+        _service.ShutdownRequested += () => Environment.Exit(0);
     }
+
+    /// <summary>The running Gateway service (exposed so a host or a test can read its state).</summary>
+    public GatewayService Service => _service;
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        FileLog.Write($"[GatewayWorker] ExecuteAsync: port={_port}");
+        FileLog.Write($"[GatewayWorker] ExecuteAsync: port={_service.Port}");
 
-        _host = new GatewayHost(_port);
-        // /shutdown support so the self-update flow is testable against a dev console gateway.
-        _host.OnShutdownRequested = () =>
-        {
-            FileLog.Write("[GatewayWorker] shutdown requested via /shutdown");
-            _ = StopAsync(CancellationToken.None).ContinueWith(_ => Environment.Exit(0));
-        };
-        await _host.StartAsync();
-
-        FileLog.Write($"[GatewayWorker] running on http://127.0.0.1:{_host.Port}");
+        await _service.StartAsync();
+        FileLog.Write($"[GatewayWorker] {_service.StatusText}");
 
         // Stay alive until the host signals shutdown (Ctrl+C or ProcessExit).
         try
@@ -51,12 +61,17 @@ public sealed class GatewayWorker : BackgroundService
         FileLog.Write("[GatewayWorker] StopAsync");
         try
         {
-            if (_host is not null)
-                await _host.StopAsync();
+            await _service.StopAsync();
         }
         finally
         {
             await base.StopAsync(cancellationToken);
         }
+    }
+
+    public override void Dispose()
+    {
+        _service.Dispose();
+        base.Dispose();
     }
 }

--- a/src/CcDirector.GatewayApp/GatewayTrayController.cs
+++ b/src/CcDirector.GatewayApp/GatewayTrayController.cs
@@ -1,6 +1,3 @@
-using System.Diagnostics;
-using System.Net.Http;
-using System.Net.Sockets;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -9,104 +6,94 @@ using Avalonia.Threading;
 using CcDirector.Core.Utilities;
 using CcDirector.Gateway;
 using CcDirector.HostedAgent;
-using CcDirector.Setup.Engine;
 
 namespace CcDirector.GatewayApp;
 
 /// <summary>
-/// Hosts the in-process <see cref="GatewayHost"/> and puts a Start/Stop control in the notification area.
+/// The tray SHIM: it puts a Start/Stop control in the notification area and renders the Gateway's state
+/// as a tooltip. That is the whole of it.
 ///
-/// The Gateway is being reshaped to behave like a WINDOWS SERVICE, and this class is deliberately the only
-/// thing standing between it and that: it is a thin SHIM around the host, not the application. A service
-/// has exactly two verbs a person can use on it - start and stop - so that is all this tray offers. There
-/// is no flyout, no status panel, no settings, no sign-in, and no "open the Cockpit": every screen the
-/// Gateway used to own now lives in the Cockpit, which is reached by browsing to the Gateway's own URL.
+/// Everything that makes the Gateway work - the host lifecycle, the managed self-update loop, autostart,
+/// the Cockpit's settings hooks, port diagnostics, the issue #880 shutdown watchdog - lives in
+/// <see cref="GatewayService"/>, in the headless library. This class only presents it.
 ///
-/// The acceptance test for the shape: DELETE THIS CLASS AND NOTHING BREAKS. Anything that would break if
-/// this file vanished belongs in CcDirector.Gateway (the headless library), not here. When the Gateway
-/// becomes a real service, this shim is deleted and nothing else changes.
+/// The rule that keeps it honest: DELETE THIS FILE AND NOTHING BREAKS. The dev console host in
+/// CcDirector.Gateway drives the very same GatewayService with no tray at all, which is what proves it.
+/// When the Gateway becomes a real Windows service, that is simply a third host, and nothing in the
+/// library changes.
 ///
-/// Consequently the Gateway NEVER opens a browser and never draws a window - a service has no desktop to
-/// draw on. Signing the Gateway in to its DevThrottle account is done from the Cockpit's Account page,
-/// which navigates to the public /account/sign-in-start front door (epic #1069).
+/// A service has exactly two verbs a person can use, so the menu is Start and Stop and nothing else - no
+/// flyout, no status panel, no settings, no sign-in, no "open the Cockpit". Every screen the Gateway used
+/// to own lives in the Cockpit, reached by browsing to the Gateway's own URL. The Gateway never opens a
+/// browser and never draws a window, because a service has no desktop to draw on.
 /// </summary>
 public sealed class GatewayTrayController : IDisposable
 {
-    private enum HostState { Starting, Running, Stopped, Failed }
-    private enum PortProbe { Nothing, OurGateway, OtherListener }
-
-    // Issue #880: how long a /shutdown-initiated graceful quit gets before the watchdog hard-exits
-    // the process. Must stay well under the self-update helper's 20-second wait for the exe to
-    // unlock, so a wedged quit can never strand an update on the old build.
-    private static readonly TimeSpan ShutdownWatchdogGrace = TimeSpan.FromSeconds(10);
-
     private readonly IClassicDesktopStyleApplicationLifetime _desktop;
-    private readonly int _port;
-    private readonly CancellationTokenSource _lifetime = new();
+    private readonly GatewayService _service;
 
     private TrayIcon? _trayIcon;
     private NativeMenuItem? _startItem;
     private NativeMenuItem? _stopItem;
-    private string _statusText = "Gateway stopped";
-    private GatewayHost? _host;
-    private HostState _state = HostState.Stopped;
     private bool _busy;
     private bool _disposed;
 
     public GatewayTrayController(IClassicDesktopStyleApplicationLifetime desktop, int port)
     {
         _desktop = desktop;
-        _port = port;
+        _service = new GatewayService(new GatewayServiceOptions
+        {
+            Port = port,
+            Managed = GatewayAppOptions.Managed,
+            RegisterAutostart = GatewayAppOptions.RegisterAutostart,
+            AutostartArguments = GatewayAppOptions.AutostartArguments(),
+            ModeLabel = GatewayAppOptions.Managed ? "managed" : "dev",
+        });
+        _service.StateChanged += Render;
+        // /shutdown (the self-update helper) has already stopped the Gateway by the time this fires; all
+        // that is left is to end THIS process, which only a host knows how to do. The service's #880
+        // watchdog hard-exits if this does not complete in time, so a wedged tray cannot strand an update.
+        _service.ShutdownRequested += () => Dispatcher.UIThread.Post(() =>
+        {
+            if (_trayIcon is not null) _trayIcon.IsVisible = false;
+            _desktop.Shutdown();
+        });
     }
 
     /// <summary>The gateway's listen port.</summary>
-    public int Port => _port;
+    public int Port => _service.Port;
 
     /// <summary>When the tray app started.</summary>
-    public DateTime StartedAtUtc { get; } = DateTime.UtcNow;
+    public DateTime StartedAtUtc => _service.StartedAtUtc;
 
     /// <summary>The running host, or null while stopped/starting.</summary>
-    public GatewayHost? Host => _host;
+    public GatewayHost? Host => _service.Host;
 
-    /// <summary>
-    /// The Gateway's in-process brain (issue #184): a warm claude.exe this process hosts
-    /// itself - no Director dependency. Owned by the <see cref="GatewayHost"/> (the brief
-    /// agent drives it, issue #185); null while the host is stopped/starting.
-    /// </summary>
-    public BrainSupervisor? Brain => _host?.Brain;
+    /// <summary>The Gateway's in-process brain (issue #184); null while the host is stopped/starting.</summary>
+    public BrainSupervisor? Brain => _service.Brain;
 
     /// <summary>Human-readable host state ("Running", "Failed", ...).</summary>
-    public string StateText => _state.ToString();
+    public string StateText => _service.State.ToString();
 
-    /// <summary>Build the tray control, register autostart, and start the gateway.</summary>
+    /// <summary>Build the tray control and start the gateway.</summary>
     public void Start()
     {
         FileLog.Write($"[GatewayTrayController] Start (managed={GatewayAppOptions.Managed})");
-
         BuildTrayIcon();
-        RegisterAutostartSafe();
-
-        SetState(HostState.Starting);
-        _ = StartHostAsync();
-
-        if (GatewayAppOptions.Managed)
-            _ = RunUpdateLoopAsync(_lifetime.Token);
+        _ = _service.StartAsync();
+        _service.StartBackgroundWork();
     }
 
     private void BuildTrayIcon()
     {
-        // Service semantics: the menu is Start and Stop, and nothing else. The Gateway's status, settings,
-        // account, devices and everything else are the Cockpit's, reached by browsing to this Gateway's
-        // URL - not by a panel hanging off this icon. The tooltip carries the one thing a person needs
-        // from the icon itself: whether it is running.
         var menu = new NativeMenu();
 
         _startItem = new NativeMenuItem("Start");
-        _startItem.Click += (_, _) => _ = StartClickedAsync();
+        _startItem.Click += (_, _) => _ = RunVerbAsync(_service.StartAsync);
         menu.Add(_startItem);
 
         _stopItem = new NativeMenuItem("Stop");
-        _stopItem.Click += (_, _) => _ = StopClickedAsync();
+        _stopItem.Click += (_, _) => _ = RunVerbAsync(_service.StopAsync);
         menu.Add(_stopItem);
 
         _trayIcon = new TrayIcon
@@ -119,308 +106,47 @@ public sealed class GatewayTrayController : IDisposable
 
         var icons = new TrayIcons { _trayIcon };
         TrayIcon.SetIcons(Application.Current!, icons);
-        ApplyMenuEnablement();
+        Render();
         FileLog.Write("[GatewayTrayController] Tray icon created (Start/Stop only)");
     }
 
-    /// <summary>Start the gateway host (the service's Start verb). A no-op while it is already up.</summary>
-    private async Task StartClickedAsync()
+    /// <summary>
+    /// Run a service verb off the click. Issue #880: never inline - run inline and the awaits inside the
+    /// host resume on the UI thread, where a synchronous brain dispose blocks, freezing the tray and
+    /// wedging the operation. Task.Run gives the chain a context-free thread.
+    /// </summary>
+    private async Task RunVerbAsync(Func<Task> verb)
     {
         if (_busy) return;
-        if (_host is not null)
-        {
-            FileLog.Write("[GatewayTrayController] Start clicked: already running - ignoring");
-            return;
-        }
         _busy = true;
+        Render();
         try
         {
-            FileLog.Write("[GatewayTrayController] Start clicked");
-            SetState(HostState.Starting);
-            // Issue #880: the start chain runs on the THREAD POOL, never inline from the click. Run
-            // inline, the awaits inside the host resume on the UI thread, where a synchronous dispose
-            // can block - freezing the tray and wedging the operation. SetState/ApplyStatus marshal to
-            // the UI thread themselves, so the tray stays responsive throughout.
-            await Task.Run(StartHostAsync);
+            await Task.Run(verb);
+        }
+        catch (Exception ex)
+        {
+            // Boundary catch (this is the click handler body): a verb that throws must never crash the
+            // tray. The service has already resolved the state; just log and re-render.
+            FileLog.Write($"[GatewayTrayController] verb FAILED: {ex.Message}");
         }
         finally
         {
             _busy = false;
-            ApplyMenuEnablement();
+            Render();
         }
     }
 
-    /// <summary>Stop the gateway host (the service's Stop verb). The tray stays, so it can be started again.</summary>
-    private async Task StopClickedAsync()
+    /// <summary>Show the service's state: the tooltip, and which verb currently applies.</summary>
+    private void Render()
     {
-        if (_busy) return;
-        if (_host is null)
-        {
-            FileLog.Write("[GatewayTrayController] Stop clicked: already stopped - ignoring");
-            return;
-        }
-        _busy = true;
-        try
-        {
-            FileLog.Write("[GatewayTrayController] Stop clicked");
-            // Issue #880: off the UI thread - the host stop also gracefully stops the host-owned brain,
-            // whose synchronous dispose would otherwise block the UI thread and wedge the stop.
-            await Task.Run(StopHostAsync);
-            SetState(HostState.Stopped);
-        }
-        finally
-        {
-            _busy = false;
-            ApplyMenuEnablement();
-        }
-    }
-
-    /// <summary>Grey out the verb that does not apply, the way a service control does.</summary>
-    private void ApplyMenuEnablement()
-    {
-        Dispatcher.UIThread.Post(() =>
-        {
-            if (_startItem is not null) _startItem.IsEnabled = _host is null && !_busy;
-            if (_stopItem is not null) _stopItem.IsEnabled = _host is not null && !_busy;
-        });
-    }
-
-    private async Task StartHostAsync()
-    {
-        try
-        {
-            // A fresh host each start: StopAsync disposes the registry and Tailscale
-            // provisioner, so a restart needs a new instance rather than reusing a torn-down one.
-            var host = new GatewayHost(_port);
-            // The self-update helper POSTs /shutdown to make this process exit so the exe unlocks.
-            host.OnShutdownRequested = () =>
-            {
-                FileLog.Write("[GatewayTrayController] shutdown requested via /shutdown (self-update)");
-                // Issue #880: /shutdown must ALWAYS end this process - the self-update swap waits
-                // (bounded) for the exe to unlock, and a graceful quit wedged behind a stuck host
-                // stop or a frozen UI thread would strand it on the old build. The watchdog
-                // hard-exits after the grace period; every store the Gateway owns is written
-                // through on mutation, so a hard exit at shutdown time loses nothing.
-                var watchdog = new Thread(() =>
-                {
-                    Thread.Sleep(ShutdownWatchdogGrace);
-                    FileLog.Write($"[GatewayTrayController] graceful quit did not finish within {ShutdownWatchdogGrace.TotalSeconds:0}s of /shutdown -> hard process exit (issue #880 watchdog)");
-                    Environment.Exit(0);
-                })
-                { IsBackground = true, Name = "shutdown-watchdog" };
-                watchdog.Start();
-                _ = QuitAsync();
-            };
-            // Back the Cockpit Settings page with the bits only THIS process knows (run mode + the
-            // per-user autostart Run-key, which needs this exe's path and the managed-launch arguments).
-            // These hooks are optional by design - GatewaySettingsHooks degrades to
-            // "unknown"/"unsupported" when null - so a headless host without this shim still serves
-            // settings correctly. That is what keeps the delete-the-shim test honest.
-            host.SettingsHooks = new CcDirector.Gateway.Api.GatewaySettingsHooks
-            {
-                Mode = () => GatewayAppOptions.Managed ? "managed" : "dev",
-                AutostartEnabled = () =>
-                    OperatingSystem.IsWindows() ? GatewayAutostart.IsRegistered() : (bool?)null,
-                SetAutostart = enable =>
-                {
-                    if (!OperatingSystem.IsWindows()) return false;
-                    if (enable)
-                    {
-                        var exe = Environment.ProcessPath
-                                  ?? throw new InvalidOperationException("Could not resolve own exe path");
-                        GatewayAutostart.EnsureRegistered(exe, GatewayAppOptions.AutostartArguments());
-                        return true;
-                    }
-                    GatewayAutostart.Unregister();
-                    return false;
-                },
-            };
-            await host.StartAsync();
-            _host = host;
-            SetState(HostState.Running);
-            ApplyMenuEnablement();
-            FileLog.Write($"[GatewayTrayController] Gateway running on :{_port}");
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[GatewayTrayController] StartHostAsync FAILED: {ex.Message}");
-            await DiagnoseStartFailureAsync();
-        }
-    }
-
-    /// <summary>
-    /// Periodic machine-tier auto-update (managed mode only): check for a newer Gateway and, if
-    /// found, launch the detached self-update helper (it POSTs /shutdown -> swap -> relaunch ->
-    /// health -> auto-rollback). The Cockpit picks up its own update on the relaunch. Failures only log.
-    /// </summary>
-    private static async Task RunUpdateLoopAsync(CancellationToken ct)
-    {
-        var layout = InstallLayout.Default();
-        // Let the gateway settle before the first check; never compete with startup.
-        try { await Task.Delay(TimeSpan.FromMinutes(2), ct); } catch (OperationCanceledException) { return; }
-
-        while (!ct.IsCancellationRequested)
-        {
-            var cfg = AutoUpdateConfig.Load(layout);
-            if (cfg.Enabled && OperatingSystem.IsWindows())
-            {
-                try
-                {
-                    var source = new ReleaseSource();
-                    var release = await source.FetchLatestAsync(ct);
-                    var version = await new GatewayUpdater(layout).CheckStageAndLaunchAsync(release, source, ct);
-                    if (version is not null)
-                    {
-                        FileLog.Write($"[GatewayTrayController] launched Gateway self-update to {version}; this process will be asked to exit");
-                        return; // the detached helper POSTs /shutdown, swaps, and relaunches us
-                    }
-                }
-                catch (Exception ex)
-                {
-                    FileLog.Write($"[GatewayTrayController] update check failed: {ex.Message}");
-                }
-            }
-            try { await Task.Delay(cfg.Enabled ? cfg.Interval : TimeSpan.FromHours(1), ct); }
-            catch (OperationCanceledException) { break; }
-        }
-    }
-
-    // A bare "FAILED" on a tray icon Windows hides by default is a silent dead-end.
-    // The overwhelmingly common cause is the port already being taken, so probe it and
-    // say what is actually there. The app stays alive either way, so Start can retry.
-    private async Task DiagnoseStartFailureAsync()
-    {
-        var probe = await ProbePortAsync();
-        var (status, tip) = probe switch
-        {
-            PortProbe.OurGateway => ($"Another gateway already on :{_port}",
-                                     $"DevThrottle Gateway - another instance is already serving :{_port}"),
-            PortProbe.OtherListener => ($"Port {_port} in use by another app",
-                                        $"DevThrottle Gateway - port {_port} is occupied by another app"),
-            _ => ("Gateway FAILED - see logs", "DevThrottle Gateway - failed to start"),
-        };
-        FileLog.Write($"[GatewayTrayController] DiagnoseStartFailure: probe={probe}, status=\"{status}\"");
-        _state = HostState.Failed;
-        ApplyStatus(status, tip);
-        ApplyMenuEnablement();
-    }
-
-    // Distinguish "our own gateway is already there" (a benign double-start) from
-    // "some other app holds the port" (a real conflict) from "nothing listening"
-    // (the bind failed for another reason entirely).
-    private async Task<PortProbe> ProbePortAsync()
-    {
-        try
-        {
-            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
-            var resp = await http.GetAsync($"http://127.0.0.1:{_port}/healthz");
-            var body = await resp.Content.ReadAsStringAsync();
-            if (body.Contains("\"status\":\"ok\"") || body.Contains("\"directors\""))
-                return PortProbe.OurGateway;
-            return PortProbe.OtherListener; // answered HTTP, but not our gateway shape
-        }
-        catch
-        {
-            // Not HTTP (or refused). A raw TCP connect tells us whether anything is
-            // listening at all.
-            return await CanConnectAsync() ? PortProbe.OtherListener : PortProbe.Nothing;
-        }
-    }
-
-    private async Task<bool> CanConnectAsync()
-    {
-        try
-        {
-            using var tcp = new TcpClient();
-            var connect = tcp.ConnectAsync("127.0.0.1", _port);
-            var done = await Task.WhenAny(connect, Task.Delay(TimeSpan.FromSeconds(1)));
-            return done == connect && tcp.Connected;
-        }
-        catch
-        {
-            return false;
-        }
-    }
-
-    private async Task StopHostAsync()
-    {
-        if (_host is null) return;
-        try
-        {
-            await _host.StopAsync();
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[GatewayTrayController] StopHostAsync error: {ex.Message}");
-        }
-        finally
-        {
-            _host = null;
-        }
-    }
-
-    /// <summary>
-    /// End the process. NOT a menu item - a service has no "quit", only stop. This is reached solely by
-    /// the self-update helper's POST /shutdown (via <see cref="GatewayHost.OnShutdownRequested"/>), which
-    /// needs this process to exit so the exe unlocks and can be swapped.
-    /// </summary>
-    private async Task QuitAsync()
-    {
-        FileLog.Write("[GatewayTrayController] QuitAsync");
-        _lifetime.Cancel();
-        // Issue #880: the host stop (which also gracefully stops the host-owned brain) must never run
-        // with the UI thread's context captured, or a slow brain stop freezes the tray and wedges the quit.
-        await Task.Run(StopHostAsync);
-        await Dispatcher.UIThread.InvokeAsync(() =>
-        {
-            if (_trayIcon is not null) _trayIcon.IsVisible = false;
-            _desktop.Shutdown();
-        });
-    }
-
-    private void RegisterAutostartSafe()
-    {
-        if (!GatewayAppOptions.RegisterAutostart)
-        {
-            FileLog.Write("[GatewayTrayController] Autostart registration skipped (--no-autostart)");
-            return;
-        }
-
-        try
-        {
-            var exePath = Environment.ProcessPath
-                          ?? Process.GetCurrentProcess().MainModule?.FileName
-                          ?? throw new InvalidOperationException("Could not resolve own exe path for autostart");
-            GatewayAutostart.EnsureRegistered(exePath, GatewayAppOptions.AutostartArguments());
-        }
-        catch (Exception ex)
-        {
-            // Autostart is a convenience, not a hard dependency of running right now.
-            // Log truthfully and keep running rather than failing the whole app.
-            FileLog.Write($"[GatewayTrayController] Autostart registration FAILED: {ex.Message}");
-        }
-    }
-
-    private void SetState(HostState state)
-    {
-        _state = state;
-        var (status, tip) = state switch
-        {
-            HostState.Starting => ("Gateway starting...", "DevThrottle Gateway - starting"),
-            HostState.Running => ($"Gateway running on :{_port}", $"DevThrottle Gateway - running on :{_port}"),
-            HostState.Stopped => ("Gateway stopped", "DevThrottle Gateway - stopped"),
-            HostState.Failed => ("Gateway FAILED - see logs", "DevThrottle Gateway - failed to start"),
-            _ => ("Gateway", "DevThrottle Gateway"),
-        };
-        ApplyStatus(status, tip);
-    }
-
-    private void ApplyStatus(string status, string tip)
-    {
-        _statusText = status;
+        var running = _service.Host is not null;
+        var tip = $"DevThrottle Gateway - {_service.StatusText}";
         Dispatcher.UIThread.Post(() =>
         {
             if (_trayIcon is not null) _trayIcon.ToolTipText = tip;
+            if (_startItem is not null) _startItem.IsEnabled = !running && !_busy;
+            if (_stopItem is not null) _stopItem.IsEnabled = running && !_busy;
         });
     }
 
@@ -428,12 +154,8 @@ public sealed class GatewayTrayController : IDisposable
     {
         if (_disposed) return;
         _disposed = true;
-        _lifetime.Cancel();
-        // Synchronous best-effort stop on shutdown.
-        try { _host?.StopAsync().GetAwaiter().GetResult(); } // also gracefully stops the host-owned brain
-        catch (Exception ex) { FileLog.Write($"[GatewayTrayController] Dispose stop error: {ex.Message}"); }
-        _host = null;
+        _service.StateChanged -= Render;
+        _service.Dispose();
         if (_trayIcon is not null) _trayIcon.IsVisible = false;
-        _lifetime.Dispose();
     }
 }


### PR DESCRIPTION
The last structural step: the Gateway's lifecycle now lives in the headless library, not inside the tray app's user interface.

## This, not the screens, was the blocker

Deleting the Gateway's screens was never what stood between it and being a Windows service. **This was:** `GatewayTrayController` owned the host, the managed self-update loop, autostart registration, the Cockpit's settings hooks, port diagnostics and the #880 shutdown watchdog. The Gateway's lifecycle was a property of its window.

Until that was untangled, "the shim could be deleted" was a **claim**, not a fact.

## GatewayService

New `GatewayService` (in `CcDirector.Gateway`) owns all of it. A host supplies the three things a service cannot know about its own process - the port, whether it is a managed install that self-updates, and what to write into the autostart Run key - and gets a complete Gateway.

It is headless by construction: no Avalonia, no Dispatcher, no windowing type. It reports state through `StateChanged` and asks to exit through `ShutdownRequested`. How to render state, and how to end the process, are the host's business.

That makes the shim an actual shim: **`GatewayTrayController` is now 161 lines** - a tray icon, two menu items and a tooltip. It knows nothing about updates, autostart, the watchdog or diagnostics.

## The proof

`GatewayWorker` (the dev console host) now drives the **same** `GatewayService`, instead of the parallel, slightly-different copy of the lifecycle it used to carry. That is what turns delete-the-shim from a claim into a fact: a second host, **with no user interface at all**, runs the identical service. A Windows service will be a third host, and nothing in the library will change.

## Two things the move surfaced rather than caused

- **Autostart needed an `OperatingSystem.IsWindows()` guard.** The tray app never needed one because it targets `net10.0-windows`; the library targets `net10.0` and runs anywhere. The constraint was always real, just hidden by the tray app's target.
- **`NoCrossMachineLoopbackGuard` caught the port probe's `127.0.0.1` literal** arriving in a scanned file. Allowlisted with its reason - it probes *this* process's own port to diagnose its own failed bind, same machine by definition - and the now-stale `GatewayWorker` and `GatewayTrayController` entries are removed, since the literal has left those files. **The list nets one shorter.**

Behaviour-preserving: the moved code is unchanged, including the #880 comments about never running the stop chain on a captured UI context.

## Proof

- Gateway **2255**, Core **3094**, Launcher **27** tests pass; Release build clean

## Known limit, stated plainly

The lifecycle internals (update loop, diagnostics) were untested before this move and still are. The new test constructs the service with **no host at all**, which pins the *shape*, not the behaviour. Starting a real `GatewayService` in a test would write to the developer's live Director folder, which this repo forbids (#1580); giving it an injectable host is its own step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)