### PR TITLE
fix(dictation): a dropped dictation is loud and gives the words back (#1590)

### DIFF
--- a/apps/mobile/src/components/DictationStatusStrip.tsx
+++ b/apps/mobile/src/components/DictationStatusStrip.tsx
@@ -97,7 +97,9 @@ export function DictationStatusStrip({ sessionId }: { sessionId: string | undefi
   // Dropped as stale (issue #1590). Sticky by construction: there is no timer on this arm, and nothing but
   // an explicit user action removes it. role="alert" because the user's words were NOT delivered.
   if (status.phase === "dropped") {
-    const words = (status.transcript ?? "").trim();
+    // The FULL message that would have been delivered (typed text included), which is exactly what "Send
+    // anyway" sends. Quoting anything else would show the user one thing and send another.
+    const words = (status.recoverableText ?? "").trim();
     const onSendAnyway = async () => {
       setUploadingNow(true);
       try {

--- a/apps/mobile/src/components/DictationStatusStrip.tsx
+++ b/apps/mobile/src/components/DictationStatusStrip.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from "react";
-import { abandonPendingDictation, retryPendingDictation } from "@devthrottle/client-core/dictation/backgroundSend";
+import {
+  abandonPendingDictation,
+  dismissDictationStatus,
+  retryDroppedDictation,
+  retryPendingDictation,
+  sendDroppedDictationAnyway,
+} from "@devthrottle/client-core/dictation/backgroundSend";
 import { clearDictationStatus, useDictationStatusFor } from "@devthrottle/client-core/dictation/status";
 
 // The on-screen live-status strip for a dictation Send, shown on the Terminal, Chat, and Voice
@@ -16,6 +22,15 @@ import { clearDictationStatus, useDictationStatusFor } from "@devthrottle/client
 // an explicit "Retry" control - the audio is safe, delivery just no longer loops on its own. A genuine
 // failure (durable storage unavailable, so nothing could be queued) shows a red alert with Dismiss; it
 // does NOT disappear on its own, so it can never be missed.
+//
+// A DROPPED send (issue #1590) is the loud one: the session moved on before the recording arrived, so the
+// server threw the user's words away. It shows a red alert that never clears itself, quotes the words back,
+// and offers "Send anyway" - which sends them as a fresh, normal turn (re-driving the dictation itself is
+// useless by design; its moved-on tombstone is permanent). On the rare drop before transcription there are no
+// words to show, so it offers "Retry" instead, which re-sends the recording under a fresh upload id. Both
+// carry a Dismiss, and Dismiss is the ONLY thing that throws the words away - never a timer.
+// An UNHEARD send is the quiet cousin: the clip arrived and had no speech in it, so there was no turn to
+// make. Nothing was lost and there is nothing to retry, but it is still an answer rather than silence.
 
 const DONE_AUTOCLEAR_MS = 2500;
 
@@ -74,6 +89,71 @@ export function DictationStatusStrip({ sessionId }: { sessionId: string | undefi
         </button>
         <button type="button" className="dictate-strip-btn dictate-strip-cancel" onClick={() => void abandonPendingDictation(status.uploadId)} disabled={uploadingNow}>
           Cancel
+        </button>
+      </div>
+    );
+  }
+
+  // Dropped as stale (issue #1590). Sticky by construction: there is no timer on this arm, and nothing but
+  // an explicit user action removes it. role="alert" because the user's words were NOT delivered.
+  if (status.phase === "dropped") {
+    const words = (status.transcript ?? "").trim();
+    const onSendAnyway = async () => {
+      setUploadingNow(true);
+      try {
+        await sendDroppedDictationAnyway(status.uploadId);
+      } finally {
+        setUploadingNow(false);
+      }
+    };
+    const onRetryFresh = async () => {
+      setUploadingNow(true);
+      try {
+        await retryDroppedDictation(status.uploadId);
+      } finally {
+        setUploadingNow(false);
+      }
+    };
+    return (
+      <div className="dictate-strip dictate-strip-dropped" role="alert">
+        <span className="dictate-strip-icon" aria-hidden="true">!</span>
+        <div className="dictate-strip-body">
+          <span className="dictate-strip-text">{status.error ?? "That recording wasn't sent."}</span>
+          {words.length > 0 && <blockquote className="dictate-strip-quote">{words}</blockquote>}
+        </div>
+        {words.length > 0 ? (
+          <button type="button" className="dictate-strip-btn" onClick={() => void onSendAnyway()} disabled={uploadingNow}>
+            {uploadingNow ? "Sending..." : "Send anyway"}
+          </button>
+        ) : (
+          <button type="button" className="dictate-strip-btn" onClick={() => void onRetryFresh()} disabled={uploadingNow}>
+            {uploadingNow ? "Retrying..." : "Retry"}
+          </button>
+        )}
+        <button
+          type="button"
+          className="dictate-strip-btn dictate-strip-dismiss"
+          onClick={() => void dismissDictationStatus(status.uploadId)}
+          disabled={uploadingNow}
+        >
+          Dismiss
+        </button>
+      </div>
+    );
+  }
+
+  // Nothing was heard (issue #1590): not a failure, but never silence either.
+  if (status.phase === "unheard") {
+    return (
+      <div className="dictate-strip dictate-strip-unheard" role="status">
+        <span className="dictate-strip-icon" aria-hidden="true">!</span>
+        <span className="dictate-strip-text">{status.error ?? "Nothing was heard in that recording."}</span>
+        <button
+          type="button"
+          className="dictate-strip-btn dictate-strip-dismiss"
+          onClick={() => void dismissDictationStatus(status.uploadId)}
+        >
+          Dismiss
         </button>
       </div>
     );

--- a/apps/mobile/src/pages/Home.tsx
+++ b/apps/mobile/src/pages/Home.tsx
@@ -442,17 +442,28 @@ function VoiceIndicator({ session }: { session: SessionDto }) {
   return null;
 }
 
-// The per-row dictation status pill (#1139 follow-up, honest states for #1182/#1184). Reads the same shared
-// store the on-screen status strip reads, so a Speak Send shows on the roster too: a muted progress label
-// while it is in flight, a calm amber "saved - still sending" while it is held on a bad connection, a
-// "saved - tap to retry" while it is parked after a permanent failure, and a red "Dictation failed" for the
+// The per-row dictation status pill (#1139 follow-up, honest states for #1182/#1184, the dropped states for
+// #1590). Reads the same shared store the on-screen status strip reads, so a Speak Send shows on the roster
+// too: a muted progress label while it is in flight, a calm amber "saved - still sending" while it is held on
+// a bad connection, a "saved - tap to retry" while it is parked after a permanent failure, a red "Not sent -
+// tap to open" when the session moved on and the words were dropped, and a red "Dictation failed" for the
 // rare hard failure. A just-"done" send shows nothing here; the brief "Sent" acknowledgement belongs on the
 // session screen, not as roster noise.
+//
+// Every non-busy phase is named EXPLICITLY, because the fallback below is a spinner: a phase that falls
+// through would sit on the roster spinning forever, claiming a finished dictation is still working.
 function DictationRowBadge({ sessionId }: { sessionId: string | undefined }) {
   const status = useDictationStatusFor(sessionId);
   if (!status || status.phase === "done") return null;
   if (status.phase === "failed") {
     return <span className="row-dictate row-dictate-failed">Dictation failed</span>;
+  }
+  if (status.phase === "dropped") {
+    // The words were NOT delivered and are waiting on the session screen to be sent or dismissed.
+    return <span className="row-dictate row-dictate-failed">Not sent - tap to open</span>;
+  }
+  if (status.phase === "unheard") {
+    return <span className="row-dictate row-dictate-parked">Nothing heard</span>;
   }
   if (status.phase === "held") {
     return <span className="row-dictate row-dictate-held">Saved - still sending</span>;

--- a/apps/mobile/src/styles.css
+++ b/apps/mobile/src/styles.css
@@ -2592,6 +2592,45 @@ a.banner-btn {
   background: rgba(148, 163, 184, 0.12);
   border-color: rgba(148, 163, 184, 0.4);
 }
+/* Dropped as stale (#1590): the session moved on and the user's words were NOT delivered. Red, like the
+   other failure, because from the user's side that is exactly what it is - and unlike every other strip it
+   wraps, because it quotes the words back so they can be sent with one tap. */
+.dictate-strip-dropped {
+  color: #ffb4b4;
+  background: rgba(241, 76, 76, 0.12);
+  border-color: rgba(241, 76, 76, 0.45);
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+/* Nothing was heard (#1590): a muted notice. Nothing was lost, so it must not read as an alarm - but it is
+   still shown, because a Send that ends in silence is the whole defect. */
+.dictate-strip-unheard {
+  color: #cbd5e1;
+  background: rgba(148, 163, 184, 0.12);
+  border-color: rgba(148, 163, 184, 0.4);
+}
+
+/* The dropped strip's stacked message + quoted words. flex-basis keeps the buttons beside it on a wide
+   screen and drops them below on a narrow phone. */
+.dictate-strip-body {
+  flex: 1 1 200px;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+/* The words handed back. Long dictations must wrap rather than push the strip sideways - the page body
+   never scrolls horizontally. */
+.dictate-strip-quote {
+  margin: 0;
+  padding: 6px 10px;
+  border-left: 3px solid rgba(241, 76, 76, 0.5);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.18);
+  color: var(--text);
+  font-style: italic;
+  overflow-wrap: anywhere;
+}
 
 .dictate-strip-icon {
   flex: 0 0 auto;
@@ -2607,6 +2646,8 @@ a.banner-btn {
 .dictate-strip-failed .dictate-strip-icon { background: rgba(241, 76, 76, 0.3); }
 .dictate-strip-held .dictate-strip-icon { background: rgba(217, 164, 65, 0.3); }
 .dictate-strip-parked .dictate-strip-icon { background: rgba(148, 163, 184, 0.3); }
+.dictate-strip-dropped .dictate-strip-icon { background: rgba(241, 76, 76, 0.3); }
+.dictate-strip-unheard .dictate-strip-icon { background: rgba(148, 163, 184, 0.3); }
 
 /* Small inline spinner for the strip's in-flight state (reuses the voice-spin keyframes). */
 .dictate-strip-spin {

--- a/docs/architecture/lost-dictations-mission-brief.md
+++ b/docs/architecture/lost-dictations-mission-brief.md
@@ -1,0 +1,126 @@
+# Mission: Lost Dictations
+
+**Status: ACTIVE** (opened 2026-07-15)
+**Mission id:** `00d27b9e-7fc4-43b6-a297-f86d1a33dc4e`
+**Mission worktree:** `D:\ReposFred\devthrottle-lost-dictations`
+**Mission branch:** `mission/lost-dictations` (cut from origin/main at `dd34a6a9`)
+**Issues:** #1593 (the drop), #1590 (the silence). #1595 is related and OUT of scope.
+**Conduct:** this brief describes the WORK only. How a mission is run - roles, authority, landing,
+inspection, the report - lives in `.claude/skills/mission/SKILL.md` and is not restated here.
+
+---
+
+## THE WHY
+
+On 2026-07-15 the owner spoke into his phone twice, and both times DevThrottle threw his words away
+and told him nothing. The Director log recorded the whole thing (session `59d2e552` at 05:31,
+`fe2ec700` at 05:34): the first delivery attempt failed to submit (the composer never echoed), the
+failed attempt itself wrote ~8,700 bytes of its own typing-and-clearing noise into the terminal, the
+phone retried, and the Gateway's moved-on guard read OUR OWN noise as "other turns happened" and
+discarded the recording as stale. The phone then deleted the audio and cleared the status strip -
+"it worked and then nothing happened."
+
+Voice is the flagship phone flow. A product whose defining feature silently eats the user's words is
+broken in the one place it most claims to work. When this mission is finished: a dictation whose
+delivery attempt fails is retried against an honest baseline and DELIVERED; and on the rare genuine
+drop, the phone says so, keeps what it heard, and offers the words back - nothing vanishes silently.
+
+## The mechanics, verified against the code at `dd34a6a9`
+
+1. `POST .../dictation/complete` transcribes, then delivers via
+   `route.PostPromptAsync` (`src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs:444`). A failed
+   submit returns 502 (`:445-446`) - RETRYABLE from the phone's point of view, and the phone
+   correctly holds the clip and retries.
+2. The moved-on guard (`:417-430`) drops a RESUMED clip when `session.TotalBufferBytes >
+   req.BaselineBufferBytes + 512`. The baseline is stamped by the phone when the clip was RECORDED
+   (`packages/client-core/src/dictation/backgroundSend.ts:114`) and never moves. The failed attempt
+   in step 1 typed the text twice and cleared it twice - thousands of bytes of growth the guard
+   cannot tell apart from real turns. So the retry of a failed delivery is judged against a baseline
+   the failure itself invalidated, and is dropped.
+3. The drop writes a durable DELIVERED tombstone with `movedOn = true` (`:426`) - by design
+   (#1183), a re-complete of the same upload id returns the same moved-on outcome forever.
+4. On the phone, `driveRecord` treats any terminal outcome with `submitted = false` as "nothing to
+   acknowledge on screen": `deletePending` + `clearDictationStatus`
+   (`packages/client-core/src/dictation/backgroundSend.ts:277-291`). Audio deleted, no banner, no
+   trace. The user is never told.
+
+## The work, in landing order (one pull request per item)
+
+### 1. The moved-on guard must never count our own failed attempt (#1593)
+
+- **The fix (server-side):** when a delivery attempt fails (`PostPromptAsync` returns not-ok at
+  `GatewayDictationEndpoint.cs:445`), RE-BASELINE that upload id before returning the 502: persist,
+  on the durable upload record, the freshest session buffer position available after the failure.
+  The moved-on guard then judges a retry against the LARGER of the request's baseline and the stored
+  re-baseline. The phone keeps sending its original baseline and needs no change for this item.
+- **Accepted consequence (ruled):** if the session genuinely moved on during the seconds of our own
+  failed attempt, the retry will now inject rather than drop. In that window the user's words win.
+  That is the correct side to err on.
+- **Implementation care:** the session snapshot held at `:409` predates the attempt, so its
+  `TotalBufferBytes` does NOT include the attempt's noise - re-read the freshest pushed value after
+  the failure rather than reusing the stale snapshot. If the push stream lags and the fresh read
+  still misses some noise, the re-baseline is still strictly better than today; say so in a comment
+  rather than pretending the window is zero.
+- **The proof that must exist:** an end-to-end test driving the REAL dictation complete endpoint
+  over loopback HTTP with a scripted Director whose prompt verb FAILS the first time (growing the
+  reported buffer, as the real failure does) and succeeds the second: the retried clip must be
+  DELIVERED, not dropped. Watched failing against the un-re-baselined guard. A control pins the
+  guard still dropping when the growth happened BEFORE any delivery attempt (a genuine move-on).
+
+### 2. A dropped dictation must be loud and give the words back (#1590)
+
+- **The fix (client-side, `packages/client-core` + `apps/mobile`):** in `driveRecord`, a terminal
+  outcome with `submitted = false` must never silently `clearDictationStatus` - except for
+  abandonment, which the user did on purpose (ruled out of scope by the issue itself). Split the arm:
+  - **Moved-on / dropped:** the outcome already carries the TRANSCRIPT
+    (`GatewayDictationEndpoint.cs:429` returns it). Keep the record visible in a parked-style sticky
+    state that names what happened in plain words, and offer the transcribed text back with a
+    "Send anyway" action that sends it as a NORMAL prompt to the session (a fresh turn - re-driving
+    the same upload id is useless by design, see mechanics point 3), plus a Dismiss. If the
+    transcript is empty (rare - dropped before transcription), keep the audio parked with an
+    explicit user Retry that re-drives under a FRESH upload id.
+  - **Empty clip** (silence - `submitted = false, movedOn = false` from `:404`): a visible,
+    dismissible notice ("nothing was heard"), no retry (there is nothing to retry), and the
+    on-device copy may be dropped.
+- **The proof that must exist:** client-core tests driving the real `driveRecord` and the real
+  status store through each terminal-not-submitted shape, asserting the status is VISIBLE and
+  carries the transcript/action, watched failing against today's silent-clear. The abandoned path
+  stays silent - pinned by a control. Mobile rules apply: failures are loud and sticky, never a
+  toast that fades.
+
+## Design rulings already made
+
+1. Scope is #1593 + #1593's safety net #1590. #1595 (counting and surfacing delivery failures
+   generally) stays open as its own issue - do not build dashboards here. (Stated by the Architect.)
+2. The #1593 re-baseline lives on the SERVER, on the durable upload record - not in the phone's
+   record - so a phone that missed the 502 response entirely still retries against the honest
+   baseline. (Inferred from the issue's "re-baseline the buffer position for that upload id".)
+3. Recovery for a moved-on drop is TRANSCRIPT-first ("here is what I heard - send it?"), because the
+   transcript already rides the outcome and re-uploading audio against a tombstoned upload id is a
+   dead end by design. (Inferred; the issue's stated bar is only "a visible message on the phone" -
+   if the transcript-first shape balloons, the visible+parked minimum lands first and the Send-anyway
+   action follows in the same pull request series.)
+4. Items land in the order above: item 1 kills the observed drop, item 2 is the safety net for
+   genuine drops. Two pull requests. (Stated by the Architect.)
+5. What cannot be proven in this mission is named in the QA report rather than papered over: no live
+   phone-to-Gateway drive is required to merge, but the endpoint-level end-to-end (real HTTP, real
+   endpoint, scripted Director) is the floor for item 1, and the issues' "driving a real drop" bar is
+   met at that level. (Stated by the Architect.)
+
+## Out of scope - do not do these
+
+- #1595 (surface/count delivery failures generally), #1594 (the submit harness), #1151 (idempotent
+  submit), and anything touching `EchoVerifiedSubmit` itself - the echo failure is the TRIGGER of
+  this defect, not its subject.
+- The desktop dictation path (#1130) and Director-side dictation code.
+- Any Gateway API surface change beyond the upload record and the complete endpoint's failure arm.
+
+## Inspection note (mission-specific fact, not conduct)
+
+The Inspector is Codex, invoked by the Architect per pull request with the diff and touched files
+bundled inline (`codex exec` cannot run shell commands on this machine). Findings go back to the
+builder; the Architect lands.
+
+---
+
+*When this mission ends, this document's status line must be updated to say so, in the past tense.*

--- a/packages/client-core/src/dictation/backgroundSend.test.ts
+++ b/packages/client-core/src/dictation/backgroundSend.test.ts
@@ -15,7 +15,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 //   - a genuinely permanent failure PARKS the clip (keeps the audio, stops the auto-loop) and only an
 //     explicit Retry re-drives it, while transient failures still auto-retry (issue #1184).
 
-vi.mock("../api/client", () => ({ uploadDictationToSession: vi.fn(), abandonDictation: vi.fn() }));
+vi.mock("../api/client", () => ({ uploadDictationToSession: vi.fn(), abandonDictation: vi.fn(), sendPrompt: vi.fn() }));
 vi.mock("./pendingStore", () => ({
   savePending: vi.fn(),
   deletePending: vi.fn(),
@@ -23,12 +23,15 @@ vi.mock("./pendingStore", () => ({
   listPending: vi.fn(),
 }));
 
-import { abandonDictation, uploadDictationToSession, type DictationSubmitResult } from "../api/client";
+import { abandonDictation, sendPrompt, uploadDictationToSession, type DictationSubmitResult } from "../api/client";
 import {
   abandonPendingDictation,
   backgroundTranscribeAndSend,
+  dismissDictationStatus,
   resumePendingDictations,
+  retryDroppedDictation,
   retryPendingDictation,
+  sendDroppedDictationAnyway,
   type CapturedUtterance,
 } from "./backgroundSend";
 import { deletePending, getPending, listPending, savePending, type PendingDictation } from "./pendingStore";
@@ -51,6 +54,27 @@ const PERMANENT: DictationSubmitResult = {
   transcript: "",
   permanent: true,
   permanentReason: "audio-too-large",
+};
+// The four terminal-not-submitted shapes (issue #1590). Only ABANDONED is silent.
+const MOVED_ON: DictationSubmitResult = {
+  terminal: true,
+  submitted: false,
+  movedOn: true,
+  transcript: "the words the user actually said",
+};
+const MOVED_ON_NO_TRANSCRIPT: DictationSubmitResult = {
+  terminal: true,
+  submitted: false,
+  movedOn: true,
+  transcript: "",
+};
+const EMPTY_CLIP: DictationSubmitResult = { terminal: true, submitted: false, movedOn: false, transcript: "" };
+const ABANDONED: DictationSubmitResult = {
+  terminal: true,
+  submitted: false,
+  movedOn: false,
+  abandoned: true,
+  transcript: "",
 };
 
 function statusFor(uploadId: string) {
@@ -84,6 +108,7 @@ beforeEach(() => {
   vi.mocked(getPending).mockResolvedValue(null);
   vi.mocked(listPending).mockResolvedValue([]);
   vi.mocked(abandonDictation).mockResolvedValue(true);
+  vi.mocked(sendPrompt).mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -283,6 +308,198 @@ describe("parking permanently-failed clips (#1184)", () => {
     // A transient outcome never parks the record.
     const parkedSave = vi.mocked(savePending).mock.calls.find((c) => c[0].parkedReason);
     expect(parkedSave).toBeUndefined();
+  });
+});
+
+// Issue #1590: a dropped dictation must be LOUD and must give the words back.
+//
+// Every one of these outcomes used to land in a single arm - deletePending + clearDictationStatus. Audio
+// gone, banner gone, no trace, and the user was never told their words had been thrown away. "It worked and
+// then nothing happened." Only the abandon is genuinely nothing to say.
+describe("a terminal outcome that did NOT submit is never silent (#1590)", () => {
+  it("a moved-on drop stays VISIBLE, carries the transcript back, and never auto-clears", async () => {
+    vi.mocked(uploadDictationToSession).mockResolvedValue(MOVED_ON);
+
+    await backgroundTranscribeAndSend("sid", captured);
+
+    const savedId = vi.mocked(savePending).mock.calls[0][0].id;
+    const status = statusFor(savedId);
+    // The defect was that this was undefined: the words vanished with no banner at all.
+    expect(status).toBeDefined();
+    expect(status?.phase).toBe("dropped");
+    // The words are handed back so the UI can offer "Send anyway".
+    expect(status?.transcript).toBe("the words the user actually said");
+    // Honest about what happened - it says the recording was NOT sent, never a success.
+    expect(status?.error).toContain("moved on");
+    expect(status?.error).toContain("wasn't sent");
+    // "Send anyway" is a fresh turn, not a retry of a tombstoned upload id.
+    expect(status?.retryable).toBe(false);
+
+    // Sticky: no timer clears it. Advancing well past every cadence leaves it exactly where it was.
+    await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+    expect(statusFor(savedId)?.phase).toBe("dropped");
+    // And nothing auto-re-drives it - re-driving a moved-on upload id could only be dropped again.
+    expect(vi.mocked(uploadDictationToSession).mock.calls.length).toBe(1);
+  });
+
+  it("a moved-on drop persists the words durably so they survive a reload", async () => {
+    vi.mocked(uploadDictationToSession).mockResolvedValue(MOVED_ON);
+
+    await backgroundTranscribeAndSend("sid", captured);
+
+    // The record is KEPT (not deleted) and marked, so no automatic trigger re-drives it...
+    expect(deletePending).not.toHaveBeenCalled();
+    const droppedSave = vi.mocked(savePending).mock.calls.find((c) => c[0].staleDropped);
+    expect(droppedSave?.[0].staleDropped).toBe(true);
+    // ...and the words are on disk, or "Send anyway" would quietly stop working after a reload.
+    expect(droppedSave?.[0].droppedTranscript).toBe("the words the user actually said");
+  });
+
+  it("re-publishes a dropped clip on app load instead of re-driving it (the words are still there)", async () => {
+    const dropped: PendingDictation = {
+      ...makeRecord("id-dropped"),
+      staleDropped: true,
+      droppedTranscript: "words from before the reload",
+    };
+    vi.mocked(listPending).mockResolvedValue([dropped]);
+
+    await resumePendingDictations();
+
+    expect(uploadDictationToSession).not.toHaveBeenCalled(); // never re-drive a tombstoned upload id
+    expect(deletePending).not.toHaveBeenCalled();
+    const status = statusFor("id-dropped");
+    expect(status?.phase).toBe("dropped");
+    expect(status?.transcript).toBe("words from before the reload");
+  });
+
+  it("a drop BEFORE transcription keeps the audio and offers a retry instead of words", async () => {
+    vi.mocked(uploadDictationToSession).mockResolvedValue(MOVED_ON_NO_TRANSCRIPT);
+
+    await backgroundTranscribeAndSend("sid", captured);
+
+    const savedId = vi.mocked(savePending).mock.calls[0][0].id;
+    const status = statusFor(savedId);
+    expect(status?.phase).toBe("dropped");
+    expect(status?.transcript).toBe("");
+    // No words to hand back, so the recording itself is the recovery: kept, and explicitly retryable.
+    expect(status?.retryable).toBe(true);
+    expect(status?.error).toContain("saved on your device");
+    expect(deletePending).not.toHaveBeenCalled();
+  });
+
+  it("an empty clip says nothing was heard, visibly and dismissibly, with nothing to retry", async () => {
+    vi.mocked(uploadDictationToSession).mockResolvedValue(EMPTY_CLIP);
+
+    await backgroundTranscribeAndSend("sid", captured);
+
+    const savedId = vi.mocked(savePending).mock.calls[0][0].id;
+    const status = statusFor(savedId);
+    expect(status).toBeDefined(); // it used to be silent
+    expect(status?.phase).toBe("unheard");
+    expect(status?.retryable).toBe(false); // there is nothing to retry
+    expect(status?.error).toContain("Nothing was heard");
+    expect(deletePending).toHaveBeenCalledWith(savedId); // the audio is of no further use
+  });
+
+  // The control. The fix must not turn into "never clear anything": an abandon is the one terminal
+  // not-submitted outcome the user caused on purpose, and it stays silent.
+  it("an ABANDONED outcome stays silent - the user did that on purpose", async () => {
+    vi.mocked(uploadDictationToSession).mockResolvedValue(ABANDONED);
+
+    await backgroundTranscribeAndSend("sid", captured);
+
+    const savedId = vi.mocked(savePending).mock.calls[0][0].id;
+    expect(statusFor(savedId)).toBeUndefined();
+    expect(deletePending).toHaveBeenCalledWith(savedId);
+  });
+
+  // The other control: a delivered turn is unaffected.
+  it("a delivered turn still shows done and drops the audio (no regression)", async () => {
+    vi.mocked(uploadDictationToSession).mockResolvedValue(SUBMITTED);
+
+    await backgroundTranscribeAndSend("sid", captured);
+
+    const savedId = vi.mocked(savePending).mock.calls[0][0].id;
+    expect(statusFor(savedId)?.phase).toBe("done");
+    expect(deletePending).toHaveBeenCalledWith(savedId);
+  });
+});
+
+describe("recovering a dropped dictation (#1590)", () => {
+  const droppedRecord = (id: string, transcript: string): PendingDictation => ({
+    ...makeRecord(id),
+    staleDropped: true,
+    droppedTranscript: transcript,
+  });
+
+  it("Send anyway sends the words as a NORMAL prompt - a fresh turn, not a re-drive of the dead upload id", async () => {
+    vi.mocked(getPending).mockResolvedValue(droppedRecord("id-send", "send me please"));
+
+    await sendDroppedDictationAnyway("id-send");
+
+    expect(sendPrompt).toHaveBeenCalledWith("sid", "send me please", true);
+    // Never re-drives the dictation: that upload id carries a permanent moved-on tombstone.
+    expect(uploadDictationToSession).not.toHaveBeenCalled();
+    // Done with: the record goes and the strip acknowledges the send.
+    expect(deletePending).toHaveBeenCalledWith("id-send");
+    expect(statusFor("id-send")?.phase).toBe("done");
+  });
+
+  it("Send anyway that fails KEEPS the words and stays sticky - a bad moment must not lose them", async () => {
+    vi.mocked(getPending).mockResolvedValue(droppedRecord("id-send-fail", "precious words"));
+    vi.mocked(sendPrompt).mockRejectedValue(new Error("network died"));
+
+    await sendDroppedDictationAnyway("id-send-fail");
+
+    expect(deletePending).not.toHaveBeenCalled();
+    const status = statusFor("id-send-fail");
+    expect(status?.phase).toBe("dropped");
+    expect(status?.transcript).toBe("precious words"); // still on screen, still recoverable
+    expect(status?.error).toContain("still here");
+  });
+
+  it("Retry re-drives the recording under a FRESH upload id, with the stale baseline cleared", async () => {
+    const old = droppedRecord("id-old", "");
+    vi.mocked(getPending).mockResolvedValue(old);
+    vi.mocked(uploadDictationToSession).mockResolvedValue(SUBMITTED);
+
+    await retryDroppedDictation("id-old");
+
+    // A brand-new id: the old one is tombstoned moved-on and could only ever be dropped again.
+    const fresh = vi.mocked(savePending).mock.calls.find((c) => c[0].id !== "id-old")?.[0];
+    expect(fresh).toBeDefined();
+    expect(fresh?.id).not.toBe("id-old");
+    expect(fresh?.blob).toBe(old.blob); // the SAME recording, under a new id - the audio is what we are retrying
+    expect(fresh?.staleDropped).toBeUndefined();
+    // The record-time baseline describes a terminal that has long since moved on; re-sending it would just
+    // invite the same drop. The user asked for this send now.
+    expect(fresh?.baselineBufferBytes).toBe(0);
+    // The fresh clip really was driven, and the old id is retired.
+    expect(vi.mocked(uploadDictationToSession).mock.calls[0][0].uploadId).toBe(fresh?.id);
+    expect(deletePending).toHaveBeenCalledWith("id-old");
+    expect(statusFor("id-old")).toBeUndefined();
+  });
+
+  it("Upload now on a dropped clip hands over to the fresh-id retry rather than re-driving a dead id", async () => {
+    // Defensive wiring: whatever calls the generic retry must not silently do nothing (or re-drop).
+    vi.mocked(getPending).mockResolvedValue(droppedRecord("id-generic", ""));
+    vi.mocked(uploadDictationToSession).mockResolvedValue(SUBMITTED);
+
+    await retryPendingDictation("id-generic");
+
+    const fresh = vi.mocked(savePending).mock.calls.find((c) => c[0].id !== "id-generic")?.[0];
+    expect(fresh).toBeDefined();
+    expect(vi.mocked(uploadDictationToSession).mock.calls[0][0].uploadId).toBe(fresh?.id);
+  });
+
+  it("Dismiss is the ONLY thing that throws the words away, and it is always deliberate", async () => {
+    vi.mocked(getPending).mockResolvedValue(droppedRecord("id-dismiss", "unwanted words"));
+
+    await dismissDictationStatus("id-dismiss");
+
+    expect(statusFor("id-dismiss")).toBeUndefined();
+    expect(deletePending).toHaveBeenCalledWith("id-dismiss");
+    expect(sendPrompt).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/client-core/src/dictation/backgroundSend.test.ts
+++ b/packages/client-core/src/dictation/backgroundSend.test.ts
@@ -328,7 +328,7 @@ describe("a terminal outcome that did NOT submit is never silent (#1590)", () =>
     expect(status).toBeDefined();
     expect(status?.phase).toBe("dropped");
     // The words are handed back so the UI can offer "Send anyway".
-    expect(status?.transcript).toBe("the words the user actually said");
+    expect(status?.recoverableText).toBe("the words the user actually said");
     // Honest about what happened - it says the recording was NOT sent, never a success.
     expect(status?.error).toContain("moved on");
     expect(status?.error).toContain("wasn't sent");
@@ -369,7 +369,7 @@ describe("a terminal outcome that did NOT submit is never silent (#1590)", () =>
     expect(deletePending).not.toHaveBeenCalled();
     const status = statusFor("id-dropped");
     expect(status?.phase).toBe("dropped");
-    expect(status?.transcript).toBe("words from before the reload");
+    expect(status?.recoverableText).toBe("words from before the reload");
   });
 
   it("a drop BEFORE transcription keeps the audio and offers a retry instead of words", async () => {
@@ -380,7 +380,7 @@ describe("a terminal outcome that did NOT submit is never silent (#1590)", () =>
     const savedId = vi.mocked(savePending).mock.calls[0][0].id;
     const status = statusFor(savedId);
     expect(status?.phase).toBe("dropped");
-    expect(status?.transcript).toBe("");
+    expect(status?.recoverableText).toBe("");
     // No words to hand back, so the recording itself is the recovery: kept, and explicitly retryable.
     expect(status?.retryable).toBe(true);
     expect(status?.error).toContain("saved on your device");
@@ -445,6 +445,113 @@ describe("recovering a dropped dictation (#1590)", () => {
     expect(statusFor("id-send")?.phase).toBe("done");
   });
 
+  it("Send anyway is guarded: two rapid taps submit the user's words exactly ONCE", async () => {
+    // There is NO server-side idempotency behind this send - it is an ordinary prompt, so the durable upload
+    // id that de-duplicates a dictation (#1183) protects nothing here. Unguarded, two taps (or two mounted
+    // strips, each with its own button state) both read the record before either deletes it, and the user
+    // gets their words twice.
+    vi.mocked(getPending).mockResolvedValue(droppedRecord("id-race", "say this once"));
+    let resolveSend!: () => void;
+    vi.mocked(sendPrompt).mockImplementation(() => new Promise<void>((res) => { resolveSend = () => res(); }));
+
+    const first = sendDroppedDictationAnyway("id-race");
+    const second = sendDroppedDictationAnyway("id-race");
+    await flush();
+
+    expect(sendPrompt).toHaveBeenCalledTimes(1); // the second tap found the first still in flight
+
+    resolveSend();
+    await Promise.all([first, second]);
+    expect(sendPrompt).toHaveBeenCalledTimes(1);
+    expect(deletePending).toHaveBeenCalledTimes(1);
+  });
+
+  it("Retry is guarded: two rapid taps stage and drive exactly ONE fresh clip", async () => {
+    // Each tap mints a NEW upload id, so nothing downstream would de-duplicate two of them - the guard is
+    // the only thing standing between an impatient double-tap and the same recording injected twice.
+    vi.mocked(getPending).mockResolvedValue(droppedRecord("id-retry-race", ""));
+    let resolveUpload!: (r: DictationSubmitResult) => void;
+    vi.mocked(uploadDictationToSession).mockImplementation(
+      () => new Promise<DictationSubmitResult>((res) => { resolveUpload = res; }),
+    );
+
+    const first = retryDroppedDictation("id-retry-race");
+    const second = retryDroppedDictation("id-retry-race");
+    await flush();
+
+    const freshSaves = vi.mocked(savePending).mock.calls.filter((c) => c[0].id !== "id-retry-race");
+    expect(freshSaves).toHaveLength(1);
+    expect(uploadDictationToSession).toHaveBeenCalledTimes(1);
+
+    resolveUpload(SUBMITTED);
+    await Promise.all([first, second]);
+    expect(uploadDictationToSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("Send anyway sends the WHOLE message - typed text included - not just the transcribed words", async () => {
+    // A Terminal Speak dictation composes the transcript with the typed text the caret split it around. The
+    // Gateway's delivery path joins before + prefix + transcript + after, skipping empties; the recovery of
+    // that same turn must send the same message, or it silently throws the typed text away - the very
+    // vanishing this item exists to end, just smaller and harder to notice.
+    const composed: PendingDictation = {
+      ...makeRecord("id-compose"),
+      staleDropped: true,
+      droppedTranscript: "the spoken words",
+      before: "typed before",
+      prefix: "an earlier paused segment",
+      after: "typed after",
+    };
+    vi.mocked(getPending).mockResolvedValue(composed);
+
+    await sendDroppedDictationAnyway("id-compose");
+
+    expect(sendPrompt).toHaveBeenCalledWith(
+      "sid",
+      "typed before an earlier paused segment the spoken words typed after",
+      true,
+    );
+  });
+
+  it("shows the user exactly what it will send (the quote and the send are one string)", async () => {
+    // The strip quotes recoverableText and Send anyway sends the composed message; if those two ever drift
+    // apart the strip shows one thing and sends another.
+    const composed: PendingDictation = {
+      ...makeRecord("id-quote"),
+      staleDropped: true,
+      droppedTranscript: "spoken",
+      before: "typed",
+      after: "",
+      prefix: "",
+    };
+    vi.mocked(listPending).mockResolvedValue([composed]);
+
+    await resumePendingDictations();
+    const shown = statusFor("id-quote")?.recoverableText;
+
+    vi.mocked(getPending).mockResolvedValue(composed);
+    await sendDroppedDictationAnyway("id-quote");
+
+    expect(shown).toBe("typed spoken");
+    expect(sendPrompt).toHaveBeenCalledWith("sid", shown, true);
+  });
+
+  it("a drop with typed text but no transcript still offers the typed words back", async () => {
+    // "No transcript" is not the same as "nothing to recover": the typed text is the user's too.
+    const typedOnly: PendingDictation = {
+      ...makeRecord("id-typed-only"),
+      staleDropped: true,
+      droppedTranscript: "",
+      before: "please run the tests",
+    };
+    vi.mocked(listPending).mockResolvedValue([typedOnly]);
+
+    await resumePendingDictations();
+
+    const status = statusFor("id-typed-only");
+    expect(status?.recoverableText).toBe("please run the tests");
+    expect(status?.retryable).toBe(false); // it has words, so the action is Send anyway, not Retry
+  });
+
   it("Send anyway that fails KEEPS the words and stays sticky - a bad moment must not lose them", async () => {
     vi.mocked(getPending).mockResolvedValue(droppedRecord("id-send-fail", "precious words"));
     vi.mocked(sendPrompt).mockRejectedValue(new Error("network died"));
@@ -454,7 +561,7 @@ describe("recovering a dropped dictation (#1590)", () => {
     expect(deletePending).not.toHaveBeenCalled();
     const status = statusFor("id-send-fail");
     expect(status?.phase).toBe("dropped");
-    expect(status?.transcript).toBe("precious words"); // still on screen, still recoverable
+    expect(status?.recoverableText).toBe("precious words"); // still on screen, still recoverable
     expect(status?.error).toContain("still here");
   });
 

--- a/packages/client-core/src/dictation/backgroundSend.ts
+++ b/packages/client-core/src/dictation/backgroundSend.ts
@@ -63,6 +63,25 @@ const UNHEARD_MESSAGE = "Nothing was heard in that recording, so nothing was sen
 const SEND_ANYWAY_FAILED_MESSAGE =
   "Couldn't send that just now. Your words are still here - try again.";
 
+// The full message a dropped dictation would have delivered (issue #1590), composed EXACTLY as the Gateway's
+// complete path composes it before injecting: the typed text the caret split the dictation around (before /
+// after), any earlier paused segments already turned to text (prefix), and the words the server heard -
+// space-joined, skipping empties.
+//
+// It must match the server's rule (GatewayDictationEndpoint.RunCompleteCoreAsync) because this IS the
+// recovery of that same turn: sending the transcript alone would silently throw away the typed text the user
+// composed around it, which is the very "your words vanished" defect this whole item exists to end - just
+// smaller and harder to notice. Every part is already on the durable record, so nothing extra is stored.
+//
+// The common voice case is the transcript alone, and this returns exactly that.
+function composeDroppedMessage(rec: PendingDictation): string {
+  return [rec.before, rec.prefix, rec.droppedTranscript ?? "", rec.after]
+    .filter((p) => (p ?? "").trim().length > 0)
+    .map((p) => p.trim())
+    .join(" ")
+    .trim();
+}
+
 /** The audio buffer + context the dialog hands up when Send is pressed. */
 export interface CapturedUtterance {
   /** The raw recorded audio exactly as the microphone produced it (WebM/Opus etc.). */
@@ -252,39 +271,53 @@ export async function abandonPendingDictation(uploadId: string): Promise<void> {
 // away, but it told us what they were. Send them as a NORMAL prompt - a fresh turn, deliberately NOT a
 // re-drive of the dictation upload id, which by design (#1183) can only ever return the same drop again.
 //
-// The words are read from the DURABLE record, not the in-memory status, so this still works after a reload.
-// On success the clip is finally done with: the record goes and the status clears. On failure NOTHING is
-// discarded - the status stays sticky with the words still in it, so a bad moment cannot lose them.
+// GUARDED by the same in-flight set the delivery driver uses. This send has NO server-side idempotency behind
+// it: it is an ordinary prompt, so the durable upload id that de-duplicates a dictation (#1183) protects
+// nothing here. Two rapid taps - or two mounted strips for one session, each with its own button state -
+// would both read the record before either deleted it, and the user would get their words twice. The button's
+// disabled state is a courtesy; THIS is the guarantee.
+//
+// The words are read from the DURABLE record, not the in-memory status, so this still works after a reload,
+// and they are composed exactly as the delivery path composes them - the typed text goes with them.
+// The record is deleted only AFTER the send is confirmed: on failure nothing is discarded, and the status
+// stays sticky with the words still in it, so a bad moment cannot lose them.
 export async function sendDroppedDictationAnyway(uploadId: string): Promise<void> {
-  let rec: PendingDictation | null;
+  if (_inFlight.has(uploadId)) return; // already sending this exact clip
+  _inFlight.add(uploadId);
   try {
-    rec = await getPending(uploadId);
-  } catch {
-    return;
-  }
-  if (rec === null) {
-    clearDictationStatus(uploadId); // already dealt with; do not leave a dead strip behind
-    return;
-  }
-  const text = (rec.droppedTranscript ?? "").trim();
-  if (text.length === 0) return; // nothing to send; this clip's action is Retry, not Send anyway
+    let rec: PendingDictation | null;
+    try {
+      rec = await getPending(uploadId);
+    } catch {
+      return;
+    }
+    if (rec === null) {
+      clearDictationStatus(uploadId); // already dealt with; do not leave a dead strip behind
+      return;
+    }
+    const text = composeDroppedMessage(rec);
+    if (text.length === 0) return; // nothing to send; this clip's action is Retry, not Send anyway
 
-  try {
-    await sendPrompt(rec.sessionId, text, true);
-  } catch {
-    // Keep the record AND the sticky status - the words are still on the device and still on screen.
-    publishDictationStatus({
-      sessionId: rec.sessionId,
-      uploadId: rec.id,
-      phase: "dropped",
-      retryable: false,
-      transcript: text,
-      error: SEND_ANYWAY_FAILED_MESSAGE,
-    });
-    return;
+    try {
+      await sendPrompt(rec.sessionId, text, true);
+    } catch {
+      // Keep the record AND the sticky status - the words are still on the device and still on screen.
+      publishDictationStatus({
+        sessionId: rec.sessionId,
+        uploadId: rec.id,
+        phase: "dropped",
+        retryable: false,
+        recoverableText: text,
+        error: SEND_ANYWAY_FAILED_MESSAGE,
+      });
+      return;
+    }
+    // Confirmed sent: only now is the durable copy safe to drop.
+    await deletePending(rec.id);
+    publishDictationStatus({ sessionId: rec.sessionId, uploadId: rec.id, phase: "done" });
+  } finally {
+    _inFlight.delete(uploadId);
   }
-  await deletePending(rec.id);
-  publishDictationStatus({ sessionId: rec.sessionId, uploadId: rec.id, phase: "done" });
 }
 
 // Retry a dropped dictation whose words we never got (the rare drop before transcription, issue #1590).
@@ -292,35 +325,47 @@ export async function sendDroppedDictationAnyway(uploadId: string): Promise<void
 // re-driven under a FRESH upload id - a genuinely new dictation carrying the same recording. The baseline
 // is cleared to zero: the recorded-at baseline describes a terminal that has long since moved on, and
 // re-sending it would simply invite the same drop. The user asked for this send now, deliberately.
+// Guarded on the OLD id by the same in-flight set: each tap mints a NEW upload id, so without this two rapid
+// taps would stage two fresh clips and inject the same recording twice - and being different ids, nothing
+// downstream would de-duplicate them.
 export async function retryDroppedDictation(uploadId: string): Promise<void> {
-  let rec: PendingDictation | null;
+  if (_inFlight.has(uploadId)) return; // already retrying this exact clip
+  _inFlight.add(uploadId);
+  let fresh: PendingDictation;
   try {
-    rec = await getPending(uploadId);
-  } catch {
-    return;
-  }
-  if (rec === null) {
-    clearDictationStatus(uploadId);
-    return;
-  }
+    let rec: PendingDictation | null;
+    try {
+      rec = await getPending(uploadId);
+    } catch {
+      return;
+    }
+    if (rec === null) {
+      clearDictationStatus(uploadId);
+      return;
+    }
 
-  const fresh: PendingDictation = {
-    ...rec,
-    id: crypto.randomUUID(),
-    staleDropped: undefined,
-    droppedTranscript: undefined,
-    baselineBufferBytes: 0,
-    createdAt: Date.now(),
-  };
-  try {
-    await savePending(fresh);
-  } catch {
-    return; // could not stage the fresh copy; leave the dropped record and its sticky status exactly as they are
+    fresh = {
+      ...rec,
+      id: crypto.randomUUID(),
+      staleDropped: undefined,
+      droppedTranscript: undefined,
+      baselineBufferBytes: 0,
+      createdAt: Date.now(),
+    };
+    try {
+      await savePending(fresh);
+    } catch {
+      return; // could not stage the fresh copy; leave the dropped record and its sticky status exactly as they are
+    }
+    // The old id is finished with only once the fresh copy is safely on disk, so a failure here can never
+    // leave the user with neither.
+    await deletePending(rec.id);
+    clearDictationStatus(rec.id);
+  } finally {
+    _inFlight.delete(uploadId);
   }
-  // The old id is finished with only once the fresh copy is safely on disk, so a failure here can never
-  // leave the user with neither.
-  await deletePending(rec.id);
-  clearDictationStatus(rec.id);
+  // Outside the old id's guard: this drives the FRESH id, which takes its own in-flight entry. Holding both
+  // would be harmless but pointless - the old id no longer exists by this point.
   await driveRecord(fresh, { resumed: false, attempt: 0 });
 }
 
@@ -575,15 +620,19 @@ function publishParked(rec: PendingDictation, reason: string): void {
 // back when we have them. With a transcript the action is "Send anyway" (a fresh turn, so NOT retryable -
 // re-driving the tombstoned upload id could only be dropped again); without one, the audio is still on the
 // device, so it is retryable under a fresh upload id instead.
+// The "do we have words to hand back" question is asked of the COMPOSED message, not of the transcript
+// alone: a Terminal Speak clip that was dropped before transcription still has the typed text the user
+// composed around it, and that text is theirs and is recoverable. Only when the whole composed message is
+// empty is there genuinely nothing to offer, and the recording itself becomes the recovery.
 function publishDropped(rec: PendingDictation): void {
-  const transcript = rec.droppedTranscript ?? "";
+  const words = composeDroppedMessage(rec);
   publishDictationStatus({
     sessionId: rec.sessionId,
     uploadId: rec.id,
     phase: "dropped",
-    retryable: transcript.length === 0,
-    transcript,
-    error: transcript.length > 0 ? DROPPED_WITH_TRANSCRIPT_MESSAGE : DROPPED_NO_TRANSCRIPT_MESSAGE,
+    retryable: words.length === 0,
+    recoverableText: words,
+    error: words.length > 0 ? DROPPED_WITH_TRANSCRIPT_MESSAGE : DROPPED_NO_TRANSCRIPT_MESSAGE,
   });
 }
 

--- a/packages/client-core/src/dictation/backgroundSend.ts
+++ b/packages/client-core/src/dictation/backgroundSend.ts
@@ -1,4 +1,4 @@
-import { abandonDictation, uploadDictationToSession } from "../api/client";
+import { abandonDictation, sendPrompt, uploadDictationToSession } from "../api/client";
 import { deletePending, getPending, listPending, savePending, type PendingDictation } from "./pendingStore";
 import { clearDictationStatus, publishDictationStatus } from "./status";
 
@@ -52,6 +52,16 @@ const PARKED_UNSUPPORTED_FORMAT_MESSAGE =
 function parkMessage(reason: string | undefined): string {
   return reason === "unsupported-format" ? PARKED_UNSUPPORTED_FORMAT_MESSAGE : PARKED_TOO_LARGE_MESSAGE;
 }
+
+// The dropped-as-stale lines (issue #1590). Plain English, and honest about what happened: the session moved
+// on, so the words were NOT delivered. Never soft-pedalled into sounding like a success, and never silent.
+const DROPPED_WITH_TRANSCRIPT_MESSAGE =
+  "The session moved on before this recording arrived, so it wasn't sent. Here is what you said - send it?";
+const DROPPED_NO_TRANSCRIPT_MESSAGE =
+  "The session moved on before this recording arrived, so it wasn't sent. Your recording is saved on your device and you can try again.";
+const UNHEARD_MESSAGE = "Nothing was heard in that recording, so nothing was sent.";
+const SEND_ANYWAY_FAILED_MESSAGE =
+  "Couldn't send that just now. Your words are still here - try again.";
 
 /** The audio buffer + context the dialog hands up when Send is pressed. */
 export interface CapturedUtterance {
@@ -156,10 +166,16 @@ export async function resumePendingDictations(): Promise<void> {
   } catch {
     return; // no durable store; nothing to resume
   }
-  // A parked clip (permanent failure, issue #1184) is NOT auto-driven: re-publish its saved-and-retryable
-  // status so the strip and roster show it after a reopen, but never re-drive it. Everything else resumes.
+  // A parked clip (permanent failure, issue #1184) and a stale-DROPPED clip (issue #1590) are NOT auto-driven:
+  // re-publish their status so the strip and roster still show them after a reopen, but never re-drive them. A
+  // dropped clip especially - its upload id carries a permanent moved-on tombstone, so re-driving it could only
+  // be dropped again, and re-publishing is what keeps a lost dictation visible instead of vanishing on reload.
   await Promise.all(
     all.map((rec) => {
+      if (rec.staleDropped) {
+        publishDropped(rec);
+        return Promise.resolve();
+      }
       if (rec.parkedReason) {
         publishParked(rec, rec.parkedReason);
         return Promise.resolve();
@@ -181,6 +197,14 @@ export async function retryPendingDictation(uploadId: string): Promise<void> {
   }
   if (rec === null) {
     clearDictationStatus(uploadId);
+    return;
+  }
+  // A stale-DROPPED clip (issue #1590) cannot be re-driven under its own id - the server holds a permanent
+  // moved-on tombstone for it, so this exact upload id can only ever be dropped again. "Retry this clip"
+  // genuinely means "send the recording as a new dictation", so hand over to the fresh-id path rather than
+  // re-driving into a guaranteed re-drop (or, worse, quietly doing nothing).
+  if (rec.staleDropped) {
+    await retryDroppedDictation(uploadId);
     return;
   }
   // If it was PARKED after a permanent failure (issue #1184), this explicit Retry moves it back to active:
@@ -222,6 +246,95 @@ export async function abandonPendingDictation(uploadId: string): Promise<void> {
     // Could not persist the flag: still drive the in-memory abandoning record below.
   }
   await driveRecord(abandoning, { resumed: true, attempt: 0 });
+}
+
+// "Send anyway" on a dropped dictation (issue #1590): the session moved on and the server threw the words
+// away, but it told us what they were. Send them as a NORMAL prompt - a fresh turn, deliberately NOT a
+// re-drive of the dictation upload id, which by design (#1183) can only ever return the same drop again.
+//
+// The words are read from the DURABLE record, not the in-memory status, so this still works after a reload.
+// On success the clip is finally done with: the record goes and the status clears. On failure NOTHING is
+// discarded - the status stays sticky with the words still in it, so a bad moment cannot lose them.
+export async function sendDroppedDictationAnyway(uploadId: string): Promise<void> {
+  let rec: PendingDictation | null;
+  try {
+    rec = await getPending(uploadId);
+  } catch {
+    return;
+  }
+  if (rec === null) {
+    clearDictationStatus(uploadId); // already dealt with; do not leave a dead strip behind
+    return;
+  }
+  const text = (rec.droppedTranscript ?? "").trim();
+  if (text.length === 0) return; // nothing to send; this clip's action is Retry, not Send anyway
+
+  try {
+    await sendPrompt(rec.sessionId, text, true);
+  } catch {
+    // Keep the record AND the sticky status - the words are still on the device and still on screen.
+    publishDictationStatus({
+      sessionId: rec.sessionId,
+      uploadId: rec.id,
+      phase: "dropped",
+      retryable: false,
+      transcript: text,
+      error: SEND_ANYWAY_FAILED_MESSAGE,
+    });
+    return;
+  }
+  await deletePending(rec.id);
+  publishDictationStatus({ sessionId: rec.sessionId, uploadId: rec.id, phase: "done" });
+}
+
+// Retry a dropped dictation whose words we never got (the rare drop before transcription, issue #1590).
+// The audio is still on the device, but its upload id is tombstoned moved-on for good (#1183), so it is
+// re-driven under a FRESH upload id - a genuinely new dictation carrying the same recording. The baseline
+// is cleared to zero: the recorded-at baseline describes a terminal that has long since moved on, and
+// re-sending it would simply invite the same drop. The user asked for this send now, deliberately.
+export async function retryDroppedDictation(uploadId: string): Promise<void> {
+  let rec: PendingDictation | null;
+  try {
+    rec = await getPending(uploadId);
+  } catch {
+    return;
+  }
+  if (rec === null) {
+    clearDictationStatus(uploadId);
+    return;
+  }
+
+  const fresh: PendingDictation = {
+    ...rec,
+    id: crypto.randomUUID(),
+    staleDropped: undefined,
+    droppedTranscript: undefined,
+    baselineBufferBytes: 0,
+    createdAt: Date.now(),
+  };
+  try {
+    await savePending(fresh);
+  } catch {
+    return; // could not stage the fresh copy; leave the dropped record and its sticky status exactly as they are
+  }
+  // The old id is finished with only once the fresh copy is safely on disk, so a failure here can never
+  // leave the user with neither.
+  await deletePending(rec.id);
+  clearDictationStatus(rec.id);
+  await driveRecord(fresh, { resumed: false, attempt: 0 });
+}
+
+// Dismiss a dropped / unheard dictation (issue #1590): the user has read it and does not want the words.
+// This is the ONLY thing that discards a dropped clip without sending it, and it is always a deliberate act -
+// nothing here ever fires on its own.
+export async function dismissDictationStatus(uploadId: string): Promise<void> {
+  clearScheduled(uploadId);
+  clearDictationStatus(uploadId);
+  try {
+    await deletePending(uploadId);
+  } catch {
+    /* the status is already gone from screen; a leftover record is re-published only if it is re-driven */
+  }
 }
 
 // ---- internals -------------------------------------------------------------------------------------
@@ -275,19 +388,54 @@ async function driveRecord(rec: PendingDictation, opts: DriveOptions): Promise<v
     });
 
     if (outcome.terminal) {
-      // The server owns the turn. This covers a fresh delivery, a server that DEDUPED a delivery it had
-      // already made (a cached-delivered outcome from the durable record, issue #1183 - treated identically
-      // to a fresh success), a deliberately dropped stale/empty clip, and an ABANDONED upload id. In every
-      // case the on-device copy is dropped so the queue does not accumulate and the clip is never re-driven;
-      // the client already acknowledged the outcome to the Gateway (in uploadDictationToSession). Publish
-      // the terminal status: a brief "done" for a delivered turn, or a quiet clear when nothing was injected
-      // (moved-on, empty, or abandoned - there is nothing to acknowledge on screen).
-      await deletePending(rec.id);
+      // The server owns the turn: a fresh delivery, a server that DEDUPED a delivery it had already made (a
+      // cached-delivered outcome from the durable record, issue #1183 - treated identically to a fresh
+      // success), a deliberately dropped stale clip, an empty clip, or an ABANDONED upload id. The client
+      // already acknowledged the outcome to the Gateway (in uploadDictationToSession).
+      //
+      // These are NOT one arm (issue #1590). Every terminal-not-submitted outcome used to fall into a single
+      // deletePending + clearDictationStatus - audio gone, banner gone, no trace, and the user was never told
+      // that the words they spoke had been thrown away. "It worked and then nothing happened." Only ONE of
+      // these outcomes is genuinely nothing to say: an abandon, which the user did on purpose.
       if (outcome.submitted) {
+        await deletePending(rec.id);
         publishDictationStatus({ sessionId: rec.sessionId, uploadId: rec.id, phase: "done" });
-      } else {
-        clearDictationStatus(rec.id);
+        return;
       }
+
+      if (outcome.abandoned) {
+        // The user gave this clip up themselves. They already know; saying it again would be noise. This is
+        // the ONLY silent terminal arm, and it stays silent deliberately (the issue rules it out of scope).
+        await deletePending(rec.id);
+        clearDictationStatus(rec.id);
+        return;
+      }
+
+      if (outcome.movedOn) {
+        // The session moved on while the clip was in flight, so the server dropped the user's words. Re-driving
+        // this upload id is useless BY DESIGN - the drop wrote a permanent moved-on tombstone (#1183), so every
+        // future complete returns the same drop. The recovery is therefore a fresh turn, not a retry.
+        //
+        // Keep the record durably (marked stale-dropped, so no automatic trigger ever re-drives it) rather than
+        // deleting it: the words must survive a reload, or "Send anyway" would quietly stop working the moment
+        // the user backgrounds the app - which is the same silent loss in a new costume.
+        const transcript = (outcome.transcript ?? "").trim();
+        const dropped: PendingDictation = { ...rec, staleDropped: true, droppedTranscript: transcript };
+        try {
+          await savePending(dropped);
+        } catch {
+          // The durable store hiccuped. The in-memory status below is still published, so this drive stays
+          // loud; it just may not survive a reload. Never fall through to a silent clear.
+        }
+        publishDropped(dropped);
+        return;
+      }
+
+      // Nothing was heard: the clip reached the server, which found no speech and no typed text in it, so
+      // there was no turn to make. Nothing was lost and there is nothing to retry - but it is still an answer,
+      // and a Send that ends in silence is the defect. The audio is of no further use, so it goes.
+      await deletePending(rec.id);
+      publishUnheard(rec);
       return;
     }
 
@@ -333,6 +481,14 @@ async function driveById(id: string, opts: DriveOptions): Promise<void> {
     clearScheduled(id); // delivered or abandoned; nothing left to drive
     return;
   }
+  if (rec.staleDropped) {
+    // Dropped as stale between scheduling and firing (issue #1590): never auto-drive it - the upload id is
+    // tombstoned moved-on, so a re-drive could only be dropped again. Defensive; a dropped clip is never
+    // given a timer.
+    clearScheduled(id);
+    publishDropped(rec);
+    return;
+  }
   if (rec.parkedReason) {
     // Parked between scheduling and firing (issue #1184): never auto-drive it. Defensive - a parked clip is
     // never given a timer, so this should not normally be reached.
@@ -344,8 +500,10 @@ async function driveById(id: string, opts: DriveOptions): Promise<void> {
 }
 
 // Resume every pending clip immediately at full speed - the connectivity/foreground kick and what the
-// `online`/`visibilitychange` listeners call. A parked clip (permanent failure, issue #1184) is skipped:
-// it never auto-drives, only an explicit user Retry re-enters the active flow.
+// `online`/`visibilitychange` listeners call. A parked clip (permanent failure, issue #1184) and a
+// stale-dropped clip (issue #1590) are skipped: neither ever auto-drives, and only an explicit user action
+// moves them. Re-driving a dropped clip would be worse than pointless - its moved-on tombstone is permanent,
+// so every kick would re-drop it.
 async function kickAll(): Promise<void> {
   let all: PendingDictation[];
   try {
@@ -354,7 +512,7 @@ async function kickAll(): Promise<void> {
     return;
   }
   for (const rec of all) {
-    if (rec.parkedReason) continue;
+    if (rec.parkedReason || rec.staleDropped) continue;
     void driveRecord(rec, { resumed: true, attempt: 0 });
   }
 }
@@ -410,6 +568,33 @@ function publishParked(rec: PendingDictation, reason: string): void {
     phase: "parked",
     retryable: true,
     error: parkMessage(reason),
+  });
+}
+
+// Publish the dropped-as-stale status (issue #1590): sticky, never auto-clearing, and carrying the words
+// back when we have them. With a transcript the action is "Send anyway" (a fresh turn, so NOT retryable -
+// re-driving the tombstoned upload id could only be dropped again); without one, the audio is still on the
+// device, so it is retryable under a fresh upload id instead.
+function publishDropped(rec: PendingDictation): void {
+  const transcript = rec.droppedTranscript ?? "";
+  publishDictationStatus({
+    sessionId: rec.sessionId,
+    uploadId: rec.id,
+    phase: "dropped",
+    retryable: transcript.length === 0,
+    transcript,
+    error: transcript.length > 0 ? DROPPED_WITH_TRANSCRIPT_MESSAGE : DROPPED_NO_TRANSCRIPT_MESSAGE,
+  });
+}
+
+// Publish the nothing-was-heard notice (issue #1590): visible and dismissible, with nothing to retry.
+function publishUnheard(rec: PendingDictation): void {
+  publishDictationStatus({
+    sessionId: rec.sessionId,
+    uploadId: rec.id,
+    phase: "unheard",
+    retryable: false,
+    error: UNHEARD_MESSAGE,
   });
 }
 

--- a/packages/client-core/src/dictation/pendingStore.ts
+++ b/packages/client-core/src/dictation/pendingStore.ts
@@ -38,6 +38,17 @@ export interface PendingDictation {
    *  timer) - the forever-loop stops. It is cleared only by an explicit user Retry, which moves the record
    *  back to active. Absent for a normal, still-auto-retrying clip. */
   parkedReason?: string;
+  /** Set when the server deliberately DROPPED this clip as stale - the session moved on while it was in
+   *  flight (issue #1590). Like `parkedReason` it EXCLUDES the record from every automatic retry trigger,
+   *  and for a stronger reason: the drop wrote a permanent moved-on tombstone against this upload id (issue
+   *  #1183), so re-driving it could only ever be dropped again. The record is kept so the drop stays visible
+   *  across a reload (nothing about a lost dictation may be silent) and so the words can be offered back.
+   *  It leaves only by an explicit user action - Send anyway, Retry, or Dismiss. Absent for a normal clip. */
+  staleDropped?: boolean;
+  /** The words the server heard before it dropped the clip as stale (issue #1590), stored durably so
+   *  "Send anyway" still works after a reload. Empty on the rare drop before transcription, where the audio
+   *  is what gets retried instead. Only meaningful alongside `staleDropped`. */
+  droppedTranscript?: string;
   /** Set when the user ABANDONED this clip (issue #1181, Task 5). The record is kept ONLY to carry the
    *  abandon through to the Gateway: while set, the retry loop no longer uploads it - it calls
    *  /dictation/{id}/abandon instead, and deletes the on-device copy once the Gateway confirms (retrying

--- a/packages/client-core/src/dictation/status.ts
+++ b/packages/client-core/src/dictation/status.ts
@@ -30,7 +30,26 @@ import { useMemo, useSyncExternalStore } from "react";
 // done        - the server confirmed it owns the turn (delivered). Brief, then auto-clears.
 // failed      - a genuine, non-recoverable failure (durable storage unavailable, so the clip could not
 //               be saved at all). Distinct from held: nothing is retrying.
-export type DictationPhase = "saving" | "uploading" | "transcribing" | "held" | "parked" | "done" | "failed";
+// dropped     - the server deliberately DROPPED this clip as stale: the session moved on while it was in
+//               flight, so the words were never delivered (issue #1590). Nothing is retrying and re-driving
+//               the same upload id is useless by design (its moved-on tombstone is permanent, issue #1183) -
+//               so this is a STICKY state that must never clear itself. It carries `transcript` when the
+//               server heard something, and the UI offers "Send anyway" (a fresh turn) plus Dismiss. On the
+//               rare drop before transcription the transcript is empty, retryable is true, and the audio is
+//               kept for an explicit Retry under a FRESH upload id.
+// unheard     - the clip was delivered to the server, which heard NOTHING in it (silence, no typed text), so
+//               there was no turn to submit (issue #1590). Nothing was lost and there is nothing to retry;
+//               this is a visible, dismissible notice so a Send never ends in silence.
+export type DictationPhase =
+  | "saving"
+  | "uploading"
+  | "transcribing"
+  | "held"
+  | "parked"
+  | "done"
+  | "failed"
+  | "dropped"
+  | "unheard";
 
 export interface DictationStatus {
   /** The session the dictation is being sent into. */
@@ -47,10 +66,17 @@ export interface DictationStatus {
    *  failed, the non-recoverable reason. */
   error?: string;
   /** True when the clip is saved durably and the UI should offer a retry control: the held phase (an
-   *  "Upload now" that kicks a waiting or throttled retry to full speed) and the parked phase (an explicit
-   *  "Retry" that re-enters the active drive after a permanent failure stopped the auto-loop). False for a
-   *  genuine, non-recoverable failure that no retry can fix. */
+   *  "Upload now" that kicks a waiting or throttled retry to full speed), the parked phase (an explicit
+   *  "Retry" that re-enters the active drive after a permanent failure stopped the auto-loop), and a
+   *  `dropped` clip with no transcript (an explicit Retry under a FRESH upload id). False for a genuine,
+   *  non-recoverable failure that no retry can fix, and for a `dropped` clip that HAS a transcript - there
+   *  the action is "Send anyway", not a retry, because re-driving that upload id can only be dropped again. */
   retryable?: boolean;
+  /** The words the server heard, carried on a `dropped` status so the UI can offer them back ("Send anyway",
+   *  issue #1590). Present only when the clip was dropped as stale AND had been transcribed - the whole point
+   *  of the dropped state is that the user's words are not thrown away silently. Empty/absent on the rare
+   *  drop before transcription, where the audio is kept for a fresh-id Retry instead. */
+  transcript?: string;
   /** Epoch milliseconds of the last update (newest-first ordering, and the done auto-clear timer). */
   updatedAt: number;
 }

--- a/packages/client-core/src/dictation/status.ts
+++ b/packages/client-core/src/dictation/status.ts
@@ -72,11 +72,13 @@ export interface DictationStatus {
    *  non-recoverable failure that no retry can fix, and for a `dropped` clip that HAS a transcript - there
    *  the action is "Send anyway", not a retry, because re-driving that upload id can only be dropped again. */
   retryable?: boolean;
-  /** The words the server heard, carried on a `dropped` status so the UI can offer them back ("Send anyway",
-   *  issue #1590). Present only when the clip was dropped as stale AND had been transcribed - the whole point
-   *  of the dropped state is that the user's words are not thrown away silently. Empty/absent on the rare
-   *  drop before transcription, where the audio is kept for a fresh-id Retry instead. */
-  transcript?: string;
+  /** The full message a `dropped` dictation would have delivered, carried so the UI can offer it back
+   *  ("Send anyway", issue #1590). NOT just the transcript: it is the typed text the caret split the dictation
+   *  around plus any earlier paused segments plus the words the server heard, composed exactly as the delivery
+   *  path composes them. This is precisely what "Send anyway" sends, which is why the UI must show THIS and
+   *  nothing else - a strip that quotes one thing and sends another is its own small lie. Empty/absent on the
+   *  rare drop before transcription with no typed text, where the audio is kept for a fresh-id Retry instead. */
+  recoverableText?: string;
   /** Epoch milliseconds of the last update (newest-first ordering, and the done auto-clear timer). */
   updatedAt: number;
 }

--- a/src/CcDirector.Gateway.Tests/Issue1593FailedAttemptRebaselineTests.cs
+++ b/src/CcDirector.Gateway.Tests/Issue1593FailedAttemptRebaselineTests.cs
@@ -1,0 +1,359 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using CcDirector.Core;
+using CcDirector.Core.Audio;
+using CcDirector.Core.Configuration;
+using CcDirector.Core.Storage;
+using CcDirector.Gateway.Contracts;
+using CcDirector.Gateway.Transcription;
+using CcDirector.Gateway.Voice;
+using Xunit;
+
+namespace CcDirector.Gateway.Tests;
+
+/// <summary>
+/// End-to-end proof for the Lost Dictations mission, issue #1593: a dictation whose delivery attempt FAILS
+/// must be re-baselined so the retry that follows is DELIVERED, not silently eaten by the moved-on guard.
+///
+/// THE DEFECT THIS PINS, as observed on 2026-07-15 (session 59d2e552 at 05:31):
+///   1. The phone stamps a baseline when the clip is RECORDED. It never moves.
+///   2. Delivery is attempted, the composer never echoes, and the attempt fails - but NOT before typing the
+///      text and clearing it twice, writing thousands of bytes of OUR OWN noise into the session buffer.
+///   3. The endpoint returns 502, which is retryable, so the phone correctly retries the same clip.
+///   4. The moved-on guard compares the now-inflated buffer against the phone's original baseline, cannot
+///      tell our own noise from other people's turns, and drops the user's words as stale - forever (the
+///      drop writes a durable movedOn tombstone).
+///
+/// This drives the REAL endpoint over loopback HTTP: a real GatewayHost, the real
+/// POST /dictation/{uploadId}/complete route, the real VoiceUploadStore on disk, the real moved-on guard, and
+/// a REAL tunnel-connected Director (<see cref="FakeTunnelDirector"/>) whose prompt verb FAILS the first time
+/// - growing its reported buffer exactly as the real failure did - and succeeds the second.
+///
+/// TUNNEL-BY-CONSTRUCTION: the Director is registered at a dead endpoint and its session arrives only via
+/// PushSnapshot, so any delivery at all proves the Gateway rode the tunnel.
+///
+/// The one thing NOT real here is the speech-to-text provider: the delivery arm sits behind a successful
+/// transcribe, and the hosted transcription URL is a compile-time constant with no local override, so the
+/// provider is a stub returning fixed text. Everything the defect actually lives in - the guard, the record,
+/// the failure arm, the retry - is the real thing.
+/// </summary>
+[Collection("DirectorRoot")]
+public sealed class Issue1593FailedAttemptRebaselineTests : IAsyncLifetime
+{
+    private const string Token = "test-token-1593-rebaseline";
+    private const string DirectorId = "dir-1593-rebaseline";
+    private const string Transcript = "the words the user actually said";
+
+    // The clip's record-time baseline, and the growth a FAILED attempt writes into the terminal by typing the
+    // text and clearing it again. The real incident logged ~8,700 bytes of such noise; the exact figure does
+    // not matter, only that it is far past the guard's 512-byte tolerance.
+    private const long RecordTimeBaseline = 1_000;
+    private const long FailedAttemptNoise = 8_700;
+
+    private readonly string _root;
+    private readonly string? _prevRoot;
+    private readonly string _instancesDir = Path.Combine(Path.GetTempPath(), "cc-1593-inst-" + Guid.NewGuid().ToString("N"));
+    private readonly string _vaultPath = Path.Combine(Path.GetTempPath(), "cc-1593-vault-" + Guid.NewGuid().ToString("N") + ".json");
+
+    private GatewayHost _gateway = null!;
+    private HttpClient _http = null!;
+    private FakeTunnelDirector _director = null!;
+    private readonly string _sessionId = Guid.NewGuid().ToString();
+    private long _pushSequence;
+
+    public Issue1593FailedAttemptRebaselineTests()
+    {
+        _prevRoot = Environment.GetEnvironmentVariable("CC_DIRECTOR_ROOT");
+        _root = Path.Combine(Path.GetTempPath(), "ccd-1593-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _root);
+    }
+
+    public async Task InitializeAsync()
+    {
+        // The key must be present or the complete path bails before it ever transcribes, let alone delivers.
+        new KeyVault(_vaultPath).Set(TranscriptionEndpointResolver.DevThrottleKeyName, "dt_test_key");
+
+        _gateway = new GatewayHost(port: AllocateFreePort(), token: Token, authEnabled: true,
+            instancesDirectory: _instancesDir,
+            keyVaultPath: _vaultPath,
+            workListsPath: Path.Combine(_instancesDir, "worklists", "worklists.json"),
+            streamMode: true,
+            dictationTranscription: StubTranscription());
+        await _gateway.StartAsync();
+
+        _http = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{_gateway.Port}/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+
+        _director = await FakeTunnelDirector.StartAsync(_gateway, Token, DirectorId);
+        await PushInitialSessionAsync(RecordTimeBaseline);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _director.DisposeAsync();
+        await _gateway.StopAsync();
+        Environment.SetEnvironmentVariable("CC_DIRECTOR_ROOT", _prevRoot);
+        try { if (Directory.Exists(_instancesDir)) Directory.Delete(_instancesDir, true); } catch { /* cleanup */ }
+        try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { /* cleanup */ }
+        try { if (File.Exists(_vaultPath)) File.Delete(_vaultPath); } catch { /* cleanup */ }
+    }
+
+    // ===== the fix =================================================================================
+
+    [Fact]
+    public async Task RetryAfterOurOwnFailedAttempt_IsDelivered_NotDroppedAsMovedOn()
+    {
+        var uploadId = await RegisterAndUploadAsync();
+
+        // Attempt 1: the guard passes (the buffer is still at the record-time baseline), delivery is
+        // attempted, and it FAILS - after growing the buffer with its own typing-and-clearing noise, exactly
+        // as the real echo-verified submit failure did.
+        var prompts = 0;
+        _director.OnCommand(cmd =>
+        {
+            if (cmd.Verb != "prompt") return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
+            if (Interlocked.Increment(ref prompts) == 1)
+            {
+                ReportBuffer(RecordTimeBaseline + FailedAttemptNoise);
+                return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "composer never echoed the text");
+            }
+            return FakeTunnelDirector.Ok(new PromptResponse());
+        });
+
+        var first = await CompleteAsync(uploadId);
+        Assert.Equal(HttpStatusCode.BadGateway, first.status); // 502 - retryable, so the phone retries
+
+        // Attempt 2: the SAME clip, with the SAME record-time baseline the phone has always sent (the phone
+        // needs no change for this fix). Today the guard reads our own 8,700 bytes of noise as "other turns
+        // happened" and drops the words. It must deliver.
+        var second = await CompleteAsync(uploadId);
+
+        Assert.Equal(HttpStatusCode.OK, second.status);
+        Assert.True(second.body.GetProperty("submitted").GetBoolean(),
+            "the retry of a delivery WE failed must inject the user's words, not be dropped as stale");
+        Assert.False(second.body.GetProperty("movedOn").GetBoolean());
+        Assert.Equal(2, prompts); // the retry really did reach the Director's prompt verb
+
+        // The durable record is a DELIVERED tombstone that says submitted - the words landed for good.
+        var record = Store().ReadRecord(uploadId)!;
+        Assert.Equal(DictationDeliveryState.Delivered, record.State);
+        Assert.True(record.Submitted);
+        Assert.False(record.MovedOn);
+    }
+
+    [Fact]
+    public async Task TheReBaselineIsPersistedOnTheServerRecord_SoAPhoneThatMissedThe502StillRetriesHonestly()
+    {
+        // Ruling 2: the re-baseline lives on the SERVER's durable record, not in the phone's request. A phone
+        // whose 502 response never arrived does not know an attempt happened at all - it just re-registers the
+        // upload id and completes again with its original baseline. That path must still be judged honestly.
+        var uploadId = await RegisterAndUploadAsync();
+
+        var prompts = 0;
+        _director.OnCommand(cmd =>
+        {
+            if (cmd.Verb != "prompt") return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
+            if (Interlocked.Increment(ref prompts) == 1)
+            {
+                ReportBuffer(RecordTimeBaseline + FailedAttemptNoise);
+                return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "composer never echoed the text");
+            }
+            return FakeTunnelDirector.Ok(new PromptResponse());
+        });
+
+        Assert.Equal(HttpStatusCode.BadGateway, (await CompleteAsync(uploadId)).status);
+
+        // The honest baseline is on disk, on the server's record, and it accounts for the noise.
+        var afterFailure = Store().ReadRecord(uploadId)!;
+        Assert.Equal(DictationDeliveryState.Pending, afterFailure.State); // still pending - the clip is alive
+        Assert.NotNull(afterFailure.RebaselineBufferBytes);
+        Assert.Equal(RecordTimeBaseline + FailedAttemptNoise, afterFailure.RebaselineBufferBytes!.Value);
+
+        // The phone re-REGISTERS (it never saw the 502) and retries. The re-register must not wipe the value.
+        await RegisterAsync(uploadId);
+        Assert.Equal(RecordTimeBaseline + FailedAttemptNoise, Store().ReadRecord(uploadId)!.RebaselineBufferBytes);
+
+        var retry = await CompleteAsync(uploadId);
+        Assert.Equal(HttpStatusCode.OK, retry.status);
+        Assert.True(retry.body.GetProperty("submitted").GetBoolean());
+    }
+
+    // ===== the control: a GENUINE move-on must still drop ===========================================
+
+    [Fact]
+    public async Task GenuineMoveOn_BeforeAnyDeliveryAttempt_IsStillDropped()
+    {
+        // The control that stops the fix from becoming "never drop anything". Here the buffer grew BEFORE any
+        // delivery attempt of ours - nothing of ours is in that growth, so it is somebody else's turns and the
+        // session really has moved on. No attempt has failed, so there is no re-baseline, and the guard must
+        // drop exactly as it always did.
+        var uploadId = await RegisterAndUploadAsync();
+        ReportBuffer(RecordTimeBaseline + FailedAttemptNoise);
+
+        var prompts = 0;
+        _director.OnCommand(cmd =>
+        {
+            if (cmd.Verb == "prompt") Interlocked.Increment(ref prompts);
+            return FakeTunnelDirector.Ok(new PromptResponse());
+        });
+
+        var result = await CompleteAsync(uploadId);
+
+        Assert.Equal(HttpStatusCode.OK, result.status);
+        Assert.False(result.body.GetProperty("submitted").GetBoolean());
+        Assert.True(result.body.GetProperty("movedOn").GetBoolean(), "a genuine move-on must still drop");
+        Assert.Equal(0, prompts); // it never reached the session at all
+        Assert.Null(Store().ReadRecord(uploadId)!.RebaselineBufferBytes); // nothing of ours ever failed
+    }
+
+    [Fact]
+    public async Task GrowthAfterOurFailedAttempt_BeyondTheReBaseline_IsStillDropped()
+    {
+        // The sharper control: our own failed attempt is forgiven, but growth ON TOP of it is not. The
+        // re-baseline moves the bar to account for OUR noise only - a real turn landing after that is still a
+        // move-on and the clip is still stale.
+        var uploadId = await RegisterAndUploadAsync();
+
+        var prompts = 0;
+        _director.OnCommand(cmd =>
+        {
+            if (cmd.Verb != "prompt") return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, $"unexpected verb {cmd.Verb}");
+            if (Interlocked.Increment(ref prompts) == 1)
+            {
+                ReportBuffer(RecordTimeBaseline + FailedAttemptNoise);
+                return DirectorCommandResult.Fail(DirectorCommandStatus.BadRequest, "composer never echoed the text");
+            }
+            return FakeTunnelDirector.Ok(new PromptResponse());
+        });
+
+        Assert.Equal(HttpStatusCode.BadGateway, (await CompleteAsync(uploadId)).status);
+
+        // Somebody else's turn lands after our failure, well past the re-baseline.
+        ReportBuffer(RecordTimeBaseline + FailedAttemptNoise + 50_000);
+
+        var retry = await CompleteAsync(uploadId);
+        Assert.Equal(HttpStatusCode.OK, retry.status);
+        Assert.False(retry.body.GetProperty("submitted").GetBoolean());
+        Assert.True(retry.body.GetProperty("movedOn").GetBoolean(),
+            "growth beyond our own failed attempt is a real move-on and must still drop");
+        Assert.Equal(1, prompts); // the retry never reached the session
+    }
+
+    // ===== helpers =================================================================================
+
+    private static VoiceUploadStore Store() => new(CcStorage.DictationUploads());
+
+    private SessionDto SessionAt(long bufferBytes) => new()
+    {
+        SessionId = _sessionId,
+        Name = "dictation target",
+        Status = "Running",
+        ActivityState = "Idle",
+        TotalBufferBytes = bufferBytes,
+    };
+
+    /// <summary>
+    /// The session's FIRST appearance, pushed through the REAL hub the way a Director reports its state. This
+    /// is what puts the session in the push store at all, so the Gateway can locate it and its owner.
+    /// </summary>
+    private async Task PushInitialSessionAsync(long bufferBytes)
+    {
+        await _director.PushSnapshotAsync(SessionAt(bufferBytes));
+        _pushSequence = 1; // FakeTunnelDirector's first push is sequence 1; later writes must climb from there.
+    }
+
+    /// <summary>
+    /// Report a new buffer position for the session, as a Director's push stream does when its terminal grows.
+    ///
+    /// This writes the push store directly rather than invoking PushSnapshot over the hub, for one reason that
+    /// the tests genuinely need: the interesting growth happens from INSIDE the Director's command handler,
+    /// while the Gateway is still awaiting the prompt result - which is exactly when the real failure writes
+    /// its noise, and what the re-baseline must see when it re-reads. Calling back into the hub from within a
+    /// hub client callback would leave the connection's message loop waiting on itself. The store IS what the
+    /// Gateway re-reads and this lands the same state a real push lands, so the seam under test is untouched;
+    /// only the transport of these later snapshots is short-cut. One sequence counter is shared with the hub
+    /// push above, because the store rejects an out-of-order sequence and would otherwise silently ignore it.
+    /// </summary>
+    private void ReportBuffer(long bufferBytes)
+    {
+        var connectionId = _gateway.PushedSessions.GetActiveConnectionId(DirectorId)!;
+        var applied = _gateway.PushedSessions.ApplyDelta(
+            DirectorId, connectionId, Interlocked.Increment(ref _pushSequence), SessionAt(bufferBytes));
+        Assert.True(applied, "the test's own buffer report must actually land, or it proves nothing");
+    }
+
+    private async Task<string> RegisterAndUploadAsync()
+    {
+        var uploadId = Guid.NewGuid().ToString();
+        await RegisterAsync(uploadId);
+        // A real (if silent) clip: a short PCM WAV, under the split budget, so the pipeline sends it whole.
+        var wav = PcmWav.Wrap(new byte[16_000 * 2], 16_000, 1, 16);
+        using var content = new ByteArrayContent(wav);
+        using var req = new HttpRequestMessage(HttpMethod.Put, $"/dictation/{uploadId}/chunk/0") { Content = content };
+        req.Headers.Add("X-Chunk-Sha256", Sha256Hex(wav));
+        var resp = await _http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        return uploadId;
+    }
+
+    private async Task RegisterAsync(string uploadId)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Post, "/dictation/upload")
+        {
+            Content = JsonContent.Create(new { sessionId = _sessionId, baselineBufferBytes = RecordTimeBaseline }),
+        };
+        req.Headers.Add("Idempotency-Key", uploadId);
+        var resp = await _http.SendAsync(req);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    /// <summary>Complete the clip exactly as the phone does on a resume: resumed, carrying the baseline it
+    /// stamped when the clip was RECORDED - the same number on every retry, because the phone never moves it.</summary>
+    private async Task<(HttpStatusCode status, JsonElement body)> CompleteAsync(string uploadId)
+    {
+        var resp = await _http.PostAsJsonAsync($"/dictation/{uploadId}/complete", new
+        {
+            sessionId = _sessionId,
+            totalChunks = 1,
+            mime = "audio/wav",
+            ext = "wav",
+            baselineBufferBytes = RecordTimeBaseline,
+            resumed = true,
+        });
+        return (resp.StatusCode, await resp.Content.ReadFromJsonAsync<JsonElement>());
+    }
+
+    /// <summary>The real transcription owner over a stub provider socket, with its own telemetry + audio
+    /// archive so it never writes into the real user's directories (the defaults are process-wide Shared
+    /// instances whose paths are baked at type-init).</summary>
+    private GatewayTranscriptionService StubTranscription() => new(
+        new KeyVault(_vaultPath),
+        http: new HttpClient(new TranscriptStub()),
+        telemetry: new TranscriptionTelemetryLog(Path.Combine(_root, "telemetry")),
+        audioArchive: new TranscriptionAudioArchive(Path.Combine(_root, "audio")));
+
+    /// <summary>Stands in for the hosted speech-to-text provider: always returns the same transcript.</summary>
+    private sealed class TranscriptStub : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent($"{{\"text\":\"{Transcript}\"}}", Encoding.UTF8, "application/json"),
+            });
+    }
+
+    private static string Sha256Hex(byte[] bytes)
+        => Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(bytes)).ToLowerInvariant();
+
+    private static int AllocateFreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+}

--- a/src/CcDirector.Gateway.Tests/VoiceUploadStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceUploadStoreTests.cs
@@ -396,6 +396,88 @@ public sealed class VoiceUploadStoreTests : IDisposable
         Assert.Contains(sidB, locked);
     }
 
+    // ===== the failed-delivery re-baseline (Lost Dictations mission, issue #1593) ==================
+
+    [Fact]
+    public void RecordFailedDeliveryBaseline_IsMonotonic_AndNeverLowersAnHonestBaseline()
+    {
+        var uploadId = _store.Register(null);
+        _store.MarkPending(uploadId, Guid.NewGuid().ToString());
+
+        Assert.True(_store.RecordFailedDeliveryBaseline(uploadId, 9_000));
+        Assert.Equal(9_000, _store.ReadRecord(uploadId)!.RebaselineBufferBytes);
+
+        // A LOWER later read (a lagging push stream) must never walk the honest baseline back down.
+        Assert.False(_store.RecordFailedDeliveryBaseline(uploadId, 4_000));
+        Assert.Equal(9_000, _store.ReadRecord(uploadId)!.RebaselineBufferBytes);
+
+        // A higher one moves it up: a second failed attempt only ever added more of our own noise.
+        Assert.True(_store.RecordFailedDeliveryBaseline(uploadId, 12_000));
+        Assert.Equal(12_000, _store.ReadRecord(uploadId)!.RebaselineBufferBytes);
+    }
+
+    [Fact]
+    public void RecordFailedDeliveryBaseline_UnderConcurrentWriters_KeepsTheLARGESTValue()
+    {
+        // The read-modify-write must be atomic. Unlocked, two writers can both read the old value and the one
+        // that computed the SMALLER max can land last, overwriting the larger - handing a retry a baseline we
+        // had already proven too low, which is exactly the drop the re-baseline exists to stop. Many writers
+        // over a shared value, from SEPARATE store instances over the same root (the gate is on the staging
+        // directory, not the object), with the largest deliberately not last.
+        var uploadId = _store.Register(null);
+        _store.MarkPending(uploadId, Guid.NewGuid().ToString());
+
+        var values = Enumerable.Range(1, 64).Select(i => (long)i * 1_000).ToArray();
+        var shuffled = values.OrderBy(v => (v * 7919) % 101).ToArray();
+        Parallel.ForEach(shuffled, v => new VoiceUploadStore(_root).RecordFailedDeliveryBaseline(uploadId, v));
+
+        Assert.Equal(values.Max(), _store.ReadRecord(uploadId)!.RebaselineBufferBytes);
+    }
+
+    [Fact]
+    public void RecordFailedDeliveryBaseline_IsANoOpForATerminalRecord()
+    {
+        // A resolved upload's guard has already run for the last time; re-baselining it would move a number
+        // nothing will ever read, and must not disturb the tombstone.
+        var delivered = _store.Register(null);
+        _store.MarkPending(delivered, Guid.NewGuid().ToString());
+        _store.MarkDelivered(delivered, submitted: false, movedOn: true, transcript: "dropped words");
+        Assert.False(_store.RecordFailedDeliveryBaseline(delivered, 9_000));
+        Assert.Null(_store.ReadRecord(delivered)!.RebaselineBufferBytes);
+        Assert.Equal(DictationDeliveryState.Delivered, _store.ReadRecord(delivered)!.State);
+
+        var abandoned = _store.Register(null);
+        _store.MarkPending(abandoned, Guid.NewGuid().ToString());
+        _store.MarkAbandoned(abandoned, "cancelled");
+        Assert.False(_store.RecordFailedDeliveryBaseline(abandoned, 9_000));
+        Assert.Null(_store.ReadRecord(abandoned)!.RebaselineBufferBytes);
+
+        // And an id with no record at all is simply not re-baselineable.
+        Assert.False(_store.RecordFailedDeliveryBaseline(Guid.NewGuid().ToString(), 9_000));
+    }
+
+    [Fact]
+    public void NonTerminalTransitions_PreserveTheReBaseline()
+    {
+        // A re-register (the phone never saw our 502) and a transcription failure on a retry both rewrite the
+        // marker. Either dropping the re-baseline would hand the next retry back the very baseline our own
+        // failed attempt invalidated.
+        var sid = Guid.NewGuid().ToString();
+        var uploadId = _store.Register(null);
+        _store.MarkPending(uploadId, sid);
+        _store.RecordFailedDeliveryBaseline(uploadId, 9_000);
+
+        _store.MarkPending(uploadId, sid); // re-register
+        Assert.Equal(9_000, _store.ReadRecord(uploadId)!.RebaselineBufferBytes);
+
+        _store.MarkFailed(uploadId, "transcription_error");
+        Assert.Equal(9_000, _store.ReadRecord(uploadId)!.RebaselineBufferBytes);
+
+        _store.ClearFailed(uploadId);
+        Assert.Equal(9_000, _store.ReadRecord(uploadId)!.RebaselineBufferBytes);
+        Assert.Equal(DictationDeliveryState.Pending, _store.ReadRecord(uploadId)!.State);
+    }
+
     [Fact]
     public void TerminalTransitions_PreserveTheSessionId()
     {

--- a/src/CcDirector.Gateway.Tests/VoiceUploadStoreTests.cs
+++ b/src/CcDirector.Gateway.Tests/VoiceUploadStoreTests.cs
@@ -435,6 +435,57 @@ public sealed class VoiceUploadStoreTests : IDisposable
     }
 
     [Fact]
+    public void RecordFailedDeliveryBaseline_CannotResurrectATombstoneThatLandsMidWrite()
+    {
+        // THE INTERLEAVING THAT MATTERS (found by inspection of the #1593 fix). Serializing the re-baseline
+        // writers against each other is not enough: the dangerous race is between DIFFERENT writers. A
+        // re-baseline reads a PENDING record, stalls, MarkDelivered lands a terminal tombstone, and the
+        // re-baseline then writes its remembered PENDING record back over it. The upload id is resurrected as
+        // pending, and #1183's durable de-dupe - the only thing standing between a delivered dictation and a
+        // SECOND injection of the same turn - is gone.
+        //
+        // Driven deterministically: the re-baseline is stalled at the exact instant between its read and its
+        // write, and a competing MarkDelivered is fired from another thread right then. With every record write
+        // behind one per-upload gate, that MarkDelivered CANNOT land inside the window - it waits, so the
+        // stall times out and the tombstone lands cleanly afterwards. With the gate removed it lands
+        // immediately, the re-baseline overwrites it, and the record comes back as Pending.
+        var uploadId = _store.Register(null);
+        _store.MarkPending(uploadId, Guid.NewGuid().ToString());
+
+        var tombstoneLanded = new ManualResetEventSlim(false);
+        Task? competing = null;
+        VoiceUploadStore.BetweenRecordReadAndWriteForTests = _ =>
+        {
+            // Fire the competing terminal write from another thread, then give it every chance to land BEFORE
+            // this re-baseline writes. The gate is what must stop it; nothing else here does.
+            competing = Task.Run(() =>
+            {
+                new VoiceUploadStore(_root).MarkDelivered(uploadId, submitted: true, movedOn: false, transcript: "delivered words");
+                tombstoneLanded.Set();
+            });
+            // A bounded wait, NOT a barrier: under the gate this must time out (the tombstone is blocked behind
+            // us, which is the whole point), so waiting forever would hang rather than pass.
+            tombstoneLanded.Wait(TimeSpan.FromSeconds(1));
+        };
+        try
+        {
+            _store.RecordFailedDeliveryBaseline(uploadId, 9_000);
+        }
+        finally
+        {
+            VoiceUploadStore.BetweenRecordReadAndWriteForTests = null;
+        }
+        competing?.Wait(TimeSpan.FromSeconds(5));
+
+        // The delivered tombstone stands. A re-complete of this upload id returns the cached delivered outcome
+        // and never injects a second turn.
+        var record = _store.ReadRecord(uploadId)!;
+        Assert.Equal(DictationDeliveryState.Delivered, record.State);
+        Assert.True(record.Submitted);
+        Assert.Equal("delivered words", record.Transcript);
+    }
+
+    [Fact]
     public void RecordFailedDeliveryBaseline_IsANoOpForATerminalRecord()
     {
         // A resolved upload's guard has already run for the last time; re-baselining it would move a number

--- a/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayDictationEndpoint.cs
@@ -417,15 +417,25 @@ internal static class GatewayDictationEndpoint
             // Moved-on guard (issue #1006): for a RESUMED clip, if the session's terminal output grew
             // materially since the clip was recorded, other turns happened - drop the stale dictation
             // rather than inject it into a session that has moved on. Immediate sends skip this.
+            //
+            // The baseline is the LARGER of what the phone recorded and what a previous FAILED delivery
+            // attempt of THIS upload id re-baselined to (Lost Dictations mission, issue #1593). The phone's
+            // baseline is stamped once, when the clip was recorded, and never moves - so after one of our own
+            // failed attempts typed the text and cleared it again, the phone's baseline describes a terminal
+            // that no longer exists, and the retry gets dropped as "moved on" by OUR OWN noise. Taking the
+            // larger of the two costs nothing when no attempt failed (the stored value is absent) and is what
+            // stops the observed drop when one did.
+            var effectiveBaseline = Math.Max(
+                req.BaselineBufferBytes, uploads.ReadRecord(uploadId)?.RebaselineBufferBytes ?? 0);
             if (req.Resumed && session is not null && req.BaselineBufferBytes > 0 &&
-                session.TotalBufferBytes > req.BaselineBufferBytes + MovedOnBufferGrowthBytes)
+                session.TotalBufferBytes > effectiveBaseline + MovedOnBufferGrowthBytes)
             {
                 // The turn is resolved (deliberately dropped as stale): a durable DELIVERED tombstone with
                 // movedOn set, so a re-complete returns the same moved-on outcome and never injects the stale
                 // clip (issue #1183). Discards the retained chunks, keeps the marker.
                 uploads.MarkDelivered(uploadId, submitted: false, movedOn: true, transcript);
                 FileLog.Write($"[GatewayDictation] complete sid={sid} uploadId={uploadId}: session moved on " +
-                    $"(buffer {req.BaselineBufferBytes}->{session.TotalBufferBytes}); dropped");
+                    $"(buffer {req.BaselineBufferBytes}/effective {effectiveBaseline}->{session.TotalBufferBytes}); dropped");
                 return DictationOutcome.Submitted(false, true, transcript);
             }
 
@@ -443,7 +453,34 @@ internal static class GatewayDictationEndpoint
             // "unknown" surface bucket, never silently dropped (decision 9).
             var (ok, _, err) = await route.PostPromptAsync(sid, new PromptRequest { Text = message, AppendEnter = true, Surface = deliverySurface ?? "unknown", DeliveryUploadId = uploadId });
             if (!ok)
+            {
+                // THE ATTEMPT WE JUST MADE INVALIDATED THE PHONE'S BASELINE (Lost Dictations mission, #1593).
+                // A failed submit is not a no-op on the terminal: the observed failure (05:31 on 2026-07-15)
+                // typed the text twice and cleared it twice, writing ~8,700 bytes of our own noise into the
+                // buffer. The phone's baseline was stamped when the clip was RECORDED and never moves, so the
+                // retry that follows this 502 would be judged against a number our own failure just made a
+                // lie, and the moved-on guard would drop the user's words as stale. Re-baseline the upload id
+                // to the freshest buffer position we can see, so the retry is judged honestly.
+                //
+                // Re-READ the session rather than reusing the `session` snapshot from before the attempt:
+                // that snapshot predates the noise by definition and would re-baseline to the same number the
+                // phone already sent, which is no re-baseline at all.
+                //
+                // NOT PROVEN TO CLOSE THE WINDOW COMPLETELY, and deliberately not dressed up as if it does:
+                // this reads the pushed store, so it sees only what the owning Director has pushed BY NOW. If
+                // the push stream lags the failure, some of the attempt's noise is not in this number yet and
+                // a retry could still be judged against a baseline that is too low. It is strictly better than
+                // today (today re-baselines by exactly zero) and it is monotonic, so a later failed attempt
+                // can only improve it - but the residual lag window is real and is not closed here.
+                var (_, freshSession) = await GatewayEndpoints.LocateSessionAsync(
+                    registry, sid, pushedSessions, streamStale, owners);
+                if (freshSession is not null)
+                    uploads.RecordFailedDeliveryBaseline(uploadId, freshSession.TotalBufferBytes);
+                FileLog.Write($"[GatewayDictation] complete sid={sid} uploadId={uploadId}: submit FAILED ({err}); " +
+                    $"re-baselined to {freshSession?.TotalBufferBytes.ToString() ?? "unavailable"} " +
+                    $"(was {req.BaselineBufferBytes}) so the retry is not dropped as stale");
                 return DictationOutcome.Error(StatusCodes.Status502BadGateway, err ?? "submit to session failed");
+            }
 
             // Write the durable DELIVERED tombstone as the IMMEDIATE next step after the session accepted the
             // prompt, before anything else, to minimize the window in which a re-complete could re-inject

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -293,6 +293,11 @@ public sealed class GatewayHost : IAsyncDisposable
     private readonly TailscaleServeProvisioner _serveProvisioner;
     private readonly GatewayTurnBriefStore _turnBriefStore;
     private readonly KeyVault _keyVault;
+
+    // Lost Dictations mission (#1593): the transcription owner the dictation endpoint uses. Null in
+    // production - StartAsync then builds the real one over _keyVault. Only a test injects a stub, because
+    // the dictation delivery arm sits BEHIND a successful transcribe and the hosted URL is a constant.
+    private readonly Transcription.GatewayTranscriptionService? _dictationTranscription;
     // Issue #881: mints/ensures the DevThrottle inference key after sign-in and at startup. Null on a
     // host with no credential service (nothing to sign in to).
     private readonly Account.TranscriptionKeyAutoProvisioner? _transcriptionKeyProvisioner;
@@ -460,7 +465,16 @@ public sealed class GatewayHost : IAsyncDisposable
     /// isolated temp path; production omits it for the shared default at
     /// <c>CcStorage.Root()\mission-notes.json</c>.
     /// </param>
-    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? snoozePath = null, string? missionsPath = null, string? missionNotesPath = null)
+    /// <param name="dictationTranscription">
+    /// Override the transcription owner the DICTATION endpoint uses (Lost Dictations mission, issue #1593).
+    /// The dictation complete path transcribes BEFORE it delivers, so an end-to-end test of the delivery
+    /// arm cannot reach that arm at all without a transcription that succeeds - and the hosted base URL is a
+    /// compile-time constant, so there is no way to point it at a local stub. Tests pass a service built over
+    /// a stub HttpClient (and their own telemetry + audio archive, which otherwise default to process-wide
+    /// Shared instances that write to the real user's directories). Production omits it and the host builds
+    /// the service over its own key vault, exactly as before.
+    /// </param>
+    public GatewayHost(int port = DefaultPort, string? token = null, bool? authEnabled = null, string? instancesDirectory = null, string? turnBriefDirectory = null, string? keyVaultPath = null, string? workListsPath = null, string? cronJobsPath = null, string? cronRunsPath = null, string? devicesPath = null, string? telemetryQueuePath = null, int? telemetryQueueMaxSize = null, TimeSpan? telemetryRetryInterval = null, Core.Account.DevThrottleAccountService? account = null, bool? streamMode = null, string? inputStatsPath = null, string? snoozePath = null, string? missionsPath = null, string? missionNotesPath = null, Transcription.GatewayTranscriptionService? dictationTranscription = null)
     {
         Port = port;
         Token = token ?? GatewayAuth.LoadOrCreate();
@@ -520,6 +534,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // Production omits keyVaultPath for the shared default; tests pass an isolated path so
         // they never touch the real %LOCALAPPDATA% key store.
         _keyVault = new KeyVault(keyVaultPath);
+        _dictationTranscription = dictationTranscription;
         // Named work lists persist across a Gateway restart (issue #301): one JSON file in the
         // Gateway data dir, loaded here (stale claims released) and written through on every
         // mutation. Tests MUST pass an isolated path so they never touch the real store.
@@ -1421,7 +1436,7 @@ public sealed class GatewayHost : IAsyncDisposable
         // in resumable chunks and the Gateway assembles → transcribes → injects the turn into the
         // owning session itself, so a refresh / dropped connection cannot lose a recorded utterance.
         GatewayDictationEndpoint.Map(_app, Registry, SessionOwners, Token,
-            new Transcription.GatewayTranscriptionService(_keyVault), _transcribingSessions, _dictationUploads, Devices,
+            _dictationTranscription ?? new Transcription.GatewayTranscriptionService(_keyVault), _transcribingSessions, _dictationUploads, Devices,
             pushedSessions: PushedSessions,
             sendCommand: SendCommandAsync);
         // Durable per-upload-id dictation record (issue #1183): a PENDING upload's chunks are retained

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -409,23 +410,32 @@ public sealed class VoiceUploadStore
     {
         var uid = NormalizeId(uploadId);
         if (uid is null) return false;
-        if (ReadRecord(uid) is not { } record) return false;
-        if (record.State is DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned) return false;
 
-        var merged = Math.Max(record.RebaselineBufferBytes ?? 0, bufferBytes);
-        if (merged <= (record.RebaselineBufferBytes ?? -1)) return false; // already at least this honest
-        try
+        // Read-modify-write under the per-upload gate. Without it the max-and-write is not atomic: two
+        // writers can both read the old value, and the one that computed the SMALLER max can land last and
+        // overwrite the larger - handing a retry a baseline lower than one we had already proven honest,
+        // which is exactly the drop this whole field exists to stop. The monotonic rule has to hold at the
+        // WRITE, not just in the arithmetic.
+        lock (GateFor(DirFor(uid)))
         {
-            // Marker only - the chunk bytes stay put, because this upload is still going to be delivered.
-            WriteRecordMarker(DirFor(uid), record with { RebaselineBufferBytes = merged });
-            FileLog.Write($"[VoiceUploadStore] RecordFailedDeliveryBaseline: uploadId={uid} rebaseline={merged} " +
-                $"(state={record.State}, chunks retained)");
-            return true;
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[VoiceUploadStore] RecordFailedDeliveryBaseline uploadId={uid} failed: {ex.Message}");
-            return false;
+            if (ReadRecord(uid) is not { } record) return false;
+            if (record.State is DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned) return false;
+
+            var merged = Math.Max(record.RebaselineBufferBytes ?? 0, bufferBytes);
+            if (merged <= (record.RebaselineBufferBytes ?? -1)) return false; // already at least this honest
+            try
+            {
+                // Marker only - the chunk bytes stay put, because this upload is still going to be delivered.
+                WriteRecordMarker(DirFor(uid), record with { RebaselineBufferBytes = merged });
+                FileLog.Write($"[VoiceUploadStore] RecordFailedDeliveryBaseline: uploadId={uid} rebaseline={merged} " +
+                    $"(state={record.State}, chunks retained)");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[VoiceUploadStore] RecordFailedDeliveryBaseline uploadId={uid} failed: {ex.Message}");
+                return false;
+            }
         }
     }
 
@@ -492,6 +502,23 @@ public sealed class VoiceUploadStore
     }
 
     // ====== internals ===============================================================
+
+    // Per-upload write gates, keyed by the upload's staging DIRECTORY - the resource itself, not the store
+    // object - so the gate holds even though callers construct their own VoiceUploadStore instances over the
+    // same root (the endpoint, the tests, and the aggregator all do). Static for the same reason: two store
+    // instances over one directory must contend for one gate, or the gate protects nothing.
+    //
+    // In-process only, and deliberately so: this guards the read-modify-write in RecordFailedDeliveryBaseline,
+    // whose writers are all inside this Gateway. It is NOT a cross-process file lock and does not claim to be;
+    // the individual marker write is already atomic (temp + move), so the worst a second process could do is
+    // land a stale value, which no deployment we run can produce (one Gateway owns a staging root).
+    //
+    // One small object per upload id that has had a failed delivery attempt. Never pruned; bounded by real
+    // failed-delivery volume, the same shape as the endpoint's own uploadId->sessionId map.
+    private static readonly ConcurrentDictionary<string, object> _recordGates =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private static object GateFor(string dir) => _recordGates.GetOrAdd(dir, _ => new object());
 
     private string DirFor(string uid) => Path.Combine(_root, uid);
     private static string ChunkPath(string dir, int index) => Path.Combine(dir, $"{index:D5}.part");

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -276,14 +275,18 @@ public sealed class VoiceUploadStore
     public void MarkPending(string uploadId, string sessionId)
     {
         var uid = NormalizeId(uploadId) ?? throw new InvalidOperationException("invalid upload id");
-        var dir = DirFor(uid);
-        Directory.CreateDirectory(dir);
-        // Carry the #1593 re-baseline forward: a phone that never saw our 502 simply RE-REGISTERS its upload
-        // id and retries. That path lands here, so dropping the value would hand the retry back the very
-        // baseline our own failed attempt invalidated - the exact drop this field exists to stop.
-        WriteRecordMarker(dir, new DictationDeliveryRecord(
-            DictationDeliveryState.Pending, false, false, "", null, sessionId ?? "", ExistingRebaseline(uid)));
-        FileLog.Write($"[VoiceUploadStore] MarkPending: uploadId={uid} sessionId={sessionId}");
+        WithRecordLock(uid, () =>
+        {
+            var dir = DirFor(uid);
+            Directory.CreateDirectory(dir);
+            // Carry the #1593 re-baseline forward: a phone that never saw our 502 simply RE-REGISTERS its
+            // upload id and retries. That path lands here, so dropping the value would hand the retry back the
+            // very baseline our own failed attempt invalidated - the exact drop this field exists to stop.
+            // Read inside the gate, so it cannot be a value from before another writer moved it.
+            WriteRecordMarker(dir, new DictationDeliveryRecord(
+                DictationDeliveryState.Pending, false, false, "", null, sessionId ?? "", ExistingRebaseline(uid)));
+            FileLog.Write($"[VoiceUploadStore] MarkPending: uploadId={uid} sessionId={sessionId}");
+        });
     }
 
     /// <summary>
@@ -331,8 +334,8 @@ public sealed class VoiceUploadStore
     /// tombstone is retired only by <see cref="Acknowledge"/>.
     /// </summary>
     public void MarkDelivered(string uploadId, bool submitted, bool movedOn, string transcript)
-        => WriteTombstone(uploadId, new DictationDeliveryRecord(
-            DictationDeliveryState.Delivered, submitted, movedOn, transcript ?? "", null, ExistingSessionId(uploadId)));
+        => WriteTombstone(uploadId, uid => new DictationDeliveryRecord(
+            DictationDeliveryState.Delivered, submitted, movedOn, transcript ?? "", null, ExistingSessionId(uid)));
 
     /// <summary>
     /// Transition this upload id to the durable ABANDONED tombstone: persist the reason and discard the
@@ -340,8 +343,8 @@ public sealed class VoiceUploadStore
     /// from the surfaces are a later task; this provides the state and its read side.
     /// </summary>
     public void MarkAbandoned(string uploadId, string reason)
-        => WriteTombstone(uploadId, new DictationDeliveryRecord(
-            DictationDeliveryState.Abandoned, false, false, "", reason ?? "", ExistingSessionId(uploadId)));
+        => WriteTombstone(uploadId, uid => new DictationDeliveryRecord(
+            DictationDeliveryState.Abandoned, false, false, "", reason ?? "", ExistingSessionId(uid)));
 
     /// <summary>
     /// Park this upload id as FAILED with a permanent-failure reason code (issue #1185). Unlike DELIVERED
@@ -353,16 +356,20 @@ public sealed class VoiceUploadStore
     public void MarkFailed(string uploadId, string reasonCode)
     {
         var uid = NormalizeId(uploadId) ?? throw new InvalidOperationException("invalid upload id");
-        var dir = DirFor(uid);
-        Directory.CreateDirectory(dir);
-        // Write ONLY the marker - keep the chunk bytes (the retry re-drives them), the opposite of a tombstone.
-        // Preserve the owning session id so a later ClearFailed can restore a PENDING marker that re-locks it,
-        // and the #1593 re-baseline so a transcription failure on a retry cannot erase what an earlier failed
-        // DELIVERY attempt already learned about the buffer.
-        WriteRecordMarker(dir, new DictationDeliveryRecord(
-            DictationDeliveryState.Failed, false, false, "", reasonCode ?? "", ExistingSessionId(uid),
-            ExistingRebaseline(uid)));
-        FileLog.Write($"[VoiceUploadStore] MarkFailed: uploadId={uid} reason={reasonCode} (chunks retained)");
+        WithRecordLock(uid, () =>
+        {
+            var dir = DirFor(uid);
+            Directory.CreateDirectory(dir);
+            // Write ONLY the marker - keep the chunk bytes (the retry re-drives them), the opposite of a
+            // tombstone. Preserve the owning session id so a later ClearFailed can restore a PENDING marker
+            // that re-locks it, and the #1593 re-baseline so a transcription failure on a retry cannot erase
+            // what an earlier failed DELIVERY attempt already learned about the buffer. Both read inside the
+            // gate, so neither can be a value from before another writer moved it.
+            WriteRecordMarker(dir, new DictationDeliveryRecord(
+                DictationDeliveryState.Failed, false, false, "", reasonCode ?? "", ExistingSessionId(uid),
+                ExistingRebaseline(uid)));
+            FileLog.Write($"[VoiceUploadStore] MarkFailed: uploadId={uid} reason={reasonCode} (chunks retained)");
+        });
     }
 
     /// <summary>
@@ -376,20 +383,25 @@ public sealed class VoiceUploadStore
     {
         var uid = NormalizeId(uploadId);
         if (uid is null) return false;
-        if (ReadRecord(uid) is not { State: DictationDeliveryState.Failed } failed) return false;
-        try
+        // Read-modify-write under the gate, read inside: without it, a ClearFailed that read FAILED could
+        // write PENDING back over a tombstone that landed in between, resurrecting a resolved upload id.
+        return WithRecordLock(uid, () =>
         {
-            WriteRecordMarker(DirFor(uid), new DictationDeliveryRecord(
-                DictationDeliveryState.Pending, false, false, "", null, failed.SessionId,
-                failed.RebaselineBufferBytes));
-            FileLog.Write($"[VoiceUploadStore] ClearFailed: uploadId={uid} back to PENDING (chunks retained)");
-            return true;
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[VoiceUploadStore] ClearFailed uploadId={uid} failed: {ex.Message}");
-            return false;
-        }
+            if (ReadRecord(uid) is not { State: DictationDeliveryState.Failed } failed) return false;
+            try
+            {
+                WriteRecordMarker(DirFor(uid), new DictationDeliveryRecord(
+                    DictationDeliveryState.Pending, false, false, "", null, failed.SessionId,
+                    failed.RebaselineBufferBytes));
+                FileLog.Write($"[VoiceUploadStore] ClearFailed: uploadId={uid} back to PENDING (chunks retained)");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[VoiceUploadStore] ClearFailed uploadId={uid} failed: {ex.Message}");
+                return false;
+            }
+        });
     }
 
     /// <summary>
@@ -411,15 +423,22 @@ public sealed class VoiceUploadStore
         var uid = NormalizeId(uploadId);
         if (uid is null) return false;
 
-        // Read-modify-write under the per-upload gate. Without it the max-and-write is not atomic: two
-        // writers can both read the old value, and the one that computed the SMALLER max can land last and
-        // overwrite the larger - handing a retry a baseline lower than one we had already proven honest,
-        // which is exactly the drop this whole field exists to stop. The monotonic rule has to hold at the
-        // WRITE, not just in the arithmetic.
-        lock (GateFor(DirFor(uid)))
+        // Read-modify-write under the per-upload gate, with the read INSIDE the lock. Two things depend on
+        // that, and the second is the serious one:
+        //   1. The max-and-write is atomic, so two re-baseline writers cannot both read the old value and let
+        //      the one that computed the SMALLER max land last - handing a retry a baseline we already knew
+        //      was too low, which is the drop this field exists to stop. Monotonicity has to hold at the
+        //      WRITE, not just in the arithmetic.
+        //   2. We write only the re-baseline field onto the record AS IT IS RIGHT NOW, never a record read
+        //      before the lock. Otherwise a stalled re-baseline could write a remembered PENDING record back
+        //      over a tombstone that landed in the meantime and resurrect a delivered upload id (issue #1183).
+        return WithRecordLock(uid, () =>
         {
             if (ReadRecord(uid) is not { } record) return false;
+            // Terminal is final: its guard has already run for the last time, and rewriting the tombstone here
+            // is precisely how a resolved upload id would come back to life.
             if (record.State is DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned) return false;
+            BetweenRecordReadAndWriteForTests?.Invoke(uid);
 
             var merged = Math.Max(record.RebaselineBufferBytes ?? 0, bufferBytes);
             if (merged <= (record.RebaselineBufferBytes ?? -1)) return false; // already at least this honest
@@ -436,7 +455,7 @@ public sealed class VoiceUploadStore
                 FileLog.Write($"[VoiceUploadStore] RecordFailedDeliveryBaseline uploadId={uid} failed: {ex.Message}");
                 return false;
             }
-        }
+        });
     }
 
     /// <summary>
@@ -449,19 +468,25 @@ public sealed class VoiceUploadStore
     {
         var uid = NormalizeId(uploadId);
         if (uid is null) return false;
-        var dir = DirFor(uid);
-        if (!Directory.Exists(dir)) return false;
-        try
+        // Retiring the record is a record mutation, so it takes the same gate. Without it, a retirement landing
+        // in the middle of another writer's read-modify-write would let that writer re-create the staging
+        // directory and a marker for an upload id that had just been acknowledged away.
+        return WithRecordLock(uid, () =>
         {
-            Directory.Delete(dir, recursive: true);
-            FileLog.Write($"[VoiceUploadStore] Acknowledge: uploadId={uid} tombstone retired");
-            return true;
-        }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[VoiceUploadStore] Acknowledge uploadId={uid} failed: {ex.Message}");
-            return false;
-        }
+            var dir = DirFor(uid);
+            if (!Directory.Exists(dir)) return false;
+            try
+            {
+                Directory.Delete(dir, recursive: true);
+                FileLog.Write($"[VoiceUploadStore] Acknowledge: uploadId={uid} tombstone retired");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[VoiceUploadStore] Acknowledge uploadId={uid} failed: {ex.Message}");
+                return false;
+            }
+        });
     }
 
     // The owning session id already recorded for this upload id (empty when there is no record yet), so a
@@ -477,19 +502,29 @@ public sealed class VoiceUploadStore
     // crash between the two leaves a valid tombstone rather than orphaned chunks with no marker. Used by the
     // TERMINAL transitions (delivered/abandoned) that no longer need the audio; FAILED keeps its bytes and
     // so writes the marker alone (see MarkFailed).
-    private void WriteTombstone(string uploadId, DictationDeliveryRecord record)
+    // The record is composed by a FACTORY run inside the gate, not passed in ready-made: a tombstone carries
+    // the session id already on the record, and reading that outside the lock would be one more
+    // read-modify-write straddling the gate - the very shape this is here to eliminate.
+    private void WriteTombstone(string uploadId, Func<string, DictationDeliveryRecord> compose)
     {
         var uid = NormalizeId(uploadId) ?? throw new InvalidOperationException("invalid upload id");
-        var dir = DirFor(uid);
-        Directory.CreateDirectory(dir);
-        WriteRecordMarker(dir, record);
-        foreach (var part in Directory.EnumerateFiles(dir, "*.part"))
+        // Under the per-upload gate like every other record write: a tombstone that lands while another writer
+        // is mid read-modify-write is exactly the interleaving that would let a resolved upload id be written
+        // back to PENDING and re-injected (issue #1183).
+        WithRecordLock(uid, () =>
         {
-            try { File.Delete(part); }
-            catch (Exception ex) { FileLog.Write($"[VoiceUploadStore] discard chunk {part} failed: {ex.Message}"); }
-        }
-        FileLog.Write($"[VoiceUploadStore] MarkRecord: uploadId={uid} state={record.State} " +
-            $"submitted={record.Submitted} movedOn={record.MovedOn}");
+            var record = compose(uid);
+            var dir = DirFor(uid);
+            Directory.CreateDirectory(dir);
+            WriteRecordMarker(dir, record);
+            foreach (var part in Directory.EnumerateFiles(dir, "*.part"))
+            {
+                try { File.Delete(part); }
+                catch (Exception ex) { FileLog.Write($"[VoiceUploadStore] discard chunk {part} failed: {ex.Message}"); }
+            }
+            FileLog.Write($"[VoiceUploadStore] MarkRecord: uploadId={uid} state={record.State} " +
+                $"submitted={record.Submitted} movedOn={record.MovedOn}");
+        });
     }
 
     // Persist the record.json marker atomically (temp + move), leaving any staged chunks untouched.
@@ -503,22 +538,91 @@ public sealed class VoiceUploadStore
 
     // ====== internals ===============================================================
 
-    // Per-upload write gates, keyed by the upload's staging DIRECTORY - the resource itself, not the store
-    // object - so the gate holds even though callers construct their own VoiceUploadStore instances over the
-    // same root (the endpoint, the tests, and the aggregator all do). Static for the same reason: two store
-    // instances over one directory must contend for one gate, or the gate protects nothing.
+    // ====== the per-upload record gate ==============================================
     //
-    // In-process only, and deliberately so: this guards the read-modify-write in RecordFailedDeliveryBaseline,
-    // whose writers are all inside this Gateway. It is NOT a cross-process file lock and does not claim to be;
-    // the individual marker write is already atomic (temp + move), so the worst a second process could do is
-    // land a stale value, which no deployment we run can produce (one Gateway owns a staging root).
+    // EVERY read-modify-write of an upload's record.json runs under this gate. Not just the re-baseline:
+    // serializing the re-baseline writers against each other only is worse than useless, because the
+    // dangerous interleaving is between DIFFERENT writers. A re-baseline that reads a PENDING record, then
+    // stalls while MarkDelivered lands a terminal tombstone, would write its remembered PENDING record back
+    // over that tombstone and RESURRECT the upload id as pending - reopening the exact re-injection door the
+    // durable record exists to close (issue #1183). Hence: one gate per upload id, every writer inside it,
+    // and every writer RE-READS the record inside the lock rather than trusting anything read outside it.
     //
-    // One small object per upload id that has had a failed delivery attempt. Never pruned; bounded by real
-    // failed-delivery volume, the same shape as the endpoint's own uploadId->sessionId map.
-    private static readonly ConcurrentDictionary<string, object> _recordGates =
+    // Keyed by the upload's staging DIRECTORY - the resource itself, not the store object - because callers
+    // construct their own VoiceUploadStore instances over the same root (the endpoint, the aggregator, and
+    // the tests all do), so a gate belonging to an instance would protect nothing. Canonicalized through
+    // Path.GetFullPath so two spellings of one directory cannot resolve to two different gates.
+    //
+    // In-process only, and deliberately so: every writer of a given staging root lives in this Gateway. It is
+    // NOT a cross-process file lock and does not pretend to be; the individual marker write is already atomic
+    // (temp + move), so the worst a second process could do is land a stale value - which no deployment we run
+    // can produce, because one Gateway owns a staging root.
+    //
+    // REFCOUNTED, so the map is bounded by CONCURRENT users rather than by lifetime upload ids - it holds
+    // nothing at rest. This is why there is no "prune on terminal transition": removing a gate that another
+    // thread is still holding would let the next caller lock a DIFFERENT object and walk straight into the
+    // section, which is the race this gate exists to prevent. An entry that nobody holds cannot be in anyone's
+    // way, and an entry that somebody holds must not be removed - refcounting is just those two rules.
+    private sealed class RecordGate
+    {
+        public int Users;
+    }
+
+    /// <summary>
+    /// Test seam: invoked INSIDE the per-upload gate, between the record read and the record write of
+    /// <see cref="RecordFailedDeliveryBaseline"/>. Null in production and never assigned outside tests.
+    ///
+    /// It exists because the tombstone-resurrection hazard is an INTERLEAVING, and an interleaving cannot be
+    /// proven by hammering threads and hoping: a test that only sometimes reproduces the race is a test that
+    /// will pass on a broken build. This lets one test stall the read-modify-write at the exact instant a
+    /// competing tombstone writer tries to land, deterministically, in both directions - the gate holding, and
+    /// the gate removed.
+    /// </summary>
+    internal static Action<string>? BetweenRecordReadAndWriteForTests;
+
+    private static readonly Dictionary<string, RecordGate> _recordGates =
         new(StringComparer.OrdinalIgnoreCase);
 
-    private static object GateFor(string dir) => _recordGates.GetOrAdd(dir, _ => new object());
+    private static RecordGate AcquireGate(string key)
+    {
+        lock (_recordGates)
+        {
+            if (!_recordGates.TryGetValue(key, out var gate))
+            {
+                gate = new RecordGate();
+                _recordGates[key] = gate;
+            }
+            gate.Users++;
+            return gate;
+        }
+    }
+
+    private static void ReleaseGate(string key, RecordGate gate)
+    {
+        lock (_recordGates)
+        {
+            if (--gate.Users == 0) _recordGates.Remove(key);
+        }
+    }
+
+    /// <summary>Run a record read-modify-write for this upload id under its per-upload gate.</summary>
+    private T WithRecordLock<T>(string uid, Func<T> body)
+    {
+        var key = GateKey(uid);
+        var gate = AcquireGate(key);
+        try
+        {
+            lock (gate) return body();
+        }
+        finally
+        {
+            ReleaseGate(key, gate);
+        }
+    }
+
+    private void WithRecordLock(string uid, Action body) => WithRecordLock(uid, () => { body(); return true; });
+
+    private string GateKey(string uid) => Path.GetFullPath(DirFor(uid));
 
     private string DirFor(string uid) => Path.Combine(_root, uid);
     private static string ChunkPath(string dir, int index) => Path.Combine(dir, $"{index:D5}.part");

--- a/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
+++ b/src/CcDirector.Gateway/Voice/VoiceUploadStore.cs
@@ -277,8 +277,11 @@ public sealed class VoiceUploadStore
         var uid = NormalizeId(uploadId) ?? throw new InvalidOperationException("invalid upload id");
         var dir = DirFor(uid);
         Directory.CreateDirectory(dir);
+        // Carry the #1593 re-baseline forward: a phone that never saw our 502 simply RE-REGISTERS its upload
+        // id and retries. That path lands here, so dropping the value would hand the retry back the very
+        // baseline our own failed attempt invalidated - the exact drop this field exists to stop.
         WriteRecordMarker(dir, new DictationDeliveryRecord(
-            DictationDeliveryState.Pending, false, false, "", null, sessionId ?? ""));
+            DictationDeliveryState.Pending, false, false, "", null, sessionId ?? "", ExistingRebaseline(uid)));
         FileLog.Write($"[VoiceUploadStore] MarkPending: uploadId={uid} sessionId={sessionId}");
     }
 
@@ -352,9 +355,12 @@ public sealed class VoiceUploadStore
         var dir = DirFor(uid);
         Directory.CreateDirectory(dir);
         // Write ONLY the marker - keep the chunk bytes (the retry re-drives them), the opposite of a tombstone.
-        // Preserve the owning session id so a later ClearFailed can restore a PENDING marker that re-locks it.
+        // Preserve the owning session id so a later ClearFailed can restore a PENDING marker that re-locks it,
+        // and the #1593 re-baseline so a transcription failure on a retry cannot erase what an earlier failed
+        // DELIVERY attempt already learned about the buffer.
         WriteRecordMarker(dir, new DictationDeliveryRecord(
-            DictationDeliveryState.Failed, false, false, "", reasonCode ?? "", ExistingSessionId(uid)));
+            DictationDeliveryState.Failed, false, false, "", reasonCode ?? "", ExistingSessionId(uid),
+            ExistingRebaseline(uid)));
         FileLog.Write($"[VoiceUploadStore] MarkFailed: uploadId={uid} reason={reasonCode} (chunks retained)");
     }
 
@@ -373,13 +379,52 @@ public sealed class VoiceUploadStore
         try
         {
             WriteRecordMarker(DirFor(uid), new DictationDeliveryRecord(
-                DictationDeliveryState.Pending, false, false, "", null, failed.SessionId));
+                DictationDeliveryState.Pending, false, false, "", null, failed.SessionId,
+                failed.RebaselineBufferBytes));
             FileLog.Write($"[VoiceUploadStore] ClearFailed: uploadId={uid} back to PENDING (chunks retained)");
             return true;
         }
         catch (Exception ex)
         {
             FileLog.Write($"[VoiceUploadStore] ClearFailed uploadId={uid} failed: {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Record the honest moved-on baseline for this upload id after one of OUR OWN delivery attempts failed
+    /// (Lost Dictations mission, issue #1593). The record stays exactly where it was - this is NOT a state
+    /// transition and NOT a tombstone: a PENDING record stays PENDING with its chunks intact, so the client's
+    /// retry re-drives normally. Only <see cref="DictationDeliveryRecord.RebaselineBufferBytes"/> moves.
+    ///
+    /// MONOTONIC: the stored value only ever grows (each failed attempt adds more of its own noise, and a
+    /// later fresh read is at least as honest as an earlier one), so repeated failures can never lower the
+    /// baseline back into a range where our own noise reads as a real turn.
+    ///
+    /// A no-op returning false when there is no record yet, or when the record is already terminal
+    /// (DELIVERED / ABANDONED): those are resolved and their guard has already run, so re-baselining them
+    /// would move a number nothing will read again.
+    /// </summary>
+    public bool RecordFailedDeliveryBaseline(string uploadId, long bufferBytes)
+    {
+        var uid = NormalizeId(uploadId);
+        if (uid is null) return false;
+        if (ReadRecord(uid) is not { } record) return false;
+        if (record.State is DictationDeliveryState.Delivered or DictationDeliveryState.Abandoned) return false;
+
+        var merged = Math.Max(record.RebaselineBufferBytes ?? 0, bufferBytes);
+        if (merged <= (record.RebaselineBufferBytes ?? -1)) return false; // already at least this honest
+        try
+        {
+            // Marker only - the chunk bytes stay put, because this upload is still going to be delivered.
+            WriteRecordMarker(DirFor(uid), record with { RebaselineBufferBytes = merged });
+            FileLog.Write($"[VoiceUploadStore] RecordFailedDeliveryBaseline: uploadId={uid} rebaseline={merged} " +
+                $"(state={record.State}, chunks retained)");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            FileLog.Write($"[VoiceUploadStore] RecordFailedDeliveryBaseline uploadId={uid} failed: {ex.Message}");
             return false;
         }
     }
@@ -412,6 +457,11 @@ public sealed class VoiceUploadStore
     // The owning session id already recorded for this upload id (empty when there is no record yet), so a
     // state transition preserves the session id first written by MarkPending at register (issue #1188).
     private string ExistingSessionId(string uploadId) => ReadRecord(uploadId)?.SessionId ?? "";
+
+    // The re-baseline already recorded for this upload id (null when there is no record, or no attempt has
+    // failed), so a NON-TERMINAL state transition preserves what a failed delivery attempt learned (#1593).
+    // The terminal tombstones deliberately do NOT carry it: their guard has already run for the last time.
+    private long? ExistingRebaseline(string uploadId) => ReadRecord(uploadId)?.RebaselineBufferBytes;
 
     // Write the small durable marker first (atomic temp+move), THEN discard the heavy chunk bytes, so a
     // crash between the two leaves a valid tombstone rather than orphaned chunks with no marker. Used by the
@@ -492,10 +542,21 @@ public enum DictationDeliveryState { Pending, Delivered, Abandoned, Failed }
 /// retry. Every state carries the <see cref="SessionId"/> so a transition (e.g. FAILED back to PENDING)
 /// preserves the owning session.
 /// </summary>
+/// <param name="RebaselineBufferBytes">
+/// The honest moved-on baseline for this upload id after one of OUR OWN delivery attempts failed (Lost
+/// Dictations mission, issue #1593), or null when no attempt has failed. A failed submit types the text into
+/// the terminal and clears it again, growing the session buffer by thousands of bytes that the moved-on guard
+/// cannot tell apart from real turns - so a retry judged against the phone's record-time baseline gets dropped
+/// as stale by noise the failure itself made. The guard therefore judges a retry against the LARGER of the
+/// request's baseline and this value. It lives on the SERVER record, not in the phone's request, so a phone
+/// that never saw the 502 still retries against the honest baseline. Null (absent) in every record written
+/// before this field existed, which reads back as "no attempt has failed" - the correct meaning.
+/// </param>
 public sealed record DictationDeliveryRecord(
     DictationDeliveryState State,
     bool Submitted,
     bool MovedOn,
     string Transcript,
     string? Reason,
-    string SessionId = "");
+    string SessionId = "",
+    long? RebaselineBufferBytes = null);


### PR DESCRIPTION
## What is broken

Every terminal outcome that did **not** submit fell into one arm:

```ts
await deletePending(rec.id);
if (outcome.submitted) { publish("done"); } else { clearDictationStatus(rec.id); }
```

Audio gone, banner gone, no trace. On 2026-07-15 the session moved on, the server threw the owner's words away, and the phone deleted the recording and cleared the status strip. **"It worked and then nothing happened."** He was never told.

This is item 2 of the Lost Dictations mission: the safety net for the genuine drops that item 1 (#1593) does not eliminate.

## The fix

Only **one** terminal-not-submitted outcome is genuinely nothing to say. The arm is split:

| Outcome | Now |
|---|---|
| **Moved-on**, with transcript | Sticky `dropped` state that never self-clears; says in plain words the recording was **not** sent; hands the transcript back with **Send anyway** + Dismiss |
| **Moved-on**, no transcript (rare) | Audio kept and parked with an explicit **Retry** under a **fresh upload id** |
| **Empty clip** | Visible, dismissible "nothing was heard" notice; nothing to retry |
| **Abandoned** | Still silent - deliberately. The user did that on purpose (ruled out of scope by the issue) |

- **"Send anyway" is a fresh, normal prompt**, not a re-drive. The drop wrote a permanent moved-on tombstone against that upload id (#1183), so re-completing it could only ever return the same drop.
- **The record is kept, not deleted** (marked `staleDropped`, excluded from every automatic trigger). The words must survive a reload - otherwise "Send anyway" would quietly stop working the moment the app is backgrounded, which is the same silent loss wearing a new costume.
- **Dismiss is the only thing that discards a dropped clip**, and it is always deliberate. Never a timer.

**Both** surfaces that read the status store are updated (`DictationStatusStrip` and the Home roster badge), because both fall through to a spinner: an unhandled phase would have sat there spinning forever, claiming a finished dictation was still working.

## Proof

`backgroundSend.test.ts` - tests driving the **real** `driveRecord` and the **real** status store (`status.ts` is not mocked) through each terminal-not-submitted shape, exactly as the UI reads them.

**Watched failing on purpose.** Reverted to the old single silent arm, the four drop/unheard tests fail with `expected undefined to be defined` - the vanishing itself - while **both controls stay green**:

- an **abandoned** outcome stays silent;
- a **delivered** turn still shows done and drops the audio.

Also pinned: the dropped state survives a reload (re-published from the durable record on app load, never re-driven), a failed "Send anyway" **keeps** the words and stays sticky, and Retry re-drives under a genuinely new id with the stale baseline cleared.

Suites: client-core **512 passed** (47 files); typecheck, lint, and the mobile PWA build all clean. `apps/mobile` has no test files of its own - the JavaScript tests live in client-core.

## Not proven

No live phone-to-Gateway drive; the tests drive the real client pipeline against a mocked API client, which is the level the brief sets as the floor for this item. The visual result of the new strip states has not been seen on a real phone screen.

## Base

Stacked on `mission/lost-dictations` (item 1, thefrederiksen/devthrottle#1687) so this diff shows only item 2. It needs re-targeting to `main` once thefrederiksen/devthrottle#1687 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
