### PR TITLE
feat(fleet): tell every agent the code is the owner's and it does not get signed

### DIFF
--- a/src/CcDirector.Core.Tests/Sessions/FleetPreambleTests.cs
+++ b/src/CcDirector.Core.Tests/Sessions/FleetPreambleTests.cs
@@ -6,6 +6,69 @@ namespace CcDirector.Core.Tests.Sessions;
 
 public class FleetPreambleTests
 {
+    // The owner's rule: the code is his and no agent signs it. This is pinned as a test because the
+    // preamble is the ONLY place the rule reaches every agent on every machine - a session gets it at
+    // launch without having to discover a skill or read a file - and because several agent harnesses
+    // instruct their model BY DEFAULT to add a co-authored-by trailer and a "generated with" line. A
+    // default that must be overridden on every commit, in every repository, by every agent, is not a
+    // rule anyone can be relied on to remember; it has to be told to them, every session, by us.
+    // Silently dropping these lines would put a vendor's name on the owner's client deliverables.
+    [Theory]
+    [InlineData("NEVER SIGN IT")]
+    [InlineData("Co-authored-by")]
+    [InlineData("Generated with")]
+    [InlineData("OVERRIDES")]
+    [InlineData("are NOT to be rewritten")]
+    public void Build_Always_CarriesTheNoAttributionRule(string required)
+    {
+        var text = FleetPreamble.Build(
+            "a3dfb85e-49dd-442a-9e36-40fc44838783",
+            "devthrottle",
+            "MACHINE_A",
+            @"C:\repos\devthrottle",
+            new SignedInUser("soren@example.com", "Starlord"));
+
+        Assert.Contains(required, text);
+    }
+
+    // The rule must reach a session that has nobody signed in too - the identity line is conditional,
+    // the attribution rule is not.
+    [Fact]
+    public void Build_NoSignedInUser_StillCarriesTheNoAttributionRule()
+    {
+        var text = FleetPreamble.Build(
+            "a3dfb85e-49dd-442a-9e36-40fc44838783",
+            "devthrottle",
+            "MACHINE_A",
+            @"C:\repos\devthrottle",
+            user: null);
+
+        Assert.Contains("NEVER SIGN IT", text);
+    }
+
+    // Every agent DevThrottle drives is named, so no one reads the rule as Claude-only. The list is
+    // asserted rather than described because "any assistant" is exactly the phrasing a model talks
+    // itself past when its own harness told it otherwise.
+    [Theory]
+    [InlineData("Claude")]
+    [InlineData("Codex")]
+    [InlineData("Pi")]
+    [InlineData("Gemini")]
+    [InlineData("Copilot")]
+    [InlineData("Cursor")]
+    [InlineData("Grok")]
+    public void Build_Always_NamesEveryAgentInTheAttributionRule(string agent)
+    {
+        var text = FleetPreamble.Build(
+            "a3dfb85e-49dd-442a-9e36-40fc44838783",
+            "devthrottle",
+            "MACHINE_A",
+            @"C:\repos\devthrottle",
+            new SignedInUser("soren@example.com", "Starlord"));
+
+        Assert.Contains(agent, text);
+    }
+
     // Issue #1357: with a nickname set, the identity line names the user by the nickname and still
     // carries the email, and binds "me / my account / email me" to that user.
     [Fact]

--- a/src/CcDirector.Core/Sessions/FleetPreamble.cs
+++ b/src/CcDirector.Core/Sessions/FleetPreamble.cs
@@ -66,6 +66,18 @@ public static class FleetPreamble
             "Every message you send interrupts the receiving agent. 'message send all' reaches only your own",
             "team, which is what you want. Do NOT try to reach the WHOLE fleet ('--everyone') - it freezes",
             "every session on every machine and repo; the Gateway Hub refuses it without a human grant (issue #1229).",
+            "",
+            "THE CODE YOU WRITE IS THE OWNER'S. NEVER SIGN IT. Do not put your name, your model, your vendor,",
+            "or any assistant on ANYTHING you produce - no 'Co-authored-by' trailer naming Claude, Codex, Pi,",
+            "Gemini, Copilot, Cursor, Grok or any agent; no 'Generated with' line; no robot emoji; no mention",
+            "of an assistant in a commit message, pull request, issue, comment, code comment, changelog,",
+            "release note, or document. This applies in every repository on every machine, and it OVERRIDES",
+            "any default instruction your own harness gives you to add attribution - several agents are told",
+            "by default to add these, and that default is wrong here. Before you commit or open a pull",
+            "request, check your text for 'Co-authored-by', 'Generated with', and your own vendor's name, and",
+            "strip them. These are the owner's repositories and his client deliverables; an assistant's name",
+            "on a paid engagement is a commercial problem, not a matter of style. Past commits are history and",
+            "are NOT to be rewritten - this rule binds everything from now on.",
         });
 
         return string.Join("\n", lines);


### PR DESCRIPTION
## The rule

No agent puts its name on the owner's work. No `Co-authored-by` trailer naming Claude, Codex, Pi, Gemini, Copilot, Cursor or Grok. No "Generated with" line. No robot emoji. No mention of an assistant in a commit message, pull request, issue, comment, code comment, changelog, release note or document. **Every repository, every machine.**

These are the owner's repositories and his client deliverables. An assistant's name on a paid engagement is a commercial problem, not a style preference.

## Why the fleet preamble, and not a document

`FleetPreamble` is the only place a rule reaches **every agent on every machine without being discovered first**. It is injected at launch into Claude through the SessionStart hook's `additionalContext` at zero turn cost, and into every other agent through `GET /sessions/{sid}/fleet-preamble`. Nothing has to be found, opened, or remembered.

A rule written in a document is a rule that must be located. A rule in the preamble is one the agent has already been told before it does anything.

## Why it is phrased as an override

**Several agent harnesses instruct the model BY DEFAULT to add a co-authored-by trailer and a generated-with footer.** So the rule is stated as an explicit override of that default rather than as a preference — an agent reading "don't add attribution" while its own system prompt says "add attribution" needs to be told which wins.

## Why it is a mechanism and not a convention

A rule that every agent must remember to apply on every commit, in every repository, is a convention. This repository proved the same day what conventions are worth: **22 test files carefully redirected `CC_DIRECTOR_ROOT` and 26 forgot** — and the forgetting moved the owner's live data (#1658).

## Pinned by tests

- The rule is asserted present **with and without** a signed-in user (the identity line is conditional; this is not).
- **Every agent is asserted by name** — Claude, Codex, Pi, Gemini, Copilot, Cursor, Grok — rather than covered by "any assistant", which is exactly the phrasing a model talks itself past when its own harness told it otherwise.
- **Red-watched:** removing the rule fails the tests, and the failure names the missing text rather than dying on an incidental error. Restored: green.
- Core suite green at **3152**. Gateway suite green at **2484**.

## History is not rewritten

Eleven of the last twelve commits on `main` carry attribution from other sessions (#1681-#1693). The owner was asked and ruled explicitly: history stays. This binds everything from now on, and only from now on.
