### PR TITLE
fix(voice): a timeout is one session's problem, never the fleet's

### DIFF
--- a/src/CcDirector.Gateway.Tests/NarrationLengthTests.cs
+++ b/src/CcDirector.Gateway.Tests/NarrationLengthTests.cs
@@ -149,7 +149,7 @@ public class NarrationLengthTests
         // the fleet went silent - the constant had rotted. Re-measured 2026-07-15 against a genuinely
         // cold provider: 16.9s, HTTP 200, real audio. So the old base of 15 failed this test's own
         // premise; it just did not know it yet. Raised to what was actually observed.
-        const double worstObservedOverheadSeconds = 16.9;
+        const double worstObservedOverheadSeconds = 39.9;
         Assert.True(TtsSynthesis.DeadlineFor(47).TotalSeconds > worstObservedOverheadSeconds,
             "a short call must outlive the worst fixed overhead we have measured, not just its own synthesis");
     }
@@ -170,7 +170,12 @@ public class NarrationLengthTests
         // A cold start must therefore cost a SLOW narration, never a failed one - at any length, since
         // the cold start does not scale with the text. The old base of 15 gave a 47-char narration a
         // 15.2s deadline against a 16.9s cold start: it could not succeed at all.
-        const double observedColdStartSeconds = 16.9;
+        // 16.9 was the worst seen when this test was written. HOURS later the same provider took
+        // 39.9s for a SIXTEEN character call, and the live log showed a 168-char narration timing out
+        // at 31s. Twice this constant has been set just above the worst-so-far and twice the provider
+        // has gone slower. Pinned to the real worst; the deadline must clear it at EVERY length,
+        // because a cold start does not scale with the text.
+        const double observedColdStartSeconds = 39.9;
         foreach (var chars in new[] { 20, 47, 469, 720, 1292, 4000, NarrationText.MaxChars })
         {
             Assert.True(TtsSynthesis.DeadlineFor(chars).TotalSeconds > observedColdStartSeconds,
@@ -198,8 +203,15 @@ public class NarrationLengthTests
         // someone raises MaxChars without thinking about what it does to the worst-case wait, they
         // will see it here. The ceiling only binds for a runaway that should never occur - a real
         // narration is ~550 chars - but it must stay a bounded wait rather than an open-ended one.
+        //
+        // Upper bound raised 90 -> 130 when the base went 30 -> 60 to clear a 39.9s cold start. This is
+        // a deliberate re-justification, not a widen-until-green: what this bound protects changed. A
+        // long deadline used to hold the fleet-wide gate's fate - one slow call could silence everyone -
+        // so 90 was rightly stingy. A timeout now costs ONLY its own session (WingmanVoiceService.TtsAsync
+        // no longer arms the shared gate on a timeout), so the worst case here is one runaway narration
+        // occupying one of two slots for 108s. That is a bounded wait, which is all this test is for.
         var atCap = TtsSynthesis.DeadlineFor(NarrationText.MaxChars);
-        Assert.InRange(atCap.TotalSeconds, 30, 90);
+        Assert.InRange(atCap.TotalSeconds, 30, 130);
     }
 
     [Fact]

--- a/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanVoiceServiceTests.cs
@@ -546,16 +546,39 @@ public sealed class WingmanVoiceServiceTests
     }
 
     [Fact]
-    public async Task StoreSpokenAsync_TtsTimesOutOnceThenSucceeds_RetriesAndMarksReady()
+    public async Task StoreSpokenAsync_AStalledCall_RecoversOnTheSessionsNextAttempt_NotByRetryingInside()
     {
-        // Regression: a single stalled upstream voice call must be retried, not surfaced as a freeze
-        // or failure. The first attempt times out; the retry returns audio, so the session is ready.
+        // This test used to assert the IN-CALL retry (attempt 1 stalls, attempt 2 returns audio, one
+        // call to StoreSpokenAsync produces voice). That retry is gone, deliberately, and this now pins
+        // the recovery that actually works.
+        //
+        // The in-call retry never did its job in production. It assumed attempt 1 eats the cold start
+        // and attempt 2 lands warm; the live log says otherwise, every time:
+        //     attempt 1/2 timed out after 33s (709 chars); retrying
+        //     attempt 2/2 timed out after 33s (709 chars); giving up
+        // Cancelling attempt 1 plausibly cancels the model load it just triggered, so attempt 2 starts
+        // the cold start again rather than arriving after it. It bought a doubled wait and a doubled
+        // load on a struggling provider, for the same failure - and on /wingman/tts, where a human is
+        // waiting, it doubled the worst case to two minutes.
+        //
+        // Recovery belongs one level up, and this is the owner's design in one line: the call either
+        // works or it does not; if it does not, THAT SESSION waits and tries again, and nobody else is
+        // affected. The voice sweep re-attempts any session without audio, so the second attempt here is
+        // what the sweep does seconds later.
         var handler = new TtsTimeoutHandler(timeouts: 1);
         var svc = ServiceWithHandler(handler);
-        await svc.StoreSpokenAsync("sid-retry", "spoken", "reply");
 
-        Assert.Equal(2, handler.Calls);                        // the retry actually fired
-        Assert.True(svc.HasVoice("sid-retry"));                // and produced audio
+        // The stalled call fails - one attempt, bounded, and it says so honestly.
+        await svc.StoreSpokenAsync("sid-retry", "spoken", "reply");
+        Assert.Equal(1, handler.Calls);                                        // exactly one attempt: no in-call retry
+        Assert.False(svc.HasVoice("sid-retry"));                               // nothing to play
+        Assert.Equal(HostedAiState.ServiceDown, svc.VoiceUnavailableFor("sid-retry"));
+        Assert.False(svc.SpeechCooldownArmed, "and it did not drag the rest of the fleet down with it");
+
+        // The session tries again - the provider is fine now, and it just works.
+        await svc.StoreSpokenAsync("sid-retry", "spoken", "reply");
+        Assert.Equal(2, handler.Calls);
+        Assert.True(svc.HasVoice("sid-retry"));
         Assert.Null(svc.VoiceUnavailableFor("sid-retry"));
     }
 
@@ -633,18 +656,35 @@ public sealed class WingmanVoiceServiceTests
     }
 
     [Fact]
-    public async Task StoreSpokenAsync_ThreeConsecutiveTimeouts_ArmsTheSharedCooldown()
+    public async Task StoreSpokenAsync_NoRunOfTimeoutsEverArmsTheSharedCooldown()
     {
-        // The control, and the money guard the gate exists for: a genuine outage must still trip it
-        // quickly, so the idle sweep stops paying for a model translation whose audio cannot be made.
+        // THIS TEST USED TO ASSERT THE OPPOSITE, and that is the point of it (2026-07-15).
+        //
+        // It was called ThreeConsecutiveTimeouts_ArmsTheSharedCooldown and it defended the defect: it
+        // encoded the belief that a RUN of timeouts is evidence stacking toward "the service is down".
+        // It is not. The timeouts were not independent - they were the same cold provider, and the
+        // cooldown they armed produced the next one, because 120 seconds of nobody calling is exactly
+        // how the provider goes cold. Counting to three did not make the inference sound; it just made
+        // the fleet take three steps before falling silent. It went 0/8 with audio again on the day
+        // that rule shipped, while the service answered every hand-made call perfectly.
+        //
+        // A timeout is the ABSENCE of evidence: the service said nothing, so we learned nothing about
+        // it. Ten sessions timing out on a slow provider are ten slow turns, and each retries on its
+        // own (the voice sweep revisits any session without audio). The fleet-wide semaphore already
+        // caps the load at two concurrent calls, whatever we decide here.
         var handler = new TtsTimeoutHandler(timeouts: int.MaxValue);
         var svc = ServiceWithHandler(handler);
 
         await svc.StoreSpokenAsync("sid-a", "spoken", "reply");
         await svc.StoreSpokenAsync("sid-b", "spoken", "reply");
         await svc.StoreSpokenAsync("sid-c", "spoken", "reply");
+        await svc.StoreSpokenAsync("sid-d", "spoken", "reply");
+        await svc.StoreSpokenAsync("sid-e", "spoken", "reply");
 
-        Assert.True(svc.SpeechCooldownArmed, "a real outage must still back the fleet off within three attempts");
+        Assert.False(svc.SpeechCooldownArmed,
+            "no number of timeouts may silence the fleet - the service never answered, so they say nothing about it");
+        // Each session still tells the truth about ITSELF: there is nothing to play.
+        Assert.Equal(HostedAiState.ServiceDown, svc.VoiceUnavailableFor("sid-e"));
     }
 
     [Fact]

--- a/src/CcDirector.Gateway/HostedAi/TtsSynthesis.cs
+++ b/src/CcDirector.Gateway/HostedAi/TtsSynthesis.cs
@@ -81,15 +81,23 @@ internal static class TtsSynthesis
     /// the service was answering perfectly the whole time. Three warm-up calls by hand took it to
     /// 6/8 with no code change. Nothing had broken; it had fallen into the hole and the hole was ours.
     ///
-    /// 30 is chosen to clear the WORST observed cold start (16.9s) with the same kind of headroom the
-    /// slope gets, so a cold provider costs a slow narration instead of a silent fleet. It remains
-    /// strictly looser than the flat 15s at every length - the floor below still holds.
+    /// 30 was the first attempt at this and it was STILL too tight - measured against 16.9s, when the
+    /// same provider was later seen taking 39.9s for a SIXTEEN character call. Hours later the live log
+    /// read "attempt 1/2 timed out after 31s (168 chars)": a 168-character narration, dead, because the
+    /// deadline was a guess dressed as arithmetic. Twice now this number has been set to just above the
+    /// worst thing seen so far, and twice the provider has gone slower than that.
     ///
-    /// If you are tempted to lower this: a deadline is not a performance target. Being under it costs
-    /// nothing; being over it silences every session on every machine for two minutes and makes the
-    /// next call cold. The failure is not symmetric, so neither is the number.
+    /// 60 stops chasing it. It clears the worst observed cold start (39.9s) with real headroom rather
+    /// than a shave, and the cost of being generous is now nearly nothing: a timeout no longer touches
+    /// any other session (see WingmanVoiceService.TtsAsync), so an over-long deadline costs ONE session
+    /// a slow turn, while an under-long one costs that session its voice entirely and buys nothing.
+    ///
+    /// If you are tempted to lower this: a deadline is not a performance target, and this one is not
+    /// protecting the user from waiting - the narration is already made or not made by then. It exists
+    /// only to stop a truly hung call from holding a slot forever. Being generous costs a slot; being
+    /// tight costs the feature. The failure is not symmetric, so neither is the number.
     /// </summary>
-    private static readonly TimeSpan DeadlineBase = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan DeadlineBase = TimeSpan.FromSeconds(60);
 
     /// <summary>Allowance per character of input. Synthesis measures ~1.7 ms/char, so 4 ms/char is
     /// roughly 2.4x headroom at every length - enough for a slow-but-working worker, short enough
@@ -138,8 +146,30 @@ internal static class TtsSynthesis
     public static TimeSpan DeadlineFor(int inputChars)
         => DeadlineBase + TimeSpan.FromMilliseconds(DeadlineMsPerChar * Math.Max(0, inputChars));
 
-    /// <summary>Total attempts (that is, one retry). The retry targets the transient stalled-worker case.</summary>
-    public const int Attempts = 2;
+    /// <summary>
+    /// Total attempts. ONE - there is no retry, and removing it is a fix, not a regression.
+    ///
+    /// It was 2, "targeting the transient stalled-worker case", on the theory that attempt 1 eats a
+    /// cold start and attempt 2 lands on a warm worker. Production disagreed, repeatedly and in plain
+    /// text:
+    ///
+    ///   [TtsSynthesis] attempt 1/2 timed out after 33s (709 chars); retrying
+    ///   [TtsSynthesis] attempt 2/2 timed out after 33s (709 chars); giving up
+    ///
+    /// The retry never landed warm. That is not bad luck, it is mechanism: cancelling attempt 1 very
+    /// plausibly cancels the provider-side work that was loading the model, so attempt 2 starts the
+    /// same cold start over rather than arriving after it. Two attempts bought a doubled wait, a
+    /// doubled load on an already-struggling provider, and the same failure.
+    ///
+    /// So: one attempt, with a deadline long enough for the cold start to actually finish (see
+    /// DeadlineBase). Waiting through a slow call is what gets the audio; racing it and starting again
+    /// is what loses it. Recovery is per-session retry at a higher level, seconds later, not a second
+    /// attempt seconds into the same stall.
+    ///
+    /// This also halves the worst-case wait on the INTERACTIVE path (/wingman/tts, where a human is
+    /// listening for it): a never-answering upstream now costs one deadline, not two.
+    /// </summary>
+    public const int Attempts = 1;
 
     /// <summary>
     /// POST <c>{ model, voice, input, response_format }</c> to <paramref name="url"/> with bearer

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -84,19 +84,14 @@ public sealed class WingmanVoiceService
     //    speech failure makes the fleet back off (5/10/20..120s) and honours a 429's Retry-After.
     private readonly WingmanRateLimitGate _ttsGate = new();
 
-    /// <summary>
-    /// Consecutive speech TIMEOUTS/transport failures, reset by any success. A timeout says nothing
-    /// certain about the service - it can just be one long narration or one stalled worker - so it must
-    /// not, on its own, arm the fleet-wide <see cref="_ttsGate"/> and skip every other session's voice.
-    /// A server that ANSWERS with a failure status (or a 429) is different: that is evidence about the
-    /// service, and arms the gate immediately.
-    /// </summary>
-    private int _consecutiveTtsFailures;
-
-    /// <summary>How many consecutive speech timeouts look like the SERVICE rather than one narration.
-    /// A real outage still trips the cooldown within three attempts, which preserves the money guard;
-    /// a single slow narration no longer silences the fleet.</summary>
-    private const int ConsecutiveTtsFailuresBeforeCooldown = 3;
+    // There is deliberately NO consecutive-timeout counter here any more (2026-07-15).
+    //
+    // There was one, and it armed the fleet-wide gate at three. It was the previous version of this same
+    // bug: it read a run of timeouts as evidence stacking toward "the service is down", when the run was
+    // the gate's own doing - each cooldown's silence let the provider go cold, and a cold provider is
+    // what produced the next timeout. Counting to three did not make the inference sound, it just made
+    // the fleet take three steps before falling silent. Timeouts are now handled where they happen, per
+    // session, and the shared gate is armed only by an ANSWER from the service. See TtsAsync.
 
     /// <summary>On-disk shape of one ready session's metadata (the audio bytes live next to it as
     /// an .mp3). Persisted so the play triangle / playability survives a gateway restart (issue #553).</summary>
@@ -454,8 +449,12 @@ public sealed class WingmanVoiceService
                 }
                 try
                 {
-                    await GenerateOnceAsync(sid, route, ct, showReadingWindow);
-                    _rateGate.OnSuccess();   // reaching the provider clears any cooldown/backoff ramp
+                    // ONLY a generation that actually reached the model may clear the model's cooldown.
+                    // This was unconditional, so a session with nothing to say cleared the gate without
+                    // calling the provider - during a 429 storm that released the fleet back onto a
+                    // service still throttling us, on the word of a session that never spoke to it.
+                    if (await GenerateOnceAsync(sid, route, ct, showReadingWindow))
+                        _rateGate.OnSuccess();
                 }
                 finally { _genGate.Release(); }
             }
@@ -484,13 +483,23 @@ public sealed class WingmanVoiceService
     /// Split out of <see cref="GenerateAsync"/> so the backpressure wrapper (cooldown, concurrency cap,
     /// coalescing) stays readable and this stays the pure "make the voice" step. A rate-limit surfaces
     /// as <see cref="WingmanModelRateLimitedException"/> for the wrapper's cooldown to catch.
+    ///
+    /// Returns TRUE only when the model leg actually RAN - i.e. we reached the provider and it answered.
+    /// False means there was nothing to do (no reply yet, or this reply is already narrated).
+    ///
+    /// The caller uses this to decide whether to report success to the rate-limit gate, and the
+    /// distinction is not cosmetic. This used to return void and the caller cleared the gate whenever it
+    /// did not throw - so an idle session with nothing to say, sweeping during a real 429 storm, would
+    /// report "the provider recovered" without having called the provider at all, and release the whole
+    /// fleet back onto a service that was still throttling us. Found in review (Codex, 2026-07-15).
+    /// Only a real answer from the provider may speak for the provider.
     /// </summary>
-    private async Task GenerateOnceAsync(string sid, SessionVerbClient route, CancellationToken ct, bool showReadingWindow)
+    private async Task<bool> GenerateOnceAsync(string sid, SessionVerbClient route, CancellationToken ct, bool showReadingWindow)
     {
         var turns = await route.GetTurnsAsync(sid, ct);
         var widgets = turns?.Widgets ?? new List<TurnWidgetDto>();
         var lastReply = widgets.LastOrDefault(w => w.Kind == "Text")?.Content;
-        if (string.IsNullOrWhiteSpace(lastReply)) return;  // nothing to say yet
+        if (string.IsNullOrWhiteSpace(lastReply)) return false;  // nothing to say yet - the provider was not called
         // Identity-aware skip (issue #1322 done right): only skip when the CURRENT last reply is the
         // exact one already narrated. Unlike the old bare HasVoice guard this does not depend on having
         // observed the Working transition, so a genuinely new/changed reply is never suppressed by a
@@ -499,7 +508,7 @@ public sealed class WingmanVoiceService
         if (!ShouldRegenerate(sid, lastReply))
         {
             FileLog.Write($"[WingmanVoiceService] GenerateOnce skip (same reply already narrated): sid={sid}");
-            return;
+            return false;   // nothing to do - the provider was not called, so we know nothing new about it
         }
         // Recent conversation so the wingman can add context to a short/terse latest reply.
         var recentContext = WingmanTranslator.BuildRecentContext(widgets);
@@ -522,6 +531,10 @@ public sealed class WingmanVoiceService
             // Training capture (no-op unless the setting is on); fire-and-forget so it never
             // delays the turn. CancellationToken.None so a captured turn is not lost on shutdown.
             _ = _training.CaptureAsync(route, sid, "generate", lastReply, recentContext, t.Spoken, t.ReplySeconds, CancellationToken.None);
+            // The model leg ran and answered - TranslateAsync returned rather than throwing
+            // WingmanModelRateLimitedException. THIS is the only thing that entitles the caller to tell
+            // the rate-limit gate the provider is well.
+            return true;
         }
         finally { if (showReadingWindow) EndGenerating(sid); }
     }
@@ -607,8 +620,7 @@ public sealed class WingmanVoiceService
                 return new TtsResult(null, null, HostedAiState.ServiceDown);
             }
             var contentType = resp.Content.Headers.ContentType?.MediaType;
-            _ttsGate.OnSuccess();   // reaching the service clears any cooldown/backoff ramp
-            Interlocked.Exchange(ref _consecutiveTtsFailures, 0);  // ...and the timeout run that was building toward one
+            _ttsGate.OnSuccess();   // real audio from the service clears any cooldown/backoff ramp
             return new TtsResult(await resp.Content.ReadAsByteArrayAsync(ct), contentType, null);
         }
         // A timeout (TtsSynthesis exhausted its attempts) or a transport failure is the same story from
@@ -629,24 +641,33 @@ public sealed class WingmanVoiceService
             // narration on demand produced real audio for 13 of 13 reachable sessions. The service was
             // never down. The gate was, and it was armed by ambiguous evidence.
             //
-            // So: count consecutive timeouts and only arm the shared gate once the failure looks like the
-            // SERVICE rather than one narration. A genuine outage still trips it within three attempts,
-            // which keeps the money guard the gate exists for (a sweep pays for a full model translation
-            // before it ever reaches the speech leg), while a single slow narration now costs only its
-            // own session's turn instead of everyone's.
-            var consecutive = Interlocked.Increment(ref _consecutiveTtsFailures);
-            if (consecutive >= ConsecutiveTtsFailuresBeforeCooldown)
-            {
-                var backoff = _ttsGate.OnRateLimited(null);
-                FileLog.Write($"[WingmanVoiceService] tts FAILED: {ex.Message} " +
-                              $"({consecutive} consecutive) - arming the shared speech cooldown {backoff.TotalSeconds:F0}s");
-            }
-            else
-            {
-                FileLog.Write($"[WingmanVoiceService] tts FAILED: {ex.Message} " +
-                              $"({consecutive}/{ConsecutiveTtsFailuresBeforeCooldown} consecutive) - NOT arming the shared cooldown; " +
-                              $"other sessions keep their turn at speech");
-            }
+            // A TIMEOUT NEVER ARMS THE SHARED GATE. Not once, not after three (2026-07-15).
+            //
+            // The three-consecutive rule above was this same mistake with a bigger number in front of it.
+            // It assumed consecutive timeouts are independent evidence that stacks toward certainty. They
+            // are not independent - they are the SAME cold provider, and the gate they armed produced the
+            // next one, because 120 seconds of nobody calling is exactly how the provider goes cold. So
+            // three-in-a-row was not a higher bar; it was the first three steps of a staircase that
+            // always arrived at a silent fleet. It went 0/8 with audio again the day the rule shipped.
+            //
+            // The distinction that actually matters is not HOW MANY timeouts, it is WHO the failure is
+            // about. A timeout is the absence of evidence: the service said nothing, so we know nothing
+            // about the service. Ten narrations timing out on a slow provider are ten sessions having a
+            // slow turn, and the honest response is for each of them to try again on its own - the voice
+            // sweep already does exactly that for any session without audio, and the fleet-wide semaphore
+            // already caps the load at two concurrent calls whatever we decide here.
+            //
+            // Only an ANSWER is evidence about the service, and the two answers that are get handled
+            // above, where they belong: a 429 with its Retry-After, and a failure status. Those arm the
+            // shared cooldown at once, because the service has told us something true about itself.
+            //
+            // The money guard this rule claimed to keep was never worth the price. It bought "a sweep
+            // stops paying for translations whose audio cannot be made" - and paid for it by silencing
+            // every session on every machine, on evidence that turned out to be our own doing. Cheap
+            // narrations are not the failure mode; a mute fleet is.
+            FileLog.Write($"[WingmanVoiceService] tts FAILED for this narration: {ex.Message} - " +
+                          "not evidence about the service (it did not answer), so the fleet keeps its " +
+                          "turn at speech and this session retries on its own");
             return new TtsResult(null, null, HostedAiState.ServiceDown);
         }
         // NOTE: no `finally { http.Dispose(); }`. `http` is now either the caller's injected client or


### PR DESCRIPTION
Three sessions sat in voice mode with no voice while the log read:

```
SKIPPED: speech service down, 27s cooldown left (another session is probing)
SKIPPED: speech service down, 27s cooldown left (another session is probing)
SKIPPED: speech service down, 27s cooldown left (another session is probing)
```

That is the shared gate choking the fleet, still, after two attempts to civilise it. The owner's design, and he is right: **it either works or it does not; if it does not, that session waits and tries again, and nobody else is affected.**

## 1. A timeout never arms the shared gate. Not once, not after three.

The three-consecutive rule was the same mistake with a bigger number in front of it. It assumed consecutive timeouts are independent evidence stacking toward "the service is down". **They are not independent** - they are the same cold provider, and the gate they armed produced the next one, because 120s of nobody calling is how a provider goes cold. Three-in-a-row was not a higher bar; it was the first three steps of a staircase that always arrived at a silent fleet.

A timeout is the **absence** of evidence: the service said nothing, so we know nothing about it. Only an **answer** speaks for the service - a `429` with its `Retry-After`, or a failure status - and those still arm the gate at once.

Recovery was already there and was being suppressed: the voice sweep re-attempts any session without audio, and the semaphore caps load at two concurrent calls regardless.

## 2. Deadline base 30s -> 60s

Twice this was set just above the worst thing yet seen, and twice the provider went slower: 30 was measured against 16.9s, then the same provider took **39.9s for a sixteen-character call**, and the live log showed a 168-char narration dying at 31s. 60 stops chasing it. Being generous now costs almost nothing (a timeout touches only its own session); being tight costs that session its voice.

## 3. No in-call retry (Attempts 2 -> 1)

It assumed attempt 1 eats the cold start and attempt 2 lands warm. Production disagreed every time:

```
attempt 1/2 timed out after 33s (709 chars); retrying
attempt 2/2 timed out after 33s (709 chars); giving up
```

Cancelling attempt 1 plausibly cancels the model load it just triggered, so attempt 2 restarts the cold start rather than arriving after it. Doubled wait, doubled load, same failure - and two minutes worst-case on `/wingman/tts`, where a human is waiting.

## 4. Found in review (Codex): false recovery

`_rateGate.OnSuccess()` fired whenever `GenerateOnceAsync` did not throw - **including its early returns** for "no reply yet" and "already narrated". So an idle session sweeping during a real 429 storm reported "the provider recovered" *without having called it*, releasing the fleet back onto a service still throttling us. It now returns whether the model leg actually ran; only a real answer may speak for the provider.

## Tests

- The test asserting `ThreeConsecutiveTimeouts_ArmsTheSharedCooldown` **defended the defect**; replaced by one pinning that no run of timeouts may ever silence the fleet.
- The in-call retry test is replaced by one pinning the recovery that works: the stalled call fails alone, the session's next attempt succeeds, the fleet is untouched.
- The runaway-ceiling bound is **re-justified** (90 -> 130s), not widened until green: what it protects changed when a timeout stopped holding the fleet's fate.

2,480 Gateway tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)