### PR TITLE
fix(voice): one slow narration silenced the whole fleet, and voice talked over you while answering

### DIFF
--- a/apps/mobile/src/pages/VoiceMode.tsx
+++ b/apps/mobile/src/pages/VoiceMode.tsx
@@ -182,8 +182,12 @@ export function VoiceMode() {
               </span>
             </div>
             <div className="voice-narr">
+              {/* "This is not your fault." was the headline here, and it told the reader nothing: it
+                  answered a question nobody asked (whose fault?) instead of the one everybody asks
+                  (what is going on?). A headline has one job - say what happened - and the sentence
+                  underneath, which comes from the Gateway, says what is being done about it. */}
               <div className="voice-narr-title">
-                {unavailableIsServiceDown ? "This is not your fault." : "No narration is ready to play."}
+                {unavailableIsServiceDown ? "The speech service did not answer." : "No narration is ready to play."}
               </div>
               <div className="voice-narr-body">
                 {unavailableReason?.text

--- a/packages/client-core/src/voice/useVoiceMode.ts
+++ b/packages/client-core/src/voice/useVoiceMode.ts
@@ -308,6 +308,11 @@ export function useVoiceMode(
   // the agent is working again - that narration is stale (the same rule the roster triangle follows).
   useEffect(() => {
     if (agentWorking) return;
+    // NEVER speak while the listener is answering. This effect fires when a NEW clip finishes
+    // downloading, and it had no idea the Respond dialog was open - so a turn that landed mid-dictation
+    // played straight over the owner while their microphone was live, which is both maddening and an
+    // echo source. Answering is a conversation: the other party stops talking.
+    if (responding) return;
     if (!phoneReady || generatedAt.length === 0) return;
     if (typeof document !== "undefined" && document.hidden) return;
     // Only auto-play a genuinely NEW clip: one this device has not auto-played AND that has no
@@ -325,7 +330,22 @@ export function useVoiceMode(
         /* autoplay policy may require a gesture; the play-triangle covers it */
       });
     }
-  }, [phoneReady, generatedAt, agentWorking, sid]);
+  }, [phoneReady, generatedAt, agentWorking, sid, responding]);
+
+  // Tapping Respond SILENCES whatever is already speaking, at once. The guard above stops a new clip
+  // from starting, but a clip already mid-sentence when Respond is tapped would otherwise keep talking
+  // into the open microphone. Both halves are needed: one stops it starting, this one stops it
+  // continuing. Both audio sinks are stopped - this screen's element and the shared roster player -
+  // because either can be the one talking.
+  useEffect(() => {
+    if (!responding) return;
+    try {
+      audioRef.current?.pause();
+    } catch {
+      /* nothing playing */
+    }
+    stopPlayback();
+  }, [responding]);
 
   // A new turn's clip resets the per-mount resume guards so its saved position (0) restores cleanly.
   useEffect(() => {
@@ -410,7 +430,13 @@ export function useVoiceMode(
       // A 402 (out of credits / no key) already raised the shared app-level credits notice and its
       // message is the shared copy. An offline owning Director resolves to 404 here - say so plainly
       // instead of leaking the raw status, because it is the most common reason generation fails.
-      if (err instanceof GatewayError && err.status === 404) {
+      //
+      // 502 means the same thing and was NOT handled: the Gateway reaches a session's Director down its
+      // stream, and when that Director is not stream-connected the endpoint answers 502 (issue #1177).
+      // Measured across the live fleet on 2026-07-15: of 16 sessions, one answered 502 and two answered
+      // 404 - all three the same story, "that computer is not reachable" - but only the 404s got the
+      // plain-English line and the 502 leaked a raw message. Same cause, same sentence.
+      if (err instanceof GatewayError && (err.status === 404 || err.status === 502)) {
         setError("This session's computer looks offline. Voice can't be generated until it reconnects.");
       } else {
         setError(err instanceof Error ? err.message : "Could not generate narration");

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
@@ -606,6 +606,59 @@ public sealed class WingmanVoiceServiceTests
         Assert.Equal(HostedAiState.ServiceDown, svc.VoiceUnavailableFor("sid-timeout"));
     }
 
+    // ONE SLOW NARRATION MUST NOT SILENCE THE FLEET.
+    //
+    // The speech cooldown (_ttsGate) is shared by every session, and GenerateAsync SKIPS a session
+    // outright while it is armed ("speech service down, 105s cooldown left"). A single TIMEOUT used to
+    // arm it, so one long narration blanked voice for every other session for up to 120 seconds.
+    //
+    // Measured against the live fleet on 2026-07-15: the speech endpoint answered an 871-character
+    // narration in 1.7 seconds from the Gateway's own machine, while the Gateway logged 1031 attempt-1
+    // timeouts and 759 give-ups and NOT ONE of 17 sessions held audio - yet asking on demand produced
+    // real audio for 13 of 13 reachable sessions. The service was never down; the shared gate was armed
+    // by evidence that never justified it.
+    [Fact]
+    public async Task StoreSpokenAsync_OneTimeout_DoesNotArmTheSharedCooldown()
+    {
+        // One timeout is not evidence about the SERVICE - it can be one long narration or one stalled
+        // worker. The session still reports ServiceDown (nothing to play, and it must say so), but the
+        // shared gate must stay open so every other session still gets its turn at speech.
+        var handler = new TtsTimeoutHandler(timeouts: TtsSynthesis.Attempts);
+        var svc = ServiceWithHandler(handler);
+
+        await svc.StoreSpokenAsync("sid-slow", "spoken", "reply");
+
+        Assert.Equal(HostedAiState.ServiceDown, svc.VoiceUnavailableFor("sid-slow"));
+        Assert.False(svc.SpeechCooldownArmed, "one timeout must not silence every other session's voice");
+    }
+
+    [Fact]
+    public async Task StoreSpokenAsync_ThreeConsecutiveTimeouts_ArmsTheSharedCooldown()
+    {
+        // The control, and the money guard the gate exists for: a genuine outage must still trip it
+        // quickly, so the idle sweep stops paying for a model translation whose audio cannot be made.
+        var handler = new TtsTimeoutHandler(timeouts: int.MaxValue);
+        var svc = ServiceWithHandler(handler);
+
+        await svc.StoreSpokenAsync("sid-a", "spoken", "reply");
+        await svc.StoreSpokenAsync("sid-b", "spoken", "reply");
+        await svc.StoreSpokenAsync("sid-c", "spoken", "reply");
+
+        Assert.True(svc.SpeechCooldownArmed, "a real outage must still back the fleet off within three attempts");
+    }
+
+    [Fact]
+    public async Task StoreSpokenAsync_ServerAnswersWithFailureStatus_ArmsTheSharedCooldownAtOnce()
+    {
+        // A server that ANSWERS 5xx is evidence about the service, not about one narration, so it does
+        // not wait for a run of three the way an ambiguous timeout does.
+        var svc = ServiceWithTts(HttpStatusCode.ServiceUnavailable, "{\"error\":\"upstream\"}");
+
+        await svc.StoreSpokenAsync("sid-5xx", "spoken", "reply");
+
+        Assert.True(svc.SpeechCooldownArmed);
+    }
+
     [Fact]
     public async Task StoreSpokenAsync_TtsOutOfCredits_StillBlamesTheAccount_NotTheService()
     {

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -84,6 +84,20 @@ public sealed class WingmanVoiceService
     //    speech failure makes the fleet back off (5/10/20..120s) and honours a 429's Retry-After.
     private readonly WingmanRateLimitGate _ttsGate = new();
 
+    /// <summary>
+    /// Consecutive speech TIMEOUTS/transport failures, reset by any success. A timeout says nothing
+    /// certain about the service - it can just be one long narration or one stalled worker - so it must
+    /// not, on its own, arm the fleet-wide <see cref="_ttsGate"/> and skip every other session's voice.
+    /// A server that ANSWERS with a failure status (or a 429) is different: that is evidence about the
+    /// service, and arms the gate immediately.
+    /// </summary>
+    private int _consecutiveTtsFailures;
+
+    /// <summary>How many consecutive speech timeouts look like the SERVICE rather than one narration.
+    /// A real outage still trips the cooldown within three attempts, which preserves the money guard;
+    /// a single slow narration no longer silences the fleet.</summary>
+    private const int ConsecutiveTtsFailuresBeforeCooldown = 3;
+
     /// <summary>On-disk shape of one ready session's metadata (the audio bytes live next to it as
     /// an .mp3). Persisted so the play triangle / playability survives a gateway restart (issue #553).</summary>
     private sealed record PersistedVoice(string Spoken, string Reply, DateTime AtUtc, string? ContentType = null);
@@ -190,6 +204,14 @@ public sealed class WingmanVoiceService
 
     /// <summary>True when this session currently has a fresh, playable cached summary.</summary>
     public bool HasVoice(string sid) => _ready.ContainsKey(sid);
+
+    /// <summary>
+    /// Whether the FLEET-WIDE speech cooldown is currently armed - that is, whether GenerateAsync will
+    /// skip every session's voice right now. Exposed because this one flag decides whether the whole
+    /// fleet has narration or none of it does, and a bug in what arms it is invisible from the outside
+    /// (it looks exactly like "the speech service is down"). Tests assert on it directly.
+    /// </summary>
+    public bool SpeechCooldownArmed => _ttsGate.InCooldown(out _);
 
     /// <summary>
     /// Whether a turn-end should (re)generate the spoken narration for this session. True when there is
@@ -548,11 +570,16 @@ public sealed class WingmanVoiceService
                 // Both false. On 2026-07-15 that cost ~45 minutes of the owner not being able to tell an
                 // outage from a bug. Say what actually happened, and back off so the sweep stops paying
                 // for a translation whose audio cannot be made.
+                //
+                // The server ANSWERED with a failure status, so this is evidence about the service and
+                // not about one narration: arm the shared cooldown at once.
+                FileLog.Write($"[WingmanVoiceService] tts {(int)resp.StatusCode} - server answered with a failure; arming the shared speech cooldown");
                 _ttsGate.OnRateLimited(null);
                 return new TtsResult(null, null, HostedAiState.ServiceDown);
             }
             var contentType = resp.Content.Headers.ContentType?.MediaType;
             _ttsGate.OnSuccess();   // reaching the service clears any cooldown/backoff ramp
+            Interlocked.Exchange(ref _consecutiveTtsFailures, 0);  // ...and the timeout run that was building toward one
             return new TtsResult(await resp.Content.ReadAsByteArrayAsync(ct), contentType, null);
         }
         // A timeout (TtsSynthesis exhausted its attempts) or a transport failure is the same story from
@@ -562,9 +589,35 @@ public sealed class WingmanVoiceService
         {
             // A TimeoutException here is TtsSynthesis giving up after its attempts - the exact failure it
             // exists to bound, and previously the one that stamped NOTHING. Same story for a transport
-            // failure: the service did not answer. Back off, and tell the truth.
-            FileLog.Write($"[WingmanVoiceService] tts FAILED: {ex.Message}");
-            _ttsGate.OnRateLimited(null);
+            // failure: the service did not answer. Tell the truth.
+            //
+            // But a timeout is NOT evidence that the service is down, and this line used to treat it as
+            // if it were: one timeout armed the SHARED gate, and GenerateAsync then SKIPPED every other
+            // session with "speech service down" for up to 120 seconds. One slow narration silenced the
+            // whole fleet. Measured on 2026-07-15 with 9 voice sessions: the speech endpoint answered a
+            // 871-character narration in 1.7 seconds from this very machine, while the Gateway logged
+            // 1031 attempt-1 timeouts and 759 give-ups, and NOT ONE session held audio - yet asking for
+            // narration on demand produced real audio for 13 of 13 reachable sessions. The service was
+            // never down. The gate was, and it was armed by ambiguous evidence.
+            //
+            // So: count consecutive timeouts and only arm the shared gate once the failure looks like the
+            // SERVICE rather than one narration. A genuine outage still trips it within three attempts,
+            // which keeps the money guard the gate exists for (a sweep pays for a full model translation
+            // before it ever reaches the speech leg), while a single slow narration now costs only its
+            // own session's turn instead of everyone's.
+            var consecutive = Interlocked.Increment(ref _consecutiveTtsFailures);
+            if (consecutive >= ConsecutiveTtsFailuresBeforeCooldown)
+            {
+                var backoff = _ttsGate.OnRateLimited(null);
+                FileLog.Write($"[WingmanVoiceService] tts FAILED: {ex.Message} " +
+                              $"({consecutive} consecutive) - arming the shared speech cooldown {backoff.TotalSeconds:F0}s");
+            }
+            else
+            {
+                FileLog.Write($"[WingmanVoiceService] tts FAILED: {ex.Message} " +
+                              $"({consecutive}/{ConsecutiveTtsFailuresBeforeCooldown} consecutive) - NOT arming the shared cooldown; " +
+                              $"other sessions keep their turn at speech");
+            }
             return new TtsResult(null, null, HostedAiState.ServiceDown);
         }
         // NOTE: no `finally { http.Dispose(); }`. `http` is now either the caller's injected client or


### PR DESCRIPTION
Investigating "a lot of sessions have no sound" against the **live fleet**. Measured, not argued.

## What was measured (17 sessions, 9 in voice mode)

- **Not one session held audio.** `voiceAudioReady` was false across the entire fleet.
- **The speech service was never down.** From the Gateway's own machine it answered a 43-char narration in **0.64s** and an 871-char one in **1.73s**; six concurrent 871-char requests all returned 200 in under 3.8s. No 429, no stall.
- The Gateway meanwhile logged **1031** `attempt 1/2 timed out` and **759** `giving up`.
- Asking for narration **on demand** produced real audio (50KB-370KB of mp3) for **13 of 13 reachable sessions**. The other 3 were unreachable Directors (404/502).

The pipeline works. The fleet was being starved by its own brakes.

## 1. One slow narration silenced the whole fleet

The speech cooldown (`_ttsGate`) is **shared by every session**, and `GenerateAsync` skips a session outright while it is armed (`speech service down, 105s cooldown left`). **A single timeout armed it.** So one long narration blanked voice for all 17 sessions for up to 120s - and with 9 voice sessions the gate sat armed near-permanently. The sweep never built voice; the phone opened on nothing and said "Voice unavailable".

A timeout is not evidence about the *service*. A server that **answers** 429 or 5xx is, and still arms the gate at once. A timeout now needs three consecutive occurrences - which keeps the money guard the gate exists for (a sweep pays for a full model translation before it reaches the speech leg) while a single slow narration costs only its own session's turn.

## 2. Voice talked over you while you were answering

The auto-play effect fires when a new clip finishes downloading. It checked the agent, the hidden tab, and the already-played mark - but had no idea the **Respond dialog was open**. A turn landing mid-dictation played straight over the owner, into a live microphone. Two guards, because there are two cases: a new clip must not **start** while responding, and one already mid-sentence must **stop** when Respond is tapped.

## 3. The error copy answered a question nobody asked

"This is not your fault." was the headline on a failed narration. It says nothing about what happened. Now: **"The speech service did not answer."** The Gateway's sentence underneath already says what is being done about it.

## 4. A 502 leaked a raw error

The Gateway answers 502 when a session's Director is not stream-connected (#1177) - the same story as the 404 that *was* handled. On the live fleet 2 sessions answered 404 and 1 answered 502; only the 404s got the plain-English line.

## Proof

Tests fail on purpose: setting the consecutive threshold back to 1 (the old behaviour) turns `StoreSpokenAsync_OneTimeout_DoesNotArmTheSharedCooldown` red with *"one timeout must not silence every other session's voice"*, while the outage control (three timeouts still arm it) and the 5xx control stay green.

476 JavaScript tests, 2429 Gateway tests, typecheck clean.

## Still open, deliberately

A **429 is still reported as ServiceDown** ("the service is not responding") when the service in fact answered and asked us to slow down. Splitting that into its own truthful state touches the `HostedAiState` enum and the eight surfaces that switch on it, so it is its own change.

Generated with [Claude Code](https://claude.com/claude-code)
