### PR TITLE
feat(core): drivers report the model the agent is currently using (#1637)

### DIFF
--- a/.claude/skills/agent-expert/agents/README.md
+++ b/.claude/skills/agent-expert/agents/README.md
@@ -37,6 +37,24 @@ The window denominator is a driver-owned per-model table (200,000 tokens for the
 models, 1,000,000 for the `[1m]` Opus id); an unmapped model falls back to the raw used-token count
 with no percent.
 
+## Current-model reporting (capability `ModelReport`, issue #1637)
+
+Can the driver answer "what model is the tool CURRENTLY using", from the tool's own records, so the
+Director can log model usage per session? The LATEST record wins, so a mid-session model switch
+(Claude's /model, Codex /model, ...) is reflected. Every row below was live-verified against the
+installed binary and its real on-disk data on 2026-07-15.
+
+| Agent | Model reporting | Where the model is recorded | Our driver |
+|-------|-----------------|------------------------------|------------|
+| Claude Code (2.1.210) | Strong (implemented) | Transcript jsonl: every assistant line's `message.model`; already parsed as `SessionUsageDto.ContextModel`. Pre-first-turn the `--model` launch value answers. | ClaudeDriver |
+| Codex (0.143.0) | Strong (implemented) | Rollout jsonl: every `turn_context` event's `payload.model`; one per turn. Located by repo. | CodexDriver |
+| pi (0.79.4) | Strong (implemented) | Session jsonl: every assistant `message.model`. Located by repo. | PiDriver |
+| Copilot (1.0.70) | Strong (implemented) | `~/.copilot/session-state/<session-id>/events.jsonl`: `assistant.turn_start` / `assistant.message` `data.model`. Addressed by the preassigned session id. NOTE: Copilot's SQLite store has NO model column - the event log is the only source. | CopilotDriver |
+| Grok (0.2.93) | Strong (implemented) | `~/.grok/sessions/<percent-encoded-cwd>/<session-id>/chat_history.jsonl`: assistant lines' `model_id`. Located via GrokSessionLocator. | GenericDriver + wired reader |
+| opencode (1.15.12) | Strong (implemented) | SQLite `opencode.db` `session.model` column (JSON `{"id","providerID"}`), newest row matching `directory`. | GenericDriver + wired reader |
+| Gemini (0.1.11) | None | The installed binary records no model anywhere readable (`tmp/<hash>/logs.json` is user prompts only). Re-probe after upgrade. | GenericDriver (not declared) |
+| Cursor | None | Not installed here; unverifiable. | CursorDriver (not declared) |
+
 ## The four mechanism families
 
 - A - shell-command hook that injects context. A config file registers a command we own; it

--- a/src/CcDirector.Core.Tests/Drivers/ModelReportTests.cs
+++ b/src/CcDirector.Core.Tests/Drivers/ModelReportTests.cs
@@ -1,0 +1,348 @@
+using CcDirector.Core.Agents;
+using CcDirector.Core.Codex;
+using CcDirector.Core.Copilot;
+using CcDirector.Core.Drivers;
+using CcDirector.Core.Grok;
+using CcDirector.Core.OpenCode;
+using CcDirector.Core.Pi;
+using CcDirector.Gateway.Contracts;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace CcDirector.Core.Tests.Drivers;
+
+// =====================================================================================
+// ModelReport capability (issue #1637): every driver that can answer "what model is the
+// tool currently using" answers it from the tool's own records; a driver that cannot is
+// honestly absent and throws. Fixture lines are copied from the REAL files verified on
+// this machine on 2026-07-15 (claude 2.1.210, codex 0.143.0, pi 0.79.4, copilot 1.0.70,
+// grok 0.2.93, opencode 1.15.12).
+// =====================================================================================
+public sealed class ModelReportTests
+{
+    // ---- Capability declarations ----
+
+    [Fact]
+    public void Capabilities_DriversWithVerifiedModelStores_DeclareModelReport()
+    {
+        Assert.True(AgentDrivers.For(AgentKind.ClaudeCode).Capabilities.HasFlag(DriverCapabilities.ModelReport));
+        Assert.True(AgentDrivers.For(AgentKind.Codex).Capabilities.HasFlag(DriverCapabilities.ModelReport));
+        Assert.True(AgentDrivers.For(AgentKind.Pi).Capabilities.HasFlag(DriverCapabilities.ModelReport));
+        Assert.True(AgentDrivers.For(AgentKind.Copilot).Capabilities.HasFlag(DriverCapabilities.ModelReport));
+        Assert.True(AgentDrivers.For(AgentKind.Grok).Capabilities.HasFlag(DriverCapabilities.ModelReport));
+        Assert.True(AgentDrivers.For(AgentKind.OpenCode).Capabilities.HasFlag(DriverCapabilities.ModelReport));
+    }
+
+    [Fact]
+    public void Capabilities_DriversWithoutVerifiedModelStores_DoNotDeclareModelReport()
+    {
+        // Gemini 0.1.11 records no model anywhere readable; Cursor is unverifiable here.
+        Assert.False(AgentDrivers.For(AgentKind.Gemini).Capabilities.HasFlag(DriverCapabilities.ModelReport));
+        Assert.False(AgentDrivers.For(AgentKind.Cursor).Capabilities.HasFlag(DriverCapabilities.ModelReport));
+    }
+
+    [Fact]
+    public void ReadCurrentModel_UndeclaredDriver_ThrowsNotSupported()
+    {
+        var gemini = new GenericDriver(AgentKind.Gemini);
+        Assert.Throws<NotSupportedException>(() => gemini.ReadCurrentModel("sid", @"C:\repo", null));
+
+        // CursorDriver inherits the interface default, which is the honest throw.
+        IAgentDriver cursor = new CursorDriver();
+        Assert.Throws<NotSupportedException>(() => cursor.ReadCurrentModel("sid", @"C:\repo", null));
+    }
+
+    [Fact]
+    public void ReadCurrentModel_GenericDriverWithReader_DeclaresAndDelegates()
+    {
+        string? seenDirectory = null;
+        var driver = new GenericDriver(AgentKind.Grok, currentModelReader: dir =>
+        {
+            seenDirectory = dir;
+            return "grok-4.5";
+        });
+
+        Assert.True(driver.Capabilities.HasFlag(DriverCapabilities.ModelReport));
+        Assert.Equal("grok-4.5", driver.ReadCurrentModel("sid", @"C:\repo", null));
+        Assert.Equal(@"C:\repo", seenDirectory);
+    }
+
+    // ---- ClaudeDriver: transcript model wins; launch args answer before the first turn ----
+
+    private static ClaudeDriver DriverReturning(SessionUsageDto? usage)
+        => new(new StubReader(usage));
+
+    [Fact]
+    public void ReadCurrentModel_Claude_TranscriptModelWins()
+    {
+        // The transcript reflects a mid-session /model switch; the launch flag is stale.
+        var usage = new SessionUsageDto { ContextModel = "claude-fable-5", AssistantMessageCount = 3 };
+        var model = DriverReturning(usage).ReadCurrentModel("sid", @"C:\repo", "--model opus");
+        Assert.Equal("claude-fable-5", model);
+    }
+
+    [Fact]
+    public void ReadCurrentModel_Claude_NoTurnYet_LaunchArgsAnswer()
+    {
+        var usage = new SessionUsageDto { AssistantMessageCount = 0 };
+        Assert.Equal("opus[1m]",
+            DriverReturning(usage).ReadCurrentModel("sid", @"C:\repo", "--dangerously-skip-permissions --model opus[1m]"));
+        Assert.Equal("sonnet",
+            DriverReturning(null).ReadCurrentModel("sid", @"C:\repo", "--model=sonnet"));
+    }
+
+    [Fact]
+    public void ReadCurrentModel_Claude_NoTranscriptNoLaunchModel_ReturnsNull()
+    {
+        Assert.Null(DriverReturning(null).ReadCurrentModel("sid", @"C:\repo", "--dangerously-skip-permissions"));
+        Assert.Null(DriverReturning(null).ReadCurrentModel("sid", @"C:\repo", null));
+    }
+
+    // ---- CodexCurrentModel: the LAST turn_context model wins ----
+
+    [Fact]
+    public void CodexCompute_RealTurnContextLine_ReturnsModel()
+    {
+        // Shape copied from a real codex-cli 0.143.0 rollout on this machine.
+        var lines = new[]
+        {
+            """{"timestamp":"2026-07-15T14:26:52.248Z","type":"session_meta","payload":{"session_id":"019f662c-4847-7822-b959-c12c7346498c","cwd":"D:\\repo","model_provider":"openai"}}""",
+            """{"timestamp":"2026-07-15T14:26:52.274Z","type":"turn_context","payload":{"turn_id":"t1","cwd":"D:\\repo","model":"gpt-5.5","comp_hash":"2911"}}""",
+        };
+        Assert.Equal("gpt-5.5", CodexCurrentModel.Compute(lines));
+    }
+
+    [Fact]
+    public void CodexCompute_ModelSwitchMidSession_LastTurnContextWins()
+    {
+        var lines = new[]
+        {
+            """{"type":"turn_context","payload":{"model":"gpt-5.5"}}""",
+            """{"type":"turn_context","payload":{"model":"gpt-5.5-codex"}}""",
+            """{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100}}}}""",
+        };
+        Assert.Equal("gpt-5.5-codex", CodexCurrentModel.Compute(lines));
+    }
+
+    [Fact]
+    public void CodexCompute_NoTurnContextOrTornTail_ReturnsNullOrSkips()
+    {
+        Assert.Null(CodexCurrentModel.Compute(new[]
+        {
+            """{"type":"session_meta","payload":{"cwd":"D:\\repo"}}""",
+        }));
+
+        // A torn tail line (codex mid-write) is skipped, earlier model still wins.
+        Assert.Equal("gpt-5.5", CodexCurrentModel.Compute(new[]
+        {
+            """{"type":"turn_context","payload":{"model":"gpt-5.5"}}""",
+            """{"type":"turn_context","payl""",
+        }));
+    }
+
+    // ---- PiCurrentModel: the LAST assistant message model wins ----
+
+    [Fact]
+    public void PiCompute_RealAssistantLine_ReturnsModel()
+    {
+        // Shape copied from a real pi 0.79.4 session file on this machine.
+        var lines = new[]
+        {
+            """{"type":"session","cwd":"D:\\repo"}""",
+            """{"type":"message","message":{"role":"user","content":"hello"}}""",
+            """{"type":"message","message":{"role":"assistant","provider":"openai-codex","model":"gpt-5.5","usage":{"input":3838,"output":33}}}""",
+        };
+        Assert.Equal("gpt-5.5", PiCurrentModel.Compute(lines));
+    }
+
+    [Fact]
+    public void PiCompute_ModelSwitch_LastAssistantWins_UserLinesIgnored()
+    {
+        var lines = new[]
+        {
+            """{"type":"message","message":{"role":"assistant","model":"gpt-5.5"}}""",
+            """{"type":"message","message":{"role":"assistant","model":"claude-fable-5"}}""",
+            """{"type":"message","message":{"role":"user","content":"thanks"}}""",
+        };
+        Assert.Equal("claude-fable-5", PiCurrentModel.Compute(lines));
+    }
+
+    [Fact]
+    public void PiCompute_NoAssistantYet_ReturnsNull()
+    {
+        Assert.Null(PiCurrentModel.Compute(new[]
+        {
+            """{"type":"session","cwd":"D:\\repo"}""",
+            """{"type":"message","message":{"role":"user","content":"hello"}}""",
+        }));
+    }
+
+    // ---- CopilotCurrentModel: the LAST model-bearing event wins ----
+
+    [Fact]
+    public void CopilotCompute_RealTurnStartEvent_ReturnsModel()
+    {
+        // Shape copied from a real copilot 1.0.70 events.jsonl on this machine.
+        var lines = new[]
+        {
+            """{"type":"session.start","data":{"sessionId":"a6448823"},"id":"e1","timestamp":"2026-07-10T15:21:06.578Z"}""",
+            """{"type":"assistant.turn_start","data":{"turnId":"0","model":"claude-haiku-4.5","interactionId":"0fdef53a"},"id":"e2","timestamp":"2026-07-10T15:21:11.344Z"}""",
+        };
+        Assert.Equal("claude-haiku-4.5", CopilotCurrentModel.Compute(lines));
+    }
+
+    [Fact]
+    public void CopilotCompute_ModelSwitch_LastEventWins()
+    {
+        var lines = new[]
+        {
+            """{"type":"assistant.turn_start","data":{"model":"claude-haiku-4.5"}}""",
+            """{"type":"assistant.message","data":{"model":"gpt-5.5","content":""}}""",
+            """{"type":"user.message","data":{"content":"hi"}}""",
+        };
+        Assert.Equal("gpt-5.5", CopilotCurrentModel.Compute(lines));
+    }
+
+    [Fact]
+    public void CopilotCompute_NoModelEventYet_ReturnsNull()
+    {
+        Assert.Null(CopilotCurrentModel.Compute(new[]
+        {
+            """{"type":"session.start","data":{"sessionId":"a6448823"}}""",
+        }));
+    }
+
+    [Fact]
+    public void CopilotReadForSession_BlankOrMissingSession_ReturnsNull()
+    {
+        Assert.Null(CopilotCurrentModel.ReadForSession(""));
+        Assert.Null(CopilotCurrentModel.ReadForSession(Guid.NewGuid().ToString()));
+    }
+
+    // ---- GrokCurrentModel: the LAST assistant model_id wins ----
+
+    [Fact]
+    public void GrokCompute_RealAssistantLine_ReturnsModelId()
+    {
+        // Shape copied from a real grok 0.2.93 chat_history.jsonl on this machine.
+        var lines = new[]
+        {
+            """{"type":"user","content":"hello"}""",
+            """{"type":"assistant","content":"hi","model_id":"grok-4.5","model_fingerprint":"fp_a39489019fa99b6e","reasoning_effort":"high"}""",
+        };
+        Assert.Equal("grok-4.5", GrokCurrentModel.Compute(lines));
+    }
+
+    [Fact]
+    public void GrokCompute_ModelSwitch_LastAssistantWins_NonAssistantIgnored()
+    {
+        var lines = new[]
+        {
+            """{"type":"assistant","model_id":"grok-4"}""",
+            """{"type":"assistant","model_id":"grok-4.5"}""",
+            """{"type":"user","content":"thanks"}""",
+        };
+        Assert.Equal("grok-4.5", GrokCurrentModel.Compute(lines));
+    }
+
+    [Fact]
+    public void GrokCompute_NoAssistantYet_ReturnsNull()
+    {
+        Assert.Null(GrokCurrentModel.Compute(new[] { """{"type":"user","content":"hello"}""" }));
+    }
+
+    // ---- OpenCodeCurrentModel: the newest matching session row's model JSON ----
+
+    [Fact]
+    public void OpenCodeParseModelId_RealBlob_ReturnsId()
+    {
+        // Blob copied from a real opencode 1.15.12 session row on this machine.
+        Assert.Equal("gpt-5.3-chat-latest",
+            OpenCodeCurrentModel.ParseModelId("""{"id":"gpt-5.3-chat-latest","providerID":"openai"}"""));
+        Assert.Null(OpenCodeCurrentModel.ParseModelId(null));
+        Assert.Null(OpenCodeCurrentModel.ParseModelId(""));
+        Assert.Null(OpenCodeCurrentModel.ParseModelId("not json"));
+        Assert.Null(OpenCodeCurrentModel.ParseModelId("""{"providerID":"openai"}"""));
+    }
+
+    [Fact]
+    public void OpenCodeReadFrom_NewestMatchingSessionWins_OtherDirectoriesIgnored()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), "opencode-model-fixture-" + Guid.NewGuid().ToString("N") + ".db");
+        const string repo = @"C:\target\repo";
+        try
+        {
+            using (var conn = OpenWritable(dbPath))
+            {
+                Execute(conn,
+                    """
+                    CREATE TABLE session (
+                        id TEXT PRIMARY KEY,
+                        directory TEXT NOT NULL,
+                        model TEXT,
+                        time_updated INTEGER
+                    );
+                    """);
+                InsertSession(conn, "ses-old", repo, """{"id":"gpt-5.3-chat-latest","providerID":"openai"}""", 1000);
+                InsertSession(conn, "ses-new", repo + "\\", """{"id":"claude-fable-5","providerID":"anthropic"}""", 2000);
+                InsertSession(conn, "ses-other", @"C:\other\repo", """{"id":"gpt-4o","providerID":"openai"}""", 3000);
+            }
+
+            Assert.Equal("claude-fable-5", OpenCodeCurrentModel.ReadFrom(repo, dbPath));
+            Assert.Null(OpenCodeCurrentModel.ReadFrom(@"C:\no\such\repo", dbPath));
+        }
+        finally
+        {
+            try { File.Delete(dbPath); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void OpenCodeReadFrom_MissingStore_ReturnsNull()
+    {
+        Assert.Null(OpenCodeCurrentModel.ReadFrom(@"C:\repo", Path.Combine(Path.GetTempPath(), "no-such.db")));
+    }
+
+    // ---- helpers ----
+
+    private static SqliteConnection OpenWritable(string path)
+    {
+        var connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = path,
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            Pooling = false,
+        }.ToString();
+        var conn = new SqliteConnection(connectionString);
+        conn.Open();
+        return conn;
+    }
+
+    private static void InsertSession(SqliteConnection conn, string id, string directory, string modelJson, long timeUpdated)
+    {
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "INSERT INTO session (id, directory, model, time_updated) VALUES (@id, @dir, @model, @updated)";
+        cmd.Parameters.AddWithValue("@id", id);
+        cmd.Parameters.AddWithValue("@dir", directory);
+        cmd.Parameters.AddWithValue("@model", modelJson);
+        cmd.Parameters.AddWithValue("@updated", timeUpdated);
+        cmd.ExecuteNonQuery();
+    }
+
+    private static void Execute(SqliteConnection conn, string sql)
+    {
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.ExecuteNonQuery();
+    }
+
+    private sealed class StubReader : ITranscriptReader
+    {
+        private readonly SessionUsageDto? _usage;
+        public StubReader(SessionUsageDto? usage) => _usage = usage;
+        public List<TurnWidgetDto> ReadWidgets(string claudeSessionId, string repoPath) => new();
+        public SessionUsageDto? ReadUsage(string claudeSessionId, string repoPath) => _usage;
+        public List<(string ClaudeSessionId, DateTime LastWriteUtc)> ListTranscripts(string repoPath) => new();
+    }
+}

--- a/src/CcDirector.Core/Codex/CodexCurrentModel.cs
+++ b/src/CcDirector.Core/Codex/CodexCurrentModel.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Codex;
+
+/// <summary>
+/// Reads the model a Codex session is currently using from its rollout JSONL. Codex writes a
+/// <c>turn_context</c> event at every turn whose payload carries the model in effect:
+///
+///   {"timestamp":"...","type":"turn_context","payload":{"model":"gpt-5.5", ...}}
+///
+/// The LAST turn_context wins, so a mid-session model switch is reflected. Null until the first
+/// turn_context exists. The rollout for a repo is located by <see cref="CodexRolloutLocator"/>
+/// (verified against codex-cli 0.143.0, issue #1637).
+/// </summary>
+public static class CodexCurrentModel
+{
+    /// <summary>The current model of the newest Codex rollout matching <paramref name="repoPath"/>,
+    /// or null when no rollout matches or none of its turn_context events carries a model yet.</summary>
+    public static string? ReadForRepo(string repoPath)
+    {
+        var rollout = CodexRolloutLocator.ResolveByRepo(repoPath);
+        if (rollout is null)
+            return null;
+        return ReadFromFile(rollout);
+    }
+
+    /// <summary>The current model from one rollout file. Reads with FileShare.ReadWrite so the live
+    /// Codex session can keep writing. Null when the file is missing or has no turn_context model.</summary>
+    public static string? ReadFromFile(string rolloutPath)
+    {
+        if (!File.Exists(rolloutPath))
+            return null;
+        using var fs = new FileStream(rolloutPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(fs);
+        return Compute(ReadLines(reader));
+    }
+
+    /// <summary>Pure core - testable on raw rollout lines. Returns the LAST turn_context model.</summary>
+    public static string? Compute(IEnumerable<string> rolloutLines)
+    {
+        ArgumentNullException.ThrowIfNull(rolloutLines);
+        string? latest = null;
+
+        foreach (var line in rolloutLines)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            JsonDocument doc;
+            try { doc = JsonDocument.Parse(line); }
+            catch (JsonException) { continue; } // torn tail line while codex writes
+
+            using (doc)
+            {
+                var root = doc.RootElement;
+                if (root.ValueKind != JsonValueKind.Object) continue;
+                if (!(root.TryGetProperty("type", out var t) && t.GetString() == "turn_context")) continue;
+                if (!root.TryGetProperty("payload", out var payload) || payload.ValueKind != JsonValueKind.Object) continue;
+
+                if (payload.TryGetProperty("model", out var model)
+                    && model.ValueKind == JsonValueKind.String
+                    && !string.IsNullOrWhiteSpace(model.GetString()))
+                {
+                    latest = model.GetString();
+                }
+            }
+        }
+
+        if (latest is not null)
+            FileLog.Write($"[CodexCurrentModel] model={latest}");
+        return latest;
+    }
+
+    private static IEnumerable<string> ReadLines(StreamReader reader)
+    {
+        string? line;
+        while ((line = reader.ReadLine()) != null)
+            yield return line;
+    }
+}

--- a/src/CcDirector.Core/Copilot/CopilotCurrentModel.cs
+++ b/src/CcDirector.Core/Copilot/CopilotCurrentModel.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Copilot;
+
+/// <summary>
+/// Reads the model a GitHub Copilot CLI session is currently using from its per-session event log
+/// (<c>~/.copilot/session-state/&lt;session-id&gt;/events.jsonl</c>). Assistant events carry the
+/// model that served the turn:
+///
+///   {"type":"assistant.turn_start","data":{"turnId":"0","model":"claude-haiku-4.5", ...}, ...}
+///   {"type":"assistant.message","data":{"model":"claude-haiku-4.5", ...}, ...}
+///
+/// The LAST event with a model wins, so a mid-session model switch is reflected. The Director
+/// preassigns the Copilot session id at launch (<c>--session-id</c>), so the directory is directly
+/// addressable - no repo scan needed. Copilot's SQLite session store has NO model column, so this
+/// event log is the only model source (verified against GitHub Copilot CLI 1.0.70, issue #1637).
+/// </summary>
+public static class CopilotCurrentModel
+{
+    /// <summary>The current model of the Copilot session <paramref name="agentSessionId"/>, or null
+    /// when its event log does not exist or carries no model-bearing event yet.</summary>
+    public static string? ReadForSession(string agentSessionId)
+    {
+        if (string.IsNullOrWhiteSpace(agentSessionId))
+            return null;
+        var path = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".copilot",
+            "session-state",
+            agentSessionId,
+            "events.jsonl");
+        return ReadFromFile(path);
+    }
+
+    /// <summary>The current model from one events.jsonl. Reads with FileShare.ReadWrite so the live
+    /// Copilot session can keep writing. Null when the file is missing or has no model event.</summary>
+    public static string? ReadFromFile(string eventsPath)
+    {
+        if (!File.Exists(eventsPath))
+            return null;
+        using var fs = new FileStream(eventsPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(fs);
+        return Compute(ReadLines(reader));
+    }
+
+    /// <summary>Pure core - testable on raw event lines. Returns the LAST event's <c>data.model</c>.</summary>
+    public static string? Compute(IEnumerable<string> eventLines)
+    {
+        ArgumentNullException.ThrowIfNull(eventLines);
+        string? latest = null;
+
+        foreach (var line in eventLines)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            JsonDocument doc;
+            try { doc = JsonDocument.Parse(line); }
+            catch (JsonException) { continue; } // torn tail line while copilot writes
+
+            using (doc)
+            {
+                var root = doc.RootElement;
+                if (root.ValueKind != JsonValueKind.Object) continue;
+                if (!root.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Object) continue;
+
+                if (data.TryGetProperty("model", out var model)
+                    && model.ValueKind == JsonValueKind.String
+                    && !string.IsNullOrWhiteSpace(model.GetString()))
+                {
+                    latest = model.GetString();
+                }
+            }
+        }
+
+        if (latest is not null)
+            FileLog.Write($"[CopilotCurrentModel] model={latest}");
+        return latest;
+    }
+
+    private static IEnumerable<string> ReadLines(StreamReader reader)
+    {
+        string? line;
+        while ((line = reader.ReadLine()) != null)
+            yield return line;
+    }
+}

--- a/src/CcDirector.Core/Drivers/AgentDrivers.cs
+++ b/src/CcDirector.Core/Drivers/AgentDrivers.cs
@@ -21,9 +21,13 @@ public static class AgentDrivers
         AgentKind.Cursor => new CursorDriver(),
         AgentKind.Copilot => new CopilotDriver(),
         AgentKind.Codex => new CodexDriver(),
+        // Gemini wires NO current-model reader: the installed binary (0.1.11) records no model
+        // anywhere readable (issue #1637) - re-probe after it is upgraded.
         AgentKind.Gemini => new GenericDriver(k, GeminiSlashCommands.All),
-        AgentKind.OpenCode => new GenericDriver(k, OpenCodeSlashCommands.All),
-        AgentKind.Grok => new GenericDriver(k, GrokSlashCommands.All, emitsContinuousIdleOutput: true),
+        AgentKind.OpenCode => new GenericDriver(k, OpenCodeSlashCommands.All,
+            currentModelReader: OpenCode.OpenCodeCurrentModel.ReadForRepo),
+        AgentKind.Grok => new GenericDriver(k, GrokSlashCommands.All, emitsContinuousIdleOutput: true,
+            currentModelReader: Grok.GrokCurrentModel.ReadForRepo),
         _ => new GenericDriver(k),
     });
 }

--- a/src/CcDirector.Core/Drivers/ClaudeDriver.cs
+++ b/src/CcDirector.Core/Drivers/ClaudeDriver.cs
@@ -48,7 +48,8 @@ public sealed class ClaudeDriver : IAgentDriver
         | DriverCapabilities.TranscriptRead
         | DriverCapabilities.PreassignedSessionId
         | DriverCapabilities.ModelSelection
-        | DriverCapabilities.ContextUsage;
+        | DriverCapabilities.ContextUsage
+        | DriverCapabilities.ModelReport;
 
     public IReadOnlyList<AgentSlashCommand> SlashCommands => BuiltInSlashCommands.All
         .Select(command => new AgentSlashCommand(
@@ -242,6 +243,23 @@ public sealed class ClaudeDriver : IAgentDriver
             PercentUsed = percent,
             AsOfUtc = usage.LastMessageUtc,
         };
+    }
+
+    /// <summary>
+    /// The model this Claude session is currently using (capability
+    /// <see cref="DriverCapabilities.ModelReport"/>). The transcript is the truth: every assistant
+    /// line records <c>message.model</c> and the LATEST line wins, so a mid-session /model switch is
+    /// reflected. Before the first turn the transcript carries no model, so the <c>--model</c> value
+    /// from the launch arguments is the answer (it is the tool's real instruction until the first
+    /// turn proves the concrete id); null when neither exists (the tool's own default, id unknown
+    /// until the first turn).
+    /// </summary>
+    public string? ReadCurrentModel(string agentSessionId, string workingDirectory, string? launchArgs)
+    {
+        var usage = _transcripts.ReadUsage(agentSessionId, workingDirectory);
+        if (!string.IsNullOrWhiteSpace(usage?.ContextModel))
+            return usage.ContextModel;
+        return ExtractLaunchModelId(launchArgs);
     }
 
     /// <summary>Extracts the value passed after this driver's <see cref="ModelFlag"/> (<c>--model</c>)

--- a/src/CcDirector.Core/Drivers/CodexDriver.cs
+++ b/src/CcDirector.Core/Drivers/CodexDriver.cs
@@ -21,7 +21,8 @@ public sealed class CodexDriver : IAgentDriver
         DriverCapabilities.Cancel
         | DriverCapabilities.Interrupt
         | DriverCapabilities.ClearContext
-        | DriverCapabilities.ContextUsage;
+        | DriverCapabilities.ContextUsage
+        | DriverCapabilities.ModelReport;
 
     public IReadOnlyList<AgentSlashCommand> SlashCommands => CodexSlashCommands.All;
 
@@ -108,6 +109,13 @@ public sealed class CodexDriver : IAgentDriver
     /// launch args are not needed. Located by repo path (Codex has no Director-preassigned id).</summary>
     public ContextUsageDto? ReadContextUsage(string agentSessionId, string workingDirectory, string? launchArgs) =>
         Codex.CodexContextUsage.ReadForRepo(workingDirectory);
+
+    /// <summary>The model this Codex session is currently using (capability
+    /// <see cref="DriverCapabilities.ModelReport"/>): the LAST <c>turn_context</c> event's model in
+    /// the rollout, so a mid-session model switch is reflected. Located by repo path (Codex has no
+    /// Director-preassigned id).</summary>
+    public string? ReadCurrentModel(string agentSessionId, string workingDirectory, string? launchArgs) =>
+        Codex.CodexCurrentModel.ReadForRepo(workingDirectory);
 
     public List<(string AgentSessionId, DateTime LastWriteUtc)> ListTranscripts(string workingDirectory) =>
         throw new NotSupportedException(

--- a/src/CcDirector.Core/Drivers/CopilotDriver.cs
+++ b/src/CcDirector.Core/Drivers/CopilotDriver.cs
@@ -48,7 +48,9 @@ public sealed class CopilotDriver : IAgentDriver
     /// live-verified.
     /// </summary>
     public DriverCapabilities Capabilities =>
-        DriverCapabilities.Interrupt | DriverCapabilities.PreassignedSessionId;
+        DriverCapabilities.Interrupt
+        | DriverCapabilities.PreassignedSessionId
+        | DriverCapabilities.ModelReport;
 
     public IReadOnlyList<AgentSlashCommand> SlashCommands => CopilotSlashCommands.All;
 
@@ -146,6 +148,13 @@ public sealed class CopilotDriver : IAgentDriver
     public List<(string AgentSessionId, DateTime LastWriteUtc)> ListTranscripts(string workingDirectory) =>
         throw new NotSupportedException(
             "[CopilotDriver] copilot's on-disk transcript location/format is not yet verified.");
+
+    /// <summary>The model this Copilot session is currently using (capability
+    /// <see cref="DriverCapabilities.ModelReport"/>): the LAST model-bearing event in the session's
+    /// events.jsonl, so a mid-session model switch is reflected. Addressed directly by the
+    /// Director-preassigned session id (issue #1637).</summary>
+    public string? ReadCurrentModel(string agentSessionId, string workingDirectory, string? launchArgs) =>
+        Copilot.CopilotCurrentModel.ReadForSession(agentSessionId);
 
     // ----------------------------------------------------------- --output-format json (JSONL)
 

--- a/src/CcDirector.Core/Drivers/GenericDriver.cs
+++ b/src/CcDirector.Core/Drivers/GenericDriver.cs
@@ -22,21 +22,26 @@ public sealed class GenericDriver : IAgentDriver
     private static readonly byte[] CtrlC = [0x03];
 
     private readonly IReadOnlyList<AgentSlashCommand> _slashCommands;
+    private readonly Func<string, string?>? _currentModelReader;
 
     public GenericDriver(
         AgentKind kind,
         IReadOnlyList<AgentSlashCommand>? slashCommands = null,
-        bool emitsContinuousIdleOutput = false)
+        bool emitsContinuousIdleOutput = false,
+        Func<string, string?>? currentModelReader = null)
     {
         Kind = kind;
         _slashCommands = slashCommands ?? [];
         EmitsContinuousIdleOutput = emitsContinuousIdleOutput;
+        _currentModelReader = currentModelReader;
     }
 
     public AgentKind Kind { get; }
 
     public DriverCapabilities Capabilities =>
-        DriverCapabilities.Cancel | DriverCapabilities.Interrupt;
+        DriverCapabilities.Cancel
+        | DriverCapabilities.Interrupt
+        | (_currentModelReader is not null ? DriverCapabilities.ModelReport : DriverCapabilities.None);
 
     /// <summary>
     /// Set true for Grok: its idle terminal keeps repainting an animated footer (spinner +
@@ -96,4 +101,17 @@ public sealed class GenericDriver : IAgentDriver
 
     public List<(string AgentSessionId, DateTime LastWriteUtc)> ListTranscripts(string workingDirectory) =>
         throw new NotSupportedException($"[GenericDriver] {Kind} has no verified transcript format.");
+
+    /// <summary>The model the tool is currently using (capability
+    /// <see cref="DriverCapabilities.ModelReport"/>), via the per-kind reader wired in
+    /// <see cref="AgentDrivers"/> - a live-verified store read keyed by the working directory
+    /// (issue #1637). A kind without a wired reader does not declare the capability and throws,
+    /// same contract as every other undeclared verb here.</summary>
+    public string? ReadCurrentModel(string agentSessionId, string workingDirectory, string? launchArgs)
+    {
+        if (_currentModelReader is null)
+            throw new NotSupportedException(
+                $"[GenericDriver] {Kind} has no verified current-model store.");
+        return _currentModelReader(workingDirectory);
+    }
 }

--- a/src/CcDirector.Core/Drivers/IAgentDriver.cs
+++ b/src/CcDirector.Core/Drivers/IAgentDriver.cs
@@ -48,6 +48,14 @@ public enum DriverCapabilities
     /// can answer the narrower question 'how full is the window right now'" - a driver may have one
     /// without the other.</summary>
     ContextUsage = 128,
+
+    /// <summary>The driver can report the model the tool is CURRENTLY using, read from the tool's
+    /// own records (transcript, rollout, event log, session store). Distinct from
+    /// <see cref="ModelSelection"/> (the tool takes a model flag at launch): the user can switch
+    /// models mid-session, so the launch flag goes stale - this capability answers "what model is
+    /// it really running right now", so the Director can log model usage per session (issue
+    /// #1637).</summary>
+    ModelReport = 256,
 }
 
 /// <summary>
@@ -147,6 +155,17 @@ public interface IAgentDriver
     ContextUsageDto? ReadContextUsage(string agentSessionId, string workingDirectory, string? launchArgs) =>
         throw new NotSupportedException(
             $"[{GetType().Name}] {Kind} does not declare DriverCapabilities.ContextUsage.");
+
+    /// <summary>The model the tool is currently using (capability
+    /// <see cref="DriverCapabilities.ModelReport"/>), read from the tool's own records - the LATEST
+    /// model the tool recorded, so a mid-session model switch is reflected. Null when it cannot be
+    /// determined yet (no turn has happened). <paramref name="launchArgs"/> is the session's launch
+    /// command line; a driver may use it as the pre-first-turn answer when its tool takes a model
+    /// flag. The default throws <see cref="NotSupportedException"/> so a driver that does not
+    /// declare the flag is honestly absent - never emulated.</summary>
+    string? ReadCurrentModel(string agentSessionId, string workingDirectory, string? launchArgs) =>
+        throw new NotSupportedException(
+            $"[{GetType().Name}] {Kind} does not declare DriverCapabilities.ModelReport.");
 
     /// <summary>The working directory's transcript files, newest first
     /// (capability TranscriptRead).</summary>

--- a/src/CcDirector.Core/Drivers/PiDriver.cs
+++ b/src/CcDirector.Core/Drivers/PiDriver.cs
@@ -30,7 +30,10 @@ public sealed class PiDriver : IAgentDriver
     public AgentKind Kind => AgentKind.Pi;
 
     public DriverCapabilities Capabilities =>
-        DriverCapabilities.Cancel | DriverCapabilities.ClearContext | DriverCapabilities.ContextUsage;
+        DriverCapabilities.Cancel
+        | DriverCapabilities.ClearContext
+        | DriverCapabilities.ContextUsage
+        | DriverCapabilities.ModelReport;
 
     public IReadOnlyList<AgentSlashCommand> SlashCommands => PiSlashCommands.All;
 
@@ -96,6 +99,13 @@ public sealed class PiDriver : IAgentDriver
     /// args are not used.</summary>
     public ContextUsageDto? ReadContextUsage(string agentSessionId, string workingDirectory, string? launchArgs) =>
         Pi.PiContextUsage.ReadForRepo(workingDirectory);
+
+    /// <summary>The model this pi session is currently using (capability
+    /// <see cref="DriverCapabilities.ModelReport"/>): the LAST assistant message's model in the
+    /// session file, so a mid-session model switch is reflected. Located by repo path (pi has no
+    /// Director-preassigned id).</summary>
+    public string? ReadCurrentModel(string agentSessionId, string workingDirectory, string? launchArgs) =>
+        Pi.PiCurrentModel.ReadForRepo(workingDirectory);
 
     public List<(string AgentSessionId, DateTime LastWriteUtc)> ListTranscripts(string workingDirectory) =>
         throw new NotSupportedException("[PiDriver] pi transcript listing is not implemented (v1).");

--- a/src/CcDirector.Core/Grok/GrokCurrentModel.cs
+++ b/src/CcDirector.Core/Grok/GrokCurrentModel.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Grok;
+
+/// <summary>
+/// Reads the model a Grok CLI session is currently using from its conversation file
+/// (<c>~/.grok/sessions/&lt;percent-encoded-cwd&gt;/&lt;session-id&gt;/chat_history.jsonl</c>).
+/// Assistant lines carry the model that produced them:
+///
+///   {"type":"assistant","content":"...","model_id":"grok-4.5","model_fingerprint":"...", ...}
+///
+/// The LAST assistant line wins, so a mid-session model switch is reflected. The file for a repo
+/// is located by <see cref="GrokSessionLocator.Scan"/> - the newest session under the per-cwd
+/// directory (verified against grok 0.2.93, issue #1637).
+/// </summary>
+public static class GrokCurrentModel
+{
+    /// <summary>The current model of the newest Grok session matching <paramref name="repoPath"/>,
+    /// or null when none matches or it has no assistant model line yet.</summary>
+    public static string? ReadForRepo(string repoPath)
+    {
+        var file = GrokSessionLocator.Scan(repoPath, SessionsDirectory());
+        if (file is null)
+            return null;
+        return ReadFromFile(file);
+    }
+
+    /// <summary>The current model from one chat_history.jsonl. Reads with FileShare.ReadWrite so
+    /// the live Grok session can keep writing. Null when the file is missing or has no model line.</summary>
+    public static string? ReadFromFile(string chatHistoryPath)
+    {
+        if (!File.Exists(chatHistoryPath))
+            return null;
+        using var fs = new FileStream(chatHistoryPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(fs);
+        return Compute(ReadLines(reader));
+    }
+
+    /// <summary>Pure core - testable on raw chat lines. Returns the LAST assistant <c>model_id</c>.</summary>
+    public static string? Compute(IEnumerable<string> chatLines)
+    {
+        ArgumentNullException.ThrowIfNull(chatLines);
+        string? latest = null;
+
+        foreach (var line in chatLines)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            JsonDocument doc;
+            try { doc = JsonDocument.Parse(line); }
+            catch (JsonException) { continue; } // torn tail line while grok writes
+
+            using (doc)
+            {
+                var root = doc.RootElement;
+                if (root.ValueKind != JsonValueKind.Object) continue;
+                if (!(root.TryGetProperty("type", out var t) && t.GetString() == "assistant")) continue;
+
+                if (root.TryGetProperty("model_id", out var model)
+                    && model.ValueKind == JsonValueKind.String
+                    && !string.IsNullOrWhiteSpace(model.GetString()))
+                {
+                    latest = model.GetString();
+                }
+            }
+        }
+
+        if (latest is not null)
+            FileLog.Write($"[GrokCurrentModel] model={latest}");
+        return latest;
+    }
+
+    private static string SessionsDirectory()
+        => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".grok", "sessions");
+
+    private static IEnumerable<string> ReadLines(StreamReader reader)
+    {
+        string? line;
+        while ((line = reader.ReadLine()) != null)
+            yield return line;
+    }
+}

--- a/src/CcDirector.Core/OpenCode/OpenCodeCurrentModel.cs
+++ b/src/CcDirector.Core/OpenCode/OpenCodeCurrentModel.cs
@@ -1,0 +1,104 @@
+using System.Text.Json;
+using CcDirector.Core.History;
+using CcDirector.Core.Utilities;
+using Microsoft.Data.Sqlite;
+
+namespace CcDirector.Core.OpenCode;
+
+/// <summary>
+/// Reads the model an OpenCode CLI session is currently using from OpenCode's local SQLite store
+/// (<c>~/.local/share/opencode/opencode.db</c>). The <c>session</c> table keeps the session's
+/// current model directly, as a JSON blob in the <c>model</c> column:
+///
+///   {"id":"gpt-5.3-chat-latest","providerID":"openai"}
+///
+/// OpenCode updates the row when the model changes, so this is the live answer. The active session
+/// is the newest <c>session</c> row whose <c>directory</c> matches the repo - the same resolution
+/// as <see cref="OpenCodeHistoryReader"/>. The store is written by a live OpenCode process, so
+/// reads go through <see cref="SqliteSnapshotReader"/> (verified against opencode 1.15.12, issue
+/// #1637).
+/// </summary>
+public static class OpenCodeCurrentModel
+{
+    /// <summary>The current model of the newest OpenCode session matching
+    /// <paramref name="repoPath"/> from the default store, or null when the store is absent, no
+    /// session matches, or the session has no model recorded.</summary>
+    public static string? ReadForRepo(string repoPath)
+    {
+        var databasePath = OpenCodeHistoryReader.DefaultDatabasePath;
+        if (databasePath is null)
+            return null;
+        return ReadFrom(repoPath, databasePath);
+    }
+
+    /// <summary>The current model from the store at <paramref name="databasePath"/>. Exposed (with
+    /// an explicit database path) for testing so it never has to touch the user profile.</summary>
+    public static string? ReadFrom(string repoPath, string databasePath)
+    {
+        if (string.IsNullOrWhiteSpace(repoPath) || string.IsNullOrWhiteSpace(databasePath) || !File.Exists(databasePath))
+            return null;
+
+        try
+        {
+            return SqliteSnapshotReader.Read(databasePath, connection => ReadFromConnection(connection, repoPath));
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[OpenCodeCurrentModel] Read error for {databasePath}: {ex.Message}");
+            return null;
+        }
+    }
+
+    private static string? ReadFromConnection(SqliteConnection connection, string repoPath)
+    {
+        var target = NormalizePath(repoPath);
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT directory, model FROM session ORDER BY time_updated DESC";
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            var directory = reader.IsDBNull(0) ? null : reader.GetString(0);
+            if (directory is null || NormalizePath(directory) != target)
+                continue;
+
+            var modelJson = reader.IsDBNull(1) ? null : reader.GetString(1);
+            var model = ParseModelId(modelJson);
+            if (model is not null)
+                FileLog.Write($"[OpenCodeCurrentModel] model={model}");
+            return model;
+        }
+
+        return null;
+    }
+
+    /// <summary>Parse the <c>id</c> out of the session row's model JSON blob, or null.</summary>
+    public static string? ParseModelId(string? modelJson)
+    {
+        if (string.IsNullOrWhiteSpace(modelJson))
+            return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(modelJson);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+                return null;
+            return root.TryGetProperty("id", out var id)
+                   && id.ValueKind == JsonValueKind.String
+                   && !string.IsNullOrWhiteSpace(id.GetString())
+                ? id.GetString()
+                : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string NormalizePath(string p)
+    {
+        try { return Path.GetFullPath(p).TrimEnd('\\', '/').ToLowerInvariant(); }
+        catch { return p.TrimEnd('\\', '/').ToLowerInvariant(); }
+    }
+}

--- a/src/CcDirector.Core/Pi/PiCurrentModel.cs
+++ b/src/CcDirector.Core/Pi/PiCurrentModel.cs
@@ -1,0 +1,82 @@
+using System.Text.Json;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Core.Pi;
+
+/// <summary>
+/// Reads the model a pi session is currently using from its session JSONL. Every assistant message
+/// line carries the model that produced it:
+///
+///   {"type":"message","message":{"role":"assistant","provider":"openai-codex","model":"gpt-5.5", ...}}
+///
+/// The LAST assistant message wins, so a mid-session model switch is reflected. Null until the
+/// first assistant message exists. The session file for a repo is located by
+/// <see cref="PiContextUsage.LocateNewestForRepo"/> (verified against pi 0.79.4, issue #1637).
+/// </summary>
+public static class PiCurrentModel
+{
+    /// <summary>The current model of the newest pi session matching <paramref name="repoPath"/>, or
+    /// null when none matches or it has no assistant message yet.</summary>
+    public static string? ReadForRepo(string repoPath)
+    {
+        var file = PiContextUsage.LocateNewestForRepo(repoPath);
+        if (file is null)
+            return null;
+        return ReadFromFile(file);
+    }
+
+    /// <summary>The current model from one pi session file. Reads with FileShare.ReadWrite so the
+    /// live pi session can keep writing. Null when the file is missing or has no assistant model.</summary>
+    public static string? ReadFromFile(string sessionPath)
+    {
+        if (!File.Exists(sessionPath))
+            return null;
+        using var fs = new FileStream(sessionPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(fs);
+        return Compute(ReadLines(reader));
+    }
+
+    /// <summary>Pure core - testable on raw session lines. Returns the LAST assistant model.</summary>
+    public static string? Compute(IEnumerable<string> sessionLines)
+    {
+        ArgumentNullException.ThrowIfNull(sessionLines);
+        string? latest = null;
+
+        foreach (var line in sessionLines)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            JsonDocument doc;
+            try { doc = JsonDocument.Parse(line); }
+            catch (JsonException) { continue; } // torn tail line while pi writes
+
+            using (doc)
+            {
+                var root = doc.RootElement;
+                if (root.ValueKind != JsonValueKind.Object) continue;
+                if (!(root.TryGetProperty("type", out var t) && t.GetString() == "message")) continue;
+                if (!root.TryGetProperty("message", out var msg) || msg.ValueKind != JsonValueKind.Object) continue;
+                if (!(msg.TryGetProperty("role", out var role) && role.GetString() == "assistant")) continue;
+
+                if (msg.TryGetProperty("model", out var model)
+                    && model.ValueKind == JsonValueKind.String
+                    && !string.IsNullOrWhiteSpace(model.GetString()))
+                {
+                    latest = model.GetString();
+                }
+            }
+        }
+
+        if (latest is not null)
+            FileLog.Write($"[PiCurrentModel] model={latest}");
+        return latest;
+    }
+
+    private static IEnumerable<string> ReadLines(StreamReader reader)
+    {
+        string? line;
+        while ((line = reader.ReadLine()) != null)
+            yield return line;
+    }
+}

--- a/src/CcDirector.HostedAgent.Tests/DriverRegistryTests.cs
+++ b/src/CcDirector.HostedAgent.Tests/DriverRegistryTests.cs
@@ -100,11 +100,12 @@ public class DriverRegistryTests
     }
 
     [Fact]
-    public void PiDriver_DeclaresCancelClearContextAndContextUsage()
+    public void PiDriver_DeclaresCancelClearContextContextUsageAndModelReport()
     {
         var caps = new PiDriver().Capabilities;
         Assert.Equal(
-            DriverCapabilities.Cancel | DriverCapabilities.ClearContext | DriverCapabilities.ContextUsage,
+            DriverCapabilities.Cancel | DriverCapabilities.ClearContext | DriverCapabilities.ContextUsage
+            | DriverCapabilities.ModelReport,
             caps);
     }
 
@@ -135,13 +136,13 @@ public class DriverRegistryTests
     }
 
     [Fact]
-    public void CodexDriver_DeclaresCancelInterruptClearAndContextUsage()
+    public void CodexDriver_DeclaresCancelInterruptClearContextUsageAndModelReport()
     {
         var caps = new CodexDriver().Capabilities;
 
         Assert.Equal(
             DriverCapabilities.Cancel | DriverCapabilities.Interrupt | DriverCapabilities.ClearContext
-            | DriverCapabilities.ContextUsage,
+            | DriverCapabilities.ContextUsage | DriverCapabilities.ModelReport,
             caps);
     }
 


### PR DESCRIPTION
Closes nothing on its own - implements the driver layer of thefrederiksen/devthrottle_internal#815; collection is the follow-up there.

## What

- New capability flag `DriverCapabilities.ModelReport` and verb `IAgentDriver.ReadCurrentModel(agentSessionId, workingDirectory, launchArgs)`: the model the tool is CURRENTLY using, read from the tool's own records. The LATEST record wins, so a mid-session model switch (Claude /model, Codex /model) is reflected. Null before the first turn. The default implementation throws NotSupportedException, so a driver without a verified store is honestly absent.
- ClaudeDriver: reuses the existing transcript walk (`ContextModel`); the `--model` launch value answers before the first turn.
- CodexDriver: new `CodexCurrentModel` - last `turn_context` event's `payload.model` in the rollout.
- PiDriver: new `PiCurrentModel` - last assistant `message.model` in the session file.
- CopilotDriver: new `CopilotCurrentModel` - last model-bearing event in `session-state/<id>/events.jsonl` (Copilot's SQLite store has NO model column).
- GenericDriver: gains an optional per-kind current-model reader; declares ModelReport only when one is wired. Grok (`chat_history.jsonl` `model_id`) and opencode (`opencode.db` `session.model`) are wired; Gemini stays undeclared (its installed binary records no model anywhere readable); CursorDriver stays undeclared (unverifiable here).
- Agent-expert skill matrix updated with a live-verified current-model reporting section.

## Proof

- Every store shape was verified against the real installed binaries (claude 2.1.210, codex 0.143.0, pi 0.79.4, copilot 1.0.70, grok 0.2.93, opencode 1.15.12) - details in thefrederiksen/devthrottle_internal#815.
- End-to-end live probe through the actual driver code on this machine returned: claude `claude-fable-5`, codex `gpt-5.5`, pi `gpt-5.5`, copilot `claude-haiku-4.5`, grok `grok-4.5`, opencode `gpt-5.3-chat-latest`.
- 23 new unit tests pinned on fixtures copied from those real files; the "last record wins" leg was deliberately broken and watched go red before being restored.
- Full solution build green; all test projects green (Core 3118+23, Gateway 2344, HostedAgent 80, Avalonia 182, Engine 62, Terminal 21, Launcher 27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)