### PR TITLE
fix(installer): give macOS a curl-based install path that Gatekeeper cannot block

### DIFF
--- a/docs/public/getting-started/02-installation.md
+++ b/docs/public/getting-started/02-installation.md
@@ -95,7 +95,19 @@ This downloads all tools from GitHub releases, places them in `%LOCALAPPDATA%\cc
 
 ### macOS
 
-On macOS, use the **DevThrottle Setup** app instead: download `devthrottle-setup-mac-arm64.zip` from the [latest release](https://github.com/example-org/devthrottle/releases/latest), unzip it, and right-click -> Open (it is ad-hoc-signed, so Gatekeeper asks once). The wizard installs the Director to `~/Applications`, installs every `cc-*` tool into one shared Python environment under `~/Library/Application Support/cc-director`, and symlinks the tools into `~/.local/bin` (added to your shell `PATH`). Apple Silicon only; Workstation-only (no Gateway on macOS).
+On macOS, use the **DevThrottle Setup** app instead. Install and open it with one command in Terminal:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/example-org/devthrottle/main/scripts/install-mac.sh | bash
+```
+
+The command downloads the wizard from the [latest release](https://github.com/example-org/devthrottle/releases/latest), verifies its SHA-256 hash against the release manifest, places **DevThrottle Setup** in `~/Applications`, and opens it.
+
+It uses `curl` on purpose. The wizard is ad-hoc-signed, not notarized by Apple, so a **browser** download of it is blocked by Gatekeeper — "Apple could not verify 'DevThrottle Setup' is free of malware" — and on macOS 15 (Sequoia) and later that dialog offers no way to open the app (the old right-click -> Open bypass was removed). Downloads made with `curl` are never quarantined, so the wizard opens normally.
+
+If you already downloaded the zip with a browser and hit that block, either run the command above (recommended), or open **System Settings -> Privacy & Security**, scroll down to the message about "DevThrottle Setup", and choose **Open Anyway**. Removing the quarantine flag with `xattr -dr com.apple.quarantine "DevThrottle Setup.app"` also works, but only on a freshly unzipped copy that has never been launched — macOS remembers a copy it has already blocked.
+
+The wizard installs the Director to `~/Applications`, installs every `cc-*` tool into one shared Python environment under `~/Library/Application Support/cc-director`, and symlinks the tools into `~/.local/bin` (added to your shell `PATH`). Apple Silicon only; Workstation-only (no Gateway on macOS).
 
 ### Verify installation
 

--- a/scripts/install-mac.sh
+++ b/scripts/install-mac.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# install-mac.sh - Install DevThrottle on macOS with one command:
+#
+#   curl -fsSL https://raw.githubusercontent.com/thefrederiksen/devthrottle/main/scripts/install-mac.sh | bash
+#
+# Why this script exists
+# ----------------------
+# The "DevThrottle Setup" wizard is ad-hoc code-signed, not notarized by Apple
+# (notarization requires a paid Apple Developer account). Any non-notarized app
+# downloaded with a browser is stamped with the com.apple.quarantine flag, and
+# Gatekeeper then refuses to open it: "Apple could not verify 'DevThrottle
+# Setup' is free of malware". On macOS 15 (Sequoia) and later the old
+# right-click -> Open bypass is gone - the dialog only offers "Move to Trash"
+# and "Done".
+#
+# Downloads made with curl are NOT stamped with the quarantine flag, so
+# Gatekeeper never blocks them. This script is that path: it downloads the
+# latest setup wizard from GitHub Releases with curl, verifies its SHA-256
+# hash against the release manifest, places it in ~/Applications, and opens
+# it. The wizard takes over from there.
+#
+# Safe to re-run: it replaces any previous copy of the wizard.
+
+set -euo pipefail
+
+REPO="${DEVTHROTTLE_REPO:-thefrederiksen/devthrottle}"
+ASSET="devthrottle-setup-mac-arm64.zip"
+MANIFEST="release-manifest.json"
+APP_NAME="DevThrottle Setup.app"
+DESTINATION_DIR="$HOME/Applications"
+BASE_URL="https://github.com/$REPO/releases/latest/download"
+
+log()  { printf '%s\n' "$*"; }
+fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+# ----------------------------------------------------------------------------
+# Preconditions: Apple Silicon Mac.
+# ----------------------------------------------------------------------------
+[[ "$(uname -s)" == "Darwin" ]] || fail "This installer is for macOS only."
+[[ "$(uname -m)" == "arm64" ]] || fail "DevThrottle for macOS requires Apple Silicon. This machine reports architecture '$(uname -m)'."
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# ----------------------------------------------------------------------------
+# Download the wizard and the release manifest from the latest release.
+# ----------------------------------------------------------------------------
+log "Downloading the latest DevThrottle Setup wizard..."
+log "  $BASE_URL/$ASSET"
+curl -fL --progress-bar -o "$WORK_DIR/$ASSET" "$BASE_URL/$ASSET" \
+    || fail "Could not download $ASSET. Check your internet connection and that the release exists at https://github.com/$REPO/releases/latest"
+curl -fsSL -o "$WORK_DIR/$MANIFEST" "$BASE_URL/$MANIFEST" \
+    || fail "Could not download $MANIFEST from the release."
+
+# ----------------------------------------------------------------------------
+# Verify the download against the SHA-256 hash recorded in the manifest.
+# ----------------------------------------------------------------------------
+log "Verifying the download against the release manifest..."
+expected_hash="$(/usr/bin/python3 -c "
+import json, sys
+manifest = json.load(open('$WORK_DIR/$MANIFEST'))
+print(manifest['assets']['$ASSET']['sha256'].lower())
+")" || fail "Could not read the SHA-256 hash for $ASSET from $MANIFEST."
+actual_hash="$(shasum -a 256 "$WORK_DIR/$ASSET" | cut -d' ' -f1)"
+[[ "$actual_hash" == "$expected_hash" ]] \
+    || fail "SHA-256 mismatch for $ASSET: expected $expected_hash, got $actual_hash. Do not run this download - try again."
+log "  SHA-256 verified: $actual_hash"
+
+# ----------------------------------------------------------------------------
+# Unpack with ditto so the app bundle's signature and permissions survive.
+# ----------------------------------------------------------------------------
+log "Unpacking..."
+ditto -xk "$WORK_DIR/$ASSET" "$WORK_DIR/unpacked" || fail "Could not unpack $ASSET."
+[[ -d "$WORK_DIR/unpacked/$APP_NAME" ]] || fail "The archive did not contain \"$APP_NAME\"."
+
+# curl downloads carry no quarantine flag, but clear any that may have been
+# inherited so Gatekeeper has nothing to evaluate.
+xattr -dr com.apple.quarantine "$WORK_DIR/unpacked/$APP_NAME" 2>/dev/null || true
+
+# ----------------------------------------------------------------------------
+# Install to ~/Applications, replacing any previous copy.
+# ----------------------------------------------------------------------------
+mkdir -p "$DESTINATION_DIR"
+if [[ -d "$DESTINATION_DIR/$APP_NAME" ]]; then
+    log "Replacing the previous copy in $DESTINATION_DIR..."
+    rm -rf "$DESTINATION_DIR/$APP_NAME"
+fi
+mv "$WORK_DIR/unpacked/$APP_NAME" "$DESTINATION_DIR/$APP_NAME"
+log "Installed \"$APP_NAME\" into $DESTINATION_DIR."
+
+# ----------------------------------------------------------------------------
+# Open the wizard (skippable for unattended or scripted runs).
+# ----------------------------------------------------------------------------
+if [[ "${DEVTHROTTLE_NO_OPEN:-}" == "1" ]]; then
+    log "DEVTHROTTLE_NO_OPEN=1 - not opening the wizard. Open it later with:"
+    log "  open \"$DESTINATION_DIR/$APP_NAME\""
+else
+    log "Opening the setup wizard..."
+    open "$DESTINATION_DIR/$APP_NAME"
+fi


### PR DESCRIPTION
## The problem

Downloading `devthrottle-setup-mac-arm64.zip` with a browser and opening the wizard produces the Gatekeeper block: **"Apple could not verify 'DevThrottle Setup' is free of malware"**, with only "Move to Trash" and "Done" as choices. The wizard is ad-hoc-signed and not notarized (notarization requires a paid Apple Developer account), and on macOS 15 (Sequoia) and later Apple removed the right-click -> Open bypass that our installation guide described. A Mac user following the docs is dead-ended.

## The fix

Downloads made with `curl` are never stamped with the quarantine flag, so Gatekeeper never evaluates them. This pull request adds `scripts/install-mac.sh`, a one-command installer:

```bash
curl -fsSL https://raw.githubusercontent.com/thefrederiksen/devthrottle/main/scripts/install-mac.sh | bash
```

It downloads the latest wizard from GitHub Releases with curl, verifies its SHA-256 hash against `release-manifest.json` (same integrity check the Windows walkthrough teaches), installs it to `~/Applications` (replacing any previous copy), and opens it. `DEVTHROTTLE_NO_OPEN=1` skips the final open for unattended runs.

The macOS section of the installation guide now leads with that command, explains why a browser download is blocked, and gives the two recovery paths for an already-downloaded copy: System Settings -> Privacy & Security -> Open Anyway, or removing the quarantine flag from a fresh copy that has never been launched.

## Proof

Run end-to-end on a Mac mini running macOS 26 against the real v1.4.0 release: the download completed, the SHA-256 hash matched the manifest (`f33183097c2f...`), the app landed in `~/Applications` with no quarantine attribute, and the wizard launched with no Gatekeeper dialog.

## Out of scope

Notarization itself. The permanent fix is an Apple Developer account plus Developer ID signing and notarization in the release workflow; this pull request makes installation work without it.