### PR TITLE
Gap 4 is decided: the owner rejected it, and why

### DIFF
--- a/docs/architecture/gap-4-desktop-asks-recommendation.md
+++ b/docs/architecture/gap-4-desktop-asks-recommendation.md
@@ -1,7 +1,32 @@
 # Gap 4 - the desktop cannot see four things the phone can
 
-**Status:** INVESTIGATION AND RECOMMENDATION ONLY. Nothing here is built. This is a decision paper for
-the Architect and, on one question, for the owner.
+**Status:** DECIDED - **OPTION A IS REJECTED BY THE OWNER, 15 July 2026. It will not be built.** This
+paper stays as the record of why, and because its analysis of the mechanism is still correct and still
+useful. Nothing here was ever built.
+
+> ## THE OWNER'S ANSWER, and it settles it
+>
+> The question this paper called the whole decision was: *when the Gateway is unreachable, what should
+> the desktop session rail show?* His answer, in his words: **"it is good that it still works without the
+> gateway"** - and the case is a laptop that cannot reach the Gateway machine, which must still run his
+> sessions.
+>
+> That kills Option A outright, exactly as this paper said it would. A rail that renders only what the
+> Gateway folded has NOTHING to show when the Gateway is unreachable. There is no clever version of that.
+> **So the desktop keeps its local fold, and gap 4 does not fully close** - the three permanent blind
+> spots (phone dictation, server transcription, voice being prepared) stay, and the desktop keeps saying
+> "Needs you" about a session that is busy doing something he asked for.
+>
+> **That is the price of a laptop that works, and he has paid it deliberately rather than drifted into
+> it.** Which is what this paper was for.
+>
+> **Option B is NOT thereby approved.** This paper argues it treats the symptom and taxes us forever, and
+> nobody has decided to pay that. It is available, knowingly, if the nagging ever justifies it. The
+> default is Option C: the gap stays named.
+>
+> **What his answer started instead:** he asked what ELSE has quietly become Gateway-dependent, because
+> the laptop must run. That audit is the real work, and it is a bigger question than this paper's.
+> See the Gateway-dependency audit that follows from it.
 **Written:** 15 July 2026, by the Session States Manager.
 **Mission:** [`mission-session-states.md`](mission-session-states.md). **Brief:** [`session-states-gaps-manager-brief.md`](session-states-gaps-manager-brief.md).
 

--- a/docs/architecture/mission-session-states.md
+++ b/docs/architecture/mission-session-states.md
@@ -156,10 +156,10 @@ That is a real piece of work and it is the owner's call.
 closed, and they are ([#1623](https://github.com/thefrederiksen/devthrottle/pull/1623)).**
 
 **Gaps 1, 2, 5 and 6 are fixed and merged.** Gap 3 is REFUSED on the evidence and stays open on purpose -
-see its census on `Session.StatusColor`. Gap 4 is a decision paper and is the ONE thing still waiting on
-the owner. A Manager is seated on them - brief at
-[`session-states-gaps-manager-brief.md`](session-states-gaps-manager-brief.md), branch
-`mission/session-states-gaps`.
+see its census on `Session.StatusColor`. **Gap 4 is DECIDED and REJECTED** - see below; nothing here is
+waiting on the owner any more. The Manager's brief is at
+[`session-states-gaps-manager-brief.md`](session-states-gaps-manager-brief.md); its work merged as
+[#1623](https://github.com/thefrederiksen/devthrottle/pull/1623) and the Manager has stood down.
 
 Two of the four are settled and being built:
 

--- a/docs/architecture/mission-session-states.md
+++ b/docs/architecture/mission-session-states.md
@@ -172,7 +172,16 @@ Two of the four are settled and being built:
   with live readers to make this document true would be the mission's own failure mode. If it cannot
   close here, it stays a named gap - that is a fine outcome; a false claim is not.
 
-**Gap 4 still needs the owner, and will come back to him with a cost.** The desktop cannot see phone
+**Gap 4 is DECIDED and REJECTED (15 July 2026).** The owner was asked the one question the decision
+paper said was the whole decision - what the desktop rail shows when the Gateway is unreachable - and his
+answer was that it must still work without the Gateway, because he uses a laptop that cannot always reach
+the Gateway machine. That kills the "desktop asks" option outright: a rail that renders only what the
+Gateway folded has nothing to show when the Gateway is gone.
+
+**So gap 4 does not close, on purpose.** The desktop keeps its local fold and its three permanent blind
+spots. That is the price of a laptop that works, paid deliberately. See
+[`gap-4-desktop-asks-recommendation.md`](gap-4-desktop-asks-recommendation.md) for the reasoning and the
+rejection. His answer started a bigger question instead: what ELSE has quietly become Gateway-dependent. The desktop cannot see phone
 dictation, server transcription, voice preparation, or a just-expired snooze, because it folds the
 DIRECTOR's view and those are Gateway-side facts. The design's own recommendation is that the desktop
 should stop working colours out and ask, as the phone does. That is an architectural change, not a


### PR DESCRIPTION
The decision paper named one question as the whole decision — *when the Gateway is unreachable, what should the desktop rail show?*

**The owner answered: it must still work without the Gateway.** His case is a laptop that cannot reach the Gateway machine and must still run his sessions.

That kills the "desktop asks" option outright, exactly as the paper predicted. A rail that renders only what the Gateway folded has nothing to show when the Gateway is unreachable. There's no clever version of that.

**So gap 4 does not close, on purpose.** The desktop keeps its local fold and its three permanent blind spots — it will go on saying "Needs you" about a session busy doing something he asked for. That's the price of a laptop that works, paid knowingly rather than drifted into. Which is what the paper was for.

**Option B is not thereby approved.** The paper argues it treats the symptom and taxes us forever, and nobody has decided to pay that. It stays available if the nagging ever justifies it. The default is Option C: the gap stays named.

Both documents now read DECIDED rather than open. A paper asking a question the owner already answered is a stale claim — and this mission ended by fixing one of exactly that shape in its own record.

Documentation only.