### PR TITLE
fix(ingest): a partial prompt-log write is a failure, not a success

### DIFF
--- a/src/CcDirector.ControlApi/GatewayPromptSink.cs
+++ b/src/CcDirector.ControlApi/GatewayPromptSink.cs
@@ -47,9 +47,15 @@ public sealed class GatewayPromptSink : IPromptSink
             if (written is null) return false;
 
             if (written != records.Count)
-                FileLog.Write($"[GatewayPromptSink] Gateway wrote {written} of {records.Count} message(s)");
+                FileLog.Write($"[GatewayPromptSink] Gateway wrote {written} of {records.Count} message(s); NOT marking them done");
 
-            return true;
+            // Anything less than all of them is a failure. The Gateway's Append swallows per-record
+            // write failures and reports a truthful count of what it stored, so a short count means
+            // those messages exist nowhere: the Director keeps no copy. Saying true here would have
+            // ConversationIngestor mark them done and the next ingest skip them - silent, permanent
+            // loss. The false path re-sends at the next turn end, and a duplicate on failure recovery
+            // is a far better trade than a hole in the only record.
+            return written == records.Count;
         }
         catch (Exception ex)
         {

--- a/src/CcDirector.Core.Tests/Storage/ConversationIngestorTests.cs
+++ b/src/CcDirector.Core.Tests/Storage/ConversationIngestorTests.cs
@@ -40,19 +40,46 @@ public sealed class ConversationIngestorTests : IDisposable
         try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
     }
 
-    /// <summary>Stands in for the Gateway: remembers what was pushed, and can refuse.</summary>
+    /// <summary>Stands in for the Gateway: remembers what was pushed, can refuse, and can be held open
+    /// mid-push so a second ingest is guaranteed to overlap the first rather than racing it by luck.</summary>
     private sealed class FakeSink : IPromptSink
     {
-        public List<PromptRecord> Received { get; } = new();
+        private readonly object _gate = new();
+        private readonly List<PromptRecord> _received = new();
+        private readonly TaskCompletionSource _firstPushEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _releaseFirstPush = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public IReadOnlyList<PromptRecord> Received { get { lock (_gate) return _received.ToList(); } }
         public int PushCalls { get; private set; }
         public bool Accept { get; set; } = true;
 
-        public Task<bool> PushAsync(IReadOnlyList<PromptRecord> records)
+        /// <summary>When set, the FIRST push blocks until <see cref="ReleaseFirstPush"/>, holding the
+        /// ingest inside the window between reading the watermark and marking it.</summary>
+        public bool HoldFirstPush { get; set; }
+
+        /// <summary>Completes once a push is inside that window.</summary>
+        public Task FirstPushEntered => _firstPushEntered.Task;
+
+        public void ReleaseFirstPush() => _releaseFirstPush.TrySetResult();
+
+        public async Task<bool> PushAsync(IReadOnlyList<PromptRecord> records)
         {
-            PushCalls++;
-            if (!Accept) return Task.FromResult(false);
-            Received.AddRange(records);
-            return Task.FromResult(true);
+            bool hold;
+            lock (_gate)
+            {
+                PushCalls++;
+                hold = HoldFirstPush && PushCalls == 1;
+            }
+
+            if (hold)
+            {
+                _firstPushEntered.TrySetResult();
+                await _releaseFirstPush.Task;
+            }
+
+            if (!Accept) return false;
+            lock (_gate) _received.AddRange(records);
+            return true;
         }
     }
 
@@ -387,6 +414,93 @@ public sealed class ConversationIngestorTests : IDisposable
         await ingestor.IngestAsync(session);
 
         Assert.True(Assert.Single(Pushed).TimestampFromAgent);
+    }
+
+    // ===== two ingests of one source must not both push =====
+    //
+    // The watermark is read, then the push is awaited, then the messages are marked - and they cannot be
+    // marked any earlier, because the Director keeps no copy and must not mark what the Gateway has not
+    // accepted. That leaves a window. The trigger fires per turn end on a Task.Run, so two quick turn
+    // ends put two ingests inside it, both see "not written", and both push.
+    //
+    // These hold the fake Gateway open mid-push to place the second ingest inside that window on purpose.
+    // Without the hold the race is real but rare, and a test that reproduces a race only sometimes is a
+    // test that certifies the bug most of the time.
+
+    [Fact]
+    public async Task Two_ingests_of_one_session_at_once_push_each_message_once()
+    {
+        var session = NewSession();
+        WriteTranscript(session, UserLine("say this once", DateTime.UtcNow));
+
+        using var ingestor = NewIngestor();
+        _sink.HoldFirstPush = true;
+
+        var first = Task.Run(() => ingestor.IngestAsync(session));
+        await _sink.FirstPushEntered;               // the first ingest is now mid-push, nothing marked yet
+
+        var second = Task.Run(() => ingestor.IngestAsync(session));
+        await Task.Delay(250);                     // room for the second to push, if nothing stops it
+
+        _sink.ReleaseFirstPush();
+        await Task.WhenAll(first, second);
+
+        Assert.Equal("say this once", Assert.Single(Pushed).Text);
+    }
+
+    [Fact]
+    public async Task Two_sessions_sharing_one_source_ingesting_at_once_push_each_message_once()
+    {
+        // Two Director sessions reading ONE transcript - the same overlap, across sessions. This is the
+        // case a per-session guard would miss: Copilot, OpenCode and Gemini resolve their conversation by
+        // repository, so two sessions on one repository genuinely read the same conversation. It is why
+        // the watermark is scoped to the source, and why the gate must be too.
+        var ts = DateTime.UtcNow;
+        var sessionA = NewSession();
+        var path = WriteTranscript(sessionA, UserLine("one shared conversation", ts));
+
+        var sessionB = NewSession();
+        sessionB.UpdateClaudeSessionPointer("claude-session-id", path, "test");
+
+        using var ingestor = NewIngestor();
+        _sink.HoldFirstPush = true;
+
+        var first = Task.Run(() => ingestor.IngestAsync(sessionA));
+        await _sink.FirstPushEntered;
+
+        var second = Task.Run(() => ingestor.IngestAsync(sessionB));
+        await Task.Delay(250);
+
+        _sink.ReleaseFirstPush();
+        await Task.WhenAll(first, second);
+
+        Assert.Equal("one shared conversation", Assert.Single(Pushed).Text);
+    }
+
+    [Fact]
+    public async Task Ingests_of_DIFFERENT_sources_are_not_serialized_behind_each_other()
+    {
+        // The control on the gate: it must not become a global lock. Two unrelated sessions ingest at the
+        // same time all day - a slow or hanging push to one source must not stall every other source's
+        // capture behind it.
+        var sessionA = NewSession();
+        WriteTranscript(sessionA, UserLine("from source A", DateTime.UtcNow));
+        var sessionB = NewSession();
+        WriteTranscript(sessionB, UserLine("from source B", DateTime.UtcNow));
+
+        using var ingestor = NewIngestor();
+        _sink.HoldFirstPush = true;
+
+        var first = Task.Run(() => ingestor.IngestAsync(sessionA));
+        await _sink.FirstPushEntered;              // A is parked mid-push and holding A's gate
+
+        // B must sail past: different source, different gate. If this hangs, the gate is too coarse.
+        await Task.Run(() => ingestor.IngestAsync(sessionB)).WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal("from source B", Assert.Single(Pushed).Text);
+
+        _sink.ReleaseFirstPush();
+        await first;
+        Assert.Equal(new[] { "from source B", "from source A" }, Pushed.Select(r => r.Text));
     }
 
     // ===== the watermark must survive a RESTART - the one case it exists for =====

--- a/src/CcDirector.Core/Storage/ConversationIngestor.cs
+++ b/src/CcDirector.Core/Storage/ConversationIngestor.cs
@@ -45,6 +45,31 @@ public sealed class ConversationIngestor : IDisposable
     private readonly IPromptSink _sink;
     private readonly ConcurrentDictionary<Guid, Action<ActivityState, ActivityState>> _handlers = new();
     private readonly IngestState _state = IngestState.Load();
+
+    /// <summary>
+    /// One gate per SOURCE, so only one ingest of a given source runs at a time.
+    ///
+    /// Without it the watermark check is a check-then-act race: an ingest reads AlreadyWritten, pushes
+    /// over HTTP, and only marks the messages afterwards - because it must not mark before the Gateway
+    /// accepts (the Director keeps no copy). Two ingests of one source that start inside that window
+    /// both see "not written", and BOTH push. Every message is duplicated in a Gateway log that appends
+    /// blindly and never dedupes. The trigger fires per turn end on a Task.Run, so two quick turn ends
+    /// are all it takes.
+    ///
+    /// Keyed by SOURCE and not by session, because the source is what the watermark itself is keyed by
+    /// (see <see cref="ScopeKey"/>). A per-session gate would still duplicate for exactly the agents the
+    /// scope key exists for: Copilot, OpenCode and Gemini resolve their conversation by REPOSITORY, so
+    /// two Director sessions on one repository read the same conversation and would hold different
+    /// gates. Locking the source locks the thing actually being read and written.
+    ///
+    /// Not cleaned up when a session goes: a source outlives any one session (that is the point of the
+    /// scope key), and an entry is a bare SemaphoreSlim keyed by a transcript path or repository. It
+    /// grows with the number of distinct sources one Director process has ever ingested, which is small
+    /// and bounded by real work. Removing entries would need refcounting against in-flight waiters, and
+    /// that risk is not worth the few bytes.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _gates = new();
+
     private bool _started;
     private int _disposed;
 
@@ -94,6 +119,9 @@ public sealed class ConversationIngestor : IDisposable
     /// <summary>
     /// Capture any not-yet-pushed messages for this session and send them to the Gateway. Public so a
     /// backfill can drive it directly. Never throws.
+    ///
+    /// Runs one at a time per SOURCE - see <see cref="_gates"/> for why that matters and why the lock is
+    /// on the source rather than the session.
     /// </summary>
     public async Task IngestAsync(Session session)
     {
@@ -101,74 +129,97 @@ public sealed class ConversationIngestor : IDisposable
         {
             if (!SessionHistoryReader.IsSupported(session)) return;
 
-            var history = ReadForRecord(session);
-            if (history.Messages.Count == 0) return;
-
             var scope = ScopeKey(session);
-            var origins = InputOriginBuffer.For(session.Id.ToString());
-            var toPush = new List<PromptRecord>();
-            var pushed = new List<(DateTime ts, ConversationRole role, string text, bool fromAgent)>();
-
-            foreach (var message in history.Messages)
+            var gate = _gates.GetOrAdd(scope, _ => new SemaphoreSlim(1, 1));
+            await gate.WaitAsync().ConfigureAwait(false);
+            try
             {
-                var text = TextOf(message);
-                if (string.IsNullOrWhiteSpace(text)) continue;
-
-                // Gemini carries no timestamps (its history is scraped from the terminal buffer), so
-                // there is nothing real to stamp with. Record capture time and mark it as ours, rather
-                // than letting an inferred time read as a measured one.
-                var fromAgent = message.Timestamp.HasValue;
-                var ts = message.Timestamp?.UtcDateTime ?? DateTime.UtcNow;
-
-                if (_state.AlreadyWritten(scope, ts, message.Role, text, fromAgent)) continue;
-
-                var isUser = message.Role == ConversationRole.User;
-                var origin = isUser ? MatchOrigin(origins, ts, fromAgent) : null;
-
-                toPush.Add(new PromptRecord
-                {
-                    TsUtc = ts,
-                    Machine = Environment.MachineName,
-                    SessionId = session.Id.ToString(),
-                    ContextId = ContextIdFor(session, message),
-                    SessionName = session.CustomName,
-                    RepoPath = session.RepoPath,
-                    Agent = session.AgentKind.ToString(),
-                    MissionName = session.MissionName,
-                    Role = isUser ? "user" : "assistant",
-                    Modality = origin?.Modality,
-                    // A user message we could not attribute is "unknown", never a guess. An assistant
-                    // reply has no origin at all, so it stays null.
-                    Surface = isUser ? (origin?.Surface ?? "unknown") : null,
-                    TimestampFromAgent = fromAgent,
-                    CharCount = text.Length,
-                    WordCount = text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Length,
-                    Text = text,
-                });
-                pushed.Add((ts, message.Role, text, fromAgent));
+                await IngestOnceAsync(session, scope).ConfigureAwait(false);
             }
-
-            if (toPush.Count == 0) return;
-
-            // Only mark as recorded once the Gateway has actually accepted them. The Director keeps no
-            // copy, so marking before a failed push would lose the messages permanently - the next
-            // ingest would skip them as already-done.
-            var accepted = await _sink.PushAsync(toPush).ConfigureAwait(false);
-            if (!accepted)
+            finally
             {
-                FileLog.Write($"[ConversationIngestor] session={session.Id}: Gateway did not accept {toPush.Count} message(s); will retry on the next turn");
-                return;
+                gate.Release();
             }
-
-            foreach (var (ts, role, text, fromAgent) in pushed)
-                _state.MarkWritten(scope, ts, role, text, fromAgent);
-            _state.Save();
-            FileLog.Write($"[ConversationIngestor] session={session.Id} pushed {toPush.Count} message(s) to the Gateway");
         }
         catch (Exception ex)
         {
             FileLog.Write($"[ConversationIngestor] Ingest FAILED (swallowed) session={session.Id}: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// One pass of capture-and-push for a source. The caller holds that source's gate, so the whole
+    /// read-check-push-mark sequence below is atomic with respect to any other ingest of the same
+    /// source - which is what makes the watermark check meaningful.
+    ///
+    /// The transcript is deliberately read INSIDE the gate: a caller that queued behind another must
+    /// re-read and re-check against the watermark the first one just wrote, or it would push what it
+    /// decided to push before waiting.
+    /// </summary>
+    private async Task IngestOnceAsync(Session session, string scope)
+    {
+        var history = ReadForRecord(session);
+        if (history.Messages.Count == 0) return;
+
+        var origins = InputOriginBuffer.For(session.Id.ToString());
+        var toPush = new List<PromptRecord>();
+        var pushed = new List<(DateTime ts, ConversationRole role, string text, bool fromAgent)>();
+
+        foreach (var message in history.Messages)
+        {
+            var text = TextOf(message);
+            if (string.IsNullOrWhiteSpace(text)) continue;
+
+            // Gemini carries no timestamps (its history is scraped from the terminal buffer), so
+            // there is nothing real to stamp with. Record capture time and mark it as ours, rather
+            // than letting an inferred time read as a measured one.
+            var fromAgent = message.Timestamp.HasValue;
+            var ts = message.Timestamp?.UtcDateTime ?? DateTime.UtcNow;
+
+            if (_state.AlreadyWritten(scope, ts, message.Role, text, fromAgent)) continue;
+
+            var isUser = message.Role == ConversationRole.User;
+            var origin = isUser ? MatchOrigin(origins, ts, fromAgent) : null;
+
+            toPush.Add(new PromptRecord
+            {
+                TsUtc = ts,
+                Machine = Environment.MachineName,
+                SessionId = session.Id.ToString(),
+                ContextId = ContextIdFor(session, message),
+                SessionName = session.CustomName,
+                RepoPath = session.RepoPath,
+                Agent = session.AgentKind.ToString(),
+                MissionName = session.MissionName,
+                Role = isUser ? "user" : "assistant",
+                Modality = origin?.Modality,
+                // A user message we could not attribute is "unknown", never a guess. An assistant
+                // reply has no origin at all, so it stays null.
+                Surface = isUser ? (origin?.Surface ?? "unknown") : null,
+                TimestampFromAgent = fromAgent,
+                CharCount = text.Length,
+                WordCount = text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Length,
+                Text = text,
+            });
+            pushed.Add((ts, message.Role, text, fromAgent));
+        }
+
+        if (toPush.Count == 0) return;
+
+        // Only mark as recorded once the Gateway has actually accepted them. The Director keeps no
+        // copy, so marking before a failed push would lose the messages permanently - the next
+        // ingest would skip them as already-done.
+        var accepted = await _sink.PushAsync(toPush).ConfigureAwait(false);
+        if (!accepted)
+        {
+            FileLog.Write($"[ConversationIngestor] session={session.Id}: Gateway did not accept {toPush.Count} message(s); will retry on the next turn");
+            return;
+        }
+
+        foreach (var (ts, role, text, fromAgent) in pushed)
+            _state.MarkWritten(scope, ts, role, text, fromAgent);
+        _state.Save();
+        FileLog.Write($"[ConversationIngestor] session={session.Id} pushed {toPush.Count} message(s) to the Gateway");
     }
 
     /// <summary>
@@ -281,6 +332,9 @@ public sealed class ConversationIngestor : IDisposable
         foreach (var s in _sessionManager.ListSessions())
             UnwireSession(s);
         _handlers.Clear();
+        foreach (var gate in _gates.Values)
+            gate.Dispose();
+        _gates.Clear();
         _state.Save();
     }
 }

--- a/src/CcDirector.Gateway.Tests/GatewayPromptSinkTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayPromptSinkTests.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using CcDirector.ControlApi;
+using CcDirector.Core.Configuration;
+using CcDirector.Gateway.Contracts;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// Tests for <see cref="GatewayPromptSink"/> - the Director half of "the Director captures, the Gateway
+/// stores" (issue #1551).
+///
+/// The whole weight of these tests rests on one fact: the Director keeps NO copy of the conversation.
+/// Whatever the Gateway accepted IS the record. So this sink's return value is not a status - it is the
+/// decision about whether the only copy exists. Return true for a message the Gateway never stored and
+/// <see cref="ConversationIngestor"/> marks it done, the next ingest skips it as already-pushed, and the
+/// message is gone from the single copy, permanently and silently.
+///
+/// These drive the REAL <see cref="GatewayClient"/> over a REAL HTTP connection to a Kestrel stub on a
+/// loopback port - the pattern the mission-lookup and token-refresh tests use - so the wire behavior is
+/// exercised rather than a hand-written fake that is politer than the transport.
+/// </summary>
+public sealed class GatewayPromptSinkTests
+{
+    /// <summary>
+    /// A Kestrel stub standing in for the Gateway's POST /prompts, on an OS-assigned loopback port.
+    /// <paramref name="handler"/> turns the records it received into the response.
+    /// </summary>
+    private static async Task<(WebApplication app, string url)> StartPromptStubAsync(
+        Func<PromptIngestRequest, IResult> handler)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        builder.WebHost.ConfigureKestrel(o => o.Listen(IPAddress.Loopback, 0));   // OS-assigned free port
+        var app = builder.Build();
+        app.MapPost("/prompts", (PromptIngestRequest req) => handler(req));
+        await app.StartAsync();
+        return (app, app.Urls.First());
+    }
+
+    private static GatewayPromptSink SinkFor(string gatewayUrl)
+    {
+        var client = new GatewayClient(new GatewayConfig { Url = gatewayUrl }, Guid.NewGuid().ToString(), 7879, "1.0.0");
+        return new GatewayPromptSink(() => client);
+    }
+
+    private static PromptRecord Record(string text) => new()
+    {
+        TsUtc = DateTime.UtcNow,
+        Machine = Environment.MachineName,
+        SessionId = Guid.NewGuid().ToString(),
+        Role = "user",
+        TimestampFromAgent = true,
+        CharCount = text.Length,
+        WordCount = 1,
+        Text = text,
+    };
+
+    private static IReadOnlyList<PromptRecord> ThreeRecords() =>
+        new[] { Record("first"), Record("second"), Record("third") };
+
+    [Fact]
+    public async Task A_partial_write_is_NOT_acknowledged_as_success()
+    {
+        // The Gateway's own Append swallows per-record write failures and reports a truthful count of
+        // what it actually stored. Two of these three were never written down anywhere.
+        var (app, url) = await StartPromptStubAsync(_ => Results.Json(new PromptIngestResponse { Written = 1 }));
+        await using var _ = app;
+
+        var accepted = await SinkFor(url).PushAsync(ThreeRecords());
+
+        // False is what stops ConversationIngestor marking all three done. The Director keeps no copy,
+        // so true here deletes the two lost messages from the only record that exists - and the log line
+        // saying "wrote 1 of 3" is the only trace, in a file nobody reads.
+        Assert.False(accepted);
+    }
+
+    [Fact]
+    public async Task A_gateway_that_stored_nothing_is_not_success()
+    {
+        var (app, url) = await StartPromptStubAsync(_ => Results.Json(new PromptIngestResponse { Written = 0 }));
+        await using var _ = app;
+
+        Assert.False(await SinkFor(url).PushAsync(ThreeRecords()));
+    }
+
+    // ===== the controls: the false path must stay narrow, or ingest retries forever and duplicates =====
+
+    [Fact]
+    public async Task A_complete_write_IS_acknowledged_as_success()
+    {
+        var (app, url) = await StartPromptStubAsync(req => Results.Json(new PromptIngestResponse { Written = req.Records.Count }));
+        await using var _ = app;
+
+        Assert.True(await SinkFor(url).PushAsync(ThreeRecords()));
+    }
+
+    [Fact]
+    public async Task An_error_from_the_gateway_is_not_success()
+    {
+        var (app, url) = await StartPromptStubAsync(_ => Results.StatusCode(500));
+        await using var _ = app;
+
+        Assert.False(await SinkFor(url).PushAsync(ThreeRecords()));
+    }
+
+    [Fact]
+    public async Task A_director_with_no_gateway_records_nothing_and_says_so()
+    {
+        // Local-only Director: there is no log to write to, so it must not claim the messages are stored.
+        Assert.False(await new GatewayPromptSink(() => null).PushAsync(ThreeRecords()));
+    }
+
+    [Fact]
+    public async Task Pushing_nothing_is_trivially_fine()
+    {
+        // Nothing to lose, so nothing to retry - this must not become a permanent false.
+        Assert.True(await new GatewayPromptSink(() => null).PushAsync(Array.Empty<PromptRecord>()));
+    }
+}


### PR DESCRIPTION
Item 2 of 4 in the Pre-Release Must-Fix mission (`docs/architecture/pre-release-must-fix-mission-brief.md`). Release blocker: a data-loss path.

## What was wrong

`GatewayPromptSink.PushAsync` logged `Gateway wrote 1 of 3 message(s)` and then **returned true anyway**. `ConversationIngestor` therefore marked all three as pushed, and the next ingest skipped them as already-done. The Director keeps no copy by design, so the two records the Gateway never stored were permanently and silently absent from the single copy that exists. The only trace was a log line in a file nobody reads.

The sink's own contract comment promised the opposite of what the code did:

> `false ... means not recorded and the caller must not mark them done`

## The fix

`GatewayPromptSink.cs:52` — `return written == records.Count;`

The Gateway half is truthful and stays exactly as it is (Architect's ruling): `Append` swallows per-record write failures and `POST /prompts` returns a real count of what it actually stored. The Director-side comparison is the fix.

The false path already retries at the next turn end, where the messages are still readable from the agent's transcript. Duplicates on failure recovery are a far better trade than a hole in the only record.

## The tests, and how they were proven

This sink had **no tests at all**. Six added. They drive the **real** `GatewayClient` over a **real** HTTP connection to a Kestrel stub on a loopback port — the pattern the mission-lookup and token-refresh tests already use — so the wire behavior is exercised rather than a hand-written fake that is politer than the transport.

Watched failing against the old `return true`, before the fix existed:

| Test | Before fix |
|---|---|
| `A_partial_write_is_NOT_acknowledged_as_success` (Gateway reports 1 of 3) | **FAIL** — returned true |
| `A_gateway_that_stored_nothing_is_not_success` (reports 0) | **FAIL** — returned true |

The four controls passed before and after, and keep the false path narrow — if it widened, ingest would retry forever and duplicate:

- `A_complete_write_IS_acknowledged_as_success`
- `An_error_from_the_gateway_is_not_success` (HTTP 500)
- `A_director_with_no_gateway_records_nothing_and_says_so`
- `Pushing_nothing_is_trivially_fine`

## Verification

Full suite green across all seven test projects: Core 3136, Gateway 2460, Avalonia 220, HostedAgent 80, Engine 62, Launcher 27, Terminal.Avalonia 21. Zero failures.

## Relationship to pull request 1680

Same subsystem, separate defect, separate proof — landed separately per the brief. 1680 makes the watermark keys stable across restarts, which is what makes this pull request's retry-on-false re-send only what was genuinely unwritten rather than everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: adjacent defect closed in this pull request (Codex inspection)

The independent Codex inspection confirmed the return-false fix and found a real adjacent hole. Verified against the code before acting on it, and it is genuine.

**The race.** `IngestAsync` reads the watermark, awaits the push, and only marks the messages afterwards — and it cannot mark any earlier, because the Director keeps no copy and must not mark what the Gateway has not accepted. That window had no guard. The trigger fires per turn end on a `Task.Run`, so two quick turn ends put two ingests inside it, both see "not written", and **both push**. Duplicated records in a log that appends blindly and never dedupes — the same corruption the watermark exists to prevent, reached by a different road.

**The fix.** One `SemaphoreSlim` per source serializes the whole read-check-push-mark sequence. The transcript is read *inside* the gate, so a queued caller re-checks against the watermark the first one just wrote.

**One deliberate deviation.** The gate is keyed by **source**, not by session as suggested. The watermark itself is keyed by source, and that is load-bearing: Copilot, OpenCode and Gemini resolve their conversation by **repository**, so two Director sessions on one repository read the same conversation and would hold two different per-session gates — duplicating for exactly the agents the scope key exists for. Locking the source locks the thing actually being read and written. `Two_sessions_sharing_one_source_ingesting_at_once_push_each_message_once` covers that case specifically and is the test a per-session gate would fail.

**Proof.** The two race tests were watched failing against the unguarded code with the reported symptom — `Assert.Single() Failure: The collection contained 2 items`, the message pushed twice. They hold the fake Gateway open mid-push so the second ingest lands inside the window on purpose: a test that reproduces a race only sometimes certifies the bug the rest of the time. The third test is the control — two *different* sources must still ingest concurrently, so the gate cannot quietly become a global lock stalling every session behind one slow push.

**Not changed:** the whole-batch retry after a partial write is the brief's accepted ruling.

Full suite green across all seven projects: Core 3139, Gateway 2460, Avalonia 220, HostedAgent 80, Engine 62, Launcher 27, Terminal.Avalonia 21.
