### PR TITLE
fix(mobile): stop the roster promising voice it cannot deliver, and take Car Mode off the session list

### DIFF
--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -109,7 +109,14 @@ export function Home() {
   // isVoiceReady IS "voiceRowState === ready", so the tab and the triangle can never disagree about
   // what "ready with voice" means. In waiting order, longest-waiting first, so it can be worked top to
   // bottom by ear.
-  const voiceReady = filtered ? inWaitingOrder(filtered.filter((s) => isVoiceReady(rowVoiceInputs(s, isWorking(s))))) : [];
+  //
+  // The reachability mark is fed in for the same reason the row feeds it: a retained session from an
+  // unreachable machine keeps its last-known voiceAudioReady and its already-downloaded clip, so it
+  // would otherwise sit in this tab claiming it can speak. This tab is the hands-free lens - the one
+  // place a false "ready" is read out loud rather than looked at - so it must not list a dead machine.
+  const voiceReady = filtered
+    ? inWaitingOrder(filtered.filter((s) => isVoiceReady(rowVoiceInputs(s, isWorking(s), !marks.has(s.sessionId ?? "")))))
+    : [];
   // The "Needs you" group is a waiting line: the session that has been waiting for you the longest
   // sits at the top, and a session that only just started needing you drops in at the bottom
   // (inWaitingOrder). This keeps the list from reshuffling under you as sessions change state, and
@@ -201,12 +208,11 @@ export function Home() {
         </Link>
       )}
 
-      {/* Car Mode (Car Mode mission): the hands-free, eyes-free voice channel to the whole fleet. Its
-          own full-screen page; one tap in, then just talk. */}
-      <Link className="car-entry" to="/car">
-        <span className="car-entry-icon" aria-hidden="true">&#9679;</span>
-        Car Mode - drive the fleet by voice
-      </Link>
+      {/* Car Mode's entry point is the nav drawer (top-left), NOT a banner here. It used to be both.
+          The roster is a list of sessions that need you; a permanent full-width call-to-action for a
+          different screen sat above that list drawing attention it had not earned - loudest element on
+          a page it is not about, and shown just as insistently on an empty roster. It is one line in
+          the drawer alongside every other destination, which is what it is. */}
 
       {sessions === null && error === null && <p className="status-line">Loading sessions...</p>}
 
@@ -381,7 +387,11 @@ function SessionRow({ session, mark }: { session: SessionDto; mark?: RosterSessi
               failed - so a dropped transcription is visible from the list, never silent. */}
           <DictationRowBadge sessionId={session.sessionId} />
         </span>
-        <VoiceIndicator session={session} />
+        {/* The voice control reads reachability for the same reason the dot, the attention state and
+            the waiting timer above it do: on a retained card from an unreachable machine every one of
+            those facts is last-known, and voice is no exception - it kept its clip and its
+            last-known voiceAudioReady, so it was the one element still promising something live. */}
+        <VoiceIndicator session={session} reachable={!unreachable} />
       </Link>
     </li>
   );
@@ -400,10 +410,10 @@ function SessionRow({ session, mark }: { session: SessionDto; mark?: RosterSessi
 // Tapping the triangle plays the locally-stored clip with no download wait; preventDefault and
 // stopPropagation keep the tap from also following the row's link. If this session's clip is playing
 // when the agent resumes, it is stopped - a stale clip must not keep talking.
-function VoiceIndicator({ session }: { session: SessionDto }) {
+function VoiceIndicator({ session, reachable }: { session: SessionDto; reachable: boolean }) {
   const sid = session.sessionId ?? "";
   const working = isWorking(session);
-  const state = voiceRowState(rowVoiceInputs(session, working));
+  const state = voiceRowState(rowVoiceInputs(session, working, reachable));
 
   useEffect(() => {
     if (working && playingSid() === sid) stopPlayback();

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -2896,25 +2896,9 @@ a.banner-btn {
 }
 
 /* ===== Car Mode (Car Mode mission) ============================================================ */
-/* The roster entry point to Car Mode - a big, unmistakable tap target above the session groups. */
-.car-entry {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin: 0 0 14px;
-  padding: 14px 16px;
-  border-radius: 12px;
-  border: 1px solid var(--accent);
-  background: linear-gradient(180deg, var(--surface-2), var(--surface));
-  color: var(--text);
-  font-size: 16px;
-  font-weight: 600;
-  text-decoration: none;
-}
-.car-entry-icon {
-  color: var(--accent);
-  font-size: 14px;
-}
+/* Car Mode is reached from the nav drawer. The roster used to ALSO carry a bordered, accent-tinted
+   full-width banner above the session groups (.car-entry) - deleted, along with these rules, because
+   it was the loudest thing on a page that is not about it. */
 
 /* The full-screen Car Mode page. Chrome-less, high-contrast, thumb-reachable controls at the bottom. It
    fills exactly one viewport and never page-scrolls: the header and the control footer are pinned, and only

--- a/packages/client-core/src/voice/clips.ts
+++ b/packages/client-core/src/voice/clips.ts
@@ -68,13 +68,38 @@ export function isPhoneReady(sid: string, generatedAt: string): boolean {
  * The current turn's stamp comes from the voice metadata syncVoiceSessions caches on every poll. A
  * session with no cached metadata has never had a narration this phone knows of, so it holds nothing
  * current by definition.
+ *
+ * `reachable` must be false for a row the roster RETAINED from an unreachable Director (the caller
+ * knows this: it is exactly "this session has a RosterSessionMark"). It cannot be derived here -
+ * a retained SessionDto looks perfectly healthy, because it IS the last healthy one - which is why
+ * the roster kept drawing triangles on dead machines. It is a required parameter rather than an
+ * optional one so a new caller has to answer the question instead of defaulting to the bug.
  */
-export function rowVoiceInputs(session: SessionDto, agentWorking: boolean): VoiceRowInputs {
+export function rowVoiceInputs(session: SessionDto, agentWorking: boolean, reachable: boolean): VoiceRowInputs {
   const sid = session.sessionId ?? "";
+  // An id-less session is not addressable: it cannot be fetched, downloaded for, or navigated to. Every
+  // per-session lookup below keys off the id, and "" is a REAL key in those stores - so without this it
+  // would read whatever happens to sit under "", i.e. another session's narration, and could describe a
+  // row using text that is not its own. Nothing can be true about this row's voice; say exactly that.
+  // Found in review.
+  if (sid.length === 0) {
+    return {
+      voiceMode: Boolean(session.voiceMode),
+      reachable,
+      agentWorking,
+      voiceUnavailable: session.voiceUnavailable != null,
+      gatewayGenerating: false,
+      gatewayHasAudio: false,
+      clipDownloading: false,
+      phoneReadyForCurrentTurn: false,
+      hasSpokenText: false,
+    };
+  }
   const meta = getVoiceMeta(sid);
   const currentGeneratedAt = meta?.ready ? (meta.generatedAt ?? "") : "";
   return {
     voiceMode: Boolean(session.voiceMode),
+    reachable,
     agentWorking,
     voiceUnavailable: session.voiceUnavailable != null,
     gatewayGenerating: Boolean(session.voiceGenerating),

--- a/packages/client-core/src/voice/rowVoiceInputs.test.ts
+++ b/packages/client-core/src/voice/rowVoiceInputs.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { rowVoiceInputs, saveVoiceMeta } from "./clips";
+import { voiceRowState } from "./voiceRowState";
+import { type SessionDto } from "../api/client";
+
+// The ADAPTER's tests. voiceRowState.ts is a pure rule with a thorough suite, but a pure rule is only
+// as honest as the thing that feeds it, and until now nothing fed-side was pinned at all: every test
+// in voiceRowState.test.ts hands the rule a hand-written VoiceRowInputs, so all of them would keep
+// passing if rowVoiceInputs mapped the session wrong. That is the gap this file closes. Found in
+// review (Claude and Codex independently, 2026-07-15).
+//
+// It matters here more than it usually would, because the bug this whole module exists to fix was
+// never in the rule - the old roster had no rule, it had `if (clip.phase === "ready")` inline. The
+// bug was, and still is, entirely in what the roster BELIEVES about a session. So this is the layer
+// where it can come back.
+//
+// The clip store's in-memory map has no test seam (it is written only by ensureClip, which downloads),
+// so these tests do not drive phoneReadyForCurrentTurn true. They cover what they can reach: the
+// session->inputs mapping, the metadata cache, and the reachability gate - and the reachability gate
+// short-circuits before phone-readiness is consulted, so the headline case below is fully exercised.
+
+/** A session that looks, in every field the roster reads, exactly like a healthy voice session. */
+function healthySession(overrides: Partial<SessionDto> = {}): SessionDto {
+  return {
+    sessionId: "sid-1",
+    voiceMode: true,
+    voiceGenerating: false,
+    voiceAudioReady: true,
+    voiceUnavailable: null,
+    ...overrides,
+  } as unknown as SessionDto;
+}
+
+let store: Map<string, string>;
+
+beforeEach(() => {
+  // node is vitest's default environment here (there is no vitest config), so localStorage does not
+  // exist and getVoiceMeta would take its capability-detection path and return null for everything -
+  // which would make these tests pass for the wrong reason. Stub a real one.
+  store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("rowVoiceInputs", () => {
+  // THE HEADLINE CASE, and the reason `reachable` was added. This is the retained-unreachable session
+  // in full: the keep-and-mark merge hands the roster the last-known DTO of a machine that has gone
+  // offline, and that DTO is healthy in every field, because it IS the last healthy one. The phone
+  // still holds the clip and the cached narration from before the outage. Nothing in the session can
+  // reveal the problem - only the caller knows the row was retained.
+  //
+  // Composed through voiceRowState, because the bug was only ever visible in the composition: the
+  // adapter reporting reachable:false is worthless if the rule then ignores it.
+  it("reports a retained unreachable session as not reachable, and the row falls silent", () => {
+    saveVoiceMeta("sid-1", { ready: true, spoken: "the agent is waiting for you", reply: "", generatedAt: "T1" });
+    const session = healthySession();
+
+    expect(rowVoiceInputs(session, false, true).reachable).toBe(true);
+    expect(rowVoiceInputs(session, false, false).reachable).toBe(false);
+    // The same session, the same cached narration, the same clip - only reachability differs.
+    expect(voiceRowState(rowVoiceInputs(session, false, false))).toBe("none");
+  });
+
+  // The classic adapter bug spot: voiceUnavailable is an OBJECT on the wire (the shared hosted-AI
+  // reason), not a boolean, and the rule takes a boolean. `!= null` is doing the work, and it has to
+  // treat a present-but-falsy-looking reason as unavailable.
+  it("maps a present voiceUnavailable reason to true, and its absence to false", () => {
+    expect(rowVoiceInputs(healthySession({ voiceUnavailable: null }), false, true).voiceUnavailable).toBe(false);
+    expect(
+      rowVoiceInputs(healthySession({ voiceUnavailable: undefined } as Partial<SessionDto>), false, true)
+        .voiceUnavailable,
+    ).toBe(false);
+    expect(
+      rowVoiceInputs(
+        healthySession({ voiceUnavailable: { state: "OutOfCredits", message: "" } } as unknown as Partial<SessionDto>),
+        false,
+        true,
+      ).voiceUnavailable,
+    ).toBe(true);
+  });
+
+  // hasSpokenText comes from the CACHED metadata, not the session - the session never carries the
+  // narration text. A wordless narration must not earn a triangle (the Voice screen refuses to speak
+  // one), so this mapping is load-bearing.
+  it("reads spoken text from the cached metadata, and reports none when there is no cache", () => {
+    expect(rowVoiceInputs(healthySession(), false, true).hasSpokenText).toBe(false);
+
+    saveVoiceMeta("sid-1", { ready: true, spoken: "", reply: "", generatedAt: "T1" });
+    expect(rowVoiceInputs(healthySession(), false, true).hasSpokenText).toBe(false);
+
+    saveVoiceMeta("sid-1", { ready: true, spoken: "some words", reply: "", generatedAt: "T1" });
+    expect(rowVoiceInputs(healthySession(), false, true).hasSpokenText).toBe(true);
+  });
+
+  // A session with no cached metadata has never had a narration this phone knows of, so it cannot be
+  // holding the current turn's bytes - whatever the clip store happens to contain.
+  it("cannot be phone-ready for the current turn with no cached metadata", () => {
+    expect(rowVoiceInputs(healthySession(), false, true).phoneReadyForCurrentTurn).toBe(false);
+  });
+
+  // meta.ready false means the cached stamp does not describe a playable narration, so it must not be
+  // used as "the current turn" to compare a held clip against.
+  it("cannot be phone-ready when the cached metadata is not ready", () => {
+    saveVoiceMeta("sid-1", { ready: false, spoken: "", reply: "", generatedAt: "T1" });
+    expect(rowVoiceInputs(healthySession(), false, true).phoneReadyForCurrentTurn).toBe(false);
+  });
+
+  // The straight passthroughs. Cheap to assert, and they are how the rule learns anything at all -
+  // a Boolean() coercion dropped here would silently disarm a guard the rule's own tests still prove.
+  it("passes the Gateway's voice booleans through to the rule", () => {
+    const i = rowVoiceInputs(healthySession({ voiceGenerating: true, voiceAudioReady: true }), true, true);
+    expect(i.voiceMode).toBe(true);
+    expect(i.gatewayGenerating).toBe(true);
+    expect(i.gatewayHasAudio).toBe(true);
+    expect(i.agentWorking).toBe(true);
+
+    const off = rowVoiceInputs(healthySession({ voiceMode: false, voiceGenerating: false, voiceAudioReady: false }), false, true);
+    expect(off.voiceMode).toBe(false);
+    expect(off.gatewayGenerating).toBe(false);
+    expect(off.gatewayHasAudio).toBe(false);
+    expect(off.agentWorking).toBe(false);
+  });
+
+  // An id-less session must not describe itself using whatever sits under the "" key. Every lookup in
+  // the adapter is keyed by session id, and "" is a perfectly valid key in localStorage and in the clip
+  // map - so before the guard, this row would have reported another entry's narration as its own.
+  //
+  // Written first as "documents today's behavior" with the wrong assertion baked in; Codex called that
+  // out in review - a test that enshrines a wart is not a reassurance, it just makes the wart harder to
+  // remove. The behavior was fixed instead, and this now pins the fix.
+  it("does not read cached metadata for a session with no id", () => {
+    saveVoiceMeta("", { ready: true, spoken: "someone else's words", reply: "", generatedAt: "T1" });
+    const i = rowVoiceInputs(healthySession({ sessionId: undefined } as Partial<SessionDto>), false, true);
+    expect(i.hasSpokenText).toBe(false);
+    expect(i.gatewayHasAudio).toBe(false);
+    expect(i.phoneReadyForCurrentTurn).toBe(false);
+    expect(voiceRowState(i)).toBe("none");
+  });
+});

--- a/packages/client-core/src/voice/voiceRowState.test.ts
+++ b/packages/client-core/src/voice/voiceRowState.test.ts
@@ -15,6 +15,7 @@ import { isVoiceReady, voiceRowState, type VoiceRowInputs } from "./voiceRowStat
 /** The honest ready state: this turn's audio is on the phone, it has words, and nothing objects. */
 const READY_FOR_THIS_TURN: VoiceRowInputs = {
   voiceMode: true,
+  reachable: true,
   agentWorking: false,
   voiceUnavailable: false,
   gatewayGenerating: false,
@@ -79,16 +80,48 @@ describe("voiceRowState", () => {
   // The Voice screen is safe from this because it fetches the current stamp live; the roster cannot,
   // so voiceAudioReady is its only live evidence that a current narration exists at all. This is the
   // one place the roster deliberately DIVERGES from voiceAvailability.ts's advice - see the header.
+  // Asserted as an EXACT state, not `not.toBe("ready")`. A negative assertion here passes for "down"
+  // and "none" too, so it would keep passing through a rewrite that silently changed what the reader
+  // sees - it only pins that the bug is absent, not that the replacement is right. Found in review.
   it("does not offer a triangle once the Gateway stops advertising audio, however ready the phone looks", () => {
-    expect(voiceRowState({ ...READY_FOR_THIS_TURN, gatewayHasAudio: false })).not.toBe("ready");
+    expect(voiceRowState({ ...READY_FOR_THIS_TURN, gatewayHasAudio: false })).toBe("none");
   });
 
   // FOUND IN REVIEW. ready and spoken are independent fields on the WingmanVoice contract, so a
   // ready-but-wordless narration is representable - and the Voice screen refuses to speak one
   // (speaking requires voice.spoken.length > 0). A triangle here would point at exactly the state the
   // screen declines to play, which is this bug wearing a different hat.
+  // Exact state, for the reason given above: this lands on "preparing" (the Gateway holds audio, this
+  // phone just has nothing playable to offer from it), and that is worth pinning rather than merely
+  // asserting the triangle is gone.
   it("does not offer a triangle for a narration with no spoken words", () => {
-    expect(voiceRowState({ ...READY_FOR_THIS_TURN, hasSpokenText: false })).not.toBe("ready");
+    expect(voiceRowState({ ...READY_FOR_THIS_TURN, hasSpokenText: false })).toBe("preparing");
+  });
+
+  // FOUND IN REVIEW (Claude and Codex, independently). The unbounded stale triangle, and the reason
+  // `reachable` exists. The keep-and-mark merge RETAINS a session whose Director went offline, holding
+  // its last-known DTO - which says voiceAudioReady: true - and the phone still holds that turn's clip.
+  // syncVoiceSessions cannot refresh the cached stamp (getWingmanVoice cannot reach a dead machine,
+  // and the failure is swallowed), so the stamp and the clip stay stale TOGETHER and agree with each
+  // other perfectly. Every input below is therefore exactly what the honest ready state looks like -
+  // that is the whole point: last-known health is indistinguishable from health. Without this gate the
+  // row shows a green triangle for as long as the machine stays down, and the Voice tab reads it out.
+  it("shows nothing on a retained session whose machine is unreachable, however ready its last-known state looks", () => {
+    expect(voiceRowState({ ...READY_FOR_THIS_TURN, reachable: false })).toBe("none");
+  });
+
+  // Unreachable beats every arrival signal too. A spinner would promise an arrival that cannot come:
+  // nothing is being downloaded from a machine that is not answering.
+  it("stays quiet on an unreachable session even with audio and a download apparently in flight", () => {
+    expect(
+      voiceRowState({
+        ...READY_FOR_THIS_TURN,
+        reachable: false,
+        gatewayGenerating: true,
+        clipDownloading: true,
+        phoneReadyForCurrentTurn: false,
+      }),
+    ).toBe("none");
   });
 
   it("shows preparing while the Gateway holds audio this phone has not pulled down yet", () => {
@@ -150,5 +183,6 @@ describe("isVoiceReady", () => {
     expect(isVoiceReady({ ...READY_FOR_THIS_TURN, phoneReadyForCurrentTurn: false })).toBe(false);
     expect(isVoiceReady({ ...READY_FOR_THIS_TURN, gatewayHasAudio: false })).toBe(false);
     expect(isVoiceReady({ ...READY_FOR_THIS_TURN, hasSpokenText: false })).toBe(false);
+    expect(isVoiceReady({ ...READY_FOR_THIS_TURN, reachable: false })).toBe(false);
   });
 });

--- a/packages/client-core/src/voice/voiceRowState.ts
+++ b/packages/client-core/src/voice/voiceRowState.ts
@@ -57,12 +57,25 @@
 //
 // RESIDUAL, known and accepted: between the poll that first sees voiceAudioReady for a NEW turn and the
 // getWingmanVoice that refreshes the cached stamp (one Gateway round trip later), the roster still
-// holds last turn's stamp and last turn's ready clip, which match - so a stale triangle can flash for
-// well under a second. It closes itself: ensureClip immediately re-stamps the clip store to the new
-// turn as "downloading", which flips the row to the spinner. Tapping inside that window lands on the
-// working card (the screen's own live fetch sees the mismatch), never the "Voice service down" screen
-// this fix is about. Closing it completely needs a per-turn narration id on SessionDto, which is not
-// worth a new contract field for a sub-second flash with a benign landing.
+// holds last turn's stamp and last turn's ready clip, which match - so a stale triangle can flash.
+// It normally closes itself within one Gateway round trip: syncVoiceSessions re-stamps the cached
+// metadata to the new turn, phoneReadyForCurrentTurn goes false against it, and the row flips to the
+// spinner. Tapping inside that window lands on the working card (the screen's own live fetch sees the
+// mismatch), never the "Voice service down" screen this fix is about.
+//
+// That window is NOT bounded, and an earlier version of this comment claimed it was ("well under a
+// second"). Two independent reviews (Claude and Codex, 2026-07-15) landed on the same correction:
+// syncVoiceSessions is fire-and-forget and SWALLOWS a failed getWingmanVoice, so the re-stamp that
+// closes the window is not guaranteed to happen at all. While the fetch keeps failing, the cached
+// stamp and the clip stay stale TOGETHER and agree with each other perfectly - which is the exact
+// shape of the original bug. Closing it properly needs a per-turn narration stamp on SessionDto
+// (the Gateway already holds it as WingmanVoiceService.VoiceReady.AtUtc, right next to the HasVoice
+// it already stamps), so the roster can compare against a LIVE turn id instead of a cached one.
+// That is a Gateway contract change and is tracked separately.
+//
+// The unbounded case that DOES have a local answer is an unreachable machine, and `reachable` below
+// closes it: no polling means no re-stamp, ever, so a retained row would hold a green triangle for
+// as long as the machine stays down.
 
 /** The clip download phases, mirrored from clips.ts (kept structural so this module imports nothing). */
 export type VoiceClipPhase = "none" | "downloading" | "ready" | "error";
@@ -70,6 +83,20 @@ export type VoiceClipPhase = "none" | "downloading" | "ready" | "error";
 export interface VoiceRowInputs {
   /** This session is in voice mode (SessionDto.voiceMode). */
   voiceMode: boolean;
+  /**
+   * This session's owning machine is answering. False for a row the keep-and-mark merge RETAINED
+   * because its Director went wobbly/offline (rosterRetention.ts): the card stays on the roster,
+   * grayed and marked, holding its last-known SessionDto.
+   *
+   * That retained DTO carries last-known voiceAudioReady=true, and syncVoiceSessions cannot refresh
+   * the cached stamp for it (getWingmanVoice fails against a machine that is not answering, and the
+   * failure is swallowed). So the stamp and the clip go stale together and agree - the roster's own
+   * "is this the current turn?" test passes while describing a turn from before the outage, and the
+   * triangle sits there for as long as the machine is down. Every other stale-suppressing element on
+   * the row already reads this fact (SessionRow suppresses the attention state and the waiting timer
+   * on an unreachable card); the voice control was the one that did not. Found in review.
+   */
+  reachable: boolean;
   /** The agent has resumed (blue): the finished-turn narration is stale and is not offered. */
   agentWorking: boolean;
   /**
@@ -110,6 +137,14 @@ export type VoiceRowState = "none" | "down" | "preparing" | "ready";
 export function voiceRowState(i: VoiceRowInputs): VoiceRowState {
   // Not a voice session: the roster says nothing about voice.
   if (!i.voiceMode) return "none";
+
+  // The owning machine is not answering, so nothing on this row is live: the DTO is last-known, and
+  // the cached stamp this function would compare the clip against cannot be refreshed while the
+  // machine is down. There is no evidence here that any narration is current, and no round trip
+  // coming to supply some. Silence, not "down": the card is already grayed and already says
+  // "Unreachable - <machine>", so a voice-down pill would restate it and imply a voice-specific
+  // outage that is not what happened. Same reasoning as the agentWorking gate below.
+  if (!i.reachable) return "none";
 
   // The agent has resumed, so the finished-turn narration is stale. This is checked BEFORE
   // voiceUnavailable: a working session's row already says "working", and stacking a voice-down pill


### PR DESCRIPTION
Two independent reviews of #1656 (Claude and Codex, run separately and converging on the same findings).

## 1. A dead machine kept its green play triangle, forever

The session list deliberately KEEPS a session when its Director goes offline - grayed, marked "Unreachable". That retained session carries its **last-known** data, which says `voiceAudioReady: true`, and the phone still holds the old clip. `syncVoiceSessions` cannot refresh the stamp against a machine that is not answering, and it **swallows** the failure - so the cached stamp and the clip go stale **together** and agree with each other perfectly. The row's own "is this the current turn?" test passes while describing a turn from before the outage.

Every other stale-suppressing element on that row already read reachability: the dot, the attention state, the waiting timer. The voice control was the only one still promising something live - so it sat green for as long as the machine stayed down, and the Voice tab (the hands-free lens) read it out loud.

`voiceRowState` now takes `reachable` and falls silent without it. Silence, not `"down"`: the card already says "Unreachable - \<machine\>".

## 2. An id-less row could describe itself with another session's narration

Every lookup in `rowVoiceInputs` keys off the session id, and `""` is a real key in localStorage and in the clip map. Found when Codex pointed out that my test for it *documented* the behavior instead of pinning it.

## 3. Car Mode had two entrances; the loud one is gone

Car Mode was already in the menu. The session list **also** carried a full-width accent-bordered banner above the sessions - the loudest element on a page that is not about it, shown just as insistently on an empty list. Deleted with its CSS; the menu entry is untouched and now the only way in.

## Known-and-left: the residual is unbounded

The header comment claimed the stale-triangle window was "well under a second". Both reviews independently concluded it is **unbounded** - the round trip that closes it is fire-and-forget and its failure is swallowed. Closing it properly needs a per-turn stamp on `SessionDto`; the Gateway already holds the value (`WingmanVoiceService.VoiceReady.AtUtc`) right beside the flag it already sends. That is a contract change, left as separate work. The comment now says so rather than offering a false reassurance.

## Proof

`rowVoiceInputs` had **no tests** - every existing test handed the pure rule a hand-written input, so all of them would have passed had the adapter mapped the session wrong. That is the layer this bug lives in.

Both fixes red-watched: with the guards removed the new tests fail with the reported symptom (`expected 'ready' to be 'none'` - the green triangle on a dead machine); controls stay green.

- 499 client-core + 133 cockpit tests green
- typecheck clean across all three workspaces
- mobile builds
- Car Mode verified reachable from the menu in a real browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)