### PR TITLE
release: v1.4.0 - steadier fleet voice, model-in-stats, live fleet map

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,6 @@
       - UIs read the version from their assembly at runtime - never hardcode it.
   -->
   <PropertyGroup>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
   </PropertyGroup>
 </Project>

--- a/docs/public/release-notes/v1.4.0.md
+++ b/docs/public/release-notes/v1.4.0.md
@@ -1,0 +1,17 @@
+## v1.4.0 - July 16, 2026
+
+A big reliability-and-visibility release: the fleet's voice is steadier, your stats now show which AI model did the work, and the desktop app gains a live fleet map.
+
+### Highlights
+- See which model did the work: your usage stats now break down by the AI model and the agent tool behind each turn, and each session's token spend is carried up to the Gateway, so you can see what you actually ran.
+- Live fleet map in the desktop app: watch every session across your machines at a glance, click to select, with the controller spawn tree laid out.
+- The wingman says which session is talking before it reads a summary, so when you are listening without looking you always know who is speaking.
+- Steadier voice: a single slow moment on one session no longer silences narration for the whole fleet, and when speech genuinely fails you are told the truth instead of getting silence.
+- Pick a snooze length: the desktop and Cockpit menus now offer a list of snooze durations, not just one default.
+
+### Also in this release
+- The Gateway now runs as a background service with a simple Start and Stop tray, and first run no longer asks for a pairing code or a consent window.
+- The mobile app's layout was reworked to sit correctly in the visible screen area, and its play controls now mean the same thing everywhere.
+- The Cockpit's settings are organized by topic, the session rail scans by icon, and workflows are served straight from the Gateway.
+- Many session-state corrections, so a session's colour and status always tell the truth.
+- Dictation is more resilient: a dropped dictation is now loud and gives your words back rather than failing quietly.


### PR DESCRIPTION
Bumps the product version to v1.4.0 (`Directory.Build.props`) and adds the public release notes at `docs/public/release-notes/v1.4.0.md`.

Ninety-one commits since v1.3.0. Highlights: usage stats broken down by model and agent tool (with per-session token spend carried to the Gateway), a live fleet map in the desktop app, the wingman naming the session it reads, hardened voice reliability (no single slow narration silences the fleet; honest state when speech is down), snooze-length menus, and the Gateway running as a background service.

Merge to make the version bump commit the tag point for `v1.4.0`.