### PR TITLE
ci: run the JavaScript tests, which CI has never run at all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,52 @@ jobs:
 
       - name: Run tests
         run: dotnet test cc-director.sln -c Release --no-build --verbosity normal
+
+  # The browser shells (the mobile PWA and the React Cockpit) and the client-core library they share.
+  #
+  # This job exists because CI ran NO JavaScript tests at all: 583 vitest tests across client-core and
+  # the Cockpit were green only when someone happened to run them by hand, so nothing stopped a pull
+  # request from landing a broken shell. The mobile voice-mode fix in #1631 is guarded by tests in
+  # client-core that CI would not have run - which is what prompted this.
+  #
+  # Ubuntu on purpose: the .NET job needs Windows because the product is a Windows app, but these are
+  # platform-independent unit tests and a Vite build, and Ubuntu runners are quicker and cheaper.
+  web:
+    name: Build & Test (web)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # tsc --noEmit across every workspace. The shells are typechecked on every build locally
+      # (#1578/#1579); this is the same gate, enforced on the pull request.
+      - name: Typecheck the workspaces
+        run: npm run typecheck
+
+      # Named one workspace per line, deliberately NOT `npm test --workspaces --if-present`: that form
+      # passes silently for a workspace with no test script, so a suite that lost its script - or a
+      # workspace renamed out from under it - would report green while testing nothing. A dead test
+      # looks exactly like coverage. If a new workspace gains tests, add a line here and this stays
+      # honest about what it actually ran.
+      - name: Run client-core tests
+        run: npm test --workspace @devthrottle/client-core
+
+      - name: Run Cockpit tests
+        run: npm test --workspace @devthrottle/cockpit
+
+      # The shells must still BUILD, not just typecheck: the production build runs the real Vite
+      # pipeline (bundling, the PWA service worker) and fails on things tsc never sees.
+      - name: Build the mobile PWA
+        run: npm run build --workspace @devthrottle/mobile
+
+      - name: Build the Cockpit
+        run: npm run build --workspace @devthrottle/cockpit


### PR DESCRIPTION
CI was **.NET only**. The browser shells - the mobile PWA, the React Cockpit, and the `client-core` library they share - had **583 vitest tests** (457 in client-core, 126 in the Cockpit) that ran only when someone thought to run them by hand.

Nothing stopped a pull request from landing a broken shell, and nothing stopped one from re-breaking a fix its tests were written to guard. The mobile voice-mode fix in #1631 is pinned by tests in `client-core` that **CI would not have run** - which is what surfaced this.

## What the new job runs

```
npm ci
npm run typecheck                              # tsc --noEmit, every workspace
npm test --workspace @devthrottle/client-core  # 457 tests
npm test --workspace @devthrottle/cockpit      # 126 tests
npm run build --workspace @devthrottle/mobile
npm run build --workspace @devthrottle/cockpit
```

Ubuntu on purpose: the .NET job needs Windows because the product is a Windows app, but these are platform-independent unit tests and a Vite build.

## Two deliberate choices

**The workspaces are named one per line**, not `npm test --workspaces --if-present`. That form passes *silently* for a workspace with no test script, so a suite that lost its script would report green while testing nothing. A dead test looks exactly like coverage. Naming them means the job fails loudly instead. If a new workspace gains tests, add a line.

**The builds run as well as the typecheck**, because the production build runs the real Vite pipeline (bundling, the PWA service worker) and fails on things `tsc` never sees.

## Verified before landing

Run against current `origin/main` in a clean worktree, so this arrives green rather than red: typecheck clean, 583 tests pass, both shells build.

And confirmed the job actually **bites**: a deliberately failing test makes `npm test --workspace @devthrottle/client-core` exit 1, so CI goes red. A gate that cannot fail is not a gate.

## Not included: `npm run lint`

Lint is **already broken on main**, independently of this change:

```
apps/cockpit/src/push/sw.test.ts
  87:3  error  Definition for rule '@typescript-eslint/no-implied-eval' was not found
```

That file carries an `eslint-disable` for a rule the config does not define, so eslint errors on the unknown rule reference. Wiring lint in would land CI red on day one. It looks like a one-line fix, but it is a separate concern from this change - worth doing next, then adding the lint step.

Generated with [Claude Code](https://claude.com/claude-code)
