### PR TITLE
Fix the Agents tab: real Codex turns were locked out, restored sessions lied about their agent, and agent-to-agent turns were never counted

### DIFF
--- a/apps/cockpit/src/throttle/AgentsTab.tsx
+++ b/apps/cockpit/src/throttle/AgentsTab.tsx
@@ -14,11 +14,12 @@ import {
 // envelope), so the tab reads its parent's snapshot rather than opening a second poll of the same feed.
 // Counts only - never any message text.
 //
-// This tab counts from agentsSinceUtc, NOT all-time. The turn totals had been accumulating long before the
-// per-agent breakdown existed, and nothing recorded which agent those earlier turns ran under - so the
-// numbers here do not reconcile with the Overview tab's totals, and the tab says so on its face rather
-// than letting the owner read a smaller number as a drop in usage. It reuses the Repos tab's row and
-// segmented-control styles so the two read as one page.
+// This tab does not reconcile with the Overview tab's totals, and says so on its face rather than letting
+// the owner read a smaller number as a drop in usage. A session the Gateway still knows about is attributed
+// in FULL, including the turns it had already driven before the breakdown existed (issue #1633). What is
+// missing is the sessions that had already finished by then: their turns are in the all-time totals, but
+// nothing ever recorded which agent they ran under, so they cannot honestly be split by agent.
+// It reuses the Repos tab's row and segmented-control styles so the two read as one page.
 
 // The three honest metrics the system actually measures per agent. Tokens are intentionally absent: the
 // tally counts turns and characters, never tokens, and this tab never fabricates a number.
@@ -150,8 +151,9 @@ export function AgentsTab({ data }: { data: ThrottleData }) {
       <div className="thr-empty">
         No agent usage counted yet
         {since !== null ? ` since ${since}, when this breakdown started counting` : ""}. Drive a session -
-        Claude Code, Codex, or any other agent - and the split will appear here, ranked. Turns driven before
-        this breakdown existed are not included: nothing recorded which agent they ran under.
+        Claude Code, Codex, or any other agent - and the split will appear here, ranked. Turns from sessions
+        that had already finished before this breakdown existed are not included: nothing recorded which
+        agent they ran under.
       </div>
     );
   }
@@ -167,7 +169,7 @@ export function AgentsTab({ data }: { data: ThrottleData }) {
         Which agent you actually drive: how your driving splits across the agent CLIs you run, ranked by{" "}
         {METRIC_WORD[metric]}. Counted at the Director, so desktop typing is included.
         {since !== null
-          ? ` Counting since ${since}, when this breakdown was added - so these numbers are smaller than your all-time totals on the other tabs.`
+          ? ` Attributing since ${since}, when this breakdown was added - so these numbers can be smaller than your all-time totals on the other tabs.`
           : ""}
       </p>
 
@@ -230,9 +232,10 @@ export function AgentsTab({ data }: { data: ThrottleData }) {
         <ul>
           {since !== null && (
             <li>
-              This tab counts from {since}, when the breakdown was added - not all-time. The turns on the
-              other tabs go back further, and nothing recorded which agent those earlier ones ran under, so
-              the two do not add up to the same number.
+              Attribution started {since}. A session still running then is counted in full, including the
+              turns it had already driven. Turns from sessions that had already finished by then are not
+              here at all - nothing recorded which agent they ran under - so this tab does not add up to the
+              all-time totals on the other tabs.
             </li>
           )}
           <li>

--- a/apps/cockpit/src/throttle/AgentsTab.tsx
+++ b/apps/cockpit/src/throttle/AgentsTab.tsx
@@ -93,12 +93,19 @@ function AgentRow({
 
   // The secondary facts depend on which metric is the headline, so the row never just repeats the big
   // number - it shows the other two honest measures alongside it.
+  // Turns other agents drove into this agent's sessions. Stated as its own fact next to the human turns,
+  // never added to them: "you drove 14, the fleet drove 300 into it" is the honest pair.
+  const agentDriven =
+    agent.agentDrivenTurns > 0
+      ? ` - ${agent.agentDrivenTurns.toLocaleString()} from agents`
+      : "";
+
   const meta =
     metric === "turns"
-      ? `${compactNumber(agent.characters)} chars - ${agent.sessions} session${agent.sessions === 1 ? "" : "s"} - ${voicePct}% voice`
+      ? `${compactNumber(agent.characters)} chars - ${agent.sessions} session${agent.sessions === 1 ? "" : "s"} - ${voicePct}% voice${agentDriven}`
       : metric === "characters"
-        ? `${agent.turns.toLocaleString()} turns - ${agent.sessions} session${agent.sessions === 1 ? "" : "s"}`
-        : `${agent.turns.toLocaleString()} turns - ${compactNumber(agent.characters)} chars`;
+        ? `${agent.turns.toLocaleString()} turns - ${agent.sessions} session${agent.sessions === 1 ? "" : "s"}${agentDriven}`
+        : `${agent.turns.toLocaleString()} turns - ${compactNumber(agent.characters)} chars${agentDriven}`;
 
   return (
     <div className="repo-row">
@@ -194,6 +201,16 @@ export function AgentsTab({ data }: { data: ThrottleData }) {
           value={formatShare(summary.totalTurns > 0 ? summary.voiceTurns / summary.totalTurns : null)}
           sub="of turns spoken, not typed"
         />
+        {/* Leverage (issue #1636): what the fleet did off the back of each turn the owner spent. Shown
+            only once the fleet has actually driven itself - a "0x" on a machine that has never run a
+            worker would be noise, not a fact. */}
+        {summary.agentDrivenTurns > 0 && (
+          <HeadlineCard
+            label="Leverage"
+            value={summary.leverage !== null ? `${summary.leverage.toFixed(1)}x` : "-"}
+            sub={`${summary.agentDrivenTurns.toLocaleString()} turns agents drove agents`}
+          />
+        )}
       </div>
 
       <div className="repos-controls">
@@ -245,6 +262,12 @@ export function AgentsTab({ data }: { data: ThrottleData }) {
           <li>
             Agents are grouped by the CLI the session runs. A session the Director reported no agent for is
             counted under &quot;(unknown)&quot; rather than dropped - the turns are real either way.
+          </li>
+          <li>
+            Turns you drove and turns agents drove into other agents are counted separately and never added
+            together. The ranked bars and the voice share are YOUR driving; &quot;from agents&quot; and
+            Leverage are the fleet driving itself. Text the product wrote itself - handover, queue drain -
+            is not a turn and is counted by neither.
           </li>
           <li>
             Tokens are not shown - the tally counts turns and characters, never tokens, and this tab never

--- a/packages/client-core/src/stats/statsClient.test.ts
+++ b/packages/client-core/src/stats/statsClient.test.ts
@@ -29,6 +29,8 @@ function data(buckets: ThrottleData["buckets"]): ThrottleData {
     repos: [],
     agents: [],
     agentsSinceUtc: "",
+    agentDrivenTurns: 0,
+    agentDrivenCharacters: 0,
     notCaptured: [],
   };
 }
@@ -37,8 +39,12 @@ function repo(repoName: string, turns: number, voiceTurns: number, characters: n
   return { repo: `D:/${repoName}`, repoName, turns, voiceTurns, typedTurns: turns - voiceTurns, characters, sessions };
 }
 
-function agent(agentToken: string, agentName: string, turns: number, voiceTurns: number, characters: number, sessions: number): AgentStat {
-  return { agent: agentToken, agentName, turns, voiceTurns, typedTurns: turns - voiceTurns, characters, sessions };
+function agent(agentToken: string, agentName: string, turns: number, voiceTurns: number, characters: number, sessions: number,
+               agentDrivenTurns = 0): AgentStat {
+  return {
+    agent: agentToken, agentName, turns, voiceTurns, typedTurns: turns - voiceTurns, characters, sessions,
+    agentDrivenTurns, agentDrivenCharacters: agentDrivenTurns * 100,
+  };
 }
 
 describe("summarizeThrottle", () => {
@@ -120,6 +126,34 @@ describe("summarizeAgents", () => {
     expect(s.topAgentName).toBe("Claude Code");
     expect(s.topShare).toBeCloseTo(0.8);
     expect(s.hasData).toBe(true);
+  });
+
+  // Issue #1636. Leverage is what the fleet did off the back of each turn the owner spent.
+  it("computes leverage as agent-driven turns per turn you drove", () => {
+    const s = summarizeAgents([
+      agent("ClaudeCode", "Claude Code", 8, 6, 640, 2, 24),
+      agent("Codex", "Codex", 2, 0, 60, 1, 6),
+    ]);
+    expect(s.agentDrivenTurns).toBe(30);
+    expect(s.leverage).toBeCloseTo(3); // 30 agent turns off the back of 10 of yours
+  });
+
+  // The trap: agent-driven turns must never inflate the human's own numbers, or the voice share moves
+  // because the definition moved rather than because the behaviour did.
+  it("keeps agent-driven turns out of the human totals and the voice share", () => {
+    const s = summarizeAgents([agent("Codex", "Codex", 4, 4, 400, 1, 500)]);
+    expect(s.totalTurns).toBe(4);
+    expect(s.voiceTurns).toBe(4);
+    expect(s.agentDrivenTurns).toBe(500);
+    expect(s.topShare).toBeCloseTo(1); // still 100% of YOUR driving
+  });
+
+  // A ratio with nothing underneath it would be a fabricated number, not a big one.
+  it("reports a null leverage (not Infinity) when you have driven no turns", () => {
+    const s = summarizeAgents([agent("Codex", "Codex", 0, 0, 0, 1, 40)]);
+    expect(s.leverage).toBeNull();
+    expect(s.agentDrivenTurns).toBe(40);
+    expect(s.hasData).toBe(true); // a fleet driving itself is a real state, not an empty one
   });
 
   // The tally starts when the breakdown ships, so "nothing yet" is the normal first state - it must read

--- a/packages/client-core/src/stats/statsClient.ts
+++ b/packages/client-core/src/stats/statsClient.ts
@@ -105,6 +105,12 @@ export interface AgentStat {
   characters: number;
   /** Distinct sessions that drove counted input through this agent. */
   sessions: number;
+  /** Turns OTHER AGENTS drove into the sessions running this agent (issue #1636) - not the human.
+   *  NOT part of `turns`, which stays the human's own driving: the two answer different questions and
+   *  adding them would corrupt the voice share. Zero from a Gateway that predates the lane. */
+  agentDrivenTurns: number;
+  /** Character volume of the `agentDrivenTurns`. */
+  agentDrivenCharacters: number;
 }
 
 /** The GET /stats/data body: the fleet-wide aggregated tally plus the honesty caveats. */
@@ -129,6 +135,12 @@ export interface ThrottleData {
    *  The other series predate it, so the Agents page states this window instead of implying the earlier
    *  turns ran under no agent. */
   agentsSinceUtc: string;
+  /** Turns the fleet drove into ITSELF: one agent prompting another (issue #1636). Reported alongside the
+   *  human tally, never inside it. The ratio of this to your own turns is your leverage - what the fleet
+   *  did off the back of each turn you spent. Zero from a Gateway that predates the lane. */
+  agentDrivenTurns: number;
+  /** Character volume of the fleet's `agentDrivenTurns`. */
+  agentDrivenCharacters: number;
   /** Plain-English caveats about what the numbers do and do not include. */
   notCaptured: string[];
 }
@@ -210,6 +222,8 @@ export async function getThrottle(signal?: AbortSignal): Promise<ThrottleData> {
     repos?: unknown;
     agents?: unknown;
     agentsSinceUtc?: unknown;
+    agentDrivenTurns?: unknown;
+    agentDrivenCharacters?: unknown;
     notCaptured?: unknown;
   } | null;
   const buckets = Array.isArray(body?.buckets) ? body!.buckets.map(normalizeBucket) : [];
@@ -229,6 +243,8 @@ export async function getThrottle(signal?: AbortSignal): Promise<ThrottleData> {
     repos,
     agents,
     agentsSinceUtc: typeof body?.agentsSinceUtc === "string" ? body.agentsSinceUtc : "",
+    agentDrivenTurns: num(body?.agentDrivenTurns),
+    agentDrivenCharacters: num(body?.agentDrivenCharacters),
     notCaptured,
   };
 }
@@ -248,6 +264,8 @@ function normalizeAgent(raw: unknown): AgentStat {
     typedTurns: num(a.typedTurns),
     characters: num(a.characters),
     sessions: num(a.sessions),
+    agentDrivenTurns: num(a.agentDrivenTurns),
+    agentDrivenCharacters: num(a.agentDrivenCharacters),
   };
 }
 
@@ -380,6 +398,12 @@ export interface AgentSummary {
   topShare: number | null;
   /** The most-driven agent's display name, or null when there is no data. */
   topAgentName: string | null;
+  /** Turns the fleet drove into itself - one agent prompting another (issue #1636). */
+  agentDrivenTurns: number;
+  /** Leverage: agent-driven turns per turn YOU drove. 3 means the fleet spent three turns off the back of
+   *  each one of yours. Null when you have driven no turns - a ratio with nothing underneath it would be
+   *  a fabricated number, not a big one. */
+  leverage: number | null;
   hasData: boolean;
 }
 
@@ -391,6 +415,7 @@ export function summarizeAgents(agents: AgentStat[]): AgentSummary {
   let totalCharacters = 0;
   let totalSessions = 0;
   let voiceTurns = 0;
+  let agentDrivenTurns = 0;
   let top: AgentStat | null = null;
 
   for (const a of agents) {
@@ -398,6 +423,7 @@ export function summarizeAgents(agents: AgentStat[]): AgentSummary {
     totalCharacters += a.characters;
     totalSessions += a.sessions;
     voiceTurns += a.voiceTurns;
+    agentDrivenTurns += a.agentDrivenTurns;
     if (top === null || a.turns > top.turns) top = a;
   }
 
@@ -409,7 +435,11 @@ export function summarizeAgents(agents: AgentStat[]): AgentSummary {
     voiceTurns,
     topShare: totalTurns > 0 && top !== null ? top.turns / totalTurns : null,
     topAgentName: top !== null ? top.agentName : null,
-    hasData: totalTurns > 0 || totalCharacters > 0,
+    agentDrivenTurns,
+    leverage: totalTurns > 0 ? agentDrivenTurns / totalTurns : null,
+    // Agent-driven turns alone are data worth showing: a fleet driving itself while the owner has driven
+    // nothing this window is a real state, not an empty one.
+    hasData: totalTurns > 0 || totalCharacters > 0 || agentDrivenTurns > 0,
   };
 }
 

--- a/src/CcDirector.Avalonia/FifoWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/FifoWindow.axaml.cs
@@ -451,7 +451,7 @@ public partial class FifoWindow : Window
         SetStatus("Sending to agent...", Yellow);
         // Desktop voice FIFO injection is framework-mediated; exempt from the dictation lock (issue #1181, Task 3b).
         // DevThrottle Stats: this is spoken input from the desktop - count it as one voice turn.
-        await _current.SendTextAsync(transcript, SendSource.Internal, InputOrigin.DesktopVoice);
+        await _current.SendTextAsync(transcript, SendSource.Framework, InputOrigin.DesktopVoice);
         SetText(ReplyText, $"Sent to {DisplayName(_current)}. Watch the terminal, then Next.");
         SetStatus("Sent - watch the terminal, then Next", Green);
     }

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -1426,7 +1426,10 @@ public partial class MainWindow : Window
 
                 progress.UpdateProgress(i + 1, total, entry.CustomName ?? entry.RepoPath);
 
-                var vm = CreateSession(entry.RepoPath, claudeArgs: entry.ClaudeArgs);
+                // Issue #1635: restore the agent the session was saved with. Before this the call passed no
+                // agentKind, so the overload default silently made every restored session ClaudeCode.
+                var vm = CreateSession(entry.RepoPath, claudeArgs: entry.ClaudeArgs,
+                    agentKind: entry.ResolveAgentKind());
                 if (vm != null)
                 {
                     vm.Rename(entry.CustomName, entry.CustomColor);
@@ -3509,7 +3512,10 @@ public partial class MainWindow : Window
             var app = AppRef();
             var sessionData = _sessions.Select(vm => new SessionData(
                 vm.DisplayName, vm.Session.RepoPath, vm.Session.CustomName,
-                vm.Session.CustomColor, vm.Session.ClaudeArgs));
+                vm.Session.CustomColor, vm.Session.ClaudeArgs,
+                // Issue #1635: record WHICH agent this session runs. Without it the agent is lost here, at
+                // save time, and the session can only come back as the CreateSession default.
+                vm.Session.AgentKind.ToString()));
             var dialog = new SaveWorkspaceDialog(app.WorkspaceStore, sessionData);
             await dialog.ShowDialog<bool?>(this);
         }));

--- a/src/CcDirector.Avalonia/MainWindow.axaml.cs
+++ b/src/CcDirector.Avalonia/MainWindow.axaml.cs
@@ -4564,7 +4564,7 @@ public partial class MainWindow : Window
             return;
         }
 
-        await _activeSession.Session.SendTextAsync("/handover", SendSource.Internal);
+        await _activeSession.Session.SendTextAsync("/handover", SendSource.Framework);
         FileLog.Write($"[MainWindow] BtnHandover_Click: sent /handover to session {_activeSession.Session.Id}");
     }
 
@@ -5474,7 +5474,7 @@ public partial class MainWindow : Window
             + "and what you think we should work on next. Show the scope of remaining work "
             + "and suggest priorities.";
 
-        await session.SendTextAsync(prompt, SendSource.Internal);
+        await session.SendTextAsync(prompt, SendSource.Framework);
         FileLog.Write($"[MainWindow] InjectHandoverPromptAsync: sent handover prompt for session {session.Id}");
     }
 

--- a/src/CcDirector.Avalonia/SaveWorkspaceDialog.axaml.cs
+++ b/src/CcDirector.Avalonia/SaveWorkspaceDialog.axaml.cs
@@ -16,7 +16,8 @@ public record SessionData(
     string RepoPath,
     string? CustomName,
     string? CustomColor,
-    string? ClaudeArgs);
+    string? ClaudeArgs,
+    string? Agent);
 
 public partial class SaveWorkspaceDialog : Window
 {
@@ -39,6 +40,7 @@ public partial class SaveWorkspaceDialog : Window
             CustomName = s.CustomName,
             CustomColor = s.CustomColor,
             ClaudeArgs = s.ClaudeArgs,
+            Agent = s.Agent,
             SortOrder = i,
             HasColor = !string.IsNullOrWhiteSpace(s.CustomColor),
             ColorBrush = GetColorBrush(s.CustomColor)
@@ -127,7 +129,8 @@ public partial class SaveWorkspaceDialog : Window
                 CustomName = s.CustomName,
                 CustomColor = s.CustomColor,
                 SortOrder = s.SortOrder,
-                ClaudeArgs = s.ClaudeArgs
+                ClaudeArgs = s.ClaudeArgs,
+                Agent = s.Agent
             }).ToList()
         };
 
@@ -158,6 +161,7 @@ public partial class SaveWorkspaceDialog : Window
         public string? CustomName { get; set; }
         public string? CustomColor { get; set; }
         public string? ClaudeArgs { get; set; }
+        public string? Agent { get; set; }
         public int SortOrder { get; set; }
         public bool HasColor { get; set; }
         public ISolidColorBrush ColorBrush { get; set; } = new SolidColorBrush(Colors.Transparent);

--- a/src/CcDirector.ControlApi/Chat/ChatService.cs
+++ b/src/CcDirector.ControlApi/Chat/ChatService.cs
@@ -101,7 +101,7 @@ public sealed class ChatService
         try
         {
             // Chat is a framework-mediated surface; exempt from the dictation lock (issue #1181, Task 3b).
-            await session.SendTextAsync(req.Text, SendSource.Internal);
+            await session.SendTextAsync(req.Text, SendSource.Framework);
         }
         catch (Exception ex)
         {

--- a/src/CcDirector.ControlApi/ControlEndpoints.cs
+++ b/src/CcDirector.ControlApi/ControlEndpoints.cs
@@ -273,7 +273,7 @@ internal static class ControlEndpoints
                     .Count(m => m.Role == CcDirector.Core.History.ConversationRole.Assistant)
                 : 0;
 
-            await target.SendTextAsync(framed, SendSource.Internal);
+            await target.SendTextAsync(framed, SendSource.Agent);
 
             // Give the target a moment to start working, then wait for the turn to settle. Both the loop and
             // the verdict read the SAME predicate, so they cannot drift apart - which is how the old pair
@@ -378,9 +378,9 @@ internal static class ControlEndpoints
             {
                 try
                 {
-                    // Fleet message delivery is framework-mediated, not a human racing the dictation, so it
-                    // is exempt from the dictation lock (issue #1181, Task 3b).
-                    await local.SendTextAsync(framed, SendSource.Internal);
+                    // Fleet message delivery is agent-driven, not a human racing the dictation, so it is
+                    // exempt from the dictation lock (issue #1181, Task 3b).
+                    await local.SendTextAsync(framed, SendSource.Agent);
                     return Results.Json(new FleetSendResponse { Accepted = true, DeliveredCount = 1 });
                 }
                 catch (Exception ex)
@@ -1025,7 +1025,7 @@ internal static class ControlEndpoints
                 {
                     try
                     {
-                        await local.SendTextAsync(framed, SendSource.Internal);
+                        await local.SendTextAsync(framed, SendSource.Agent);
                         count++;
                     }
                     catch (Exception ex)

--- a/src/CcDirector.ControlApi/GatewayClient.cs
+++ b/src/CcDirector.ControlApi/GatewayClient.cs
@@ -241,7 +241,11 @@ public sealed class GatewayClient : IGatewayHold, IDisposable
             throw new ArgumentException("Target session id is required", nameof(toSessionId));
 
         FileLog.Write($"[GatewayClient] SendPromptToFleetAsync: POST /sessions/{toSessionId}/prompt");
-        var body = new PromptRequest { Text = text, AppendEnter = true, WaitForIdle = false };
+        // AgentDriven: this relay exists only to carry a FLEET message to a session on another Director, so
+        // it is by construction one agent prompting another (issue #1636). The target Director cannot tell
+        // that from the prompt alone - the marker is what stops the same message counting differently
+        // depending on which machine the target happened to be on.
+        var body = new PromptRequest { Text = text, AppendEnter = true, WaitForIdle = false, AgentDriven = true };
         using var resp = await _http.PostAsJsonAsync($"sessions/{toSessionId}/prompt", body, ct);
         if (!resp.IsSuccessStatusCode)
             throw await RelayFailureAsync(resp, $"prompt to {toSessionId}", ct);

--- a/src/CcDirector.ControlApi/QueueGitExecutor.cs
+++ b/src/CcDirector.ControlApi/QueueGitExecutor.cs
@@ -214,7 +214,7 @@ internal sealed class QueueGitExecutor : ISessionCommandArea
     /// BadRequest, missing session -&gt; NotFound, an Exited/Failed session -&gt; Conflict (the REST layer returns
     /// an empty 409, so no body is carried here), a missing queue item -&gt; NotFound - and returns the resulting
     /// queue. The drain is an explicit ordered mechanism (issue #1181, Task 3b lists it exempt from the dictation
-    /// lock), so it sends as <see cref="SendSource.Internal"/> exactly as the REST lambda did.
+    /// lock), so it sends as <see cref="SendSource.Framework"/> exactly as the REST lambda did.
     /// </summary>
     internal static async Task<DirectorCommandResult> QueueSendAsync(SessionManager sessionManager, DirectorCommand command)
     {
@@ -236,7 +236,7 @@ internal sealed class QueueGitExecutor : ISessionCommandArea
         var text = item.Text;
         session.PromptQueue.Remove(itemGuid);
         FileLog.Write($"[QueueGitExecutor] queue-send: session={guid} item={itemGuid}");
-        await session.SendTextAsync(text, SendSource.Internal);
+        await session.SendTextAsync(text, SendSource.Framework);
         return DirectorCommandResult.Success(SerializeQueue(session));
     }
 

--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -199,19 +199,25 @@ internal static class SessionCommandExecutor
         // Gateway prompt handler and the dictation delivery) always set, stamping "unknown" when the device
         // key did not resolve. A phone/cockpit key maps to that surface; "unknown" maps to the Unknown
         // bucket the dashboard shows (decision 9: excluded volume is surfaced, never silently dropped).
+        // Issue #1636: a fleet message addressed to a session on ANOTHER Director arrives here as an
+        // ordinary prompt, so the relay marks it in the DTO - the same trick DeliveryUploadId uses for a
+        // dictation. Without it, the identical fleet message would be counted as agent-driven or not
+        // depending only on whether the two sessions happened to share a Director.
+        var effectiveSource = request.AgentDriven ? SendSource.Agent : source;
+
         // This origin is the HUMAN tally only. Neither a framework send nor an agent prompting another
         // agent is a person driving, so both are excluded here by name rather than by relying on their
-        // Surface being null (issue #1636 - agent-driven turns are counted on their own separate lane, and
-        // must never leak into the voice-versus-typed numbers).
-        var human = source is SendSource.UserInput or SendSource.Delivery;
+        // Surface being null (agent-driven turns are counted on their own separate lane, and must never
+        // leak into the voice-versus-typed numbers).
+        var human = effectiveSource is SendSource.UserInput or SendSource.Delivery;
         InputOrigin? origin = (human && request.Surface is not null)
             ? new InputOrigin(
-                source == SendSource.Delivery ? InputModality.Voice : InputModality.Typed,
+                effectiveSource == SendSource.Delivery ? InputModality.Voice : InputModality.Typed,
                 InputOrigin.RemoteSurfaceFromDeviceType(request.Surface))
             : null;
 
         if (request.AppendEnter)
-            await session.SendTextAsync(request.Text, source, origin);
+            await session.SendTextAsync(request.Text, effectiveSource, origin);
         else
             session.SendInput(Encoding.UTF8.GetBytes(request.Text), origin);
 

--- a/src/CcDirector.ControlApi/SessionCommandExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionCommandExecutor.cs
@@ -176,8 +176,9 @@ internal static class SessionCommandExecutor
     /// The prompt core, past the id/session guards: reject an exited session, capture the pre-send
     /// buffer cursor, then deliver the text. Shared by the verb handler and directly testable against
     /// a session. <paramref name="source"/> names who is sending - <see cref="SendSource.UserInput"/>
-    /// (the default), <see cref="SendSource.Delivery"/> (a dictation's own arrival) or
-    /// <see cref="SendSource.Internal"/> - for diagnostics only; no source is ever refused. The old
+    /// (the default), <see cref="SendSource.Delivery"/> (a dictation's own arrival),
+    /// <see cref="SendSource.Agent"/> (another agent) or <see cref="SendSource.Framework"/> - for
+    /// diagnostics and the tally; no source is ever refused. The old
     /// dictation-lock refusal was removed deliberately (single-operator tool; the operator may inject
     /// into their own sessions whenever they like).
     /// </summary>
@@ -198,9 +199,12 @@ internal static class SessionCommandExecutor
         // Gateway prompt handler and the dictation delivery) always set, stamping "unknown" when the device
         // key did not resolve. A phone/cockpit key maps to that surface; "unknown" maps to the Unknown
         // bucket the dashboard shows (decision 9: excluded volume is surfaced, never silently dropped).
-        // A framework send (SendSource.Internal) and machine-to-machine traffic (fanout/broadcast, which
-        // never sets Surface, so it is null) are correctly NOT counted.
-        InputOrigin? origin = (source != SendSource.Internal && request.Surface is not null)
+        // This origin is the HUMAN tally only. Neither a framework send nor an agent prompting another
+        // agent is a person driving, so both are excluded here by name rather than by relying on their
+        // Surface being null (issue #1636 - agent-driven turns are counted on their own separate lane, and
+        // must never leak into the voice-versus-typed numbers).
+        var human = source is SendSource.UserInput or SendSource.Delivery;
+        InputOrigin? origin = (human && request.Surface is not null)
             ? new InputOrigin(
                 source == SendSource.Delivery ? InputModality.Voice : InputModality.Typed,
                 InputOrigin.RemoteSurfaceFromDeviceType(request.Surface))
@@ -584,7 +588,7 @@ internal static class SessionCommandExecutor
                     }
                     FileLog.Write($"[SessionCommandExecutor] PrePrompt: dispatching to sid={capturedSession.Id}, len={prePrompt.Length}");
                     // Framework pre-prompt (not a human racing the dictation): exempt (issue #1181, Task 3b).
-                    await capturedSession.SendTextAsync(prePrompt, SendSource.Internal);
+                    await capturedSession.SendTextAsync(prePrompt, SendSource.Framework);
                 }
                 catch (Exception ex)
                 {

--- a/src/CcDirector.ControlApi/SessionWriteExecutor.cs
+++ b/src/CcDirector.ControlApi/SessionWriteExecutor.cs
@@ -481,7 +481,7 @@ internal sealed class SessionWriteExecutor : ISessionCommandArea
             if (existing.Status is SessionStatus.Exited or SessionStatus.Failed)
                 return DirectorCommandResult.Fail(DirectorCommandStatus.Conflict, "target session has exited");
             target = existing;
-            await target.SendTextAsync(contextText, SendSource.Internal);
+            await target.SendTextAsync(contextText, SendSource.Framework);
         }
         else
         {
@@ -520,7 +520,7 @@ internal sealed class SessionWriteExecutor : ISessionCommandArea
                     if (st is ActivityState.Exited) { FileLog.Write($"[SessionWriteExecutor] handover-generate target exited before idle, sid={capturedTarget.Id}"); return; }
                     await Task.Delay(500);
                 }
-                try { await capturedTarget.SendTextAsync(capturedText, SendSource.Internal); }
+                try { await capturedTarget.SendTextAsync(capturedText, SendSource.Framework); }
                 catch (Exception ex) { FileLog.Write($"[SessionWriteExecutor] handover-generate dispatch FAILED: {ex.Message}"); }
             });
         }

--- a/src/CcDirector.Core.Tests/TerminalPromptInjectionChokepointTests.cs
+++ b/src/CcDirector.Core.Tests/TerminalPromptInjectionChokepointTests.cs
@@ -20,8 +20,8 @@ public sealed class TerminalPromptInjectionChokepointTests
         // transcript through a language-model summarize step the product removed everywhere else.)
         Assert.Contains("await _activeSession.Session.SendTextAsync(text, origin: InputOrigin.DesktopTyped);", main);
         Assert.Contains("await target.SendTextAsync(text, origin: InputOrigin.DesktopVoice);", main);
-        Assert.Contains("await _activeSession.Session.SendTextAsync(\"/handover\", SendSource.Internal);", main);
-        Assert.Contains("await _current.SendTextAsync(transcript, SendSource.Internal, InputOrigin.DesktopVoice);", fifo);
+        Assert.Contains("await _activeSession.Session.SendTextAsync(\"/handover\", SendSource.Framework);", main);
+        Assert.Contains("await _current.SendTextAsync(transcript, SendSource.Framework, InputOrigin.DesktopVoice);", fifo);
 
         Assert.DoesNotContain("ScheduleEnterRetry", main);
         Assert.DoesNotContain("RetryEnterAfterDelay", main);
@@ -55,8 +55,8 @@ public sealed class TerminalPromptInjectionChokepointTests
         // The queue-send and chat submit paths use the SAME chokepoint. (Fleet-message delivery is now
         // Gateway-native and rides the prompt verb above, so it funnels through the same chokepoint; the
         // VoiceTurn endpoint was retired at the cut.)
-        Assert.Contains("await session.SendTextAsync(text, SendSource.Internal);", queueGit);
-        Assert.Contains("await session.SendTextAsync(req.Text, SendSource.Internal);", chat);
+        Assert.Contains("await session.SendTextAsync(text, SendSource.Framework);", queueGit);
+        Assert.Contains("await session.SendTextAsync(req.Text, SendSource.Framework);", chat);
 
         // Raw SendInput is still allowed when the caller explicitly asked not to append Enter; that is
         // terminal typing, not prompt submission.

--- a/src/CcDirector.Core.Tests/TerminalPromptInjectionChokepointTests.cs
+++ b/src/CcDirector.Core.Tests/TerminalPromptInjectionChokepointTests.cs
@@ -51,7 +51,9 @@ public sealed class TerminalPromptInjectionChokepointTests
         Assert.Contains("\"prompt\" => await SessionCommandExecutor.PromptAsync(sessionManager, command, context.Source),", writeExec);
         Assert.Contains("SessionCommandExecutor.DispatchAsync(_sessionManager, DirectorId, cmd,", host);
         // PromptAsync funnels submitted text through the session submit chokepoint.
-        Assert.Contains("await session.SendTextAsync(request.Text, source, origin);", executor);
+        // effectiveSource, not source: a relayed fleet prompt marks itself agent-driven in the DTO, and the
+        // executor resolves that before the send (issue #1636). Still the same one chokepoint.
+        Assert.Contains("await session.SendTextAsync(request.Text, effectiveSource, origin);", executor);
         // The queue-send and chat submit paths use the SAME chokepoint. (Fleet-message delivery is now
         // Gateway-native and rides the prompt verb above, so it funnels through the same chokepoint; the
         // VoiceTurn endpoint was retired at the cut.)

--- a/src/CcDirector.Core.Tests/WorkspaceStoreTests.cs
+++ b/src/CcDirector.Core.Tests/WorkspaceStoreTests.cs
@@ -1,3 +1,4 @@
+using CcDirector.Core.Agents;
 using CcDirector.Core.Sessions;
 using Xunit;
 
@@ -148,6 +149,89 @@ public class WorkspaceStoreTests : IDisposable
         Assert.Equal(0, loaded.Sessions[0].SortOrder);
         Assert.Equal("--allowedTools bash", loaded.Sessions[0].ClaudeArgs);
         Assert.Null(loaded.Sessions[1].CustomName);
+    }
+
+    // ==================== Issue #1635: the agent survives a save/load ====================
+
+    // The reported symptom: save a workspace containing a Codex session, load it back, and it is Claude
+    // Code. The agent was lost at SAVE time - WorkspaceSessionEntry had no agent field at all - so the
+    // restore had nothing to read and fell to the CreateSession default.
+    [Fact]
+    public void Save_AndLoad_RoundTripsTheAgent()
+    {
+        var store = new WorkspaceStore(_tempDir);
+        var workspace = MakeWorkspace("Codex Project");
+        workspace.Sessions = new List<WorkspaceSessionEntry>
+        {
+            new() { RepoPath = @"D:\Repos\project-a", SortOrder = 0, Agent = nameof(AgentKind.Codex) },
+            new() { RepoPath = @"D:\Repos\project-b", SortOrder = 1, Agent = nameof(AgentKind.ClaudeCode) },
+        };
+
+        store.Save(workspace);
+        var loaded = store.Load("codex-project");
+
+        Assert.NotNull(loaded);
+        Assert.Equal(nameof(AgentKind.Codex), loaded.Sessions[0].Agent);
+        Assert.Equal(AgentKind.Codex, loaded.Sessions[0].ResolveAgentKind());
+        Assert.Equal(AgentKind.ClaudeCode, loaded.Sessions[1].ResolveAgentKind());
+    }
+
+    // Every agent must survive the round trip, not just the one the fix was written against - a test of
+    // only today's value goes stale the moment another agent kind is added.
+    [Theory]
+    [InlineData(AgentKind.ClaudeCode)]
+    [InlineData(AgentKind.Pi)]
+    [InlineData(AgentKind.Codex)]
+    [InlineData(AgentKind.Gemini)]
+    [InlineData(AgentKind.OpenCode)]
+    [InlineData(AgentKind.RawCli)]
+    [InlineData(AgentKind.Cursor)]
+    [InlineData(AgentKind.Grok)]
+    public void Save_AndLoad_RoundTripsEveryAgentKind(AgentKind kind)
+    {
+        var store = new WorkspaceStore(_tempDir);
+        var workspace = MakeWorkspace("Agent Round Trip");
+        workspace.Sessions = new List<WorkspaceSessionEntry>
+        {
+            new() { RepoPath = @"D:\Repos\project-a", SortOrder = 0, Agent = kind.ToString() },
+        };
+
+        store.Save(workspace);
+        var loaded = store.Load("agent-round-trip");
+
+        Assert.NotNull(loaded);
+        Assert.Equal(kind, loaded.Sessions[0].ResolveAgentKind());
+    }
+
+    // A workspace saved before the agent field existed. ClaudeCode is not a guess here: every session in
+    // such a file was created through the old CreateSession default, so that is what it actually was.
+    [Fact]
+    public void ResolveAgentKind_AgentNeverRecorded_IsClaudeCode()
+    {
+        var entry = new WorkspaceSessionEntry { RepoPath = @"D:\Repos\legacy", SortOrder = 0 };
+
+        Assert.Null(entry.Agent);
+        Assert.Equal(AgentKind.ClaudeCode, entry.ResolveAgentKind());
+    }
+
+    // A hand-edited file, or one written by a newer build that knows an agent this one does not. It must
+    // not throw and take the whole workspace load down with it.
+    [Fact]
+    public void ResolveAgentKind_UnknownAgent_IsClaudeCodeAndDoesNotThrow()
+    {
+        var entry = new WorkspaceSessionEntry { RepoPath = @"D:\Repos\x", Agent = "NotARealAgent" };
+
+        Assert.Equal(AgentKind.ClaudeCode, entry.ResolveAgentKind());
+    }
+
+    // The agent name is written by AgentKind.ToString(), but a human editing the file by hand will not
+    // match its casing.
+    [Fact]
+    public void ResolveAgentKind_DifferentCasing_StillResolves()
+    {
+        var entry = new WorkspaceSessionEntry { RepoPath = @"D:\Repos\x", Agent = "codex" };
+
+        Assert.Equal(AgentKind.Codex, entry.ResolveAgentKind());
     }
 
     [Fact]

--- a/src/CcDirector.Core/Sessions/SendSource.cs
+++ b/src/CcDirector.Core/Sessions/SendSource.cs
@@ -8,12 +8,23 @@ namespace CcDirector.Core.Sessions;
 ///
 /// While a dictation is inbound to a session (an explicit PENDING delivery marker exists for it -
 /// see <see cref="DictationLockReader"/>) that session is LOCKED: <see cref="UserInput"/> is
-/// rejected so a half-arrived dictation and the user's own typing cannot collide. The two
+/// rejected so a half-arrived dictation and the user's own typing cannot collide. The three
 /// non-user sources are exempt:
 /// - <see cref="Delivery"/>: the dictation's OWN arrival (the Gateway injecting the transcribed
 ///   text). It must reach the session even while locked - it is what the lock is waiting for.
-/// - <see cref="Internal"/>: framework-authored, non-user sends (handover text, queue drain) that
-///   carry no human keystrokes and must not be blocked by the lock.
+/// - <see cref="Agent"/>: one agent prompting another across the fleet.
+/// - <see cref="Framework"/>: text the product itself authored (handover, queue drain, pre-prompt).
+///
+/// <see cref="Agent"/> and <see cref="Framework"/> were ONE value ("Internal") until issue #1636.
+/// They behave identically for the dictation lock, which is why they were ever conflated, but they
+/// are nothing alike as work: a manager prompting a worker is a real turn that drives real
+/// development, while a queue drain is plumbing that carries no decision at all. Counting the two
+/// together would have counted framing noise as development, so the split has to exist before the
+/// agent-to-agent tally can mean anything.
+///
+/// This enum says WHO SENT the text. It is not the counting gate - that is the InputOrigin passed
+/// alongside it (a null origin is not counted). The two are separate on purpose: the desktop
+/// dictation path sends <see cref="Internal"/>-class text that IS a human voice turn.
 /// </summary>
 public enum SendSource
 {
@@ -23,6 +34,17 @@ public enum SendSource
     /// <summary>The inbound dictation's own delivery. Exempt - it is what the lock is held for.</summary>
     Delivery,
 
-    /// <summary>Framework-authored, non-user text (handover, queue drain). Exempt.</summary>
-    Internal,
+    /// <summary>
+    /// One agent prompting another: a fleet message, a fleet ask, or a broadcast delivery. A REAL turn -
+    /// the sender decided to send it - but driven by an agent rather than by the human. Exempt from the
+    /// lock (it is not a human racing the dictation).
+    /// </summary>
+    Agent,
+
+    /// <summary>
+    /// Text the product authored itself: handover context, a queue drain, a pre-prompt, chat relay. Carries
+    /// no human keystrokes and no agent's decision, so it is never counted as a turn by anything. Exempt
+    /// from the lock.
+    /// </summary>
+    Framework,
 }

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -1925,8 +1925,9 @@ public sealed class Session : IDisposable
     /// backend-specific whole-turn semantics.
     ///
     /// <paramref name="source"/> names who is sending: a human (<see cref="SendSource.UserInput"/>,
-    /// the default), an arriving dictation (<see cref="SendSource.Delivery"/>), or the framework
-    /// itself (<see cref="SendSource.Internal"/>). It is diagnostic only - sends are never refused
+    /// the default), an arriving dictation (<see cref="SendSource.Delivery"/>), another agent across
+    /// the fleet (<see cref="SendSource.Agent"/>), or the framework itself
+    /// (<see cref="SendSource.Framework"/>). It is diagnostic only - sends are never refused
     /// by source. The old dictation-lock rejection here was removed deliberately: this is a
     /// single-operator tool, and a collision between the operator's own phone dictation and their
     /// own typed send is theirs to make, not the Director's to police.

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -1958,12 +1958,19 @@ public sealed class Session : IDisposable
         HoldState = HoldState.None;
         SetActivityState(ActivityState.Working);
         // DevThrottle Stats: a SendTextAsync is exactly one submitted turn. Count it (plus its character
-        // volume) for the tagged origin. Null origin = framework-internal (handover, queue drain) - not
-        // counted, even though it still submits a turn to the agent.
+        // volume) for the tagged origin. Null origin = not a human turn - either another agent (counted on
+        // its own lane below) or framework text (handover, queue drain), which carries nobody's decision
+        // and is not counted at all.
         if (origin is InputOrigin o)
         {
             InputStats.RecordTurn(o, text?.Length ?? 0);
             RecordOrigin(o, text?.Length ?? 0);
+        }
+        else if (source == SendSource.Agent)
+        {
+            // Issue #1636: one agent prompting another IS a real turn - the sending agent decided to send
+            // it - so it is counted, but never into the human buckets above.
+            InputStats.RecordAgentTurn(text?.Length ?? 0);
         }
     }
 

--- a/src/CcDirector.Core/Sessions/SessionInputStats.cs
+++ b/src/CcDirector.Core/Sessions/SessionInputStats.cs
@@ -31,6 +31,10 @@ public sealed class SessionInputStats
 
     private readonly ConcurrentDictionary<(InputModality Modality, InputSurface Surface), Counters> _buckets = new();
 
+    // Turns this session was driven by ANOTHER AGENT (issue #1636), on their own lane - never in _buckets.
+    // See InputStatsDto.AgentDrivenTurns for why they are kept apart rather than given a modality.
+    private readonly Counters _agentDriven = new();
+
     /// <summary>Raised after any recorded change, so the host can persist and push a delta (debounced by
     /// the host - this fires per keystroke). Carries no data; readers call <see cref="Snapshot"/>.</summary>
     public event Action? Changed;
@@ -62,10 +66,30 @@ public sealed class SessionInputStats
         Changed?.Invoke();
     }
 
+    /// <summary>
+    /// Record one turn that ANOTHER AGENT drove into this session (issue #1636) - a fleet message, ask, or
+    /// broadcast. A real turn: the sending agent decided to send it. Counted on its own lane, never into
+    /// the human buckets, so the voice-versus-typed and phone-versus-desktop numbers stay about the human.
+    ///
+    /// Framework-authored text (handover, queue drain, pre-prompt) is NOT this: it carries nobody's
+    /// decision and is not counted at all, by anything.
+    /// </summary>
+    public void RecordAgentTurn(int characters)
+    {
+        Interlocked.Increment(ref _agentDriven.Turns);
+        if (characters > 0)
+            Interlocked.Add(ref _agentDriven.Characters, characters);
+        Changed?.Invoke();
+    }
+
     /// <summary>An immutable snapshot of the tally as the shared wire DTO, buckets in a stable order.</summary>
     public InputStatsDto Snapshot()
     {
-        var dto = new InputStatsDto();
+        var dto = new InputStatsDto
+        {
+            AgentDrivenTurns = Interlocked.Read(ref _agentDriven.Turns),
+            AgentDrivenCharacters = Interlocked.Read(ref _agentDriven.Characters),
+        };
         foreach (var kvp in _buckets
                      .OrderBy(b => b.Key.Modality)
                      .ThenBy(b => b.Key.Surface))
@@ -82,8 +106,10 @@ public sealed class SessionInputStats
         return dto;
     }
 
-    /// <summary>True when nothing has been counted yet (used to skip pushing an empty tally).</summary>
-    public bool IsEmpty => _buckets.IsEmpty;
+    /// <summary>True when nothing has been counted yet (used to skip pushing an empty tally). A session
+    /// driven ONLY by other agents has no buckets but is not empty - it must still reach the wire, or the
+    /// agent-to-agent tally would silently miss exactly the sessions it is about.</summary>
+    public bool IsEmpty => _buckets.IsEmpty && Interlocked.Read(ref _agentDriven.Turns) == 0;
 
     /// <summary>
     /// Replace the tally with a persisted snapshot (Director restart restore). Buckets not present in
@@ -93,6 +119,8 @@ public sealed class SessionInputStats
     public void Seed(InputStatsDto? dto)
     {
         _buckets.Clear();
+        Interlocked.Exchange(ref _agentDriven.Turns, dto?.AgentDrivenTurns ?? 0);
+        Interlocked.Exchange(ref _agentDriven.Characters, dto?.AgentDrivenCharacters ?? 0);
         if (dto?.Buckets is null) return;
         foreach (var b in dto.Buckets)
         {

--- a/src/CcDirector.Core/Sessions/WorkspaceDefinition.cs
+++ b/src/CcDirector.Core/Sessions/WorkspaceDefinition.cs
@@ -1,3 +1,6 @@
+using CcDirector.Core.Agents;
+using CcDirector.Core.Utilities;
+
 namespace CcDirector.Core.Sessions;
 
 /// <summary>
@@ -11,6 +14,41 @@ public class WorkspaceSessionEntry
     public string? CustomColor { get; set; }
     public int SortOrder { get; set; }
     public string? ClaudeArgs { get; set; }
+
+    /// <summary>
+    /// Which agent CLI this session ran (the <see cref="Agents.AgentKind"/> name, e.g. "Codex").
+    /// Restored so a saved Codex session comes back as Codex rather than as the CreateSession default
+    /// (issue #1635) - without this the restored session reports the wrong agent on its snapshot and its
+    /// turns are miscounted against Claude Code on the Agents tab.
+    ///
+    /// Null means the workspace was saved before this field existed. That is not a guess: every session in
+    /// such a file was created through the old default, so those genuinely were ClaudeCode.
+    /// </summary>
+    public string? Agent { get; set; }
+
+    /// <summary>
+    /// Which agent this entry should be restored as (issue #1635).
+    ///
+    /// Null/empty means the workspace predates <see cref="Agent"/>, and ClaudeCode is what those sessions
+    /// actually were - see the field's note.
+    ///
+    /// A non-empty value that does not parse is a real problem (a hand-edited file, or a workspace written
+    /// by a newer build that knows an agent this one does not). It is logged with the offending value
+    /// rather than passed over in silence: restoring a session as the wrong agent is the very defect this
+    /// method exists to fix, so the log is what makes it findable.
+    /// </summary>
+    public AgentKind ResolveAgentKind()
+    {
+        var raw = (Agent ?? "").Trim();
+        if (raw.Length == 0) return AgentKind.ClaudeCode;
+
+        if (Enum.TryParse<AgentKind>(raw, ignoreCase: true, out var kind))
+            return kind;
+
+        FileLog.Write($"[WorkspaceSessionEntry] ResolveAgentKind: unknown agent '{raw}' for {RepoPath} - " +
+                      $"restoring as {AgentKind.ClaudeCode}; the session will run the wrong agent CLI");
+        return AgentKind.ClaudeCode;
+    }
 }
 
 /// <summary>

--- a/src/CcDirector.Gateway.Contracts/InputStatsDto.cs
+++ b/src/CcDirector.Gateway.Contracts/InputStatsDto.cs
@@ -32,4 +32,19 @@ public sealed class InputStatsDto
 {
     /// <summary>The per-bucket tallies. Empty when the session has taken no counted input yet.</summary>
     public List<InputStatBucketDto> Buckets { get; set; } = new();
+
+    /// <summary>
+    /// Turns this session was driven by ANOTHER AGENT rather than by the human (issue #1636): a fleet
+    /// message, ask, or broadcast that one agent decided to send. Real work - increasingly most of it - but
+    /// a different question from "how do you drive", so it rides its own lane.
+    ///
+    /// Deliberately NOT a bucket above. An agent has neither hands nor a mouth, so it has no modality and
+    /// no surface; and folding these into the buckets would drop the voice share overnight and break every
+    /// comparison with history - a number that moved because the definition moved, not because anything
+    /// about the work did. Kept apart so that cannot happen by accident.
+    /// </summary>
+    public long AgentDrivenTurns { get; set; }
+
+    /// <summary>Character volume of the <see cref="AgentDrivenTurns"/>.</summary>
+    public long AgentDrivenCharacters { get; set; }
 }

--- a/src/CcDirector.Gateway.Contracts/PromptRequest.cs
+++ b/src/CcDirector.Gateway.Contracts/PromptRequest.cs
@@ -21,6 +21,20 @@ public sealed class PromptRequest
     public int TimeoutMs { get; set; } = 120_000;
 
     /// <summary>
+    /// True when this prompt is one AGENT prompting another across the fleet (issue #1636), rather than a
+    /// person. Set by the fleet relay when a message is addressed to a session on ANOTHER Director: such a
+    /// message arrives here as an ordinary prompt, and without this marker it is indistinguishable from a
+    /// human one - so the same fleet message would count as agent-driven or not purely by the accident of
+    /// whether the two sessions happened to share a Director.
+    ///
+    /// Same trick as <see cref="DeliveryUploadId"/>, which marks a dictation delivery over the tunnel: the
+    /// DTO carries what an HTTP header used to.
+    ///
+    /// Never counted as a human turn, whatever Surface accompanies it.
+    /// </summary>
+    public bool AgentDriven { get; set; }
+
+    /// <summary>
     /// DevThrottle Stats surface tag: which surface this remote prompt came from - "phone", "cockpit",
     /// or null when unknown. GATEWAY-AUTHORITATIVE: the Gateway resolves it from the verified per-device
     /// key and OVERWRITES any client-supplied value before forwarding, so it cannot be forged from a

--- a/src/CcDirector.Gateway.Tests/AgentDrivenTurnChokepointTests.cs
+++ b/src/CcDirector.Gateway.Tests/AgentDrivenTurnChokepointTests.cs
@@ -1,0 +1,193 @@
+using CcDirector.Core.Sessions;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Issue #1636: that the Session choke point actually EMITS the agent-driven tally the Gateway aggregates.
+///
+/// The aggregator tests set InputStatsDto.AgentDrivenTurns by hand, which proves the fold but proves
+/// nothing about whether anything ever produces that value - a live consumer reading a field no producer
+/// assigns is the most common defect in this codebase, and it always looks like green tests. These drive
+/// the real Session.SendTextAsync with a real SendSource and read the real snapshot.
+/// </summary>
+public sealed class AgentDrivenTurnChokepointTests
+{
+    private static (SessionManager sm, Session session) NewSession()
+    {
+        var sm = new SessionManager(new Core.Configuration.AgentOptions());
+        var session = sm.CreateEmbeddedSession(Path.GetTempPath(), null, new ExecuteActionTestBackend());
+        return (sm, session);
+    }
+
+    // One agent prompting another is a real turn and must be counted - on its own lane.
+    [Fact]
+    public async Task AgentSend_IsCountedAsAnAgentDrivenTurn()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            const string text = "a manager prompting its worker";
+            await session.SendTextAsync(text, SendSource.Agent);
+
+            var snap = session.InputStats.Snapshot();
+            Assert.Equal(1, snap.AgentDrivenTurns);
+            Assert.Equal(text.Length, snap.AgentDrivenCharacters);
+            // ...and NEVER into the human buckets: that is the whole point of the separate lane.
+            Assert.Empty(snap.Buckets);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // Text the product authored itself carries nobody's decision. It is not a turn for anyone.
+    [Fact]
+    public async Task FrameworkSend_IsNotCountedAtAll()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            await session.SendTextAsync("handover context the product wrote", SendSource.Framework);
+
+            var snap = session.InputStats.Snapshot();
+            Assert.Equal(0, snap.AgentDrivenTurns);
+            Assert.Equal(0, snap.AgentDrivenCharacters);
+            Assert.Empty(snap.Buckets);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // A human turn stays a human turn: the agent lane must not swallow it.
+    [Fact]
+    public async Task HumanSend_IsCountedAsAHumanTurn_NotAnAgentOne()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            await session.SendTextAsync("what I said", SendSource.UserInput, InputOrigin.DesktopVoice);
+
+            var snap = session.InputStats.Snapshot();
+            Assert.Equal(0, snap.AgentDrivenTurns);
+            var bucket = Assert.Single(snap.Buckets);
+            Assert.Equal("voice", bucket.Modality);
+            Assert.Equal("desktop", bucket.Surface);
+            Assert.Equal(1, bucket.Turns);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // A session driven only by other agents has no buckets, so IsEmpty must not hide it from the wire -
+    // those are exactly the sessions the agent-to-agent tally is about.
+    [Fact]
+    public async Task AgentOnlySession_IsNotReportedAsEmpty()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            Assert.True(session.InputStats.IsEmpty);
+            await session.SendTextAsync("worker, do the thing", SendSource.Agent);
+            Assert.False(session.InputStats.IsEmpty);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // A fleet message to a session on ANOTHER Director arrives as an ordinary prompt over the tunnel, with
+    // no Surface and the source defaulting to UserInput - indistinguishable from a human prompt. Without
+    // the DTO marker the SAME message counts as agent-driven or not depending only on whether the two
+    // sessions happened to share a Director, which is not a property of the work at all.
+    [Fact]
+    public async Task RelayedFleetPrompt_MarkedAgentDriven_IsCountedAsAnAgentTurn()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var request = new Gateway.Contracts.PromptRequest
+            {
+                Text = "a manager on another machine, prompting its worker",
+                AppendEnter = true,
+                AgentDriven = true, // what GatewayClient.SendPromptToFleetAsync sets on the relay
+            };
+
+            await ControlApi.SessionCommandExecutor.SendPromptAsync(session, request);
+
+            var snap = session.InputStats.Snapshot();
+            Assert.Equal(1, snap.AgentDrivenTurns);
+            Assert.Empty(snap.Buckets); // never a human turn
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // An agent-driven prompt must not be counted as human even if a Surface rides along with it: the
+    // marker decides, not the surface.
+    [Fact]
+    public async Task RelayedFleetPrompt_WithASurface_IsStillNotAHumanTurn()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var request = new Gateway.Contracts.PromptRequest
+            {
+                Text = "still an agent",
+                AppendEnter = true,
+                AgentDriven = true,
+                Surface = "phone",
+            };
+
+            await ControlApi.SessionCommandExecutor.SendPromptAsync(session, request);
+
+            var snap = session.InputStats.Snapshot();
+            Assert.Equal(1, snap.AgentDrivenTurns);
+            Assert.Empty(snap.Buckets);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // The control: an ordinary human prompt through the same entry point is still a human turn.
+    [Fact]
+    public async Task Prompt_NotMarkedAgentDriven_IsStillAHumanTurn()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            var request = new Gateway.Contracts.PromptRequest
+            {
+                Text = "me, typing on my phone",
+                AppendEnter = true,
+                Surface = "phone",
+            };
+
+            await ControlApi.SessionCommandExecutor.SendPromptAsync(session, request);
+
+            var snap = session.InputStats.Snapshot();
+            Assert.Equal(0, snap.AgentDrivenTurns);
+            var bucket = Assert.Single(snap.Buckets);
+            Assert.Equal("typed", bucket.Modality);
+            Assert.Equal("phone", bucket.Surface);
+        }
+        finally { sm.Dispose(); }
+    }
+
+    // The tally survives a Director restart restore, or every restart would silently reset the fleet's
+    // driving to zero while the human's numbers carried on.
+    [Fact]
+    public async Task AgentDrivenTally_SurvivesASeedRoundTrip()
+    {
+        var (sm, session) = NewSession();
+        try
+        {
+            await session.SendTextAsync("one", SendSource.Agent);
+            await session.SendTextAsync("two", SendSource.Agent);
+            var saved = session.InputStats.Snapshot();
+
+            var (sm2, restored) = NewSession();
+            try
+            {
+                restored.InputStats.Seed(saved);
+                var snap = restored.InputStats.Snapshot();
+                Assert.Equal(2, snap.AgentDrivenTurns);
+                Assert.Equal(6, snap.AgentDrivenCharacters);
+            }
+            finally { sm2.Dispose(); }
+        }
+        finally { sm.Dispose(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/DesktopRoleStampWireProofTests.cs
+++ b/src/CcDirector.Gateway.Tests/DesktopRoleStampWireProofTests.cs
@@ -80,7 +80,7 @@ public sealed class DesktopRoleStampWireProofTests
                 new SetResolvedRoleRequest { Role = role },
                 new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web)),
         };
-        var context = new SessionCommandContext(manager, "director-under-test", Services: null, SendSource.Internal);
+        var context = new SessionCommandContext(manager, "director-under-test", Services: null, SendSource.Framework);
         return FleetRoleExecutor.SetResolvedRole(context, command);
     }
 

--- a/src/CcDirector.Gateway.Tests/DictationDesktopLockTests.cs
+++ b/src/CcDirector.Gateway.Tests/DictationDesktopLockTests.cs
@@ -118,7 +118,7 @@ public sealed class DictationDesktopLockTests
                 await session.SendTextAsync("typed", SendSource.UserInput);
                 await session.SendTextAsync("typed default"); // default is UserInput
                 await session.SendTextAsync("delivered", SendSource.Delivery);
-                await session.SendTextAsync("internal", SendSource.Internal);
+                await session.SendTextAsync("internal", SendSource.Framework);
             }
             finally
             {

--- a/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
@@ -391,6 +391,107 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
         Assert.Equal(10, agentTurns);
     }
 
+    // ==================== Issue #1636: the agent-to-agent lane ====================
+
+    // A session being driven by other agents: the fleet prompting itself.
+    private static SessionDto AgentDrivenSession(string id, string agent, long turns, long chars,
+        params (string modality, string surface, long turns, long chars)[] humanBuckets)
+    {
+        var dto = SessionOnAgent(id, agent, humanBuckets);
+        dto.InputStats!.AgentDrivenTurns = turns;
+        dto.InputStats.AgentDrivenCharacters = chars;
+        return dto;
+    }
+
+    // THE TRAP this whole design exists to avoid. Agent turns are typed by definition, so folding them in
+    // with the human's would drop the voice share overnight and break every comparison with history - a
+    // number that moved because the definition moved, not because anything about the work did.
+    [Fact]
+    public void AgentDrivenTurns_NeverEnterTheHumanTotals()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        // 2 human voice turns, and 100 turns the fleet drove into the same session.
+        agg.Observe(AgentDrivenSession("s1", "Codex", 100, 10_000, ("voice", "desktop", 2, 200)));
+
+        // The human totals are untouched by the fleet's 100.
+        Assert.Equal(2, agg.CurrentTotals().Buckets.Sum(b => b.Turns));
+        Assert.Equal(2, Turns(agg.CurrentTotals(), "voice", "desktop"));
+        Assert.Equal(200, agg.CurrentTotals().Buckets.Sum(b => b.Characters));
+
+        // The voice share stays 100% of the human's driving, not 2%.
+        Assert.Equal(2, Agent(agg, "Codex")!.VoiceTurns);
+        Assert.Equal(2, Agent(agg, "Codex")!.Turns);
+
+        // And the fleet's driving is reported on its own lane.
+        Assert.Equal(100, Agent(agg, "Codex")!.AgentDrivenTurns);
+        Assert.Equal((100, 10_000), agg.AgentDrivenUsage());
+    }
+
+    // The hourly "working day" series is about when the HUMAN worked. A fleet that ran all night must not
+    // appear in it as the owner's hours.
+    [Fact]
+    public void AgentDrivenTurns_NeverEnterTheHourlySeries()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        agg.Observe(AgentDrivenSession("s1", "Codex", 50, 5_000));
+
+        Assert.DoesNotContain(agg.HourlyTurns(), h => h.Turns > 0);
+        Assert.Equal(50, agg.AgentDrivenUsage().Turns);
+    }
+
+    // A session driven ONLY by other agents has no human buckets at all - and those are exactly the
+    // sessions this tally is about, so it must not be skipped by the buckets guard.
+    [Fact]
+    public void AgentDrivenSession_WithNoHumanTurns_IsStillCounted()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        agg.Observe(AgentDrivenSession("worker-1", "Codex", 12, 1_200));
+
+        Assert.Equal(12, agg.AgentDrivenUsage().Turns);
+        Assert.Equal(12, Agent(agg, "Codex")!.AgentDrivenTurns);
+        Assert.Equal(0, Agent(agg, "Codex")!.Turns);
+    }
+
+    [Fact]
+    public void AgentDrivenTurns_RepeatedSnapshot_DoesNotDoubleCount()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        agg.Observe(AgentDrivenSession("s1", "Codex", 10, 1_000));
+        agg.Observe(AgentDrivenSession("s1", "Codex", 10, 1_000));
+        agg.Observe(AgentDrivenSession("s1", "Codex", 14, 1_400));
+
+        Assert.Equal(14, agg.AgentDrivenUsage().Turns);
+        Assert.Equal(1_400, agg.AgentDrivenUsage().Characters);
+    }
+
+    // A Director restarted this session id with a fresh tally, so the reported count DROPPED. The whole
+    // current count is new activity from zero - the same rule the human buckets follow.
+    [Fact]
+    public void AgentDrivenTurns_DroppedCount_IsTreatedAsFreshActivity()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+        agg.Observe(AgentDrivenSession("s1", "Codex", 10, 1_000));
+        agg.Observe(AgentDrivenSession("s1", "Codex", 3, 300));
+
+        Assert.Equal(13, agg.AgentDrivenUsage().Turns);
+    }
+
+    [Fact]
+    public void AgentDrivenTurns_SurviveAGatewayRestart()
+    {
+        var first = new GatewayInputStatsAggregator(_path);
+        first.Observe(AgentDrivenSession("s1", "Codex", 10, 1_000));
+
+        var restarted = new GatewayInputStatsAggregator(_path);
+        Assert.Equal(10, restarted.AgentDrivenUsage().Turns);
+        Assert.Equal(10, Agent(restarted, "Codex")!.AgentDrivenTurns);
+
+        // The high-water survived too, so re-observing the same counts adds nothing.
+        restarted.Observe(AgentDrivenSession("s1", "Codex", 10, 1_000));
+        Assert.Equal(10, restarted.AgentDrivenUsage().Turns);
+    }
+
     // ==================== Issue #1633: the high-water lockout ====================
 
     // A store exactly as a build WITHOUT the agent tally left it: the session's turns are already consumed

--- a/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
@@ -390,4 +390,180 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
         Assert.Equal(totalTurns, agentTurns);
         Assert.Equal(10, agentTurns);
     }
+
+    // ==================== Issue #1633: the high-water lockout ====================
+
+    // A store exactly as a build WITHOUT the agent tally left it: the session's turns are already consumed
+    // into the totals and its high-water, so its delta is zero from here on. No Agents map, and no
+    // AgentsSeeded - the shape the aggregator actually finds in the field.
+    private void WriteLegacyStore(string sessionId, string modality, string surface, long turns, long chars)
+    {
+        var json = $$"""
+        {
+          "Totals": [ { "Modality": "{{modality}}", "Surface": "{{surface}}", "Turns": {{turns}}, "Characters": {{chars}} } ],
+          "HighWater": {
+            "{{sessionId}}": [ { "Modality": "{{modality}}", "Surface": "{{surface}}", "Turns": {{turns}}, "Characters": {{chars}} } ]
+          },
+          "Hourly": {},
+          "WingmanTurns": 0,
+          "WingmanSessions": [],
+          "Repos": {},
+          "Agents": {},
+          "AgentsSinceUtc": ""
+        }
+        """;
+        File.WriteAllText(_path, json);
+    }
+
+    // THE REPORTED SYMPTOM. A live Codex session carrying real turns showed nowhere on the Agents page,
+    // which read "100% Claude Code / 1 agent driven", because its turns were consumed before the agent
+    // tally existed and its delta is zero forever.
+    [Fact]
+    public void LegacyStore_TurnsAlreadyCounted_AreAttributedToTheirAgentOnTheNextFold()
+    {
+        WriteLegacyStore("codex-1", "typed", "unknown", 1, 623);
+        var agg = new GatewayInputStatsAggregator(_path);
+        Assert.Empty(agg.AgentTotals()); // the store had no agent breakdown at all
+
+        // The same session, unchanged: turns=1 is what it already reported, so the delta is ZERO.
+        agg.Observe(SessionOnAgent("codex-1", "Codex", ("typed", "unknown", 1, 623)));
+
+        var codex = Agent(agg, "Codex");
+        Assert.NotNull(codex);
+        Assert.Equal(1, codex!.Turns);
+        Assert.Equal(623, codex.Characters);
+        Assert.Equal(1, codex.Sessions);
+    }
+
+    // The back-fill is a one-shot. Folding the same session again must not attribute its history twice.
+    [Fact]
+    public void LegacyStore_BackFill_DoesNotDoubleCount_OnRepeatedFold()
+    {
+        WriteLegacyStore("codex-1", "typed", "unknown", 4, 400);
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        agg.Observe(SessionOnAgent("codex-1", "Codex", ("typed", "unknown", 4, 400)));
+        agg.Observe(SessionOnAgent("codex-1", "Codex", ("typed", "unknown", 4, 400)));
+        agg.Observe(SessionOnAgent("codex-1", "Codex", ("typed", "unknown", 4, 400)));
+
+        Assert.Equal(4, Agent(agg, "Codex")!.Turns);
+    }
+
+    // The hazard the persisted seed-set exists to prevent: without it every Gateway restart would re-run
+    // the back-fill and inflate the agent numbers a little more each time.
+    [Fact]
+    public void LegacyStore_BackFill_DoesNotDoubleCount_AcrossAGatewayRestart()
+    {
+        WriteLegacyStore("codex-1", "typed", "unknown", 4, 400);
+        var first = new GatewayInputStatsAggregator(_path);
+        first.Observe(SessionOnAgent("codex-1", "Codex", ("typed", "unknown", 4, 400)));
+        Assert.Equal(4, Agent(first, "Codex")!.Turns);
+
+        var restarted = new GatewayInputStatsAggregator(_path);
+        Assert.Equal(4, Agent(restarted, "Codex")!.Turns);
+
+        restarted.Observe(SessionOnAgent("codex-1", "Codex", ("typed", "unknown", 4, 400)));
+        Assert.Equal(4, Agent(restarted, "Codex")!.Turns);
+    }
+
+    // Back-filled history and new activity must add up, with the increase counted once.
+    [Fact]
+    public void LegacyStore_BackFill_ThenNewTurns_CountsTheHistoryAndTheIncrease()
+    {
+        WriteLegacyStore("codex-1", "typed", "unknown", 4, 400);
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        agg.Observe(SessionOnAgent("codex-1", "Codex", ("typed", "unknown", 4, 400)));
+        agg.Observe(SessionOnAgent("codex-1", "Codex", ("typed", "unknown", 7, 700)));
+
+        var codex = Agent(agg, "Codex");
+        Assert.Equal(7, codex!.Turns);
+        Assert.Equal(700, codex.Characters);
+    }
+
+    // The back-fill must not invent turns for a session that never had any. A fresh session with an empty
+    // high-water back-fills nothing, and the ordinary delta path does all the work - the control that says
+    // the back-fill only ever recovers history that genuinely happened.
+    [Fact]
+    public void FreshSession_BackFillsNothing_AndStillCountsNormally()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        agg.Observe(SessionOnAgent("new-1", "Codex", ("typed", "desktop", 2, 20)));
+        Assert.Equal(2, Agent(agg, "Codex")!.Turns);
+
+        agg.Observe(SessionOnAgent("new-1", "Codex", ("typed", "desktop", 2, 20)));
+        Assert.Equal(2, Agent(agg, "Codex")!.Turns);
+    }
+
+    // THE SHAPE ACTUALLY FOUND IN THE FIELD, and the one that makes the back-fill dangerous: a store where
+    // the agent tally was live for a while, so SOME of a session's turns are already attributed - and those
+    // same turns are also in its high-water. Nothing says which sessions those were.
+    //
+    // Here the session has 10 turns in its high-water, 3 of which the delta path already attributed to
+    // Codex. Adding the high-water on top would report 13. The answer is 10: the partial tally is discarded
+    // and rebuilt from the high-water, never added to.
+    [Fact]
+    public void HybridStore_PartiallyAttributed_IsRebuiltNotDoubleCounted()
+    {
+        var json = """
+        {
+          "Totals": [ { "Modality": "voice", "Surface": "desktop", "Turns": 10, "Characters": 1000 } ],
+          "HighWater": {
+            "codex-1": [ { "Modality": "voice", "Surface": "desktop", "Turns": 10, "Characters": 1000 } ]
+          },
+          "Hourly": {},
+          "WingmanTurns": 0,
+          "WingmanSessions": [],
+          "Repos": {},
+          "Agents": {
+            "Codex": { "VoiceTurns": 3, "TypedTurns": 0, "Characters": 300, "Sessions": [ "codex-1" ] }
+          },
+          "AgentsSinceUtc": "2026-07-15T16:03:53.6255973Z"
+        }
+        """;
+        File.WriteAllText(_path, json);
+
+        var agg = new GatewayInputStatsAggregator(_path);
+        agg.Observe(SessionOnAgent("codex-1", "Codex", ("voice", "desktop", 10, 1000)));
+
+        var codex = Agent(agg, "Codex");
+        Assert.NotNull(codex);
+        Assert.Equal(10, codex!.Turns);
+        Assert.Equal(1000, codex.Characters);
+        Assert.Equal(1, codex.Sessions);
+    }
+
+    // The rebuild is one-time. Once rebuilt, the store carries the seed set and a restart must leave the
+    // numbers exactly where they are rather than discarding and rebuilding again.
+    [Fact]
+    public void HybridStore_OnceRebuilt_IsStableAcrossAFurtherRestart()
+    {
+        WriteLegacyStore("codex-1", "voice", "desktop", 10, 1000);
+        var first = new GatewayInputStatsAggregator(_path);
+        first.Observe(SessionOnAgent("codex-1", "Codex", ("voice", "desktop", 10, 1000)));
+        Assert.Equal(10, Agent(first, "Codex")!.Turns);
+
+        var second = new GatewayInputStatsAggregator(_path);
+        Assert.Equal(10, Agent(second, "Codex")!.Turns);
+        second.Observe(SessionOnAgent("codex-1", "Codex", ("voice", "desktop", 12, 1200)));
+        Assert.Equal(12, Agent(second, "Codex")!.Turns);
+
+        var third = new GatewayInputStatsAggregator(_path);
+        Assert.Equal(12, Agent(third, "Codex")!.Turns);
+    }
+
+    // "Agents driven" counted only agents that submitted a turn in the observed window, so an agent being
+    // actively run showed as absent rather than as present-with-no-new-turns.
+    [Fact]
+    public void LegacyStore_SessionWithNoNewTurns_StillRegistersItsAgent()
+    {
+        WriteLegacyStore("codex-1", "typed", "unknown", 2, 200);
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        agg.Observe(SessionOnAgent("codex-1", "Codex", ("typed", "unknown", 2, 200)));
+
+        Assert.Single(agg.AgentTotals());
+        Assert.Equal(1, Agent(agg, "Codex")!.Sessions);
+    }
 }

--- a/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
+++ b/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
@@ -99,11 +99,23 @@ public sealed class GatewayInputStatsAggregator
         public readonly HashSet<string> Sessions = new(StringComparer.Ordinal);
     }
 
+    // Agent-driven turns per session (issue #1636), high-watered exactly like the human buckets so a
+    // repeated snapshot never double-counts and a Director restart of the same session id is treated as
+    // fresh activity. Kept on its own lane: these never enter _totals, _hourly or the buckets, because the
+    // human voice-versus-typed numbers must stay about the human.
+    private readonly Dictionary<string, Counters> _agentDrivenHighWater = new(StringComparer.Ordinal);
+    private long _agentDrivenTurns;
+    private long _agentDrivenCharacters;
+
     private sealed class AgentTally
     {
         public long VoiceTurns;
         public long TypedTurns;
         public long Characters;
+        // Turns OTHER agents drove into the sessions running this agent (issue #1636) - "how much is this
+        // agent being driven by other agents", as opposed to by the human.
+        public long AgentDrivenTurns;
+        public long AgentDrivenCharacters;
         // The distinct session ids that drove counted input through this agent, so "sessions" is a true
         // distinct count across a re-push or a Gateway restart (the set is persisted; re-adding is a no-op).
         public readonly HashSet<string> Sessions = new(StringComparer.Ordinal);
@@ -177,6 +189,16 @@ public sealed class GatewayInputStatsAggregator
         {
             if (_highWater.Remove(sessionId)) Save();
         }
+    }
+
+    /// <summary>
+    /// All-time turns that agents drove into other agents' sessions (issue #1636), and their character
+    /// volume. NOT part of the human totals: this is the fleet driving itself, which is a different
+    /// question from how the owner drives.
+    /// </summary>
+    public (long Turns, long Characters) AgentDrivenUsage()
+    {
+        lock (_lock) { return (_agentDrivenTurns, _agentDrivenCharacters); }
     }
 
     /// <summary>An immutable snapshot of the all-time totals for the dashboard, buckets in a stable order.</summary>
@@ -271,6 +293,8 @@ public sealed class GatewayInputStatsAggregator
                     TypedTurns = t.TypedTurns,
                     Characters = t.Characters,
                     Sessions = t.Sessions.Count,
+                    AgentDrivenTurns = t.AgentDrivenTurns,
+                    AgentDrivenCharacters = t.AgentDrivenCharacters,
                 });
             }
             // Rank by turns (the headline metric), then characters, then name, so the order is stable.
@@ -344,6 +368,12 @@ public sealed class GatewayInputStatsAggregator
         // mode on - recorded even if it has no input this fold, so a voice-mode session that never typed a
         // turn still counts. The set is all-time, never pruned on removal (like the totals).
         if (s.VoiceMode && _wingmanSessions.Add(s.SessionId))
+            changed = true;
+
+        // Issue #1636: turns other agents drove into this session, on their own lane. Folded BEFORE the
+        // buckets guard below, because a session driven only by other agents has no human buckets at all -
+        // and those are exactly the sessions this tally is about.
+        if (FoldAgentDrivenLocked(s))
             changed = true;
 
         if (s.InputStats?.Buckets is null || s.InputStats.Buckets.Count == 0)
@@ -442,6 +472,43 @@ public sealed class GatewayInputStatsAggregator
         return changed;
     }
 
+    // Fold the turns OTHER agents drove into this session (issue #1636) via the same high-water increment
+    // the human buckets use: only the increase counts, and a reported count that DROPPED (a Director
+    // restarted this session id with a fresh tally) is treated as new activity from zero. Attributed to the
+    // RECEIVING session's agent - "how much is Codex being driven by other agents". Returns true when
+    // anything changed. Caller holds the lock.
+    private bool FoldAgentDrivenLocked(SessionDto s)
+    {
+        var turns = s.InputStats?.AgentDrivenTurns ?? 0;
+        var chars = s.InputStats?.AgentDrivenCharacters ?? 0;
+        if (turns == 0 && chars == 0) return false;
+
+        _agentDrivenHighWater.TryGetValue(s.SessionId, out var prev);
+        var prevTurns = prev?.Turns ?? 0;
+        var prevChars = prev?.Characters ?? 0;
+
+        var deltaTurns = turns >= prevTurns ? turns - prevTurns : turns;
+        var deltaChars = chars >= prevChars ? chars - prevChars : chars;
+
+        _agentDrivenHighWater[s.SessionId] = new Counters { Turns = turns, Characters = chars };
+        if (deltaTurns <= 0 && deltaChars <= 0) return false;
+
+        _agentDrivenTurns += deltaTurns;
+        _agentDrivenCharacters += deltaChars;
+
+        var agentKey = s.Agent ?? "";
+        if (!_agents.TryGetValue(agentKey, out var agent))
+        {
+            agent = new AgentTally();
+            _agents[agentKey] = agent;
+        }
+        agent.AgentDrivenTurns += deltaTurns;
+        agent.AgentDrivenCharacters += deltaChars;
+        if (!string.IsNullOrEmpty(s.SessionId))
+            agent.Sessions.Add(s.SessionId);
+        return true;
+    }
+
     // Attribute <paramref name="turns"/> and <paramref name="characters"/> to the agent CLI that session
     // drives (the private Agents page). Used by BOTH the ordinary delta path and the first-fold back-fill
     // (issue #1633), so the two can never drift apart.
@@ -498,6 +565,11 @@ public sealed class GatewayInputStatsAggregator
         public Dictionary<string, RepoTallyStore> Repos { get; set; } = new();
         public Dictionary<string, AgentTallyStore> Agents { get; set; } = new();
         public string AgentsSinceUtc { get; set; } = "";
+        // Issue #1636: the agent-to-agent lane. Absent in older stores, which is correct - no agent-driven
+        // turns had been counted then, so zero and an empty high-water are the truth, not a guess.
+        public long AgentDrivenTurns { get; set; }
+        public long AgentDrivenCharacters { get; set; }
+        public Dictionary<string, InputStatBucketDto> AgentDrivenHighWater { get; set; } = new();
         // Issue #1633. NULL (not empty) when the key is absent, which is how a store written before the
         // back-fill existed is recognised - see Load, which must rebuild such a store's agent tally rather
         // than add to it. Nullable on purpose: an empty list is a real value (a store with nothing folded
@@ -526,6 +598,8 @@ public sealed class GatewayInputStatsAggregator
         public long TypedTurns { get; set; }
         public long Characters { get; set; }
         public List<string> Sessions { get; set; } = new();
+        public long AgentDrivenTurns { get; set; }
+        public long AgentDrivenCharacters { get; set; }
     }
 
     private void Load()
@@ -574,10 +648,21 @@ public sealed class GatewayInputStatsAggregator
         }
         foreach (var (agentKey, at) in parsed.Agents)
         {
-            var tally = new AgentTally { VoiceTurns = at.VoiceTurns, TypedTurns = at.TypedTurns, Characters = at.Characters };
+            var tally = new AgentTally
+            {
+                VoiceTurns = at.VoiceTurns,
+                TypedTurns = at.TypedTurns,
+                Characters = at.Characters,
+                AgentDrivenTurns = at.AgentDrivenTurns,
+                AgentDrivenCharacters = at.AgentDrivenCharacters,
+            };
             foreach (var sid in at.Sessions) tally.Sessions.Add(sid);
             _agents[agentKey] = tally;
         }
+        _agentDrivenTurns = parsed.AgentDrivenTurns;
+        _agentDrivenCharacters = parsed.AgentDrivenCharacters;
+        foreach (var (sid, b) in parsed.AgentDrivenHighWater)
+            _agentDrivenHighWater[sid] = new Counters { Turns = b.Turns, Characters = b.Characters };
         _agentsSinceUtc = parsed.AgentsSinceUtc ?? "";
 
         // Issue #1633. A store written before the back-fill existed (no AgentsSeeded key) is a HYBRID: some
@@ -644,9 +729,15 @@ public sealed class GatewayInputStatsAggregator
                     TypedTurns = at.TypedTurns,
                     Characters = at.Characters,
                     Sessions = at.Sessions.ToList(),
+                    AgentDrivenTurns = at.AgentDrivenTurns,
+                    AgentDrivenCharacters = at.AgentDrivenCharacters,
                 };
             file.AgentsSinceUtc = _agentsSinceUtc;
             file.AgentsSeeded = _agentsSeeded.ToList();
+            file.AgentDrivenTurns = _agentDrivenTurns;
+            file.AgentDrivenCharacters = _agentDrivenCharacters;
+            foreach (var (sid, c) in _agentDrivenHighWater)
+                file.AgentDrivenHighWater[sid] = new InputStatBucketDto { Turns = c.Turns, Characters = c.Characters };
 
             var json = JsonSerializer.Serialize(file, FileJsonOptions);
             var tmp = _path + ".tmp";
@@ -736,4 +827,17 @@ public sealed class AgentStatBucketDto
 
     /// <summary>Distinct sessions that drove counted input through this agent.</summary>
     public int Sessions { get; set; }
+
+    /// <summary>
+    /// Turns OTHER AGENTS drove into the sessions running this agent (issue #1636) - "how much is this
+    /// agent being driven by other agents", as opposed to by the human.
+    ///
+    /// Deliberately NOT part of <see cref="Turns"/>: that stays the human's own driving. The two answer
+    /// different questions, and adding them together would drop the voice share overnight and break every
+    /// comparison with history.
+    /// </summary>
+    public long AgentDrivenTurns { get; set; }
+
+    /// <summary>Character volume of the <see cref="AgentDrivenTurns"/>.</summary>
+    public long AgentDrivenCharacters { get; set; }
 }

--- a/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
+++ b/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
@@ -65,6 +65,22 @@ public sealed class GatewayInputStatsAggregator
     // Stamped once, the first time a Gateway runs a build that has the tally, and persisted from then on.
     private string _agentsSinceUtc = "";
 
+    // Session ids whose already-counted turns have been attributed to their agent (issue #1633).
+    //
+    // The agent tally is YOUNGER than the high-water map. A session first seen before the tally existed had
+    // its turns consumed into the totals then, so its high-water already equals its current count and its
+    // delta is zero forever - which meant its real, known-agent turns could never be attributed, and the
+    // Agents page read "100% Claude Code" while live Codex sessions sat there with turns on them.
+    //
+    // So on the FIRST fold of a session, whatever its high-water already holds is attributed to that
+    // session's agent (a back-fill), and the id is recorded here. For a session first seen after this
+    // shipped the high-water is empty, the back-fill contributes nothing, and the ordinary delta path does
+    // all the work - the same code path either way, with no one-time migration to run.
+    //
+    // MUST be persisted: without it a Gateway restart would back-fill every live session a second time and
+    // double the agent numbers.
+    private readonly HashSet<string> _agentsSeeded = new(StringComparer.Ordinal);
+
     private sealed class HourTurns
     {
         public long VoiceTurns;
@@ -339,6 +355,17 @@ public sealed class GatewayInputStatsAggregator
             _highWater[s.SessionId] = hw;
         }
 
+        // Issue #1633: the first time this session is folded, attribute what it has ALREADY counted to its
+        // agent. Read before the loop below moves the high-water on, so this is exactly the turns consumed
+        // into the totals before the agent tally existed - real turns, whose agent we now know. Empty (and
+        // therefore a no-op) for any session first seen after this shipped.
+        if (_agentsSeeded.Add(s.SessionId))
+        {
+            foreach (var (key, prior) in hw)
+                if (AttributeToAgentLocked(s, key.Modality, prior.Turns, prior.Characters))
+                    changed = true;
+        }
+
         long sessionDeltaTurns = 0;
         foreach (var b in s.InputStats.Buckets)
         {
@@ -399,22 +426,8 @@ public sealed class GatewayInputStatsAggregator
                     repo.Sessions.Add(s.SessionId);
 
                 // Attribute the SAME increase to the agent CLI the session drives (the private Agents page):
-                // which agent the work went through. A session whose agent the Director did not report is
-                // counted under the empty key and shown as "(unknown)" - never silently dropped, and never
-                // guessed at from the command line.
-                var agentKey = s.Agent ?? "";
-                if (!_agents.TryGetValue(agentKey, out var agent))
-                {
-                    agent = new AgentTally();
-                    _agents[agentKey] = agent;
-                }
-                if (isVoice)
-                    agent.VoiceTurns += deltaTurns;
-                else
-                    agent.TypedTurns += deltaTurns;
-                agent.Characters += deltaChars;
-                if (!string.IsNullOrEmpty(s.SessionId))
-                    agent.Sessions.Add(s.SessionId);
+                // which agent the work went through.
+                AttributeToAgentLocked(s, key.Item1, deltaTurns, deltaChars);
 
                 changed = true;
             }
@@ -427,6 +440,36 @@ public sealed class GatewayInputStatsAggregator
             _wingmanTurns += sessionDeltaTurns;
 
         return changed;
+    }
+
+    // Attribute <paramref name="turns"/> and <paramref name="characters"/> to the agent CLI that session
+    // drives (the private Agents page). Used by BOTH the ordinary delta path and the first-fold back-fill
+    // (issue #1633), so the two can never drift apart.
+    //
+    // A session whose agent the Director did not report is counted under the empty key and shown as
+    // "(unknown)" - never silently dropped, and never guessed at from the command line.
+    //
+    // The session id is registered even when it brought no turns with it, so "Agents driven" and the
+    // per-agent session counts describe the agents actually being run rather than only the ones that
+    // happened to submit a turn in the observed window. Returns true when anything changed. Caller holds
+    // the lock.
+    private bool AttributeToAgentLocked(SessionDto s, string modality, long turns, long characters)
+    {
+        var agentKey = s.Agent ?? "";
+        if (!_agents.TryGetValue(agentKey, out var agent))
+        {
+            agent = new AgentTally();
+            _agents[agentKey] = agent;
+        }
+
+        if (string.Equals(modality, "voice", StringComparison.OrdinalIgnoreCase))
+            agent.VoiceTurns += turns;
+        else
+            agent.TypedTurns += turns;
+        agent.Characters += characters;
+
+        var registered = !string.IsNullOrEmpty(s.SessionId) && agent.Sessions.Add(s.SessionId);
+        return registered || turns > 0 || characters > 0;
     }
 
     private static InputStatsDto ToDtoLocked(Dictionary<(string Modality, string Surface), Counters> src)
@@ -455,6 +498,11 @@ public sealed class GatewayInputStatsAggregator
         public Dictionary<string, RepoTallyStore> Repos { get; set; } = new();
         public Dictionary<string, AgentTallyStore> Agents { get; set; } = new();
         public string AgentsSinceUtc { get; set; } = "";
+        // Issue #1633. NULL (not empty) when the key is absent, which is how a store written before the
+        // back-fill existed is recognised - see Load, which must rebuild such a store's agent tally rather
+        // than add to it. Nullable on purpose: an empty list is a real value (a store with nothing folded
+        // yet) and must not be confused with an absent one.
+        public List<string>? AgentsSeeded { get; set; }
     }
 
     private sealed class HourTurnsStore
@@ -531,7 +579,29 @@ public sealed class GatewayInputStatsAggregator
             _agents[agentKey] = tally;
         }
         _agentsSinceUtc = parsed.AgentsSinceUtc ?? "";
-        FileLog.Write($"[GatewayInputStatsAggregator] Load: restored {_totals.Count} total bucket(s), {_highWater.Count} live session(s), {_hourly.Count} hourly bucket(s), {_wingmanSessions.Count} wingman session(s)/{_wingmanTurns} wingman turn(s), {_repos.Count} repo(s), {_agents.Count} agent(s) since '{_agentsSinceUtc}' from {_path}");
+
+        // Issue #1633. A store written before the back-fill existed (no AgentsSeeded key) is a HYBRID: some
+        // sessions had turns attributed by the ordinary delta path while the tally was live, and the SAME
+        // turns are also sitting in those sessions' high-water. Nothing records which of the two applies to
+        // which session, so back-filling on top of it would count those turns twice.
+        //
+        // So the partial tally is DISCARDED and rebuilt from the high-water, which is the authoritative
+        // per-session count. What is lost is the contribution of sessions that both ran and ended inside
+        // that short window - their high-water is already pruned, so it cannot be recovered. That is a small
+        // honest loss, and far better than silently inflating every agent's numbers.
+        if (parsed.AgentsSeeded is null)
+        {
+            FileLog.Write($"[GatewayInputStatsAggregator] Load: store predates the agent back-fill (issue #1633); " +
+                          $"discarding {_agents.Count} partially-attributed agent tally/tallies and rebuilding from " +
+                          $"the high-water of {_highWater.Count} known session(s)");
+            _agents.Clear();
+        }
+        else
+        {
+            foreach (var id in parsed.AgentsSeeded)
+                if (!string.IsNullOrEmpty(id)) _agentsSeeded.Add(id);
+        }
+        FileLog.Write($"[GatewayInputStatsAggregator] Load: restored {_totals.Count} total bucket(s), {_highWater.Count} live session(s), {_hourly.Count} hourly bucket(s), {_wingmanSessions.Count} wingman session(s)/{_wingmanTurns} wingman turn(s), {_repos.Count} repo(s), {_agents.Count} agent(s) since '{_agentsSinceUtc}' ({_agentsSeeded.Count} attributed) from {_path}");
     }
 
     private void Quarantine(string reason)
@@ -576,6 +646,7 @@ public sealed class GatewayInputStatsAggregator
                     Sessions = at.Sessions.ToList(),
                 };
             file.AgentsSinceUtc = _agentsSinceUtc;
+            file.AgentsSeeded = _agentsSeeded.ToList();
 
             var json = JsonSerializer.Serialize(file, FileJsonOptions);
             var tmp = _path + ".tmp";

--- a/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
+++ b/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
@@ -67,6 +67,12 @@ public static class StatsPageEndpoint
                 // turns ran under no agent.
                 agents = aggregator.AgentTotals(),
                 agentsSinceUtc = aggregator.AgentsSinceUtc,
+                // DevThrottle Stats (issue #1636): turns the fleet drove into ITSELF - one agent prompting
+                // another. Reported alongside the human tally but never inside it: "how do you drive" and
+                // "how much does the fleet drive itself" are different questions, and the ratio between
+                // them is the leverage the owner actually gets per turn they spend.
+                agentDrivenTurns = aggregator.AgentDrivenUsage().Turns,
+                agentDrivenCharacters = aggregator.AgentDrivenUsage().Characters,
                 notCaptured = NotCaptured,
             });
         });


### PR DESCRIPTION
Fixes #1635, #1633, #1636. Four commits, each independently correct and reviewable on its own.

## Why

The Agents tab read "100% Claude Code / 1 agent driven" while live Codex sessions sat there carrying real turns. The plumbing was never wrong - the Director reports the agent, the Gateway attributes by it. Three separate problems were stacked on top of each other.

## 1635 - workspace restore lost the agent

The agent was lost at SAVE time: `WorkspaceSessionEntry` had no agent field at all, so the restore had nothing to read and fell to the `CreateSession` default. Any Codex session restored from a saved workspace came back claiming to be Claude Code, and its turns counted as Claude Code. Silent misattribution - the number looks plausible and is wrong.

A null agent still means ClaudeCode: not a guess, every session in a workspace saved before this was created through the old default.

## 1633 - the high-water lockout

The agent breakdown is younger than the high-water map. A session first seen before the breakdown existed had its turns consumed into the totals then, so its high-water equals its current count and its delta is zero forever - and the whole attribution sat inside the delta guard. 114 sessions on the owner's machine, including a Codex session whose real operator turn was locked out permanently.

The first fold of a session now attributes what its high-water already holds, with a persisted seed set so it happens once.

**The trap, found by checking the real store rather than trusting the design:** the deployed store is a HYBRID. The tally had been live for a few hours, so some sessions already had turns attributed AND those same turns sit in their high-water, with nothing recording which sessions those were. Back-filling on top would have double-counted them - measured on the real file, ClaudeCode's 27 attributed voice turns would have been added a second time. A store with no seed set therefore has its partial tally DISCARDED and rebuilt from the high-water. That loses sessions which both ran and ended inside that window; their high-water is already pruned, so it cannot be recovered. A small honest loss beats silently inflating every agent.

The tab copy claimed the earlier turns had no recorded agent and were excluded. That is no longer true, so it now says what is: a session still running is counted in full; only sessions that had already finished are absent.

## 1636 - agents driving agents

Not tracked anywhere - dropped before any counter was touched. Split into two commits: the `SendSource.Internal` split (no behaviour change), then the tally.

Counted on a separate lane, never in the human buckets. Agent turns are typed by definition, so folding them in would drop the voice share overnight and break every comparison with history. Headline is **leverage**: agent turns per turn the owner spent.

**The cross-Director gap:** a fleet message to a session on another Director arrives as an ordinary prompt over the tunnel - no Surface, source defaulting to UserInput, indistinguishable from a human. Only same-Director messages would have counted, so the identical message would count or not depending on which machine the target was on. The relay now marks it in the DTO, the same trick `DeliveryUploadId` already uses.

## Proof

Every fix reverted separately and watched go red with the reported symptom, controls staying green:

| Reverted | Red | Green controls |
|---|---|---|
| `ResolveAgentKind` to always-ClaudeCode | 9 - every non-Claude agent | ClaudeCode, legacy, unknown-agent |
| the #1633 back-fill | 5 legacy tests | fresh-session (proves it recovers history, not invents turns) |
| only the hybrid discard | 1 - at 13 turns where 10 are real | the other 26 |
| the Director's `RecordAgentTurn` | 3 chokepoint tests | human + framework |
| the relay marker | 2 relayed-prompt tests | local delivery + human prompts |

The `RecordAgentTurn` revert is why the chokepoint tests exist: the aggregator tests set `AgentDrivenTurns` by hand, so they proved the fold while proving nothing about whether anything emits it. Reverting the producer left them all green - the live-consumer/dead-producer shape this codebase keeps producing.

All seven test projects pass (5,837 tests). One unrelated flake seen once: `LoopbackLoginListenerTests.WaitForCredentialAsync_CapturesBothTokensFromQueryString_Transition` failed on an `HttpListener` port collision, passes in isolation, and this branch does not touch that file.

## Known gaps, filed not guessed

- **The Repos tally has the same lockout** (high-water arrived in #1345, the repo tally in #1484) but CANNOT take this fix: sessions first seen between those releases are already repo-attributed and nothing marks which, so a back-fill would double-count them. Needs its own approach.
- Agent-driven turns are attributed to the RECEIVING agent only. Which agent SENT it is not recorded; per-pair attribution is a later step.
