### PR TITLE
feat(cockpit): serve workflows from the Gateway, and flatten the rail (#1617)

### DIFF
--- a/apps/cockpit/src/AppShell.tsx
+++ b/apps/cockpit/src/AppShell.tsx
@@ -12,11 +12,18 @@ import { CockpitStatusPill } from "./network/CockpitStatusPill";
 // clipping). Per-page detail regions (roster, dock, awareness) belong to the routed pages
 // themselves - see SessionsView - not to this frame.
 
-// The left-rail destinations, grouped into three labeled sections (issue #1247): Fleet (what is
-// running and how it is driven), Data (the corpora and tools the fleet reads and writes), and System
-// (this browser's account and the app's own settings). Every built page that is meant to be reachable
-// has an entry - the pages that used to be reachable only by typing their address (Voice Recorder,
-// Executables) are now in the menu.
+// The left-rail destinations. This was three LABELED sections - Fleet, Data, System (issue #1247) -
+// until the labels were removed (issue #1617). They were dim uppercase headers that lost to the item
+// labels beneath them, so instead of chunking the list they added three rows of noise you scanned
+// past. Raising their contrast was the obvious fix and the wrong one: it makes them louder without
+// making them useful, because the grouping was not earning its keep - "Dictionary, Voice Recorder,
+// Executables, Transcription, Network, Learning" under "DATA" is not a category anyone feels, it is a
+// category invented to justify a header. So the list is flat now, which is what comparable product
+// navigation does at this size.
+//
+// The one surviving grouping is positional, not labeled: the destinations about the app itself
+// (Account, Your Throttle, Settings, About) sit in a second list pinned to the BOTTOM of the rail,
+// away from the fleet work. That is a grouping you feel without being told.
 //
 // The Fleet Map is first and is the default landing (issue #1303): a fresh boot at "/" redirects to
 // it, so the Cockpit opens on the whole-fleet picture (main.tsx). Sessions lives at its own /sessions
@@ -31,36 +38,29 @@ interface NavItem {
   subtree?: string;
 }
 
-const NAV_SECTIONS: ReadonlyArray<{ title: string; items: ReadonlyArray<NavItem> }> = [
-  {
-    title: "Fleet",
-    items: [
-      { to: "/fleet-map", label: "Fleet Map" },
-      { to: "/sessions", label: "Sessions", subtree: "/session" },
-      { to: "/directors", label: "Directors" },
-      { to: "/schedule", label: "Schedule" },
-    ],
-  },
-  {
-    title: "Data",
-    items: [
-      { to: "/dictionary", label: "Dictionary" },
-      { to: "/transcripts", label: "Voice Recorder" },
-      { to: "/exes", label: "Executables" },
-      { to: "/transcription", label: "Transcription" },
-      { to: "/network", label: "Network" },
-      { to: "/learn", label: "Learning" },
-    ],
-  },
-  {
-    title: "System",
-    items: [
-      { to: "/account", label: "Account" },
-      { to: "/your-throttle", label: "Your Throttle" },
-      { to: "/settings", label: "Settings" },
-      { to: "/about", label: "About" },
-    ],
-  },
+// The fleet work: what is running, how it is driven, and the corpora and tools it reads and writes.
+// Workflows sits with Schedule on purpose - Schedule is what runs when, Workflows is how work runs,
+// and it is next to the place you start work rather than filed away under settings.
+const NAV_MAIN: ReadonlyArray<NavItem> = [
+  { to: "/fleet-map", label: "Fleet Map" },
+  { to: "/sessions", label: "Sessions", subtree: "/session" },
+  { to: "/directors", label: "Directors" },
+  { to: "/schedule", label: "Schedule" },
+  { to: "/workflows", label: "Workflows" },
+  { to: "/dictionary", label: "Dictionary" },
+  { to: "/transcripts", label: "Voice Recorder" },
+  { to: "/exes", label: "Executables" },
+  { to: "/transcription", label: "Transcription" },
+  { to: "/network", label: "Network" },
+  { to: "/learn", label: "Learning" },
+];
+
+// This browser's account and the app's own settings - pinned to the bottom of the rail.
+const NAV_FOOT: ReadonlyArray<NavItem> = [
+  { to: "/account", label: "Account" },
+  { to: "/your-throttle", label: "Your Throttle" },
+  { to: "/settings", label: "Settings" },
+  { to: "/about", label: "About" },
 ];
 
 export function AppShell() {
@@ -74,30 +74,8 @@ export function AppShell() {
         <div className="brand">DevThrottle</div>
         <CockpitStatusPill />
         <div className="nav">
-          {NAV_SECTIONS.map((section) => (
-            <div className="nav-section" key={section.title}>
-              <div className="nav-section-title">{section.title}</div>
-              <ul className="nav-list">
-                {section.items.map((item) => {
-                  const inSubtree =
-                    item.subtree !== undefined && location.pathname.startsWith(item.subtree);
-                  return (
-                    <li key={item.to}>
-                      <NavLink
-                        to={item.to}
-                        end={item.to === "/"}
-                        className={({ isActive }) =>
-                          isActive || inSubtree ? "nav-link nav-link-active" : "nav-link"
-                        }
-                      >
-                        {item.label}
-                      </NavLink>
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
-          ))}
+          <NavList items={NAV_MAIN} pathname={location.pathname} />
+          <NavList items={NAV_FOOT} pathname={location.pathname} className="nav-list-foot" />
         </div>
         <div className="rail-foot">Cockpit (React)</div>
       </nav>
@@ -106,5 +84,36 @@ export function AppShell() {
         <Outlet />
       </main>
     </div>
+  );
+}
+
+function NavList({
+  items,
+  pathname,
+  className,
+}: {
+  items: ReadonlyArray<NavItem>;
+  pathname: string;
+  className?: string;
+}) {
+  return (
+    <ul className={className === undefined ? "nav-list" : `nav-list ${className}`}>
+      {items.map((item) => {
+        const inSubtree = item.subtree !== undefined && pathname.startsWith(item.subtree);
+        return (
+          <li key={item.to}>
+            <NavLink
+              to={item.to}
+              end={item.to === "/"}
+              className={({ isActive }) =>
+                isActive || inSubtree ? "nav-link nav-link-active" : "nav-link"
+              }
+            >
+              {item.label}
+            </NavLink>
+          </li>
+        );
+      })}
+    </ul>
   );
 }

--- a/apps/cockpit/src/main.tsx
+++ b/apps/cockpit/src/main.tsx
@@ -17,6 +17,7 @@ import { FleetMapView } from "./fleet/FleetMapView";
 import { DirectorsView } from "./fleet/DirectorsView";
 import { DirectorDetailView } from "./fleet/DirectorDetailView";
 import { ScheduleView } from "./schedule/ScheduleView";
+import { WorkflowsView } from "./workflows/WorkflowsView";
 import { DictionaryView } from "./dictionary/DictionaryView";
 import { TranscriptsView } from "./transcripts/TranscriptsView";
 import { ExesView } from "./exes/ExesView";
@@ -34,6 +35,7 @@ import "./fleet/fleet.css";
 import "./fleet/fleetmap.css";
 import "./missions/missions.css";
 import "./schedule/schedule.css";
+import "./workflows/workflows.css";
 import "./dictionary/dictionary.css";
 import "./transcripts/transcripts.css";
 import "./exes/exes.css";
@@ -150,6 +152,12 @@ const router = createBrowserRouter(
             // only ever rendered an idle "Disabled" snapshot. "Wingman" now means only the live voice
             // narration (the phone/Cockpit Voice mode), not a fleet pipeline surface.
             { path: "/schedule", element: <ScheduleView /> },
+            // The Workflows page (issue #1617): the shapes of work the fleet knows how to run - which
+            // agent starts a step, which reviews it, where the human is asked. Reads the Gateway's
+            // workflow catalog (GET /workflows) through client-core; the Gateway is the home for these,
+            // so the page renders what the Gateway serves rather than a list baked into this bundle.
+            // It sits beside Schedule in the rail: Schedule is what runs when, Workflows is how work runs.
+            { path: "/workflows", element: <WorkflowsView /> },
             // The tools + data pages (issue #977): one-to-one ports of the Blazor Dictionary.razor,
             // Transcripts.razor, Exes.razor, and Learning.razor over the same Gateway REST surface.
             // All four have a Data-section nav entry now (issue #1247, exposing Voice Recorder and

--- a/apps/cockpit/src/styles.css
+++ b/apps/cockpit/src/styles.css
@@ -72,28 +72,16 @@ body {
   padding: 4px 8px 16px;
 }
 
-/* The rail body holds the labeled sections (issue #1247); it grows to fill the rail so the footer
-   sits at the bottom. */
+/* The rail body. It grows to fill the rail so the footer sits at the bottom.
+
+   The labeled sections (issue #1247) are gone (issue #1617): the rail is one flat list of fleet
+   destinations plus a second, unlabeled list pinned to the bottom for the app's own pages. See
+   AppShell for why the labels went. */
 .nav {
   display: flex;
   flex-direction: column;
   gap: 14px;
   flex: 1;
-}
-
-.nav-section {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.nav-section-title {
-  padding: 4px 10px 4px;
-  font-size: 10.5px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-dim);
 }
 
 .nav-list {
@@ -103,6 +91,13 @@ body {
   display: flex;
   flex-direction: column;
   gap: 2px;
+}
+
+/* The app's own destinations sit at the bottom of the rail, separated from the fleet work by
+   whitespace rather than a labeled header. margin-top:auto eats the free space above it, so the
+   grouping holds whether the rail is taller than the list or not. */
+.nav-list-foot {
+  margin-top: auto;
 }
 
 .nav-link {

--- a/apps/cockpit/src/workflows/WorkflowsView.tsx
+++ b/apps/cockpit/src/workflows/WorkflowsView.tsx
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useState } from "react";
+import { getWorkflows, type WorkflowDefinition } from "@devthrottle/client-core/workflows/workflowsClient";
+import { gatewayErrorMessage } from "@devthrottle/client-core/api/client";
+import { ErrorBanner, LoadingState } from "../components";
+
+// The Workflows page (issue #1617): the shapes of work this fleet knows how to run.
+//
+// A workflow is a named, saved definition of how a piece of work gets done by agents - which seats
+// exist, which one starts, which one reviews, and where the human is asked. Until now that lived
+// implicitly in whichever skill file an agent happened to read, which meant there was no place to look
+// to see how the team works. This page is that place.
+//
+// The definitions come from the GATEWAY, not from this bundle. That is the whole architectural point:
+// the Gateway is the home, every Director asks it, and later an administrator sets an organisation's
+// workflows once there and every machine picks them up. A page that hardcoded the list would read the
+// same today and be a lie tomorrow.
+//
+// Read-only at this step. Choosing a workflow when starting work, and authoring them here, are later
+// steps - so this page deliberately ships no buttons it cannot honour.
+export function WorkflowsView() {
+  const [workflows, setWorkflows] = useState<WorkflowDefinition[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (signal?: AbortSignal) => {
+    try {
+      const fresh = await getWorkflows(signal);
+      setWorkflows(fresh);
+      setError(null);
+    } catch (err) {
+      if (signal?.aborted === true) return;
+      // No fallback to an empty list: an unreadable catalog says so, it does not render as "you have
+      // no workflows".
+      setError(gatewayErrorMessage(err));
+    }
+  }, []);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    void load(ctrl.signal);
+    return () => ctrl.abort();
+  }, [load]);
+
+  return (
+    <div className="page wf">
+      <header className="ui-page-header">
+        <div className="ui-page-header-text">
+          <h1 className="ui-page-title">Workflows</h1>
+          <p className="ui-page-subtitle">
+            How work gets done by your agents. A workflow decides which agent starts, which one reviews,
+            and where you get asked.
+          </p>
+        </div>
+      </header>
+
+      <p className="wf-intro">
+        These are served by the Gateway, so every Director on every machine runs the same set. Editing
+        them here is not built yet.
+      </p>
+
+      {error !== null ? (
+        <ErrorBanner message={error} onRetry={() => void load()} />
+      ) : workflows === null ? (
+        <LoadingState message="Loading workflows..." />
+      ) : (
+        <div className="wf-list">
+          {workflows.map((wf) => (
+            <WorkflowCard key={wf.id} workflow={wf} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function WorkflowCard({ workflow }: { workflow: WorkflowDefinition }) {
+  return (
+    <section className="wf-card">
+      <div className="wf-card-head">
+        <h2 className="wf-name">{workflow.name}</h2>
+        <span className="wf-steps-count">
+          {workflow.steps.length} {workflow.steps.length === 1 ? "step" : "steps"}
+        </span>
+      </div>
+      <p className="wf-summary">{workflow.summary}</p>
+
+      <dl className="wf-facts">
+        <dt>When to use it</dt>
+        <dd>{workflow.whenToUse}</dd>
+        <dt>You are asked</dt>
+        <dd>{workflow.humanCheckpoint}</dd>
+      </dl>
+
+      <ol className="wf-steps">
+        {workflow.steps.map((step, i) => (
+          <li className="wf-step" key={step.name}>
+            <div className="wf-step-num" aria-hidden="true">
+              {i + 1}
+            </div>
+            <div className="wf-step-body">
+              <div className="wf-step-name">{step.name}</div>
+              <p className="wf-step-desc">{step.description}</p>
+              <div className="wf-seats">
+                <span className="wf-seat">
+                  <span className="wf-seat-label">Does it</span>
+                  <span className="wf-seat-who">{step.doer}</span>
+                </span>
+                <span className="wf-seat">
+                  <span className="wf-seat-label">Reviews it</span>
+                  {/* "No review" is a real statement the workflow is making - show it, do not leave a gap
+                      that reads as missing data. */}
+                  <span className={step.reviewer === null ? "wf-seat-who wf-seat-none" : "wf-seat-who"}>
+                    {step.reviewer ?? "No review"}
+                  </span>
+                </span>
+                <span className="wf-seat wf-seat-done">
+                  <span className="wf-seat-label">Done when</span>
+                  <span className="wf-seat-who">{step.done}</span>
+                </span>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/apps/cockpit/src/workflows/workflows.css
+++ b/apps/cockpit/src/workflows/workflows.css
@@ -1,0 +1,175 @@
+/* The Workflows page (issue #1617). Rendered as normal scrolling content inside the padded main pane,
+   on the shell theme tokens (src/styles.css :root) so it reads as one product with the rest.
+
+   The layout answers one question per card: what shape of work is this, and who sits in which seat.
+   The steps are a numbered spine so the order is readable at a glance, and each step states its seats
+   on one row - who does it, who reviews it, what done means - because those three are the whole reason
+   the feature exists. */
+
+.wf {
+  max-width: 880px;
+}
+
+.wf-intro {
+  margin: 0 0 20px;
+  max-width: 68ch;
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.wf-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.wf-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 18px 20px;
+}
+
+.wf-card-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.wf-name {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.wf-steps-count {
+  font-size: 11px;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.wf-summary {
+  margin: 6px 0 0;
+  max-width: 68ch;
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+/* The two standing facts about a workflow, as a label/value grid rather than prose: they are the
+   things you compare ACROSS workflows when choosing one, so they need to sit in the same place on
+   every card. */
+.wf-facts {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 14px;
+  margin: 14px 0 0;
+  padding: 12px 0 0;
+  border-top: 1px solid var(--border);
+}
+
+.wf-facts dt {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  padding-top: 1px;
+}
+
+.wf-facts dd {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text);
+}
+
+.wf-steps {
+  list-style: none;
+  margin: 16px 0 0;
+  padding: 14px 0 0;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.wf-step {
+  display: grid;
+  grid-template-columns: 24px 1fr;
+  gap: 12px;
+  align-items: start;
+}
+
+.wf-step-num {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  font-size: 12px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.wf-step-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.wf-step-desc {
+  margin: 3px 0 0;
+  max-width: 62ch;
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+/* The seats row. Wraps rather than scrolls: on a narrow pane the seats stack instead of clipping the
+   "Done when" value, which is the longest of the three. */
+.wf-seats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+  margin-top: 8px;
+}
+
+.wf-seat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+/* "Done when" carries a sentence, not a name - let it take the remaining width instead of squeezing
+   into a name-sized column. */
+.wf-seat-done {
+  flex: 1 1 22ch;
+}
+
+.wf-seat-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.wf-seat-who {
+  font-size: 13px;
+  color: var(--text);
+  line-height: 1.45;
+}
+
+/* A step with no review seat states that plainly, dimmed - it is a real answer, not missing data. */
+.wf-seat-none {
+  color: var(--text-dim);
+  font-style: italic;
+}

--- a/packages/client-core/src/workflows/workflowsClient.ts
+++ b/packages/client-core/src/workflows/workflowsClient.ts
@@ -1,0 +1,67 @@
+// The workflow catalog surface of the Gateway (issue #1617): the typed, same-origin client the
+// Cockpit's Workflows page reads.
+//
+// A workflow is a named, saved definition of how a piece of work gets done by agents - which seats
+// exist, which seat starts, which seat reviews, and where the human is asked. The Gateway is the home
+// for them, so this is a read against the Gateway front door like every other client here; the page
+// never reaches a Director.
+//
+// Read-only on purpose at this step: the Gateway serves a built-in set, and authoring/editing is a
+// later step. When that lands, the write calls belong here beside the read.
+import { authHeaders, GatewayError } from "../api/client";
+
+/** One step of a workflow: who does it, who reviews it, and what finishing it means. */
+export interface WorkflowStep {
+  name: string;
+  description: string;
+  /** The seat that does the work. */
+  doer: string;
+  /** The seat that reviews it, or null when this step has no separate review seat. */
+  reviewer: string | null;
+  /** What finishing this step means - the workflow's own definition of done. */
+  done: string;
+}
+
+/** One workflow: a shape of work the fleet knows how to run. */
+export interface WorkflowDefinition {
+  id: string;
+  name: string;
+  summary: string;
+  whenToUse: string;
+  /** Where the human is asked - the interruption budget this workflow spends. */
+  humanCheckpoint: string;
+  steps: WorkflowStep[];
+}
+
+async function gatewayErrorFrom(res: Response, label: string): Promise<GatewayError> {
+  let detail = `${res.status}`;
+  try {
+    const text = await res.text();
+    if (text.length > 0) {
+      try {
+        const body = JSON.parse(text) as { error?: string; detail?: string };
+        detail = body.error ?? body.detail ?? text;
+      } catch {
+        detail = text;
+      }
+    }
+  } catch {
+    /* body unreadable - keep the status code */
+  }
+  return new GatewayError(res.status, `${label} failed: ${detail}`);
+}
+
+// GET /gateway/workflows - every workflow the Gateway serves. Throws on a non-2xx or a transport failure so
+// the page shows an error banner rather than an empty list that reads as "you have no workflows".
+export async function getWorkflows(signal?: AbortSignal): Promise<WorkflowDefinition[]> {
+  const res = await fetch("/gateway/workflows", {
+    method: "GET",
+    headers: { Accept: "application/json", ...authHeaders() },
+    signal,
+  });
+  if (!res.ok) throw await gatewayErrorFrom(res, "GET /gateway/workflows");
+  const body = (await res.json()) as { workflows?: WorkflowDefinition[] } | null;
+  const workflows = body?.workflows;
+  if (workflows === undefined) throw new GatewayError(res.status, "GET /gateway/workflows returned no workflows field");
+  return workflows;
+}

--- a/src/CcDirector.Gateway.Tests/WorkflowEndpointsTests.cs
+++ b/src/CcDirector.Gateway.Tests/WorkflowEndpointsTests.cs
@@ -1,0 +1,150 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using CcDirector.Gateway;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// End-to-end proof for the workflow catalog (issue #1617). Boots a real GatewayHost on an ephemeral
+/// port with an isolated CC_DIRECTOR_ROOT and reads the routes over real HTTP, so this proves the
+/// endpoint is actually mapped on the host - not merely that BuiltInWorkflows returns a list.
+///
+/// The point of the feature is that the Gateway is the HOME for workflows, so what is worth asserting
+/// is that a client asking the Gateway gets the three shapes back, each with the seats filled in.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class WorkflowEndpointsTests : IAsyncLifetime
+{
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _instancesDir =
+        Path.Combine(Path.GetTempPath(), "cc-workflows-" + Guid.NewGuid().ToString("N"));
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+
+    public WorkflowEndpointsTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-workflows-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: "test-token-12345", authEnabled: true,
+            instancesDirectory: _instancesDir,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"));
+        await _gateway.StartAsync();
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "test-token-12345");
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* best effort */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task Get_workflows_serves_the_three_shapes_of_work()
+    {
+        var body = await _http.GetFromJsonAsync<JsonObject>("gateway/workflows");
+
+        var workflows = body!["workflows"]!.AsArray();
+        var ids = workflows.Select(w => (string?)w!["id"]).ToArray();
+        Assert.Equal(new[] { "mission", "standalone", "standalone-with-review" }, ids);
+    }
+
+    [Fact]
+    public async Task Every_workflow_states_its_seats_and_what_done_means()
+    {
+        var body = await _http.GetFromJsonAsync<JsonObject>("gateway/workflows");
+
+        foreach (var workflow in body!["workflows"]!.AsArray())
+        {
+            var name = (string?)workflow!["name"];
+            Assert.False(string.IsNullOrWhiteSpace(name));
+            Assert.False(string.IsNullOrWhiteSpace((string?)workflow["summary"]));
+            Assert.False(string.IsNullOrWhiteSpace((string?)workflow["whenToUse"]));
+            Assert.False(string.IsNullOrWhiteSpace((string?)workflow["humanCheckpoint"]));
+
+            var steps = workflow["steps"]!.AsArray();
+            Assert.NotEmpty(steps);
+            foreach (var step in steps)
+            {
+                // A step without a doer or without a definition of done is not a workflow step, it is a
+                // wish. These are the two fields the whole feature exists to make explicit.
+                Assert.False(string.IsNullOrWhiteSpace((string?)step!["doer"]), $"{name}: step has no doer");
+                Assert.False(string.IsNullOrWhiteSpace((string?)step["done"]), $"{name}: step has no done");
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Standalone_with_review_puts_the_review_in_a_separate_seat()
+    {
+        var body = await _http.GetFromJsonAsync<JsonObject>("gateway/workflows/standalone-with-review");
+
+        var steps = body!["steps"]!.AsArray();
+        Assert.Equal(2, steps.Count);
+        // The whole point of this workflow versus plain Standalone: the reviewing seat is not the seat
+        // that did the work. If these ever collapse to one doer, the workflow is a lie.
+        Assert.Equal("Worker", (string?)steps[0]!["doer"]);
+        Assert.Equal("Reviewer", (string?)steps[1]!["doer"]);
+    }
+
+    [Fact]
+    public async Task Standalone_has_no_review_seat()
+    {
+        var body = await _http.GetFromJsonAsync<JsonObject>("gateway/workflows/standalone");
+
+        var steps = body!["steps"]!.AsArray();
+        var step = Assert.Single(steps);
+        Assert.Null((string?)step!["reviewer"]);
+    }
+
+    [Fact]
+    public async Task Get_workflow_by_id_is_case_insensitive()
+    {
+        var body = await _http.GetFromJsonAsync<JsonObject>("gateway/workflows/MISSION");
+        Assert.Equal("Mission", (string?)body!["name"]);
+    }
+
+    [Fact]
+    public async Task Get_unknown_workflow_reports_not_found()
+    {
+        // No fallback to "the first workflow" or an empty object: an unknown id is an explicit 404.
+        var resp = await _http.GetAsync("gateway/workflows/does-not-exist");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task The_api_does_not_squat_on_the_cockpit_page_path()
+    {
+        // Regression: the catalog was first mapped at a bare /workflows, which is the path the Cockpit's
+        // Workflows PAGE owns. The Gateway serves the single-page app at "/" and falls unknown page paths
+        // back to index.html, so an API there WINS the path and a hard navigation to /workflows renders
+        // raw JSON instead of the page. Caught by opening the page in a browser, not by a green test.
+        var resp = await _http.GetAsync("workflows");
+        var body = await resp.Content.ReadAsStringAsync();
+
+        Assert.DoesNotContain("\"whenToUse\"", body);
+        Assert.DoesNotContain("\"humanCheckpoint\"", body);
+    }
+
+    private static int AllocateFreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/src/CcDirector.Gateway/Api/WorkflowEndpoints.cs
+++ b/src/CcDirector.Gateway/Api/WorkflowEndpoints.cs
@@ -1,0 +1,54 @@
+using CcDirector.Core.Utilities;
+using CcDirector.Gateway.Workflows;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace CcDirector.Gateway.Api;
+
+/// <summary>
+/// The workflow catalog (issue #1617): the shapes of work this fleet knows how to run.
+///
+///   GET /gateway/workflows        -> { workflows: [ ... ] }
+///   GET /gateway/workflows/{id}   -> { ... } | 404
+///
+/// The routes sit under /gateway (the same convention as /gateway/ai/*) and NOT at a bare /workflows,
+/// because the Cockpit's Workflows PAGE owns the /workflows path. The Gateway serves the single-page
+/// app at "/" and falls unknown page paths back to index.html, so an API mapped at /workflows would win
+/// that path and a hard navigation to the page would render raw JSON instead of the Cockpit.
+///
+/// The Gateway is the HOME for workflows. It serves them and every Director asks it, rather than each
+/// machine carrying its own private copy of how the team works. That is what makes an organisation-wide
+/// rollout possible later: an administrator defines the workflows once on their Gateway and every
+/// Director picks them up.
+///
+/// The set is built in and read-only at this step (see BuiltInWorkflows); authoring and editing is a
+/// later step. Inherits the host-wide token middleware, like every other Gateway route.
+/// </summary>
+internal static class WorkflowEndpoints
+{
+    public static void Map(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/gateway/workflows", () =>
+        {
+            var workflows = BuiltInWorkflows.All();
+            FileLog.Write($"[WorkflowEndpoints] list workflows: count={workflows.Count}");
+            return Results.Json(new { workflows });
+        });
+
+        app.MapGet("/gateway/workflows/{id}", (string id) =>
+        {
+            var workflow = BuiltInWorkflows.All()
+                .FirstOrDefault(w => string.Equals(w.Id, id, StringComparison.OrdinalIgnoreCase));
+            if (workflow is null)
+            {
+                FileLog.Write($"[WorkflowEndpoints] get workflow: id={id}, result=not found");
+                return Results.Json(new { error = $"no workflow with id '{id}'" },
+                    statusCode: StatusCodes.Status404NotFound);
+            }
+
+            FileLog.Write($"[WorkflowEndpoints] get workflow: id={id}, result=found");
+            return Results.Json(workflow);
+        });
+    }
+}

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -1443,6 +1443,12 @@ public sealed class GatewayHost : IAsyncDisposable
         // models, test a chat model, save the chosen wingman/speech model). Uses the vault credential.
         Api.AiModelsEndpoint.Map(_app, _keyVault);
 
+        // The workflow catalog (issue #1617): the shapes of work the fleet knows how to run - Mission,
+        // Standalone, Standalone with review. The Gateway is the home for these; Directors and the
+        // Cockpit ask it rather than each carrying a private copy. Built in and read-only at this step.
+        // Inherits the host-wide token middleware above.
+        Api.WorkflowEndpoints.Map(_app);
+
         // Gateway Centralization Phase 1 (issue #628): the inbound login-telemetry RELAY. The Director
         // POSTs its login-telemetry event here (instead of the cloud) and the Gateway forwards it on,
         // so the Gateway becomes the single egress. Best-effort: a backend failure is logged and the

--- a/src/CcDirector.Gateway/Workflows/BuiltInWorkflows.cs
+++ b/src/CcDirector.Gateway/Workflows/BuiltInWorkflows.cs
@@ -1,0 +1,131 @@
+namespace CcDirector.Gateway.Workflows;
+
+/// <summary>
+/// One step of a workflow: a named piece of work, who does it, who reviews it, and what finishing it
+/// means. Reviewer is null when the step has no separate review seat - which is itself a statement the
+/// workflow is making, not an omission.
+/// </summary>
+public sealed record WorkflowStep(
+    string Name,
+    string Description,
+    string Doer,
+    string? Reviewer,
+    string Done);
+
+/// <summary>
+/// A workflow: a named, saved definition of how a piece of work gets done by agents. The workflow -
+/// not the agent, and not a skill file in a repository - decides the shape of the work: which seats
+/// exist, which seat starts, which seat reviews, and where the human is asked.
+/// </summary>
+public sealed record WorkflowDefinition(
+    string Id,
+    string Name,
+    string Summary,
+    string WhenToUse,
+    string HumanCheckpoint,
+    IReadOnlyList<WorkflowStep> Steps);
+
+/// <summary>
+/// The workflows the Gateway ships with (issue #1617). These are the three shapes of work this fleet
+/// already runs by hand, written down so they can be seen and chosen rather than being implied by
+/// which skill file an agent happened to read.
+///
+/// They are BUILT IN and read-only at this step, on purpose. The Gateway is the home for workflows -
+/// it serves them, and every Director asks it rather than carrying a private copy - but authoring and
+/// editing them (in the Cockpit, and later per-tenant for an organisation) is a later step. Serving a
+/// fixed set first means the Cockpit page reads real Gateway data from day one instead of a stub that
+/// has to be torn out.
+/// </summary>
+public static class BuiltInWorkflows
+{
+    private static readonly IReadOnlyList<WorkflowDefinition> Definitions = new[]
+    {
+        new WorkflowDefinition(
+            Id: "mission",
+            Name: "Mission",
+            Summary: "An Architect settles the design, a Manager drives the phases, and Workers build. "
+                   + "The owner is bothered once, at the report.",
+            WhenToUse: "Work big enough to need a design settled before anyone builds, or work that runs "
+                     + "across more than one phase.",
+            HumanCheckpoint: "Once, at the quality report. The Architect directs the Manager; only "
+                           + "owner-level calls reach the human.",
+            Steps: new[]
+            {
+                new WorkflowStep(
+                    Name: "Settle the design",
+                    Description: "The Architect decides what is being built and why, and writes the phases down. "
+                               + "Nothing is built until the design is settled.",
+                    Doer: "Architect",
+                    Reviewer: null,
+                    Done: "The phases are written down and the why is stated."),
+                new WorkflowStep(
+                    Name: "Drive the phase",
+                    Description: "The Manager takes one phase and drives it to merged. A fresh Manager is seated "
+                               + "per phase so context does not silt up across phases.",
+                    Doer: "Manager",
+                    Reviewer: "Architect",
+                    Done: "The phase is merged to the main branch."),
+                new WorkflowStep(
+                    Name: "Build",
+                    Description: "Workers do the building under the Manager, each in its own worktree so two "
+                               + "workstreams never share a tree.",
+                    Doer: "Worker",
+                    Reviewer: "Manager",
+                    Done: "A merged pull request. Committed and pushed is still in progress."),
+                new WorkflowStep(
+                    Name: "Report",
+                    Description: "The quality report goes to the owner. This is the one interruption the mission "
+                               + "is allowed to spend.",
+                    Doer: "Manager",
+                    Reviewer: "Architect",
+                    Done: "The owner has the report."),
+            }),
+
+        new WorkflowDefinition(
+            Id: "standalone",
+            Name: "Standalone",
+            Summary: "One agent picks up the work and finishes it. No manager, no review seat.",
+            WhenToUse: "Work small enough that a second pair of eyes would cost more than it catches - a "
+                     + "typo, a version bump, a one-line fix with a test already around it.",
+            HumanCheckpoint: "Once, when the work is merged.",
+            Steps: new[]
+            {
+                new WorkflowStep(
+                    Name: "Do the work",
+                    Description: "One agent takes the work from the request to a merged pull request, in its own "
+                               + "worktree cut from the main branch.",
+                    Doer: "Worker",
+                    Reviewer: null,
+                    Done: "A merged pull request."),
+            }),
+
+        new WorkflowDefinition(
+            Id: "standalone-with-review",
+            Name: "Standalone with review",
+            Summary: "One agent does the work, a second and separate agent reviews it before it is called done.",
+            WhenToUse: "The default for ordinary work. Small enough not to need an Architect, big enough that "
+                     + "nobody should mark their own homework.",
+            HumanCheckpoint: "Once, when the review passes.",
+            Steps: new[]
+            {
+                new WorkflowStep(
+                    Name: "Do the work",
+                    Description: "One agent takes the work to a pull request, with the proof that it does what it "
+                               + "is supposed to.",
+                    Doer: "Worker",
+                    Reviewer: null,
+                    Done: "A pull request with proof attached."),
+                new WorkflowStep(
+                    Name: "Review",
+                    Description: "A SEPARATE agent - never the one that wrote it - verifies the work against the "
+                               + "reported symptom rather than trusting the report, then passes it or sends it back "
+                               + "with a written defect.",
+                    Doer: "Reviewer",
+                    Reviewer: null,
+                    Done: "The reviewer passed it, and the pull request is merged."),
+            }),
+    };
+
+    /// <summary>Every workflow the Gateway serves, in the order the Cockpit lists them.</summary>
+    public static IReadOnlyList<WorkflowDefinition> All() => Definitions;
+}


### PR DESCRIPTION
First step of thefrederiksen/devthrottle_internal#813: workflows become a thing you can see, served by the Gateway.

## What this does

**Workflows are a page now.** The Gateway serves three built-in workflows - Mission, Standalone, and Standalone with review - at `GET /gateway/workflows`, and a new Cockpit page at `/workflows` renders them. Each states when to use it, where the human is asked, and for each step: who does it, who reviews it, and what done means. A step with no review seat says "No review" rather than leaving a blank, because that is a real statement the workflow is making.

The page renders **what the Gateway serves**, not a list baked into the bundle. That is the architectural point of the issue - the Gateway is the home, every Director asks it, and later an administrator defines an organisation's workflows once and every machine picks them up.

Built in and read-only at this step, on purpose. Authoring them, and choosing one when starting work, are later steps, so the page ships no buttons it cannot honour.

**The rail loses its section labels.** FLEET, DATA, and SYSTEM were dim uppercase headers that lost to the item labels beneath them - three rows of noise rather than a chunking of the list. The list is flat now; the one surviving grouping is positional, not labeled: the app's own pages (Account, Your Throttle, Settings, About) sit at the bottom, away from the fleet work. Workflows sits with Schedule - Schedule is what runs when, Workflows is how work runs.

## A real bug this caught

The API was first mapped at a bare `/workflows`, which is the path the **page** owns. The Gateway serves the single-page app at `/` and falls unknown page paths back to `index.html`, so the API won the path and a hard navigation to the page rendered raw JSON instead of the Cockpit. That would have shipped broken in production, not only in dev.

It was caught by opening the page in a browser. No test caught it, so there is now one that does (`The_api_does_not_squat_on_the_cockpit_page_path`). The API lives at `/gateway/workflows`, matching the existing `/gateway/ai/*` convention.

## Proof

- Seven new tests in `WorkflowEndpointsTests`, each against a **real** GatewayHost over HTTP on an ephemeral port with an isolated root - so they prove the endpoint is actually mapped, not merely that `BuiltInWorkflows` returns a list.
- **Verified they fail on purpose**: unmapping the endpoint turns five red; re-introducing the route collision turns the regression test red on exactly that symptom.
- All seven test projects pass. One Gateway test failed in the first full run and passed on both reruns; its name was not captured, so it is not claimed here as related or unrelated - just reported.
- The page was driven in a real browser against a live Gateway: the rail renders flat, Workflows highlights under Schedule, the app pages sit at the bottom, and the three cards render live Gateway data.

## Not in this change

Icons in the rail (the flat list reads fine without them), editing workflows, choosing one when starting work, and per-tenant workflows. Each is its own step on thefrederiksen/devthrottle_internal#813.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
