### PR TITLE
fix(sessions): only the owner lifts a hold, so a hold actually holds

### DIFF
--- a/src/CcDirector.Core.Tests/SessionInteractiveTests.cs
+++ b/src/CcDirector.Core.Tests/SessionInteractiveTests.cs
@@ -57,27 +57,33 @@ public sealed class SessionInteractiveTests
     // ---- THE RULE: a held session that starts working comes off hold, every time ----
 
     [Fact]
-    public void HeldSession_ThatStartsWorking_LiftsTheHold()
+    public void HeldSession_ThatStartsWorking_KeepsTheHold()
     {
+        // ACTIVITY IS NOT CONSENT. This test used to assert the OPPOSITE - that work lifts the hold - and
+        // that rule is what killed all 16 holds set on 15 July 2026 within 1-21 minutes. The terminal
+        // detector flips a session to Working on a single byte out of the ConPTY, so a bare repaint of an
+        // idle session reached here and destroyed a 12-hour hold (session 7ed715c7, 21:42:46, with nothing
+        // delivered to it in the preceding 7 minutes).
         var backend = new RecordingBackend();
         using var s = NewSession(backend, ActivityState.Idle);
         s.RequestHold(true);
         Assert.True(s.OnHold);
 
-        // The agent comes back to life on its own - a background task landed, a sub-agent reported,
-        // the model resumed. Nobody submitted anything.
+        // The session starts working with nobody having submitted anything - a repaint, a background task
+        // landing, a sub-agent reporting. None of that is the owner asking for the session back.
         s.ApplyTerminalActivityState(ActivityState.Working);
 
-        Assert.False(s.OnHold);                       // it cannot be parked and working at once
-        Assert.Equal(HoldState.None, s.HoldState);
+        Assert.True(s.OnHold);                        // held AND working: reachable, and correct
+        Assert.Equal(HoldState.Held, s.HoldState);
     }
 
     [Fact]
-    public void HeldSession_ThatStartsWorking_LiftsEvenWithNoSubmissionBehindIt()
+    public void DeferredHold_ThatLanded_SurvivesTheSessionWakingUpAgain()
     {
-        // THE REGRESSION THIS MACHINE EXISTS TO KILL. Before, the lift was gated on a turn latch that
-        // was armed only by Enter and destroyed by any 10 seconds of terminal quiet - so an ordinary
-        // slow command mid-turn left the session able to work forever while still reading "Snoozed".
+        // The end-to-end shape of the owner's 12-hour hold, and the exact sequence that failed on session
+        // 7ed715c7: hold asked for mid-turn -> deferred -> lands when the turn settles -> the session
+        // stirs again. It must still be held. This test previously asserted the hold came back off "every
+        // time", which is the defect.
         var backend = new RecordingBackend();
         using var s = NewSession(backend, ActivityState.Working);
 
@@ -87,8 +93,9 @@ public sealed class SessionInteractiveTests
         s.ApplyTerminalActivityState(ActivityState.WaitingForInput); // the turn really ends -> parks
         Assert.True(s.OnHold);
 
-        s.ApplyTerminalActivityState(ActivityState.Working);         // it wakes up again
-        Assert.False(s.OnHold);                                      // and comes back. Every time.
+        s.ApplyTerminalActivityState(ActivityState.Working);         // it stirs again (byte / repaint)
+        Assert.True(s.OnHold);                                       // and STAYS parked. Every time.
+        Assert.Equal(HoldState.Held, s.HoldState);
     }
 
     [Fact]
@@ -122,15 +129,110 @@ public sealed class SessionInteractiveTests
     }
 
     [Fact]
-    public void SendInput_WithSubmitByte_ClearsOnHold()
+    public void SendInput_WithSubmitByte_FromTheOwner_ClearsOnHold()
     {
         var backend = new RecordingBackend();
         using var s = NewSession(backend, ActivityState.Idle);
         s.RequestHold(true);
 
-        s.SendInput(new byte[] { (byte)'h', (byte)'i', 0x0D }); // text + CR (Enter)
+        // The owner typing at the desktop terminal - every keystroke is tagged DesktopTyped.
+        s.SendInput(new byte[] { (byte)'h', (byte)'i', 0x0D }, InputOrigin.DesktopTyped);
 
-        Assert.False(s.OnHold);
+        Assert.False(s.OnHold); // the owner is back, so the hold goes
+    }
+
+    [Fact]
+    public void SendInput_WithSubmitByte_ButNoHumanOrigin_LeavesOnHold()
+    {
+        // A null origin at this choke point means nobody typed it - it is an agent's prompt arriving with
+        // AppendEnter=false. An agent must not un-snooze a session the owner parked.
+        var backend = new RecordingBackend();
+        using var s = NewSession(backend, ActivityState.Idle);
+        s.RequestHold(true);
+
+        s.SendInput(new byte[] { (byte)'h', (byte)'i', 0x0D }); // submit, but no human behind it
+
+        Assert.True(s.OnHold);
+        Assert.Equal(HoldState.Held, s.HoldState);
+    }
+
+    [Fact]
+    public async Task SendTextAsync_FromAnotherAgent_LeavesOnHold()
+    {
+        // THE REGRESSION. Session 8c17dc1c was held at 13:20:16 on 15 July 2026 and un-held 93 seconds
+        // later by a fleet message from a reviewer session ("Message [message from Gateway SQLite - Codex
+        // Reviewer ...]"). One agent messaging another is real work, but it is not the OWNER, and it must
+        // not cancel the owner's snooze.
+        var backend = new RecordingBackend();
+        using var s = NewSession(backend, ActivityState.Idle);
+        s.RequestHold(true);
+        Assert.True(s.OnHold);
+
+        await s.SendTextAsync("a fleet message from another agent", SendSource.Agent);
+
+        Assert.True(s.OnHold);
+        Assert.Equal(HoldState.Held, s.HoldState);
+    }
+
+    [Fact]
+    public async Task SendTextAsync_FrameworkPlumbing_LeavesOnHold()
+    {
+        // Handover text, a queue drain, a pre-prompt: the product talking to itself. No human, no hold lift.
+        var backend = new RecordingBackend();
+        using var s = NewSession(backend, ActivityState.Idle);
+        s.RequestHold(true);
+
+        await s.SendTextAsync("/handover", SendSource.Framework);
+
+        Assert.True(s.OnHold);
+    }
+
+    [Fact]
+    public async Task SendTextAsync_CarryingTheOwnersOwnVoice_ClearsOnHold()
+    {
+        // The desktop dictation path sends the owner's transcribed voice tagged Framework - the TRANSPORT
+        // is framework, the ACTOR is the human. Only the non-null InputOrigin tells them apart, which is
+        // why the origin, not the source, is the primary owner-intent signal.
+        var backend = new RecordingBackend();
+        using var s = NewSession(backend, ActivityState.Idle);
+        s.RequestHold(true);
+
+        await s.SendTextAsync("what is the status", SendSource.Framework, InputOrigin.DesktopVoice);
+
+        Assert.False(s.OnHold); // the owner spoke, so the hold goes
+    }
+
+    [Fact]
+    public async Task SendTextAsync_FromTheOwner_SupersedesADeferredHold()
+    {
+        // The owner's rule, in his words: "if you type into a turn and the hold had already been set, it's
+        // not the same turn, it's a new turn, so no it should not hold."
+        var backend = new RecordingBackend();
+        using var s = NewSession(backend, ActivityState.Working);
+        s.RequestHold(true);
+        Assert.Equal(HoldState.DeferredHold, s.HoldState);
+
+        await s.SendTextAsync("actually, keep going", SendSource.UserInput, InputOrigin.DesktopTyped);
+
+        Assert.Equal(HoldState.None, s.HoldState); // the armed hold is discarded, not deferred onward
+    }
+
+    [Fact]
+    public async Task SendTextAsync_FromAnotherAgent_DoesNotSupersedeADeferredHold()
+    {
+        // An agent poking a working session must not cancel the owner's pending hold - it still lands when
+        // the session settles.
+        var backend = new RecordingBackend();
+        using var s = NewSession(backend, ActivityState.Working);
+        s.RequestHold(true);
+        Assert.Equal(HoldState.DeferredHold, s.HoldState);
+
+        await s.SendTextAsync("a fleet message", SendSource.Agent);
+        Assert.Equal(HoldState.DeferredHold, s.HoldState); // still armed
+
+        s.ApplyTerminalActivityState(ActivityState.WaitingForInput);
+        Assert.Equal(HoldState.Held, s.HoldState);         // and it lands
+        Assert.True(s.OnHold);
     }
 
     [Fact]
@@ -325,17 +427,18 @@ public sealed class SessionInteractiveTests
     }
 
     [Fact]
-    public void RestoreHoldState_Held_OnAWorkingSession_IsLifted()
+    public void RestoreHoldState_Held_OnAWorkingSession_IsKept()
     {
-        // Working ALWAYS clears a hold - the load-bearing rule of the whole machine. A restore is not an
-        // exception to it: a session that came back working is not parked, whatever the store said.
+        // A restart that happens to catch the session mid-turn must not throw the owner's hold away. This
+        // test asserted the opposite on the old "working ALWAYS clears a hold" rule, which is gone: only
+        // the owner lifts a hold, and a Director restarting is not the owner.
         var backend = new RecordingBackend();
         using var s = NewSession(backend, ActivityState.Working);
 
         s.RestoreHoldState(HoldState.Held);
 
-        Assert.Equal(HoldState.None, s.HoldState);
-        Assert.False(s.OnHold);
+        Assert.Equal(HoldState.Held, s.HoldState);
+        Assert.True(s.OnHold);
     }
 
     [Fact]

--- a/src/CcDirector.Core/Sessions/HoldState.cs
+++ b/src/CcDirector.Core/Sessions/HoldState.cs
@@ -8,20 +8,33 @@ namespace CcDirector.Core.Sessions;
 /// (<see cref="ActivityState"/>, the authoritative live fact - never a latch):
 ///
 /// <code>
-///                      +---------------- it starts working ----------------+
-///                      v                                                   |
 ///   [None] --- Snooze pressed while settled -------------------------> [Held]
 ///     ^                                                                    ^
 ///     |--- Unsnooze pressed ---------------------------------------------- |
+///     |--- the OWNER types or speaks into it (supersedes) ---------------- |
+///     |--- the snooze timer expires (Gateway sweep) ---------------------- |
+///     |--- it exits ------------------------------------------------------ |
 ///     |                                                                    |
-///     |--- you send a prompt (supersedes) ---+                             |
-///     |                                      |                             |
 ///     +--- Snooze pressed while working -> [DeferredHold] --- it stops ----+
 /// </code>
 ///
-/// The load-bearing edge is Held + it starts working -> None: a held session that comes back to life
-/// takes itself off hold, every time, and its snooze timer is cancelled with it. A session can never be
-/// simultaneously held and working - that combination is unreachable by construction, which is the point.
+/// The load-bearing rule is: ONLY THE OWNER LIFTS A HOLD. A hold is the owner saying "do not bother me
+/// with this session", so only the owner withdraws it - by un-snoozing, by typing or speaking into it
+/// (Session.IsOwnerDriven), or by letting the snooze timer run out. An exited session drops its hold too,
+/// because a dead session must never hide behind a "Snoozed" label.
+///
+/// ACTIVITY IS NOT CONSENT, and this is the correction that defines this machine. Until 15 July 2026 the
+/// load-bearing edge was the opposite - "Held + it starts working -> None", justified by the claim that a
+/// session can never be simultaneously held and working. That invariant WAS the bug. Work is not the
+/// owner: another agent's fleet message is real work driven by an agent, and the terminal detector's rule
+/// ("a byte out of the ConPTY means working") fires on a bare repaint. So every hold was destroyed by
+/// something that was not the owner - all 16 set on 15 July 2026 died within 1-21 minutes, and a 12-hour
+/// hold was unreachable.
+///
+/// So <see cref="Held"/> + working IS now reachable, deliberately: a parked session can do background work
+/// for another agent and stay parked. That is not a lie - it is exactly what the owner asked for. The
+/// roster keeps rendering it as Snoozed; hold wins over the activity colour, because suppressing attention
+/// is the entire purpose of a hold.
 /// </summary>
 public enum HoldState
 {

--- a/src/CcDirector.Core/Sessions/Session.cs
+++ b/src/CcDirector.Core/Sessions/Session.cs
@@ -748,10 +748,13 @@ public sealed class Session : IDisposable
 
         if (IsWorking)
         {
-            // Working always clears a landed hold; a deferral is still waiting for this work to stop.
-            var restored = persisted == HoldState.DeferredHold ? HoldState.DeferredHold : HoldState.None;
-            FileLog.Write($"[Session] Restore: persisted hold {persisted} on a working session -> {restored}: session={Id}");
-            HoldState = restored;
+            // A working session keeps whatever was persisted: a Held stays Held (work does not lift a hold
+            // - only the owner does), and a deferral stays deferred, still waiting for this work to stop.
+            // This branch used to downgrade a restored Held to None on the "working always clears a hold"
+            // rule; that rule is gone, and honouring it here threw away a hold across every restart that
+            // happened to catch the session mid-turn.
+            FileLog.Write($"[Session] Restore: persisted hold {persisted} on a working session -> {persisted}: session={Id}");
+            HoldState = persisted;
             return;
         }
 
@@ -1932,10 +1935,13 @@ public sealed class Session : IDisposable
                 RecordOrigin(so, _pendingOriginChars);
             _pendingOriginChars = 0;
             IsBrandNew = false;
-            // A real submission means the user is driving this session again, so neither a hold nor a
-            // not-yet-landed deferral reflects intent any more - both are superseded (issue #470).
-            // The HoldState setter no-ops when already None.
-            HoldState = HoldState.None;
+            // A submission supersedes a hold only when the OWNER made it. SendInput carries no SendSource,
+            // so the origin IS the whole signal here: non-null means a person typed this (the desktop
+            // terminal tags every keystroke DesktopTyped). A null origin reaches here from the Gateway
+            // prompt path when an AGENT sends text with AppendEnter=false, and that must not un-snooze a
+            // session the owner parked. See IsOwnerDriven for the same rule on the text path.
+            if (origin is not null)
+                HoldState = HoldState.None;
             SetActivityState(ActivityState.Working);
         }
     }
@@ -2023,6 +2029,28 @@ public sealed class Session : IDisposable
     /// single-operator tool, and a collision between the operator's own phone dictation and their
     /// own typed send is theirs to make, not the Director's to police.
     /// </summary>
+    /// <summary>
+    /// Did the OWNER drive this send - a person typing or speaking - as opposed to an agent or the
+    /// framework? This is the ONLY thing allowed to lift a hold, because a hold is the owner's statement
+    /// "do not bother me with this session", and only the owner can withdraw it.
+    ///
+    /// Two independent signals, either of which suffices:
+    ///  * A non-null <see cref="InputOrigin"/>. Its contract is exactly this question: "a null origin at a
+    ///    choke point means the caller is framework-internal ... it carries no human keystrokes and no
+    ///    spoken words". It is the intent axis, which is what we need - the desktop dictation path sends
+    ///    the owner's OWN transcribed voice tagged <see cref="SendSource.Framework"/> (the transport is
+    ///    framework, the actor is the human), and only the origin tells those apart.
+    ///  * <see cref="SendSource.UserInput"/> / <see cref="SendSource.Delivery"/> - a human typing, or the
+    ///    human's own dictation landing. Kept as a second signal because UserInput is the enum's
+    ///    fail-closed default: an untagged call site reads as a human, which errs toward LIFTING a hold
+    ///    the owner can re-apply, rather than stranding a session the owner is actively typing into.
+    ///
+    /// A new framework or agent call site MUST tag its source (and pass no origin), or it will silently
+    /// eat holds. Every call site was audited when this rule landed.
+    /// </summary>
+    private static bool IsOwnerDriven(SendSource source, InputOrigin? origin)
+        => origin is not null || source is SendSource.UserInput or SendSource.Delivery;
+
     public async Task SendTextAsync(string text, SendSource source = SendSource.UserInput, InputOrigin? origin = null)
     {
         if (_disposed || Status is SessionStatus.Exited or SessionStatus.Failed) return;
@@ -2043,10 +2071,13 @@ public sealed class Session : IDisposable
             await _backend.SendTextAsync(text);
         }
         IsBrandNew = false;
-        // A SendTextAsync is always a submitted turn -- the user is driving this session again, so both a
-        // hold and a not-yet-landed deferral are superseded (issue #470). The HoldState setter no-ops when
-        // already None.
-        HoldState = HoldState.None;
+        // A submitted turn supersedes a hold ONLY when the OWNER submitted it (issue #470 refined). Not
+        // every send is the owner coming back: a fleet message from another agent (SendSource.Agent) and
+        // framework plumbing (handover text, a queue drain, a pre-prompt) also land here, and clearing the
+        // hold for those un-snoozed a session the owner had explicitly parked. That is what made a 12-hour
+        // hold die 90 seconds later when another agent messaged it. See IsOwnerDriven.
+        if (IsOwnerDriven(source, origin))
+            HoldState = HoldState.None;
         SetActivityState(ActivityState.Working);
         // DevThrottle Stats: a SendTextAsync is exactly one submitted turn. Count it (plus its character
         // volume) for the tagged origin. Null origin = not a human turn - either another agent (counted on
@@ -2195,22 +2226,23 @@ public sealed class Session : IDisposable
         // ActivityState has already been assigned above, so IsWorking below reads the NEW state.
         if (IsWorking)
         {
-            // THE RULE: a held session that starts working takes itself off hold, every time, with no
-            // condition attached. A session cannot be both held and working - the user would see a parked
-            // session quietly doing work, which is exactly the lie this machine exists to make impossible.
+            // A hold SURVIVES work. Activity is not consent: a held session starting to work says nothing
+            // about whether the owner wants it back, so it must not lift the hold. Only the owner lifts a
+            // hold - by un-holding it, by typing/speaking into it (see IsOwnerDriven), or by letting the
+            // snooze timer expire.
             //
-            // This is safe against cosmetic repaints - the concern the old turn-latch was built to handle -
-            // because the detector no longer reports cosmetic Working. Both of its paths filter noise before
-            // they get here: for a byte-silent-idle agent a byte IS real output, and for an agent with an
-            // animated idle footer the continuous-idle path diffs the screen BODY and stays silent on
-            // footer-only repaints (see TerminalStateDetector). The GitHubActions backend's ActivitySink is
-            // authoritative run status. So reaching Working means real work, on every path.
-            if (HoldState == HoldState.Held)
-            {
-                FileLog.Write($"[Session] Session started working - lifting hold: session={Id}");
-                HoldState = HoldState.None;
-            }
-            // A DeferredHold deliberately survives here: it is WAITING for this work to stop.
+            // This edge used to read "a held session that starts working takes itself off hold, every time"
+            // and justified itself with "reaching Working means real work, on every path". Both halves were
+            // wrong, and the log proved it: 16 of 16 holds set on 15 July 2026 died here within 1-21
+            // minutes, none reaching even 1% of a 12-hour hold.
+            //  * Work is not always the owner. Another agent's fleet message is real work, driven by an
+            //    agent. Session 8c17dc1c was held at 13:20:16 and un-held at 13:21:49 by a fleet message
+            //    from a reviewer session. The owner never touched it.
+            //  * Work is not always real. The detector's rule is "a byte out of the ConPTY means working",
+            //    which fires on a spontaneous repaint. Session 7ed715c7 landed a 12-hour hold at 21:35:30
+            //    and lost it at 21:42:46 to a lone byte, with nothing delivered in the 7 minutes between.
+            //
+            // A DeferredHold also survives here: it is WAITING for this work to stop.
         }
         else if (newState is ActivityState.Exited)
         {

--- a/tools/cc-devthrottle/src/cli.py
+++ b/tools/cc-devthrottle/src/cli.py
@@ -112,6 +112,29 @@ _ACTIONS = [
         "args": [{"name": "repo", "required": True}],
     },
     {
+        "id": "session-hold",
+        "description": (
+            "Park a session so it stops asking for attention, for a set number of minutes. Defaults "
+            "to THIS session. A session holding ITSELF is always mid-turn, so the hold is deferred "
+            "automatically and lands when the turn ends - there is no separate verb for that, and the "
+            "reply says 'pending' when it deferred. Only the owner lifts a hold: releasing it, typing "
+            "or speaking into the session, or the timer expiring. Another agent's message does not."
+        ),
+        "command": "cc-devthrottle session hold [target] --minutes <n>",
+        "mutatesState": True,
+        "args": [
+            {"name": "target", "required": False},
+            {"name": "minutes", "required": False},
+        ],
+    },
+    {
+        "id": "session-hold-release",
+        "description": "Release a hold, bringing a parked session back into the normal roster.",
+        "command": "cc-devthrottle session hold [target] --release",
+        "mutatesState": True,
+        "args": [{"name": "target", "required": False}],
+    },
+    {
         "id": "message-send",
         "description": "Send a one-way message to a session, or broadcast to all sessions.",
         "command": 'cc-devthrottle message send <target|all> "<message>"',
@@ -396,9 +419,15 @@ def hold(
 ) -> None:
     """Park a session so it stops asking for you, or release it.
 
-    A hold asked for while the session is still working is DEFERRED - it applies when the turn
-    finishes, and you are told so. A held session that starts working again always takes itself
-    off hold.
+    Hold THIS session when you have nothing left to report and do not want to keep asking for
+    attention: `cc-devthrottle session hold --minutes 720`. You do not need a special verb for
+    that. A hold asked for while the session is still working - which is always the case when a
+    session holds ITSELF, since it is mid-turn - is DEFERRED automatically: it applies the moment
+    the turn finishes, and the reply tells you so with `pending`.
+
+    ONLY THE OWNER LIFTS A HOLD - by releasing it, by typing or speaking into the session, or by
+    the --minutes timer running out. Another agent messaging the session, or the terminal simply
+    repainting, no longer un-holds it, so a hold you set actually lasts as long as you asked for.
     """
     hold_session(target, release=release, minutes=minutes)
 


### PR DESCRIPTION
## The bug

Holds do not hold. Every hold set on 15 July 2026 - **all sixteen, across eight sessions** - died within 1 to 21 minutes, every one of them to the same log line, `Session started working - lifting hold`. A twelve-hour hold was unreachable. This is from the Director's own log:

```
13:20 8c17dc1c Held -> 13:21 lifted (1m)     17:05 4f07be08 Held -> 17:16 lifted (11m)
13:28 f0d6aea7 Held -> 13:29 lifted (1m)     17:09 cedcb053 Held -> 17:09 lifted (41s)
14:01 8c17dc1c Held -> 14:05 lifted (4m)     17:21 e35352bb Held -> 17:39 lifted (18m)
15:32 60ffd96b Held -> 15:53 lifted (21m)    19:02 e35352bb Held -> 19:09 lifted (7m)
16:09 f0d6aea7 Held -> 16:29 lifted (20m)    21:35 7ed715c7 Held -> 21:42 lifted (7m)
```

## Root cause: activity was treated as consent

A hold is the owner saying "do not bother me with this session". Two separate paths overrode that, neither of them the owner.

**1. Any send cleared the hold.** `Session.SendTextAsync` ran `HoldState = HoldState.None` unconditionally, for every sender. So a fleet message from another agent un-held the session. Observed - session `8c17dc1c`, held at 13:20:16, woken 93 seconds later:

```
13:21:49 [Session] SendTextAsync: session=8c17dc1c, source=Internal,
           text="Message [message from Gateway SQLite - Codex Reviewer ..."
13:21:49 [Session] Session started working - lifting hold: session=8c17dc1c
```

**2. Any byte cleared the hold.** `SetActivityState` lifted the hold on the edge into `Working`, justified in a comment by "reaching Working means real work, on every path". `TerminalStateDetector`'s actual rule is "a byte out of the ConPTY means working", so a bare repaint of an idle session qualified. Observed - session `7ed715c7` landed a twelve-hour hold and lost it to one byte, with nothing delivered in the seven minutes between:

```
21:35:30 [Session] Deferred hold landed at settle (WaitingForInput): session=7ed715c7
21:42:46 [TerminalStateDetector] 7ed715c7 terminal=ACTIVE (byte) | hook=WaitingForInput
21:42:46 [Session] Session started working - lifting hold: session=7ed715c7
```

Note the set path was never broken. `RequestHold` correctly defers a mid-turn hold and it correctly landed. The hold was then killed at the *lift* edge.

## The fix

**Only the owner lifts a hold** - by releasing it, by typing or speaking into the session, or by the snooze timer expiring. An exited session still drops its hold; a dead session must never hide behind a "Snoozed" label.

Owner intent is read from the `InputOrigin` already threaded to both input choke points. Its contract is exactly this question - a null origin "carries no human keystrokes and no spoken words". The origin, not the `SendSource`, is the primary signal, because the desktop dictation path sends the owner's **own transcribed voice** tagged `SendSource.Framework`: the transport is the framework, the actor is the human, and only the origin separates them. Every `SendTextAsync` and `SendInput` call site was audited.

`Held + working` is now reachable, deliberately. A parked session can do background work for another agent and stay parked; the roster still renders it Snoozed, because suppressing attention is the entire purpose of a hold. The old "that combination is unreachable by construction, which is the point" invariant **was** the defect.

Restore no longer discards a persisted hold when a restart catches the session mid-turn, for the same reason: a Director restarting is not the owner.

## Discoverability

`cc-devthrottle session hold` existed but was absent from `actions --json` - the list agents actually discover - and its help text still promised the old behaviour ("a held session that starts working again always takes itself off hold"). Both fixed. No new verb is needed: a session holding itself is always mid-turn, so the existing command defers automatically and reports `pending`.

## Tests

Four tests pinned the old rule and have been inverted; they described the defect as intended behaviour ("the agent comes back to life on its own ... nobody submitted anything" -> asserts the hold lifts). Six new tests cover the fleet-message case, the framework case, the owner's-voice-via-framework case, and deferred-hold supersession.

Proven to fail on purpose: with the guard reverted to the old unconditional lift, the three fleet-message tests go red and the owner-driven controls stay green.

- `CcDirector.Core.Tests`: 3145 passed, 0 failed
- `CcDirector.Gateway.Tests` (hold and snooze): 154 passed, 0 failed

## Known gap, not addressed here

`TerminalStateDetector` still reports Claude Code as Working on a spontaneous byte while idle. That no longer eats holds, but it can still make an idle session read blue. That is an activity-classification problem, separate from this state-machine bug, and should not block this fix.