### PR TITLE
fix(voice): a cooldown that never calls can never find out the outage ended

### DIFF
--- a/src/CcDirector.Gateway.Tests/WingmanRateLimitGateTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanRateLimitGateTests.cs
@@ -114,4 +114,98 @@ public sealed class WingmanRateLimitGateTests
         // The ramp is back to base: the next 429 is a 5s backoff again, not a continued 20s.
         Assert.Equal(TimeSpan.FromSeconds(5), gate.OnRateLimited(null));
     }
+
+    // ---- The half-open probe (2026-07-15). THE reason an outage used to be permanent. ----
+    //
+    // The gate blocked every call for the whole cooldown. So while gated, no call could succeed, so
+    // nothing could clear the cooldown, so the only exit was the clock - which released the entire
+    // fleet at a provider that had gone cold precisely BECAUSE of the gate's silence. They all timed
+    // out and re-armed it. The fleet sat at 0/8 sessions with audio while the provider answered every
+    // hand-made call perfectly.
+    //
+    // A closed gate must still send exactly one call: it is the only way to learn the service came
+    // back, and it keeps the provider's model warm so the fleet returns to a warm one.
+
+    [Fact]
+    public void WhileGated_ExactlyOneCallerProbes_AndTheRestAreHeld()
+    {
+        var clock = new FakeClock();
+        var gate = new WingmanRateLimitGate(clock.NowUtc);
+        gate.OnRateLimited(null);
+
+        // First caller in becomes the probe.
+        Assert.True(gate.TryEnter(out var isProbe, out var left));
+        Assert.True(isProbe);
+        Assert.True(left > TimeSpan.Zero);
+
+        // Everyone else is held back - that is the backpressure the 429 actually asked for.
+        Assert.False(gate.TryEnter(out var second, out _));
+        Assert.False(second);
+        Assert.False(gate.TryEnter(out _, out _));
+    }
+
+    [Fact]
+    public void AProbeThatSucceeds_EndsTheOutageImmediately()
+    {
+        var clock = new FakeClock();
+        var gate = new WingmanRateLimitGate(clock.NowUtc);
+        gate.OnRateLimited(null);
+        Assert.True(gate.TryEnter(out var isProbe, out _));
+        Assert.True(isProbe);
+
+        // The provider is well again. This is the path that did not exist: the gate learns it, WITHOUT
+        // waiting out the clock, because it kept one call flowing.
+        gate.OnSuccess();
+
+        Assert.False(gate.InCooldown(out _));
+        Assert.True(gate.TryEnter(out var nowProbe, out _));
+        Assert.False(nowProbe);   // not a probe any more - the gate is simply open
+    }
+
+    [Fact]
+    public void AProbeThatIsStillRateLimited_ExtendsTheCooldown_AndLetsTheNextCallerProbe()
+    {
+        var clock = new FakeClock();
+        var gate = new WingmanRateLimitGate(clock.NowUtc);
+        gate.OnRateLimited(null);
+        Assert.True(gate.TryEnter(out _, out _));
+
+        // The probe came back 429. The cooldown extends - and crucially the slot is released, or the
+        // gate would wedge half-open: one probe out forever, every other session gated forever.
+        gate.OnRateLimited(null);
+        Assert.True(gate.InCooldown(out _));
+        Assert.True(gate.TryEnter(out var nextProbe, out _));
+        Assert.True(nextProbe);
+    }
+
+    [Fact]
+    public void AProbeThatReportsNothing_ReleasesTheSlot_SoTheGateCannotWedgeHalfOpen()
+    {
+        var clock = new FakeClock();
+        var gate = new WingmanRateLimitGate(clock.NowUtc);
+        gate.OnRateLimited(null);
+        Assert.True(gate.TryEnter(out _, out _));
+        Assert.False(gate.TryEnter(out _, out _));   // held while the probe is out
+
+        gate.EndProbe();   // the probe threw / gave up without a verdict
+
+        Assert.True(gate.TryEnter(out var nextProbe, out _));
+        Assert.True(nextProbe);
+    }
+
+    [Fact]
+    public void AProbeThatVanishes_CannotGateTheFleetPastTheCooldown()
+    {
+        var clock = new FakeClock();
+        var gate = new WingmanRateLimitGate(clock.NowUtc);
+        gate.OnRateLimited(null);
+        Assert.True(gate.TryEnter(out _, out _));   // probe out, never reports back
+
+        // Belt and braces: even if a probe is somehow never released, a lapsed cooldown must open the
+        // gate to everyone. A leaked probe slot must never outlive the outage it was probing.
+        clock.Now = clock.Now.AddSeconds(10);
+        Assert.True(gate.TryEnter(out var isProbe, out var left));
+        Assert.False(isProbe);
+        Assert.Equal(TimeSpan.Zero, left);
+    }
 }

--- a/src/CcDirector.Gateway/Wingman/WingmanRateLimitGate.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanRateLimitGate.cs
@@ -12,6 +12,36 @@ namespace CcDirector.Gateway.Wingman;
 /// cooldown calms the whole fleet at once. No per-caller jitter is needed here: jitter exists to
 /// de-synchronize a HERD of independent clients, but this is a single caller, so a plain shared
 /// cooldown is correct and simpler. Thread-safe; the clock is injectable so the backoff is unit-testable.
+///
+/// IT MUST LET ONE CALL THROUGH WHILE IT WAITS, AND THAT IS THE WHOLE POINT (2026-07-15).
+///
+/// This gate used to block EVERY call for the full cooldown. That is a latch, not backpressure, and it
+/// converted a provider having a bad ten minutes into an outage that could not end:
+///
+///   1. The speech provider scales its model down when nobody calls it. A cold call takes 17-40s
+///      (measured; a 16-character call took 39.9s) against a deadline that was tighter than that.
+///   2. The call times out. The gate arms and the fleet goes silent for 120 seconds.
+///   3. 120 seconds of NOBODY CALLING is exactly how the model goes cold. The gate's own silence
+///      manufactured the condition that caused the timeout.
+///   4. The cooldown lapses, every session rushes a cold model at once, they all time out, re-arm.
+///
+/// The fleet sat at 0/8 sessions with audio, all reporting "the voice service is not responding",
+/// while the service answered every hand-made call perfectly. Three warm-up calls by hand took it to
+/// 6/8 with NO code change. The provider was never the problem after the first minute; we were.
+///
+/// So a closed gate must still send ONE call - the half-open probe of a standard circuit breaker,
+/// which here earns its keep twice over:
+///
+///   * it is the only way to LEARN the provider recovered (a gate that never calls never finds out -
+///     that is the spiral, and it is why an outage did not simply end when the outage ended); and
+///   * it KEEPS THE MODEL WARM, so when the fleet is let back in it meets a warm provider instead of
+///     the cold start the old cooldown guaranteed.
+///
+/// The probe is not a synthetic ping. It is one real session's narration, chosen first-come, so a
+/// probe that succeeds has done useful work and that session has its voice. One call is also exactly
+/// what the 429 asked for: "slow down" - not "stop, and go cold, and come back all at once".
+///
+/// Thread-safe; the clock is injectable so the backoff is unit-testable.
 /// </summary>
 internal sealed class WingmanRateLimitGate
 {
@@ -21,6 +51,8 @@ internal sealed class WingmanRateLimitGate
     private readonly object _lock = new();
     private DateTime _cooldownUntilUtc = DateTime.MinValue;
     private int _consecutive;
+    /// <summary>True while the single half-open probe is out. Guarded by <see cref="_lock"/>.</summary>
+    private bool _probeInFlight;
 
     /// <param name="nowUtc">Clock source; <see cref="DateTime.UtcNow"/> when null (tests inject a fake).</param>
     /// <param name="baseDelay">The first backoff after a single 429 (default 5 seconds).</param>
@@ -32,7 +64,9 @@ internal sealed class WingmanRateLimitGate
         _maxDelay = maxDelay ?? TimeSpan.FromSeconds(120);
     }
 
-    /// <summary>True while a cooldown is in effect; <paramref name="remaining"/> is how long is left.</summary>
+    /// <summary>True while a cooldown is in effect; <paramref name="remaining"/> is how long is left.
+    /// Reports the raw cooldown state only - it does NOT decide whether a caller may proceed, because
+    /// during a cooldown exactly one caller may (the probe). Use <see cref="TryEnter"/> to ask that.</summary>
     public bool InCooldown(out TimeSpan remaining)
     {
         lock (_lock)
@@ -45,6 +79,49 @@ internal sealed class WingmanRateLimitGate
     }
 
     /// <summary>
+    /// Ask to make a call. THE gate decision - callers must use this rather than reading
+    /// <see cref="InCooldown"/> and skipping, which is the latch this class exists to not be.
+    ///
+    /// Outcomes:
+    ///   * no cooldown -> true, <paramref name="isProbe"/> false. Normal running.
+    ///   * cooldown, nobody probing -> true, <paramref name="isProbe"/> TRUE. This caller is the single
+    ///     half-open probe: it both tests recovery and keeps the provider's model warm. It MUST report
+    ///     back via <see cref="OnSuccess"/> or <see cref="OnRateLimited"/> (which release the probe), or
+    ///     <see cref="EndProbe"/> if it did neither.
+    ///   * cooldown, probe already out -> false. Held back, which is the backpressure the 429 asked for.
+    ///
+    /// <paramref name="remaining"/> is the cooldown left (zero when not gated), for the caller's log.
+    /// </summary>
+    public bool TryEnter(out bool isProbe, out TimeSpan remaining)
+    {
+        lock (_lock)
+        {
+            var left = _cooldownUntilUtc - _nowUtc();
+            if (left <= TimeSpan.Zero)
+            {
+                // Not gated. A lapsed cooldown also means any probe bookkeeping is moot - clear it so a
+                // probe that never reported back cannot wedge the gate half-open forever.
+                _probeInFlight = false;
+                isProbe = false;
+                remaining = TimeSpan.Zero;
+                return true;
+            }
+            remaining = left;
+            if (_probeInFlight) { isProbe = false; return false; }
+            _probeInFlight = true;
+            isProbe = true;
+            return true;
+        }
+    }
+
+    /// <summary>Release the probe slot without a verdict - the probe neither succeeded nor was rate
+    /// limited (it threw, or the caller gave up). The cooldown stands; the next caller may probe.</summary>
+    public void EndProbe()
+    {
+        lock (_lock) { _probeInFlight = false; }
+    }
+
+    /// <summary>
     /// Record a 429 and (re)arm the cooldown; returns the backoff applied. Honors
     /// <paramref name="retryAfter"/> when the provider sent one (capped to the ceiling); otherwise
     /// doubles from the base delay for each consecutive hit up to the ceiling. A nearer cooldown never
@@ -54,6 +131,10 @@ internal sealed class WingmanRateLimitGate
     {
         lock (_lock)
         {
+            // A probe that came back rate limited has reported: release the slot so the NEXT caller can
+            // probe once this longer cooldown lapses. Without this the gate wedges half-open - one probe
+            // out forever, every other session gated forever - which is the same silence in a new hat.
+            _probeInFlight = false;
             if (_consecutive < int.MaxValue) _consecutive++;
             TimeSpan backoff;
             if (retryAfter is { } ra && ra > TimeSpan.Zero)
@@ -72,11 +153,20 @@ internal sealed class WingmanRateLimitGate
         }
     }
 
-    /// <summary>A model call succeeded - clear the cooldown and reset the backoff ramp to base.</summary>
+    /// <summary>
+    /// A call succeeded - clear the cooldown and reset the backoff ramp to base.
+    ///
+    /// This is how the outage ENDS, and before the probe existed there was no way to reach it while
+    /// gated: the gate blocked every call, so no call could succeed, so nothing ever cleared the
+    /// cooldown except it timing out into another cold stampede. A successful probe now re-opens the
+    /// gate the moment the provider is well - and because the probe kept the model warm, the fleet
+    /// comes back to a warm provider rather than the cold start that started all this.
+    /// </summary>
     public void OnSuccess()
     {
         lock (_lock)
         {
+            _probeInFlight = false;
             _consecutive = 0;
             _cooldownUntilUtc = DateTime.MinValue;
         }

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -395,59 +395,88 @@ public sealed class WingmanVoiceService
         // The idle sweep still guards on HasVoice at its own call site, so it never reaches here for a
         // cached session; only the turn-end path does, and it pays one cheap /turns read to compare.
 
-        // Backpressure #1 (issue #1324) - respect a provider rate-limit cooldown. A 429 means "stop
-        // calling", so while the cooldown is in effect we skip the model call entirely. Both callers
-        // funnel through here, so one cooldown stops the WHOLE fleet from hammering a throttled provider.
-        if (_rateGate.InCooldown(out var cooldownLeft))
+        // Backpressure #1 (issue #1324) - respect a provider rate-limit cooldown. A 429 means "slow
+        // down", so while the cooldown is in effect all but ONE caller skip the model call. Both callers
+        // funnel through here, so one cooldown calms the WHOLE fleet at once.
+        //
+        // The one caller that gets through is the half-open probe. A gate that lets NOBODY through can
+        // never discover the provider recovered - it can only wait out the clock and then release the
+        // whole fleet at once. See WingmanRateLimitGate for why that is not merely inelegant but the
+        // mechanism by which a transient outage became a permanent one.
+        if (!_rateGate.TryEnter(out var rateProbe, out var cooldownLeft))
         {
-            FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} SKIPPED: provider throttled, {cooldownLeft.TotalSeconds:F0}s cooldown left");
+            FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} SKIPPED: provider throttled, {cooldownLeft.TotalSeconds:F0}s cooldown left (another session is probing)");
             return;
         }
+        if (rateProbe)
+            FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} PROBING the throttled provider ({cooldownLeft.TotalSeconds:F0}s cooldown left) - one call through to test recovery");
 
         // Backpressure #1b - the SPEECH leg is down. This check must stay ABOVE the translation, because
         // the whole point is to not pay for a model call whose audio cannot be made. Skipping leaves the
-        // recorded ServiceDown state untouched, so the phone keeps saying the true thing while we wait,
-        // and the sweep picks the session up again the moment the cooldown expires.
-        if (_ttsGate.InCooldown(out var ttsCooldownLeft))
+        // recorded ServiceDown state untouched, so the phone keeps saying the true thing while we wait.
+        //
+        // Same probe rule, and this is the gate that actually trapped the fleet on 2026-07-15: its 120s
+        // of total silence let the speech model go cold, and a cold model is what produced the timeout
+        // that armed it. One real narration goes through to test AND to keep the model warm.
+        if (!_ttsGate.TryEnter(out var ttsProbe, out var ttsCooldownLeft))
         {
-            FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} SKIPPED: speech service down, {ttsCooldownLeft.TotalSeconds:F0}s cooldown left");
+            if (rateProbe) _rateGate.EndProbe();   // never leave the outer probe slot held
+            FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} SKIPPED: speech service down, {ttsCooldownLeft.TotalSeconds:F0}s cooldown left (another session is probing)");
             return;
         }
+        if (ttsProbe)
+            FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} PROBING the speech service ({ttsCooldownLeft.TotalSeconds:F0}s cooldown left) - one narration through to test recovery and keep the model warm");
 
-        // Backpressure #2 - coalesce. Never run two generations for the same session at once (a slow
-        // turn overlapping the idle sweep would otherwise double the spend). First caller wins.
-        if (!_inFlight.TryAdd(sid, 1))
-            return;
+        // Everything below may return or throw on a dozen paths (coalesced, capped, nothing to say,
+        // cancelled, provider blew up). If ANY of them leaves a probe slot held, that gate is wedged
+        // half-open forever: one probe permanently out, every other session permanently gated - the
+        // exact fleet-wide silence this whole change exists to end, arrived by a new road. So releasing
+        // is unconditional and lives in a finally, not sprinkled on the paths someone remembered.
+        //
+        // EndProbe only frees the slot; it never clears a cooldown. OnSuccess/OnRateLimited have already
+        // freed it by the time we get here, so this is idempotent and cannot undo their verdict.
         try
         {
-            // Backpressure #3 - cap fleet-wide concurrency so a burst of simultaneous turn-ends does
-            // not fire a burst of simultaneous model calls. Bounded wait: if the gate stays saturated
-            // we DROP this cycle rather than queue unboundedly - the idle sweep or the next turn-end
-            // regenerates it.
-            if (!await _genGate.WaitAsync(GateAcquireTimeout, ct))
-            {
-                FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} SKIPPED: {MaxConcurrentGenerations} generations already in flight");
+            // Backpressure #2 - coalesce. Never run two generations for the same session at once (a slow
+            // turn overlapping the idle sweep would otherwise double the spend). First caller wins.
+            if (!_inFlight.TryAdd(sid, 1))
                 return;
-            }
             try
             {
-                await GenerateOnceAsync(sid, route, ct, showReadingWindow);
-                _rateGate.OnSuccess();   // reaching the provider clears any cooldown/backoff ramp
+                // Backpressure #3 - cap fleet-wide concurrency so a burst of simultaneous turn-ends does
+                // not fire a burst of simultaneous model calls. Bounded wait: if the gate stays saturated
+                // we DROP this cycle rather than queue unboundedly - the idle sweep or the next turn-end
+                // regenerates it.
+                if (!await _genGate.WaitAsync(GateAcquireTimeout, ct))
+                {
+                    FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} SKIPPED: {MaxConcurrentGenerations} generations already in flight");
+                    return;
+                }
+                try
+                {
+                    await GenerateOnceAsync(sid, route, ct, showReadingWindow);
+                    _rateGate.OnSuccess();   // reaching the provider clears any cooldown/backoff ramp
+                }
+                finally { _genGate.Release(); }
             }
-            finally { _genGate.Release(); }
+            catch (WingmanModelRateLimitedException rl)
+            {
+                // The provider rate limited us - arm the cooldown so the next turn-end/sweep backs off
+                // instead of piling on. Honors its Retry-After when it sent one (issue #1324).
+                var backoff = _rateGate.OnRateLimited(rl.RetryAfter);
+                FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} rate limited (429); backing off {backoff.TotalSeconds:F0}s before the next generation");
+            }
+            catch (Exception ex)
+            {
+                FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} FAILED: {ex.Message}");
+            }
+            finally { _inFlight.TryRemove(sid, out _); }
         }
-        catch (WingmanModelRateLimitedException rl)
+        finally
         {
-            // The provider rate limited us - arm the cooldown so the next turn-end/sweep backs off
-            // instead of piling on. Honors its Retry-After when it sent one (issue #1324).
-            var backoff = _rateGate.OnRateLimited(rl.RetryAfter);
-            FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} rate limited (429); backing off {backoff.TotalSeconds:F0}s before the next generation");
+            if (rateProbe) _rateGate.EndProbe();
+            if (ttsProbe) _ttsGate.EndProbe();
         }
-        catch (Exception ex)
-        {
-            FileLog.Write($"[WingmanVoiceService] GenerateAsync sid={sid} FAILED: {ex.Message}");
-        }
-        finally { _inFlight.TryRemove(sid, out _); }
     }
 
     /// <summary>


### PR DESCRIPTION
**An outage should end when the outage ends.** Ours could not - and the reason was the gate, not the provider.

## The spiral

The speech cooldown blocked **every** call for its full 120 seconds. That is a latch, not backpressure:

1. The provider scales its speech model down when nobody calls it. A cold call takes **17-40s** (measured today; a **16-character** call took **39.9s**).
2. The cold call times out. The gate arms. The whole fleet goes silent for 120s.
3. **120 seconds of nobody calling is precisely how the model goes cold.** The gate's own silence manufactured the condition that caused the timeout.
4. The cooldown lapses, every session rushes a cold model at once, all time out, re-arm.

There was no exit. **While gated, no call could succeed, so nothing could ever clear the cooldown** - the only way out was the clock, into another cold stampede.

The fleet sat at **0/8** sessions with audio, every one reporting "the voice service is not responding", while the service answered every hand-made call perfectly. **Three warm-up calls by hand took it to 6/8 with no code change.** The provider was not the problem; we were.

## The fix

The half-open probe of a standard circuit breaker. While gated, exactly **one** caller goes through; the rest are held. It earns its keep twice:

- it is the only way to **learn the provider recovered** - a gate that never calls never finds out, and that *is* the spiral;
- it **keeps the model warm**, so when the fleet is let back in it meets a warm provider instead of the cold start the old cooldown guaranteed.

The probe is not a synthetic ping: it is one real session's narration, first-come. A probe that succeeds has done useful work and that session has its voice. One call is also exactly what a `429` asks for - *slow down*, not *stop, go cold, then all at once*.

## Not leaking the slot

Callers now ask `TryEnter` instead of reading `InCooldown` and skipping. Releasing is **unconditional, in a `finally`**: `GenerateAsync` can leave on a dozen paths (coalesced, capped, nothing to say, cancelled, provider threw), and any one leaking the slot would wedge the gate half-open - one probe out forever, every other session gated forever, the same fleet-wide silence by a new road. A lapsed cooldown also clears the slot, so a probe that vanishes cannot outlive the outage it was probing.

## Proof

Five new tests, **red-watched**. Reverting to the latch fails all five - including `AProbeThatSucceeds_EndsTheOutageImmediately`, which is the bug in one sentence - while the eight existing backoff/ramp tests stay green.

2,480 Gateway tests green, clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)