### PR TITLE
fix(mobile): the network pill sat on top of the Voice mode tab

### DIFF
--- a/apps/mobile/src/components/SessionAppBar.tsx
+++ b/apps/mobile/src/components/SessionAppBar.tsx
@@ -89,8 +89,20 @@ export function SessionAppBar({ title, manage, showSnooze = false, showSwitchToV
           &larr; Sessions
         </button>
 
-        {/* Claims the middle of row 1, pushing the menu button into the corner it should have had all
-            along. It guesses nothing: it just takes whatever is left between the two controls. */}
+        {/* Two spacers, so the pill sits in the CENTRE of row 1 and the menu button still gets the
+            corner. Nothing guesses any widths - the spacers just split whatever is left over. */}
+        <div className="session-bar-spacer" />
+
+        {/* The network pill lives here, mid-row-1, because it is the only tappable thing on this screen
+            that nobody means to tap. It navigates to Diagnostics, and it spent a few hours parked at the
+            right end of the TITLE row - which put a small link directly above "Voice mode", the
+            right-hand tab and the most-pressed control on the screen. A tap a few pixels high landed on
+            it and threw you off the screen you were opening (owner, 2026-07-15: "several times when I
+            wanted to go to voice mode, I hit the fast by accident"). Mid-row-1 is a whole row clear of
+            the tabs and horizontally clear of both controls: an indicator you can still reach on purpose
+            and stop hitting by accident. */}
+        <StatusPill inline />
+
         <div className="session-bar-spacer" />
 
         <div className="session-menu-wrap" ref={menuRef}>
@@ -166,15 +178,13 @@ export function SessionAppBar({ title, manage, showSnooze = false, showSwitchToV
 
       </header>
 
-      {/* The session name gets its OWN row. It cannot share row one: between the back button and the
-          menu button there is not enough room left for a real session name ("102 Ghost Directors from
-          tests" collapsed to "102 M..."). The network pill rides HERE, at the end of this row, because
-          it is an indicator - it reads as the status of this session's connection, it can no longer
-          cover the name the way the fixed pill did, and it is out of the corner the menu needs. The
-          name still flexes and ellipsizes (.term-title), so the pill costs it only the pill's width. */}
+      {/* The session name gets its OWN row, and now the WHOLE row: it cannot share row one, where the
+          back button and the menu button leave no room for a real name ("102 Ghost Directors from tests"
+          collapsed to "102 M..."). The network pill used to ride the end of this row and has moved up to
+          the middle of row 1 - see the note there; in short, it was sitting directly above the Voice mode
+          tab and getting hit instead of it. */}
       <div className="session-title-row">
         <h1 className="term-title session-title">{title}</h1>
-        <StatusPill inline />
       </div>
 
       {manage.error !== null && <div className="banner banner-error" role="alert">{manage.error}</div>}

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -2115,8 +2115,14 @@ a.banner-btn {
 
    Layout, and why it is two rows:
 
-     row 1:  [<- Sessions] .................... [...]      navigation left, overflow menu right
-     row 2:  102 devthrottle / f9e7 ..... ( o Fast )       name flexes; the indicator rides the end
+     row 1:  [<- Sessions] ..... ( o Fast ) ..... [...]    navigation left, indicator centre, menu right
+     row 2:  102 devthrottle / f9e7                        the name gets the whole row
+
+   The pill is CENTRED in row 1 because it is the one tappable thing here that nobody means to tap - it
+   navigates to Diagnostics. It briefly sat at the right end of row 2, which put a small link directly
+   above "Voice mode": the right-hand tab, the most-pressed control on the screen, and a few pixels away.
+   It got hit instead of the tab. Centre of row 1 is a whole row clear of the tabs and horizontally clear
+   of both controls.
 
    The corner belongs to the CONTROL, not the indicator. This bar used to put the menu button on the
    LEFT because the network pill was position:fixed in the top-right and nothing wanted to guess how
@@ -2131,6 +2137,18 @@ a.banner-btn {
    costs it only the pill's width, and .term-title already flexes and ellipsizes. */
 .session-app-bar {
   gap: 8px;
+  position: relative;   /* the anchor the centred pill below positions against */
+}
+
+/* TRUE centre, not "whatever the flex spacers left over". Back ("<- Sessions") is much wider than the
+   menu button, so two equal spacers push the pill ~30px right of centre - which is 30px back toward the
+   Voice mode tab, the exact thing this move exists to get away from. Absolute centring is independent of
+   both controls' widths, so the pill cannot drift as their labels change. It stays out of the flex flow;
+   the spacers keep the row's own geometry unchanged. */
+.session-app-bar .net-pill-inline {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 /* Claims the middle of row 1, so the menu button is pushed to the right edge. Guesses nothing - it
@@ -2140,11 +2158,10 @@ a.banner-btn {
   min-width: 0;
 }
 
-/* Row two: the session name, flexing, with the network pill parked at its end. */
+/* Row two: the session name, with the whole row to itself. */
 .session-title-row {
   display: flex;
   align-items: center;
-  gap: 10px;
   padding: 6px 2px 2px;
 }
 


### PR DESCRIPTION
The pill moved onto the title row this morning (#1631) to free the top-right corner for the overflow menu. That parked it at the **right end of the title row - directly above "Voice mode"**, which is the right-hand tab and the most-pressed control on the screen. A tap a few pixels high hit a small link that navigates to Diagnostics and threw you off the screen you were opening.

Reported by the owner with a screenshot: *"several times when I wanted to go to voice mode, I hit the fast by accident because it's a pretty small button to hit."*

The pill is the only tappable thing on this screen that nobody means to tap, so it goes where the screen is empty - the middle of row 1:

```
row 1:  [<- Sessions] ..... ( o Fast ) ..... [...]
row 2:  102 devthrottle - mobile
```

**Centred absolutely, not by flex spacers.** Back is much wider than the menu button, so equal spacers push the pill ~30px right of centre - which is 30px back toward the Voice mode tab, the exact thing this move exists to escape. Absolute centring is independent of both controls' widths, so the pill cannot drift as their labels change.

Measured at 390x844: pill centre **x=195** against a viewport centre of **195**; **65px** vertical clearance from the Voice mode tab and **25px** horizontal. Before, it shared an edge with it.

476 JavaScript tests pass, typecheck clean.

Generated with [Claude Code](https://claude.com/claude-code)
