### PR TITLE
fix(voice): stop cutting narration at OpenAI's dead limit, and give the deadline a reason

### DIFF
--- a/src/CcDirector.Gateway.Tests/NarrationLengthTests.cs
+++ b/src/CcDirector.Gateway.Tests/NarrationLengthTests.cs
@@ -1,0 +1,138 @@
+using CcDirector.Gateway.HostedAi;
+using CcDirector.Gateway.Wingman;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1612. Narration was silently cut at 4000 characters to satisfy OpenAI's /audio/speech limit
+/// - months after we stopped calling OpenAI. It happened 24 times in one day (of 873): the worst lost
+/// 969 characters, about 55 seconds of speech, dropped mid-word with the user told nothing.
+///
+/// These pin the two mechanisms the fix rests on. The third and most important part - the wingman
+/// actually summarising - is pinned in WingmanTranslatorTests, because that is a prompt contract.
+/// </summary>
+public class NarrationLengthTests
+{
+    // ---- The cut is the lie, not the limit ---------------------------------
+
+    [Fact]
+    public void LimitForSpeech_NormalNarration_PassesThroughUntouched()
+    {
+        // A real narration (~30 seconds spoken) must never be touched. If this ever trips, the guard
+        // has become a product limit, which is the bug it replaced.
+        var text = new string('a', 550);
+        var result = NarrationText.LimitForSpeech(text, out var wasCut);
+        Assert.False(wasCut);
+        Assert.Equal(text, result);
+    }
+
+    [Fact]
+    public void LimitForSpeech_TheWorstEverObserved_IsNoLongerCut()
+    {
+        // 4,969 chars: the worst real case on 2026-07-15, which lost ~55 seconds under the old 4000
+        // cap. It is well inside the guard now, so it is spoken in full.
+        var result = NarrationText.LimitForSpeech(new string('a', 4969), out var wasCut);
+        Assert.False(wasCut);
+        Assert.Equal(4969, result.Length);
+    }
+
+    [Fact]
+    public void LimitForSpeech_RunawayText_IsCutButSaysSo()
+    {
+        // The guard fires only for a runaway. When it does, the listener MUST hear that they are
+        // missing something - being cut off mid-word in silence is the defect.
+        var text = string.Join(" ", Enumerable.Repeat("word", 5000));   // ~25,000 chars
+        var result = NarrationText.LimitForSpeech(text, out var wasCut);
+
+        Assert.True(wasCut);
+        Assert.Contains("as much as I can read out", result);
+        Assert.Contains("open the session to read the full reply", result);
+        Assert.True(result.Length <= NarrationText.MaxChars,
+            $"the result must stay within the ceiling the deadline is derived from, was {result.Length}");
+    }
+
+    [Fact]
+    public void LimitForSpeech_NeverCutsMidWord()
+    {
+        // The old behaviour was a bare text[..4000], which cut mid-word and made truncation sound
+        // like a crash. Whatever we cut, the last spoken word must be a whole word.
+        var text = string.Join(" ", Enumerable.Repeat("indistinguishable", 2000));
+        var result = NarrationText.LimitForSpeech(text, out var wasCut);
+
+        Assert.True(wasCut);
+        var spokenPart = result[..result.IndexOf(" That is as much as I can read out", StringComparison.Ordinal)];
+        Assert.All(spokenPart.Split(' ', StringSplitOptions.RemoveEmptyEntries),
+            w => Assert.Equal("indistinguishable", w));
+    }
+
+    [Fact]
+    public void LimitForSpeech_PrefersASentenceBoundary()
+    {
+        // Cut at the end of a thought where we can, so the listener hears something whole before
+        // being told the rest is missing.
+        var text = string.Join(" ", Enumerable.Repeat("The agent changed the timeout.", 1000));
+        var result = NarrationText.LimitForSpeech(text, out var wasCut);
+
+        Assert.True(wasCut);
+        var spokenPart = result[..result.IndexOf(" That is as much as I can read out", StringComparison.Ordinal)];
+        Assert.EndsWith(".", spokenPart);
+    }
+
+    [Fact]
+    public void LimitForSpeech_NullOrEmpty_IsSafe()
+    {
+        Assert.Equal("", NarrationText.LimitForSpeech(null, out var cutNull));
+        Assert.False(cutNull);
+        Assert.Equal("", NarrationText.LimitForSpeech("", out var cutEmpty));
+        Assert.False(cutEmpty);
+    }
+
+    // ---- The cap and the deadline are ONE decision -------------------------
+
+    [Theory]
+    // input, measured synthesis seconds direct to the provider (2026-07-15, production key).
+    // The deadline must clear the MEASURED time at every length. A flat 15s - the old value - fails
+    // this at 8,000 and 12,000, which is exactly why raising the cap alone would have turned silent
+    // truncation into silent failure.
+    [InlineData(4_000, 7.3)]
+    [InlineData(5_000, 11.6)]
+    [InlineData(8_000, 14.0)]
+    [InlineData(12_000, 21.1)]
+    public void DeadlineFor_ClearsTheMeasuredSynthesisTime_WithHeadroom(int chars, double measuredSeconds)
+    {
+        var deadline = TtsSynthesis.DeadlineFor(chars).TotalSeconds;
+        Assert.True(deadline > measuredSeconds * 2,
+            $"{chars} chars: deadline {deadline:F1}s must leave >2x headroom over the measured {measuredSeconds}s");
+    }
+
+    [Fact]
+    public void DeadlineFor_ScalesWithTheText_SoItCannotRotWhenTheCapMoves()
+    {
+        // The point of the change: the deadline is DERIVED, not picked. A longer text gets more time,
+        // automatically. The old flat 15s was only ever right for the 4000-char world it was born in.
+        var shortDeadline = TtsSynthesis.DeadlineFor(550);
+        var longDeadline = TtsSynthesis.DeadlineFor(NarrationText.MaxChars);
+
+        Assert.True(longDeadline > shortDeadline);
+        // A normal narration must not wait on a budget sized for a runaway.
+        Assert.True(shortDeadline < TimeSpan.FromSeconds(10),
+            $"a ~30-second narration should get a snug deadline, got {shortDeadline.TotalSeconds:F1}s");
+    }
+
+    [Fact]
+    public void DeadlineFor_AtTheRunawayCeiling_StaysBounded()
+    {
+        // The cap is what keeps the derived deadline finite. If someone raises MaxChars without
+        // thinking about this, they will see it here.
+        var atCap = TtsSynthesis.DeadlineFor(NarrationText.MaxChars);
+        Assert.InRange(atCap.TotalSeconds, 30, 60);
+    }
+
+    [Fact]
+    public void DeadlineFor_IsNeverNegative_ForDegenerateInput()
+    {
+        Assert.True(TtsSynthesis.DeadlineFor(0) > TimeSpan.Zero);
+        Assert.True(TtsSynthesis.DeadlineFor(-1) > TimeSpan.Zero);
+    }
+}

--- a/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
@@ -157,6 +157,11 @@ public sealed class WingmanTranslatorTests
         // framing, not the old word, so a drift back to "keep everything" fails here.
         Assert.Contains("Brevity is the GOAL", prompt);
         Assert.Contains("CONSTRAINT", prompt);
+        // v5.1: the framing needs a NUMBER next to it. v5 said "there is no length limit" - true of
+        // the provider, irrelevant to the listener - and measured ~1m42 on a long reply against ~48s
+        // once the budget was stated. If this assertion ever goes, the essays come back.
+        Assert.Contains("THIRTY SECONDS", prompt);
+        Assert.DoesNotContain("There is no length limit", prompt);
         Assert.Contains("what did you change?", prompt); // the person's message is present
     }
 

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -50,11 +50,11 @@ internal static class GatewayWingmanVoiceEndpoint
 
     private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(750);
 
-    /// <summary>Per-call input cap: hosted speech endpoints accept bounded input and
-    /// spoken summaries are short. The model + voice are no longer hardcoded here - they are resolved
-    /// through the hosted routing target (<see cref="TranscriptionEndpointResolver.ResolveTts"/>) and per user
-    /// (<see cref="TtsVoiceConfig"/>).</summary>
-    private const int TtsMaxChars = 4000;
+    // The old per-call TtsMaxChars = 4000 is gone (issue #1612). Its comment claimed "hosted speech
+    // endpoints accept bounded input and spoken summaries are short" - both halves are now disproved:
+    // the provider accepts 12,000+ characters (measured), our own metered API has no cap at all, and
+    // the wingman was writing four-minute essays that the cap was quietly hiding. The runaway guard
+    // now lives in Wingman.NarrationText, which tells the listener when it fires.
 
     /// <summary>
     /// The one HTTP client for the speech leg (issue: hosted-AI client behaviour).
@@ -304,16 +304,24 @@ internal static class GatewayWingmanVoiceEndpoint
                 return Results.Json(new { error = "no DevThrottle account key configured in the gateway vault - sign in to DevThrottle" },
                     statusCode: StatusCodes.Status503ServiceUnavailable);
 
-            var input = req.Text.Length > TtsMaxChars ? req.Text[..TtsMaxChars] : req.Text;
+            // Read-aloud of caller-supplied text. It is metered and the caller pays, so there is no
+            // product limit here - only the runaway guard, which announces itself when it fires
+            // (issue #1612). This used to cut at 4000 characters, silently and mid-word, to satisfy
+            // OpenAI's limit long after we stopped calling OpenAI.
+            var input = Wingman.NarrationText.LimitForSpeech(req.Text, out var wasCut);
+            if (wasCut)
+                FileLog.Write($"[GatewayWingmanVoice] tts text EXCEEDED {Wingman.NarrationText.MaxChars} chars " +
+                              $"({req.Text.Length}) - spoken text cut and the listener told");
             var voice = string.IsNullOrWhiteSpace(req.Voice) ? TtsVoiceConfig.Resolve(mode) : req.Voice.Trim();
             var model = string.IsNullOrWhiteSpace(req.Model) ? TtsModelConfig.Resolve(mode) : req.Model.Trim();
             var url = tts.BaseUrl.TrimEnd('/') + "/audio/speech";
             try
             {
-                // Short per-attempt timeout + one retry (TtsSynthesis) so a stalled upstream voice
-                // worker fails fast and retries instead of freezing the caller for a flat 60 seconds.
+                // Per-attempt deadline derived from the text length + one retry (TtsSynthesis), so a
+                // stalled upstream voice worker fails fast and retries instead of freezing the caller,
+                // while a legitimately long read still gets the time it actually needs.
                 // The client is the shared static (see SharedTtsHttp) - never a per-call one.
-                using var resp = await TtsSynthesis.PostAsync(ttsHttp, url, key, new { model, voice, input, response_format = "mp3" }, ct);
+                using var resp = await TtsSynthesis.PostAsync(ttsHttp, url, key, new { model, voice, input, response_format = "mp3" }, input.Length, ct);
                 if (!resp.IsSuccessStatusCode)
                 {
                     var status = (int)resp.StatusCode;

--- a/src/CcDirector.Gateway/HostedAi/TtsSynthesis.cs
+++ b/src/CcDirector.Gateway/HostedAi/TtsSynthesis.cs
@@ -10,26 +10,61 @@ namespace CcDirector.Gateway.HostedAi;
 
 /// <summary>
 /// Forwards a text-to-speech request to the configured provider-compatible <c>/audio/speech</c>
-/// endpoint with a SHORT per-attempt timeout and a single retry.
+/// endpoint with a per-attempt deadline DERIVED FROM THE TEXT, and a single retry.
 ///
 /// The upstream speech model (the DevThrottle proxy forwarding to DeepInfra's Kokoro) is bimodal: a
 /// healthy call returns in about a second, but an intermittently cold or overloaded worker never
-/// answers. The former flat 60-second client timeout with no retry turned one such stall into a full
-/// 60-second freeze on the phone (every wingman turn hung for a minute). A 15-second per-attempt cap
-/// fails fast on the stalled worker, and one retry almost always lands on a warm worker - so the
-/// caller sees about a second normally and about sixteen seconds in the worst realistic case instead
-/// of a minute.
+/// answers. A flat 60-second client timeout with no retry turned one such stall into a full
+/// 60-second freeze on the phone (every wingman turn hung for a minute). A per-attempt cap fails
+/// fast on the stalled worker, and one retry almost always lands on a warm worker.
+///
+/// A deadline must exist: the provider does not queue (200 concurrent per model, 429 immediately
+/// when busy), so a long silence is a genuine hang, not work in progress.
+///
+/// WHY THE DEADLINE IS COMPUTED AND NOT A CONSTANT (issue #1612). It used to be a flat 15 seconds.
+/// That number was only ever right for a 4000-character world, because synthesis scales LINEARLY
+/// with the text - about 1.7 ms per character, measured. The 4000 cap and the 15 s deadline were one
+/// decision pretending to be two, so raising the cap alone would have converted silent truncation
+/// into silent FAILURE: 12,000 characters needs ~21 s and would have blown a 15 s deadline every
+/// time. A constant here is the same disease that produced the 4000 in the first place - correct
+/// once, never re-derived when the world moved. Derive it from the work and it cannot rot when the
+/// cap moves again.
+///
+/// This is the ONLY deadline on the speech path. The server-side proxy had its own, nested wrongly
+/// inside this one, and it was deleted (devthrottle_internal#360) - a proxy must not invent policy.
+/// Do NOT reintroduce a second one anywhere: that nesting was the original bug.
 ///
 /// This is NOT a fallback that hides a failure: a genuine provider response (success, 402, any 4xx or
-/// 5xx) is returned immediately with no retry, and when BOTH attempts exceed the per-attempt cap the
+/// 5xx) is returned immediately with no retry, and when BOTH attempts exceed the deadline the
 /// caller is told the synthesis failed (a thrown <see cref="TimeoutException"/>). Only the transient
 /// "the worker never answered in time" case is retried.
 /// </summary>
 internal static class TtsSynthesis
 {
-    /// <summary>Per-attempt ceiling. Well above the roughly one-second healthy latency, well below the
-    /// former 60-second freeze.</summary>
-    public static readonly TimeSpan PerAttemptTimeout = TimeSpan.FromSeconds(15);
+    /// <summary>Fixed cost allowed for everything that is not synthesis: TLS, auth, the credit
+    /// pre-flight, and the network both ways. It does not scale with the text.</summary>
+    private static readonly TimeSpan DeadlineBase = TimeSpan.FromSeconds(5);
+
+    /// <summary>Allowance per character of input. Synthesis measures ~1.7 ms/char, so 4 ms/char is
+    /// roughly 2.4x headroom at every length - enough for a slow-but-working worker, short enough
+    /// that a genuine hang is still caught quickly.</summary>
+    private const double DeadlineMsPerChar = 4.0;
+
+    /// <summary>
+    /// The per-attempt deadline for synthesising <paramref name="inputChars"/> characters:
+    /// <see cref="DeadlineBase"/> + <see cref="DeadlineMsPerChar"/> per character.
+    ///
+    /// Checked against measurements taken direct to the provider (2026-07-15, production key), which
+    /// is where the 2.4-2.9x headroom claim comes from - not from arithmetic on faith:
+    ///   4,000 chars -> synthesis 7.3 s, deadline 21 s (2.9x)
+    ///   5,000 chars -> synthesis 11.6 s, deadline 25 s (2.2x)
+    ///   8,000 chars -> synthesis 14.0 s, deadline 37 s (2.6x)
+    ///   12,000 chars -> synthesis 21.1 s, deadline 53 s (2.5x)
+    /// A typical narration after the wingman was told to actually summarise (~550 chars, about 30
+    /// seconds spoken) gets ~7 s for a call that takes about one.
+    /// </summary>
+    public static TimeSpan DeadlineFor(int inputChars)
+        => DeadlineBase + TimeSpan.FromMilliseconds(DeadlineMsPerChar * Math.Max(0, inputChars));
 
     /// <summary>Total attempts (that is, one retry). The retry targets the transient stalled-worker case.</summary>
     public const int Attempts = 2;
@@ -37,17 +72,21 @@ internal static class TtsSynthesis
     /// <summary>
     /// POST <c>{ model, voice, input, response_format }</c> to <paramref name="url"/> with bearer
     /// <paramref name="key"/>. Returns the provider's response (success or error) for the caller to
-    /// read and dispose. Throws <see cref="TimeoutException"/> when every attempt exceeds
-    /// <see cref="PerAttemptTimeout"/>. Honors <paramref name="ct"/>: caller cancellation propagates
-    /// immediately and is never mistaken for a per-attempt timeout.
+    /// read and dispose. Throws <see cref="TimeoutException"/> when every attempt exceeds the
+    /// deadline for <paramref name="inputChars"/> (see <see cref="DeadlineFor"/>). Honors
+    /// <paramref name="ct"/>: caller cancellation propagates immediately and is never mistaken for a
+    /// per-attempt timeout.
     /// </summary>
-    public static async Task<HttpResponseMessage> PostAsync(HttpClient http, string url, string key, object payload, CancellationToken ct)
+    /// <param name="inputChars">Length of the text being synthesised. The deadline is derived from
+    /// it, so pass the length of the text actually in <paramref name="payload"/>.</param>
+    public static async Task<HttpResponseMessage> PostAsync(HttpClient http, string url, string key, object payload, int inputChars, CancellationToken ct)
     {
+        var deadline = DeadlineFor(inputChars);
         TimeoutException? lastTimeout = null;
         for (var attempt = 1; attempt <= Attempts; attempt++)
         {
             using var perAttempt = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            perAttempt.CancelAfter(PerAttemptTimeout);
+            perAttempt.CancelAfter(deadline);
             using var req = new HttpRequestMessage(HttpMethod.Post, url)
             {
                 Content = JsonContent.Create(payload),
@@ -61,9 +100,10 @@ internal static class TtsSynthesis
             {
                 // Our per-attempt timer fired (the caller did not cancel): the upstream worker stalled.
                 lastTimeout = new TimeoutException(
-                    $"text-to-speech attempt {attempt} exceeded {PerAttemptTimeout.TotalSeconds:0}s");
+                    $"text-to-speech attempt {attempt} exceeded {deadline.TotalSeconds:0}s for {inputChars} characters");
                 FileLog.Write($"[TtsSynthesis] attempt {attempt}/{Attempts} timed out after " +
-                    $"{PerAttemptTimeout.TotalSeconds:0}s{(attempt < Attempts ? "; retrying" : "; giving up")}");
+                    $"{deadline.TotalSeconds:0}s ({inputChars} chars)" +
+                    $"{(attempt < Attempts ? "; retrying" : "; giving up")}");
             }
         }
         throw lastTimeout!;

--- a/src/CcDirector.Gateway/Wingman/NarrationText.cs
+++ b/src/CcDirector.Gateway/Wingman/NarrationText.cs
@@ -1,0 +1,80 @@
+namespace CcDirector.Gateway.Wingman;
+
+/// <summary>
+/// The runaway guard on text handed to speech synthesis - and, when it fires, the sentence that
+/// TELLS the listener their narration was cut (issue #1612).
+///
+/// Two things this is NOT:
+///
+/// 1. It is NOT the length limit for a narration. That belongs where the text is PRODUCED - the
+///    wingman's own instructions (<see cref="WingmanTranslator.FidelityPrompt"/>), which now carry a
+///    spoken-length budget of about thirty seconds. A summary is short because we asked for a
+///    summary, not because we cut an essay in half. This is only the backstop for when that fails.
+///
+/// 2. It is NOT a provider limit. There is no such limit. The old cap was 4000 characters, inherited
+///    from OpenAI's <c>/v1/audio/speech</c> (which genuinely caps at 4096) by commit 265af32b on
+///    2026-06-19 - correct for a provider we then stopped using. The provider was swapped and the cap
+///    rode along unexamined, so for months narration was silently cut to satisfy a limit belonging to
+///    a company we no longer call. It happened 24 times in one day: of 873 narrations, the worst lost
+///    969 characters - about 55 seconds of speech - dropped mid-word with the user told nothing. It is
+///    the longest, most complex turns that get cut: exactly the ones whose ending matters most. Our
+///    own metered API has no cap at all and is a correct pass-through; the cut was entirely ours.
+///
+/// THE CUT IS THE LIE, NOT THE LIMIT. A guard is fine. Cutting someone off mid-word and saying
+/// nothing is not. If this fires, the listener hears that they are missing something and can go read
+/// the reply - which is a recoverable situation. Silence is not.
+/// </summary>
+internal static class NarrationText
+{
+    /// <summary>
+    /// The runaway ceiling: the longest input we have MEASURED working end to end (2026-07-15,
+    /// production key: 12,000 chars -> 200 OK, 4.8 MB mp3, 21.1 s). It is deliberately the largest
+    /// measured-good value rather than a number someone liked: beyond it we would be guessing, and
+    /// guessing is what put a 4000 here for a year.
+    ///
+    /// It is ~22x a normal narration (~550 chars) and 2.4x the worst ever observed (4,969), so in
+    /// normal operation it never fires. It exists so a runaway wingman cannot bill us for a
+    /// four-minute synthesis, and it is what bounds <see cref="HostedAi.TtsSynthesis.DeadlineFor"/> -
+    /// the cap and the deadline are ONE decision.
+    /// </summary>
+    public const int MaxChars = 12_000;
+
+    /// <summary>What the listener hears instead of being cut off mid-word in silence. Plain spoken
+    /// prose, no markup - it is appended to text going straight to synthesis.</summary>
+    private const string CutNotice =
+        " That is as much as I can read out. This summary was too long, so the rest is not spoken - "
+        + "open the session to read the full reply.";
+
+    /// <summary>
+    /// Bound <paramref name="text"/> for synthesis. Returns the text unchanged when it is within
+    /// <see cref="MaxChars"/>. Otherwise it cuts at the last sentence end (falling back to a word
+    /// boundary, never mid-word) and appends <see cref="CutNotice"/> so the cut is AUDIBLE.
+    /// </summary>
+    /// <param name="wasCut">True when the text was shortened - the caller should say so in its log,
+    /// because a cut is a defect worth seeing, not routine.</param>
+    public static string LimitForSpeech(string? text, out bool wasCut)
+    {
+        wasCut = false;
+        if (string.IsNullOrEmpty(text) || text.Length <= MaxChars) return text ?? "";
+
+        wasCut = true;
+        // Leave room for the notice so the result stays near the ceiling the deadline is derived from.
+        var budget = MaxChars - CutNotice.Length;
+        var head = text[..budget];
+
+        // Prefer the last sentence end, so the listener hears a whole thought before being told the
+        // rest is missing. Only accept one in the last third, otherwise a text with no punctuation
+        // for pages would be cut absurdly short.
+        var lastStop = head.LastIndexOfAny(new[] { '.', '!', '?' });
+        if (lastStop >= budget * 2 / 3)
+            return head[..(lastStop + 1)] + CutNotice;
+
+        // No usable sentence end: fall back to the last word boundary. Never cut mid-word - that is
+        // the old behaviour, and it is what made the truncation sound like a crash.
+        var lastSpace = head.LastIndexOf(' ');
+        if (lastSpace >= budget * 2 / 3)
+            return head[..lastSpace].TrimEnd() + CutNotice;
+
+        return head.TrimEnd() + CutNotice;
+    }
+}

--- a/src/CcDirector.Gateway/Wingman/WingmanTranslator.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanTranslator.cs
@@ -42,8 +42,27 @@ public sealed class WingmanTranslator
     /// Nobody listens to a four-minute summary of one turn. That was the prompt WORKING, not
     /// failing - so the framing is what changed, not another rule bolted on.
     ///
-    /// There is NO length cap - the cap was OpenAI's 4096 and we do not call them (issue
-    /// #1612). Length is a cost to justify, not a budget to spend.
+    /// There is NO length CAP - that cap was OpenAI's 4096 and we do not call them (issue #1612).
+    /// But a cap and a TARGET are different things, and v5.1 exists because conflating them cost most
+    /// of the fix. v5 told the model "there is no length limit": true of the provider, and irrelevant
+    /// to the listener, whose patience is the actual constraint. The reframing was right and did real
+    /// work - what it lacked was a NUMBER. "Prefer three sentences to six" sitting next to "there is
+    /// no length limit" produced twelve. Models discount a principle and obey a budget.
+    ///
+    /// Measured against a real model, 3 runs per prompt (only same-batch numbers are compared - run
+    /// to run variance is real):
+    ///   A LONG, dense reply (3,652 chars) - the case that actually hurts:
+    ///     v4 ("fidelity over brevity")   -> 2,892 chars, ~2m42 spoken
+    ///     v5 (reframed, no number)       -> 1,810 chars, ~1m42 spoken
+    ///     v5.1 (v5 + the ~30s budget)    ->   854 chars, ~48s spoken   (2.1x better than v5)
+    ///   A TYPICAL reply (479 chars):
+    ///     v5 -> ~30s spoken;  v5.1 -> ~29s spoken   (no difference - both already fine)
+    ///
+    /// So the budget binds exactly where the defect lives: the long, complex turns, which are the
+    /// ones whose ending matters most and the ones the old 4000-char cut used to eat. v5.1 is not on
+    /// the ~30s target for the hardest replies (~48s) - it halves the worst case without making the
+    /// typical case vaguer, which is the trade we want. Tune further only with measurements; a prompt
+    /// change whose effect is asserted rather than measured is how this rule rotted in the first place.
     /// </summary>
     internal const string FidelityPrompt = """
         You are the wingman: you turn a coding agent's written reply into words a person
@@ -51,8 +70,11 @@ public sealed class WingmanTranslator
         Say the LEAST you can while leaving the listener knowing everything that would change
         what they think or do next. Brevity is the GOAL; keeping the answer true is the
         CONSTRAINT. They are LISTENING, not reading, so say it the way a person would explain
-        it out loud, and lead with the point. There is no length limit - but every extra
-        sentence is a cost you must justify, not a budget you may spend. Rules:
+        it out loud, and lead with the point. AIM FOR ABOUT THIRTY SECONDS OUT LOUD: two to
+        four sentences, roughly 500 characters. That is how long a person will actually listen
+        to a summary of one turn - it is not a technical limit, and going past it is the most
+        common way to fail this job. A short reply needs less; never stretch one to fill it.
+        Every extra sentence is a cost you must justify, not a budget you may spend. Rules:
         - BE SHORT. Lead with the single most important thing first - the answer, the result,
           or the ask - in your opening sentence, then add only what is needed to understand
           it, and STOP. If removing a sentence would not change what the listener knows or
@@ -131,7 +153,7 @@ public sealed class WingmanTranslator
     /// instructions is shown that the recommended default changed and can switch to it. The content
     /// hash is the real identity; this is the human-facing label.
     /// </summary>
-    public const string DefaultInstructionsVersion = "5";
+    public const string DefaultInstructionsVersion = "6";
 
     private readonly Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> _brainProvider;
     private readonly Action<string> _log;

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -492,15 +492,23 @@ public sealed class WingmanVoiceService
         if (string.IsNullOrWhiteSpace(key))
             return new TtsResult(null, null, HostedAiState.NeedsKey);
 
-        var input = text.Length > 4000 ? text[..4000] : text;
+        // The runaway guard, and it announces itself when it fires (issue #1612). This used to be a
+        // bare `text[..4000]`: a silent mid-word cut enforcing OpenAI's 4096 limit on a provider that
+        // has none, months after we stopped calling OpenAI. The real length control is now the
+        // wingman's own instructions (a ~30-second spoken budget) - a summary is short because we
+        // asked for a summary, not because we cut an essay in half.
+        var input = NarrationText.LimitForSpeech(text, out var wasCut);
+        if (wasCut)
+            FileLog.Write($"[WingmanVoiceService] narration EXCEEDED {NarrationText.MaxChars} chars " +
+                          $"({text.Length}) - spoken text cut and the listener told. The wingman is not summarising.");
         var voice = TtsVoiceConfig.Resolve(mode);
         var model = TtsModelConfig.Resolve(mode);
         var url = tts.BaseUrl.TrimEnd('/') + "/audio/speech";
         // The injected client (tests) or the shared static - never a per-call one. Auth goes on the
         // REQUEST, not the client's default headers, so one shared client is safe under concurrent
-        // turn-ends. The effective timeout is the short per-attempt cap inside TtsSynthesis, which also
-        // retries once when a stalled upstream worker never answers - so a flaky voice backend no longer
-        // freezes the turn.
+        // turn-ends. The effective timeout is the per-attempt deadline inside TtsSynthesis - derived
+        // from the text length, since synthesis scales linearly with it - which also retries once when
+        // a stalled upstream worker never answers, so a flaky voice backend no longer freezes the turn.
         //
         // This was `_ttsHttp ?? new HttpClient()`: in production _ttsHttp is null, so EVERY turn-end
         // built and dropped a client, leaving a socket in TIME_WAIT and forfeiting the warm TLS
@@ -509,7 +517,7 @@ public sealed class WingmanVoiceService
         var http = _ttsHttp ?? SharedTtsHttp;
         try
         {
-            using var resp = await TtsSynthesis.PostAsync(http, url, key, new { model, voice, input, response_format = "mp3" }, ct);
+            using var resp = await TtsSynthesis.PostAsync(http, url, key, new { model, voice, input, response_format = "mp3" }, input.Length, ct);
             if (!resp.IsSuccessStatusCode)
             {
                 var body = await resp.Content.ReadAsStringAsync(ct);


### PR DESCRIPTION
Closes #1612 (items 2 and 3, plus a measured tune of item 1 on top of #1615).

## The cut

Narration was silently cut at 4000 characters to satisfy a limit belonging to a company we stopped calling. 24 times on 2026-07-15 alone, of 873. The worst lost **969 characters — about 55 seconds of speech — dropped mid-word, with the user told nothing.** It is the longest, most complex turns that get cut: exactly the ones whose ending matters most.

The 4000 came from `265af32b` (2026-06-19), which called OpenAI's `/v1/audio/speech` — that genuinely caps at 4096. We swapped to DeepInfra and the cap rode along unexamined. Same disease as the legacy `/v1/inference` endpoint (devthrottle_internal#360): **right once, never re-derived when the world moved underneath it.**

## The cap and the deadline were one decision pretending to be two

Synthesis scales linearly (~1.7 ms/char), so the flat 15s deadline was only ever right in the 4000 world. **Raising the cap alone would have converted silent truncation into silent failure** — 12k chars needs 21s.

- **`TtsSynthesis.DeadlineFor(chars) = 5s + 4ms/char`**, replacing the constant. It is *derived*, so it cannot rot when the cap moves again — picking another constant is the disease, not the cure. Checked against measurements taken direct to the provider rather than arithmetic on faith: 4k→7.3s, 5k→11.6s, 8k→14.0s, 12k→21.1s, **>2x headroom at every length**. This is now the **only** deadline on the speech path; the server's own was deleted in #360 and must not come back.
- **`NarrationText.MaxChars = 12,000`** — the largest length we have *measured working*, not a number someone liked. Beyond it we would be guessing, and guessing is what put a 4000 here. It is ~22x a normal narration and 2.4x the worst ever observed, so in normal operation it never fires; it exists so a runaway cannot bill us for a four-minute synthesis, and it is what keeps the derived deadline finite.
- **Never cut silently.** The cut is the lie, not the limit. If the guard fires, the listener *hears* that they are missing something and where to read the rest, and it cuts at a sentence or word boundary — **never mid-word**, which is what made the old truncation sound like a crash. A cut is logged as the defect it is: *"the wingman is not summarising"*.
- **No limit added to the server API.** It is metered and the caller pays; the constraint belongs where the text is produced, not where it is proxied. `TtsMaxChars` is deleted, and the comment claiming "hosted speech endpoints accept bounded input and spoken summaries are short" is gone — both halves are disproved.

## Prompt v5.1 — a cap and a target are different things

@architect: your v5 reframing was right and did real work. But it told the model **"there is no length limit"** — true of the *provider*, and irrelevant to the *listener*, whose patience is the actual constraint. Deleting a dead provider cap doesn't mean the narration has no target. `Prefer three sentences to six` sitting next to `there is no length limit` produced twelve. **Models discount a principle and obey a budget.**

So v5.1 keeps your framing verbatim and replaces that one sentence with a number derived from the human, not the API.

### Measured against a real model, 3 runs per prompt (same-batch comparisons only — run-to-run variance is real)

**A long, dense reply (3,652 chars) — the case that actually hurts:**

| prompt | narration | spoken |
|---|---|---|
| v4 ("fidelity over brevity") | 2,892 | ~2m 42s |
| v5 (reframed, no number) | 1,810 | ~1m 42s |
| **v5.1 (v5 + the ~30s budget)** | **854** | **~48s** (2.1x better than v5) |

**A typical reply (479 chars):** v5 ~30s, v5.1 ~29s — **no difference, both already fine.**

So the budget binds exactly where the defect lives: the long turns the old cut used to eat. It halves the worst case without making the typical case vaguer.

**Being straight about it: v5.1 is not on the ~30s target for the hardest replies (~48s).** The code comment says so. It halves the worst case, which is the trade worth taking now; tuning further needs more measurement, not more conviction.

One incidental finding that confirms your thesis: v4's output on that reply was **2,892 chars — under the 4000 cap**, so it would never have been truncated, and was still a 2m42 narration. **The cap was hiding the essays, not causing them.**

`DefaultInstructionsVersion` 5 → 6 so a user who has customised their instructions is told the default moved.

## Verification

Every new guard **mutation-verified to fail on purpose**, then restored:

- revert the deadline to the old flat **15s** → **5 tests fail** (the test would have caught the exact constant that caused this bug)
- make the cut **silent** again → **3 tests fail**
- delete the **budget** from the prompt → **1 test fails**
- all restore green

Full Gateway suite **2303 passed, 0 failed**.

*(`FanoutAndEventsTests.Events_endpoint_streams_director_events` flaked once mid-work on a `CronJobStore` file lock under parallel execution — it passes in isolation and on a clean run, and this branch touches nothing it uses. Unrelated, not introduced here.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
