### PR TITLE
fix(voice): the derived deadline must never be tighter than the one it replaced

### DIFF
--- a/src/CcDirector.Gateway.Tests/NarrationLengthTests.cs
+++ b/src/CcDirector.Gateway.Tests/NarrationLengthTests.cs
@@ -90,11 +90,12 @@ public class NarrationLengthTests
 
     // ---- The cap and the deadline are ONE decision -------------------------
 
+    /// <summary>The flat deadline this replaced. The derived one must never be tighter than it, at any
+    /// length - deriving a number is only an improvement if it cannot be worse than the constant.</summary>
+    private static readonly TimeSpan OldFlatDeadline = TimeSpan.FromSeconds(15);
+
     [Theory]
     // input, measured synthesis seconds direct to the provider (2026-07-15, production key).
-    // The deadline must clear the MEASURED time at every length. A flat 15s - the old value - fails
-    // this at 8,000 and 12,000, which is exactly why raising the cap alone would have turned silent
-    // truncation into silent failure.
     [InlineData(4_000, 7.3)]
     [InlineData(5_000, 11.6)]
     [InlineData(8_000, 14.0)]
@@ -106,6 +107,48 @@ public class NarrationLengthTests
             $"{chars} chars: deadline {deadline:F1}s must leave >2x headroom over the measured {measuredSeconds}s");
     }
 
+    [Theory]
+    // THE REGRESSION GUARD, and the one test here that was written from a real outage.
+    //
+    // The deadline shipped as 5s + 4ms/char. It looked right - it cleared every measured synthesis
+    // time with >2x headroom - and it was TIGHTER than the flat 15s it replaced for anything under
+    // ~2,500 chars, which is almost every real narration. Minutes after deploy, on the owner's
+    // Gateway:
+    //   [TtsSynthesis] attempt 1/2 timed out after 5s (20 chars); retrying
+    //   [TtsSynthesis] attempt 2/2 timed out after 5s (20 chars); giving up
+    //
+    // The theory above could not catch it, because it only ever asked "is there room for the
+    // SYNTHESIS?" - and synthesis was never the problem. The same 47-char call measured 0.7s, 1.3s
+    // and 13.3s on one day with 72ms of GPU: the fixed overhead is large and VARIABLE, and it hits a
+    // 20-char call as hard as a 4,000-char one. So this asks the other question, the one that
+    // actually failed: is it ever WORSE than what we replaced?
+    [InlineData(0)]
+    [InlineData(20)]        // the exact length that died in production
+    [InlineData(47)]        // the call measured at 0.7s / 1.3s / 13.3s
+    [InlineData(479)]
+    [InlineData(550)]
+    [InlineData(1_292)]     // today's median narration
+    [InlineData(2_500)]
+    [InlineData(NarrationText.MaxChars)]
+    public void DeadlineFor_IsNeverTighterThanTheFlatDeadlineItReplaced(int chars)
+    {
+        var deadline = TtsSynthesis.DeadlineFor(chars);
+        Assert.True(deadline >= OldFlatDeadline,
+            $"{chars} chars: deadline {deadline.TotalSeconds:F1}s is TIGHTER than the flat "
+            + $"{OldFlatDeadline.TotalSeconds:F0}s it replaced - that is a regression, not a derivation");
+    }
+
+    [Fact]
+    public void DeadlineFor_LeavesRoomForTheOverheadOutlier_NotJustSynthesis()
+    {
+        // The 47-char call that took 13.3s of wall time for 72ms of GPU. A deadline that only budgets
+        // for synthesis kills this call every time. Whatever the formula becomes, a short narration
+        // must survive the worst overhead we have actually observed.
+        const double worstObservedOverheadSeconds = 13.3;
+        Assert.True(TtsSynthesis.DeadlineFor(47).TotalSeconds > worstObservedOverheadSeconds,
+            "a short call must outlive the worst fixed overhead we have measured, not just its own synthesis");
+    }
+
     [Fact]
     public void DeadlineFor_ScalesWithTheText_SoItCannotRotWhenTheCapMoves()
     {
@@ -115,18 +158,17 @@ public class NarrationLengthTests
         var longDeadline = TtsSynthesis.DeadlineFor(NarrationText.MaxChars);
 
         Assert.True(longDeadline > shortDeadline);
-        // A normal narration must not wait on a budget sized for a runaway.
-        Assert.True(shortDeadline < TimeSpan.FromSeconds(10),
-            $"a ~30-second narration should get a snug deadline, got {shortDeadline.TotalSeconds:F1}s");
     }
 
     [Fact]
     public void DeadlineFor_AtTheRunawayCeiling_StaysBounded()
     {
-        // The cap is what keeps the derived deadline finite. If someone raises MaxChars without
-        // thinking about this, they will see it here.
+        // The cap is what keeps the derived deadline finite: cap and deadline are ONE decision. If
+        // someone raises MaxChars without thinking about what it does to the worst-case wait, they
+        // will see it here. The ceiling only binds for a runaway that should never occur - a real
+        // narration is ~550 chars - but it must stay a bounded wait rather than an open-ended one.
         var atCap = TtsSynthesis.DeadlineFor(NarrationText.MaxChars);
-        Assert.InRange(atCap.TotalSeconds, 30, 60);
+        Assert.InRange(atCap.TotalSeconds, 30, 90);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/HostedAi/TtsSynthesis.cs
+++ b/src/CcDirector.Gateway/HostedAi/TtsSynthesis.cs
@@ -41,9 +41,29 @@ namespace CcDirector.Gateway.HostedAi;
 /// </summary>
 internal static class TtsSynthesis
 {
-    /// <summary>Fixed cost allowed for everything that is not synthesis: TLS, auth, the credit
-    /// pre-flight, and the network both ways. It does not scale with the text.</summary>
-    private static readonly TimeSpan DeadlineBase = TimeSpan.FromSeconds(5);
+    /// <summary>
+    /// Fixed cost allowed for everything that is NOT synthesis: TLS, auth, the credit pre-flight, and
+    /// the network both ways. It does not scale with the text - and it is not small or steady, which
+    /// is the whole reason this number is 15 and not 5.
+    ///
+    /// It shipped as 5s and that was a REGRESSION (fixed same day). 5s + 4ms/char is TIGHTER than the
+    /// flat 15s it replaced for anything under ~2,500 characters - which is almost every real
+    /// narration. It failed immediately on the owner's Gateway:
+    ///   [TtsSynthesis] attempt 1/2 timed out after 5s (20 chars); retrying
+    ///   [TtsSynthesis] attempt 2/2 timed out after 5s (20 chars); giving up
+    /// Twenty characters. Roughly 30ms of GPU. Dead in 10 seconds.
+    ///
+    /// The mistake was believing latency scales with length. Synthesis does; the CALL does not. Three
+    /// same-day measurements of the SAME 47-character call: 0.7s, 1.3s, and 13.3s - with only 72ms of
+    /// GPU in all three. That ~13s of variance is network and provider overhead, and it lands on a
+    /// 20-character call exactly as hard as on a 4,000-character one. A base of 5 gave it nowhere to
+    /// go. The base must absorb the fixed overhead INCLUDING its outliers; the slope absorbs synthesis.
+    ///
+    /// 15 is chosen so the derived deadline is NEVER tighter than the constant it replaced, at any
+    /// length. That is the floor this must always clear (pinned by a test) - deriving a deadline is
+    /// only an improvement if it cannot be worse than the number it replaced.
+    /// </summary>
+    private static readonly TimeSpan DeadlineBase = TimeSpan.FromSeconds(15);
 
     /// <summary>Allowance per character of input. Synthesis measures ~1.7 ms/char, so 4 ms/char is
     /// roughly 2.4x headroom at every length - enough for a slow-but-working worker, short enough
@@ -54,14 +74,32 @@ internal static class TtsSynthesis
     /// The per-attempt deadline for synthesising <paramref name="inputChars"/> characters:
     /// <see cref="DeadlineBase"/> + <see cref="DeadlineMsPerChar"/> per character.
     ///
-    /// Checked against measurements taken direct to the provider (2026-07-15, production key), which
-    /// is where the 2.4-2.9x headroom claim comes from - not from arithmetic on faith:
-    ///   4,000 chars -> synthesis 7.3 s, deadline 21 s (2.9x)
-    ///   5,000 chars -> synthesis 11.6 s, deadline 25 s (2.2x)
-    ///   8,000 chars -> synthesis 14.0 s, deadline 37 s (2.6x)
-    ///   12,000 chars -> synthesis 21.1 s, deadline 53 s (2.5x)
-    /// A typical narration after the wingman was told to actually summarise (~550 chars, about 30
-    /// seconds spoken) gets ~7 s for a call that takes about one.
+    /// READ THIS BEFORE CHANGING THE NUMBERS. The table below used to list ONLY healthy runs, and
+    /// that is exactly how a regression shipped: every row cleared its deadline comfortably, the
+    /// arithmetic looked sound, and a 20-character narration then died in 5 seconds on a real
+    /// machine. A headroom claim measured against best-case runs is not a headroom claim. Any
+    /// deadline for a network call must be justified against its WORST observed behaviour, because
+    /// the worst case is the only one a deadline exists for.
+    ///
+    /// Measured direct to the provider, 2026-07-15, production key:
+    ///
+    ///   SYNTHESIS (scales with length - this is what the slope pays for):
+    ///     4,000 chars -> 7.3 s     8,000 chars -> 14.0 s
+    ///     5,000 chars -> 11.6 s   12,000 chars -> 21.1 s
+    ///
+    ///   FIXED OVERHEAD (does NOT scale - this is what the base pays for, and it is the part that
+    ///   bites). The SAME 47-character call, three times in one day: 0.7 s, 1.3 s, 13.3 s - with
+    ///   72 ms of GPU in all three. So ~13 s of the wall time had nothing to do with the text, and a
+    ///   short call is exposed to it just as much as a long one.
+    ///
+    /// Deadlines that follow, against the worst case at each length:
+    ///     20 chars    -> 15.1 s   (vs ~13.3 s of observed overhead alone)
+    ///     1,292 chars -> 20.2 s   (today's median narration)
+    ///     4,000 chars -> 31.0 s   (7.3 s synthesis + room for the overhead outlier)
+    ///     12,000 chars-> 63.0 s   (21.1 s synthesis + the same)
+    ///
+    /// Never tighter than the flat 15 s this replaced, at ANY length - that is the floor, and
+    /// <c>NarrationLengthTests</c> pins it so the short end cannot be regressed again.
     /// </summary>
     public static TimeSpan DeadlineFor(int inputChars)
         => DeadlineBase + TimeSpan.FromMilliseconds(DeadlineMsPerChar * Math.Max(0, inputChars));


### PR DESCRIPTION
**Regression fix for #1616, which I shipped hours ago.** Live on the owner's Gateway.

## What broke

The deadline went out as `5s + 4ms/char`. That is **tighter than the flat 15s it replaced for anything under ~2,500 characters** — which is almost every real narration. Minutes after deploy:

```
[TtsSynthesis] attempt 1/2 timed out after 5s (20 chars); retrying
[TtsSynthesis] attempt 2/2 timed out after 5s (20 chars); giving up
```

Twenty characters. About 30ms of GPU. Dead in ten seconds. **We fixed the rare long case and broke the common short one.**

| chars | shipped (5s base) | old flat | fixed (15s base) |
|---|---|---|---|
| 20 | **5.1s** ← died | 15s | 15.1s |
| 479 | **6.9s** | 15s | 16.9s |
| 1,292 (today's median) | **10.2s** | 15s | 20.2s |
| 4,000 | 21.0s | 15s | 31.0s |
| 12,000 | 53.0s | 15s | 63.0s |

## Why it got through — the part worth keeping

The formula assumes latency scales with length. **Synthesis does; the call does not.** The same 47-character call measured **0.7s, 1.3s and 13.3s** in one day — with 72ms of GPU in all three. That ~13s of variance is network and provider overhead. It does not scale with the text, and it hits a 20-char call exactly as hard as a 4,000-char one. A base of 5 gave it nowhere to go.

The headroom table I validated against listed **only the healthy runs**, so the base absorbed none of that variance. Every row cleared comfortably; the arithmetic looked sound. **A headroom claim measured against best-case runs is not a headroom claim.**

Being straight about my part: the disproving number was already in #1612 — *"one 47-character call (72 ms of GPU) took 13.3 s of wall time"* — and I checked the formula against the table instead of against the outlier printed beside it. The architect owns the suggested constant; I own shipping it without testing it against the evidence I'd already read.

**And my own test enshrined the bug.** `DeadlineFor_ScalesWithTheText` asserted `shortDeadline < 10s` — *"a normal narration should get a snug deadline"*. It pinned the regression as correct. The theory test couldn't catch it either, because it only ever asked *"is there room for the synthesis?"* — and synthesis was never the problem.

## The fix: the base, not the slope

`DeadlineBase` 5s → 15s, `4ms/char` unchanged. Never tighter than the constant it replaced at **any** length. Still derived, still scales, still can't rot when the cap moves.

## New guards, aimed at the failure that actually happened

- **`DeadlineFor_IsNeverTighterThanTheFlatDeadlineItReplaced`** — a floor across `0 / 20 / 47 / 479 / 550 / 1292 / 2500 / MaxChars`, including the exact 20-char length that died. *Deriving a number is only an improvement if it cannot be worse than the constant it replaced.*
- **`DeadlineFor_LeavesRoomForTheOverheadOutlier_NotJustSynthesis`** — pins the 13.3s call, so any future formula must survive the worst overhead **observed**, not just its own synthesis.
- The doc comment now separates **SYNTHESIS** (scales — the slope pays) from **FIXED OVERHEAD** (doesn't scale, variable — the base pays), and states the outliers rather than only the healthy runs, because citing only the good runs is precisely how this shipped.

### Mutation-verified against the real bug

- restore the **5s** base (the exact shipped regression) → **7 tests fail**
- a subtler **14s** base, tighter than the floor only at the short end → **3 tests fail**
- both restore green; targeted suite **178/178**

## Not this bug

DeepInfra is degraded right now independently — a direct call with nothing of ours in the path times out at 60s, and `/wingman/tts` returns 504. Voice will fail regardless of this fix; not chased here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
