### PR TITLE
The inventory claimed a feature the product does not have (main is red)

### DIFF
--- a/docs/features/feature-inventory.yaml
+++ b/docs/features/feature-inventory.yaml
@@ -186,16 +186,22 @@ features:
     summary: Compose-and-preview surface for LinkedIn, Twitter/X, and Reddit with scheduling. Preview system present; full send pipeline still being completed.
 
   # --- Wingman and voice --------------------------------------------------
-  - id: wingman-tab
-    title: Wingman Briefing Tab
-    category: voice-wingman
-    status: implemented
-    screen: main-window
-    source:
-      - src/CcDirector.Avalonia/Controls/CleanView.axaml
-      - src/CcDirector.Avalonia/Controls/CleanView.axaml.cs
-    screenshot: wingman-tab.png
-    summary: Clean structured briefing of what Claude wants you to do next - verbatim validation, synthesized actions, tap-to-answer buttons, a voice preview, and the final reply rendered as markdown.
+  # THE WINGMAN BRIEFING TAB IS GONE, and this file said "status: implemented" about it for a month.
+  #
+  # Its view (Controls/CleanView.axaml + .axaml.cs) stopped being instantiated on 13 July 2026 when the
+  # desktop tabs were removed; the dead files were finally deleted on 15 July by pull request 1598. The
+  # entry described a screen the product does not have, in the document whose whole job is to say what the
+  # product has.
+  #
+  # THE DRIFT CHECK WAS GREEN THE WHOLE TIME, and that is the part worth keeping. It verifies that the
+  # listed FILES EXIST - not that the FEATURE does. So a feature could be ripped out, leave its corpse on
+  # disk, and this file could go on calling it "implemented" with the check nodding along. It went red only
+  # when someone deleted the corpse, which means the check reports the tidying-up and misses the removal.
+  # The check is not wrong, it is narrow: passing it means the paths resolve, and NOT that anything here is
+  # true. If you delete a feature, delete its entry - the check will not remind you.
+  #
+  # (Session States mission, 15 July 2026. Found because the check went red on an unrelated pull request,
+  # after the mission that deleted the corpse had merged without anyone noticing main had gone red.)
 
   - id: fifo-window
     title: FIFO Full-Screen Mode


### PR DESCRIPTION
**Main is red right now** and has been since #1598 merged. The inventory drift check fails: `feature-inventory.yaml` points at `CleanView.axaml` and `CleanView.axaml.cs`, and neither exists.

**This is mine.** Slice 5 deleted those files and I merged it without noticing the trunk had gone red — through fifteen inspection passes on the *next* slice. Nobody checked whether the previous one left main green.

**But the entry was already a lie before anyone deleted anything.** The Wingman Briefing Tab stopped being instantiated on 13 July when the desktop tabs were removed. #1598 deleted the corpse, not the feature. So for a month this file said `status: implemented` about a screen the product doesn't have — in the document whose whole job is to say what the product has.

## The finding worth keeping

**The drift check was green for all of it.** It verifies *the listed files exist*. It does not verify *the feature exists*. So a feature can be ripped out, leave its files on disk, and this document can keep calling it implemented with the check nodding along. It went red only when someone deleted the corpse — the check reports the **tidying up** and misses the **removal**.

It isn't wrong; it's narrow. Passing it means the paths resolve, and nothing about whether a word of the file is true.

That is this mission's defect one more time, in the last place I looked: a green check guarding a claim it never examined. Fifteen passes were spent proving an instrument could fail before believing its zero — while the trunk's own check sat green about a deleted feature, three feet away.

The entry is removed (the screenshot was already gone), and a comment records what the check does **not** check, so the next person to delete a feature knows this file won't remind them.

Swept the rest: every other entry's paths resolve. This was the only one. Documentation only.