### PR TITLE
fix(gateway-tests): stop the test suite writing into the owner's live storage

### DIFF
--- a/src/CcDirector.Gateway.Tests/TestStorageRootRedirect.cs
+++ b/src/CcDirector.Gateway.Tests/TestStorageRootRedirect.cs
@@ -1,0 +1,60 @@
+using System.Runtime.CompilerServices;
+using CcDirector.Core.Storage;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Redirects <see cref="CcStorage.Root"/> to a throwaway temporary directory for the WHOLE test assembly,
+/// before any test runs.
+///
+/// WHAT THIS GUARDS, AND IT IS NOT THE STATISTICS. Forty-eight test files in this assembly construct a
+/// <c>GatewayHost</c>. Its constructor points live stores at <c>CcStorage.Root()</c> when it is given no
+/// explicit path - and that root is the OWNER'S REAL <c>%LOCALAPPDATA%\cc-director</c>, holding his live
+/// fleet state: <c>missions.json</c> (the running missions, including the one that produced this file),
+/// <c>cronjobs.json</c>, <c>keyvault.json</c>, and the statistics stores. Without this redirect, running the
+/// test suite writes into all of it.
+///
+/// This is not theoretical. On 2026-07-15 a full-suite run drove the then-current input-statistics import
+/// against the owner's LIVE gateway-input-stats.json and RENAMED IT ASIDE. Nothing was lost, but only by
+/// luck: the running Gateway happened to hold its state in memory and rewrote the file on its next save. A
+/// Gateway restart inside that window would have found no file, started empty, and saved empty over it -
+/// losing the lot. The exposure had existed for a long time; the import was merely the first operation that
+/// MOVED a file rather than overwriting it with equivalent content.
+///
+/// WHY A MODULE INITIALIZER RATHER THAN A CONVENTION. The hazard was already known and already mitigated -
+/// by a convention. Twenty-two of the forty-eight files carefully set and restore CC_DIRECTOR_ROOT
+/// themselves. The other twenty-six do not. A convention followed by fewer than half the sites that need it
+/// is not a mitigation, it is a folk memory: it was demonstrably forgotten twenty-six times, by people who
+/// knew about it. So the protection belongs somewhere it cannot be forgotten - here, once, for everyone.
+///
+/// <see cref="CcStorage.Root"/> re-reads the environment variable on EVERY call (CcStorage.cs:32-34), so a
+/// process-wide redirect also protects the stores that accept no path at all and resolve the root
+/// themselves, such as <c>GatewaySessionConcurrencyStats</c>.
+///
+/// Pinned by <see cref="TestStorageRootRedirectTests"/>, which asserts the redirect is actually in force. An
+/// initializer that silently fails to run is exactly the dead-test-that-looks-like-coverage shape, and this
+/// one is guarding the owner's live state.
+/// </summary>
+internal static class TestStorageRootRedirect
+{
+    /// <summary>The temporary root this assembly's tests resolve to.</summary>
+    internal static string Root { get; private set; } = "";
+
+    [ModuleInitializer]
+    internal static void Redirect()
+    {
+        // Unconditional, deliberately. Respecting an already-set value would look considerate and would be
+        // a hole: if the variable happened to be pointing at the real root, the suite would quietly run
+        // unprotected, which is the failure this file exists to end. A test needing a specific root sets it
+        // for itself - twenty-two of them already do, and they still work, because they set it after this
+        // has run and restore it to this temporary root afterwards.
+        Root = Path.Combine(Path.GetTempPath(), "cc-gateway-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Root);
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", Root);
+
+        AppDomain.CurrentDomain.ProcessExit += (_, _) =>
+        {
+            try { Directory.Delete(Root, recursive: true); } catch (Exception) { /* best effort */ }
+        };
+    }
+}

--- a/src/CcDirector.Gateway.Tests/TestStorageRootRedirectTests.cs
+++ b/src/CcDirector.Gateway.Tests/TestStorageRootRedirectTests.cs
@@ -1,0 +1,51 @@
+using CcDirector.Core.Storage;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Proves the storage-root redirect is actually IN FORCE during a test run.
+///
+/// This exists because <see cref="TestStorageRootRedirect"/> is the only thing standing between this test
+/// suite and the owner's live fleet state, and a module initializer that silently does not run leaves no
+/// trace at all - the suite would simply go back to writing into his real %LOCALAPPDATA%\cc-director, and
+/// every test would still pass. That is the dead-test-that-looks-like-coverage shape, so the guard gets a
+/// guard.
+/// </summary>
+public sealed class TestStorageRootRedirectTests
+{
+    [Fact]
+    public void CcStorageRoot_ResolvesUnderTheTemporaryRoot_NotTheOwnersRealStorage()
+    {
+        var root = CcStorage.Root();
+
+        // The property being pinned: whatever this suite resolves as "the storage root" is disposable.
+        Assert.Equal(TestStorageRootRedirect.Root, root);
+        Assert.StartsWith(Path.GetTempPath(), root, StringComparison.OrdinalIgnoreCase);
+        Assert.True(Directory.Exists(root));
+    }
+
+    [Fact]
+    public void CcStorageRoot_IsNotTheRealLocalApplicationDataRoot()
+    {
+        // Named explicitly rather than inferred from the temp path, because THIS is the location that must
+        // never be touched: it holds missions.json, cronjobs.json, keyvault.json and the statistics stores.
+        var real = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "cc-director");
+
+        Assert.NotEqual(real, CcStorage.Root());
+    }
+
+    [Fact]
+    public void GatewayHostDefaultPaths_LandUnderTheTemporaryRoot()
+    {
+        // The actual exposure path: GatewayHost resolves these from CcStorage.Root() when given no explicit
+        // path, and 26 of the 48 test files that construct one pass nothing. Pinning the resolution rather
+        // than constructing a host keeps this test cheap while still failing if the redirect stops working.
+        foreach (var store in new[] { "missions.json", "cronjobs.json", "gateway-input-stats.json", "gateway-stats.db" })
+        {
+            var resolved = Path.Combine(CcStorage.Root(), store);
+            Assert.StartsWith(Path.GetTempPath(), resolved, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}


### PR DESCRIPTION
## What happened

A full Gateway test run **moved the owner's live `gateway-input-stats.json` aside**. No data was lost — the running Gateway held its state in memory and rewrote the file — but between the rename and that rewrite there was a window in which a Gateway restart would have found no file, started empty, and saved empty over it. **What prevented total loss was timing, not a safeguard.**

## The exposure is not about statistics, and it is not new

`GatewayHost` defaults its stores to `CcStorage.Root()`, and **26 of the 48** Gateway test files that construct a `GatewayHost` never redirect `CC_DIRECTOR_ROOT`. That root holds `missions.json`, `cronjobs.json` and `keyvault.json` — live fleet state, not just statistics.

It was survivable only while tests overwrote those files with equivalent state. The first operation that **moved** one made it lethal.

## This is the second instance of a class we already fixed once

The existing `ModuleInitializer` in `TestEnvironment.cs` exists for **#322**, where a test wrote an instance file into the real Director instances directory, and the production Gateway's watcher discovered it and painted a phantom Director in the owner's real Cockpit.

The diagnosis was right. The fix was scoped to the one directory that had been noticed, leaving tests resolving to the real storage root fully live. **A fix scoped to the instance you noticed leaves the class alive** — and it came back today wearing a worse costume: #322 left a stray file, this one moved one.

## Why an assembly-level initializer rather than fixing the tests that write

22 files already redirect by hand. So the hazard was known and the mitigation was a *convention* — followed by fewer than half the sites. **A convention that fails 26 times out of 48 is not a mitigation.** Structure is the only thing the next test author cannot forget.

The redirect is **unconditional** by design. Respecting an already-set value would look considerate and would be a hole: if the variable happened to point at the real root, the suite would quietly run unprotected. The 22 tests that set their own root still work — they set it *after* this runs, and restore to this temporary root rather than to the owner's live one, which improves them.

## Proof

- **Red-watched, not asserted.** Disabling the initializer fails all three guard tests, and the failure *mode* is the reported symptom — they print `C:\Users\soren\AppData\Local\cc-director`, the owner's real root — rather than dying on an incidental error. Restored: green.
- Full Gateway suite green at **2432**.
- Empirically, a guarded full run added no new file to the real root.

## Known limits, stated rather than papered over

- This does **not** make process-wide `CC_DIRECTOR_ROOT` mutation race-free; many tests still change the variable temporarily. It changes the *default and restored* value from the owner's live root to a disposable temp root, which is the live-data protection that matters.
- **Only the Gateway suite is guarded.** Whether Core, Engine and Launcher have the same exposure is untested and worth a look.
- "No change to the owner's root" is not claimable as proof while his Gateway is live and rewriting its stores continuously. The only available proof is the absence of any *new* file, and that is the only claim made.

## Provenance

Split out of the `feat/gateway-sqlite` mission branch on the Codex reviewer's recommendation. That mission's SQLite database has no production caller yet and is deliberately **not** included here — this fix is independent of it and stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)