### PR TITLE
The Gateway statistics record which model did the work

### DIFF
--- a/docs/architecture/review-model-dimension-2026-07-16.md
+++ b/docs/architecture/review-model-dimension-2026-07-16.md
@@ -1,0 +1,33 @@
+# Review: Model Dimension Schema Version 2
+
+## Verdict
+
+No blocking findings. I would land this change.
+
+## Findings
+
+None.
+
+## Review Notes
+
+The version 2 migration is atomic with the version stamp in the current implementation. `Migrate` opens one transaction, runs `MigrateToVersion2`, writes `PRAGMA user_version=2`, and commits only after all steps complete. The migration adds `model_id` with `ALTER TABLE`, creates `model_identity`, and inserts the `models_since_utc` meta row inside that same transaction. A version 1 database cannot be stamped as version 2 unless those steps complete.
+
+The migration preserves existing rows. `ALTER TABLE stat_delta ADD COLUMN model_id INTEGER` appends a nullable column, so preexisting rows read as `NULL` without a table rebuild or data copy. The tests assert both row totals and the new column, which matters because the unconditional final version stamp would otherwise make a missing step look successful.
+
+The prune fold keeps the archive correct. The archive insert carries `model_id` in both the `SELECT` list and the `GROUP BY`, so pruning cannot collapse different models into one archived row or rewrite known models as unknown. SQLite groups `NULL` values together, so unknown model rows aggregate into a single unknown bucket per remaining archive key, which matches the intended absence semantics.
+
+The `bool isRepo` to `IdentityKind` refactor preserves the existing repository and agent behavior. Repository and agent identity lookup still uses the same case-insensitive dictionaries, pending identity dedup still uses ordinal ignore case comparison, and session membership is still only recorded for repository and agent identities. The added model kind is rejected by `SessionsFor`, so a model cannot silently enter a repository or agent session table.
+
+`ModelTotals` includes archive rows and the null bucket without double counting. It groups directly over `stat_delta` by `model_id`, includes all rows like the other all-time totals, and does not join against the identity table in a way that could multiply rows. Each counted human turn lands in exactly one model bucket: a concrete model id or `NULL`.
+
+## Verification
+
+Ran:
+
+```text
+dotnet test src/CcDirector.Gateway.Tests/CcDirector.Gateway.Tests.csproj --filter "FullyQualifiedName~GatewayStatsDatabaseTests|FullyQualifiedName~GatewayInputStatsAggregatorTests" --no-restore
+```
+
+Result: passed, 48 tests.
+
+One remaining coverage gap is that the new tests do not directly force pruning of rows with multiple model ids and a null model id. I traced the SQL path above and do not consider this blocking.

--- a/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
@@ -668,6 +668,53 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
     }
 
     [Fact]
+    public void Prune_ArchivingOldRows_KeepsEveryModelsTurnsWhereTheyWere()
+    {
+        // The ninety-day fold is where this dimension would die quietly. PruneLocked collapses detail rows
+        // into one archive row per grouping key, so model_id must be in BOTH its select and its group by:
+        // missing from the select, every archived turn silently becomes "model unknown"; missing from the
+        // group by, different models collapse into one row under an arbitrary id. Either way the loss lands
+        // ninety days after the change that caused it, against real data, with nothing to point at.
+        //
+        // The aggregator's own comment claims this works. This test is what makes the claim checkable.
+        var agg = new GatewayInputStatsAggregator(_path);
+        var old = new DateTime(2026, 1, 1, 9, 0, 0, DateTimeKind.Utc);
+        var now = old.AddDays(200); // Comfortably past the ninety-day retention window.
+
+        agg.Observe(SessionOnModel("old-1", "claude-opus-4-8", ("typed", "desktop", 5, 50)), old);
+        agg.Observe(SessionOnModel("old-2", "gpt-5.5", ("voice", "phone", 3, 30)), old);
+        agg.Observe(SessionOnModel("old-3", null, ("typed", "desktop", 2, 20)), old);
+
+        // Two rows for one model, so the archive fold has something to actually merge rather than just
+        // copy - a per-model SUM that never adds two rows together would not notice a broken group by.
+        agg.Observe(SessionOnModel("old-4", "claude-opus-4-8", ("typed", "desktop", 4, 40)), old);
+
+        var beforePrune = agg.ModelTotals().ToDictionary(m => m.Model ?? "(null)", m => m.Turns);
+
+        // This fold carries a row, which is what triggers the prune.
+        agg.Observe(SessionOnModel("new-1", "claude-sonnet-5", ("typed", "desktop", 1, 10)), now);
+
+        // FIRST: prove the prune actually fired. Without this the test could pass by doing nothing at all -
+        // an assertion that cannot fail is not coverage. HourlyTurns excludes the archive marker, so the old
+        // hour disappearing from it IS the archiving having happened.
+        Assert.DoesNotContain(agg.HourlyTurns(), h => h.Hour == "2026-01-01T09");
+
+        // THEN: the numbers are untouched. An all-time tally must not shrink or move between models because
+        // detail was pruned - that is the entire point of archiving rather than deleting.
+        var afterPrune = agg.ModelTotals().ToDictionary(m => m.Model ?? "(null)", m => m.Turns);
+
+        Assert.Equal(9, beforePrune["claude-opus-4-8"]);
+        Assert.Equal(9, afterPrune["claude-opus-4-8"]);
+        Assert.Equal(3, afterPrune["gpt-5.5"]);
+        Assert.Equal(2, afterPrune["(null)"]);
+        Assert.Equal(1, afterPrune["claude-sonnet-5"]);
+
+        // And nothing leaked between buckets: every pruned turn is still exactly where it was earned.
+        // 9 opus + 3 gpt + 2 unknown = 14, the whole of what was folded before the cutoff.
+        Assert.Equal(14, afterPrune.Where(kv => kv.Key != "claude-sonnet-5").Sum(kv => kv.Value));
+    }
+
+    [Fact]
     public void ModelsSinceUtc_IsStampedByTheMigration_SoANullModelCanBeRead()
     {
         var agg = new GatewayInputStatsAggregator(_path);

--- a/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayInputStatsAggregatorTests.cs
@@ -553,4 +553,129 @@ public sealed class GatewayInputStatsAggregatorTests : IDisposable
         agg.Observe(SessionOnAgent("new-1", "Codex", ("typed", "desktop", 2, 20)));
         Assert.Equal(2, Agent(agg, "Codex")!.Turns);
     }
+
+    // ---- The model dimension (issue #1637): which model actually did the work. ----
+
+    private static SessionDto SessionOnModel(string id, string? model, params (string modality, string surface, long turns, long chars)[] buckets)
+    {
+        var dto = Session(id, buckets);
+        dto.CurrentModel = model;
+        return dto;
+    }
+
+    private static ModelStatBucketDto? Model(GatewayInputStatsAggregator agg, string? model) =>
+        agg.ModelTotals().FirstOrDefault(m => m.Model == model);
+
+    [Fact]
+    public void Model_ReportedByTheDirector_IsAttributedToThatModel()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        agg.Observe(SessionOnModel("s-1", "claude-opus-4-8", ("typed", "desktop", 3, 30)));
+        agg.Observe(SessionOnModel("s-2", "gpt-5.5", ("voice", "phone", 2, 20)));
+
+        Assert.Equal(3, Model(agg, "claude-opus-4-8")!.Turns);
+        Assert.Equal(3, Model(agg, "claude-opus-4-8")!.TypedTurns);
+        Assert.Equal(30, Model(agg, "claude-opus-4-8")!.Characters);
+        Assert.Equal(2, Model(agg, "gpt-5.5")!.VoiceTurns);
+    }
+
+    [Fact]
+    public void Model_NotYetRecordedByTheAgent_FoldsAsNullAndIsNotAModelNamedNothing()
+    {
+        // The permanent state, not a corner case: CurrentModel is records-only, so EVERY session's first
+        // turn folds before its agent has recorded a model, and it stays that way - this store records
+        // forward and never revisits a written row. The null bucket is therefore a real, honest answer.
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        agg.Observe(SessionOnModel("s-1", null, ("typed", "desktop", 4, 40)));
+
+        Assert.Equal(4, Model(agg, null)!.Turns);
+        // It must NOT become an identity spelled "" - that would rank among the models and render as a
+        // model named nothing, which is the empty-string trap repo_id lives with and this column avoids.
+        Assert.DoesNotContain(agg.ModelTotals(), m => m.Model == "");
+    }
+
+    [Fact]
+    public void Model_SwitchedMidSession_AttributesEachTurnToTheModelThatProducedIt()
+    {
+        // The reason the producer re-reads the model at every turn-end rather than trusting the launch
+        // flag: the owner switches model mid-session (Claude's /model). The turns before the switch belong
+        // to the old model and the turns after belong to the new one, and neither may be restated.
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        agg.Observe(SessionOnModel("s-1", "claude-opus-4-8", ("typed", "desktop", 5, 50)));
+        agg.Observe(SessionOnModel("s-1", "claude-sonnet-5", ("typed", "desktop", 8, 80)));
+
+        // Only the INCREASE is folded, so the switch moves 3 turns to the new model and leaves the first 5
+        // where they were earned. A design that stamped the session's current model over its history would
+        // report 8 and 0 here.
+        Assert.Equal(5, Model(agg, "claude-opus-4-8")!.Turns);
+        Assert.Equal(3, Model(agg, "claude-sonnet-5")!.Turns);
+    }
+
+    [Fact]
+    public void Model_DifferingOnlyByCase_IsOneModel_DecidedInCSharpAndNeverBySqliteCollation()
+    {
+        // The same rule as the repository dimension, and the reason the column is a surrogate id: SQLite's
+        // default BINARY collation would answer case-SENSITIVELY and split one model into two. Identity is
+        // decided by the in-memory OrdinalIgnoreCase map, so it cannot.
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        agg.Observe(SessionOnModel("s-1", "claude-opus-4-8", ("typed", "desktop", 2, 20)));
+        agg.Observe(SessionOnModel("s-2", "Claude-Opus-4-8", ("typed", "desktop", 3, 30)));
+
+        var models = agg.ModelTotals().Where(m => m.Model is not null).ToList();
+        Assert.Single(models);
+        Assert.Equal(5, models[0].Turns);
+        // First-seen spelling wins, exactly as a Dictionary keeps the key it was first given.
+        Assert.Equal("claude-opus-4-8", models[0].Model);
+    }
+
+    [Fact]
+    public void Model_SurvivesAGatewayRestart_WithItsIdentityAndItsTurnsIntact()
+    {
+        using (var first = new GatewayInputStatsAggregator(_path))
+            first.Observe(SessionOnModel("s-1", "claude-opus-4-8", ("typed", "desktop", 6, 60)));
+
+        // A restart rebuilds the identity mirror FROM the database. If model_identity were not loaded, the
+        // next fold would mint a SECOND id for the same model and split its turns in two.
+        using var reopened = new GatewayInputStatsAggregator(_path);
+        reopened.Observe(SessionOnModel("s-2", "claude-opus-4-8", ("typed", "desktop", 4, 40)));
+
+        var models = reopened.ModelTotals().Where(m => m.Model is not null).ToList();
+        Assert.Single(models);
+        Assert.Equal(10, models[0].Turns);
+    }
+
+    [Fact]
+    public void ModelTurns_SumToTheTotalTurns_IncludingTheNullBucket()
+    {
+        // The property that makes the page trustworthy: every counted turn is in exactly one model bucket.
+        // If the null bucket were ever dropped or filtered, this would break - and a reader would see model
+        // turns that quietly fail to add up to the totals.
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        agg.Observe(SessionOnModel("s-1", "claude-opus-4-8", ("typed", "desktop", 3, 30)));
+        agg.Observe(SessionOnModel("s-2", null, ("typed", "desktop", 4, 40)));
+        agg.Observe(SessionOnModel("s-3", "gpt-5.5", ("voice", "phone", 5, 50)));
+
+        var totals = agg.CurrentTotals();
+        var modelTurns = agg.ModelTotals().Sum(m => m.Turns);
+
+        Assert.Equal(totals.Buckets.Sum(b => b.Turns), modelTurns);
+        Assert.Equal(12, modelTurns);
+    }
+
+    [Fact]
+    public void ModelsSinceUtc_IsStampedByTheMigration_SoANullModelCanBeRead()
+    {
+        var agg = new GatewayInputStatsAggregator(_path);
+
+        // A page cannot interpret a null model without this: it separates "folded before the dimension
+        // existed" from "the agent had not recorded a model yet". Both store null.
+        Assert.False(string.IsNullOrEmpty(agg.ModelsSinceUtc));
+        Assert.True(DateTime.TryParse(agg.ModelsSinceUtc, System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.RoundtripKind, out _));
+    }
 }

--- a/src/CcDirector.Gateway.Tests/GatewayStatsDatabaseTests.cs
+++ b/src/CcDirector.Gateway.Tests/GatewayStatsDatabaseTests.cs
@@ -71,6 +71,7 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
         // Folded grouping key to first-seen display spelling.
         Assert.True(TableExists(db, "repo_identity"));
         Assert.True(TableExists(db, "agent_identity"));
+        Assert.True(TableExists(db, "model_identity"));
         // The agent-to-agent lane (issue #1636) - its OWN tables, so these turns cannot be summed
         // into the human voice-versus-typed totals by accident.
         Assert.True(TableExists(db, "agent_driven_delta"));
@@ -177,14 +178,18 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
         var expected = new[]
         {
             "id", "hour_utc", "session_id", "modality", "surface",
-            "is_voice", "repo_id", "wingman", "turns", "chars",
+            "is_voice", "repo_id", "model_id", "wingman", "turns", "chars",
         };
         Assert.Equal(expected.OrderBy(c => c, StringComparer.Ordinal),
                      columns.Keys.OrderBy(c => c, StringComparer.Ordinal));
 
-        // The repository and agent dimensions are integers, so SQLite cannot be asked to compare a
-        // repository or agent string here even by accident.
+        // The repository and model dimensions are integers, so SQLite cannot be asked to compare a
+        // repository or model string here even by accident. model_id is stated here deliberately, which is
+        // what this whitelist exists to force: it is a surrogate id for the SAME reason repo_id is - the
+        // model is free text with unbounded cardinality and casing by convention only, so the in-memory
+        // OrdinalIgnoreCase map must be the only thing that ever decides two model names are one model.
         Assert.Equal("INTEGER", columns["repo_id"]);
+        Assert.Equal("INTEGER", columns["model_id"]);
 
         // Ruling B: agent_id is NOT on stat_delta. The agent tally is not derivable from these rows -
         // the first-fold back-fill attributes turns that are already in the totals, so a row here would
@@ -249,5 +254,166 @@ public sealed class GatewayStatsDatabaseTests : IDisposable
 
         Assert.Contains(blocked, ex.Message);
         Assert.Contains("will not fall back", ex.Message);
+    }
+
+    // ---- Schema version 2: the model dimension. THE FIRST REAL MIGRATION. ----
+    //
+    // These tests are why the mission exists. Version 1 shipped the migration MACHINERY against a single
+    // version, where nothing exercised it - a green suite proved only that the machinery compiled. The
+    // claim being made now is the one the owner is actually owed: his database, holding real turns, gains
+    // a dimension and does not lose a number.
+    //
+    // A hand-built version 1 file, not a downgraded current one. It is the shape the PREVIOUS BUILD wrote,
+    // reproduced from its migration: stat_delta without model_id, no model_identity, user_version=1. That
+    // is what is on the owner's disk right now, and a test that starts from the current schema and pretends
+    // would prove nothing about it.
+    private void WriteVersion1Database(params (string Hour, long Turns, long Chars)[] rows)
+    {
+        using var connection = new SqliteConnection($"Data Source={_path}");
+        connection.Open();
+        void Run(string sql)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = sql;
+            cmd.ExecuteNonQuery();
+        }
+
+        Run(@"CREATE TABLE stat_delta (
+                  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                  hour_utc   TEXT    NOT NULL,
+                  session_id TEXT    NOT NULL,
+                  modality   TEXT    NOT NULL,
+                  surface    TEXT    NOT NULL,
+                  is_voice   INTEGER NOT NULL,
+                  repo_id    INTEGER NOT NULL,
+                  wingman    INTEGER NOT NULL,
+                  turns      INTEGER NOT NULL,
+                  chars      INTEGER NOT NULL)");
+        Run("CREATE TABLE session_highwater (session_id TEXT NOT NULL, modality TEXT NOT NULL, surface TEXT NOT NULL, turns INTEGER NOT NULL, chars INTEGER NOT NULL, PRIMARY KEY (session_id, modality, surface))");
+        Run("CREATE TABLE wingman_session (session_id TEXT PRIMARY KEY)");
+        Run("CREATE TABLE repo_session (repo_id INTEGER NOT NULL, session_id TEXT NOT NULL, PRIMARY KEY (repo_id, session_id))");
+        Run("CREATE TABLE agent_session (agent_id INTEGER NOT NULL, session_id TEXT NOT NULL, PRIMARY KEY (agent_id, session_id))");
+        Run("CREATE TABLE repo_identity (repo_id INTEGER PRIMARY KEY AUTOINCREMENT, repo_display TEXT NOT NULL)");
+        Run("CREATE TABLE agent_identity (agent_id INTEGER PRIMARY KEY AUTOINCREMENT, agent_display TEXT NOT NULL)");
+        Run("CREATE TABLE agent_delta (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id INTEGER NOT NULL, is_voice INTEGER NOT NULL, turns INTEGER NOT NULL, chars INTEGER NOT NULL)");
+        Run("CREATE TABLE agent_driven_delta (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id INTEGER NOT NULL, turns INTEGER NOT NULL, chars INTEGER NOT NULL)");
+        Run("CREATE TABLE agent_driven_highwater (session_id TEXT PRIMARY KEY, turns INTEGER NOT NULL, chars INTEGER NOT NULL)");
+        Run("CREATE TABLE agents_seeded (session_id TEXT PRIMARY KEY)");
+        Run("CREATE TABLE meta (name TEXT PRIMARY KEY, value TEXT NOT NULL)");
+        Run("INSERT INTO repo_identity(repo_display) VALUES ('D:\\ReposFred\\devthrottle')");
+
+        foreach (var (hour, turns, chars) in rows)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = @"INSERT INTO stat_delta(hour_utc, session_id, modality, surface, is_voice, repo_id, wingman, turns, chars)
+                                VALUES ($h, 'sess-1', 'typed', 'desktop', 0, 1, 0, $t, $c)";
+            cmd.Parameters.AddWithValue("$h", hour);
+            cmd.Parameters.AddWithValue("$t", turns);
+            cmd.Parameters.AddWithValue("$c", chars);
+            cmd.ExecuteNonQuery();
+        }
+
+        Run("PRAGMA user_version=1");
+        connection.Close();
+        SqliteConnection.ClearAllPools();
+    }
+
+    private static long ScalarLong(GatewayStatsDatabase db, string sql)
+    {
+        using var cmd = db.Connection.CreateCommand();
+        cmd.CommandText = sql;
+        return Convert.ToInt64(cmd.ExecuteScalar());
+    }
+
+    [Fact]
+    public void Migrate_Version1File_UpgradesToVersion2AndKeepsEveryRow()
+    {
+        WriteVersion1Database(("2026-07-16T09", 40, 400), ("2026-07-16T10", 27, 270));
+
+        using var db = new GatewayStatsDatabase(_path);
+
+        Assert.Equal(2, UserVersion(db));
+
+        // The version stamp ALONE proves nothing, and this assertion is here because the first draft of
+        // this test proved nothing: Migrate writes PRAGMA user_version unconditionally, after the steps, so
+        // a version 2 stamp appears whether or not the version 2 step ran. With MigrateToVersion2 disabled
+        // this test still passed, green and useless, exactly the "dead test that looks like coverage" this
+        // mission keeps finding. Reading back the column the step ADDS is what makes the name true.
+        Assert.Contains("model_id", ColumnsOf(db, "stat_delta"));
+
+        // The numbers are the promise. A migration that loses turns is the failure this whole mission
+        // exists to prevent, so it is asserted on the totals and not merely on the row count.
+        Assert.Equal(2, ScalarLong(db, "SELECT COUNT(*) FROM stat_delta"));
+        Assert.Equal(67, ScalarLong(db, "SELECT SUM(turns) FROM stat_delta"));
+        Assert.Equal(670, ScalarLong(db, "SELECT SUM(chars) FROM stat_delta"));
+    }
+
+    private static List<string> ColumnsOf(GatewayStatsDatabase db, string table)
+    {
+        var names = new List<string>();
+        using var cmd = db.Connection.CreateCommand();
+        cmd.CommandText = $"SELECT name FROM pragma_table_info('{table}')";
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read()) names.Add(reader.GetString(0));
+        return names;
+    }
+
+    [Fact]
+    public void Migrate_Version1File_AddsTheModelDimensionAndReadsNullOnPreExistingRows()
+    {
+        WriteVersion1Database(("2026-07-16T09", 40, 400));
+
+        using var db = new GatewayStatsDatabase(_path);
+
+        Assert.True(TableExists(db, "model_identity"));
+        // Every row folded before the dimension existed reads NULL, which is the true thing to say about
+        // them: they were recorded when no model was being observed at all. Not zero, not a placeholder id.
+        Assert.Equal(1, ScalarLong(db, "SELECT COUNT(*) FROM stat_delta WHERE model_id IS NULL"));
+        Assert.Equal(0, ScalarLong(db, "SELECT COUNT(*) FROM stat_delta WHERE model_id IS NOT NULL"));
+    }
+
+    [Fact]
+    public void Migrate_Version1File_StampsWhenTheModelDimensionBegan()
+    {
+        var before = DateTime.UtcNow.AddSeconds(-1);
+        WriteVersion1Database(("2026-07-16T09", 40, 400));
+
+        using var db = new GatewayStatsDatabase(_path);
+
+        using var cmd = db.Connection.CreateCommand();
+        cmd.CommandText = "SELECT value FROM meta WHERE name=$n";
+        cmd.Parameters.AddWithValue("$n", GatewayStatsDatabase.ModelsSinceKey);
+        var stamped = cmd.ExecuteScalar() as string;
+
+        // Without this stamp a null model_id is unreadable: a row that predates the dimension and a row
+        // whose session had recorded no model yet both store NULL, and only the stamp separates them.
+        Assert.False(string.IsNullOrEmpty(stamped));
+        Assert.True(DateTime.TryParse(stamped, System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.RoundtripKind, out var since));
+        Assert.True(since >= before, $"models_since_utc '{stamped}' predates the migration.");
+    }
+
+    [Fact]
+    public void Migrate_AlreadyMigratedFile_DoesNotMoveTheModelSinceStamp()
+    {
+        // The stamp records when the dimension BEGAN. Re-stamping it on a later open would push it past
+        // rows that already carry real models and silently reclassify them as predating the dimension -
+        // a re-run that quietly rewrites history is precisely the failure mode the version guard exists for.
+        WriteVersion1Database(("2026-07-16T09", 40, 400));
+
+        string? first;
+        using (var db = new GatewayStatsDatabase(_path))
+        {
+            using var cmd = db.Connection.CreateCommand();
+            cmd.CommandText = $"SELECT value FROM meta WHERE name='{GatewayStatsDatabase.ModelsSinceKey}'";
+            first = cmd.ExecuteScalar() as string;
+        }
+        SqliteConnection.ClearAllPools();
+
+        using var reopened = new GatewayStatsDatabase(_path);
+        using var read = reopened.Connection.CreateCommand();
+        read.CommandText = $"SELECT value FROM meta WHERE name='{GatewayStatsDatabase.ModelsSinceKey}'";
+
+        Assert.Equal(first, read.ExecuteScalar() as string);
     }
 }

--- a/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
+++ b/src/CcDirector.Gateway/Stats/GatewayInputStatsAggregator.cs
@@ -61,17 +61,20 @@ public sealed class GatewayInputStatsAggregator : IDisposable
 
     // Display spelling -> surrogate id. THE COMPARER HERE IS THE WHOLE REASON THE SCHEMA USES SURROGATE IDS:
     // it is the same StringComparer.OrdinalIgnoreCase the old dictionaries used, so grouping is decided by
-    // the identical object with identical semantics and SQLite is never asked to compare a repository or
-    // agent string. First-seen-wins on the display spelling, which is what a Dictionary does.
+    // the identical object with identical semantics and SQLite is never asked to compare a repository,
+    // agent or model string. First-seen-wins on the display spelling, which is what a Dictionary does.
     private readonly Dictionary<string, long> _repoIds = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, long> _agentIds = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, long> _modelIds = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<long, string> _repoDisplay = new();
     private readonly Dictionary<long, string> _agentDisplay = new();
+    private readonly Dictionary<long, string> _modelDisplay = new();
 
     private readonly HashSet<(long Id, string SessionId)> _repoSessions = new();
     private readonly HashSet<(long Id, string SessionId)> _agentSessions = new();
 
     private string _agentsSinceUtc = "";
+    private string _modelsSinceUtc = "";
 
     /// <summary>Every statement executed against the database. The seam acceptance criterion 3 measures: an
     /// IDLE poll must not move this at all, and a fold must move it by an amount bounded by what CHANGED,
@@ -83,6 +86,52 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         public long Turns { get; set; }
         public long Characters { get; set; }
     }
+
+    /// <summary>
+    /// Which identity table a display spelling belongs to. This replaced a <c>bool isRepo</c> when the model
+    /// dimension arrived and made the question three-valued: a boolean cannot name a third kind, and the
+    /// alternative - a second parallel set of NeedIdentity/Resolve methods for models - would have
+    /// duplicated the batch-level OrdinalIgnoreCase dedup, which is the subtle part.
+    ///
+    /// <see cref="Model"/> is a first-class kind here but has NO distinct-session set: nothing asks how many
+    /// sessions ran a model, so <see cref="SessionsFor"/> refuses it rather than carrying a set nothing
+    /// populates. It is also the only kind that can be ABSENT - see <see cref="FoldLocked"/>.
+    /// </summary>
+    private enum IdentityKind { Repo, Agent, Model }
+
+    private Dictionary<string, long> IdsFor(IdentityKind kind) => kind switch
+    {
+        IdentityKind.Repo => _repoIds,
+        IdentityKind.Agent => _agentIds,
+        IdentityKind.Model => _modelIds,
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unknown identity kind."),
+    };
+
+    private Dictionary<long, string> DisplayFor(IdentityKind kind) => kind switch
+    {
+        IdentityKind.Repo => _repoDisplay,
+        IdentityKind.Agent => _agentDisplay,
+        IdentityKind.Model => _modelDisplay,
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unknown identity kind."),
+    };
+
+    // The distinct-session sets exist for repositories and agents only. A model has none, deliberately, so
+    // asking for one is a programming error and says so rather than inventing an empty answer.
+    private HashSet<(long Id, string SessionId)> SessionsFor(IdentityKind kind) => kind switch
+    {
+        IdentityKind.Repo => _repoSessions,
+        IdentityKind.Agent => _agentSessions,
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind,
+            "Only repositories and agents keep distinct-session sets."),
+    };
+
+    private static (string Table, string Column) IdentityTableFor(IdentityKind kind) => kind switch
+    {
+        IdentityKind.Repo => ("repo_identity", "repo_display"),
+        IdentityKind.Agent => ("agent_identity", "agent_display"),
+        IdentityKind.Model => ("model_identity", "model_display"),
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unknown identity kind."),
+    };
 
     /// <param name="path">The statistics database. Defaults to gateway-stats.db under the cc-director
     /// storage root, beside the store it replaces.</param>
@@ -152,13 +201,25 @@ public sealed class GatewayInputStatsAggregator : IDisposable
                 var id = r.GetInt64(0); var d = r.GetString(1);
                 _agentIds[d] = id; _agentDisplay[id] = d;
             });
+            Read("SELECT model_id, model_display FROM model_identity", r =>
+            {
+                var id = r.GetInt64(0); var d = r.GetString(1);
+                _modelIds[d] = id; _modelDisplay[id] = d;
+            });
             Read("SELECT repo_id, session_id FROM repo_session", r => _repoSessions.Add((r.GetInt64(0), r.GetString(1))));
             Read("SELECT agent_id, session_id FROM agent_session", r => _agentSessions.Add((r.GetInt64(0), r.GetString(1))));
             _agentsSinceUtc = ReadScalarString("SELECT value FROM meta WHERE name=$n", ("$n", AgentsSinceKey)) ?? "";
 
+            // Written by the version 2 migration, so it is present on every database this build can open -
+            // the migration runs before this does. Read into the mirror because the stats surface reports it
+            // on every request and it never changes at runtime.
+            _modelsSinceUtc = ReadScalarString("SELECT value FROM meta WHERE name=$n",
+                ("$n", GatewayStatsDatabase.ModelsSinceKey)) ?? "";
+
             FileLog.Write($"[GatewayInputStatsAggregator] LoadMirror: {_highWater.Count} live session(s), " +
                           $"{_wingmanSessions.Count} wingman session(s), {_repoIds.Count} repo(s), {_agentIds.Count} agent(s), " +
-                          $"{_agentsSeeded.Count} seeded, agentsSince='{_agentsSinceUtc}' from {_db.Path}");
+                          $"{_modelIds.Count} model(s), {_agentsSeeded.Count} seeded, agentsSince='{_agentsSinceUtc}', " +
+                          $"modelsSince='{_modelsSinceUtc}' from {_db.Path}");
         }
     }
 
@@ -202,15 +263,17 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         public DateTime NowUtc { get; }
         public string HourKey { get; }
 
-        public readonly List<(string Hour, string SessionId, string Modality, string Surface, bool IsVoice, string Repo, bool Wingman, long Turns, long Chars)> Rows = new();
+        // Model is the only nullable member of a row: null means the owning Director had recorded no model
+        // for that session when the turn folded, which is the honest state and never a lookup failure.
+        public readonly List<(string Hour, string SessionId, string Modality, string Surface, bool IsVoice, string Repo, string? Model, bool Wingman, long Turns, long Chars)> Rows = new();
         public readonly List<(string Agent, bool IsVoice, long Turns, long Chars)> AgentRows = new();
         public readonly List<(string Agent, long Turns, long Chars)> AgentDrivenRows = new();
         public readonly List<(string SessionId, string Modality, string Surface, long Turns, long Chars)> HighWater = new();
         public readonly List<(string SessionId, long Turns, long Chars)> AgentDrivenHighWater = new();
         public readonly List<string> NewWingmanSessions = new();
         public readonly List<string> NewSeeded = new();
-        public readonly List<(string Display, bool IsRepo)> NewIdentities = new();
-        public readonly List<(string Display, string SessionId, bool IsRepo)> NewIdentitySessions = new();
+        public readonly List<(string Display, IdentityKind Kind)> NewIdentities = new();
+        public readonly List<(string Display, string SessionId, IdentityKind Kind)> NewIdentitySessions = new();
         public string? StampAgentsSince;
 
         public bool IsEmpty => Rows.Count == 0 && AgentRows.Count == 0 && AgentDrivenRows.Count == 0
@@ -279,6 +342,16 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         // is his question, not this mission's.
         var repoKey = s.RepoPath ?? "";
 
+        // The model this session's agent was last RECORDED using (issue #1637). Unlike the repository and
+        // the agent, an unknown model is stored as SQL NULL rather than folded into an empty-string
+        // identity: the producer reports null until the agent's own records name a model, so "not said" is a
+        // real and permanent state for a session's first turn, and it is not a model named "".
+        //
+        // Whitespace is treated as absent too. The producer says null, but a display spelling of " " could
+        // only ever become an identity row that renders as nothing - the same broken cell an empty string
+        // would give, arrived at by a different route.
+        var modelKey = string.IsNullOrWhiteSpace(s.CurrentModel) ? null : s.CurrentModel;
+
         foreach (var b in s.InputStats.Buckets)
         {
             var key = (b.Modality ?? "", b.Surface ?? "");
@@ -300,10 +373,15 @@ public sealed class GatewayInputStatsAggregator : IDisposable
                 // the flag keeps it out of the query layer.
                 var isVoice = string.Equals(key.Item1, "voice", StringComparison.OrdinalIgnoreCase);
 
-                batch.Rows.Add((batch.HourKey, s.SessionId, key.Item1, key.Item2, isVoice, repoKey, wingman, deltaTurns, deltaChars));
-                NeedIdentity(repoKey, isRepo: true, batch);
-                if (!KnownIdentitySession(repoKey, s.SessionId, isRepo: true, batch))
-                    batch.NewIdentitySessions.Add((repoKey, s.SessionId, true));
+                batch.Rows.Add((batch.HourKey, s.SessionId, key.Item1, key.Item2, isVoice, repoKey, modelKey, wingman, deltaTurns, deltaChars));
+                NeedIdentity(repoKey, IdentityKind.Repo, batch);
+                if (!KnownIdentitySession(repoKey, s.SessionId, IdentityKind.Repo, batch))
+                    batch.NewIdentitySessions.Add((repoKey, s.SessionId, IdentityKind.Repo));
+
+                // Only a model the Director actually named earns an identity. An absent model writes a null
+                // model_id and creates nothing, so model_identity never grows a row for "not said".
+                if (modelKey is not null)
+                    NeedIdentity(modelKey, IdentityKind.Model, batch);
 
                 AttributeToAgentLocked(s, key.Item1, deltaTurns, deltaChars, batch);
             }
@@ -324,7 +402,7 @@ public sealed class GatewayInputStatsAggregator : IDisposable
     private void AttributeToAgentLocked(SessionDto s, string modality, long turns, long characters, FoldBatch batch)
     {
         var agentKey = s.Agent ?? "";
-        NeedIdentity(agentKey, isRepo: false, batch);
+        NeedIdentity(agentKey, IdentityKind.Agent, batch);
 
         if (turns > 0 || characters > 0)
         {
@@ -332,8 +410,8 @@ public sealed class GatewayInputStatsAggregator : IDisposable
             batch.AgentRows.Add((agentKey, isVoice, turns, characters));
         }
 
-        if (!string.IsNullOrEmpty(s.SessionId) && !KnownIdentitySession(agentKey, s.SessionId, isRepo: false, batch))
-            batch.NewIdentitySessions.Add((agentKey, s.SessionId, false));
+        if (!string.IsNullOrEmpty(s.SessionId) && !KnownIdentitySession(agentKey, s.SessionId, IdentityKind.Agent, batch))
+            batch.NewIdentitySessions.Add((agentKey, s.SessionId, IdentityKind.Agent));
     }
 
     // Fold the turns OTHER agents drove into this session (issue #1636) via the same high-water increment
@@ -364,33 +442,28 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         if (deltaTurns <= 0 && deltaChars <= 0) return;
 
         var agentKey = s.Agent ?? "";
-        NeedIdentity(agentKey, isRepo: false, batch);
+        NeedIdentity(agentKey, IdentityKind.Agent, batch);
         batch.AgentDrivenRows.Add((agentKey, deltaTurns, deltaChars));
-        if (!string.IsNullOrEmpty(s.SessionId) && !KnownIdentitySession(agentKey, s.SessionId, isRepo: false, batch))
-            batch.NewIdentitySessions.Add((agentKey, s.SessionId, false));
+        if (!string.IsNullOrEmpty(s.SessionId) && !KnownIdentitySession(agentKey, s.SessionId, IdentityKind.Agent, batch))
+            batch.NewIdentitySessions.Add((agentKey, s.SessionId, IdentityKind.Agent));
     }
 
-    private void NeedIdentity(string display, bool isRepo, FoldBatch batch)
+    private void NeedIdentity(string display, IdentityKind kind, FoldBatch batch)
     {
-        var known = isRepo ? _repoIds : _agentIds;
-        if (known.ContainsKey(display)) return;
+        if (IdsFor(kind).ContainsKey(display)) return;
         // The pending list is compared with the SAME comparer, so two spellings differing only by case
         // inside one batch resolve to one identity, exactly as the dictionary would.
-        foreach (var (d, r) in batch.NewIdentities)
-            if (r == isRepo && StringComparer.OrdinalIgnoreCase.Equals(d, display)) return;
-        batch.NewIdentities.Add((display, isRepo));
+        foreach (var (d, k) in batch.NewIdentities)
+            if (k == kind && StringComparer.OrdinalIgnoreCase.Equals(d, display)) return;
+        batch.NewIdentities.Add((display, kind));
     }
 
-    private bool KnownIdentitySession(string display, string sessionId, bool isRepo, FoldBatch batch)
+    private bool KnownIdentitySession(string display, string sessionId, IdentityKind kind, FoldBatch batch)
     {
-        var ids = isRepo ? _repoIds : _agentIds;
-        if (ids.TryGetValue(display, out var id))
-        {
-            var set = isRepo ? _repoSessions : _agentSessions;
-            if (set.Contains((id, sessionId))) return true;
-        }
-        foreach (var (d, sid, r) in batch.NewIdentitySessions)
-            if (r == isRepo && sid == sessionId && StringComparer.OrdinalIgnoreCase.Equals(d, display)) return true;
+        if (IdsFor(kind).TryGetValue(display, out var id) && SessionsFor(kind).Contains((id, sessionId)))
+            return true;
+        foreach (var (d, sid, k) in batch.NewIdentitySessions)
+            if (k == kind && sid == sessionId && StringComparer.OrdinalIgnoreCase.Equals(d, display)) return true;
         return false;
     }
 
@@ -406,37 +479,46 @@ public sealed class GatewayInputStatsAggregator : IDisposable
             Execute("INSERT OR REPLACE INTO meta(name, value) VALUES ($n, $v)", tx,
                 ("$n", AgentsSinceKey), ("$v", batch.StampAgentsSince));
 
-        var newRepoIds = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
-        var newAgentIds = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
-        foreach (var (display, isRepo) in batch.NewIdentities)
+        // Freshly minted ids, per kind, keyed with the SAME comparer as the mirror they will join.
+        var newIds = new Dictionary<IdentityKind, Dictionary<string, long>>
         {
-            var table = isRepo ? "repo_identity" : "agent_identity";
-            var column = isRepo ? "repo_display" : "agent_display";
+            [IdentityKind.Repo] = new(StringComparer.OrdinalIgnoreCase),
+            [IdentityKind.Agent] = new(StringComparer.OrdinalIgnoreCase),
+            [IdentityKind.Model] = new(StringComparer.OrdinalIgnoreCase),
+        };
+        foreach (var (display, kind) in batch.NewIdentities)
+        {
+            var (table, column) = IdentityTableFor(kind);
             var id = ExecuteScalarLong($"INSERT INTO {table}({column}) VALUES ($d); SELECT last_insert_rowid()", tx, ("$d", display));
-            (isRepo ? newRepoIds : newAgentIds)[display] = id;
+            newIds[kind][display] = id;
         }
 
-        long Resolve(string display, bool isRepo)
+        long Resolve(string display, IdentityKind kind)
         {
-            var pending = isRepo ? newRepoIds : newAgentIds;
-            if (pending.TryGetValue(display, out var fresh)) return fresh;
-            return (isRepo ? _repoIds : _agentIds)[display];
+            if (newIds[kind].TryGetValue(display, out var fresh)) return fresh;
+            return IdsFor(kind)[display];
         }
+
+        // An absent model resolves to nothing at all - DBNull, so the column is SQL NULL rather than a
+        // sentinel id that a later reader could mistake for a real model.
+        object ResolveModel(string? display) =>
+            display is null ? DBNull.Value : Resolve(display, IdentityKind.Model);
 
         foreach (var r in batch.Rows)
-            Execute(@"INSERT INTO stat_delta(hour_utc, session_id, modality, surface, is_voice, repo_id, wingman, turns, chars)
-                      VALUES ($h, $s, $m, $u, $v, $r, $w, $t, $c)", tx,
+            Execute(@"INSERT INTO stat_delta(hour_utc, session_id, modality, surface, is_voice, repo_id, model_id, wingman, turns, chars)
+                      VALUES ($h, $s, $m, $u, $v, $r, $d, $w, $t, $c)", tx,
                 ("$h", r.Hour), ("$s", r.SessionId), ("$m", r.Modality), ("$u", r.Surface),
-                ("$v", r.IsVoice ? 1 : 0), ("$r", Resolve(r.Repo, true)), ("$w", r.Wingman ? 1 : 0),
+                ("$v", r.IsVoice ? 1 : 0), ("$r", Resolve(r.Repo, IdentityKind.Repo)),
+                ("$d", ResolveModel(r.Model)), ("$w", r.Wingman ? 1 : 0),
                 ("$t", r.Turns), ("$c", r.Chars));
 
         foreach (var a in batch.AgentRows)
             Execute("INSERT INTO agent_delta(agent_id, is_voice, turns, chars) VALUES ($a, $v, $t, $c)", tx,
-                ("$a", Resolve(a.Agent, false)), ("$v", a.IsVoice ? 1 : 0), ("$t", a.Turns), ("$c", a.Chars));
+                ("$a", Resolve(a.Agent, IdentityKind.Agent)), ("$v", a.IsVoice ? 1 : 0), ("$t", a.Turns), ("$c", a.Chars));
 
         foreach (var a in batch.AgentDrivenRows)
             Execute("INSERT INTO agent_driven_delta(agent_id, turns, chars) VALUES ($a, $t, $c)", tx,
-                ("$a", Resolve(a.Agent, false)), ("$t", a.Turns), ("$c", a.Chars));
+                ("$a", Resolve(a.Agent, IdentityKind.Agent)), ("$t", a.Turns), ("$c", a.Chars));
 
         foreach (var h in batch.HighWater)
             Execute(@"INSERT INTO session_highwater(session_id, modality, surface, turns, chars)
@@ -455,12 +537,17 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         foreach (var sid in batch.NewSeeded)
             Execute("INSERT OR IGNORE INTO agents_seeded(session_id) VALUES ($s)", tx, ("$s", sid));
 
-        foreach (var (display, sessionId, isRepo) in batch.NewIdentitySessions)
+        foreach (var (display, sessionId, kind) in batch.NewIdentitySessions)
         {
-            var table = isRepo ? "repo_session" : "agent_session";
-            var column = isRepo ? "repo_id" : "agent_id";
+            // SessionsFor refuses a model, so a model queued here would fail loudly rather than write a row
+            // into a table that does not exist. Nothing queues one - the fold never adds a model to
+            // NewIdentitySessions - and this is the check that keeps that true.
+            _ = SessionsFor(kind);
+            var (table, column) = kind == IdentityKind.Repo
+                ? ("repo_session", "repo_id")
+                : ("agent_session", "agent_id");
             Execute($"INSERT OR IGNORE INTO {table}({column}, session_id) VALUES ($i, $s)", tx,
-                ("$i", Resolve(display, isRepo)), ("$s", sessionId));
+                ("$i", Resolve(display, kind)), ("$s", sessionId));
         }
 
         if (batch.Rows.Count > 0) PruneLocked(batch.NowUtc, tx);
@@ -469,8 +556,8 @@ public sealed class GatewayInputStatsAggregator : IDisposable
 
         // ---- Committed. Only now does the mirror move. ----
         if (batch.StampAgentsSince is not null) _agentsSinceUtc = batch.StampAgentsSince;
-        foreach (var (d, id) in newRepoIds) { _repoIds[d] = id; _repoDisplay[id] = d; }
-        foreach (var (d, id) in newAgentIds) { _agentIds[d] = id; _agentDisplay[id] = d; }
+        foreach (var (kind, minted) in newIds)
+            foreach (var (d, id) in minted) { IdsFor(kind)[d] = id; DisplayFor(kind)[id] = d; }
         foreach (var h in batch.HighWater)
         {
             if (!_highWater.TryGetValue(h.SessionId, out var hw))
@@ -484,11 +571,8 @@ public sealed class GatewayInputStatsAggregator : IDisposable
             _agentDrivenHighWater[h.SessionId] = new Counters { Turns = h.Turns, Characters = h.Chars };
         foreach (var sid in batch.NewWingmanSessions) _wingmanSessions.Add(sid);
         foreach (var sid in batch.NewSeeded) _agentsSeeded.Add(sid);
-        foreach (var (display, sessionId, isRepo) in batch.NewIdentitySessions)
-        {
-            var id = isRepo ? _repoIds[display] : _agentIds[display];
-            (isRepo ? _repoSessions : _agentSessions).Add((id, sessionId));
-        }
+        foreach (var (display, sessionId, kind) in batch.NewIdentitySessions)
+            SessionsFor(kind).Add((IdsFor(kind)[display], sessionId));
     }
 
     /// <summary>
@@ -517,11 +601,19 @@ public sealed class GatewayInputStatsAggregator : IDisposable
     private void PruneLocked(DateTime nowUtc, SqliteTransaction tx)
     {
         var cutoff = HourKey(nowUtc.AddDays(-RetentionDays));
-        Execute(@"INSERT INTO stat_delta(hour_utc, session_id, modality, surface, is_voice, repo_id, wingman, turns, chars)
-                  SELECT $marker, $marker, modality, surface, is_voice, repo_id, wingman, SUM(turns), SUM(chars)
+        // model_id is carried through the archive fold, and it MUST be in BOTH lists. Left out of the SELECT
+        // the archive row would read NULL and every pruned turn would silently become "model unknown"; left
+        // out of the GROUP BY it would collapse different models into one row and take an arbitrary model
+        // id with it. Adding a dimension to this table means adding it here, in both places, or pruning
+        // quietly destroys it ninety days later - long after the change that caused it.
+        //
+        // SQLite groups NULLs together, so every unknown-model row of a bucket archives into ONE row that is
+        // still honestly NULL. That is the wanted behaviour: absence aggregates as absence.
+        Execute(@"INSERT INTO stat_delta(hour_utc, session_id, modality, surface, is_voice, repo_id, model_id, wingman, turns, chars)
+                  SELECT $marker, $marker, modality, surface, is_voice, repo_id, model_id, wingman, SUM(turns), SUM(chars)
                     FROM stat_delta
                    WHERE hour_utc <> $marker AND hour_utc < $cutoff
-                   GROUP BY modality, surface, is_voice, repo_id, wingman", tx,
+                   GROUP BY modality, surface, is_voice, repo_id, model_id, wingman", tx,
             ("$marker", GatewayStatsDatabase.ArchiveMarker), ("$cutoff", cutoff));
         Execute("DELETE FROM stat_delta WHERE hour_utc <> $marker AND hour_utc < $cutoff", tx,
             ("$marker", GatewayStatsDatabase.ArchiveMarker), ("$cutoff", cutoff));
@@ -724,6 +816,71 @@ public sealed class GatewayInputStatsAggregator : IDisposable
         get { lock (_lock) { return _agentsSinceUtc; } }
     }
 
+    /// <summary>
+    /// When the model dimension started recording (round-trip UTC), stamped by the schema version 2
+    /// migration. A page NEEDS this to read a null model honestly: a turn folded before this moment predates
+    /// the dimension and could never have carried a model, while one folded after it belongs to a session
+    /// whose agent had recorded no model yet. Both store null and only this stamp tells them apart.
+    /// </summary>
+    public string ModelsSinceUtc
+    {
+        get { lock (_lock) { return _modelsSinceUtc; } }
+    }
+
+    /// <summary>
+    /// The per-model all-time tally (turns by modality, character volume), ranked most-driven first, for the
+    /// private Models page. Includes the null-model bucket, which is a real answer and not a gap - see
+    /// <see cref="ModelStatBucketDto"/>.
+    ///
+    /// No distinct-session count, unlike the repository and agent tallies: a session's model can CHANGE
+    /// mid-session (the whole reason the producer re-reads it at every turn-end), so "sessions that ran this
+    /// model" is not a question this store can answer without a per-session-per-model set nothing keeps. A
+    /// count of sessions here would be a number that looks like the neighbouring ones and means something
+    /// weaker, so it is absent rather than approximated.
+    /// </summary>
+    public IReadOnlyList<ModelStatBucketDto> ModelTotals()
+    {
+        lock (_lock)
+        {
+            var list = new List<ModelStatBucketDto>();
+            // Archive rows are INCLUDED - the marker convention only excludes them from hourly and
+            // working-day series, and an all-time tally that dropped them would shrink as history is pruned.
+            Read(@"SELECT model_id,
+                          COALESCE(SUM(CASE WHEN is_voice = 1 THEN turns ELSE 0 END), 0),
+                          COALESCE(SUM(CASE WHEN is_voice = 0 THEN turns ELSE 0 END), 0),
+                          SUM(chars)
+                     FROM stat_delta GROUP BY model_id", r =>
+            {
+                var voice = r.GetInt64(1);
+                var typed = r.GetInt64(2);
+                // A null model_id is the "not recorded" bucket and stays null all the way to the page. The
+                // display spelling comes from the identity mirror, never from a SQL join that might be
+                // tempted to group or order by the string.
+                string? display = r.IsDBNull(0)
+                    ? null
+                    : (_modelDisplay.TryGetValue(r.GetInt64(0), out var d) ? d : "");
+                list.Add(new ModelStatBucketDto
+                {
+                    Model = display,
+                    Turns = voice + typed,
+                    VoiceTurns = voice,
+                    TypedTurns = typed,
+                    Characters = r.GetInt64(3),
+                });
+            });
+            // Ranked in C#, matching the repository and agent tallies. The null bucket sorts by its numbers
+            // like any other and is deliberately not pinned anywhere: it is a bucket, not a footnote.
+            list.Sort((a, b) =>
+            {
+                var byTurns = b.Turns.CompareTo(a.Turns);
+                if (byTurns != 0) return byTurns;
+                var byChars = b.Characters.CompareTo(a.Characters);
+                return byChars != 0 ? byChars : string.CompareOrdinal(a.Model ?? "", b.Model ?? "");
+            });
+            return list;
+        }
+    }
+
     // An explicit map, not a PascalCase splitter: "OpenCode" is the product's own spelling and must not
     // become "Open Code". An unrecognised token is shown verbatim - it is a real value we simply do not have
     // a nicer name for, so showing it is honest where hiding it behind "Other" would not be.
@@ -832,6 +989,26 @@ public sealed class RepoStatBucketDto
 
     /// <summary>Distinct sessions that drove counted input into this repo.</summary>
     public int Sessions { get; set; }
+}
+
+/// <summary>
+/// One model's all-time input tally for the private Models page (issue #1637).
+///
+/// The "unknown model" row is a REAL row here, not an omission: it is where every turn folded before its
+/// session's agent had recorded a model lands, and it is the only bucket that can never shrink to zero -
+/// each session's first turn is permanently in it. A page must show it and label it honestly rather than
+/// filter it out, or the model turns will not add up to the total turns and the page will look broken.
+/// </summary>
+public sealed class ModelStatBucketDto
+{
+    /// <summary>The model the owning Director recorded, e.g. "claude-opus-4-8" - or null for the bucket of
+    /// turns folded when no model had been recorded. Never an empty string: absence is null.</summary>
+    public string? Model { get; set; }
+
+    public long Turns { get; set; }
+    public long VoiceTurns { get; set; }
+    public long TypedTurns { get; set; }
+    public long Characters { get; set; }
 }
 
 /// <summary>One agent CLI's all-time input tally for the private Agents page.</summary>

--- a/src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs
+++ b/src/CcDirector.Gateway/Stats/GatewayStatsDatabase.cs
@@ -35,7 +35,12 @@ public sealed class GatewayStatsDatabase : IDisposable
 {
     /// <summary>The schema version this build understands. Bump it and add a migration step; never reshape
     /// an existing table in place without one.</summary>
-    public const int SchemaVersion = 1;
+    public const int SchemaVersion = 2;
+
+    /// <summary>The meta key holding when the model dimension started recording - an ISO-8601 UTC stamp
+    /// written once, by the migration that added the dimension. See <see cref="MigrateToVersion2"/> for why
+    /// a reader cannot interpret a null model_id without it.</summary>
+    public const string ModelsSinceKey = "models_since_utc";
 
     /// <summary>The marker written into hour_utc and session_id when a pruned row is folded into an archive
     /// row. Cannot collide with a real hour key ("yyyy-MM-ddTHH") or a real session id.
@@ -120,6 +125,9 @@ public sealed class GatewayStatsDatabase : IDisposable
 
         if (current < 1)
             MigrateToVersion1(tx);
+
+        if (current < 2)
+            MigrateToVersion2(tx);
 
         Execute($"PRAGMA user_version={SchemaVersion}", tx);
         tx.Commit();
@@ -336,6 +344,65 @@ public sealed class GatewayStatsDatabase : IDisposable
             )", tx);
     }
 
+    // Version 2: the model dimension - which model produced each turn.
+    //
+    // THIS IS THE FIRST REAL MIGRATION, and that is half its value. Version 1 shipped the machinery
+    // (PRAGMA user_version, a transaction per step, a loud refusal to open a newer file) against a single
+    // version, where nothing exercised it. This step is the proof: an existing database at version 1 - the
+    // owner's, carrying real turns - gains a column and a table and keeps every row it had.
+    //
+    // model_id is NULLABLE, alone among the dimensions, and the nullability is the design rather than a
+    // concession. SessionDto.CurrentModel is RECORDS-ONLY: the owning Director stamps it from the agent's
+    // own records at each turn-end and reports null until the tool has actually recorded a model. So a
+    // session's first turn folds before any record of its model exists, and it folds that way FOREVER -
+    // this store records forward only and never revisits a written row. A NOT NULL column would have to
+    // invent a value for that turn; a null says the true thing.
+    //
+    // Deliberately NOT the empty-string identity that repo_id and agent_id use for "the Director did not
+    // say". An empty display spelling would appear in model_identity as a model, be ranked among models, and
+    // read as a model named nothing. Absence is not a value here, so it is stored as the absence of one.
+    //
+    // ALTER TABLE ADD COLUMN, not a table rebuild: SQLite appends the column and reads NULL for every
+    // existing row, which is exactly the state those rows are in - folded before the dimension existed.
+    private void MigrateToVersion2(SqliteTransaction tx)
+    {
+        Execute("ALTER TABLE stat_delta ADD COLUMN model_id INTEGER", tx);
+
+        // Surrogate id to first-seen display spelling, exactly as repo_identity and agent_identity: the
+        // in-memory OrdinalIgnoreCase map decides identity and SQLite is never asked to compare a model
+        // string. The reasoning is identical and is written out at length on repo_identity above - most of
+        // all the part about there being no normalizer equivalent to the comparer, which is why no folded
+        // string is stored.
+        //
+        // Model names need it as much as repositories do: CurrentModel is free text with unbounded
+        // cardinality and casing by convention only.
+        Execute(@"
+            CREATE TABLE IF NOT EXISTS model_identity (
+                model_id      INTEGER PRIMARY KEY AUTOINCREMENT,
+                model_display TEXT    NOT NULL
+            )", tx);
+
+        // When the model dimension began, stamped HERE rather than at the first fold, because the migration
+        // is the moment it began and it is the only moment that is exactly knowable.
+        //
+        // Without this a null model_id is UNREADABLE, and that is the whole reason it exists. Two different
+        // facts both store NULL: a row folded BEFORE this migration ran, which predates the dimension
+        // entirely and could never have carried a model; and a row folded AFTER it, whose session had
+        // genuinely not recorded a model yet. Same null, different meanings, and a page that cannot tell
+        // them apart would report the owner's entire history as "model unknown" as though the data were
+        // missing rather than never collected. Compared against a row's hour_utc, this separates them.
+        //
+        // agents_since_utc is the same idea one dimension earlier, and its comment on the meta table above -
+        // "not a statistic: a fact about when a statistic began" - describes this exactly.
+        //
+        // INSERT OR IGNORE, not INSERT: this stamp is written once and never moved. If a database somehow
+        // already carries the key, the ORIGINAL is the true beginning and overwriting it with a later time
+        // would silently reclassify real model rows as predating the dimension.
+        Execute("INSERT OR IGNORE INTO meta(name, value) VALUES ($n, $v)", tx,
+            ("$n", ModelsSinceKey),
+            ("$v", DateTime.UtcNow.ToString("o", System.Globalization.CultureInfo.InvariantCulture)));
+    }
+
     private int QueryUserVersion()
     {
         using var cmd = _connection.CreateCommand();
@@ -349,6 +416,18 @@ public sealed class GatewayStatsDatabase : IDisposable
         using var cmd = _connection.CreateCommand();
         if (tx is not null) cmd.Transaction = tx;
         cmd.CommandText = sql;
+        cmd.ExecuteNonQuery();
+    }
+
+    /// <summary>Execute with bound parameters. Values reach SQLite as parameters, never as text pasted into
+    /// the statement - the same rule the aggregator's own Execute follows.</summary>
+    private void Execute(string sql, SqliteTransaction? tx, params (string Name, object Value)[] parameters)
+    {
+        using var cmd = _connection.CreateCommand();
+        if (tx is not null) cmd.Transaction = tx;
+        cmd.CommandText = sql;
+        foreach (var (name, value) in parameters)
+            cmd.Parameters.AddWithValue(name, value);
         cmd.ExecuteNonQuery();
     }
 

--- a/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
+++ b/src/CcDirector.Gateway/Stats/StatsPageEndpoint.cs
@@ -67,6 +67,13 @@ public static class StatsPageEndpoint
                 // turns ran under no agent.
                 agents = aggregator.AgentTotals(),
                 agentsSinceUtc = aggregator.AgentsSinceUtc,
+                // DevThrottle Stats (issue #1637): the per-model all-time tally - which model actually did
+                // the work, ranked most-driven first. Like the agents series it starts at modelsSinceUtc
+                // rather than at the beginning of the totals, so the page states that window instead of
+                // implying the earlier turns ran under no model. A null model in this list is the honest
+                // "the agent had not recorded one yet" bucket, not a missing value to hide.
+                models = aggregator.ModelTotals(),
+                modelsSinceUtc = aggregator.ModelsSinceUtc,
                 // DevThrottle Stats (issue #1636): turns the fleet drove into ITSELF - one agent prompting
                 // another. Reported alongside the human tally but never inside it: "how do you drive" and
                 // "how much does the fleet drive itself" are different questions, and the ratio between


### PR DESCRIPTION
The Gateway saw the model on every roster poll and threw it away. It now folds it, behind the first real schema migration this database has had.

## Why this one first

The producer (`SessionDto.CurrentModel`, thefrederiksen/devthrottle_internal#815) merged last night, so this was a column and a migration rather than a wire. That makes it the cheapest place to prove the thing the SQLite mission actually exists for: **`PRAGMA user_version` is a real migration path, not scaffolding.** Version 1 shipped the machinery against a single version, where nothing exercised it. This is the proof that a database on disk, holding real turns, gains a dimension and keeps every number it had.

## What it does

Schema version 2 adds `model_id` to `stat_delta` and a `model_identity` table.

`model_id` is a surrogate integer, the same shape as `repo_id`, for the same reason: the model is free text with unbounded cardinality and casing by convention only, so the in-memory ordinal-ignore-case map must be the only thing that ever decides two model names are one model. SQLite is never asked to compare a model string.

It is also the only nullable dimension, and that is the design rather than a concession. The producer is records-only: it reports the model from the agent's own records at each turn-end and reports nothing until those records name one. So every session's first turn folds with no model, permanently - this store records forward and never revisits a written row. A null says the true thing where a placeholder would invent one, and `models_since_utc`, stamped by the migration, is what lets a reader tell "folded before the dimension existed" from "the agent had not recorded a model yet". Both store null; only the stamp separates them.

Absence is not an empty-string identity, unlike the repository and agent dimensions: that would rank among the models and render as a model named nothing.

`/stats/data` serves the per-model tally and the since-stamp. The null bucket is reported as a real bucket, not filtered - the model turns must add up to the total turns or the page looks broken. There is no model screen here; the embedded stats page renders neither repos nor agents, so that belongs with the governance views.

## The two things most worth reviewing

**Pruning.** The archive fold carries `model_id` in both its select and its group by. Left out of either, pruning silently erases the dimension ninety days later, long after the change that caused it. This is now covered by a test that asserts the prune fired before asserting what it preserved.

**The refactor.** `bool isRepo` became a three-valued `IdentityKind`. A boolean cannot name a third kind, and a parallel set of methods for models would have duplicated the batch-level dedup, which is the subtle part. A model has no distinct-session set - nothing asks how many sessions ran a model, and a session's model can change mid-session - so `SessionsFor` refuses one rather than carrying a set nothing populates. This path carries live data, so the repository and agent behaviour is unchanged.

## Proof

- All seven test projects green: Gateway 2502, Core 3158, Engine 62, Avalonia 220, HostedAgent 80, Launcher 27, Terminal 21.
- **Every new test was watched failing**, with the migration disabled and with `model_id` dropped from the archive select. One of them needed that: the first migration test asserted the version stamp, which `Migrate` writes unconditionally after the steps, so it passed green with the version 2 step switched off. It now reads back the column the step adds.
- Independently reviewed before merge; the review is in `docs/architecture/review-model-dimension-2026-07-16.md` and the prune test exists because that review found it missing.