### PR TITLE
docs(architecture): rescue the four v1.3.0 manager briefs

### DIFF
--- a/docs/architecture/post-release-followups-brief.md
+++ b/docs/architecture/post-release-followups-brief.md
@@ -1,0 +1,144 @@
+# Manager brief - post-v1.3.0 follow-ups
+
+Architect: session `2eef41a3` ("Stable Release - Architect").
+
+**v1.3.0 is CUT AND PUBLISHED.** So is v1.2.0. Do not touch the tags, do not re-cut a release.
+Main is at 1.3.0 and open for the next cycle.
+
+## Standing authority
+
+- **The Architect holds the owner's authority to COMMIT and to MERGE TO MAIN.** He granted it in his own
+  words: *"I have given you full authority to go to main, origin main, commit"* and *"don't wait for me,
+  don't ask for approval."* Drive each item all the way to a merged pull request. Merged is the only done.
+- Do not ask for approval. Do not stop. Report to the Architect as each item lands.
+- One pull request per item. Never batch. Squash merge, delete the branch.
+
+## The rules that cost us today - read these, they are not decoration
+
+1. **A call site is not a caller, and a retired purpose is not a dead file.** Ask "who STARTS this?", not
+   "does this exist?".
+2. **Verify before you claim** - `git show origin/main:<path>` / `git grep <pattern> origin/main`. Never a
+   commit message, never a memory, never this brief.
+3. **This brief is not evidence.** Six briefs I wrote today were corrected by Managers who checked the code
+   instead of trusting me, and every one of them was right. **Items 2 and 3 below are UNVERIFIED CLAIMS made
+   by a previous Manager. Verify each one before you fix it. If a bug is not real, say so and close it - do
+   not manufacture a fix for it.**
+4. **Proof is a running build, not a green test.** Sixteen green tests agreed with each other and were all
+   wrong today because they tested a fake politer than the real transport.
+5. **No silent degradation, ever.** A change that looks successful and quietly breaks something is the worst
+   thing we can ship. Deleting `streamMode` would have silently killed the Launcher; a stray
+   `CC_DIRECTOR_ROOT` at user scope would have silently emptied the owner's fleet. Both were near-misses.
+6. **Seven** test projects, not two. Core plus Gateway alone is a false green. Last full run: 5524 passed.
+7. **Plain English, ASCII only.** No abbreviations, no jargon, no emoji.
+8. **Work in a worktree cut from origin/main.** Never `git checkout -b` in the shared checkout - it is on
+   another session's live `feat/prompt-log`. Do not touch it.
+
+## The items, in priority order
+
+### 1. Issue #1548 - spawning into a Gateway mission fails with "unknown mission" (REAL - verified by the Architect)
+
+Missions live in TWO stores that do not sync. The **Gateway** store is the source of truth
+(`cc-devthrottle mission list` reads it). The **Director-local** `MissionStore`
+(`%LOCALAPPDATA%\cc-director\config\director\missions.json`) is a documented TEMPORARY bridge.
+
+`SessionCommandExecutor` resolves a mission three ways:
+- `MissionId` AND `MissionName` both set -> Gateway path, stamps directly, no local lookup. **The documented
+  end state, and the only one that works.**
+- `MissionId` only -> transitional bridge -> looks up the Director-local store -> fails
+  `unknown mission '<id>'. Create it first with POST /missions.`
+- No `MissionId` -> no attach.
+
+So `cc-devthrottle session spawn <repo> --mission <id>` can **never** work for a Gateway mission: the CLI
+sends the id with no name, hits the bridge, and is rejected against the wrong store. **The error is a lie -
+it tells you to create a mission that already exists.** I hit this myself and had to POST `fleet/spawn`
+directly with both fields to get any Manager started today.
+
+Fix at the root. The Gateway knows the name; make the spawn path carry it, or have the Director resolve
+against the Gateway. Do not paper over it in the CLI.
+
+### 2. UNVERIFIED CLAIM - a crashed session is indistinguishable from an exited one
+
+Claimed as a regression from #1537 by the Working-is-Blue Manager. What I checked myself, and no further:
+`ActivityState` has **no** `Crashed` member (Starting, Idle, Working, WaitingForInput, WaitingForPerm,
+Exited), while `SessionViewModel` still has an `ErrorStatusBrush` and Crashed handling. Issue #959
+introduced a deep-red "Crashed" that is deliberately darker than the "needs you" red.
+
+Verify whether crashed is genuinely unreachable now, and where it went. If real, fix it under the standing
+law (below). If not real, close it and tell me.
+
+### 3. UNVERIFIED CLAIM - the prompt queue can never auto-drain
+
+Claimed to be gated on `ActivityState.Idle`, which nothing ever writes. Partial corroboration: the only
+reference to `ActivityState.Idle` I found in Core is a **comparison** at `Session.cs:1954`, not an
+assignment - so nothing appears to assign it. `PromptQueue.cs` contains no `Idle` reference at all, so the
+gate is elsewhere if it exists. Find the real gate before touching anything.
+
+### 4. `TunnelFailure`'s default branch drops Director messages into a bare 502
+
+Item 1's endpoint gap, generalised. The router now produces a plain-English error naming what happened, and
+roughly 20 endpoint legs still collapse any non-Ok result into a bodyless 502, so the human never sees it.
+The Tier 1 Manager scoped its status-and-words mapping to its own two routes only, deliberately, leaving the
+general case for this item.
+
+Do it the way item 1 did: **keep every existing status byte-identical** and carry the body only for the
+Gateway-synthesized outcomes. Do NOT route them through `MapDirectorFailure` - that would turn today's 502
+into a 400/404 and change a shipped contract. **Check who READS the message before assuming the fix lands.**
+
+### 5. Cleanup the Architect deferred - now unblocked
+
+- **`GatewayClient.cs` dead code.** Tier 2 deleted `SelectActiveUrlThenRegisterAsync`, the `HeartbeatTick`,
+  `MaybeReRegisterOnIdentityChange`, plus the never-assigned `_heartbeat` and `_reRegistering` fields - but
+  **I dropped that file's changes when resolving a rebase conflict** against the verify-handshake deletion,
+  to avoid delicate surgery at speed during the release. Everything else in that cleanup shipped. Re-apply
+  it against current main. My deferral, my fault, and it changes nothing for any user.
+- **`DirectorVerification.cs`** (`DirectorVerifyRequest` + `DirectorVerifyResultDto`) and
+  **`DirectorDto.TwoWayVerifiedAt`**. These were HELD by Tier 2 because the verify handshake had not merged
+  yet. **It has now merged (#1555).** Re-check callers on current main - they should be orphaned now.
+  `TwoWayVerifiedAt` is declared but written nowhere and serialises null forever to every caller, which is
+  its own small lie on the wire.
+- **Watch for same-name traps:** there are two different `HeartbeatTick`s and two different
+  `_serveProvisioner`s. One of each is LIVE. Prove by callers.
+
+### 6. About a dozen comment blocks that contradict themselves two lines apart
+
+`GatewayEndpoints.cs:1043` says "falls back to the HTTP dial below" while `:1045` says "Post-cut:
+tunnel-only... collapses to 502" - and `DirectorEndpointClient` is deleted, so there IS no dial below.
+Bounded and mechanical: delete the false pre-cut sentence, keep the post-cut truth.
+
+**Do NOT do a blanket sweep.** The real count of comments mentioning an HTTP fallback is **44**, not 7, and
+they need per-line judgement. **`MachineSessionSpawner` is NOT stale** - it says "tunnel-first,
+byte-identical HTTP fallback", which is TRUE, because the launcher leg genuinely still has that fallback.
+Deleting a correct comment and replacing it with a false one would make the documentation worse. Fix only
+the self-contradicting blocks.
+
+## Explicitly NOT in scope
+
+- **`streamMode`** - the Launcher still gates on it (`LauncherStreamClient.IsEnabled`) and enrollment writes
+  it. Removing it silently kills the Launcher's persistent join. It is a design decision, not a cleanup.
+- The LAN addressing option being a user-visible control that now does nothing - the owner's call.
+- Anything in Tier 3: mobile resilience (#1181, #1187, #1139, #1326, #1325), the Cockpit regression (#1296),
+  flaky tests (#1541, #1221), the Gateway dialling the launcher over HTTP.
+- `docs/cencon/proof/issue-509/ask-sequence.log` - a tracked file a test rewrites with fresh GUIDs each run.
+  Revert it if it dirties your tree; do not fix it here.
+
+## The fleet
+
+| Director | Port | Use |
+|---|---|---|
+| slot 1 | 7879 | The owner's build of latest main. **Do not touch.** |
+| slot 2 | 7884 | Permanent. The Architect runs here. Do not disturb. |
+| slot 6 | 7883 | **NOT throwaway** - hosts REAL user sessions. Restarting it KILLS them. |
+| your own | pick 8+ | Your own proof Director, its OWN scheduled task, own root via `CC_DIRECTOR_ROOT`. |
+
+**Set `CC_DIRECTOR_ROOT` for your PROCESS only - never at user or machine scope.** Setting it at user scope
+would silently redirect the owner's next Director into your scratchpad and he would find an empty fleet with
+no error. This nearly happened today. Verify it is unset when you finish.
+
+Never kill a `cc-director*.exe` you did not launch. Shut your own down with
+`POST http://127.0.0.1:<port>/shutdown` - a force-kill leaves a phantom session. Never drive the GUI: a
+screenshot attempt today grabbed the owner's live desktop mid-dictation.
+
+## Definition of done
+
+Per item: root cause fixed or the claim disproved and closed, seven suites green, proven on a running build
+where it has a runtime surface, merged to main, branch deleted. Report each as it lands.

--- a/docs/architecture/stable-release-tier1-rest-brief.md
+++ b/docs/architecture/stable-release-tier1-rest-brief.md
@@ -1,0 +1,92 @@
+# Manager brief - Tier 1 items 2, 3, 4 (Stable Release, v1.3.0)
+
+Mission id: `ac6883bb-09e2-4b5a-96bf-df3eae8d9f63`
+Architect: session `2eef41a3` ("Stable Release - Architect").
+
+Read the mission brief for the WHY: `docs/architecture/stable-release-mission-2026-07-14.html`
+
+**Stay in scope. Do not invent work. Do not re-open a Tier 3 decision. Do not go near session state,
+colours, or the rail - that is another lane and it is not yours.** Item 1 is already merged
+(`bcb94dbb`); do not touch `DirectorCommandRouter.cs`.
+
+## Your three items, in this order
+
+### 2. Close the open inbound port
+
+`src/CcDirector.ControlApi/ControlApiHost.cs:272` - `builder.WebHost.ConfigureKestrel(o =>
+o.Listen(IPAddress.Any, Port));`. LAN addressing mode binds the Director's Control API to every interface,
+directly contradicting the tunnel-only cut's stated invariant that the inbound port stays closed. Nothing
+dials it any more, so it is pure attack surface with no user. Verified by the Architect on origin/main.
+
+Care required: `AddressingMode` has other readers. Read them before you cut. The floor must keep working on
+loopback - that is what every local caller and the CLI use.
+
+### 3. Cockpit Director Settings is broken
+
+`/directors/{id}/settings` returns the single-page-app HTML shell instead of data. Verified: the Cockpit
+calls it (`apps/cockpit/src/fleet/DirectorDetailView.tsx`, which even documents `GET/PUT
+/directors/{id}/settings`), but **no such route is mapped on the Gateway** - so it falls through to the
+SPA fallback and answers with HTML. Same disease as rename: a caller left pointing at something the cut
+moved.
+
+### 4. "Verify now" can never succeed
+
+`GatewayConnectionPanel.axaml.cs:284` -> `ControlApiHost.VerifyGatewayNowAsync` ->
+`GatewayClient.VerifyAsync` (`src/CcDirector.ControlApi/GatewayClient.cs:931`), which posts to
+`directors/{id}/verify`. That route was **deliberately deleted** - see the comment at
+`src/CcDirector.Gateway/Api/GatewayEndpoints.cs:505`. Worse than dead: on the 404 the client tells the user
+*"The Gateway ... does not support the verify handshake - update the Gateway"*, which is a lie that sends
+the owner off to do a day of work that would fix nothing. A button that cannot work is worse than no button.
+
+## Carried forward from item 1 - this WILL bite you
+
+- **Check who READS the message before assuming a fix lands.** Item 1's router computed a perfect error and
+  ~20 endpoints threw it away as a bare status with no body. A fix the human never sees is not a fix.
+- **The transport's exception type is not a contract.** Anything touching the tunnel branches on the TOKEN,
+  never on the exception type - SignalR does not throw `OperationCanceledException` on a cancelled client
+  result. Sixteen green tests missed this because the hand-written fake was politer than the real transport.
+- There are still 7 stale "fall back to the HTTP dial" comments in `GatewayEndpoints` that the cut made
+  false. Nearly free. Fold them in if you are already in that file; do not make a project of it.
+
+## The rules that are not negotiable
+
+1. **Verify before you claim.** `git show origin/main:<path>` / `git grep <pattern> origin/main`. Never a
+   commit message, never a memory, never a tree that may be behind.
+2. **Work in a worktree cut from origin/main.** Never `git checkout -b` in the shared checkout - it is
+   currently on another session's live `feat/prompt-log` work. Do not touch it.
+3. **Probe the route, never the version.** `/healthz` cannot tell a fixed build from a broken one. Probe
+   the real route against a deliberately fake one. **Never probe `POST /fleet/spawn`** - it returns 201 and
+   creates a real session.
+4. **Proof is a running build, not a green test.** Item 1 proved this the hard way. Demonstrate each item on
+   a running slot Director.
+5. **No fallbacks.** Fix the root cause or fail loudly with a clear message.
+6. **Plain English, ASCII only.** No abbreviations, no jargon, no emoji.
+7. **Do not commit without the OWNER asking.** Not the Architect - the owner. Permission never carries
+   forward. Ask me and I will go get it. Do not merge unless the owner asks.
+8. Report to the Architect. Ping at every milestone. Fleet messages are ONE line. Do not message the owner.
+
+## Testing
+
+**Seven** test projects, not two. Core plus Gateway alone is a false green - the other Manager's full run was
+5510 passed. One suite green proves nothing.
+
+## The fleet - read this carefully
+
+| Director | Port | Use |
+|---|---|---|
+| slot 6 | 7883 | **NOT throwaway.** It hosts REAL user sessions (AgentEyes, mindzieWeb). Rebuilding or restarting it KILLS them. Leave it alone. |
+| slot 2 | 7884 | Permanent. The Architect runs here. Do not disturb. |
+| installed app | 7879 | v1.1.0, the broken build. Never test against it. |
+| your own slot | pick 8+ | Stand up your own proof Director with its OWN scheduled task (`cc-director-launch-slot<n>`). |
+
+A shared scheduled task kills whichever Director it launched last - this already killed a Director today.
+Never kill a `cc-director*.exe` you did not launch. Shut your own down gracefully with
+`POST http://127.0.0.1:<port>/shutdown` - a force-kill leaves a phantom session.
+
+Build a slot: `powershell -ExecutionPolicy Bypass -File scripts\local-build-avalonia.ps1 -Slot <n>`
+
+## Definition of done
+
+Per item: the defect is fixed at the root, demonstrated on a running Director, all seven suites green, and
+the work sits ready in your worktree. **You do not commit and you do not merge until the owner asks** - tell
+me when an item is ready and I will get his word. Report each item as it lands; do not batch all three.

--- a/docs/architecture/stable-release-tier2-brief.md
+++ b/docs/architecture/stable-release-tier2-brief.md
@@ -1,0 +1,114 @@
+# Manager brief - Tier 2 items 5, 6, 7 (Stable Release, v1.3.0)
+
+Mission id: `ac6883bb-09e2-4b5a-96bf-df3eae8d9f63`
+Architect: session `2eef41a3` ("Stable Release - Architect").
+
+Read the mission brief for the WHY: `docs/architecture/stable-release-mission-2026-07-14.html`
+
+**The mission is LATE. The owner has waited two days. Move.**
+
+## Standing authority - read this first
+
+- **The Architect holds the owner's delegated authority to COMMIT.** He granted it in his own words:
+  *"You have full authority to commit. Just don't merge it to master. Just commit and keep moving."*
+  You do NOT wait for the owner's word on a commit. You do not ask. Commit and keep going.
+- **NOTHING merges to main.** Not by you, not by me. Push the branch, open the pull request, leave it OPEN.
+- Do not stop for approvals. Do not batch. Report each item as it lands and move to the next.
+
+## Your three items
+
+Tier 1 is done and merged: dropped-command timeout (`bcb94dbb`), the blue fix (`5b09f71f`), plus the
+loopback bind / settings route / verify-handshake deletion sitting in an open pull request. Do not redo any
+of it.
+
+### 5. Delete the dead code - ONE focused, statically-safe deletion
+
+Named by both reviews: the register and heartbeat cluster inside `GatewayClient`; `DirectorForwarding` and
+the unused forwarder registration; the orphaned `DispatchContracts`; the `CockpitWsUrls` and
+`CockpitShotUrls` contracts; the now-inert `streamMode` configuration key; the never-assigned
+`_serveProvisioner` field with its dependent branches.
+
+**THE STANDING DEAD-CODE LIST IS UNRELIABLE. Verify callers before deleting a single file.** It names files
+by their RETIRED PURPOSE, not by who still calls them. Proven false positive:
+
+- **`GatewayConnectivitySelfTest` is NOT dead** - the desktop Gateway panel's diagnostics ladder still uses
+  it. Deleting it breaks the panel. This was caught before it cost anything; do not un-catch it.
+
+The rule, learned twice today in opposite directions: **a call site is not a caller, and a retired purpose
+is not a dead file.** `git grep` real callers on `origin/main` and confirm the path that reaches them
+actually runs. `_serveProvisioner` is genuinely never assigned (declared at `ControlApiHost.cs:101`, only
+ever set to null) - its dependent branches are dead. `GatewayClient.Start` never starts the register /
+heartbeat / verify loops (see the comment at `GatewayClient.cs:588`), so that cluster is genuinely
+unreachable.
+
+**Verified orphaned by Tier 1 item 4** - fold these in: `src/CcDirector.Gateway.Contracts/DirectorVerification.cs`
+(`DirectorVerifyRequest` + `DirectorVerifyResultDto`, now zero users repo-wide), and
+`DirectorDto.TwoWayVerifiedAt`, declared but written nowhere - it serialises null forever to every caller,
+its own small lie on the wire.
+
+### 6. Fix the public API reference
+
+`docs/public/api/01-control-api.md` still describes sessions, prompts, buffers, git and handover endpoints
+on the Director. The Director floor has about a dozen routes. **This document is public and is actively
+misleading anyone reading it today** - it is the same failure mode that cost the owner yesterday, still
+live. Nine references to deleted session endpoints, verified.
+
+Do not guess the real surface. Read it: `git show origin/main:src/CcDirector.ControlApi/ControlEndpoints.cs`
+and list the actual `app.Map*` routes. Document what IS, not what was.
+
+### 7. Delete the documents describing worlds that never shipped
+
+Five architecture documents describe designs never built or fully dead. No salvage value; every one is a
+trap for the next reader. Identify them from the two reviews
+(`docs/reviews/tunnel-only-review-codex-2026-07-14.md`, `docs/reviews/tunnel-only-review-claude-2026-07-14.md`).
+
+**Do not delete the state/colour documents** - they were corrected and superseded earlier today by
+`docs/architecture/session-state-authoritative-2026-07-14.html`. That work is done; leave it alone.
+
+## Also in scope if cheap - stale comments that now contradict each other
+
+7 stale "fall back to the HTTP dial" comments in `GatewayEndpoints` that the cut made false, while
+`ICronWorkListDrainLauncher.cs:39` and `MachineSessionSpawner.cs:23-26` already say the endpoint is ignored
+post-cut. Two sets of comments contradicting each other in one repo. Fold in; do not make a project of it.
+
+## Explicitly NOT yours - do not start these
+
+- The LAN addressing option being a user-visible control that now does nothing (owner's call).
+- `TunnelFailure`'s default branch dropping Director messages into a bare 502 across ~20 legs.
+- `docs/cencon/proof/issue-509/ask-sequence.log` - a tracked file a test rewrites with fresh GUIDs each run.
+- Anything about session state, colours, or the rail.
+
+## The rules that are not negotiable
+
+1. **Verify before you claim.** `git show origin/main:<path>` / `git grep <pattern> origin/main`.
+2. **Work in a worktree cut from origin/main.** Never `git checkout -b` in the shared checkout - it is on
+   another session's live `feat/prompt-log`. Do not touch it.
+3. **Proof:** items 5 and 7 are deletions - the proof is that the solution still builds and all seven suites
+   stay green, plus a running Director boots and its diagnostics panel still works (you deleted around it).
+   Item 6 is a document - the proof is that every route it lists exists on `origin/main`.
+4. **No fallbacks.** Fix the root cause or fail loudly.
+5. **Plain English, ASCII only.** No abbreviations, no jargon, no emoji.
+6. **Commit freely under the Architect's delegated authority. NEVER merge.**
+7. Report to the Architect. Fleet messages are ONE line. Never message the owner.
+
+## Testing
+
+**Seven** test projects, not two - Core plus Gateway alone is a false green. The last full run was 5517
+passed. A deletion that drops the count needs an explanation.
+
+## The fleet
+
+| Director | Port | Use |
+|---|---|---|
+| slot 6 | 7883 | **NOT throwaway** - hosts REAL user sessions. Restarting it KILLS them. Leave it alone. |
+| slot 2 | 7884 | Permanent. The Architect runs here. Do not disturb. |
+| installed app | 7879 | v1.1.0, the broken build. Never test against it. |
+| your own slot | pick 8+ | Your own proof Director, its OWN scheduled task, own root via `CC_DIRECTOR_ROOT`. |
+
+Never kill a `cc-director*.exe` you did not launch. Shut your own down with
+`POST http://127.0.0.1:<port>/shutdown` - a force-kill leaves a phantom session.
+
+## Definition of done
+
+Each item: fixed at the root, seven suites green, committed and pushed, pull request OPEN and not merged.
+Report each as it lands. Then hand me anything Tier 2 orphaned for the release notes.

--- a/docs/architecture/stable-release-working-is-blue-brief.md
+++ b/docs/architecture/stable-release-working-is-blue-brief.md
@@ -1,0 +1,104 @@
+# Manager brief - Working is BLUE (Stable Release, Tier 1)
+
+Mission id: `ac6883bb-09e2-4b5a-96bf-df3eae8d9f63`
+You are a **Manager** for this ONE item. The Architect is session `2eef41a3` ("Stable Release - Architect").
+Another Manager owns Tier 1 item 1 (the dropped-command timeout) in a different worktree - do not touch its
+files: `DirectorCommandRouter.cs`, `GatewayHost.cs`, `GatewayEndpoints.cs`.
+
+Read the mission brief for the WHY: `docs/architecture/stable-release-mission-2026-07-14.html`
+
+## The law (owner's ruling, 2026-07-14 - this is not open for debate)
+
+1. **If a session is working, it is BLUE. No matter what. Period, full stop.** Nothing outranks Working.
+2. **The Gateway owns every state, centrally.** It is the ONLY thing that decides a colour.
+3. **The Director decides nothing.** It reports FACTS - "I am working", plus a heartbeat.
+4. Gateway-side rules sit on top of the facts: a session that terminates and has not pinged for about ten
+   seconds may be set red - or gray if controlled.
+5. **Gray-when-controlled is a LATER, more intelligent feature.** It applies ONLY to a RED (needs-you)
+   controlled session. It must NEVER touch a working one. Do not build it now.
+
+This **supersedes** the 2026-07-10 decision in issue #1286 ("a controlled worker always shows the recessive
+Supporting colour"). The owner was explicit that the old decision is void. Do not restore it. Do not cite it.
+
+## The proven defect (verified by the Architect against origin/main - build on this)
+
+`src/CcDirector.Gateway.Contracts/SessionOrdering.cs`, in `BaseColor`:
+
+```
+if (controlled && !isRed)
+    return "supporting";
+```
+
+Any controlled session that is NOT red returns `"supporting"` - slate, labelled "Sub-agent" by
+`StateLabel`. The real activity state is **discarded**. That is why session 107 ("Stable Release - Manager")
+rendered gray while 23 minutes and 56k tokens into real work.
+
+The SECOND rule immediately below it is different and is NOT in scope to delete:
+
+```
+if (isRed && s.SessionRole == Worker)
+    return "supporting";
+```
+
+That one suppresses a worker's RED, which is attention-routing (the need goes to its manager, not the
+human). Per the law above, red-suppression is legitimate and stays for now. Blue-suppression is what
+destroys information: blue never nagged anyone.
+
+Also relevant: three near-identical grays exist and are indistinguishable in a small rail dot - slate
+"supporting" (#64748B), light-gray on-hold (#9CA3AF), dark-gray exited (#6A6A6A). That is why the owner read
+a working session as "on hold". Note it; do not redesign the palette in this item.
+
+## Scope of THIS item
+
+**Minimum:** a working session renders blue and labels "Working" on every surface, including a controlled
+sub-agent. Remove the blue-suppression. Keep the red-suppression.
+
+Ownership is already carried by a SEPARATE channel - the rail's role badges ("M", "A"). Colour must never
+be used to say who owns a session. If removing the label leaves a gap, ownership belongs on the badge, not
+the dot.
+
+**Not in this item** (name them, do not build them): making the Director report Working as a fact to the
+Gateway rather than computing anything; the Gateway ping/timeout rule; removing the remaining client
+bypasses (issue #1241); the gray palette redesign. Those are the follow-on mission.
+
+## The rules that are not negotiable
+
+1. **Verify before you claim.** `git show origin/main:<path>` / `git grep <pattern> origin/main`. Never a
+   commit message, never a memory, never a tree that may be behind.
+2. **Work in a worktree cut from origin/main.** Never `git checkout -b` in the shared checkout.
+   `git worktree add ../devthrottle-working-is-blue -b <branch> origin/main`
+3. **Proof is a running build, not a green test.** Demonstrate on a slot Director that a controlled,
+   working session shows blue "Working". A screenshot of the rail is the proof the owner asked for.
+4. **No fallbacks.** Fix the root cause or fail loudly.
+5. **Plain English, ASCII only.** No abbreviations, no jargon, no emoji, anywhere.
+6. **Do not commit without the owner asking.** Do not merge. Do not tag.
+7. Report to the Architect, not the owner. Ping at every milestone; never stall silently. Fleet messages are
+   ONE line.
+
+## Tests you will have to face honestly
+
+`DesktopGatewayFoldAgreementTests` and `SessionOrderingTests` pin the CURRENT behaviour, including
+`Assert.Equal("Sub-agent", SessionOrdering.StateLabel(...))`. Those assertions encode the superseded
+decision. Update them to the new law - and say so plainly in the pull request. Do not weaken a test to make
+a build pass, and do not delete an assertion without replacing it with one that pins the NEW rule.
+
+There are **seven** test projects, not two. Core plus Gateway alone is a false green.
+
+## The fleet
+
+| Director | Port | Use |
+|---|---|---|
+| slot 6 | 7883 | Testing. Shared with the other Manager - coordinate through the Architect. |
+| slot 2 | 7884 | Permanent. The Architect runs here. Do not disturb. |
+| installed app | 7879 | v1.1.0. Never test against it. |
+
+Build a slot: `powershell -ExecutionPolicy Bypass -File scripts\local-build-avalonia.ps1 -Slot 6`
+Never kill a `cc-director*.exe` you did not launch.
+
+## Definition of done
+
+1. A controlled, working session renders blue and reads "Working" - proven on a running Director with a
+   screenshot of the rail.
+2. A controlled, red session still recedes (red-suppression intact).
+3. Tests pin the NEW law, and the superseded assertions are gone.
+4. A pull request is open and green. You do not merge it.


### PR DESCRIPTION
## What

Four Manager briefs from the Stable Release mission (`ac6883bb`, **v1.3.0, released 2026-07-14**), found **untracked in the shared checkout** during a hygiene sweep. They were on no branch, in no pull request, and nowhere on main - while the mission they drove shipped. Committed byte-for-byte as written, no edits.

| Brief | Lines | What it drove |
|---|---|---|
| `stable-release-working-is-blue-brief.md` | 104 | Tier 1: the "Working is BLUE" state ruling |
| `stable-release-tier1-rest-brief.md` | 92 | Tier 1 items 2, 3, 4 |
| `stable-release-tier2-brief.md` | 114 | Tier 2 items 5, 6, 7 |
| `post-release-followups-brief.md` | 144 | The post-v1.3.0 follow-ups |

## Why on main

The record is otherwise half-there. The mission brief each of these says to read - `stable-release-mission-2026-07-14.html` - is **already committed**, and so is a Phase 1 manager brief, so there is precedent and these are the missing pieces. Together they record which lane each Manager owned, which files were fenced off from whom, and the reasoning behind a ruling ("the Gateway owns every state; the Director decides nothing") that is now shipped behaviour someone will eventually want the *why* for.

## One thing worth a human's eye before merging

These are **history, not instructions**, and they should be read that way. Each is scoped to a finished mission and a cut release, and says so in its opening lines.

But they contain passages like *"full authority to commit"* and *"do not ask for approval"*. That was the owner's delegation **to named sessions, for that mission's duration**. It is a record of what was granted then - **not** a standing licence for any later session that finds these on main. The standing rule is unchanged: ask before committing.

I have deliberately **not** edited the files to add that caveat - rescuing someone's work means preserving it, not rewriting it - so I am raising it here instead. If you would rather these carried a "historical, superseded" header, or would rather they not live on main at all, say so and I will adjust.

## Scope

Documentation only. No code, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)