### PR TITLE
The mission run-book: give the rules a home so briefs stop granting them

### DIFF
--- a/.claude/skills/mission/SKILL.md
+++ b/.claude/skills/mission/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mission
-description: How a mission is RUN in this repository - the Architect, the Manager, the Workers, and the independent Inspector, plus the four standing laws (ask up front then run alone; commit to the branch, never merge to main; a different agent inspects before anything reaches main; the Architect is the only one who merges). Read this BEFORE starting or seeding any mission, and before writing any mission brief. Triggers on "/mission", "start a mission", "run a mission", "seed an architect", "write a mission brief", "mission brief", "who merges", "mission roles".
+description: How a mission is RUN in this repository - the Architect, the Manager, the Workers, and the independent Inspector, plus the four standing laws (ask up front then run alone, and NEVER guess - bring the owner in when something is genuinely undecidable; the mission branch holds the work and only the Architect lands it on main; a different agent family inspects before anything reaches main; merged to origin/main is the only done). Read this BEFORE starting or seeding any mission, and before writing any mission brief. Triggers on "/mission", "start a mission", "run a mission", "seed an architect", "write a mission brief", "mission brief", "who merges", "mission roles".
 ---
 
 # How a mission runs
@@ -13,12 +13,19 @@ the naming, and the attachment rules. Read that for the object. Read this for th
 > **THIS FILE IS THE ONLY PLACE THE RULES LIVE. A mission brief must never restate them, and must
 > never GRANT them.**
 >
-> Before this file existed, every brief wrote the rules out from memory. They drifted - one brief
-> said commit freely, another said never commit - and each one read like it was handing out
-> authority. Then a brief got merged to main, and the sentence "You have standing commit authority
-> for the whole mission" sat in a permanent architecture document, in imperative voice, with its
-> expiry in a different paragraph. Retrieval does not fetch the other paragraph. That is how a
-> mission-scoped grant becomes a standing one that nobody ever decided to give.
+> Before this file existed, every brief wrote the rules out from memory. They drifted - they
+> contradicted each other on whether a mission could commit at all - and each one read like it was
+> handing out authority. Then one got merged to main, and a sentence granting that mission open
+> authority to commit came to rest in a permanent architecture document: imperative voice, addressed
+> to the reader, with the words that limited it to one branch and one week sitting in a different
+> paragraph. Retrieval does not fetch the other paragraph. That is how a mission-scoped grant becomes
+> a standing one that nobody ever decided to give.
+>
+> *The offending sentence is deliberately paraphrased here and not quoted. Quoting it would leave the
+> exact imperative string in this file, searchable, one retrieval away from being read as live - the
+> very failure being described. It is in git history on `backup/session-state-truth-2026-07-15` if it
+> is ever needed. The same reasoning is why that brief had the text deleted rather than struck
+> through: strike-through is a visual convention, and it means nothing to a grep.*
 >
 > A brief describes the WORK. This file describes the CONDUCT. A brief that grants a permission is
 > a bug in the brief.
@@ -49,9 +56,11 @@ patch.
 
 ## THE FOUR LAWS
 
-### 1. Ask everything UP FRONT, then run alone
+### 1. Ask everything UP FRONT, then run alone - and NEVER guess
 
-**Get your questions answered before you start. Then run the whole mission without coming back.**
+**Get your questions answered before you start, then run the whole mission without coming back - but
+NEVER guess. If something genuinely undecidable turns up mid-run, bring the owner in. Running alone
+is not the goal; it is what you get for having asked properly first.**
 
 The owner is not a reviewer and must not be used as one. A mission that stops at every step to ask
 "shall I do the next bit?" has moved the work into his lap and made him read a novel to say yes. He
@@ -73,36 +82,50 @@ what you found."
 The test: *could I have known to ask this before I started?* If yes, you asked too late. If no,
 asking now is correct.
 
-### 2. Commit to the branch. NEVER merge to main.
+### 2. The mission branch holds the work. Only the Architect lands it.
 
-**The Manager and Workers commit freely, and often, to the mission branch. They never push to main,
-never merge a pull request, never touch `main` at all.**
+**A seated mission has exactly one branch, and it is where the work lives. Nothing but the Architect
+puts anything on `main`.**
 
-This is not a formality; it is what keeps the work alive. This repository has already lost a
-mission's worth of work to a machine crash - fourteen commits, complete and passing, stranded on one
-disk because they were never pushed anywhere. **Uncommitted work is work you are one crash away from
-losing.** Commit early, commit often, push the branch.
+*This section describes how a chartered mission operates. It is not a grant, and it authorises
+nothing. If you are not seated on a mission the owner has chartered, with a branch cut for it, none
+of this applies to you and the repository's ordinary rule stands unchanged: never commit without
+being asked, and having been asked once is not being asked again.*
 
-- Committing to the mission branch **needs no permission**. It is the safe act.
-- Merging to `main` is the irreversible one, and it belongs to the Architect alone.
-- The repository's standing rule - *never commit without being asked* - is about the owner's
-  repository, not your own branch. Inside a mission, on the mission's branch, committing IS the job.
-  Do not seek approval for it, and do not read that as licence anywhere else.
+**Why the branch matters.** This repository has already lost a mission's worth of work to a machine
+crash - fourteen commits, complete and passing, stranded on one disk because they were never pushed
+anywhere. Work that exists in one place is work you are one crash away from losing. Keeping the
+mission branch current and pushed is mission hygiene, in the same way that leaving the site tidy is
+part of building, not a favour to anyone.
+
+**The authority chain, stated once:**
+
+- Work accumulates on the mission branch. That is the ordinary operation of a mission and the
+  Architect who chartered it has already accounted for it.
+- Landing anything on `main` is the irreversible act, and it is the **Architect's alone** - not the
+  Manager's, not a Worker's, and not via a merged pull request opened by anyone else.
+- This section never reaches outside a seated mission branch. It cannot be read as covering the
+  shared checkout, another mission's branch, or `main`.
 
 ### 3. A DIFFERENT agent inspects before anything reaches main
 
 **No work reaches `main` un-inspected, and the inspector is not the one who wrote it.**
 
 Use a genuinely different agent family, not another instance of the same one - if the Manager is
-Claude Code, the Inspector is Codex. Different training, different blind spots. That is the whole
-mechanism, and it works:
+Claude Code, the Inspector is Codex. The operational requirement is simply *different family*: an
+agent reviewing its own family's work shares too much of its judgement to be a check on it. That is
+the whole mechanism, and it works:
 
-> On one 64-file pull request, an independent Codex inspector found **seven real defects across five
+> On pull request 1598, an independent Codex inspector found **seven real defects across five
 > passes**, and not one was a false alarm. It found that the mission's headline feature **did not
 > work at all** - the value was computed correctly and nothing told the screen to re-read it - and
 > then found that the *fix for that* was itself half-done, and then that the same fault existed in
 > five more places. The author had verified the code, revert-tested the fixes, and watched the tests
 > fail on purpose. All of it green. All of it would have shipped.
+>
+> That is not lore: the review-driven commits on 1598 record it, one per finding, and pull requests
+> 1584, 1585, 1588 and 1596 carry the same shape. Check the branch history rather than take the
+> number on trust - which is, after all, the point of this law.
 
 - **The Architect calls the inspection**, not the Manager. The builder does not book his own
   inspection, and does not get to mark his own work as passed.

--- a/.claude/skills/mission/SKILL.md
+++ b/.claude/skills/mission/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: mission
+description: How a mission is RUN in this repository - the Architect, the Manager, the Workers, and the independent Inspector, plus the four standing laws (ask up front then run alone; commit to the branch, never merge to main; a different agent inspects before anything reaches main; the Architect is the only one who merges). Read this BEFORE starting or seeding any mission, and before writing any mission brief. Triggers on "/mission", "start a mission", "run a mission", "seed an architect", "write a mission brief", "mission brief", "who merges", "mission roles".
+---
+
+# How a mission runs
+
+A **mission** is a body of work too big for one session and too long for one sitting. This document
+is the run-book for how one is RUN. It is not about what a Mission *is* as an object in the product -
+that is `docs/new_architecture/mission-as-first-class-unit-of-work.md`, which defines the data model,
+the naming, and the attachment rules. Read that for the object. Read this for the conduct.
+
+> **THIS FILE IS THE ONLY PLACE THE RULES LIVE. A mission brief must never restate them, and must
+> never GRANT them.**
+>
+> Before this file existed, every brief wrote the rules out from memory. They drifted - one brief
+> said commit freely, another said never commit - and each one read like it was handing out
+> authority. Then a brief got merged to main, and the sentence "You have standing commit authority
+> for the whole mission" sat in a permanent architecture document, in imperative voice, with its
+> expiry in a different paragraph. Retrieval does not fetch the other paragraph. That is how a
+> mission-scoped grant becomes a standing one that nobody ever decided to give.
+>
+> A brief describes the WORK. This file describes the CONDUCT. A brief that grants a permission is
+> a bug in the brief.
+
+---
+
+## The house
+
+The analogy is the owner's and it is exact - use it when a question comes up that the rules below do
+not cover, and answer the way the house answers.
+
+- **The owner** wants a house. He says what it is for, answers the questions, and is otherwise left
+  alone.
+- **The Architect** owns the mission. Settles the design, writes the brief, hires the builder,
+  decides when it is done, and is the only one who signs anything off into `main`.
+- **The Manager** is the builder. Takes the work, gets it done - hiring Workers as needed - and
+  **leaves when the work is finished**. A Manager is a delivery vehicle, not a resident.
+- **The Workers** are the trades. One task each. They finish and go.
+- **The Inspector** is an independent agent, from a **different family** to the Manager, who comes in
+  after the builder has left and inspects the work. He does not build. He was not there when it was
+  built. That is the entire point of him.
+
+The Architect does not inspect his own building, and the builder does not inspect his own work. The
+Architect calls the inspection. Failures go back to the builder to fix, not to the inspector to
+patch.
+
+---
+
+## THE FOUR LAWS
+
+### 1. Ask everything UP FRONT, then run alone
+
+**Get your questions answered before you start. Then run the whole mission without coming back.**
+
+The owner is not a reviewer and must not be used as one. A mission that stops at every step to ask
+"shall I do the next bit?" has moved the work into his lap and made him read a novel to say yes. He
+has said so plainly, more than once. If he has to follow along, the mission has failed at its job.
+
+- **Before you start:** think hard about what you genuinely do not know, and ask it all, in one go,
+  in plain words. Scope. Product calls. Anything where guessing wrong wastes the run.
+- **Then go.** No per-phase approval. No per-pull-request approval. No "just checking".
+- **Bother him ONCE at the end**, with the QA report: what changed, what it does for him, what is
+  proven, what is not.
+
+**The exception, and it is real: NEVER GUESS.** If something turns up that you genuinely cannot
+decide - a product question nobody has answered, a discovery that changes what the mission is for,
+a choice with a cost he should carry - bring him in. Say what you found, recommend one option, and
+ask. Guessing to preserve the appearance of autonomy is the worse failure by a distance. Autonomy
+means "do not ask permission for the work you were sent to do." It has never meant "do not tell him
+what you found."
+
+The test: *could I have known to ask this before I started?* If yes, you asked too late. If no,
+asking now is correct.
+
+### 2. Commit to the branch. NEVER merge to main.
+
+**The Manager and Workers commit freely, and often, to the mission branch. They never push to main,
+never merge a pull request, never touch `main` at all.**
+
+This is not a formality; it is what keeps the work alive. This repository has already lost a
+mission's worth of work to a machine crash - fourteen commits, complete and passing, stranded on one
+disk because they were never pushed anywhere. **Uncommitted work is work you are one crash away from
+losing.** Commit early, commit often, push the branch.
+
+- Committing to the mission branch **needs no permission**. It is the safe act.
+- Merging to `main` is the irreversible one, and it belongs to the Architect alone.
+- The repository's standing rule - *never commit without being asked* - is about the owner's
+  repository, not your own branch. Inside a mission, on the mission's branch, committing IS the job.
+  Do not seek approval for it, and do not read that as licence anywhere else.
+
+### 3. A DIFFERENT agent inspects before anything reaches main
+
+**No work reaches `main` un-inspected, and the inspector is not the one who wrote it.**
+
+Use a genuinely different agent family, not another instance of the same one - if the Manager is
+Claude Code, the Inspector is Codex. Different training, different blind spots. That is the whole
+mechanism, and it works:
+
+> On one 64-file pull request, an independent Codex inspector found **seven real defects across five
+> passes**, and not one was a false alarm. It found that the mission's headline feature **did not
+> work at all** - the value was computed correctly and nothing told the screen to re-read it - and
+> then found that the *fix for that* was itself half-done, and then that the same fault existed in
+> five more places. The author had verified the code, revert-tested the fixes, and watched the tests
+> fail on purpose. All of it green. All of it would have shipped.
+
+- **The Architect calls the inspection**, not the Manager. The builder does not book his own
+  inspection, and does not get to mark his own work as passed.
+- **The Manager finishes and leaves. Then the inspection happens.** If it finds something, the
+  Architect brings the Manager back - or seats a fresh one - and hands it over. The Inspector never
+  fixes anything: an inspector who picks up a hammer is no longer an inspector.
+- **Tell the inspector to be adversarial, and tell it not to trust the mission's own report.** A
+  mission's QA report is self-testimony. It is written by the people who did the work, about their
+  own work, and it is exactly as persuasive as it is unreliable.
+- **Give it the sharp questions**: what does this claim that the code does not support? Where could
+  a constant be substituted and the suite stay green? What is unguarded?
+- **Fleet messages truncate at the first newline.** Have the inspector write its review to a FILE and
+  reply with one single line. Do not ask for a review in a message; you will get the first heading
+  and nothing else.
+
+### 4. Merged to origin/main is the only "done"
+
+Committed is not done. Pushed is not done. An open pull request is not done. The Architect drives
+each piece all the way to a merged pull request, deletes the branch, and parks the checkout back on
+`main`. A branch that cannot merge today was too big - split it.
+
+---
+
+## Roles, seats, and hygiene
+
+- **One Architect per mission.** It holds the design, the brief, the merge authority, and the whole
+  picture. It does not build.
+- **One Manager at a time**, seated per phase. A Manager that has finished its phase is **killed, not
+  kept** - a stale Manager burns context and starts inventing work. The Architect kills the Manager;
+  the Manager kills its Workers. Never ask a session to kill itself. Never kill uncommitted work -
+  make it commit and push first (law 2).
+- **Re-seat the Architect too**, at clean boundaries. It is not exempt from context rot.
+- **ONE worktree per mission**, cut from `origin/main`, never the shared checkout. Never
+  `git checkout -b` in the shared tree - other sessions are working in it.
+- **Name sessions `Mission - Role`**: `Session States - Architect`, `Session States - Manager`.
+  Mission first, dash, not slash.
+- **A message interrupts the receiving agent.** `message send all` reaches your own team. Never
+  broadcast to the whole fleet.
+
+---
+
+## Writing a mission brief
+
+The brief describes the WORK and nothing else. It does not grant, it does not restate these laws, it
+links here.
+
+Every brief needs:
+
+1. **THE WHY, front and centre.** Not the tasks - the reason. What is broken for the owner, in his
+   words where you have them, and what is true when this is finished. A mission without a why
+   produces work nobody wanted.
+2. **The design decisions already made**, as rulings, with a note on which were *inferred* rather
+   than stated. Putting words in the owner's mouth is the same defect as putting a cause in a log's
+   mouth.
+3. **The work**, in the order it lands.
+4. **What is explicitly out of scope**, so the Manager does not invent it.
+5. **A link to this file** for how to conduct itself.
+
+**Mark the status honestly and keep it current.** A brief that says ACTIVE about a finished mission,
+or points at a worktree that no longer exists, is a lie the next agent will believe. When the mission
+ends, say so in the document, in the past tense.
+
+---
+
+## Landing the work
+
+**Slice it.** One pull request per coherent piece, in the order the work was built. A 95-file pull
+request does not get reviewed; it gets waved through. Six small ones get read.
+
+**A fix and the thing that stops it regressing are ONE unit.** Never land a fix in one slice and its
+guard in another - the window between them is exactly where the defect lives, and on one branch that
+gap is invisible.
+
+**Prove each fix can fail.** Revert it, watch the test go red *with the reported symptom*, watch the
+controls stay green, then restore. A test that has never been watched failing is decoration. In this
+repository a green suite has certified a fully broken feature for fourteen months - assume nothing
+from green.
+
+**Say what is NOT proven.** Write the gaps into the code as gaps. An unproven claim in a comment is
+worse than no comment, because the next reader spends their scepticism somewhere else.
+
+---
+
+## The QA report - the one time you bother the owner
+
+Written for the owner, not for the repository. Plain English, no abbreviations, no process.
+
+Lead with what it does for him. Then: what is proven and how you know; what is NOT proven, named
+honestly; what you got wrong along the way; and any decision that is genuinely his.
+
+Do not narrate the run. He does not want to know how the sausage was made - he wants to know whether
+he can eat it.

--- a/docs/architecture/mission-session-states.md
+++ b/docs/architecture/mission-session-states.md
@@ -1,0 +1,139 @@
+# Mission: Session States
+
+**Status:** ACTIVE. Opened 15 July 2026.
+**Architect:** the session named `Session States - Architect`.
+**How this mission is conducted:** [`.claude/skills/mission/SKILL.md`](../../.claude/skills/mission/SKILL.md) - the roles and the four laws. This document does not restate them and grants nothing.
+**The specification:** [`docs/new_architecture/session-state.html`](../new_architecture/session-state.html) - the only document that defines session state. Read it before writing a line.
+**The first mission's record:** [`mission-session-state-truth.md`](mission-session-state-truth.md) - the original run, which produced the work this mission is landing. Historical.
+
+---
+
+## THE WHY
+
+**DevThrottle lied about what your sessions were doing, and it lied plausibly.**
+
+The owner watched a session render a calm grey dot - the one that means "parked" - while it was
+twenty-three minutes and fifty-six thousand tokens into real work. Nothing looked broken. That is the
+whole problem: a wrong answer gets caught in a day, and an answer that looks ordinary does not.
+
+He looks at those dots to decide where to spend his attention. A dot that says "parked" about a
+working session is not a cosmetic bug. It is the product giving him bad information about his own
+fleet, in the one place he trusts it.
+
+**When this mission is done, every screen tells him the truth about every session, and the next agent
+cannot quietly restore a lie, because the tests and the specification both defend the law.**
+
+---
+
+## THE LAW
+
+> **If a session is working, it is BLUE. Always. Nothing outranks working.**
+
+The Gateway owns every state and is the ONLY thing that picks a colour. The Director reports facts.
+Clients render and decide nothing.
+
+This is settled. Do not re-litigate it.
+
+---
+
+## Where this mission came from, and why it exists separately
+
+The first mission - "Session State Truth", 14-15 July - did the work: it found the defects, fixed
+them, and wrote a QA report. Then **the machine crashed**, and fourteen finished commits were
+stranded on one disk, never pushed. They sat there, complete and passing, one disk failure from
+gone.
+
+The owner declined to merge fourteen commits he could not read, and he was right to. **This mission
+is landing that work** - in six slices, each small enough to review, each independently inspected -
+and then closing what the first mission left open.
+
+The unsliced original is preserved on `backup/session-state-truth-2026-07-15`.
+
+---
+
+## What was actually wrong
+
+Every one of these was a place the product said something false about a session.
+
+| What you saw | What happens now |
+|---|---|
+| A sub-agent doing real work showed a grey "Sub-agent" dot | **Blue "Working"** - nothing outranks working |
+| A snoozed session woke up and stayed grey and buried | **Blue "Working"**, back at the top |
+| You snoozed a working session; the snooze **never expired** | The clock starts **when the work ends**, as asked |
+| A snoozed session that exited still read "Snoozed" forever | **"Exited"** - a dead session never hides behind a snooze |
+| A dictation that never finished wedged the dot orange - one stood **90 minutes** about an upload that was not uploading | Orange requires actual progress. The audio is retained and still delivered |
+| A crashed session looked exactly like one that finished cleanly | **Dark red "Crashed"**, distinct from grey "Exited" |
+| A session flagged for deletion got painted grey by the wrong component | The dot tells the truth about the **work**; deletion rides as a **badge** |
+| The desktop and the phone disagreed about the same session | **One fold** behind every screen |
+
+---
+
+## The slices
+
+| # | What it lands | Pull request | Status |
+|---|---|---|---|
+| 1 | The specification corrections (documentation only) | [#1584](https://github.com/thefrederiksen/devthrottle/pull/1584) | **Merged** |
+| 2 | The snooze that never ends; the dead session hiding behind it (defects 12, 20, 21, 22) | [#1585](https://github.com/thefrederiksen/devthrottle/pull/1585) | **Merged** |
+| 3 | The orange dot that lied about the phone (defect 19) | [#1588](https://github.com/thefrederiksen/devthrottle/pull/1588) | **Merged** |
+| 4 | Deletion is a badge, never a colour (defect 23) | [#1596](https://github.com/thefrederiksen/devthrottle/pull/1596) | **Merged** |
+| 5 | One fold everywhere; the desktop stops guessing (defect 5) | [#1598](https://github.com/thefrederiksen/devthrottle/pull/1598) | **Merged** |
+| 6 | The agreement check and the QA report | - | **Not started** |
+
+Slices are cut from `origin/main` in build order and cherry-picked - the fourteen commits are a
+stacked chain (three touch `SessionDto.cs`, three touch `GatewayHost.cs`), so they cannot be
+reordered without conflicts.
+
+---
+
+## What the inspection found, and why it is the point
+
+Every slice was inspected by an independent **Codex** agent before it merged. It was not decoration.
+
+**On slice 5 alone it found seven real defects across five passes. Not one was a false alarm.**
+
+The one that matters most: **the mission's headline feature did not work.** The Gateway resolved a
+session's role and stamped it, the fold read it correctly and suppressed a controlled worker's red -
+and the desktop still showed red, because nothing told the rail to re-read. Every mapper test passed
+throughout, because they read the fold, and reading is not rendering. Then the fix for that was
+itself half-done - the dot repainted while the row text still said "Needs you" with a live timer -
+and then the same fault turned out to exist in five more places, and finally in the gate that guards
+two of them.
+
+Smaller, and just as instructive: an old Director's silence being read as "not snoozed" would have
+deleted a live snooze fifteen seconds after it was asked for - defect 12, resurrected by a default
+value on the receiving DTO after the wire that killed it had been fixed.
+
+**The author had verified the code, revert-tested every fix, and watched the tests fail on purpose.
+All of it was green. All of it would have shipped.** That is the argument for the inspector, and it
+is why the mission skill now makes one mandatory.
+
+---
+
+## Still open - the four named gaps
+
+Left deliberately, named in the code where they live, and NOT hidden in a backlog.
+
+1. **The desktop's role badge still resolves locally.** The colour reads the Gateway's stamp; the
+   glyph reads the Director's own guess. One row can disagree with itself. Moving it needs an answer
+   to "what shows before the first stamp arrives", and guessing one is how these defects were built.
+2. **The FIFO queue window bypasses the shared fold.** It reads raw red, so it still queues a
+   controlled worker the rail is not calling red.
+3. **The Director's cooked colour is not deleted** until its last consumer is gone.
+4. **The cross-Director role case under a machine filter** - a real cost and product decision.
+
+Plus, from the first mission's own report and worth keeping visible: **the desktop still cannot see
+four things the phone can** - phone dictation, server transcription, voice preparation, and a
+just-expired snooze. The first three do not heal on their own. The recommendation the design already
+implies is that the desktop should stop working colours out and simply **ask**, as the phone does.
+That is a real piece of work and it is the owner's call.
+
+**Open question for the owner:** does this mission end at slice 6, or does it continue until these
+are closed?
+
+---
+
+## Out of scope
+
+- Re-opening the law, or any ruling in the specification's section 7.
+- Any new colour, state, or surface.
+- Deleting the Director's cooked `StatusColor` while anything still reads it.

--- a/docs/architecture/mission-session-states.md
+++ b/docs/architecture/mission-session-states.md
@@ -20,8 +20,15 @@ He looks at those dots to decide where to spend his attention. A dot that says "
 working session is not a cosmetic bug. It is the product giving him bad information about his own
 fleet, in the one place he trusts it.
 
-**When this mission is done, every screen tells him the truth about every session, and the next agent
-cannot quietly restore a lie, because the tests and the specification both defend the law.**
+**THE OBJECTIVE - not yet achieved, and stated as an aim rather than an accomplishment:** every
+screen tells him the truth about every session, and the next agent cannot quietly restore a lie,
+because the tests and the specification both defend the law.
+
+**Today it is partly true.** The eight lies below are fixed and merged. Four named gaps remain open
+(see "Still open"), and until they close, there are still places where a screen can disagree with
+another. Whether this mission ends at slice 6 or runs until those gaps close is an open question for
+the owner, recorded there. Do not quote the objective as though it were the current state - that is
+the exact failure this mission exists to end.
 
 ---
 
@@ -32,7 +39,16 @@ cannot quietly restore a lie, because the tests and the specification both defen
 The Gateway owns every state and is the ONLY thing that picks a colour. The Director reports facts.
 Clients render and decide nothing.
 
-This is settled. Do not re-litigate it.
+This is settled as a **RULING, and it is the target architecture - it is NOT a description of the
+code today.** Two clients still decide things: `MainWindow.axaml.cs` stamps the role badge from the
+Director's own `ResolveLocalRole`, and `FifoWindow.axaml.cs` filters on the raw `StatusColor`. Both
+are on `main` right now, both carry a comment saying so, and both are in "Still open" below.
+
+Read it as the rule you build toward and measure against, never as a claim about what is already
+true. A law written in the present tense reads like a finished fact, and this whole mission is a
+story about true-sounding sentences that were not.
+
+Do not re-litigate the rule itself.
 
 ---
 
@@ -89,7 +105,10 @@ reordered without conflicts.
 
 Every slice was inspected by an independent **Codex** agent before it merged. It was not decoration.
 
-**On slice 5 alone it found seven real defects across five passes. Not one was a false alarm.**
+**On slice 5 alone it found seven real defects across five passes. Not one was a false alarm.** The
+review-driven commits on [#1598](https://github.com/thefrederiksen/devthrottle/pull/1598) record
+them, roughly one per finding; slices 1 to 4 carry the same shape. The number is checkable from the
+branch history rather than something you have to take on trust - which is the point.
 
 The one that matters most: **the mission's headline feature did not work.** The Gateway resolved a
 session's role and stamped it, the fold read it correctly and suppressed a controlled worker's red -

--- a/docs/architecture/mission-session-states.md
+++ b/docs/architecture/mission-session-states.md
@@ -36,11 +36,15 @@ the exact failure this mission exists to end.
 
 > **If a session is working, it is BLUE. Always. Nothing outranks working.**
 
-The Gateway owns every state and is the ONLY thing that picks a colour. The Director reports facts.
-Clients render and decide nothing.
+**The ruling we build toward - not a description of the code today:** the Gateway is to own every
+state and be the ONLY thing that picks a colour; the Director is to report facts; clients are to
+render and decide nothing.
 
-This is settled as a **RULING, and it is the target architecture - it is NOT a description of the
-code today.** Two clients still decide things: `MainWindow.axaml.cs` stamps the role badge from the
+Every sentence of that carries its own qualifier on purpose. An earlier draft stated it in the
+present tense and put the caveat in the paragraph below - and a paragraph below is not where a
+retrieved fragment brings its reader.
+
+**It is NOT true today.** Two clients still decide things: `MainWindow.axaml.cs` stamps the role badge from the
 Director's own `ResolveLocalRole`, and `FifoWindow.axaml.cs` filters on the raw `StatusColor`. Both
 are on `main` right now, both carry a comment saying so, and both are in "Still open" below.
 
@@ -80,7 +84,7 @@ Every one of these was a place the product said something false about a session.
 | A dictation that never finished wedged the dot orange - one stood **90 minutes** about an upload that was not uploading | Orange requires actual progress. The audio is retained and still delivered |
 | A crashed session looked exactly like one that finished cleanly | **Dark red "Crashed"**, distinct from grey "Exited" |
 | A session flagged for deletion got painted grey by the wrong component | The dot tells the truth about the **work**; deletion rides as a **badge** |
-| The desktop and the phone disagreed about the same session | **One fold** behind every screen |
+| The desktop rail and the phone disagreed about the same session | The rail, the phone and the Cockpit now share **one fold**. The FIFO queue window still does not - see "Still open" |
 
 ---
 

--- a/docs/new_architecture/mission-as-first-class-unit-of-work.md
+++ b/docs/new_architecture/mission-as-first-class-unit-of-work.md
@@ -10,6 +10,19 @@ role cardinality attached to it. It does NOT redefine role behavior or attention
 the role-behavior contract's lane. It adds ONE new idea: the Mission as a first-class object that
 sessions attach to.
 
+> **This is the OBJECT. For how a mission is RUN, read [`.claude/skills/mission/SKILL.md`](../../.claude/skills/mission/SKILL.md).**
+>
+> Two different questions, deliberately in two files. This one answers "what is a Mission, what
+> attaches to it, what is it called". The skill answers "how does an Architect conduct one" - the
+> four laws (ask up front then run alone; commit to the branch and never merge to main; a different
+> agent inspects before anything reaches main; only the Architect merges), and how to write a brief.
+>
+> The rules live THERE and only there. Before that file existed they lived nowhere, so every mission
+> brief restated them from memory - they drifted, and each brief read as though it were granting
+> authority. One such brief reached main carrying the sentence "You have standing commit authority
+> for the whole mission", in imperative voice, with its expiry in a different paragraph. A brief
+> describes the WORK; it must never grant a permission. If you are writing one, start at the skill.
+
 ## The idea in one line
 
 A **Mission** is the named unit of work a pod is collectively chartered to accomplish. Sessions

--- a/docs/new_architecture/mission-as-first-class-unit-of-work.md
+++ b/docs/new_architecture/mission-as-first-class-unit-of-work.md
@@ -19,9 +19,14 @@ sessions attach to.
 >
 > The rules live THERE and only there. Before that file existed they lived nowhere, so every mission
 > brief restated them from memory - they drifted, and each brief read as though it were granting
-> authority. One such brief reached main carrying the sentence "You have standing commit authority
-> for the whole mission", in imperative voice, with its expiry in a different paragraph. A brief
-> describes the WORK; it must never grant a permission. If you are writing one, start at the skill.
+> authority. One such brief reached main carrying a sentence that granted that mission open authority
+> to commit: imperative voice, addressed to the reader, with the words limiting it to one branch and
+> one week in a different paragraph. A brief describes the WORK; it must never grant a permission. If
+> you are writing one, start at the skill.
+>
+> *(Paraphrased on purpose. Quoting that sentence would leave the exact imperative string in a
+> permanent document, searchable, one retrieval away from being read as live - the failure it is
+> cited as an example of. It is in git history on `backup/session-state-truth-2026-07-15`.)*
 
 ## The idea in one line
 


### PR DESCRIPTION
## What this is

Three documents, no code. It gives the mission rules a home.

## The problem

There was no run-book for how a mission is **run**. `mission-as-first-class-unit-of-work.md` defines the mission *object* - what attaches to it, what it is called - and says nothing about conduct. So every mission brief wrote the rules out from memory. They drifted, and each one read as though it were **handing out authority**.

Then one reached `main` carrying the sentence *"You have standing commit authority for the whole mission"* - imperative voice, permanent architecture document, expiry in a different paragraph. Retrieval does not fetch the other paragraph. That is how a mission-scoped grant quietly becomes a standing one nobody decided to give.

**Rules with no home get re-invented at every use, and re-invented rules grant.**

## What lands

`.claude/skills/mission/SKILL.md` is now the only home for the rules. A brief describes the **work** and links to it. A brief that grants a permission is a bug in the brief.

**The four laws:**

1. **Ask up front, then run alone.** Questions answered before the run; then no per-slice approval; bother the owner **once**, at the QA report. The exception is real and it is *never guess* - if something genuinely undecidable turns up, bring him in.
2. **Commit to the branch, never merge to main.** Committing is the *safe* act and needs no permission - this repository has already lost fourteen finished commits to a crash because they were never pushed. Merging is the irreversible one, and it is the Architect's alone.
3. **A different agent inspects before anything reaches main.** Claude builds, Codex inspects. The **Architect** calls the inspection, not the Manager - the builder does not book his own inspection. The inspector never fixes; failures go back to the builder.
4. **Merged to origin/main is the only done.**

`docs/architecture/mission-session-states.md` - the Session States mission: the why, the six slices, what the inspection found, and the four gaps left open and named.

The model document now points at the skill so the two cannot drift.

## Why law 3 is not decoration

On one 64-file pull request, an independent Codex inspector found **seven real defects across five passes**, and not one was a false alarm. It found the mission's headline feature **did not work at all**, then that the fix for that was itself half-done, then that the same fault existed in five more places.

The author had verified the code, revert-tested every fix, and watched the tests fail on purpose. All green. All of it would have shipped.
