### PR TITLE
fix(mobile): stop voice mode calling a narration missing before it has looked for it

### DIFF
--- a/apps/mobile/src/components/SessionAppBar.tsx
+++ b/apps/mobile/src/components/SessionAppBar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
+import { StatusPill } from "./StatusPill";
 import type { SessionManage } from "./useSessionManage";
 
 // The ONE app bar shared by every per-session screen: Chat, Terminal and Voice mode (owner design
@@ -18,9 +19,16 @@ import type { SessionManage } from "./useSessionManage";
 //     puts Snooze and Respond there. Screens with no bottom room for Snooze (Chat/Terminal, whose
 //     bottom is the message composer) pass showSnooze so it appears in this menu instead.
 //
-// The right edge is shared with the globally-mounted network StatusPill (.net-pill, position: fixed,
-// top-right). The app bar reserves space for it (--net-pill-reserve) so the overflow button sits
-// clear of it and the title no longer runs underneath it.
+// A CONTROL outranks an INDICATOR for the top-right corner. This bar used to put the overflow button
+// on the LEFT, because the globally-mounted network pill was fixed to the top-right and nothing wanted
+// to guess its width. The cost was a broken menu: .session-menu is anchored right:0 - correct for a
+// button on the right - so hanging it off a LEFT button opened it off the left edge of the screen,
+// cut in half and unreadable. The pill now rides the title row as an ordinary inline item (the fixed
+// one stands down on session screens, see GatedLayout), the button is back in the corner, and its menu
+// opens inward. Nothing guesses any widths: both rows are plain flex.
+//
+//   row 1:  [<- Sessions] ................... [...]     navigation left, menu right
+//   row 2:  102 devthrottle / f9e7 ....... ( o Fast )    name flexes, indicator rides along
 
 export interface SessionAppBarProps {
   title: string;
@@ -28,12 +36,17 @@ export interface SessionAppBarProps {
   /** Put Snooze/Unsnooze in the overflow menu. Screens that surface Snooze in their own bottom bar
    *  (Voice mode) leave this off, so the verb is never in two places at once. */
   showSnooze?: boolean;
+  /** Offer "Switch to voice mode" in the menu. The screens that are NOT voice (Chat/Terminal) pass
+   *  this so voice is reachable in one tap from where you already are, instead of making you open the
+   *  Voice mode tab first purely to find the button on it. */
+  showSwitchToVoice?: boolean;
   /** Screen-specific menu entries, rendered above Remove. Use <button className="menu-item">. */
   extraMenuItems?: ReactNode;
 }
 
-export function SessionAppBar({ title, manage, showSnooze = false, extraMenuItems }: SessionAppBarProps) {
+export function SessionAppBar({ title, manage, showSnooze = false, showSwitchToVoice = false, extraMenuItems }: SessionAppBarProps) {
   const navigate = useNavigate();
+  const { sessionId } = useParams<{ sessionId: string }>();
   const [open, setOpen] = useState(false);
   const [confirming, setConfirming] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
@@ -76,6 +89,10 @@ export function SessionAppBar({ title, manage, showSnooze = false, extraMenuItem
           &larr; Sessions
         </button>
 
+        {/* Claims the middle of row 1, pushing the menu button into the corner it should have had all
+            along. It guesses nothing: it just takes whatever is left between the two controls. */}
+        <div className="session-bar-spacer" />
+
         <div className="session-menu-wrap" ref={menuRef}>
           <button
             type="button"
@@ -90,6 +107,26 @@ export function SessionAppBar({ title, manage, showSnooze = false, extraMenuItem
 
           {open && (
             <div className="session-menu" role="menu">
+              {showSwitchToVoice && (
+                <button
+                  type="button"
+                  className="menu-item"
+                  role="menuitem"
+                  onClick={() => {
+                    setOpen(false);
+                    // Hand the switch-on to the Voice screen rather than doing it here: useVoiceMode
+                    // already owns that verb (mark the session Voice on its Director, then explain on
+                    // the Gateway). Duplicating it here would be a second copy free to disagree with
+                    // the first. The screen reads this and runs its own onSwitchOn once, on arrival.
+                    navigate(`/session/${encodeURIComponent(sessionId ?? "")}/voice`, {
+                      state: { switchOn: true },
+                    });
+                  }}
+                >
+                  Switch to voice mode
+                </button>
+              )}
+
               {showSnooze && (
                 <button
                   type="button"
@@ -127,19 +164,18 @@ export function SessionAppBar({ title, manage, showSnooze = false, extraMenuItem
           )}
         </div>
 
-        {/* Row one ends here. The right of this row is left EMPTY on purpose: it is where the
-            globally-mounted network pill (.net-pill, position: fixed, top-right) lands, so it reads
-            as the status item of this bar instead of sitting on top of a control. Nothing here
-            needs to guess how wide that pill is. */}
-        <div className="session-bar-spacer" />
       </header>
 
-      {/* The session name gets its OWN row, at full width. It cannot share the bar: between the back
-          button, the menu button and the fixed network pill there is not enough room left for a real
-          session name ("102 Ghost Directors from tests" collapsed to "102 M..."). This row is also
-          what the name used to do WRONG - run underneath the pill and get covered by it. Even with
-          this extra row the screen is shorter than before, because the three-slab manage row is gone. */}
-      <h1 className="term-title session-title">{title}</h1>
+      {/* The session name gets its OWN row. It cannot share row one: between the back button and the
+          menu button there is not enough room left for a real session name ("102 Ghost Directors from
+          tests" collapsed to "102 M..."). The network pill rides HERE, at the end of this row, because
+          it is an indicator - it reads as the status of this session's connection, it can no longer
+          cover the name the way the fixed pill did, and it is out of the corner the menu needs. The
+          name still flexes and ellipsizes (.term-title), so the pill costs it only the pill's width. */}
+      <div className="session-title-row">
+        <h1 className="term-title session-title">{title}</h1>
+        <StatusPill inline />
+      </div>
 
       {manage.error !== null && <div className="banner banner-error" role="alert">{manage.error}</div>}
       {manage.held && <span className="manage-held-pill">Snoozed</span>}

--- a/apps/mobile/src/components/StatusPill.tsx
+++ b/apps/mobile/src/components/StatusPill.tsx
@@ -5,12 +5,25 @@ import { useNetStatus } from "@devthrottle/client-core/net/useNetStatus";
 // grey dot + label that tells you your connection quality at a glance without opening a page. Its colour
 // comes from the authoritative direct-vs-relay for this device (never the speed-test guess), and it never
 // flashes red on the normal cold-start. Tapping it opens the full Diagnostics page.
-export function StatusPill() {
+//
+// It has two homes, because it is an INDICATOR and must never hold a corner a CONTROL needs:
+//
+//   * Default (fixed): pinned top-right on the screens that have no title row of their own to give it.
+//   * inline: an ordinary flex item, rendered on the session screens' title row (SessionAppBar). The
+//     fixed pill used to own the top-right corner of the session screens, which pushed the overflow
+//     menu button to the LEFT of the bar - and its menu, anchored right:0, then opened off the left
+//     edge of the screen and was unreadable. The indicator was costing the control its corner.
+export interface StatusPillProps {
+  /** Render as a normal flex item instead of a fixed top-right overlay. */
+  inline?: boolean;
+}
+
+export function StatusPill({ inline = false }: StatusPillProps) {
   const status = useNetStatus();
   return (
     <Link
       to="/diagnostics"
-      className={`net-pill net-pill-${status.level}`}
+      className={`net-pill net-pill-${status.level}${inline ? " net-pill-inline" : ""}`}
       title={status.detail}
       aria-label={`Network: ${status.label}. ${status.detail}`}
     >

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { createBrowserRouter, RouterProvider, Navigate, Outlet } from "react-router-dom";
+import { createBrowserRouter, RouterProvider, Navigate, Outlet, useLocation } from "react-router-dom";
 import { Home } from "./pages/Home";
 import { NewSession } from "./pages/NewSession";
 import { Terminal } from "./pages/Terminal";
@@ -57,10 +57,16 @@ function GatedLayout() {
   // The one global bad-connection banner (mobile-resilience mission): mounted once here so it pins to
   // the top of every gated screen and is the single voice for a bad connection. Hidden while the
   // connection is good; the pages keep their last-known content underneath either way.
+  // The network pill is fixed top-right on every screen that has no title row of its own to give it.
+  // The session screens DO have one, and they render their own inline pill on it (SessionAppBar), so
+  // the fixed one stands down there - otherwise both would show. The session screens need that corner
+  // back for their overflow menu button: while the pill held it, the button lived on the LEFT of the
+  // bar and its right-anchored menu opened off the left edge of the screen.
+  const onSessionScreen = useLocation().pathname.startsWith("/session/");
   return (
     <>
       <ConnectionBanner />
-      <StatusPill />
+      {!onSessionScreen && <StatusPill />}
       <Outlet />
     </>
   );

--- a/apps/mobile/src/pages/Chat.tsx
+++ b/apps/mobile/src/pages/Chat.tsx
@@ -86,7 +86,7 @@ export function Chat() {
     <div className="terminal-screen">
       {/* Snooze is in the overflow here: this screen's bottom belongs to the message composer, so
           there is no thumb-zone room for it (Voice mode, which has room, keeps it one tap). */}
-      <SessionAppBar title={name ?? "Session"} manage={manage} showSnooze />
+      <SessionAppBar title={name ?? "Session"} manage={manage} showSnooze showSwitchToVoice />
 
       <ViewTabs sessionId={sessionId} active="chat" />
 

--- a/apps/mobile/src/pages/Terminal.tsx
+++ b/apps/mobile/src/pages/Terminal.tsx
@@ -92,7 +92,7 @@ export function Terminal() {
     <div className="terminal-screen">
       {/* Snooze is in the overflow here: this screen's bottom belongs to the composer and the key
           rows, so there is no thumb-zone room for it (Voice mode, which has room, keeps it one tap). */}
-      <SessionAppBar title={name ?? "Session"} manage={manage} showSnooze />
+      <SessionAppBar title={name ?? "Session"} manage={manage} showSnooze showSwitchToVoice />
 
       <ViewTabs sessionId={sessionId} active="terminal" />
 

--- a/apps/mobile/src/pages/VoiceMode.tsx
+++ b/apps/mobile/src/pages/VoiceMode.tsx
@@ -20,8 +20,14 @@ export function VoiceMode() {
   // The roster hands the known voice-mode state on navigation (issue #1015), so the screen renders
   // the right state on the FIRST paint instead of flashing OFF while its first poll resolves. Read it
   // from the router here and pass it into the hook - the shared hook stays router-free.
+  //
+  // switchOn arrives from "Switch to voice mode" in the Chat/Terminal overflow menu (SessionAppBar):
+  // that menu item navigates here and asks the hook to run its own onSwitchOn, so the one place that
+  // knows how to enter voice mode stays the one place that does it.
   const location = useLocation();
-  const seededVoiceOn = (location.state as { voiceMode?: boolean } | null)?.voiceMode;
+  const navState = location.state as { voiceMode?: boolean; switchOn?: boolean } | null;
+  const seededVoiceOn = navState?.voiceMode;
+  const autoSwitchOn = navState?.switchOn;
 
   const {
     voiceOn,
@@ -59,7 +65,7 @@ export function VoiceMode() {
     onTogglePlay,
     onRespondSend,
     onRespondSendAudio,
-  } = useVoiceMode(sessionId, { seededVoiceOn });
+  } = useVoiceMode(sessionId, { seededVoiceOn, autoSwitchOn });
 
   // Snooze and Remove share this one live held-state, so the bottom bar and the overflow menu can
   // never disagree about it.

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -2113,31 +2113,42 @@ a.banner-btn {
    destructive Remove were the same size and colour, sitting directly under the Voice mode tab -
    which is how Remove got mis-tapped.
 
-   Layout, and why it is two rows: the top-right corner is NOT ours. The network pill (.net-pill) is
-   mounted globally and is position: fixed, top-right, and its width changes with its label ("Fast" /
-   "Warming up" / "Direct LAN"). So:
+   Layout, and why it is two rows:
 
-     row 1:  [<- Sessions] [...]            <- controls left; the right is left free for the pill
-     row 2:  the session name, full width   <- sits BELOW the pill, so nothing can cover it
+     row 1:  [<- Sessions] .................... [...]      navigation left, overflow menu right
+     row 2:  102 devthrottle / f9e7 ..... ( o Fast )       name flexes; the indicator rides the end
 
-   Putting the controls on the left means no code has to guess how wide the pill is. The name used to
-   share row 1 and run underneath the pill; giving it its own row is what makes a real session name
-   ("102 Ghost Directors from tests") readable instead of "102 M...". */
+   The corner belongs to the CONTROL, not the indicator. This bar used to put the menu button on the
+   LEFT because the network pill was position:fixed in the top-right and nothing wanted to guess how
+   wide it was ("Fast" / "Warming up" / "Direct LAN"). That broke the menu outright: .session-menu is
+   anchored right:0, which is correct for a button on the right, so hanging it off a LEFT button opened
+   it off the left edge of the screen - about half of it was unreadable. The pill is now an ordinary
+   inline item on row 2 (.net-pill-inline; the fixed one stands down on session screens), so the button
+   is back in the corner and its menu opens inward. Both rows are plain flex - nothing guesses widths.
+
+   The name keeps its own row: between the two controls there was never enough of row 1 left for a real
+   session name ("102 Ghost Directors from tests" collapsed to "102 M..."). Sharing row 2 with the pill
+   costs it only the pill's width, and .term-title already flexes and ellipsizes. */
 .session-app-bar {
   gap: 8px;
 }
 
-/* Pushes nothing - it just claims the empty right end of row 1 where the fixed pill sits. */
+/* Claims the middle of row 1, so the menu button is pushed to the right edge. Guesses nothing - it
+   takes whatever is left between the back button and the menu button. */
 .session-bar-spacer {
   flex: 1 1 auto;
   min-width: 0;
 }
 
-
-/* Row two: the session name, full width, nothing overlapping it. */
-.session-title {
-  flex: 0 0 auto;
+/* Row two: the session name, flexing, with the network pill parked at its end. */
+.session-title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   padding: 6px 2px 2px;
+}
+
+.session-title {
   font-size: 17px;
 }
 
@@ -2793,6 +2804,17 @@ a.banner-btn {
   text-decoration: none;
   line-height: 1;
 }
+/* The session screens give the pill a real home on their title row instead of letting it hold the
+   top-right corner (which cost the overflow menu its corner, and broke that menu - see .session-app-bar).
+   Declared AFTER .net-pill so it wins on position/inset at equal specificity. */
+.net-pill-inline {
+  position: static;
+  top: auto;
+  right: auto;
+  z-index: auto;
+  flex: 0 0 auto;
+}
+
 .net-pill-dot {
   width: 8px;
   height: 8px;

--- a/packages/client-core/src/voice/useVoiceMode.ts
+++ b/packages/client-core/src/voice/useVoiceMode.ts
@@ -13,6 +13,7 @@ import {
 import { backgroundTranscribeAndSend, type CapturedUtterance } from "../dictation/backgroundSend";
 import { ensureClip, getClipState, getVoiceMeta, saveVoiceMeta, stopPlayback, useVoiceClips, type ClipPhase } from "./clips";
 import { positionFor, saveMark, wasAutoPlayed } from "./playbackPositions";
+import { isAudioUnavailable } from "./voiceAvailability";
 import { isWorking } from "../sessions/ordering";
 
 // Session Voice mode (issue #850): the hands-free Wingman narration screen, the third session view
@@ -123,13 +124,21 @@ export interface VoiceModeView {
   onRespondSendAudio: (captured: CapturedUtterance) => void;
 }
 
-export function useVoiceMode(sessionId: string | undefined, opts?: { seededVoiceOn?: boolean }): VoiceModeView {
+export function useVoiceMode(
+  sessionId: string | undefined,
+  opts?: { seededVoiceOn?: boolean; autoSwitchOn?: boolean },
+): VoiceModeView {
   const sid = sessionId ?? "";
 
   // The roster hands the known voice-mode state on navigation (issue #1015), so the screen renders
   // the right state on the FIRST paint instead of flashing OFF while its first poll resolves. The
   // view reads this seed from its router location and passes it in - the hook stays router-free.
   const seededVoiceOn = opts?.seededVoiceOn;
+  // Arriving from "Switch to voice mode" in another screen's overflow menu: turn voice on for this
+  // session on arrival, so the menu item does the whole job. The menu deliberately does NOT make those
+  // calls itself - onSwitchOn below is the ONE implementation of that verb, and a second copy in a menu
+  // handler would be free to drift from it.
+  const autoSwitchOn = opts?.autoSwitchOn;
 
   const [name, setName] = useState<string | null>(null);
   const [session, setSession] = useState<SessionDto | null>(null);
@@ -138,7 +147,20 @@ export function useVoiceMode(sessionId: string | undefined, opts?: { seededVoice
   const [error, setError] = useState<string | null>(null);
   // Whether a real poll has resolved the true state yet. Until it has, we never paint the OFF card -
   // the screen starts blank (or ON when the roster seeded it) and only shows OFF once confirmed.
+  // NOTE: this is knowledge of the SESSION only. It says nothing about the voice - it is set as soon
+  // as listSessions resolves, while the getWingmanVoice call below has not even been made yet. The
+  // unavailable verdict used to read it as if it meant both, which is why the screen announced "no
+  // narration" and then played the narration; voiceKnown is the fact it actually needed.
   const [pollDone, setPollDone] = useState(false);
+  // Whether the getWingmanVoice fetch has RESOLVED for this session - i.e. we have actually asked
+  // about the voice and been answered. Only then may the screen say voice is unavailable.
+  const [voiceKnown, setVoiceKnown] = useState(false);
+
+  // A different session is a different question: forget what we knew about the last one's voice, so
+  // its answer can never be used to declare THIS session's narration missing.
+  useEffect(() => {
+    setVoiceKnown(false);
+  }, [sid]);
 
   // Optimistic "this session is now a voice session" the instant Switch is tapped, so the screen
   // moves to the working state immediately (responsive UI) before the roster reflects voiceMode.
@@ -233,6 +255,7 @@ export function useVoiceMode(sessionId: string | undefined, opts?: { seededVoice
 
         const v = await getWingmanVoice(sid, signal);
         setVoice((prev) => (sameVoice(prev, v) ? prev : v));
+        setVoiceKnown(true); // we have now ASKED about the voice, so a "no narration" verdict is allowed
         saveVoiceMeta(sid, v); // keep the cached state + text fresh for the next instant entry (#1015)
         // Kick the phone-side download the moment a (new) clip is ready on the Gateway.
         if (v.ready && v.generatedAt) void ensureClip(sid, v.generatedAt);
@@ -315,6 +338,10 @@ export function useVoiceMode(sessionId: string | undefined, opts?: { seededVoice
     setEnabling(true);
     setError(null);
     setLocalEnabled(true); // show the working screen immediately (responsive UI)
+    // Voice was just switched on, so nothing has asked about THIS session's narration yet. Without
+    // this the old answer ("off", hence no voice) survived the switch and the screen flashed the red
+    // unavailable banner over the top of the narration it had just asked the Gateway to make.
+    setVoiceKnown(false);
     try {
       // Two steps, matching the native phone app's enter-voice flow: first mark the session a Voice
       // session on the owning Director (ViewMode=Voice) so SessionDto.VoiceMode flips true and the
@@ -347,6 +374,7 @@ export function useVoiceMode(sessionId: string | undefined, opts?: { seededVoice
     stopPlayback(); // stop any roster clip too
     setLocalEnabled(false);
     setVoice(null);
+    setVoiceKnown(false);
     setEnableNote("");
     setSession((prev) => (prev ? { ...prev, voiceMode: false } : prev));
     restoredForRef.current = "";
@@ -542,17 +570,38 @@ export function useVoiceMode(sessionId: string | undefined, opts?: { seededVoice
   const gatewayPreparing = voiceOn && !speaking && !agentWorking && Boolean(session?.voiceGenerating);
   const phoneDownloadPending =
     voiceOn && !speaking && !agentWorking && Boolean(session?.voiceAudioReady) && clip.phase !== "error";
-  const audioUnavailable =
-    voiceOn
-    && pollDone
-    && !speaking
-    && !agentWorking
-    && !gatewayPreparing
-    && !phoneDownloadPending
-    && enableNote.length === 0;
+  // "Voice unavailable" is a POSITIVE finding - something looked and reported no narration - never the
+  // gap left when no other state matched. The rule and the two windows it closes are documented in
+  // voiceAvailability.ts; the short version is that this screen used to say "no narration is ready to
+  // play" while it was still fetching the answer, and then play the narration. Notably clipDownloading
+  // asks THIS PHONE what it holds, where phoneDownloadPending only relays what the GATEWAY holds.
+  const audioUnavailable = isAudioUnavailable({
+    voiceOn,
+    sessionKnown: pollDone,
+    voiceKnown,
+    speaking,
+    agentWorking,
+    gatewayPreparing,
+    phoneDownloadPending,
+    clipDownloading: clip.phase === "downloading",
+    hasEnableNote: enableNote.length > 0,
+  });
   const working = voiceOn && !speaking && !audioUnavailable;
   const narrative = voice?.spoken ?? "";
   const title = session?.number ? `${session.number} ${name ?? "Session"}` : name ?? "Session";
+
+  // "Switch to voice mode" from another screen's overflow menu navigated here asking for voice ON.
+  // Run the screen's own onSwitchOn exactly once, and only once a poll has told us the session is not
+  // already a voice session - so arriving at a session that is ALREADY in voice mode is a no-op rather
+  // than a pointless re-narration of the turn you came to listen to.
+  const autoSwitchedRef = useRef(false);
+  useEffect(() => {
+    if (autoSwitchOn !== true || autoSwitchedRef.current) return;
+    if (!pollDone) return; // we do not know yet whether it is already on; the next tick decides
+    autoSwitchedRef.current = true;
+    if (voiceOn) return;
+    void onSwitchOn();
+  }, [autoSwitchOn, pollDone, voiceOn, onSwitchOn]);
 
   // WHY voice is unavailable, straight from the Gateway. This field has been arriving on every poll and
   // being thrown away: it had ZERO readers, while the screens hardcoded a guess ("the Gateway has not

--- a/packages/client-core/src/voice/voiceAvailability.test.ts
+++ b/packages/client-core/src/voice/voiceAvailability.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { isAudioUnavailable, type VoiceAvailabilityInputs } from "./voiceAvailability";
+
+// The reported bug, in the owner's words: "when I go into voice mode, it often shows that I don't have
+// the voice generated, even though it's there and it plays it. So it says voice unavailable, no
+// narration to play, and then it plays the voice."
+//
+// That is one defect wearing two hats, and both are pinned below: the screen rendered its failure copy
+// during windows in which it had not yet looked. These tests are written from the two windows, so a
+// future edit that goes back to deriving "unavailable" by elimination fails here rather than on a phone.
+
+/** The state in which voice genuinely IS unavailable: we looked, and nothing is coming. */
+const LOOKED_AND_NOTHING_THERE: VoiceAvailabilityInputs = {
+  voiceOn: true,
+  sessionKnown: true,
+  voiceKnown: true,
+  speaking: false,
+  agentWorking: false,
+  gatewayPreparing: false,
+  phoneDownloadPending: false,
+  clipDownloading: false,
+  hasEnableNote: false,
+};
+
+describe("isAudioUnavailable", () => {
+  // The control. If this ever goes false the verdict has been guarded into never firing at all, and a
+  // genuinely voiceless session would spin on the working card forever.
+  it("says unavailable once we have looked and nothing is on its way", () => {
+    expect(isAudioUnavailable(LOOKED_AND_NOTHING_THERE)).toBe(true);
+  });
+
+  // Window 1: pollDone means "I know the SESSION", not "I know the VOICE". The poll sets it when
+  // listSessions resolves, which is before it awaits getWingmanVoice - so the whole voice round trip
+  // ran with the verdict already firing, and the narration arrived immediately after and played.
+  it("stays silent while the voice fetch has not resolved, even though the session is known", () => {
+    expect(isAudioUnavailable({ ...LOOKED_AND_NOTHING_THERE, voiceKnown: false })).toBe(false);
+  });
+
+  // Window 2: the only download guard read session.voiceAudioReady - the GATEWAY's cache. What plays
+  // is the clip in THIS PHONE's Cache Storage. When the Gateway had dropped its copy but the phone was
+  // warming its own, every guard was false, the red banner rendered - and then the clip played.
+  it("stays silent while this phone is warming a clip the Gateway no longer holds", () => {
+    expect(
+      isAudioUnavailable({
+        ...LOOKED_AND_NOTHING_THERE,
+        phoneDownloadPending: false, // the Gateway says it has no audio...
+        clipDownloading: true, // ...but the phone is pulling the bytes it does have
+      }),
+    ).toBe(false);
+  });
+
+  it("stays silent before the session itself is known", () => {
+    expect(isAudioUnavailable({ ...LOOKED_AND_NOTHING_THERE, sessionKnown: false })).toBe(false);
+  });
+
+  it("never fires for a session that is not in voice mode - that is the off card, not a failure", () => {
+    expect(isAudioUnavailable({ ...LOOKED_AND_NOTHING_THERE, voiceOn: false, voiceKnown: false })).toBe(false);
+  });
+
+  it("stays silent while a clip is playable", () => {
+    expect(isAudioUnavailable({ ...LOOKED_AND_NOTHING_THERE, speaking: true })).toBe(false);
+  });
+
+  it("stays silent while the agent is working, where the narration is withheld on purpose", () => {
+    expect(isAudioUnavailable({ ...LOOKED_AND_NOTHING_THERE, agentWorking: true })).toBe(false);
+  });
+
+  it("stays silent while the Gateway is synthesizing the narration", () => {
+    expect(isAudioUnavailable({ ...LOOKED_AND_NOTHING_THERE, gatewayPreparing: true })).toBe(false);
+  });
+
+  it("stays silent while the Gateway holds audio the phone has not pulled yet", () => {
+    expect(isAudioUnavailable({ ...LOOKED_AND_NOTHING_THERE, phoneDownloadPending: true })).toBe(false);
+  });
+
+  it("stays silent when the Gateway said there is nothing to narrate yet", () => {
+    expect(isAudioUnavailable({ ...LOOKED_AND_NOTHING_THERE, hasEnableNote: true })).toBe(false);
+  });
+});

--- a/packages/client-core/src/voice/voiceAvailability.ts
+++ b/packages/client-core/src/voice/voiceAvailability.ts
@@ -1,0 +1,77 @@
+// The "voice is unavailable" verdict for the Voice mode screen, as a pure function.
+//
+// It lives in its own module, with no imports, because it is the one rule on this screen that was
+// getting silently mis-derived and it needs to be directly testable without a React tree.
+//
+// THE RULE: "unavailable" is a POSITIVE finding. It is what we render when something actually told us
+// there is no narration - never the gap left over when no other state happened to match.
+//
+// It used to be pure elimination:
+//
+//   audioUnavailable = voiceOn && pollDone && !speaking && !agentWorking
+//                      && !gatewayPreparing && !phoneDownloadPending && enableNote.length === 0
+//
+// Nothing in that asserts the narration is missing. So the screen announced "No narration is ready to
+// play" during every window in which it had simply not looked yet - and then played the narration a
+// second later when the answer arrived. Two windows did it, and both are real:
+//
+//   1. pollDone means "I know the SESSION", not "I know the VOICE". The poll sets it the moment
+//      listSessions resolves, which is BEFORE it awaits getWingmanVoice - so the entire voice round
+//      trip ran with pollDone already true and the verdict already firing. `voiceKnown` closes that:
+//      it is set only once the voice fetch has actually RESOLVED.
+//
+//   2. The only download guard, phoneDownloadPending, is stamped from session.voiceAudioReady - the
+//      GATEWAY's cache (GatewayHost wires it to WingmanVoiceService.HasVoice). But what actually
+//      plays is the clip held on THIS PHONE, in Cache Storage, warmed by ensureClip with no network
+//      at all. Those are two different caches. While the phone was warming a clip the Gateway no
+//      longer had, every guard was false and the red banner rendered on top of audio that was about
+//      to play. `clipDownloading` closes that: to know what the phone has, ask the phone.
+//
+// Absence of evidence was being rendered as evidence of absence. While we do not know, the caller
+// falls through to the working card and stays quiet; we only say "unavailable" once something said so.
+
+export interface VoiceAvailabilityInputs {
+  /** This is a voice session (confirmed by the roster, or optimistically just switched on). */
+  voiceOn: boolean;
+  /** A poll has resolved THIS SESSION. Not a statement about its voice. */
+  sessionKnown: boolean;
+  /** The getWingmanVoice fetch has RESOLVED for this session - we have actually asked. */
+  voiceKnown: boolean;
+  /** A phone-ready clip is playable right now. */
+  speaking: boolean;
+  /** The agent has resumed: the finished-turn narration is stale and is not offered. */
+  agentWorking: boolean;
+  /** The Gateway says it is synthesizing this turn's narration now. */
+  gatewayPreparing: boolean;
+  /** The Gateway holds audio this phone has not finished pulling down. */
+  phoneDownloadPending: boolean;
+  /** This phone is fetching or warming the clip bytes right now (clips.ts "downloading"). */
+  clipDownloading: boolean;
+  /** The Gateway told us there is genuinely nothing to narrate yet (a fresh/text-only session). */
+  hasEnableNote: boolean;
+}
+
+/** True only when we have looked and something told us there is no narration to play. */
+export function isAudioUnavailable(i: VoiceAvailabilityInputs): boolean {
+  // Not a voice session: the screen shows the off card, not a failure.
+  if (!i.voiceOn) return false;
+
+  // We have not looked yet. Not knowing is not the same as nothing being there - this is the whole
+  // bug. Both facts are required: the session AND the voice.
+  if (!i.sessionKnown) return false;
+  if (!i.voiceKnown) return false;
+
+  // Audio is playable, or is deliberately withheld because the turn moved on.
+  if (i.speaking) return false;
+  if (i.agentWorking) return false;
+
+  // Audio is on its way - from the Gateway, or into this phone's own cache.
+  if (i.gatewayPreparing) return false;
+  if (i.phoneDownloadPending) return false;
+  if (i.clipDownloading) return false;
+
+  // There is nothing to narrate yet, which the working card already says truthfully in its own words.
+  if (i.hasEnableNote) return false;
+
+  return true;
+}


### PR DESCRIPTION
Voice mode announced **"Voice unavailable / No narration is ready to play"** and then played the narration a moment later. Reported by the owner, who uses this daily.

## The bug: one rule stated backwards

The verdict was derived by elimination:

```
audioUnavailable = voiceOn && pollDone && !speaking && !agentWorking
                   && !gatewayPreparing && !phoneDownloadPending && !enableNote
```

Nothing in that asserts the narration is missing. It says "no good state matched, so show the failure copy" - which renders *I have not looked yet* as *there is nothing there*. Two windows made it fire, and both are real:

1. **`pollDone` means "I know the SESSION", not "I know the VOICE".** The poll sets it as soon as `listSessions` resolves, which is *before* it awaits `getWingmanVoice` - so the whole voice round trip, and the clip download after it, ran with the banner already up. `voiceKnown` closes that: set only once the voice fetch has actually **resolved**. It also resets on switch-on, so tapping "Switch to voice mode" no longer flashes the same false banner.

2. **It asked the wrong cache.** The only download guard, `phoneDownloadPending`, reads `session.voiceAudioReady` - the **Gateway's** cache (`GatewayHost` -> `WingmanVoiceService.HasVoice`). What actually plays is the clip on **this phone**, in Cache Storage, warmed by `ensureClip` with no network at all. Two different caches. While the phone warmed a clip the Gateway had dropped, every guard was false and the banner rendered over audio that was about to play. `clipDownloading` closes that: to know what the phone holds, ask the phone.

"Unavailable" is now a **positive finding**, in a dependency-free `voiceAvailability.ts` so it is testable without a React tree. While we do not know, the screen shows the working card and stays quiet.

## The app bar, broken by the same corner-squatting

```
row 1:  [<- Sessions] ................... [...]
row 2:  102 devthrottle / f9e7 ..... ( o Fast )
```

The overflow button sat on the **left** because the network pill was `position: fixed` top-right and nothing wanted to guess its width. But `.session-menu` is anchored `right: 0` - correct for a button on the right - so off a **left** button it opened off the left edge. Measured: **39px of a 390px viewport cut away**, rendering "Turn voice off" as "rn voice off" and "Remove session" as "move session".

A control outranks an indicator for that corner. The pill is now an ordinary inline item on the title row (the fixed one stands down on session screens; the roster and every other screen keep theirs unchanged), the button is back in the corner, and the menu opens inward. Both rows are plain flex - nothing guesses any widths.

Voice mode is also now reachable in one tap from Chat and Terminal via **"Switch to voice mode"** in that menu, instead of making you open the Voice tab first purely to find the button on it. The menu item navigates and asks the screen to run its own `onSwitchOn`, so `useVoiceMode` stays the ONE implementation of that verb.

## Proof

The tests fail on purpose: reverting to the elimination logic turns exactly the two window tests red with the reported symptom, and leaves all eight controls green - including "genuinely unavailable still reports unavailable", so the verdict has not just been guarded into never firing.

Driven in the real app (Vite dev + a fetch shim, 390x844 mobile emulation):

- menu fully on screen (left 170, right 378 of 390); before: left **-39**
- title and pill share row 2, no overlap; exactly one pill per screen
- Chat menu shows `Switch to voice mode | Snooze | Remove session`
- roster pill still `position: fixed`, top-right, unchanged

Typecheck clean across all three workspaces, eslint clean, 457 tests pass, mobile production build succeeds.

**Note:** CI (`ci.yml`) is .NET only and runs no JavaScript tests, so the vitest suite here is local-run only. Worth wiring up separately.

The Cockpit Voice tab shares `useVoiceMode`, so it gets the voice fix for free; the app bar changes are mobile-only.

Generated with [Claude Code](https://claude.com/claude-code)
