### PR TITLE
fix(mobile): make the roster's play triangle mean what the Voice screen means, and add the Voice mode tab

### DIFF
--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -7,7 +7,8 @@ import { classify, contextLine, dotColor, effectiveColor, inBucket, inDesktopOrd
 import { applyFilter, filterIsActive, filterSummary, machineName, pruneFilter } from "@devthrottle/client-core/sessions/filter";
 import { useDictationStatusFor } from "@devthrottle/client-core/dictation/status";
 import { useNow, waitingLabel } from "@devthrottle/client-core/sessions/waiting";
-import { getClipState, playClip, playingSid, stopPlayback, syncVoiceSessions, useVoiceClips } from "@devthrottle/client-core/voice/clips";
+import { playClip, playingSid, rowVoiceInputs, stopPlayback, syncVoiceSessions, useVoiceClips } from "@devthrottle/client-core/voice/clips";
+import { isVoiceReady, voiceRowState } from "@devthrottle/client-core/voice/voiceRowState";
 import { NavDrawer } from "../components/NavDrawer";
 import { SessionFilterPanel } from "../components/SessionFilterPanel";
 import { useSessionFilter } from "../hooks/useSessionFilter";
@@ -25,6 +26,9 @@ import { enablePush, notificationPermission, pushSupported, reconcileBadge } fro
 // session and back) without churning React state.
 const POLL_INTERVAL_MS = 5000;
 
+/** The roster's two lenses: the full roster, or only the sessions that can speak to you right now. */
+type RosterTab = "all" | "voice";
+
 export function Home() {
   const [sessions, setSessions] = useState<SessionDto[] | null>(null);
   // Per-session reachability marks from the merge - only unreachable (wobbly/offline) sessions have one.
@@ -35,6 +39,15 @@ export function Home() {
   // is persisted across navigations and restarts by the hook; the panel is transient UI state.
   const [filter, setFilter] = useSessionFilter();
   const [showFilter, setShowFilter] = useState(false);
+  // The roster's two tabs. "All" is the roster as it has always been; "Voice" is the hands-free view -
+  // only the sessions with narration ready to play THIS INSTANT, nothing else. When you are listening
+  // rather than reading, a session that is working, executing, or has nothing to say is not a smaller
+  // priority, it is noise, so the Voice tab does not rank it down - it leaves it out.
+  //
+  // Transient by design: it is a lens you pick up for a minute, not a mode you can get stranded in.
+  // Persisting it (as the machine/repo filter is persisted) would mean coming back to the app hours
+  // later, during an outage, to an empty roster and no memory of why.
+  const [tab, setTab] = useState<RosterTab>("all");
 
   // Re-render the roster when a voice clip finishes downloading (a card flips from the yellow
   // working state to the play-triangle the moment its audio is phone-ready).
@@ -92,6 +105,11 @@ export function Home() {
   // The roster narrowed to the active machine/repo filter. Facet lists in the panel and the total
   // count in the app bar come from the FULL roster; only the displayed groups below are narrowed.
   const filtered = sessions ? applyFilter(sessions, filter) : sessions;
+  // The Voice tab's roster: exactly the sessions whose row shows a play-triangle, by construction -
+  // isVoiceReady IS "voiceRowState === ready", so the tab and the triangle can never disagree about
+  // what "ready with voice" means. In waiting order, longest-waiting first, so it can be worked top to
+  // bottom by ear.
+  const voiceReady = filtered ? inWaitingOrder(filtered.filter((s) => isVoiceReady(rowVoiceInputs(s, isWorking(s))))) : [];
   // The "Needs you" group is a waiting line: the session that has been waiting for you the longest
   // sits at the top, and a session that only just started needing you drops in at the bottom
   // (inWaitingOrder). This keeps the list from reshuffling under you as sessions change state, and
@@ -150,12 +168,38 @@ export function Home() {
 
       <EnableAlerts />
 
+      {/* The roster's two lenses, in the same segmented control the session screen uses for its own
+          views, so "Voice mode" means the same thing and looks the same wherever it appears. */}
+      <div className="view-tabs" role="tablist" aria-label="Roster view">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === "all"}
+          className={`view-tab${tab === "all" ? " active" : ""}`}
+          onClick={() => setTab("all")}
+        >
+          All
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === "voice"}
+          className={`view-tab${tab === "voice" ? " active" : ""}`}
+          onClick={() => setTab("voice")}
+        >
+          Voice mode
+        </button>
+      </div>
+
       {/* "+ New session" entry (issue #812): opens the add-session flow (machine -> repo -> create),
-          a faithful translation of the Android NewSessionPanel. */}
-      <Link className="new-session-entry" to="/new">
-        <span className="new-session-plus" aria-hidden="true">+</span>
-        New session
-      </Link>
+          a faithful translation of the Android NewSessionPanel. Hidden in the Voice tab: starting a new
+          session is a typing job, and the Voice tab is for the sessions that can talk right now. */}
+      {tab === "all" && (
+        <Link className="new-session-entry" to="/new">
+          <span className="new-session-plus" aria-hidden="true">+</span>
+          New session
+        </Link>
+      )}
 
       {/* Car Mode (Car Mode mission): the hands-free, eyes-free voice channel to the whole fleet. Its
           own full-screen page; one tap in, then just talk. */}
@@ -170,9 +214,31 @@ export function Home() {
         <p className="status-line">No sessions running.</p>
       )}
 
+      {/* The Voice tab, empty. Said plainly and without alarm: nothing is ready to listen to yet. The
+          way out is one tap, so an empty voice roster is never a dead end. */}
+      {tab === "voice" && sessions !== null && total > 0 && voiceReady.length === 0 && (
+        <p className="status-line">
+          Nothing to listen to right now.{" "}
+          <button type="button" className="link-btn" onClick={() => setTab("all")}>
+            Show all sessions
+          </button>
+        </p>
+      )}
+
+      {tab === "voice" && voiceReady.length > 0 && (
+        <section className="group">
+          <h2 className="group-title">Ready to play</h2>
+          <ul className="roster">
+            {voiceReady.map((s) => (
+              <SessionRow key={`voice-${s.sessionId}`} session={s} mark={marks.get(s.sessionId ?? "")} />
+            ))}
+          </ul>
+        </section>
+      )}
+
       {/* Sessions exist but the active filter hides them all: say so plainly and offer a way back,
           instead of an empty screen that reads like "no sessions running". */}
-      {sessions !== null && total > 0 && shownTotal === 0 && (
+      {tab === "all" && sessions !== null && total > 0 && shownTotal === 0 && (
         <p className="status-line">
           No sessions match this filter.{" "}
           <button type="button" className="link-btn" onClick={() => setFilter({ machines: [], repos: [] })}>
@@ -181,7 +247,7 @@ export function Home() {
         </p>
       )}
 
-      {needsYou.length > 0 && (
+      {tab === "all" && needsYou.length > 0 && (
         <section className="group">
           <h2 className="group-title group-title-attention">Needs you</h2>
           <ul className="roster">
@@ -192,7 +258,7 @@ export function Home() {
         </section>
       )}
 
-      {others.length > 0 && (
+      {tab === "all" && others.length > 0 && (
         <section className="group">
           <h2 className="group-title">Other sessions</h2>
           <ul className="roster">
@@ -321,30 +387,29 @@ function SessionRow({ session, mark }: { session: SessionDto; mark?: RosterSessi
   );
 }
 
-// Issue #850: the trailing voice control on a voice-mode card. A play-triangle appears ONLY once
-// the clip's audio is on the phone (clip phase "ready"); while the Wingman is generating on the
-// Gateway or the phone is still downloading, a yellow spinner shows instead. Non-voice sessions
-// render nothing here. Tapping the triangle plays the locally-stored clip with no download wait;
-// preventDefault/stopPropagation keep the tap from also following the row's link.
+// Issue #850: the trailing voice control on a voice-mode card. What it is allowed to say is decided by
+// the shared voiceRowState rule (client-core/voice/voiceRowState.ts), which this component only
+// renders. That rule is shared with the Voice screen's own readiness test on purpose: the triangle is a
+// promise that tapping through will speak, and the roster must not make that promise on weaker evidence
+// than the screen it hands you to.
 //
-// The finished-turn narration is retired the instant the session starts working again: while
-// isWorking(session) is true the whole indicator renders nothing (no triangle, no spinner), because
-// that verbal cue is now stale. If this session's clip is playing at that moment it is stopped, so a
-// stale clip cannot keep talking after the agent has resumed.
+// It used to make exactly that mistake - it drew the triangle on `clip.phase === "ready"`, which asks
+// "do I hold any bytes?" and never "which turn are they for?". A held clip from an older turn earned a
+// green triangle; tapping it landed on "Voice service down". See voiceRowState.ts for the full account.
+//
+// Tapping the triangle plays the locally-stored clip with no download wait; preventDefault and
+// stopPropagation keep the tap from also following the row's link. If this session's clip is playing
+// when the agent resumes, it is stopped - a stale clip must not keep talking.
 function VoiceIndicator({ session }: { session: SessionDto }) {
   const sid = session.sessionId ?? "";
   const working = isWorking(session);
+  const state = voiceRowState(rowVoiceInputs(session, working));
 
   useEffect(() => {
     if (working && playingSid() === sid) stopPlayback();
   }, [working, sid]);
 
-  if (!session.voiceMode) return null;
-  if (working) return null;
-
-  const clip = getClipState(sid);
-
-  if (clip.phase === "ready") {
+  if (state === "ready") {
     const isPlaying = playingSid() === sid;
     return (
       <button
@@ -363,9 +428,15 @@ function VoiceIndicator({ session }: { session: SessionDto }) {
     );
   }
 
-  // Voice on but no phone-ready clip yet: generating on the Gateway, or downloading to the phone.
-  if (session.voiceGenerating || session.voiceAudioReady || clip.phase === "downloading") {
+  if (state === "preparing") {
     return <span className="row-spin" aria-label="Preparing voice" />;
+  }
+
+  // The Gateway cannot make voice for this session and said so. Say it on the row, quietly: the owner
+  // asked to be told there is no voice rather than be handed a play button that leads to a dead screen.
+  // No call to action - the Gateway is already retrying, and out-of-credits has its own banner.
+  if (state === "down") {
+    return <span className="row-voice-down">No voice</span>;
   }
 
   return null;

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -1607,6 +1607,22 @@ a.banner-btn {
   animation: voice-spin 0.9s linear infinite;
 }
 
+/* "No voice": what a voice session shows in place of the play-triangle when the Gateway has told us it
+   cannot make voice for it. Muted, not red - this is a statement of fact, not an error to act on, and
+   it sits where the triangle would have been so the absence reads as deliberate rather than missing. */
+.row-voice-down {
+  flex: 0 0 auto;
+  align-self: center;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 4px 8px;
+  white-space: nowrap;
+}
+
 /* The bubble list fills the remaining vertical space; .chat-scroll is the single scroll container. */
 .chat-stage {
   flex: 1 1 auto;

--- a/packages/client-core/src/voice/clips.ts
+++ b/packages/client-core/src/voice/clips.ts
@@ -81,6 +81,7 @@ export function rowVoiceInputs(session: SessionDto, agentWorking: boolean): Voic
     gatewayHasAudio: Boolean(session.voiceAudioReady),
     clipDownloading: getClipState(sid).phase === "downloading",
     phoneReadyForCurrentTurn: currentGeneratedAt.length > 0 && isPhoneReady(sid, currentGeneratedAt),
+    hasSpokenText: (meta?.spoken?.length ?? 0) > 0,
   };
 }
 

--- a/packages/client-core/src/voice/clips.ts
+++ b/packages/client-core/src/voice/clips.ts
@@ -14,6 +14,7 @@
 
 import { useEffect, useState } from "react";
 import { fetchWingmanVoiceAudio, getWingmanVoice, type SessionDto, type WingmanVoice } from "../api/client";
+import { type VoiceRowInputs } from "./voiceRowState";
 
 export type ClipPhase = "none" | "downloading" | "ready" | "error";
 
@@ -54,6 +55,33 @@ export function getClipState(sid: string): ClipState {
 export function isPhoneReady(sid: string, generatedAt: string): boolean {
   const s = _state.get(sid);
   return s !== undefined && s.phase === "ready" && s.generatedAt === generatedAt && s.url !== null;
+}
+
+/**
+ * The roster's voice verdict for a session, assembled from the two facts only this module can see (what
+ * THIS PHONE holds, and which turn it holds it for) plus the four the Gateway stamped on the session.
+ *
+ * It lives here, next to the clip store, so the roster cannot accidentally ask the weaker question that
+ * caused the reported bug - "do I hold any bytes?" instead of "do I hold THIS turn's bytes?". The rule
+ * itself is pure and tested in voiceRowState.ts; this is the one place that feeds it real state.
+ *
+ * The current turn's stamp comes from the voice metadata syncVoiceSessions caches on every poll. A
+ * session with no cached metadata has never had a narration this phone knows of, so it holds nothing
+ * current by definition.
+ */
+export function rowVoiceInputs(session: SessionDto, agentWorking: boolean): VoiceRowInputs {
+  const sid = session.sessionId ?? "";
+  const meta = getVoiceMeta(sid);
+  const currentGeneratedAt = meta?.ready ? (meta.generatedAt ?? "") : "";
+  return {
+    voiceMode: Boolean(session.voiceMode),
+    agentWorking,
+    voiceUnavailable: session.voiceUnavailable != null,
+    gatewayGenerating: Boolean(session.voiceGenerating),
+    gatewayHasAudio: Boolean(session.voiceAudioReady),
+    clipDownloading: getClipState(sid).phase === "downloading",
+    phoneReadyForCurrentTurn: currentGeneratedAt.length > 0 && isPhoneReady(sid, currentGeneratedAt),
+  };
 }
 
 // ----- Cache Storage durability layer (best-effort capability, not a fallback) -----

--- a/packages/client-core/src/voice/voiceRowState.test.ts
+++ b/packages/client-core/src/voice/voiceRowState.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { isVoiceReady, voiceRowState, type VoiceRowInputs } from "./voiceRowState";
+
+// The reported bug, in the owner's words: "why would the list view show that it's ready with voice when
+// there's no voice? If the voice doesn't work, why the fuck is it showing the green triangle so I can
+// click it? ... I should never be able to get to this screen if I click a session that has a green
+// triangle on it."
+//
+// The screen he could not get away from said "Voice service down". So these tests are written from the
+// outage that produced it: the roster held LAST TURN's clip, still marked ready, and drew a triangle on
+// top of a session whose voice the Gateway had already disowned. Each test below pins one of the facts
+// the roster had in its hand and ignored, so an edit that goes back to "any bytes will do" fails here
+// rather than on a phone.
+
+/** The honest ready state: this turn's audio is on the phone, and nothing objects. */
+const READY_FOR_THIS_TURN: VoiceRowInputs = {
+  voiceMode: true,
+  agentWorking: false,
+  voiceUnavailable: false,
+  gatewayGenerating: false,
+  gatewayHasAudio: true,
+  clipDownloading: false,
+  phoneReadyForCurrentTurn: true,
+};
+
+describe("voiceRowState", () => {
+  // The control. If this ever stops being "ready" the triangle has been guarded out of existence and
+  // voice mode has no entry point at all - which would pass every test below while shipping nothing.
+  it("shows the play triangle when this turn's audio is on the phone", () => {
+    expect(voiceRowState(READY_FOR_THIS_TURN)).toBe("ready");
+  });
+
+  // THE BUG. The Gateway said "I cannot make voice for this session" (the speech service was down) and
+  // the roster drew a green triangle anyway, because it never read the field. Tapping the row landed on
+  // "Voice service down" - a screen the owner should never have been able to reach from a triangle.
+  it("never offers a triangle when the Gateway says voice is unavailable, even holding ready bytes", () => {
+    const state = voiceRowState({ ...READY_FOR_THIS_TURN, voiceUnavailable: true });
+    expect(state).toBe("down");
+    expect(state).not.toBe("ready");
+  });
+
+  // The same outage seen from the other side: during it, the sync stops downloading for the session, so
+  // whatever is in the clip store is by definition last turn's. "Down" must beat every arrival signal -
+  // a spinner here would promise audio that is never coming.
+  it("says down rather than preparing when the Gateway has disowned the voice", () => {
+    expect(
+      voiceRowState({
+        ...READY_FOR_THIS_TURN,
+        voiceUnavailable: true,
+        gatewayGenerating: true,
+        clipDownloading: true,
+        phoneReadyForCurrentTurn: false,
+      }),
+    ).toBe("down");
+  });
+
+  // The staleness rule itself, with no outage involved. Bytes on the phone that narrate an OLDER turn
+  // are not a play triangle - this is precisely the check the Voice screen makes (phoneReady compares
+  // clip.generatedAt to the current voice.generatedAt) and the roster did not.
+  it("does not offer a triangle for a clip held from an older turn", () => {
+    expect(voiceRowState({ ...READY_FOR_THIS_TURN, phoneReadyForCurrentTurn: false })).toBe("preparing");
+  });
+
+  // A newer narration being synthesized is a positive statement that anything held is stale. The roster
+  // used to draw the triangle straight through this window, offering last turn's audio while this
+  // turn's was being made.
+  it("shows preparing, not ready, while the Gateway is generating a newer narration", () => {
+    expect(voiceRowState({ ...READY_FOR_THIS_TURN, gatewayGenerating: true })).toBe("preparing");
+  });
+
+  // The Gateway's cache is NOT the gate on ready - the phone's is. Gating on the Gateway still holding
+  // the bytes is the mistake voiceAvailability.ts documents (its window 2): the phone can hold a
+  // perfectly playable clip for the current turn after the Gateway has dropped its copy.
+  it("still plays this turn's clip from the phone after the Gateway has dropped its copy", () => {
+    expect(voiceRowState({ ...READY_FOR_THIS_TURN, gatewayHasAudio: false })).toBe("ready");
+  });
+
+  it("shows preparing while the Gateway holds audio this phone has not pulled down yet", () => {
+    expect(
+      voiceRowState({ ...READY_FOR_THIS_TURN, phoneReadyForCurrentTurn: false, gatewayHasAudio: true }),
+    ).toBe("preparing");
+  });
+
+  it("shows preparing while this phone is downloading the clip", () => {
+    expect(
+      voiceRowState({
+        ...READY_FOR_THIS_TURN,
+        phoneReadyForCurrentTurn: false,
+        gatewayHasAudio: false,
+        clipDownloading: true,
+      }),
+    ).toBe("preparing");
+  });
+
+  // The working gate, unchanged from the old roster behavior: the instant the agent resumes, the
+  // finished-turn narration is stale and the whole indicator goes quiet.
+  it("shows nothing while the agent is working again", () => {
+    expect(voiceRowState({ ...READY_FOR_THIS_TURN, agentWorking: true })).toBe("none");
+  });
+
+  // A working session's row already says "working". An outage pill on top of it would report a problem
+  // on a row that is not waiting on anyone and cannot be acted on.
+  it("stays quiet on a working session even when voice is unavailable", () => {
+    expect(voiceRowState({ ...READY_FOR_THIS_TURN, agentWorking: true, voiceUnavailable: true })).toBe("none");
+  });
+
+  it("shows nothing for a session that is not in voice mode", () => {
+    expect(voiceRowState({ ...READY_FOR_THIS_TURN, voiceMode: false })).toBe("none");
+  });
+
+  // A voice session that has simply never produced a turn yet: nothing is wrong, and nothing is coming.
+  it("shows nothing for a voice session with no narration and none on its way", () => {
+    expect(
+      voiceRowState({
+        ...READY_FOR_THIS_TURN,
+        phoneReadyForCurrentTurn: false,
+        gatewayHasAudio: false,
+        gatewayGenerating: false,
+        clipDownloading: false,
+      }),
+    ).toBe("none");
+  });
+});
+
+describe("isVoiceReady", () => {
+  // The Voice tab's membership rule. It is defined as "voiceRowState === ready" precisely so the tab
+  // and the triangle can never disagree: if a session is in the Voice tab it HAS a triangle, and if it
+  // has a triangle it is in the Voice tab. One rule, one answer.
+  it("is exactly the sessions that show a play triangle", () => {
+    expect(isVoiceReady(READY_FOR_THIS_TURN)).toBe(true);
+    expect(isVoiceReady({ ...READY_FOR_THIS_TURN, voiceUnavailable: true })).toBe(false);
+    expect(isVoiceReady({ ...READY_FOR_THIS_TURN, agentWorking: true })).toBe(false);
+    expect(isVoiceReady({ ...READY_FOR_THIS_TURN, gatewayGenerating: true })).toBe(false);
+    expect(isVoiceReady({ ...READY_FOR_THIS_TURN, phoneReadyForCurrentTurn: false })).toBe(false);
+  });
+});

--- a/packages/client-core/src/voice/voiceRowState.test.ts
+++ b/packages/client-core/src/voice/voiceRowState.test.ts
@@ -12,7 +12,7 @@ import { isVoiceReady, voiceRowState, type VoiceRowInputs } from "./voiceRowStat
 // the roster had in its hand and ignored, so an edit that goes back to "any bytes will do" fails here
 // rather than on a phone.
 
-/** The honest ready state: this turn's audio is on the phone, and nothing objects. */
+/** The honest ready state: this turn's audio is on the phone, it has words, and nothing objects. */
 const READY_FOR_THIS_TURN: VoiceRowInputs = {
   voiceMode: true,
   agentWorking: false,
@@ -21,6 +21,7 @@ const READY_FOR_THIS_TURN: VoiceRowInputs = {
   gatewayHasAudio: true,
   clipDownloading: false,
   phoneReadyForCurrentTurn: true,
+  hasSpokenText: true,
 };
 
 describe("voiceRowState", () => {
@@ -68,11 +69,26 @@ describe("voiceRowState", () => {
     expect(voiceRowState({ ...READY_FOR_THIS_TURN, gatewayGenerating: true })).toBe("preparing");
   });
 
-  // The Gateway's cache is NOT the gate on ready - the phone's is. Gating on the Gateway still holding
-  // the bytes is the mistake voiceAvailability.ts documents (its window 2): the phone can hold a
-  // perfectly playable clip for the current turn after the Gateway has dropped its copy.
-  it("still plays this turn's clip from the phone after the Gateway has dropped its copy", () => {
-    expect(voiceRowState({ ...READY_FOR_THIS_TURN, gatewayHasAudio: false })).toBe("ready");
+  // FOUND IN REVIEW, and it is the same bug hiding one level up. The roster's notion of "the current
+  // turn" comes from the cached voice metadata, which syncVoiceSessions only refreshes for sessions
+  // with voiceAudioReady. So when the Gateway stops advertising audio, the cached stamp AND the clip
+  // go stale together and agree with each other perfectly - phoneReadyForCurrentTurn stays true while
+  // describing last turn. A Gateway restart does exactly this (its voice cache is in memory) with no
+  // outage stamped, so voiceUnavailable does not save us here.
+  //
+  // The Voice screen is safe from this because it fetches the current stamp live; the roster cannot,
+  // so voiceAudioReady is its only live evidence that a current narration exists at all. This is the
+  // one place the roster deliberately DIVERGES from voiceAvailability.ts's advice - see the header.
+  it("does not offer a triangle once the Gateway stops advertising audio, however ready the phone looks", () => {
+    expect(voiceRowState({ ...READY_FOR_THIS_TURN, gatewayHasAudio: false })).not.toBe("ready");
+  });
+
+  // FOUND IN REVIEW. ready and spoken are independent fields on the WingmanVoice contract, so a
+  // ready-but-wordless narration is representable - and the Voice screen refuses to speak one
+  // (speaking requires voice.spoken.length > 0). A triangle here would point at exactly the state the
+  // screen declines to play, which is this bug wearing a different hat.
+  it("does not offer a triangle for a narration with no spoken words", () => {
+    expect(voiceRowState({ ...READY_FOR_THIS_TURN, hasSpokenText: false })).not.toBe("ready");
   });
 
   it("shows preparing while the Gateway holds audio this phone has not pulled down yet", () => {
@@ -132,5 +148,7 @@ describe("isVoiceReady", () => {
     expect(isVoiceReady({ ...READY_FOR_THIS_TURN, agentWorking: true })).toBe(false);
     expect(isVoiceReady({ ...READY_FOR_THIS_TURN, gatewayGenerating: true })).toBe(false);
     expect(isVoiceReady({ ...READY_FOR_THIS_TURN, phoneReadyForCurrentTurn: false })).toBe(false);
+    expect(isVoiceReady({ ...READY_FOR_THIS_TURN, gatewayHasAudio: false })).toBe(false);
+    expect(isVoiceReady({ ...READY_FOR_THIS_TURN, hasSpokenText: false })).toBe(false);
   });
 });

--- a/packages/client-core/src/voice/voiceRowState.ts
+++ b/packages/client-core/src/voice/voiceRowState.ts
@@ -35,10 +35,34 @@
 //   2. gatewayGenerating - a NEWER narration is being synthesized, which is a positive statement that
 //      the clip on the phone is last turn's. Held bytes are not offered while a replacement is coming.
 //
-// Note what is deliberately NOT a gate: the Gateway currently holding the audio (voiceAudioReady).
-// What plays is the clip in THIS PHONE's cache, and those are two different caches - gating "ready" on
-// the Gateway's copy is the exact mistake voiceAvailability.ts documents at length (its window 2). The
-// staleness fix is "the bytes must be for the CURRENT turn", not "the Gateway must still have them".
+//   3. gatewayHasAudio - the Gateway says it holds narration for this session's latest turn.
+//
+// Guard 3 deserves its own note, because voiceAvailability.ts argues the OPPOSITE for the Voice screen
+// and is right to: what plays is the clip in THIS PHONE's cache, so the screen must never withhold
+// playable audio just because the Gateway has since dropped its copy (that module's window 2).
+//
+// The reasoning does not carry over, because the two surfaces know different things. The Voice screen
+// fetches getWingmanVoice live, so it learns the CURRENT turn's stamp first-hand and can compare the
+// phone's clip against it. The roster has no such fetch - it reads the stamp from the same cached voice
+// metadata that syncVoiceSessions writes, and that sync only runs for sessions with voiceAudioReady.
+// So the moment the Gateway stops advertising audio, the roster's "current turn" and the clip it is
+// comparing go stale TOGETHER, and agree with each other perfectly while both describe last turn.
+// (A Gateway restart does exactly this: its voice cache is in memory, so voiceAudioReady drops across
+// the fleet with no outage stamped anywhere.) voiceAudioReady is the only LIVE evidence the roster has
+// that a current narration exists at all, so on this surface it is a gate. Found in review.
+//
+// The cost is a false NEGATIVE - a missing triangle where the phone could in fact have played - which
+// is the right way for this to fail. The roster promises out loud; a promise it cannot substantiate is
+// the bug being fixed here, and silence is not.
+//
+// RESIDUAL, known and accepted: between the poll that first sees voiceAudioReady for a NEW turn and the
+// getWingmanVoice that refreshes the cached stamp (one Gateway round trip later), the roster still
+// holds last turn's stamp and last turn's ready clip, which match - so a stale triangle can flash for
+// well under a second. It closes itself: ensureClip immediately re-stamps the clip store to the new
+// turn as "downloading", which flips the row to the spinner. Tapping inside that window lands on the
+// working card (the screen's own live fetch sees the mismatch), never the "Voice service down" screen
+// this fix is about. Closing it completely needs a per-turn narration id on SessionDto, which is not
+// worth a new contract field for a sub-second flash with a benign landing.
 
 /** The clip download phases, mirrored from clips.ts (kept structural so this module imports nothing). */
 export type VoiceClipPhase = "none" | "downloading" | "ready" | "error";
@@ -64,6 +88,14 @@ export interface VoiceRowInputs {
    * derive it with isPhoneReady(sid, currentGeneratedAt); a clip held for an older turn is false.
    */
   phoneReadyForCurrentTurn: boolean;
+  /**
+   * The narration has spoken TEXT (WingmanVoice.spoken is non-empty). `ready` and `spoken` are
+   * independent fields on the contract, so a ready-but-wordless narration is representable - and the
+   * Voice screen refuses to speak one (its `speaking` requires voice.spoken.length > 0). The roster
+   * must refuse it too, or it would draw a triangle onto exactly the state the screen declines to
+   * play, which is this bug wearing a different hat. Found in review.
+   */
+  hasSpokenText: boolean;
 }
 
 /**
@@ -91,8 +123,10 @@ export function voiceRowState(i: VoiceRowInputs): VoiceRowState {
   // A newer narration is on its way, which means anything held is last turn's. Not offered.
   if (i.gatewayGenerating) return "preparing";
 
-  // The promise the triangle makes: THIS turn's bytes, on this phone, playable with no wait.
-  if (i.phoneReadyForCurrentTurn) return "ready";
+  // The promise the triangle makes, in full: the Gateway confirms a narration exists for the latest
+  // turn, this phone holds THAT turn's bytes, and there are words in it. Every clause is load-bearing;
+  // dropping any one of them is a way this has already gone wrong.
+  if (i.gatewayHasAudio && i.phoneReadyForCurrentTurn && i.hasSpokenText) return "ready";
 
   // Audio exists or is arriving, but this phone cannot play it yet.
   if (i.gatewayHasAudio || i.clipDownloading) return "preparing";

--- a/packages/client-core/src/voice/voiceRowState.ts
+++ b/packages/client-core/src/voice/voiceRowState.ts
@@ -1,0 +1,106 @@
+// What a session's voice control on the ROSTER is allowed to say, as a pure function.
+//
+// THE RULE: the roster's play-triangle must mean exactly what the Voice screen means by "speaking".
+// A triangle is a promise - "tap this and you will hear this session's latest turn, right now, with no
+// wait". The roster is not allowed to make that promise on weaker evidence than the screen it hands
+// you to.
+//
+// It used to make it on much weaker evidence. Home.tsx asked one question:
+//
+//   if (clip.phase === "ready") -> draw the triangle
+//
+// which is "do I hold ANY bytes for this session?" - with no regard for WHICH TURN those bytes narrate.
+// The Voice screen asks the harder question (useVoiceMode.ts, phoneReady):
+//
+//   clip.phase === "ready" && clip.generatedAt === voice.generatedAt
+//
+// "do I hold the bytes for the turn that is waiting RIGHT NOW?" Two different questions, and on
+// 2026-07-15 they gave two different answers on the same session at the same moment.
+//
+// How they came apart: the clip store is sticky. syncVoiceSessions only downloads for sessions the
+// Gateway says have audio (voiceAudioReady), so when the speech service went down and the Gateway
+// stopped producing narration, those sessions dropped out of the sync entirely - and the PREVIOUS
+// turn's clip sat in the store still marked "ready". The roster saw "ready", drew a green triangle,
+// and the owner tapped it. The Voice screen then checked that clip against the current turn, correctly
+// refused it as stale, and rendered "Voice service down". The triangle was not lying about holding a
+// file; it was lying about which turn the file was for.
+//
+// Two guards close that, and both are inputs the roster already had in its hand and ignored:
+//
+//   1. voiceUnavailable - the Gateway TELLS the roster when it cannot make voice (GatewayEndpoints
+//      stamps SessionDto.VoiceUnavailable on every session in the poll: out of credits, no key, cap
+//      reached, or the speech service is down). The roster rendered play controls straight through it.
+//      A session whose voice the Gateway has disowned shows "down", never a triangle.
+//
+//   2. gatewayGenerating - a NEWER narration is being synthesized, which is a positive statement that
+//      the clip on the phone is last turn's. Held bytes are not offered while a replacement is coming.
+//
+// Note what is deliberately NOT a gate: the Gateway currently holding the audio (voiceAudioReady).
+// What plays is the clip in THIS PHONE's cache, and those are two different caches - gating "ready" on
+// the Gateway's copy is the exact mistake voiceAvailability.ts documents at length (its window 2). The
+// staleness fix is "the bytes must be for the CURRENT turn", not "the Gateway must still have them".
+
+/** The clip download phases, mirrored from clips.ts (kept structural so this module imports nothing). */
+export type VoiceClipPhase = "none" | "downloading" | "ready" | "error";
+
+export interface VoiceRowInputs {
+  /** This session is in voice mode (SessionDto.voiceMode). */
+  voiceMode: boolean;
+  /** The agent has resumed (blue): the finished-turn narration is stale and is not offered. */
+  agentWorking: boolean;
+  /**
+   * The Gateway reported that it cannot make voice for this session - out of credits, no key, cap
+   * reached, or the speech service is down (SessionDto.voiceUnavailable is non-null).
+   */
+  voiceUnavailable: boolean;
+  /** The Gateway is synthesizing this turn's narration now (SessionDto.voiceGenerating). */
+  gatewayGenerating: boolean;
+  /** The Gateway holds audio for this session's latest turn (SessionDto.voiceAudioReady). */
+  gatewayHasAudio: boolean;
+  /** This phone is pulling clip bytes down right now (clips.ts "downloading"). */
+  clipDownloading: boolean;
+  /**
+   * This phone holds playable bytes FOR THE CURRENT TURN - the whole point of this module. Callers
+   * derive it with isPhoneReady(sid, currentGeneratedAt); a clip held for an older turn is false.
+   */
+  phoneReadyForCurrentTurn: boolean;
+}
+
+/**
+ * What the roster shows for a session's voice:
+ * - "ready"     a green play-triangle: this turn's audio is on the phone, tap and it speaks.
+ * - "preparing" a yellow spinner: audio for this turn is being made or downloaded.
+ * - "down"      the Gateway cannot make voice for this session and says so.
+ * - "none"      nothing to show (not a voice session, or the agent is working again).
+ */
+export type VoiceRowState = "none" | "down" | "preparing" | "ready";
+
+export function voiceRowState(i: VoiceRowInputs): VoiceRowState {
+  // Not a voice session: the roster says nothing about voice.
+  if (!i.voiceMode) return "none";
+
+  // The agent has resumed, so the finished-turn narration is stale. This is checked BEFORE
+  // voiceUnavailable: a working session's row already says "working", and stacking a voice-down pill
+  // onto it would report an outage the reader can do nothing about on a row that is not waiting.
+  if (i.agentWorking) return "none";
+
+  // The Gateway has disowned this session's voice. Never a triangle, never a spinner - a triangle here
+  // is the reported bug, and a spinner would promise an arrival that is not coming.
+  if (i.voiceUnavailable) return "down";
+
+  // A newer narration is on its way, which means anything held is last turn's. Not offered.
+  if (i.gatewayGenerating) return "preparing";
+
+  // The promise the triangle makes: THIS turn's bytes, on this phone, playable with no wait.
+  if (i.phoneReadyForCurrentTurn) return "ready";
+
+  // Audio exists or is arriving, but this phone cannot play it yet.
+  if (i.gatewayHasAudio || i.clipDownloading) return "preparing";
+
+  return "none";
+}
+
+/** True when this row belongs in the roster's Voice tab: it has voice ready to play, right now. */
+export function isVoiceReady(i: VoiceRowInputs): boolean {
+  return voiceRowState(i) === "ready";
+}


### PR DESCRIPTION
## The bug

A session on the phone's roster showed the green voice-ready play triangle. Tapping the row landed on the Voice mode screen showing **"Voice service down"** - the one screen a triangle should guarantee you never reach.

Reported: *"why would the list view show that it's ready with voice when there's no voice? ... I should never be able to get to this screen if I click a session that has a green triangle on it."*

## Why

The roster and the Voice screen were asking different questions about the same clip.

| | The question it asked |
|---|---|
| Roster (`Home.tsx`) | `clip.phase === "ready"` - "do I hold **any** bytes?" |
| Voice screen (`useVoiceMode.ts`) | `clip.phase === "ready" && clip.generatedAt === voice.generatedAt` - "do I hold the bytes for the turn waiting **right now**?" |

They came apart because the clip store is sticky. `syncVoiceSessions` only downloads for sessions the Gateway says have audio, so when the speech service went down on 2026-07-15 and the Gateway stopped producing narration, those sessions dropped out of the sync entirely - and the previous turn's clip sat in the store still marked ready. The roster drew a triangle on it; the screen checked it against the current turn, correctly refused it as stale, and rendered the outage.

The triangle was not lying about holding a file. It was lying about **which turn the file was for**.

The roster also had the answer in its hand and ignored it: the Gateway stamps `SessionDto.VoiceUnavailable` on every session in the poll (`GatewayEndpoints.cs:803`), and the roster rendered play controls straight through it.

## The fix

The rule now lives in one pure, tested place - `voiceRowState.ts` - instead of being written twice and drifting, the same shape as its sibling `voiceAvailability.ts`. A triangle requires **all** of: the Gateway confirms a narration for the latest turn, this phone holds *that turn's* bytes, the narration has words, no newer one is being made, and no outage is reported. A session whose voice the Gateway has disowned shows a quiet "No voice" instead of a play button.

Plus the requested **Voice mode tab** on the roster: only the sessions that can speak right now, nothing working or executing. Its membership is *defined* as `voiceRowState === "ready"`, so the tab and the triangle cannot disagree.

## Review

Reviewed by Codex, which found two further holes - both the same defect one level up, both fixed in 4b5e7e2c:

1. **The Gateway holding audio must gate "ready".** The first commit argued it must not, citing `voiceAvailability.ts`. That argument is right for the *screen* (which fetches the current stamp live) and wrong for the *roster* (which reads the stamp from the same cache as the clip, so both go stale together and agree). A Gateway restart drops `voiceAudioReady` fleet-wide with no outage stamped, reviving the exact bug.
2. **A ready-but-wordless narration** earned a triangle, though the screen refuses to speak one (`ready` and `spoken` are independent contract fields).

A third finding - that `isWorking` might not be pure - was checked and dismissed: `ordering.ts:76` reads a Gateway-stamped field.

One residual is documented rather than papered over: a sub-second stale-triangle flash after a new turn's audio appears, before the metadata refetch lands. It closes itself, and tapping inside it lands on the working card, never the outage screen.

## Verification

- 490 client-core tests pass; typecheck clean across all three workspaces; lint clean; PWA builds.
- **Tests verified by reverting the fix**, per the tests-must-fail-on-purpose rule: 7 fail with the reported symptom, controls stay green. The two review guards likewise: 3 fail when dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)