### PR TITLE
fix(voice): tell the truth when speech is down, and stop paying to fail

### DIFF
--- a/apps/mobile/src/pages/VoiceMode.tsx
+++ b/apps/mobile/src/pages/VoiceMode.tsx
@@ -28,6 +28,8 @@ export function VoiceMode() {
     speaking,
     working,
     audioUnavailable,
+    unavailableReason,
+    unavailableIsServiceDown,
     agentWorking,
     pollDone,
     narrative,
@@ -136,31 +138,46 @@ export function VoiceMode() {
           </div>
         )}
 
+        {/* Voice is unavailable. The Gateway usually KNOWS why, and now says so (unavailableReason).
+            This screen used to hardcode a guess - "the Gateway has not made one, or this session's
+            computer is offline" - which during the 2026-07-15 speech outage was false on both counts,
+            and left the owner unable to tell an outage from a bug for 45 minutes. Never invent a cause
+            here; render what the Gateway reported, and only fall back to the generic line when it has
+            said nothing. */}
         {audioUnavailable && (
           <>
             <div className="voice-statusbar">
-              <span className="voice-state voice-state-red">Voice unavailable</span>
+              <span className="voice-state voice-state-red">
+                {unavailableIsServiceDown ? "Voice service down" : "Voice unavailable"}
+              </span>
             </div>
             <div className="voice-narr">
-              <div className="voice-narr-title">No narration is ready to play.</div>
+              <div className="voice-narr-title">
+                {unavailableIsServiceDown ? "This is not your fault." : "No narration is ready to play."}
+              </div>
               <div className="voice-narr-body">
-                {clipPhase === "error"
-                  ? "The phone could not download the spoken audio for this turn. Tap Generate narration to make it again."
-                  : narrative.length > 0
-                    ? narrative
-                    : "There is no spoken summary for this session's latest turn yet - the Gateway has not made one, or this session's computer is offline. Tap Generate narration to make one now."}
+                {unavailableReason?.text
+                  ? unavailableReason.text
+                  : clipPhase === "error"
+                    ? "The phone could not download the spoken audio for this turn. Tap Generate narration to make it again."
+                    : narrative.length > 0
+                      ? narrative
+                      : "There is no spoken summary for this session's latest turn yet. Tap Generate narration to make one now."}
               </div>
             </div>
-            {/* The minimum recovery: while voice is on but nothing was produced, let the person ask
-                the Gateway to generate the narration right now instead of being stuck. */}
-            <button
-              type="button"
-              className="voice-switch"
-              onClick={() => void onGenerateNow()}
-              disabled={regenerating}
-            >
-              {regenerating ? "Generating narration..." : "Generate narration now"}
-            </button>
+            {/* No button during a service outage: the Gateway is already backing off and retrying, and
+                pressing Generate would hit the same dead service and fail the same way. A button that
+                cannot work is worse than no button - it invites you to keep trying and blame yourself. */}
+            {!unavailableIsServiceDown && (
+              <button
+                type="button"
+                className="voice-switch"
+                onClick={() => void onGenerateNow()}
+                disabled={regenerating}
+              >
+                {regenerating ? "Generating narration..." : "Generate narration now"}
+              </button>
+            )}
           </>
         )}
 

--- a/packages/client-core/src/voice/useVoiceMode.ts
+++ b/packages/client-core/src/voice/useVoiceMode.ts
@@ -49,6 +49,10 @@ function sameSessionForVoice(a: SessionDto | null, b: SessionDto | null): boolea
     && Boolean(a.onHold) === Boolean(b.onHold)
     && Boolean(a.voiceGenerating) === Boolean(b.voiceGenerating)
     && Boolean(a.voiceAudioReady) === Boolean(b.voiceAudioReady)
+    // The reason voice is unavailable is part of what the screen shows, so a CHANGE in it has to count
+    // as a change. Leaving it out meant the poll could carry a fresh reason every 3 seconds and this
+    // guard would declare the session identical, so the screen never re-rendered to show it.
+    && (a.voiceUnavailable?.state ?? null) === (b.voiceUnavailable?.state ?? null)
     && a.statusColor === b.statusColor
     && a.assessedState === b.assessedState
     && a.activityState === b.activityState;
@@ -78,6 +82,11 @@ export interface VoiceModeView {
   speaking: boolean;
   working: boolean;
   audioUnavailable: boolean;
+  /** WHY voice is unavailable, as the Gateway reported it (null when it has nothing to say). Render
+   *  this instead of guessing - the guess was wrong during a real outage. */
+  unavailableReason: { state?: string; text?: string; ctaLabel?: string; ctaAction?: string; ctaUrl?: string | null } | null;
+  /** The hosted service is down: not the user's fault, nothing for them to press, already retrying. */
+  unavailableIsServiceDown: boolean;
   gatewayPreparing: boolean;
   phoneDownloadPending: boolean;
   agentWorking: boolean;
@@ -545,11 +554,23 @@ export function useVoiceMode(sessionId: string | undefined, opts?: { seededVoice
   const narrative = voice?.spoken ?? "";
   const title = session?.number ? `${session.number} ${name ?? "Session"}` : name ?? "Session";
 
+  // WHY voice is unavailable, straight from the Gateway. This field has been arriving on every poll and
+  // being thrown away: it had ZERO readers, while the screens hardcoded a guess ("the Gateway has not
+  // made one, or this session's computer is offline") that was simply speculation - and during the
+  // 2026-07-15 speech outage it was flatly false on both counts. Surface the real reason, and let the
+  // views render it instead of inventing one. Null when the Gateway has nothing to say.
+  const unavailableReason = session?.voiceUnavailable ?? null;
+  // A service outage is not the user's fault and there is nothing for them to press: the Gateway is
+  // already backing off and retrying. Offering a "Generate narration now" button here would be a lie.
+  const unavailableIsServiceDown = unavailableReason?.state === "ServiceDown";
+
   return {
     voiceOn,
     speaking,
     working,
     audioUnavailable,
+    unavailableReason,
+    unavailableIsServiceDown,
     gatewayPreparing,
     phoneDownloadPending,
     agentWorking,

--- a/src/CcDirector.Core/HostedAi/HostedAiMessages.cs
+++ b/src/CcDirector.Core/HostedAi/HostedAiMessages.cs
@@ -39,6 +39,17 @@ public static class HostedAiMessages
             HostedAiCtaAction.OpenSettings,
             null),
 
+        // The far end is down. Nothing is wrong with the account, the setup, or this machine, so there
+        // is NO call to action - offering the user a button here would be a lie, because pressing it
+        // fails the same way. The surface retries on its own; the copy's job is to say what is true and
+        // that recovery is already happening, so the user stops hunting for a bug that is not theirs.
+        // Names no provider, per the copy rules above.
+        HostedAiState.ServiceDown => new HostedAiMessage(
+            "The voice service is not responding. Retrying automatically - this usually comes back on its own.",
+            "",
+            HostedAiCtaAction.None,
+            null),
+
         _ => throw new ArgumentOutOfRangeException(nameof(state), state, "Unknown hosted-AI state"),
     };
 }

--- a/src/CcDirector.Core/HostedAi/HostedAiState.cs
+++ b/src/CcDirector.Core/HostedAi/HostedAiState.cs
@@ -25,4 +25,20 @@ public enum HostedAiState
 
     /// <summary>DevThrottle AI setup is incomplete for this machine.</summary>
     NeedsKey = 3,
+
+    /// <summary>
+    /// The hosted service itself is failing - it answered with an error, or did not answer at all.
+    /// Nothing is wrong with the account, the setup, or this machine: the far end is down.
+    ///
+    /// This state exists because we USED to throw this reason away. WingmanVoiceService mapped 402 and
+    /// NeedsKey and returned a bare null for everything else ("other provider error: logged, no shared
+    /// state"), so a real outage reached the phone as "the Gateway has not made one, or this session's
+    /// computer is offline" - both false, and neither actionable. On 2026-07-15 speech failed for ~45
+    /// minutes (84 failures / 55 successes) and the owner could not tell an outage from a bug, because
+    /// the one fact that explained it was discarded three lines from where it was known.
+    ///
+    /// It is NOT the user's fault and there is nothing for them to fix, so the surface must say so and
+    /// RETRY BY ITSELF rather than offering a button that fails the same way.
+    /// </summary>
+    ServiceDown = 4,
 }

--- a/src/CcDirector.Core/HostedAi/RetryAfterHeader.cs
+++ b/src/CcDirector.Core/HostedAi/RetryAfterHeader.cs
@@ -1,0 +1,37 @@
+using System.Net.Http.Headers;
+
+namespace CcDirector.Core.HostedAi;
+
+/// <summary>
+/// Read a provider's <c>Retry-After</c> into a positive wait (issue #1324).
+///
+/// This lives in Core, next to <see cref="HostedAiErrorMapper"/>, because BOTH hosted legs need it and
+/// it must behave identically on each: the model leg (chat/translation) and the speech leg. It was
+/// private inside HostedInferenceBrain, which is why the speech leg simply dropped the header on the
+/// floor and retried on its own schedule - the provider told us how long to wait and we did not listen.
+/// One copy, so the two legs cannot drift.
+///
+/// When the provider gives no usable hint the caller falls back to its own backoff ramp, so a null here
+/// is "no hint", never "retry immediately".
+/// </summary>
+public static class RetryAfterHeader
+{
+    /// <summary>
+    /// Accepts both header forms: a delta in seconds and an absolute HTTP date. A past date or a
+    /// non-positive delta is treated as "no hint".
+    /// </summary>
+    public static TimeSpan? Parse(RetryConditionHeaderValue? header)
+    {
+        if (header is null) return null;
+        if (header.Delta is { } delta && delta > TimeSpan.Zero) return delta;
+        if (header.Date is { } when)
+        {
+            var wait = when - DateTimeOffset.UtcNow;
+            if (wait > TimeSpan.Zero) return wait;
+        }
+        return null;
+    }
+
+    /// <summary>Convenience for a response's headers: reads <c>Retry-After</c> when present.</summary>
+    public static TimeSpan? Parse(HttpResponseHeaders? headers) => Parse(headers?.RetryAfter);
+}

--- a/src/CcDirector.Gateway/Wingman/HostedInferenceBrain.cs
+++ b/src/CcDirector.Gateway/Wingman/HostedInferenceBrain.cs
@@ -97,7 +97,7 @@ public sealed class HostedInferenceBrain : IAgentBrain
             if ((int)resp.StatusCode == 429)
                 throw new WingmanModelRateLimitedException(
                     $"The wingman model call failed: {(int)resp.StatusCode} {resp.StatusCode}. " + detail,
-                    ParseRetryAfter(resp.Headers.RetryAfter));
+                    CcDirector.Core.HostedAi.RetryAfterHeader.Parse(resp.Headers.RetryAfter));
             throw new InvalidOperationException(
                 $"The wingman model call failed: {(int)resp.StatusCode} {resp.StatusCode}. " + detail);
         }
@@ -111,22 +111,6 @@ public sealed class HostedInferenceBrain : IAgentBrain
         return new AskResult { Text = content, ReplySeconds = sw.Elapsed.TotalSeconds };
     }
 
-    /// <summary>
-    /// Read the provider's Retry-After header into a positive wait, or null when it gave none
-    /// (issue #1324). Accepts both header forms: a delta in seconds and an absolute HTTP date. A
-    /// past date or non-positive delta is treated as "no hint" so the caller falls back to its own backoff.
-    /// </summary>
-    private static TimeSpan? ParseRetryAfter(RetryConditionHeaderValue? header)
-    {
-        if (header is null) return null;
-        if (header.Delta is { } delta && delta > TimeSpan.Zero) return delta;
-        if (header.Date is { } when)
-        {
-            var wait = when - DateTimeOffset.UtcNow;
-            if (wait > TimeSpan.Zero) return wait;
-        }
-        return null;
-    }
 
     /// <summary>
     /// Pull the assistant message text out of a provider-compatible chat-completions response

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -59,6 +59,17 @@ public sealed class WingmanVoiceService
     private readonly ConcurrentDictionary<string, byte> _inFlight = new();   // sid -> a generation is running now
     private readonly WingmanRateLimitGate _rateGate = new();
 
+    //  * _ttsGate: the same cooldown, armed by a failing TEXT-TO-SPEECH leg rather than the model leg.
+    //    Without it, a speech outage costs real money for nothing: the idle sweep
+    //    (GatewayHost.SweepVoiceSessionsAsync, every 45s, 3 sessions a cycle) regenerates any session
+    //    missing voice, and each pass runs a full model TRANSLATION *before* it reaches the speech call
+    //    that is going to fail again. On 2026-07-15 speech was down ~45 minutes: that is ~60 sweeps
+    //    re-translating and re-failing, burning model spend the whole way, and none of it could ever
+    //    produce audio. Voice already comes back by itself when the service returns - the sweep is the
+    //    retry - so the gap was never "no retry", it was "retry with no brakes". Arming this gate on a
+    //    speech failure makes the fleet back off (5/10/20..120s) and honours a 429's Retry-After.
+    private readonly WingmanRateLimitGate _ttsGate = new();
+
     /// <summary>On-disk shape of one ready session's metadata (the audio bytes live next to it as
     /// an .mp3). Persisted so the play triangle / playability survives a gateway restart (issue #553).</summary>
     private sealed record PersistedVoice(string Spoken, string Reply, DateTime AtUtc, string? ContentType = null);
@@ -357,6 +368,16 @@ public sealed class WingmanVoiceService
             return;
         }
 
+        // Backpressure #1b - the SPEECH leg is down. This check must stay ABOVE the translation, because
+        // the whole point is to not pay for a model call whose audio cannot be made. Skipping leaves the
+        // recorded ServiceDown state untouched, so the phone keeps saying the true thing while we wait,
+        // and the sweep picks the session up again the moment the cooldown expires.
+        if (_ttsGate.InCooldown(out var ttsCooldownLeft))
+        {
+            FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} SKIPPED: speech service down, {ttsCooldownLeft.TotalSeconds:F0}s cooldown left");
+            return;
+        }
+
         // Backpressure #2 - coalesce. Never run two generations for the same session at once (a slow
         // turn overlapping the idle sweep would otherwise double the spend). First caller wins.
         if (!_inFlight.TryAdd(sid, 1))
@@ -475,14 +496,49 @@ public sealed class WingmanVoiceService
                 FileLog.Write($"[WingmanVoiceService] tts {mode.ToConfigString()} {(int)resp.StatusCode}");
                 // Out of credits / monthly cap (402): map by code to the shared state so the caller
                 // records the consistent unavailable state instead of a silent null (issue #939).
+                // 402 is the account, not the service: out of credits or over the cap. It is the user's
+                // to fix, so it must NOT arm the speech cooldown - backing off would only delay the
+                // moment they see the message telling them what to do.
                 if ((int)resp.StatusCode == HostedAiHttp.PaymentRequired)
                     return new TtsResult(null, null, HostedAiErrorMapper.Map402(body));
-                return new TtsResult(null, null, null);   // other provider error: logged, no shared state
+
+                // A 429 is the provider saying "stop calling", and it usually says for how long. We used
+                // to drop that header on the floor here and simply try again on the next sweep. Honour it.
+                if ((int)resp.StatusCode == 429)
+                {
+                    var retryAfter = RetryAfterHeader.Parse(resp.Headers);
+                    var backoff = _ttsGate.OnRateLimited(retryAfter);
+                    FileLog.Write($"[WingmanVoiceService] tts 429 - backing off {backoff.TotalSeconds:F0}s" +
+                                  $"{(retryAfter is null ? "" : $" (Retry-After {retryAfter.Value.TotalSeconds:F0}s)")}");
+                    return new TtsResult(null, null, HostedAiState.ServiceDown);
+                }
+
+                // Any other error status means the far end failed, and we KNOW it. This used to return a
+                // bare null ("other provider error: logged, no shared state") - the reason was written to
+                // a log nobody reads and thrown away three lines from where it was known, so the phone
+                // fell back to "the Gateway has not made one, or this session's computer is offline".
+                // Both false. On 2026-07-15 that cost ~45 minutes of the owner not being able to tell an
+                // outage from a bug. Say what actually happened, and back off so the sweep stops paying
+                // for a translation whose audio cannot be made.
+                _ttsGate.OnRateLimited(null);
+                return new TtsResult(null, null, HostedAiState.ServiceDown);
             }
             var contentType = resp.Content.Headers.ContentType?.MediaType;
+            _ttsGate.OnSuccess();   // reaching the service clears any cooldown/backoff ramp
             return new TtsResult(await resp.Content.ReadAsByteArrayAsync(ct), contentType, null);
         }
-        catch (Exception ex) { FileLog.Write($"[WingmanVoiceService] tts FAILED: {ex.Message}"); return new TtsResult(null, null, null); }
+        // A timeout (TtsSynthesis exhausted its attempts) or a transport failure is the same story from
+        // the user's side: the service did not answer. It is not their fault and there is nothing for
+        // them to fix, so it must reach them as ServiceDown rather than as silence.
+        catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)
+        {
+            // A TimeoutException here is TtsSynthesis giving up after its attempts - the exact failure it
+            // exists to bound, and previously the one that stamped NOTHING. Same story for a transport
+            // failure: the service did not answer. Back off, and tell the truth.
+            FileLog.Write($"[WingmanVoiceService] tts FAILED: {ex.Message}");
+            _ttsGate.OnRateLimited(null);
+            return new TtsResult(null, null, HostedAiState.ServiceDown);
+        }
         finally { if (_ttsHttp is null) http.Dispose(); }
     }
 


### PR DESCRIPTION
The Gateway half of the speech work (the server half shipped as devthrottle_internal#360, live, 10x smaller payloads).

During the 2026-07-15 outage the phone blamed the user's own machine. Four defects: (1) no HostedAiState meant 'the service is down', which is why non-402 errors returned a bare null; (2) the TimeoutException that TtsSynthesis exists to bound stamped nothing; (3) a 429's Retry-After was dropped on the speech leg while the model leg has honoured it since #1324 - now reuses WingmanRateLimitGate, with ParseRetryAfter lifted to Core so the legs cannot drift; (4) the sweep already retries every 45s, so voice DID come back by itself - the real bug was no brakes: each pass paid for a full model translation before failing at speech again.

And SessionDto.VoiceUnavailable had ZERO readers across mobile/cockpit/client-core while two views hardcoded a false string. Fixed in the hook, and added to sameSessionForVoice so a changed reason actually re-renders.

Verified: 61/61 hosted-AI + copy rules, 69/69 wingman voice + gate + aggregation, mobile build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)