### PR TITLE
fix(self-update): authenticate POST /shutdown so the swap can actually happen (#1609)

### DIFF
--- a/scripts/test-gateway-selfupdate.ps1
+++ b/scripts/test-gateway-selfupdate.ps1
@@ -42,8 +42,8 @@ param(
 $ErrorActionPreference = 'Continue'
 $repo = Split-Path -Parent $PSScriptRoot
 $work = Join-Path $env:TEMP ("cc-gwsu-" + [Guid]::NewGuid().ToString('N'))
-$installed = Join-Path $work 'installed\cc-director-gateway.exe'
-$staged    = Join-Path $work 'staged\cc-director-gateway.exe'
+$installed = Join-Path $work 'installed\devthrottle-gateway.exe'
+$staged    = Join-Path $work 'staged\devthrottle-gateway.exe'
 $runArgs   = "--port $Port --no-autostart"
 
 # --- Isolation (issue #176): the self-update helper writes installed.json / update-pins.json into
@@ -76,7 +76,7 @@ $env:CC_GATEWAY_NO_TAILSCALE = '1'
 
 function Stop-Throwaway {
     # Only processes running from OUR temp dir - never the live Gateway.
-    Get-Process -Name cc-director-gateway -ErrorAction SilentlyContinue |
+    Get-Process -Name devthrottle-gateway -ErrorAction SilentlyContinue |
         Where-Object { $_.Path -like "$work*" } |
         ForEach-Object { try { $_.Kill() } catch {} }
 }
@@ -100,7 +100,7 @@ function Healthy([int]$p, [int]$tries = 15) {
 Write-Output "=== building Gateway tray app from current source ==="
 $pub = Join-Path $work 'publish'
 & dotnet publish "$repo\src\CcDirector.GatewayApp\CcDirector.GatewayApp.csproj" -c Release -r win-x64 --self-contained false -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o $pub --nologo | Out-Null
-$built = Join-Path $pub 'cc-director-gateway.exe'
+$built = Join-Path $pub 'devthrottle-gateway.exe'
 if (-not (Test-Path $built)) { Write-Output "FAILED: gateway build not found at $built"; Cleanup; exit 1 }
 
 New-Item -ItemType Directory -Force (Split-Path $installed) | Out-Null

--- a/src/CcDirector.GatewayApp/Program.cs
+++ b/src/CcDirector.GatewayApp/Program.cs
@@ -1,7 +1,9 @@
 using System.Diagnostics;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using Avalonia;
 using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Util;
 using CcDirector.Setup.Engine;
 
 namespace CcDirector.GatewayApp;
@@ -55,6 +57,38 @@ public static class Program
         }
     }
 
+    /// <summary>
+    /// Read the running Gateway's bearer token so the self-update helper can authenticate its
+    /// POST /shutdown (issue #1609). Deliberately READ-ONLY: GatewayAuth.LoadOrCreate would MINT a token
+    /// when the file is absent, and a freshly minted token is precisely the one the already-running
+    /// Gateway does not know - it would 401 exactly like sending none, only more confusingly. Returns
+    /// null when there is no token to read, so the caller can say so instead of blaming the exe lock.
+    /// </summary>
+    private static string? TryReadGatewayToken()
+    {
+        try
+        {
+            var path = GatewayAuth.TokenFile;
+            if (!File.Exists(path))
+            {
+                FileLog.Write($"[Program] gateway token file not found at {path}");
+                return null;
+            }
+            var token = File.ReadAllText(path).Trim();
+            if (token.Length == 0)
+            {
+                FileLog.Write($"[Program] gateway token file is empty at {path}");
+                return null;
+            }
+            return token;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[Program] could not read the gateway token: {ex.Message}");
+            return null;
+        }
+    }
+
     private static int ApplyUpdate(string[] args)
     {
         string Arg(string name) { var i = Array.IndexOf(args, name); return i >= 0 && i + 1 < args.Length ? args[i + 1] : ""; }
@@ -74,14 +108,31 @@ public static class Program
             target, stagedSelf, version,
             stopGateway: () =>
             {
-                // Best-effort graceful exit; GatewaySelfUpdate's exe-writability wait is the real
-                // exit barrier (a single-file exe unlocks only when its process has fully exited,
-                // which also releases the single-instance mutex for the relaunch).
+                // Issue #1609: /shutdown is behind the Gateway's token gate, so this MUST authenticate.
+                // Sent token-less, it was answered 401, the Gateway never exited, its exe never unlocked,
+                // and every self-update aborted with the misleading "exe still locked after stop" - which
+                // is why no managed install has updated since the gate closed. The exe-writability wait
+                // below is only a barrier if the process actually exits; it cannot substitute for it.
+                //
+                // Reading the token is legitimate here: this helper is the Gateway's own exe, running as
+                // the same user on the same machine, and the file it reads is the very one the running
+                // Gateway loaded its token from (GatewayAuth.TokenFile).
+                var request = new HttpRequestMessage(HttpMethod.Post, $"http://127.0.0.1:{port}/shutdown");
+                var token = TryReadGatewayToken();
+                if (token is null)
+                {
+                    // Fail loudly rather than post a request we know will 401 and then blame the exe lock.
+                    FileLog.Write("[Program] /shutdown SKIPPED: no gateway token readable; cannot ask the Gateway to exit, so the swap will abort");
+                    return false;
+                }
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
                 try
                 {
-                    using var resp = http.PostAsync($"http://127.0.0.1:{port}/shutdown", content: null)
-                        .GetAwaiter().GetResult();
+                    using var resp = http.SendAsync(request).GetAwaiter().GetResult();
                     FileLog.Write($"[Program] /shutdown -> {(int)resp.StatusCode}");
+                    if (!resp.IsSuccessStatusCode)
+                        FileLog.Write($"[Program] /shutdown REFUSED ({(int)resp.StatusCode}); the Gateway will not exit and the swap will abort on a locked exe");
                     return resp.IsSuccessStatusCode;
                 }
                 catch (Exception ex)

--- a/src/CcDirector.Launcher/Program.cs
+++ b/src/CcDirector.Launcher/Program.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using Avalonia;
 using CcDirector.Core.Utilities;
 using CcDirector.Setup.Engine;
@@ -110,6 +111,38 @@ public static class Program
         }
     }
 
+    /// <summary>
+    /// Read the running Launcher's bearer token so the self-update helper can authenticate its
+    /// POST /shutdown (issue #1609). READ-ONLY on purpose: LoadOrCreateToken would MINT one when the file
+    /// is absent, and a freshly minted token is exactly the one the already-running Launcher does not
+    /// know - it would 401 just like sending none. Null means "no token to read", so the caller can say
+    /// that instead of blaming the exe lock.
+    /// </summary>
+    private static string? TryReadLauncherToken()
+    {
+        try
+        {
+            var path = LauncherAuth.TokenFile;
+            if (!File.Exists(path))
+            {
+                FileLog.Write($"[Program] launcher token file not found at {path}");
+                return null;
+            }
+            var token = File.ReadAllText(path).Trim();
+            if (token.Length == 0)
+            {
+                FileLog.Write($"[Program] launcher token file is empty at {path}");
+                return null;
+            }
+            return token;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[Program] could not read the launcher token: {ex.Message}");
+            return null;
+        }
+    }
+
     private static int ApplyUpdate(string[] args)
     {
         string Arg(string name) { var i = Array.IndexOf(args, name); return i >= 0 && i + 1 < args.Length ? args[i + 1] : ""; }
@@ -129,14 +162,26 @@ public static class Program
             target, stagedSelf, version,
             stopLauncher: () =>
             {
-                // Best-effort graceful exit; LauncherSelfUpdate's exe-writability wait is the real
-                // exit barrier (a single-file exe unlocks only when its process has fully exited,
-                // which also releases the single-instance mutex for the relaunch).
+                // Issue #1609: /shutdown is behind LauncherHost's token gate, so this MUST authenticate.
+                // Sent token-less it was answered 401, the Launcher never exited, its exe never unlocked,
+                // and the self-update aborted with the misleading "exe still locked after stop". The
+                // exe-writability wait below is only a barrier if the process actually exits; it cannot
+                // substitute for it. Same defect, same fix, as the Gateway helper.
+                var request = new HttpRequestMessage(HttpMethod.Post, $"http://127.0.0.1:{port}/shutdown");
+                var token = TryReadLauncherToken();
+                if (token is null)
+                {
+                    FileLog.Write("[Program] /shutdown SKIPPED: no launcher token readable; cannot ask the Launcher to exit, so the swap will abort");
+                    return false;
+                }
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
                 try
                 {
-                    using var resp = http.PostAsync($"http://127.0.0.1:{port}/shutdown", content: null)
-                        .GetAwaiter().GetResult();
+                    using var resp = http.SendAsync(request).GetAwaiter().GetResult();
                     FileLog.Write($"[Program] /shutdown -> {(int)resp.StatusCode}");
+                    if (!resp.IsSuccessStatusCode)
+                        FileLog.Write($"[Program] /shutdown REFUSED ({(int)resp.StatusCode}); the Launcher will not exit and the swap will abort on a locked exe");
                     return resp.IsSuccessStatusCode;
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Fixes #1609. **Self-update has never succeeded on this machine** - every logged outcome is `Failed: ... exe still locked after stop; aborting swap`, for both the Gateway and the Launcher, going back to at least 2026-07-13. Managed installs have been stranded on whatever build they had, which means cutting a release delivered it to nobody.

Found while checking release-readiness for the headless Gateway work. **Pre-existing** - it predates that work.

## One missing header

`/shutdown` sits behind the token gate, and both self-update helpers posted it with no credential:

```
08:45:02 [Program]     --apply-update: version=1.3.0, target=...devthrottle-gateway.exe, port=7878
08:45:02 [GatewayHost] POST /shutdown -> 401
08:45:02 [Program]     /shutdown -> 401
08:45:22 [Program]     self-update outcome=Failed: Gateway exe still locked after stop; aborting swap.
```

401 → the handler never runs → the process never exits → its single-file exe never unlocks → the swap aborts ~20s later **blaming the lock**. That message named the symptom and hid the cause, which is why this survived.

## The fix

Both helpers now read the token the running process itself loaded (`GatewayAuth.TokenFile` / `LauncherAuth.TokenFile`) and send it as Bearer. This is legitimate: the helper is the same product's own exe, running as the same user on the same machine, reading the same file.

Deliberately **read-only** - `LoadOrCreate` would *mint* a token when the file is absent, and a fresh token is precisely the one the running process does not know. It would 401 identically, only more confusingly.

Failure is honest now: a refused `/shutdown` logs that it was refused and that the swap will abort, instead of letting "exe still locked" take the blame. No token readable → say so, and don't post a request we know will 401.

## The test that should have caught this was itself dead

`scripts/test-gateway-selfupdate.ps1` still looked for `cc-director-gateway.exe`. The exe was renamed to `devthrottle-gateway.exe` in `4e606e29`, and the harness has not been touched since `7bbc8afe` - which predates the rename. It failed at "build not found" before ever exercising the update.

**Nobody noticed the 401 because nobody could run the test.** Renamed the four occurrences. Its `Stop-Throwaway` path guard (`Path -like "$work*"`) already prevents it touching the live Gateway, so the rename does not put that at risk.

## Proof

`scripts/test-gateway-selfupdate.ps1`, fully isolated (port 7899, own root, `CC_GATEWAY_NO_TAILSCALE=1`, no autostart):

```
TEST 1 (happy):    exit=0  healthy=True
TEST 2 (rollback): exit=1  healthy-after-rollback=True
production setup state byte-identical
RESULT: PASS - self-update applies a healthy build, auto-rolls-back an unhealthy one
```

**Verified it fails on purpose:** with the `Authorization` header removed, TEST 1 goes `exit=1` and the harness reports `FAIL` - reproducing the exact production symptom. Restored → PASS.

Solution builds. Setup.Engine **297**, Launcher **27** tests pass. The live Gateway on 7878 was untouched throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)