### PR TITLE
fix(dictation): never let our own failed attempt look like a moved-on session (#1593)

### DIFF
--- a/docs/architecture/lost-dictations-mission-brief.md
+++ b/docs/architecture/lost-dictations-mission-brief.md
@@ -1,0 +1,126 @@
+# Mission: Lost Dictations
+
+**Status: ACTIVE** (opened 2026-07-15)
+**Mission id:** `00d27b9e-7fc4-43b6-a297-f86d1a33dc4e`
+**Mission worktree:** `D:\ReposFred\devthrottle-lost-dictations`
+**Mission branch:** `mission/lost-dictations` (cut from origin/main at `dd34a6a9`)
+**Issues:** #1593 (the drop), #1590 (the silence). #1595 is related and OUT of scope.
+**Conduct:** this brief describes the WORK only. How a mission is run - roles, authority, landing,
+inspection, the report - lives in `.claude/skills/mission/SKILL.md` and is not restated here.
+
+---
+
+## THE WHY
+
+On 2026-07-15 the owner spoke into his phone twice, and both times DevThrottle threw his words away
+and told him nothing. The Director log recorded the whole thing (session `59d2e552` at 05:31,
+`fe2ec700` at 05:34): the first delivery attempt failed to submit (the composer never echoed), the
+failed attempt itself wrote ~8,700 bytes of its own typing-and-clearing noise into the terminal, the
+phone retried, and the Gateway's moved-on guard read OUR OWN noise as "other turns happened" and
+discarded the recording as stale. The phone then deleted the audio and cleared the status strip -
+"it worked and then nothing happened."
+
+Voice is the flagship phone flow. A product whose defining feature silently eats the user's words is
+broken in the one place it most claims to work. When this mission is finished: a dictation whose
+delivery attempt fails is retried against an honest baseline and DELIVERED; and on the rare genuine
+drop, the phone says so, keeps what it heard, and offers the words back - nothing vanishes silently.
+
+## The mechanics, verified against the code at `dd34a6a9`
+
+1. `POST .../dictation/complete` transcribes, then delivers via
+   `route.PostPromptAsync` (`src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs:444`). A failed
+   submit returns 502 (`:445-446`) - RETRYABLE from the phone's point of view, and the phone
+   correctly holds the clip and retries.
+2. The moved-on guard (`:417-430`) drops a RESUMED clip when `session.TotalBufferBytes >
+   req.BaselineBufferBytes + 512`. The baseline is stamped by the phone when the clip was RECORDED
+   (`packages/client-core/src/dictation/backgroundSend.ts:114`) and never moves. The failed attempt
+   in step 1 typed the text twice and cleared it twice - thousands of bytes of growth the guard
+   cannot tell apart from real turns. So the retry of a failed delivery is judged against a baseline
+   the failure itself invalidated, and is dropped.
+3. The drop writes a durable DELIVERED tombstone with `movedOn = true` (`:426`) - by design
+   (#1183), a re-complete of the same upload id returns the same moved-on outcome forever.
+4. On the phone, `driveRecord` treats any terminal outcome with `submitted = false` as "nothing to
+   acknowledge on screen": `deletePending` + `clearDictationStatus`
+   (`packages/client-core/src/dictation/backgroundSend.ts:277-291`). Audio deleted, no banner, no
+   trace. The user is never told.
+
+## The work, in landing order (one pull request per item)
+
+### 1. The moved-on guard must never count our own failed attempt (#1593)
+
+- **The fix (server-side):** when a delivery attempt fails (`PostPromptAsync` returns not-ok at
+  `GatewayDictationEndpoint.cs:445`), RE-BASELINE that upload id before returning the 502: persist,
+  on the durable upload record, the freshest session buffer position available after the failure.
+  The moved-on guard then judges a retry against the LARGER of the request's baseline and the stored
+  re-baseline. The phone keeps sending its original baseline and needs no change for this item.
+- **Accepted consequence (ruled):** if the session genuinely moved on during the seconds of our own
+  failed attempt, the retry will now inject rather than drop. In that window the user's words win.
+  That is the correct side to err on.
+- **Implementation care:** the session snapshot held at `:409` predates the attempt, so its
+  `TotalBufferBytes` does NOT include the attempt's noise - re-read the freshest pushed value after
+  the failure rather than reusing the stale snapshot. If the push stream lags and the fresh read
+  still misses some noise, the re-baseline is still strictly better than today; say so in a comment
+  rather than pretending the window is zero.
+- **The proof that must exist:** an end-to-end test driving the REAL dictation complete endpoint
+  over loopback HTTP with a scripted Director whose prompt verb FAILS the first time (growing the
+  reported buffer, as the real failure does) and succeeds the second: the retried clip must be
+  DELIVERED, not dropped. Watched failing against the un-re-baselined guard. A control pins the
+  guard still dropping when the growth happened BEFORE any delivery attempt (a genuine move-on).
+
+### 2. A dropped dictation must be loud and give the words back (#1590)
+
+- **The fix (client-side, `packages/client-core` + `apps/mobile`):** in `driveRecord`, a terminal
+  outcome with `submitted = false` must never silently `clearDictationStatus` - except for
+  abandonment, which the user did on purpose (ruled out of scope by the issue itself). Split the arm:
+  - **Moved-on / dropped:** the outcome already carries the TRANSCRIPT
+    (`GatewayDictationEndpoint.cs:429` returns it). Keep the record visible in a parked-style sticky
+    state that names what happened in plain words, and offer the transcribed text back with a
+    "Send anyway" action that sends it as a NORMAL prompt to the session (a fresh turn - re-driving
+    the same upload id is useless by design, see mechanics point 3), plus a Dismiss. If the
+    transcript is empty (rare - dropped before transcription), keep the audio parked with an
+    explicit user Retry that re-drives under a FRESH upload id.
+  - **Empty clip** (silence - `submitted = false, movedOn = false` from `:404`): a visible,
+    dismissible notice ("nothing was heard"), no retry (there is nothing to retry), and the
+    on-device copy may be dropped.
+- **The proof that must exist:** client-core tests driving the real `driveRecord` and the real
+  status store through each terminal-not-submitted shape, asserting the status is VISIBLE and
+  carries the transcript/action, watched failing against today's silent-clear. The abandoned path
+  stays silent - pinned by a control. Mobile rules apply: failures are loud and sticky, never a
+  toast that fades.
+
+## Design rulings already made
+
+1. Scope is #1593 + #1593's safety net #1590. #1595 (counting and surfacing delivery failures
+   generally) stays open as its own issue - do not build dashboards here. (Stated by the Architect.)
+2. The #1593 re-baseline lives on the SERVER, on the durable upload record - not in the phone's
+   record - so a phone that missed the 502 response entirely still retries against the honest
+   baseline. (Inferred from the issue's "re-baseline the buffer position for that upload id".)
+3. Recovery for a moved-on drop is TRANSCRIPT-first ("here is what I heard - send it?"), because the
+   transcript already rides the outcome and re-uploading audio against a tombstoned upload id is a
+   dead end by design. (Inferred; the issue's stated bar is only "a visible message on the phone" -
+   if the transcript-first shape balloons, the visible+parked minimum lands first and the Send-anyway
+   action follows in the same pull request series.)
+4. Items land in the order above: item 1 kills the observed drop, item 2 is the safety net for
+   genuine drops. Two pull requests. (Stated by the Architect.)
+5. What cannot be proven in this mission is named in the QA report rather than papered over: no live
+   phone-to-Gateway drive is required to merge, but the endpoint-level end-to-end (real HTTP, real
+   endpoint, scripted Director) is the floor for item 1, and the issues' "driving a real drop" bar is
+   met at that level. (Stated by the Architect.)
+
+## Out of scope - do not do these
+
+- #1595 (surface/count delivery failures generally), #1594 (the submit harness), #1151 (idempotent
+  submit), and anything touching `EchoVerifiedSubmit` itself - the echo failure is the TRIGGER of
+  this defect, not its subject.
+- The desktop dictation path (#1130) and Director-side dictation code.
+- Any Gateway API surface change beyond the upload record and the complete endpoint's failure arm.
+
+## Inspection note (mission-specific fact, not conduct)
+
+The Inspector is Codex, invoked by the Architect per pull request with the diff and touched files
+bundled inline (`codex exec` cannot run shell commands on this machine). Findings go back to the
+builder; the Architect lands.
+
+---
+
+*When this mission ends, this document's status line must be updated to say so, in the past tense.*

--- a/src/CcDirector.Gateway.Tests/Issue1593FailedAttemptRebaselineTests.cs
+++ b/src/CcDirector.Gateway.Tests/Issue1593FailedAttemptRebaselineTests.cs
@@ -1,0 +1,359 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core;
+using CcDirector.Core.Audio;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Storage;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Transcription;
+using CcDirector.Gateway.Voice;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// End-to-end proof for the Lost Dictations mission, issue #1593: a dictation whose delivery attempt FAILS
+/// must be re-baselined so the retry that follows is DELIVERED, not silently eaten by the moved-on guard.
+///
+/// THE DEFECT THIS PINS, as observed on 2026-07-15 (session 59d2e552 at 05:31):
+///   1. The phone stamps a baseline when the clip is RECORDED. It never moves.
+///   2. Delivery is attempted, the composer never echoes, and the attempt fails - but NOT before typing the
+///      text and clearing it twice, writing thousands of bytes of OUR OWN noise into the session buffer.
+///   3. The endpoint returns 502, which is retryable, so the phone correctly retries the same clip.
+///   4. The moved-on guard compares the now-inflated buffer against the phone's original baseline, cannot
+///      tell our own noise from other people's turns, and drops the user's words as stale - forever (the
+///      drop writes a durable movedOn tombstone).
+///
+/// This drives the REAL endpoint over loopback HTTP: a real GatewayHost, the real
+/// POST /dictation/{uploadId}/complete route, the real VoiceUploadStore on disk, the real moved-on guard, and
+/// a REAL tunnel-connected Director (<see cref="FakeTunnelDirector"/>) whose prompt verb FAILS the first time
+/// - growing its reported buffer exactly as the real failure did - and succeeds the second.
+///
+/// TUNNEL-BY-CONSTRUCTION: the Director is registered at a dead endpoint and its session arrives only via
+/// PushSnapshot, so any delivery at all proves the Gateway rode the tunnel.
+///
+/// The one thing NOT real here is the speech-to-text provider: the delivery arm sits behind a successful
+/// transcribe, and the hosted transcription URL is a compile-time constant with no local override, so the
+/// provider is a stub returning fixed text. Everything the defect actually lives in - the guard, the record,
+/// the failure arm, the retry - is the real thing.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class Issue1593FailedAttemptRebaselineTests : IAsyncLifetime
+{
+    private const string Token = "test-token-1593-rebaseline";
+    private const string DirectorId = "dir-1593-rebaseline";
+    private const string Transcript = "the words the user actually said";
+
+    // The clip's record-time baseline, and the growth a FAILED attempt writes into the terminal by typing the
+    // text and clearing it again. The real incident logged ~8,700 bytes of such noise; the exact figure does
+    // not matter, only that it is far past the guard's 512-byte tolerance.
+    private const long RecordTimeBaseline = 1_000;
+    private const long FailedAttemptNoise = 8_700;
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _instancesDir = Path.Combine(Path.GetTempPath(), "cc-1593-inst-" + Guid.NewGuid().ToString("N"));
+    private readonly string _vaultPath = Path.Combine(Path.GetTempPath(), "cc-1593-vault-" + Guid.NewGuid().ToString("N") + ".json");
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private FakeTunnelDirector _director = null!;
+    private readonly string _sessionId = Guid.NewGuid().ToString();
+    private long _pushSequence;
+
+    public Issue1593FailedAttemptRebaselineTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-1593-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        // The key must be present or the complete path bails before it ever transcribes, let alone delivers.
+        new KeyVault(_vaultPath).Set(TranscriptionEndpointResolver.DevThrottleKeyName, "dt_test_key");
+
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            keyVaultPath: _vaultPath,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            streamMode: true,
+            dictationTranscription: StubTranscription());
+        await _gateway.StartAsync();
+
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+
+        _director = await FakeTunnelDirector.StartAsync(_gateway, Token, DirectorId);
+        await PushInitialSessionAsync(RecordTimeBaseline);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _director.DisposeAsync();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* cleanup */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* cleanup */ }
+        try { if (File.Exists(_vaultPath)) File.Delete(_vaultPath); } catch { /* cleanup */ }
+    }
+
+    // ===== the fix =================================================================================
+
+    [Fact]
+    public async Task RetryAfterOurOwnFailedAttempt_IsDelivered_NotDroppedAsMovedOn()
+    {
+        var uploadId = await RegisterAndUploadAsync();
+
+        // Attempt 1: the guard passes (the buffer is still at the record-time baseline), delivery is
+        // attempted, and it FAILS - after growing the buffer with its own typing-and-clearing noise, exactly
+        // as the real echo-verified submit failure did.
+        var prompts = 0;
+        _director.OnCommand(cmd =>
+        {
+            if (cmd.Verb != "prompt") return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
+            if (Interlocked.Increment(ref prompts) == 1)
+            {
+                ReportBuffer(RecordTimeBaseline + FailedAttemptNoise);
+                return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "composer never echoed the text");
+            }
+            return FakeTunnelDirector.Ok(new PromptResponse());
+        });
+
+        var first = await CompleteAsync(uploadId);
+        Assert.Equal(HttpStatusCode.BadGateway, first.status); // 502 - retryable, so the phone retries
+
+        // Attempt 2: the SAME clip, with the SAME record-time baseline the phone has always sent (the phone
+        // needs no change for this fix). Today the guard reads our own 8,700 bytes of noise as "other turns
+        // happened" and drops the words. It must deliver.
+        var second = await CompleteAsync(uploadId);
+
+        Assert.Equal(HttpStatusCode.OK, second.status);
+        Assert.True(second.body.GetProperty("submitted").GetBoolean(),
+            "the retry of a delivery WE failed must inject the user's words, not be dropped as stale");
+        Assert.False(second.body.GetProperty("movedOn").GetBoolean());
+        Assert.Equal(2, prompts); // the retry really did reach the Director's prompt verb
+
+        // The durable record is a DELIVERED tombstone that says submitted - the words landed for good.
+        var record = Store().ReadRecord(uploadId)!;
+        Assert.Equal(DictationDeliveryState.Delivered, record.State);
+        Assert.True(record.Submitted);
+        Assert.False(record.MovedOn);
+    }
+
+    [Fact]
+    public async Task TheReBaselineIsPersistedOnTheServerRecord_SoAPhoneThatMissedThe502StillRetriesHonestly()
+    {
+        // Ruling 2: the re-baseline lives on the SERVER's durable record, not in the phone's request. A phone
+        // whose 502 response never arrived does not know an attempt happened at all - it just re-registers the
+        // upload id and completes again with its original baseline. That path must still be judged honestly.
+        var uploadId = await RegisterAndUploadAsync();
+
+        var prompts = 0;
+        _director.OnCommand(cmd =>
+        {
+            if (cmd.Verb != "prompt") return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
+            if (Interlocked.Increment(ref prompts) == 1)
+            {
+                ReportBuffer(RecordTimeBaseline + FailedAttemptNoise);
+                return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "composer never echoed the text");
+            }
+            return FakeTunnelDirector.Ok(new PromptResponse());
+        });
+
+        Assert.Equal(HttpStatusCode.BadGateway, (await CompleteAsync(uploadId)).status);
+
+        // The honest baseline is on disk, on the server's record, and it accounts for the noise.
+        var afterFailure = Store().ReadRecord(uploadId)!;
+        Assert.Equal(DictationDeliveryState.Pending, afterFailure.State); // still pending - the clip is alive
+        Assert.NotNull(afterFailure.RebaselineBufferBytes);
+        Assert.Equal(RecordTimeBaseline + FailedAttemptNoise, afterFailure.RebaselineBufferBytes!.Value);
+
+        // The phone re-REGISTERS (it never saw the 502) and retries. The re-register must not wipe the value.
+        await RegisterAsync(uploadId);
+        Assert.Equal(RecordTimeBaseline + FailedAttemptNoise, Store().ReadRecord(uploadId)!.RebaselineBufferBytes);
+
+        var retry = await CompleteAsync(uploadId);
+        Assert.Equal(HttpStatusCode.OK, retry.status);
+        Assert.True(retry.body.GetProperty("submitted").GetBoolean());
+    }
+
+    // ===== the control: a GENUINE move-on must still drop ===========================================
+
+    [Fact]
+    public async Task GenuineMoveOn_BeforeAnyDeliveryAttempt_IsStillDropped()
+    {
+        // The control that stops the fix from becoming "never drop anything". Here the buffer grew BEFORE any
+        // delivery attempt of ours - nothing of ours is in that growth, so it is somebody else's turns and the
+        // session really has moved on. No attempt has failed, so there is no re-baseline, and the guard must
+        // drop exactly as it always did.
+        var uploadId = await RegisterAndUploadAsync();
+        ReportBuffer(RecordTimeBaseline + FailedAttemptNoise);
+
+        var prompts = 0;
+        _director.OnCommand(cmd =>
+        {
+            if (cmd.Verb == "prompt") Interlocked.Increment(ref prompts);
+            return FakeTunnelDirector.Ok(new PromptResponse());
+        });
+
+        var result = await CompleteAsync(uploadId);
+
+        Assert.Equal(HttpStatusCode.OK, result.status);
+        Assert.False(result.body.GetProperty("submitted").GetBoolean());
+        Assert.True(result.body.GetProperty("movedOn").GetBoolean(), "a genuine move-on must still drop");
+        Assert.Equal(0, prompts); // it never reached the session at all
+        Assert.Null(Store().ReadRecord(uploadId)!.RebaselineBufferBytes); // nothing of ours ever failed
+    }
+
+    [Fact]
+    public async Task GrowthAfterOurFailedAttempt_BeyondTheReBaseline_IsStillDropped()
+    {
+        // The sharper control: our own failed attempt is forgiven, but growth ON TOP of it is not. The
+        // re-baseline moves the bar to account for OUR noise only - a real turn landing after that is still a
+        // move-on and the clip is still stale.
+        var uploadId = await RegisterAndUploadAsync();
+
+        var prompts = 0;
+        _director.OnCommand(cmd =>
+        {
+            if (cmd.Verb != "prompt") return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
+            if (Interlocked.Increment(ref prompts) == 1)
+            {
+                ReportBuffer(RecordTimeBaseline + FailedAttemptNoise);
+                return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "composer never echoed the text");
+            }
+            return FakeTunnelDirector.Ok(new PromptResponse());
+        });
+
+        Assert.Equal(HttpStatusCode.BadGateway, (await CompleteAsync(uploadId)).status);
+
+        // Somebody else's turn lands after our failure, well past the re-baseline.
+        ReportBuffer(RecordTimeBaseline + FailedAttemptNoise + 50_000);
+
+        var retry = await CompleteAsync(uploadId);
+        Assert.Equal(HttpStatusCode.OK, retry.status);
+        Assert.False(retry.body.GetProperty("submitted").GetBoolean());
+        Assert.True(retry.body.GetProperty("movedOn").GetBoolean(),
+            "growth beyond our own failed attempt is a real move-on and must still drop");
+        Assert.Equal(1, prompts); // the retry never reached the session
+    }
+
+    // ===== helpers =================================================================================
+
+    private static VoiceUploadStore Store() => new(CcStorage.DictationUploads());
+
+    private SessionDto SessionAt(long bufferBytes) => new()
+    {
+        SessionId = _sessionId,
+        Name = "dictation target",
+        Status = "Running",
+        ActivityState = "Idle",
+        TotalBufferBytes = bufferBytes,
+    };
+
+    /// <summary>
+    /// The session's FIRST appearance, pushed through the REAL hub the way a Director reports its state. This
+    /// is what puts the session in the push store at all, so the Gateway can locate it and its owner.
+    /// </summary>
+    private async Task PushInitialSessionAsync(long bufferBytes)
+    {
+        await _director.PushSnapshotAsync(SessionAt(bufferBytes));
+        _pushSequence = 1; // FakeTunnelDirector's first push is sequence 1; later writes must climb from there.
+    }
+
+    /// <summary>
+    /// Report a new buffer position for the session, as a Director's push stream does when its terminal grows.
+    ///
+    /// This writes the push store directly rather than invoking PushSnapshot over the hub, for one reason that
+    /// the tests genuinely need: the interesting growth happens from INSIDE the Director's command handler,
+    /// while the Gateway is still awaiting the prompt result - which is exactly when the real failure writes
+    /// its noise, and what the re-baseline must see when it re-reads. Calling back into the hub from within a
+    /// hub client callback would leave the connection's message loop waiting on itself. The store IS what the
+    /// Gateway re-reads and this lands the same state a real push lands, so the seam under test is untouched;
+    /// only the transport of these later snapshots is short-cut. One sequence counter is shared with the hub
+    /// push above, because the store rejects an out-of-order sequence and would otherwise silently ignore it.
+    /// </summary>
+    private void ReportBuffer(long bufferBytes)
+    {
+        var connectionId = _gateway.PushedSessions.GetActiveConnectionId(DirectorId)!;
+        var applied = _gateway.PushedSessions.ApplyDelta(
+            DirectorId, connectionId, Interlocked.Increment(ref _pushSequence), SessionAt(bufferBytes));
+        Assert.True(applied, "the test's own buffer report must actually land, or it proves nothing");
+    }
+
+    private async Task<string> RegisterAndUploadAsync()
+    {
+        var uploadId = Guid.NewGuid().ToString();
+        await RegisterAsync(uploadId);
+        // A real (if silent) clip: a short PCM WAV, under the split budget, so the pipeline sends it whole.
+        var wav = PcmWav.Wrap(new byte[16_000 * 2], 16_000, 1, 16);
+        using var content = new ByteArrayContent(wav);
+        using var req = new HttpRequestMessage(HttpMethod.Put, $"/dictation/{uploadId}/chunk/0") { Content = content };
+        req.Headers.Add("X-Chunk-Sha256", Sha256Hex(wav));
+        var resp = await _http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        return uploadId;
+    }
+
+    private async Task RegisterAsync(string uploadId)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Post, "/dictation/upload")
+        {
+            Content = JsonContent.Create(new { sessionId = _sessionId, baselineBufferBytes = RecordTimeBaseline }),
+        };
+        req.Headers.Add("Idempotency-Key", uploadId);
+        var resp = await _http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    /// <summary>Complete the clip exactly as the phone does on a resume: resumed, carrying the baseline it
+    /// stamped when the clip was RECORDED - the same number on every retry, because the phone never moves it.</summary>
+    private async Task<(HttpStatusCode status, JsonElement body)> CompleteAsync(string uploadId)
+    {
+        var resp = await _http.PostAsJsonAsync($"/dictation/{uploadId}/complete", new
+        {
+            sessionId = _sessionId,
+            totalChunks = 1,
+            mime = "audio/wav",
+            ext = "wav",
+            baselineBufferBytes = RecordTimeBaseline,
+            resumed = true,
+        });
+        return (resp.StatusCode, await resp.Content.ReadFromJsonAsync<JsonElement>());
+    }
+
+    /// <summary>The real transcription owner over a stub provider socket, with its own telemetry + audio
+    /// archive so it never writes into the real user's directories (the defaults are process-wide Shared
+    /// instances whose paths are baked at type-init).</summary>
+    private GatewayTranscriptionService StubTranscription() => new(
+        new KeyVault(_vaultPath),
+        http: new HttpClient(new TranscriptStub()),
+        telemetry: new TranscriptionTelemetryLog(Path.Combine(_root, "telemetry")),
+        audioArchive: new TranscriptionAudioArchive(Path.Combine(_root, "audio")));
+
+    /// <summary>Stands in for the hosted speech-to-text provider: always returns the same transcript.</summary>
+    private sealed class TranscriptStub : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent($"{{\"text\":\"{Transcript}\"}}", Encoding.UTF8, "application/json"),
+            });
+    }
+
+    private static string Sha256Hex(byte[] bytes)
+        => Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(bytes)).ToLowerInvariant();
+
+    private static int AllocateFreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/VoiceUploadStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceUploadStoreTests.cs
@@ -396,6 +396,88 @@ public sealed class VoiceUploadStoreTests : IDisposable
         Assert.Contains(sidB, locked);
     }
 
+    // ===== the failed-delivery re-baseline (Lost Dictations mission, issue #1593) ==================
+
+    [Fact]
+    public void RecordFailedDeliveryBaseline_IsMonotonic_AndNeverLowersAnHonestBaseline()
+    {
+        var uploadId = _store.Register(null);
+        _store.MarkPending(uploadId, Guid.NewGuid().ToString());
+
+        Assert.True(_store.RecordFailedDeliveryBaseline(uploadId, 9_000));
+        Assert.Equal(9_000, _store.ReadRecord(uploadId)!.RebaselineBufferBytes);
+
+        // A LOWER later read (a lagging push stream) must never walk the honest baseline back down.
+        Assert.False(_store.RecordFailedDeliveryBaseline(uploadId, 4_000));
+        Assert.Equal(9_000, _store.ReadRecord(uploadId)!.RebaselineBufferBytes);
+
+        // A higher one moves it up: a second failed attempt only ever added more of our own noise.
+        Assert.True(_store.RecordFailedDeliveryBaseline(uploadId, 12_000));
+        Assert.Equal(12_000, _store.ReadRecord(uploadId)!.RebaselineBufferBytes);
+    }
+
+    [Fact]
+    public void RecordFailedDeliveryBaseline_UnderConcurrentWriters_KeepsTheLARGESTValue()
+    {
+        // The read-modify-write must be atomic. Unlocked, two writers can both read the old value and the one
+        // that computed the SMALLER max can land last, overwriting the larger - handing a retry a baseline we
+        // had already proven too low, which is exactly the drop the re-baseline exists to stop. Many writers
+        // over a shared value, from SEPARATE store instances over the same root (the gate is on the staging
+        // directory, not the object), with the largest deliberately not last.
+        var uploadId = _store.Register(null);
+        _store.MarkPending(uploadId, Guid.NewGuid().ToString());
+
+        var values = Enumerable.Range(1, 64).Select(i => (long)i * 1_000).ToArray();
+        var shuffled = values.OrderBy(v => (v * 7919) % 101).ToArray();
+        Parallel.ForEach(shuffled, v => new VoiceUploadStore(_root).RecordFailedDeliveryBaseline(uploadId, v));
+
+        Assert.Equal(values.Max(), _store.ReadRecord(uploadId)!.RebaselineBufferBytes);
+    }
+
+    [Fact]
+    public void RecordFailedDeliveryBaseline_IsANoOpForATerminalRecord()
+    {
+        // A resolved upload's guard has already run for the last time; re-baselining it would move a number
+        // nothing will ever read, and must not disturb the tombstone.
+        var delivered = _store.Register(null);
+        _store.MarkPending(delivered, Guid.NewGuid().ToString());
+        _store.MarkDelivered(delivered, submitted: false, movedOn: true, transcript: "dropped words");
+        Assert.False(_store.RecordFailedDeliveryBaseline(delivered, 9_000));
+        Assert.Null(_store.ReadRecord(delivered)!.RebaselineBufferBytes);
+        Assert.Equal(DictationDeliveryState.Delivered, _store.ReadRecord(delivered)!.State);
+
+        var abandoned = _store.Register(null);
+        _store.MarkPending(abandoned, Guid.NewGuid().ToString());
+        _store.MarkAbandoned(abandoned, "cancelled");
+        Assert.False(_store.RecordFailedDeliveryBaseline(abandoned, 9_000));
+        Assert.Null(_store.ReadRecord(abandoned)!.RebaselineBufferBytes);
+
+        // And an id with no record at all is simply not re-baselineable.
+        Assert.False(_store.RecordFailedDeliveryBaseline(Guid.NewGuid().ToString(), 9_000));
+    }
+
+    [Fact]
+    public void NonTerminalTransitions_PreserveTheReBaseline()
+    {
+        // A re-register (the phone never saw our 502) and a transcription failure on a retry both rewrite the
+        // marker. Either dropping the re-baseline would hand the next retry back the very baseline our own
+        // failed attempt invalidated.
+        var sid = Guid.NewGuid().ToString();
+        var uploadId = _store.Register(null);
+        _store.MarkPending(uploadId, sid);
+        _store.RecordFailedDeliveryBaseline(uploadId, 9_000);
+
+        _store.MarkPending(uploadId, sid); // re-register
+        Assert.Equal(9_000, _store.ReadRecord(uploadId)!.RebaselineBufferBytes);
+
+        _store.MarkFailed(uploadId, "transcription_error");
+        Assert.Equal(9_000, _store.ReadRecord(uploadId)!.RebaselineBufferBytes);
+
+        _store.ClearFailed(uploadId);
+        Assert.Equal(9_000, _store.ReadRecord(uploadId)!.RebaselineBufferBytes);
+        Assert.Equal(DictationDeliveryState.Pending, _store.ReadRecord(uploadId)!.State);
+    }
+
     [Fact]
     public void TerminalTransitions_PreserveTheSessionId()
     {

--- a/src/CcDirector.Gateway.Tests/VoiceUploadStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceUploadStoreTests.cs
@@ -435,6 +435,57 @@ public sealed class VoiceUploadStoreTests : IDisposable
     }
 
     [Fact]
+    public void RecordFailedDeliveryBaseline_CannotResurrectATombstoneThatLandsMidWrite()
+    {
+        // THE INTERLEAVING THAT MATTERS (found by inspection of the #1593 fix). Serializing the re-baseline
+        // writers against each other is not enough: the dangerous race is between DIFFERENT writers. A
+        // re-baseline reads a PENDING record, stalls, MarkDelivered lands a terminal tombstone, and the
+        // re-baseline then writes its remembered PENDING record back over it. The upload id is resurrected as
+        // pending, and #1183's durable de-dupe - the only thing standing between a delivered dictation and a
+        // SECOND injection of the same turn - is gone.
+        //
+        // Driven deterministically: the re-baseline is stalled at the exact instant between its read and its
+        // write, and a competing MarkDelivered is fired from another thread right then. With every record write
+        // behind one per-upload gate, that MarkDelivered CANNOT land inside the window - it waits, so the
+        // stall times out and the tombstone lands cleanly afterwards. With the gate removed it lands
+        // immediately, the re-baseline overwrites it, and the record comes back as Pending.
+        var uploadId = _store.Register(null);
+        _store.MarkPending(uploadId, Guid.NewGuid().ToString());
+
+        var tombstoneLanded = new ManualResetEventSlim(false);
+        Task? competing = null;
+        VoiceUploadStore.BetweenRecordReadAndWriteForTests = _ =>
+        {
+            // Fire the competing terminal write from another thread, then give it every chance to land BEFORE
+            // this re-baseline writes. The gate is what must stop it; nothing else here does.
+            competing = Task.Run(() =>
+            {
+                new VoiceUploadStore(_root).MarkDelivered(uploadId, submitted: true, movedOn: false, transcript: "delivered words");
+                tombstoneLanded.Set();
+            });
+            // A bounded wait, NOT a barrier: under the gate this must time out (the tombstone is blocked behind
+            // us, which is the whole point), so waiting forever would hang rather than pass.
+            tombstoneLanded.Wait(TimeSpan.FromSeconds(1));
+        };
+        try
+        {
+            _store.RecordFailedDeliveryBaseline(uploadId, 9_000);
+        }
+        finally
+        {
+            VoiceUploadStore.BetweenRecordReadAndWriteForTests = null;
+        }
+        competing?.Wait(TimeSpan.FromSeconds(5));
+
+        // The delivered tombstone stands. A re-complete of this upload id returns the cached delivered outcome
+        // and never injects a second turn.
+        var record = _store.ReadRecord(uploadId)!;
+        Assert.Equal(DictationDeliveryState.Delivered, record.State);
+        Assert.True(record.Submitted);
+        Assert.Equal("delivered words", record.Transcript);
+    }
+
+    [Fact]
     public void RecordFailedDeliveryBaseline_IsANoOpForATerminalRecord()
     {
         // A resolved upload's guard has already run for the last time; re-baselining it would move a number

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -417,15 +417,25 @@ internal static class GatewayDictationEndpoint
             // Moved-on guard (issue #1006): for a RESUMED clip, if the session's terminal output grew
             // materially since the clip was recorded, other turns happened - drop the stale dictation
             // rather than inject it into a session that has moved on. Immediate sends skip this.
+            //
+            // The baseline is the LARGER of what the phone recorded and what a previous FAILED delivery
+            // attempt of THIS upload id re-baselined to (Lost Dictations mission, issue #1593). The phone's
+            // baseline is stamped once, when the clip was recorded, and never moves - so after one of our own
+            // failed attempts typed the text and cleared it again, the phone's baseline describes a terminal
+            // that no longer exists, and the retry gets dropped as "moved on" by OUR OWN noise. Taking the
+            // larger of the two costs nothing when no attempt failed (the stored value is absent) and is what
+            // stops the observed drop when one did.
+            var effectiveBaseline = Math.Max(
+                req.BaselineBufferBytes, uploads.ReadRecord(uploadId)?.RebaselineBufferBytes ?? 0);
             if (req.Resumed && session is not null && req.BaselineBufferBytes > 0 &&
-                session.TotalBufferBytes > req.BaselineBufferBytes + MovedOnBufferGrowthBytes)
+                session.TotalBufferBytes > effectiveBaseline + MovedOnBufferGrowthBytes)
             {
                 // The turn is resolved (deliberately dropped as stale): a durable DELIVERED tombstone with
                 // movedOn set, so a re-complete returns the same moved-on outcome and never injects the stale
                 // clip (issue #1183). Discards the retained chunks, keeps the marker.
                 uploads.MarkDelivered(uploadId, submitted: false, movedOn: true, transcript);
                 FileLog.Write($"[GatewayDictation] complete sid={sid} uploadId={uploadId}: session moved on " +
-                    $"(buffer {req.BaselineBufferBytes}->{session.TotalBufferBytes}); dropped");
+                    $"(buffer {req.BaselineBufferBytes}/effective {effectiveBaseline}->{session.TotalBufferBytes}); dropped");
                 return DictationOutcome.Submitted(false, true, transcript);
             }
 
@@ -443,7 +453,34 @@ internal static class GatewayDictationEndpoint
             // "unknown" surface bucket, never silently dropped (decision 9).
             var (ok, _, err) = await route.PostPromptAsync(sid, new PromptRequest { Text = message, AppendEnter = true, Surface = deliverySurface ?? "unknown", DeliveryUploadId = uploadId });
             if (!ok)
+            {
+                // THE ATTEMPT WE JUST MADE INVALIDATED THE PHONE'S BASELINE (Lost Dictations mission, #1593).
+                // A failed submit is not a no-op on the terminal: the observed failure (05:31 on 2026-07-15)
+                // typed the text twice and cleared it twice, writing ~8,700 bytes of our own noise into the
+                // buffer. The phone's baseline was stamped when the clip was RECORDED and never moves, so the
+                // retry that follows this 502 would be judged against a number our own failure just made a
+                // lie, and the moved-on guard would drop the user's words as stale. Re-baseline the upload id
+                // to the freshest buffer position we can see, so the retry is judged honestly.
+                //
+                // Re-READ the session rather than reusing the `session` snapshot from before the attempt:
+                // that snapshot predates the noise by definition and would re-baseline to the same number the
+                // phone already sent, which is no re-baseline at all.
+                //
+                // NOT PROVEN TO CLOSE THE WINDOW COMPLETELY, and deliberately not dressed up as if it does:
+                // this reads the pushed store, so it sees only what the owning Director has pushed BY NOW. If
+                // the push stream lags the failure, some of the attempt's noise is not in this number yet and
+                // a retry could still be judged against a baseline that is too low. It is strictly better than
+                // today (today re-baselines by exactly zero) and it is monotonic, so a later failed attempt
+                // can only improve it - but the residual lag window is real and is not closed here.
+                var (_, freshSession) = await GatewayEndpoints.LocateSessionAsync(
+                    registry, sid, pushedSessions, streamStale, owners);
+                if (freshSession is not null)
+                    uploads.RecordFailedDeliveryBaseline(uploadId, freshSession.TotalBufferBytes);
+                FileLog.Write($"[GatewayDictation] complete sid={sid} uploadId={uploadId}: submit FAILED ({err}); " +
+                    $"re-baselined to {freshSession?.TotalBufferBytes.ToString() ?? "unavailable"} " +
+                    $"(was {req.BaselineBufferBytes}) so the retry is not dropped as stale");
                 return DictationOutcome.Error(StatusCodes.Status502BadGateway, err ?? "submit to session failed");
+            }
 
             // Write the durable DELIVERED tombstone as the IMMEDIATE next step after the session accepted the
             // prompt, before anything else, to minimize the window in which a re-complete could re-inject

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -293,6 +293,11 @@ public sealed class GatewayHost : IAsyncDisposable
     private readonly TailscaleServeProvisioner _serveProvisioner;
     private readonly GatewayTurnBriefStore _turnBriefStore;
     private readonly KeyVault _keyVault;
+
+    // Lost Dictations mission (#1593): the transcription owner the dictation endpoint uses. Null in
+    // production - StartAsync then builds the real one over _keyVault. Only a test injects a stub, because
+    // the dictation delivery arm sits BEHIND a successful transcribe and the hosted URL is a constant.
+    private readonly Transcription.GatewayTranscriptionService? _dictationTranscription;
     // Issue #881: mints/ensures the DevThrottle inference key after sign-in and at startup. Null on a
     // host with no credential service (nothing to sign in to).
     private readonly Account.TranscriptionKeyAutoProvisioner? _transcriptionKeyProvisioner;
@@ -460,7 +465,16 @@ public sealed class GatewayHost : IAsyncDisposable
     /// isolated temp path; production omits it for the shared default at
     /// <c>CcStorage.Root()\mission-notes.json</c>.
     /// </param>
-    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? snoozePath = null, string? missionsPath = null, string? missionNotesPath = null)
+    /// <param name="dictationTranscription">
+    /// Override the transcription owner the DICTATION endpoint uses (Lost Dictations mission, issue #1593).
+    /// The dictation complete path transcribes BEFORE it delivers, so an end-to-end test of the delivery
+    /// arm cannot reach that arm at all without a transcription that succeeds - and the hosted base URL is a
+    /// compile-time constant, so there is no way to point it at a local stub. Tests pass a service built over
+    /// a stub HttpClient (and their own telemetry + audio archive, which otherwise default to process-wide
+    /// Shared instances that write to the real user's directories). Production omits it and the host builds
+    /// the service over its own key vault, exactly as before.
+    /// </param>
+    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? snoozePath = null, string? missionsPath = null, string? missionNotesPath = null, Transcription.GatewayTranscriptionService? dictationTranscription = null)
     {
         Port = port;
         Token = token ?? GatewayAuth.LoadOrCreate();
@@ -520,6 +534,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // Production omits keyVaultPath for the shared default; tests pass an isolated path so
         // they never touch the real %LOCALAPPDATA% key store.
         _keyVault = new KeyVault(keyVaultPath);
+        _dictationTranscription = dictationTranscription;
         // Named work lists persist across a Gateway restart (issue #301): one JSON file in the
         // Gateway data dir, loaded here (stale claims released) and written through on every
         // mutation. Tests MUST pass an isolated path so they never touch the real store.
@@ -1421,7 +1436,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // in resumable chunks and the Gateway assembles → transcribes → injects the turn into the
         // owning session itself, so a refresh / dropped connection cannot lose a recorded utterance.
         GatewayDictationEndpoint.Map(_app, Registry, SessionOwners, Token,
-            new Transcription.GatewayTranscriptionService(_keyVault), _transcribingSessions, _dictationUploads, Devices,
+            _dictationTranscription ?? new Transcription.GatewayTranscriptionService(_keyVault), _transcribingSessions, _dictationUploads, Devices,
             pushedSessions: PushedSessions,
             sendCommand: SendCommandAsync);
         // Durable per-upload-id dictation record (issue #1183): a PENDING upload's chunks are retained

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -409,23 +410,32 @@ public sealed class VoiceUploadStore
     {
         var uid = NormalizeId(uploadId);
         if (uid is null) return false;
-        if (ReadRecord(uid) is not { } record) return false;
-        if (record.State is DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned) return false;
 
-        var merged = Math.Max(record.RebaselineBufferBytes ?? 0, bufferBytes);
-        if (merged <= (record.RebaselineBufferBytes ?? -1)) return false; // already at least this honest
-        try
+        // Read-modify-write under the per-upload gate. Without it the max-and-write is not atomic: two
+        // writers can both read the old value, and the one that computed the SMALLER max can land last and
+        // overwrite the larger - handing a retry a baseline lower than one we had already proven honest,
+        // which is exactly the drop this whole field exists to stop. The monotonic rule has to hold at the
+        // WRITE, not just in the arithmetic.
+        lock (GateFor(DirFor(uid)))
         {
-            // Marker only - the chunk bytes stay put, because this upload is still going to be delivered.
-            WriteRecordMarker(DirFor(uid), record with { RebaselineBufferBytes = merged });
-            FileLog.Write($"[VoiceUploadStore] RecordFailedDeliveryBaseline: uploadId={uid} rebaseline={merged} " +
-                $"(state={record.State}, chunks retained)");
-            return true;
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[VoiceUploadStore] RecordFailedDeliveryBaseline uploadId={uid} failed: {ex.Message}");
-            return false;
+            if (ReadRecord(uid) is not { } record) return false;
+            if (record.State is DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned) return false;
+
+            var merged = Math.Max(record.RebaselineBufferBytes ?? 0, bufferBytes);
+            if (merged <= (record.RebaselineBufferBytes ?? -1)) return false; // already at least this honest
+            try
+            {
+                // Marker only - the chunk bytes stay put, because this upload is still going to be delivered.
+                WriteRecordMarker(DirFor(uid), record with { RebaselineBufferBytes = merged });
+                FileLog.Write($"[VoiceUploadStore] RecordFailedDeliveryBaseline: uploadId={uid} rebaseline={merged} " +
+                    $"(state={record.State}, chunks retained)");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[VoiceUploadStore] RecordFailedDeliveryBaseline uploadId={uid} failed: {ex.Message}");
+                return false;
+            }
         }
     }
 
@@ -492,6 +502,23 @@ public sealed class VoiceUploadStore
     }
 
     // ====== internals ===============================================================
+
+    // Per-upload write gates, keyed by the upload's staging DIRECTORY - the resource itself, not the store
+    // object - so the gate holds even though callers construct their own VoiceUploadStore instances over the
+    // same root (the endpoint, the tests, and the aggregator all do). Static for the same reason: two store
+    // instances over one directory must contend for one gate, or the gate protects nothing.
+    //
+    // In-process only, and deliberately so: this guards the read-modify-write in RecordFailedDeliveryBaseline,
+    // whose writers are all inside this Gateway. It is NOT a cross-process file lock and does not claim to be;
+    // the individual marker write is already atomic (temp + move), so the worst a second process could do is
+    // land a stale value, which no deployment we run can produce (one Gateway owns a staging root).
+    //
+    // One small object per upload id that has had a failed delivery attempt. Never pruned; bounded by real
+    // failed-delivery volume, the same shape as the endpoint's own uploadId->sessionId map.
+    private static readonly ConcurrentDictionary<string, object> _recordGates =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private static object GateFor(string dir) => _recordGates.GetOrAdd(dir, _ => new object());
 
     private string DirFor(string uid) => Path.Combine(_root, uid);
     private static string ChunkPath(string dir, int index) => Path.Combine(dir, $"{index:D5}.part");

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -276,14 +275,18 @@ public sealed class VoiceUploadStore
     public void MarkPending(string uploadId, string sessionId)
     {
         var uid = NormalizeId(uploadId) ?? throw new InvalidOperationException("invalid upload id");
-        var dir = DirFor(uid);
-        Directory.CreateDirectory(dir);
-        // Carry the #1593 re-baseline forward: a phone that never saw our 502 simply RE-REGISTERS its upload
-        // id and retries. That path lands here, so dropping the value would hand the retry back the very
-        // baseline our own failed attempt invalidated - the exact drop this field exists to stop.
-        WriteRecordMarker(dir, new DictationDeliveryRecord(
-            DictationDeliveryState.Pending, false, false, "", null, sessionId ?? "", ExistingRebaseline(uid)));
-        FileLog.Write($"[VoiceUploadStore] MarkPending: uploadId={uid} sessionId={sessionId}");
+        WithRecordLock(uid, () =>
+        {
+            var dir = DirFor(uid);
+            Directory.CreateDirectory(dir);
+            // Carry the #1593 re-baseline forward: a phone that never saw our 502 simply RE-REGISTERS its
+            // upload id and retries. That path lands here, so dropping the value would hand the retry back the
+            // very baseline our own failed attempt invalidated - the exact drop this field exists to stop.
+            // Read inside the gate, so it cannot be a value from before another writer moved it.
+            WriteRecordMarker(dir, new DictationDeliveryRecord(
+                DictationDeliveryState.Pending, false, false, "", null, sessionId ?? "", ExistingRebaseline(uid)));
+            FileLog.Write($"[VoiceUploadStore] MarkPending: uploadId={uid} sessionId={sessionId}");
+        });
     }
 
     /// <summary>
@@ -331,8 +334,8 @@ public sealed class VoiceUploadStore
     /// tombstone is retired only by <see cref="Acknowledge"/>.
     /// </summary>
     public void MarkDelivered(string uploadId, bool submitted, bool movedOn, string transcript)
-        => WriteTombstone(uploadId, new DictationDeliveryRecord(
-            DictationDeliveryState.Delivered, submitted, movedOn, transcript ?? "", null, ExistingSessionId(uploadId)));
+        => WriteTombstone(uploadId, uid => new DictationDeliveryRecord(
+            DictationDeliveryState.Delivered, submitted, movedOn, transcript ?? "", null, ExistingSessionId(uid)));
 
     /// <summary>
     /// Transition this upload id to the durable ABANDONED tombstone: persist the reason and discard the
@@ -340,8 +343,8 @@ public sealed class VoiceUploadStore
     /// from the surfaces are a later task; this provides the state and its read side.
     /// </summary>
     public void MarkAbandoned(string uploadId, string reason)
-        => WriteTombstone(uploadId, new DictationDeliveryRecord(
-            DictationDeliveryState.Abandoned, false, false, "", reason ?? "", ExistingSessionId(uploadId)));
+        => WriteTombstone(uploadId, uid => new DictationDeliveryRecord(
+            DictationDeliveryState.Abandoned, false, false, "", reason ?? "", ExistingSessionId(uid)));
 
     /// <summary>
     /// Park this upload id as FAILED with a permanent-failure reason code (issue #1185). Unlike DELIVERED
@@ -353,16 +356,20 @@ public sealed class VoiceUploadStore
     public void MarkFailed(string uploadId, string reasonCode)
     {
         var uid = NormalizeId(uploadId) ?? throw new InvalidOperationException("invalid upload id");
-        var dir = DirFor(uid);
-        Directory.CreateDirectory(dir);
-        // Write ONLY the marker - keep the chunk bytes (the retry re-drives them), the opposite of a tombstone.
-        // Preserve the owning session id so a later ClearFailed can restore a PENDING marker that re-locks it,
-        // and the #1593 re-baseline so a transcription failure on a retry cannot erase what an earlier failed
-        // DELIVERY attempt already learned about the buffer.
-        WriteRecordMarker(dir, new DictationDeliveryRecord(
-            DictationDeliveryState.Failed, false, false, "", reasonCode ?? "", ExistingSessionId(uid),
-            ExistingRebaseline(uid)));
-        FileLog.Write($"[VoiceUploadStore] MarkFailed: uploadId={uid} reason={reasonCode} (chunks retained)");
+        WithRecordLock(uid, () =>
+        {
+            var dir = DirFor(uid);
+            Directory.CreateDirectory(dir);
+            // Write ONLY the marker - keep the chunk bytes (the retry re-drives them), the opposite of a
+            // tombstone. Preserve the owning session id so a later ClearFailed can restore a PENDING marker
+            // that re-locks it, and the #1593 re-baseline so a transcription failure on a retry cannot erase
+            // what an earlier failed DELIVERY attempt already learned about the buffer. Both read inside the
+            // gate, so neither can be a value from before another writer moved it.
+            WriteRecordMarker(dir, new DictationDeliveryRecord(
+                DictationDeliveryState.Failed, false, false, "", reasonCode ?? "", ExistingSessionId(uid),
+                ExistingRebaseline(uid)));
+            FileLog.Write($"[VoiceUploadStore] MarkFailed: uploadId={uid} reason={reasonCode} (chunks retained)");
+        });
     }
 
     /// <summary>
@@ -376,20 +383,25 @@ public sealed class VoiceUploadStore
     {
         var uid = NormalizeId(uploadId);
         if (uid is null) return false;
-        if (ReadRecord(uid) is not { State: DictationDeliveryState.Failed } failed) return false;
-        try
+        // Read-modify-write under the gate, read inside: without it, a ClearFailed that read FAILED could
+        // write PENDING back over a tombstone that landed in between, resurrecting a resolved upload id.
+        return WithRecordLock(uid, () =>
         {
-            WriteRecordMarker(DirFor(uid), new DictationDeliveryRecord(
-                DictationDeliveryState.Pending, false, false, "", null, failed.SessionId,
-                failed.RebaselineBufferBytes));
-            FileLog.Write($"[VoiceUploadStore] ClearFailed: uploadId={uid} back to PENDING (chunks retained)");
-            return true;
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[VoiceUploadStore] ClearFailed uploadId={uid} failed: {ex.Message}");
-            return false;
-        }
+            if (ReadRecord(uid) is not { State: DictationDeliveryState.Failed } failed) return false;
+            try
+            {
+                WriteRecordMarker(DirFor(uid), new DictationDeliveryRecord(
+                    DictationDeliveryState.Pending, false, false, "", null, failed.SessionId,
+                    failed.RebaselineBufferBytes));
+                FileLog.Write($"[VoiceUploadStore] ClearFailed: uploadId={uid} back to PENDING (chunks retained)");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[VoiceUploadStore] ClearFailed uploadId={uid} failed: {ex.Message}");
+                return false;
+            }
+        });
     }
 
     /// <summary>
@@ -411,15 +423,22 @@ public sealed class VoiceUploadStore
         var uid = NormalizeId(uploadId);
         if (uid is null) return false;
 
-        // Read-modify-write under the per-upload gate. Without it the max-and-write is not atomic: two
-        // writers can both read the old value, and the one that computed the SMALLER max can land last and
-        // overwrite the larger - handing a retry a baseline lower than one we had already proven honest,
-        // which is exactly the drop this whole field exists to stop. The monotonic rule has to hold at the
-        // WRITE, not just in the arithmetic.
-        lock (GateFor(DirFor(uid)))
+        // Read-modify-write under the per-upload gate, with the read INSIDE the lock. Two things depend on
+        // that, and the second is the serious one:
+        //   1. The max-and-write is atomic, so two re-baseline writers cannot both read the old value and let
+        //      the one that computed the SMALLER max land last - handing a retry a baseline we already knew
+        //      was too low, which is the drop this field exists to stop. Monotonicity has to hold at the
+        //      WRITE, not just in the arithmetic.
+        //   2. We write only the re-baseline field onto the record AS IT IS RIGHT NOW, never a record read
+        //      before the lock. Otherwise a stalled re-baseline could write a remembered PENDING record back
+        //      over a tombstone that landed in the meantime and resurrect a delivered upload id (issue #1183).
+        return WithRecordLock(uid, () =>
         {
             if (ReadRecord(uid) is not { } record) return false;
+            // Terminal is final: its guard has already run for the last time, and rewriting the tombstone here
+            // is precisely how a resolved upload id would come back to life.
             if (record.State is DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned) return false;
+            BetweenRecordReadAndWriteForTests?.Invoke(uid);
 
             var merged = Math.Max(record.RebaselineBufferBytes ?? 0, bufferBytes);
             if (merged <= (record.RebaselineBufferBytes ?? -1)) return false; // already at least this honest
@@ -436,7 +455,7 @@ public sealed class VoiceUploadStore
                 FileLog.Write($"[VoiceUploadStore] RecordFailedDeliveryBaseline uploadId={uid} failed: {ex.Message}");
                 return false;
             }
-        }
+        });
     }
 
     /// <summary>
@@ -449,19 +468,25 @@ public sealed class VoiceUploadStore
     {
         var uid = NormalizeId(uploadId);
         if (uid is null) return false;
-        var dir = DirFor(uid);
-        if (!Directory.Exists(dir)) return false;
-        try
+        // Retiring the record is a record mutation, so it takes the same gate. Without it, a retirement landing
+        // in the middle of another writer's read-modify-write would let that writer re-create the staging
+        // directory and a marker for an upload id that had just been acknowledged away.
+        return WithRecordLock(uid, () =>
         {
-            Directory.Delete(dir, recursive: true);
-            FileLog.Write($"[VoiceUploadStore] Acknowledge: uploadId={uid} tombstone retired");
-            return true;
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[VoiceUploadStore] Acknowledge uploadId={uid} failed: {ex.Message}");
-            return false;
-        }
+            var dir = DirFor(uid);
+            if (!Directory.Exists(dir)) return false;
+            try
+            {
+                Directory.Delete(dir, recursive: true);
+                FileLog.Write($"[VoiceUploadStore] Acknowledge: uploadId={uid} tombstone retired");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[VoiceUploadStore] Acknowledge uploadId={uid} failed: {ex.Message}");
+                return false;
+            }
+        });
     }
 
     // The owning session id already recorded for this upload id (empty when there is no record yet), so a
@@ -477,19 +502,29 @@ public sealed class VoiceUploadStore
     // crash between the two leaves a valid tombstone rather than orphaned chunks with no marker. Used by the
     // TERMINAL transitions (delivered/abandoned) that no longer need the audio; FAILED keeps its bytes and
     // so writes the marker alone (see MarkFailed).
-    private void WriteTombstone(string uploadId, DictationDeliveryRecord record)
+    // The record is composed by a FACTORY run inside the gate, not passed in ready-made: a tombstone carries
+    // the session id already on the record, and reading that outside the lock would be one more
+    // read-modify-write straddling the gate - the very shape this is here to eliminate.
+    private void WriteTombstone(string uploadId, Func<string, DictationDeliveryRecord> compose)
     {
         var uid = NormalizeId(uploadId) ?? throw new InvalidOperationException("invalid upload id");
-        var dir = DirFor(uid);
-        Directory.CreateDirectory(dir);
-        WriteRecordMarker(dir, record);
-        foreach (var part in Directory.EnumerateFiles(dir, "*.part"))
+        // Under the per-upload gate like every other record write: a tombstone that lands while another writer
+        // is mid read-modify-write is exactly the interleaving that would let a resolved upload id be written
+        // back to PENDING and re-injected (issue #1183).
+        WithRecordLock(uid, () =>
         {
-            try { File.Delete(part); }
-            catch (Exception ex) { FileLog.Write($"[VoiceUploadStore] discard chunk {part} failed: {ex.Message}"); }
-        }
-        FileLog.Write($"[VoiceUploadStore] MarkRecord: uploadId={uid} state={record.State} " +
-            $"submitted={record.Submitted} movedOn={record.MovedOn}");
+            var record = compose(uid);
+            var dir = DirFor(uid);
+            Directory.CreateDirectory(dir);
+            WriteRecordMarker(dir, record);
+            foreach (var part in Directory.EnumerateFiles(dir, "*.part"))
+            {
+                try { File.Delete(part); }
+                catch (Exception ex) { FileLog.Write($"[VoiceUploadStore] discard chunk {part} failed: {ex.Message}"); }
+            }
+            FileLog.Write($"[VoiceUploadStore] MarkRecord: uploadId={uid} state={record.State} " +
+                $"submitted={record.Submitted} movedOn={record.MovedOn}");
+        });
     }
 
     // Persist the record.json marker atomically (temp + move), leaving any staged chunks untouched.
@@ -503,22 +538,91 @@ public sealed class VoiceUploadStore
 
     // ====== internals ===============================================================
 
-    // Per-upload write gates, keyed by the upload's staging DIRECTORY - the resource itself, not the store
-    // object - so the gate holds even though callers construct their own VoiceUploadStore instances over the
-    // same root (the endpoint, the tests, and the aggregator all do). Static for the same reason: two store
-    // instances over one directory must contend for one gate, or the gate protects nothing.
+    // ====== the per-upload record gate ==============================================
     //
-    // In-process only, and deliberately so: this guards the read-modify-write in RecordFailedDeliveryBaseline,
-    // whose writers are all inside this Gateway. It is NOT a cross-process file lock and does not claim to be;
-    // the individual marker write is already atomic (temp + move), so the worst a second process could do is
-    // land a stale value, which no deployment we run can produce (one Gateway owns a staging root).
+    // EVERY read-modify-write of an upload's record.json runs under this gate. Not just the re-baseline:
+    // serializing the re-baseline writers against each other only is worse than useless, because the
+    // dangerous interleaving is between DIFFERENT writers. A re-baseline that reads a PENDING record, then
+    // stalls while MarkDelivered lands a terminal tombstone, would write its remembered PENDING record back
+    // over that tombstone and RESURRECT the upload id as pending - reopening the exact re-injection door the
+    // durable record exists to close (issue #1183). Hence: one gate per upload id, every writer inside it,
+    // and every writer RE-READS the record inside the lock rather than trusting anything read outside it.
     //
-    // One small object per upload id that has had a failed delivery attempt. Never pruned; bounded by real
-    // failed-delivery volume, the same shape as the endpoint's own uploadId->sessionId map.
-    private static readonly ConcurrentDictionary<string, object> _recordGates =
+    // Keyed by the upload's staging DIRECTORY - the resource itself, not the store object - because callers
+    // construct their own VoiceUploadStore instances over the same root (the endpoint, the aggregator, and
+    // the tests all do), so a gate belonging to an instance would protect nothing. Canonicalized through
+    // Path.GetFullPath so two spellings of one directory cannot resolve to two different gates.
+    //
+    // In-process only, and deliberately so: every writer of a given staging root lives in this Gateway. It is
+    // NOT a cross-process file lock and does not pretend to be; the individual marker write is already atomic
+    // (temp + move), so the worst a second process could do is land a stale value - which no deployment we run
+    // can produce, because one Gateway owns a staging root.
+    //
+    // REFCOUNTED, so the map is bounded by CONCURRENT users rather than by lifetime upload ids - it holds
+    // nothing at rest. This is why there is no "prune on terminal transition": removing a gate that another
+    // thread is still holding would let the next caller lock a DIFFERENT object and walk straight into the
+    // section, which is the race this gate exists to prevent. An entry that nobody holds cannot be in anyone's
+    // way, and an entry that somebody holds must not be removed - refcounting is just those two rules.
+    private sealed class RecordGate
+    {
+        public int Users;
+    }
+
+    /// <summary>
+    /// Test seam: invoked INSIDE the per-upload gate, between the record read and the record write of
+    /// <see cref="RecordFailedDeliveryBaseline"/>. Null in production and never assigned outside tests.
+    ///
+    /// It exists because the tombstone-resurrection hazard is an INTERLEAVING, and an interleaving cannot be
+    /// proven by hammering threads and hoping: a test that only sometimes reproduces the race is a test that
+    /// will pass on a broken build. This lets one test stall the read-modify-write at the exact instant a
+    /// competing tombstone writer tries to land, deterministically, in both directions - the gate holding, and
+    /// the gate removed.
+    /// </summary>
+    internal static Action<string>? BetweenRecordReadAndWriteForTests;
+
+    private static readonly Dictionary<string, RecordGate> _recordGates =
         new(StringComparer.OrdinalIgnoreCase);
 
-    private static object GateFor(string dir) => _recordGates.GetOrAdd(dir, _ => new object());
+    private static RecordGate AcquireGate(string key)
+    {
+        lock (_recordGates)
+        {
+            if (!_recordGates.TryGetValue(key, out var gate))
+            {
+                gate = new RecordGate();
+                _recordGates[key] = gate;
+            }
+            gate.Users++;
+            return gate;
+        }
+    }
+
+    private static void ReleaseGate(string key, RecordGate gate)
+    {
+        lock (_recordGates)
+        {
+            if (--gate.Users == 0) _recordGates.Remove(key);
+        }
+    }
+
+    /// <summary>Run a record read-modify-write for this upload id under its per-upload gate.</summary>
+    private T WithRecordLock<T>(string uid, Func<T> body)
+    {
+        var key = GateKey(uid);
+        var gate = AcquireGate(key);
+        try
+        {
+            lock (gate) return body();
+        }
+        finally
+        {
+            ReleaseGate(key, gate);
+        }
+    }
+
+    private void WithRecordLock(string uid, Action body) => WithRecordLock(uid, () => { body(); return true; });
+
+    private string GateKey(string uid) => Path.GetFullPath(DirFor(uid));
 
     private string DirFor(string uid) => Path.Combine(_root, uid);
     private static string ChunkPath(string dir, int index) => Path.Combine(dir, $"{index:D5}.part");

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -277,8 +277,11 @@ public sealed class VoiceUploadStore
         var uid = NormalizeId(uploadId) ?? throw new InvalidOperationException("invalid upload id");
         var dir = DirFor(uid);
         Directory.CreateDirectory(dir);
+        // Carry the #1593 re-baseline forward: a phone that never saw our 502 simply RE-REGISTERS its upload
+        // id and retries. That path lands here, so dropping the value would hand the retry back the very
+        // baseline our own failed attempt invalidated - the exact drop this field exists to stop.
         WriteRecordMarker(dir, new DictationDeliveryRecord(
-            DictationDeliveryState.Pending, false, false, "", null, sessionId ?? ""));
+            DictationDeliveryState.Pending, false, false, "", null, sessionId ?? "", ExistingRebaseline(uid)));
         FileLog.Write($"[VoiceUploadStore] MarkPending: uploadId={uid} sessionId={sessionId}");
     }
 
@@ -352,9 +355,12 @@ public sealed class VoiceUploadStore
         var dir = DirFor(uid);
         Directory.CreateDirectory(dir);
         // Write ONLY the marker - keep the chunk bytes (the retry re-drives them), the opposite of a tombstone.
-        // Preserve the owning session id so a later ClearFailed can restore a PENDING marker that re-locks it.
+        // Preserve the owning session id so a later ClearFailed can restore a PENDING marker that re-locks it,
+        // and the #1593 re-baseline so a transcription failure on a retry cannot erase what an earlier failed
+        // DELIVERY attempt already learned about the buffer.
         WriteRecordMarker(dir, new DictationDeliveryRecord(
-            DictationDeliveryState.Failed, false, false, "", reasonCode ?? "", ExistingSessionId(uid)));
+            DictationDeliveryState.Failed, false, false, "", reasonCode ?? "", ExistingSessionId(uid),
+            ExistingRebaseline(uid)));
         FileLog.Write($"[VoiceUploadStore] MarkFailed: uploadId={uid} reason={reasonCode} (chunks retained)");
     }
 
@@ -373,13 +379,52 @@ public sealed class VoiceUploadStore
         try
         {
             WriteRecordMarker(DirFor(uid), new DictationDeliveryRecord(
-                DictationDeliveryState.Pending, false, false, "", null, failed.SessionId));
+                DictationDeliveryState.Pending, false, false, "", null, failed.SessionId,
+                failed.RebaselineBufferBytes));
             FileLog.Write($"[VoiceUploadStore] ClearFailed: uploadId={uid} back to PENDING (chunks retained)");
             return true;
         }
         catch (Exception ex)
         {
             FileLog.Write($"[VoiceUploadStore] ClearFailed uploadId={uid} failed: {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Record the honest moved-on baseline for this upload id after one of OUR OWN delivery attempts failed
+    /// (Lost Dictations mission, issue #1593). The record stays exactly where it was - this is NOT a state
+    /// transition and NOT a tombstone: a PENDING record stays PENDING with its chunks intact, so the client's
+    /// retry re-drives normally. Only <see cref="DictationDeliveryRecord.RebaselineBufferBytes"/> moves.
+    ///
+    /// MONOTONIC: the stored value only ever grows (each failed attempt adds more of its own noise, and a
+    /// later fresh read is at least as honest as an earlier one), so repeated failures can never lower the
+    /// baseline back into a range where our own noise reads as a real turn.
+    ///
+    /// A no-op returning false when there is no record yet, or when the record is already terminal
+    /// (DELIVERED / ABANDONED): those are resolved and their guard has already run, so re-baselining them
+    /// would move a number nothing will read again.
+    /// </summary>
+    public bool RecordFailedDeliveryBaseline(string uploadId, long bufferBytes)
+    {
+        var uid = NormalizeId(uploadId);
+        if (uid is null) return false;
+        if (ReadRecord(uid) is not { } record) return false;
+        if (record.State is DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned) return false;
+
+        var merged = Math.Max(record.RebaselineBufferBytes ?? 0, bufferBytes);
+        if (merged <= (record.RebaselineBufferBytes ?? -1)) return false; // already at least this honest
+        try
+        {
+            // Marker only - the chunk bytes stay put, because this upload is still going to be delivered.
+            WriteRecordMarker(DirFor(uid), record with { RebaselineBufferBytes = merged });
+            FileLog.Write($"[VoiceUploadStore] RecordFailedDeliveryBaseline: uploadId={uid} rebaseline={merged} " +
+                $"(state={record.State}, chunks retained)");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[VoiceUploadStore] RecordFailedDeliveryBaseline uploadId={uid} failed: {ex.Message}");
             return false;
         }
     }
@@ -412,6 +457,11 @@ public sealed class VoiceUploadStore
     // The owning session id already recorded for this upload id (empty when there is no record yet), so a
     // state transition preserves the session id first written by MarkPending at register (issue #1188).
     private string ExistingSessionId(string uploadId) => ReadRecord(uploadId)?.SessionId ?? "";
+
+    // The re-baseline already recorded for this upload id (null when there is no record, or no attempt has
+    // failed), so a NON-TERMINAL state transition preserves what a failed delivery attempt learned (#1593).
+    // The terminal tombstones deliberately do NOT carry it: their guard has already run for the last time.
+    private long? ExistingRebaseline(string uploadId) => ReadRecord(uploadId)?.RebaselineBufferBytes;
 
     // Write the small durable marker first (atomic temp+move), THEN discard the heavy chunk bytes, so a
     // crash between the two leaves a valid tombstone rather than orphaned chunks with no marker. Used by the
@@ -492,10 +542,21 @@ public enum DictationDeliveryState { Pending, Delivered, Abandoned, Failed }
 /// retry. Every state carries the <see cref="SessionId"/> so a transition (e.g. FAILED back to PENDING)
 /// preserves the owning session.
 /// </summary>
+/// <param name="RebaselineBufferBytes">
+/// The honest moved-on baseline for this upload id after one of OUR OWN delivery attempts failed (Lost
+/// Dictations mission, issue #1593), or null when no attempt has failed. A failed submit types the text into
+/// the terminal and clears it again, growing the session buffer by thousands of bytes that the moved-on guard
+/// cannot tell apart from real turns - so a retry judged against the phone's record-time baseline gets dropped
+/// as stale by noise the failure itself made. The guard therefore judges a retry against the LARGER of the
+/// request's baseline and this value. It lives on the SERVER record, not in the phone's request, so a phone
+/// that never saw the 502 still retries against the honest baseline. Null (absent) in every record written
+/// before this field existed, which reads back as "no attempt has failed" - the correct meaning.
+/// </param>
 public sealed record DictationDeliveryRecord(
     DictationDeliveryState State,
     bool Submitted,
     bool MovedOn,
     string Transcript,
     string? Reason,
-    string SessionId = "");
+    string SessionId = "",
+    long? RebaselineBufferBytes = null);


### PR DESCRIPTION
## What is broken

On 2026-07-15 the owner spoke into his phone and DevThrottle threw his words away. The Director log recorded the whole thing (session `59d2e552` at 05:31).

1. The phone stamps a moved-on baseline when the clip is **recorded**. It never moves.
2. Delivery is attempted, the composer never echoes, and the attempt fails - but not before typing the text and clearing it twice, writing **~8,700 bytes of our own noise** into the session buffer.
3. The endpoint returns 502, which is retryable, so the phone correctly retries the same clip.
4. The moved-on guard compares the now-inflated buffer against the phone's original baseline, cannot tell our own noise from other people's turns, and drops the recording as stale - **permanently**, since the drop writes a durable `movedOn` tombstone (by design, thefrederiksen/devthrottle_internal#726).

The retry of a delivery *we* failed was being judged against a baseline *our own failure* invalidated.

## The fix

When `PostPromptAsync` fails, re-baseline that upload id to the freshest buffer position available after the failure, persisted on the **durable server-side record**. The guard then judges a retry against the **larger** of the request's baseline and the stored re-baseline.

- **Server-side, per ruling 2** - so a phone that never saw the 502 and simply re-registers still retries against an honest baseline. The phone needs no change.
- **Monotonic**, and carried across the non-terminal state transitions (`MarkPending` / `MarkFailed` / `ClearFailed`). Without that, a re-register or a transcription failure on a retry would erase what a failed delivery attempt already learned - and the re-register path is exactly the phone-missed-the-502 case.
- The terminal tombstones deliberately do **not** carry it: their guard has already run for the last time.
- The re-read deliberately does not reuse the pre-attempt session snapshot, which by definition predates the noise and would re-baseline to the number the phone already sent.

**Accepted consequence (ruled):** if the session genuinely moved on during the seconds of our own failed attempt, the retry now injects rather than drops. In that window the user's words win.

## What is NOT proven

Written into the code as a gap, not papered over: the re-read sees only what the owning Director has **pushed by then**. A lagging push stream can still leave some of the attempt's noise out of the number, so a retry could be judged against a baseline that is too low. It is strictly better than today (which re-baselines by exactly zero) and monotonic, so a later failed attempt can only improve it - but the residual lag window is real and is not closed here.

## Proof

`Issue1593FailedAttemptRebaselineTests` - four tests driving the **real** complete endpoint over loopback HTTP: a real `GatewayHost`, the real route, the real `VoiceUploadStore` on disk, the real guard, and a real tunnel-connected Director whose prompt verb **fails the first time** (growing its reported buffer as the real failure does) and succeeds the second. Tunnel-by-construction: the Director is registered at a dead endpoint and its session arrives only via `PushSnapshot`.

**Watched failing on purpose.** With the guard reverted to the request baseline, the two fix tests fail with the reported symptom - *"the retry of a delivery WE failed must inject the user's words, not be dropped as stale"* - and **both controls stay green**:

- a genuine move-on **before** any delivery attempt still drops (and never reaches the session);
- growth **beyond** our own failed attempt is still a real move-on and still drops.

The one thing not real here is the speech-to-text provider: the delivery arm sits behind a successful transcribe and the hosted URL is a compile-time constant with no local override, so the provider is a stub returning fixed text. This needed a test seam on `GatewayHost` (`dictationTranscription`, null in production). Everything the defect lives in - the guard, the record, the failure arm, the retry - is the real thing.

Suites: Gateway 2469 passed, Core 3139, Engine 62, HostedAgent 80, Launcher 27. Zero failures.

Item 1 of 2 in the Lost Dictations mission. Item 2 (#1590 - a dropped dictation must be loud and give the words back) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
