### PR TITLE
feat(wingman): say which session is talking before summarizing it

### DIFF
--- a/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/WingmanTranslatorTests.cs
@@ -73,7 +73,8 @@ public sealed class WingmanTranslatorTests
 
         var result = await translator.TranslateAsync(
             "Did the login fix work?",
-            "I patched the auth flow in `LoginService.cs` and the suite is green: 73/73.");
+            "I patched the auth flow in `LoginService.cs` and the suite is green: 73/73.",
+            sessionTitle: null);
 
         Assert.Equal("The login bug is fixed. All seventy-three tests passed.", result.Spoken);
     }
@@ -91,7 +92,7 @@ public sealed class WingmanTranslatorTests
             },
             log: _ => { });
 
-        await translator.TranslateAsync("recent context", "the agent reply to translate");
+        await translator.TranslateAsync("recent context", "the agent reply to translate", sessionTitle: null);
         await translator.AskDirectAsync("hey wingman, what is going on?");
 
         Assert.Equal(new[] { WingmanModelRole.Fast, WingmanModelRole.Thinking }, roles);
@@ -103,8 +104,8 @@ public sealed class WingmanTranslatorTests
         var brain = new FakeBrain(_ => "Done.");
         var translator = BuildTranslator(brain);
 
-        await translator.TranslateAsync("q1", "reply one");
-        await translator.TranslateAsync("q2", "reply two");
+        await translator.TranslateAsync("q1", "reply one", sessionTitle: null);
+        await translator.TranslateAsync("q2", "reply two", sessionTitle: null);
 
         // Keep alive, but clear between uses (issue #531): one clear per translation.
         Assert.Equal(2, brain.ClearCount);
@@ -117,9 +118,66 @@ public sealed class WingmanTranslatorTests
         var translator = new WingmanTranslator((_, _) => Task.FromResult<IAgentBrain>(brain), log: _ => { });
 
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => translator.TranslateAsync("q", "some reply"));
+            () => translator.TranslateAsync("q", "some reply", sessionTitle: null));
 
         Assert.Equal(1, brain.ClearCount);
+    }
+
+    // ---- The session title, spoken first (FidelityPrompt v5.2) ---------------------------------
+    // Someone listening with the phone in a pocket cannot see WHICH of a dozen sessions produced a
+    // summary - the one fact the screen carried for free and the audio dropped. The rule in the
+    // prompt is worthless on its own: before this change the translator had no title parameter at
+    // all, so a "say the title first" instruction would have had nothing to say and the model would
+    // have invented one. These prove the title actually REACHES the model, which is the real fix.
+
+    [Fact]
+    public void FidelityPrompt_TellsTheWingmanToOpenWithTheSessionTitle()
+    {
+        Assert.Contains("OPEN WITH THE SESSION TITLE", WingmanTranslator.FidelityPrompt);
+    }
+
+    [Fact]
+    public async Task TranslateAsync_PutsTheSessionTitle_InThePromptTheModelSees()
+    {
+        var brain = new FakeBrain(_ => "spoken");
+        var translator = BuildTranslator(brain);
+
+        await translator.TranslateAsync("q", "a reply", sessionTitle: "devthrottle - mobile");
+
+        var prompt = Assert.Single(brain.Asks);
+        Assert.Contains("devthrottle - mobile", prompt);
+        Assert.Contains("Open the narration by saying", prompt);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task TranslateAsync_NoSessionTitle_OmitsTheTitleBlockEntirely(string? title)
+    {
+        var brain = new FakeBrain(_ => "spoken");
+        var translator = BuildTranslator(brain);
+
+        await translator.TranslateAsync("q", "a reply", sessionTitle: title);
+
+        // Absent, not blank. Handing the model an empty title block invites it to voice something
+        // for it ("untitled session"); omitting the block lets the rule's own escape clause fire
+        // and the narration simply leads with the point, which is the honest degrade.
+        var prompt = Assert.Single(brain.Asks);
+        Assert.DoesNotContain("Open the narration by saying", prompt);
+    }
+
+    [Fact]
+    public void BuildPrompt_CarriesTheSessionTitleVerbatim_ForTheModelToSpeakForTheEar()
+    {
+        // Verbatim including its punctuation: the MODEL naturalizes "/" and "#" into speech (that is
+        // why the title is spoken rather than glued on in code). Pre-mangling it here would just be
+        // a second, worse implementation of the SPEAK FOR THE EAR rule.
+        var prompt = WingmanTranslator.BuildPrompt(
+            WingmanTranslator.FidelityPrompt, "recent", "the reply", "Athene / Stephanie #2624");
+
+        Assert.Contains("Athene / Stephanie #2624", prompt);
+        Assert.Contains("the reply", prompt);
     }
 
     private sealed class ThrowingBrain : IAgentBrain
@@ -148,7 +206,7 @@ public sealed class WingmanTranslatorTests
         var translator = BuildTranslator(brain);
         const string reply = "I changed the timeout to 30 seconds and re-ran the failing case.";
 
-        await translator.TranslateAsync("what did you change?", reply);
+        await translator.TranslateAsync("what did you change?", reply, sessionTitle: null);
 
         var prompt = Assert.Single(brain.Asks);
         Assert.Contains(reply, prompt);
@@ -175,7 +233,7 @@ public sealed class WingmanTranslatorTests
         var brain = new FakeBrain(_ => "ok");
         var translator = BuildTranslator(brain);
 
-        await translator.TranslateAsync("q", "I edited file:///D:/repo/x.html");
+        await translator.TranslateAsync("q", "I edited file:///D:/repo/x.html", sessionTitle: null);
 
         var prompt = Assert.Single(brain.Asks);
         Assert.Contains("BE SHORT", prompt);   // v5: was "BE FOCUSED" - focus is delivery, short is length
@@ -194,7 +252,7 @@ public sealed class WingmanTranslatorTests
         var brain = new FakeBrain(_ => "ok");
         var translator = BuildTranslator(brain);
 
-        await translator.TranslateAsync("q", "session fe2ec700-458e-420e used 5,254,730 bytes");
+        await translator.TranslateAsync("q", "session fe2ec700-458e-420e used 5,254,730 bytes", sessionTitle: null);
 
         var prompt = Assert.Single(brain.Asks);
         Assert.Contains("NEVER READ OUT IDENTIFIERS OR LONG NUMBERS", prompt);
@@ -209,7 +267,7 @@ public sealed class WingmanTranslatorTests
         var brain = new FakeBrain(_ => "ok");
         var translator = BuildTranslator(brain);
 
-        await translator.TranslateAsync("read me the file", "…");
+        await translator.TranslateAsync("read me the file", "…", sessionTitle: null);
 
         var prompt = Assert.Single(brain.Asks);
         Assert.Contains("READ IN FULL", prompt);
@@ -226,7 +284,7 @@ public sealed class WingmanTranslatorTests
         var brain = new FakeBrain(_ => "ok");
         var translator = BuildTranslator(brain);
 
-        await translator.TranslateAsync("q", "**BPMN Studio** is option 1. ## Root cause: the panel path.");
+        await translator.TranslateAsync("q", "**BPMN Studio** is option 1. ## Root cause: the panel path.", sessionTitle: null);
 
         var prompt = Assert.Single(brain.Asks);
         Assert.Contains("NO MARKDOWN", prompt);
@@ -256,7 +314,7 @@ public sealed class WingmanTranslatorTests
     public async Task TranslateAsync_EmptyReply_ThrowsBecauseThereIsNothingToTranslate()
     {
         var translator = BuildTranslator(new FakeBrain(_ => "x"));
-        await Assert.ThrowsAsync<ArgumentException>(() => translator.TranslateAsync("q", "   "));
+        await Assert.ThrowsAsync<ArgumentException>(() => translator.TranslateAsync("q", "   ", sessionTitle: null));
     }
 
     [Fact]
@@ -267,7 +325,7 @@ public sealed class WingmanTranslatorTests
         // 502 - the reliability fix for the explain/voice-turn path.
         var brain = new NoMarkersBrain();   // returns "just some text with no markers at all"
         var translator = new WingmanTranslator((_, _) => Task.FromResult<IAgentBrain>(brain), log: _ => { });
-        var result = await translator.TranslateAsync("q", "a reply");
+        var result = await translator.TranslateAsync("q", "a reply", sessionTitle: null);
         Assert.Equal("just some text with no markers at all", result.Spoken);
     }
 
@@ -282,7 +340,7 @@ public sealed class WingmanTranslatorTests
         var brain = new FixedReplyBrain($"{raggedOpen}\nThe session started fine.\n{raggedClose}");
         var translator = new WingmanTranslator((_, _) => Task.FromResult<IAgentBrain>(brain), log: _ => { });
 
-        var result = await translator.TranslateAsync("q", "a reply");
+        var result = await translator.TranslateAsync("q", "a reply", sessionTitle: null);
 
         Assert.Equal("The session started fine.", result.Spoken);
         Assert.DoesNotContain("=", result.Spoken);
@@ -496,7 +554,7 @@ public sealed class WingmanTranslatorTests
         var brain = new FakeBrain(_ => "All set.");
         var translator = BuildTranslator(brain);
 
-        var result = await translator.TranslateAsync("status?", "Everything is committed and pushed.");
+        var result = await translator.TranslateAsync("status?", "Everything is committed and pushed.", sessionTitle: null);
 
         Assert.Equal("All set.", result.Spoken);
         Assert.Single(brain.Asks);
@@ -526,7 +584,7 @@ public sealed class WingmanTranslatorTests
         var rows = new List<WingmanQaRow>();
         foreach (var f in fixtures)
         {
-            var r = await translator.TranslateAsync(f.UserMessage, f.AgentReply);
+            var r = await translator.TranslateAsync(f.UserMessage, f.AgentReply, sessionTitle: null);
             rows.Add(new WingmanQaRow
             {
                 Label = f.Label,

--- a/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/GatewayWingmanVoiceEndpoint.cs
@@ -132,6 +132,16 @@ internal static class GatewayWingmanVoiceEndpoint
         Task<SessionVerbClient?> ResolveRouteAsync(string sid) =>
             SessionVerbClient.ResolveAsync(sid, registry, pushedSessions, stale, owners, sendCommand);
 
+        // The session's title, which the wingman speaks before the summary so a listener who cannot
+        // see the screen knows which session is talking (WingmanTranslator.FidelityPrompt v5.2). Same
+        // push-store read as ResolveRouteAsync above - no dial. Null (unknown session, or no name) is
+        // the honest answer and simply means no title is spoken; see GatewayHost.ResolveSessionTitle.
+        string? SessionTitle(string sid)
+        {
+            var name = pushedSessions?.TryLocate(sid, stale)?.Session.Name;
+            return string.IsNullOrWhiteSpace(name) ? null : name;
+        }
+
         // The single Gateway owner of speech-to-text (issue #839): both batch transcribe paths below
         // (the resumable /wingman/utterance/complete and the one-shot /wingman/transcribe) go through
         // it, so they resolve the mode + key and pick the hosted endpoint exactly the same way every
@@ -420,7 +430,7 @@ internal static class GatewayWingmanVoiceEndpoint
                     var opt = menu.Options[idx];
                     var submit = string.Equals(menu.SelectionMode, "multiple", StringComparison.OrdinalIgnoreCase) ? menu.Submit : "";
                     FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: menu choice -> option {idx + 1}");
-                    return await PressAndSummarizeAsync(route, translator, voice, sid, opt.Send, submit, $"Selecting option {idx + 1}. ", "voice-menu", ct);
+                    return await PressAndSummarizeAsync(route, translator, voice, sid, SessionTitle(sid), opt.Send, submit, $"Selecting option {idx + 1}. ", "voice-menu", ct);
                 }
                 // Heard them, but no confident option: re-read the menu and send NOTHING (don't burn the turn).
                 FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: menu present, choice unclear");
@@ -462,7 +472,7 @@ internal static class GatewayWingmanVoiceEndpoint
                 var recentContext = string.IsNullOrWhiteSpace(priorContext)
                     ? "You: " + req.Text.Trim()
                     : priorContext + "\n\nYou: " + req.Text.Trim();
-                var t = await translator.TranslateAsync(recentContext, reply, CancellationToken.None);
+                var t = await translator.TranslateAsync(recentContext, reply, SessionTitle(sid), CancellationToken.None);
                 await voice.StoreSpokenAsync(sid, t.Spoken, reply, CancellationToken.None);   // make it a voice session + cache audio
                 FileLog.Write($"[GatewayWingmanVoice] voice-turn sid={sid}: replyLen={reply.Length}, spokenLen={t.Spoken.Length}");
                 // Training capture (no-op unless the setting is on); fire-and-forget so it adds no latency.
@@ -573,7 +583,7 @@ internal static class GatewayWingmanVoiceEndpoint
             voice.BeginGenerating(sid);
             try
             {
-                var t = await translator.TranslateAsync(recentContext, lastReply, CancellationToken.None);
+                var t = await translator.TranslateAsync(recentContext, lastReply, SessionTitle(sid), CancellationToken.None);
                 await voice.StoreSpokenAsync(sid, t.Spoken, lastReply, CancellationToken.None);   // cache spoken + audio, ready to play
                 FileLog.Write($"[GatewayWingmanVoice] explain sid={sid}: replyLen={lastReply.Length}, spokenLen={t.Spoken.Length}");
                 // Training capture (no-op unless the setting is on); fire-and-forget so it adds no latency.
@@ -655,7 +665,7 @@ internal static class GatewayWingmanVoiceEndpoint
             var route = await ResolveRouteAsync(sid);
             if (route is null)
                 return Results.Json(new { error = "session not found on any director" }, statusCode: StatusCodes.Status404NotFound);
-            return await PressAndSummarizeAsync(route, translator, voice, sid, req.Send, req.Submit, null, "menu-press", ct);
+            return await PressAndSummarizeAsync(route, translator, voice, sid, SessionTitle(sid), req.Send, req.Submit, null, "menu-press", ct);
         });
     }
 
@@ -677,7 +687,7 @@ internal static class GatewayWingmanVoiceEndpoint
     /// option-button tap (menu-press) and the spoken-choice path (voice-turn).</summary>
     private static async Task<IResult> PressAndSummarizeAsync(
         SessionVerbClient route, WingmanTranslator translator, WingmanVoiceService voice,
-        string sid, string send, string? submit, string? confirmPrefix, string source, CancellationToken ct)
+        string sid, string? sessionTitle, string send, string? submit, string? confirmPrefix, string source, CancellationToken ct)
     {
         voice.OnSessionWorking(sid);   // a new turn is coming; drop the stale cached summary
         var before = await CountTextWidgetsAsync(route, sid, ct);
@@ -700,7 +710,7 @@ internal static class GatewayWingmanVoiceEndpoint
         voice.BeginGenerating(sid);
         try
         {
-            var t = await translator.TranslateAsync("(you picked a menu option)", reply, CancellationToken.None);
+            var t = await translator.TranslateAsync("(you picked a menu option)", reply, sessionTitle, CancellationToken.None);
             var spoken = prefix + t.Spoken;
             await voice.StoreSpokenAsync(sid, spoken, reply, CancellationToken.None);
             _ = voice.CaptureTrainingAsync(route, sid, source, reply, "(menu pick)", spoken, t.ReplySeconds, CancellationToken.None);

--- a/src/CcDirector.Gateway/Api/WingmanInstructionsEndpoint.cs
+++ b/src/CcDirector.Gateway/Api/WingmanInstructionsEndpoint.cs
@@ -134,7 +134,13 @@ internal static class WingmanInstructionsEndpoint
                 if (string.IsNullOrWhiteSpace(rec.Reply)) { results.Add(new { id, error = "record has no agent reply to translate" }); continue; }
                 try
                 {
-                    var t = await translator.TranslateWithAsync(req.Content, rec.RecentContext, rec.Reply, ct);
+                    // No session title: a training record stores only the session ID, and the session it
+                    // was captured from may be long gone, so there is no name to resolve. Null makes the
+                    // OPEN WITH THE SESSION TITLE rule no-op for this comparison (passing the ID instead
+                    // would make the wingman read out an identifier, which the same prompt forbids). The
+                    // draft-vs-live diff this endpoint shows is therefore title-less on both sides, which
+                    // is the honest comparison - both were produced without one.
+                    var t = await translator.TranslateWithAsync(req.Content, rec.RecentContext, rec.Reply, sessionTitle: null, ct);
                     results.Add(new { id, source = rec.Source, reply = rec.Reply, oldSpoken = rec.Spoken, newSpoken = t.Spoken, replySeconds = t.ReplySeconds });
                 }
                 catch (Exception ex)

--- a/src/CcDirector.Gateway/GatewayHost.cs
+++ b/src/CcDirector.Gateway/GatewayHost.cs
@@ -876,6 +876,23 @@ public sealed class GatewayHost : IAsyncDisposable
     }
 
     /// <summary>
+    /// The title of a session, for the wingman to speak first (WingmanTranslator.FidelityPrompt
+    /// v5.2). Reads the pushed-session store, so it costs no round trip and stays inside the same
+    /// stream-freshness window as every other stream-mode read.
+    ///
+    /// Returns null when the session is unknown or has no name, and that is deliberate rather than
+    /// a placeholder: the prompt rule no-ops on a missing title, so the listener gets an untitled
+    /// narration - whereas inventing something ("unknown session", the raw id) would either mislead
+    /// or read out an identifier, which the same instructions explicitly forbid.
+    /// </summary>
+    private string? ResolveSessionTitle(string sessionId)
+    {
+        var located = PushedSessions.TryLocate(sessionId, _streamStaleAfter);
+        var name = located?.Session.Name;
+        return string.IsNullOrWhiteSpace(name) ? null : name;
+    }
+
+    /// <summary>
     /// Pre-build voice for voice sessions that are idle and missing it, so the session list shows
     /// them "voice ready" BEFORE the person enters - including after a gateway restart (the voice-
     /// session set is persisted). Gentle: at most a few per cycle, idle sessions only (a working
@@ -999,7 +1016,10 @@ public sealed class GatewayHost : IAsyncDisposable
         // #186 by Director doorbell pings and heartbeat snapshots (wired into the endpoints below);
         // the only pull left is the one-time startup catch-up sweep.
         FileLog.Write("[GatewayHost] StartAsync: starting the turn-end watcher (voice auto-refresh only; turn-brief pipeline retired in #549)");
-        _voiceService ??= new Wingman.WingmanVoiceService(WingmanBrainAsync, _keyVault, training: _trainingStore, instructionsProvider: () => _instructionsStore.ActiveContent);
+        // sessionTitleResolver: the wingman opens every narration with the session's title, so a
+        // listener with the phone in a pocket knows WHICH session is talking before anything else
+        // (WingmanTranslator.FidelityPrompt v5.2). Push-store read - no dial. See ResolveSessionTitle.
+        _voiceService ??= new Wingman.WingmanVoiceService(WingmanBrainAsync, _keyVault, training: _trainingStore, instructionsProvider: () => _instructionsStore.ActiveContent, sessionTitleResolver: ResolveSessionTitle);
         _turnEndWatcher = new TurnEndWatcher(
             onTurnEnd: signal =>
             {
@@ -1394,7 +1414,10 @@ public sealed class GatewayHost : IAsyncDisposable
         // Wingman-voice surface for the Cockpit's Voice tab (issue #531): drive one turn of a
         // session and have the persistent wingman brain translate the reply into speakable form,
         // plus the direct-to-wingman path. Backed by the same warm Brain the brief agent uses.
-        _voiceService ??= new Wingman.WingmanVoiceService(WingmanBrainAsync, _keyVault, training: _trainingStore, instructionsProvider: () => _instructionsStore.ActiveContent);
+        // sessionTitleResolver: the wingman opens every narration with the session's title, so a
+        // listener with the phone in a pocket knows WHICH session is talking before anything else
+        // (WingmanTranslator.FidelityPrompt v5.2). Push-store read - no dial. See ResolveSessionTitle.
+        _voiceService ??= new Wingman.WingmanVoiceService(WingmanBrainAsync, _keyVault, training: _trainingStore, instructionsProvider: () => _instructionsStore.ActiveContent, sessionTitleResolver: ResolveSessionTitle);
         GatewayWingmanVoiceEndpoint.Map(_app, Registry, WingmanBrainAsync, _keyVault, _voiceService,
             pushedSessions: PushedSessions,
             sendCommand: SendCommandAsync,

--- a/src/CcDirector.Gateway/Wingman/WingmanTranslator.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanTranslator.cs
@@ -63,6 +63,14 @@ public sealed class WingmanTranslator
     /// the ~30s target for the hardest replies (~48s) - it halves the worst case without making the
     /// typical case vaguer, which is the trade we want. Tune further only with measurements; a prompt
     /// change whose effect is asserted rather than measured is how this rule rotted in the first place.
+    ///
+    /// v5.2 opens every narration with the SESSION TITLE. Someone listening with the phone in a pocket
+    /// hears a summary with no idea which of a dozen sessions produced it - the one fact the screen was
+    /// carrying for free, and the one the audio dropped. The title is spoken, not glued on in code,
+    /// because real session names carry punctuation ("Athene / Stephanie #2624") and a literal
+    /// prepend would read it out as "slash" and "hashtag" - exactly what SPEAK FOR THE EAR forbids.
+    /// The model naturalizes it; code cannot. It costs a few words against the ~30s budget, which is
+    /// why the rule says the title and nothing else about the session.
     /// </summary>
     internal const string FidelityPrompt = """
         You are the wingman: you turn a coding agent's written reply into words a person
@@ -75,6 +83,16 @@ public sealed class WingmanTranslator
         to a summary of one turn - it is not a technical limit, and going past it is the most
         common way to fail this job. A short reply needs less; never stretch one to fill it.
         Every extra sentence is a cost you must justify, not a budget you may spend. Rules:
+        - OPEN WITH THE SESSION TITLE, then go straight into the summary. The session's title
+          is given below. Your first words are that title - the listener usually cannot see
+          the screen, so they need to know WHICH session is talking before they hear anything
+          else. The title is the ONE thing allowed before the point; it is not preamble. Say
+          ONLY the title: do not describe the session, do not say what it is working on, and
+          do not wrap it in words like "the session ... says". Speak it for the ear like any
+          other text - drop the punctuation instead of voicing it, so "devthrottle - mobile"
+          becomes "devthrottle mobile" and "Banya/Yibo - WebSocket voice mode (architect)"
+          becomes "Banya Yibo, WebSocket voice mode, architect". If no session title is given
+          below, skip this rule and lead with the point.
         - BE SHORT. Lead with the single most important thing first - the answer, the result,
           or the ask - in your opening sentence, then add only what is needed to understand
           it, and STOP. If removing a sentence would not change what the listener knows or
@@ -153,7 +171,7 @@ public sealed class WingmanTranslator
     /// instructions is shown that the recommended default changed and can switch to it. The content
     /// hash is the real identity; this is the human-facing label.
     /// </summary>
-    public const string DefaultInstructionsVersion = "6";
+    public const string DefaultInstructionsVersion = "7";
 
     private readonly Func<WingmanModelRole, CancellationToken, Task<IAgentBrain>> _brainProvider;
     private readonly Action<string> _log;
@@ -216,25 +234,29 @@ public sealed class WingmanTranslator
     /// the recent conversation BEFORE that reply (oldest first) - the wingman uses it to add just
     /// enough context when the latest reply is too short to stand on its own (e.g. "Done", "Yes").
     /// <paramref name="latestReply"/> is the agent's latest written reply, the thing to translate.
+    /// <paramref name="sessionTitle"/> is the name of the session the reply came from - the wingman
+    /// opens the narration with it so a listener who cannot see the screen knows who is talking.
+    /// Pass null ONLY when there is genuinely no session behind the reply (the draft-prompt A/B
+    /// path); the rule then no-ops rather than inventing a title.
     /// </summary>
     /// <returns>The faithful, speakable translation and how long the brain took.</returns>
     /// <exception cref="ArgumentException">The latest reply is empty - there is nothing to translate.</exception>
-    public Task<WingmanTranslation> TranslateAsync(string recentContext, string latestReply, CancellationToken ct = default)
-        => TranslateWithAsync(_instructions(), recentContext, latestReply, ct);
+    public Task<WingmanTranslation> TranslateAsync(string recentContext, string latestReply, string? sessionTitle, CancellationToken ct = default)
+        => TranslateWithAsync(_instructions(), recentContext, latestReply, sessionTitle, ct);
 
     /// <summary>
     /// Same as <see cref="TranslateAsync"/> but with caller-supplied instructions instead of the
     /// active ones (issue #537 A/B testing): re-run a DRAFT prompt over a captured reply to compare
     /// its spoken output against what the wingman said before, without changing the live instructions.
     /// </summary>
-    public async Task<WingmanTranslation> TranslateWithAsync(string instructions, string recentContext, string latestReply, CancellationToken ct = default)
+    public async Task<WingmanTranslation> TranslateWithAsync(string instructions, string recentContext, string latestReply, string? sessionTitle, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(latestReply))
             throw new ArgumentException("Latest reply is required - there is nothing to translate.", nameof(latestReply));
 
-        _log($"[WingmanTranslator] TranslateWithAsync: instrLen={instructions?.Length ?? 0}, contextLen={recentContext?.Length ?? 0}, replyLen={latestReply.Length}");
+        _log($"[WingmanTranslator] TranslateWithAsync: instrLen={instructions?.Length ?? 0}, contextLen={recentContext?.Length ?? 0}, replyLen={latestReply.Length}, title={(string.IsNullOrWhiteSpace(sessionTitle) ? "(none)" : sessionTitle)}");
 
-        var prompt = BuildPrompt(instructions ?? FidelityPrompt, recentContext ?? "", latestReply);
+        var prompt = BuildPrompt(instructions ?? FidelityPrompt, recentContext ?? "", latestReply, sessionTitle);
 
         var brain = await _brainProvider(WingmanModelRole.Fast, ct);
         AskResult ask;
@@ -543,22 +565,31 @@ public sealed class WingmanTranslator
     }
 
     /// <summary>
-    /// Wrap the agent reply in the fidelity contract and the shared answer markers. Public
-    /// so a test can assert the exact contract text and that the reply is carried verbatim.
+    /// Wrap the agent reply in the fidelity contract and the shared answer markers, with
+    /// caller-supplied instructions (issue #537: the user's active, possibly-edited wingman
+    /// instructions; pass <see cref="FidelityPrompt"/> for the deployed default). Public so a test
+    /// can assert the exact contract text and that the reply is carried verbatim.
+    ///
+    /// <paramref name="sessionTitle"/> is the name of the session the reply came from, which the
+    /// OPEN WITH THE SESSION TITLE rule speaks first. It is a REQUIRED parameter and not an
+    /// optional one on purpose: every caller that has a session must be made to pass it, and the
+    /// compiler is the only thing that reliably enforces that. Null/blank is the honest "there is
+    /// no session here" case (the draft-prompt A/B path) and omits the block entirely, which the
+    /// rule's own escape clause covers - the model is never handed an empty title to voice.
     /// </summary>
-    public static string BuildPrompt(string recentContext, string latestReply)
-        => BuildPrompt(FidelityPrompt, recentContext, latestReply);
-
-    /// <summary>
-    /// Same as <see cref="BuildPrompt(string,string)"/> but with caller-supplied instructions
-    /// (issue #537: the user's active, possibly-edited wingman instructions) instead of the
-    /// embedded default. Public so a test can assert the active instructions are what gets used.
-    /// </summary>
-    public static string BuildPrompt(string instructions, string recentContext, string latestReply)
+    public static string BuildPrompt(string instructions, string recentContext, string latestReply, string? sessionTitle)
     {
         var sb = new StringBuilder();
         sb.Append(string.IsNullOrWhiteSpace(instructions) ? FidelityPrompt : instructions);
         sb.Append("\n\n");
+        if (!string.IsNullOrWhiteSpace(sessionTitle))
+        {
+            sb.Append("The title of the session this reply came from. Open the narration by saying ");
+            sb.Append("this, in words, before anything else:\n");
+            sb.Append("---\n");
+            sb.Append(sessionTitle.Trim());
+            sb.Append("\n---\n\n");
+        }
         if (!string.IsNullOrWhiteSpace(recentContext))
         {
             sb.Append("Recent conversation for context, oldest first. Use ONLY as much of this as the ");

--- a/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
+++ b/src/CcDirector.Gateway/Wingman/WingmanVoiceService.cs
@@ -45,6 +45,7 @@ public sealed class WingmanVoiceService
     private readonly string _persistPath;
     private readonly string _audioDir;
     private readonly HttpClient? _ttsHttp;   // test seam for TtsAsync (issue #939); the shared static when null
+    private readonly Func<string, string?>? _sessionTitleResolver;   // sid -> session title, spoken first
 
     /// <summary>
     /// The one HTTP client for the narration speech leg, used whenever no test client is injected.
@@ -99,10 +100,15 @@ public sealed class WingmanVoiceService
 
     /// <param name="ttsHttpClient">Optional HTTP client for the text-to-speech call (tests inject a stub
     /// over a fake handler, issue #939). A per-call 60-second client is created when null.</param>
-    public WingmanVoiceService(Func<Core.Configuration.WingmanModelRole, CancellationToken, Task<IAgentBrain>> brainProvider, KeyVault vault, string? persistPath = null, WingmanTrainingStore? training = null, Func<string>? instructionsProvider = null, HttpClient? ttsHttpClient = null)
+    /// <param name="sessionTitleResolver">Resolves a session id to its title, which the wingman speaks
+    /// first so a listener knows which session is talking. The host wires this to the pushed-session
+    /// store; a null resolver (or one returning null for an unknown session) simply means no title is
+    /// spoken, which is the correct degrade - a narration with no title is worth far more than none.</param>
+    public WingmanVoiceService(Func<Core.Configuration.WingmanModelRole, CancellationToken, Task<IAgentBrain>> brainProvider, KeyVault vault, string? persistPath = null, WingmanTrainingStore? training = null, Func<string>? instructionsProvider = null, HttpClient? ttsHttpClient = null, Func<string, string?>? sessionTitleResolver = null)
     {
         _translator = new WingmanTranslator(brainProvider, instructionsProvider: instructionsProvider);
         _vault = vault;
+        _sessionTitleResolver = sessionTitleResolver;
         // Post-cut: the owning Director is reached through the tunnel-only SessionVerbClient the callers pass
         // into GenerateAsync, so this service holds no Director client.
         _ttsHttp = ttsHttpClient;
@@ -518,7 +524,7 @@ public sealed class WingmanVoiceService
         if (showReadingWindow) BeginGenerating(sid);
         try
         {
-            var t = await _translator.TranslateAsync(recentContext, lastReply, ct);
+            var t = await _translator.TranslateAsync(recentContext, lastReply, _sessionTitleResolver?.Invoke(sid), ct);
             await StoreSpokenAsync(sid, t.Spoken, lastReply, ct);
             // Log the TRUE outcome: StoreSpokenAsync only makes the session playable when the
             // text-to-speech synthesis actually returned audio. Logging "voice ready"


### PR DESCRIPTION
## Why

Listening to a wingman narration with the phone in a pocket, you cannot tell WHICH of a dozen sessions produced it. The screen was carrying that fact for free; the audio dropped it.

## The finding that shaped the change

Adding the rule to the instructions alone would NOT have worked. The wingman was never told which session it was summarizing: `BuildPrompt` took the instructions, the recent conversation, and the reply - no title - and the voice endpoint that calls it only ever had the session id. A "say the title first" instruction with no title to say invites the model to invent one.

So the title is plumbed through to the model, and spoken as the first words.

## What changed

* `FidelityPrompt` v5.2 gains **OPEN WITH THE SESSION TITLE**, carved out explicitly from the existing "no preamble" rule so the two do not fight.
* `BuildPrompt` / `TranslateAsync` take `sessionTitle` as a **required** parameter, not an optional one - every caller with a session is then forced by the compiler to pass it. Null is the honest "no session here" case (the draft-prompt A/B path, whose training records keep only a session id) and omits the block entirely, which the rule's own escape clause covers.
* The Gateway resolves the title from the pushed-session store - no dial, same freshness window as every other stream-mode read.
* `DefaultInstructionsVersion` 6 -> 7, so anyone running customized instructions is told the recommended default moved.

## Two judgement calls

**The model speaks the title; code does not prepend it.** Real session names carry punctuation ("Athene / Stephanie #2624"), and a literal prepend would read out "slash" and "hashtag" - exactly what the SPEAK FOR THE EAR rule in the same prompt forbids. The model naturalizes it; code cannot.

**Both `BuildPrompt` overloads collapse into one 4-argument method.** Keeping a 3-argument convenience alongside it would have let an existing `(instructions, recentContext, latestReply)` call bind silently to the new `(recentContext, latestReply, sessionTitle)` meaning - a wrong-argument bug the compiler could not catch. Nothing outside the class called it.

## Known limitation

The summary string is used for both the spoken audio and the text shown on screen (one string, one model call), so the title also appears at the front of the text version, where the session is already visible. Accepted deliberately rather than splitting into two model calls.

## Proof

* The two title tests were watched **failing** with the title absent from the prompt when the block is removed; the other 33 stayed green.
* All seven test projects pass: 6,058 tests, 0 failures.
