### PR TITLE
feat(cockpit): give the rail icons, so the flat list scans by shape (#1617)

### DIFF
--- a/apps/cockpit/src/AppShell.tsx
+++ b/apps/cockpit/src/AppShell.tsx
@@ -1,5 +1,6 @@
 import { NavLink, Outlet, useLocation } from "react-router-dom";
 import { useKeepWarm } from "@devthrottle/client-core/net/useKeepWarm";
+import { NavIcon, type NavIconName } from "./components";
 import { CockpitStatusPill } from "./network/CockpitStatusPill";
 
 // The desktop layout frame (epic #967): a two-region shell - a left rail (navigation) and the main
@@ -21,6 +22,10 @@ import { CockpitStatusPill } from "./network/CockpitStatusPill";
 // category invented to justify a header. So the list is flat now, which is what comparable product
 // navigation does at this size.
 //
+// Every destination carries an ICON, and that is what replaced the headers rather than merely
+// decorating them: in a flat rail the scan is carried by SHAPE - you find the row by silhouette
+// before you read the word - which is the job the dim headers were failing to do. See NavIcon.
+//
 // The one surviving grouping is positional, not labeled: the destinations about the app itself
 // (Account, Your Throttle, Settings, About) sit in a second list pinned to the BOTTOM of the rail,
 // away from the fleet work. That is a grouping you feel without being told.
@@ -35,6 +40,7 @@ import { CockpitStatusPill } from "./network/CockpitStatusPill";
 interface NavItem {
   to: string;
   label: string;
+  icon: NavIconName;
   subtree?: string;
 }
 
@@ -42,25 +48,25 @@ interface NavItem {
 // Workflows sits with Schedule on purpose - Schedule is what runs when, Workflows is how work runs,
 // and it is next to the place you start work rather than filed away under settings.
 const NAV_MAIN: ReadonlyArray<NavItem> = [
-  { to: "/fleet-map", label: "Fleet Map" },
-  { to: "/sessions", label: "Sessions", subtree: "/session" },
-  { to: "/directors", label: "Directors" },
-  { to: "/schedule", label: "Schedule" },
-  { to: "/workflows", label: "Workflows" },
-  { to: "/dictionary", label: "Dictionary" },
-  { to: "/transcripts", label: "Voice Recorder" },
-  { to: "/exes", label: "Executables" },
-  { to: "/transcription", label: "Transcription" },
-  { to: "/network", label: "Network" },
-  { to: "/learn", label: "Learning" },
+  { to: "/fleet-map", label: "Fleet Map", icon: "fleet-map" },
+  { to: "/sessions", label: "Sessions", icon: "sessions", subtree: "/session" },
+  { to: "/directors", label: "Directors", icon: "directors" },
+  { to: "/schedule", label: "Schedule", icon: "schedule" },
+  { to: "/workflows", label: "Workflows", icon: "workflows" },
+  { to: "/dictionary", label: "Dictionary", icon: "dictionary" },
+  { to: "/transcripts", label: "Voice Recorder", icon: "voice-recorder" },
+  { to: "/exes", label: "Executables", icon: "executables" },
+  { to: "/transcription", label: "Transcription", icon: "transcription" },
+  { to: "/network", label: "Network", icon: "network" },
+  { to: "/learn", label: "Learning", icon: "learning" },
 ];
 
 // This browser's account and the app's own settings - pinned to the bottom of the rail.
 const NAV_FOOT: ReadonlyArray<NavItem> = [
-  { to: "/account", label: "Account" },
-  { to: "/your-throttle", label: "Your Throttle" },
-  { to: "/settings", label: "Settings" },
-  { to: "/about", label: "About" },
+  { to: "/account", label: "Account", icon: "account" },
+  { to: "/your-throttle", label: "Your Throttle", icon: "throttle" },
+  { to: "/settings", label: "Settings", icon: "settings" },
+  { to: "/about", label: "About", icon: "about" },
 ];
 
 export function AppShell() {
@@ -109,7 +115,8 @@ function NavList({
                 isActive || inSubtree ? "nav-link nav-link-active" : "nav-link"
               }
             >
-              {item.label}
+              <NavIcon name={item.icon} />
+              <span className="nav-link-label">{item.label}</span>
             </NavLink>
           </li>
         );

--- a/apps/cockpit/src/components/NavIcon.tsx
+++ b/apps/cockpit/src/components/NavIcon.tsx
@@ -1,0 +1,180 @@
+// The left-rail icons (issue #1617 follow-up).
+//
+// The rail's section labels were removed because they were not chunking the list. What actually
+// carries the scan in a flat rail is SHAPE: every row gets a distinct silhouette, so you hit the
+// destination you want by outline before you read the word. That only works if the shapes are
+// genuinely distinct from each other - which is the constraint that picked this set.
+//
+// These are hand-drawn inline SVG rather than an icon package. The Cockpit has four dependencies
+// (react, react-dom, react-router-dom, client-core); adding a library and its build weight for
+// fifteen glyphs is not a trade worth making, and inline paths cannot go missing at runtime.
+//
+// Every icon is drawn on the same 24x24 grid with the same 2px stroke and round caps, and paints in
+// currentColor - so a row's icon takes the nav link's color for free, including the dim/hover/active
+// states, and the set reads as one family rather than fifteen separate drawings.
+
+export type NavIconName =
+  | "fleet-map"
+  | "sessions"
+  | "directors"
+  | "schedule"
+  | "workflows"
+  | "dictionary"
+  | "voice-recorder"
+  | "executables"
+  | "transcription"
+  | "network"
+  | "learning"
+  | "account"
+  | "throttle"
+  | "settings"
+  | "about";
+
+// The shapes, keyed by name. Each value is the icon's paint - the <svg> wrapper (grid, stroke, size)
+// is applied once below, so no glyph can drift off the shared geometry.
+const PAINT: Record<NavIconName, JSX.Element> = {
+  // A folded map: the fleet's spatial picture.
+  "fleet-map": (
+    <>
+      <path d="M14.1 5.55a2 2 0 0 1-1.79 0L8.1 3.45a2 2 0 0 0-1.79 0L3.55 4.83A1 1 0 0 0 3 5.72v12.76a1 1 0 0 0 1.45.9l2.86-1.43a2 2 0 0 1 1.79 0l4.21 2.11a2 2 0 0 0 1.79 0l3.66-1.83a1 1 0 0 0 .55-.9V4.62a1 1 0 0 0-1.45-.9z" />
+      <path d="M9 3.24v15" />
+      <path d="M15 5.76v15" />
+    </>
+  ),
+  // A terminal prompt: the thing a session actually is.
+  sessions: (
+    <>
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <path d="m7 11 2-2-2-2" />
+      <path d="M11 13h4" />
+    </>
+  ),
+  // A monitor: one machine running the fleet.
+  directors: (
+    <>
+      <rect x="2" y="3" width="20" height="14" rx="2" />
+      <path d="M8 21h8" />
+      <path d="M12 17v4" />
+    </>
+  ),
+  // A calendar: what runs when.
+  schedule: (
+    <>
+      <rect x="3" y="4" width="18" height="18" rx="2" />
+      <path d="M16 2v4" />
+      <path d="M8 2v4" />
+      <path d="M3 10h18" />
+    </>
+  ),
+  // Two boxes joined by a branching path: how work runs. Deliberately unlike the calendar next to it.
+  workflows: (
+    <>
+      <rect x="3" y="3" width="8" height="8" rx="2" />
+      <rect x="13" y="13" width="8" height="8" rx="2" />
+      <path d="M7 11v4a2 2 0 0 0 2 2h4" />
+    </>
+  ),
+  // A book.
+  dictionary: (
+    <>
+      <path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H19a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1H6.5a2.5 2.5 0 0 1 0-5H20" />
+    </>
+  ),
+  // A microphone.
+  "voice-recorder": (
+    <>
+      <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z" />
+      <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+      <path d="M12 19v3" />
+    </>
+  ),
+  // A package: the built binaries.
+  executables: (
+    <>
+      <path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+      <path d="m3.3 7 8.7 5 8.7-5" />
+      <path d="M12 22V12" />
+    </>
+  ),
+  // A waveform: speech turned into text.
+  transcription: (
+    <>
+      <path d="M2 12h2" />
+      <path d="M6 8v8" />
+      <path d="M10 5v14" />
+      <path d="M14 8v8" />
+      <path d="M18 5v14" />
+      <path d="M22 12h-2" />
+    </>
+  ),
+  // A globe: how the machines reach each other.
+  network: (
+    <>
+      <circle cx="12" cy="12" r="10" />
+      <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
+      <path d="M2 12h20" />
+    </>
+  ),
+  // A graduation cap.
+  learning: (
+    <>
+      <path d="M22 10 12 5 2 10l10 5z" />
+      <path d="M6 12v5c0 1.66 2.69 3 6 3s6-1.34 6-3v-5" />
+    </>
+  ),
+  // A person.
+  account: (
+    <>
+      <circle cx="12" cy="7" r="4" />
+      <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
+    </>
+  ),
+  // A gauge: your throttle.
+  throttle: (
+    <>
+      <path d="M3.34 19a10 10 0 1 1 17.32 0" />
+      <path d="m12 14 4-4" />
+    </>
+  ),
+  // A gear.
+  settings: (
+    <>
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+    </>
+  ),
+  // An information mark.
+  about: (
+    <>
+      <circle cx="12" cy="12" r="10" />
+      <path d="M12 16v-4" />
+      <path d="M12 8h.01" />
+    </>
+  ),
+};
+
+export interface NavIconProps {
+  name: NavIconName;
+}
+
+/**
+ * One rail icon. Decorative: the nav link's text is the accessible name, so the icon is hidden from
+ * screen readers rather than repeating that word.
+ */
+export function NavIcon({ name }: NavIconProps) {
+  return (
+    <svg
+      className="nav-icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      {PAINT[name]}
+    </svg>
+  );
+}

--- a/apps/cockpit/src/components/index.ts
+++ b/apps/cockpit/src/components/index.ts
@@ -40,3 +40,6 @@ export type { SortDirection, SortState } from "./dataTableCore";
 
 export { useFlash } from "./useFlash";
 export type { Flash, FlashController } from "./useFlash";
+
+export { NavIcon } from "./NavIcon";
+export type { NavIconName, NavIconProps } from "./NavIcon";

--- a/apps/cockpit/src/styles.css
+++ b/apps/cockpit/src/styles.css
@@ -100,13 +100,35 @@ body {
   margin-top: auto;
 }
 
+/* A rail row: icon then label. The icon is what carries the scan now that the section headers are
+   gone (issue #1617) - see NavIcon. */
 .nav-link {
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: 10px;
   padding: 9px 10px;
   border-radius: 8px;
   color: var(--text-dim);
   text-decoration: none;
   font-size: 14px;
+}
+
+/* The icon paints in currentColor, so it inherits the link's dim/hover/active color for free and the
+   whole row lights up as one thing. flex-shrink:0 keeps every label starting on the same x - a
+   squashed icon on one row would break the vertical edge the eye follows down the rail. */
+.nav-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+/* Long destinations ("Voice Recorder", "Your Throttle") ellipsize rather than wrapping to a second
+   line or pushing the rail wider. min-width:0 is what actually lets a flex child shrink. */
+.nav-link-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .nav-link:hover {


### PR DESCRIPTION
Follow-up to #1624, which removed the rail's section headers.

## Why

Dropping FLEET/DATA/SYSTEM left a flat list of fifteen destinations with nothing but words to scan. Icons are what **replace** those headers rather than merely decorate the rows: in a flat rail the scan is carried by shape - you find the row by silhouette before you read the word - which is the job the dim headers were failing to do.

That constraint picked the set, not decoration. Every glyph has to be distinct from its neighbours, which is why Workflows is a branching pair of boxes rather than a second calendar sitting next to Schedule.

## How

Hand-drawn inline SVG in one `NavIcon` component, not an icon package. The Cockpit has four dependencies (react, react-dom, react-router-dom, client-core); adding a library and its build weight for fifteen glyphs is not a trade worth making, and inline paths cannot go missing at runtime.

Every glyph sits on the same 24x24 grid with the same 2px round-capped stroke and paints in `currentColor` - so a row's icon inherits the link's dim/hover/active color for free, and the set reads as one family instead of fifteen separate drawings. Labels ellipsize rather than wrap and the icons never shrink, so every label starts on the same x and the rail keeps the vertical edge the eye follows down it.

The icons are decorative and `aria-hidden`: the link text is already the accessible name, so repeating it would just make every row announce twice.

## Proof

Driven in a real browser against a live Gateway. Every silhouette is distinct at 16px, Workflows reads clearly apart from Schedule beside it, and the active row lights icon and label together as one thing.

Typecheck is clean across all three workspaces. This change is cockpit-only - no C# is touched, and the one C# test that reads frontend source (`MobileViewportContractTests`) reads the **mobile** shell, not this rail - so the .NET suite is left to CI here rather than re-run locally.

## Not in this change

The rail is still text-plus-icon at a fixed width; a collapsed icon-only rail is not part of this and has not been asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
