### PR TITLE
fix(transcription): keep the audio, so a transcript that lies can be proven

### DIFF
--- a/src/CcDirector.Core.Tests/Storage/CcStorageProductionLocationTests.cs
+++ b/src/CcDirector.Core.Tests/Storage/CcStorageProductionLocationTests.cs
@@ -59,6 +59,7 @@ public sealed class CcStorageProductionLocationTests : IDisposable
             (CcStorage.Transcripts(), Local("transcripts"), nameof(CcStorage.Transcripts)),
             (CcStorage.PromptLog(), Local("prompt-log"), nameof(CcStorage.PromptLog)),
             (CcStorage.TranscriptionLog(), Local("transcription-log"), nameof(CcStorage.TranscriptionLog)),
+            (CcStorage.TranscriptionAudio(), Local("transcription-audio"), nameof(CcStorage.TranscriptionAudio)),
             (CcStorage.TerminalCaptures(), Local("terminal-captures"), nameof(CcStorage.TerminalCaptures)),
             (CcStorage.WebView2Card(), Local("webview2-card"), nameof(CcStorage.WebView2Card)),
             (CcStorage.Bin(), Local("bin"), nameof(CcStorage.Bin)),

--- a/src/CcDirector.Core/Storage/CcStorage.cs
+++ b/src/CcDirector.Core/Storage/CcStorage.cs
@@ -217,6 +217,11 @@ public static class CcStorage
     /// <summary>Transcription telemetry: base/transcription-log/.</summary>
     public static string TranscriptionLog() => Path.Combine(Base(), "transcription-log");
 
+    /// <summary>Rolling archive of the audio behind each transcription, keyed by the telemetry turn id.
+    /// Bounded by age and count by its owner (TranscriptionAudioArchive); sits beside TranscriptionLog()
+    /// so a suspicious transcript line leads straight to the clip that produced it.</summary>
+    public static string TranscriptionAudio() => Path.Combine(Base(), "transcription-audio");
+
     /// <summary>Terminal screen captures: base/terminal-captures/.</summary>
     public static string TerminalCaptures() => Path.Combine(Base(), "terminal-captures");
 

--- a/src/CcDirector.Gateway.Tests/GatewayTranscriptionServiceTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTranscriptionServiceTests.cs
@@ -56,6 +56,79 @@ public sealed class GatewayTranscriptionServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task TranscribeAsync_Success_KEEPSTheAudio()
+    {
+        // THE regression. The old desktop net saved the clip then deleted it the moment the words were
+        // delivered, so it caught a transcription that FAILED but never one that LIED - a truncated
+        // transcript is a "success", and its audio was deleted seconds later. A real turn came back with
+        // 7 words out of a full 18-second recording and there was nothing left to play. Success is
+        // exactly the case that must keep the audio.
+        TranscriptionModeConfig.Set(TranscriptionMode.DevThrottle);
+        new KeyVault(_vaultPath).Set(TranscriptionEndpointResolver.DevThrottleKeyName, "dt_live_abc");
+
+        var archiveDir = Path.Combine(_root, "archive");
+        var service = new GatewayTranscriptionService(
+            new KeyVault(_vaultPath),
+            http: new HttpClient(new StatusHandler(HttpStatusCode.OK, "{\"text\":\"only the first sentence\"}")),
+            audioArchive: new TranscriptionAudioArchive(archiveDir));
+
+        var audio = Enumerable.Repeat((byte)0x42, 512).ToArray();
+        var result = await service.TranscribeAsync(audio, "clip.wav", "audio/wav", applyCorrection: false, default);
+
+        Assert.Equal(TranscriptionOutcome.Ok, result.Outcome);
+        var archived = Directory.GetFiles(archiveDir, "turn-*.wav");
+        var file = Assert.Single(archived);
+        Assert.Equal(audio, File.ReadAllBytes(file));
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_ArchivedClipIsNamedForTheTelemetryTurnId()
+    {
+        // The clip is only useful if a suspicious transcript line leads to it. Both the telemetry record
+        // and the file are keyed by the same turn id, so the log IS the index.
+        TranscriptionModeConfig.Set(TranscriptionMode.DevThrottle);
+        new KeyVault(_vaultPath).Set(TranscriptionEndpointResolver.DevThrottleKeyName, "dt_live_abc");
+
+        var archiveDir = Path.Combine(_root, "archive");
+        var telemetryDir = Path.Combine(_root, "telemetry");
+        var service = new GatewayTranscriptionService(
+            new KeyVault(_vaultPath),
+            http: new HttpClient(new StatusHandler(HttpStatusCode.OK, "{\"text\":\"hello\"}")),
+            telemetry: new TranscriptionTelemetryLog(telemetryDir),
+            audioArchive: new TranscriptionAudioArchive(archiveDir));
+
+        await service.TranscribeAsync(
+            Enumerable.Repeat((byte)0x42, 512).ToArray(), "clip.wav", "audio/wav", applyCorrection: false, default);
+
+        var line = Assert.Single(File.ReadAllLines(Directory.GetFiles(telemetryDir, "*.jsonl").Single()));
+        using var doc = System.Text.Json.JsonDocument.Parse(line);
+        var loggedTurnId = doc.RootElement.GetProperty("turnId").GetString();
+        Assert.NotNull(loggedTurnId);
+        Assert.True(File.Exists(Path.Combine(archiveDir, $"turn-{loggedTurnId}.wav")));
+    }
+
+    [Fact]
+    public async Task TranscribeAsync_ProviderFails_StillKeepsTheAudio()
+    {
+        // The clip is archived BEFORE the attempt, so a provider failure cannot lose the only copy of
+        // what was said either.
+        TranscriptionModeConfig.Set(TranscriptionMode.DevThrottle);
+        new KeyVault(_vaultPath).Set(TranscriptionEndpointResolver.DevThrottleKeyName, "dt_live_abc");
+
+        var archiveDir = Path.Combine(_root, "archive");
+        var body = "{\"error\":{\"code\":\"insufficient_credits\",\"message\":\"no credits\"}}";
+        var service = new GatewayTranscriptionService(
+            new KeyVault(_vaultPath),
+            http: new HttpClient(new StatusHandler(HttpStatusCode.PaymentRequired, body)),
+            audioArchive: new TranscriptionAudioArchive(archiveDir));
+
+        var audio = Enumerable.Repeat((byte)0x42, 512).ToArray();
+        await service.TranscribeAsync(audio, "clip.wav", "audio/wav", applyCorrection: false, default);
+
+        Assert.Single(Directory.GetFiles(archiveDir, "turn-*.wav"));
+    }
+
+    [Fact]
     public async Task TranscribeAsync_ProviderReturns402_YieldsOutOfCreditsOutcome()
     {
         // Issue #885: a 402 insufficient_credits from the hosted service becomes a distinct

--- a/src/CcDirector.Gateway.Tests/Transcription/TranscriptionAudioArchiveTests.cs
+++ b/src/CcDirector.Gateway.Tests/Transcription/TranscriptionAudioArchiveTests.cs
@@ -1,0 +1,154 @@
+using CcDirector.Gateway.Transcription;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests.Transcription;
+
+/// <summary>
+/// The archive exists so a transcription that silently drops half the speech can be PROVEN against the
+/// audio that produced it. These tests pin the two properties that failure needs: the clip survives a
+/// successful turn (the old net deleted exactly then), and it is findable from the turn id in the
+/// telemetry log. The rest pin the bounds that keep it from filling the disk.
+///
+/// Every test writes to its own scratch directory - never the real user's archive.
+/// </summary>
+public sealed class TranscriptionAudioArchiveTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "cc-audio-archive-tests", Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch { /* scratch cleanup is best-effort */ }
+    }
+
+    private TranscriptionAudioArchive NewArchive() => new(_dir);
+
+    private static byte[] Clip(byte fill = 0x42) => Enumerable.Repeat(fill, 64).ToArray();
+
+    [Fact]
+    public void TrySave_WritesTheExactBytesSent()
+    {
+        var archive = NewArchive();
+        var audio = Clip();
+
+        var path = archive.TrySave("turn1", audio, "audio/wav");
+
+        Assert.NotNull(path);
+        Assert.True(File.Exists(path));
+        Assert.Equal(audio, File.ReadAllBytes(path!));
+    }
+
+    [Fact]
+    public void TrySave_FileIsFoundFromTheTelemetryTurnId()
+    {
+        // The whole point of the key: a suspicious line in transcription-log names a turnId, and that
+        // turnId must lead to the clip with no other index in between.
+        var archive = NewArchive();
+        const string turnId = "0b7e368634d1467fa063ec90218d71f9";
+
+        var saved = archive.TrySave(turnId, Clip(), "audio/wav");
+
+        Assert.Equal(archive.FileFor(turnId, ".wav"), saved);
+        Assert.True(File.Exists(archive.FileFor(turnId, ".wav")));
+    }
+
+    [Theory]
+    [InlineData("audio/wav", ".wav")]
+    [InlineData("audio/mpeg", ".mp3")]
+    [InlineData("audio/webm", ".webm")]
+    [InlineData("audio/ogg", ".ogg")]
+    [InlineData("audio/mp4", ".m4a")]
+    [InlineData("application/octet-stream", ".bin")]
+    public void TrySave_NamesTheFileSoAPlayerCanOpenIt(string contentType, string expectedExtension)
+    {
+        var path = NewArchive().TrySave("turn1", Clip(), contentType);
+
+        Assert.Equal(expectedExtension, Path.GetExtension(path));
+    }
+
+    [Fact]
+    public void TrySave_EmptyAudio_SavesNothing()
+    {
+        var archive = NewArchive();
+
+        Assert.Null(archive.TrySave("turn1", Array.Empty<byte>(), "audio/wav"));
+        Assert.Null(archive.TrySave("turn1", null!, "audio/wav"));
+    }
+
+    [Fact]
+    public void TrySave_BlankTurnId_SavesNothing()
+    {
+        Assert.Null(NewArchive().TrySave("  ", Clip(), "audio/wav"));
+    }
+
+    [Fact]
+    public void TrySave_UnwritableDirectory_ReturnsNullAndNeverThrows()
+    {
+        // Fail-open contract: a broken archive degrades diagnostics, never the transcription. The
+        // directory path is occupied by a FILE, so creating it cannot succeed.
+        var occupied = Path.Combine(_dir, "occupied");
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(occupied, "not a directory");
+        var archive = new TranscriptionAudioArchive(occupied);
+
+        var path = archive.TrySave("turn1", Clip(), "audio/wav");
+
+        Assert.Null(path);
+    }
+
+    [Fact]
+    public void TrySave_PrunesClipsOlderThanMaxAge()
+    {
+        var archive = NewArchive();
+        archive.TrySave("stale", Clip(), "audio/wav");
+        var stalePath = archive.FileFor("stale", ".wav");
+        File.SetLastWriteTimeUtc(stalePath, DateTime.UtcNow - TranscriptionAudioArchive.MaxAge - TimeSpan.FromMinutes(1));
+
+        archive.TrySave("fresh", Clip(), "audio/wav");
+
+        Assert.False(File.Exists(stalePath));
+        Assert.True(File.Exists(archive.FileFor("fresh", ".wav")));
+    }
+
+    [Fact]
+    public void TrySave_KeepsClipsInsideMaxAge()
+    {
+        var archive = NewArchive();
+        archive.TrySave("recent", Clip(), "audio/wav");
+        var recentPath = archive.FileFor("recent", ".wav");
+        File.SetLastWriteTimeUtc(recentPath, DateTime.UtcNow - TranscriptionAudioArchive.MaxAge + TimeSpan.FromMinutes(5));
+
+        archive.TrySave("fresh", Clip(), "audio/wav");
+
+        Assert.True(File.Exists(recentPath));
+    }
+
+    [Fact]
+    public void TrySave_PrunesOldestOnceOverMaxClips()
+    {
+        var archive = NewArchive();
+        var baseTime = DateTime.UtcNow - TimeSpan.FromHours(1);
+
+        // One clip over the ceiling, each a minute newer than the last so "oldest" is unambiguous.
+        for (var i = 0; i <= TranscriptionAudioArchive.MaxClips; i++)
+        {
+            var id = $"turn{i:D4}";
+            archive.TrySave(id, Clip(), "audio/wav");
+            File.SetLastWriteTimeUtc(archive.FileFor(id, ".wav"), baseTime.AddMinutes(i));
+        }
+
+        var remaining = Directory.GetFiles(_dir, "turn-*");
+        Assert.Equal(TranscriptionAudioArchive.MaxClips, remaining.Length);
+        Assert.False(File.Exists(archive.FileFor("turn0000", ".wav")));
+        Assert.True(File.Exists(archive.FileFor($"turn{TranscriptionAudioArchive.MaxClips:D4}", ".wav")));
+    }
+
+    [Fact]
+    public void MaxAge_IsAtLeastADay()
+    {
+        // A problem reported "yesterday" must still have its audio; a shorter window silently
+        // reintroduces the failure this archive exists to end.
+        Assert.True(TranscriptionAudioArchive.MaxAge >= TimeSpan.FromHours(24));
+    }
+}

--- a/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
+++ b/src/CcDirector.Gateway/Transcription/GatewayTranscriptionService.cs
@@ -39,6 +39,7 @@ public sealed class GatewayTranscriptionService
     private readonly HttpClient? _http;
     private readonly string _cleanupModel;
     private readonly TranscriptionTelemetryLog _telemetry;
+    private readonly TranscriptionAudioArchive _audioArchive;
 
     /// <param name="vault">The Gateway key vault - the single store for the transcription key.</param>
     /// <param name="dictionaryProvider">Supplies the live dictation dictionary the corrector uses;
@@ -53,13 +54,17 @@ public sealed class GatewayTranscriptionService
     /// not a model). Defaults to the dictation default when blank.</param>
     /// <param name="telemetry">Local transcription telemetry sink. Defaults to the process-wide shared
     /// log (<see cref="TranscriptionTelemetryLog.Shared"/>); tests inject their own.</param>
+    /// <param name="audioArchive">Rolling archive of the audio behind each turn. Defaults to the
+    /// process-wide shared archive (<see cref="TranscriptionAudioArchive.Shared"/>); tests inject their
+    /// own so they never write into the real user's archive.</param>
     public GatewayTranscriptionService(
         KeyVault vault,
         Func<DictationDictionary>? dictionaryProvider = null,
         Func<TranscriptionMode>? modeProvider = null,
         HttpClient? http = null,
         string? cleanupModel = null,
-        TranscriptionTelemetryLog? telemetry = null)
+        TranscriptionTelemetryLog? telemetry = null,
+        TranscriptionAudioArchive? audioArchive = null)
     {
         _vault = vault ?? throw new ArgumentNullException(nameof(vault));
         _dictionaryProvider = dictionaryProvider ?? (() => DictionaryLoader.LoadFromDisk(DictionaryPath()));
@@ -67,6 +72,7 @@ public sealed class GatewayTranscriptionService
         _http = http;
         _cleanupModel = string.IsNullOrWhiteSpace(cleanupModel) ? CleanupOrchestrator.DefaultModel : cleanupModel;
         _telemetry = telemetry ?? TranscriptionTelemetryLog.Shared;
+        _audioArchive = audioArchive ?? TranscriptionAudioArchive.Shared;
     }
 
     /// <summary>
@@ -111,6 +117,14 @@ public sealed class GatewayTranscriptionService
             return GatewayTranscriptionResult.NoKey(mode, routing.Endpoint.Model);
 
         var turnId = Guid.NewGuid().ToString("N");
+
+        // Archive the clip BEFORE transcribing, keyed by the same turn id the telemetry log records.
+        // Before, so a crash or a hang cannot lose it; and kept afterwards WHATEVER the outcome, because
+        // the failure this exists for is a transcription that succeeds and silently drops half the
+        // speech. Only the audio can tell "the provider lost it" from "the microphone went quiet", and a
+        // net that deletes on success is exactly the net that is never there when that happens.
+        _audioArchive.TrySave(turnId, audio, contentType);
+
         var swTranscribe = Stopwatch.StartNew();
         string raw;
         try

--- a/src/CcDirector.Gateway/Transcription/TranscriptionAudioArchive.cs
+++ b/src/CcDirector.Gateway/Transcription/TranscriptionAudioArchive.cs
@@ -1,0 +1,150 @@
+using CcDirector.Core.Storage;
+using CcDirector.Core.Utilities;
+
+namespace CcDirector.Gateway.Transcription;
+
+/// <summary>
+/// Rolling on-disk archive of the audio behind every transcription the Gateway performs.
+///
+/// WHY THIS EXISTS. The desktop dictation safety net (<c>DictationRecordingStore</c>) saves the clip
+/// before transcribing and DELETES it the moment the words are delivered. That net catches a
+/// transcription that FAILS. It does not catch one that LIES: a truncated transcript is a "success", so
+/// the audio that would prove it is deleted seconds later. When a turn came back with a fraction of
+/// what was said, the recording was already gone and the loss could not be localized - the byte count
+/// matching the wall clock proves no samples were DROPPED, but it can never prove the bytes carried
+/// speech. Only the audio can settle that. So the audio is now KEPT.
+///
+/// WHY HERE. This sits beside <see cref="TranscriptionTelemetryLog"/> on purpose. That log is the one
+/// place that sees EVERY turn from every surface (desktop Send, the Speak dialog, the phone, Car Mode),
+/// because they all transcribe through <see cref="GatewayTranscriptionService"/>. The two desktop
+/// dictation paths do not agree on this: only the fire-and-forget Send saves a clip at all. Archiving at
+/// the choke point covers every surface once instead of per-caller.
+///
+/// The file is named for the same <c>turnId</c> the telemetry log records, so a suspicious line in
+/// transcription-log-YYYYMMDD.jsonl leads straight to the audio that produced it.
+///
+/// BOUNDED BY CONSTRUCTION. This is a diagnostic window, not an archive that grows forever: every save
+/// prunes clips older than <see cref="MaxAge"/> and, whatever their age, all but the newest
+/// <see cref="MaxClips"/>. Both bounds apply, so neither a quiet week nor a busy hour can run the disk up.
+///
+/// Privacy: LOCAL disk only, exactly like the telemetry text it sits next to. Never transmitted.
+///
+/// Fail-safe: archiving must never break a transcription. Every operation swallows and logs its errors,
+/// the same fail-open contract as the telemetry log.
+/// </summary>
+public sealed class TranscriptionAudioArchive
+{
+    /// <summary>Process-wide shared archive used by the transcription service.</summary>
+    public static readonly TranscriptionAudioArchive Shared = new();
+
+    /// <summary>How long a clip is kept. A problem reported "yesterday" must still have its audio.</summary>
+    public static readonly TimeSpan MaxAge = TimeSpan.FromHours(24);
+
+    /// <summary>
+    /// Hard ceiling on clip count regardless of age, so a heavy dictation day cannot fill the disk
+    /// before <see cref="MaxAge"/> retires anything. At a typical turn size this is a few hundred
+    /// megabytes at the very worst.
+    /// </summary>
+    public const int MaxClips = 500;
+
+    private readonly object _gate = new();
+    private readonly string _directory;
+
+    /// <param name="directory">Override the archive directory (tests). Defaults to the per-user location.</param>
+    public TranscriptionAudioArchive(string? directory = null)
+    {
+        _directory = string.IsNullOrWhiteSpace(directory) ? DefaultDirectory() : directory;
+    }
+
+    /// <summary>The per-user transcription-audio directory.</summary>
+    public static string DefaultDirectory() => CcStorage.TranscriptionAudio();
+
+    /// <summary>The file a clip for <paramref name="turnId"/> lands in.</summary>
+    public string FileFor(string turnId, string extension)
+        => Path.Combine(_directory, $"turn-{SafeName(turnId)}{extension}");
+
+    /// <summary>
+    /// Keep a turn id to characters a filename allows. Production ids are GUIDs and pass through
+    /// untouched; this only stops a hand-supplied id from escaping the archive directory.
+    /// </summary>
+    private static string SafeName(string name)
+        => string.Join("_", name.Split(Path.GetInvalidFileNameChars()));
+
+    /// <summary>
+    /// Archive the exact bytes sent for transcription and return the saved path, or null when nothing
+    /// was saved. Never throws: a full disk must degrade the diagnostics, never the transcription.
+    /// </summary>
+    /// <param name="turnId">The telemetry turn id; ties the clip to its transcription-log line.</param>
+    /// <param name="audio">The clip bytes, exactly as sent to the provider.</param>
+    /// <param name="contentType">The clip's MIME type, used to pick a playable file extension.</param>
+    public string? TrySave(string turnId, byte[] audio, string contentType)
+    {
+        if (string.IsNullOrWhiteSpace(turnId)) return null;
+        if (audio is null || audio.Length == 0) return null;
+
+        try
+        {
+            lock (_gate)
+            {
+                Directory.CreateDirectory(_directory);
+                var path = FileFor(turnId, ExtensionFor(contentType));
+                File.WriteAllBytes(path, audio);
+                FileLog.Write($"[TranscriptionAudioArchive] archived {audio.Length} bytes for turn {turnId} to {path}");
+                Prune();
+                return path;
+            }
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[TranscriptionAudioArchive] TrySave FAILED for turn {turnId}: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Enforce both bounds: drop anything past <see cref="MaxAge"/>, then drop the oldest until at most
+    /// <see cref="MaxClips"/> remain. Caller holds the lock. Never throws - a clip that cannot be
+    /// deleted is disk noise, not a functional problem.
+    /// </summary>
+    private void Prune()
+    {
+        var files = new DirectoryInfo(_directory)
+            .GetFiles("turn-*")
+            .OrderByDescending(f => f.LastWriteTimeUtc)
+            .ToList();
+
+        var cutoff = DateTime.UtcNow - MaxAge;
+        var doomed = files
+            .Where((f, index) => index >= MaxClips || f.LastWriteTimeUtc < cutoff)
+            .ToList();
+
+        foreach (var file in doomed)
+        {
+            try
+            {
+                file.Delete();
+                FileLog.Write($"[TranscriptionAudioArchive] pruned {file.Name}");
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[TranscriptionAudioArchive] prune FAILED for {file.Name}: {ex.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// A playable extension for the clip's MIME type. The archive exists to be listened to, so the file
+    /// must open in a player by double-click. An unrecognized type keeps its bytes under .bin rather
+    /// than claiming a format it may not be.
+    /// </summary>
+    private static string ExtensionFor(string contentType) => contentType?.ToLowerInvariant() switch
+    {
+        "audio/wav" or "audio/wave" or "audio/x-wav" => ".wav",
+        "audio/mpeg" or "audio/mp3" => ".mp3",
+        "audio/webm" => ".webm",
+        "audio/ogg" => ".ogg",
+        "audio/mp4" or "audio/m4a" or "audio/x-m4a" => ".m4a",
+        "audio/flac" or "audio/x-flac" => ".flac",
+        _ => ".bin",
+    };
+}


### PR DESCRIPTION
## Why

A dictation turn came back with **7 words out of a complete 18-second recording**. The rest of what was said never appeared. It could not be diagnosed, because the audio was already gone.

The desktop safety net (`DictationRecordingStore`) saves the clip before transcribing and deletes it the moment the words are delivered:

```csharp
savedPath = DictationRecordingStore.TrySave(captured.Wav, ...);   // net goes up
transcript = await transcriber.TranscribeAsync(captured.Wav);     // one attempt
await submit(text);
DictationRecordingStore.TryDelete(savedPath);                     // net comes down
```

That net catches a transcription that **fails**. It never catches one that **lies**. A truncated transcript is a "success", so the one piece of evidence that could settle it is deleted seconds after the loss.

The turn's own numbers (`RecordingDurationMs` 18,249 against 875,458 bytes at 48,000 bytes/sec = 18.239s) show the byte count matched the wall clock to **0.056%** — no samples were dropped. But a byte count can never prove those bytes carried speech. Only the audio distinguishes "the provider lost it" from "the microphone went quiet". The audio was gone, so the question stayed open.

## What

The audio is now kept, at the Gateway choke point every surface transcribes through — desktop Send, the Speak dialog, the phone, Car Mode.

The two desktop dictation paths did not agree on this: **only the fire-and-forget Send saved a clip at all**, which is why the turn that started this had no recording even before the delete. Archiving where the `turnId` is minted covers every surface once instead of per-caller.

- Clips land in `transcription-audio/`, keyed by the same `turnId` the telemetry log already records — a suspicious line in `transcription-log-YYYYMMDD.jsonl` leads straight to the audio that produced it. The log IS the index; no second one to keep in step.
- Saved **before** the attempt and kept **whatever the outcome**, so neither a crash nor a silent truncation can lose it.
- **Bounded by construction**: pruned on every save to 24 hours AND a 500-clip ceiling. Both bounds apply, so neither a quiet week nor a busy hour runs the disk up.
- **Fail-open**, like the telemetry it sits beside: a full disk degrades diagnostics, never a transcription.
- Local disk only, exactly like the transcript text already stored next to it. Never transmitted.

The desktop net still deletes its own temporary copy on success — that stays correct now the archive holds one regardless.

## Proof

Tests **verified to fail on purpose**. Reverting the single archive call turns the three integration tests red while the archive unit tests stay green as controls:

```
Failed!  - Failed: 3, Passed: 27   <- archive call reverted
Passed!  - Failed: 0, Passed: 30   <- restored
```

Full suites, no regressions:

```
Gateway  Passed! - Failed: 0, Passed: 2362
Core     Passed! - Failed: 0, Passed: 3095
```

## What this does NOT do

It does not explain the original 7-word turn — that audio is gone for good. It makes the **next** one answerable in the time it takes to play a file.

Still open, and worth a follow-up: only 6 of that day's 313 turns recorded the wall clock at all, and the per-chunk loudness we compute for the equalizer bars is thrown away. A loudness trace would separate "silent mic" from "provider dropped it" even with no audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
