### PR TITLE
fix(cli): give back the session buffer exactly as the terminal held it

### DIFF
--- a/tools/cc-devthrottle/src/session_ops.py
+++ b/tools/cc-devthrottle/src/session_ops.py
@@ -307,7 +307,13 @@ def read_session_buffer(target: Optional[str]) -> None:
     if text is None:
         console.print("[red]Error:[/red] the Director did not return the session's buffer.")
         raise typer.Exit(1)
-    console.print(text)
+    # Plain print, not console.print, for the same reason as list_sessions above. This is raw terminal
+    # text from another session, so it is arbitrary and nobody controls its shape: Rich reads a token
+    # like [/tmp/x] as a closing tag and raises MarkupError - an uncaught traceback out of a read-only
+    # verb - eats style-shaped tokens like [bold], and rewraps every line at 80 columns when stdout is
+    # not a TTY, which is exactly how an agent or a pipe calls this. The caller asked what the terminal
+    # is showing; the answer must be what the terminal was showing, byte for byte.
+    print(text)
 
 
 def set_session_role(target: Optional[str], role: Optional[str]) -> Dict[str, Any]:

--- a/tools/cc-devthrottle/src/session_ops.py
+++ b/tools/cc-devthrottle/src/session_ops.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import typer
 from rich import box
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
 
 
@@ -294,7 +295,11 @@ def read_session_buffer(target: Optional[str]) -> None:
     try:
         resp = director.get_json(f"fleet/buffer?sessionId={sid}")
     except director.DirectorError as err:
-        console.print(f"[red]Error:[/red] {err}")
+        # escape(): the error text comes from the server, so it is no more ours to trust than the buffer
+        # itself - it can quote a path or a fragment of the session's own output. Interpolated raw, a
+        # token like [/tmp/x] raises the very MarkupError this verb was crashing on, from the branch whose
+        # job is to REPORT a failure. The "Error:" label is ours, so it keeps its markup.
+        console.print(f"[red]Error:[/red] {escape(str(err))}")
         raise typer.Exit(1)
 
     # The buffer verb returns the terminal text under one of a couple of shapes depending on the
@@ -311,8 +316,14 @@ def read_session_buffer(target: Optional[str]) -> None:
     # text from another session, so it is arbitrary and nobody controls its shape: Rich reads a token
     # like [/tmp/x] as a closing tag and raises MarkupError - an uncaught traceback out of a read-only
     # verb - eats style-shaped tokens like [bold], and rewraps every line at 80 columns when stdout is
-    # not a TTY, which is exactly how an agent or a pipe calls this. The caller asked what the terminal
-    # is showing; the answer must be what the terminal was showing, byte for byte.
+    # not a TTY, which is exactly how an agent or a pipe calls this.
+    #
+    # What this does and does not promise: the text is not INTERPRETED - not parsed as markup, not
+    # rewrapped, not truncated, nothing added or removed in the middle. It is not a byte-for-byte
+    # guarantee, and claiming one would be a lie the next reader would rely on: print appends a trailing
+    # newline, the text layer translates newlines on the way out, and this module reconfigures stdout
+    # with errors="replace" (line 73), so a character the console encoding cannot represent still
+    # becomes a replacement character. Those three are the whole of the difference.
     print(text)
 
 

--- a/tools/cc-devthrottle/tests/test_session_buffer.py
+++ b/tools/cc-devthrottle/tests/test_session_buffer.py
@@ -18,6 +18,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import typer
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
@@ -75,9 +76,30 @@ def test_a_style_shaped_token_is_not_eaten(buffer_text, capsys):
     assert capsys.readouterr().out == text + "\n"
 
 
-def test_terminal_content_survives_byte_for_byte(buffer_text, capsys):
+def test_the_error_branch_does_not_crash_on_the_servers_error_text(buffer_text, monkeypatch, capsys):
+    # The failure branch had the SAME defect as the success branch it reports on: the error text comes
+    # from the server and can quote a path or a fragment of the session's own output, and it was
+    # interpolated straight into Rich markup. A closing-tag-shaped token in it raised MarkupError - a
+    # traceback out of the code whose only job is to explain a failure.
+    monkeypatch.setenv("CC_SESSION_ID", SESSION_ID)
+
+    def boom(path):
+        raise session_ops.director.DirectorError("no session at [/tmp/x] on that Director")
+
+    monkeypatch.setattr(session_ops.director, "get_json", boom)
+
+    with pytest.raises(typer.Exit):
+        session_ops.read_session_buffer(None)
+
+    out = capsys.readouterr().out
+    assert "no session at [/tmp/x] on that Director" in out   # reported literally, not swallowed
+    assert "Error:" in out                                     # and still human-readable
+
+
+def test_terminal_content_survives_uninterpreted(buffer_text, capsys):
     # The whole contract in one: markup-shaped tokens, a closing-tag shape, a long line, and blank lines
-    # all come back exactly as the terminal held them.
+    # all come back as the terminal held them - unparsed, unwrapped, nothing added or removed in the
+    # middle. Not a byte-for-byte claim: print adds the trailing newline, and the platform translates it.
     text = "\n".join(
         [
             "$ ls [/tmp/x]",

--- a/tools/cc-devthrottle/tests/test_session_buffer.py
+++ b/tools/cc-devthrottle/tests/test_session_buffer.py
@@ -1,0 +1,105 @@
+"""Tests for `cc-devthrottle session buffer`: the terminal text comes back exactly as the terminal held it.
+
+The buffer verb's whole job is to hand back another session's raw terminal content. That content is
+arbitrary text nobody controls - file paths, prompts, code, log lines - so anything that INTERPRETS it on
+the way out is a defect, not a feature. Printing it through Rich did two things:
+
+  (a) a token shaped like a closing tag - `[/tmp/x]`, `[/INST]` - raised rich.errors.MarkupError as an
+      uncaught traceback, so the verb crashed on perfectly ordinary output;
+  (b) with stdout not a terminal - exactly how an agent or a pipe calls it - Rich rewrapped every line at
+      80 columns and silently ate style-shaped tokens like `[bold]`.
+
+Both are asserted here with stdout captured as a pipe (capsys), which is the non-TTY path (a). and (b).
+both live on. The same hazard was already fixed in this file for the JSON output of list_sessions, with a
+comment explaining why; this is the same fix for the same reason.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src import session_ops  # noqa: E402
+
+SESSION_ID = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture
+def buffer_text(monkeypatch):
+    """Serve a chosen buffer text from the Director, without any real HTTP."""
+
+    def serve(text: str) -> str:
+        monkeypatch.setenv("CC_SESSION_ID", SESSION_ID)
+        monkeypatch.setattr(session_ops.director, "get_json", lambda path: {"text": text})
+        return text
+
+    return serve
+
+
+def test_a_bracketed_path_does_not_crash_the_verb(buffer_text, capsys):
+    # A real terminal shows paths like this constantly. Rich reads [/tmp/x] as a CLOSING TAG for a style
+    # that was never opened and raises MarkupError - an uncaught traceback out of a read-only verb.
+    text = "checked [/tmp/x] and it was fine"
+    buffer_text(text)
+
+    session_ops.read_session_buffer(None)
+
+    assert capsys.readouterr().out == text + "\n"
+
+
+def test_a_long_line_is_not_rewrapped(buffer_text, capsys):
+    # Piped stdout is not a terminal, so Rich falls back to 80 columns and injects newlines. The caller
+    # asked what the terminal is showing; a line broken in a place the terminal never broke it is a lie
+    # about the session's output, and it is exactly what an agent reads.
+    text = "x" * 200
+    buffer_text(text)
+
+    session_ops.read_session_buffer(None)
+
+    out = capsys.readouterr().out
+    assert out == text + "\n"
+    assert "\n" not in out[:-1], "the 200-character line was rewrapped"
+
+
+def test_a_style_shaped_token_is_not_eaten(buffer_text, capsys):
+    # [bold] is valid Rich markup, so Rich consumes it and emits nothing - the text silently loses
+    # characters that were genuinely on the terminal.
+    text = "the literal token [bold] was on screen"
+    buffer_text(text)
+
+    session_ops.read_session_buffer(None)
+
+    assert capsys.readouterr().out == text + "\n"
+
+
+def test_terminal_content_survives_byte_for_byte(buffer_text, capsys):
+    # The whole contract in one: markup-shaped tokens, a closing-tag shape, a long line, and blank lines
+    # all come back exactly as the terminal held them.
+    text = "\n".join(
+        [
+            "$ ls [/tmp/x]",
+            "[bold]not a style, just text[/bold]",
+            "y" * 200,
+            "",
+            "  indented  and   spaced  ",
+        ]
+    )
+    buffer_text(text)
+
+    session_ops.read_session_buffer(None)
+
+    assert capsys.readouterr().out == text + "\n"
+
+
+def test_the_buffer_shape_from_the_other_path_is_still_read(buffer_text, monkeypatch, capsys):
+    # The verb accepts the text under "text" or "buffer" depending on the path it came back through.
+    # Keep that working - this fix is about HOW the text is printed, not which shape carries it.
+    monkeypatch.setenv("CC_SESSION_ID", SESSION_ID)
+    monkeypatch.setattr(session_ops.director, "get_json", lambda path: {"buffer": "from the other shape"})
+
+    session_ops.read_session_buffer(None)
+
+    assert capsys.readouterr().out == "from the other shape\n"


### PR DESCRIPTION
Item 3 of 4 in the Pre-Release Must-Fix mission (`docs/architecture/pre-release-must-fix-mission-brief.md`). Release blocker: a crashing fleet verb.

## What was wrong

`cc-devthrottle session buffer` printed another session's **raw terminal text** through Rich, with markup and wrapping enabled. Terminal text is arbitrary — nobody controls its shape — so interpreting it on the way out was never going to hold. Two failures, both reproduced:

1. **It crashed.** A token shaped like a closing tag raised `rich.errors.MarkupError` as an uncaught traceback:
   ```
   rich.errors.MarkupError: closing tag '[/tmp/x]' at position 5 doesn't match any open tag
   ```
   `[/tmp/x]` is not an exotic input — it is what an `ls` of a temp path looks like. `[/INST]` does it too.

2. **It rewrapped and ate text.** With stdout not a terminal — **exactly how an agent or a pipe calls it** — Rich fell back to 80 columns and rewrapped every line, and silently consumed style-shaped tokens like `[bold]`. A line broken where the terminal never broke it is a lie about what the session is doing, and an agent reading the fleet is this verb's main caller.

## The fix

Plain `print()`. This is not a new idea — `list_sessions` in the same file already does exactly this for its JSON output, a hundred lines up, with a comment giving this same reason:

> `Plain print, not console.print: Rich wraps to 80 columns when stdout is not a TTY and injects newlines into long values, producing invalid JSON for agents/pipes.`

The error paths keep `console.print` — those strings are ours and their markup is intended.

## The tests, and how they were proven

Five tests, with stdout captured as a pipe (the non-TTY path both failures live on). Four were **watched failing before the fix existed**:

| Test | Before fix |
|---|---|
| `test_a_bracketed_path_does_not_crash_the_verb` | **FAIL** — `MarkupError` traceback |
| `test_a_long_line_is_not_rewrapped` (200 chars) | **FAIL** — rewrapped at 80 |
| `test_a_style_shaped_token_is_not_eaten` (`[bold]`) | **FAIL** — token eaten |
| `test_terminal_content_survives_byte_for_byte` | **FAIL** |

The fifth is the control — the verb reads the text under either `text` or `buffer` depending on the path it came back through, and it passed throughout. This fix is about *how* the text is printed, not which shape carries it.

## Verification

`tools/cc-devthrottle`: 71 tests pass, no regressions.

## One note on the brief

The brief says to leave `--json` output untouched. The `buffer` verb has no `--json` option of its own — that note refers to `list_sessions`' JSON output, which this pull request does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: the error branch had the same defect (Codex inspection)

The independent Codex inspection confirmed the payload fix and found that **the branch that reports a failure had the same defect as the branch it reports on**.

`console.print(f"[red]Error:[/red] {err}")` interpolates the Director's error text straight into Rich markup — and that text is the server's, not ours. It can quote a path or a fragment of the session's own output. A closing-tag-shaped token in it raises the exact `MarkupError` this pull request exists to kill, from the one place whose whole job is to explain what went wrong.

Now escaped, so the error text is reported literally; the `Error:` label is ours and keeps its markup. `test_the_error_branch_does_not_crash_on_the_servers_error_text` was watched failing with the `MarkupError`, in its final form.

## Correction: "byte for byte" was an overclaim

Codex was right to call this out, and the code comment now says what is actually true. The honest promise is that the text is **not interpreted** — not parsed as markup, not rewrapped, not truncated, nothing added or removed in the middle. It is *not* byte-for-byte:

- `print` appends a trailing newline;
- the text layer translates newlines on the way out;
- this module reconfigures stdout with `errors="replace"`, so a character the console encoding cannot represent still becomes a replacement character.

Those three are named in the comment as the whole of the difference. A comment that overclaims is worse than no comment — the next reader spends their scepticism somewhere else. The test name changed from `..._byte_for_byte` to `..._uninterpreted` to match.

## Known, deliberately not fixed here

The same raw-interpolation pattern exists in other verbs in this file (`_get_sessions`, `hold_session`, and others). They are not this mission's four defects, so they are reported to the Architect rather than folded into this pull request.

`tools/cc-devthrottle`: 72 tests pass.
