### PR TITLE
feat(stats): break Your Throttle down by which agent CLI you drive

### DIFF
--- a/apps/cockpit/src/throttle/AgentsTab.tsx
+++ b/apps/cockpit/src/throttle/AgentsTab.tsx
@@ -1,0 +1,254 @@
+import { useMemo, useState } from "react";
+import {
+  summarizeAgents,
+  formatShare,
+  type ThrottleData,
+  type AgentStat,
+  type AgentSummary,
+} from "@devthrottle/client-core/stats/statsClient";
+
+// The "Agents" tab of Your Throttle (owner ask): which agent CLI the work actually goes through - how
+// driving splits across Claude Code, Codex, Gemini and the rest, ranked by submitted turns.
+//
+// Data arrives as a prop: Your Throttle already polls GET /stats/data (the agent tally rides on that
+// envelope), so the tab reads its parent's snapshot rather than opening a second poll of the same feed.
+// Counts only - never any message text.
+//
+// This tab counts from agentsSinceUtc, NOT all-time. The turn totals had been accumulating long before the
+// per-agent breakdown existed, and nothing recorded which agent those earlier turns ran under - so the
+// numbers here do not reconcile with the Overview tab's totals, and the tab says so on its face rather
+// than letting the owner read a smaller number as a drop in usage. It reuses the Repos tab's row and
+// segmented-control styles so the two read as one page.
+
+// The three honest metrics the system actually measures per agent. Tokens are intentionally absent: the
+// tally counts turns and characters, never tokens, and this tab never fabricates a number.
+type Metric = "turns" | "characters" | "sessions";
+const METRIC_LABEL: Record<Metric, string> = {
+  turns: "Turns",
+  characters: "Characters",
+  sessions: "Sessions",
+};
+const METRIC_WORD: Record<Metric, string> = {
+  turns: "turns",
+  characters: "characters",
+  sessions: "sessions",
+};
+
+function metricValue(a: AgentStat, metric: Metric): number {
+  return metric === "turns" ? a.turns : metric === "characters" ? a.characters : a.sessions;
+}
+
+function formatValue(value: number, metric: Metric): string {
+  return metric === "characters" ? compactNumber(value) : value.toLocaleString();
+}
+
+/** Compact large character counts (e.g. 48200 -> "48.2K", 1_200_000 -> "1.2M"); plain below 1,000. */
+function compactNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+/** The since-stamp as a plain date the owner can read ("15 Jul 2026"). Returns null when the Gateway sent
+ * no stamp or an unparseable one, so the caller states nothing rather than inventing a start date. */
+function sinceDate(iso: string): string | null {
+  if (iso === "") return null;
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return null;
+  return new Date(t).toLocaleDateString(undefined, { day: "numeric", month: "short", year: "numeric" });
+}
+
+/** A big headline metric card, built from the same thr-stat tokens the Overview and Repos tabs use. */
+function HeadlineCard({ label, value, sub }: { label: string; value: string; sub: string }) {
+  return (
+    <div className="thr-stat">
+      <div className="thr-stat-value">{value}</div>
+      <div className="thr-stat-label">{label}</div>
+      <div className="thr-stat-label thr-stat-sub">{sub}</div>
+    </div>
+  );
+}
+
+/** One ranked agent row: rank, name, a proportional bar (voice/typed split on the turns metric, single
+ * accent otherwise), and the active metric's value with its share of the total. */
+function AgentRow({
+  rank,
+  agent,
+  metric,
+  max,
+  total,
+}: {
+  rank: number;
+  agent: AgentStat;
+  metric: Metric;
+  max: number;
+  total: number;
+}) {
+  const value = metricValue(agent, metric);
+  const width = max > 0 ? (value / max) * 100 : 0;
+  const share = total > 0 ? Math.round((value / total) * 100) : 0;
+  const voicePct = agent.turns > 0 ? Math.round((agent.voiceTurns / agent.turns) * 100) : 0;
+  const showSplit = metric === "turns" && agent.turns > 0;
+
+  // The secondary facts depend on which metric is the headline, so the row never just repeats the big
+  // number - it shows the other two honest measures alongside it.
+  const meta =
+    metric === "turns"
+      ? `${compactNumber(agent.characters)} chars - ${agent.sessions} session${agent.sessions === 1 ? "" : "s"} - ${voicePct}% voice`
+      : metric === "characters"
+        ? `${agent.turns.toLocaleString()} turns - ${agent.sessions} session${agent.sessions === 1 ? "" : "s"}`
+        : `${agent.turns.toLocaleString()} turns - ${compactNumber(agent.characters)} chars`;
+
+  return (
+    <div className="repo-row">
+      <div className="repo-rank">{rank}</div>
+      <div className="repo-main">
+        <div className="repo-top">
+          <span className="repo-name">{agent.agentName}</span>
+          {agent.agent === "" && (
+            <span className="repo-path">sessions whose agent was not recorded</span>
+          )}
+        </div>
+        <div className="repo-meta">{meta}</div>
+        <div className="repo-bar-track" title={`${formatValue(value, metric)} ${METRIC_WORD[metric]}`}>
+          {showSplit ? (
+            <>
+              <div className="repo-bar-voice" style={{ width: `${(width * voicePct) / 100}%` }} />
+              <div className="repo-bar-typed" style={{ width: `${(width * (100 - voicePct)) / 100}%` }} />
+            </>
+          ) : (
+            <div className="repo-bar-voice" style={{ width: `${width}%` }} />
+          )}
+        </div>
+      </div>
+      <div className="repo-val">
+        <div className="repo-val-num">{formatValue(value, metric)}</div>
+        <div className="repo-val-share">{share}%</div>
+      </div>
+    </div>
+  );
+}
+
+export function AgentsTab({ data }: { data: ThrottleData }) {
+  const [metric, setMetric] = useState<Metric>("turns");
+
+  const agents = data.agents ?? [];
+  const summary: AgentSummary = summarizeAgents(agents);
+  const since = sinceDate(data.agentsSinceUtc ?? "");
+
+  // Rank by the active metric (the feed arrives ranked by turns; re-sort so switching to characters or
+  // sessions re-orders the list honestly).
+  const ranked = useMemo(
+    () => [...agents].sort((a, b) => metricValue(b, metric) - metricValue(a, metric)),
+    [agents, metric],
+  );
+  const max = ranked.length > 0 ? metricValue(ranked[0], metric) : 0;
+  const total = ranked.reduce((t, a) => t + metricValue(a, metric), 0);
+
+  if (!summary.hasData) {
+    return (
+      <div className="thr-empty">
+        No agent usage counted yet
+        {since !== null ? ` since ${since}, when this breakdown started counting` : ""}. Drive a session -
+        Claude Code, Codex, or any other agent - and the split will appear here, ranked. Turns driven before
+        this breakdown existed are not included: nothing recorded which agent they ran under.
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="repos-private" title="This tab is only ever shown to you">
+        <span className="repos-lock" aria-hidden="true" />
+        Private - only you
+      </div>
+
+      <p className="repos-intro">
+        Which agent you actually drive: how your driving splits across the agent CLIs you run, ranked by{" "}
+        {METRIC_WORD[metric]}. Counted at the Director, so desktop typing is included.
+        {since !== null
+          ? ` Counting since ${since}, when this breakdown was added - so these numbers are smaller than your all-time totals on the other tabs.`
+          : ""}
+      </p>
+
+      <div className="thr-stats repos-cards">
+        <HeadlineCard
+          label="Agents driven"
+          value={String(summary.agentCount)}
+          sub={`${summary.totalSessions} session${summary.totalSessions === 1 ? "" : "s"} in total`}
+        />
+        <HeadlineCard
+          label="Turns counted"
+          value={summary.totalTurns.toLocaleString()}
+          sub={since !== null ? `since ${since}` : `${compactNumber(summary.totalCharacters)} characters`}
+        />
+        <HeadlineCard
+          label="Most driven"
+          value={formatShare(summary.topShare)}
+          sub={summary.topAgentName !== null ? `${summary.topAgentName} leads` : "of your turns"}
+        />
+        <HeadlineCard
+          label="Voice-driven"
+          value={formatShare(summary.totalTurns > 0 ? summary.voiceTurns / summary.totalTurns : null)}
+          sub="of turns spoken, not typed"
+        />
+      </div>
+
+      <div className="repos-controls">
+        <span className="repos-controls-label">Rank by</span>
+        <div className="repos-seg" role="tablist" aria-label="Rank agents by">
+          {(["turns", "characters", "sessions"] as Metric[]).map((m) => (
+            <button
+              key={m}
+              type="button"
+              role="tab"
+              aria-selected={metric === m}
+              className={metric === m ? "repos-seg-btn on" : "repos-seg-btn"}
+              onClick={() => setMetric(m)}
+            >
+              {METRIC_LABEL[m]}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="thr-panel">
+        <div className="thr-panel-head">
+          <h2>By agent</h2>
+        </div>
+        <div className="repo-rows">
+          {ranked.map((a, i) => (
+            <AgentRow key={a.agent} rank={i + 1} agent={a} metric={metric} max={max} total={total} />
+          ))}
+        </div>
+      </div>
+
+      {/* Only the caveats specific to grouping by agent. The general "what these numbers do not include"
+          list lives on the Breakdown tab of this same page, so it is not repeated here. */}
+      <div className="thr-caveats">
+        <h2>What this does and doesn&apos;t count</h2>
+        <ul>
+          {since !== null && (
+            <li>
+              This tab counts from {since}, when the breakdown was added - not all-time. The turns on the
+              other tabs go back further, and nothing recorded which agent those earlier ones ran under, so
+              the two do not add up to the same number.
+            </li>
+          )}
+          <li>
+            On the turns view, each bar splits that agent&apos;s turns: the blue part is the share you
+            spoke, the grey part is the share you typed.
+          </li>
+          <li>
+            Agents are grouped by the CLI the session runs. A session the Director reported no agent for is
+            counted under &quot;(unknown)&quot; rather than dropped - the turns are real either way.
+          </li>
+          <li>
+            Tokens are not shown - the tally counts turns and characters, never tokens, and this tab never
+            fabricates a number it did not measure.
+          </li>
+        </ul>
+      </div>
+    </>
+  );
+}

--- a/apps/cockpit/src/throttle/YourThrottleView.tsx
+++ b/apps/cockpit/src/throttle/YourThrottleView.tsx
@@ -20,6 +20,7 @@ import {
 } from "@devthrottle/client-core/stats/statsClient";
 import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
 import { ReposTab } from "./ReposTab";
+import { AgentsTab } from "./AgentsTab";
 import { TABS, DEFAULT_TAB, isThrottleTab, type ThrottleTab } from "./throttleTabs";
 
 // The "Your Throttle" page (devthrottle-stats mission): the in-Cockpit view of how the owner drives the
@@ -133,6 +134,7 @@ export function YourThrottleView() {
           {tab === "activity" && <ActivityTab data={data} />}
           {tab === "breakdown" && <BreakdownTab summary={summary} data={data} />}
           {tab === "repos" && <ReposTab data={data} />}
+          {tab === "agents" && <AgentsTab data={data} />}
         </>
       )}
     </div>

--- a/apps/cockpit/src/throttle/throttleTabs.test.ts
+++ b/apps/cockpit/src/throttle/throttleTabs.test.ts
@@ -2,12 +2,16 @@ import { describe, expect, it } from "vitest";
 import { TABS, DEFAULT_TAB, isThrottleTab } from "./throttleTabs";
 
 describe("TABS", () => {
-  it("lists the four tabs in reading order, Repos last", () => {
-    expect(TABS.map((t) => t.key)).toEqual(["overview", "activity", "breakdown", "repos"]);
+  it("lists the five tabs in reading order, the private breakdowns last", () => {
+    expect(TABS.map((t) => t.key)).toEqual(["overview", "activity", "breakdown", "repos", "agents"]);
   });
 
   it("carries the Repos tab folded in from the retired standalone page", () => {
     expect(TABS.find((t) => t.key === "repos")?.label).toBe("Repos");
+  });
+
+  it("carries the Agents tab - which agent CLI the work goes through", () => {
+    expect(TABS.find((t) => t.key === "agents")?.label).toBe("Agents");
   });
 
   it("defaults to the tab that leads with the headline percentages", () => {
@@ -25,6 +29,10 @@ describe("isThrottleTab", () => {
   // reject the stored value and quietly drop the owner back on Overview every visit.
   it("accepts a stored repos tab", () => {
     expect(isThrottleTab("repos")).toBe(true);
+  });
+
+  it("accepts a stored agents tab", () => {
+    expect(isThrottleTab("agents")).toBe(true);
   });
 
   it("rejects a tab that no longer exists, junk, and empty text", () => {

--- a/apps/cockpit/src/throttle/throttleTabs.ts
+++ b/apps/cockpit/src/throttle/throttleTabs.ts
@@ -6,13 +6,14 @@
 // to update - and the failure is quiet: the stored tab silently fails validation and the owner is
 // dropped back on Overview every time they return to the page.
 
-export type ThrottleTab = "overview" | "activity" | "breakdown" | "repos";
+export type ThrottleTab = "overview" | "activity" | "breakdown" | "repos" | "agents";
 
 export const TABS: ReadonlyArray<{ key: ThrottleTab; label: string }> = [
   { key: "overview", label: "Overview" },
   { key: "activity", label: "Activity" },
   { key: "breakdown", label: "Breakdown" },
   { key: "repos", label: "Repos" },
+  { key: "agents", label: "Agents" },
 ];
 
 /** The tab shown when nothing valid is stored. */

--- a/packages/client-core/src/stats/statsClient.test.ts
+++ b/packages/client-core/src/stats/statsClient.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   summarizeThrottle,
   summarizeRepos,
+  summarizeAgents,
   formatShare,
   last24HourKeys,
   windowSeries,
@@ -10,6 +11,7 @@ import {
   safeTimeZone,
   type ThrottleData,
   type RepoStat,
+  type AgentStat,
   type InputHour,
 } from "./statsClient";
 
@@ -25,12 +27,18 @@ function data(buckets: ThrottleData["buckets"]): ThrottleData {
     concurrency: null,
     wingman: { turns: 0, sessions: 0 },
     repos: [],
+    agents: [],
+    agentsSinceUtc: "",
     notCaptured: [],
   };
 }
 
 function repo(repoName: string, turns: number, voiceTurns: number, characters: number, sessions: number): RepoStat {
   return { repo: `D:/${repoName}`, repoName, turns, voiceTurns, typedTurns: turns - voiceTurns, characters, sessions };
+}
+
+function agent(agentToken: string, agentName: string, turns: number, voiceTurns: number, characters: number, sessions: number): AgentStat {
+  return { agent: agentToken, agentName, turns, voiceTurns, typedTurns: turns - voiceTurns, characters, sessions };
 }
 
 describe("summarizeThrottle", () => {
@@ -94,6 +102,34 @@ describe("summarizeRepos", () => {
     expect(s.totalTurns).toBe(0);
     expect(s.topShare).toBeNull();
     expect(s.topRepoName).toBeNull();
+    expect(s.hasData).toBe(false);
+  });
+});
+
+describe("summarizeAgents", () => {
+  it("totals turns, characters and distinct sessions, and finds the most-driven agent's share", () => {
+    const s = summarizeAgents([
+      agent("ClaudeCode", "Claude Code", 8, 6, 640, 2),
+      agent("Codex", "Codex", 2, 0, 60, 1),
+    ]);
+    expect(s.agentCount).toBe(2);
+    expect(s.totalTurns).toBe(10);
+    expect(s.totalCharacters).toBe(700);
+    expect(s.totalSessions).toBe(3);
+    expect(s.voiceTurns).toBe(6);
+    expect(s.topAgentName).toBe("Claude Code");
+    expect(s.topShare).toBeCloseTo(0.8);
+    expect(s.hasData).toBe(true);
+  });
+
+  // The tally starts when the breakdown ships, so "nothing yet" is the normal first state - it must read
+  // as no data rather than as a real 0%.
+  it("reports a null top share (not 0%) when nothing is counted yet", () => {
+    const s = summarizeAgents([]);
+    expect(s.agentCount).toBe(0);
+    expect(s.totalTurns).toBe(0);
+    expect(s.topShare).toBeNull();
+    expect(s.topAgentName).toBeNull();
     expect(s.hasData).toBe(false);
   });
 });

--- a/packages/client-core/src/stats/statsClient.ts
+++ b/packages/client-core/src/stats/statsClient.ts
@@ -87,6 +87,26 @@ export interface RepoStat {
   sessions: number;
 }
 
+/** One agent CLI's all-time input tally for the private Agents page: how much development you drive
+ * through this agent, in submitted turns (total + voice/typed split), character volume, and distinct
+ * sessions. Mirrors the Gateway AgentStatBucketDto. Counts only - never any message text. */
+export interface AgentStat {
+  /** The agent token the Director reported ("ClaudeCode", "Codex", ...), or "" when none (the key). */
+  agent: string;
+  /** Display name of the agent, e.g. "Claude Code"; "(unknown)" when the session carried no agent. */
+  agentName: string;
+  /** Total submitted turns driven through this agent (voice + typed). */
+  turns: number;
+  /** Submitted turns driven by voice. */
+  voiceTurns: number;
+  /** Submitted turns driven by typing. */
+  typedTurns: number;
+  /** Total character volume of input driven through this agent. */
+  characters: number;
+  /** Distinct sessions that drove counted input through this agent. */
+  sessions: number;
+}
+
 /** The GET /stats/data body: the fleet-wide aggregated tally plus the honesty caveats. */
 export interface ThrottleData {
   /** When the Gateway generated this snapshot (ISO 8601 UTC), or "" when absent. */
@@ -103,6 +123,12 @@ export interface ThrottleData {
   wingman: WingmanUsage;
   /** Per-repository all-time tally, ranked most-driven first (the private Repos page). */
   repos: RepoStat[];
+  /** Per-agent all-time tally, ranked most-driven first (the private Agents page). */
+  agents: AgentStat[];
+  /** When the per-agent tally started counting (ISO 8601 UTC), or "" when it has never been stamped.
+   *  The other series predate it, so the Agents page states this window instead of implying the earlier
+   *  turns ran under no agent. */
+  agentsSinceUtc: string;
   /** Plain-English caveats about what the numbers do and do not include. */
   notCaptured: string[];
 }
@@ -182,11 +208,14 @@ export async function getThrottle(signal?: AbortSignal): Promise<ThrottleData> {
     concurrency?: unknown;
     wingman?: unknown;
     repos?: unknown;
+    agents?: unknown;
+    agentsSinceUtc?: unknown;
     notCaptured?: unknown;
   } | null;
   const buckets = Array.isArray(body?.buckets) ? body!.buckets.map(normalizeBucket) : [];
   const hourlyTurns = Array.isArray(body?.hourlyTurns) ? body!.hourlyTurns.map(normalizeInputHour) : [];
   const repos = Array.isArray(body?.repos) ? body!.repos.map(normalizeRepo) : [];
+  const agents = Array.isArray(body?.agents) ? body!.agents.map(normalizeAgent) : [];
   const notCaptured = Array.isArray(body?.notCaptured)
     ? body!.notCaptured.filter((x): x is string => typeof x === "string")
     : [];
@@ -198,6 +227,8 @@ export async function getThrottle(signal?: AbortSignal): Promise<ThrottleData> {
     concurrency: normalizeConcurrency(body?.concurrency),
     wingman: normalizeWingman(body?.wingman),
     repos,
+    agents,
+    agentsSinceUtc: typeof body?.agentsSinceUtc === "string" ? body.agentsSinceUtc : "",
     notCaptured,
   };
 }
@@ -205,6 +236,19 @@ export async function getThrottle(signal?: AbortSignal): Promise<ThrottleData> {
 function normalizeWingman(raw: unknown): WingmanUsage {
   const w = (raw ?? {}) as { turns?: unknown; sessions?: unknown };
   return { turns: num(w.turns), sessions: num(w.sessions) };
+}
+
+function normalizeAgent(raw: unknown): AgentStat {
+  const a = (raw ?? {}) as Partial<Record<keyof AgentStat, unknown>>;
+  return {
+    agent: String(a.agent ?? ""),
+    agentName: String(a.agentName ?? ""),
+    turns: num(a.turns),
+    voiceTurns: num(a.voiceTurns),
+    typedTurns: num(a.typedTurns),
+    characters: num(a.characters),
+    sessions: num(a.sessions),
+  };
 }
 
 function normalizeRepo(raw: unknown): RepoStat {
@@ -317,6 +361,56 @@ export interface RepoSummary {
   /** The most-driven repo's display name, or null when there is no data. */
   topRepoName: string | null;
   hasData: boolean;
+}
+
+/** The Agents-page headline summary: how much you drive each agent CLI. */
+export interface AgentSummary {
+  /** How many agents have any counted input. */
+  agentCount: number;
+  /** Total submitted turns across every agent. */
+  totalTurns: number;
+  /** Total character volume across every agent. */
+  totalCharacters: number;
+  /** Total distinct sessions across every agent (a session drives exactly one agent, so summing the
+   * per-agent distinct counts is itself a distinct total). */
+  totalSessions: number;
+  /** Total voice-driven turns across every agent. */
+  voiceTurns: number;
+  /** The most-driven agent's share of all turns, or null when no turns are counted yet. */
+  topShare: number | null;
+  /** The most-driven agent's display name, or null when there is no data. */
+  topAgentName: string | null;
+  hasData: boolean;
+}
+
+/** Derive the Agents-page headline summary from the per-agent tally. Shares are null (never a fabricated
+ * 0%) when there are no counted turns yet - the tally starts when the breakdown shipped, so an empty
+ * page is the honest state until the fleet has driven a turn under it. */
+export function summarizeAgents(agents: AgentStat[]): AgentSummary {
+  let totalTurns = 0;
+  let totalCharacters = 0;
+  let totalSessions = 0;
+  let voiceTurns = 0;
+  let top: AgentStat | null = null;
+
+  for (const a of agents) {
+    totalTurns += a.turns;
+    totalCharacters += a.characters;
+    totalSessions += a.sessions;
+    voiceTurns += a.voiceTurns;
+    if (top === null || a.turns > top.turns) top = a;
+  }
+
+  return {
+    agentCount: agents.length,
+    totalTurns,
+    totalCharacters,
+    totalSessions,
+    voiceTurns,
+    topShare: totalTurns > 0 && top !== null ? top.turns / totalTurns : null,
+    topAgentName: top !== null ? top.agentName : null,
+    hasData: totalTurns > 0 || totalCharacters > 0,
+  };
 }
 
 /** Derive the Repos-page headline summary from the per-repo tally. Shares are null (never a fabricated

--- a/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
@@ -54,6 +54,17 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
     private static RepoStatBucketDto? Repo(GatewayInputStatsAggregator agg, string repoName) =>
         agg.RepoTotals().FirstOrDefault(r => r.RepoName == repoName);
 
+    // A session driving a named agent CLI - the Agents breakdown ("how much Claude Code vs Codex").
+    private static SessionDto SessionOnAgent(string id, string agent, params (string modality, string surface, long turns, long chars)[] buckets)
+    {
+        var dto = Session(id, buckets);
+        dto.Agent = agent;
+        return dto;
+    }
+
+    private static AgentStatBucketDto? Agent(GatewayInputStatsAggregator agg, string agentName) =>
+        agg.AgentTotals().FirstOrDefault(a => a.AgentName == agentName);
+
 
     private static long Turns(InputStatsDto dto, string modality, string surface) =>
         dto.Buckets.FirstOrDefault(b => b.Modality == modality && b.Surface == surface)?.Turns ?? 0;
@@ -284,5 +295,99 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
         Assert.Equal(5, app2!.Turns);
         Assert.Equal(200, app2.Characters);
         Assert.Equal(1, app2.Sessions);
+    }
+
+    [Fact]
+    public void AgentTotals_AttributeTurnsToAgent_SplitByModality_AndRankByTurns()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        // The owner's question: how much Claude Code compared to Codex. Claude Code gets more, so it ranks first.
+        agg.Observe(SessionOnAgent("s1", "ClaudeCode", ("voice", "phone", 6, 600)));
+        agg.Observe(SessionOnAgent("s2", "ClaudeCode", ("typed", "desktop", 2, 40)));
+        agg.Observe(SessionOnAgent("s3", "Codex", ("typed", "cockpit", 3, 90)));
+
+        var ranked = agg.AgentTotals();
+        Assert.Equal(2, ranked.Count);
+        Assert.Equal("Claude Code", ranked[0].AgentName);   // 8 turns - ranked first
+        Assert.Equal("Codex", ranked[1].AgentName);         // 3 turns
+
+        var cc = ranked[0];
+        Assert.Equal("ClaudeCode", cc.Agent);               // the raw token stays the grouping key
+        Assert.Equal(8, cc.Turns);
+        Assert.Equal(6, cc.VoiceTurns);
+        Assert.Equal(2, cc.TypedTurns);
+        Assert.Equal(640, cc.Characters);
+        Assert.Equal(2, cc.Sessions);                       // two distinct sessions drove it
+    }
+
+    [Fact]
+    public void AgentTotals_DistinctSessions_NoDoubleCountAcrossRepush_AndSurviveRestart()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        agg.Observe(SessionOnAgent("s1", "Codex", ("voice", "phone", 3, 120)));
+        agg.Observe(SessionOnAgent("s1", "Codex", ("voice", "phone", 3, 120))); // re-push, no change
+        agg.Observe(SessionOnAgent("s1", "Codex", ("voice", "phone", 5, 200))); // grew by 2
+
+        var codex = Agent(agg, "Codex");
+        Assert.NotNull(codex);
+        Assert.Equal(5, codex!.Turns);
+        Assert.Equal(1, codex.Sessions); // the same session id must count once, not three times
+
+        // Gateway restart: the per-agent tally (and its distinct-session set) reload from disk.
+        var reloaded = new GatewayInputStatsAggregator(_path);
+        var codex2 = Agent(reloaded, "Codex");
+        Assert.NotNull(codex2);
+        Assert.Equal(5, codex2!.Turns);
+        Assert.Equal(200, codex2.Characters);
+        Assert.Equal(1, codex2.Sessions);
+    }
+
+    [Fact]
+    public void AgentTotals_SessionWithNoAgent_IsCountedAsUnknown_NeverDropped()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        // A Director that reported no agent must not silently vanish from the breakdown - the turns are real.
+        agg.Observe(Session("s1", ("typed", "desktop", 4, 80)));
+
+        var unknown = Agent(agg, "(unknown)");
+        Assert.NotNull(unknown);
+        Assert.Equal("", unknown!.Agent);
+        Assert.Equal(4, unknown.Turns);
+    }
+
+    [Fact]
+    public void AgentsSince_IsStampedOnFirstObservation_AndNeverMovesAfterwards()
+    {
+        var first = new DateTime(2026, 7, 15, 9, 0, 0, DateTimeKind.Utc);
+        var agg = new GatewayInputStatsAggregator(_path);
+        Assert.Equal("", agg.AgentsSinceUtc); // nothing observed yet - no claim about a window
+
+        agg.Observe(SessionOnAgent("s1", "ClaudeCode", ("typed", "desktop", 1, 10)), first);
+        var stamped = agg.AgentsSinceUtc;
+        Assert.NotEqual("", stamped);
+        Assert.StartsWith("2026-07-15T09:00:00", stamped);
+
+        // A later observation must NOT move the since-date, or the page would understate its own window.
+        agg.Observe(SessionOnAgent("s1", "ClaudeCode", ("typed", "desktop", 9, 90)), first.AddHours(5));
+        Assert.Equal(stamped, agg.AgentsSinceUtc);
+
+        // It survives a Gateway restart, so the window does not reset every time the Gateway starts.
+        var reloaded = new GatewayInputStatsAggregator(_path);
+        Assert.Equal(stamped, reloaded.AgentsSinceUtc);
+    }
+
+    [Fact]
+    public void AgentTotals_TrackTheSameTurnsAsTheTotals_FromTheSameDeltas()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        // The agent tally rides the SAME high-water deltas as the totals, so for turns folded while it was
+        // live, the two must agree - the breakdown is a split of the totals, not a second count of them.
+        agg.Observe(SessionOnAgent("s1", "ClaudeCode", ("voice", "phone", 6, 600)));
+        agg.Observe(SessionOnAgent("s2", "Codex", ("typed", "desktop", 4, 40)));
+
+        var totalTurns = agg.CurrentTotals().Buckets.Sum(b => b.Turns);
+        var agentTurns = agg.AgentTotals().Sum(a => a.Turns);
+        Assert.Equal(totalTurns, agentTurns);
+        Assert.Equal(10, agentTurns);
     }
 }

--- a/src/CcDirector.Gateway.Tests/StatsPageEndpointTests.cs
+++ b/src/CcDirector.Gateway.Tests/StatsPageEndpointTests.cs
@@ -158,6 +158,44 @@ public sealed class StatsPageEndpointTests : IDisposable
     }
 
     [Fact]
+    public async Task StatsData_RanksAgents_ByTurns_AndCarriesTheSinceStamp()
+    {
+        var agg = new GatewayInputStatsAggregator(Path.Combine(_dir, "s.json"));
+        agg.Observe(new SessionDto
+        {
+            SessionId = "s1",
+            Agent = "ClaudeCode",
+            InputStats = new InputStatsDto { Buckets = { new InputStatBucketDto { Modality = "voice", Surface = "phone", Turns = 6, Characters = 600 } } },
+        });
+        agg.Observe(new SessionDto
+        {
+            SessionId = "s2",
+            Agent = "Codex",
+            InputStats = new InputStatsDto { Buckets = { new InputStatBucketDto { Modality = "typed", Surface = "desktop", Turns = 2, Characters = 40 } } },
+        });
+
+        var (app, http) = await StartAsync(agg, authEnabled: false);
+        try
+        {
+            using var doc = JsonDocument.Parse(await (await http.GetAsync("/stats/data")).Content.ReadAsStringAsync());
+            var agents = doc.RootElement.GetProperty("agents");
+            Assert.Equal(2, agents.GetArrayLength());
+
+            var first = agents[0];
+            Assert.Equal("Claude Code", first.GetProperty("agentName").GetString()); // most turns ranks first
+            Assert.Equal("ClaudeCode", first.GetProperty("agent").GetString());
+            Assert.Equal(6, first.GetProperty("turns").GetInt64());
+            Assert.Equal(6, first.GetProperty("voiceTurns").GetInt64());
+            Assert.Equal(1, first.GetProperty("sessions").GetInt32());
+            Assert.Equal("Codex", agents[1].GetProperty("agentName").GetString());
+
+            // The page states the window its numbers cover, so the stamp has to reach the client.
+            Assert.NotEqual("", doc.RootElement.GetProperty("agentsSinceUtc").GetString());
+        }
+        finally { http.Dispose(); await app.DisposeAsync(); }
+    }
+
+    [Fact]
     public async Task AuthEnabled_NoToken_Returns401_AndWithToken_Returns200()
     {
         var agg = new GatewayInputStatsAggregator(Path.Combine(_dir, "s.json"));

--- a/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
+++ b/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
@@ -54,6 +54,17 @@ public sealed class GatewayInputStatsAggregator
     // happens"). All-time, like the totals - never pruned. Only counts travel; never any message text.
     private readonly Dictionary<string, RepoTally> _repos = new(StringComparer.OrdinalIgnoreCase);
 
+    // Per-agent all-time tally, keyed by the session's Agent token (the AgentKind name: "ClaudeCode",
+    // "Codex", ...). Accumulated from the SAME high-water deltas as the totals: when a session's counted
+    // input grows, that increase is also attributed to the agent CLI that session drives. Feeds the private
+    // Agents page ("which agent you actually drive"). All-time, like the totals - never pruned.
+    private readonly Dictionary<string, AgentTally> _agents = new(StringComparer.OrdinalIgnoreCase);
+
+    // When the per-agent tally started counting. The totals predate this breakdown, so the agent numbers do
+    // NOT reconcile with them and the page must say so rather than imply the earlier turns had no agent.
+    // Stamped once, the first time a Gateway runs a build that has the tally, and persisted from then on.
+    private string _agentsSinceUtc = "";
+
     private sealed class HourTurns
     {
         public long VoiceTurns;
@@ -69,6 +80,16 @@ public sealed class GatewayInputStatsAggregator
         // The distinct session ids that drove counted input into this repo, so "sessions" is a true
         // distinct count that never double-counts across a re-push or a Gateway restart (the set is
         // persisted and re-adding a known id is a no-op).
+        public readonly HashSet<string> Sessions = new(StringComparer.Ordinal);
+    }
+
+    private sealed class AgentTally
+    {
+        public long VoiceTurns;
+        public long TypedTurns;
+        public long Characters;
+        // The distinct session ids that drove counted input through this agent, so "sessions" is a true
+        // distinct count across a re-push or a Gateway restart (the set is persisted; re-adding is a no-op).
         public readonly HashSet<string> Sessions = new(StringComparer.Ordinal);
     }
 
@@ -96,7 +117,7 @@ public sealed class GatewayInputStatsAggregator
         var hourKey = HourKey(now);
         lock (_lock)
         {
-            var changed = false;
+            var changed = StampAgentsSinceLocked(now);
             foreach (var s in sessions)
                 changed |= FoldLocked(s, hourKey);
             if (changed) { PruneLocked(now); Save(); }
@@ -111,8 +132,22 @@ public sealed class GatewayInputStatsAggregator
         var hourKey = HourKey(now);
         lock (_lock)
         {
-            if (FoldLocked(session, hourKey)) { PruneLocked(now); Save(); }
+            var changed = StampAgentsSinceLocked(now);
+            changed |= FoldLocked(session, hourKey);
+            if (changed) { PruneLocked(now); Save(); }
         }
+    }
+
+    // Stamp when the per-agent tally started counting, the first time a Gateway with the tally observes
+    // anything - from either entry point, so the date does not depend on which one fired first. The all-time
+    // totals predate the breakdown, so this is what lets the Agents page state which window its numbers
+    // cover instead of implying the earlier turns ran under no agent. Returns true when it stamped (the
+    // caller must persist it). Caller holds the lock.
+    private bool StampAgentsSinceLocked(DateTime nowUtc)
+    {
+        if (_agentsSinceUtc.Length > 0) return false;
+        _agentsSinceUtc = nowUtc.ToUniversalTime().ToString("o", System.Globalization.CultureInfo.InvariantCulture);
+        return true;
     }
 
     /// <summary>
@@ -200,6 +235,59 @@ public sealed class GatewayInputStatsAggregator
             return list;
         }
     }
+
+    /// <summary>The per-agent all-time tally (turns by modality, character volume, distinct sessions),
+    /// ranked most-driven first, for the private Agents page. Agents with no counted turns are omitted.</summary>
+    public IReadOnlyList<AgentStatBucketDto> AgentTotals()
+    {
+        lock (_lock)
+        {
+            var list = new List<AgentStatBucketDto>(_agents.Count);
+            foreach (var kvp in _agents)
+            {
+                var t = kvp.Value;
+                list.Add(new AgentStatBucketDto
+                {
+                    Agent = kvp.Key,
+                    AgentName = AgentDisplayName(kvp.Key),
+                    Turns = t.VoiceTurns + t.TypedTurns,
+                    VoiceTurns = t.VoiceTurns,
+                    TypedTurns = t.TypedTurns,
+                    Characters = t.Characters,
+                    Sessions = t.Sessions.Count,
+                });
+            }
+            // Rank by turns (the headline metric), then characters, then name, so the order is stable.
+            list.Sort((a, b) =>
+            {
+                var byTurns = b.Turns.CompareTo(a.Turns);
+                if (byTurns != 0) return byTurns;
+                var byChars = b.Characters.CompareTo(a.Characters);
+                return byChars != 0 ? byChars : string.CompareOrdinal(a.AgentName, b.AgentName);
+            });
+            return list;
+        }
+    }
+
+    /// <summary>When the per-agent tally started counting (round-trip UTC), or "" if it has never been
+    /// stamped. The all-time totals predate it, so the Agents page states this rather than implying the
+    /// earlier turns ran under no agent.</summary>
+    public string AgentsSinceUtc
+    {
+        get { lock (_lock) { return _agentsSinceUtc; } }
+    }
+
+    // The display name of an agent token (the AgentKind enum name the Director reports). An explicit map,
+    // not a PascalCase splitter: "OpenCode" is the product's own spelling and must not become "Open Code".
+    // An unrecognised token is shown verbatim - it is a real value we simply do not have a nicer name for,
+    // so showing it is honest where hiding it behind "Other" would not be.
+    private static string AgentDisplayName(string agent) => agent switch
+    {
+        "" => "(unknown)",
+        "ClaudeCode" => "Claude Code",
+        "RawCli" => "Raw CLI",
+        _ => agent,
+    };
 
     // The display leaf of a repository path: the last path segment of the working directory, so
     // "D:\ReposFred\devthrottle" reads as "devthrottle". Handles both slash styles across machines (the
@@ -310,6 +398,24 @@ public sealed class GatewayInputStatsAggregator
                 if (!string.IsNullOrEmpty(s.SessionId))
                     repo.Sessions.Add(s.SessionId);
 
+                // Attribute the SAME increase to the agent CLI the session drives (the private Agents page):
+                // which agent the work went through. A session whose agent the Director did not report is
+                // counted under the empty key and shown as "(unknown)" - never silently dropped, and never
+                // guessed at from the command line.
+                var agentKey = s.Agent ?? "";
+                if (!_agents.TryGetValue(agentKey, out var agent))
+                {
+                    agent = new AgentTally();
+                    _agents[agentKey] = agent;
+                }
+                if (isVoice)
+                    agent.VoiceTurns += deltaTurns;
+                else
+                    agent.TypedTurns += deltaTurns;
+                agent.Characters += deltaChars;
+                if (!string.IsNullOrEmpty(s.SessionId))
+                    agent.Sessions.Add(s.SessionId);
+
                 changed = true;
             }
 
@@ -347,6 +453,8 @@ public sealed class GatewayInputStatsAggregator
         public long WingmanTurns { get; set; }
         public List<string> WingmanSessions { get; set; } = new();
         public Dictionary<string, RepoTallyStore> Repos { get; set; } = new();
+        public Dictionary<string, AgentTallyStore> Agents { get; set; } = new();
+        public string AgentsSinceUtc { get; set; } = "";
     }
 
     private sealed class HourTurnsStore
@@ -357,6 +465,14 @@ public sealed class GatewayInputStatsAggregator
     }
 
     private sealed class RepoTallyStore
+    {
+        public long VoiceTurns { get; set; }
+        public long TypedTurns { get; set; }
+        public long Characters { get; set; }
+        public List<string> Sessions { get; set; } = new();
+    }
+
+    private sealed class AgentTallyStore
     {
         public long VoiceTurns { get; set; }
         public long TypedTurns { get; set; }
@@ -408,7 +524,14 @@ public sealed class GatewayInputStatsAggregator
             foreach (var sid in rt.Sessions) tally.Sessions.Add(sid);
             _repos[repoKey] = tally;
         }
-        FileLog.Write($"[GatewayInputStatsAggregator] Load: restored {_totals.Count} total bucket(s), {_highWater.Count} live session(s), {_hourly.Count} hourly bucket(s), {_wingmanSessions.Count} wingman session(s)/{_wingmanTurns} wingman turn(s), {_repos.Count} repo(s) from {_path}");
+        foreach (var (agentKey, at) in parsed.Agents)
+        {
+            var tally = new AgentTally { VoiceTurns = at.VoiceTurns, TypedTurns = at.TypedTurns, Characters = at.Characters };
+            foreach (var sid in at.Sessions) tally.Sessions.Add(sid);
+            _agents[agentKey] = tally;
+        }
+        _agentsSinceUtc = parsed.AgentsSinceUtc ?? "";
+        FileLog.Write($"[GatewayInputStatsAggregator] Load: restored {_totals.Count} total bucket(s), {_highWater.Count} live session(s), {_hourly.Count} hourly bucket(s), {_wingmanSessions.Count} wingman session(s)/{_wingmanTurns} wingman turn(s), {_repos.Count} repo(s), {_agents.Count} agent(s) since '{_agentsSinceUtc}' from {_path}");
     }
 
     private void Quarantine(string reason)
@@ -444,6 +567,15 @@ public sealed class GatewayInputStatsAggregator
                     Characters = rt.Characters,
                     Sessions = rt.Sessions.ToList(),
                 };
+            foreach (var (agentKey, at) in _agents)
+                file.Agents[agentKey] = new AgentTallyStore
+                {
+                    VoiceTurns = at.VoiceTurns,
+                    TypedTurns = at.TypedTurns,
+                    Characters = at.Characters,
+                    Sessions = at.Sessions.ToList(),
+                };
+            file.AgentsSinceUtc = _agentsSinceUtc;
 
             var json = JsonSerializer.Serialize(file, FileJsonOptions);
             var tmp = _path + ".tmp";
@@ -502,5 +634,35 @@ public sealed class RepoStatBucketDto
     public long Characters { get; set; }
 
     /// <summary>Distinct sessions that drove counted input into this repo.</summary>
+    public int Sessions { get; set; }
+}
+
+/// <summary>One agent CLI's all-time input tally for the private Agents page: how much development you
+/// drive through this agent, measured in submitted TURNS (total and split voice vs typed), CHARACTER
+/// volume, and the count of distinct SESSIONS that drove input through it. Only counts ever travel - never
+/// message text. The tally starts when the breakdown shipped, so it does not reconcile with the all-time
+/// totals; see <see cref="GatewayInputStatsAggregator.AgentsSinceUtc"/>.</summary>
+public sealed class AgentStatBucketDto
+{
+    /// <summary>The agent token the Director reported (the AgentKind name: "ClaudeCode", "Codex", ...),
+    /// or "" when the session carried no agent (the grouping key).</summary>
+    public string Agent { get; set; } = "";
+
+    /// <summary>The display name of <see cref="Agent"/>, e.g. "Claude Code"; "(unknown)" when empty.</summary>
+    public string AgentName { get; set; } = "";
+
+    /// <summary>Total submitted turns driven through this agent (voice + typed).</summary>
+    public long Turns { get; set; }
+
+    /// <summary>Submitted turns driven by voice.</summary>
+    public long VoiceTurns { get; set; }
+
+    /// <summary>Submitted turns driven by typing.</summary>
+    public long TypedTurns { get; set; }
+
+    /// <summary>Total character volume of input driven through this agent.</summary>
+    public long Characters { get; set; }
+
+    /// <summary>Distinct sessions that drove counted input through this agent.</summary>
     public int Sessions { get; set; }
 }

--- a/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
+++ b/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
@@ -60,6 +60,13 @@ public static class StatsPageEndpoint
                 // owner-only auth as the rest of this feed; rendered on a SEPARATE page from Your Throttle
                 // so it never rides along when the throttle is shared.
                 repos = aggregator.RepoTotals(),
+                // DevThrottle Stats (private Agents page): the per-agent all-time tally, ranked most-driven
+                // first, so the owner can see which agent CLI the work actually goes through. Unlike the
+                // other series this one starts at agentsSinceUtc - the breakdown was added after the totals
+                // had been accumulating - so the page states that window rather than implying the earlier
+                // turns ran under no agent.
+                agents = aggregator.AgentTotals(),
+                agentsSinceUtc = aggregator.AgentsSinceUtc,
                 notCaptured = NotCaptured,
             });
         });


### PR DESCRIPTION
## Why

"How much do I use Claude Code compared to Codex" had no answer. The stats store counts turns by `(modality, surface)` and tallies them per repo, but nothing recorded which agent the work went through.

It turned out the value was already there: `SessionDto.Agent` (a populated `AgentKind` enum - `ClaudeCode`, `Codex`, `Gemini`, `Pi`, `OpenCode`, `Cursor`, `Grok`, `Copilot`) sits on the very object the aggregator folds, and `FoldLocked` was reading `RepoPath` off it while ignoring `Agent`.

## What

The same high-water delta the repo tally already uses is now attributed to the session's agent as well, so the breakdown is a **split of the existing totals, not a second count of them** - pinned by `AgentTotals_TrackTheSameTurnsAsTheTotals_FromTheSameDeltas`.

A fifth "Agents" tab renders it, cloned from Repos: same ranked rows, same voice/typed split bar, same turns/characters/sessions metric toggle, same private badge.

## Two honesty decisions

**It counts from when it ships, not all-time.** The totals had been accumulating for weeks and nothing recorded the agent behind them. So the tab states its own window ("Counting since \<date\>") rather than letting a smaller number read as a drop in usage. The stamp is set on the first observation from either entry point, never moves afterwards, and survives a restart. The owner explicitly accepted this trade-off.

**A session with no reported agent is counted under "(unknown)", not dropped.** The turns are real either way, and guessing the agent from a command line would be a fabrication.

## The road not taken

The prompt log (`PromptRecord.Agent`) does stamp the agent per message and is unbounded by design - but on a real machine it only goes back two days, because the log itself is new. It would have bought a negligible backfill at the cost of a second source of truth that would not reconcile with the rest of the page.

## Verification

- Gateway 2,314 tests (6 new), client-core 447 (2 new), cockpit 123 (2 new). Typecheck, lint, build clean.
- Proven to fail on purpose: removing the agent fold turns 4 of the new tests red while the 15 existing aggregator tests stay green.
- Wire-level test asserts `/stats/data` actually serves `agents` ranked by turns plus `agentsSinceUtc` - so the endpoint is proven to expose it, not just the aggregator to compute it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
