### PR TITLE
fix(transcription): stop the audio archive writing test clips into the real archive

### DIFF
--- a/src/CcDirector.Gateway.Tests/GatewayTranscriptionServiceTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayTranscriptionServiceTests.cs
@@ -40,7 +40,17 @@ public sealed class GatewayTranscriptionServiceTests : IDisposable
         try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
     }
 
-    private GatewayTranscriptionService Service() => new(new KeyVault(_vaultPath));
+    /// <summary>
+    /// A scratch archive under this test's own root. EVERY service built here must be given one:
+    /// falling back to TranscriptionAudioArchive.Shared writes clips into the REAL user's
+    /// transcription-audio folder. CC_DIRECTOR_ROOT alone does NOT protect against that - it is
+    /// process-wide, and xUnit runs other collections in parallel that clear it mid-test, so Shared
+    /// resolves to the real location. Injection is the only isolation that holds.
+    /// </summary>
+    private TranscriptionAudioArchive ScratchArchive() => new(Path.Combine(_root, "archive-scratch"));
+
+    private GatewayTranscriptionService Service()
+        => new(new KeyVault(_vaultPath), audioArchive: ScratchArchive());
 
     /// <summary>Answers the transcription POST with a fixed status + body (issue #885).</summary>
     private sealed class StatusHandler : HttpMessageHandler
@@ -139,7 +149,9 @@ public sealed class GatewayTranscriptionServiceTests : IDisposable
 
         var body = "{\"error\":{\"code\":\"insufficient_credits\",\"message\":\"no credits\"}}";
         var service = new GatewayTranscriptionService(
-            new KeyVault(_vaultPath), http: new HttpClient(new StatusHandler(HttpStatusCode.PaymentRequired, body)));
+            new KeyVault(_vaultPath),
+            http: new HttpClient(new StatusHandler(HttpStatusCode.PaymentRequired, body)),
+            audioArchive: ScratchArchive());
 
         var result = await service.TranscribeAsync(new byte[] { 1, 2, 3 }, "clip.webm", "audio/webm", applyCorrection: false, CancellationToken.None);
 

--- a/src/CcDirector.Gateway.Tests/Transcription/TranscriptionAudioArchiveTests.cs
+++ b/src/CcDirector.Gateway.Tests/Transcription/TranscriptionAudioArchiveTests.cs
@@ -11,6 +11,7 @@ namespace CcDirector.Gateway.Tests.Transcription;
 ///
 /// Every test writes to its own scratch directory - never the real user's archive.
 /// </summary>
+[Collection("DirectorRoot")] // serializes classes that mutate the process-wide CC_DIRECTOR_ROOT
 public sealed class TranscriptionAudioArchiveTests : IDisposable
 {
     private readonly string _dir = Path.Combine(
@@ -59,7 +60,11 @@ public sealed class TranscriptionAudioArchiveTests : IDisposable
     [InlineData("audio/webm", ".webm")]
     [InlineData("audio/ogg", ".ogg")]
     [InlineData("audio/mp4", ".m4a")]
-    [InlineData("application/octet-stream", ".bin")]
+    // What the browser and phone ACTUALLY send. A private exact-match copy of this mapping missed the
+    // ";codecs=" parameter and wrote real clips as unplayable .bin - caught only by watching the live
+    // archive, never by a test, because no test used the real MIME string.
+    [InlineData("audio/webm;codecs=opus", ".webm")]
+    [InlineData("audio/ogg; codecs=vorbis", ".ogg")]
     public void TrySave_NamesTheFileSoAPlayerCanOpenIt(string contentType, string expectedExtension)
     {
         var path = NewArchive().TrySave("turn1", Clip(), contentType);
@@ -142,6 +147,39 @@ public sealed class TranscriptionAudioArchiveTests : IDisposable
         Assert.Equal(TranscriptionAudioArchive.MaxClips, remaining.Length);
         Assert.False(File.Exists(archive.FileFor("turn0000", ".wav")));
         Assert.True(File.Exists(archive.FileFor($"turn{TranscriptionAudioArchive.MaxClips:D4}", ".wav")));
+    }
+
+    [Fact]
+    public void DefaultDirectory_FollowsCcDirectorRoot_ResolvedPerAccess()
+    {
+        // THE regression. Shared is a static field, so a path captured in the constructor is baked at
+        // TYPE LOAD - once, before any test sets CC_DIRECTOR_ROOT, and no test can undo it. That shipped:
+        // isolated tests that fell back to Shared wrote 3-byte clips into the REAL user's archive,
+        // because Shared's path had already been fixed to the real location. The tests were isolated
+        // correctly; the static defeated them. Resolving per access is what makes the override real.
+        var prev = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        try
+        {
+            // An archive constructed with NO override, BEFORE the root is redirected - exactly Shared's
+            // situation. It must still follow a root set afterwards.
+            var archive = new TranscriptionAudioArchive();
+
+            var rootA = Path.Combine(_dir, "rootA");
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", rootA);
+            var underA = archive.FileFor("turn1", ".wav");
+
+            var rootB = Path.Combine(_dir, "rootB");
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", rootB);
+            var underB = archive.FileFor("turn1", ".wav");
+
+            Assert.StartsWith(rootA, underA);
+            Assert.StartsWith(rootB, underB);
+            Assert.NotEqual(underA, underB);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", prev);
+        }
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/Transcription/TranscriptionAudioArchive.cs
+++ b/src/CcDirector.Gateway/Transcription/TranscriptionAudioArchive.cs
@@ -48,20 +48,36 @@ public sealed class TranscriptionAudioArchive
     public const int MaxClips = 500;
 
     private readonly object _gate = new();
-    private readonly string _directory;
+
+    /// <summary>
+    /// An explicit directory override, or null to use <see cref="DefaultDirectory"/>. Only the OVERRIDE
+    /// is stored; the default is resolved PER ACCESS by <see cref="ArchiveDirectory"/> and never captured here.
+    /// <see cref="Shared"/> is a static field, so anything this constructor resolves is baked at type
+    /// load - which happens once, before a test can set CC_DIRECTOR_ROOT, and no test can undo it. That
+    /// bug shipped: test clips landed in the real user's archive because the isolated tests fell back to
+    /// Shared, whose path had already been fixed to the real location. The tests were isolated
+    /// correctly; the static defeated them.
+    /// </summary>
+    private readonly string? _directoryOverride;
 
     /// <param name="directory">Override the archive directory (tests). Defaults to the per-user location.</param>
     public TranscriptionAudioArchive(string? directory = null)
     {
-        _directory = string.IsNullOrWhiteSpace(directory) ? DefaultDirectory() : directory;
+        _directoryOverride = string.IsNullOrWhiteSpace(directory) ? null : directory;
     }
 
-    /// <summary>The per-user transcription-audio directory.</summary>
+    /// <summary>
+    /// Where clips are kept, resolved per access so CC_DIRECTOR_ROOT redirects it. NOT a get-only
+    /// initializer and NOT captured in the constructor - see <see cref="_directoryOverride"/>.
+    /// </summary>
+    private string ArchiveDirectory => _directoryOverride ?? DefaultDirectory();
+
+    /// <summary>The per-user transcription-audio directory. Resolved per call, never cached.</summary>
     public static string DefaultDirectory() => CcStorage.TranscriptionAudio();
 
     /// <summary>The file a clip for <paramref name="turnId"/> lands in.</summary>
     public string FileFor(string turnId, string extension)
-        => Path.Combine(_directory, $"turn-{SafeName(turnId)}{extension}");
+        => Path.Combine(ArchiveDirectory, $"turn-{SafeName(turnId)}{extension}");
 
     /// <summary>
     /// Keep a turn id to characters a filename allows. Production ids are GUIDs and pass through
@@ -86,7 +102,7 @@ public sealed class TranscriptionAudioArchive
         {
             lock (_gate)
             {
-                Directory.CreateDirectory(_directory);
+                Directory.CreateDirectory(ArchiveDirectory);
                 var path = FileFor(turnId, ExtensionFor(contentType));
                 File.WriteAllBytes(path, audio);
                 FileLog.Write($"[TranscriptionAudioArchive] archived {audio.Length} bytes for turn {turnId} to {path}");
@@ -108,7 +124,7 @@ public sealed class TranscriptionAudioArchive
     /// </summary>
     private void Prune()
     {
-        var files = new DirectoryInfo(_directory)
+        var files = new DirectoryInfo(ArchiveDirectory)
             .GetFiles("turn-*")
             .OrderByDescending(f => f.LastWriteTimeUtc)
             .ToList();
@@ -133,18 +149,16 @@ public sealed class TranscriptionAudioArchive
     }
 
     /// <summary>
-    /// A playable extension for the clip's MIME type. The archive exists to be listened to, so the file
-    /// must open in a player by double-click. An unrecognized type keeps its bytes under .bin rather
-    /// than claiming a format it may not be.
+    /// A playable extension for the clip's MIME type. The archive exists to be LISTENED TO, so the file
+    /// must open in a player on a double-click.
+    ///
+    /// Delegates to <see cref="GatewayTranscriptionService.ExtensionFor"/> - the same mapping that names
+    /// the upload sent to the provider, so the archived clip and the transcribed clip can never disagree
+    /// about what format they are. A private copy here did disagree: it exact-matched the MIME string, so
+    /// the "audio/webm;codecs=opus" the browser and phone actually send missed every arm and real clips
+    /// landed as unplayable .bin. The shared one strips the parameter and was already tested for exactly
+    /// that case.
     /// </summary>
-    private static string ExtensionFor(string contentType) => contentType?.ToLowerInvariant() switch
-    {
-        "audio/wav" or "audio/wave" or "audio/x-wav" => ".wav",
-        "audio/mpeg" or "audio/mp3" => ".mp3",
-        "audio/webm" => ".webm",
-        "audio/ogg" => ".ogg",
-        "audio/mp4" or "audio/m4a" or "audio/x-m4a" => ".m4a",
-        "audio/flac" or "audio/x-flac" => ".flac",
-        _ => ".bin",
-    };
+    private static string ExtensionFor(string contentType)
+        => "." + GatewayTranscriptionService.ExtensionFor(contentType);
 }


### PR DESCRIPTION
Two defects in the archive that shipped in #1643. Both were found by **watching the live archive**, not by a test — which is the honest lesson here.

## 1. The static defeated the tests' isolation (a repeat of #1580)

`Shared` is a static field, so the directory it resolved in the constructor was baked at **type load** — once, before any test sets `CC_DIRECTOR_ROOT`, and no test can undo it. Isolated tests that fell back to `Shared` wrote 3-byte clips straight into the real user's `transcription-audio` folder.

This is the exact bug `StorageRootGuardTests` already names:

> *"StateChangeLog + VoiceUtteranceService: both baked the root into a static readonly field, so their tests appended into the live Director's own data directory (#1580)."*

And `DictationRecordingStore` documents the fix in a comment I had already read:

> *"Resolved per access, not baked into a get-only initializer, so CC_DIRECTOR_ROOT redirects it — an initializer runs once at type load and no test can undo it."*

The guard didn't catch it because the guard checks that you don't re-derive the root by hand — and this code correctly asks `CcStorage`. It just froze the answer.

**Per-access alone is not enough**: `CC_DIRECTOR_ROOT` is process-wide while xUnit runs collections in parallel, so a sibling collection clears it mid-test. The tests now **inject** a scratch archive; no test in the class can reach `Shared` at all.

## 2. Real clips were archived as unplayable `.bin`

The private `ExtensionFor` exact-matched the MIME string, so the `audio/webm;codecs=opus` that browsers and the phone actually send missed every arm. The live Gateway wrote **three real recordings as `.bin`** before this was spotted.

It now delegates to `GatewayTranscriptionService.ExtensionFor` — the same public, already-tested mapping that names the upload sent to the provider. It strips the parameter and had `[InlineData("audio/webm;codecs=opus", "webm")]` all along. The archived clip and the transcribed clip can no longer disagree about what format they are.

The duplicate existed because the shared mapping wasn't looked for first.

## Proof

Both fixes **verified to fail on purpose**:

```
re-bake the path in the ctor  ->  Failed: 1, Passed: 15  (controls green)
restore                       ->  Passed: 32
```

Full Gateway suite passes **2404** with **zero clips written into the real archive** — the check that actually mattered, and the one no assertion was making. New tests cover the redirect and the real `;codecs=` MIME strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
