### PR TITLE
fix(mobile): the file viewer lost its network pill, and voice could switch itself back on

### DIFF
--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -57,11 +57,21 @@ function GatedLayout() {
   // The one global bad-connection banner (mobile-resilience mission): mounted once here so it pins to
   // the top of every gated screen and is the single voice for a bad connection. Hidden while the
   // connection is good; the pages keep their last-known content underneath either way.
-  // The network pill is fixed top-right on every screen that has no title row of its own to give it.
-  // The session screens DO have one, and they render their own inline pill on it (SessionAppBar), so
-  // the fixed one stands down there - otherwise both would show. The session screens need that corner
-  // back for their overflow menu button: while the pill held it, the button lived on the LEFT of the
-  // bar and its right-anchored menu opened off the left edge of the screen.
+  // The network pill is fixed top-right on every screen that has no header of its own to give it. The
+  // /session/ screens DO have one and render their own inline pill there, so the fixed one stands down
+  // for that whole subtree - otherwise both would show. They need that corner back for the overflow
+  // menu button: while the pill held it, the button lived on the LEFT of the bar and its right-anchored
+  // menu opened off the left edge of the screen.
+  //
+  // THIS SUPPRESSES THE PILL FOR THE ENTIRE /session/ SUBTREE, so every screen routed under /session/
+  // MUST render its own <StatusPill inline />, or it will show no network status at all. Today:
+  //
+  //   /session/:id, /chat, /terminal, /voice  -> SessionAppBar renders it
+  //   /session/:id/file                       -> FileView renders it in its own header
+  //
+  // The file viewer was missed when the pill was first moved inline (caught in review of #1631) - it is
+  // under /session/ but does not use SessionAppBar, so it silently lost its pill. Add a new /session/
+  // route and you own its pill too.
   const onSessionScreen = useLocation().pathname.startsWith("/session/");
   return (
     <>

--- a/apps/mobile/src/pages/FileView.tsx
+++ b/apps/mobile/src/pages/FileView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { StatusPill } from "../components/StatusPill";
 import { classifyFile, formatFileSize } from "@devthrottle/client-core/history/fileTypes";
 import type { FileViewerType } from "@devthrottle/client-core/history/fileTypes";
 import {
@@ -81,6 +82,7 @@ export function FileView() {
         <header className="app-bar">
           <button type="button" className="file-view-back" onClick={goBack}>Back</button>
           <h1 className="term-title">File</h1>
+          <StatusPill inline />
         </header>
         <div className="file-view-body">
           <div className="file-view-error">No file path was provided.</div>
@@ -95,10 +97,16 @@ export function FileView() {
 
   return (
     <div className="terminal-screen">
+      {/* The pill is rendered here, inline, because this screen lives under /session/ and the globally
+          mounted fixed pill stands down for that whole subtree (GatedLayout). Every /session/ screen
+          therefore has to carry its own - Chat, Terminal and Voice get theirs from SessionAppBar; the
+          file viewer has its own header, so it renders its own. Without this the file viewer showed no
+          network status at all. */}
       <header className="app-bar">
         <button type="button" className="file-view-back" onClick={goBack}>Back</button>
         <h1 className="term-title" title={path}>{name}</h1>
         <DownloadButton url={url} name={name} />
+        <StatusPill inline />
       </header>
       <div className="file-view-body">
         <FileViewContent type={type} url={url} name={name} sessionId={sessionId} path={path} />

--- a/apps/mobile/src/pages/VoiceMode.tsx
+++ b/apps/mobile/src/pages/VoiceMode.tsx
@@ -1,4 +1,5 @@
-import { useLocation, useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { DictationDialog } from "@devthrottle/client-core/dictation/DictationDialog";
 import { formatClock, useVoiceMode } from "@devthrottle/client-core/voice/useVoiceMode";
 import { DictationStatusStrip } from "../components/DictationStatusStrip";
@@ -25,9 +26,32 @@ export function VoiceMode() {
   // that menu item navigates here and asks the hook to run its own onSwitchOn, so the one place that
   // knows how to enter voice mode stays the one place that does it.
   const location = useLocation();
+  const navigate = useNavigate();
   const navState = location.state as { voiceMode?: boolean; switchOn?: boolean } | null;
   const seededVoiceOn = navState?.voiceMode;
-  const autoSwitchOn = navState?.switchOn;
+
+  // switchOn is a ONE-SHOT COMMAND, so it is read once and then scrubbed off the history entry.
+  //
+  // It cannot be read straight from location.state on every render: router state is persisted in the
+  // history entry and survives a reload, while the hook's "already did it" guard is only a ref, which a
+  // remount resets. So the command would fire AGAIN on any remount of this history entry - turn voice
+  // on from the Chat menu, turn it off, let the service worker update reload the app (it does, on every
+  // deploy), and voice would switch itself back on against your explicit wish. Caught in review of
+  // #1631.
+  //
+  // useState's initializer captures the command exactly once, at mount; the effect then rewrites the
+  // entry with switchOn cleared, so any later remount reads a spent command and does nothing.
+  const [autoSwitchOn] = useState(() => navState?.switchOn === true);
+  useEffect(() => {
+    if (navState?.switchOn !== true) return;
+    navigate(location.pathname + location.search, {
+      replace: true,
+      state: { ...navState, switchOn: false },
+    });
+    // Mount-only: this consumes the arriving command. Re-running it on navState changes would fight
+    // the very rewrite it performs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const {
     voiceOn,


### PR DESCRIPTION
Two defects found reviewing #1631 (a Codex session reading `origin/main`). Both are in code that pull request introduced.

## 1. The file viewer lost its network pill - a regression

#1631 moved the network pill inline onto the session screens' title row and had the globally mounted fixed pill stand down for the whole `/session/` subtree. But **the suppression is by URL prefix, while the inline pill is supplied by `SessionAppBar`** - and the file viewer is routed under `/session/:sessionId/file` with its **own** header, so it renders no `SessionAppBar` and got no pill.

Open a file from Chat or Terminal and the network status simply vanished.

The file viewer now renders its own `<StatusPill inline />` in both header branches. The comment in `main.tsx` no longer just says the fixed pill "stands down" - it says the suppression covers the **entire subtree**, names every route under it and where each one's pill comes from, and says a new `/session/` route owns its pill. The vague comment is what let this slip.

## 2. Voice could switch itself back on after you turned it off

#1631 added "Switch to voice mode" to the Chat/Terminal menu, which navigates to the voice screen with `{ switchOn: true }` in router state. The screen read that straight from `location.state` on every render, guarded only by a ref.

**Router state is persisted in the history entry and survives a reload; the ref is per-mount and does not.** So the one-shot command was not one-shot: switch voice on from the menu, turn it off, let the service worker update reload the app - which it does on every deploy - and the command fires again and voice switches back on against your explicit wish.

The command is now read once via `useState`'s initializer and then scrubbed off the history entry, so a later remount reads a spent command and does nothing.

## Proof

Driven end-to-end in a real browser (Vite dev + a fetch shim, 390x844), counting actual `POST /voice-mode` calls:

| | history state after arriving | calls after reloading that entry |
|---|---|---|
| **fixed** | `switchOn: false` (spent) | **1** - correct |
| **reverted** | `switchOn: true` (never consumed) | **2** - the bug |

And the file viewer's pill: present, inline, exactly one, after the fix.

## Not changed, on purpose

The review also flagged that `voiceKnown` is not reset per poll, and that the overflow menu claims ARIA menu semantics without arrow-key focus handling. The first is the poll's intended keep-last-known behaviour (and the banner holding while "Generating narration..." runs is by design); the second is a real accessibility gap but predates #1631. Both are separate work.

Typecheck clean, 583 tests pass, both shells build. This is the first pull request whose JavaScript tests CI actually runs (#1642).

Generated with [Claude Code](https://claude.com/claude-code)
