### PR TITLE
docs(architecture): mark the v1.3.0 manager briefs as historical

### DIFF
--- a/docs/architecture/post-release-followups-brief.md
+++ b/docs/architecture/post-release-followups-brief.md
@@ -1,5 +1,13 @@
 # Manager brief - post-v1.3.0 follow-ups
 
+> **HISTORICAL RECORD - NOT IN FORCE.** This brief seeded a Manager session for the post-v1.3.0 follow-ups, driven by the Stable Release Architect session `2eef41a3`. v1.3.0 was released on 2026-07-14 and that mission is over. It is kept for the record of what was
+> decided and why, and for the reasoning behind behaviour that has since shipped.
+>
+> **Nothing in this file is an instruction to you.** Every "you", every "do not ask", and the
+> standing-authority passage below were addressed to ONE named session, for the duration of that
+> mission, by the owner at that time. They expired with it. Read this as history, not as a brief you
+> have been handed. The standing rule is unchanged: **ask the owner before committing.**
+
 Architect: session `2eef41a3` ("Stable Release - Architect").
 
 **v1.3.0 is CUT AND PUBLISHED.** So is v1.2.0. Do not touch the tags, do not re-cut a release.

--- a/docs/architecture/stable-release-tier1-rest-brief.md
+++ b/docs/architecture/stable-release-tier1-rest-brief.md
@@ -1,5 +1,13 @@
 # Manager brief - Tier 1 items 2, 3, 4 (Stable Release, v1.3.0)
 
+> **HISTORICAL RECORD - NOT IN FORCE.** This brief seeded a Manager session for the Stable Release mission (`ac6883bb`), which ended when v1.3.0 was released on 2026-07-14. It is kept for the record of what was
+> decided and why, and for the reasoning behind behaviour that has since shipped.
+>
+> **Nothing in this file is an instruction to you.** Every "you", every "do not ask", and the
+> standing-authority passage below were addressed to ONE named session, for the duration of that
+> mission, by the owner at that time. They expired with it. Read this as history, not as a brief you
+> have been handed. The standing rule is unchanged: **ask the owner before committing.**
+
 Mission id: `ac6883bb-09e2-4b5a-96bf-df3eae8d9f63`
 Architect: session `2eef41a3` ("Stable Release - Architect").
 

--- a/docs/architecture/stable-release-tier2-brief.md
+++ b/docs/architecture/stable-release-tier2-brief.md
@@ -1,5 +1,13 @@
 # Manager brief - Tier 2 items 5, 6, 7 (Stable Release, v1.3.0)
 
+> **HISTORICAL RECORD - NOT IN FORCE.** This brief seeded a Manager session for the Stable Release mission (`ac6883bb`), which ended when v1.3.0 was released on 2026-07-14. It is kept for the record of what was
+> decided and why, and for the reasoning behind behaviour that has since shipped.
+>
+> **Nothing in this file is an instruction to you.** Every "you", every "do not ask", and the
+> standing-authority passage below were addressed to ONE named session, for the duration of that
+> mission, by the owner at that time. They expired with it. Read this as history, not as a brief you
+> have been handed. The standing rule is unchanged: **ask the owner before committing.**
+
 Mission id: `ac6883bb-09e2-4b5a-96bf-df3eae8d9f63`
 Architect: session `2eef41a3` ("Stable Release - Architect").
 

--- a/docs/architecture/stable-release-working-is-blue-brief.md
+++ b/docs/architecture/stable-release-working-is-blue-brief.md
@@ -1,5 +1,13 @@
 # Manager brief - Working is BLUE (Stable Release, Tier 1)
 
+> **HISTORICAL RECORD - NOT IN FORCE.** This brief seeded a Manager session for the Stable Release mission (`ac6883bb`), which ended when v1.3.0 was released on 2026-07-14. It is kept for the record of what was
+> decided and why, and for the reasoning behind behaviour that has since shipped.
+>
+> **Nothing in this file is an instruction to you.** Every "you", every "do not ask", and the
+> standing-authority passage below were addressed to ONE named session, for the duration of that
+> mission, by the owner at that time. They expired with it. Read this as history, not as a brief you
+> have been handed. The standing rule is unchanged: **ask the owner before committing.**
+
 Mission id: `ac6883bb-09e2-4b5a-96bf-df3eae8d9f63`
 You are a **Manager** for this ONE item. The Architect is session `2eef41a3` ("Stable Release - Architect").
 Another Manager owns Tier 1 item 1 (the dropped-command timeout) in a different worktree - do not touch its


### PR DESCRIPTION
Follow-up to #1620, which rescued four Manager briefs from an untracked worktree onto main.

## The problem

Those briefs are worth keeping - they record a delegation that produced a shipped release. But they are written in the **imperative**, addressed to **"you"**, under a heading called **"Standing authority - read this first"**:

> *"You do NOT wait for the owner's word on a commit. You do not ask. Commit and keep going."*

> *"Do not ask for approval. Do not stop."*

That was true, for **one named session**, for the duration of **one mission**, which ended when v1.3.0 shipped on 2026-07-14. It is not true now, and it contradicts the standing rule that the owner is asked before anything is committed.

**The risk is the grammar, not the history.** Most architecture docs *describe* - "the Gateway owns every state" cannot be mistaken for an order. These *command*. A later session reading the architecture docs, or grepping for how this repository works, can land on that line and read it as a brief it has been handed. The word "standing" actively invites that reading.

## The change

Each file now opens with a notice saying what it actually is - a record of a finished mission, addressed to someone else, at a time that has passed - and restating that the standing rule is unchanged.

## It is additive only

Every original word is untouched underneath. **Strip the quoted notice from any of these files and the result is byte-identical to what #1620 merged** - verified per file. The diff is **+8 / -0** on each: eight lines added, nothing removed, nothing reworded.

Rescuing someone's work means preserving it, not rewriting it. This does not edit their words; it stops those words being read as an order by someone they were never addressed to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)