### PR TITLE
fix(gateway): stop the speech leg destroying the answers it is given

### DIFF
--- a/src/CcDirector.Gateway.Tests/VaultEndpointsAuthTests.cs
+++ b/src/CcDirector.Gateway.Tests/VaultEndpointsAuthTests.cs
@@ -1,0 +1,175 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Pairing;
+using CcDirector.Gateway.Util;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Proves the trust boundary in front of the key vault actually holds, at the ROUTE level.
+///
+/// Why this exists: <see cref="VaultEndpoints"/> hands out secret VALUES
+/// (<c>GET /vault/keys/{name}</c>) and lets a caller overwrite them (<c>PUT /vault/keys/{name}</c>),
+/// and its own doc comment says the protection is not in the route at all - "Auth is the Gateway's
+/// host-wide token middleware, so these routes inherit it". That is a correct design and an untested
+/// assumption: the routes contain no check of their own, so IF the host-wide gate were ever bypassed,
+/// reordered, or handed a path that lands in the public allow-list, these endpoints would read and
+/// write secrets for anyone who asked, and nothing in the suite would notice.
+///
+/// So these tests boot the REAL <see cref="AuthMiddleware"/> in front of the REAL
+/// <see cref="VaultEndpoints"/> on an ephemeral port and drive it over real HTTP - the same shape the
+/// account endpoint tests use. What is being proven is the composition, not either half:
+///
+///   1. an unauthenticated GET cannot read a key value - and the secret is not in the body;
+///   2. an unauthenticated PUT cannot write - and the stored value is UNCHANGED afterwards
+///      (a 401 that still mutated would be the worst of both worlds);
+///   3. an unauthenticated DELETE cannot remove a key;
+///   4. an unauthenticated list cannot even enumerate key names;
+///   5. a valid credential still works - so a future "fix" cannot pass these by breaking the vault.
+///
+/// The tailnet half of the boundary is a network-level control (the Gateway binds where it binds) and
+/// is not reproducible in-process; this covers the credential half, which is the half that lives in
+/// code and can regress in a pull request.
+/// </summary>
+public sealed class VaultEndpointsAuthTests
+{
+    private const string GatewayToken = "test-gateway-token-for-vault-auth";
+    private const string SecretName = "DEVTHROTTLE_API_KEY";
+    private const string SecretValue = "dt_live_THIS_MUST_NEVER_LEAK";
+
+    private static KeyVault TempVault()
+    {
+        var vault = new KeyVault(Path.Combine(Path.GetTempPath(), "cc-vault-auth-" + Guid.NewGuid().ToString("N") + ".json"));
+        vault.Set(SecretName, SecretValue);
+        return vault;
+    }
+
+    /// <summary>Boot the real middleware + the real vault routes on an ephemeral port.</summary>
+    private static async Task<(WebApplication App, HttpClient Http, KeyVault Vault)> StartAsync()
+    {
+        var vault = TempVault();
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        var requireToken = new AuthMiddleware.RequireToken
+        {
+            Token = GatewayToken,
+            Devices = new DeviceRegistry(Path.Combine(Path.GetTempPath(), "cc-vault-auth-devices-" + Guid.NewGuid().ToString("N") + ".json")),
+        };
+        app.Use(async (ctx, next) => await AuthMiddleware.Run(ctx, requireToken, next));
+
+        VaultEndpoints.Map(app, vault);
+        await app.StartAsync();
+
+        var http = new HttpClient { BaseAddress = new Uri(app.Urls.First()) };
+        return (app, http, vault);
+    }
+
+    private static HttpRequestMessage Authed(HttpMethod method, string url, string? json = null)
+    {
+        var req = new HttpRequestMessage(method, url);
+        req.Headers.Add("Authorization", $"Bearer {GatewayToken}");
+        if (json is not null) req.Content = new StringContent(json, Encoding.UTF8, "application/json");
+        return req;
+    }
+
+    // (1) The read that hands out a secret value must not answer an anonymous caller - and the secret
+    //     must not appear in whatever it DOES answer (a 401 page that echoes the value is still a leak).
+    [Fact]
+    public async Task GetVaultKey_WithoutCredential_Returns401AndDoesNotLeakTheValue()
+    {
+        var (app, http, _) = await StartAsync();
+        await using var _app = app;
+
+        var res = await http.GetAsync($"/vault/keys/{SecretName}");
+        var body = await res.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.Unauthorized, res.StatusCode);
+        Assert.DoesNotContain(SecretValue, body, StringComparison.Ordinal);
+    }
+
+    // (2) The write must not land. The status is necessary but not sufficient: assert the STORED value
+    //     is untouched, because "rejected the caller but wrote anyway" is the failure that matters.
+    [Fact]
+    public async Task PutVaultKey_WithoutCredential_Returns401AndDoesNotMutateTheVault()
+    {
+        var (app, http, vault) = await StartAsync();
+        await using var _app = app;
+
+        var res = await http.PutAsync($"/vault/keys/{SecretName}",
+            new StringContent("{\"value\":\"attacker-supplied\"}", Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, res.StatusCode);
+        Assert.Equal(SecretValue, vault.Get(SecretName));   // unchanged
+    }
+
+    // (3) Nor may an anonymous caller delete a key: denial of service on the vault is still an attack.
+    [Fact]
+    public async Task DeleteVaultKey_WithoutCredential_Returns401AndTheKeySurvives()
+    {
+        var (app, http, vault) = await StartAsync();
+        await using var _app = app;
+
+        var res = await http.DeleteAsync($"/vault/keys/{SecretName}");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, res.StatusCode);
+        Assert.Equal(SecretValue, vault.Get(SecretName));
+    }
+
+    // (4) Even the names are gated. They are not values, but they are a map of what this machine holds.
+    [Fact]
+    public async Task ListVaultKeys_WithoutCredential_Returns401()
+    {
+        var (app, http, _) = await StartAsync();
+        await using var _app = app;
+
+        var res = await http.GetAsync("/vault/keys");
+        var body = await res.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.Unauthorized, res.StatusCode);
+        Assert.DoesNotContain(SecretName, body, StringComparison.Ordinal);
+    }
+
+    // (5) The control. Without this, every test above would still pass if the vault routes were simply
+    //     broken or unmapped - which would prove nothing about the boundary.
+    [Fact]
+    public async Task VaultRoutes_WithValidCredential_StillReadAndWrite()
+    {
+        var (app, http, vault) = await StartAsync();
+        await using var _app = app;
+
+        var read = await http.SendAsync(Authed(HttpMethod.Get, $"/vault/keys/{SecretName}"));
+        Assert.Equal(HttpStatusCode.OK, read.StatusCode);
+        using (var doc = JsonDocument.Parse(await read.Content.ReadAsStringAsync()))
+        {
+            Assert.Equal(SecretValue, doc.RootElement.GetProperty("value").GetString());
+        }
+
+        var write = await http.SendAsync(Authed(HttpMethod.Put, "/vault/keys/NEW_KEY", "{\"value\":\"set-by-an-authorized-caller\"}"));
+        Assert.Equal(HttpStatusCode.OK, write.StatusCode);
+        Assert.Equal("set-by-an-authorized-caller", vault.Get("NEW_KEY"));
+    }
+
+    // The vault path must never drift into the middleware's public allow-list. That list is edited as
+    // new public surfaces are added (sign-in, enroll, assets), and this asserts the invariant directly
+    // at the place the decision is made, not just through one route's behaviour.
+    [Theory]
+    [InlineData("/vault/keys")]
+    [InlineData("/vault/keys/DEVTHROTTLE_API_KEY")]
+    public async Task VaultPath_WithoutCredential_IsNeverPublic(string path)
+    {
+        var (app, http, _) = await StartAsync();
+        await using var _app = app;
+
+        var res = await http.GetAsync(path);
+        Assert.Equal(HttpStatusCode.Unauthorized, res.StatusCode);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/VoiceUploadLimitsTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceUploadLimitsTests.cs
@@ -1,0 +1,201 @@
+using System.Net;
+using System.Net.Http.Headers;
+using CcDirector.Core;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Voice;
+using CcDirector.Gateway.Wingman;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Proves the voice upload front doors bound what they will hold in memory.
+///
+/// The defect these cover: both routes copied the whole request body into a <c>MemoryStream</c> with no
+/// ceiling - <c>await ctx.Request.Body.CopyToAsync(ms, ct)</c> - so the SENDER decided how much of this
+/// machine's memory to use. The Gateway shares a machine with the user's editors and agents, and these
+/// are the mobile paths clients retry automatically, so a bad recording arrives repeatedly rather than
+/// once. The cloud audio endpoint has had a 4 MB cap since day one; the local leg had none.
+///
+/// These boot the REAL <see cref="GatewayWingmanVoiceEndpoint"/> on an ephemeral port and drive it over
+/// real HTTP, with storage redirected to a temp root (CC_DIRECTOR_ROOT) so the suite never touches the
+/// developer's own voice-upload staging.
+/// </summary>
+[Collection("VoiceUploadLimits")]   // serial: these mutate the CC_DIRECTOR_ROOT process env var
+public sealed class VoiceUploadLimitsTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string? _previousRoot;
+
+    public VoiceUploadLimitsTests()
+    {
+        _previousRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "cc-voice-limits-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _previousRoot);
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+    }
+
+    /// <summary>Boot the real voice endpoint. No auth middleware here on purpose: the trust boundary is
+    /// covered by its own tests, and what is under test is the SIZE guard, which must hold on its own.</summary>
+    private static async Task<(WebApplication App, HttpClient Http)> StartAsync()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        var vaultPath = Path.Combine(Path.GetTempPath(), "cc-voice-limits-" + Guid.NewGuid().ToString("N") + ".vault");
+        var vault = new KeyVault(vaultPath);
+        var persistPath = Path.Combine(Path.GetTempPath(), "cc-voice-limits-" + Guid.NewGuid().ToString("N") + ".json");
+
+        var voice = new WingmanVoiceService(
+            (_, _) => throw new InvalidOperationException("the brain must not be reached by an upload-size test"),
+            vault, persistPath);
+
+        GatewayWingmanVoiceEndpoint.Map(
+            app,
+            new DirectorRegistry(Path.Combine(Path.GetTempPath(), "cc-voice-limits-inst-" + Guid.NewGuid().ToString("N"))),
+            (_, _) => throw new InvalidOperationException("the brain must not be reached by an upload-size test"),
+            vault,
+            voice);
+
+        await app.StartAsync();
+        return (app, new HttpClient { BaseAddress = new Uri(app.Urls.First()) });
+    }
+
+    private static async Task<string> RegisterUploadAsync(HttpClient http)
+    {
+        var res = await http.PostAsync("/wingman/utterance/upload", new StringContent(""));
+        res.EnsureSuccessStatusCode();
+        using var doc = System.Text.Json.JsonDocument.Parse(await res.Content.ReadAsStringAsync());
+        var id = doc.RootElement.GetProperty("upload_id").GetString();
+        // Explicit check rather than the null-forgiving operator, which the coding standard forbids:
+        // if registration ever stopped returning an id, this says so instead of a NullReference later.
+        if (id is null) throw new InvalidOperationException("upload registration returned no upload_id");
+        return id;
+    }
+
+    private static ByteArrayContent Body(byte[] bytes)
+    {
+        var content = new ByteArrayContent(bytes);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        return content;
+    }
+
+    // A normal chunk still works. Without this, the tests below would pass on an endpoint that rejected
+    // everything, which would prove nothing.
+    [Fact]
+    public async Task PutChunk_WithinLimit_IsAccepted()
+    {
+        var (app, http) = await StartAsync();
+        await using var _ = app;
+
+        var id = await RegisterUploadAsync(http);
+        var res = await http.PutAsync($"/wingman/utterance/{id}/chunk/0", Body(new byte[64 * 1024]));
+
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+    }
+
+    // The declared-size door: an honest client that says how big the chunk is gets refused up front.
+    [Fact]
+    public async Task PutChunk_OverLimitWithDeclaredLength_Returns413()
+    {
+        var (app, http) = await StartAsync();
+        await using var _ = app;
+
+        var id = await RegisterUploadAsync(http);
+        var oversize = new byte[VoiceUploadLimits.MaxChunkBytes + 1];
+        var res = await http.PutAsync($"/wingman/utterance/{id}/chunk/0", Body(oversize));
+
+        Assert.Equal(HttpStatusCode.RequestEntityTooLarge, res.StatusCode);
+    }
+
+    // The real guard. Content-Length is the client's CLAIM; a chunked body makes no claim at all, so the
+    // read itself has to stop. This sends an over-limit body with NO Content-Length - if the endpoint
+    // trusted the header alone, this is the request that would sail through and be buffered whole.
+    [Fact]
+    public async Task PutChunk_OverLimitWithNoDeclaredLength_Returns413()
+    {
+        var (app, http) = await StartAsync();
+        await using var _ = app;
+
+        var id = await RegisterUploadAsync(http);
+
+        // A StreamContent over a non-seekable stream has no Content-Length: HttpClient sends it
+        // chunked, exactly like a client that streams a recording as it captures it.
+        var oversize = new MemoryStream(new byte[VoiceUploadLimits.MaxChunkBytes + 1024]);
+        var content = new StreamContent(new NonSeekableStream(oversize));
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+
+        var res = await http.PutAsync($"/wingman/utterance/{id}/chunk/0", content);
+
+        Assert.Equal(HttpStatusCode.RequestEntityTooLarge, res.StatusCode);
+    }
+
+    // The upload total is bounded across chunks, not just per chunk: many legal chunks must not add up
+    // to an unbounded upload.
+    [Fact]
+    public async Task PutChunk_ExceedingTheUploadTotal_Returns413()
+    {
+        var (app, http) = await StartAsync();
+        await using var _ = app;
+
+        var id = await RegisterUploadAsync(http);
+        var chunk = new byte[VoiceUploadLimits.MaxChunkBytes];              // 8 MB each
+        var allowed = (int)(VoiceUploadLimits.MaxTotalUploadBytes / VoiceUploadLimits.MaxChunkBytes);
+
+        for (var i = 0; i < allowed; i++)
+        {
+            var ok = await http.PutAsync($"/wingman/utterance/{id}/chunk/{i}", Body(chunk));
+            Assert.Equal(HttpStatusCode.OK, ok.StatusCode);
+        }
+
+        var overflow = await http.PutAsync($"/wingman/utterance/{id}/chunk/{allowed}", Body(chunk));
+        Assert.Equal(HttpStatusCode.RequestEntityTooLarge, overflow.StatusCode);
+    }
+
+    // Re-sending a chunk must stay free. The total guard counts what is on disk, and a retry REPLACES a
+    // chunk rather than adding one - if the guard forgot that, a client retrying its last chunk at the
+    // ceiling (the normal case on a flaky phone connection) would be refused forever.
+    [Fact]
+    public async Task PutChunk_ResentAtTheCeiling_IsNotCountedTwice()
+    {
+        var (app, http) = await StartAsync();
+        await using var _ = app;
+
+        var id = await RegisterUploadAsync(http);
+        var chunk = new byte[VoiceUploadLimits.MaxChunkBytes];
+        var allowed = (int)(VoiceUploadLimits.MaxTotalUploadBytes / VoiceUploadLimits.MaxChunkBytes);
+
+        for (var i = 0; i < allowed; i++)
+            Assert.Equal(HttpStatusCode.OK, (await http.PutAsync($"/wingman/utterance/{id}/chunk/{i}", Body(chunk))).StatusCode);
+
+        // The upload is now exactly at the ceiling. Re-send the last chunk, as a retrying client does.
+        var resend = await http.PutAsync($"/wingman/utterance/{id}/chunk/{allowed - 1}", Body(chunk));
+        Assert.Equal(HttpStatusCode.OK, resend.StatusCode);
+    }
+
+    /// <summary>A stream that cannot report its length, so HttpClient must send it chunked.</summary>
+    private sealed class NonSeekableStream(Stream inner) : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => inner.Read(buffer, offset, count);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/src/CcDirector.Gateway.Tests/WingmanTtsStatusPassthroughTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanTtsStatusPassthroughTests.cs
@@ -1,0 +1,184 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using CcDirector.Core;
+using CcDirector.Gateway.Api;
+using CcDirector.Gateway.Discovery;
+using CcDirector.Gateway.Wingman;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Proves <c>POST /wingman/tts</c> tells the caller what the far end actually said.
+///
+/// The defect: every non-402 upstream answer was flattened into a bare <c>502</c> and the
+/// <c>Retry-After</c> header was dropped. The cloud proxy goes out of its way to forward the upstream's
+/// status and Retry-After verbatim - it was rewritten for exactly that on 2026-07-15, after a flattened
+/// status turned a provider hiccup into a 45-minute misdiagnosis - and then this endpoint destroyed the
+/// same evidence one hop later. A client told "the gateway is broken" when the truth is "wait four
+/// seconds" cannot back off; it retries straight into the same wall.
+///
+/// What is asserted here is only PASS-THROUGH. The Gateway must not sleep, retry, or invent a policy of
+/// its own on these statuses: the far end is the only layer that knows when to come back, so the whole
+/// job is to relay its answer without editing it.
+/// </summary>
+public sealed class WingmanTtsStatusPassthroughTests
+{
+    /// <summary>An upstream that answers with a fixed status, body, and optional Retry-After.</summary>
+    private sealed class UpstreamStub(HttpStatusCode status, string body, string? retryAfter = null) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var resp = new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            };
+            if (retryAfter is not null) resp.Headers.TryAddWithoutValidation("Retry-After", retryAfter);
+            return Task.FromResult(resp);
+        }
+    }
+
+    /// <summary>An upstream that never answers, so TtsSynthesis exhausts its attempts and gives up.</summary>
+    private sealed class StallingUpstream : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            await Task.Delay(Timeout.Infinite, ct);   // only the per-attempt timeout ends this
+            throw new UnreachableException();
+        }
+    }
+
+    private static async Task<(WebApplication App, HttpClient Http)> StartAsync(HttpMessageHandler upstream)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.Urls.Add("http://127.0.0.1:0");
+
+        // A key must be present or the endpoint short-circuits to 503 before ever calling upstream.
+        var vault = new KeyVault(Path.Combine(Path.GetTempPath(), "cc-tts-pass-" + Guid.NewGuid().ToString("N") + ".vault"));
+        vault.Set("DEVTHROTTLE_API_KEY", "dt_live_test_not_a_real_key");
+        vault.Set("OPENAI_API_KEY", "sk-test-not-a-real-key");
+
+        var persistPath = Path.Combine(Path.GetTempPath(), "cc-tts-pass-" + Guid.NewGuid().ToString("N") + ".json");
+        var voice = new WingmanVoiceService(
+            (_, _) => throw new InvalidOperationException("the brain must not be reached by a tts status test"),
+            vault, persistPath);
+
+        GatewayWingmanVoiceEndpoint.Map(
+            app,
+            new DirectorRegistry(Path.Combine(Path.GetTempPath(), "cc-tts-pass-inst-" + Guid.NewGuid().ToString("N"))),
+            (_, _) => throw new InvalidOperationException("the brain must not be reached by a tts status test"),
+            vault,
+            voice,
+            ttsHttpClient: new HttpClient(upstream) { Timeout = Timeout.InfiniteTimeSpan });
+
+        await app.StartAsync();
+        return (app, new HttpClient { BaseAddress = new Uri(app.Urls.First()) });
+    }
+
+    private static StringContent Say(string text = "hello") =>
+        new($"{{\"text\":\"{text}\"}}", Encoding.UTF8, "application/json");
+
+    // The headline: a 429 reaches the caller AS a 429, carrying the wait the provider asked for.
+    [Fact]
+    public async Task PostTts_Upstream429_PassesThroughTheStatusAndRetryAfter()
+    {
+        var (app, http) = await StartAsync(new UpstreamStub(HttpStatusCode.TooManyRequests, "{\"error\":\"slow down\"}", retryAfter: "4"));
+        await using var _ = app;
+
+        var res = await http.PostAsync("/wingman/tts", Say());
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, res.StatusCode);
+        Assert.Equal("4", res.Headers.GetValues("Retry-After").Single());
+    }
+
+    // Retry-After also has a DATE form. RetryAfterHeader normalizes both, so a client never has to parse
+    // an HTTP date to learn it should wait.
+    [Fact]
+    public async Task PostTts_Upstream429WithDateRetryAfter_NormalizesTheHintToSeconds()
+    {
+        var when = DateTimeOffset.UtcNow.AddSeconds(30).ToString("R");
+        var (app, http) = await StartAsync(new UpstreamStub(HttpStatusCode.TooManyRequests, "{}", retryAfter: when));
+        await using var _ = app;
+
+        var res = await http.PostAsync("/wingman/tts", Say());
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, res.StatusCode);
+        var seconds = int.Parse(res.Headers.GetValues("Retry-After").Single());
+        Assert.InRange(seconds, 1, 31);   // ~30s, allowing for clock/scheduling slack
+    }
+
+    // A 429 with no hint is still a 429. The status is the load-bearing part; the header is a bonus.
+    [Fact]
+    public async Task PostTts_Upstream429WithNoHint_StillPassesTheStatusThrough()
+    {
+        var (app, http) = await StartAsync(new UpstreamStub(HttpStatusCode.TooManyRequests, "{}"));
+        await using var _ = app;
+
+        var res = await http.PostAsync("/wingman/tts", Say());
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, res.StatusCode);
+        Assert.False(res.Headers.Contains("Retry-After"));
+    }
+
+    // 503 is the other "come back later" answer and travels the same road.
+    [Fact]
+    public async Task PostTts_Upstream503_PassesThroughTheStatusAndRetryAfter()
+    {
+        var (app, http) = await StartAsync(new UpstreamStub(HttpStatusCode.ServiceUnavailable, "{}", retryAfter: "12"));
+        await using var _ = app;
+
+        var res = await http.PostAsync("/wingman/tts", Say());
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, res.StatusCode);
+        Assert.Equal("12", res.Headers.GetValues("Retry-After").Single());
+    }
+
+    // 402 keeps its existing shape: the account state, not a transport status. Proving it here stops a
+    // future edit to the pass-through branch from swallowing the credits flow.
+    [Fact]
+    public async Task PostTts_Upstream402_StillMapsToTheSharedPaymentState()
+    {
+        var (app, http) = await StartAsync(new UpstreamStub(HttpStatusCode.PaymentRequired,
+            "{\"error\":{\"code\":\"insufficient_credits\",\"message\":\"out of credits\"}}"));
+        await using var _ = app;
+
+        var res = await http.PostAsync("/wingman/tts", Say());
+
+        Assert.Equal(HttpStatusCode.PaymentRequired, res.StatusCode);
+        var body = await res.Content.ReadAsStringAsync();
+        Assert.Contains("NeedsCredits", body, StringComparison.Ordinal);
+    }
+
+    // An upstream 500 is a bad gateway: the far end answered, and it answered badly.
+    [Fact]
+    public async Task PostTts_Upstream500_Returns502BadGateway()
+    {
+        var (app, http) = await StartAsync(new UpstreamStub(HttpStatusCode.InternalServerError, "{}"));
+        await using var _ = app;
+
+        var res = await http.PostAsync("/wingman/tts", Say());
+
+        Assert.Equal(HttpStatusCode.BadGateway, res.StatusCode);
+    }
+
+    // ...and a stall is a gateway TIMEOUT, which is a different fact about the world. These two used to
+    // be the same 502, which is precisely what makes an outage unreadable from the outside: "it answered
+    // with an error" and "it never answered" call for different responses from a client and different
+    // questions from support.
+    [Fact]
+    public async Task PostTts_UpstreamNeverAnswers_Returns504NotBadGateway()
+    {
+        var (app, http) = await StartAsync(new StallingUpstream());
+        await using var _ = app;
+
+        var res = await http.PostAsync("/wingman/tts", Say());
+
+        Assert.Equal(HttpStatusCode.GatewayTimeout, res.StatusCode);
+    }
+}

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -55,6 +56,54 @@ internal static class GatewayWingmanVoiceEndpoint
     /// (<see cref="TtsVoiceConfig"/>).</summary>
     private const int TtsMaxChars = 4000;
 
+    /// <summary>
+    /// The one HTTP client for the speech leg (issue: hosted-AI client behaviour).
+    ///
+    /// This used to be <c>using var http = new HttpClient()</c> INSIDE the request handler - a fresh
+    /// client, and therefore a fresh connection pool, for every single synthesis. Disposing a client
+    /// leaves its socket in TIME_WAIT, so a burst of turns churns through ports and the pool never gets
+    /// to reuse a warm TLS connection to the proxy. One shared, never-disposed static is the pattern the
+    /// rest of this codebase already uses for hosted calls (AiModelsEndpoint, CarModeChat,
+    /// HostedInferenceBrain, ...), and it is safe here because the credential rides on the REQUEST
+    /// (TtsSynthesis sets a per-request Authorization header), never on the client's default headers -
+    /// so concurrent turns for different keys cannot bleed into each other.
+    ///
+    /// Timeout is INFINITE on purpose: <see cref="TtsSynthesis"/> owns the deadline (a 15-second
+    /// per-attempt cap on a linked CancellationTokenSource, plus one retry). Leaving the client's own
+    /// 100-second default in place would create a SECOND, slower deadline authority racing the first -
+    /// exactly the kind of ambiguity that made the 2026-07-15 stall so hard to read. One timeout, one
+    /// owner. Callers must go through TtsSynthesis, which always supplies the bound.
+    /// </summary>
+    private static readonly HttpClient SharedTtsHttp = new() { Timeout = Timeout.InfiniteTimeSpan };
+
+    /// <summary>413 with a reason the client can show and a support engineer can read.</summary>
+    private static IResult TooLarge(string error) =>
+        Results.Json(new { error }, statusCode: StatusCodes.Status413PayloadTooLarge);
+
+    /// <summary>
+    /// Read a request body into memory, giving up the moment it exceeds <paramref name="max"/>.
+    ///
+    /// The point is the giving up. <c>CopyToAsync(ms)</c> - what these routes used to do - is unbounded
+    /// by construction: it faithfully buffers whatever arrives, so the sender chooses how much of this
+    /// machine's memory to use. Here the ceiling is ours: nothing beyond <paramref name="max"/> is ever
+    /// retained, and the read stops rather than continuing to drain a body we have already refused.
+    ///
+    /// Returns null when the body is over the cap (the caller answers 413). Never trusts Content-Length -
+    /// that is the client's claim about the body, not the body.
+    /// </summary>
+    private static async Task<byte[]?> ReadBoundedAsync(Stream body, long max, CancellationToken ct)
+    {
+        using var ms = new MemoryStream();
+        var buffer = new byte[81920];
+        while (true)
+        {
+            var read = await body.ReadAsync(buffer, ct);
+            if (read == 0) return ms.ToArray();
+            if (ms.Length + read > max) return null;   // over: stop now, keep nothing
+            ms.Write(buffer, 0, read);
+        }
+    }
+
     public static void Map(
         IEndpointRouteBuilder app,
         DirectorRegistry registry,
@@ -65,8 +114,15 @@ internal static class GatewayWingmanVoiceEndpoint
         DirectorCommandRouter.SendDirectorCommandAsync? sendCommand = null,
         SessionOwnerCache? owners = null,
         TimeSpan? streamStale = null,
-        Func<string>? instructionsProvider = null)
+        Func<string>? instructionsProvider = null,
+        HttpClient? ttsHttpClient = null)
     {
+        // The speech transport: the shared static in production, an injected stub in a test. This is the
+        // same seam WingmanVoiceService already exposes for its narration leg (ttsHttpClient) and it
+        // exists for the same reason - the upstream base URL is a compile-time const, so without it the
+        // status mapping below could only be proven by calling the real provider over the internet.
+        var ttsHttp = ttsHttpClient ?? SharedTtsHttp;
+
         var translator = new WingmanTranslator(brainProvider, instructionsProvider: instructionsProvider);
 
         // Post-cut: resolve the owning Director once (from the push store) and reach its session verbs
@@ -143,10 +199,38 @@ internal static class GatewayWingmanVoiceEndpoint
         {
             if (!uploads.Exists(uploadId))
                 return Results.Json(new { error = "unknown upload id (register it first)" }, statusCode: StatusCodes.Status404NotFound);
+
+            // Refuse an oversized chunk BEFORE reading a byte of it, when the client declares its size.
+            // This is the cheap door: no allocation, no read, and the client learns immediately.
+            if (ctx.Request.ContentLength is { } declared && declared > VoiceUploadLimits.MaxChunkBytes)
+            {
+                FileLog.Write($"[GatewayWingmanVoice] chunk rejected: declared {declared} bytes > {VoiceUploadLimits.MaxChunkBytes} cap (upload={uploadId}, index={index})");
+                return TooLarge($"chunk is {declared} bytes; the limit is {VoiceUploadLimits.MaxChunkBytes}");
+            }
+
             var sha = ctx.Request.Headers["X-Chunk-Sha256"].ToString();
-            using var ms = new MemoryStream();
-            await ctx.Request.Body.CopyToAsync(ms, ct);
-            try { await uploads.StoreChunkAsync(uploadId, index, ms.ToArray(), string.IsNullOrEmpty(sha) ? null : sha, ct); return Results.Json(new { ok = true, index }); }
+
+            // Content-Length is the client's CLAIM. It can be absent (chunked transfer-encoding) and it
+            // can be wrong, so the read itself is bounded too: this stops the moment the body exceeds
+            // the cap instead of faithfully buffering however much someone chooses to send.
+            var bytes = await ReadBoundedAsync(ctx.Request.Body, VoiceUploadLimits.MaxChunkBytes, ct);
+            if (bytes is null)
+            {
+                FileLog.Write($"[GatewayWingmanVoice] chunk rejected: body exceeded the {VoiceUploadLimits.MaxChunkBytes}-byte cap (upload={uploadId}, index={index})");
+                return TooLarge($"chunk exceeded the {VoiceUploadLimits.MaxChunkBytes}-byte limit");
+            }
+
+            // Total across the whole upload. Excluding THIS index is what keeps a resend free: the
+            // client's retry replaces chunk N, it does not add a second copy of it, and retrying is the
+            // normal case on this path.
+            var staged = uploads.StagedBytes(uploadId, excludeIndex: index);
+            if (staged + bytes.Length > VoiceUploadLimits.MaxTotalUploadBytes)
+            {
+                FileLog.Write($"[GatewayWingmanVoice] chunk rejected: upload total would be {staged + bytes.Length} > {VoiceUploadLimits.MaxTotalUploadBytes} cap (upload={uploadId})");
+                return TooLarge($"upload would exceed the {VoiceUploadLimits.MaxTotalUploadBytes}-byte total limit");
+            }
+
+            try { await uploads.StoreChunkAsync(uploadId, index, bytes, string.IsNullOrEmpty(sha) ? null : sha, ct); return Results.Json(new { ok = true, index }); }
             catch (Exception ex) { return Results.Json(new { error = ex.Message }, statusCode: StatusCodes.Status400BadRequest); }
         });
 
@@ -208,7 +292,7 @@ internal static class GatewayWingmanVoiceEndpoint
         // page plays in an <audio> element. DevThrottle routes to the hosted proxy's
         // provider-compatible /audio/speech. The voice is the user's choice (TtsVoiceConfig); a
         // request Voice overrides it. The credential comes from the gateway key vault.
-        app.MapPost("/wingman/tts", async (WingmanTtsRequest? req, CancellationToken ct) =>
+        app.MapPost("/wingman/tts", async (WingmanTtsRequest? req, HttpContext ctx, CancellationToken ct) =>
         {
             if (req is null || string.IsNullOrWhiteSpace(req.Text))
                 return Results.Json(new { error = "text is required" }, statusCode: StatusCodes.Status400BadRequest);
@@ -228,17 +312,53 @@ internal static class GatewayWingmanVoiceEndpoint
             {
                 // Short per-attempt timeout + one retry (TtsSynthesis) so a stalled upstream voice
                 // worker fails fast and retries instead of freezing the caller for a flat 60 seconds.
-                using var http = new HttpClient();
-                using var resp = await TtsSynthesis.PostAsync(http, url, key, new { model, voice, input, response_format = "mp3" }, ct);
+                // The client is the shared static (see SharedTtsHttp) - never a per-call one.
+                using var resp = await TtsSynthesis.PostAsync(ttsHttp, url, key, new { model, voice, input, response_format = "mp3" }, ct);
                 if (!resp.IsSuccessStatusCode)
                 {
+                    var status = (int)resp.StatusCode;
                     var body = await resp.Content.ReadAsStringAsync(ct);
-                    FileLog.Write($"[GatewayWingmanVoice] tts {mode.ToConfigString()} {(int)resp.StatusCode}: {body[..Math.Min(200, body.Length)]}");
+                    FileLog.Write($"[GatewayWingmanVoice] tts {mode.ToConfigString()} {status}: {body[..Math.Min(200, body.Length)]}");
+
                     // Out of credits / monthly cap (issue #939): map to the shared 402 state by code
                     // instead of a generic "text-to-speech returned 402".
-                    if ((int)resp.StatusCode == HostedAiHttp.PaymentRequired)
+                    if (status == HostedAiHttp.PaymentRequired)
                         return HostedAiHttp.PaymentRequiredResult(HostedAiErrorMapper.Map402(body));
-                    return Results.Json(new { error = $"text-to-speech returned {(int)resp.StatusCode}" },
+
+                    // A 429 or a 503 is the far end telling the caller to come back later, and it often
+                    // says HOW MUCH later. Both used to be flattened into a bare 502 with the hint
+                    // dropped on the floor: the cloud proxy deliberately forwards the upstream status and
+                    // Retry-After verbatim (it was rewritten for exactly this on 2026-07-15), and this
+                    // endpoint then destroyed the evidence one hop later. A client cannot back off
+                    // correctly against a status that says "the gateway is broken" when the truth is
+                    // "wait four seconds" - it just retries into the same wall.
+                    //
+                    // This is not the Gateway inventing a policy: it does NOT sleep, retry, or decide
+                    // anything here. It passes the far end's own answer through, which is the only layer
+                    // that knows when to come back. WingmanVoiceService already honours this header on
+                    // the narration leg (via the same RetryAfterHeader); now the endpoint does too, so
+                    // the two legs cannot drift.
+                    //
+                    // KNOWN OVERLAP: this route already answers 503 for "no key in the vault" (above).
+                    // An upstream 503 now shares that status. They are distinguishable - the transient
+                    // one carries Retry-After and says "rate limited or unavailable", the setup one says
+                    // "sign in to DevThrottle" - and a client that reads the body cannot confuse them.
+                    // Left as-is deliberately: the setup case arguably wants a different status
+                    // entirely, but that is a client-visible contract change and does not belong in a
+                    // fix whose whole point is to stop DESTROYING information.
+                    if (status is 429 or StatusCodes.Status503ServiceUnavailable)
+                    {
+                        // Normalized to seconds: RetryAfterHeader accepts both wire forms (a delta and an
+                        // HTTP date) and a browser reading this should not have to.
+                        if (RetryAfterHeader.Parse(resp.Headers) is { } wait)
+                            ctx.Response.Headers.RetryAfter = ((int)Math.Ceiling(wait.TotalSeconds)).ToString(CultureInfo.InvariantCulture);
+                        FileLog.Write($"[GatewayWingmanVoice] tts {status} passed through" +
+                            $"{(ctx.Response.Headers.RetryAfter.Count > 0 ? $" (Retry-After {ctx.Response.Headers.RetryAfter})" : " (no Retry-After hint)")}");
+                        return Results.Json(new { error = $"text-to-speech is rate limited or unavailable ({status})" },
+                            statusCode: status);
+                    }
+
+                    return Results.Json(new { error = $"text-to-speech returned {status}" },
                         statusCode: StatusCodes.Status502BadGateway);
                 }
                 var bytes = await resp.Content.ReadAsByteArrayAsync(ct);
@@ -247,6 +367,17 @@ internal static class GatewayWingmanVoiceEndpoint
                 var contentType = resp.Content.Headers.ContentType?.MediaType ?? "audio/mpeg";
                 FileLog.Write($"[GatewayWingmanVoice] tts ok: provider={mode.ToConfigString()}, chars={input.Length}, bytes={bytes.Length}, model={model}, voice={voice}, type={contentType}");
                 return Results.Bytes(bytes, contentType);
+            }
+            // TtsSynthesis exhausted its attempts: the worker never answered inside the per-attempt cap.
+            // That is a GATEWAY TIMEOUT (504), not a bad gateway (502). The two used to be the same 502,
+            // which is the collapse that makes an outage unreadable from the outside: "the upstream
+            // returned an error" and "the upstream never answered" want different responses from a
+            // client and different answers from support, so they must not share a status.
+            catch (TimeoutException ex)
+            {
+                FileLog.Write($"[GatewayWingmanVoice] tts TIMED OUT: {ex.Message}");
+                return Results.Json(new { error = "text-to-speech timed out: " + ex.Message },
+                    statusCode: StatusCodes.Status504GatewayTimeout);
             }
             catch (Exception ex)
             {
@@ -356,6 +487,16 @@ internal static class GatewayWingmanVoiceEndpoint
             var file = form.Files.GetFile("audio") ?? form.Files.FirstOrDefault();
             if (file is null || file.Length == 0)
                 return Results.Json(new { error = "no audio in the upload" }, statusCode: StatusCodes.Status400BadRequest);
+
+            // Bound the clip before it is copied into memory below. This route has no resume and buffers
+            // the file whole, so it is the wrong door for a long recording - the resumable chunk path is
+            // the right one, and saying so beats quietly allocating whatever was sent.
+            if (file.Length > VoiceUploadLimits.MaxOneShotFileBytes)
+            {
+                FileLog.Write($"[GatewayWingmanVoice] transcribe rejected: {file.Length} bytes > {VoiceUploadLimits.MaxOneShotFileBytes} cap");
+                return TooLarge($"audio is {file.Length} bytes; the limit for this endpoint is " +
+                    $"{VoiceUploadLimits.MaxOneShotFileBytes}. Use the resumable upload for long recordings.");
+            }
 
             // Both modes (byo/devthrottle) require the configured key to be present in the vault
             // (issue #887). The single transcription owner resolves this and runs the right provider.

--- a/src/CcDirector.Gateway/Voice/VoiceUploadLimits.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadLimits.cs
@@ -1,0 +1,54 @@
+namespace CcDirector.Gateway.Voice;
+
+/// <summary>
+/// The size bounds for audio arriving at the Gateway's voice front doors: the resumable chunk upload
+/// (<c>PUT /wingman/utterance/{id}/chunk/{i}</c>) and the one-shot multipart post
+/// (<c>POST /wingman/transcribe</c>).
+///
+/// Why this exists: both routes used to copy the whole request body into a <c>MemoryStream</c> with no
+/// ceiling of any kind - the store's only rule was "not empty". The cloud audio endpoint has always had
+/// a 4 MB body cap; the local Gateway had none, so the LOCAL leg was the softer target of the two. That
+/// matters more than it looks: these are the mobile paths, they are latency-sensitive, and clients are
+/// built to RETRY them - so a bad recording does not arrive once, it arrives repeatedly, and every
+/// attempt is held in the Gateway's memory in full. The Gateway shares a machine with the user's
+/// editors, agents, and builds; memory it wastes is memory they do not get.
+///
+/// These are ceilings, not targets. Every number here is far above any real recording:
+/// a MediaRecorder timeslice fragment is measured in KILObytes, and an hour of the opus the phone
+/// actually sends is a few megabytes. If a request trips one of these, something is wrong with it -
+/// which is exactly when we want a clear 413 instead of a silent allocation.
+/// </summary>
+internal static class VoiceUploadLimits
+{
+    /// <summary>
+    /// The most one resumable chunk may carry. This is the number that bounds PER-REQUEST MEMORY, since
+    /// a chunk is buffered whole before it is stored.
+    ///
+    /// 8 MB is roughly a thousand times a real timeslice fragment. It is set that high on purpose: this
+    /// is a safety rail against a broken or hostile client, NOT a tuning knob for the honest one, and a
+    /// rail that a real user can touch is a bug report waiting to happen.
+    /// </summary>
+    public const long MaxChunkBytes = 8L * 1024 * 1024;
+
+    /// <summary>
+    /// The most one upload may total across all its chunks.
+    ///
+    /// This bounds two things at once: the disk a single upload id can occupy while it is staged, and -
+    /// the reason it is not larger - the assembled clip, which <c>AssembleAsync</c> returns as one
+    /// <c>byte[]</c> held in memory. 64 MB is many hours of the opus the phone sends and about an hour
+    /// of far denser audio, so no honest dictation reaches it; a byte[] much past this would be
+    /// large-object-heap pressure on a machine that is also running the user's real work.
+    /// </summary>
+    public const long MaxTotalUploadBytes = 64L * 1024 * 1024;
+
+    /// <summary>
+    /// The most the one-shot multipart path may accept in its audio file.
+    ///
+    /// Lower than <see cref="MaxTotalUploadBytes"/> deliberately: the one-shot route has no resume and
+    /// buffers the file whole, so it is the wrong door for a long recording - that is what the
+    /// resumable chunk path exists for. 25 MB matches the ceiling hosted speech-to-text APIs commonly
+    /// enforce, so a clip this route accepts is one the upstream will accept too, rather than one we
+    /// carry all the way there to have rejected.
+    /// </summary>
+    public const long MaxOneShotFileBytes = 25L * 1024 * 1024;
+}

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -67,6 +67,37 @@ public sealed class VoiceUploadStore
     }
 
     /// <summary>
+    /// The bytes this upload currently occupies on disk, optionally IGNORING one chunk index.
+    ///
+    /// The caller uses this to enforce the total-upload ceiling before staging another chunk. The
+    /// exclusion is what makes that safe under the store's own idempotency: re-sending chunk 5 REPLACES
+    /// chunk 5, it does not add to the total, so counting the copy already on disk would push a
+    /// perfectly legal retry over the ceiling - and retries are the normal case on the mobile path this
+    /// serves, not the exception.
+    ///
+    /// Returns 0 for an unknown upload. Best-effort: a chunk that vanishes mid-enumeration (the sweeper)
+    /// is skipped rather than throwing, because this is a guard rail, not an accounting record.
+    /// </summary>
+    public long StagedBytes(string uploadId, int? excludeIndex = null)
+    {
+        var uid = NormalizeId(uploadId);
+        if (uid is null) return 0;
+        var dir = DirFor(uid);
+        if (!Directory.Exists(dir)) return 0;
+
+        var exclude = excludeIndex is { } i ? ChunkPath(dir, i) : null;
+        long total = 0;
+        foreach (var path in Directory.EnumerateFiles(dir))
+        {
+            if (exclude is not null && string.Equals(path, exclude, StringComparison.OrdinalIgnoreCase)) continue;
+            try { total += new FileInfo(path).Length; }
+            catch (FileNotFoundException) { /* swept mid-enumeration */ }
+            catch (DirectoryNotFoundException) { /* swept mid-enumeration */ }
+        }
+        return total;
+    }
+
+    /// <summary>
     /// Store one chunk. Idempotent on (index, bytes): a chunk already on disk with the same
     /// SHA256 is accepted without rewriting, so retries are free. A supplied SHA that does not
     /// match the bytes is rejected so corruption never enters the assembly.

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -44,7 +44,21 @@ public sealed class WingmanVoiceService
     private readonly ConcurrentDictionary<string, HostedAiState> _voiceUnavailable = new();  // sid -> why voice is off (issue #939)
     private readonly string _persistPath;
     private readonly string _audioDir;
-    private readonly HttpClient? _ttsHttp;   // test seam for TtsAsync (issue #939); a per-call client when null
+    private readonly HttpClient? _ttsHttp;   // test seam for TtsAsync (issue #939); the shared static when null
+
+    /// <summary>
+    /// The one HTTP client for the narration speech leg, used whenever no test client is injected.
+    ///
+    /// Static and never disposed, matching the hosted-call pattern used across this codebase
+    /// (AiModelsEndpoint, CarModeChat, HostedInferenceBrain, ...) and the /wingman/tts endpoint's own
+    /// SharedTtsHttp. Safe to share because the credential goes on each REQUEST inside TtsSynthesis,
+    /// never on this client's default headers.
+    ///
+    /// Timeout is INFINITE deliberately: TtsSynthesis owns the deadline (a 15-second per-attempt cap on
+    /// a linked CancellationTokenSource, plus one retry). A second, slower client-level timeout racing
+    /// it would only make a stall harder to read. One timeout, one owner.
+    /// </summary>
+    private static readonly HttpClient SharedTtsHttp = new() { Timeout = Timeout.InfiniteTimeSpan };
 
     // Backpressure so a busy fleet cannot storm the hosted model into 429s (issue #1324). All
     // generation - the turn-end hook AND the idle sweep - funnels through GenerateAsync, so gating
@@ -482,11 +496,17 @@ public sealed class WingmanVoiceService
         var voice = TtsVoiceConfig.Resolve(mode);
         var model = TtsModelConfig.Resolve(mode);
         var url = tts.BaseUrl.TrimEnd('/') + "/audio/speech";
-        // Reuse the injected client (tests) or a per-call one; auth goes on the request, not the shared
-        // client's default headers, so a shared client is safe under concurrent turn-ends. The effective
-        // timeout is the short per-attempt cap inside TtsSynthesis, which also retries once when a
-        // stalled upstream worker never answers - so a flaky voice backend no longer freezes the turn.
-        var http = _ttsHttp ?? new HttpClient();
+        // The injected client (tests) or the shared static - never a per-call one. Auth goes on the
+        // REQUEST, not the client's default headers, so one shared client is safe under concurrent
+        // turn-ends. The effective timeout is the short per-attempt cap inside TtsSynthesis, which also
+        // retries once when a stalled upstream worker never answers - so a flaky voice backend no longer
+        // freezes the turn.
+        //
+        // This was `_ttsHttp ?? new HttpClient()`: in production _ttsHttp is null, so EVERY turn-end
+        // built and dropped a client, leaving a socket in TIME_WAIT and forfeiting the warm TLS
+        // connection to the proxy. The narration leg fires on a sweep, so that was the hottest speech
+        // path in the product paying the reconnect cost every time.
+        var http = _ttsHttp ?? SharedTtsHttp;
         try
         {
             using var resp = await TtsSynthesis.PostAsync(http, url, key, new { model, voice, input, response_format = "mp3" }, ct);
@@ -539,7 +559,9 @@ public sealed class WingmanVoiceService
             _ttsGate.OnRateLimited(null);
             return new TtsResult(null, null, HostedAiState.ServiceDown);
         }
-        finally { if (_ttsHttp is null) http.Dispose(); }
+        // NOTE: no `finally { http.Dispose(); }`. `http` is now either the caller's injected client or
+        // the shared static, and disposing EITHER would be wrong - the static must outlive every call
+        // (that is the entire point of sharing it) and the injected one belongs to the test that made it.
     }
 
     private static string? NormalizeContentType(string? contentType)


### PR DESCRIPTION
The four findings from the 2026-07-15 server implementation review that live in this repository. The other findings were in the website repository and shipped separately (devthrottle_internal pull request 366).

Every fix below is proven by a test that fails without it.

## 1. The text-to-speech endpoint told the caller the wrong thing

Every upstream answer that was not a 402 became a bare 502, and `Retry-After` was dropped on the floor.

This is worse than it sounds because of where it sits. The cloud proxy deliberately forwards the upstream status and `Retry-After` verbatim - it was rewritten for exactly that on 2026-07-15, after a flattened status turned a provider hiccup into a forty-five minute misdiagnosis. This endpoint then destroyed the same evidence one hop later. A client told "the gateway is broken" when the truth is "wait four seconds" cannot back off correctly; it retries straight into the same wall.

| upstream says | caller used to hear | caller now hears |
|---|---|---|
| 429 + Retry-After 4 | 502, no hint | 429 + Retry-After 4 |
| 503 + Retry-After 12 | 502, no hint | 503 + Retry-After 12 |
| 402 out of credits | 402 shared payment state | unchanged |
| 500 | 502 | 502 |
| never answers | 502 | **504** |

The gateway does not sleep, retry, or decide anything on these statuses - only the far end knows when to come back. It relays the answer without editing it, reusing the same `RetryAfterHeader` the narration leg already honours, so the two legs cannot drift. The last row matters on its own: "it answered badly" and "it never answered" are different facts that call for different responses, and they were the same status.

## 2. Every synthesis built and dropped its own HTTP client

The endpoint used `using var http = new HttpClient()` per request. The narration leg used `_ttsHttp ?? new HttpClient()`, whose null branch is the production one - and that leg fires on a sweep, so the hottest speech path in the product built, used, and discarded a client every time, leaving a socket in TIME_WAIT and forfeiting the warm connection to the proxy.

Both now use one shared static client, the pattern the rest of this codebase already follows (`AiModelsEndpoint`, `CarModeChat`, `HostedInferenceBrain`, and others). Safe to share because the credential rides on each request, never on the client's default headers. The timeout is infinite on purpose: `TtsSynthesis` owns the deadline, and a second slower deadline racing it only makes a stall harder to read.

Note the `finally { if (_ttsHttp is null) http.Dispose(); }` is gone along with the per-call client it belonged to. Leaving it would have disposed the shared client after the first call and broken every one after it.

## 3. The voice uploads would hold anything they were sent

Both front doors copied the whole request body into a `MemoryStream` with no ceiling of any kind - the store's only rule was "not empty". The sender decided how much of this machine's memory to use, and this machine also runs the user's editors, agents, and builds. These are the mobile paths, and clients retry them automatically, so a bad recording does not arrive once - it arrives repeatedly, each attempt held whole. The cloud audio endpoint has had a four megabyte cap since day one; the local leg had none, which made the local leg the softer target.

There are now explicit bounds at the route boundary (`VoiceUploadLimits`): 8 MB per chunk, 64 MB per upload total, 25 MB for the one-shot multipart file. Every number is far above any real recording - a timeslice fragment is measured in kilobytes - because these are rails against a broken client, not tuning knobs for an honest one.

Two details worth review:

- **`Content-Length` is checked first, but the read is bounded too.** The header is the client's *claim* about the body, not the body; a chunked request makes no claim at all. The bounded read is what actually holds, and the test that proves it is the one sending an over-limit body with no declared length.
- **The total guard excludes the chunk being replaced.** A resend replaces chunk N rather than adding a second copy, so counting the copy on disk would refuse a client retrying its last chunk at the ceiling - the normal case on a flaky phone connection, not the exception.

## 4. The key vault's protection was correct and untested

`VaultEndpoints` hands out secret values and accepts new ones, and contains no check of its own - its own comment says the protection is the host-wide middleware it inherits. That is a sound design and an unverified assumption. If that gate were ever bypassed, reordered, or handed a path that landed in the public allow-list, these routes would read and write secrets for anyone who asked, and nothing in the suite would have noticed.

There is now a route-level test booting the **real** middleware in front of the **real** routes on an ephemeral port. An unauthenticated caller cannot read a value (and the secret is not in the body), cannot write one (asserted against the *stored value*, because a 401 that still mutated would be the worst of both worlds), cannot delete, and cannot list names. A valid credential still works, so the tests cannot pass by simply breaking the vault.

The tailnet half of that boundary is a network-level control and is not reproducible in-process; this covers the credential half, which is the half that lives in code and can regress in a pull request.

## Verification

- All **2307** gateway tests pass; the full solution builds with **0 warnings**.
- The 19 new tests were **mutation-checked**, because a test that cannot fail proves nothing:
  - removing the auth middleware fails the vault tests (5 of them) and leaves the control passing, exactly as it should;
  - removing the read bound fails precisely one test - the chunked-body case that `Content-Length` cannot catch.

## Not included

The review's remaining items were website-side and are already live. Its P2-1 (transcription provider migration) and P2-3 (admin rollups) were judged real risk and premature respectively, and the API key reveal was kept by product decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)