### PR TITLE
fix(ingest): key the prompt-log watermark on content, not a per-process hash

### DIFF
--- a/src/CcDirector.Core.Tests/Storage/ConversationIngestorTests.cs
+++ b/src/CcDirector.Core.Tests/Storage/ConversationIngestorTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using CcDirector.Core.Configuration;
+using CcDirector.Core.History;
 using CcDirector.Core.Sessions;
 using CcDirector.Core.Storage;
 using CcDirector.Core.Tests.Wingman; // BufferOnlyBackend (internal test stub)
@@ -386,5 +387,67 @@ public sealed class ConversationIngestorTests : IDisposable
         await ingestor.IngestAsync(session);
 
         Assert.True(Assert.Single(Pushed).TimestampFromAgent);
+    }
+
+    // ===== the watermark must survive a RESTART - the one case it exists for =====
+    //
+    // Every dedupe test above runs in a single process, which is precisely where the watermark cannot
+    // fail: .NET randomizes string.GetHashCode()'s seed per process, so a key built from it is stable
+    // for exactly as long as the process lives - and the file outlives the process. The two tests below
+    // are the only ones that cross that boundary, so they are the only ones that can catch it.
+    //
+    // The expected hashes here were computed OUTSIDE this codebase (python hashlib.sha256) so they
+    // anchor to the standard algorithm rather than recording whatever our own implementation emits - a
+    // golden that echoes the code it guards proves nothing.
+
+    /// <summary>SHA-256 of "restart must not re-push this", first 32 hex characters.</summary>
+    private const string HashOfRestartMessage = "835a674409124218ea244c65a37c8028";
+
+    /// <summary>SHA-256 of "an old reply", first 32 hex characters.</summary>
+    private const string HashOfOldReply = "69a9d10430492b3eba43929f72617200";
+
+    [Fact]
+    public async Task A_watermark_from_a_previous_process_still_dedupes_after_a_restart()
+    {
+        var session = NewSession();
+        var ts = new DateTime(2026, 7, 15, 12, 0, 0, DateTimeKind.Utc);
+        const string text = "restart must not re-push this";
+        WriteTranscript(session, UserLine(text, ts));
+
+        // A watermark file left behind by an EARLIER Director process - hand-written here with keys
+        // this process never computed, which is exactly what a real restart reads off disk.
+        var scope = SessionHistoryReader.ResolveTranscriptPath(session)!;
+        var key = $"{ts:O}|{(int)ConversationRole.User}|{HashOfRestartMessage}";
+        File.WriteAllText(
+            Path.Combine(_root, "prompt-ingest-state.json"),
+            JsonSerializer.Serialize(new Dictionary<string, HashSet<string>> { [scope] = new() { key } }));
+
+        // Constructing the ingestor loads that file: this IS the restart.
+        using var ingestor = NewIngestor();
+        await ingestor.IngestAsync(session);
+
+        // The message was already handed to the Gateway before the restart. Pushing it again means the
+        // Gateway's prompt log - which appends blindly and never dedupes - grows a duplicate copy of the
+        // whole conversation on every single Director restart.
+        Assert.Empty(Pushed);
+    }
+
+    [Fact]
+    public void The_persisted_key_is_a_content_hash_that_any_process_computes_identically()
+    {
+        var ts = new DateTime(2026, 7, 15, 12, 0, 0, DateTimeKind.Utc);
+
+        var state = new IngestState();
+        state.MarkWritten("some-scope", ts, ConversationRole.Assistant, "an old reply", tsFromAgent: true);
+        state.Save();
+
+        var written = JsonSerializer.Deserialize<Dictionary<string, HashSet<string>>>(
+            File.ReadAllText(Path.Combine(_root, "prompt-ingest-state.json")))!;
+
+        // The on-disk format is a contract with every FUTURE process that reads this file, so the key
+        // must be a pure function of the message's content. A per-process value - string.GetHashCode()
+        // being the obvious one - is unreadable by the process that comes next.
+        var expected = $"{ts:O}|{(int)ConversationRole.Assistant}|{HashOfOldReply}";
+        Assert.Equal(expected, Assert.Single(written["some-scope"]));
     }
 }

--- a/src/CcDirector.Core/Storage/ConversationIngestor.cs
+++ b/src/CcDirector.Core/Storage/ConversationIngestor.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using CcDirector.Core.Agents;
 using CcDirector.Core.Gemini;
@@ -300,6 +302,10 @@ public interface IPromptSink
 /// This is a watermark, not a log: it holds hashes and never text. The Director keeps no copy of the
 /// conversation; this only records what it has already handed to the Gateway, so a restart cannot
 /// re-push a whole history.
+///
+/// Because the file outlives the process, every key written into it must be computable identically by
+/// the NEXT process - see <see cref="ContentHash"/>. Anything seeded per process reads as a miss after
+/// a restart, which is the one failure this file exists to prevent.
 /// </summary>
 internal sealed class IngestState
 {
@@ -314,8 +320,21 @@ internal sealed class IngestState
         // so its key must not include the time or nothing would ever dedupe. Text + role is what we
         // genuinely have for those agents.
         var timePart = tsFromAgent ? ts.ToString("O") : "no-ts";
-        return $"{timePart}|{(int)role}|{text.GetHashCode()}";
+        return $"{timePart}|{(int)role}|{ContentHash(text)}";
     }
+
+    /// <summary>
+    /// A hash of the text that is the SAME in every process, forever. This MUST NOT be
+    /// <c>string.GetHashCode()</c>: .NET randomizes its seed per process, so keys built from it stop
+    /// matching the moment the Director restarts - every recomputed key misses, AlreadyWritten answers
+    /// false for everything, and the first turn end after startup re-pushes the entire conversation
+    /// history into a Gateway log that appends blindly and never dedupes.
+    ///
+    /// Truncated to 128 bits: this only needs to tell two messages apart within one source, and the key
+    /// already carries the timestamp and role.
+    /// </summary>
+    private static string ContentHash(string text)
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(text)))[..32].ToLowerInvariant();
 
     public bool AlreadyWritten(string scope, DateTime ts, ConversationRole role, string text, bool tsFromAgent)
     {


### PR DESCRIPTION
Item 1 of 4 in the Pre-Release Must-Fix mission (`docs/architecture/pre-release-must-fix-mission-brief.md`). Release blocker: a data-corruption path.

## What was wrong

`prompt-ingest-state.json` exists for exactly one reason, and the class comment says so outright: a restart must not re-push a whole conversation history. It could not do that job.

The key was built from `text.GetHashCode()`. .NET randomizes that seed on every process start, so after any restart every recomputed key missed every persisted key, `AlreadyWritten` answered false for everything, and the first turn end after startup pushed the **entire** conversation history again. The Gateway prompt log appends blindly (no dedupe on receipt, retention deliberately unbounded), so ten restarts meant ten copies of everything. For the agents whose ingest scope is per repository (Gemini, Copilot, OpenCode), merely opening a new session on a repository re-pushed months of that repository's history.

## The fix

`ConversationIngestor.cs:317` — the key is now SHA-256 of the text, truncated to 128 bits. The key shape is otherwise unchanged.

## Why the existing tests never caught it

All 17 of them run inside one process, which is precisely where this cannot fail: the hash seed is constant for as long as the process lives, and the file outlives the process. The exact case the persisted file exists for — a process restart — was untested.

## The tests, and how they were proven

Two new tests, both **watched failing against `GetHashCode()` before the fix existed**:

1. `A_watermark_from_a_previous_process_still_dedupes_after_a_restart` — hand-writes a watermark file containing keys this process never computed, which is exactly what a real restart reads off disk, then asserts nothing is re-pushed. Failed with the reported symptom: the watermarked message was pushed again.
2. `The_persisted_key_is_a_content_hash_that_any_process_computes_identically` — pins the on-disk key format, which is a contract with every future process that reads the file. Failed emitting `...|1|707545595` — a random per-process integer where the hash belongs.

The expected hashes were computed **outside this codebase** (python `hashlib.sha256`) so they anchor to the standard algorithm rather than recording whatever our own implementation happens to emit. A golden that echoes the code it guards proves nothing.

xunit v2 builds a library, not an executable, so a genuine two-live-process test would need a new helper project. The watermark-file-from-a-previous-process test is the faithful substitute: the file genuinely carries keys this process did not compute, which is the whole of what a restart changes.

## Accepted consequence (ruled by the Architect, not re-litigated)

Existing watermark files hold old-format keys, so the **first** run of this build re-pushes once more — identical to what every restart does today, and never again after that. Deliberately no migration for the old keys.

## Verification

Full suite green across all seven test projects: Core 3136, Gateway 2451, Avalonia 220, HostedAgent 80, Engine 62, Launcher 27, Terminal.Avalonia 21. Zero failures.

## Not in scope

Item 2 (the sink acknowledging a failed write as success) touches the same subsystem and is a separate defect with a separate proof — it lands as its own pull request, per the brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
